### PR TITLE
feat: add docs integration

### DIFF
--- a/examples/basic/docs.json
+++ b/examples/basic/docs.json
@@ -1,0 +1,9 @@
+{
+  "entry": "docs",
+  "metadata": {
+    "description": "Farm.js example documentation"
+  },
+  "nav": {
+    "title": "Farm Docs"
+  }
+}

--- a/examples/basic/farm.config.ts
+++ b/examples/basic/farm.config.ts
@@ -150,6 +150,10 @@ export default defineFarmConfig({
     }
   },
 
+  docs: {
+    entry: '/docs',
+  },
+
   // Plugins
   plugins: [
     createLoggerPlugin({}),

--- a/examples/basic/src/app/docs/getting-started/page.md
+++ b/examples/basic/src/app/docs/getting-started/page.md
@@ -1,0 +1,14 @@
+---
+title: Getting Started
+description: A short docs page for the basic example.
+---
+
+# Getting Started
+
+Run the example with:
+
+```bash
+pnpm dev
+```
+
+Then open `/docs` or `/docs/getting-started`.

--- a/examples/basic/src/app/docs/page.md
+++ b/examples/basic/src/app/docs/page.md
@@ -1,0 +1,12 @@
+---
+title: Farm.js Docs
+description: Local docs served by the Farm docs integration.
+---
+
+# Farm.js Docs
+
+This page is served from Markdown through the built-in Farm docs integration.
+
+- It uses `docs: { entry: "/docs" }` in `farm.config.ts`.
+- It can also read shared docs settings from `docs.json`.
+- Markdown can be fetched directly from `/docs.md`.

--- a/examples/basic/src/farm-routes.d.ts
+++ b/examples/basic/src/farm-routes.d.ts
@@ -3,7 +3,7 @@
  * Link href is typed automatically via module augmentation. Regenerated on dev start and when routes change.
  * Set suppressLintOnLink: true in farm.config.ts to accept any string on Link href.
  */
-export type RoutePath = "/" | "/about" | "/api-demo" | "/api-demo-client" | "/api-demo-client-advanced" | "/boundaries/error" | "/boundaries/loading" | "/boundaries/suspense" | "/contact" | "/farm-query-client-demo" | "/farm-query-demo" | "/prefetch-e2e" | "/query-demo" | "/storage-demo" | "/store-e2e" | `/users/${string}`;
+export type RoutePath = "/" | "/about" | "/api-demo" | "/api-demo-client" | "/api-demo-client-advanced" | "/boundaries/error" | "/boundaries/loading" | "/boundaries/suspense" | "/contact" | "/docs" | `/docs/${string}` | "/docs/reference" | "/farm-query-client-demo" | "/farm-query-demo" | "/prefetch-e2e" | "/query-demo" | "/storage-demo" | "/store-e2e" | `/users/${string}`;
 declare module "@farmjs/core/client" {
   interface LinkDefaultRoute {
     _: import("./farm-routes").RoutePath;
@@ -24,3 +24,4 @@ declare module "@farmjs/core/dist/client.js" {
     _: import("./farm-routes").RoutePath;
   }
 }
+

--- a/examples/docs-integration/README.md
+++ b/examples/docs-integration/README.md
@@ -1,6 +1,7 @@
 # Farm docs integration example
 
-This example shows the Farm docs runtime and the Next-style API wrapper.
+This example shows Farm's docs runtime and the Next-style docs API wrapper inspired by
+`@farming-labs/docs`.
 
 ```ts
 // src/app/api/docs/route.ts
@@ -9,11 +10,30 @@ import { createDocsAPI } from '@farmjs/core/docs';
 export const { GET, POST } = createDocsAPI();
 ```
 
+The catch-all route uses the same wrapper so path-style machine routes work too:
+
+```ts
+// src/app/api/docs/[...docs]/route.ts
+import { createDocsAPI } from '@farmjs/core/docs';
+
+export const { GET, POST } = createDocsAPI();
+export const revalidate = false;
+```
+
 Try:
 
 - `/docs`
 - `/docs/getting-started`
+- `/docs/server-wrapper`
 - `/docs/getting-started.md`
+- `/api/docs/getting-started.md`
 - `/api/docs?format=config`
 - `/api/docs?format=markdown&path=getting-started`
 - `/api/docs?query=api`
+- `/api/docs?format=llms`
+- `/api/docs?format=llms-full`
+- `/api/docs?format=sitemap-xml`
+- `/api/docs?format=sitemap-md`
+- `/api/docs?format=robots`
+- `/api/docs?format=skill`
+- `/api/docs/agent/spec`

--- a/examples/docs-integration/README.md
+++ b/examples/docs-integration/README.md
@@ -1,24 +1,32 @@
 # Farm docs integration example
 
-This example shows Farm's docs runtime and the Next-style docs API wrapper inspired by
-`@farming-labs/docs`.
+This example shows Farm's docs runtime and the docs API surface inspired by
+`@farming-labs/docs`. Enabling docs in `farm.config.ts` automatically serves both the human docs
+entry and `/api/docs/*` machine routes.
+
+```ts
+// farm.config.ts
+import { defineFarmConfig } from '@farmjs/core';
+
+export default defineFarmConfig({
+  docs: {
+    entry: '/docs',
+  },
+});
+```
+
+You only need app route wrappers when you want to override the default handler:
 
 ```ts
 // src/app/api/docs/route.ts
 import { createDocsAPI } from '@farmjs/core/docs';
 
 export const { GET, POST } = createDocsAPI();
-```
-
-The catch-all route uses the same wrapper so path-style machine routes work too:
-
-```ts
-// src/app/api/docs/[...docs]/route.ts
-import { createDocsAPI } from '@farmjs/core/docs';
-
-export const { GET, POST } = createDocsAPI();
 export const revalidate = false;
 ```
+
+Add the same exports in `src/app/api/docs/[...docs]/route.ts` when your override should also own
+path-style URLs like `/api/docs/getting-started.md`.
 
 Try:
 

--- a/examples/docs-integration/README.md
+++ b/examples/docs-integration/README.md
@@ -1,0 +1,19 @@
+# Farm docs integration example
+
+This example shows the Farm docs runtime and the Next-style API wrapper.
+
+```ts
+// src/app/api/docs/route.ts
+import { createDocsAPI } from '@farmjs/core/docs';
+
+export const { GET, POST } = createDocsAPI();
+```
+
+Try:
+
+- `/docs`
+- `/docs/getting-started`
+- `/docs/getting-started.md`
+- `/api/docs?format=config`
+- `/api/docs?format=markdown&path=getting-started`
+- `/api/docs?query=api`

--- a/examples/docs-integration/docs.json
+++ b/examples/docs-integration/docs.json
@@ -1,0 +1,9 @@
+{
+  "entry": "docs",
+  "metadata": {
+    "description": "Farm docs integration example"
+  },
+  "nav": {
+    "title": "Farm Docs"
+  }
+}

--- a/examples/docs-integration/farm.config.ts
+++ b/examples/docs-integration/farm.config.ts
@@ -1,0 +1,11 @@
+import { defineFarmConfig } from '@farmjs/core';
+
+export default defineFarmConfig({
+  srcDir: 'src',
+  deploy: {
+    target: 'vercel',
+  },
+  docs: {
+    entry: '/docs',
+  },
+});

--- a/examples/docs-integration/package.json
+++ b/examples/docs-integration/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "farm-docs-integration-example",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "farm dev",
+    "build": "farm build",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@farmjs/core": "workspace:*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@farmjs/cli": "workspace:*",
+    "@types/react": "^18.2.45",
+    "@types/react-dom": "^18.2.18",
+    "typescript": "^5.5.3",
+    "vite": "^5.0.10"
+  }
+}

--- a/examples/docs-integration/src/app/api/docs/[...docs]/route.ts
+++ b/examples/docs-integration/src/app/api/docs/[...docs]/route.ts
@@ -1,4 +1,0 @@
-import { createDocsAPI } from '@farmjs/core/docs';
-
-export const { GET, POST } = createDocsAPI();
-export const revalidate = false;

--- a/examples/docs-integration/src/app/api/docs/[...docs]/route.ts
+++ b/examples/docs-integration/src/app/api/docs/[...docs]/route.ts
@@ -1,0 +1,4 @@
+import { createDocsAPI } from '@farmjs/core/docs';
+
+export const { GET, POST } = createDocsAPI();
+export const revalidate = false;

--- a/examples/docs-integration/src/app/api/docs/route.ts
+++ b/examples/docs-integration/src/app/api/docs/route.ts
@@ -1,4 +1,0 @@
-import { createDocsAPI } from '@farmjs/core/docs';
-
-export const { GET, POST } = createDocsAPI();
-export const revalidate = false;

--- a/examples/docs-integration/src/app/api/docs/route.ts
+++ b/examples/docs-integration/src/app/api/docs/route.ts
@@ -1,0 +1,4 @@
+import { createDocsAPI } from '@farmjs/core/docs';
+
+export const { GET, POST } = createDocsAPI();
+export const revalidate = false;

--- a/examples/docs-integration/src/app/docs/getting-started/page.md
+++ b/examples/docs-integration/src/app/docs/getting-started/page.md
@@ -1,0 +1,14 @@
+---
+title: Getting Started
+description: A minimal docs page for the Farm docs example.
+---
+
+# Getting Started
+
+Run the example with:
+
+```bash
+pnpm dev
+```
+
+Then open `/docs`, `/docs/getting-started`, or `/api/docs?query=api`.

--- a/examples/docs-integration/src/app/docs/page.md
+++ b/examples/docs-integration/src/app/docs/page.md
@@ -1,0 +1,16 @@
+---
+title: Farm Docs
+description: Docs rendered from Markdown by Farm.
+---
+
+# Farm Docs
+
+This page is loaded from `src/app/docs/page.md` through the Farm docs integration.
+
+The matching API route uses the same shape as a Next.js route handler:
+
+```ts
+import { createDocsAPI } from '@farmjs/core/docs';
+
+export const { GET, POST } = createDocsAPI();
+```

--- a/examples/docs-integration/src/app/docs/page.md
+++ b/examples/docs-integration/src/app/docs/page.md
@@ -5,18 +5,22 @@ description: Docs rendered from Markdown by Farm.
 
 # Farm Docs
 
-This page is loaded from `src/app/docs/page.md` through the Farm docs integration.
-
-The matching API route uses the same shape as the `@farming-labs/docs` Next.js adapter:
+This page is loaded from `src/app/docs/page.md` through the Farm docs integration. The matching
+machine API route is registered automatically when docs are enabled in `farm.config.ts`:
 
 ```ts
-import { createDocsAPI } from '@farmjs/core/docs';
+import { defineFarmConfig } from '@farmjs/core';
 
-export const { GET, POST } = createDocsAPI();
+export default defineFarmConfig({
+  docs: {
+    entry: '/docs',
+  },
+});
 ```
 
-The example also uses the same handler in `src/app/api/docs/[...docs]/route.ts`, so the same server
-wrapper can answer path-style machine routes.
+If you need custom behavior, you can still add `src/app/api/docs/route.ts` and export
+`createDocsAPI()` handlers as an override. Add the same exports in
+`src/app/api/docs/[...docs]/route.ts` when the override should own path-style URLs too.
 
 ## Machine routes
 

--- a/examples/docs-integration/src/app/docs/page.md
+++ b/examples/docs-integration/src/app/docs/page.md
@@ -7,10 +7,27 @@ description: Docs rendered from Markdown by Farm.
 
 This page is loaded from `src/app/docs/page.md` through the Farm docs integration.
 
-The matching API route uses the same shape as a Next.js route handler:
+The matching API route uses the same shape as the `@farming-labs/docs` Next.js adapter:
 
 ```ts
 import { createDocsAPI } from '@farmjs/core/docs';
 
 export const { GET, POST } = createDocsAPI();
 ```
+
+The example also uses the same handler in `src/app/api/docs/[...docs]/route.ts`, so the same server
+wrapper can answer path-style machine routes.
+
+## Machine routes
+
+- Search JSON: `/api/docs?query=api`
+- Config JSON: `/api/docs?format=config`
+- Markdown by query: `/api/docs?format=markdown&path=getting-started`
+- Markdown by path: `/api/docs/getting-started.md`
+- LLM summary: `/api/docs?format=llms`
+- Full LLM document: `/api/docs?format=llms-full`
+- Sitemap XML: `/api/docs?format=sitemap-xml`
+- Sitemap Markdown: `/api/docs?format=sitemap-md`
+- Robots text: `/api/docs?format=robots`
+- Skill Markdown: `/api/docs?format=skill`
+- Agent spec JSON: `/api/docs/agent/spec`

--- a/examples/docs-integration/src/app/docs/server-wrapper/page.md
+++ b/examples/docs-integration/src/app/docs/server-wrapper/page.md
@@ -1,11 +1,27 @@
 ---
-title: Server Wrapper
-description: How the Farm docs API mirrors the farming-labs docs adapter shape.
+title: Automatic API Route
+description: How Farm registers the docs API while keeping a Next-style override.
 ---
 
-# Server Wrapper
+# Automatic API Route
 
-Farm keeps the app route small:
+Farm registers the docs API automatically from `farm.config.ts`:
+
+```ts
+import { defineFarmConfig } from '@farmjs/core';
+
+export default defineFarmConfig({
+  docs: {
+    entry: '/docs',
+  },
+});
+```
+
+That gives the app the human docs entry and the machine routes without adding files under
+`src/app/api/docs`.
+
+When you need to customize the server behavior, add a route file and Farm will use it instead of
+the default for that matched path:
 
 ```ts
 import { createDocsAPI } from '@farmjs/core/docs';
@@ -14,19 +30,8 @@ export const { GET, POST } = createDocsAPI();
 export const revalidate = false;
 ```
 
-That shape intentionally follows the `@farming-labs/docs` adapter pattern where a docs server owns
-the shared `GET` and `POST` handlers for search, markdown, agent, and AI surfaces.
-
-The catch-all route uses the same wrapper:
-
-```ts
-import { createDocsAPI } from '@farmjs/core/docs';
-
-export const { GET, POST } = createDocsAPI();
-export const revalidate = false;
-```
-
-With both files in place, the example supports the compact query API and the path-style API:
+Add the same exports in `src/app/api/docs/[...docs]/route.ts` when your override should also own
+path-style URLs. The automatic default supports both compact query routes and path-style routes:
 
 - `/api/docs?format=markdown&path=getting-started`
 - `/api/docs/getting-started.md`

--- a/examples/docs-integration/src/app/docs/server-wrapper/page.md
+++ b/examples/docs-integration/src/app/docs/server-wrapper/page.md
@@ -1,0 +1,33 @@
+---
+title: Server Wrapper
+description: How the Farm docs API mirrors the farming-labs docs adapter shape.
+---
+
+# Server Wrapper
+
+Farm keeps the app route small:
+
+```ts
+import { createDocsAPI } from '@farmjs/core/docs';
+
+export const { GET, POST } = createDocsAPI();
+export const revalidate = false;
+```
+
+That shape intentionally follows the `@farming-labs/docs` adapter pattern where a docs server owns
+the shared `GET` and `POST` handlers for search, markdown, agent, and AI surfaces.
+
+The catch-all route uses the same wrapper:
+
+```ts
+import { createDocsAPI } from '@farmjs/core/docs';
+
+export const { GET, POST } = createDocsAPI();
+export const revalidate = false;
+```
+
+With both files in place, the example supports the compact query API and the path-style API:
+
+- `/api/docs?format=markdown&path=getting-started`
+- `/api/docs/getting-started.md`
+- `/api/docs/agent/spec`

--- a/examples/docs-integration/src/app/globals.css
+++ b/examples/docs-integration/src/app/globals.css
@@ -1,0 +1,10 @@
+body {
+  margin: 0;
+}
+
+code {
+  background: #f3f5f4;
+  border: 1px solid #dfe8e2;
+  border-radius: 4px;
+  padding: 2px 5px;
+}

