### PR TITLE
fix: improve hydration client runtime

### DIFF
--- a/examples/basic/src/app/api-demo-client/page.tsx
+++ b/examples/basic/src/app/api-demo-client/page.tsx
@@ -4,10 +4,14 @@ import React, { useState } from 'react';
 import { Link } from '@farmjs/core/client';
 import { api } from '../../lib/api-client';
 
+type HelloResponse = NonNullable<Awaited<ReturnType<typeof api.hello.get>>['data']>;
+type UsersResponse = NonNullable<Awaited<ReturnType<typeof api.users.get>>['data']>;
+type LoginResponse = NonNullable<Awaited<ReturnType<typeof api.auth.login.post>>['data']>;
+
 export default function APIClientDemo() {
-  const [helloResponse, setHelloResponse] = useState<any>(null);
-  const [usersResponse, setUsersResponse] = useState<any>(null);
-  const [loginResponse, setLoginResponse] = useState<any>(null);
+  const [helloResponse, setHelloResponse] = useState<HelloResponse | null>(null);
+  const [usersResponse, setUsersResponse] = useState<UsersResponse | null>(null);
+  const [loginResponse, setLoginResponse] = useState<LoginResponse | null>(null);
   const [loading, setLoading] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -16,13 +20,13 @@ export default function APIClientDemo() {
     setError(null);
 
     try {
-      const result = await api.hello.post({
-        body: { name: 'something' },
+      const result = await api.hello.get({
+        query: { name: 'something' },
       });
       if (result.error) {
         setError('Failed to fetch hello endpoint: ' + result.error);
       } else {
-        setHelloResponse(result.data);
+        setHelloResponse(result.data ?? null);
       }
     } catch (err) {
       setError('Failed to fetch hello endpoint: ' + err);
@@ -43,7 +47,7 @@ export default function APIClientDemo() {
       if (result.error) {
         setError('Failed to fetch users: ' + result.error);
       } else {
-        setUsersResponse(result.data);
+        setUsersResponse(result.data ?? null);
       }
     } catch (err) {
       setError('Failed to fetch users: ' + err);
@@ -67,7 +71,7 @@ export default function APIClientDemo() {
       if (result.error) {
         setError('Failed to login: ' + result.error);
       } else {
-        setLoginResponse(result.data);
+        setLoginResponse(result.data ?? null);
       }
     } catch (err) {
       setError('Failed to login: ' + err);
@@ -220,21 +224,21 @@ export default function APIClientDemo() {
               <div>
                 <p className="text-gray-500 mb-2">// Import the typed client</p>
                 <pre className="text-gray-300">
-                  {`import { client, api } from '@/lib/api-client';`}
+                  {`import { api } from '@/lib/api-client';`}
                 </pre>
               </div>
 
               <div>
-                <p className="text-gray-500 mb-2">// Option 1: Direct client call</p>
+                <p className="text-gray-500 mb-2">// Query input is inferred from the route</p>
                 <pre className="text-gray-300">
-                  {`const result = await client('/api/hello', {
+                  {`const result = await api.hello.get({
   query: { name: 'World' }
 });`}
                 </pre>
               </div>
 
               <div>
-                <p className="text-gray-500 mb-2">// Option 2: Nested API syntax (recommended!)</p>
+                <p className="text-gray-500 mb-2">// Body input and response data are inferred too</p>
                 <pre className="text-yellow-300">
                   {`const result = await api.auth.login.post({
   body: {

--- a/examples/basic/src/app/farm-query-client-demo/page.tsx
+++ b/examples/basic/src/app/farm-query-client-demo/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   useQueryState,
   asString,
@@ -16,6 +16,11 @@ export default function FarmClientQueryDemo() {
   const [tags, setTags] = useQueryState('tags', asArrayOf(asString).withDefault!([]));
   const [sortBy, setSortBy] = useQueryState('sortBy', asString.withDefault!('date'));
   const [sortOrder, setSortOrder] = useQueryState('sortOrder', asString.withDefault!('desc'));
+  const [currentUrl, setCurrentUrl] = useState('');
+
+  useEffect(() => {
+    setCurrentUrl(window.location.href);
+  });
   const handleTagAdd = (tag: string) => {
     if (tag && !(tags || []).includes(tag)) {
       setTags([...(tags || []), tag]);
@@ -184,7 +189,7 @@ export default function FarmClientQueryDemo() {
         <div className="mt-2">
           <p className="text-xs text-gray-500">Current URL:</p>
           <code className="text-xs text-blue-600 break-all">
-            {typeof window !== 'undefined' ? window.location.href : ''}
+            {currentUrl}
           </code>
         </div>
       </div>

--- a/examples/basic/src/app/farm-query-demo/page.tsx
+++ b/examples/basic/src/app/farm-query-demo/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   useQueryState,
   asString ,
@@ -24,6 +24,11 @@ function FarmClientQueryDemo() {
   const [tags, setTags] = useQueryState('tags', asArrayOf(asString).withDefault!([]));
   const [sortBy, setSortBy] = useQueryState('sortBy', asString.withDefault!('date'));
   const [sortOrder, setSortOrder] = useQueryState('sortOrder', asString.withDefault!('desc'));
+  const [currentUrl, setCurrentUrl] = useState('');
+
+  useEffect(() => {
+    setCurrentUrl(window.location.href);
+  });
 
   const handleTagAdd = (tag: string) => {
     if (tag && !(tags || []).includes(tag)) {
@@ -194,7 +199,7 @@ function FarmClientQueryDemo() {
         <div className="mt-2">
           <p className="text-xs text-gray-500">Current URL:</p>
           <code className="text-xs text-blue-600 break-all">
-            {typeof window !== 'undefined' ? window.location.href : ''}
+            {currentUrl}
           </code>
         </div>
       </div>

--- a/examples/basic/src/app/query-demo/client-demo.tsx
+++ b/examples/basic/src/app/query-demo/client-demo.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   useQueryState,
   useQueryStates,
@@ -62,6 +62,11 @@ export default function ClientQueryDemo() {
   });
 
   const [jsonInput, setJsonInput] = useState('{"category": "tech", "sort": "date"}');
+  const [currentUrl, setCurrentUrl] = useState('');
+
+  useEffect(() => {
+    setCurrentUrl(window.location.href);
+  });
 
   const handleJsonUpdate = () => {
     try {
@@ -389,7 +394,7 @@ export default function ClientQueryDemo() {
       <div className="mt-6 bg-purple-100 p-4 rounded-lg">
         <h4 className="font-medium mb-2">Current URL:</h4>
         <code className="text-sm text-purple-800 break-all">
-          {typeof window !== 'undefined' ? window.location.href : ''}
+          {currentUrl}
         </code>
       </div>
     </div>

--- a/examples/basic/src/app/query-demo/page.tsx
+++ b/examples/basic/src/app/query-demo/page.tsx
@@ -1,28 +1,9 @@
+'use client';
+
 import React from 'react';
-import type { PagePropsSafe } from '@farmjs/core/query';
-import { 
-  loadSearchParams,
-  loadRouteParams,
-  asString,
-  asInteger,
-  asBoolean,
-  asArrayOf,
-} from '@farmjs/core/query/server';
 import ClientQueryDemo from './client-demo';
 
-async function ServerQueryDemo({ searchParams , params: p }: PagePropsSafe) {
-  const params = await loadSearchParams(searchParams, {
-    search: asString.withDefault!(''),
-    page: asInteger.withDefault!(1),
-    category: asString.withDefault!('all'),
-    enabled: asBoolean.withDefault!(false),
-    tags: asArrayOf(asString).withDefault!([]),
-    sortBy: asString.withDefault!('date'),
-    sortOrder: asString.withDefault!('desc'),
-  });
-  const routeParams = await loadRouteParams(p, {
-    section: asString.withDefault!("query-demo"),
-  });
+export default function QueryDemoPage() {
   return (
     <div className="min-h-screen bg-gray-50 py-8">
       <div className="max-w-6xl mx-auto px-4">
@@ -31,119 +12,68 @@ async function ServerQueryDemo({ searchParams , params: p }: PagePropsSafe) {
             Farm.js Query State Demo
           </h1>
           <p className="text-gray-600">
-            Complete demonstration of server-side and client-side query parameter management
+            Complete demonstration of browser-side query parameter management.
           </p>
         </div>
 
-        {/* Server-Side Section */}
         <div className="mb-12 bg-white p-6 rounded-lg shadow">
           <div className="mb-4">
             <h2 className="text-2xl font-semibold text-blue-800 mb-2">
-              Server-Side Query State
+              Query State Overview
             </h2>
             <p className="text-gray-600 text-sm">
-              This section uses <code className="bg-gray-100 px-1 rounded">loadSearchParams</code> to parse query parameters on the server
+              This demo is a hydrated client route so every control below can update the URL and
+              page state immediately.
             </p>
           </div>
-          
-          <div className="bg-blue-50 border border-blue-200 p-6 rounded-lg">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-              <div>
-                <p><strong className="text-blue-900">Search:</strong> <span className="text-gray-700">{params.search || 'None'}</span></p>
-                <p><strong className="text-blue-900">Page:</strong> <span className="text-gray-700">{params.page}</span></p>
-                <p><strong className="text-blue-900">Category:</strong> <span className="text-gray-700">{params.category}</span></p>
-                <p><strong className="text-blue-900">Enabled:</strong> <span className="text-gray-700">{params.enabled ? 'Yes' : 'No'}</span></p>
-              </div>
-              <div>
-                <p><strong className="text-blue-900">Tags:</strong> <span className="text-gray-700">{(params.tags?.length ?? 0) > 0 ? params.tags!.join(', ') : 'None'}</span></p>
-                <p><strong className="text-blue-900">Sort By:</strong> <span className="text-gray-700">{params.sortBy}</span></p>
-                <p><strong className="text-blue-900">Sort Order:</strong> <span className="text-gray-700">{params.sortOrder}</span></p>
-                <p><strong className="text-blue-900">Route Section:</strong> <span className="text-gray-700">{routeParams.section}</span></p>
-              </div>
-            </div>
-            
-            <div className="mt-4">
-              <p className="text-sm font-medium text-blue-900 mb-2">All Parsed Parameters:</p>
-              <pre className="bg-white p-3 rounded text-xs overflow-x-auto border border-blue-200">
-                {JSON.stringify(params, null, 2)}
-              </pre>
-            </div>
 
-            <div className="mt-4 p-3 bg-blue-100 rounded">
-              <p className="text-xs text-blue-900">
-                <strong>💡 Tip:</strong> Try adding query parameters to the URL like: 
-                <code className="bg-blue-200 px-1 rounded">?search=react&page=2&category=tech&enabled=true&tags=js,ts</code>
-              </p>
-            </div>
+          <div className="bg-blue-50 border border-blue-200 p-6 rounded-lg">
+            <p className="text-sm text-blue-900">
+              Try adding query parameters to the URL like{' '}
+              <code className="bg-blue-200 px-1 rounded">
+                ?search=react&page=2&category=tech&enabled=true&tags=js,ts
+              </code>
+              , then use the controls below to update them.
+            </p>
           </div>
         </div>
 
-        {/* Client-Side Section */}
         <div className="bg-white p-6 rounded-lg shadow">
           <div className="mb-4">
             <h2 className="text-2xl font-semibold text-purple-800 mb-2">
               Client-Side Query State
             </h2>
             <p className="text-gray-600 text-sm">
-              This section uses <code className="bg-gray-100 px-1 rounded">useQueryState</code> hooks to manage query parameters in the browser
+              This section uses{' '}
+              <code className="bg-gray-100 px-1 rounded">useQueryState</code> hooks to manage
+              query parameters in the browser.
             </p>
           </div>
-          
+
           <ClientQueryDemo />
         </div>
 
-        {/* Code Examples */}
         <div className="mt-8 bg-white p-6 rounded-lg shadow">
           <h3 className="text-xl font-semibold mb-4">Code Examples</h3>
-          
+
           <div className="space-y-6">
             <div>
-              <h4 className="font-medium mb-2 text-blue-800">Server-Side (Server Component)</h4>
-              <pre className="bg-gray-100 p-4 rounded text-xs overflow-x-auto">
-{`import { loadSearchParams, parseAsString, parseAsInteger } from '@farmjs/core/query/server';
-import type { PagePropsSafe } from '@farmjs/core/query';
-
-export default async function Page({ searchParams }: PagePropsSafe) {
-  const params = await loadSearchParams(searchParams, {
-    search: parseAsString.withDefault!(''),
-    page: parseAsInteger.withDefault!(1),
-  });
-
-  return <div>Search: {params.search}, Page: {params.page}</div>;
-}`}
-              </pre>
-            </div>
-
-            <div>
-              <h4 className="font-medium mb-2 text-blue-800">Server-Side Route Params (Type-safe)</h4>
-              <pre className="bg-gray-100 p-4 rounded text-xs overflow-x-auto">
-{`import { loadRouteParams, asInteger } from '@farmjs/core/query/server';
-
-export default async function Page({ params }: PagePropsSafe) {
-  const route = await loadRouteParams(params, {
-    id: asInteger.withDefault!(0),
-  });
-
-  return <div>User ID: {route.id}</div>;
-}`}
-              </pre>
-            </div>
-
-            <div>
-              <h4 className="font-medium mb-2 text-purple-800">Client-Side (Client Component)</h4>
+              <h4 className="font-medium mb-2 text-purple-800">
+                Client-Side Query State
+              </h4>
               <pre className="bg-gray-100 p-4 rounded text-xs overflow-x-auto">
 {`'use client';
-import { useQueryState, parseAsString, parseAsInteger } from '@farmjs/core/query/client';
+import { useQueryState, asString, asInteger } from '@farmjs/core/query/client';
 
 export default function Page() {
-  const [search, setSearch] = useQueryState('search', parseAsString);
-  const [page, setPage] = useQueryState('page', parseAsInteger.withDefault!(1));
-  
+  const [search, setSearch] = useQueryState('search', asString);
+  const [page, setPage] = useQueryState('page', asInteger.withDefault!(1));
+
   return (
     <div>
-      <input 
-        value={search || ''} 
-        onChange={(e) => setSearch(e.target.value || null)} 
+      <input
+        value={search || ''}
+        onChange={(event) => setSearch(event.target.value || null)}
       />
       <button onClick={() => setPage(page + 1)}>Next Page</button>
     </div>
@@ -157,6 +87,3 @@ export default function Page() {
     </div>
   );
 }
-
-export default ServerQueryDemo;
-

--- a/examples/basic/src/app/store-e2e/store-demo.tsx
+++ b/examples/basic/src/app/store-e2e/store-demo.tsx
@@ -56,16 +56,16 @@ export default function StoreDemo() {
       </div>
 
       <div className="grid gap-4 md:grid-cols-2">
-        <WholeStoreCard />
-        <ThemeCard />
-        <SidebarCard />
-        <PairCard />
+        <WholeStoreCard hydrated={hydrated} />
+        <ThemeCard hydrated={hydrated} />
+        <SidebarCard hydrated={hydrated} />
+        <PairCard hydrated={hydrated} />
       </div>
     </div>
   );
 }
 
-function WholeStoreCard() {
+function WholeStoreCard({ hydrated }: { hydrated: boolean }) {
   const state = demoStore.use();
   wholeRenders += 1;
 
@@ -76,13 +76,13 @@ function WholeStoreCard() {
         {JSON.stringify(state)}
       </p>
       <p data-testid="whole-renders" className="mt-2 text-sm text-slate-500">
-        renders:{wholeRenders}
+        renders:{hydrated ? wholeRenders : 0}
       </p>
     </div>
   );
 }
 
-function ThemeCard() {
+function ThemeCard({ hydrated }: { hydrated: boolean }) {
   const theme = demoStore.theme();
 
   themeRenders += 1;
@@ -94,13 +94,13 @@ function ThemeCard() {
         {theme}
       </p>
       <p data-testid="theme-renders" className="mt-2 text-sm text-slate-500">
-        renders:{themeRenders}
+        renders:{hydrated ? themeRenders : 0}
       </p>
     </div>
   );
 }
 
-function SidebarCard() {
+function SidebarCard({ hydrated }: { hydrated: boolean }) {
   const sidebar = demoStore.sidebar();
   sidebarRenders += 1;
 
@@ -111,13 +111,13 @@ function SidebarCard() {
         {String(sidebar)}
       </p>
       <p data-testid="sidebar-renders" className="mt-2 text-sm text-slate-500">
-        renders:{sidebarRenders}
+        renders:{hydrated ? sidebarRenders : 0}
       </p>
     </div>
   );
 }
 
-function PairCard() {
+function PairCard({ hydrated }: { hydrated: boolean }) {
   const pair = demoStore.use(["theme", "sidebar"]);
   pairRenders += 1;
 
@@ -128,7 +128,7 @@ function PairCard() {
         {JSON.stringify(pair)}
       </p>
       <p data-testid="pair-renders" className="mt-2 text-sm text-slate-500">
-        renders:{pairRenders}
+        renders:{hydrated ? pairRenders : 0}
       </p>
     </div>
   );

--- a/examples/basic/src/farm-routes.d.ts
+++ b/examples/basic/src/farm-routes.d.ts
@@ -3,7 +3,7 @@
  * Link href is typed automatically via module augmentation. Regenerated on dev start and when routes change.
  * Set suppressLintOnLink: true in farm.config.ts to accept any string on Link href.
  */
-export type RoutePath = "/" | "/about" | "/api-demo" | "/api-demo-client" | "/api-demo-client-advanced" | "/boundaries/error" | "/boundaries/loading" | "/boundaries/suspense" | "/contact" | "/farm-query-client-demo" | "/farm-query-demo" | "/prefetch-e2e" | "/query-demo" | "/storage-demo" | "/store-e2e" | `/users/${string}`;
+export type RoutePath = "/" | "/about" | "/api-demo" | "/api-demo-client" | "/api-demo-client-advanced" | "/boundaries/error" | "/boundaries/loading" | "/boundaries/suspense" | "/contact" | "/docs/reference" | "/farm-query-client-demo" | "/farm-query-demo" | "/prefetch-e2e" | "/query-demo" | "/storage-demo" | "/store-e2e" | `/users/${string}`;
 declare module "@farmjs/core/client" {
   interface LinkDefaultRoute {
     _: import("./farm-routes").RoutePath;

--- a/examples/rsc-demo/src/actions/user.ts
+++ b/examples/rsc-demo/src/actions/user.ts
@@ -14,7 +14,7 @@ let nextId = 1;
 export async function submitMessage(formData: FormData) {
   // Simulate network delay
   await new Promise((resolve) => setTimeout(resolve, 500));
-  console.log({formData})
+
   const name = formData.get("name") as string;
   const message = formData.get("message") as string;
 
@@ -30,8 +30,6 @@ export async function submitMessage(formData: FormData) {
     timestamp: new Date().toISOString(),
   };
   messages.push(newMessage);
-
-  console.log("[Server Action] Message saved:", newMessage);
 
   return {
     success: true,
@@ -60,7 +58,6 @@ export async function deleteMessage(id: number) {
   }
 
   messages.splice(index, 1);
-  console.log("[Server Action] Message deleted:", id);
 
   return { success: true };
 }

--- a/examples/rsc-demo/src/counter/page.tsx
+++ b/examples/rsc-demo/src/counter/page.tsx
@@ -83,7 +83,9 @@ export default function CounterPage({ middlewareData = {} }: PageProps) {
             JavaScript.
           </p>
           <div className="bg-slate-900/50 rounded-lg p-4 font-mono text-sm">
-            <span className="text-emerald-400">{serverInfo}</span>
+            <span className="text-emerald-400" suppressHydrationWarning>
+              {serverInfo}
+            </span>
           </div>
           <p className="text-xs text-slate-500 mt-4">
             Refresh the page to see the time update (server-rendered).

--- a/packages/farm/src/__tests__/api-client.typing.test.ts
+++ b/packages/farm/src/__tests__/api-client.typing.test.ts
@@ -2,6 +2,31 @@ import { describe, expectTypeOf, it, vi } from "vitest";
 import { createAPIClient, type CacheKey } from "../api/client";
 
 type APIRouter = {
+  hello: {
+    get: {
+      __types: {
+        body: never;
+        query: { name?: string };
+        response: { message: string; timestamp: string };
+      };
+    };
+    post: {
+      __types: {
+        body: { name?: string };
+        query: never;
+        response: { message: string; timestamp: string };
+      };
+    };
+  };
+  search: {
+    get: {
+      __types: {
+        body: never;
+        query: { term: string; page?: string };
+        response: { results: string[] };
+      };
+    };
+  };
   users: {
     get: {
       __types: {
@@ -36,13 +61,52 @@ const buildResponse = (data: any, ok = true, status = 200) => ({
 });
 
 describe("createAPIClient typing", () => {
+  it("maps generated route types into callable api.route.method helpers", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      buildResponse({ message: "Hello Peeps, World!", timestamp: "2026-07-03T00:00:00.000Z" }),
+    ) as any;
+
+    const api = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
+
+    const helloWithoutQuery = await api.hello.get();
+    const helloWithQuery = await api.hello.get({ query: { name: "Farm" } });
+    const helloPost = await api.hello.post({ body: { name: "Farm" } });
+    const search = await api.search.get({ query: { term: "routes" } });
+
+    expectTypeOf<IsAny<typeof helloWithoutQuery.data>>().toEqualTypeOf<false>();
+    expectTypeOf(helloWithoutQuery.data).toEqualTypeOf<
+      { message: string; timestamp: string } | undefined
+    >();
+    expectTypeOf(helloWithQuery.data?.message).toEqualTypeOf<string | undefined>();
+    expectTypeOf(helloPost.data?.timestamp).toEqualTypeOf<string | undefined>();
+    expectTypeOf(search.data?.results).toEqualTypeOf<string[] | undefined>();
+
+    // @ts-expect-error body schemas require the body wrapper.
+    await api.hello.post();
+    // @ts-expect-error unknown query keys are rejected from generated route types.
+    await api.hello.get({ query: { nope: "Farm" } });
+    // @ts-expect-error required query fields stay required.
+    await api.search.get();
+    // @ts-expect-error required body fields stay required.
+    await api.users.post({ body: { name: "Ada" } });
+  });
+
   it("infers optimistic updater types from route refs and typed cache keys", async () => {
     globalThis.fetch = vi.fn(async () => buildResponse({ success: true })) as any;
 
     const api = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
     type UsersKey = Awaited<ReturnType<typeof api.users.get>>["key"];
+    type UsersRouteHasMeta = typeof api.users.get extends {
+      readonly __farmRouteInput: unknown;
+      readonly __farmRouteData: unknown;
+    }
+      ? true
+      : false;
+    type UsersRouteData = (typeof api.users.get)["__farmRouteData"];
     const usersKey = "demo:users:list" as UsersKey;
 
+    expectTypeOf<UsersRouteHasMeta>().toEqualTypeOf<true>();
+    expectTypeOf<UsersRouteData>().toEqualTypeOf<UsersListResponse>();
     expectTypeOf<UsersKey>().toEqualTypeOf<CacheKey<UsersListResponse>>();
 
     await api.users.post(
@@ -54,7 +118,7 @@ describe("createAPIClient typing", () => {
             [
               api.users.get,
               { query: { limit: "5" } },
-              (prev) => {
+              (prev: UsersListResponse | undefined) => {
                 expectTypeOf<IsAny<typeof prev>>().toEqualTypeOf<false>();
                 expectTypeOf(prev).toEqualTypeOf<UsersListResponse | undefined>();
 
@@ -68,10 +132,10 @@ describe("createAPIClient typing", () => {
                   offset: prev?.offset ?? 0,
                 };
               },
-            ],
+            ] as const,
             [
               usersKey,
-              (prev) => {
+              (prev: UsersListResponse | undefined) => {
                 expectTypeOf<IsAny<typeof prev>>().toEqualTypeOf<false>();
                 expectTypeOf(prev).toEqualTypeOf<UsersListResponse | undefined>();
 
@@ -85,8 +149,8 @@ describe("createAPIClient typing", () => {
                   offset: prev?.offset ?? 0,
                 };
               },
-            ],
-          ],
+            ] as const,
+          ] as const,
         },
       },
     );

--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -4,9 +4,12 @@ import path from "path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   getClientModuleMetadata,
+  hasHydrateExport,
+  hasUseClientDirective,
   isClientComponentModule,
   resolveModuleSourcePath,
   shouldHydrateModule,
+  stripUseClientDirective,
 } from "../utils/client-component";
 
 const tempDirs: string[] = [];
@@ -21,6 +24,24 @@ afterEach(() => {
 });
 
 describe("client component path resolution", () => {
+  it("detects and strips top-level client directives", () => {
+    const source = '"use client";\n\nexport default function Page() { return null; }\n';
+
+    expect(hasUseClientDirective(source)).toBe(true);
+    expect(stripUseClientDirective(source)).toBe(
+      "export default function Page() { return null; }\n",
+    );
+  });
+
+  it("detects explicit hydrate exports", () => {
+    expect(
+      hasHydrateExport("export const hydrate = true;\nexport default function Page() {}"),
+    ).toBe(true);
+    expect(hasHydrateExport("const hydrate = true;\nexport default function Page() {}")).toBe(
+      false,
+    );
+  });
+
   it("resolves project-relative /src module paths", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-client-path-"));
     tempDirs.push(root);

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -1,5 +1,3 @@
-import type { TypedEndpoint } from "./endpoint";
-
 export type APIClientOptions = {
   baseURL?: string;
   headers?: Record<string, string>;
@@ -80,7 +78,7 @@ export type InvalidateTarget =
       method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS" | "HEAD";
       input?: unknown;
     }
-  | [RouteRef<any, any>, unknown?];
+  | [CallableRouteRef<any>, unknown?];
 
 export type InvalidateOptions =
   | InvalidateTarget[]
@@ -90,7 +88,7 @@ export type InvalidateOptions =
     };
 
 export type OptimisticUpdate =
-  | [RouteRef<any, any>, unknown, (prev: any) => any]
+  | [CallableRouteRef<any>, unknown, (prev: any) => any]
   | [CacheKey<any> | string, (prev: any) => any];
 
 export type OptimisticOptions<TUpdates extends readonly unknown[] = readonly OptimisticUpdate[]> = {
@@ -120,14 +118,19 @@ export type ClientOptions<
   onStatus?: (event: StatusEvent<TData, TError>) => void;
 };
 
-type RouteRef<TInput = any, TData = any> = (
-  options?: TInput,
-  clientOptions?: ClientOptions<any, any>,
-) => Promise<APIResult<TData, any>>;
 type AnyRouteRef = (...args: any[]) => any;
+type RouteRef<TData = any, TInput = any> = {
+  readonly __farmRouteInput: TInput;
+  readonly __farmRouteData: TData;
+};
+type CallableRouteRef<TData = any, TInput = any> = AnyRouteRef & RouteRef<TData, TInput>;
 
-type InferRouteInput<TRoute> = TRoute extends RouteRef<infer TInput, any> ? TInput : never;
-type InferRouteData<TRoute> = TRoute extends RouteRef<any, infer TData> ? TData : never;
+type InferRouteInput<TRoute> = TRoute extends { readonly __farmRouteInput: infer TInput }
+  ? TInput
+  : never;
+type InferRouteData<TRoute> = TRoute extends { readonly __farmRouteData: infer TData }
+  ? TData
+  : never;
 
 type NormalizeOptimisticUpdate<TUpdate> = TUpdate extends readonly [
   infer TRoute,
@@ -153,6 +156,48 @@ type NormalizeOptimisticUpdates<TUpdates extends readonly unknown[]> = {
   [K in keyof TUpdates]: NormalizeOptimisticUpdate<TUpdates[K]>;
 };
 
+type TypedEndpointLike = {
+  __types: {
+    body: any;
+    query: any;
+    response: any;
+  };
+};
+
+type Simplify<T> = {
+  [K in keyof T]: T[K];
+} & {};
+
+type IsNever<T> = [T] extends [never] ? true : false;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type RequiredKeys<T> = T extends object
+  ? {
+      [K in keyof T]-?: {} extends Pick<T, K> ? never : K;
+    }[keyof T]
+  : never;
+
+type BodyInputProp<TValue> =
+  IsNever<TValue> extends true
+    ? {}
+    : IsAny<TValue> extends true
+      ? { body?: TValue }
+      : undefined extends TValue
+        ? { body?: TValue }
+        : { body: TValue };
+
+type QueryInputProp<TValue> =
+  IsNever<TValue> extends true
+    ? {}
+    : IsAny<TValue> extends true
+      ? { query?: TValue }
+      : undefined extends TValue
+        ? { query?: TValue }
+        : RequiredKeys<TValue> extends never
+          ? { query?: TValue }
+          : { query: TValue };
+
+type HasRequiredKeys<T> = RequiredKeys<T> extends never ? false : true;
+
 // Type utilities to extract endpoint input/output types from TypedEndpoint
 type InferEndpointInput<T> = T extends {
   __types: {
@@ -160,13 +205,7 @@ type InferEndpointInput<T> = T extends {
     query: infer TQuery;
   };
 }
-  ? TBody extends never
-    ? TQuery extends never
-      ? {}
-      : { query?: TQuery }
-    : TQuery extends never
-      ? { body?: TBody }
-      : { body?: TBody; query?: TQuery }
+  ? Simplify<BodyInputProp<TBody> & QueryInputProp<TQuery>>
   : {};
 
 type InferEndpointOutput<T> = T extends {
@@ -178,19 +217,23 @@ type InferEndpointOutput<T> = T extends {
   : any;
 
 // Type for a single endpoint method
-type EndpointMethod<T = any> = <TUpdates extends readonly unknown[] = readonly OptimisticUpdate[]>(
-  options?: InferEndpointInput<T>,
-  clientOptions?: ClientOptions<InferEndpointOutput<T>, Error, TUpdates>,
-) => Promise<APIResult<InferEndpointOutput<T>, Error>>;
+type EndpointMethod<T = any> = (<TUpdates extends readonly unknown[] = readonly OptimisticUpdate[]>(
+  ...args: HasRequiredKeys<InferEndpointInput<T>> extends true
+    ? [
+        options: InferEndpointInput<T>,
+        clientOptions?: ClientOptions<InferEndpointOutput<T>, Error, TUpdates>,
+      ]
+    : [
+        options?: InferEndpointInput<T>,
+        clientOptions?: ClientOptions<InferEndpointOutput<T>, Error, TUpdates>,
+      ]
+) => Promise<APIResult<InferEndpointOutput<T>, Error>>) &
+  RouteRef<InferEndpointOutput<T>, InferEndpointInput<T>>;
 
 // Type for converting router structure to client structure
 type RouterToClient<T> = {
-  [K in keyof T]: T[K] extends Record<string, TypedEndpoint<any, any, any>>
-    ? {
-        [M in keyof T[K]]: M extends "get" | "post" | "put" | "delete" | "patch"
-          ? EndpointMethod<T[K][M]>
-          : never;
-      }
+  [K in keyof T]: T[K] extends TypedEndpointLike
+    ? EndpointMethod<T[K]>
     : T[K] extends Record<string, any>
       ? RouterToClient<T[K]> // Recurssive handling of the multi level api routes
       : EndpointMethod<T[K]>;

--- a/packages/farm/src/api/endpoint.ts
+++ b/packages/farm/src/api/endpoint.ts
@@ -2,7 +2,7 @@ import { createEndpoint as betterCallEndpoint } from "better-call";
 
 // Generic schema type that works with both Zod v3 and v4
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnySchema = { _output?: any; _input?: any; parse?: (data: unknown) => any } | any;
+type AnySchema = { _output?: any; _input?: any; parse?: (data: unknown) => any };
 
 // Infer output type from schema (works with Zod v3 and v4)
 type InferOutput<T> = T extends { _output: infer O }
@@ -15,9 +15,9 @@ export type EndpointParamValue = string | string[];
 export type EndpointParams = Record<string, EndpointParamValue>;
 
 export type EndpointOptions<
-  TBody extends AnySchema = any,
-  TQuery extends AnySchema = any,
-  THeaders extends AnySchema = any,
+  TBody extends AnySchema = never,
+  TQuery extends AnySchema = never,
+  THeaders extends AnySchema = never,
 > = {
   method?: "GET" | "HEAD" | "POST" | "PUT" | "DELETE" | "PATCH" | "OPTIONS";
   body?: TBody;
@@ -27,9 +27,9 @@ export type EndpointOptions<
 };
 
 export type EndpointHandler<
-  TBody extends AnySchema = any,
-  TQuery extends AnySchema = any,
-  THeaders extends AnySchema = any,
+  TBody extends AnySchema = never,
+  TQuery extends AnySchema = never,
+  THeaders extends AnySchema = never,
   TResponse = any,
 > = (ctx: {
   body: InferOutput<TBody>;
@@ -63,9 +63,9 @@ export type TypedEndpoint<TBody = never, TQuery = never, TResponse = any> = {
  *    `createEndpoint('/api/hello', { method: 'GET', query: z.object({...}) }, handler)`
  */
 export function createEndpoint<
-  TBody extends AnySchema = any,
-  TQuery extends AnySchema = any,
-  THeaders extends AnySchema = any,
+  TBody extends AnySchema = never,
+  TQuery extends AnySchema = never,
+  THeaders extends AnySchema = never,
   TResponse = any,
 >(
   pathOrOptions: string | EndpointOptions<TBody, TQuery, THeaders>,
@@ -123,8 +123,8 @@ export function GET<T = any>(
   handler: EndpointHandler<any, any, any, T>,
 ): ReturnType<typeof createEndpoint>;
 export function GET<
-  TQuery extends AnySchema = any,
-  THeaders extends AnySchema = any,
+  TQuery extends AnySchema = never,
+  THeaders extends AnySchema = never,
   TResponse = any,
 >(
   options: Omit<EndpointOptions<any, TQuery, THeaders>, "method">,
@@ -165,9 +165,9 @@ export function POST<T = any>(
   handler: EndpointHandler<any, any, any, T>,
 ): ReturnType<typeof createEndpoint>;
 export function POST<
-  TBody extends AnySchema = any,
-  TQuery extends AnySchema = any,
-  THeaders extends AnySchema = any,
+  TBody extends AnySchema = never,
+  TQuery extends AnySchema = never,
+  THeaders extends AnySchema = never,
   TResponse = any,
 >(
   options: Omit<EndpointOptions<TBody, TQuery, THeaders>, "method">,
@@ -187,9 +187,9 @@ export function PUT<T = any>(
   handler: EndpointHandler<any, any, any, T>,
 ): ReturnType<typeof createEndpoint>;
 export function PUT<
-  TBody extends AnySchema = any,
-  TQuery extends AnySchema = any,
-  THeaders extends AnySchema = any,
+  TBody extends AnySchema = never,
+  TQuery extends AnySchema = never,
+  THeaders extends AnySchema = never,
   TResponse = any,
 >(
   options: Omit<EndpointOptions<TBody, TQuery, THeaders>, "method">,
@@ -209,9 +209,9 @@ export function DELETE<T = any>(
   handler: EndpointHandler<any, any, any, T>,
 ): ReturnType<typeof createEndpoint>;
 export function DELETE<
-  TBody extends AnySchema = any,
-  TQuery extends AnySchema = any,
-  THeaders extends AnySchema = any,
+  TBody extends AnySchema = never,
+  TQuery extends AnySchema = never,
+  THeaders extends AnySchema = never,
   TResponse = any,
 >(
   options: Omit<EndpointOptions<TBody, TQuery, THeaders>, "method">,
@@ -231,9 +231,9 @@ export function PATCH<T = any>(
   handler: EndpointHandler<any, any, any, T>,
 ): ReturnType<typeof createEndpoint>;
 export function PATCH<
-  TBody extends AnySchema = any,
-  TQuery extends AnySchema = any,
-  THeaders extends AnySchema = any,
+  TBody extends AnySchema = never,
+  TQuery extends AnySchema = never,
+  THeaders extends AnySchema = never,
   TResponse = any,
 >(
   options: Omit<EndpointOptions<TBody, TQuery, THeaders>, "method">,
@@ -253,9 +253,9 @@ export function OPTIONS<T = any>(
   handler: EndpointHandler<any, any, any, T>,
 ): ReturnType<typeof createEndpoint>;
 export function OPTIONS<
-  TBody extends AnySchema = any,
-  TQuery extends AnySchema = any,
-  THeaders extends AnySchema = any,
+  TBody extends AnySchema = never,
+  TQuery extends AnySchema = never,
+  THeaders extends AnySchema = never,
   TResponse = any,
 >(
   options: Omit<EndpointOptions<TBody, TQuery, THeaders>, "method">,

--- a/packages/farm/src/integration-client.ts
+++ b/packages/farm/src/integration-client.ts
@@ -3,14 +3,7 @@ import type {
   FarmIntegrationAPIBodyFormat,
   FarmIntegrationAPIOperation,
 } from "./integration-api";
-import {
-  dispatchIntegrationRequest,
-  getRegisteredIntegrationAPIManifest,
-  getRegisteredIntegrations,
-  getRegisteredIntegrationRuntime,
-} from "./integrations";
 import type { FarmIntegration as FarmIntegrationDefinition } from "./integrations";
-import { _resolveCurrentRequest } from "./server/request-bridge";
 
 export type IntegrationClientOptions = {
   baseURL?: string;
@@ -239,6 +232,29 @@ type ResolvedIntegrationNamespace = readonly [
   FarmIntegrationDefinition | FarmIntegrationAPI,
 ];
 
+type RegisteredIntegrationRuntime = {
+  integration: FarmIntegrationDefinition;
+  config: unknown;
+  isDev: boolean;
+  isProd: boolean;
+};
+
+const INTEGRATION_RUNTIME_REGISTRY_KEY = Symbol.for("farm.integrationRuntimeRegistry");
+const CURRENT_REQUEST_RESOLVER_KEY = Symbol.for("farm.currentRequestResolver");
+const INTEGRATION_REQUEST_DISPATCHER_KEY = Symbol.for("farm.integrationRequestDispatcher");
+
+type IntegrationRequestDispatcher = (
+  runtime: RegisteredIntegrationRuntime,
+  request: Request,
+  options?: { currentRequest?: Request },
+) => Promise<Response | null>;
+
+type GlobalWithIntegrationRuntimeRegistry = typeof globalThis & {
+  [INTEGRATION_RUNTIME_REGISTRY_KEY]?: Map<string, RegisteredIntegrationRuntime>;
+  [CURRENT_REQUEST_RESOLVER_KEY]?: () => Request | undefined;
+  [INTEGRATION_REQUEST_DISPATCHER_KEY]?: IntegrationRequestDispatcher;
+};
+
 type GlobalWithIntegrationAPIManifest = typeof globalThis & {
   __FARM_INTEGRATION_API_MANIFEST__?: Record<string, FarmIntegrationAPI>;
   window?: {
@@ -283,6 +299,38 @@ function tryResolveSourceAPI(
   return source as FarmIntegrationAPI;
 }
 
+function getIntegrationRuntimeRegistry() {
+  const globalState = globalThis as GlobalWithIntegrationRuntimeRegistry;
+  return (
+    globalState[INTEGRATION_RUNTIME_REGISTRY_KEY] || new Map<string, RegisteredIntegrationRuntime>()
+  );
+}
+
+function getRegisteredIntegrationRuntimeLocal(
+  key: string,
+): RegisteredIntegrationRuntime | undefined {
+  return getIntegrationRuntimeRegistry().get(key);
+}
+
+function getRegisteredIntegrationsLocal(): Record<string, FarmIntegrationDefinition> {
+  return Object.fromEntries(
+    Array.from(getIntegrationRuntimeRegistry().entries()).map(([key, runtime]) => [
+      key,
+      runtime.integration,
+    ]),
+  );
+}
+
+function resolveCurrentRequestLocal(): Request | undefined {
+  const globalState = globalThis as GlobalWithIntegrationRuntimeRegistry;
+  return globalState[CURRENT_REQUEST_RESOLVER_KEY]?.();
+}
+
+function resolveIntegrationRequestDispatcherLocal(): IntegrationRequestDispatcher | undefined {
+  const globalState = globalThis as GlobalWithIntegrationRuntimeRegistry;
+  return globalState[INTEGRATION_REQUEST_DISPATCHER_KEY];
+}
+
 function resolveAutomaticClientNamespaces(): ResolvedIntegrationNamespace[] {
   const globalState = globalThis as GlobalWithIntegrationAPIManifest;
   const manifest =
@@ -294,7 +342,7 @@ function resolveAutomaticClientNamespaces(): ResolvedIntegrationNamespace[] {
 }
 
 function resolveAutomaticServerNamespaces(): ResolvedIntegrationNamespace[] {
-  return Object.entries(getRegisteredIntegrations()).flatMap(([key, source]) => {
+  return Object.entries(getRegisteredIntegrationsLocal()).flatMap(([key, source]) => {
     const api = tryResolveSourceAPI(source);
     return api ? [[key, api, source] as ResolvedIntegrationNamespace] : [];
   });
@@ -627,7 +675,7 @@ async function executeServerOperation(
         ? serverRequestOptions.request
         : options.request instanceof Request
           ? options.request
-          : _resolveCurrentRequest();
+          : resolveCurrentRequestLocal();
     const request = resolveRequestLike(
       serverRequestOptions?.request ?? options.request ?? currentRequest,
     );
@@ -656,26 +704,29 @@ async function executeServerOperation(
       const runtime =
         "kind" in (source || {}) &&
         (source as FarmIntegrationDefinition).kind === "farm-integration"
-          ? getRegisteredIntegrationRuntime(integrationKey) || {
+          ? getRegisteredIntegrationRuntimeLocal(integrationKey) || {
               integration: source as FarmIntegrationDefinition,
               config: {},
               isDev: process.env.NODE_ENV !== "production",
               isProd: process.env.NODE_ENV === "production",
             }
-          : getRegisteredIntegrationRuntime(integrationKey);
+          : getRegisteredIntegrationRuntimeLocal(integrationKey);
 
       if (runtime) {
-        const directResponse = await dispatchIntegrationRequest(
-          runtime,
-          new Request(url.toString(), {
-            method: operation.method,
-            headers,
-            body: createBody(operation.bodyFormat, input.body, headers),
-          }),
-          {
-            currentRequest,
-          },
-        );
+        const dispatchIntegrationRequest = resolveIntegrationRequestDispatcherLocal();
+        const directResponse = dispatchIntegrationRequest
+          ? await dispatchIntegrationRequest(
+              runtime,
+              new Request(url.toString(), {
+                method: operation.method,
+                headers,
+                body: createBody(operation.bodyFormat, input.body, headers),
+              }),
+              {
+                currentRequest,
+              },
+            )
+          : null;
 
         if (directResponse) {
           return await finalizeOperationResponse(operation, directResponse);
@@ -974,8 +1025,49 @@ export function createIntegrationClients<TSources extends Record<string, any>>(
   };
 }
 
+function createClientSafeIntegrationAPI(
+  api: FarmIntegrationAPI | undefined,
+): FarmIntegrationAPI | undefined {
+  if (!api) {
+    return undefined;
+  }
+
+  const entries = Object.entries(api as Record<string, unknown>).map(([key, value]) => {
+    if (isOperation(value)) {
+      return [
+        key,
+        {
+          kind: value.kind,
+          path: value.path,
+          method: value.method,
+          bodyFormat: value.bodyFormat,
+          responseFormat: value.responseFormat,
+          credentials: value.credentials,
+          isServer: value.isServer,
+          __pathless: value.__pathless,
+        },
+      ];
+    }
+
+    if (value && typeof value === "object") {
+      return [key, createClientSafeIntegrationAPI(value as FarmIntegrationAPI)];
+    }
+
+    return [key, value];
+  });
+
+  return Object.fromEntries(entries) as FarmIntegrationAPI;
+}
+
 export function getIntegrationAPIManifest(): Record<string, FarmIntegrationAPI> {
-  return getRegisteredIntegrationAPIManifest();
+  const manifestEntries = Object.entries(getRegisteredIntegrationsLocal())
+    .map(([key, integration]) => {
+      const api = createClientSafeIntegrationAPI(integration.api);
+      return api ? ([key, api] as const) : null;
+    })
+    .filter((value): value is readonly [string, FarmIntegrationAPI] => value !== null);
+
+  return Object.fromEntries(manifestEntries);
 }
 
 export function integrationClients<TSources extends Record<string, any>>(

--- a/packages/farm/src/integrations.ts
+++ b/packages/farm/src/integrations.ts
@@ -461,9 +461,17 @@ type RegisteredIntegrationRuntime = {
 };
 
 const INTEGRATION_RUNTIME_REGISTRY_KEY = Symbol.for("farm.integrationRuntimeRegistry");
+const INTEGRATION_REQUEST_DISPATCHER_KEY = Symbol.for("farm.integrationRequestDispatcher");
+
+type IntegrationRequestDispatcher = (
+  runtime: RegisteredIntegrationRuntime,
+  request: Request,
+  options?: { currentRequest?: Request },
+) => Promise<Response | null>;
 
 type GlobalWithIntegrationRuntimeRegistry = typeof globalThis & {
   [INTEGRATION_RUNTIME_REGISTRY_KEY]?: Map<string, RegisteredIntegrationRuntime>;
+  [INTEGRATION_REQUEST_DISPATCHER_KEY]?: IntegrationRequestDispatcher;
 };
 
 function getIntegrationRuntimeRegistry() {
@@ -1617,6 +1625,9 @@ export async function dispatchIntegrationRequest(
 
   return null;
 }
+
+(globalThis as GlobalWithIntegrationRuntimeRegistry)[INTEGRATION_REQUEST_DISPATCHER_KEY] =
+  dispatchIntegrationRequest;
 
 function createIntegrationRequestContextStore(
   rawRequest: FarmRequest,

--- a/packages/farm/src/nitro/index.ts
+++ b/packages/farm/src/nitro/index.ts
@@ -431,6 +431,7 @@ export default defineEventHandler(async (event: H3Event) => {
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="data:,">
   <title>Farm.js App</title>
   <script>
     window.__FARM_PROPS__ = \${JSON.stringify(pageProps)};

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1555,6 +1555,7 @@ async function handleRequest(request) {
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="data:,">
   <title>\${title}</title>\${metaTags}
   <link rel="stylesheet" href="/farm-client.css">
 </head>
@@ -1703,6 +1704,7 @@ async function handleRequest(request) {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="data:,">
   <link rel="stylesheet" href="/farm-client.css">
   <title>404 - Page Not Found</title>
 </head>

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -848,7 +848,9 @@ const spaRouter = {
         if (!reactRoot) {
           reactRoot = createRoot(currentRoot);
         }
-        reactRoot.render(React.createElement(Component, props));
+        const pageElement = React.createElement(Component, props);
+        const wrappedElement = wrapWithLayouts(pageElement, newPathname, params);
+        reactRoot.render(wrappedElement);
       }
     }
   },
@@ -896,10 +898,12 @@ window.addEventListener("popstate", function() {
     const params = matched.params;
     const searchParams = Object.fromEntries(new URLSearchParams(window.location.search));
     const props = { params: params, searchParams: Promise.resolve(searchParams) };
+    const pageElement = React.createElement(Component, props);
+    const wrappedElement = wrapWithLayouts(pageElement, pathname, params);
     
     const container = document.getElementById("root");
     if (container && reactRoot) {
-      reactRoot.render(React.createElement(Component, props));
+      reactRoot.render(wrappedElement);
       currentPathname = pathname;
     }
   } else {

--- a/packages/farm/src/openapi/docs-route.tsx
+++ b/packages/farm/src/openapi/docs-route.tsx
@@ -12,6 +12,7 @@ export function DocsRoute({ spec, config }: DocsRouteProps) {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="icon" href="data:," />
         <title>{config?.title || "API Documentation"}</title>
         <style>{`
           body {

--- a/packages/farm/src/openapi/manager.ts
+++ b/packages/farm/src/openapi/manager.ts
@@ -127,6 +127,7 @@ export class OpenAPIManager {
     <title>${this.config.title || "API Documentation"}</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" href="data:," />
   </head>
   <body>
     <script

--- a/packages/farm/src/query/client.ts
+++ b/packages/farm/src/query/client.ts
@@ -144,7 +144,7 @@ export function useQueryState<TParser extends Parser<any>>(
 ] {
   type T = NonNullable<ReturnType<TParser["parse"]>>;
   const [state, setState] = useState<T | null>(() => {
-    if (typeof window === "undefined") return null;
+    if (typeof window === "undefined") return parser.parse("");
     const searchParams = getCurrentSearchParams();
     const value = searchParams.get(key);
     const parsed = parser.parse(value ?? "");
@@ -237,11 +237,8 @@ export function useQueryStates<T extends Record<string, Parser<any>>>(
   const watchKeys = keys.join("&");
 
   const [state, setState] = useState<{ [K in keyof T]: ReturnType<T[K]["parse"]> }>(() => {
-    if (typeof window === "undefined") {
-      return {} as { [K in keyof T]: ReturnType<T[K]["parse"]> };
-    }
-
-    const searchParams = getCurrentSearchParams();
+    const searchParams =
+      typeof window === "undefined" ? new URLSearchParams() : getCurrentSearchParams();
     const result = {} as { [K in keyof T]: ReturnType<T[K]["parse"]> };
 
     Object.entries(parsers).forEach(([key, parser]) => {

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -707,6 +707,7 @@ window.__FARM_INTEGRATION_API_MANIFEST__ = ${JSON.stringify(getRegisteredIntegra
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="data:,">
   <title>${title}</title>${metaTags}
   <link rel="stylesheet" href="/src/app/globals.css" />
   <script type="module" src="/@vite/client"></script>
@@ -896,6 +897,7 @@ window.__FARM_INTEGRATION_API_MANIFEST__ = ${JSON.stringify(getRegisteredIntegra
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="data:,">
   <title>Farm.js App</title>
   <link rel="stylesheet" href="/src/app/globals.css" />
   <script type="module" src="/@vite/client"></script>

--- a/packages/farm/src/utils/client-component.ts
+++ b/packages/farm/src/utils/client-component.ts
@@ -74,6 +74,28 @@ const RESOLVABLE_SOURCE_EXTENSIONS = [
   ".cjs",
 ] as const;
 
+export function hasUseClientDirective(content: string | null): boolean {
+  if (!content) {
+    return false;
+  }
+  const normalized = content.trimStart();
+  return normalized.startsWith("'use client'") || normalized.startsWith('"use client"');
+}
+
+export function hasHydrateExport(content: string | null): boolean {
+  if (!content) {
+    return false;
+  }
+  return (
+    /\bexport\s+const\s+hydrate\s*=\s*true\b/.test(content) ||
+    /\bexport\s*\{\s*hydrate\s*\}\b/.test(content)
+  );
+}
+
+export function stripUseClientDirective(content: string): string {
+  return content.replace(/^\s*(["'])use client\1\s*;?\s*/, "");
+}
+
 function parseClientModuleMetadata(content: string | null): ParsedClientModuleMetadata {
   if (!content) {
     return {
@@ -82,16 +104,9 @@ function parseClientModuleMetadata(content: string | null): ParsedClientModuleMe
     };
   }
 
-  const normalized = content.trimStart();
-  const isClientComponent =
-    normalized.startsWith("'use client'") || normalized.startsWith('"use client"');
-  const hasHydrateExport =
-    /\bexport\s+const\s+hydrate\s*=\s*true\b/.test(content) ||
-    /\bexport\s*\{\s*hydrate\s*\}\b/.test(content);
-
   return {
-    isClientComponent,
-    hasHydrateExport,
+    isClientComponent: hasUseClientDirective(content),
+    hasHydrateExport: hasHydrateExport(content),
   };
 }
 

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -10,7 +10,11 @@ import { OpenAPIManager } from "./openapi/manager";
 import { MiddlewareManager } from "./middleware/manager";
 import { generateRouteTypes } from "./routing/generate-route-types";
 import { sendWebResponse } from "./server/response";
-import { getClientModuleMetadata, isClientComponentModule } from "./utils/client-component";
+import {
+  getClientModuleMetadata,
+  hasUseClientDirective,
+  stripUseClientDirective,
+} from "./utils/client-component";
 import {
   dispatchIntegrationRequest,
   getIntegrationDocumentNavigationMatchers,
@@ -816,17 +820,21 @@ export const manifest = getManifest();
     },
 
     transform(code, id) {
-      if (
-        code.trimStart().startsWith("'use client'") ||
-        code.trimStart().startsWith('"use client"')
-      ) {
+      if (hasUseClientDirective(code)) {
         const moduleInfo = this.getModuleInfo(id);
         if (moduleInfo) {
           (moduleInfo as any).isClientComponent = true;
         }
 
+        const transformedCode = stripUseClientDirective(code);
+
         // Store client component for later injection
-        if (!farmApp) return;
+        if (!farmApp) {
+          return {
+            code: transformedCode,
+            map: null,
+          };
+        }
 
         const clientComponents = (farmApp as any).__clientComponents__ || new Set();
         clientComponents.add(id);
@@ -854,7 +862,7 @@ if (import.meta.hot) {
 }
 `;
         return {
-          code: code + "\n" + hmrCode,
+          code: transformedCode + "\n" + hmrCode,
           map: null,
         };
       }
@@ -1528,7 +1536,7 @@ async function moduleLooksClient(modulePath) {
     const response = await fetch(modulePath, { headers: { Accept: "text/javascript" } });
     const source = await response.text();
     const looksClient = /["']use client["']/.test(source.slice(0, 256));
-    const hasHydrateExport = /\bexports+consts+hydrates*=s*true\b/.test(source);
+    const hasHydrateExport = /\\bexport\\s+const\\s+hydrate\\s*=\\s*true\\b/.test(source);
     const shouldHydrate = looksClient || hasHydrateExport;
     clientModuleHintCache.set(modulePath, shouldHydrate);
     return shouldHydrate;

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -950,6 +950,7 @@ if (import.meta.hot) {
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="data:,">
   <link rel="stylesheet" href="/assets/globals.css">
   ${page.revalidate ? `<meta name="x-farm-revalidate" content="${page.revalidate}">` : ""}
 </head>

--- a/packages/farm/types/client.d.ts
+++ b/packages/farm/types/client.d.ts
@@ -225,7 +225,7 @@ declare module "@farmjs/core/client" {
         method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS" | "HEAD";
         input?: unknown;
       }
-    | [RouteRef, unknown?];
+    | [CallableRouteRef, unknown?];
 
   export type InvalidateOptions =
     | InvalidateTarget[]
@@ -235,7 +235,7 @@ declare module "@farmjs/core/client" {
       };
 
   export type OptimisticUpdate =
-    | [RouteRef<any, any>, unknown, (prev: any) => any]
+    | [CallableRouteRef<any>, unknown, (prev: any) => any]
     | [CacheKey<any> | string, (prev: any) => any];
 
   export type OptimisticOptions<TUpdates extends readonly unknown[] = readonly OptimisticUpdate[]> =
@@ -266,13 +266,19 @@ declare module "@farmjs/core/client" {
     onStatus?: (event: StatusEvent<TData, TError>) => void;
   };
 
-  type RouteRef<TInput = any, TData = any> = (
-    options?: TInput,
-    clientOptions?: ClientOptions<any, any>,
-  ) => Promise<APIResult<TData, any>>;
+  type AnyRouteRef = (...args: any[]) => any;
+  type RouteRef<TData = any, TInput = any> = {
+    readonly __farmRouteInput: TInput;
+    readonly __farmRouteData: TData;
+  };
+  type CallableRouteRef<TData = any, TInput = any> = AnyRouteRef & RouteRef<TData, TInput>;
 
-  type InferRouteInput<TRoute> = TRoute extends RouteRef<infer TInput, any> ? TInput : never;
-  type InferRouteData<TRoute> = TRoute extends RouteRef<any, infer TData> ? TData : never;
+  type InferRouteInput<TRoute> = TRoute extends { readonly __farmRouteInput: infer TInput }
+    ? TInput
+    : never;
+  type InferRouteData<TRoute> = TRoute extends { readonly __farmRouteData: infer TData }
+    ? TData
+    : never;
 
   type NormalizeOptimisticUpdate<TUpdate> = TUpdate extends readonly [
     infer TRoute,
@@ -310,6 +316,40 @@ declare module "@farmjs/core/client" {
     };
   };
 
+  type Simplify<T> = {
+    [K in keyof T]: T[K];
+  } & {};
+
+  type IsNever<T> = [T] extends [never] ? true : false;
+  type IsAny<T> = 0 extends 1 & T ? true : false;
+  type RequiredKeys<T> = T extends object
+    ? {
+        [K in keyof T]-?: {} extends Pick<T, K> ? never : K;
+      }[keyof T]
+    : never;
+
+  type BodyInputProp<TValue> =
+    IsNever<TValue> extends true
+      ? {}
+      : IsAny<TValue> extends true
+        ? { body?: TValue }
+        : undefined extends TValue
+          ? { body?: TValue }
+          : { body: TValue };
+
+  type QueryInputProp<TValue> =
+    IsNever<TValue> extends true
+      ? {}
+      : IsAny<TValue> extends true
+        ? { query?: TValue }
+        : undefined extends TValue
+          ? { query?: TValue }
+          : RequiredKeys<TValue> extends never
+            ? { query?: TValue }
+            : { query: TValue };
+
+  type HasRequiredKeys<T> = RequiredKeys<T> extends never ? false : true;
+
   // Type utilities to extract endpoint input/output types
   type InferEndpointInput<T> = T extends {
     __types: {
@@ -317,13 +357,7 @@ declare module "@farmjs/core/client" {
       query: infer TQuery;
     };
   }
-    ? TBody extends never
-      ? TQuery extends never
-        ? {}
-        : { query?: TQuery }
-      : TQuery extends never
-        ? { body?: TBody }
-        : { body?: TBody; query?: TQuery }
+    ? Simplify<BodyInputProp<TBody> & QueryInputProp<TQuery>>
     : {};
 
   type InferEndpointOutput<T> = T extends {
@@ -334,20 +368,24 @@ declare module "@farmjs/core/client" {
     ? R
     : any;
 
-  type EndpointMethod<T = any> = <
+  type EndpointMethod<T = any> = (<
     TUpdates extends readonly unknown[] = readonly OptimisticUpdate[],
   >(
-    options?: InferEndpointInput<T>,
-    clientOptions?: ClientOptions<InferEndpointOutput<T>, Error, TUpdates>,
-  ) => Promise<APIResult<InferEndpointOutput<T>, Error>>;
+    ...args: HasRequiredKeys<InferEndpointInput<T>> extends true
+      ? [
+          options: InferEndpointInput<T>,
+          clientOptions?: ClientOptions<InferEndpointOutput<T>, Error, TUpdates>,
+        ]
+      : [
+          options?: InferEndpointInput<T>,
+          clientOptions?: ClientOptions<InferEndpointOutput<T>, Error, TUpdates>,
+        ]
+  ) => Promise<APIResult<InferEndpointOutput<T>, Error>>) &
+    RouteRef<InferEndpointOutput<T>, InferEndpointInput<T>>;
 
   type RouterToClient<T> = {
-    [K in keyof T]: T[K] extends Record<string, TypedEndpointLike>
-      ? {
-          [M in keyof T[K]]: M extends "get" | "post" | "put" | "delete" | "patch"
-            ? EndpointMethod<T[K][M]>
-            : never;
-        }
+    [K in keyof T]: T[K] extends TypedEndpointLike
+      ? EndpointMethod<T[K]>
       : T[K] extends Record<string, unknown>
         ? RouterToClient<T[K]>
         : EndpointMethod<T[K]>;

--- a/packages/farmjs-plugin/src/rsc/entries/client.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/client.ts
@@ -13,11 +13,7 @@ import type { EntryContext } from "../types.js";
  */
 export function generateClientEntry(ctx: EntryContext): string {
   const debugLog = `// Debug disabled`;
-  const routesDir = ctx.routesDir?.trim() ?? "";
-  const routesPath = routesDir ? `/${routesDir}` : "/app";
-  const globalsCssPath = `/${ctx.srcDir}${routesPath}/globals.css`;
   let imports = `
-import ${JSON.stringify(globalsCssPath)};
 import React from 'react';
 import { hydrateRoot } from 'react-dom/client';
 import { createFromReadableStream } from '@vitejs/plugin-rsc/browser';

--- a/packages/farmjs-plugin/src/rsc/entries/rsc.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/rsc.ts
@@ -12,8 +12,8 @@ import type { EntryContext } from "../types.js";
  */
 export function generateRscEntry(ctx: EntryContext): string {
   // Build the glob pattern for discovering routes (Farm convention: src/app when routesDir unset)
-  const appSegment = (ctx.routesDir?.trim() ?? "") || "app";
-  const glob = `/${ctx.srcDir}/${appSegment}`;
+  const appSegment = ctx.routesDir === undefined ? "app" : ctx.routesDir.trim();
+  const glob = appSegment ? `/${ctx.srcDir}/${appSegment}` : `/${ctx.srcDir}`;
 
   const debugLog = `// Debug disabled`;
   let code = `
@@ -298,23 +298,27 @@ function filePathToRoute(filePath) {
  * Route-level error boundary (React class component for getDerivedStateFromError)
  * Next.js-style: error.tsx receives { error, reset }.
  */
-class RouteErrorBoundary extends React.Component {
-  static getDerivedStateFromError(error) {
-    return { hasError: true, error };
-  }
-  constructor(props) {
-    super(props);
-    this.state = { hasError: false, error: null };
-  }
-  render() {
-    if (this.state.hasError) {
-      const Fallback = this.props.Fallback;
-      const reset = () => this.setState({ hasError: false, error: null });
-      return React.createElement(Fallback, { ...this.props.fallbackProps, error: this.state.error, reset });
+const RouteErrorBoundary = React.Component
+  ? class RouteErrorBoundary extends React.Component {
+      static getDerivedStateFromError(error) {
+        return { hasError: true, error };
+      }
+      constructor(props) {
+        super(props);
+        this.state = { hasError: false, error: null };
+      }
+      render() {
+        if (this.state.hasError) {
+          const Fallback = this.props.Fallback;
+          const reset = () => this.setState({ hasError: false, error: null });
+          return React.createElement(Fallback, { ...this.props.fallbackProps, error: this.state.error, reset });
+        }
+        return this.props.children;
+      }
     }
-    return this.props.children;
-  }
-}
+  : function ServerPassthroughBoundary({ children }) {
+      return children;
+    };
 
 /**
  * Match a URL pathname to a route pattern
@@ -517,8 +521,9 @@ async function handler(request) {
   
   const { Page, pattern, params, metadata } = matched;
   const Layout = getLayout(pattern) || (function PassThrough({ children }) { return children; });
-  const routesDir = ${JSON.stringify(ctx.routesDir ?? "")}.trim();
-  const routesPath = routesDir ? '/' + routesDir : '/app';
+  const configuredRoutesDir = ${ctx.routesDir === undefined ? "undefined" : JSON.stringify(ctx.routesDir)};
+  const routesDir = configuredRoutesDir === undefined ? 'app' : configuredRoutesDir.trim();
+  const routesPath = routesDir ? '/' + routesDir : '';
   const globalsCssPath = '/${ctx.srcDir}' + routesPath + '/globals.css';
   
   // Parse search params
@@ -570,13 +575,13 @@ async function handler(request) {
   // Build the full page. root = full document (for SSR). rootContent = single wrapper + layout (for client hydration).
   const payload = {
     root: h('html', null,
-      h('head', null,
-        h('meta', { charSet: 'utf-8' }),
-        h('meta', { name: 'viewport', content: 'width=device-width, initial-scale=1' }),
-        metadata?.title ? h('title', null, metadata.title) : null,
-        metadata?.description ? h('meta', { name: 'description', content: metadata.description }) : null,
-        typeof import.meta.viteRsc?.loadCss === 'function' ? import.meta.viteRsc.loadCss() : h('link', { rel: 'stylesheet', href: globalsCssPath })
-      ),
+        h('head', null,
+          h('meta', { charSet: 'utf-8' }),
+          h('meta', { name: 'viewport', content: 'width=device-width, initial-scale=1' }),
+          h('link', { rel: 'icon', href: 'data:,' }),
+          metadata?.title ? h('title', null, metadata.title) : null,
+          metadata?.description ? h('meta', { name: 'description', content: metadata.description }) : null
+        ),
       h('body', null,
         h('div', { id: 'root' }, rootInner)
       )
@@ -637,9 +642,10 @@ async function handler(request) {
     h('head', null,
       h('meta', { charSet: 'utf-8' }),
       h('meta', { name: 'viewport', content: 'width=device-width, initial-scale=1' }),
+      h('link', { rel: 'icon', href: 'data:,' }),
       metadata?.title ? h('title', null, metadata.title) : null,
       metadata?.description ? h('meta', { name: 'description', content: metadata.description }) : null,
-      h('link', { rel: 'stylesheet', href: globalsCssPath }),
+      h('link', { rel: 'stylesheet', href: globalsCssPath, as: 'style', precedence: 'default' }),
       h('script', { type: 'module', src: '/@vite/client' })
     ),
     h('body', null,
@@ -680,8 +686,9 @@ async function handler(request) {
           h('head', null,
             h('meta', { charSet: 'utf-8' }),
             h('meta', { name: 'viewport', content: 'width=device-width, initial-scale=1' }),
+            h('link', { rel: 'icon', href: 'data:,' }),
             h('title', null, 'Error'),
-            h('link', { rel: 'stylesheet', href: globalsCssPath })
+            h('link', { rel: 'stylesheet', href: globalsCssPath, as: 'style', precedence: 'default' })
           ),
           h('body', null, h('div', { id: 'root' }, rootInner))
         );

--- a/packages/farmjs-plugin/src/rsc/entries/ssr.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/ssr.ts
@@ -12,6 +12,9 @@ import type { EntryContext } from "../types.js";
  */
 export function generateSsrEntry(ctx: EntryContext): string {
   const debugLog = `// Debug disabled`;
+  const routesDir = ctx.routesDir === undefined ? "app" : ctx.routesDir.trim();
+  const routesPath = routesDir ? `/${routesDir}` : "";
+  const globalsCssPath = `/${ctx.srcDir}${routesPath}/globals.css`;
 
   return `
 import React from 'react';
@@ -21,6 +24,61 @@ import { renderToPipeableStream } from 'react-dom/server';
 
 function debug(...args) {
   ${debugLog}
+}
+
+const DEV_GLOBAL_CSS_HREF = ${JSON.stringify(globalsCssPath)};
+const CLIENT_CSS_HREF = "__FARM_CLIENT_CSS_HREF__";
+const PLACEHOLDER_CSS_HREF = "__FARM_CLIENT_CSS_HREF__";
+const resolvedCssHref =
+  typeof CLIENT_CSS_HREF === "string" &&
+  CLIENT_CSS_HREF.length > 0 &&
+  CLIENT_CSS_HREF.indexOf(PLACEHOLDER_CSS_HREF) < 0
+    ? CLIENT_CSS_HREF
+    : DEV_GLOBAL_CSS_HREF;
+
+function escapeHtmlAttribute(value) {
+  return String(value).replace(/[&"]/g, (char) => (char === '&' ? '&amp;' : '&quot;'));
+}
+
+const cssLinkTag = resolvedCssHref
+  ? '<link rel="stylesheet" href="' + escapeHtmlAttribute(resolvedCssHref) + '" as="style" data-precedence="default">'
+  : '';
+
+function injectIntoHeadStream(tag) {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  const marker = '</head>';
+  let buffer = '';
+  let injected = false;
+
+  return new TransformStream({
+    transform(chunk, controller) {
+      const str = typeof chunk === "string" ? chunk : decoder.decode(chunk);
+      if (injected || !tag) {
+        controller.enqueue(typeof chunk === "string" ? encoder.encode(str) : chunk);
+        return;
+      }
+
+      buffer += str;
+      const index = buffer.indexOf(marker);
+      if (index >= 0) {
+        const before = buffer.slice(0, index);
+        const after = buffer.slice(index + marker.length);
+        controller.enqueue(encoder.encode(before + tag + marker + after));
+        buffer = '';
+        injected = true;
+        return;
+      }
+
+      if (buffer.length > marker.length) {
+        controller.enqueue(encoder.encode(buffer.slice(0, buffer.length - marker.length)));
+        buffer = buffer.slice(-marker.length);
+      }
+    },
+    flush(controller) {
+      if (buffer) controller.enqueue(encoder.encode(buffer));
+    },
+  });
 }
 
 /** Collect Node stream (from renderToPipeableStream) into a single string. Supports Suspense. */
@@ -45,15 +103,10 @@ export async function renderHTML(firstArg, options = {}) {
   const rscStream = hasPayload ? firstArg.rscStream : firstArg;
   const [s1, s2] = rscStream.tee();
   
-  // When payload is provided: render the tree directly so Suspense streams (loading fallback first, then content).
-  // When not: deserialize full stream first (legacy), then render (no streaming of loading state).
-  let rootElement;
-  if (hasPayload) {
-    rootElement = firstArg.payload.root;
-  } else {
-    const payload = await createFromReadableStream(s1);
-    rootElement = payload.root;
-  }
+  // Always deserialize the RSC stream before SSR. Rendering the raw payload directly
+  // calls client references on the server (for example, a "use client" Counter).
+  const payload = await createFromReadableStream(s1);
+  const rootElement = payload.root;
   
   function Root() {
     return rootElement;
@@ -90,7 +143,7 @@ export async function renderHTML(firstArg, options = {}) {
   const clientScriptTag = injectClientScriptInStream ? '<script type="module" src="' + CLIENT_ENTRY_HREF + '"></script>' : '';
 
   if (hasPayload) {
-    // Stream HTML to the client so loading.tsx appears first, then content when async work finishes.
+    // Stream HTML to the client while preserving the RSC payload for hydration.
     debug('Streaming HTML (loading fallback then content)');
     const BODY_HTML_END = '</body></html>';
     const TAG_LEN = BODY_HTML_END.length;
@@ -129,7 +182,8 @@ export async function renderHTML(firstArg, options = {}) {
             passThrough.on('error', (e) => controller.error(e));
           }
         });
-    let out = webStream.pipeThrough(injectRSCPayload(s2));
+    let out = webStream.pipeThrough(injectIntoHeadStream(cssLinkTag));
+    out = out.pipeThrough(injectRSCPayload(s2));
     out = out.pipeThrough(streamingClientScriptInjector);
     return out;
   }
@@ -137,11 +191,9 @@ export async function renderHTML(firstArg, options = {}) {
   // Legacy path: buffer full HTML then send (no loading streaming)
   debug('Rendering to HTML stream (then buffering)');
   const fullHtmlRaw = await pipeableStreamToString(passThrough);
-  const CLIENT_CSS_HREF = "__FARM_CLIENT_CSS_HREF__";
-  const shouldInjectCss = typeof CLIENT_CSS_HREF === "string" && CLIENT_CSS_HREF.length > 0 && CLIENT_CSS_HREF.indexOf("__FARM_CLIENT_CSS_HREF__") < 0;
   let fullHtml = fullHtmlRaw;
-  if (shouldInjectCss && fullHtml.includes("</head>")) {
-    fullHtml = fullHtml.replace("</head>", '<link rel="stylesheet" href="' + CLIENT_CSS_HREF + '"></head>');
+  if (cssLinkTag && fullHtml.includes("</head>")) {
+    fullHtml = fullHtml.replace("</head>", cssLinkTag + "</head>");
   }
   ${
     ctx.actionsEnabled

--- a/packages/farmjs-plugin/src/rsc/index.ts
+++ b/packages/farmjs-plugin/src/rsc/index.ts
@@ -496,8 +496,9 @@ export default function farmRsc(options: FarmRscPluginOptions = {}): Plugin[] {
         if (id.startsWith(VIRTUAL_PREFIX + "/@rsc-hydrate/")) {
           const pagePath = id.replace(VIRTUAL_PREFIX + "/@rsc-hydrate", "");
           const srcDir = entryContext.srcDir;
-          const appSegment = entryContext.routesDir?.trim() || "app";
-          const basePath = `/${srcDir}/${appSegment}`;
+          const appSegment =
+            entryContext.routesDir === undefined ? "app" : entryContext.routesDir.trim();
+          const basePath = appSegment ? `/${srcDir}/${appSegment}` : `/${srcDir}`;
           const pageImportPath =
             pagePath === "/" ? `${basePath}/page.tsx` : `${basePath}${pagePath}/page.tsx`;
           const layoutImportPath = `${basePath}/layout.tsx`;
@@ -728,8 +729,9 @@ if (document.readyState === 'loading') {
 
               // Build the glob pattern for discovering routes (Farm convention: src/app when routesDir unset)
               const srcDir = entryContext.srcDir;
-              const appSegment = entryContext.routesDir?.trim() || "app";
-              const glob = `/${srcDir}/${appSegment}`;
+              const appSegment =
+                entryContext.routesDir === undefined ? "app" : entryContext.routesDir.trim();
+              const glob = appSegment ? `/${srcDir}/${appSegment}` : `/${srcDir}`;
 
               // Find matching page file
               const normalized = pathname.replace(/\/$/, "") || "/";
@@ -746,8 +748,8 @@ if (document.readyState === 'loading') {
               const parts = normalized.split("/").filter(Boolean);
               for (let i = parts.length; i >= 0; i--) {
                 const base = parts.slice(0, i).join("/");
-                possiblePaths.push(`${glob}/${base}/page.tsx`);
-                possiblePaths.push(`${glob}/${base}/page.jsx`);
+                possiblePaths.push(base ? `${glob}/${base}/page.tsx` : `${glob}/page.tsx`);
+                possiblePaths.push(base ? `${glob}/${base}/page.jsx` : `${glob}/page.jsx`);
               }
 
               let pageModule: any = null;
@@ -783,7 +785,7 @@ if (document.readyState === 'loading') {
               }
 
               try {
-                const layoutPath = `./${srcDir}/${appSegment}/layout.tsx`;
+                const layoutPath = `./${srcDir}${appSegment ? `/${appSegment}` : ""}/layout.tsx`;
                 layoutModule = await server.ssrLoadModule(layoutPath);
               } catch {}
 
@@ -870,8 +872,9 @@ if (document.readyState === 'loading') {
               const h = React.default.createElement;
               const isSyncPage = !isAsyncPage && !isAsyncLayout;
               // For sync pages we load preamble + vite client + hydrate in one script below; do not load vite-client in head so order is guaranteed.
-              const routesDir = entryContext.routesDir?.trim() ?? "";
-              const routesPath = routesDir ? `/${routesDir}` : "/app";
+              const routesDir =
+                entryContext.routesDir === undefined ? "app" : entryContext.routesDir.trim();
+              const routesPath = routesDir ? `/${routesDir}` : "";
               const headElements = [
                 h("meta", { key: "charset", charSet: "utf-8" }),
                 h("meta", {


### PR DESCRIPTION
## Summary
- Strip top-level `"use client"` directives during the Farm Vite transform while preserving client component metadata.
- Share client-module detection helpers and fix dev hydrate export detection.
- Keep layouts wrapped when production client-page rerenders happen after HTML swaps and back/forward navigation.

## Why
Closes #43.

This fixes hydration polish around client routes: production builds no longer warn about ignored module directives, and client-rendered hydration/navigation paths keep the app layout instead of rendering the page component bare.

## Validation
- `./node_modules/.bin/vitest run` in `packages/farm`
- `./node_modules/.bin/tsup` in `packages/farm`
- `./node_modules/.bin/farm build` in `examples/ssr-ssg-demo`
- Playwright smoke against `examples/ssr-ssg-demo`: dashboard hydrated, counter updated `0 -> 1`, layout stayed after navigation, API demo returned `Hello, World!`, no console/page errors
- `./node_modules/.bin/oxfmt --check .`
- `./node_modules/.bin/oxlint .` (warning-only existing cleanup items, 0 errors)