### PR TITLE
feat: add ORM-backed integration storage

### DIFF
--- a/packages/farm-integrations/src/farm-core-shim.d.ts
+++ b/packages/farm-integrations/src/farm-core-shim.d.ts
@@ -231,6 +231,19 @@ declare module "@farmjs/core" {
     schema: TSchema,
   ): TSchema;
 
+  export interface CreateIntegrationOrmOptions<TClient = unknown> {
+    schema: FarmIntegrationSchema;
+    config?: {
+      storage?: unknown;
+    };
+    storage?: unknown;
+    client?: TClient | (() => TClient | Promise<TClient>);
+  }
+
+  export function createIntegrationOrm<TClient = unknown>(
+    options: CreateIntegrationOrmOptions<TClient>,
+  ): Promise<Record<string, unknown>>;
+
   export type FarmIntegrationAPIMethod =
     | "GET"
     | "POST"

--- a/packages/farm-integrations/src/stripe/index.ts
+++ b/packages/farm-integrations/src/stripe/index.ts
@@ -1,5 +1,6 @@
 import Stripe from "stripe";
 import {
+  createIntegrationOrm,
   defineIntegration,
   integrationRoute,
   type FarmIntegration,
@@ -8,9 +9,7 @@ import {
   type FarmIntegrationLogger,
   type FarmIntegrationSchema,
 } from "@farmjs/core";
-import { api as clientApi } from "@farmjs/core/client";
 import {
-  getOrigin,
   normalizeWebhookConfig,
   resolveAppPath,
   toAbsoluteUrl,
@@ -35,7 +34,6 @@ import {
   type StripeBillingUpgradeResult,
   type StripeBillingFeaturesResult,
   type StripeBillingLimitsResult,
-  stripeClient,
   type StripeBillingUsageInput,
   type StripeBillingUsageResult,
   type StripeBillingStatusResult,
@@ -57,6 +55,7 @@ import {
 } from "./client.js";
 import {
   drizzleStorageAdapter,
+  ormStorageAdapter,
   prismaStorageAdapter,
   sqliteStorageAdapter,
   type StripeBillingFeatures,
@@ -119,7 +118,12 @@ export type {
   StripeSessionResult,
   StripeWebhookResult,
 } from "./client.js";
-export { drizzleStorageAdapter, prismaStorageAdapter, sqliteStorageAdapter } from "./storage.js";
+export {
+  drizzleStorageAdapter,
+  ormStorageAdapter,
+  prismaStorageAdapter,
+  sqliteStorageAdapter,
+} from "./storage.js";
 export type {
   StripeBillingFeatures,
   StripeBillingHookTools,
@@ -2831,35 +2835,65 @@ function getBillingMeter(
   return meter ?? null;
 }
 
+function hasConfiguredStorageRuntimeClient(context: FarmIntegrationHandlerContext): boolean {
+  const storage = (context.config as { storage?: unknown }).storage;
+  return (
+    !!storage &&
+    typeof storage === "object" &&
+    "client" in storage &&
+    (storage as { client?: unknown }).client != null
+  );
+}
+
+function resolveConfiguredBillingStorage(
+  context: FarmIntegrationHandlerContext,
+  schema: FarmIntegrationSchema,
+): StripeBillingStorageAdapter | undefined {
+  if (!hasConfiguredStorageRuntimeClient(context)) {
+    return undefined;
+  }
+
+  let ormPromise: ReturnType<typeof createIntegrationOrm> | undefined;
+  return ormStorageAdapter({
+    orm: () =>
+      (ormPromise ??= createIntegrationOrm({
+        schema,
+        config: context.config,
+      })),
+  });
+}
+
 function resolveBillingPersistence(
   billing: StripeBillingOptions | undefined,
   context: FarmIntegrationHandlerContext,
   stripe: Stripe | null,
+  schema: FarmIntegrationSchema = stripeSchema,
 ) {
   const tools: StripeBillingHookTools = {
     ctx: context,
     stripe,
   };
+  const storage = billing?.storage ?? resolveConfiguredBillingStorage(context, schema);
 
   return {
     tools,
     getBillingAccount: billing?.hooks?.getBillingAccount
       ? (owner: StripeBillingOwner) => billing.hooks!.getBillingAccount!(owner, tools)
-      : billing?.storage?.getBillingAccount
-        ? (owner: StripeBillingOwner) => billing.storage!.getBillingAccount(owner)
+      : storage?.getBillingAccount
+        ? (owner: StripeBillingOwner) => storage.getBillingAccount(owner)
         : undefined,
     getBillingAccountByStripeCustomerId: billing?.hooks?.getBillingAccountByStripeCustomerId
       ? (customerId: string) =>
           billing.hooks!.getBillingAccountByStripeCustomerId!(customerId, tools)
-      : billing?.storage?.getBillingAccountByStripeCustomerId
-        ? (customerId: string) => billing.storage!.getBillingAccountByStripeCustomerId(customerId)
+      : storage?.getBillingAccountByStripeCustomerId
+        ? (customerId: string) => storage.getBillingAccountByStripeCustomerId(customerId)
         : undefined,
     ensureCustomer: billing?.hooks?.ensureCustomer
       ? (owner: StripeBillingOwner) => billing.hooks!.ensureCustomer!(owner, tools)
-      : billing?.storage?.ensureCustomer
+      : storage?.ensureCustomer
         ? stripe
           ? (owner: StripeBillingOwner) =>
-              billing.storage!.ensureCustomer({
+              storage.ensureCustomer({
                 owner,
                 stripe,
               })
@@ -2867,13 +2901,13 @@ function resolveBillingPersistence(
         : undefined,
     saveBillingSnapshot: billing?.hooks?.saveBillingSnapshot
       ? (snapshot: StripeBillingSnapshot) => billing.hooks!.saveBillingSnapshot!(snapshot, tools)
-      : billing?.storage?.saveBillingSnapshot
-        ? (snapshot: StripeBillingSnapshot) => billing.storage!.saveBillingSnapshot(snapshot)
+      : storage?.saveBillingSnapshot
+        ? (snapshot: StripeBillingSnapshot) => storage.saveBillingSnapshot(snapshot)
         : undefined,
     clearBillingSnapshot: billing?.hooks?.clearBillingSnapshot
       ? (owner: StripeBillingOwner) => billing.hooks!.clearBillingSnapshot!(owner, tools)
-      : billing?.storage?.clearBillingSnapshot
-        ? (owner: StripeBillingOwner) => billing.storage!.clearBillingSnapshot(owner)
+      : storage?.clearBillingSnapshot
+        ? (owner: StripeBillingOwner) => storage.clearBillingSnapshot(owner)
         : undefined,
   };
 }
@@ -3245,6 +3279,7 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
   const rawInstance = input.instance || (env.secretKey ? new Stripe(env.secretKey) : undefined);
   const instance = resolveStripeInstance(input, env);
   const stripeSdk = rawInstance && isStripeSdkInstance(rawInstance) ? rawInstance : null;
+  const integrationSchema = input.schema ?? stripeSchema;
 
   const configuredProducts = input.billing?.products
     ? normalizeBillingProducts(input.billing.products)
@@ -3349,7 +3384,12 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
           };
 
           if (input.billing) {
-            const persistence = resolveBillingPersistence(input.billing, context, stripeSdk);
+            const persistence = resolveBillingPersistence(
+              input.billing,
+              context,
+              stripeSdk,
+              integrationSchema,
+            );
 
             if (
               event.type === "checkout.session.completed" &&
@@ -3527,7 +3567,7 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
       portalPath,
       sessionPath,
     }) as unknown as FarmIntegrationAPI,
-    schema: input.schema ?? stripeSchema,
+    schema: integrationSchema,
     log: input.log,
     routes: [
       integrationRoute.get<typeof productsPath, StripeCatalogProduct[]>(productsPath, {
@@ -3575,7 +3615,12 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
             );
           }
 
-          const persistence = resolveBillingPersistence(input.billing, context, stripeSdk);
+          const persistence = resolveBillingPersistence(
+            input.billing,
+            context,
+            stripeSdk,
+            integrationSchema,
+          );
           const getBillingAccount = requireBillingMethod(
             persistence.getBillingAccount,
             "getBillingAccount",
@@ -3649,7 +3694,12 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
             );
           }
 
-          const persistence = resolveBillingPersistence(input.billing, context, stripeSdk);
+          const persistence = resolveBillingPersistence(
+            input.billing,
+            context,
+            stripeSdk,
+            integrationSchema,
+          );
           const getBillingAccount = requireBillingMethod(
             persistence.getBillingAccount,
             "getBillingAccount",
@@ -3689,7 +3739,12 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
             );
           }
 
-          const persistence = resolveBillingPersistence(input.billing, context, stripeSdk);
+          const persistence = resolveBillingPersistence(
+            input.billing,
+            context,
+            stripeSdk,
+            integrationSchema,
+          );
           const getBillingAccount = requireBillingMethod(
             persistence.getBillingAccount,
             "getBillingAccount",
@@ -3744,7 +3799,12 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
               );
             }
 
-            const persistence = resolveBillingPersistence(input.billing, context, stripeSdk);
+            const persistence = resolveBillingPersistence(
+              input.billing,
+              context,
+              stripeSdk,
+              integrationSchema,
+            );
             const getBillingAccount = requireBillingMethod(
               persistence.getBillingAccount,
               "getBillingAccount",
@@ -3831,7 +3891,12 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
             );
           }
 
-          const persistence = resolveBillingPersistence(input.billing, context, stripeSdk);
+          const persistence = resolveBillingPersistence(
+            input.billing,
+            context,
+            stripeSdk,
+            integrationSchema,
+          );
           const getBillingAccount = requireBillingMethod(
             persistence.getBillingAccount,
             "getBillingAccount",
@@ -3959,7 +4024,12 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
             );
           }
 
-          const persistence = resolveBillingPersistence(input.billing, context, stripeSdk);
+          const persistence = resolveBillingPersistence(
+            input.billing,
+            context,
+            stripeSdk,
+            integrationSchema,
+          );
           const getBillingAccount = requireBillingMethod(
             persistence.getBillingAccount,
             "getBillingAccount",
@@ -4076,7 +4146,12 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
               );
             }
 
-            const persistence = resolveBillingPersistence(input.billing, context, stripeSdk);
+            const persistence = resolveBillingPersistence(
+              input.billing,
+              context,
+              stripeSdk,
+              integrationSchema,
+            );
             const getBillingAccount = requireBillingMethod(
               persistence.getBillingAccount,
               "getBillingAccount",
@@ -4276,7 +4351,12 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
             );
           }
 
-          const persistence = resolveBillingPersistence(input.billing, context, stripeSdk);
+          const persistence = resolveBillingPersistence(
+            input.billing,
+            context,
+            stripeSdk,
+            integrationSchema,
+          );
           const getBillingAccount = requireBillingMethod(
             persistence.getBillingAccount,
             "getBillingAccount",
@@ -4616,7 +4696,12 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
               );
             }
 
-            const persistence = resolveBillingPersistence(input.billing, context, stripeSdk);
+            const persistence = resolveBillingPersistence(
+              input.billing,
+              context,
+              stripeSdk,
+              integrationSchema,
+            );
             const getBillingAccount = requireBillingMethod(
               persistence.getBillingAccount,
               "getBillingAccount",
@@ -4704,7 +4789,12 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
                 );
               }
 
-              const persistence = resolveBillingPersistence(input.billing, context, stripeSdk);
+              const persistence = resolveBillingPersistence(
+                input.billing,
+                context,
+                stripeSdk,
+                integrationSchema,
+              );
               const existingSnapshot =
                 input.billing && billingOwner && persistence.getBillingAccount
                   ? await persistence.getBillingAccount(billingOwner)
@@ -4883,7 +4973,12 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
               Number.NaN,
             );
             const prorationBehavior = normalizeProrationBehavior(body.prorationBehavior);
