### PR TITLE
feat: add revalidation cache primitives

### DIFF
--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -33,6 +33,9 @@
       "storage": [
         "./dist/storage.d.ts"
       ],
+      "cache": [
+        "./dist/cache.d.ts"
+      ],
       "api": [
         "./types/api.d.ts",
         "./dist/api.d.ts"
@@ -79,6 +82,11 @@
       "types": "./dist/storage.d.ts",
       "import": "./dist/storage.mjs",
       "require": "./dist/storage.cjs"
+    },
+    "./cache": {
+      "types": "./dist/cache.d.ts",
+      "import": "./dist/cache.mjs",
+      "require": "./dist/cache.cjs"
     },
     "./vite": {
       "types": "./dist/vite.d.ts",

--- a/packages/farm/src/__tests__/cache.test.ts
+++ b/packages/farm/src/__tests__/cache.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createFarmCacheKey,
+  getFarmDataCache,
+  normalizeRevalidatePath,
+  revalidatePath,
+  revalidateTag,
+  unstable_cache,
+  updateTag,
+} from "../cache";
+
+describe("server cache primitives", () => {
+  afterEach(() => {
+    getFarmDataCache().clear();
+    vi.useRealTimers();
+  });
+
+  it("caches unstable_cache results by key parts and arguments", async () => {
+    let calls = 0;
+    const getProduct = unstable_cache(
+      async (id: string) => {
+        calls++;
+        return { id, calls };
+      },
+      ["product"],
+      { tags: ["products"], revalidate: 60 },
+    );
+
+    await expect(getProduct("a")).resolves.toEqual({ id: "a", calls: 1 });
+    await expect(getProduct("a")).resolves.toEqual({ id: "a", calls: 1 });
+    await expect(getProduct("b")).resolves.toEqual({ id: "b", calls: 2 });
+    expect(calls).toBe(2);
+  });
+
+  it("revalidates cached entries by tag", async () => {
+    let calls = 0;
+    const getProducts = unstable_cache(
+      async () => {
+        calls++;
+        return [`call-${calls}`];
+      },
+      ["products"],
+      { tags: ["products"] },
+    );
+
+    await expect(getProducts()).resolves.toEqual(["call-1"]);
+    await expect(getProducts()).resolves.toEqual(["call-1"]);
+
+    revalidateTag("products", "max");
+
+    await expect(getProducts()).resolves.toEqual(["call-2"]);
+    expect(calls).toBe(2);
+  });
+
+  it("revalidates cached entries by path", async () => {
+    let calls = 0;
+    const getDashboard = unstable_cache(
+      async () => {
+        calls++;
+        return { calls };
+      },
+      ["dashboard"],
+      { paths: ["/dashboard/"] },
+    );
+
+    await expect(getDashboard()).resolves.toEqual({ calls: 1 });
+    revalidatePath("dashboard");
+    await expect(getDashboard()).resolves.toEqual({ calls: 2 });
+  });
+
+  it("supports updateTag as immediate tag invalidation", async () => {
+    let calls = 0;
+    const getUser = unstable_cache(
+      async () => {
+        calls++;
+        return { calls };
+      },
+      ["user"],
+      { tags: ["user:1"] },
+    );
+
+    await expect(getUser()).resolves.toEqual({ calls: 1 });
+    updateTag("user:1");
+    await expect(getUser()).resolves.toEqual({ calls: 2 });
+  });
+
+  it("expires entries using revalidate seconds", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const getStats = unstable_cache(
+      async () => {
+        calls++;
+        return { calls };
+      },
+      ["stats"],
+      { revalidate: 1 },
+    );
+
+    await expect(getStats()).resolves.toEqual({ calls: 1 });
+    await expect(getStats()).resolves.toEqual({ calls: 1 });
+
+    vi.advanceTimersByTime(1001);
+
+    await expect(getStats()).resolves.toEqual({ calls: 2 });
+  });
+
+  it("dedupes concurrent cache fills", async () => {
+    let calls = 0;
+    const getProfile = unstable_cache(async () => {
+      calls++;
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      return { calls };
+    }, ["profile"]);
+
+    const [first, second] = await Promise.all([getProfile(), getProfile()]);
+
+    expect(first).toEqual({ calls: 1 });
+    expect(second).toEqual({ calls: 1 });
+    expect(calls).toBe(1);
+  });
+
+  it("normalizes paths and stable cache keys", () => {
+    expect(normalizeRevalidatePath("https://example.com/docs/?q=1")).toBe("/docs");
+    expect(normalizeRevalidatePath("docs///intro/")).toBe("/docs/intro");
+    expect(createFarmCacheKey([{ b: 1, a: 2 }])).toBe(createFarmCacheKey([{ a: 2, b: 1 }]));
+  });
+});