--- a/examples/docs-integration/src/app/layout.tsx
+++ b/examples/docs-integration/src/app/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from 'react';
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <head>
+        <title>Farm Docs Integration</title>
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/examples/docs-integration/src/app/page.tsx
+++ b/examples/docs-integration/src/app/page.tsx
@@ -9,6 +9,10 @@ export default function Page() {
         <code>@farming-labs/docs</code>: human docs, markdown reads, search, llms output,
         sitemap, robots, skill markdown, and agent discovery.
       </p>
+      <p>
+        The docs API is registered automatically from <code>farm.config.ts</code>, so this example
+        does not need a <code>src/app/api/docs/route.ts</code> file unless you want to override it.
+      </p>
       <ul>
         <li>
           <Link href="/docs">Docs home</Link>
@@ -17,7 +21,7 @@ export default function Page() {
           <Link href="/docs/getting-started">Getting started</Link>
         </li>
         <li>
-          <Link href="/docs/server-wrapper">Server wrapper</Link>
+          <Link href="/docs/server-wrapper">Automatic API route</Link>
         </li>
         <li>
           <a href="/docs/getting-started.md">Markdown output</a>

--- a/examples/docs-integration/src/app/page.tsx
+++ b/examples/docs-integration/src/app/page.tsx
@@ -1,0 +1,30 @@
+import { Link } from '@farmjs/core';
+
+export default function Page() {
+  return (
+    <main style={{ fontFamily: 'system-ui, sans-serif', padding: 48, maxWidth: 840 }}>
+      <h1>Farm docs integration</h1>
+      <p>
+        This example serves Markdown docs from <code>src/app/docs</code> and exposes a
+        Next-style docs API route from <code>src/app/api/docs/route.ts</code>.
+      </p>
+      <ul>
+        <li>
+          <Link href="/docs">Docs home</Link>
+        </li>
+        <li>
+          <Link href="/docs/getting-started">Getting started</Link>
+        </li>
+        <li>
+          <a href="/docs/getting-started.md">Markdown output</a>
+        </li>
+        <li>
+          <a href="/api/docs?format=config">Docs API config</a>
+        </li>
+        <li>
+          <a href="/api/docs?format=markdown&path=getting-started">Docs API markdown</a>
+        </li>
+      </ul>
+    </main>
+  );
+}

--- a/examples/docs-integration/src/app/page.tsx
+++ b/examples/docs-integration/src/app/page.tsx
@@ -5,8 +5,9 @@ export default function Page() {
     <main style={{ fontFamily: 'system-ui, sans-serif', padding: 48, maxWidth: 840 }}>
       <h1>Farm docs integration</h1>
       <p>
-        This example serves Markdown docs from <code>src/app/docs</code> and exposes a
-        Next-style docs API route from <code>src/app/api/docs/route.ts</code>.
+        A compact Farm adapter example for the same unified docs surface used by
+        <code>@farming-labs/docs</code>: human docs, markdown reads, search, llms output,
+        sitemap, robots, skill markdown, and agent discovery.
       </p>
       <ul>
         <li>
@@ -16,13 +17,34 @@ export default function Page() {
           <Link href="/docs/getting-started">Getting started</Link>
         </li>
         <li>
+          <Link href="/docs/server-wrapper">Server wrapper</Link>
+        </li>
+        <li>
           <a href="/docs/getting-started.md">Markdown output</a>
+        </li>
+        <li>
+          <a href="/api/docs/getting-started.md">API markdown by path</a>
         </li>
         <li>
           <a href="/api/docs?format=config">Docs API config</a>
         </li>
         <li>
           <a href="/api/docs?format=markdown&path=getting-started">Docs API markdown</a>
+        </li>
+        <li>
+          <a href="/api/docs?query=api">Docs API search</a>
+        </li>
+        <li>
+          <a href="/api/docs?format=llms">LLM summary</a>
+        </li>
+        <li>
+          <a href="/api/docs?format=sitemap-xml">Sitemap XML</a>
+        </li>
+        <li>
+          <a href="/api/docs?format=skill">Skill markdown</a>
+        </li>
+        <li>
+          <a href="/api/docs/agent/spec">Agent spec</a>
         </li>
       </ul>
     </main>

--- a/examples/docs-integration/src/farm-routes.d.ts
+++ b/examples/docs-integration/src/farm-routes.d.ts
@@ -1,0 +1,27 @@
+/**
+ * Auto-generated route types from src/app.
+ * Link href is typed automatically via module augmentation. Regenerated on dev start and when routes change.
+ * Set suppressLintOnLink: true in farm.config.ts to accept any string on Link href.
+ */
+export type RoutePath = "/" | "/docs" | `/docs/${string}`;
+declare module "@farmjs/core/client" {
+  interface LinkDefaultRoute {
+    _: import("./farm-routes").RoutePath;
+  }
+}
+
+declare module "@farmjs/core" {
+  interface LinkDefaultRoute {
+    _: import("./farm-routes").RoutePath;
+  }
+  // Ensure root import ("@farmjs/core") uses the same typed Link signature as client entry.
+  const Link: typeof import("@farmjs/core/client").Link;
+}
+
+// Internal declaration path used by @farmjs/core root type re-exports.
+declare module "@farmjs/core/dist/client.js" {
+  interface LinkDefaultRoute {
+    _: import("./farm-routes").RoutePath;
+  }
+}
+

--- a/examples/docs-integration/tsconfig.json
+++ b/examples/docs-integration/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true
+  },
+  "include": ["src", "farm.config.ts"]
+}

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -36,6 +36,9 @@
       "cache": [
         "./dist/cache.d.ts"
       ],
+      "docs": [
+        "./dist/docs.d.ts"
+      ],
       "api": [
         "./types/api.d.ts",
         "./dist/api.d.ts"
@@ -87,6 +90,11 @@
       "types": "./dist/cache.d.ts",
       "import": "./dist/cache.mjs",
       "require": "./dist/cache.cjs"
+    },
+    "./docs": {
+      "types": "./dist/docs.d.ts",
+      "import": "./dist/docs.mjs",
+      "require": "./dist/docs.cjs"
     },
     "./vite": {
       "types": "./dist/vite.d.ts",
@@ -151,6 +159,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@farming-labs/docs": "^0.2.44",
     "@farming-labs/orm": "0.0.62",
     "@farming-labs/orm-runtime": "0.0.62",
     "@scalar/api-reference": "^1.38.1",

--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { loadConfig, resolveConfig, resolveDeployConfig } from "../config";
+import { loadConfig, resolveConfig, resolveDeployConfig, resolveDocsConfig } from "../config";
 
 const originalEnv = { ...process.env };
 
@@ -74,10 +74,7 @@ describe("loadConfig", () => {
   it("throws when a discovered config file fails to import", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-config-env-"));
 
-    await fs.writeFile(
-      path.join(root, "farm.config.mjs"),
-      "throw new Error('broken config import');",
-    );
+    await fs.writeFile(path.join(root, "farm.config.mjs"), "throw new Error('broken config import');");
 
     await expect(loadConfig(root, undefined, "development")).rejects.toThrow(
       "Failed to load config from farm.config.mjs: broken config import",
@@ -173,5 +170,67 @@ describe("resolveDeployConfig", () => {
       preset: "netlify",
       outputDir: "custom-output",
     });
+  });
+});
+
+describe("resolveDocsConfig", () => {
+  it("normalizes a Farm docs entry route into docs config shape", async () => {
+    const docs = await resolveDocsConfig({
+      entry: "/docs",
+      config: {
+        metadata: {
+          description: "Example docs",
+        },
+      },
+    });
+
+    expect(docs).toMatchObject({
+      enabled: true,
+      entry: "/docs",
+      config: {
+        entry: "docs",
+        docsPath: "/docs",
+        metadata: {
+          description: "Example docs",
+        },
+      },
+    });
+  });
+
+  it("auto-enables docs when docs.json exists", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-docs-json-"));
+    await fs.writeFile(
+      path.join(root, "docs.json"),
+      JSON.stringify({
+        entry: "guides",
+        metadata: {
+          description: "Guide docs",
+        },
+      }),
+    );
+
+    const docs = await resolveDocsConfig(undefined, { root });
+
+    expect(docs).toMatchObject({
+      enabled: true,
+      entry: "/guides",
+      config: {
+        entry: "guides",
+        docsPath: "/guides",
+        metadata: {
+          description: "Guide docs",
+        },
+      },
+    });
+    expect(docs.configPath).toBe(path.join(root, "docs.json"));
+  });
+
+  it("lets docs false opt out even when a docs config file exists", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-docs-disabled-"));
+    await fs.writeFile(path.join(root, "docs.json"), JSON.stringify({ entry: "guides" }));
+
+    const docs = await resolveDocsConfig(false, { root });
+
+    expect(docs.enabled).toBe(false);
   });
 });

--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -111,6 +111,36 @@ describe("createDocsAPI", () => {
       results: [expect.objectContaining({ title: "Guide" })],
     });
 
+    const pathMarkdownResponse = await handlers.GET(
+      new Request("http://farm.test/api/docs/guide.md"),
+    );
+    expect(pathMarkdownResponse.headers.get("content-type")).toContain("text/markdown");
+    await expect(pathMarkdownResponse.text()).resolves.toContain("Use `farm dev` to start.");
+
+    const skillResponse = await handlers.GET(new Request("http://farm.test/api/docs?format=skill"));
+    expect(skillResponse.headers.get("content-type")).toContain("text/markdown");
+    await expect(skillResponse.text()).resolves.toContain("Search JSON: /api/docs?query=<term>");
+
+    const skillPathResponse = await handlers.GET(new Request("http://farm.test/api/docs/skill.md"));
+    expect(skillPathResponse.headers.get("content-type")).toContain("text/markdown");
+    await expect(skillPathResponse.text()).resolves.toContain("Agent spec JSON: /api/docs/agent/spec");
+
+    const sitemapPathResponse = await handlers.GET(new Request("http://farm.test/api/docs/sitemap.md"));
+    expect(sitemapPathResponse.headers.get("content-type")).toContain("text/markdown");
+    await expect(sitemapPathResponse.text()).resolves.toContain("[Guide](/docs/guide)");
+
+    const agentResponse = await handlers.GET(new Request("http://farm.test/api/docs/agent/spec"));
+    await expect(agentResponse.json()).resolves.toMatchObject({
+      name: "Farm API Docs",
+      capabilities: {
+        search: true,
+        markdown: true,
+      },
+      routes: {
+        search: "http://farm.test/api/docs?query=<term>",
+      },
+    });
+
     const postResponse = await handlers.POST(
       new Request("http://farm.test/api/docs", { method: "POST" }),
     );

--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -5,7 +5,12 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveDocsConfig } from "../config";
-import { createDocsAPI, createFarmDocsHandler } from "../docs";
+import {
+  createDocsAPI,
+  createFarmDocsAPIHandler,
+  createFarmDocsHandler,
+  isFarmDocsAPIRequest,
+} from "../docs";
 
 describe("createFarmDocsHandler", () => {
   async function createDocsFixture() {
@@ -83,6 +88,26 @@ describe("createDocsAPI", () => {
     );
     return root;
   }
+
+  it("creates a built-in Farm docs API handler for automatic /api/docs routing", async () => {
+    const root = await createDocsFixture();
+    const handler = createFarmDocsAPIHandler({ rootDir: root, srcDir: "src" });
+
+    expect(isFarmDocsAPIRequest("/api/docs")).toBe(true);
+    expect(isFarmDocsAPIRequest("/api/docs/agent/spec")).toBe(true);
+    expect(isFarmDocsAPIRequest("/docs")).toBe(false);
+
+    await expect(handler(new Request("http://farm.test/api/other"))).resolves.toBeNull();
+
+    const configResponse = await handler(new Request("http://farm.test/api/docs?format=config"));
+    expect(configResponse?.status).toBe(200);
+    await expect(configResponse?.json()).resolves.toMatchObject({
+      entry: "/docs",
+      config: {
+        entry: "docs",
+      },
+    });
+  });
 
   it("creates Next-style GET and POST route handlers for Farm API routes", async () => {
     const root = await createDocsFixture();

--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveDocsConfig } from "../config";
-import { createFarmDocsHandler } from "../docs";
+import { createDocsAPI, createFarmDocsHandler } from "../docs";
 
 describe("createFarmDocsHandler", () => {
   async function createDocsFixture() {
@@ -61,5 +61,85 @@ describe("createFarmDocsHandler", () => {
     const handler = createFarmDocsHandler({ ...docs, enabled: false }, { root, srcDir: "src" });
 
     await expect(handler(new Request("http://farm.test/docs"))).resolves.toBeNull();
+  });
+});
+
+describe("createDocsAPI", () => {
+  async function createDocsFixture() {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-docs-api-"));
+    const docsDir = path.join(root, "src", "app", "docs");
+    await fs.mkdir(path.join(docsDir, "guide"), { recursive: true });
+    await fs.writeFile(
+      path.join(root, "docs.json"),
+      JSON.stringify({
+        entry: "docs",
+        nav: { title: "Farm API Docs" },
+      }),
+    );
+    await fs.writeFile(path.join(docsDir, "page.md"), "# Farm API Docs\n\nWelcome docs.");
+    await fs.writeFile(
+      path.join(docsDir, "guide", "page.md"),
+      "# Guide\n\nUse `farm dev` to start.",
+    );
+    return root;
+  }
+
+  it("creates Next-style GET and POST route handlers for Farm API routes", async () => {
+    const root = await createDocsFixture();
+    const handlers = createDocsAPI({ rootDir: root, srcDir: "src" });
+
+    expect(Object.keys(handlers).sort()).toEqual(["GET", "POST"]);
+
+    const configResponse = await handlers.GET(new Request("http://farm.test/api/docs?format=config"));
+    await expect(configResponse.json()).resolves.toMatchObject({
+      entry: "/docs",
+      config: {
+        entry: "docs",
+        docsPath: "/docs",
+      },
+    });
+
+    const markdownResponse = await handlers.GET(
+      new Request("http://farm.test/api/docs?format=markdown&path=guide"),
+    );
+    expect(markdownResponse.headers.get("content-type")).toContain("text/markdown");
+    await expect(markdownResponse.text()).resolves.toContain("Use `farm dev` to start.");
+
+    const searchResponse = await handlers.GET(new Request("http://farm.test/api/docs?query=guide"));
+    await expect(searchResponse.json()).resolves.toMatchObject({
+      query: "guide",
+      results: [expect.objectContaining({ title: "Guide" })],
+    });
+
+    const postResponse = await handlers.POST(
+      new Request("http://farm.test/api/docs", { method: "POST" }),
+    );
+    expect(postResponse.status).toBe(501);
+  });
+
+  it("uses Farm's injected docs runtime config when route handlers are zero-config", async () => {
+    const root = await createDocsFixture();
+    const docs = await resolveDocsConfig({ entry: "/docs" }, { root, srcDir: "src" });
+    const previousRuntimeConfig = globalThis.__FARM_DOCS_RUNTIME_CONFIG__;
+
+    try {
+      globalThis.__FARM_DOCS_RUNTIME_CONFIG__ = {
+        root,
+        srcDir: "src",
+        docs,
+      };
+
+      const handlers = createDocsAPI();
+      const response = await handlers.GET(new Request("http://farm.test/api/docs?format=config"));
+
+      await expect(response.json()).resolves.toMatchObject({
+        entry: "/docs",
+        config: {
+          nav: { title: "Farm API Docs" },
+        },
+      });
+    } finally {
+      globalThis.__FARM_DOCS_RUNTIME_CONFIG__ = previousRuntimeConfig;
+    }
   });
 });

--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment node
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveDocsConfig } from "../config";
+import { createFarmDocsHandler } from "../docs";
+
+describe("createFarmDocsHandler", () => {
+  async function createDocsFixture() {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-docs-handler-"));
+    const docsDir = path.join(root, "src", "app", "docs");
+    await fs.mkdir(path.join(docsDir, "guide"), { recursive: true });
+    await fs.writeFile(
+      path.join(docsDir, "page.md"),
+      [
+        "---",
+        "title: Farm Docs",
+        "description: Local docs",
+        "---",
+        "",
+        "# Farm Docs",
+        "",
+        "Welcome to **Farm** docs.",
+      ].join("\n"),
+    );
+    await fs.writeFile(path.join(docsDir, "guide", "page.md"), ["# Guide", "", "Use `farm dev` to start."].join("\n"));
+    const docs = await resolveDocsConfig({ entry: "/docs" }, { root, srcDir: "src" });
+    return { root, docs };
+  }
+
+  it("serves docs markdown files as HTML", async () => {
+    const { root, docs } = await createDocsFixture();
+    const handler = createFarmDocsHandler(docs, { root, srcDir: "src" });
+
+    const response = await handler(
+      new Request("http://farm.test/docs", {
+        headers: { accept: "text/html" },
+      }),
+    );
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("content-type")).toContain("text/html");
+    await expect(response?.text()).resolves.toContain("<h1>Farm Docs</h1>");
+  });
+
+  it("serves markdown when requested by markdown URL", async () => {
+    const { root, docs } = await createDocsFixture();
+    const handler = createFarmDocsHandler(docs, { root, srcDir: "src" });
+
+    const response = await handler(new Request("http://farm.test/docs/guide.md"));
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("content-type")).toContain("text/markdown");
+    await expect(response?.text()).resolves.toContain("Use `farm dev` to start.");
+  });
+
+  it("returns null when docs are disabled", async () => {
+    const { root, docs } = await createDocsFixture();
+    const handler = createFarmDocsHandler({ ...docs, enabled: false }, { root, srcDir: "src" });
+
+    await expect(handler(new Request("http://farm.test/docs"))).resolves.toBeNull();
+  });
+});

--- a/packages/farm/src/__tests__/generate-route-types.test.ts
+++ b/packages/farm/src/__tests__/generate-route-types.test.ts
@@ -76,10 +76,12 @@ describe("generateRouteTypes", () => {
     const outPath = await generateRouteTypes({
       root: tmpDir,
       srcDir: "src",
-      extraRoutes: ["/docs/reference"],
+      extraRoutes: ["/docs/reference", "/docs", "/docs/[...docs]"],
     });
 
     const content = fs.readFileSync(outPath, "utf8");
     expect(content).toContain('"/docs/reference"');
+    expect(content).toContain('"/docs"');
+    expect(content).toContain("`/docs/${string}`");
   });
 });