-            const persistence = resolveBillingPersistence(input.billing, context, stripeSdk);
+            const persistence = resolveBillingPersistence(
+              input.billing,
+              context,
+              stripeSdk,
+              integrationSchema,
+            );
             const getBillingAccount = requireBillingMethod(
               persistence.getBillingAccount,
               "getBillingAccount",
@@ -5033,7 +5128,12 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
           try {
             let customerId = typeof body.customerId === "string" ? body.customerId : undefined;
 
-            const persistence = resolveBillingPersistence(input.billing, context, stripeSdk);
+            const persistence = resolveBillingPersistence(
+              input.billing,
+              context,
+              stripeSdk,
+              integrationSchema,
+            );
 
             if (!customerId && typeof body.sessionId === "string") {
               const session = await instance.retrieveCheckoutSession(body.sessionId);
@@ -5124,7 +5224,12 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
               const session = await instance.retrieveCheckoutSession(sessionId);
 
               if (input.billing) {
-                const persistence = resolveBillingPersistence(input.billing, context, stripeSdk);
+                const persistence = resolveBillingPersistence(
+                  input.billing,
+                  context,
+                  stripeSdk,
+                  integrationSchema,
+                );
                 const snapshot = await resolveBillingSnapshotForSession(
                   session,
                   configuredProducts,

--- a/packages/farm-integrations/src/stripe/index.ts
+++ b/packages/farm-integrations/src/stripe/index.ts
@@ -2845,21 +2845,57 @@ function hasConfiguredStorageRuntimeClient(context: FarmIntegrationHandlerContex
   );
 }
 
+async function resolveConfiguredStorageRuntimeClient(
+  context: FarmIntegrationHandlerContext,
+): Promise<unknown | undefined> {
+  if (!hasConfiguredStorageRuntimeClient(context)) {
+    return undefined;
+  }
+
+  const storage = (context.config as { storage?: { client?: unknown } }).storage;
+  const client = storage?.client;
+  return typeof client === "function"
+    ? await (client as () => unknown | Promise<unknown>)()
+    : client;
+}
+
+function createBillingHookTools(
+  context: FarmIntegrationHandlerContext,
+  stripe: Stripe | null,
+  schema: FarmIntegrationSchema,
+): StripeBillingHookTools {
+  let clientPromise: Promise<unknown | undefined> | undefined;
+  let ormPromise: ReturnType<typeof createIntegrationOrm> | undefined;
+
+  return {
+    ctx: context,
+    stripe,
+    storage: {
+      getClient() {
+        clientPromise ??= resolveConfiguredStorageRuntimeClient(context);
+        return clientPromise;
+      },
+      getOrm() {
+        ormPromise ??= createIntegrationOrm({
+          schema,
+          config: context.config,
+        });
+        return ormPromise;
+      },
+    },
+  };
+}
+
 function resolveConfiguredBillingStorage(
   context: FarmIntegrationHandlerContext,
-  schema: FarmIntegrationSchema,
+  tools: StripeBillingHookTools,
 ): StripeBillingStorageAdapter | undefined {
   if (!hasConfiguredStorageRuntimeClient(context)) {
     return undefined;
   }
 
-  let ormPromise: ReturnType<typeof createIntegrationOrm> | undefined;
   return ormStorageAdapter({
-    orm: () =>
-      (ormPromise ??= createIntegrationOrm({
-        schema,
-        config: context.config,
-      })),
+    orm: () => tools.storage.getOrm(),
   });
 }
 
@@ -2868,12 +2904,9 @@ function resolveBillingPersistence(
   context: FarmIntegrationHandlerContext,
   stripe: Stripe | null,
   schema: FarmIntegrationSchema = stripeSchema,
+  tools: StripeBillingHookTools = createBillingHookTools(context, stripe, schema),
 ) {
-  const tools: StripeBillingHookTools = {
-    ctx: context,
-    stripe,
-  };
-  const storage = billing?.storage ?? resolveConfiguredBillingStorage(context, schema);
+  const storage = billing?.storage ?? resolveConfiguredBillingStorage(context, tools);
 
   return {
     tools,
@@ -2918,6 +2951,14 @@ function requireBillingMethod<T>(value: T | undefined, label: string): T {
   }
 
   return value;
+}
+
+async function resolveBillingOwner(
+  billing: StripeBillingOptions,
+  context: FarmIntegrationHandlerContext,
+  tools: StripeBillingHookTools,
+): Promise<StripeBillingOwner | null> {
+  return await billing.resolveOwner(context, tools);
 }
 
 function resolveProductIdFromSession(session: StripeSessionResult): string | null {
@@ -3199,7 +3240,7 @@ async function resolveBillingSnapshotForSession(
     return null;
   }
 
-  let owner = await billing.resolveOwner(context);
+  let owner = await resolveBillingOwner(billing, context, persistence.tools);
   let existingSnapshot: StripeBillingSnapshot | null = null;
 
   if (session.customerId && persistence.getBillingAccountByStripeCustomerId) {
@@ -3603,7 +3644,8 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
             );
           }
 
-          const owner = await input.billing.resolveOwner(context);
+          const billingTools = createBillingHookTools(context, stripeSdk, integrationSchema);
+          const owner = await resolveBillingOwner(input.billing, context, billingTools);
           if (!owner) {
             return Response.json(
               {
@@ -3620,6 +3662,7 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
             context,
             stripeSdk,
             integrationSchema,
+            billingTools,
           );
           const getBillingAccount = requireBillingMethod(
             persistence.getBillingAccount,
@@ -3682,7 +3725,8 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
             );
           }
 
-          const owner = await input.billing.resolveOwner(context);
+          const billingTools = createBillingHookTools(context, stripeSdk, integrationSchema);
+          const owner = await resolveBillingOwner(input.billing, context, billingTools);
           if (!owner) {
             return Response.json(
               {
@@ -3699,6 +3743,7 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
             context,
             stripeSdk,
             integrationSchema,
+            billingTools,
           );
           const getBillingAccount = requireBillingMethod(
             persistence.getBillingAccount,
@@ -3727,7 +3772,8 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
             );
           }
 
-          const owner = await input.billing.resolveOwner(context);
+          const billingTools = createBillingHookTools(context, stripeSdk, integrationSchema);
+          const owner = await resolveBillingOwner(input.billing, context, billingTools);
           if (!owner) {
             return Response.json(
               {
@@ -3744,6 +3790,7 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
             context,
             stripeSdk,
             integrationSchema,
+            billingTools,
           );
           const getBillingAccount = requireBillingMethod(
             persistence.getBillingAccount,
@@ -3774,7 +3821,8 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
               );
             }
 
-            const owner = await input.billing.resolveOwner(context);
+            const billingTools = createBillingHookTools(context, stripeSdk, integrationSchema);
+            const owner = await resolveBillingOwner(input.billing, context, billingTools);
             if (!owner) {
               return Response.json(
                 {
@@ -3804,6 +3852,7 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
               context,
               stripeSdk,
               integrationSchema,
+              billingTools,
             );
             const getBillingAccount = requireBillingMethod(
               persistence.getBillingAccount,
@@ -3854,7 +3903,8 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
             );
           }
 
-          const owner = await input.billing.resolveOwner(context);
+          const billingTools = createBillingHookTools(context, stripeSdk, integrationSchema);
+          const owner = await resolveBillingOwner(input.billing, context, billingTools);
           if (!owner) {
             return Response.json(
               {
@@ -3896,6 +3946,7 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
             context,
             stripeSdk,
             integrationSchema,
+            billingTools,
           );
           const getBillingAccount = requireBillingMethod(
             persistence.getBillingAccount,
@@ -4012,7 +4063,8 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
             );
           }
 
-          const owner = await input.billing.resolveOwner(context);
+          const billingTools = createBillingHookTools(context, stripeSdk, integrationSchema);
+          const owner = await resolveBillingOwner(input.billing, context, billingTools);
           if (!owner) {
             return Response.json(
               {
@@ -4029,6 +4081,7 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
             context,
             stripeSdk,
             integrationSchema,
+            billingTools,
           );
           const getBillingAccount = requireBillingMethod(
             persistence.getBillingAccount,
@@ -4134,7 +4187,8 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
               );
             }
 
-            const owner = await input.billing.resolveOwner(context);
+            const billingTools = createBillingHookTools(context, stripeSdk, integrationSchema);
+            const owner = await resolveBillingOwner(input.billing, context, billingTools);
             if (!owner) {
               return Response.json(
                 {
@@ -4151,6 +4205,7 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
               context,
               stripeSdk,
               integrationSchema,
+              billingTools,
             );
             const getBillingAccount = requireBillingMethod(
               persistence.getBillingAccount,
@@ -4268,7 +4323,8 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
             );
           }
 
-          const owner = await input.billing.resolveOwner(context);
+          const billingTools = createBillingHookTools(context, stripeSdk, integrationSchema);
+          const owner = await resolveBillingOwner(input.billing, context, billingTools);
           if (!owner) {
             return Response.json(
               {
@@ -4356,6 +4412,7 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
             context,
             stripeSdk,
             integrationSchema,
+            billingTools,
           );
           const getBillingAccount = requireBillingMethod(
             persistence.getBillingAccount,
@@ -4657,7 +4714,8 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
               );
             }
 
-            const owner = await input.billing.resolveOwner(context);
+            const billingTools = createBillingHookTools(context, stripeSdk, integrationSchema);
+            const owner = await resolveBillingOwner(input.billing, context, billingTools);
             if (!owner) {
               return Response.json(
                 {
@@ -4701,6 +4759,7 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
               context,
               stripeSdk,
               integrationSchema,
+              billingTools,
             );
             const getBillingAccount = requireBillingMethod(
               persistence.getBillingAccount,
@@ -4777,7 +4836,13 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
 
             try {
               const product = getProduct(configuredProducts, productId);
-              const billingOwner = input.billing ? await input.billing.resolveOwner(context) : null;
+              const billingTools = input.billing
+                ? createBillingHookTools(context, stripeSdk, integrationSchema)
+                : undefined;
+              const billingOwner =
+                input.billing && billingTools
+                  ? await resolveBillingOwner(input.billing, context, billingTools)
+                  : null;
               if (input.billing && !billingOwner) {
                 return Response.json(
                   {
@@ -4794,6 +4859,7 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
                 context,
                 stripeSdk,
                 integrationSchema,
+                billingTools,
               );
               const existingSnapshot =
                 input.billing && billingOwner && persistence.getBillingAccount
@@ -4954,7 +5020,8 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
             );
           }
 
-          const owner = await input.billing.resolveOwner(context);
+          const billingTools = createBillingHookTools(context, stripeSdk, integrationSchema);
+          const owner = await resolveBillingOwner(input.billing, context, billingTools);
           if (!owner) {
             return Response.json(
               {
@@ -4978,6 +5045,7 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
               context,
               stripeSdk,
               integrationSchema,
+              billingTools,
             );
             const getBillingAccount = requireBillingMethod(
               persistence.getBillingAccount,
@@ -5128,11 +5196,15 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
           try {
             let customerId = typeof body.customerId === "string" ? body.customerId : undefined;
 
+            const billingTools = input.billing
+              ? createBillingHookTools(context, stripeSdk, integrationSchema)
+              : undefined;
             const persistence = resolveBillingPersistence(
               input.billing,
               context,
               stripeSdk,
               integrationSchema,
+              billingTools,
             );
 
             if (!customerId && typeof body.sessionId === "string") {
@@ -5141,7 +5213,7 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
             }
 
             if (!customerId && input.billing) {
-              const owner = await input.billing.resolveOwner(context);
+              const owner = await resolveBillingOwner(input.billing, context, persistence.tools);
               if (owner) {
                 const getBillingAccount = requireBillingMethod(
                   persistence.getBillingAccount,

--- a/packages/farm-integrations/src/stripe/index.ts
+++ b/packages/farm-integrations/src/stripe/index.ts
@@ -58,6 +58,7 @@ import {
   ormStorageAdapter,
   prismaStorageAdapter,
   sqliteStorageAdapter,
+  type StripeBillingArgs,
   type StripeBillingFeatures,
   type StripeBillingHookTools,
   type StripeBillingHooks,
@@ -125,6 +126,7 @@ export {
   sqliteStorageAdapter,
 } from "./storage.js";
 export type {
+  StripeBillingArgs,
   StripeBillingFeatures,
   StripeBillingHookTools,
   StripeBillingHooks,

--- a/packages/farm-integrations/src/stripe/storage.ts
+++ b/packages/farm-integrations/src/stripe/storage.ts
@@ -153,9 +153,15 @@ export interface StripeBillingStorageAdapter {
   clearBillingSnapshot(owner: StripeBillingOwner): Promise<void>;
 }
 
+export interface StripeBillingStorageTools {
+  getClient(): Promise<unknown | undefined>;
+  getOrm(): Promise<unknown>;
+}
+
 export interface StripeBillingHookTools {
   ctx: FarmIntegrationHandlerContext;
   stripe: Stripe | null;
+  storage: StripeBillingStorageTools;
 }
 
 export interface StripeBillingUsageOptions {
@@ -251,6 +257,7 @@ export interface StripeBillingHooks {
 export interface StripeBillingOptions {
   resolveOwner(
     context: FarmIntegrationHandlerContext,
+    tools?: StripeBillingHookTools,
   ): Promise<StripeBillingOwner | null> | StripeBillingOwner | null;
   plans?: Record<string, StripeBillingPlan>;
   products?: Record<string, StripeBillingProduct>;

--- a/packages/farm-integrations/src/stripe/storage.ts
+++ b/packages/farm-integrations/src/stripe/storage.ts
@@ -275,6 +275,81 @@ type PrismaStorageOptions = {
   model?: string;
 };
 
+type StripeOrmModelClient = {
+  findFirst(args: { where: Record<string, unknown> }): Promise<Record<string, unknown> | null>;
+  create(args: { data: Record<string, unknown> }): Promise<Record<string, unknown>>;
+  update(args: {
+    where: Record<string, unknown>;
+    data: Record<string, unknown>;
+  }): Promise<Record<string, unknown> | null>;
+};
+
+type StripeOrmStorageOptions = {
+  orm: unknown | Promise<unknown> | (() => unknown | Promise<unknown>);
+  model?: string;
+};
+
+type StripeBillingSnapshotRecord = {
+  id?: string;
+  ownerId: string;
+  ownerKind: StripeBillingOwner["kind"];
+  stripeCustomerId: string | null;
+  stripeSubscriptionId: string | null;
+  planId: string;
+  productId: string | null;
+  status: StripeBillingStatus;
+  currentPeriodEnd: Date | null;
+  cancelAtPeriodEnd: boolean;
+  trialEndsAt: Date | null;
+  trialUsedAt: Date | null;
+  seatQuantity: number | null;
+  seatAllowanceOverride: number | null;
+  createdAt?: Date;
+  updatedAt: Date;
+};
+
+function requireOrmModel(options: { orm: unknown; model: string }): StripeOrmModelClient {
+  const modelClient = (options.orm as Record<string, unknown> | null)?.[options.model];
+
+  if (!modelClient || typeof modelClient !== "object") {
+    throw new Error(`Stripe ORM storage adapter could not find orm.${options.model}.`);
+  }
+
+  const candidate = modelClient as Partial<StripeOrmModelClient>;
+  if (
+    typeof candidate.findFirst !== "function" ||
+    typeof candidate.create !== "function" ||
+    typeof candidate.update !== "function"
+  ) {
+    throw new Error(
+      `Stripe ORM storage adapter expected orm.${options.model} to expose findFirst, create, and update.`,
+    );
+  }
+
+  return candidate as StripeOrmModelClient;
+}
+
+function createBillingSnapshotData(
+  snapshot: StripeBillingSnapshot,
+): Omit<StripeBillingSnapshotRecord, "id" | "createdAt"> {
+  return {
+    ownerId: snapshot.owner.id,
+    ownerKind: snapshot.owner.kind,
+    stripeCustomerId: snapshot.stripeCustomerId,
+    stripeSubscriptionId: snapshot.stripeSubscriptionId,
+    planId: snapshot.planId,
+    productId: snapshot.productId,
+    status: snapshot.status,
+    currentPeriodEnd: snapshot.currentPeriodEnd,
+    cancelAtPeriodEnd: snapshot.cancelAtPeriodEnd,
+    trialEndsAt: snapshot.trialEndsAt,
+    trialUsedAt: snapshot.trialUsedAt,
+    seatQuantity: snapshot.seatQuantity,
+    seatAllowanceOverride: snapshot.seatAllowanceOverride,
+    updatedAt: new Date(),
+  };
+}
+
 function isUnknownPrismaFieldError(error: unknown, field: string): boolean {
   if (!(error instanceof Error)) {
     return false;
@@ -581,6 +656,161 @@ export function prismaStorageAdapter(options: PrismaStorageOptions): StripeBilli
         },
         ["seatQuantity", "trialEndsAt", "productId"],
       );
+    },
+  };
+}
+
+export function ormStorageAdapter(options: StripeOrmStorageOptions): StripeBillingStorageAdapter {
+  const modelName = options.model ?? "billingAccount";
+  let modelPromise: Promise<StripeOrmModelClient> | undefined;
+
+  async function getModel(): Promise<StripeOrmModelClient> {
+    modelPromise ??= Promise.resolve(
+      typeof options.orm === "function" ? options.orm() : options.orm,
+    ).then((orm) =>
+      requireOrmModel({
+        orm,
+        model: modelName,
+      }),
+    );
+
+    return modelPromise;
+  }
+
+  async function findByOwner(owner: StripeBillingOwner) {
+    const model = await getModel();
+    return await model.findFirst({
+      where: {
+        ownerKind: owner.kind,
+        ownerId: owner.id,
+      },
+    });
+  }
+
+  async function findByCustomerId(customerId: string) {
+    const model = await getModel();
+    return await model.findFirst({
+      where: {
+        stripeCustomerId: customerId,
+      },
+    });
+  }
+
+  return {
+    async getBillingAccount(owner) {
+      const record = await findByOwner(owner);
+      return record ? toSnapshot(record) : null;
+    },
+
+    async getBillingAccountByStripeCustomerId(customerId) {
+      const record = await findByCustomerId(customerId);
+      return record ? toSnapshot(record) : null;
+    },
+
+    async ensureCustomer({ owner, stripe }) {
+      const existing = await findByOwner(owner);
+      const existingCustomerId =
+        existing && getNullableString(existing, "stripeCustomerId", "stripe_customer_id");
+      if (existingCustomerId) {
+        return {
+          customerId: existingCustomerId,
+        };
+      }
+
+      const customer = await stripe.customers.create({
+        email: owner.email,
+        metadata: {
+          ownerId: owner.id,
+          ownerKind: owner.kind,
+        },
+      });
+
+      const model = await getModel();
+      if (existing?.id) {
+        await model.update({
+          where: {
+            id: existing.id,
+          },
+          data: {
+            stripeCustomerId: customer.id,
+            updatedAt: new Date(),
+          },
+        });
+      } else {
+        await model.create({
+          data: {
+            id: createBillingRecordId(),
+            ownerId: owner.id,
+            ownerKind: owner.kind,
+            stripeCustomerId: customer.id,
+            stripeSubscriptionId: null,
+            planId: "free",
+            productId: null,
+            status: "free",
+            currentPeriodEnd: null,
+            cancelAtPeriodEnd: false,
+            trialEndsAt: null,
+            trialUsedAt: null,
+            seatQuantity: null,
+            seatAllowanceOverride: null,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        });
+      }
+
+      return {
+        customerId: customer.id,
+      };
+    },
+
+    async saveBillingSnapshot(snapshot) {
+      const existing = await findByOwner(snapshot.owner);
+      const data = createBillingSnapshotData(snapshot);
+      const model = await getModel();
+
+      if (existing?.id) {
+        await model.update({
+          where: {
+            id: existing.id,
+          },
+          data,
+        });
+        return;
+      }
+
+      await model.create({
+        data: {
+          id: createBillingRecordId(),
+          ...data,
+          createdAt: new Date(),
+        },
+      });
+    },
+
+    async clearBillingSnapshot(owner) {
+      const existing = await findByOwner(owner);
+      if (!existing?.id) {
+        return;
+      }
+
+      const model = await getModel();
+      await model.update({
+        where: {
+          id: existing.id,
+        },
+        data: {
+          planId: "free",
+          productId: null,
+          status: "free",
+          stripeSubscriptionId: null,
+          currentPeriodEnd: null,
+          cancelAtPeriodEnd: false,
+          trialEndsAt: null,
+          seatQuantity: null,
+          updatedAt: new Date(),
+        },
+      });
     },
   };
 }

--- a/packages/farm-integrations/src/stripe/storage.ts
+++ b/packages/farm-integrations/src/stripe/storage.ts
@@ -81,7 +81,7 @@ export interface StripeBillingTrial {
   oncePerOwner?: boolean;
   eligible?(
     input: StripeBillingTrialEligibilityInput,
-    tools: StripeBillingHookTools,
+    args: StripeBillingArgs,
   ): Promise<boolean> | boolean;
 }
 
@@ -158,38 +158,37 @@ export interface StripeBillingStorageTools {
   getOrm(): Promise<unknown>;
 }
 
-export interface StripeBillingHookTools {
+export interface StripeBillingArgs {
   ctx: FarmIntegrationHandlerContext;
   stripe: Stripe | null;
   storage: StripeBillingStorageTools;
 }
 
+export type StripeBillingHookTools = StripeBillingArgs;
+
 export interface StripeBillingUsageOptions {
   resolve(
     owner: StripeBillingOwner,
     key: string,
-    tools: StripeBillingHookTools,
+    args: StripeBillingArgs,
   ): Promise<number | null> | number | null;
 }
 
 export interface StripeBillingHooks {
   getBillingAccount?(
     owner: StripeBillingOwner,
-    tools: StripeBillingHookTools,
+    args: StripeBillingArgs,
   ): Promise<StripeBillingSnapshot | null>;
   getBillingAccountByStripeCustomerId?(
     customerId: string,
-    tools: StripeBillingHookTools,
+    args: StripeBillingArgs,
   ): Promise<StripeBillingSnapshot | null>;
   ensureCustomer?(
     owner: StripeBillingOwner,
-    tools: StripeBillingHookTools,
+    args: StripeBillingArgs,
   ): Promise<{ customerId: string }>;
-  saveBillingSnapshot?(
-    snapshot: StripeBillingSnapshot,
-    tools: StripeBillingHookTools,
-  ): Promise<void>;
-  clearBillingSnapshot?(owner: StripeBillingOwner, tools: StripeBillingHookTools): Promise<void>;
+  saveBillingSnapshot?(snapshot: StripeBillingSnapshot, args: StripeBillingArgs): Promise<void>;
+  clearBillingSnapshot?(owner: StripeBillingOwner, args: StripeBillingArgs): Promise<void>;
   onCheckoutCreated?(
     payload: {
       owner: StripeBillingOwner;
@@ -200,44 +199,29 @@ export interface StripeBillingHooks {
       trialApplied: boolean;
       trialDays: number | null;
     },
-    tools: StripeBillingHookTools,
+    args: StripeBillingArgs,
   ): Promise<void> | void;
   onCheckoutCompleted?(
     snapshot: StripeBillingSnapshot & {
       sessionId: string;
     },
-    tools: StripeBillingHookTools,
+    args: StripeBillingArgs,
   ): Promise<void> | void;
   onTrialStarted?(
     snapshot: StripeBillingSnapshot & {
       trialDays: number;
     },
-    tools: StripeBillingHookTools,
+    args: StripeBillingArgs,
   ): Promise<void> | void;
-  onTrialWillEnd?(
-    snapshot: StripeBillingSnapshot,
-    tools: StripeBillingHookTools,
-  ): Promise<void> | void;
-  onTrialEnded?(
-    snapshot: StripeBillingSnapshot,
-    tools: StripeBillingHookTools,
-  ): Promise<void> | void;
-  onTrialExpired?(
-    snapshot: StripeBillingSnapshot,
-    tools: StripeBillingHookTools,
-  ): Promise<void> | void;
-  onBillingSync?(
-    snapshot: StripeBillingSnapshot,
-    tools: StripeBillingHookTools,
-  ): Promise<void> | void;
+  onTrialWillEnd?(snapshot: StripeBillingSnapshot, args: StripeBillingArgs): Promise<void> | void;
+  onTrialEnded?(snapshot: StripeBillingSnapshot, args: StripeBillingArgs): Promise<void> | void;
+  onTrialExpired?(snapshot: StripeBillingSnapshot, args: StripeBillingArgs): Promise<void> | void;
+  onBillingSync?(snapshot: StripeBillingSnapshot, args: StripeBillingArgs): Promise<void> | void;
   onPaymentSucceeded?(
     snapshot: StripeBillingSnapshot,
-    tools: StripeBillingHookTools,
+    args: StripeBillingArgs,
   ): Promise<void> | void;
-  onPaymentFailed?(
-    snapshot: StripeBillingSnapshot,
-    tools: StripeBillingHookTools,
-  ): Promise<void> | void;
+  onPaymentFailed?(snapshot: StripeBillingSnapshot, args: StripeBillingArgs): Promise<void> | void;
   onUsageReported?(
     payload: {
       owner: StripeBillingOwner;
@@ -250,14 +234,14 @@ export interface StripeBillingHooks {
       stripeEventIdentifier: string;
       properties?: StripeBillingUsageProperties;
     },
-    tools: StripeBillingHookTools,
+    args: StripeBillingArgs,
   ): Promise<void> | void;
 }
 
 export interface StripeBillingOptions {
   resolveOwner(
     context: FarmIntegrationHandlerContext,
-    tools?: StripeBillingHookTools,
+    args?: StripeBillingArgs,
   ): Promise<StripeBillingOwner | null> | StripeBillingOwner | null;
   plans?: Record<string, StripeBillingPlan>;
   products?: Record<string, StripeBillingProduct>;

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -143,6 +143,8 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@farming-labs/orm": "0.0.62",
+    "@farming-labs/orm-runtime": "0.0.62",
     "@scalar/api-reference": "^1.38.1",
     "@scalar/openapi-parser": "^0.22.3",
     "@tailwindcss/vite": "^4.1.0",

--- a/packages/farm/src/__tests__/integration-orm.test.ts
+++ b/packages/farm/src/__tests__/integration-orm.test.ts
@@ -1,0 +1,210 @@
+// @vitest-environment node
+import { mkdtemp, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createIntegrationOrm, farmIntegrationSchemaToOrmSchema } from "../integration-orm";
+import { defineIntegrationSchema } from "../integrations";
+
+type SqliteDatabase = {
+  exec(sql: string): unknown;
+  close(): unknown;
+};
+
+const requireModule = createRequire(import.meta.url);
+const tempDirs = new Set<string>();
+
+async function createTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), prefix));
+  tempDirs.add(dir);
+  return dir;
+}
+
+async function createSqliteDatabase(filePath: string): Promise<SqliteDatabase> {
+  const { DatabaseSync } = requireModule("node:sqlite") as {
+    DatabaseSync: new (path: string) => SqliteDatabase;
+  };
+  return new DatabaseSync(filePath) as SqliteDatabase;
+}
+
+const billingSchema = defineIntegrationSchema({
+  models: {
+    billingAccount: {
+      name: "billing_account",
+      fields: {
+        id: {
+          type: "id",
+          name: "id",
+          primaryKey: true,
+        },
+        ownerId: {
+          type: "string",
+          name: "owner_id",
+          required: true,
+        },
+        status: {
+          type: "enum",
+          name: "status",
+          required: true,
+          values: ["free", "active"],
+          default: "free",
+        },
+        seatQuantity: {
+          type: "integer",
+          name: "seat_quantity",
+          nullable: true,
+        },
+        createdAt: {
+          type: "datetime",
+          name: "created_at",
+          required: true,
+          default: "now",
+        },
+      },
+      constraints: [
+        {
+          type: "unique",
+          fields: ["ownerId"],
+          name: "billing_account_owner_unique",
+        },
+      ],
+    },
+  },
+});
+
+describe("integration ORM storage", () => {
+  afterEach(async () => {
+    await Promise.all(
+      [...tempDirs].map(async (dir) => {
+        await rm(dir, { recursive: true, force: true });
+        tempDirs.delete(dir);
+      }),
+    );
+  });
+
+  it("converts Farm integration schemas to Farming Labs ORM schemas", async () => {
+    const schema = await farmIntegrationSchemaToOrmSchema(billingSchema);
+
+    expect(schema._tag).toBe("schema");
+    expect(schema.models.billingAccount.table).toBe("billing_account");
+    expect(schema.models.billingAccount.fields.ownerId.config.mappedName).toBe("owner_id");
+    expect(schema.models.billingAccount.constraints.unique).toEqual([["ownerId"]]);
+  });
+
+  it("uses storage.client as the unified ORM runtime client with real sqlite data", async () => {
+    const dir = await createTempDir("farm-integration-orm-");
+    const db = await createSqliteDatabase(path.join(dir, "integration.sqlite"));
+
+    try {
+      db.exec(`
+        CREATE TABLE billing_account (
+          id TEXT PRIMARY KEY,
+          owner_id TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'free',
+          seat_quantity INTEGER,
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          UNIQUE(owner_id)
+        );
+      `);
+
+      const orm = await createIntegrationOrm({
+        schema: billingSchema,
+        config: {
+          storage: {
+            client: db,
+          },
+        },
+      });
+
+      await orm.billingAccount.create({
+        data: {
+          id: "acct_1",
+          ownerId: "user_1",
+          status: "free",
+          seatQuantity: 3,
+        },
+      });
+
+      await orm.billingAccount.update({
+        where: {
+          ownerId: "user_1",
+        },
+        data: {
+          status: "active",
+          seatQuantity: 5,
+        },
+      });
+
+      const account = await orm.billingAccount.findFirst({
+        where: {
+          ownerId: "user_1",
+        },
+      });
+
+      expect(account).toMatchObject({
+        id: "acct_1",
+        ownerId: "user_1",
+        status: "active",
+        seatQuantity: 5,
+      });
+      expect(account?.createdAt).toBeInstanceOf(Date);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("supports lazy storage.client factories", async () => {
+    const dir = await createTempDir("farm-integration-orm-lazy-");
+    const db = await createSqliteDatabase(path.join(dir, "integration.sqlite"));
+    let calls = 0;
+
+    try {
+      db.exec(`
+        CREATE TABLE billing_account (
+          id TEXT PRIMARY KEY,
+          owner_id TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'free',
+          seat_quantity INTEGER,
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          UNIQUE(owner_id)
+        );
+      `);
+
+      const orm = await createIntegrationOrm({
+        schema: billingSchema,
+        config: {
+          storage: {
+            client: async () => {
+              calls += 1;
+              return db;
+            },
+          },
+        },
+      });
+
+      await orm.billingAccount.create({
+        data: {
+          id: "acct_2",
+          ownerId: "user_2",
+          status: "active",
+        },
+      });
+
+      const account = await orm.billingAccount.findUnique({
+        where: {
+          ownerId: "user_2",
+        },
+      });
+
+      expect(calls).toBe(1);
+      expect(account).toMatchObject({
+        id: "acct_2",
+        ownerId: "user_2",
+        status: "active",
+      });
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/packages/farm/src/__tests__/storage.test.ts
+++ b/packages/farm/src/__tests__/storage.test.ts
@@ -21,6 +21,7 @@ import {
   sqliteStorage,
   upstashStorage,
   vercelKVStorage,
+  resolveStorageRuntimeClient,
 } from "../storage";
 import type { MiddlewareContext } from "../middleware/types";
 
@@ -178,6 +179,39 @@ describe("Storage", () => {
     expect(await sqlite.getItem("project")).toEqual({ name: "farm" });
 
     await sqlite.dispose();
+  });
+
+  it("preserves storage.client for helper-created Farm storage clients", async () => {
+    const backing = createStorageClient({
+      driver: "memory",
+    });
+    await backing.setItem("project", { name: "farm" });
+
+    const storage = await createFarmStorage({
+      client: backing,
+    });
+
+    expect(await storage.getItem("project")).toEqual({ name: "farm" });
+
+    await storage.dispose();
+  });
+
+  it("treats non-Farm storage.client values as runtime clients", async () => {
+    const runtimeClient = {
+      prepare() {},
+      exec() {},
+    };
+    const storage = await createFarmStorage({
+      driver: "memory",
+      client: runtimeClient,
+    });
+
+    await storage.setItem("key", "value");
+
+    expect(await storage.getItem("key")).toBe("value");
+    expect(await resolveStorageRuntimeClient({ client: runtimeClient })).toBe(runtimeClient);
+
+    await storage.dispose();
   });
 
   it("persists sqlite data across recreated instances and supports delete/clear", async () => {

--- a/packages/farm/src/__tests__/stripe-orm-storage.test.ts
+++ b/packages/farm/src/__tests__/stripe-orm-storage.test.ts
@@ -155,8 +155,8 @@ describe("stripe ORM-backed storage", () => {
         id: "user_orm_1",
         email: "owner@example.com",
       };
-      let ownerToolsClient: unknown;
-      let ownerToolsOrmStatus: unknown;
+      let ownerArgsClient: unknown;
+      let ownerArgsOrmStatus: unknown;
       const integration = stripe({
         instance: {
           async createCheckoutSession() {
@@ -178,13 +178,13 @@ describe("stripe ORM-backed storage", () => {
           },
         },
         billing: {
-          async resolveOwner(_context, tools) {
-            if (!tools) {
-              throw new Error("Expected Stripe billing tools.");
+          async resolveOwner(_context, args) {
+            if (!args) {
+              throw new Error("Expected Stripe billing args.");
             }
 
-            ownerToolsClient = await tools.storage.getClient();
-            const orm = (await tools.storage.getOrm()) as {
+            ownerArgsClient = await args.storage.getClient();
+            const orm = (await args.storage.getOrm()) as {
               billingAccount: {
                 findFirst(args: {
                   where: Record<string, unknown>;
@@ -196,7 +196,7 @@ describe("stripe ORM-backed storage", () => {
                 ownerId: owner.id,
               },
             });
-            ownerToolsOrmStatus = account?.status;
+            ownerArgsOrmStatus = account?.status;
             return owner;
           },
           plans: {
@@ -245,8 +245,8 @@ describe("stripe ORM-backed storage", () => {
       const json = JSON.parse(await response.text()) as Record<string, unknown>;
 
       expect(response.status).toBe(200);
-      expect(ownerToolsClient).toBe(db);
-      expect(ownerToolsOrmStatus).toBe("active");
+      expect(ownerArgsClient).toBe(db);
+      expect(ownerArgsOrmStatus).toBe("active");
       expect(json).toMatchObject({
         owner: {
           kind: "user",

--- a/packages/farm/src/__tests__/stripe-orm-storage.test.ts
+++ b/packages/farm/src/__tests__/stripe-orm-storage.test.ts
@@ -155,6 +155,8 @@ describe("stripe ORM-backed storage", () => {
         id: "user_orm_1",
         email: "owner@example.com",
       };
+      let ownerToolsClient: unknown;
+      let ownerToolsOrmStatus: unknown;
       const integration = stripe({
         instance: {
           async createCheckoutSession() {
@@ -176,7 +178,25 @@ describe("stripe ORM-backed storage", () => {
           },
         },
         billing: {
-          async resolveOwner() {
+          async resolveOwner(_context, tools) {
+            if (!tools) {
+              throw new Error("Expected Stripe billing tools.");
+            }
+
+            ownerToolsClient = await tools.storage.getClient();
+            const orm = (await tools.storage.getOrm()) as {
+              billingAccount: {
+                findFirst(args: {
+                  where: Record<string, unknown>;
+                }): Promise<Record<string, unknown> | null>;
+              };
+            };
+            const account = await orm.billingAccount.findFirst({
+              where: {
+                ownerId: owner.id,
+              },
+            });
+            ownerToolsOrmStatus = account?.status;
             return owner;
           },
           plans: {
@@ -225,6 +245,8 @@ describe("stripe ORM-backed storage", () => {
       const json = JSON.parse(await response.text()) as Record<string, unknown>;
 
       expect(response.status).toBe(200);
+      expect(ownerToolsClient).toBe(db);
+      expect(ownerToolsOrmStatus).toBe("active");
       expect(json).toMatchObject({
         owner: {
           kind: "user",

--- a/packages/farm/src/__tests__/stripe-orm-storage.test.ts
+++ b/packages/farm/src/__tests__/stripe-orm-storage.test.ts
@@ -1,0 +1,254 @@
+// @vitest-environment node
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { FarmIntegrationHandlerContext } from "../integrations";
+import { stripe } from "../../../farm-integrations/src/stripe/index";
+
+type SqliteDatabase = {
+  exec(sql: string): unknown;
+  close(): unknown;
+};
+
+const requireModule = createRequire(import.meta.url);
+const tempDirs = new Set<string>();
+
+async function createTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), prefix));
+  tempDirs.add(dir);
+  return dir;
+}
+
+async function createSqliteDatabase(filePath: string): Promise<SqliteDatabase> {
+  const { DatabaseSync } = requireModule("node:sqlite") as {
+    DatabaseSync: new (path: string) => SqliteDatabase;
+  };
+  return new DatabaseSync(filePath) as SqliteDatabase;
+}
+
+function createRequestContextStore() {
+  return {
+    get() {
+      return undefined;
+    },
+    set() {},
+    has() {
+      return false;
+    },
+    delete() {
+      return false;
+    },
+    clear() {},
+    snapshot() {
+      return new Map<string, unknown>();
+    },
+  };
+}
+
+function createContext(
+  request: Request,
+  method: string,
+  path: string,
+  instance: unknown,
+  config: FarmIntegrationHandlerContext["config"],
+): FarmIntegrationHandlerContext {
+  return {
+    request,
+    requestId: "req_test",
+    url: new URL(request.url),
+    pathname: new URL(request.url).pathname,
+    method,
+    params: {},
+    input: {},
+    integration: {
+      category: "payment",
+      slot: "payment",
+      type: "stripe",
+      instance,
+    },
+    route: {
+      kind: "route",
+      path,
+      methods: [method],
+    },
+    requestContext: createRequestContextStore(),
+    config,
+    isDev: true,
+    isProd: false,
+  };
+}
+
+describe("stripe ORM-backed storage", () => {
+  afterEach(async () => {
+    await Promise.all(
+      [...tempDirs].map(async (dir) => {
+        await rm(dir, { recursive: true, force: true });
+        tempDirs.delete(dir);
+      }),
+    );
+  });
+
+  it("uses farm.config storage.client as billing storage through the integration route", async () => {
+    const dir = await createTempDir("farm-stripe-orm-storage-");
+    const db = await createSqliteDatabase(path.join(dir, "stripe.sqlite"));
+
+    try {
+      db.exec(`
+        CREATE TABLE billing_account (
+          id TEXT PRIMARY KEY,
+          owner_id TEXT NOT NULL,
+          owner_kind TEXT NOT NULL DEFAULT 'user',
+          stripe_customer_id TEXT UNIQUE,
+          stripe_subscription_id TEXT UNIQUE,
+          plan_id TEXT NOT NULL DEFAULT 'free',
+          product_id TEXT,
+          status TEXT NOT NULL DEFAULT 'free',
+          current_period_end TEXT,
+          cancel_at_period_end INTEGER NOT NULL DEFAULT 0,
+          trial_ends_at TEXT,
+          trial_used_at TEXT,
+          seat_quantity INTEGER,
+          seat_allowance_override INTEGER,
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          UNIQUE(owner_kind, owner_id)
+        );
+
+        INSERT INTO billing_account (
+          id,
+          owner_id,
+          owner_kind,
+          stripe_customer_id,
+          stripe_subscription_id,
+          plan_id,
+          product_id,
+          status,
+          current_period_end,
+          cancel_at_period_end,
+          trial_ends_at,
+          trial_used_at,
+          seat_quantity,
+          seat_allowance_override
+        ) VALUES (
+          'acct_orm_1',
+          'user_orm_1',
+          'user',
+          'cus_orm_1',
+          'sub_orm_1',
+          'pro',
+          'proMonthly',
+          'active',
+          '2026-01-02T03:04:05.000Z',
+          1,
+          NULL,
+          '2025-12-20T00:00:00.000Z',
+          4,
+          8
+        );
+      `);
+
+      const owner = {
+        kind: "user" as const,
+        id: "user_orm_1",
+        email: "owner@example.com",
+      };
+      const integration = stripe({
+        instance: {
+          async createCheckoutSession() {
+            return {
+              id: "cs_unused",
+              url: "https://example.com/checkout/cs_unused",
+            };
+          },
+          async createPortalSession() {
+            return {
+              url: "https://example.com/portal",
+            };
+          },
+          async retrieveCheckoutSession() {
+            throw new Error("retrieveCheckoutSession should not be called by this test.");
+          },
+          async constructWebhookEvent() {
+            throw new Error("constructWebhookEvent should not be called by this test.");
+          },
+        },
+        billing: {
+          async resolveOwner() {
+            return owner;
+          },
+          plans: {
+            free: {
+              public: true,
+            },
+            pro: {
+              public: true,
+              features: {
+                teams: true,
+              },
+              limits: {
+                seats: 5,
+              },
+            },
+          },
+          products: {
+            proMonthly: {
+              public: true,
+              kind: "subscription",
+              planId: "pro",
+              name: "Pro Monthly",
+              currency: "usd",
+              unitAmount: 1200,
+              interval: "month",
+            },
+          },
+        },
+      });
+      const route = integration.routes.find(
+        (candidate) => candidate.path === "/billing/status" && candidate.method === "GET",
+      );
+      expect(route).toBeTruthy();
+
+      const request = new Request("http://example.com/billing/status", {
+        method: "GET",
+      });
+      const response = await route!.handler(
+        request,
+        createContext(request, "GET", "/billing/status", integration.instance, {
+          storage: {
+            client: db,
+          },
+        }),
+      );
+      const json = JSON.parse(await response.text()) as Record<string, unknown>;
+
+      expect(response.status).toBe(200);
+      expect(json).toMatchObject({
+        owner: {
+          kind: "user",
+          id: "user_orm_1",
+        },
+        planId: "pro",
+        productId: "proMonthly",
+        status: "active",
+        stripeCustomerId: "cus_orm_1",
+        stripeSubscriptionId: "sub_orm_1",
+        currentPeriodEnd: "2026-01-02T03:04:05.000Z",
+        cancelAtPeriodEnd: true,
+        trialUsedAt: "2025-12-20T00:00:00.000Z",
+        seatQuantity: 4,
+        seatAllowanceOverride: 8,
+        features: {
+          teams: true,
+        },
+        limits: {
+          seats: 8,
+        },
+      });
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -2,6 +2,7 @@ export * from "./types";
 export * from "./utils";
 export * from "./storage";
 export * from "./integrations";
+export * from "./integration-orm";
 export * from "./integration-api";
 export { createFarmApp } from "./app";
 export { FarmProvider } from "./provider";

--- a/packages/farm/src/integration-orm.ts
+++ b/packages/farm/src/integration-orm.ts
@@ -1,0 +1,190 @@
+import type {
+  AnyFieldBuilder,
+  AnyModelDefinition,
+  OrmClient,
+  SchemaDefinition,
+  SchemaModels,
+} from "@farming-labs/orm";
+import type {
+  FarmIntegrationSchema,
+  FarmIntegrationSchemaField,
+  FarmIntegrationSchemaModel,
+} from "./integrations";
+import { resolveStorageRuntimeClient } from "./storage";
+import type { FarmStorageUserConfig } from "./storage/types";
+import type { FarmConfig } from "./types";
+
+type RuntimeClientFactory<TClient> = () => TClient | Promise<TClient>;
+
+export type FarmIntegrationOrmSchema = SchemaDefinition<Record<string, AnyModelDefinition>>;
+
+export type FarmIntegrationOrmClient<TSchema extends FarmIntegrationOrmSchema> = OrmClient<TSchema>;
+
+export interface CreateIntegrationOrmOptions<TClient = unknown> {
+  schema: FarmIntegrationSchema;
+  config?: Pick<FarmConfig, "storage">;
+  storage?: FarmStorageUserConfig;
+  client?: TClient | RuntimeClientFactory<TClient>;
+}
+
+export async function createIntegrationOrm<TClient = unknown>(
+  options: CreateIntegrationOrmOptions<TClient>,
+): Promise<FarmIntegrationOrmClient<FarmIntegrationOrmSchema>> {
+  const [schema, client] = await Promise.all([
+    farmIntegrationSchemaToOrmSchema(options.schema),
+    resolveIntegrationOrmRuntimeClient(options),
+  ]);
+
+  if (!client) {
+    throw new Error(
+      "Schema-backed integration storage requires a runtime client at farm.config storage.client.",
+    );
+  }
+
+  const { createOrmFromRuntime } = await import("@farming-labs/orm-runtime");
+  return createOrmFromRuntime({
+    schema,
+    client,
+  }) as Promise<FarmIntegrationOrmClient<FarmIntegrationOrmSchema>>;
+}
+
+export async function resolveIntegrationOrmRuntimeClient<TClient = unknown>(
+  options: Omit<CreateIntegrationOrmOptions<TClient>, "schema">,
+): Promise<TClient | unknown | undefined> {
+  if (options.client !== undefined) {
+    return typeof options.client === "function"
+      ? await (options.client as RuntimeClientFactory<TClient>)()
+      : options.client;
+  }
+
+  return resolveStorageRuntimeClient(options.storage ?? options.config?.storage);
+}
+
+export async function farmIntegrationSchemaToOrmSchema(
+  schema: FarmIntegrationSchema,
+): Promise<FarmIntegrationOrmSchema> {
+  const orm = await import("@farming-labs/orm");
+  const models: Record<string, AnyModelDefinition> = {};
+
+  for (const [modelKey, modelSchema] of Object.entries(schema.models)) {
+    models[modelKey] = orm.model({
+      table: modelSchema.name ?? modelKey,
+      fields: createOrmModelFields(orm, modelSchema),
+      constraints: createOrmModelConstraints(modelSchema),
+      description: modelSchema.description,
+    }) as AnyModelDefinition;
+  }
+
+  return orm.defineSchema(models) as FarmIntegrationOrmSchema;
+}
+
+function createOrmModelFields(
+  orm: typeof import("@farming-labs/orm"),
+  modelSchema: FarmIntegrationSchemaModel,
+): Record<string, AnyFieldBuilder> {
+  return Object.fromEntries(
+    Object.entries(modelSchema.fields).map(([fieldKey, fieldSchema]) => [
+      fieldKey,
+      createOrmField(orm, fieldKey, fieldSchema),
+    ]),
+  );
+}
+
+function createOrmField(
+  orm: typeof import("@farming-labs/orm"),
+  fieldKey: string,
+  field: FarmIntegrationSchemaField,
+): AnyFieldBuilder {
+  let builder = createOrmFieldBuilder(orm, fieldKey, field) as AnyFieldBuilder;
+
+  if (field.unique) {
+    builder = builder.unique();
+  }
+
+  if (field.nullable || field.required === false) {
+    builder = builder.nullable();
+  }
+
+  if (field.default !== undefined) {
+    builder =
+      field.type === "datetime" && field.default === "now"
+        ? builder.defaultNow()
+        : builder.default(field.default as never);
+  }
+
+  if (field.reference) {
+    builder = builder.references(`${field.reference.model}.${field.reference.field}`);
+  }
+
+  if (field.name && field.name !== fieldKey) {
+    builder = builder.map(field.name);
+  }
+
+  if (field.description) {
+    builder = builder.describe(field.description);
+  }
+
+  return builder;
+}
+
+function createOrmFieldBuilder(
+  orm: typeof import("@farming-labs/orm"),
+  fieldKey: string,
+  field: FarmIntegrationSchemaField,
+): AnyFieldBuilder {
+  switch (field.type) {
+    case "id":
+    case "uuid":
+      return orm.id();
+    case "string":
+    case "text":
+      return orm.string();
+    case "boolean":
+      return orm.boolean();
+    case "integer":
+      return orm.integer();
+    case "number":
+      return orm.decimal();
+    case "datetime":
+      return orm.datetime();
+    case "json":
+      return orm.json();
+    case "enum": {
+      if (!field.values?.length) {
+        throw new Error(`Integration schema enum field "${fieldKey}" must define values.`);
+      }
+
+      return orm.enumeration(field.values as readonly [string, ...string[]]);
+    }
+    default:
+      throw new Error(
+        `Unsupported integration schema field type "${field.type}" for "${fieldKey}".`,
+      );
+  }
+}
+
+function createOrmModelConstraints(modelSchema: FarmIntegrationSchemaModel) {
+  const unique: Array<readonly [string, ...string[]]> = [];
+  const indexes: Array<readonly [string, ...string[]]> = [];
+
+  for (const constraint of modelSchema.constraints ?? []) {
+    if (!constraint.fields.length) {
+      continue;
+    }
+
+    const fields = constraint.fields as readonly [string, ...string[]];
+    if (constraint.type === "unique") {
+      unique.push(fields);
+    } else {
+      indexes.push(fields);
+    }
+  }
+
+  return {
+    unique,
+    indexes,
+  };
+}
+
+export type IntegrationOrmModelNames<TSchema extends FarmIntegrationOrmSchema> =
+  keyof SchemaModels<TSchema> & string;

--- a/packages/farm/src/storage/index.ts
+++ b/packages/farm/src/storage/index.ts
@@ -10,6 +10,7 @@ import type {
   FarmStorageDatabaseConfig,
   FarmStorageDatabaseDriverMap,
   FarmStorageDatabaseDriverName,
+  FarmStorageRuntimeClient,
   FarmStorageMountConfig,
   FarmStorageMounts,
   FarmStorageUserConfig,
@@ -24,6 +25,7 @@ export type {
   FarmStorageDatabaseConfig,
   FarmStorageDatabaseDriverName,
   FarmStorageLocalDriverConfig,
+  FarmStorageRuntimeClient,
   FarmStorageMountConfig,
   FarmStorageMounts,
   FarmStorageUserConfig,
@@ -174,17 +176,20 @@ function isStorageClient(value: unknown): value is FarmStorageClient {
   );
 }
 
-function isStorageConfigObject(value: FarmStorageUserConfig): value is FarmStorageConfigObject {
-  return !isStorageClient(value);
-}
-
 function isDatabaseDriverName(name: string): name is FarmStorageDatabaseDriverName {
   return name in DATABASE_CONNECTORS;
 }
 
 function extractDriverOptions(config: FarmStorageClientConfig): Record<string, any> | undefined {
   const source = config as Record<string, any>;
-  const { client, driver, mounts, options, tableName, ...inlineOptions } = source;
+  const {
+    client: _client,
+    driver: _driver,
+    mounts: _mounts,
+    options,
+    tableName: _tableName,
+    ...inlineOptions
+  } = source;
   const hasInlineOptions = Object.keys(inlineOptions).length > 0;
 
   if (options && typeof options === "object" && !Array.isArray(options)) {
@@ -484,13 +489,28 @@ export async function createFarmStorage(config: FarmStorageUserConfig = {}): Pro
     return config.createStorage();
   }
 
-  const rootConfig = config.client ?? config;
+  const rootConfig = isStorageClient(config.client) ? config.client : config;
   const storage = createStorage({
     driver: await resolveDriver(rootConfig),
   });
 
   await mountNamespaces(storage, config.mounts);
   return storage;
+}
+
+export async function resolveStorageRuntimeClient(
+  config: FarmStorageUserConfig | undefined,
+): Promise<unknown | undefined> {
+  if (!config || isStorageInstance(config) || isStorageClient(config)) {
+    return undefined;
+  }
+
+  const client = config.client;
+  if (!client || isStorageInstance(client) || isStorageClient(client)) {
+    return undefined;
+  }
+
+  return typeof client === "function" ? await client() : client;
 }
 
 export async function initStorage(config: FarmStorageUserConfig = {}): Promise<Storage> {

--- a/packages/farm/src/storage/types.ts
+++ b/packages/farm/src/storage/types.ts
@@ -69,6 +69,8 @@ export interface FarmStorageClient extends Storage {
   resolveDriver(): Promise<Driver>;
 }
 
+export type FarmStorageRuntimeClient = object | (() => unknown | Promise<unknown>);
+
 export interface FarmStorageCustomDriverConfig {
   driver: Driver | (() => Driver | Promise<Driver>);
 }
@@ -85,7 +87,12 @@ export type FarmStorageMountConfig = FarmStorageClientConfig | FarmStorageClient
 export type FarmStorageMounts = Record<string, FarmStorageMountConfig>;
 
 export type FarmStorageConfigObject = FarmStorageClientConfig & {
-  client?: FarmStorageClient;
+  /**
+   * Existing FarmStorageClient instances still drive Farm's key/value storage.
+   * Other objects/functions are treated as application runtime clients for
+   * schema-backed integration persistence via @farming-labs/orm.
+   */
+  client?: FarmStorageClient | FarmStorageRuntimeClient;
   mounts?: FarmStorageMounts;
 };
 

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   format: ["cjs", "esm"],
   dts: true,
   clean: true,
-  external: ["react", "react-dom", "vite"],
+  external: ["react", "react-dom", "vite", /^@farming-labs\/orm/],
   sourcemap: true,
   splitting: false,
   treeshake: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -901,6 +901,12 @@ importers:
 
   packages/farm:
     dependencies:
+      '@farming-labs/orm':
+        specifier: 0.0.62
+        version: 0.0.62
+      '@farming-labs/orm-runtime':
+        specifier: 0.0.62
+        version: 0.0.62(@mikro-orm/core@7.1.5)(@prisma/client@6.7.0)(@xata.io/client@0.30.1)(db0@0.3.4)(drizzle-orm@0.45.2)(kysely@0.28.17)(mongodb@6.21.0)(mongoose@8.24.1)(sequelize@6.37.8)(surrealdb@2.0.4)(typeorm@0.3.30)
       '@scalar/api-reference':
         specifier: ^1.38.1
         version: 1.38.1(supports-color@10.2.2)(tailwindcss@4.1.18)(typescript@5.9.3)
@@ -918,7 +924,7 @@ importers:
         version: 1.0.19
       db0:
         specifier: ^0.3.4
-        version: 0.3.4
+        version: 0.3.4(drizzle-orm@0.45.2)
       esbuild:
         specifier: ^0.19.11
         version: 0.19.12
@@ -930,7 +936,7 @@ importers:
         version: 2.0.1-rc.5
       nitro:
         specifier: 3.0.1-alpha.0
-        version: 3.0.1-alpha.0(vite@5.4.20)
+        version: 3.0.1-alpha.0(drizzle-orm@0.45.2)(mongodb@6.21.0)(vite@5.4.20)
       pg:
         specifier: ^8.20.0
         version: 8.20.0
@@ -957,7 +963,7 @@ importers:
         version: 4.1.18
       unstorage:
         specifier: ^2.0.0-alpha.3
-        version: 2.0.0-alpha.3(db0@0.3.4)(ofetch@1.5.1)
+        version: 2.0.0-alpha.3(db0@0.3.4)(mongodb@6.21.0)(ofetch@1.5.1)
       vite:
         specifier: ^5.0.10
         version: 5.4.20(@types/node@20.19.21)
@@ -1077,7 +1083,7 @@ importers:
         version: 1.0.19
       nitro:
         specifier: 3.0.1-alpha.0
-        version: 3.0.1-alpha.0(rolldown@1.1.2)(vite@6.4.1)
+        version: 3.0.1-alpha.0(rolldown@1.1.4)(vite@6.4.1)
       picocolors:
         specifier: ^1.0.0
         version: 1.1.1
@@ -1169,6 +1175,254 @@ packages:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
     dev: true
+
+  /@aws-sdk/client-dynamodb@3.1078.0:
+    resolution: {integrity: sha512-DQJaTSSD8R6RuDXkFiQ4aiWyIhDtNeZksULp2gk+RFcl7CI9mzIO+aX7ucnckEnE6q4iOId3NJAULASUASfWJg==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/credential-provider-node': 3.972.61
+      '@aws-sdk/dynamodb-codec': 3.973.26
+      '@aws-sdk/middleware-endpoint-discovery': 3.972.22
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/fetch-http-handler': 5.6.2
+      '@smithy/node-http-handler': 4.9.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/core@3.974.26:
+    resolution: {integrity: sha512-wRj7Pthvjk3anees97pUWlxlTa0DUjeGrEQU5fKDZVdWZV0ekaprbof0df2uaE9g8u67t035v2j+ne2AW2UMkA==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@aws-sdk/xml-builder': 3.972.33
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.29.0
+      '@smithy/signature-v4': 5.6.1
+      '@smithy/types': 4.15.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-env@3.972.52:
+    resolution: {integrity: sha512-sxuaHZGHqOgKB8OdL3doXa1NJjqmO60FPfyTnYVKGjX9taRsIEGS9pd+2yALmo06hijZ8L94uSK0kfXZsRmVyA==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-http@3.972.54:
+    resolution: {integrity: sha512-e6yz52nq3SpR1oPLcvfsDM7H7k2gIYk/NSn/rwsFqzGXEwr3g0mRMlPbLaKCPCGNZJMU/gZg6/64B3eSam+gBw==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/fetch-http-handler': 5.6.2
+      '@smithy/node-http-handler': 4.9.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-ini@3.972.59:
+    resolution: {integrity: sha512-9Um/UpruN76AdpiLnvwChVkJJwJ9Vx9ykk/2AeLxxSCM/YYRD8Kkq2towUk9fZQLV7dd9ATlsi87U7hKs0z/iQ==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/credential-provider-env': 3.972.52
+      '@aws-sdk/credential-provider-http': 3.972.54
+      '@aws-sdk/credential-provider-login': 3.972.58
+      '@aws-sdk/credential-provider-process': 3.972.52
+      '@aws-sdk/credential-provider-sso': 3.972.58
+      '@aws-sdk/credential-provider-web-identity': 3.972.58
+      '@aws-sdk/nested-clients': 3.997.26
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/credential-provider-imds': 4.4.5
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-login@3.972.58:
+    resolution: {integrity: sha512-H3q96qF8/DJsPsXMVtMRqSWOc85K5O4zos32untdw+vE5vw0f3a6qJo1YqbND4BsEIKd4iZmzzVUq9kV4LjbHg==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/nested-clients': 3.997.26
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-node@3.972.61:
+    resolution: {integrity: sha512-2U2KHMRCt1dlZoLU3KZR5g5EL4b0h2HHw96SkaUBK7qvEXPZj5rGRO/3ZTeJmh37dIYQuCnA2273rZOQvmsiHw==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.52
+      '@aws-sdk/credential-provider-http': 3.972.54
+      '@aws-sdk/credential-provider-ini': 3.972.59
+      '@aws-sdk/credential-provider-process': 3.972.52
+      '@aws-sdk/credential-provider-sso': 3.972.58
+      '@aws-sdk/credential-provider-web-identity': 3.972.58
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/credential-provider-imds': 4.4.5
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-process@3.972.52:
+    resolution: {integrity: sha512-Aff9Ebs42lz+Ep1wkS+Nlwh5S0eahakpyskPsuKGjiBJ6ExOjNtxbfKJTKovQtQNgJ7oG1BH6esJwGrbs7qgSA==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-sso@3.972.58:
+    resolution: {integrity: sha512-syloC58mXOacUqM2toPNfwd7X3jT+tWj0F/cN7qdW1FQyI0q41J0tPf6DIZ56BF0x82iS9j3ALP45MoBz79YuQ==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/nested-clients': 3.997.26
+      '@aws-sdk/token-providers': 3.1078.0
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-web-identity@3.972.58:
+    resolution: {integrity: sha512-pTBImKzcGK+pcMKjL0fAJbnYzzYd1c0UDc7BSIOGNQhF9Nuk66vWlIXfYTYyzNSs+w8Q/vfbbNDDU8zdrouwLg==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/nested-clients': 3.997.26
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/dynamodb-codec@3.973.26:
+    resolution: {integrity: sha512-DeC9hY4sczIbhXYIAkSbfILBLZmpJhJh19IJNxowWomADjW1OjeycS8/d1IPhN1cUWICXn2aMgAE5Gqc9hpU4g==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/endpoint-cache@3.972.8:
+    resolution: {integrity: sha512-bBmkG0Dnhfq0/T4Z0PpUr7HkncBVaWvvCbvafeaUM+yC9wa8GGjLJmonq0QL17REB9WivgGeYgWQ5A80Uw5UnQ==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      mnemonist: 0.38.3
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/lib-dynamodb@3.1078.0(@aws-sdk/client-dynamodb@3.1078.0):
+    resolution: {integrity: sha512-rr7tPp35YzExjPgKNpN9HJl0W0ejEF29Hdi6AZmepLSZ8/AmG1mhZIuO2FO2Q/aAjKpzm0DPKcZoCzXmwfAyBA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-dynamodb': ^3.1078.0
+    dependencies:
+      '@aws-sdk/client-dynamodb': 3.1078.0
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/util-dynamodb': 3.996.5(@aws-sdk/client-dynamodb@3.1078.0)
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/middleware-endpoint-discovery@3.972.22:
+    resolution: {integrity: sha512-GMoLg4XAnkiwevqcOfgz0lOTYmIdM7MJK/BL9EAvsoMFqKIGRpyNIvuSNg5gdFzP57yB+EklMlK0+TwBqj1tCg==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/endpoint-cache': 3.972.8
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/nested-clients@3.997.26:
+    resolution: {integrity: sha512-Lwe3F6K7bs+jEubp1LbrvzeMBYb5fMazJ1IxV9TtKWPF8CSh67Fmwyq9fLz3NL/k55Dfpuph5Dimw76JFgr+SA==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/signature-v4-multi-region': 3.996.38
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/fetch-http-handler': 5.6.2
+      '@smithy/node-http-handler': 4.9.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/signature-v4-multi-region@3.996.38:
+    resolution: {integrity: sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@smithy/signature-v4': 5.6.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/token-providers@3.1078.0:
+    resolution: {integrity: sha512-/uyXLBGu3Lw1GbBA2X66hcOMnKtMcqAIF+3/eHfxBQmUeXF2sdqozDPrTfEr/TnSd0D6deZar+eVyhEqqWu29w==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/nested-clients': 3.997.26
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/types@3.973.15:
+    resolution: {integrity: sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/util-dynamodb@3.996.5(@aws-sdk/client-dynamodb@3.1078.0):
+    resolution: {integrity: sha512-m9bdmYq3WtbMHAKGALw9XWiMBfKu5T8ukgdJT7Mc/d2oOwDGNFmhsnnkQ18xomoXo/ZHxAuIDi3Y6slsblW1Mg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-dynamodb': ^3.1069.0
+    dependencies:
+      '@aws-sdk/client-dynamodb': 3.1078.0
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/xml-builder@3.972.33:
+    resolution: {integrity: sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws/lambda-invoke-store@0.2.4:
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
+    dev: false
 
   /@babel/code-frame@7.27.1:
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -1878,14 +2132,6 @@ packages:
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
-    optional: true
-
-  /@emnapi/runtime@1.10.0:
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
-    requiresBuild: true
-    dependencies:
-      tslib: 2.8.1
-    dev: true
     optional: true
 
   /@emnapi/runtime@1.11.1:
@@ -2876,6 +3122,251 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@farming-labs/orm-d1@0.0.62:
+    resolution: {integrity: sha512-yIeY4quFnWjclFzh8xuvgYVvr7fO+1yCPKDbgX9qMqS+uHCH1HFnPI58UJf9Tj1n6bSq11OUcBqwODeRHwK/3w==}
+    dependencies:
+      '@farming-labs/orm': 0.0.62
+      '@farming-labs/orm-sql': 0.0.62
+    dev: false
+
+  /@farming-labs/orm-drizzle@0.0.62(drizzle-orm@0.45.2):
+    resolution: {integrity: sha512-XJ6KtJ4pMfJVDBEi78vBuD4cWvqjK3JbK+Y5GbpJxdqNIpNoWEoDGsWnY/JwBMqJJdZbNLuV845uzuHzvTIXSw==}
+    peerDependencies:
+      drizzle-orm: ^0.45.2
+    dependencies:
+      '@farming-labs/orm': 0.0.62
+      '@farming-labs/orm-sql': 0.0.62
+      drizzle-orm: 0.45.2(@prisma/client@6.7.0)(@types/better-sqlite3@7.6.13)(@xata.io/client@0.30.1)(kysely@0.28.17)(pg@8.20.0)
+    dev: false
+
+  /@farming-labs/orm-dynamodb@0.0.62:
+    resolution: {integrity: sha512-ycOpgK46F4lnI2oj7E3MLfVDw/BvYWdOkaYgP5/eAXJj5bcbFjTRGPdS/LBm9NPDPugzd4f7SBNGUVJCqaS/0A==}
+    dependencies:
+      '@aws-sdk/client-dynamodb': 3.1078.0
+      '@aws-sdk/lib-dynamodb': 3.1078.0(@aws-sdk/client-dynamodb@3.1078.0)
+      '@farming-labs/orm': 0.0.62
+    dev: false
+
+  /@farming-labs/orm-edgedb@0.0.62:
+    resolution: {integrity: sha512-O3e9qwUnASDmpAK82T8YeFBpwSctr5XXRMNDLLfhtW12x9HBbED/uk2qq3df4HK7L+3t43viwO9lyeYR33LIoQ==}
+    dependencies:
+      '@farming-labs/orm': 0.0.62
+      '@farming-labs/orm-sql': 0.0.62
+    dev: false
+
+  /@farming-labs/orm-firestore@0.0.62:
+    resolution: {integrity: sha512-0aU0LnQZTDHqKkPYsP4OVcPBvdsHLVNFoAloheaj/3wxSoVYj0CvMY5VvyUaad8lSFhzAPQCf/ThnWqP8X9x1A==}
+    dependencies:
+      '@farming-labs/orm': 0.0.62
+    dev: false
+
+  /@farming-labs/orm-kv@0.0.62:
+    resolution: {integrity: sha512-ly98TndFaKX2ZU07dXqicUzE6Wy9tB2kflHhV8gPL6CZ7Z/9gaH497kw1oTjD57cHfIQUygluvq16En40KLq+Q==}
+    dependencies:
+      '@farming-labs/orm': 0.0.62
+    dev: false
+
+  /@farming-labs/orm-kysely@0.0.62(kysely@0.28.17):
+    resolution: {integrity: sha512-C2JQKWDnZOK+xrEWUASwCO3nQ3WMlZKo+CIhbGtLuEx/CiCzETUj9c22gO/N40AVy4UWqJa5dDps3Amp/DfzGw==}
+    peerDependencies:
+      kysely: ^0.28.17
+    dependencies:
+      '@farming-labs/orm': 0.0.62
+      '@farming-labs/orm-sql': 0.0.62
+      kysely: 0.28.17
+    dev: false
+
+  /@farming-labs/orm-mikroorm@0.0.62(@mikro-orm/core@7.1.5):
+    resolution: {integrity: sha512-BSU7t+26Jtzk05yhhGLglJ3yi2QQGATGVJCEpWKQw1a75spU6jweh6pSBqBc68hXhgrmP5/9bdekJu0BNhAzDw==}
+    peerDependencies:
+      '@mikro-orm/core': ^7.0.17
+    dependencies:
+      '@farming-labs/orm': 0.0.62
+      '@farming-labs/orm-sql': 0.0.62
+      '@mikro-orm/core': 7.1.5
+    dev: false
+
+  /@farming-labs/orm-mongo@0.0.62(mongodb@6.21.0)(mongoose@8.24.1):
+    resolution: {integrity: sha512-wJZuaYoeePgRLcL+4GWLG8L9+k+VkmqeQgog2pT6zCrTKeactW+ZnFnJG5XNt8uRpRf29TZBglG6zPhCg36yPg==}
+    peerDependencies:
+      mongodb: ^6.0.0
+    dependencies:
+      '@farming-labs/orm': 0.0.62
+      '@farming-labs/orm-mongoose': 0.0.62(mongoose@8.24.1)
+      mongodb: 6.21.0
+    transitivePeerDependencies:
+      - mongoose
+    dev: false
+
+  /@farming-labs/orm-mongoose@0.0.62(mongoose@8.24.1):
+    resolution: {integrity: sha512-POrb37nRg5VKPzATl9QGpox9fzEi4COoJ70K/Mnkpwh5/PihWceOPtAAbr3i6DylYnW22Aa4E+/XW4LGVTI3Hw==}
+    peerDependencies:
+      mongoose: ^8.0.0
+    dependencies:
+      '@farming-labs/orm': 0.0.62
+      mongoose: 8.24.1(supports-color@10.2.2)
+    dev: false
+
+  /@farming-labs/orm-neo4j@0.0.62:
+    resolution: {integrity: sha512-LqpmSXrwRKxYvUFpjWoYwXcP+7lKJl/C17aaPSapQE2Nktig4Yw8iPi4OV7F7A9VLNTLaDWbl3qnDF1Cz13/iQ==}
+    dependencies:
+      '@farming-labs/orm': 0.0.62
+    dev: false
+
+  /@farming-labs/orm-prisma@0.0.62(@prisma/client@6.7.0):
+    resolution: {integrity: sha512-rAmBWDxFwpo6Cg7PZz5jGzek00klsOrR0Rd3MxTYvJX11OQrHlg3MYtJHMUyIrb+rpeniI8EuNmei5n2Vx2mDA==}
+    peerDependencies:
+      '@prisma/client': ^6.0.0
+    dependencies:
+      '@farming-labs/orm': 0.0.62
+      '@prisma/client': 6.7.0(prisma@6.7.0)(typescript@5.9.3)
+    dev: false
+
+  /@farming-labs/orm-redis@0.0.62:
+    resolution: {integrity: sha512-jXwdXXz3rSy4aVyhjhMjusgFZbtI4UWLLP7exEApfAk87134jrmdhqfvFlKK/yEeHO9s2iGkjJ4KB/BUHGUueg==}
+    dependencies:
+      '@farming-labs/orm': 0.0.62
+    dev: false
+
+  /@farming-labs/orm-runtime@0.0.62(@mikro-orm/core@7.1.5)(@prisma/client@6.7.0)(@xata.io/client@0.30.1)(db0@0.3.4)(drizzle-orm@0.45.2)(kysely@0.28.17)(mongodb@6.21.0)(mongoose@8.24.1)(sequelize@6.37.8)(surrealdb@2.0.4)(typeorm@0.3.30):
+    resolution: {integrity: sha512-h95+Fma0rbWH4jxrQ1ZAopAJ7OUH076RlImwRd0Unmy9oWoXZ5QK/g0qNR8LLg1CWEY14T2/HJ8d/MnQBuoYKw==}
+    dependencies:
+      '@aws-sdk/client-dynamodb': 3.1078.0
+      '@farming-labs/orm': 0.0.62
+      '@farming-labs/orm-d1': 0.0.62
+      '@farming-labs/orm-drizzle': 0.0.62(drizzle-orm@0.45.2)
+      '@farming-labs/orm-dynamodb': 0.0.62
+      '@farming-labs/orm-edgedb': 0.0.62
+      '@farming-labs/orm-firestore': 0.0.62
+      '@farming-labs/orm-kv': 0.0.62
+      '@farming-labs/orm-kysely': 0.0.62(kysely@0.28.17)
+      '@farming-labs/orm-mikroorm': 0.0.62(@mikro-orm/core@7.1.5)
+      '@farming-labs/orm-mongo': 0.0.62(mongodb@6.21.0)(mongoose@8.24.1)
+      '@farming-labs/orm-mongoose': 0.0.62(mongoose@8.24.1)
+      '@farming-labs/orm-neo4j': 0.0.62
+      '@farming-labs/orm-prisma': 0.0.62(@prisma/client@6.7.0)
+      '@farming-labs/orm-redis': 0.0.62
+      '@farming-labs/orm-sequelize': 0.0.62(sequelize@6.37.8)
+      '@farming-labs/orm-sql': 0.0.62
+      '@farming-labs/orm-supabase': 0.0.62
+      '@farming-labs/orm-surrealdb': 0.0.62(surrealdb@2.0.4)
+      '@farming-labs/orm-typeorm': 0.0.62(typeorm@0.3.30)
+      '@farming-labs/orm-unstorage': 0.0.62(db0@0.3.4)
+      '@farming-labs/orm-xata': 0.0.62(@xata.io/client@0.30.1)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@mikro-orm/core'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@prisma/client'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@xata.io/client'
+      - aws4fetch
+      - db0
+      - drizzle-orm
+      - idb-keyval
+      - ioredis
+      - kysely
+      - mongodb
+      - mongoose
+      - sequelize
+      - surrealdb
+      - typeorm
+      - uploadthing
+    dev: false
+
+  /@farming-labs/orm-sequelize@0.0.62(sequelize@6.37.8):
+    resolution: {integrity: sha512-MY/bzu4DZAcbfilWBpuaEWQvF61p2BYVJj2y/OvcJlRgif+qHOVGiL6C48yl1g2E+4SpROSqgwLjWinLpFrjlQ==}
+    peerDependencies:
+      sequelize: ^6.37.8
+    dependencies:
+      '@farming-labs/orm': 0.0.62
+      '@farming-labs/orm-sql': 0.0.62
+      sequelize: 6.37.8(pg@8.20.0)(supports-color@10.2.2)
+    dev: false
+
+  /@farming-labs/orm-sql@0.0.62:
+    resolution: {integrity: sha512-Ufr4z4wphmihazj02ZzaW8UoG09v4TRhG+FcnNQBmPHKEkvAoBaGnB74/StzBVMBeKK64HeaZEY7azjOn3vB6g==}
+    dependencies:
+      '@farming-labs/orm': 0.0.62
+    dev: false
+
+  /@farming-labs/orm-supabase@0.0.62:
+    resolution: {integrity: sha512-GSv4KjGcPKuxF0TMSTDUGdvo28YoDe86baKotcxeMDffJ2F+lkxlxutpxcqBXMMVbJ5ZIdw+Udikf/MbsE54gA==}
+    dependencies:
+      '@farming-labs/orm': 0.0.62
+    dev: false
+
+  /@farming-labs/orm-surrealdb@0.0.62(surrealdb@2.0.4):
+    resolution: {integrity: sha512-oxJwgq5FNCsR9jG2CZMi3Wun0XsDgPJl+Vv5BUnuSGzMUGqDAdnK2wnDdQ2OuBXNmvRIEL7w9SPvcfE7Jl1rZg==}
+    peerDependencies:
+      surrealdb: ^2.0.3
+    dependencies:
+      '@farming-labs/orm': 0.0.62
+      surrealdb: 2.0.4(tslib@2.8.1)(typescript@5.9.3)
+    dev: false
+
+  /@farming-labs/orm-typeorm@0.0.62(typeorm@0.3.30):
+    resolution: {integrity: sha512-cJ1rnLzw+KJIYlGnWgziYtAEKFx8gso8pI8+CHwHahud8RE7Ua+kZni11LXmPv6ZGabV15zI9PEo9+JDv/c60A==}
+    peerDependencies:
+      typeorm: ^0.3.28
+    dependencies:
+      '@farming-labs/orm': 0.0.62
+      '@farming-labs/orm-sql': 0.0.62
+      typeorm: 0.3.30(mongodb@6.21.0)(pg@8.20.0)(supports-color@10.2.2)
+    dev: false
+
+  /@farming-labs/orm-unstorage@0.0.62(db0@0.3.4):
+    resolution: {integrity: sha512-90ZedhspZfXFSnNbtMXQvlp2wv1K8bnnO2m02wbB3QdB8O3FWnPQCsXZlZH3IjXGtHB7S7JCH1TFJDK9H20pbg==}
+    dependencies:
+      '@farming-labs/orm': 0.0.62
+      unstorage: 1.17.5(db0@0.3.4)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - idb-keyval
+      - ioredis
+      - uploadthing
+    dev: false
+
+  /@farming-labs/orm-xata@0.0.62(@xata.io/client@0.30.1):
+    resolution: {integrity: sha512-gvpH0wjkg0WPQubHUcL6S+Wy0g6+pIm1G1CN+ANciQ2f19DnclxrSLZF/iL81RHVnLglvrWqZ3rnaKyRRQukEQ==}
+    peerDependencies:
+      '@xata.io/client': ^0.30.1
+    dependencies:
+      '@farming-labs/orm': 0.0.62
+      '@farming-labs/orm-sql': 0.0.62
+      '@xata.io/client': 0.30.1(typescript@5.9.3)
+    dev: false
+
+  /@farming-labs/orm@0.0.62:
+    resolution: {integrity: sha512-L36KN/y7UVdlbxQYVBqtPebKjfYfRuVDyzhCBnOM64HnhkmmWtUAt2HNvx6/jvv9ixe2uXS1aLj6o8cn+QOU7w==}
+    dev: false
+
   /@floating-ui/core@1.7.3:
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
     dependencies:
@@ -3167,7 +3658,7 @@ packages:
     cpu: [wasm32]
     requiresBuild: true
     dependencies:
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/runtime': 1.11.1
     dev: true
     optional: true
 
@@ -3234,7 +3725,6 @@ packages:
       strip-ansi-cjs: /strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: /wrap-ansi@7.0.0
-    dev: true
 
   /@istanbuljs/schema@0.1.3:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
@@ -3371,14 +3861,24 @@ packages:
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
     dev: false
 
+  /@mikro-orm/core@7.1.5:
+    resolution: {integrity: sha512-jYsR65PcFF+YKUlg/qytjP0PTyk558JvTKI1GzD6Vy/nshTkbcqMN5fDm2d5GJuxliPk0C8+M8tDn3GXeCAqow==}
+    engines: {node: '>= 22.17.0'}
+    peerDependencies:
+      dataloader: 2.2.3
+    peerDependenciesMeta:
+      dataloader:
+        optional: true
+    dev: false
+
   /@mongodb-js/saslprep@1.4.6:
     resolution: {integrity: sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==}
     dependencies:
       sparse-bitfield: 3.0.3
     dev: false
 
-  /@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
-    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+  /@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     requiresBuild: true
     peerDependencies:
       '@emnapi/core': ^1.7.1
@@ -3386,7 +3886,7 @@ packages:
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
-      '@tybys/wasm-util': 0.10.2
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   /@next/env@16.2.4:
@@ -3493,8 +3993,8 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  /@oxc-project/types@0.137.0:
-    resolution: {integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==}
+  /@oxc-project/types@0.138.0:
+    resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
 
   /@oxfmt/darwin-arm64@0.27.0:
     resolution: {integrity: sha512-3vwqyzNlVTVFVzHMlrqxb4tgVgHp6FYS0uIxsIZ/SeEDG0azaqiOw/2t8LlJ9f72PKRLWSey+Ak99tiKgpbsnQ==}
@@ -3753,7 +4253,6 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
     requiresBuild: true
-    dev: true
     optional: true
 
   /@playwright/test@1.58.2:
@@ -4160,123 +4659,123 @@ packages:
       '@codemirror/view': 6.38.6
     dev: false
 
-  /@rolldown/binding-android-arm64@1.1.2:
-    resolution: {integrity: sha512-2cZ+7xRS+DBcuJBJKnfzsbleumJhBqSlJVpuzHC0nTqfd3QQ7Vx2/x5YR/D7cBamKSeWplwo82Fn9lqYUDEMfA==}
+  /@rolldown/binding-android-arm64@1.1.4:
+    resolution: {integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-darwin-arm64@1.1.2:
-    resolution: {integrity: sha512-RkPMJnygxsgOYdkfqgpwY0/Fzm8d0VQe6HGU2/B00Xa9eqdLbrII+DOKAodbJAn3ZL1AJxGHkZRPYazgGY6Ljw==}
+  /@rolldown/binding-darwin-arm64@1.1.4:
+    resolution: {integrity: sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-darwin-x64@1.1.2:
-    resolution: {integrity: sha512-Uiczh6vFhwyfd7WNe7Q7mCA4KxAiLdz7jPE/WGizfRpIieoyFuNVMmM8HqZ9HwudTkY6/AeMQwlNJ9NJijguWw==}
+  /@rolldown/binding-darwin-x64@1.1.4:
+    resolution: {integrity: sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-freebsd-x64@1.1.2:
-    resolution: {integrity: sha512-+TpdtTRgHiJFjCVFbw311SuLk3KfytPOQQn+VlAEv+gBxYPtL7E6JS9e/tk+8CwxhIZvemJKo4rTKgfWNsKkkA==}
+  /@rolldown/binding-freebsd-x64@1.1.4:
+    resolution: {integrity: sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-linux-arm-gnueabihf@1.1.2:
-    resolution: {integrity: sha512-4lv1/tkmi7ueIVHnyreaOeUpiZP26BH9rRy6hoYfR9310A2B9nUEVRDvBx69vx64Nr3eTPPRkyciqJJs+j9Jmw==}
+  /@rolldown/binding-linux-arm-gnueabihf@1.1.4:
+    resolution: {integrity: sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-linux-arm64-gnu@1.1.2:
-    resolution: {integrity: sha512-gBSUVO0eaWgw1JMjK3gB8BMlX2Mk148s2lTiVT3e9vjVxbl7UDfMWWY8CfIaaqiXuM9fVTMxIpUz6CAo/B6Vlw==}
+  /@rolldown/binding-linux-arm64-gnu@1.1.4:
+    resolution: {integrity: sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-linux-arm64-musl@1.1.2:
-    resolution: {integrity: sha512-LjQP/iZLBu8o8PjIfk4x3At0/mT6h282pvz8Z5LAyhGbu/kDezyO7ea62rF5uoqmgnIYqbN/MqJ3Si3Aymi7xQ==}
+  /@rolldown/binding-linux-arm64-musl@1.1.4:
+    resolution: {integrity: sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-linux-ppc64-gnu@1.1.2:
-    resolution: {integrity: sha512-X/7bVLWelEsbyWDUSXt7zVsTniLLPIY2n1rH58qr78l9i7MNbbxBWD8gI2vRfBWf4NUXJCUuQnfZDsp32LqsfQ==}
+  /@rolldown/binding-linux-ppc64-gnu@1.1.4:
+    resolution: {integrity: sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-linux-s390x-gnu@1.1.2:
-    resolution: {integrity: sha512-gb6dYKW/1KDorGXyy48glEBJs/sxVSC5pcVrox/pFGV4mvwSFeg2sK5L2tRkVsVlh7kueqOgg4GEcuipJcGuKg==}
+  /@rolldown/binding-linux-s390x-gnu@1.1.4:
+    resolution: {integrity: sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-linux-x64-gnu@1.1.2:
-    resolution: {integrity: sha512-JY4w85pU3iAiJVMh5nuk4/Mh9GjMsupe8MrIN53rwxAZW64GKrWeJBuN6SxQg9QTU5uB1cxyhDzW8jqRn1EABw==}
+  /@rolldown/binding-linux-x64-gnu@1.1.4:
+    resolution: {integrity: sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-linux-x64-musl@1.1.2:
-    resolution: {integrity: sha512-xvpA7o5KCYLB0Rwscmuylb1/zHHSUx4g4xilm4prC5jP76pEUlzBmMbgpbh7bVDbId4NcfT96gN5i6mE6UDaiw==}
+  /@rolldown/binding-linux-x64-musl@1.1.4:
+    resolution: {integrity: sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-openharmony-arm64@1.1.2:
-    resolution: {integrity: sha512-p/ts6KBLjuk49Bp21XH77poQGt02iNz7ChgHep7tudPOaLinR/De/RHdxF8w8Yj4r/bF/bqXwH6PZrB2sA+Nvw==}
+  /@rolldown/binding-openharmony-arm64@1.1.4:
+    resolution: {integrity: sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-wasm32-wasi@1.1.2:
-    resolution: {integrity: sha512-VMu/wmrZ9hJzYlRhbw7jK5PODlugyKZ5mOdX78+lS8OvuFkWNQdz1pFLrI2p3P0pjXOmUZ7B48o5VnMH9QOGtg==}
+  /@rolldown/binding-wasm32-wasi@1.1.4:
+    resolution: {integrity: sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
     requiresBuild: true
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  /@rolldown/binding-win32-arm64-msvc@1.1.2:
-    resolution: {integrity: sha512-xtUJqs8qEkuSviS0n1tsohaPuz3a1SPhZywOji4Oo+sgrJs8daEDMZ0QtqL0OS7dx8PoVpg2J/ZZycPY5I2+Zg==}
+  /@rolldown/binding-win32-arm64-msvc@1.1.4:
+    resolution: {integrity: sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-win32-x64-msvc@1.1.2:
-    resolution: {integrity: sha512-85YiLQqjUKgSO/Zjnf9e0XIn5Ymrh1fLDWBeAkZqpuBR/3R8TpfoHXuyblqyQrftSSgWO9qpcHN8mkyKsLraoA==}
+  /@rolldown/binding-win32-x64-msvc@1.1.4:
+    resolution: {integrity: sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -4882,6 +5381,61 @@ packages:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
 
+  /@smithy/core@3.29.0:
+    resolution: {integrity: sha512-sEvpvkBVoMxjoek35XyJFn2ZD3EJ1RpiZrT47WaZodxzAIWS44zkdvbqGE/ZlugtjiQp62cffYZ9ldyRkjAGnA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/credential-provider-imds@4.4.5:
+    resolution: {integrity: sha512-LnjUTNG0GgQlKIq7IioeOrPaEmC5xOd1WtAz24TLSiYQnWX2uHr53GrFuQhkrJBktPYCMga/NbUOW7hFbSA2Cg==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/fetch-http-handler@5.6.2:
+    resolution: {integrity: sha512-q96PSDOAGw+X+nuELd7Cjebps0SYr+YlPbviEX9sLVw+VM4M7VV8hn1nL1mGS6urDu33eQ5A7WhlphaDO6kUyQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/node-http-handler@4.9.2:
+    resolution: {integrity: sha512-s0yAIRj6TVfHgl+QzVyqal1KMGZ9B5512IrxKc6+dOpw8fUmFL3CvuAhjv0J+aNjUPfVZ2IhqPEDvkB5Ncx9oA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/signature-v4@5.6.1:
+    resolution: {integrity: sha512-SqvuP75p/DmgWWI7jv4kf/UW+V4LFmlUn19s604SgAcRuJRB1vDnWwzZMYCLUcmKxko9wDn6iLgGEIpTNgZbIQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/types@4.15.1:
+    resolution: {integrity: sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@sqltools/formatter@1.2.5:
+    resolution: {integrity: sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==}
+    dev: false
+
   /@stablelib/base64@1.0.1:
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
@@ -4951,6 +5505,23 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+    dev: false
+
+  /@surrealdb/cbor@2.0.0-alpha.4:
+    resolution: {integrity: sha512-l/hNZ3ZCOJq8rzwx1y5ZV/8b2bYCWdhGqRVY33Pu50NAHyAW5qLsMn3ZBkZow77mAKwNCsbDsRGnyYEuU95mjw==}
+    engines: {node: '>=18.0.0'}
+    dev: false
+
+  /@surrealdb/sqon@0.1.0(tslib@2.8.1)(typescript@5.9.3):
+    resolution: {integrity: sha512-pooKLZ0W6mN8XHzJQavGOdfZOZksycmIjhwFwvG0kdCAt4I5U6KKPHcXQwFkTDNKFKFKdufczLRnzHapPIslQw==}
+    peerDependencies:
+      tslib: ^2.6.3
+      typescript: ^5.0.0
+    dependencies:
+      '@surrealdb/cbor': 2.0.0-alpha.4
+      tslib: 2.8.1
+      typescript: 5.9.3
+      uuidv7: 1.2.1
     dev: false
 
   /@swc/counter@0.1.3:
@@ -5141,8 +5712,8 @@ packages:
       vue: 3.5.22(typescript@5.9.3)
     dev: false
 
-  /@tybys/wasm-util@0.10.2:
-    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+  /@tybys/wasm-util@0.10.3:
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
     requiresBuild: true
     dependencies:
       tslib: 2.8.1
@@ -5285,6 +5856,10 @@ packages:
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
     dev: false
 
+  /@types/validator@13.15.10:
+    resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
+    dev: false
+
   /@types/web-bluetooth@0.0.20:
     resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==}
     dev: false
@@ -5295,6 +5870,12 @@ packages:
 
   /@types/webidl-conversions@7.0.3:
     resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
+    dev: false
+
+  /@types/whatwg-url@11.0.5:
+    resolution: {integrity: sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==}
+    dependencies:
+      '@types/webidl-conversions': 7.0.3
     dev: false
 
   /@types/whatwg-url@13.0.0:
@@ -5748,6 +6329,15 @@ packages:
     engines: {node: '>=20.15.0'}
     dev: false
 
+  /@xata.io/client@0.30.1(typescript@5.9.3):
+    resolution: {integrity: sha512-dAzDPHmIfenVIpF39m1elmW5ngjWu2mO8ZqJBN7dmYdXr98uhPANfLdVZnc3mUNG+NH37LqY1dSO862hIo2oRw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      typescript: '>=4.5'
+    dependencies:
+      typescript: 5.9.3
+    dev: false
+
   /@xtuc/ieee754@1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -5859,19 +6449,16 @@ packages:
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
-    dev: true
 
   /ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
-    dev: true
 
   /ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
@@ -5881,7 +6468,6 @@ packages:
   /ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
-    dev: true
 
   /ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
@@ -5897,7 +6483,11 @@ packages:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
-    dev: true
+
+  /app-root-path@3.1.0:
+    resolution: {integrity: sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==}
+    engines: {node: '>= 6.0.0'}
+    dev: false
 
   /arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
@@ -5995,13 +6585,19 @@ packages:
       zod: 4.3.6
     dev: false
 
+  /available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      possible-typed-array-names: 1.1.0
+    dev: false
+
   /bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
     dev: false
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-    dev: true
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -6346,6 +6942,10 @@ packages:
       readable-stream: 3.6.2
     dev: false
 
+  /bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+    dev: false
+
   /brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
     dependencies:
@@ -6357,7 +6957,6 @@ packages:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
     dependencies:
       balanced-match: 1.0.2
-    dev: true
 
   /braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -6376,6 +6975,11 @@ packages:
       node-releases: 2.0.23
       update-browserslist-db: 1.1.3(browserslist@4.26.3)
 
+  /bson@6.10.4:
+    resolution: {integrity: sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==}
+    engines: {node: '>=16.20.1'}
+    dev: false
+
   /bson@7.2.0:
     resolution: {integrity: sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==}
     engines: {node: '>=20.19.0'}
@@ -6386,6 +6990,13 @@ packages:
 
   /buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    dev: false
+
+  /buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
@@ -6474,7 +7085,24 @@ packages:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
-    dev: true
+
+  /call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+    dev: false
+
+  /call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+    dev: false
 
   /camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
@@ -6549,6 +7177,13 @@ packages:
     dependencies:
       readdirp: 4.1.2
 
+  /chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+    dependencies:
+      readdirp: 5.0.0
+    dev: false
+
   /chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
     dev: false
@@ -6570,6 +7205,15 @@ packages:
   /client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
     dev: true
+
+  /cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+    dev: false
 
   /clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -6593,11 +7237,9 @@ packages:
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
-    dev: true
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-    dev: true
 
   /combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -6646,6 +7288,10 @@ packages:
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  /cookie-es@1.2.3:
+    resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
+    dev: false
+
   /cookie-es@2.0.0:
     resolution: {integrity: sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==}
     dev: false
@@ -6666,7 +7312,12 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-    dev: true
+
+  /crossws@0.3.5:
+    resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
+    dependencies:
+      uncrypto: 0.1.3
+    dev: false
 
   /crossws@0.4.1(srvx@0.8.16):
     resolution: {integrity: sha512-E7WKBcHVhAVrY6JYD5kteNqVq1GSZxqGrdSiwXR9at+XHi43HJoCQKXcCczR5LBnBquFZPsB3o7HklulKoBU5w==}
@@ -6716,7 +7367,11 @@ packages:
       whatwg-url: 14.2.0
     dev: true
 
-  /db0@0.3.4:
+  /dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
+    dev: false
+
+  /db0@0.3.4(drizzle-orm@0.45.2):
     resolution: {integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==}
     peerDependencies:
       '@electric-sql/pglite': '*'
@@ -6738,6 +7393,8 @@ packages:
         optional: true
       sqlite3:
         optional: true
+    dependencies:
+      drizzle-orm: 0.45.2(@prisma/client@6.7.0)(@types/better-sqlite3@7.6.13)(@xata.io/client@0.30.1)(kysely@0.28.17)(pg@8.20.0)
     dev: false
 
   /debug@4.4.3(supports-color@10.2.2):
@@ -6774,6 +7431,15 @@ packages:
       mimic-response: 3.1.0
     dev: false
 
+  /dedent@1.7.2:
+    resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+    dev: false
+
   /deep-eql@4.1.4:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
     engines: {node: '>=6'}
@@ -6795,8 +7461,21 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+    dev: false
+
   /defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  /defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+    dev: false
 
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -6884,6 +7563,11 @@ packages:
   /dotenv@17.2.3:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
     engines: {node: '>=12'}
+    dev: false
+
+  /dottie@2.0.7:
+    resolution: {integrity: sha512-7lAK2A0b3zZr3UC5aE69CPdCFR4RHW1o2Dr74TqFykxkUCBXSRJum/yPc7g8zRHJqWKomPLHwFLLoUnn8PXXRg==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     dev: false
 
   /drizzle-kit@0.31.10:
@@ -6992,6 +7676,105 @@ packages:
       kysely: 0.28.12
     dev: false
 
+  /drizzle-orm@0.45.2(@prisma/client@6.7.0)(@types/better-sqlite3@7.6.13)(@xata.io/client@0.30.1)(kysely@0.28.17)(pg@8.20.0):
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+    dependencies:
+      '@prisma/client': 6.7.0(prisma@6.7.0)(typescript@5.9.3)
+      '@types/better-sqlite3': 7.6.13
+      '@xata.io/client': 0.30.1(typescript@5.9.3)
+      kysely: 0.28.17
+      pg: 8.20.0
+    dev: false
+
   /dts-resolver@2.1.2:
     resolution: {integrity: sha512-xeXHBQkn2ISSXxbJWD828PFjtyg+/UrMDo7W4Ffcs7+YWCquxU8YjV1KoxuiL+eJ5pg3ll+bC6flVv61L3LKZg==}
     engines: {node: '>=20.18.0'}
@@ -7009,11 +7792,9 @@ packages:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
-    dev: true
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-    dev: true
 
   /effect@3.18.4:
     resolution: {integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==}
@@ -7026,11 +7807,9 @@ packages:
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-    dev: true
 
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-    dev: true
 
   /empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
@@ -7077,12 +7856,10 @@ packages:
   /es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -7096,7 +7873,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       es-errors: 1.3.0
-    dev: true
 
   /es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
@@ -7445,13 +8221,19 @@ packages:
       tabbable: 6.2.0
     dev: false
 
+  /for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      is-callable: 1.2.7
+    dev: false
+
   /foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
-    dev: true
 
   /form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
@@ -7511,7 +8293,6 @@ packages:
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-    dev: true
 
   /fuse.js@7.1.0:
     resolution: {integrity: sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==}
@@ -7529,6 +8310,11 @@ packages:
   /gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  /get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+    dev: false
 
   /get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
@@ -7548,7 +8334,6 @@ packages:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
-    dev: true
 
   /get-own-enumerable-keys@1.0.0:
     resolution: {integrity: sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==}
@@ -7561,7 +8346,6 @@ packages:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
-    dev: true
 
   /get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
@@ -7620,6 +8404,19 @@ packages:
       path-scurry: 1.11.1
     dev: true
 
+  /glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+    dev: false
+
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -7647,10 +8444,23 @@ packages:
   /gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  /h3@1.15.11:
+    resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
+    dependencies:
+      cookie-es: 1.2.3
+      crossws: 0.3.5
+      defu: 6.1.7
+      destr: 2.0.5
+      iron-webcrypto: 1.2.1
+      node-mock-http: 1.0.4
+      radix3: 1.1.2
+      ufo: 1.6.4
+      uncrypto: 0.1.3
+    dev: false
 
   /h3@2.0.1-rc.2(crossws@0.4.1):
     resolution: {integrity: sha512-2vS7OETzPDzGQxmmcs6ttu7p0NW25zAdkPXYOr43dn4GZf81uUljJvupa158mcpUGpsQUqIy4O4THWUQT1yVeA==}
@@ -7685,24 +8495,27 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  /has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+    dependencies:
+      es-define-property: 1.0.1
+    dev: false
+
   /has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.1.0
-    dev: true
 
   /hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2
-    dev: true
 
   /hast-util-embedded@3.0.0:
     resolution: {integrity: sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==}
@@ -7983,6 +8796,11 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
+  /inflection@1.13.4:
+    resolution: {integrity: sha512-6I/HUDeYFfuNCVS3td055BaXBwKYuzw7K3ExVMStBowKo9oOAMJIXIHvdyR3iboTCp1b+1i5DSkIZTcwIktuDw==}
+    engines: {'0': node >= 0.4.0}
+    dev: false
+
   /inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -7998,6 +8816,10 @@ packages:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
     dev: false
 
+  /iron-webcrypto@1.2.1:
+    resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
+    dev: false
+
   /is-absolute-url@4.0.1:
     resolution: {integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -8009,6 +8831,11 @@ packages:
     dependencies:
       binary-extensions: 2.3.0
     dev: true
+
+  /is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+    dev: false
 
   /is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -8024,7 +8851,6 @@ packages:
   /is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
-    dev: true
 
   /is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -8073,14 +8899,24 @@ packages:
       better-path-resolve: 1.0.0
     dev: true
 
+  /is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      which-typed-array: 1.1.22
+    dev: false
+
   /is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+    dev: false
+
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-    dev: true
 
   /istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -8121,7 +8957,6 @@ packages:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
-    dev: true
 
   /jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
@@ -8256,12 +9091,22 @@ packages:
     resolution: {integrity: sha512-silMIRiFjUWlfaDhkgSzpuAyQ6EX/o09Eu8ZBfmFwQMbax7+LQzeIU2CBrICT6Ne4l86ITCGvUCBpCubWYy0Yw==}
     dev: false
 
+  /kareem@2.6.3:
+    resolution: {integrity: sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==}
+    engines: {node: '>=12.0.0'}
+    dev: false
+
   /kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
 
   /kysely@0.28.12:
     resolution: {integrity: sha512-kWiueDWXhbCchgiotwXkwdxZE/6h56IHAeFWg4euUfW0YsmO9sxbAxzx1KLLv2lox15EfuuxHQvgJ1qIfZuHGw==}
+    engines: {node: '>=20.0.0'}
+    dev: false
+
+  /kysely@0.28.17:
+    resolution: {integrity: sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==}
     engines: {node: '>=20.0.0'}
     dev: false
 
@@ -8429,6 +9274,10 @@ packages:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
     dev: true
 
+  /lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+    dev: false
+
   /longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
     dev: false
@@ -8456,7 +9305,11 @@ packages:
 
   /lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-    dev: true
+
+  /lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+    dev: false
 
   /lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -8501,7 +9354,6 @@ packages:
   /math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
@@ -8941,7 +9793,6 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.2
-    dev: true
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -8950,7 +9801,6 @@ packages:
   /minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
-    dev: true
 
   /mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
@@ -8965,12 +9815,99 @@ packages:
       ufo: 1.6.1
     dev: true
 
+  /mnemonist@0.38.3:
+    resolution: {integrity: sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==}
+    dependencies:
+      obliterator: 1.6.1
+    dev: false
+
+  /moment-timezone@0.5.48:
+    resolution: {integrity: sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==}
+    dependencies:
+      moment: 2.30.1
+    dev: false
+
+  /moment@2.30.1:
+    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
+    dev: false
+
+  /mongodb-connection-string-url@3.0.2:
+    resolution: {integrity: sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==}
+    dependencies:
+      '@types/whatwg-url': 11.0.5
+      whatwg-url: 14.2.0
+    dev: false
+
   /mongodb-connection-string-url@7.0.1:
     resolution: {integrity: sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==}
     engines: {node: '>=20.19.0'}
     dependencies:
       '@types/whatwg-url': 13.0.0
       whatwg-url: 14.2.0
+    dev: false
+
+  /mongodb@6.20.0:
+    resolution: {integrity: sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==}
+    engines: {node: '>=16.20.1'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.188.0
+      '@mongodb-js/zstd': ^1.1.0 || ^2.0.0
+      gcp-metadata: ^5.2.0
+      kerberos: ^2.0.1
+      mongodb-client-encryption: '>=6.0.0 <7'
+      snappy: ^7.3.2
+      socks: ^2.7.1
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
+      socks:
+        optional: true
+    dependencies:
+      '@mongodb-js/saslprep': 1.4.6
+      bson: 6.10.4
+      mongodb-connection-string-url: 3.0.2
+    dev: false
+
+  /mongodb@6.21.0:
+    resolution: {integrity: sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==}
+    engines: {node: '>=16.20.1'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.188.0
+      '@mongodb-js/zstd': ^1.1.0 || ^2.0.0
+      gcp-metadata: ^5.2.0
+      kerberos: ^2.0.1
+      mongodb-client-encryption: '>=6.0.0 <7'
+      snappy: ^7.3.2
+      socks: ^2.7.1
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
+      socks:
+        optional: true
+    dependencies:
+      '@mongodb-js/saslprep': 1.4.6
+      bson: 6.10.4
+      mongodb-connection-string-url: 3.0.2
     dev: false
 
   /mongodb@7.1.0:
@@ -9003,6 +9940,42 @@ packages:
       '@mongodb-js/saslprep': 1.4.6
       bson: 7.2.0
       mongodb-connection-string-url: 7.0.1
+    dev: false
+
+  /mongoose@8.24.1(supports-color@10.2.2):
+    resolution: {integrity: sha512-UpHBA0l5kHyKJQFjmBaFYQFo5sgz1DK0TRqDkOyBLYbqiIbKKhIvBpHWBXqeo0rgW4kGI1UhhAw+kTQZoj1BdA==}
+    engines: {node: '>=16.20.1'}
+    dependencies:
+      bson: 6.10.4
+      kareem: 2.6.3
+      mongodb: 6.20.0
+      mpath: 0.9.0
+      mquery: 5.0.0(supports-color@10.2.2)
+      ms: 2.1.3
+      sift: 17.1.3
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - snappy
+      - socks
+      - supports-color
+    dev: false
+
+  /mpath@0.9.0:
+    resolution: {integrity: sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==}
+    engines: {node: '>=4.0.0'}
+    dev: false
+
+  /mquery@5.0.0(supports-color@10.2.2):
+    resolution: {integrity: sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /mri@1.2.0:
@@ -9118,7 +10091,7 @@ packages:
       consola: 3.4.2
       cookie-es: 2.0.0
       crossws: 0.4.1(srvx@0.8.16)
-      db0: 0.3.4
+      db0: 0.3.4(drizzle-orm@0.45.2)
       esbuild: 0.25.12
       fetchdts: 0.1.7
       h3: 2.0.1-rc.2(crossws@0.4.1)
@@ -9162,7 +10135,7 @@ packages:
       - uploadthing
     dev: false
 
-  /nitro@3.0.1-alpha.0(rolldown@1.1.2)(vite@6.4.1):
+  /nitro@3.0.1-alpha.0(drizzle-orm@0.45.2)(mongodb@6.21.0)(vite@5.4.20):
     resolution: {integrity: sha512-lR3RplfXBOZXNlFQf9AJkqFVFhg5/CNbpBijM0dSYhGymb+FthJSdL6crmXVg518h2NVOd40rehhGZaf9ijW9w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
@@ -9181,7 +10154,7 @@ packages:
       consola: 3.4.2
       cookie-es: 2.0.0
       crossws: 0.4.1(srvx@0.8.16)
-      db0: 0.3.4
+      db0: 0.3.4(drizzle-orm@0.45.2)
       esbuild: 0.25.12
       fetchdts: 0.1.7
       h3: 2.0.1-rc.2(crossws@0.4.1)
@@ -9190,77 +10163,77 @@ packages:
       ofetch: 1.5.1
       ohash: 2.0.11
       rendu: 0.0.6
-      rolldown: 1.1.2
+      rollup: 4.52.4
+      srvx: 0.8.16
+      undici: 7.16.0
+      unenv: 2.0.0-rc.21
+      unstorage: 2.0.0-alpha.3(db0@0.3.4)(mongodb@6.21.0)(ofetch@1.5.1)
+      vite: 5.4.20(@types/node@20.19.21)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - better-sqlite3
+      - chokidar
+      - drizzle-orm
+      - idb-keyval
+      - ioredis
+      - lru-cache
+      - mongodb
+      - mysql2
+      - sqlite3
+      - uploadthing
+    dev: false
+
+  /nitro@3.0.1-alpha.0(rolldown@1.1.4)(vite@6.4.1):
+    resolution: {integrity: sha512-lR3RplfXBOZXNlFQf9AJkqFVFhg5/CNbpBijM0dSYhGymb+FthJSdL6crmXVg518h2NVOd40rehhGZaf9ijW9w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      rolldown: '*'
+      vite: ^7
+      xml2js: ^0.6.2
+    peerDependenciesMeta:
+      rolldown:
+        optional: true
+      vite:
+        optional: true
+      xml2js:
+        optional: true
+    dependencies:
+      consola: 3.4.2
+      cookie-es: 2.0.0
+      crossws: 0.4.1(srvx@0.8.16)
+      db0: 0.3.4(drizzle-orm@0.45.2)
+      esbuild: 0.25.12
+      fetchdts: 0.1.7
+      h3: 2.0.1-rc.2(crossws@0.4.1)
+      jiti: 2.6.1
+      nf3: 0.1.5
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      rendu: 0.0.6
+      rolldown: 1.1.4
       rollup: 4.52.4
       srvx: 0.8.16
       undici: 7.16.0
       unenv: 2.0.0-rc.21
       unstorage: 2.0.0-alpha.3(db0@0.3.4)(ofetch@1.5.1)
       vite: 6.4.1(@types/node@20.19.21)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - better-sqlite3
-      - chokidar
-      - drizzle-orm
-      - idb-keyval
-      - ioredis
-      - lru-cache
-      - mongodb
-      - mysql2
-      - sqlite3
-      - uploadthing
-    dev: false
-
-  /nitro@3.0.1-alpha.0(vite@5.4.20):
-    resolution: {integrity: sha512-lR3RplfXBOZXNlFQf9AJkqFVFhg5/CNbpBijM0dSYhGymb+FthJSdL6crmXVg518h2NVOd40rehhGZaf9ijW9w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      rolldown: '*'
-      vite: ^7
-      xml2js: ^0.6.2
-    peerDependenciesMeta:
-      rolldown:
-        optional: true
-      vite:
-        optional: true
-      xml2js:
-        optional: true
-    dependencies:
-      consola: 3.4.2
-      cookie-es: 2.0.0
-      crossws: 0.4.1(srvx@0.8.16)
-      db0: 0.3.4
-      esbuild: 0.25.12
-      fetchdts: 0.1.7
-      h3: 2.0.1-rc.2(crossws@0.4.1)
-      jiti: 2.6.1
-      nf3: 0.1.5
-      ofetch: 1.5.1
-      ohash: 2.0.11
-      rendu: 0.0.6
-      rollup: 4.52.4
-      srvx: 0.8.16
-      undici: 7.16.0
-      unenv: 2.0.0-rc.21
-      unstorage: 2.0.0-alpha.3(db0@0.3.4)(ofetch@1.5.1)
-      vite: 5.4.20(@types/node@20.19.21)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9301,13 +10274,16 @@ packages:
   /node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
+  /node-mock-http@1.0.4:
+    resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
+    dev: false
+
   /node-releases@2.0.23:
     resolution: {integrity: sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==}
 
   /normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /normalize-range@0.1.2:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
@@ -9345,6 +10321,10 @@ packages:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
     dev: true
+
+  /obliterator@1.6.1:
+    resolution: {integrity: sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==}
+    dev: false
 
   /ofetch@1.5.1:
     resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
@@ -9450,7 +10430,6 @@ packages:
 
   /package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
-    dev: true
 
   /package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
@@ -9496,7 +10475,6 @@ packages:
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-    dev: true
 
   /path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
@@ -9513,7 +10491,6 @@ packages:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
-    dev: true
 
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -9668,6 +10645,11 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
+
+  /possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
+    dev: false
 
   /postal-mime@2.7.4:
     resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
@@ -9951,6 +10933,10 @@ packages:
       - '@vue/composition-api'
     dev: false
 
+  /radix3@1.1.2:
+    resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
+    dev: false
+
   /randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
     dependencies:
@@ -10076,6 +11062,11 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  /readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
+    dev: false
+
   /reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
     dev: false
@@ -10179,6 +11170,11 @@ packages:
       srvx: 0.8.16
     dev: false
 
+  /require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -10215,11 +11211,15 @@ packages:
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
 
+  /retry-as-promised@7.1.1:
+    resolution: {integrity: sha512-hMD7odLOt3LkTjcif8aRZqi/hybjpLNgSk5oF5FCowfCjok6LukpN2bDX7R5wDmbgBQFn7YoBxSagmtXHaJYJw==}
+    dev: false
+
   /reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  /rolldown-plugin-dts@0.16.11(rolldown@1.1.2)(supports-color@10.2.2)(typescript@5.9.3):
+  /rolldown-plugin-dts@0.16.11(rolldown@1.1.4)(supports-color@10.2.2)(typescript@5.9.3):
     resolution: {integrity: sha512-9IQDaPvPqTx3RjG2eQCK5GYZITo203BxKunGI80AGYicu1ySFTUyugicAaTZWRzFWh9DSnzkgNeMNbDWBbSs0w==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
@@ -10247,36 +11247,36 @@ packages:
       dts-resolver: 2.1.2
       get-tsconfig: 4.12.0
       magic-string: 0.30.19
-      rolldown: 1.1.2
+      rolldown: 1.1.4
       typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver
       - supports-color
     dev: true
 
-  /rolldown@1.1.2:
-    resolution: {integrity: sha512-x0CrQQqCXWGeI8dTvFfN/Dnv3yMKT9hv5jFjlOreKAx9wqLq9wz7VvLLHyaAXC90/CpggTu9SisSbsJJTPSjNQ==}
+  /rolldown@1.1.4:
+    resolution: {integrity: sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     dependencies:
-      '@oxc-project/types': 0.137.0
+      '@oxc-project/types': 0.138.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.1.2
-      '@rolldown/binding-darwin-arm64': 1.1.2
-      '@rolldown/binding-darwin-x64': 1.1.2
-      '@rolldown/binding-freebsd-x64': 1.1.2
-      '@rolldown/binding-linux-arm-gnueabihf': 1.1.2
-      '@rolldown/binding-linux-arm64-gnu': 1.1.2
-      '@rolldown/binding-linux-arm64-musl': 1.1.2
-      '@rolldown/binding-linux-ppc64-gnu': 1.1.2
-      '@rolldown/binding-linux-s390x-gnu': 1.1.2
-      '@rolldown/binding-linux-x64-gnu': 1.1.2
-      '@rolldown/binding-linux-x64-musl': 1.1.2
-      '@rolldown/binding-openharmony-arm64': 1.1.2
-      '@rolldown/binding-wasm32-wasi': 1.1.2
-      '@rolldown/binding-win32-arm64-msvc': 1.1.2
-      '@rolldown/binding-win32-x64-msvc': 1.1.2
+      '@rolldown/binding-android-arm64': 1.1.4
+      '@rolldown/binding-darwin-arm64': 1.1.4
+      '@rolldown/binding-darwin-x64': 1.1.4
+      '@rolldown/binding-freebsd-x64': 1.1.4
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.4
+      '@rolldown/binding-linux-arm64-gnu': 1.1.4
+      '@rolldown/binding-linux-arm64-musl': 1.1.4
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.4
+      '@rolldown/binding-linux-s390x-gnu': 1.1.4
+      '@rolldown/binding-linux-x64-gnu': 1.1.4
+      '@rolldown/binding-linux-x64-musl': 1.1.4
+      '@rolldown/binding-openharmony-arm64': 1.1.4
+      '@rolldown/binding-wasm32-wasi': 1.1.4
+      '@rolldown/binding-win32-arm64-msvc': 1.1.4
+      '@rolldown/binding-win32-x64-msvc': 1.1.4
 
   /rollup@4.52.4:
     resolution: {integrity: sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==}
@@ -10388,6 +11388,65 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  /sequelize-pool@7.1.0:
+    resolution: {integrity: sha512-G9c0qlIWQSK29pR/5U2JF5dDQeqqHRragoyahj/Nx4KOOQ3CPPfzxnfqFPCSB7x5UgjOgnZ61nSxz+fjDpRlJg==}
+    engines: {node: '>= 10.0.0'}
+    dev: false
+
+  /sequelize@6.37.8(pg@8.20.0)(supports-color@10.2.2):
+    resolution: {integrity: sha512-HJ0IQFqcTsTiqbEgiuioYFMSD00TP6Cz7zoTti+zVVBwVe9fEhev9cH6WnM3XU31+ABS356durAb99ZuOthnKw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      ibm_db: '*'
+      mariadb: '*'
+      mysql2: '*'
+      oracledb: '*'
+      pg: '*'
+      pg-hstore: '*'
+      snowflake-sdk: '*'
+      sqlite3: '*'
+      tedious: '*'
+    peerDependenciesMeta:
+      ibm_db:
+        optional: true
+      mariadb:
+        optional: true
+      mysql2:
+        optional: true
+      oracledb:
+        optional: true
+      pg:
+        optional: true
+      pg-hstore:
+        optional: true
+      snowflake-sdk:
+        optional: true
+      sqlite3:
+        optional: true
+      tedious:
+        optional: true
+    dependencies:
+      '@types/debug': 4.1.12
+      '@types/validator': 13.15.10
+      debug: 4.4.3(supports-color@10.2.2)
+      dottie: 2.0.7
+      inflection: 1.13.4
+      lodash: 4.18.1
+      moment: 2.30.1
+      moment-timezone: 0.5.48
+      pg: 8.20.0
+      pg-connection-string: 2.12.0
+      retry-as-promised: 7.1.1
+      semver: 7.7.3
+      sequelize-pool: 7.1.0
+      toposort-class: 1.0.1
+      uuid: 8.3.2
+      validator: 13.15.35
+      wkx: 0.5.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
     dependencies:
@@ -10399,6 +11458,28 @@ packages:
 
   /set-cookie-parser@3.0.1:
     resolution: {integrity: sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==}
+    dev: false
+
+  /set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+    dev: false
+
+  /sha.js@2.4.12:
+    resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
+    engines: {node: '>= 0.10'}
+    hasBin: true
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+      to-buffer: 1.2.2
     dev: false
 
   /sharp@0.34.5:
@@ -10442,16 +11523,18 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       shebang-regex: 3.0.0
-    dev: true
 
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-    dev: true
 
   /shell-quote@1.8.3:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
+    dev: false
+
+  /sift@17.1.3:
+    resolution: {integrity: sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==}
     dev: false
 
   /siginfo@2.0.0:
@@ -10461,7 +11544,6 @@ packages:
   /signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
-    dev: true
 
   /simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
@@ -10547,6 +11629,11 @@ packages:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
     dev: true
 
+  /sql-highlight@6.1.0:
+    resolution: {integrity: sha512-ed7OK4e9ywpE7pgRMkMQmZDPKSVdm0oX5IEtZiKnFucSF0zu6c80GZBe38UqHuVhTWJ9xsKgSMjCG2bml86KvA==}
+    engines: {node: '>=14'}
+    dev: false
+
   /srvx@0.10.1:
     resolution: {integrity: sha512-A//xtfak4eESMWWydSRFUVvCTQbSwivnGCEf8YGPe2eHU0+Z6znfUTCPF0a7oV3sObSOcrXHlL6Bs9vVctfXdg==}
     engines: {node: '>=20.16.0'}
@@ -10585,7 +11672,6 @@ packages:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-    dev: true
 
   /string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
@@ -10594,7 +11680,6 @@ packages:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.2
-    dev: true
 
   /string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -10623,14 +11708,12 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       ansi-regex: 5.0.1
-    dev: true
 
   /strip-ansi@7.1.2:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
     dependencies:
       ansi-regex: 6.2.2
-    dev: true
 
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -10727,6 +11810,17 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
     dev: true
+
+  /surrealdb@2.0.4(tslib@2.8.1)(typescript@5.9.3):
+    resolution: {integrity: sha512-tCmMzcsLB/CVDZtxsj/xOWY6NWy9MrX2abMuwnVpAI5xj7kvnq9noRtc1nhjuDihei/Njfkxe/NYMxy7ZLLl4g==}
+    peerDependencies:
+      tslib: ^2.6.3
+      typescript: ^5.0.0 || ^6.0.0
+    dependencies:
+      '@surrealdb/sqon': 0.1.0(tslib@2.8.1)(typescript@5.9.3)
+      tslib: 2.8.1
+      typescript: 5.9.3
+    dev: false
 
   /svix@1.88.0:
     resolution: {integrity: sha512-vm/JrrUd3bVyBE+3L33TIyVSs8gS5fYx7lrISvKlDJXTYX1ACH4REX8P1tHxsSKoZi/rvifM1t0XRc5Vc45THw==}
@@ -10940,11 +12034,24 @@ packages:
       tldts-core: 6.1.86
     dev: true
 
+  /to-buffer@1.2.2:
+    resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      isarray: 2.0.5
+      safe-buffer: 5.2.1
+      typed-array-buffer: 1.0.3
+    dev: false
+
   /to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
+
+  /toposort-class@1.0.1:
+    resolution: {integrity: sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg==}
+    dev: false
 
   /totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -11015,8 +12122,8 @@ packages:
       diff: 8.0.2
       empathic: 2.0.0
       hookable: 5.5.3
-      rolldown: 1.1.2
-      rolldown-plugin-dts: 0.16.11(rolldown@1.1.2)(supports-color@10.2.2)(typescript@5.9.3)
+      rolldown: 1.1.4
+      rolldown-plugin-dts: 0.16.11(rolldown@1.1.4)(supports-color@10.2.2)(typescript@5.9.3)
       semver: 7.7.3
       tinyexec: 1.0.1
       tinyglobby: 0.2.15
@@ -11181,6 +12288,92 @@ packages:
       tagged-tag: 1.0.0
     dev: false
 
+  /typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
+    dev: false
+
+  /typeorm@0.3.30(mongodb@6.21.0)(pg@8.20.0)(supports-color@10.2.2):
+    resolution: {integrity: sha512-8T35PzjefOdqc2ZR9mwLQj0pUGp6lQhMbK2EvVMwJVJWlaoHm0v/Q6dThNOZkFchD+0yMg8gwjKM28ePiLSXSQ==}
+    engines: {node: '>=16.13.0'}
+    hasBin: true
+    peerDependencies:
+      '@google-cloud/spanner': ^5.18.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      '@sap/hana-client': ^2.14.22
+      better-sqlite3: ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0
+      ioredis: ^5.0.4
+      mongodb: ^5.8.0 || ^6.0.0
+      mssql: ^9.1.1 || ^10.0.0 || ^11.0.0 || ^12.0.0
+      mysql2: ^2.2.5 || ^3.0.1
+      oracledb: ^6.3.0
+      pg: ^8.5.1
+      pg-native: ^3.0.0
+      pg-query-stream: ^4.0.0
+      redis: ^3.1.1 || ^4.0.0 || ^5.0.14
+      sql.js: ^1.4.0
+      sqlite3: ^5.0.3
+      ts-node: ^10.7.0
+      typeorm-aurora-data-api-driver: ^2.0.0 || ^3.0.0
+    peerDependenciesMeta:
+      '@google-cloud/spanner':
+        optional: true
+      '@sap/hana-client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      ioredis:
+        optional: true
+      mongodb:
+        optional: true
+      mssql:
+        optional: true
+      mysql2:
+        optional: true
+      oracledb:
+        optional: true
+      pg:
+        optional: true
+      pg-native:
+        optional: true
+      pg-query-stream:
+        optional: true
+      redis:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+      ts-node:
+        optional: true
+      typeorm-aurora-data-api-driver:
+        optional: true
+    dependencies:
+      '@sqltools/formatter': 1.2.5
+      ansis: 4.2.0
+      app-root-path: 3.1.0
+      buffer: 6.0.3
+      dayjs: 1.11.21
+      debug: 4.4.3(supports-color@10.2.2)
+      dedent: 1.7.2
+      dotenv: 16.6.1
+      glob: 10.5.0
+      mongodb: 6.21.0
+      pg: 8.20.0
+      reflect-metadata: 0.2.2
+      sha.js: 2.4.12
+      sql-highlight: 6.1.0
+      tslib: 2.8.1
+      uuid: 11.1.1
+      yargs: 17.7.3
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+    dev: false
+
   /typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -11188,6 +12381,10 @@ packages:
 
   /ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
+
+  /ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+    dev: false
 
   /unconfig@7.3.3:
     resolution: {integrity: sha512-QCkQoOnJF8L107gxfHL0uavn7WD9b3dpBcFX6HtfQYmjw2YzWxGuFQ0N0J6tE9oguCBJn9KOvfqYDCMPHIZrBA==}
@@ -11286,6 +12483,158 @@ packages:
     engines: {node: '>= 4.0.0'}
     dev: true
 
+  /unstorage@1.17.5(db0@0.3.4):
+    resolution: {integrity: sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==}
+    peerDependencies:
+      '@azure/app-configuration': ^1.8.0
+      '@azure/cosmos': ^4.2.0
+      '@azure/data-tables': ^13.3.0
+      '@azure/identity': ^4.6.0
+      '@azure/keyvault-secrets': ^4.9.0
+      '@azure/storage-blob': ^12.26.0
+      '@capacitor/preferences': ^6 || ^7 || ^8
+      '@deno/kv': '>=0.9.0'
+      '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
+      '@planetscale/database': ^1.19.0
+      '@upstash/redis': ^1.34.3
+      '@vercel/blob': '>=0.27.1'
+      '@vercel/functions': ^2.2.12 || ^3.0.0
+      '@vercel/kv': ^1 || ^2 || ^3
+      aws4fetch: ^1.0.20
+      db0: '>=0.2.1'
+      idb-keyval: ^6.2.1
+      ioredis: ^5.4.2
+      uploadthing: ^7.4.4
+    peerDependenciesMeta:
+      '@azure/app-configuration':
+        optional: true
+      '@azure/cosmos':
+        optional: true
+      '@azure/data-tables':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/keyvault-secrets':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@capacitor/preferences':
+        optional: true
+      '@deno/kv':
+        optional: true
+      '@netlify/blobs':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      '@vercel/functions':
+        optional: true
+      '@vercel/kv':
+        optional: true
+      aws4fetch:
+        optional: true
+      db0:
+        optional: true
+      idb-keyval:
+        optional: true
+      ioredis:
+        optional: true
+      uploadthing:
+        optional: true
+    dependencies:
+      anymatch: 3.1.3
+      chokidar: 5.0.0
+      db0: 0.3.4(drizzle-orm@0.45.2)
+      destr: 2.0.5
+      h3: 1.15.11
+      lru-cache: 11.5.1
+      node-fetch-native: 1.6.7
+      ofetch: 1.5.1
+      ufo: 1.6.4
+    dev: false
+
+  /unstorage@2.0.0-alpha.3(db0@0.3.4)(mongodb@6.21.0)(ofetch@1.5.1):
+    resolution: {integrity: sha512-BeoqISVh8jxqnPseHH7/92twe2VkQztrudXg8RFZVbXb4ckkFdpLk1LnNvsUndDltyodBMVxgI6V7JcbJYt2VQ==}
+    peerDependencies:
+      '@azure/app-configuration': ^1.8.0
+      '@azure/cosmos': ^4.2.0
+      '@azure/data-tables': ^13.3.0
+      '@azure/identity': ^4.6.0
+      '@azure/keyvault-secrets': ^4.9.0
+      '@azure/storage-blob': ^12.26.0
+      '@capacitor/preferences': ^6.0.3 || ^7.0.0
+      '@deno/kv': '>=0.9.0'
+      '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
+      '@planetscale/database': ^1.19.0
+      '@upstash/redis': ^1.34.3
+      '@vercel/blob': '>=0.27.1'
+      '@vercel/functions': ^2.2.12 || ^3.0.0
+      '@vercel/kv': ^1.0.1
+      aws4fetch: ^1.0.20
+      chokidar: ^4.0.3
+      db0: '>=0.2.1'
+      idb-keyval: ^6.2.1
+      ioredis: ^5.4.2
+      lru-cache: ^11.2.2
+      mongodb: ^6.20.0
+      ofetch: ^1.4.1
+      uploadthing: ^7.4.4
+    peerDependenciesMeta:
+      '@azure/app-configuration':
+        optional: true
+      '@azure/cosmos':
+        optional: true
+      '@azure/data-tables':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/keyvault-secrets':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@capacitor/preferences':
+        optional: true
+      '@deno/kv':
+        optional: true
+      '@netlify/blobs':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      '@vercel/functions':
+        optional: true
+      '@vercel/kv':
+        optional: true
+      aws4fetch:
+        optional: true
+      chokidar:
+        optional: true
+      db0:
+        optional: true
+      idb-keyval:
+        optional: true
+      ioredis:
+        optional: true
+      lru-cache:
+        optional: true
+      mongodb:
+        optional: true
+      ofetch:
+        optional: true
+      uploadthing:
+        optional: true
+    dependencies:
+      db0: 0.3.4(drizzle-orm@0.45.2)
+      mongodb: 6.21.0
+      ofetch: 1.5.1
+    dev: false
+
   /unstorage@2.0.0-alpha.3(db0@0.3.4)(ofetch@1.5.1):
     resolution: {integrity: sha512-BeoqISVh8jxqnPseHH7/92twe2VkQztrudXg8RFZVbXb4ckkFdpLk1LnNvsUndDltyodBMVxgI6V7JcbJYt2VQ==}
     peerDependencies:
@@ -11360,7 +12709,7 @@ packages:
       uploadthing:
         optional: true
     dependencies:
-      db0: 0.3.4
+      db0: 0.3.4(drizzle-orm@0.45.2)
       ofetch: 1.5.1
     dev: false
 
@@ -11382,9 +12731,30 @@ packages:
     hasBin: true
     dev: false
 
+  /uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
+    dev: false
+
+  /uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+    dev: false
+
   /uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
+    dev: false
+
+  /uuidv7@1.2.1:
+    resolution: {integrity: sha512-4kPkK3/XTQW9Hbm4CaqfICn+kY9LJtDVEOfgsRRra/+n2Ofg4NqzRFceAkxvQ/Ud/6BpHOPzj8cirqM7TzTN5Q==}
+    hasBin: true
+    dev: false
+
+  /validator@13.15.35:
+    resolution: {integrity: sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==}
+    engines: {node: '>= 0.10'}
     dev: false
 
   /vfile-location@5.0.3:
@@ -11765,13 +13135,25 @@ packages:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
 
+  /which-typed-array@1.1.22:
+    resolution: {integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+    dev: false
+
   /which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
     dependencies:
       isexe: 2.0.0
-    dev: true
 
   /why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -11782,6 +13164,12 @@ packages:
       stackback: 0.0.2
     dev: true
 
+  /wkx@0.5.0:
+    resolution: {integrity: sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==}
+    dependencies:
+      '@types/node': 20.19.21
+    dev: false
+
   /wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -11789,7 +13177,6 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    dev: true
 
   /wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
@@ -11798,7 +13185,6 @@ packages:
       ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.1.2
-    dev: true
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -11829,6 +13215,11 @@ packages:
     engines: {node: '>=0.4'}
     dev: false
 
+  /y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+    dev: false
+
   /yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -11842,6 +13233,24 @@ packages:
     resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
     engines: {node: '>= 14.6'}
     hasBin: true
+    dev: false
+
+  /yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+    engines: {node: '>=12'}
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
     dev: false
 
   /yocto-queue@1.2.1:


### PR DESCRIPTION
## Summary
- add a minimal `storage.client` runtime-client path for schema-backed integration persistence
- add `createIntegrationOrm` to bridge Farm integration schemas into `@farming-labs/orm`
- wire Stripe billing persistence to fall back to the ORM-backed adapter when `farm.config.ts` provides `storage.client`
- expose `args.storage.getClient()` and `args.storage.getOrm()` to Stripe billing callbacks, including `resolveOwner(ctx, args)`
- add real SQLite coverage for the generic ORM bridge, the Stripe `/billing/status` route, and callback access to storage args

## Validation
- `corepack pnpm --filter @farmjs/core test`
- `corepack pnpm --filter @farmjs/core build`
- `corepack pnpm --filter @farmjs/integrations build`
- `corepack pnpm exec oxfmt --check ...`
- `corepack pnpm exec oxlint ...`