--- a/packages/farm/src/cache.ts
+++ b/packages/farm/src/cache.ts
@@ -1,0 +1,357 @@
+export type RevalidateTagProfile =
+  | "max"
+  | "default"
+  | "seconds"
+  | "minutes"
+  | "hours"
+  | "days"
+  | "weeks"
+  | "months"
+  | { expire?: number };
+
+export interface FarmCacheOptions {
+  /**
+   * Tag cached data so it can be invalidated with revalidateTag/updateTag.
+   */
+  tags?: readonly string[];
+  /**
+   * Path tags let revalidatePath invalidate data tied to a route.
+   */
+  paths?: readonly string[];
+  /**
+   * Time in seconds before the entry becomes stale. False means no TTL.
+   */
+  revalidate?: number | false;
+}
+
+export interface FarmCacheSetOptions extends FarmCacheOptions {
+  createdAt?: number;
+}
+
+export interface FarmCacheEntry<T = unknown> {
+  key: string;
+  value: T;
+  tags: readonly string[];
+  createdAt: number;
+  createdVersion?: number;
+  revalidate?: number | false;
+}
+
+interface InternalFarmCacheEntry<T = unknown> {
+  key: string;
+  value: T;
+  tags: Set<string>;
+  createdAt: number;
+  createdVersion: number;
+  revalidate?: number | false;
+}
+
+export interface GetFarmCacheEntryOptions {
+  allowStale?: boolean;
+  now?: number;
+}
+
+interface FarmCacheStaleEntry {
+  tags: Iterable<string>;
+  createdAt: number;
+  createdVersion?: number;
+  revalidate?: number | false;
+}
+
+export class FarmDataCache {
+  private entries = new Map<string, InternalFarmCacheEntry>();
+  private inflight = new Map<string, Promise<unknown>>();
+  private invalidatedTagVersions = new Map<string, number>();
+  private version = 0;
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  get<T>(key: string, options: GetFarmCacheEntryOptions = {}): T | undefined {
+    return this.getEntry<T>(key, options)?.value;
+  }
+
+  getEntry<T = unknown>(
+    key: string,
+    options: GetFarmCacheEntryOptions = {},
+  ): FarmCacheEntry<T> | undefined {
+    const entry = this.entries.get(key) as InternalFarmCacheEntry<T> | undefined;
+    if (!entry) return undefined;
+    if (!options.allowStale && this.isStale(entry, options.now)) {
+      return undefined;
+    }
+    return this.toPublicEntry(entry);
+  }
+
+  set<T>(key: string, value: T, options: FarmCacheSetOptions = {}): FarmCacheEntry<T> {
+    const tags = new Set<string>();
+    for (const tag of options.tags ?? []) {
+      tags.add(normalizeCacheTag(tag));
+    }
+    for (const routePath of options.paths ?? []) {
+      tags.add(createPathCacheTag(routePath));
+    }
+
+    const entry: InternalFarmCacheEntry<T> = {
+      key,
+      value,
+      tags,
+      createdAt: options.createdAt ?? Date.now(),
+      createdVersion: ++this.version,
+      revalidate: normalizeRevalidate(options.revalidate),
+    };
+
+    this.entries.set(key, entry);
+    return this.toPublicEntry(entry);
+  }
+
+  delete(key: string): boolean {
+    return this.entries.delete(key);
+  }
+
+  clear(): void {
+    this.entries.clear();
+    this.inflight.clear();
+    this.invalidatedTagVersions.clear();
+    this.version = 0;
+  }
+
+  isStale(entry: FarmCacheStaleEntry, now = Date.now()): boolean {
+    if (
+      typeof entry.revalidate === "number" &&
+      entry.revalidate > 0 &&
+      now - entry.createdAt >= entry.revalidate * 1000
+    ) {
+      return true;
+    }
+
+    for (const tag of entry.tags) {
+      const invalidatedVersion = this.invalidatedTagVersions.get(normalizeCacheTag(tag));
+      if (
+        typeof invalidatedVersion === "number" &&
+        typeof entry.createdVersion === "number" &&
+        invalidatedVersion > entry.createdVersion
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  revalidateTag(tag: string): number {
+    const normalized = normalizeCacheTag(tag);
+    this.invalidatedTagVersions.set(normalized, ++this.version);
+    return this.countEntriesForTag(normalized);
+  }
+
+  revalidatePath(routePath: string): number {
+    return this.revalidateTag(createPathCacheTag(routePath));
+  }
+
+  async getOrSet<T>(
+    key: string,
+    producer: () => Promise<T> | T,
+    options: FarmCacheOptions = {},
+  ): Promise<T> {
+    const cached = this.getEntry<T>(key);
+    if (cached) {
+      return cached.value;
+    }
+
+    const inflight = this.inflight.get(key) as Promise<T> | undefined;
+    if (inflight) {
+      return inflight;
+    }
+
+    const promise = Promise.resolve()
+      .then(producer)
+      .then((value) => {
+        this.set(key, value, options);
+        return value;
+      })
+      .finally(() => {
+        this.inflight.delete(key);
+      });
+
+    this.inflight.set(key, promise);
+    return promise;
+  }
+
+  private countEntriesForTag(tag: string): number {
+    let count = 0;
+    for (const entry of this.entries.values()) {
+      if (entry.tags.has(tag)) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private toPublicEntry<T>(entry: InternalFarmCacheEntry<T>): FarmCacheEntry<T> {
+    return {
+      key: entry.key,
+      value: entry.value,
+      tags: Array.from(entry.tags),
+      createdAt: entry.createdAt,
+      createdVersion: entry.createdVersion,
+      revalidate: entry.revalidate,
+    };
+  }
+}
+
+const sharedFarmDataCache = new FarmDataCache();
+const functionIds = new WeakMap<Function, number>();
+let nextFunctionId = 0;
+
+export function getFarmDataCache(): FarmDataCache {
+  return sharedFarmDataCache;
+}
+
+export function unstable_cache<Args extends unknown[], Result>(
+  fn: (...args: Args) => Result | Promise<Result>,
+  keyParts: readonly unknown[] = [],
+  options: FarmCacheOptions = {},
+): (...args: Args) => Promise<Result> {
+  return async (...args: Args): Promise<Result> => {
+    const key = createFarmCacheKey([
+      "unstable_cache",
+      getFunctionCacheIdentity(fn),
+      keyParts,
+      args,
+    ]);
+    return getFarmDataCache().getOrSet<Result>(key, () => fn(...args), options);
+  };
+}
+
+export function revalidateTag(_tag: string, _profile?: RevalidateTagProfile): void {
+  getFarmDataCache().revalidateTag(_tag);
+}
+
+export function updateTag(tag: string): void {
+  getFarmDataCache().revalidateTag(tag);
+}
+
+export function revalidatePath(routePath: string): void {
+  getFarmDataCache().revalidatePath(routePath);
+}
+
+export function createPathCacheTag(routePath: string): string {
+  return `path:${normalizeRevalidatePath(routePath)}`;
+}
+
+export function normalizeRevalidatePath(routePath: string): string {
+  if (typeof routePath !== "string") {
+    throw new TypeError("revalidatePath expects a path string.");
+  }
+
+  let normalized = routePath.trim();
+  if (!normalized) {
+    throw new Error("revalidatePath expects a non-empty path.");
+  }
+
+  try {
+    if (/^https?:\/\//.test(normalized)) {
+      normalized = new URL(normalized).pathname;
+    }
+  } catch {
+    // Keep the original path if URL parsing fails.
+  }
+
+  normalized = normalized.split("?")[0] ?? normalized;
+  normalized = normalized.startsWith("/") ? normalized : `/${normalized}`;
+  normalized = normalized.replace(/\/{2,}/g, "/");
+  if (normalized.length > 1) {
+    normalized = normalized.replace(/\/+$/, "");
+  }
+  return normalized || "/";
+}
+
+export function createFarmCacheKey(parts: readonly unknown[]): string {
+  return stableSerialize(parts);
+}
+
+function normalizeRevalidate(revalidate: number | false | undefined): number | false | undefined {
+  if (revalidate === false || revalidate === undefined) {
+    return revalidate;
+  }
+  if (!Number.isFinite(revalidate) || revalidate <= 0) {
+    return undefined;
+  }
+  return revalidate;
+}
+
+function normalizeCacheTag(tag: string): string {
+  if (typeof tag !== "string") {
+    throw new TypeError("Cache tags must be strings.");
+  }
+  const normalized = tag.trim();
+  if (!normalized) {
+    throw new Error("Cache tags cannot be empty.");
+  }
+  return normalized;
+}
+
+function getFunctionCacheIdentity(fn: Function): string {
+  if (fn.name) {
+    return `name:${fn.name}`;
+  }
+
+  let id = functionIds.get(fn);
+  if (!id) {
+    id = ++nextFunctionId;
+    functionIds.set(fn, id);
+  }
+  return `anonymous:${id}`;
+}
+
+function stableSerialize(value: unknown, seen = new WeakSet<object>()): string {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+
+  const valueType = typeof value;
+  if (valueType === "string") return JSON.stringify(value);
+  if (valueType === "number" || valueType === "boolean" || valueType === "bigint") {
+    return `${valueType}:${String(value)}`;
+  }
+  if (valueType === "symbol") {
+    return `symbol:${String(value)}`;
+  }
+  if (valueType === "function") {
+    return `function:${getFunctionCacheIdentity(value as Function)}`;
+  }
+
+  if (value instanceof Date) {
+    return `date:${value.toISOString()}`;
+  }
+  if (value instanceof URL) {
+    return `url:${value.toString()}`;
+  }
+  if (value instanceof RegExp) {
+    return `regexp:${value.toString()}`;
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableSerialize(item, seen)).join(",")}]`;
+  }
+
+  if (value && typeof value === "object") {
+    if (seen.has(value)) {
+      return "[Circular]";
+    }
+    seen.add(value);
+
+    const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
+      a.localeCompare(b),
+    );
+    const serialized = entries
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableSerialize(item, seen)}`)
+      .join(",");
+
+    seen.delete(value);
+    return `{${serialized}}`;
+  }
+
+  return String(value);
+}

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -21,6 +21,7 @@ export type { GenerateRouteTypesOptions } from "./routing/generate-route-types";
 export * from "./build/index";
 export * from "./client";
 export * from "./ssg";
+export * from "./cache";
 export type {
   FarmPlugin,
   FarmPluginContext,

--- a/packages/farm/src/server.ts
+++ b/packages/farm/src/server.ts
@@ -5,5 +5,6 @@ export { farmPlugin, defineConfig } from "./vite";
 export * from "./types";
 export * from "./utils";
 export * from "./storage";
+export * from "./cache";
 export { createServer, startDevServer } from "./server/create-server";
 export { getCurrentRequest } from "./server/request";

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -12,6 +12,7 @@ import { getRequestContextSnapshot } from "../request-context";
 import { isSSGModule, matchSSGPage } from "../ssg";
 import { getIntegrationProviders, getRegisteredIntegrationAPIManifest } from "../integrations";
 import { _runWithCurrentRequest, createWebRequestFromFarmRequest } from "./request";
+import { createFarmCacheKey, getFarmDataCache, normalizeRevalidatePath } from "../cache";
 
 let cachedClerkProvider: {
   ClerkProvider: React.ComponentType<{ children?: React.ReactNode } & Record<string, unknown>>;
@@ -20,6 +21,11 @@ let cachedClerkProvider: {
 const importRuntimeModule = new Function("specifier", "return import(specifier);") as (
   specifier: string,
 ) => Promise<any>;
+
+interface CachedSSGPage {
+  html: string;
+  document: boolean;
+}
 
 function toMiddlewareMap(input: unknown): Map<string, any> {
   if (input instanceof Map) {
@@ -65,7 +71,7 @@ export class ServerRenderer {
   private config: Required<FarmConfig>;
   private routeManager: RouteManager;
   private ssgManifest: SSGPage[] = [];
-  private ssgCache: Map<string, { html: string; timestamp: number }> = new Map();
+  private dataCache = getFarmDataCache();
 
   constructor(config: Required<FarmConfig>, routeManager: RouteManager) {
     this.config = config;
@@ -96,19 +102,40 @@ export class ServerRenderer {
     const ssgPage = matchSSGPage(pathname, this.ssgManifest);
     if (!ssgPage) return null;
 
-    // Check ISR revalidation
-    if (ssgPage.revalidate) {
-      const cached = this.ssgCache.get(pathname);
-      if (cached) {
-        const age = (Date.now() - cached.timestamp) / 1000;
-        if (age > ssgPage.revalidate) {
-          // Stale - needs revalidation (serve stale, regenerate in background)
-          this.regenerateSSGPage(ssgPage);
-        }
-      }
+    const cached = this.getCachedSSGPage(pathname);
+    if (cached && this.dataCache.isStale(cached)) {
+      // Stale - needs revalidation (serve stale, regenerate in background)
+      this.regenerateSSGPage(ssgPage);
     }
 
     return ssgPage;
+  }
+
+  private getSSGCacheKey(urlPath: string): string {
+    return createFarmCacheKey(["ssg", normalizeRevalidatePath(urlPath)]);
+  }
+
+  private getCachedSSGPage(urlPath: string) {
+    return this.dataCache.getEntry<CachedSSGPage>(this.getSSGCacheKey(urlPath), {
+      allowStale: true,
+    });
+  }
+
+  private cacheSSGPage(
+    page: SSGPage,
+    html: string,
+    options: { document: boolean; createdAt?: number },
+  ): void {
+    this.dataCache.set(
+      this.getSSGCacheKey(page.urlPath),
+      { html, document: options.document },
+      {
+        createdAt: options.createdAt,
+        paths: [page.urlPath],
+        tags: ["ssg"],
+        revalidate: page.revalidate ?? false,
+      },
+    );
   }
 
   /**
@@ -154,8 +181,7 @@ export class ServerRenderer {
           const { renderToString } = await import("react-dom/server");
           const html = renderToString(await this.wrapWithIntegrationProviders(pageElement));
 
-          // Update cache
-          this.ssgCache.set(page.urlPath, { html, timestamp: Date.now() });
+          this.cacheSSGPage(page, html, { document: false });
 
           logger.info(`ISR: Regenerated ${page.urlPath}`);
         } catch (error) {
@@ -172,14 +198,14 @@ export class ServerRenderer {
    */
   private async serveSSGPage(req: FarmRequest, res: FarmResponse, page: SSGPage): Promise<boolean> {
     // Check cache first (for ISR)
-    const cached = this.ssgCache.get(page.urlPath);
+    const cached = this.getCachedSSGPage(page.urlPath);
     if (cached) {
       res.setHeader("Content-Type", "text/html; charset=utf-8");
       res.setHeader("X-Farm-SSG", "cached");
       if (page.revalidate) {
         res.setHeader("Cache-Control", `s-maxage=${page.revalidate}, stale-while-revalidate`);
       }
-      res.write(this.createFullHTML(cached.html));
+      res.write(cached.value.document ? cached.value.html : this.createFullHTML(cached.value.html));
       res.end();
       return true;
     }
@@ -192,7 +218,14 @@ export class ServerRenderer {
           : path.join(this.config.root, this.config.outDir, "client", page.urlPath + ".html");
 
       if (fs.existsSync(htmlPath)) {
+        const stat = fs.statSync(htmlPath);
         const html = fs.readFileSync(htmlPath, "utf-8");
+        this.cacheSSGPage(page, html, { document: true, createdAt: stat.mtimeMs });
+        const fileCacheEntry = this.getCachedSSGPage(page.urlPath);
+        if (fileCacheEntry && this.dataCache.isStale(fileCacheEntry)) {
+          this.regenerateSSGPage(page);
+        }
+
         res.setHeader("Content-Type", "text/html; charset=utf-8");
         res.setHeader("X-Farm-SSG", "file");
         if (page.revalidate) {

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     api: "src/api/index.ts",
     plugin: "src/plugin.ts",
     storage: "src/storage/index.ts",
+    cache: "src/cache.ts",
   },
   format: ["cjs", "esm"],
   dts: true,


### PR DESCRIPTION
## Summary

- add a public @farmjs/core/cache entry with unstable_cache, revalidatePath, revalidateTag, updateTag, and a shared FarmDataCache
- support cache tags, path tags, revalidate TTLs, stable cache keys, and concurrent fill deduping
- move SSG/ISR page caching onto the shared cache so page entries are path-tagged and can participate in revalidation

Refs #12

## Validation

- ./node_modules/.bin/vitest run (packages/farm)
- ./node_modules/.bin/tsup (packages/farm)
- ./node_modules/.bin/oxfmt --check .
- ./node_modules/.bin/oxlint . (existing warnings, 0 errors)