--- a/packages/farm/src/__tests__/type-generator.test.ts
+++ b/packages/farm/src/__tests__/type-generator.test.ts
@@ -1,3 +1,6 @@
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { APITypeGenerator } from "../type-generator";
 
@@ -17,5 +20,22 @@ describe("APITypeGenerator", () => {
     expect(content).toContain('"storage-demo": {');
     expect(content).toContain("get: typeof GET_storagedemo;");
     expect(content).toContain("post: typeof POST_storagedemo;");
+  });
+
+  it("creates the output directory before writing generated API types", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "farm-api-types-"));
+    const appDir = path.join(root, "src", "app");
+    const routeDir = path.join(appDir, "api", "docs");
+    mkdirSync(routeDir, { recursive: true });
+    const outputPath = path.join(root, "src", "lib", "api.generated.ts");
+
+    const routePath = path.join(routeDir, "route.ts");
+    writeFileSync(routePath, "export const GET = async () => new Response('ok');\n");
+
+    const generator = new APITypeGenerator(appDir);
+    generator.generateAPIIndex(outputPath);
+
+    expect(existsSync(outputPath)).toBe(true);
+    expect(readFileSync(outputPath, "utf8")).toContain("Auto-generated API router types");
   });
 });

--- a/packages/farm/src/api/route-manager.ts
+++ b/packages/farm/src/api/route-manager.ts
@@ -267,6 +267,10 @@ export class APIRouteManager {
     return pathname === "/api" || pathname.startsWith("/api/");
   }
 
+  matchRoute(pathname: string): APIRouteMatch<APIRoute> | null {
+    return matchAPIRoute(this.routes, pathname);
+  }
+
   /**
    * Get all routes for client type generation
    */

--- a/packages/farm/src/app.ts
+++ b/packages/farm/src/app.ts
@@ -1,4 +1,5 @@
 import type { FarmConfig } from "./types";
+import type { FarmDocsResolvedConfig } from "./docs/types";
 import { resolveAppPath, fileExists, logger } from "./utils";
 import { initStorage } from "./storage";
 import { RouteManager } from "./routing/route-manager";
@@ -6,8 +7,22 @@ import { ServerRenderer } from "./server/renderer";
 import path from "path";
 import type { ViteDevServer } from "vite";
 
