### PR TITLE
feat: add vercel ai sdk integration

### DIFF
--- a/packages/farm-cli/bin/farm.js
+++ b/packages/farm-cli/bin/farm.js
@@ -89,6 +89,7 @@ addCommand
   .option("-f, --file <file>", "Path to the app integrations registry", "src/lib/integrations.ts")
   .option("--force", "Overwrite an existing generated integration component")
   .option("--dry-run", "Show what would be added without writing files")
+  .option("--route-file <file>", "Route file path for route-based integrations")
   .option("--skip-package-json", "Do not add @farmjs/integrations to package.json")
   .option("--skip-config", "Do not create or update farm.config")
   .option("-l, --list", "List supported integration providers")
@@ -116,6 +117,7 @@ addCommand
         provider,
         key: options.key,
         integrationsFile: options.file,
+        routeFile: options.routeFile,
         dryRun: options.dryRun,
         force: options.force,
         skipPackageJson: options.skipPackageJson,
@@ -123,7 +125,11 @@ addCommand
       });
 
       const verb = options.dryRun ? "Prepared" : "Added";
-      console.log(`${verb} ${result.provider} integration as appIntegrations.${result.key}`);
+      if (result.mode === "route") {
+        console.log(`${verb} ${result.provider} route at ${result.routePath || result.routeFile}`);
+      } else {
+        console.log(`${verb} ${result.provider} integration as appIntegrations.${result.key}`);
+      }
 
       if (result.created.length) {
         console.log("Created:");

--- a/packages/farm-cli/src/add-integration.ts
+++ b/packages/farm-cli/src/add-integration.ts
@@ -14,6 +14,7 @@ export interface AddFarmIntegrationOptions {
   provider: string;
   key?: string;
   integrationsFile?: string;
+  routeFile?: string;
   skipPackageJson?: boolean;
   skipConfig?: boolean;
   dryRun?: boolean;
@@ -23,8 +24,11 @@ export interface AddFarmIntegrationOptions {
 export interface AddFarmIntegrationResult {
   provider: FarmIntegrationProvider;
   key: string;
+  mode?: "integration" | "route";
   integrationFile: string;
   registryFile: string;
+  routeFile?: string;
+  routePath?: string;
   packageJson?: string;
   configFile?: string;
   created: string[];
@@ -35,6 +39,7 @@ export interface AddFarmIntegrationResult {
 }
 
 export type FarmIntegrationProvider =
+  | "ai"
   | "auth0"
   | "authjs"
   | "autumn"
@@ -61,6 +66,27 @@ interface IntegrationProviderDefinition {
 }
 
 const PROVIDERS: readonly IntegrationProviderDefinition[] = [
+  {
+    provider: "ai",
+    aliases: ["ai-sdk", "vercel-ai", "vercel-ai-sdk", "chat"],
+    defaultKey: "chat",
+    fileName: "chat",
+    exportName: "POST",
+    description: "Vercel AI SDK chat route",
+    env: ["AI_GATEWAY_API_KEY"],
+    notes: [
+      'Use @ai-sdk/react useChat with api: "/api/chat" on the client.',
+      "Replace model with any AI SDK provider model or Vercel AI Gateway model id.",
+      "No farm.config integration wiring is required for this route.",
+    ],
+    template: () => `import { aiChatRoute } from "@farmjs/integrations/ai";
+
+export const POST = aiChatRoute({
+  model: "openai/gpt-4o-mini",
+  system: "You are a helpful assistant.",
+});
+`,
+  },
   {
     provider: "stripe",
     aliases: ["billing-stripe", "payments", "stripe-billing"],
@@ -385,6 +411,18 @@ export async function addFarmIntegration(
 ): Promise<AddFarmIntegrationResult> {
   const root = path.resolve(options.root || process.cwd());
   const definition = resolveProvider(options.provider);
+
+  if (definition.provider === "ai") {
+    return addAIRouteIntegration({
+      root,
+      definition,
+      routeFile: options.routeFile,
+      skipPackageJson: options.skipPackageJson,
+      dryRun: options.dryRun,
+      force: options.force,
+    });
+  }
+
   const key = options.key || definition.defaultKey;
   assertValidIntegrationKey(key);
 
@@ -400,6 +438,7 @@ export async function addFarmIntegration(
   const result: AddFarmIntegrationResult = {
     provider: definition.provider,
     key,
+    mode: "integration",
     integrationFile,
     registryFile,
     created: [],
@@ -438,6 +477,52 @@ export async function addFarmIntegration(
       root,
       registryFile,
       dryRun: options.dryRun,
+      result,
+    });
+  }
+
+  return result;
+}
+
+async function addAIRouteIntegration(input: {
+  root: string;
+  definition: IntegrationProviderDefinition;
+  routeFile?: string;
+  skipPackageJson?: boolean;
+  dryRun?: boolean;
+  force?: boolean;
+}): Promise<AddFarmIntegrationResult> {
+  const routeFile = path.resolve(
+    input.root,
+    input.routeFile || path.join("src", "app", "api", "chat", "route.ts"),
+  );
+  const result: AddFarmIntegrationResult = {
+    provider: "ai",
+    key: input.definition.defaultKey,
+    mode: "route",
+    integrationFile: routeFile,
+    registryFile: "",
+    routeFile,
+    routePath: "/api/chat",
+    created: [],
+    updated: [],
+    skipped: [],
+    env: [...input.definition.env],
+    notes: [...(input.definition.notes || [])],
+  };
+
+  await writeIntegrationComponent({
+    path: routeFile,
+    definition: input.definition,
+    force: input.force,
+    dryRun: input.dryRun,
+    result,
+  });
+
+  if (!input.skipPackageJson) {
+    await updatePackageJson({
+      root: input.root,
+      dryRun: input.dryRun,
       result,
     });
   }

--- a/packages/farm-cli/test/add-integration.test.mjs
+++ b/packages/farm-cli/test/add-integration.test.mjs
@@ -12,6 +12,7 @@ test("lists official integration providers", () => {
   const providers = listFarmIntegrationProviders().map((provider) => provider.name);
 
   assert.ok(providers.includes("stripe"));
+  assert.ok(providers.includes("ai"));
   assert.ok(providers.includes("supabase"));
   assert.ok(providers.includes("jobs-inngest"));
 });
@@ -106,6 +107,43 @@ export default defineFarmConfig({
     assert.match(config, /import \{ appIntegrations \}/);
     assert.match(config, /integrations: appIntegrations/);
     assert.match(config, /vite:/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("adds a Vercel AI SDK chat route template", async () => {
+  const root = await createTempProject({
+    packageJson: {
+      type: "module",
+      dependencies: {
+        "@farmjs/core": "workspace:*",
+      },
+    },
+  });
+
+  try {
+    const result = await addFarmIntegration({
+      root,
+      provider: "vercel-ai-sdk",
+    });
+
+    const packageJson = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
+    const routeFile = path.join(root, "src/app/api/chat/route.ts");
+    const route = await readFile(routeFile, "utf8");
+
+    assert.equal(result.provider, "ai");
+    assert.equal(result.key, "chat");
+    assert.equal(result.mode, "route");
+    assert.equal(result.routeFile, routeFile);
+    assert.equal(result.routePath, "/api/chat");
+    assert.deepEqual(result.env, ["AI_GATEWAY_API_KEY"]);
+    assert.equal(packageJson.dependencies["@farmjs/integrations"], "workspace:*");
+    assert.match(route, /import \{ aiChatRoute \} from "@farmjs\/integrations\/ai"/);
+    assert.match(route, /export const POST = aiChatRoute/);
+    assert.match(route, /model: "openai\/gpt-4o-mini"/);
+    await assert.rejects(() => readFile(path.join(root, "src/lib/integrations.ts"), "utf8"));
+    await assert.rejects(() => readFile(path.join(root, "farm.config.ts"), "utf8"));
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/farm-integrations/package.json
+++ b/packages/farm-integrations/package.json
@@ -19,6 +19,10 @@
       "types": "./dist/better-auth/index.d.ts",
       "import": "./dist/better-auth/index.js"
     },
+    "./ai": {
+      "types": "./dist/ai/index.d.ts",
+      "import": "./dist/ai/index.js"
+    },
     "./authjs": {
       "types": "./dist/authjs/index.d.ts",
       "import": "./dist/authjs/index.js"
@@ -109,6 +113,7 @@
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.99.2",
     "@workos-inc/node": "^8.9.0",
+    "ai": "^7.0.11",
     "autumn-js": "^1.2.7",
     "resend": "6.10.0",
     "standardwebhooks": "^1.0.0",

--- a/packages/farm-integrations/src/ai/index.ts
+++ b/packages/farm-integrations/src/ai/index.ts
@@ -1,0 +1,312 @@
+import { createEndpoint } from "@farmjs/core";
+import {
+  convertToModelMessages,
+  streamText,
+  type LanguageModel,
+  type UIMessage,
+  type UIMessageStreamOptions,
+} from "ai";
+
+type AIStreamTextFunction = typeof streamText;
+type AIConvertToModelMessagesFunction = typeof convertToModelMessages;
+type AIStreamTextInput = Parameters<AIStreamTextFunction>[0];
+type AIConvertToModelMessagesOptions = NonNullable<Parameters<AIConvertToModelMessagesFunction>[1]>;
+
+export interface AIChatRequestBody<TMessage = Omit<UIMessage, "id">> {
+  messages: TMessage[];
+  [key: string]: unknown;
+}
+
+export interface AIChatValidationIssue {
+  path: readonly (string | number)[];
+  code: string;
+  message: string;
+}
+
+export type AIChatStreamTextOptions = Partial<
+  Omit<AIStreamTextInput, "model" | "messages" | "prompt">
+>;
+
+export type AIChatResponseOptions = ResponseInit &
+  UIMessageStreamOptions<UIMessage> & {
+    consumeSseStream?: (options: { stream: ReadableStream<string> }) => PromiseLike<void> | void;
+  };
+
+export interface AIChatPrepareContext<TBody extends AIChatRequestBody = AIChatRequestBody> {
+  request: Request;
+  body: TBody;
+  messages: unknown[];
+  modelMessages: Awaited<ReturnType<AIConvertToModelMessagesFunction>>;
+}
+
+export interface AIChatRouteOptions<TBody extends AIChatRequestBody = AIChatRequestBody> {
+  model: LanguageModel;
+  system?: AIStreamTextInput["system"];
+  instructions?: AIStreamTextInput["instructions"];
+  streamText?: AIStreamTextFunction;
+  convertToModelMessages?: AIConvertToModelMessagesFunction;
+  convertToModelMessagesOptions?: AIConvertToModelMessagesOptions;
+  options?: AIChatStreamTextOptions;
+  responseOptions?:
+    | AIChatResponseOptions
+    | ((
+        context: AIChatPrepareContext<TBody>,
+      ) => AIChatResponseOptions | Promise<AIChatResponseOptions>);
+  selectMessages?: (body: TBody, request: Request) => unknown[];
+  prepare?: (
+    context: AIChatPrepareContext<TBody>,
+  ) => AIChatStreamTextOptions | Promise<AIChatStreamTextOptions>;
+}
+
+type AIChatRequestBodySchema = {
+  parse(value: unknown): AIChatRequestBody;
+  safeParse(value: unknown):
+    | {
+        success: true;
+        data: AIChatRequestBody;
+      }
+    | {
+        success: false;
+        error: {
+          issues: AIChatValidationIssue[];
+        };
+      };
+};
+
+export const aiChatRequestBodySchema: AIChatRequestBodySchema = {
+  parse(value) {
+    const validation = validateAIChatRequestBody(value);
+    if (!validation.success) {
+      throw createAIChatValidationError(validation.issues);
+    }
+
+    return validation.data;
+  },
+  safeParse(value) {
+    const validation = validateAIChatRequestBody(value);
+    if (validation.success) {
+      return validation;
+    }
+
+    return {
+      success: false,
+      error: {
+        issues: validation.issues,
+      },
+    };
+  },
+};
+
+/**
+ * Create a Vercel AI SDK chat route for Farm's Next-style app/api convention.
+ *
+ * // src/app/api/chat/route.ts
+ * export const POST = aiChatRoute({ model: "openai/gpt-4o-mini" });
+ */
+export function aiChatRoute<TBody extends AIChatRequestBody = AIChatRequestBody>(
+  input: AIChatRouteOptions<TBody>,
+) {
+  return createEndpoint(
+    {
+      method: "POST",
+      body: aiChatRequestBodySchema,
+    },
+    async (context) => {
+      return createAIChatResponse(input, context.request, context.body);
+    },
+  );
+}
+
+export const createAIChatRoute = aiChatRoute;
+export const defineAIChatRoute = aiChatRoute;
+
+async function createAIChatResponse<TBody extends AIChatRequestBody>(
+  input: AIChatRouteOptions<TBody>,
+  request: Request,
+  bodyInput?: unknown,
+) {
+  const bodyValidation = validateAIChatRequestBody(bodyInput ?? (await readJsonBody(request)));
+  if (!bodyValidation.success) {
+    return createAIChatValidationResponse(bodyValidation.issues);
+  }
+
+  const body = bodyValidation.data as TBody;
+  const messages = input.selectMessages?.(body, request) ?? body.messages;
+  if (!Array.isArray(messages)) {
+    return createAIChatValidationResponse([
+      {
+        path: ["messages"],
+        code: "invalid_type",
+        message: "Expected selected messages to be an array.",
+      },
+    ]);
+  }
+
+  const convertMessages = input.convertToModelMessages ?? convertToModelMessages;
+  const modelMessages = await convertMessages(
+    messages as Parameters<AIConvertToModelMessagesFunction>[0],
+    {
+      ...input.convertToModelMessagesOptions,
+      tools: input.convertToModelMessagesOptions?.tools ?? (input.options as any)?.tools,
+    },
+  );
+  const prepareContext: AIChatPrepareContext<TBody> = {
+    request,
+    body,
+    messages,
+    modelMessages,
+  };
+  const preparedOptions = await input.prepare?.(prepareContext);
+  const streamInput = {
+    ...input.options,
+    system: input.system ?? input.options?.system,
+    instructions: input.instructions ?? input.options?.instructions,
+    ...preparedOptions,
+    model: input.model,
+    messages: modelMessages,
+  } as AIStreamTextInput;
+  const responseOptions =
+    typeof input.responseOptions === "function"
+      ? await input.responseOptions(prepareContext)
+      : input.responseOptions;
+  const stream = (input.streamText ?? streamText)(streamInput);
+
+  return stream.toUIMessageStreamResponse(responseOptions);
+}
+
+async function readJsonBody(request: Request) {
+  try {
+    const text = await request.clone().text();
+    if (text.trim().length === 0) {
+      return undefined;
+    }
+
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+function validateAIChatRequestBody(value: unknown):
+  | {
+      success: true;
+      data: AIChatRequestBody;
+    }
+  | {
+      success: false;
+      issues: AIChatValidationIssue[];
+    } {
+  if (!isRecord(value)) {
+    return {
+      success: false,
+      issues: [
+        {
+          path: [],
+          code: "invalid_type",
+          message: "Expected AI chat request body to be an object.",
+        },
+      ],
+    };
+  }
+
+  const messages = value.messages;
+  if (!Array.isArray(messages)) {
+    return {
+      success: false,
+      issues: [
+        {
+          path: ["messages"],
+          code: "invalid_type",
+          message: "Expected messages to be an array.",
+        },
+      ],
+    };
+  }
+
+  const issues: AIChatValidationIssue[] = [];
+  if (messages.length === 0) {
+    issues.push({
+      path: ["messages"],
+      code: "too_small",
+      message: "Expected at least one message.",
+    });
+  }
+
+  for (const [messageIndex, message] of messages.entries()) {
+    if (!isRecord(message)) {
+      issues.push({
+        path: ["messages", messageIndex],
+        code: "invalid_type",
+        message: "Expected message to be an object.",
+      });
+      continue;
+    }
+
+    if (!isAIMessageRole(message.role)) {
+      issues.push({
+        path: ["messages", messageIndex, "role"],
+        code: "invalid_enum_value",
+        message: "Expected message role to be system, user, or assistant.",
+      });
+    }
+
+    if (!Array.isArray(message.parts)) {
+      issues.push({
+        path: ["messages", messageIndex, "parts"],
+        code: "invalid_type",
+        message: "Expected message parts to be an array.",
+      });
+      continue;
+    }
+
+    for (const [partIndex, part] of message.parts.entries()) {
+      if (!isRecord(part) || typeof part.type !== "string") {
+        issues.push({
+          path: ["messages", messageIndex, "parts", partIndex],
+          code: "invalid_type",
+          message: "Expected message part to be an object with a string type.",
+        });
+      }
+    }
+  }
+
+  if (issues.length > 0) {
+    return {
+      success: false,
+      issues,
+    };
+  }
+
+  return {
+    success: true,
+    data: value as AIChatRequestBody,
+  };
+}
+
+function createAIChatValidationResponse(issues: AIChatValidationIssue[]) {
+  return Response.json(
+    {
+      error: "AI chat request body validation failed",
+      issues,
+    },
+    {
+      status: 400,
+    },
+  );
+}
+
+function createAIChatValidationError(issues: AIChatValidationIssue[]) {
+  const error = new Error("AI chat request body validation failed") as Error & {
+    issues: AIChatValidationIssue[];
+  };
+  error.issues = issues;
+  return error;
+}
+
+function isAIMessageRole(value: unknown) {
+  return value === "system" || value === "user" || value === "assistant";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/farm-integrations/src/farm-core-shim.d.ts
+++ b/packages/farm-integrations/src/farm-core-shim.d.ts
@@ -427,6 +427,52 @@ declare module "@farmjs/core" {
     integration: TIntegration,
   ): DefinedIntegration<TIntegration>;
 
+  type FarmEndpointSchema<TValue = unknown> = {
+    parse(value: unknown): TValue;
+  };
+
+  type InferFarmEndpointSchema<TSchema> =
+    TSchema extends FarmEndpointSchema<infer TValue> ? TValue : unknown;
+
+  export type FarmTypedEndpoint<TBody = never, TQuery = never, TResponse = unknown> = {
+    __types: {
+      body: TBody;
+      query: TQuery;
+      response: TResponse;
+    };
+    __path?: string;
+    __method?: string;
+  } & ((options?: { body?: TBody; query?: TQuery }) => Promise<TResponse>);
+
+  export function createEndpoint<
+    TBodySchema extends FarmEndpointSchema | undefined = undefined,
+    TQuerySchema extends FarmEndpointSchema | undefined = undefined,
+    THeadersSchema extends FarmEndpointSchema | undefined = undefined,
+    TResponse = unknown,
+  >(
+    options: {
+      method?: FarmIntegrationAPIMethod;
+      body?: TBodySchema;
+      query?: TQuerySchema;
+      headers?: THeadersSchema;
+      use?: unknown[];
+    },
+    handler: (context: {
+      body: InferFarmEndpointSchema<TBodySchema>;
+      query: InferFarmEndpointSchema<TQuerySchema>;
+      headers: THeadersSchema extends FarmEndpointSchema
+        ? InferFarmEndpointSchema<THeadersSchema>
+        : Record<string, string>;
+      request: Request;
+      context: unknown;
+      params: FarmIntegrationRouteParams;
+    }) => TResponse | Promise<TResponse>,
+  ): FarmTypedEndpoint<
+    InferFarmEndpointSchema<TBodySchema>,
+    InferFarmEndpointSchema<TQuerySchema>,
+    Awaited<TResponse>
+  >;
+
   export const integrationRoute: {
     get<TPath extends string, TResponse = unknown, TQuery = never, TServer extends boolean = false>(
       path: TPath,

--- a/packages/farm-integrations/src/index.ts
+++ b/packages/farm-integrations/src/index.ts
@@ -1,4 +1,10 @@
 export { betterAuth } from "./better-auth/index.js";
+export {
+  aiChatRequestBodySchema,
+  aiChatRoute,
+  createAIChatRoute,
+  defineAIChatRoute,
+} from "./ai/index.js";
 export { authjs } from "./authjs/index.js";
 export { clerk } from "./clerk/index.js";
 export { auth0 } from "./auth0/index.js";
@@ -22,6 +28,14 @@ export {
   stripe,
   stripeSchema,
 } from "./stripe/index.js";
+export type {
+  AIChatPrepareContext,
+  AIChatRequestBody,
+  AIChatResponseOptions,
+  AIChatRouteOptions,
+  AIChatStreamTextOptions,
+  AIChatValidationIssue,
+} from "./ai/index.js";
 export type {
   StripeBillingFeatures,
   StripeBillingHookTools,

--- a/packages/farm/src/__tests__/ai-integration.test.ts
+++ b/packages/farm/src/__tests__/ai-integration.test.ts
@@ -1,0 +1,227 @@
+// @vitest-environment node
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import { APIRouteManager, invokeAPIRouteEndpoint } from "../api/route-manager";
+import { aiChatRequestBodySchema, aiChatRoute } from "../../../farm-integrations/src/ai/index";
+
+const chatMessages = [
+  {
+    id: "msg_1",
+    role: "user",
+    parts: [
+      {
+        type: "text",
+        text: "Hello",
+      },
+    ],
+  },
+] as const;
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("ai integration", () => {
+  it("creates a Next-style chat route that streams an AI SDK UI response", async () => {
+    const streamTextCalls: unknown[] = [];
+    const POST = aiChatRoute({
+      model: "openai/gpt-4o-mini",
+      system: "You are a helpful Farm.js assistant.",
+      convertToModelMessages: async (messages) => {
+        expect(messages).toEqual(chatMessages);
+        return [
+          {
+            role: "user",
+            content: "Hello",
+          },
+        ] as any;
+      },
+      streamText: ((input: unknown) => {
+        streamTextCalls.push(input);
+        return {
+          toUIMessageStreamResponse(init?: ResponseInit) {
+            return new Response("mock-ui-stream", {
+              status: init?.status ?? 200,
+              headers: {
+                "content-type": "text/event-stream",
+                "x-farm-ai": "route",
+              },
+            });
+          },
+        };
+      }) as any,
+      responseOptions: {
+        status: 202,
+      },
+      prepare({ body }) {
+        return {
+          temperature: Number(body.temperature),
+        } as any;
+      },
+    });
+
+    const response = await invokeAPIRouteEndpoint(
+      POST,
+      new Request("http://example.com/api/chat", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          messages: chatMessages,
+          temperature: 0.2,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(response.headers.get("x-farm-ai")).toBe("route");
+    await expect(response.text()).resolves.toBe("mock-ui-stream");
+    expect(streamTextCalls).toEqual([
+      expect.objectContaining({
+        model: "openai/gpt-4o-mini",
+        system: "You are a helpful Farm.js assistant.",
+        temperature: 0.2,
+        messages: [
+          {
+            role: "user",
+            content: "Hello",
+          },
+        ],
+      }),
+    ]);
+  });
+
+  it("is discoverable from a Next-style src/app/api/chat/route.ts export", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-ai-route-"));
+    tempDirs.push(root);
+
+    const appDir = path.join(root, "src", "app");
+    const routeDir = path.join(appDir, "api", "chat");
+    fs.mkdirSync(routeDir, { recursive: true });
+    const routeFile = path.join(routeDir, "route.ts");
+    fs.writeFileSync(routeFile, "export {};\n");
+
+    const streamTextCalls: unknown[] = [];
+    const manager = new APIRouteManager(appDir, {
+      ssrLoadModule: async (filePath: string) => {
+        expect(filePath).toBe(routeFile);
+        return {
+          POST: aiChatRoute({
+            model: "openai/gpt-4o-mini",
+            convertToModelMessages: async (messages) => {
+              expect(messages).toEqual(chatMessages);
+              return [
+                {
+                  role: "user",
+                  content: "Hello",
+                },
+              ] as any;
+            },
+            streamText: ((input: unknown) => {
+              streamTextCalls.push(input);
+              return {
+                toUIMessageStreamResponse() {
+                  return new Response("next-ai-stream", {
+                    headers: {
+                      "content-type": "text/event-stream",
+                    },
+                  });
+                },
+              };
+            }) as any,
+          }),
+        };
+      },
+    } as any);
+
+    await manager.discoverRoutes();
+    const handler = manager.getHandler();
+
+    expect(handler).toBeTypeOf("function");
+    expect(Array.from(manager.getRoutes().keys())).toEqual(["/api/chat"]);
+
+    const response = await handler!(
+      new Request("http://example.com/api/chat", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          messages: chatMessages,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/event-stream");
+    await expect(response.text()).resolves.toBe("next-ai-stream");
+    expect(streamTextCalls).toEqual([
+      expect.objectContaining({
+        model: "openai/gpt-4o-mini",
+        messages: [
+          {
+            role: "user",
+            content: "Hello",
+          },
+        ],
+      }),
+    ]);
+  });
+
+  it("returns 400 for invalid chat route request bodies", async () => {
+    const POST = aiChatRoute({
+      model: "openai/gpt-4o-mini",
+      streamText: (() => {
+        throw new Error("streamText should not run for invalid input.");
+      }) as any,
+    });
+
+    const response = await invokeAPIRouteEndpoint(
+      POST,
+      new Request("http://example.com/api/chat", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          prompt: "missing messages",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid request body",
+      details: [
+        {
+          path: ["messages"],
+          message: "Expected messages to be an array.",
+        },
+      ],
+    });
+  });
+
+  it("exposes a reusable chat request schema", () => {
+    expect(aiChatRequestBodySchema.safeParse({ messages: chatMessages }).success).toBe(true);
+    expect(
+      aiChatRequestBodySchema.safeParse({
+        messages: [
+          {
+            role: "user",
+            parts: [{}],
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/farm/src/__tests__/api-route-manager.test.ts
+++ b/packages/farm/src/__tests__/api-route-manager.test.ts
@@ -215,6 +215,70 @@ describe("APIRouteManager", () => {
     });
   });
 
+  it("supports Next-style POST exports created with createEndpoint", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-api-route-"));
+    tempDirs.push(root);
+
+    const routeDir = path.join(root, "api", "chat");
+    fs.mkdirSync(routeDir, { recursive: true });
+    const routeFile = path.join(routeDir, "route.js");
+    fs.writeFileSync(routeFile, "export {};\n");
+
+    const manager = new APIRouteManager(root, {
+      ssrLoadModule: async (filePath: string) => {
+        expect(filePath).toBe(routeFile);
+        return {
+          POST: createEndpoint(
+            {
+              method: "POST",
+              body: z.object({
+                message: z.string().min(1),
+              }),
+            },
+            async (ctx) =>
+              Response.json({
+                message: ctx.body.message,
+                path: new URL(ctx.request.url).pathname,
+              }),
+          ),
+        };
+      },
+    } as any);
+
+    await manager.discoverRoutes();
+    const handler = manager.getHandler();
+
+    expect(handler).toBeTypeOf("function");
+    expect(Array.from(manager.getRoutes().keys())).toEqual(["/api/chat"]);
+
+    const response = await handler!(
+      new Request("http://example.com/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: "hello" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      message: "hello",
+      path: "/api/chat",
+    });
+
+    const invalidResponse = await handler!(
+      new Request("http://example.com/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: "" }),
+      }),
+    );
+
+    expect(invalidResponse.status).toBe(400);
+    await expect(invalidResponse.json()).resolves.toMatchObject({
+      error: "Invalid request body",
+    });
+  });
+
   it("discovers explicit-path createEndpoint routes from root routes files", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-api-route-"));
     tempDirs.push(root);

--- a/packages/farm/src/api/endpoint.ts
+++ b/packages/farm/src/api/endpoint.ts
@@ -56,6 +56,7 @@ export type TypedEndpoint<TBody = never, TQuery = never, TResponse = any> = {
  *
  * Supports two patterns:
  * 1. File-based routing (path auto-inferred from file location):
+ *    `export const POST = createEndpoint({ method: 'POST', body: schema }, handler)`
  *    `createEndpoint({ method: 'GET', query: z.object({...}) }, handler)`
  *
  * 2. Explicit path (for routes.ts at project root):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1035,6 +1035,9 @@ importers:
       '@workos-inc/node':
         specifier: ^8.9.0
         version: 8.9.0
+      ai:
+        specifier: ^7.0.11
+        version: 7.0.11(zod@4.3.6)
       autumn-js:
         specifier: ^1.2.7
         version: 1.2.7(react@19.2.4)
@@ -1111,6 +1114,38 @@ importers:
         version: 6.4.1(@types/node@20.19.21)
 
 packages:
+
+  /@ai-sdk/gateway@4.0.8(zod@4.3.6):
+    resolution: {integrity: sha512-esHzojMp+LllqOnEu6sYa6NKOmPcE5UObPV61LE6L2QAzCH6WHMgTS+Q/HF5HU3lVUWsHtkDzN7TNqMfv/ecCg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/provider': 4.0.1
+      '@ai-sdk/provider-utils': 5.0.3(zod@4.3.6)
+      '@vercel/oidc': 3.2.0
+      zod: 4.3.6
+    dev: false
+
+  /@ai-sdk/provider-utils@5.0.3(zod@4.3.6):
+    resolution: {integrity: sha512-El0JOXXGcHFe6+owJ1UV0VgB9XtdivP8vcZni+rUIt6lt+cBHCnUdddaA6LE2avJGJ5AD0uXSY+uAvRL2tSvgw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/provider': 4.0.1
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.3.6
+    dev: false
+
+  /@ai-sdk/provider@4.0.1:
+    resolution: {integrity: sha512-6p3C/vGqVIjcptBu1DnVd/BZJ2wWmV9TUv9192vT6ZvT9KNED8EwRTqyqFpoQZKgSbMDSvBSq3dqR524Nt/Crw==}
+    engines: {node: '>=22'}
+    dependencies:
+      json-schema: 0.4.0
+    dev: false
 
   /@alloc/quick-lru@5.2.0:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -5311,6 +5346,11 @@ packages:
       vue: 3.5.22(typescript@5.9.3)
     dev: false
 
+  /@vercel/oidc@3.2.0:
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+    dev: false
+
   /@vitejs/plugin-react@4.7.0(supports-color@10.2.2)(vite@5.4.20):
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -5699,6 +5739,10 @@ packages:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
+  /@workflow/serde@4.1.0:
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+    dev: false
+
   /@workos-inc/node@8.9.0:
     resolution: {integrity: sha512-io5D4Scoy7RwjNQGyWWVeljwQz4RSqGRILP1/tbv5vXUxJdhpcGqGwML4AHamgacEay+QyiDW9RvgfjiQN3KLw==}
     engines: {node: '>=20.15.0'}
@@ -5746,6 +5790,18 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
     dev: true
+
+  /ai@7.0.11(zod@4.3.6):
+    resolution: {integrity: sha512-ecCtume1NKJG/8oIkV8G26KL9jmFJRx6+Gjx2260FcDZqIUGPiF1uBoNeGy4S1vxbHmFxUul4D7axqiXZZ1XuA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/gateway': 4.0.8(zod@4.3.6)
+      '@ai-sdk/provider': 4.0.1
+      '@ai-sdk/provider-utils': 5.0.3(zod@4.3.6)
+      zod: 4.3.6
+    dev: false
 
   /ajv-draft-04@1.0.0(ajv@8.17.1):
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
@@ -7267,6 +7323,11 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  /eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+    dev: false
+
   /execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
@@ -8157,6 +8218,10 @@ packages:
 
   /json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  /json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+    dev: false
 
   /json-stringify-deterministic@1.0.12:
     resolution: {integrity: sha512-q3PN0lbUdv0pmurkBNdJH3pfFvOTL/Zp0lquqpvcjfKzt6Y0j49EPHAmVHCAS4Ceq/Y+PejWTzyiVpoY71+D6g==}


### PR DESCRIPTION
## Summary
- add @farmjs/integrations/ai with aiChatRoute() for Next-style/Farm API route files
- validate UI message request bodies and stream AI SDK UI responses through raw Response passthrough
- make farm add integration ai scaffold src/app/api/chat/route.ts directly, without farm.config/appIntegrations wiring
- cover manual `export const POST = createEndpoint(...)` and AI chat route discovery from `src/app/api/chat/route.ts`

## Verification
- corepack pnpm install --frozen-lockfile --ignore-scripts
- corepack pnpm --filter @farmjs/integrations build
- corepack pnpm --filter @farmjs/cli test
- corepack pnpm --filter @farmjs/core test
- corepack pnpm --filter @farmjs/core test -- api-route-manager.test.ts ai-integration.test.ts
- corepack pnpm exec oxfmt --check packages/farm/src/api/endpoint.ts packages/farm-integrations/src/ai/index.ts packages/farm/src/__tests__/api-route-manager.test.ts packages/farm/src/__tests__/ai-integration.test.ts
- corepack pnpm exec oxlint packages/farm/src/api/endpoint.ts packages/farm-integrations/src/ai/index.ts packages/farm/src/__tests__/api-route-manager.test.ts packages/farm/src/__tests__/ai-integration.test.ts

Closes #60