+type NormalizedFarmConfig = Required<FarmConfig> & {
+  docs: FarmDocsResolvedConfig;
+};
+
+const defaultDocsConfig: FarmDocsResolvedConfig = {
+  enabled: false,
+  entry: "/docs",
+  config: { entry: "docs", docsPath: "/docs" },
+};
+
+function isResolvedDocsConfig(value: FarmConfig["docs"]): value is FarmDocsResolvedConfig {
+  return !!value && typeof value === "object" && "enabled" in value && "entry" in value && "config" in value;
+}
+
 export class FarmApp {
-  private config: Required<FarmConfig>;
+  private config: NormalizedFarmConfig;
   private routeManager: RouteManager;
   private serverRenderer: ServerRenderer;
   private viteServer?: ViteDevServer;
@@ -46,11 +61,11 @@ export class FarmApp {
     return this.serverRenderer;
   }
 
-  getConfig(): Required<FarmConfig> {
+  getConfig(): NormalizedFarmConfig {
     return this.config;
   }
 
-  private normalizeConfig(config: FarmConfig): Required<FarmConfig> {
+  private normalizeConfig(config: FarmConfig): NormalizedFarmConfig {
     const root = config.root || process.cwd();
 
     return {
@@ -62,6 +77,7 @@ export class FarmApp {
       deploy: config.deploy || {},
       storage: config.storage || {},
       integrations: config.integrations || {},
+      docs: isResolvedDocsConfig(config.docs) ? config.docs : defaultDocsConfig,
       suppressLintOnLink: config.suppressLintOnLink ?? false,
       experimental: {
         serverComponents: config.experimental?.serverComponents ?? false,

--- a/packages/farm/src/build/index.ts
+++ b/packages/farm/src/build/index.ts
@@ -9,6 +9,7 @@ import { createFarmApp } from "../app";
 import { APIRouteManager } from "../api/route-manager";
 import { resolveAppPath } from "../utils";
 import { buildUniversal } from "../nitro/universal-build";
+import { getFarmDocsRouteTypeEntries } from "../docs";
 import { generateRouteTypes } from "../routing/generate-route-types";
 import { PluginManager } from "../plugin";
 
@@ -56,7 +57,15 @@ export async function build(config: ResolvedFarmConfig, options: BuildOptions = 
     const serverRenderer = farmApp.getServerRenderer();
 
     try {
-      await generateRouteTypes({ root, srcDir, suppressLintOnLink: config.suppressLintOnLink });
+      await generateRouteTypes({
+        root,
+        srcDir,
+        extraRoutes: [
+          ...(config.openapi?.enabled && config.openapi.route ? [config.openapi.route] : []),
+          ...getFarmDocsRouteTypeEntries(config.docs),
+        ],
+        suppressLintOnLink: config.suppressLintOnLink,
+      });
     } catch {
       // Non-fatal; type generation is for DX only
     }

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -1,9 +1,13 @@
 import type { FarmConfig as BaseFarmConfig } from "./types";
+import type { DocsConfig } from "@farming-labs/docs";
+import type { FarmDocsResolvedConfig, FarmDocsUserConfig } from "./docs/types";
 import type { FarmIntegrationsUserConfig } from "./integrations";
 import type { FarmPlugin } from "./plugin";
 import type { UserConfig as ViteUserConfig } from "vite";
 import { resolveIntegrationPlugins } from "./integrations";
 import path from "path";
+
+export type { FarmDocsConfigInput, FarmDocsResolvedConfig, FarmDocsUserConfig } from "./docs/types";
 
 export interface RedirectConfig {
   source: string;
@@ -107,11 +111,12 @@ export interface ResolvedFarmDeployConfig extends Omit<FarmDeployConfig, "output
   outputDir: string;
 }
 
-export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite"> {
+export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite" | "docs"> {
   plugins?: FarmPlugin[];
   integrations?: FarmIntegrationsUserConfig;
   preset?: BaseFarmConfig["preset"];
   deploy?: FarmDeployConfig;
+  docs?: FarmDocsUserConfig;
 
   trailingSlash?: boolean;
   redirects?: () => Promise<RedirectConfig[]> | RedirectConfig[];
@@ -154,11 +159,12 @@ export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite"> {
 }
 
 export interface ResolvedFarmConfig extends Required<
-  Omit<FarmUserConfig, "plugins" | "vite" | "deploy">
+  Omit<FarmUserConfig, "plugins" | "vite" | "deploy" | "docs">
 > {
   plugins: FarmPlugin[];
   vite: ViteUserConfig;
   deploy: ResolvedFarmDeployConfig;
+  docs: FarmDocsResolvedConfig;
 }
 
 export function defineFarmConfig(config: FarmUserConfig): FarmUserConfig {
@@ -253,6 +259,235 @@ export function resolveDeployConfig(
   };
 }
 
+export const DOCS_CONFIG_FILENAMES = [
+  "docs.config.ts",
+  "docs.config.tsx",
+  "docs.config.mts",
+  "docs.config.cts",
+  "docs.config.js",
+  "docs.config.jsx",
+  "docs.config.mjs",
+  "docs.config.cjs",
+  "docs.json",
+];
+
+function normalizeDocsRoute(value: string | undefined, fallback = "/docs"): string {
+  const raw = (value || fallback).trim();
+  if (!raw || raw === "/") return "/";
+  const normalized = raw.replace(/\\/g, "/").replace(/\/+/g, "/").replace(/^\/?/, "/").replace(/\/+$/, "");
+  return normalized || "/";
+}
+
+function docsRouteToEntry(route: string): string {
+  const entry = route.replace(/^\/+/, "").replace(/\/+$/, "");
+  return entry || "docs";
+}
+
+function normalizeDocsContentDir(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const normalized = value.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+$/, "");
+  return normalized || undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function cloneSerializable(value: unknown, seen = new WeakSet<object>()): any {
+  if (value === null) return null;
+
+  const valueType = typeof value;
+  if (valueType === "string" || valueType === "number" || valueType === "boolean") {
+    return value;
+  }
+  if (valueType === "undefined" || valueType === "function" || valueType === "symbol") {
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => cloneSerializable(item, seen)).filter((item) => item !== undefined);
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (isRecord(value)) {
+    if (seen.has(value)) return undefined;
+    seen.add(value);
+
+    const output: Record<string, any> = {};
+    for (const [key, nestedValue] of Object.entries(value)) {
+      const clonedValue = cloneSerializable(nestedValue, seen);
+      if (clonedValue !== undefined) {
+        output[key] = clonedValue;
+      }
+    }
+    return output;
+  }
+
+  return undefined;
+}
+
+function sanitizeDocsConfig(config: Partial<DocsConfig>): Partial<DocsConfig> {
+  return cloneSerializable(config) || {};
+}
+
+export async function findDocsConfigPath(rootDir: string, configPath?: string): Promise<string | undefined> {
+  const { existsSync } = await import("fs");
+  const root = rootDir || process.cwd();
+
+  if (configPath) {
+    const resolvedPath = path.isAbsolute(configPath) ? configPath : path.join(root, configPath);
+    if (!existsSync(resolvedPath)) {
+      throw new Error(`Could not find docs config at ${configPath}.`);
+    }
+    return path.resolve(resolvedPath);
+  }
+
+  for (const filename of DOCS_CONFIG_FILENAMES) {
+    const resolvedPath = path.join(root, filename);
+    if (existsSync(resolvedPath)) {
+      return resolvedPath;
+    }
+  }
+
+  return undefined;
+}
+
+export async function loadDocsConfig(
+  rootDir: string,
+  configPath?: string,
+): Promise<{ config: Partial<DocsConfig>; configPath: string } | undefined> {
+  const fs = await import("fs/promises");
+  const { pathToFileURL } = await import("url");
+  const { build } = await import("esbuild");
+  const root = rootDir || process.cwd();
+  const resolvedPath = await findDocsConfigPath(root, configPath);
+
+  if (!resolvedPath) return undefined;
+
+  try {
+    if (resolvedPath.endsWith(".json")) {
+      const content = await fs.readFile(resolvedPath, "utf8");
+      return { config: JSON.parse(content), configPath: resolvedPath };
+    }
+
+    const configCacheDir = path.join(root, ".farm", ".config-loader");
+    await fs.mkdir(configCacheDir, { recursive: true });
+    const modulePath = path.join(
+      configCacheDir,
+      `docs-config-${Date.now()}-${Math.random().toString(36).slice(2)}.mjs`,
+    );
+
+    await build({
+      absWorkingDir: root,
+      entryPoints: [resolvedPath],
+      outfile: modulePath,
+      bundle: true,
+      format: "esm",
+      platform: "node",
+      target: `node${process.versions.node.split(".")[0]}`,
+      packages: "external",
+      jsx: "automatic",
+      logLevel: "silent",
+      sourcemap: "inline",
+    });
+
+    const moduleUrl = pathToFileURL(modulePath).href + `?t=${Date.now()}`;
+    let importedConfig: any;
+
+    try {
+      importedConfig = await import(/* @vite-ignore */ moduleUrl);
+    } finally {
+      await fs.unlink(modulePath).catch(() => undefined);
+    }
+
+    return {
+      config: importedConfig.default || importedConfig,
+      configPath: resolvedPath,
+    };
+  } catch (error: any) {
+    const relativePath = path.relative(root, resolvedPath) || resolvedPath;
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to load docs config from ${relativePath}: ${message}`);
+  }
+}
+
+export async function resolveDocsConfig(
+  userDocs: FarmDocsUserConfig | undefined,
+  options: {
+    root?: string;
+    srcDir?: string;
+  } = {},
+): Promise<FarmDocsResolvedConfig> {
+  const root = options.root || process.cwd();
+
+  if (userDocs === false) {
+    return {
+      enabled: false,
+      entry: "/docs",
+      config: { entry: "docs", docsPath: "/docs" },
+    };
+  }
+
+  const docsOptions = isRecord(userDocs) ? userDocs : {};
+  if (docsOptions.enabled === false) {
+    return {
+      enabled: false,
+      entry: "/docs",
+      config: { entry: "docs", docsPath: "/docs" },
+    };
+  }
+
+  const loadedConfig = await loadDocsConfig(root, docsOptions.configPath);
+  const hasExplicitDocsConfig = userDocs === true || isRecord(userDocs);
+
+  if (!hasExplicitDocsConfig && !loadedConfig) {
+    return {
+      enabled: false,
+      entry: "/docs",
+      config: { entry: "docs", docsPath: "/docs" },
+    };
+  }
+
+  const inlineDocsConfig = sanitizeDocsConfig(docsOptions.config || {});
+  const directDocsConfig = sanitizeDocsConfig({
+    ...docsOptions,
+    enabled: undefined,
+    config: undefined,
+    configPath: undefined,
+  } as Partial<DocsConfig>);
+  const loadedDocsConfig = sanitizeDocsConfig(loadedConfig?.config || {});
+  const mergedDocsConfig: Partial<DocsConfig> = {
+    ...loadedDocsConfig,
+    ...inlineDocsConfig,
+    ...directDocsConfig,
+  };
+
+  const explicitRoute = typeof docsOptions.entry === "string" ? docsOptions.entry : undefined;
+  const configuredDocsPath = typeof mergedDocsConfig.docsPath === "string" ? mergedDocsConfig.docsPath : undefined;
+  const configuredEntry = typeof mergedDocsConfig.entry === "string" ? mergedDocsConfig.entry : undefined;
+  const entryRoute = normalizeDocsRoute(
+    configuredDocsPath || explicitRoute || (configuredEntry ? `/${configuredEntry}` : undefined),
+  );
+  const docsEntry =
+    explicitRoute && explicitRoute.startsWith("/")
+      ? docsRouteToEntry(explicitRoute)
+      : docsRouteToEntry(configuredEntry || entryRoute);
+  const contentDir = normalizeDocsContentDir(docsOptions.contentDir || mergedDocsConfig.contentDir);
+
+  return {
+    enabled: true,
+    entry: entryRoute,
+    contentDir,
+    configPath: loadedConfig?.configPath,
+    config: {
+      ...mergedDocsConfig,
+      entry: docsEntry,
+      docsPath: entryRoute,
+      ...(contentDir ? { contentDir } : {}),
+    },
+  };
+}
+
 export async function resolveConfig(
   userConfig: FarmUserConfig,
   mode: "development" | "production",
@@ -275,14 +510,18 @@ export async function resolveConfig(
       : userConfig.headers || [];
 
   const deploy = resolveDeployConfig(userConfig);
+  const root = userConfig.root || process.cwd();
+  const srcDir = userConfig.srcDir || "src";
+  const docs = await resolveDocsConfig(userConfig.docs, { root, srcDir });
 
   const resolved: ResolvedFarmConfig = {
-    root: userConfig.root || process.cwd(),
-    srcDir: userConfig.srcDir || "src",
+    root,
+    srcDir,
     outDir: userConfig.outDir || "dist",
     basePath: userConfig.basePath || "/",
     preset: deploy.preset || "node-server",
     deploy,
+    docs,
     storage: userConfig.storage || {},
     suppressLintOnLink: userConfig.suppressLintOnLink ?? false,
     experimental: {

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -358,7 +358,6 @@ export async function loadDocsConfig(
 ): Promise<{ config: Partial<DocsConfig>; configPath: string } | undefined> {
   const fs = await import("fs/promises");
   const { pathToFileURL } = await import("url");
-  const { build } = await import("esbuild");
   const root = rootDir || process.cwd();
   const resolvedPath = await findDocsConfigPath(root, configPath);
 
@@ -370,6 +369,7 @@ export async function loadDocsConfig(
       return { config: JSON.parse(content), configPath: resolvedPath };
     }
 
+    const { build } = await import("esbuild");
     const configCacheDir = path.join(root, ".farm", ".config-loader");
     await fs.mkdir(configCacheDir, { recursive: true });
     const modulePath = path.join(

--- a/packages/farm/src/docs/api.ts
+++ b/packages/farm/src/docs/api.ts
@@ -1,0 +1,352 @@
+import type { DocsConfig } from "@farming-labs/docs";
+import { resolveDocsConfig } from "../config";
+import type { FarmDocsResolvedConfig, FarmDocsUserConfig } from "./types";
+import {
+  discoverFarmDocsPages,
+  loadFarmDocsPage,
+  resolveFarmDocsContentDir,
+} from "./handler";
+
+export interface FarmDocsAPIOptions {
+  rootDir?: string;
+  root?: string;
+  srcDir?: string;
+  docs?: FarmDocsUserConfig | FarmDocsResolvedConfig;
+  config?: Partial<DocsConfig>;
+  configPath?: string;
+  entry?: string;
+  docsPath?: string;
+  contentDir?: string;
+}
+
+export interface FarmDocsCloudRouteOptions {
+  locale?: string;
+  publicBaseUrl?: string;
+}
+
+export interface FarmDocsCloudServer {
+  handleRequest(request: Request, options?: FarmDocsCloudRouteOptions): Promise<Response>;
+}
+
+export type FarmDocsCloudIntegration =
+  | FarmDocsCloudServer
+  | (FarmDocsCloudRouteOptions & { docsCloud?: FarmDocsCloudServer });
+
+export interface FarmDocsAPIRouteHandlers {
+  GET(request: Request): Promise<Response>;
+  POST(request: Request): Promise<Response>;
+}
+
+interface FarmDocsAPIContext {
+  root: string;
+  srcDir: string;
+  docs: FarmDocsResolvedConfig;
+  contentDir: string;
+}
+
+type JsonRecord = Record<string, unknown>;
+type FarmDocsRuntimeConfig = {
+  root?: string;
+  srcDir?: string;
+  docs?: FarmDocsResolvedConfig;
+};
+
+declare global {
+  // Injected by Farm's generated server entry so route wrappers can stay zero-config.
+  // eslint-disable-next-line no-var
+  var __FARM_DOCS_RUNTIME_CONFIG__: FarmDocsRuntimeConfig | undefined;
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isResolvedDocsConfig(value: unknown): value is FarmDocsResolvedConfig {
+  return (
+    isRecord(value) &&
+    typeof value.enabled === "boolean" &&
+    typeof value.entry === "string" &&
+    isRecord(value.config)
+  );
+}
+
+function json(data: unknown, init: ResponseInit = {}): Response {
+  const headers = new Headers(init.headers);
+  if (!headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+  return new Response(JSON.stringify(data), { ...init, headers });
+}
+
+function text(content: string, contentType: string, init: ResponseInit = {}): Response {
+  const headers = new Headers(init.headers);
+  headers.set("Content-Type", contentType);
+  return new Response(content, { ...init, headers });
+}
+
+function normalizeAction(value: string | null | undefined): string | undefined {
+  return value?.trim().toLowerCase().replace(/_/g, "-") || undefined;
+}
+
+function isDocsCloudServer(value: unknown): value is FarmDocsCloudServer {
+  return isRecord(value) && typeof value.handleRequest === "function";
+}
+
+function resolveDocsCloudIntegration(
+  integration?: FarmDocsCloudIntegration,
+): { docsCloud: FarmDocsCloudServer; routeOptions: FarmDocsCloudRouteOptions } | undefined {
+  if (!integration) return undefined;
+
+  if (isDocsCloudServer(integration)) {
+    return { docsCloud: integration, routeOptions: {} };
+  }
+
+  if (!integration.docsCloud) return undefined;
+
+  return {
+    docsCloud: integration.docsCloud,
+    routeOptions: {
+      locale: integration.locale,
+      publicBaseUrl: integration.publicBaseUrl,
+    },
+  };
+}
+
+function isDocsCloudGetRequest(request: Request): boolean {
+  const url = new URL(request.url);
+  const cloud = normalizeAction(url.searchParams.get("cloud"));
+  const action = normalizeAction(url.searchParams.get("action"));
+  const format = normalizeAction(url.searchParams.get("format"));
+
+  return (
+    cloud === "config" ||
+    cloud === "public-config" ||
+    action === "cloud-config" ||
+    action === "docs-cloud-config" ||
+    format === "cloud-config" ||
+    format === "docs-cloud-config"
+  );
+}
+
+function isDocsCloudAction(action: string | undefined): boolean {
+  return Boolean(
+    action &&
+      ["analytics", "track", "track-event", "event", "ask-ai", "ai", "chat", "docs-cloud"].includes(
+        action,
+      ),
+  );
+}
+
+async function readJson(request: Request): Promise<unknown> {
+  try {
+    return await request.clone().json();
+  } catch {
+    return undefined;
+  }
+}
+
+async function isDocsCloudPostRequest(request: Request): Promise<boolean> {
+  const url = new URL(request.url);
+  const cloud = normalizeAction(url.searchParams.get("cloud"));
+  const action = normalizeAction(url.searchParams.get("action"));
+
+  if (isDocsCloudAction(cloud) || isDocsCloudAction(action)) return true;
+
+  const body = await readJson(request);
+  if (!isRecord(body)) return false;
+
+  const bodyAction = normalizeAction(typeof body.action === "string" ? body.action : undefined);
+  if (isDocsCloudAction(bodyAction)) return true;
+
+  if (typeof body.type === "string") return true;
+  if (isRecord(body.event) && typeof body.event.type === "string") return true;
+  if (isRecord(body.payload) && typeof body.payload.type === "string") return true;
+
+  return false;
+}
+
+function normalizeDocsApiSlug(value: string | null | undefined, docs: FarmDocsResolvedConfig): string {
+  const entry = docs.entry.replace(/^\/+|\/+$/g, "");
+  let slug = (value || "").trim().replace(/^\/+|\/+$/g, "");
+
+  if (entry && slug === entry) return "";
+  if (entry && slug.startsWith(`${entry}/`)) {
+    slug = slug.slice(entry.length + 1);
+  }
+
+  return decodeURIComponent(slug).replace(/\.(mdx?|markdown)$/i, "");
+}
+
+function getDocsAPIFormat(request: Request): string | undefined {
+  const url = new URL(request.url);
+  return normalizeAction(url.searchParams.get("format") || url.searchParams.get("type"));
+}
+
+function renderLlmsTxt(context: FarmDocsAPIContext, full: boolean): string {
+  const pages = discoverFarmDocsPages(context.contentDir, context.docs);
+  const title =
+    typeof context.docs.config.nav === "object" &&
+    context.docs.config.nav &&
+    "title" in context.docs.config.nav
+      ? String((context.docs.config.nav as { title?: unknown }).title || "Documentation")
+      : "Documentation";
+
+  const lines = [`# ${title}`, ""];
+  for (const page of pages) {
+    lines.push(`- [${page.title}](${page.href})${page.description ? `: ${page.description}` : ""}`);
+    if (full) {
+      const loadedPage = loadFarmDocsPage(context.contentDir, context.docs, page.slug);
+      if (loadedPage?.body) {
+        lines.push("", `## ${loadedPage.title}`, "", loadedPage.body.trim(), "");
+      }
+    }
+  }
+
+  return `${lines.join("\n").trim()}\n`;
+}
+
+function renderSitemapMarkdown(context: FarmDocsAPIContext): string {
+  const pages = discoverFarmDocsPages(context.contentDir, context.docs);
+  return `${["# Docs Sitemap", "", ...pages.map((page) => `- [${page.title}](${page.href})`)].join("\n")}\n`;
+}
+
+function renderSitemapXml(context: FarmDocsAPIContext, request: Request): string {
+  const origin = new URL(request.url).origin;
+  const pages = discoverFarmDocsPages(context.contentDir, context.docs);
+  const urls = pages
+    .map((page) => `  <url><loc>${origin}${page.href}</loc></url>`)
+    .join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;
+}
+
+function searchDocs(context: FarmDocsAPIContext, query: string) {
+  const normalizedQuery = query.trim().toLowerCase();
+  const pages = discoverFarmDocsPages(context.contentDir, context.docs);
+
+  return pages
+    .map((page) => {
+      const loadedPage = loadFarmDocsPage(context.contentDir, context.docs, page.slug);
+      const haystack = `${page.title}\n${page.description || ""}\n${loadedPage?.body || ""}`.toLowerCase();
+      return {
+        ...page,
+        score: normalizedQuery && haystack.includes(normalizedQuery) ? 1 : 0,
+      };
+    })
+    .filter((page) => !normalizedQuery || page.score > 0);
+}
+
+async function resolveAPIContext(options: FarmDocsAPIOptions): Promise<FarmDocsAPIContext> {
+  const runtimeConfig = globalThis.__FARM_DOCS_RUNTIME_CONFIG__;
+  const root = options.rootDir || options.root || runtimeConfig?.root || process.cwd();
+  const srcDir = options.srcDir || runtimeConfig?.srcDir || "src";
+  const canUseRuntimeDocs =
+    options.docs === undefined &&
+    options.config === undefined &&
+    options.configPath === undefined &&
+    options.entry === undefined &&
+    options.docsPath === undefined &&
+    options.contentDir === undefined &&
+    options.root === undefined &&
+    options.rootDir === undefined &&
+    options.srcDir === undefined;
+  const docsInput =
+    options.docs ??
+    (canUseRuntimeDocs ? runtimeConfig?.docs : undefined) ??
+    ({
+      enabled: true,
+      entry: options.entry,
+      docsPath: options.docsPath,
+      contentDir: options.contentDir,
+      config: options.config,
+      configPath: options.configPath,
+    } satisfies Exclude<FarmDocsUserConfig, boolean>);
+  const docs = isResolvedDocsConfig(docsInput)
+    ? docsInput
+    : await resolveDocsConfig(docsInput, { root, srcDir });
+
+  return {
+    root,
+    srcDir,
+    docs,
+    contentDir: resolveFarmDocsContentDir(docs, { root, srcDir }),
+  };
+}
+
+async function handleDocsAPIGet(request: Request, context: FarmDocsAPIContext): Promise<Response> {
+  if (!context.docs.enabled) {
+    return json({ error: "Docs are disabled" }, { status: 404 });
+  }
+
+  const url = new URL(request.url);
+  const format = getDocsAPIFormat(request);
+
+  if (format === "config" || format === "docs-config") {
+    return json({
+      entry: context.docs.entry,
+      contentDir: context.docs.contentDir || context.docs.config.contentDir || null,
+      config: context.docs.config,
+    });
+  }
+
+  if (format === "markdown" || url.pathname.endsWith(".md")) {
+    const pathParam = url.searchParams.get("path");
+    const slug = normalizeDocsApiSlug(
+      pathParam ?? (url.pathname.endsWith(".md") ? url.pathname : ""),
+      context.docs,
+    );
+    const page = loadFarmDocsPage(context.contentDir, context.docs, slug);
+    if (!page) return text("Docs page not found\n", "text/plain; charset=utf-8", { status: 404 });
+    return text(`${page.body.trim()}\n`, "text/markdown; charset=utf-8");
+  }
+
+  if (format === "llms") return text(renderLlmsTxt(context, false), "text/plain; charset=utf-8");
+  if (format === "llms-full") return text(renderLlmsTxt(context, true), "text/plain; charset=utf-8");
+  if (format === "sitemap-md") return text(renderSitemapMarkdown(context), "text/markdown; charset=utf-8");
+  if (format === "sitemap-xml" || format === "sitemap") {
+    return text(renderSitemapXml(context, request), "application/xml; charset=utf-8");
+  }
+  if (format === "robots") {
+    return text("User-agent: *\nAllow: /\n", "text/plain; charset=utf-8");
+  }
+
+  const query = url.searchParams.get("query") || url.searchParams.get("q") || "";
+  return json({
+    query,
+    results: searchDocs(context, query),
+  });
+}
+
+export function createDocsAPI(
+  options: FarmDocsAPIOptions = {},
+  cloudIntegration?: FarmDocsCloudIntegration,
+): FarmDocsAPIRouteHandlers {
+  let contextPromise: Promise<FarmDocsAPIContext> | undefined;
+  const getContext = () => {
+    contextPromise ??= resolveAPIContext(options);
+    return contextPromise;
+  };
+  const integration = resolveDocsCloudIntegration(cloudIntegration);
+
+  return {
+    async GET(request: Request) {
+      if (integration && isDocsCloudGetRequest(request)) {
+        return integration.docsCloud.handleRequest(request, integration.routeOptions);
+      }
+
+      return handleDocsAPIGet(request, await getContext());
+    },
+    async POST(request: Request) {
+      if (integration && (await isDocsCloudPostRequest(request))) {
+        return integration.docsCloud.handleRequest(request, integration.routeOptions);
+      }
+
+      return json(
+        {
+          error: "AI is not enabled for this Farm docs API route yet.",
+        },
+        { status: 501 },
+      );
+    },
+  };
+}

--- a/packages/farm/src/docs/api.ts
+++ b/packages/farm/src/docs/api.ts
@@ -37,6 +37,8 @@ export interface FarmDocsAPIRouteHandlers {
   POST(request: Request): Promise<Response>;
 }
 
+export type FarmDocsAPIHandler = (request: Request) => Promise<Response | null>;
+
 interface FarmDocsAPIContext {
   root: string;
   srcDir: string;
@@ -72,6 +74,15 @@ function isResolvedDocsConfig(value: unknown): value is FarmDocsResolvedConfig {
     typeof value.entry === "string" &&
     isRecord(value.config)
   );
+}
+
+export function isFarmDocsAPIRequest(requestOrPathname: Request | string): boolean {
+  const pathname =
+    typeof requestOrPathname === "string"
+      ? requestOrPathname
+      : new URL(requestOrPathname.url).pathname;
+
+  return pathname === "/api/docs" || pathname.startsWith("/api/docs/");
 }
 
 function json(data: unknown, init: ResponseInit = {}): Response {
@@ -457,5 +468,36 @@ export function createDocsAPI(
         { status: 501 },
       );
     },
+  };
+}
+
+export function createFarmDocsAPIHandler(
+  options: FarmDocsAPIOptions = {},
+  cloudIntegration?: FarmDocsCloudIntegration,
+): FarmDocsAPIHandler {
+  const handlers = createDocsAPI(options, cloudIntegration);
+
+  return async function handleFarmDocsAPIRequest(request: Request): Promise<Response | null> {
+    if (!isFarmDocsAPIRequest(request)) return null;
+
+    const method = request.method.toUpperCase();
+    if (method === "GET" || method === "HEAD") {
+      return handlers.GET(request);
+    }
+    if (method === "POST") {
+      return handlers.POST(request);
+    }
+
+    return json(
+      {
+        error: "Method Not Allowed",
+      },
+      {
+        status: 405,
+        headers: {
+          Allow: "GET, HEAD, POST",
+        },
+      },
+    );
   };
 }

--- a/packages/farm/src/docs/api.ts
+++ b/packages/farm/src/docs/api.ts
@@ -45,6 +45,10 @@ interface FarmDocsAPIContext {
 }
 
 type JsonRecord = Record<string, unknown>;
+type DocsAPIPathTarget = {
+  format?: string;
+  slug?: string;
+};
 type FarmDocsRuntimeConfig = {
   root?: string;
   srcDir?: string;
@@ -86,6 +90,12 @@ function text(content: string, contentType: string, init: ResponseInit = {}): Re
 
 function normalizeAction(value: string | null | undefined): string | undefined {
   return value?.trim().toLowerCase().replace(/_/g, "-") || undefined;
+}
+
+function getDocsTitle(docs: FarmDocsResolvedConfig): string {
+  return typeof docs.config.nav === "object" && docs.config.nav && "title" in docs.config.nav
+    ? String((docs.config.nav as { title?: unknown }).title || "Documentation")
+    : "Documentation";
 }
 
 function isDocsCloudServer(value: unknown): value is FarmDocsCloudServer {
@@ -177,19 +187,39 @@ function normalizeDocsApiSlug(value: string | null | undefined, docs: FarmDocsRe
   return decodeURIComponent(slug).replace(/\.(mdx?|markdown)$/i, "");
 }
 
+function getDocsAPIPathTarget(request: Request): DocsAPIPathTarget {
+  const pathname = new URL(request.url).pathname.replace(/\/+$/, "") || "/";
+  const prefix = "/api/docs";
+
+  if (pathname !== prefix && !pathname.startsWith(`${prefix}/`)) return {};
+
+  const rawValue = pathname === prefix ? "" : pathname.slice(prefix.length + 1);
+  const value = rawValue.replace(/^\/+|\/+$/g, "");
+  const normalizedValue = normalizeAction(value);
+
+  if (!value) return {};
+  if (normalizedValue === "agent" || normalizedValue === "agent.json" || normalizedValue === "agent/spec") {
+    return { format: "agent-spec" };
+  }
+  if (normalizedValue === "skill" || normalizedValue === "skill.md") return { format: "skill" };
+  if (normalizedValue === "llms.txt") return { format: "llms" };
+  if (normalizedValue === "llms-full.txt") return { format: "llms-full" };
+  if (normalizedValue === "sitemap.md") return { format: "sitemap-md" };
+  if (normalizedValue === "sitemap.xml") return { format: "sitemap-xml" };
+  if (normalizedValue === "robots.txt") return { format: "robots" };
+  if (/\.(mdx?|markdown)$/i.test(value)) return { format: "markdown", slug: value };
+
+  return { slug: value };
+}
+
 function getDocsAPIFormat(request: Request): string | undefined {
   const url = new URL(request.url);
-  return normalizeAction(url.searchParams.get("format") || url.searchParams.get("type"));
+  return normalizeAction(url.searchParams.get("format") || url.searchParams.get("type")) || getDocsAPIPathTarget(request).format;
 }
 
 function renderLlmsTxt(context: FarmDocsAPIContext, full: boolean): string {
   const pages = discoverFarmDocsPages(context.contentDir, context.docs);
-  const title =
-    typeof context.docs.config.nav === "object" &&
-    context.docs.config.nav &&
-    "title" in context.docs.config.nav
-      ? String((context.docs.config.nav as { title?: unknown }).title || "Documentation")
-      : "Documentation";
+  const title = getDocsTitle(context.docs);
 
   const lines = [`# ${title}`, ""];
   for (const page of pages) {
@@ -218,6 +248,84 @@ function renderSitemapXml(context: FarmDocsAPIContext, request: Request): string
     .join("\n");
 
   return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;
+}
+
+function renderSkillDocument(context: FarmDocsAPIContext, request: Request): string {
+  const url = new URL(request.url);
+  const title = getDocsTitle(context.docs);
+  const pages = discoverFarmDocsPages(context.contentDir, context.docs);
+  const lines = [
+    `# ${title}`,
+    "",
+    "Use this Farm docs surface to answer questions from the local documentation.",
+    "",
+    "## Routes",
+    "",
+    `- Human docs: ${context.docs.entry}`,
+    "- Search JSON: /api/docs?query=<term>",
+    "- Config JSON: /api/docs?format=config",
+    "- Markdown by query: /api/docs?format=markdown&path=<slug>",
+    "- Markdown by path: /api/docs/<slug>.md",
+    "- LLM summary: /api/docs?format=llms",
+    "- Full LLM document: /api/docs?format=llms-full",
+    "- Sitemap XML: /api/docs?format=sitemap-xml",
+    "- Agent spec JSON: /api/docs/agent/spec",
+    "",
+    "## Pages",
+    "",
+    ...pages.map((page) => `- [${page.title}](${url.origin}${page.href})${page.description ? `: ${page.description}` : ""}`),
+  ];
+
+  return `${lines.join("\n").trim()}\n`;
+}
+
+function buildAgentSpec(context: FarmDocsAPIContext, request: Request) {
+  const url = new URL(request.url);
+  const origin = url.origin;
+  const pages = discoverFarmDocsPages(context.contentDir, context.docs);
+
+  return {
+    name: getDocsTitle(context.docs),
+    entry: context.docs.entry,
+    routes: {
+      docs: `${origin}${context.docs.entry}`,
+      config: `${origin}/api/docs?format=config`,
+      search: `${origin}/api/docs?query=<term>`,
+      markdown: `${origin}/api/docs/<slug>.md`,
+      markdownQuery: `${origin}/api/docs?format=markdown&path=<slug>`,
+      llms: `${origin}/api/docs?format=llms`,
+      llmsFull: `${origin}/api/docs?format=llms-full`,
+      sitemapXml: `${origin}/api/docs?format=sitemap-xml`,
+      sitemapMarkdown: `${origin}/api/docs?format=sitemap-md`,
+      robots: `${origin}/api/docs?format=robots`,
+      skill: `${origin}/api/docs?format=skill`,
+      agentSpec: `${origin}/api/docs/agent/spec`,
+    },
+    capabilities: {
+      search: true,
+      markdown: true,
+      llms: true,
+      sitemap: true,
+      robots: true,
+      post: false,
+    },
+    pages,
+  };
+}
+
+function buildDiagnostics(context: FarmDocsAPIContext) {
+  const pages = discoverFarmDocsPages(context.contentDir, context.docs);
+
+  return {
+    enabled: context.docs.enabled,
+    entry: context.docs.entry,
+    root: context.root,
+    srcDir: context.srcDir,
+    contentDir: context.contentDir,
+    configPath: context.docs.configPath || null,
+    pageCount: pages.length,
+    pages,
+  };
 }
 
 function searchDocs(context: FarmDocsAPIContext, query: string) {
@@ -280,6 +388,7 @@ async function handleDocsAPIGet(request: Request, context: FarmDocsAPIContext): 
 
   const url = new URL(request.url);
   const format = getDocsAPIFormat(request);
+  const pathTarget = getDocsAPIPathTarget(request);
 
   if (format === "config" || format === "docs-config") {
     return json({
@@ -289,17 +398,9 @@ async function handleDocsAPIGet(request: Request, context: FarmDocsAPIContext): 
     });
   }
 
-  if (format === "markdown" || url.pathname.endsWith(".md")) {
-    const pathParam = url.searchParams.get("path");
-    const slug = normalizeDocsApiSlug(
-      pathParam ?? (url.pathname.endsWith(".md") ? url.pathname : ""),
-      context.docs,
-    );
-    const page = loadFarmDocsPage(context.contentDir, context.docs, slug);
-    if (!page) return text("Docs page not found\n", "text/plain; charset=utf-8", { status: 404 });
-    return text(`${page.body.trim()}\n`, "text/markdown; charset=utf-8");
-  }
-
+  if (format === "skill") return text(renderSkillDocument(context, request), "text/markdown; charset=utf-8");
+  if (format === "agent" || format === "agent-spec") return json(buildAgentSpec(context, request));
+  if (format === "diagnostics") return json(buildDiagnostics(context));
   if (format === "llms") return text(renderLlmsTxt(context, false), "text/plain; charset=utf-8");
   if (format === "llms-full") return text(renderLlmsTxt(context, true), "text/plain; charset=utf-8");
   if (format === "sitemap-md") return text(renderSitemapMarkdown(context), "text/markdown; charset=utf-8");
@@ -308,6 +409,14 @@ async function handleDocsAPIGet(request: Request, context: FarmDocsAPIContext): 
   }
   if (format === "robots") {
     return text("User-agent: *\nAllow: /\n", "text/plain; charset=utf-8");
+  }
+
+  if (format === "markdown" || url.pathname.endsWith(".md")) {
+    const pathParam = url.searchParams.get("path") || url.searchParams.get("slug");
+    const slug = normalizeDocsApiSlug(pathParam ?? pathTarget.slug ?? "", context.docs);
+    const page = loadFarmDocsPage(context.contentDir, context.docs, slug);
+    if (!page) return text("Docs page not found\n", "text/plain; charset=utf-8", { status: 404 });
+    return text(`${page.body.trim()}\n`, "text/markdown; charset=utf-8");
   }
 
   const query = url.searchParams.get("query") || url.searchParams.get("q") || "";

--- a/packages/farm/src/docs/handler.ts
+++ b/packages/farm/src/docs/handler.ts
@@ -15,7 +15,7 @@ export interface FarmDocsPage {
   sourcePath: string;
 }
 
-interface LoadedDocsPage extends FarmDocsPage {
+export interface LoadedFarmDocsPage extends FarmDocsPage {
   body: string;
   frontmatter: Record<string, string>;
 }
@@ -160,8 +160,11 @@ function titleFromMarkdown(body: string, fallback: string): string {
   return heading || fallback;
 }
 
-function loadPage(contentDir: string, docs: FarmDocsResolvedConfig, request: Request): LoadedDocsPage | null {
-  const slug = getRequestSlug(docs, request);
+export function loadFarmDocsPage(
+  contentDir: string,
+  docs: FarmDocsResolvedConfig,
+  slug: string,
+): LoadedFarmDocsPage | null {
   const sourcePath = findDocsPageFile(contentDir, slug);
   if (!sourcePath) return null;
 
@@ -203,7 +206,18 @@ function pathToSlug(contentDir: string, filePath: string): string | null {
   return withoutExtension;
 }
 
-function discoverPages(contentDir: string, docs: FarmDocsResolvedConfig): FarmDocsPage[] {
+function loadPage(
+  contentDir: string,
+  docs: FarmDocsResolvedConfig,
+  request: Request,
+): LoadedFarmDocsPage | null {
+  return loadFarmDocsPage(contentDir, docs, getRequestSlug(docs, request));
+}
+
+export function discoverFarmDocsPages(
+  contentDir: string,
+  docs: FarmDocsResolvedConfig,
+): FarmDocsPage[] {
   if (!existsSync(contentDir)) return [];
 
   const pages: FarmDocsPage[] = [];
@@ -332,7 +346,11 @@ function shouldReturnMarkdown(request: Request): boolean {
   );
 }
 
-function renderDocsHtml(page: LoadedDocsPage, pages: FarmDocsPage[], docs: FarmDocsResolvedConfig): string {
+function renderDocsHtml(
+  page: LoadedFarmDocsPage,
+  pages: FarmDocsPage[],
+  docs: FarmDocsResolvedConfig,
+): string {
   const navTitle =
     typeof docs.config.nav === "object" && docs.config.nav && "title" in docs.config.nav
       ? String((docs.config.nav as { title?: unknown }).title || "Docs")
@@ -407,7 +425,7 @@ export function createFarmDocsHandler(docs: FarmDocsResolvedConfig | undefined, 
       });
     }
 
-    return new Response(renderDocsHtml(page, discoverPages(contentDir, docs), docs), {
+    return new Response(renderDocsHtml(page, discoverFarmDocsPages(contentDir, docs), docs), {
       status: 200,
       headers: {
         "Content-Type": "text/html; charset=utf-8",

--- a/packages/farm/src/docs/handler.ts
+++ b/packages/farm/src/docs/handler.ts
@@ -1,0 +1,418 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import type { FarmDocsResolvedConfig } from "./types";
+
+export interface FarmDocsHandlerOptions {
+  root: string;
+  srcDir?: string;
+}
+
+export interface FarmDocsPage {
+  slug: string;
+  title: string;
+  description?: string;
+  href: string;
+  sourcePath: string;
+}
+
+interface LoadedDocsPage extends FarmDocsPage {
+  body: string;
+  frontmatter: Record<string, string>;
+}
+
+const DOCS_FILE_NAMES = ["page.mdx", "page.md", "index.mdx", "index.md"];
+const DOCS_FILE_EXTENSIONS = [".mdx", ".md"];
+
+function trimSlashes(value: string): string {
+  return value.replace(/^\/+|\/+$/g, "");
+}
+
+function normalizeEntry(entry: string | undefined): string {
+  if (!entry || entry === "/") return "/";
+  return `/${trimSlashes(entry)}`;
+}
+
+function normalizeSlug(value: string): string {
+  return trimSlashes(decodeURIComponent(value)).replace(/\.(mdx?|markdown)$/i, "");
+}
+
+function isSafeSegment(segment: string): boolean {
+  return segment !== ".." && !segment.includes("/") && !segment.includes("\\");
+}
+
+function resolveInside(root: string, target: string): string | null {
+  const resolvedRoot = path.resolve(root);
+  const resolvedTarget = path.resolve(target);
+  const relative = path.relative(resolvedRoot, resolvedTarget);
+  if (relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))) {
+    return resolvedTarget;
+  }
+  return null;
+}
+
+export function isFarmDocsRequest(docs: FarmDocsResolvedConfig | undefined, request: Request) {
+  if (!docs?.enabled) return false;
+  if (request.method !== "GET" && request.method !== "HEAD") return false;
+
+  const pathname = new URL(request.url).pathname;
+  const entry = normalizeEntry(docs.entry);
+  if (entry === "/") return true;
+
+  return pathname === entry || pathname === `${entry}.md` || pathname.startsWith(`${entry}/`);
+}
+
+export function resolveFarmDocsContentDir(docs: FarmDocsResolvedConfig, options: FarmDocsHandlerOptions): string {
+  const root = path.resolve(options.root);
+  const srcDir = options.srcDir || "src";
+  const configuredContentDir = docs.contentDir || docs.config.contentDir;
+
+  if (configuredContentDir) {
+    return path.isAbsolute(configuredContentDir) ? configuredContentDir : path.join(root, configuredContentDir);
+  }
+
+  const entryDir = docs.config.entry || trimSlashes(docs.entry) || "docs";
+  const appDocsDir = path.join(root, srcDir, "app", entryDir);
+  if (existsSync(appDocsDir)) return appDocsDir;
+
+  return path.join(root, entryDir);
+}
+
+export function getFarmDocsRouteTypeEntries(docs: FarmDocsResolvedConfig | undefined): string[] {
+  if (!docs?.enabled) return [];
+  const entry = normalizeEntry(docs.entry);
+  if (entry === "/") return ["/", "/[...docs]"];
+  return [entry, `${entry}/[...docs]`];
+}
+
+function getRequestSlug(docs: FarmDocsResolvedConfig, request: Request): string {
+  const pathname = new URL(request.url).pathname;
+  const entry = normalizeEntry(docs.entry);
+
+  if (entry === "/") return normalizeSlug(pathname);
+  if (pathname === entry || pathname === `${entry}.md`) return "";
+
+  return normalizeSlug(pathname.slice(entry.length));
+}
+
+function findDocsPageFile(contentDir: string, slug: string): string | null {
+  const segments = slug ? slug.split("/").filter(Boolean) : [];
+  if (!segments.every(isSafeSegment)) return null;
+
+  const slugDir = path.join(contentDir, ...segments);
+  const candidates =
+    segments.length === 0
+      ? DOCS_FILE_NAMES.map((filename) => path.join(contentDir, filename))
+      : [
+          ...DOCS_FILE_NAMES.map((filename) => path.join(slugDir, filename)),
+          ...DOCS_FILE_EXTENSIONS.map((extension) => path.join(contentDir, `${slug}${extension}`)),
+        ];
+
+  for (const candidate of candidates) {
+    const safePath = resolveInside(contentDir, candidate);
+    if (safePath && existsSync(safePath) && statSync(safePath).isFile()) {
+      return safePath;
+    }
+  }
+
+  return null;
+}
+
+function parseFrontmatter(source: string): {
+  frontmatter: Record<string, string>;
+  body: string;
+} {
+  if (!source.startsWith("---")) {
+    return { frontmatter: {}, body: source };
+  }
+
+  const endIndex = source.indexOf("\n---", 3);
+  if (endIndex === -1) return { frontmatter: {}, body: source };
+
+  const frontmatterSource = source.slice(3, endIndex).trim();
+  const body = source.slice(source.indexOf("\n", endIndex + 1) + 1);
+  const frontmatter: Record<string, string> = {};
+
+  for (const line of frontmatterSource.split(/\r?\n/)) {
+    const separator = line.indexOf(":");
+    if (separator === -1) continue;
+    const key = line.slice(0, separator).trim();
+    const value = line
+      .slice(separator + 1)
+      .trim()
+      .replace(/^["']|["']$/g, "");
+    if (key && value) frontmatter[key] = value;
+  }
+
+  return { frontmatter, body };
+}
+
+function titleFromSlug(slug: string): string {
+  const lastSegment = slug.split("/").filter(Boolean).pop() || "Docs";
+  return lastSegment
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function titleFromMarkdown(body: string, fallback: string): string {
+  const heading = body.match(/^#\s+(.+)$/m)?.[1]?.trim();
+  return heading || fallback;
+}
+
+function loadPage(contentDir: string, docs: FarmDocsResolvedConfig, request: Request): LoadedDocsPage | null {
+  const slug = getRequestSlug(docs, request);
+  const sourcePath = findDocsPageFile(contentDir, slug);
+  if (!sourcePath) return null;
+
+  const source = readFileSync(sourcePath, "utf8");
+  const { frontmatter, body } = parseFrontmatter(source);
+  const title = frontmatter.title || titleFromMarkdown(body, titleFromSlug(slug));
+  const href = createDocsHref(docs.entry, slug);
+
+  return {
+    slug,
+    title,
+    description: frontmatter.description,
+    href,
+    sourcePath,
+    frontmatter,
+    body,
+  };
+}
+
+function createDocsHref(entry: string, slug: string): string {
+  const normalizedEntry = normalizeEntry(entry);
+  const normalizedSlug = trimSlashes(slug);
+  if (normalizedEntry === "/") return normalizedSlug ? `/${normalizedSlug}` : "/";
+  return normalizedSlug ? `${normalizedEntry}/${normalizedSlug}` : normalizedEntry;
+}
+
+function pathToSlug(contentDir: string, filePath: string): string | null {
+  const relative = path.relative(contentDir, filePath).replace(/\\/g, "/");
+  if (relative.startsWith("..")) return null;
+
+  const extension = path.extname(relative);
+  if (!DOCS_FILE_EXTENSIONS.includes(extension)) return null;
+
+  const withoutExtension = relative.slice(0, -extension.length);
+  if (withoutExtension === "page" || withoutExtension === "index") return "";
+  if (withoutExtension.endsWith("/page") || withoutExtension.endsWith("/index")) {
+    return withoutExtension.replace(/\/(page|index)$/, "");
+  }
+  return withoutExtension;
+}
+
+function discoverPages(contentDir: string, docs: FarmDocsResolvedConfig): FarmDocsPage[] {
+  if (!existsSync(contentDir)) return [];
+
+  const pages: FarmDocsPage[] = [];
+  const visit = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+      const absolutePath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        visit(absolutePath);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+
+      const slug = pathToSlug(contentDir, absolutePath);
+      if (slug === null) continue;
+
+      const source = readFileSync(absolutePath, "utf8");
+      const { frontmatter, body } = parseFrontmatter(source);
+      pages.push({
+        slug,
+        title: frontmatter.title || titleFromMarkdown(body, titleFromSlug(slug)),
+        description: frontmatter.description,
+        href: createDocsHref(docs.entry, slug),
+        sourcePath: absolutePath,
+      });
+    }
+  };
+
+  visit(contentDir);
+  return pages.sort((a, b) => a.href.localeCompare(b.href));
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+function renderInlineMarkdown(value: string): string {
+  return escapeHtml(value)
+    .replace(/`([^`]+)`/g, "<code>$1</code>")
+    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*([^*]+)\*/g, "<em>$1</em>")
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+}
+
+function renderMarkdown(body: string): string {
+  const lines = body
+    .replace(/^\s*import\s.+$/gm, "")
+    .replace(/^\s*export\s+(const|default)\s.+$/gm, "")
+    .split(/\r?\n/);
+  const html: string[] = [];
+  let inCode = false;
+  let inList = false;
+  let paragraph: string[] = [];
+
+  const flushParagraph = () => {
+    if (paragraph.length === 0) return;
+    html.push(`<p>${renderInlineMarkdown(paragraph.join(" "))}</p>`);
+    paragraph = [];
+  };
+  const closeList = () => {
+    if (!inList) return;
+    html.push("</ul>");
+    inList = false;
+  };
+
+  for (const line of lines) {
+    if (line.startsWith("```")) {
+      flushParagraph();
+      closeList();
+      if (inCode) {
+        html.push("</code></pre>");
+        inCode = false;
+      } else {
+        html.push("<pre><code>");
+        inCode = true;
+      }
+      continue;
+    }
+
+    if (inCode) {
+      html.push(escapeHtml(line));
+      continue;
+    }
+
+    const heading = line.match(/^(#{1,6})\s+(.+)$/);
+    if (heading) {
+      flushParagraph();
+      closeList();
+      const level = heading[1].length;
+      html.push(`<h${level}>${renderInlineMarkdown(heading[2].trim())}</h${level}>`);
+      continue;
+    }
+
+    const listItem = line.match(/^\s*[-*]\s+(.+)$/);
+    if (listItem) {
+      flushParagraph();
+      if (!inList) {
+        html.push("<ul>");
+        inList = true;
+      }
+      html.push(`<li>${renderInlineMarkdown(listItem[1].trim())}</li>`);
+      continue;
+    }
+
+    if (!line.trim()) {
+      flushParagraph();
+      closeList();
+      continue;
+    }
+
+    paragraph.push(line.trim());
+  }
+
+  flushParagraph();
+  closeList();
+  if (inCode) html.push("</code></pre>");
+  return html.join("\n");
+}
+
+function shouldReturnMarkdown(request: Request): boolean {
+  const url = new URL(request.url);
+  return (
+    url.pathname.endsWith(".md") ||
+    request.headers.get("accept")?.includes("text/markdown") === true ||
+    request.headers.get("accept")?.includes("text/plain") === true
+  );
+}
+
+function renderDocsHtml(page: LoadedDocsPage, pages: FarmDocsPage[], docs: FarmDocsResolvedConfig): string {
+  const navTitle =
+    typeof docs.config.nav === "object" && docs.config.nav && "title" in docs.config.nav
+      ? String((docs.config.nav as { title?: unknown }).title || "Docs")
+      : "Docs";
+  const description = page.description || docs.config.metadata?.description || "";
+  const navItems = pages
+    .map(
+      (item) =>
+        `<a class="${item.href === page.href ? "active" : ""}" href="${escapeHtml(item.href)}">${escapeHtml(item.title)}</a>`,
+    )
+    .join("\n");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(page.title)}</title>
+  ${description ? `<meta name="description" content="${escapeHtml(description)}">` : ""}
+  <style>
+    :root { color-scheme: light dark; --bg: #ffffff; --text: #17211b; --muted: #607067; --border: #dfe8e2; --accent: #1d8f52; --panel: #f7faf8; }
+    @media (prefers-color-scheme: dark) { :root { --bg: #101512; --text: #edf6f0; --muted: #9baea3; --border: #27342c; --accent: #61d394; --panel: #151d19; } }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: var(--bg); color: var(--text); font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .shell { display: grid; grid-template-columns: minmax(180px, 260px) minmax(0, 1fr); min-height: 100vh; }
+    nav { border-right: 1px solid var(--border); padding: 28px 20px; background: var(--panel); }
+    nav strong { display: block; margin-bottom: 18px; font-size: 15px; }
+    nav a { display: block; color: var(--muted); text-decoration: none; padding: 8px 0; font-size: 14px; }
+    nav a.active, nav a:hover { color: var(--accent); }
+    main { width: min(860px, 100%); padding: 52px min(7vw, 72px); }
+    article { line-height: 1.72; font-size: 16px; }
+    h1 { font-size: clamp(34px, 6vw, 56px); line-height: 1; margin: 0 0 18px; }
+    h2, h3 { margin-top: 36px; line-height: 1.2; }
+    p { color: var(--muted); }
+    code { background: var(--panel); border: 1px solid var(--border); border-radius: 4px; padding: 2px 5px; }
+    pre { overflow: auto; border: 1px solid var(--border); border-radius: 8px; padding: 16px; background: var(--panel); }
+    a { color: var(--accent); }
+    @media (max-width: 760px) { .shell { display: block; } nav { border-right: 0; border-bottom: 1px solid var(--border); } main { padding: 34px 22px; } }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <nav>
+      <strong>${escapeHtml(navTitle)}</strong>
+      ${navItems}
+    </nav>
+    <main>
+      <article>
+${renderMarkdown(page.body)}
+      </article>
+    </main>
+  </div>
+</body>
+</html>`;
+}
+
+export function createFarmDocsHandler(docs: FarmDocsResolvedConfig | undefined, options: FarmDocsHandlerOptions) {
+  return async function handleFarmDocsRequest(request: Request): Promise<Response | null> {
+    if (!docs?.enabled || !isFarmDocsRequest(docs, request)) return null;
+
+    const contentDir = resolveFarmDocsContentDir(docs, options);
+    const page = loadPage(contentDir, docs, request);
+    if (!page) return null;
+
+    if (shouldReturnMarkdown(request)) {
+      return new Response(page.body, {
+        status: 200,
+        headers: {
+          "Content-Type": "text/markdown; charset=utf-8",
+          "Cache-Control": "public, max-age=60",
+        },
+      });
+    }
+
+    return new Response(renderDocsHtml(page, discoverPages(contentDir, docs), docs), {
+      status: 200,
+      headers: {
+        "Content-Type": "text/html; charset=utf-8",
+        "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+      },
+    });
+  };
+}

--- a/packages/farm/src/docs/index.ts
+++ b/packages/farm/src/docs/index.ts
@@ -1,0 +1,8 @@
+export {
+  createFarmDocsHandler,
+  getFarmDocsRouteTypeEntries,
+  isFarmDocsRequest,
+  resolveFarmDocsContentDir,
+} from "./handler";
+export type { FarmDocsHandlerOptions, FarmDocsPage } from "./handler";
+export type { FarmDocsConfigInput, FarmDocsResolvedConfig, FarmDocsUserConfig } from "./types";

--- a/packages/farm/src/docs/index.ts
+++ b/packages/farm/src/docs/index.ts
@@ -6,13 +6,14 @@ export {
   loadFarmDocsPage,
   resolveFarmDocsContentDir,
 } from "./handler";
-export { createDocsAPI } from "./api";
+export { createDocsAPI, createFarmDocsAPIHandler, isFarmDocsAPIRequest } from "./api";
 export type {
   FarmDocsHandlerOptions,
   FarmDocsPage,
   LoadedFarmDocsPage,
 } from "./handler";
 export type {
+  FarmDocsAPIHandler,
   FarmDocsAPIOptions,
   FarmDocsAPIRouteHandlers,
   FarmDocsCloudIntegration,

--- a/packages/farm/src/docs/index.ts
+++ b/packages/farm/src/docs/index.ts
@@ -1,8 +1,22 @@
 export {
   createFarmDocsHandler,
+  discoverFarmDocsPages,
   getFarmDocsRouteTypeEntries,
   isFarmDocsRequest,
+  loadFarmDocsPage,
   resolveFarmDocsContentDir,
 } from "./handler";
-export type { FarmDocsHandlerOptions, FarmDocsPage } from "./handler";
+export { createDocsAPI } from "./api";
+export type {
+  FarmDocsHandlerOptions,
+  FarmDocsPage,
+  LoadedFarmDocsPage,
+} from "./handler";
+export type {
+  FarmDocsAPIOptions,
+  FarmDocsAPIRouteHandlers,
+  FarmDocsCloudIntegration,
+  FarmDocsCloudRouteOptions,
+  FarmDocsCloudServer,
+} from "./api";
 export type { FarmDocsConfigInput, FarmDocsResolvedConfig, FarmDocsUserConfig } from "./types";

--- a/packages/farm/src/docs/types.ts
+++ b/packages/farm/src/docs/types.ts
@@ -1,0 +1,29 @@
+import type { DocsConfig } from "@farming-labs/docs";
+
+export type FarmDocsConfigInput = Partial<DocsConfig> & {
+  /**
+   * Farm public route for docs, e.g. "/docs". When passed through
+   * `config`, this is converted to the docs package's folder-style `entry`.
+   */
+  entry?: string;
+  /** Explicit public route prefix. Defaults to `entry`. */
+  docsPath?: string;
+  /** Source content directory, relative to the project root. */
+  contentDir?: string;
+  /** Set to false to opt out even when a docs config file exists. */
+  enabled?: boolean;
+  /** Inline @farming-labs/docs config object. */
+  config?: Partial<DocsConfig>;
+  /** Path to docs.config.* or docs.json. */
+  configPath?: string;
+};
+
+export type FarmDocsUserConfig = boolean | FarmDocsConfigInput;
+
+export interface FarmDocsResolvedConfig {
+  enabled: boolean;
+  entry: string;
+  contentDir?: string;
+  configPath?: string;
+  config: Partial<DocsConfig> & Pick<DocsConfig, "entry">;
+}

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -25,6 +25,7 @@ export { APITypeGenerator } from "./type-generator";
 export * from "./openapi";
 export * from "./query";
 export * from "./middleware";
+export * from "./docs";
 export { generateRouteTypes } from "./routing/generate-route-types";
 export type { GenerateRouteTypesOptions } from "./routing/generate-route-types";
 export * from "./build/index";
@@ -63,6 +64,8 @@ export type {
   FarmDeployConfig,
   ResolvedFarmDeployConfig,
   FarmDeployTarget,
+  FarmDocsResolvedConfig,
+  FarmDocsUserConfig,
 } from "./config";
 
 export type { ComponentType, ReactNode, ReactElement, FC, PropsWithChildren } from "react";

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1253,7 +1253,10 @@ function generateVirtualEntryCode(
 
   // Generate import for custom not-found page if exists
   const notFoundImport = notFoundPath ? `import * as CustomNotFound from "${notFoundPath}";` : "";
-  const apiRouterImport = apiRoutes.length > 0 ? `import { createRouter } from "better-call";` : "";
+  const apiRouteHelpersImport =
+    apiRoutes.length > 0
+      ? `import { invokeAPIRouteEndpoint, matchAPIRoute } from "farm/api/route-manager";`
+      : "";
   const docsHandlerImport = config.docs?.enabled ? `import { createFarmDocsHandler } from "farm/docs";` : "";
   const integrationImports = configModulePath
     ? `
@@ -1264,36 +1267,47 @@ import { dispatchIntegrationRequest, matchIntegrationRoute } from "farm";
   const apiHandlerCode =
     apiRoutes.length > 0
       ? `
-function createAPIHandler() {
-  const allEndpoints = {};
+const apiRouteMap = new Map(apiRoutes.map((route) => [route.path, route]));
 
-  for (const route of apiRoutes) {
-    for (const method of route.methods) {
-      const handler = route.handlers[method];
-      if (handler) {
-        // Set path on handler for better-call
-        if (!handler.__path) {
-          handler.__path = route.path;
-        }
-        const key = \`\${method.toLowerCase()}_\${route.path.replace(/\\//g, "_").replace(/-/g, "_")}\`;
-        allEndpoints[key] = handler;
-      }
-    }
+async function handleAPIRequest(request) {
+  const url = new URL(request.url);
+  const method = request.method.toUpperCase();
+  const match = matchAPIRoute(apiRouteMap, url.pathname);
+
+  if (!match) {
+    return new Response(
+      JSON.stringify({ error: "API route not found", pathname: url.pathname }),
+      { status: 404, headers: { "Content-Type": "application/json" } }
+    );
   }
 
-  if (Object.keys(allEndpoints).length > 0) {
-    const router = createRouter(allEndpoints, { basePath: "" });
-    return router.handler;
+  const { route, params } = match;
+  const endpoint = route.handlers[method];
+  if (!endpoint) {
+    return new Response(
+      JSON.stringify({ error: "Method Not Allowed" }),
+      { status: 405, headers: { "Content-Type": "application/json" } }
+    );
   }
 
-  return null;
+  try {
+    return await invokeAPIRouteEndpoint(endpoint, request, params);
+  } catch (error) {
+    console.error(\`[API Error] \${url.pathname}:\`, error);
+    return new Response(
+      JSON.stringify({ error: error.message || "Internal Server Error" }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
 }
-
-// Create the API handler at runtime
-const apiHandler = createAPIHandler();
 `
       : `
-const apiHandler = null;
+async function handleAPIRequest(request) {
+  return new Response(
+    JSON.stringify({ error: "API route not found", pathname: new URL(request.url).pathname }),
+    { status: 404, headers: { "Content-Type": "application/json" } }
+  );
+}
 `;
 
   return `
@@ -1304,7 +1318,7 @@ ${apiImports.join("\n")}
 ${pageImports.join("\n")}
 ${layoutImports.join("\n")}
 ${notFoundImport}
-${apiRouterImport}
+${apiRouteHelpersImport}
 ${docsHandlerImport}
 ${integrationImports}
 
@@ -1316,6 +1330,11 @@ const farmUserConfig = ${
   };
 const configuredIntegrations = farmUserConfig?.integrations || {};
 const integrationRuntimeConfig = farmUserConfig || {};
+globalThis.__FARM_DOCS_RUNTIME_CONFIG__ = {
+  root: ${JSON.stringify(config.root)},
+  srcDir: ${JSON.stringify(config.srcDir)},
+  docs: ${JSON.stringify(config.docs)},
+};
 const farmDocsHandler = ${
     config.docs?.enabled
       ? `createFarmDocsHandler(${JSON.stringify(config.docs)}, { root: ${JSON.stringify(config.root)}, srcDir: ${JSON.stringify(config.srcDir)} })`
@@ -1432,21 +1451,7 @@ async function handleRequest(request) {
 
   // Handle API routes
   if (pathname.startsWith("/api/")) {
-    if (apiHandler) {
-      try {
-        return await apiHandler(request);
-      } catch (error) {
-        return new Response(
-          JSON.stringify({ error: error.message || "Internal Server Error" }),
-          { status: 500, headers: { "Content-Type": "application/json" } }
-        );
-      }
-    }
-    
-    return new Response(
-      JSON.stringify({ error: "API route not found", pathname }),
-      { status: 404, headers: { "Content-Type": "application/json" } }
-    );
+    return handleAPIRequest(request);
   }
 
   // Handle page routes (SSR)

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1257,7 +1257,9 @@ function generateVirtualEntryCode(
     apiRoutes.length > 0
       ? `import { invokeAPIRouteEndpoint, matchAPIRoute } from "farm/api/route-manager";`
       : "";
-  const docsHandlerImport = config.docs?.enabled ? `import { createFarmDocsHandler } from "farm/docs";` : "";
+  const docsHandlerImport = config.docs?.enabled
+    ? `import { createFarmDocsAPIHandler, createFarmDocsHandler } from "farm/docs";`
+    : "";
   const integrationImports = configModulePath
     ? `
 import * as FarmUserConfigModule from "${configModulePath}";
@@ -1275,10 +1277,7 @@ async function handleAPIRequest(request) {
   const match = matchAPIRoute(apiRouteMap, url.pathname);
 
   if (!match) {
-    return new Response(
-      JSON.stringify({ error: "API route not found", pathname: url.pathname }),
-      { status: 404, headers: { "Content-Type": "application/json" } }
-    );
+    return null;
   }
 
   const { route, params } = match;
@@ -1303,10 +1302,7 @@ async function handleAPIRequest(request) {
 `
       : `
 async function handleAPIRequest(request) {
-  return new Response(
-    JSON.stringify({ error: "API route not found", pathname: new URL(request.url).pathname }),
-    { status: 404, headers: { "Content-Type": "application/json" } }
-  );
+  return null;
 }
 `;
 
@@ -1338,6 +1334,11 @@ globalThis.__FARM_DOCS_RUNTIME_CONFIG__ = {
 const farmDocsHandler = ${
     config.docs?.enabled
       ? `createFarmDocsHandler(${JSON.stringify(config.docs)}, { root: ${JSON.stringify(config.root)}, srcDir: ${JSON.stringify(config.srcDir)} })`
+      : "null"
+  };
+const farmDocsAPIHandler = ${
+    config.docs?.enabled
+      ? `createFarmDocsAPIHandler({ rootDir: ${JSON.stringify(config.root)}, srcDir: ${JSON.stringify(config.srcDir)}, docs: ${JSON.stringify(config.docs)} })`
       : "null"
   };
 
@@ -1451,7 +1452,22 @@ async function handleRequest(request) {
 
   // Handle API routes
   if (pathname.startsWith("/api/")) {
-    return handleAPIRequest(request);
+    const apiResponse = await handleAPIRequest(request.clone());
+    if (apiResponse) {
+      return apiResponse;
+    }
+
+    if (farmDocsAPIHandler) {
+      const docsAPIResponse = await farmDocsAPIHandler(request.clone());
+      if (docsAPIResponse) {
+        return docsAPIResponse;
+      }
+    }
+
+    return new Response(
+      JSON.stringify({ error: "API route not found", pathname }),
+      { status: 404, headers: { "Content-Type": "application/json" } }
+    );
   }
 
   // Handle page routes (SSR)

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1254,6 +1254,7 @@ function generateVirtualEntryCode(
   // Generate import for custom not-found page if exists
   const notFoundImport = notFoundPath ? `import * as CustomNotFound from "${notFoundPath}";` : "";
   const apiRouterImport = apiRoutes.length > 0 ? `import { createRouter } from "better-call";` : "";
+  const docsHandlerImport = config.docs?.enabled ? `import { createFarmDocsHandler } from "farm/docs";` : "";
   const integrationImports = configModulePath
     ? `
 import * as FarmUserConfigModule from "${configModulePath}";
@@ -1304,6 +1305,7 @@ ${pageImports.join("\n")}
 ${layoutImports.join("\n")}
 ${notFoundImport}
 ${apiRouterImport}
+${docsHandlerImport}
 ${integrationImports}
 
 // Custom 404 page component (if provided)
@@ -1314,6 +1316,11 @@ const farmUserConfig = ${
   };
 const configuredIntegrations = farmUserConfig?.integrations || {};
 const integrationRuntimeConfig = farmUserConfig || {};
+const farmDocsHandler = ${
+    config.docs?.enabled
+      ? `createFarmDocsHandler(${JSON.stringify(config.docs)}, { root: ${JSON.stringify(config.root)}, srcDir: ${JSON.stringify(config.srcDir)} })`
+      : "null"
+  };
 
 // API routes bundled at build time
 const apiRoutes = [${apiRegistrations.join(",")}
@@ -1414,6 +1421,13 @@ async function handleRequest(request) {
   const integrationResponse = await handleIntegrationRequest(request.clone());
   if (integrationResponse) {
     return integrationResponse;
+  }
+
+  if (farmDocsHandler) {
+    const docsResponse = await farmDocsHandler(request.clone());
+    if (docsResponse) {
+      return docsResponse;
+    }
   }
 
   // Handle API routes

--- a/packages/farm/src/type-generator.ts
+++ b/packages/farm/src/type-generator.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, existsSync, readdirSync } from "fs";
+import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync } from "fs";
 import { join, relative, dirname } from "path";
 
 export interface APIRouteInfo {
@@ -244,6 +244,7 @@ ${typeExports}
     const routes = this.scanAPIRoutes();
     const content = this.generateAPIRouter(routes);
 
+    mkdirSync(dirname(outputPath), { recursive: true });
     writeFileSync(outputPath, content, "utf-8");
     console.log(`✅ Generated API types for ${routes.length} routes`);
   }

--- a/packages/farm/src/types.ts
+++ b/packages/farm/src/types.ts
@@ -2,6 +2,7 @@ import type { ReactNode, ComponentType } from "react";
 import type { IncomingMessage, ServerResponse } from "http";
 import type { FarmStorageUserConfig } from "./storage/types";
 import type { FarmIntegrationsUserConfig } from "./integrations";
+import type { FarmDocsResolvedConfig, FarmDocsUserConfig } from "./docs/types";
 
 export type NitroPreset =
   | "node-server"
@@ -49,6 +50,7 @@ export interface FarmConfig {
   };
   storage?: FarmStorageUserConfig;
   integrations?: FarmIntegrationsUserConfig;
+  docs?: FarmDocsUserConfig | FarmDocsResolvedConfig;
   /**
    * When true, Link href is not strictly typed (accepts any string).
    * Use when you want to skip route-type errors on Link or don't use generated route types.

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -9,6 +9,7 @@ import { APIRouteManager } from "./api/route-manager";
 import { OpenAPIManager } from "./openapi/manager";
 import { MiddlewareManager } from "./middleware/manager";
 import { generateRouteTypes } from "./routing/generate-route-types";
+import { createFarmDocsHandler, getFarmDocsRouteTypeEntries } from "./docs";
 import { sendWebResponse } from "./server/response";
 import {
   getClientModuleMetadata,
@@ -100,12 +101,15 @@ export function farmPlugin(
       await farmApp.initialize();
 
       const farmConfig = farmApp.getConfig();
+      const getExtraRouteTypes = () => [
+        ...(options.openapi?.enabled && options.openapi.route ? [options.openapi.route] : []),
+        ...getFarmDocsRouteTypeEntries(farmConfig.docs),
+      ];
       try {
         await generateRouteTypes({
           root: farmConfig.root,
           srcDir: farmConfig.srcDir,
-          extraRoutes:
-            options.openapi?.enabled && options.openapi.route ? [options.openapi.route] : [],
+          extraRoutes: getExtraRouteTypes(),
           suppressLintOnLink: farmConfig.suppressLintOnLink,
         });
       } catch (e) {
@@ -126,8 +130,7 @@ export function farmPlugin(
           generateRouteTypes({
             root: farmConfig.root,
             srcDir: farmConfig.srcDir,
-            extraRoutes:
-              options.openapi?.enabled && options.openapi.route ? [options.openapi.route] : [],
+            extraRoutes: getExtraRouteTypes(),
             suppressLintOnLink: farmConfig.suppressLintOnLink,
           }).catch(() => {});
         }, 100);
@@ -197,6 +200,11 @@ export function farmPlugin(
         logger.success("✅ OpenAPI documentation enabled");
       }
 
+      const farmDocsHandler = createFarmDocsHandler(farmConfig.docs, {
+        root: farmConfig.root,
+        srcDir: farmConfig.srcDir,
+      });
+
       // Built-in terminal logging (always enabled in development, independent of logger plugin)
       const logRequest = (method: string, urlPath: string, tag: "API" | "PAGE") => {
         try {
@@ -265,6 +273,23 @@ export function farmPlugin(
         if (openAPIManager && req.url === options.openapi?.route) {
           const docsHandler = openAPIManager.getDocsRouteHandler();
           return docsHandler(req, res);
+        }
+
+        const docsHeaders = new Headers();
+        for (const [key, value] of Object.entries(req.headers)) {
+          if (value) {
+            docsHeaders.set(key, Array.isArray(value) ? value.join(", ") : value);
+          }
+        }
+        const docsResponse = await farmDocsHandler(
+          new Request(fullUrl, {
+            method: requestMethod,
+            headers: docsHeaders,
+          }),
+        );
+        if (docsResponse) {
+          await sendWebResponse(res, docsResponse);
+          return;
         }
 
         const currentConfig = farmApp?.getConfig() ?? options;

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -9,7 +9,12 @@ import { APIRouteManager } from "./api/route-manager";
 import { OpenAPIManager } from "./openapi/manager";
 import { MiddlewareManager } from "./middleware/manager";
 import { generateRouteTypes } from "./routing/generate-route-types";
-import { createFarmDocsHandler, getFarmDocsRouteTypeEntries } from "./docs";
+import {
+  createFarmDocsAPIHandler,
+  createFarmDocsHandler,
+  getFarmDocsRouteTypeEntries,
+  isFarmDocsAPIRequest,
+} from "./docs";
 import { sendWebResponse } from "./server/response";
 import {
   getClientModuleMetadata,
@@ -204,6 +209,13 @@ export function farmPlugin(
         root: farmConfig.root,
         srcDir: farmConfig.srcDir,
       });
+      const farmDocsAPIHandler = farmConfig.docs?.enabled
+        ? createFarmDocsAPIHandler({
+            rootDir: farmConfig.root,
+            srcDir: farmConfig.srcDir,
+            docs: farmConfig.docs,
+          })
+        : null;
 
       // Built-in terminal logging (always enabled in development, independent of logger plugin)
       const logRequest = (method: string, urlPath: string, tag: "API" | "PAGE") => {
@@ -391,6 +403,8 @@ export function farmPlugin(
           const startTime = Date.now();
           const method = req.method || "GET";
           const urlPath = req.url || "/";
+          const pathname = new URL(urlPath, `http://${req.headers.host || "localhost:3000"}`)
+            .pathname;
 
           try {
             if (pm) {
@@ -412,7 +426,8 @@ export function farmPlugin(
           }
 
           const apiHandler = apiRouteManager.getHandler();
-          if (apiHandler) {
+          const hasExplicitAPIRoute = Boolean(apiRouteManager.matchRoute(pathname));
+          if (apiHandler && hasExplicitAPIRoute) {
             // Log API request
             // logRequest(method, urlPath, "API");
 
@@ -476,6 +491,71 @@ export function farmPlugin(
               return;
             }
           }
+
+          if (farmDocsAPIHandler && isFarmDocsAPIRequest(pathname)) {
+            try {
+              const url = `http://${req.headers.host || "localhost:3000"}${req.url}`;
+              const headers = new Headers();
+              for (const [key, value] of Object.entries(req.headers)) {
+                if (value) {
+                  headers.set(key, Array.isArray(value) ? value.join(", ") : value);
+                }
+              }
+
+              let body: string | undefined;
+              if (req.method !== "GET" && req.method !== "HEAD") {
+                body = await new Promise<string>((resolve) => {
+                  let data = "";
+                  req.on("data", (chunk) => {
+                    data += chunk;
+                  });
+                  req.on("end", () => {
+                    resolve(data);
+                  });
+                });
+              }
+
+              const request = new Request(url, {
+                method: req.method,
+                headers,
+                body: body || undefined,
+              });
+
+              const apiLifecyclePayload = {
+                pathname,
+                method,
+                routePath: urlPath,
+              };
+              const handledRequest: Request = pm
+                ? await pm.runHookSerial("beforeApiHandler", request, apiLifecyclePayload)
+                : request;
+
+              const docsResponse = await farmDocsAPIHandler(handledRequest);
+              if (docsResponse) {
+                const handledResponse: Response = pm
+                  ? await pm.runHookSerial("afterApiHandler", docsResponse, apiLifecyclePayload)
+                  : docsResponse;
+                const duration = Date.now() - startTime;
+                logResponse(method, urlPath, handledResponse.status, duration, "API");
+                await sendWebResponse(res, handledResponse);
+                return;
+              }
+            } catch (error) {
+              await emitPluginError("docs-api-handler", error, { urlPath, method });
+              logger.error(`Docs API route error: ${error}`);
+              res.statusCode = 500;
+              res.setHeader("Content-Type", "application/json");
+              res.end(JSON.stringify({ error: "Internal server error" }));
+              return;
+            }
+          }
+
+          const duration = Date.now() - startTime;
+          logResponse(method, urlPath, 404, duration, "API");
+          res.statusCode = 404;
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ error: "API route not found", pathname }));
+          return;
         }
 
         // Skip internal Vite requests

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     plugin: "src/plugin.ts",
     storage: "src/storage/index.ts",
     cache: "src/cache.ts",
+    docs: "src/docs/index.ts",
   },
   format: ["cjs", "esm"],
   dts: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,6 +314,34 @@ importers:
         specifier: ^5.0.10
         version: 5.4.20(@types/node@20.19.21)
 
+  examples/docs-integration:
+    dependencies:
+      '@farmjs/core':
+        specifier: workspace:*
+        version: link:../../packages/farm
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@farmjs/cli':
+        specifier: workspace:*
+        version: link:../../packages/farm-cli
+      '@types/react':
+        specifier: ^18.2.45
+        version: 18.3.26
+      '@types/react-dom':
+        specifier: ^18.2.18
+        version: 18.3.7(@types/react@18.3.26)
+      typescript:
+        specifier: ^5.5.3
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.10
+        version: 5.4.20(@types/node@20.19.21)
+
   examples/email-integrations/resend-example:
     dependencies:
       '@farmjs/core':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -892,6 +892,9 @@ importers:
 
   packages/farm:
     dependencies:
+      '@farming-labs/docs':
+        specifier: ^0.2.44
+        version: 0.2.44(react@19.2.4)(supports-color@10.2.2)
       '@farming-labs/orm':
         specifier: 0.0.62
         version: 0.0.62
@@ -1900,6 +1903,21 @@ packages:
       human-id: 4.1.2
       prettier: 2.8.8
     dev: true
+
+  /@clack/core@0.4.1:
+    resolution: {integrity: sha512-Pxhij4UXg8KSr7rPek6Zowm+5M22rbd2g1nfojHJkxp5YkFqiZ2+YLEM/XGVIzvGOcM0nqjIFxrpDwWRZYWYjA==}
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+    dev: false
+
+  /@clack/prompts@0.9.1:
+    resolution: {integrity: sha512-JIpyaboYZeWYlyP0H+OoPPxd6nqueG/CmN6ixBiNFsIDHREevjIf0n0Ohh5gr5C8pEDknzgvz+pIJ8dMhzWIeg==}
+    dependencies:
+      '@clack/core': 0.4.1
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+    dev: false
 
   /@clerk/backend@3.2.0(react-dom@19.2.4)(react@19.2.4):
     resolution: {integrity: sha512-3APNJ5jt5Db9f441FPVTjgzvPxjLhekygomkMOhsvPpItRNNEHgFZM/bGXYetgcOtUrO6vWcuhf1rlNSTRelhg==}
@@ -3113,6 +3131,31 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@farming-labs/docs@0.2.44(react@19.2.4)(supports-color@10.2.2):
+    resolution: {integrity: sha512-Y+qC2lC4sG36QeMAUXUQE8hYseNpFhkA2bCWjCxXdGAT4Mhw3pf1WwiT1umZFc2jvluN9ywVW1ShyN/BVMQxVA==}
+    hasBin: true
+    peerDependencies:
+      react: '>=19.2.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+    dependencies:
+      '@clack/prompts': 0.9.1
+      '@modelcontextprotocol/sdk': 1.29.0(supports-color@10.2.2)(zod@4.3.6)
+      '@scalar/core': 0.4.6
+      '@vercel/sandbox': 2.4.0
+      gray-matter: 4.0.3
+      jiti: 2.6.1
+      picocolors: 1.1.1
+      react: 19.2.4
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - bare-abort-controller
+      - react-native-b4a
+      - supports-color
+    dev: false
+
   /@farming-labs/orm-d1@0.0.62:
     resolution: {integrity: sha512-yIeY4quFnWjclFzh8xuvgYVvr7fO+1yCPKDbgX9qMqS+uHCH1HFnPI58UJf9Tj1n6bSq11OUcBqwODeRHwK/3w==}
     dependencies:
@@ -3407,6 +3450,15 @@ packages:
 
   /@hexagon/base64@1.1.28:
     resolution: {integrity: sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==}
+    dev: false
+
+  /@hono/node-server@1.19.14(hono@4.12.27):
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+    dependencies:
+      hono: 4.12.27
     dev: false
 
   /@hyperjump/browser@1.3.1:
@@ -3860,6 +3912,37 @@ packages:
     peerDependenciesMeta:
       dataloader:
         optional: true
+    dev: false
+
+  /@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.3.6):
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.27)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1(supports-color@10.2.2)
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.27
+      jose: 6.2.1
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@mongodb-js/saslprep@1.4.6:
@@ -5120,6 +5203,13 @@ packages:
       - typescript
     dev: false
 
+  /@scalar/core@0.4.6:
+    resolution: {integrity: sha512-lIlCUx0O18ei63j7Z7QTAVAuh66sdms9zoDPhpDOzHTVObnb7n0f3J306sT3H9KQsoWKQrEsnKx4LcZLw/TlPw==}
+    engines: {node: '>=22'}
+    dependencies:
+      '@scalar/types': 0.7.6
+    dev: false
+
   /@scalar/draggable@0.2.0(typescript@5.9.3):
     resolution: {integrity: sha512-UetHRB5Bqo5egVYlS21roWBcICmyk8CKh2htsidO+bFGAjl2e7Te+rY0borhNrMclr0xezHlPuLpEs1dvgLS2g==}
     engines: {node: '>=20'}
@@ -5132,6 +5222,11 @@ packages:
   /@scalar/helpers@0.0.12:
     resolution: {integrity: sha512-4NDmHShyi1hrVRsJCdRZT/FIpy+/5PFbVbQLRYX/pjpu5cYqHBj9s6n5RI6gGDXEBHAIFi63g9FC6Isgr66l1Q==}
     engines: {node: '>=20'}
+    dev: false
+
+  /@scalar/helpers@0.4.3:
+    resolution: {integrity: sha512-Gv2V7SFreLx3DltzF2lKXdaJSH5cP1LOyt9PxON1cSWGxkrs3sg93c1taEJsW24E9ckfYXkL5hjCAVLfAN3wQw==}
+    engines: {node: '>=22'}
     dev: false
 
   /@scalar/icons@0.4.7(typescript@5.9.3):
@@ -5269,6 +5364,16 @@ packages:
       nanoid: 5.1.5
       type-fest: 5.0.0
       zod: 4.1.11
+    dev: false
+
+  /@scalar/types@0.7.6:
+    resolution: {integrity: sha512-n5d7neeGTY/yS36AwAv3FAyCnJbbLjMPwyuEXBLgxHcb5i8DXnNfwy1nzz8jx/EJ88i1zmQ8BuMs+207saHgNA==}
+    engines: {node: '>=22'}
+    dependencies:
+      '@scalar/helpers': 0.4.3
+      nanoid: 5.1.16
+      type-fest: 5.7.0
+      zod: 4.3.6
     dev: false
 
   /@scalar/use-codemirror@0.12.43(supports-color@10.2.2)(typescript@5.9.3):
@@ -5920,6 +6025,25 @@ packages:
     engines: {node: '>= 20'}
     dev: false
 
+  /@vercel/sandbox@2.4.0:
+    resolution: {integrity: sha512-pifnr8hex/rgQ3EPyLYHYwHyf0Kwmc4Vbya9kHGk4aERFVGj44P+742S8/SDdt2guMxBriXBOMkMLq1Kaiyyeg==}
+    dependencies:
+      '@vercel/oidc': 3.2.0
+      '@workflow/serde': 4.1.0-beta.2
+      async-retry: 1.3.3
+      jose: 6.2.3
+      jsonlines: 0.1.1
+      ms: 2.1.3
+      picocolors: 1.1.1
+      tar-stream: 3.1.7
+      undici: 7.28.0
+      xdg-app-paths: 5.1.0
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    dev: false
+
   /@vitejs/plugin-react@4.7.0(supports-color@10.2.2)(vite@5.4.20):
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -6312,6 +6436,10 @@ packages:
     resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
     dev: false
 
+  /@workflow/serde@4.1.0-beta.2:
+    resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
+    dev: false
+
   /@workos-inc/node@8.9.0:
     resolution: {integrity: sha512-io5D4Scoy7RwjNQGyWWVeljwQz4RSqGRILP1/tbv5vXUxJdhpcGqGwML4AHamgacEay+QyiDW9RvgfjiQN3KLw==}
     engines: {node: '>=20.15.0'}
@@ -6331,6 +6459,14 @@ packages:
 
   /@xtuc/long@4.2.2:
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
+
+  /accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+    dev: false
 
   /acorn-import-phases@1.0.4(acorn@8.15.0):
     resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
@@ -6485,7 +6621,6 @@ packages:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
     dependencies:
       sprintf-js: 1.0.3
-    dev: true
 
   /args-tokenizer@0.3.0:
     resolution: {integrity: sha512-xXAd7G2Mll5W8uo37GETpQ2VrE84M181Z7ugHFGQnJZ50M2mbOv0osSZ9VsSgPfJQ+LVG0prSi0th+ELMsno7Q==}
@@ -6523,6 +6658,12 @@ packages:
       '@babel/parser': 7.28.4
       pathe: 2.0.3
     dev: true
+
+  /async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+    dependencies:
+      retry: 0.13.1
+    dev: false
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -6580,12 +6721,30 @@ packages:
       possible-typed-array-names: 1.1.0
     dev: false
 
+  /b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+    dev: false
+
   /bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
     dev: false
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  /bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+    dev: false
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -6930,6 +7089,23 @@ packages:
       readable-stream: 3.6.2
     dev: false
 
+  /body-parser@2.3.0(supports-color@10.2.2):
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3(supports-color@10.2.2)
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
     dev: false
@@ -7019,6 +7195,11 @@ packages:
       esbuild: 0.27.3
       load-tsconfig: 0.2.5
     dev: true
+
+  /bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+    dev: false
 
   /c12@3.1.0:
     resolution: {integrity: sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==}
@@ -7268,9 +7449,19 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  /content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+    dev: false
+
   /content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+    dev: false
+
+  /content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
     dev: false
 
   /convert-source-map@2.0.0:
@@ -7284,9 +7475,27 @@ packages:
     resolution: {integrity: sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==}
     dev: false
 
+  /cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+    dev: false
+
+  /cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
   /cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+    dev: false
+
+  /cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
     dev: false
 
   /crelt@1.0.6:
@@ -7469,6 +7678,11 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
     dev: true
+
+  /depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+    dev: false
 
   /dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -7784,6 +7998,10 @@ packages:
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  /ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    dev: false
+
   /effect@3.18.4:
     resolution: {integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==}
     dependencies:
@@ -7803,6 +8021,11 @@ packages:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
 
+  /encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
   /end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
     dependencies:
@@ -7815,7 +8038,6 @@ packages:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
-    dev: false
 
   /enhanced-resolve@5.20.0:
     resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
@@ -8041,6 +8263,10 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  /escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+    dev: false
+
   /escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
@@ -8057,7 +8283,6 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: true
 
   /esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -8083,6 +8308,19 @@ packages:
       '@types/estree': 1.0.8
     dev: true
 
+  /etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+    dev: false
+
   /events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -8090,6 +8328,13 @@ packages:
   /eventsource-parser@3.1.0:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
+    dev: false
+
+  /eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      eventsource-parser: 3.1.0
     dev: false
 
   /execa@8.0.1:
@@ -8112,8 +8357,61 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
+  /express-rate-limit@8.5.2(express@5.2.1):
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+    dependencies:
+      express: 5.2.1(supports-color@10.2.2)
+      ip-address: 10.2.0
+    dev: false
+
+  /express@5.2.1(supports-color@10.2.2):
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0(supports-color@10.2.2)
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3(supports-color@10.2.2)
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1(supports-color@10.2.2)
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0(supports-color@10.2.2)
+      send: 1.2.1(supports-color@10.2.2)
+      serve-static: 2.2.1(supports-color@10.2.2)
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /exsolve@1.0.7:
     resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
+
+  /extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-extendable: 0.1.1
+    dev: false
 
   /extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -8131,6 +8429,10 @@ packages:
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  /fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+    dev: false
 
   /fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -8181,6 +8483,20 @@ packages:
   /filter-obj@5.1.0:
     resolution: {integrity: sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==}
     engines: {node: '>=14.16'}
+    dev: false
+
+  /finalhandler@2.1.1(supports-color@10.2.2):
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /find-up@4.1.0:
@@ -8234,9 +8550,19 @@ packages:
       mime-types: 2.1.35
     dev: true
 
+  /forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
   /fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
     dev: true
+
+  /fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+    dev: false
 
   /fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -8435,6 +8761,16 @@ packages:
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  /gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+    dependencies:
+      js-yaml: 3.14.1
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+    dev: false
 
   /h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
@@ -8684,6 +9020,11 @@ packages:
     resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
     dev: false
 
+  /hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+    engines: {node: '>=16.9.0'}
+    dev: false
+
   /hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
@@ -8724,6 +9065,17 @@ packages:
       domhandler: 5.0.3
       domutils: 3.2.2
       entities: 4.5.0
+    dev: false
+
+  /http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
     dev: false
 
   /http-proxy-agent@7.0.2(supports-color@10.2.2):
@@ -8773,7 +9125,13 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
-    dev: true
+
+  /iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: false
 
   /ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -8804,6 +9162,16 @@ packages:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
     dev: false
 
+  /ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+    dev: false
+
+  /ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+    dev: false
+
   /iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
     dev: false
@@ -8831,6 +9199,11 @@ packages:
     dependencies:
       hasown: 2.0.2
     dev: true
+
+  /is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -8863,6 +9236,10 @@ packages:
   /is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
     dev: true
+
+  /is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+    dev: false
 
   /is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
@@ -8967,6 +9344,10 @@ packages:
     resolution: {integrity: sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==}
     dev: false
 
+  /jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+    dev: false
+
   /joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -8993,7 +9374,6 @@ packages:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
-    dev: true
 
   /jsdom@25.0.1(supports-color@10.2.2):
     resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
@@ -9042,6 +9422,10 @@ packages:
   /json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
+  /json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+    dev: false
+
   /json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
     dev: false
@@ -9066,6 +9450,10 @@ packages:
       graceful-fs: 4.2.11
     dev: true
 
+  /jsonlines@0.1.1:
+    resolution: {integrity: sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==}
+    dev: false
+
   /jsonpointer@5.0.1:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
@@ -9082,6 +9470,11 @@ packages:
   /kareem@2.6.3:
     resolution: {integrity: sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==}
     engines: {node: '>=12.0.0'}
+    dev: false
+
+  /kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
     dev: false
 
   /kleur@3.0.3:
@@ -9469,8 +9862,18 @@ packages:
       '@types/mdast': 4.0.4
     dev: false
 
+  /media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
   /memory-pager@1.5.0:
     resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
+    dev: false
+
+  /merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
     dev: false
 
   /merge-stream@2.0.0:
@@ -9742,11 +10145,23 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  /mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
   /mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
+
+  /mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+    dependencies:
+      mime-db: 1.54.0
+    dev: false
 
   /mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
@@ -9980,6 +10395,12 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  /nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    dev: false
+
   /nanoid@5.1.5:
     resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
     engines: {node: ^18 || >=20}
@@ -9993,6 +10414,11 @@ packages:
 
   /napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+    dev: false
+
+  /negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
     dev: false
 
   /neo-async@2.6.2:
@@ -10291,12 +10717,16 @@ packages:
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
     dev: true
+
+  /object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+    dev: false
 
   /obliterator@1.6.1:
     resolution: {integrity: sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==}
@@ -10313,6 +10743,13 @@ packages:
   /ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
+  /on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      ee-first: 1.1.1
+    dev: false
+
   /once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
@@ -10324,6 +10761,11 @@ packages:
     dependencies:
       mimic-fn: 4.0.0
     dev: true
+
+  /os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
+    dev: false
 
   /outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
@@ -10438,6 +10880,11 @@ packages:
       peberminta: 0.9.0
     dev: false
 
+  /parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -10467,6 +10914,10 @@ packages:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
+
+  /path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+    dev: false
 
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -10590,6 +11041,11 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
     dev: true
+
+  /pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+    dev: false
 
   /pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -10847,6 +11303,14 @@ packages:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
     dev: false
 
+  /proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+    dev: false
+
   /pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
     dependencies:
@@ -10870,6 +11334,14 @@ packages:
   /pvutils@1.1.5:
     resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
     engines: {node: '>=16.0.0'}
+    dev: false
+
+  /qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
     dev: false
 
   /quansync@0.2.11:
@@ -10917,6 +11389,21 @@ packages:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
     dependencies:
       safe-buffer: 5.2.1
+
+  /range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.0
+      unpipe: 1.0.0
+    dev: false
 
   /rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
@@ -11191,6 +11678,11 @@ packages:
     resolution: {integrity: sha512-hMD7odLOt3LkTjcif8aRZqi/hybjpLNgSk5oF5FCowfCjok6LukpN2bDX7R5wDmbgBQFn7YoBxSagmtXHaJYJw==}
     dev: false
 
+  /retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+    dev: false
+
   /reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -11301,6 +11793,19 @@ packages:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
     dev: false
 
+  /router@2.2.0(supports-color@10.2.2):
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /rrweb-cssom@0.7.1:
     resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
     dev: true
@@ -11322,7 +11827,6 @@ packages:
 
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-    dev: true
 
   /saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -11349,6 +11853,14 @@ packages:
       ajv-formats: 2.1.1(ajv@8.17.1)
       ajv-keywords: 5.1.0(ajv@8.17.1)
 
+  /section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+    dev: false
+
   /selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
     dependencies:
@@ -11363,6 +11875,25 @@ packages:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
     hasBin: true
+
+  /send@1.2.1(supports-color@10.2.2):
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /sequelize-pool@7.1.0:
     resolution: {integrity: sha512-G9c0qlIWQSK29pR/5U2JF5dDQeqqHRragoyahj/Nx4KOOQ3CPPfzxnfqFPCSB7x5UgjOgnZ61nSxz+fjDpRlJg==}
@@ -11428,6 +11959,18 @@ packages:
     dependencies:
       randombytes: 2.1.0
 
+  /serve-static@2.2.1(supports-color@10.2.2):
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
     dev: false
@@ -11446,6 +11989,10 @@ packages:
       get-intrinsic: 1.3.0
       gopd: 1.2.0
       has-property-descriptors: 1.0.2
+    dev: false
+
+  /setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
     dev: false
 
   /sha.js@2.4.12:
@@ -11507,6 +12054,46 @@ packages:
   /shell-quote@1.8.3:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
+    dev: false
+
+  /side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+    dev: false
+
+  /side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+    dev: false
+
+  /side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+    dev: false
+
+  /side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
     dev: false
 
   /sift@17.1.3:
@@ -11603,7 +12190,6 @@ packages:
 
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-    dev: true
 
   /sql-highlight@6.1.0:
     resolution: {integrity: sha512-ed7OK4e9ywpE7pgRMkMQmZDPKSVdm0oX5IEtZiKnFucSF0zu6c80GZBe38UqHuVhTWJ9xsKgSMjCG2bml86KvA==}
@@ -11638,8 +12224,24 @@ packages:
       '@stablelib/base64': 1.0.1
       fast-sha256: 1.3.0
 
+  /statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
   /std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
+
+  /streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    dev: false
 
   /string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -11690,6 +12292,11 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       ansi-regex: 6.2.2
+
+  /strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -11881,6 +12488,17 @@ packages:
       readable-stream: 3.6.2
     dev: false
 
+  /tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+    dependencies:
+      b4a: 1.8.1
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    dev: false
+
   /term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
@@ -11953,6 +12571,14 @@ packages:
       minimatch: 3.1.2
     dev: true
 
+  /text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
+    dev: false
+
   /thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -12024,6 +12650,11 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
+
+  /toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+    dev: false
 
   /toposort-class@1.0.1:
     resolution: {integrity: sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg==}
@@ -12264,6 +12895,22 @@ packages:
       tagged-tag: 1.0.0
     dev: false
 
+  /type-fest@5.7.0:
+    resolution: {integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==}
+    engines: {node: '>=20'}
+    dependencies:
+      tagged-tag: 1.0.0
+    dev: false
+
+  /type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+    dev: false
+
   /typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -12383,6 +13030,11 @@ packages:
     engines: {node: '>=20.18.1'}
     dev: false
 
+  /undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
+    dev: false
+
   /unenv@2.0.0-rc.21:
     resolution: {integrity: sha512-Wj7/AMtE9MRnAXa6Su3Lk0LNCfqDYgfwVjwRFVum9U7wsto1imuHqk4kTm7Jni+5A0Hn7dttL6O/zjvUvoo+8A==}
     dependencies:
@@ -12458,6 +13110,11 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
     dev: true
+
+  /unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+    dev: false
 
   /unstorage@1.17.5(db0@0.3.4):
     resolution: {integrity: sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==}
@@ -12731,6 +13388,11 @@ packages:
   /validator@13.15.35:
     resolution: {integrity: sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==}
     engines: {node: '>= 0.10'}
+    dev: false
+
+  /vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
     dev: false
 
   /vfile-location@5.0.3:
@@ -13177,6 +13839,20 @@ packages:
       utf-8-validate:
         optional: true
 
+  /xdg-app-paths@5.1.0:
+    resolution: {integrity: sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==}
+    engines: {node: '>=6'}
+    dependencies:
+      xdg-portable: 7.3.0
+    dev: false
+
+  /xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
+    dependencies:
+      os-paths: 4.4.0
+    dev: false
+
   /xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -13241,6 +13917,14 @@ packages:
   /zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
     dev: true
+
+  /zod-to-json-schema@3.25.2(zod@4.3.6):
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+    dependencies:
+      zod: 4.3.6
+    dev: false
 
   /zod@3.24.1:
     resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}


### PR DESCRIPTION
## What changed
- Added a Farm docs config surface: `docs: true`, `docs: { entry: "/docs" }`, inline `config`, `configPath`, and auto-discovery for `docs.config.*` / `docs.json`.
- Added a lightweight Farm docs handler that serves markdown/MDX docs as HTML or `text/markdown` and wires it into dev middleware and the generated universal SSR entry.
- Added route typing for configured docs entries, plus a basic example using `docs.json` and markdown docs pages.

## Validation
- `corepack pnpm@8.12.1 --filter @farmjs/core exec vitest run src/__tests__/config.test.ts src/__tests__/docs-handler.test.ts src/__tests__/generate-route-types.test.ts`
- `corepack pnpm@8.12.1 --filter @farmjs/core run build`
- `corepack pnpm@8.12.1 --filter farm-example-basic run build`
- Direct SSR fetch check: `/docs` returns HTML 200 and `/docs/getting-started.md` returns markdown 200.

## Notes
- Full `corepack pnpm@8.12.1 --filter @farmjs/core run type-check` still fails on existing Nitro/query-state issues outside this docs integration (for example `src/nitro/api-handler.ts`, `src/nitro/vite-plugin.ts`, and missing `nuqs` query-state types).