### PR TITLE
feat: add integration api namespace

### DIFF
--- a/packages/farm-integrations/src/auth0/index.ts
+++ b/packages/farm-integrations/src/auth0/index.ts
@@ -7,6 +7,7 @@ import {
   createRequestCookie,
   getOrigin,
   getReturnTo,
+  integrationConfig,
   normalizeMatchers,
   parseCookieHeaderMap,
   resolveCallbackSettings,
@@ -388,6 +389,24 @@ export function auth0(input: Auth0IntegrationInput = {}) {
       clientId,
       protectedRoutes: protectedMatchers,
     },
+    config: integrationConfig<ResolvedAuth0Env>({
+      label: "Auth0 integration",
+      env: {
+        domain: "AUTH0_DOMAIN",
+        clientId: "AUTH0_CLIENT_ID",
+        clientSecret: "AUTH0_CLIENT_SECRET",
+        secret: "AUTH0_SECRET",
+        appBaseUrl: "APP_BASE_URL",
+      },
+      input: {
+        domain,
+        clientId,
+        clientSecret,
+        secret,
+        appBaseUrl,
+      },
+      required: ["domain", "clientId", "secret"],
+    }),
     api: createAuth0Api({
       loginPath,
       signUpPath,

--- a/packages/farm-integrations/src/autumn/index.ts
+++ b/packages/farm-integrations/src/autumn/index.ts
@@ -20,7 +20,12 @@ import {
   type FarmIntegrationHandlerContext,
   type FarmIntegrationLogger,
 } from "@farmjs/core";
-import { normalizeWebhookConfig, resolveAppPath, toAbsoluteUrl } from "../utils/index.js";
+import {
+  integrationConfig,
+  normalizeWebhookConfig,
+  resolveAppPath,
+  toAbsoluteUrl,
+} from "../utils/index.js";
 import type {
   FarmWebhookAckResult,
   FarmWebhookConfig,
@@ -261,6 +266,13 @@ export interface AutumnIntegrationInput extends AutumnClientPathOptions {
   webhooks?: AutumnWebhookConfig;
   billing: AutumnBillingOptions;
   log?: FarmIntegrationLogger;
+}
+
+interface ResolvedAutumnConfig {
+  secretKey?: string;
+  serverURL?: string;
+  appBaseUrl?: string;
+  webhookSecret?: string;
 }
 
 interface ResolvedAutumnProduct extends AutumnBillingProduct {
@@ -1143,6 +1155,8 @@ export function autumn<TInput extends AutumnIntegrationInput>(
   input: TInput,
 ): AutumnIntegrationResult<FarmIntegrationAPI> {
   const secretKey = input.secretKey ?? process.env.AUTUMN_SECRET_KEY ?? "";
+  const appBaseUrl = input.appBaseUrl ?? process.env.APP_BASE_URL ?? undefined;
+  const webhookSecret = process.env.AUTUMN_WEBHOOK_SECRET ?? undefined;
   if (!input.instance && !secretKey) {
     throw new Error("Autumn integration requires AUTUMN_SECRET_KEY or an Autumn instance.");
   }
@@ -1203,7 +1217,7 @@ export function autumn<TInput extends AutumnIntegrationInput>(
     webhooks: input.webhooks,
     defaultName: "default",
     defaultPath: "/billing/webhook",
-    defaultSecret: process.env.AUTUMN_WEBHOOK_SECRET ?? undefined,
+    defaultSecret: webhookSecret,
   });
   const plans = billing.plans ?? {};
   const products = normalizeProducts(billing.products);
@@ -1299,6 +1313,21 @@ export function autumn<TInput extends AutumnIntegrationInput>(
         planId: product.planId ?? null,
       })),
     },
+    config: integrationConfig<ResolvedAutumnConfig>({
+      label: "Autumn integration",
+      env: {
+        secretKey: "AUTUMN_SECRET_KEY",
+        appBaseUrl: "APP_BASE_URL",
+        webhookSecret: "AUTUMN_WEBHOOK_SECRET",
+      },
+      input: {
+        secretKey,
+        serverURL: input.serverURL,
+        appBaseUrl,
+        webhookSecret,
+      },
+      required: input.instance ? [] : ["secretKey"],
+    }),
     api: createAutumnApi({
       productsPath,
       statusPath,
@@ -1953,7 +1982,6 @@ export function autumn<TInput extends AutumnIntegrationInput>(
           }
 
           const resolved = await requireOwner(ctx, billing, sdk);
-          const appBaseUrl = input.appBaseUrl ?? process.env.APP_BASE_URL;
           const successPath = resolveAppPath(body.successPath, "Autumn checkout successPath");
           const successUrl = successPath
             ? toAbsoluteUrl(successPath, ctx.request, appBaseUrl).toString()
@@ -1994,7 +2022,6 @@ export function autumn<TInput extends AutumnIntegrationInput>(
         async handler(request, ctx) {
           const body = (await request.json().catch(() => ({}))) as AutumnPortalInput;
           const resolved = await requireOwner(ctx, billing, sdk);
-          const appBaseUrl = input.appBaseUrl ?? process.env.APP_BASE_URL;
           const returnPath = resolveAppPath(body.returnTo, "Autumn portal returnTo");
           const returnUrl = returnPath
             ? toAbsoluteUrl(returnPath, ctx.request, appBaseUrl).toString()

--- a/packages/farm-integrations/src/clerk/index.ts
+++ b/packages/farm-integrations/src/clerk/index.ts
@@ -1,6 +1,10 @@
 import { createClerkClient, type ClerkClient } from "@clerk/backend";
 import { defineIntegration, type FarmIntegrationLogger } from "@farmjs/core";
-import { createDocumentNavigationMatchers, normalizeMatchers } from "../utils/index.js";
+import {
+  createDocumentNavigationMatchers,
+  integrationConfig,
+  normalizeMatchers,
+} from "../utils/index.js";
 
 export interface ClerkIntegrationInput {
   publishableKey?: string;
@@ -13,7 +17,12 @@ export interface ClerkIntegrationInput {
   log?: FarmIntegrationLogger;
 }
 
-function resolveClerkKeys(input: ClerkIntegrationInput) {
+interface ResolvedClerkConfig {
+  publishableKey: string;
+  secretKey: string;
+}
+
+function resolveClerkKeys(input: ClerkIntegrationInput): ResolvedClerkConfig {
   const publishableKey =
     input.publishableKey ??
     process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ??
@@ -60,6 +69,18 @@ export function clerk(input: ClerkIntegrationInput = {}) {
       secretKey: "[redacted]",
       protectedRoutes: protectedMatchers,
     },
+    config: integrationConfig<ResolvedClerkConfig>({
+      label: "Clerk integration",
+      env: {
+        publishableKey: ["NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY", "CLERK_PUBLISHABLE_KEY"],
+        secretKey: "CLERK_SECRET_KEY",
+      },
+      input: {
+        publishableKey,
+        secretKey,
+      },
+      required: ["publishableKey", "secretKey"],
+    }),
     log: input.log,
     providers: [
       {

--- a/packages/farm-integrations/src/email/index.ts
+++ b/packages/farm-integrations/src/email/index.ts
@@ -1,6 +1,6 @@
 import { render, toPlainText } from "@react-email/render";
 import { defineIntegration, integrationRoute, type FarmIntegrationLogger } from "@farmjs/core";
-import { normalizeWebhookConfig } from "../utils/index.js";
+import { integrationConfig, normalizeWebhookConfig } from "../utils/index.js";
 import type { FarmWebhookConfig, FarmWebhookEvent } from "../utils/webhooks.js";
 import {
   createResendClientApi,
@@ -67,6 +67,13 @@ export interface ResendIntegrationInput<TTemplates extends EmailTemplates = Emai
   templates: TTemplates;
   webhooks?: ResendWebhookConfig;
   log?: FarmIntegrationLogger;
+}
+
+interface ResolvedResendConfig {
+  apiKey?: string;
+  from?: string;
+  replyTo?: string | string[];
+  webhookSecret?: string;
 }
 
 function createResendApi<
@@ -144,6 +151,7 @@ export function resend<const TTemplates extends EmailTemplates>(
     from: input.defaults?.from ?? process.env.RESEND_FROM_EMAIL ?? undefined,
     replyTo: input.defaults?.replyTo ?? process.env.RESEND_REPLY_TO_EMAIL ?? undefined,
   };
+  const webhookSecret = process.env.RESEND_WEBHOOK_SECRET ?? undefined;
 
   if (!input.instance && !apiKey) {
     throw new Error("Resend integration requires RESEND_API_KEY or an explicit instance.");
@@ -157,7 +165,7 @@ export function resend<const TTemplates extends EmailTemplates>(
     webhooks: input.webhooks,
     defaultName: "default",
     defaultPath: `${basePath}/webhook`,
-    defaultSecret: process.env.RESEND_WEBHOOK_SECRET ?? undefined,
+    defaultSecret: webhookSecret,
   });
 
   const sdk = input.instance ?? new ResendSdk(apiKey);
@@ -253,6 +261,22 @@ export function resend<const TTemplates extends EmailTemplates>(
       templateIds: templateEntries.map(([id]) => id),
       liveMode: !!apiKey,
     },
+    config: integrationConfig<ResolvedResendConfig>({
+      label: "Resend integration",
+      env: {
+        apiKey: "RESEND_API_KEY",
+        from: "RESEND_FROM_EMAIL",
+        replyTo: "RESEND_REPLY_TO_EMAIL",
+        webhookSecret: "RESEND_WEBHOOK_SECRET",
+      },
+      input: {
+        apiKey,
+        from: defaults.from,
+        replyTo: defaults.replyTo,
+        webhookSecret,
+      },
+      required: input.instance ? [] : ["apiKey"],
+    }),
     api: createResendApi<TTemplates>({
       sendPath,
       schedulePath,

--- a/packages/farm-integrations/src/farm-core-shim.d.ts
+++ b/packages/farm-integrations/src/farm-core-shim.d.ts
@@ -52,8 +52,27 @@ declare module "@farmjs/core" {
       };
 
   export interface FarmIntegrationInputSchema<TValue = unknown> {
+    _output?: TValue;
+    parse?(value: unknown): MaybePromise<TValue>;
     safeParse?(value: unknown): MaybePromise<FarmIntegrationValidationResult<TValue>>;
     safeParseAsync?(value: unknown): Promise<FarmIntegrationValidationResult<TValue>>;
+    "~standard"?: {
+      validate(value: unknown): MaybePromise<
+        | {
+            value: TValue;
+          }
+        | {
+            issues: readonly {
+              path?: readonly (string | number)[];
+              code?: string;
+              message: string;
+            }[];
+          }
+      >;
+      types?: {
+        output: TValue;
+      };
+    };
   }
 
   export interface FarmIntegrationRouteInputSchemas<TBody = unknown, TQuery = unknown> {
@@ -70,7 +89,90 @@ declare module "@farmjs/core" {
     snapshot(options?: { exposedOnly?: boolean }): Map<string, unknown>;
   }
 
-  export interface FarmIntegrationHandlerContext<TBody = unknown, TQuery = unknown> {
+  export type FarmIntegrationRouteDb<TSchema extends FarmIntegrationSchema | undefined> = Record<
+    string,
+    any
+  >;
+
+  export interface FarmIntegrationRouteStorageArgs<
+    TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+  > {
+    getClient(): Promise<unknown | undefined>;
+    getOrm(): Promise<FarmIntegrationRouteDb<TSchema>>;
+  }
+
+  export interface FarmIntegrationRouteArgs<
+    TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+  > {
+    db: FarmIntegrationRouteDb<TSchema>;
+    getDb(): Promise<FarmIntegrationRouteDb<TSchema>>;
+    storage: FarmIntegrationRouteStorageArgs<TSchema>;
+  }
+
+  export interface FarmIntegrationConfigContext<
+    TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+  > {
+    key: string;
+    integration: FarmIntegration<TSchema, any>;
+    appConfig: Record<string, unknown>;
+    config: Record<string, unknown>;
+    args: FarmIntegrationRouteArgs<TSchema>;
+    env: Record<string, string | undefined>;
+    isDev: boolean;
+    isProd: boolean;
+  }
+
+  export interface FarmIntegrationConfigDefinition<
+    TConfig = unknown,
+    TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+  > {
+    schema?: FarmIntegrationInputSchema<TConfig>;
+    env?: Record<string, string | readonly string[]>;
+    defaults?:
+      | Partial<TConfig>
+      | ((context: FarmIntegrationConfigContext<TSchema>) => MaybePromise<Partial<TConfig>>);
+    input?:
+      | Partial<TConfig>
+      | ((context: FarmIntegrationConfigContext<TSchema>) => MaybePromise<Partial<TConfig>>);
+    resolve?(
+      context: FarmIntegrationConfigContext<TSchema>,
+    ): MaybePromise<TConfig | Partial<TConfig> | undefined>;
+  }
+
+  export type FarmIntegrationConfigInput<
+    TConfig = unknown,
+    TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+  > = FarmIntegrationInputSchema<TConfig> | FarmIntegrationConfigDefinition<TConfig, TSchema>;
+
+  export type FarmIntegrationLifecycleLogLevel = "info" | "warn" | "error";
+
+  export interface FarmIntegrationLifecycleLogger {
+    info(message: string, meta?: Record<string, unknown>): void;
+    warn(message: string, meta?: Record<string, unknown>): void;
+    error(message: string, meta?: Record<string, unknown>): void;
+  }
+
+  export interface FarmIntegrationLifecycleContext<
+    TConfig = unknown,
+    TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+  > extends FarmIntegrationConfigContext<TSchema> {
+    integration: FarmIntegration<TSchema, TConfig>;
+    integrationConfig: TConfig;
+    log: FarmIntegrationLifecycleLogger;
+    reason?: string;
+    cleanup(callback?: () => MaybePromise<void>): Promise<void>;
+  }
+
+  export type FarmIntegrationLifecycleHook<
+    TConfig = unknown,
+    TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+  > = (context: FarmIntegrationLifecycleContext<TConfig, TSchema>) => MaybePromise<void>;
+
+  export interface FarmIntegrationHandlerContext<
+    TBody = unknown,
+    TQuery = unknown,
+    TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+  > {
     request: Request;
     requestId: string;
     url: URL;
@@ -78,6 +180,7 @@ declare module "@farmjs/core" {
     method: string;
     params: FarmIntegrationRouteParams;
     input: FarmIntegrationRouteInput<TBody, TQuery>;
+    args: FarmIntegrationRouteArgs<TSchema>;
     integration: {
       category: FarmIntegrationCategory;
       /** @deprecated Use category instead. */
@@ -96,24 +199,53 @@ declare module "@farmjs/core" {
     isProd: boolean;
   }
 
-  export interface FarmIntegrationRoute<TBody = unknown, TQuery = unknown> {
+  export interface FarmIntegrationRouteHookContext<
+    TBody = unknown,
+    TQuery = unknown,
+    TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+  > extends FarmIntegrationHandlerContext<TBody, TQuery, TSchema> {
+    response?: Response;
+  }
+
+  export type FarmIntegrationRouteHook<
+    TBody = unknown,
+    TQuery = unknown,
+    TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+  > = {
+    bivarianceHack(
+      request: Request,
+      context: FarmIntegrationRouteHookContext<TBody, TQuery, TSchema>,
+    ): Promise<Response | void> | Response | void;
+  }["bivarianceHack"];
+
+  export interface FarmIntegrationRoute<
+    TBody = unknown,
+    TQuery = unknown,
+    TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+  > {
     path: string;
     method?: FarmIntegrationRouteMethod;
     methods?: readonly FarmIntegrationRouteMethod[];
-    middleware?: readonly FarmIntegrationRouteMiddleware[];
+    middleware?: readonly FarmIntegrationRouteMiddleware<TSchema>[];
+    before?: readonly FarmIntegrationRouteHook<TBody, TQuery, TSchema>[];
+    after?: readonly FarmIntegrationRouteHook<TBody, TQuery, TSchema>[];
     rawBody?: boolean;
     bodyFormat?: FarmIntegrationAPIBodyFormat;
+    body?: FarmIntegrationInputSchema<TBody>;
+    query?: FarmIntegrationInputSchema<TQuery>;
     input?: FarmIntegrationRouteInputSchemas<TBody, TQuery>;
     handler(
       request: Request,
-      context: FarmIntegrationHandlerContext<TBody, TQuery>,
+      context: FarmIntegrationHandlerContext<TBody, TQuery, TSchema>,
     ): Promise<Response> | Response;
   }
 
-  export interface FarmIntegrationRouteMiddleware {
+  export interface FarmIntegrationRouteMiddleware<
+    TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+  > {
     handler(
       request: Request,
-      context: FarmIntegrationHandlerContext,
+      context: FarmIntegrationHandlerContext<unknown, unknown, TSchema>,
     ): Promise<Response | void> | Response | void;
   }
 
@@ -124,17 +256,20 @@ declare module "@farmjs/core" {
     TResponse = unknown,
     TServer extends boolean = false,
     TMethod extends FarmIntegrationAPIMethod = FarmIntegrationAPIMethod,
-  > extends FarmIntegrationRoute<TBody, TQuery> {
+    TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+  > extends FarmIntegrationRoute<TBody, TQuery, TSchema> {
     path: TPath;
     method: TMethod;
     __operation: FarmIntegrationAPIOperation<TBody, TQuery, TResponse, TServer>;
   }
 
-  export interface FarmIntegrationMiddleware {
+  export interface FarmIntegrationMiddleware<
+    TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+  > {
     matcher?: string | string[];
     handler(
       request: Request,
-      context: FarmIntegrationHandlerContext,
+      context: FarmIntegrationHandlerContext<unknown, unknown, TSchema>,
     ): Promise<Response | void> | Response | void;
   }
 
@@ -152,6 +287,29 @@ declare module "@farmjs/core" {
   export interface FarmIntegrationDocumentNavigation {
     matcher: string | readonly string[];
   }
+
+  export type FarmIntegrationEndpointValue<
+    TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+  > =
+    | FarmIntegrationRoute<any, any, TSchema>
+    | readonly FarmIntegrationEndpointValue<TSchema>[]
+    | {
+        readonly [key: string]: FarmIntegrationEndpointValue<TSchema> | undefined;
+      };
+
+  export type FarmIntegrationEndpoints<
+    TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+  > = {
+    readonly [key: string]: FarmIntegrationEndpointValue<TSchema> | undefined;
+  };
+
+  export type FarmIntegrationEndpointsFactory<
+    TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+  > = (context: {
+    endpoint: typeof integrationRoute;
+    route: typeof integrationRoute;
+    integrationRoute: typeof integrationRoute;
+  }) => FarmIntegrationEndpoints<TSchema>;
 
   export type FarmIntegrationSchemaFieldType =
     | "id"
@@ -231,8 +389,11 @@ declare module "@farmjs/core" {
     schema: TSchema,
   ): TSchema;
 
-  export interface CreateIntegrationOrmOptions<TClient = unknown> {
-    schema: FarmIntegrationSchema;
+  export interface CreateIntegrationOrmOptions<
+    TClient = unknown,
+    TSchema extends FarmIntegrationSchema = FarmIntegrationSchema,
+  > {
+    schema: TSchema;
     config?: {
       storage?: unknown;
     };
@@ -240,9 +401,10 @@ declare module "@farmjs/core" {
     client?: TClient | (() => TClient | Promise<TClient>);
   }
 
-  export function createIntegrationOrm<TClient = unknown>(
-    options: CreateIntegrationOrmOptions<TClient>,
-  ): Promise<Record<string, unknown>>;
+  export function createIntegrationOrm<
+    TClient = unknown,
+    TSchema extends FarmIntegrationSchema = FarmIntegrationSchema,
+  >(options: CreateIntegrationOrmOptions<TClient, TSchema>): Promise<Record<string, unknown>>;
 
   export type FarmIntegrationAPIMethod =
     | "GET"
@@ -370,6 +532,10 @@ declare module "@farmjs/core" {
 
   export type FarmIntegrationLogPhase =
     | "registered"
+    | "validate"
+    | "setup"
+    | "ready"
+    | "dispose"
     | "request:start"
     | "request:end"
     | "request:error";
@@ -390,12 +556,18 @@ declare module "@farmjs/core" {
     response?: Response;
     error?: unknown;
     durationMs?: number;
+    level?: FarmIntegrationLifecycleLogLevel;
+    message?: string;
+    meta?: Record<string, unknown>;
     context: Map<string, unknown>;
   }
 
   export type FarmIntegrationLogger = (event: FarmIntegrationLogEvent) => void | Promise<void>;
 
-  export interface FarmIntegration {
+  export interface FarmIntegration<
+    TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+    TConfig = unknown,
+  > {
     readonly kind: "farm-integration";
     category: FarmIntegrationCategory;
     /** @deprecated Use category instead. */
@@ -403,17 +575,28 @@ declare module "@farmjs/core" {
     type: string;
     instance: unknown;
     api?: FarmIntegrationAPI;
-    schema?: FarmIntegrationSchema;
+    schema?: TSchema;
+    config?: FarmIntegrationConfigInput<TConfig, TSchema>;
+    validate?: FarmIntegrationLifecycleHook<TConfig, TSchema>;
+    setup?: FarmIntegrationLifecycleHook<TConfig, TSchema>;
+    ready?: FarmIntegrationLifecycleHook<TConfig, TSchema>;
+    dispose?: FarmIntegrationLifecycleHook<TConfig, TSchema>;
     log?: FarmIntegrationLogger;
-    routes?: readonly FarmIntegrationRoute[];
-    middleware?: readonly FarmIntegrationMiddleware[];
+    routes?: readonly FarmIntegrationRoute<any, any, TSchema>[];
+    endpoints?: FarmIntegrationEndpoints<TSchema>;
+    middleware?: readonly FarmIntegrationMiddleware<TSchema>[];
     providers?: readonly FarmIntegrationProvider[];
     documentNavigations?: readonly FarmIntegrationDocumentNavigation[];
     plugins?: readonly FarmPlugin[];
   }
 
-  export type FarmIntegrationInput = Omit<FarmIntegration, "kind" | "category" | "slot"> &
-    (
+  export type FarmIntegrationInput = Omit<
+    FarmIntegration,
+    "kind" | "category" | "slot" | "config" | "endpoints"
+  > & {
+    config?: FarmIntegrationConfigInput;
+    endpoints?: FarmIntegrationEndpoints | FarmIntegrationEndpointsFactory;
+  } & (
       | {
           category: FarmIntegrationCategory;
           slot?: FarmIntegrationCategory;
@@ -496,7 +679,10 @@ declare module "@farmjs/core" {
         credentials?: RequestCredentials;
         responseFormat?: FarmIntegrationAPIResponseFormat;
         isServer?: TServer;
+        query?: FarmIntegrationInputSchema<TQuery>;
         input?: FarmIntegrationRouteInputSchemas<never, TQuery>;
+        before?: readonly FarmIntegrationRouteHook<never, TQuery>[];
+        after?: readonly FarmIntegrationRouteHook<never, TQuery>[];
         handler(
           request: Request,
           context: FarmIntegrationHandlerContext<never, TQuery>,
@@ -519,7 +705,11 @@ declare module "@farmjs/core" {
         bodyFormat?: FarmIntegrationAPIBodyFormat;
         responseFormat?: FarmIntegrationAPIResponseFormat;
         isServer?: TServer;
+        body?: FarmIntegrationInputSchema<TBody>;
+        query?: FarmIntegrationInputSchema<TQuery>;
         input?: FarmIntegrationRouteInputSchemas<TBody, TQuery>;
+        before?: readonly FarmIntegrationRouteHook<TBody, TQuery>[];
+        after?: readonly FarmIntegrationRouteHook<TBody, TQuery>[];
         handler(
           request: Request,
           context: FarmIntegrationHandlerContext<TBody, TQuery>,

--- a/packages/farm-integrations/src/jobs/index.ts
+++ b/packages/farm-integrations/src/jobs/index.ts
@@ -6,6 +6,7 @@ import {
 } from "@farmjs/core";
 import { api } from "@farmjs/core/client";
 import type { FarmIntegrationAPIOperation } from "@farmjs/core/client";
+import { integrationConfig } from "../utils/index.js";
 
 export type JobsRuntimeKind = "trigger" | "inngest";
 
@@ -285,6 +286,26 @@ export interface InngestJobsRuntimeDefinition {
 }
 
 export type JobsRuntimeDefinition = TriggerJobsRuntimeDefinition | InngestJobsRuntimeDefinition;
+
+interface ResolvedTriggerJobsConfig {
+  kind: "trigger";
+  projectRef: string;
+  apiKey: string;
+  webhookSecret: string;
+  apiBaseUrl: string;
+}
+
+interface ResolvedInngestJobsConfig {
+  kind: "inngest";
+  appId: string;
+  eventKey: string;
+  signingKey: string;
+  eventBaseUrl: string;
+  apiBaseUrl: string;
+  eventNamePrefix: string;
+}
+
+type ResolvedJobsConfig = ResolvedTriggerJobsConfig | ResolvedInngestJobsConfig;
 
 export interface JobsIntegrationInputBase<TTasks extends JobsTaskMap> {
   basePath?: string;
@@ -1280,6 +1301,48 @@ function createRuntime(runtime: JobsRuntimeDefinition) {
   return createInngestRuntime(runtime.config);
 }
 
+function resolveJobsIntegrationConfig(runtime: JobsRuntimeDefinition) {
+  if (runtime.kind === "trigger") {
+    const resolved = {
+      kind: "trigger" as const,
+      projectRef: runtime.config.projectRef ?? process.env.TRIGGER_PROJECT_REF ?? "",
+      apiKey: runtime.config.apiKey ?? process.env.TRIGGER_SECRET_KEY ?? "",
+      webhookSecret: runtime.config.webhookSecret ?? process.env.TRIGGER_WEBHOOK_SECRET ?? "",
+      apiBaseUrl: (runtime.config.apiBaseUrl ?? "https://api.trigger.dev").replace(/\/+$/g, ""),
+    };
+
+    return integrationConfig<ResolvedTriggerJobsConfig>({
+      label: "Trigger jobs runtime",
+      env: {
+        projectRef: "TRIGGER_PROJECT_REF",
+        apiKey: "TRIGGER_SECRET_KEY",
+        webhookSecret: "TRIGGER_WEBHOOK_SECRET",
+      },
+      input: resolved,
+    });
+  }
+
+  const resolved = {
+    kind: "inngest" as const,
+    appId: runtime.config.appId ?? process.env.INNGEST_APP_ID ?? "",
+    eventKey: runtime.config.eventKey ?? process.env.INNGEST_EVENT_KEY ?? "",
+    signingKey: runtime.config.signingKey ?? process.env.INNGEST_SIGNING_KEY ?? "",
+    eventBaseUrl: (runtime.config.eventBaseUrl ?? "https://inn.gs").replace(/\/+$/g, ""),
+    apiBaseUrl: (runtime.config.apiBaseUrl ?? "https://api.inngest.com").replace(/\/+$/g, ""),
+    eventNamePrefix: runtime.config.eventNamePrefix ?? "farm",
+  };
+
+  return integrationConfig<ResolvedInngestJobsConfig>({
+    label: "Inngest jobs runtime",
+    env: {
+      appId: "INNGEST_APP_ID",
+      eventKey: "INNGEST_EVENT_KEY",
+      signingKey: "INNGEST_SIGNING_KEY",
+    },
+    input: resolved,
+  });
+}
+
 function createJobsApi<TTasks extends JobsTaskMap>(
   tasks: readonly JobsNormalizedTask[],
   tasksPath: string,
@@ -1485,7 +1548,8 @@ function normalizeCancelInput(body: Record<string, unknown> | undefined) {
 export function jobs<const TTasks extends JobsTaskMap>(input: JobsIntegrationInput<TTasks>) {
   const basePath = normalizeBasePath(input.basePath);
   const tasksPath = joinPath(basePath, "tasks");
-  const runtime = createRuntime(resolveRuntimeDefinition(input));
+  const runtimeDefinition = resolveRuntimeDefinition(input);
+  const runtime = createRuntime(runtimeDefinition);
   const normalizedTasks = normalizeTasks(input.tasks, basePath, runtime);
 
   return defineIntegration({
@@ -1496,6 +1560,7 @@ export function jobs<const TTasks extends JobsTaskMap>(input: JobsIntegrationInp
       configured: runtime.isConfigured(),
       tasks: normalizedTasks.map((task) => task.metadata),
     },
+    config: resolveJobsIntegrationConfig(runtimeDefinition),
     api: createJobsApi<TTasks>(normalizedTasks, tasksPath),
     log: input.log,
     routes: [

--- a/packages/farm-integrations/src/polar/index.ts
+++ b/packages/farm-integrations/src/polar/index.ts
@@ -15,7 +15,12 @@ import {
   type FarmIntegrationHandlerContext,
   type FarmIntegrationLogger,
 } from "@farmjs/core";
-import { normalizeWebhookConfig, resolveAppPath, toAbsoluteUrl } from "../utils/index.js";
+import {
+  integrationConfig,
+  normalizeWebhookConfig,
+  resolveAppPath,
+  toAbsoluteUrl,
+} from "../utils/index.js";
 import type {
   FarmWebhookAckResult,
   FarmWebhookConfig,
@@ -237,6 +242,13 @@ export interface PolarIntegrationInput {
   portalPath?: string;
   billing: PolarBillingOptions;
   log?: FarmIntegrationLogger;
+}
+
+interface ResolvedPolarConfig {
+  accessToken: string;
+  server: "sandbox" | "production";
+  appBaseUrl?: string;
+  webhookSecret?: string;
 }
 
 interface ResolvedPolarProduct extends PolarBillingProduct {
@@ -900,6 +912,8 @@ export function polar<TInput extends PolarIntegrationInput>(
   const accessToken = input.accessToken ?? process.env.POLAR_ACCESS_TOKEN ?? "";
   const server =
     input.server ?? (process.env.POLAR_SERVER as "sandbox" | "production" | undefined) ?? "sandbox";
+  const appBaseUrl = input.appBaseUrl ?? process.env.APP_BASE_URL ?? undefined;
+  const webhookSecret = process.env.POLAR_WEBHOOK_SECRET ?? undefined;
 
   if (!accessToken) {
     throw new Error("Polar integration requires POLAR_ACCESS_TOKEN.");
@@ -957,7 +971,7 @@ export function polar<TInput extends PolarIntegrationInput>(
     webhooks: input.webhooks,
     defaultName: "default",
     defaultPath: "/billing/webhook",
-    defaultSecret: process.env.POLAR_WEBHOOK_SECRET ?? undefined,
+    defaultSecret: webhookSecret,
   });
   const plans = billing.plans ?? {};
   const products = normalizeProducts(billing.products);
@@ -1051,6 +1065,22 @@ export function polar<TInput extends PolarIntegrationInput>(
         planId: product.planId ?? null,
       })),
     },
+    config: integrationConfig<ResolvedPolarConfig>({
+      label: "Polar integration",
+      env: {
+        accessToken: "POLAR_ACCESS_TOKEN",
+        server: "POLAR_SERVER",
+        appBaseUrl: "APP_BASE_URL",
+        webhookSecret: "POLAR_WEBHOOK_SECRET",
+      },
+      input: {
+        accessToken,
+        server,
+        appBaseUrl,
+        webhookSecret,
+      },
+      required: ["accessToken", "server"],
+    }),
     api: createPolarApi({
       productsPath,
       statusPath,
@@ -1675,9 +1705,9 @@ export function polar<TInput extends PolarIntegrationInput>(
             "/success";
           const cancelPath =
             resolveAppPath(body.cancelPath ?? "/cancel", "Polar checkout cancelPath") ?? "/cancel";
-          const successUrl = toAbsoluteUrl(successPath, request, input.appBaseUrl);
+          const successUrl = toAbsoluteUrl(successPath, request, appBaseUrl);
           successUrl.searchParams.set("checkout_id", "{CHECKOUT_ID}");
-          const returnUrl = toAbsoluteUrl(cancelPath, request, input.appBaseUrl);
+          const returnUrl = toAbsoluteUrl(cancelPath, request, appBaseUrl);
           const checkout = await sdk.checkouts.create({
             products: [product.productId],
             successUrl: successUrl.toString(),
@@ -1702,7 +1732,7 @@ export function polar<TInput extends PolarIntegrationInput>(
           const body = (await request.json().catch(() => ({}))) as PolarPortalInput;
           const resolved = await requireOwner(ctx, billing, sdk);
           const returnPath = resolveAppPath(body.returnTo ?? "/", "Polar portal returnTo") ?? "/";
-          const returnUrl = toAbsoluteUrl(returnPath, request, input.appBaseUrl);
+          const returnUrl = toAbsoluteUrl(returnPath, request, appBaseUrl);
           const session = await sdk.customerSessions.create({
             externalCustomerId: resolved.externalCustomerId,
             returnUrl: returnUrl.toString(),

--- a/packages/farm-integrations/src/stripe/index.ts
+++ b/packages/farm-integrations/src/stripe/index.ts
@@ -10,6 +10,7 @@ import {
   type FarmIntegrationSchema,
 } from "@farmjs/core";
 import {
+  integrationConfig,
   normalizeWebhookConfig,
   resolveAppPath,
   toAbsoluteUrl,
@@ -3611,6 +3612,16 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
       sessionPath,
     }) as unknown as FarmIntegrationAPI,
     schema: integrationSchema,
+    config: integrationConfig<ResolvedStripeEnv>({
+      label: "Stripe integration",
+      env: {
+        secretKey: "STRIPE_SECRET_KEY",
+        webhookSecret: "STRIPE_WEBHOOK_SECRET",
+        appBaseUrl: "APP_BASE_URL",
+      },
+      input: env,
+      required: input.instance ? [] : ["secretKey"],
+    }),
     log: input.log,
     routes: [
       integrationRoute.get<typeof productsPath, StripeCatalogProduct[]>(productsPath, {

--- a/packages/farm-integrations/src/supabase/index.ts
+++ b/packages/farm-integrations/src/supabase/index.ts
@@ -11,6 +11,7 @@ import {
   escapeHtml,
   getOrigin,
   getReturnTo,
+  integrationConfig,
   normalizeMatchers,
   parseCookieHeaderList,
   resolveAppPath,
@@ -837,6 +838,22 @@ export function supabase(input: SupabaseIntegrationInput = {}) {
       providers,
       pages,
     },
+    config: integrationConfig<ResolvedSupabaseEnv>({
+      label: "Supabase integration",
+      env: {
+        url: ["SUPABASE_URL", "NEXT_PUBLIC_SUPABASE_URL"],
+        anonKey: [
+          "SUPABASE_ANON_KEY",
+          "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+          "SUPABASE_PUBLISHABLE_KEY",
+          "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
+          "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY",
+        ],
+        appBaseUrl: "APP_BASE_URL",
+      },
+      input: env,
+      required: ["url", "anonKey"],
+    }),
     api,
     log: input.log,
     documentNavigations: [

--- a/packages/farm-integrations/src/utils/config.ts
+++ b/packages/farm-integrations/src/utils/config.ts
@@ -1,0 +1,56 @@
+import type { FarmIntegrationConfigDefinition } from "@farmjs/core";
+
+type ConfigKey<TConfig> = Extract<keyof TConfig, string>;
+
+export interface ResolvedIntegrationConfigOptions<TConfig extends object> {
+  label: string;
+  env?: Partial<Record<ConfigKey<TConfig>, string | readonly string[]>>;
+  defaults?: Partial<TConfig>;
+  input?: Partial<TConfig>;
+  required?: readonly ConfigKey<TConfig>[];
+}
+
+export function integrationConfig<TConfig extends object>(
+  options: ResolvedIntegrationConfigOptions<TConfig>,
+): FarmIntegrationConfigDefinition<TConfig> {
+  return {
+    env: options.env as Record<string, string | readonly string[]> | undefined,
+    defaults: options.defaults,
+    input: options.input,
+    schema: {
+      safeParse(value) {
+        const data = (isObject(value) ? value : {}) as TConfig;
+        const issues =
+          options.required
+            ?.filter((key) => isMissingConfigValue(data[key]))
+            .map((key) => ({
+              path: [key],
+              code: "required",
+              message: `${options.label} requires ${String(key)}.`,
+            })) ?? [];
+
+        if (issues.length > 0) {
+          return {
+            success: false,
+            error: {
+              issues,
+            },
+          };
+        }
+
+        return {
+          success: true,
+          data,
+        };
+      },
+    },
+  };
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isMissingConfigValue(value: unknown): boolean {
+  return value === undefined || value === null || value === "";
+}

--- a/packages/farm-integrations/src/utils/index.ts
+++ b/packages/farm-integrations/src/utils/index.ts
@@ -1,4 +1,5 @@
 export { escapeHtml } from "./html.js";
+export { integrationConfig } from "./config.js";
 export {
   createAuthRouteIntegration,
   createPathInferredClientApi,

--- a/packages/farm-integrations/src/workos/index.ts
+++ b/packages/farm-integrations/src/workos/index.ts
@@ -7,6 +7,7 @@ import {
   createRequestCookie,
   getCookieValue,
   getReturnTo,
+  integrationConfig,
   normalizeMatchers,
 } from "../utils/index.js";
 import type { WorkOSRedirectQuery, WorkOSRedirectResult, WorkOSSessionResult } from "./client.js";
@@ -27,6 +28,12 @@ export interface WorkOSIntegrationInput {
 }
 
 const DEV_COOKIE_PASSWORD = "farmjs-workos-cookie-password-development-2026";
+
+interface ResolvedWorkOSConfig {
+  clientId: string;
+  apiKey: string;
+  cookiePassword: string;
+}
 
 function createWorkOSApi(input: {
   loginPath: string;
@@ -54,7 +61,7 @@ function createWorkOSApi(input: {
   );
 }
 
-function resolveEnv(input: WorkOSIntegrationInput) {
+function resolveEnv(input: WorkOSIntegrationInput): ResolvedWorkOSConfig {
   const clientId = input.clientId ?? process.env.WORKOS_CLIENT_ID ?? "";
   const apiKey = input.apiKey ?? process.env.WORKOS_API_KEY ?? "";
   const cookiePassword =
@@ -145,6 +152,20 @@ export function workos(input: WorkOSIntegrationInput = {}) {
       apiKey: "[redacted]",
       protectedRoutes: protectedMatchers,
     },
+    config: integrationConfig<ResolvedWorkOSConfig>({
+      label: "WorkOS integration",
+      env: {
+        clientId: "WORKOS_CLIENT_ID",
+        apiKey: "WORKOS_API_KEY",
+        cookiePassword: ["WORKOS_COOKIE_PASSWORD", "FARM_WORKOS_COOKIE_PASSWORD"],
+      },
+      input: {
+        clientId,
+        apiKey,
+        cookiePassword,
+      },
+      required: ["clientId", "apiKey", "cookiePassword"],
+    }),
     api: createWorkOSApi({
       loginPath,
       signUpPath,

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createAPIClient } from "../api/client";
+import { createAPIClient, createServerAPIClient } from "../api/client";
+import { endpoint } from "../integration-api";
+import { defineIntegration, integrationRoute, resolveIntegrationPlugins } from "../integrations";
+import { PluginManager } from "../plugin";
+import { _runWithCurrentRequest } from "../server/request";
 
 type APIRouter = {
   users: {
@@ -45,6 +49,7 @@ function createDeferred<T>() {
 
 beforeEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("createAPIClient", () => {
@@ -406,5 +411,146 @@ describe("createAPIClient", () => {
     expect(getCount).toBe(2);
 
     vi.useRealTimers();
+  });
+
+  it("exposes integration APIs under createAPIClient().integrations in the browser", async () => {
+    vi.stubGlobal("window", {
+      location: {
+        origin: "http://localhost:3000",
+      },
+      __FARM_INTEGRATION_API_MANIFEST__: {
+        localDemo: {
+          message: endpoint.route(
+            "/api/local-demo/message",
+            endpoint.get<{ ok: boolean; source: string }>({
+              responseFormat: "json",
+            }),
+          ),
+        },
+      },
+    });
+
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "http://example.com/api/users?limit=5") {
+        return new Response(
+          JSON.stringify({
+            users: [{ id: "1", name: "Alice" }],
+            total: 1,
+            limit: 5,
+            offset: 0,
+          }),
+          {
+            headers: {
+              "content-type": "application/json",
+            },
+          },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          source: "integration",
+        }),
+        {
+          headers: {
+            "content-type": "application/json",
+          },
+        },
+      );
+    });
+    globalThis.fetch = fetchMock as any;
+
+    type AppIntegrations = {
+      localDemo: {
+        message: {
+          get: ReturnType<typeof endpoint.get<{ ok: boolean; source: string }>>;
+        };
+      };
+    };
+
+    const api = createAPIClient<APIRouter, AppIntegrations>({
+      baseURL: "http://example.com",
+    });
+
+    const routeResult = await api.users.get({ query: { limit: "5" } });
+    const integrationResult = await api.integrations.localDemo.message.get();
+
+    expect(routeResult.error).toBeNull();
+    expect(routeResult.data?.users[0].id).toBe("1");
+    expect(integrationResult.error).toBeNull();
+    expect(integrationResult.data).toEqual({
+      ok: true,
+      source: "integration",
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "http://example.com/api/local-demo/message",
+      expect.objectContaining({
+        method: "GET",
+      }),
+    );
+  });
+
+  it("exposes registered integration handlers under createServerAPIClient().integrations", async () => {
+    vi.stubGlobal("window", undefined);
+    vi.stubGlobal("document", undefined);
+
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const handlerSpy = vi.fn();
+    const integration = defineIntegration({
+      category: "custom",
+      type: "local-demo",
+      instance: {},
+      routes: [
+        integrationRoute.get<
+          "/api/local-demo/message",
+          { ok: boolean; source: string },
+          never,
+          true
+        >("/api/local-demo/message", {
+          responseFormat: "json",
+          isServer: true,
+          handler() {
+            handlerSpy();
+            return Response.json({
+              ok: true,
+              source: "handler",
+            });
+          },
+        }),
+      ],
+    });
+
+    const manager = new PluginManager({
+      config: {
+        integrations: {
+          localDemo: integration,
+        },
+      } as any,
+      isDev: true,
+      isProd: false,
+    });
+    manager.addPlugins(
+      resolveIntegrationPlugins({
+        localDemo: integration,
+      }),
+    );
+    await manager.runHookParallel("init");
+
+    const api = createServerAPIClient<{}, { localDemo: typeof integration }>({});
+
+    await _runWithCurrentRequest(new Request("https://farmjs.dev/server-demo"), async () => {
+      const result = await api.integrations.localDemo.message.get();
+
+      expect(result.error).toBeNull();
+      expect(result.data).toEqual({
+        ok: true,
+        source: "handler",
+      });
+    });
+
+    expect(handlerSpy).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/farm/src/__tests__/api-client.typing.test.ts
+++ b/packages/farm/src/__tests__/api-client.typing.test.ts
@@ -1,5 +1,6 @@
 import { describe, expectTypeOf, it, vi } from "vitest";
-import { createAPIClient, type CacheKey } from "../api/client";
+import { createAPIClient, createServerAPIClient, type CacheKey } from "../api/client";
+import { endpoint } from "../integration-api";
 
 type APIRouter = {
   hello: {
@@ -51,6 +52,16 @@ type APIRouter = {
 };
 
 type UsersListResponse = APIRouter["users"]["get"]["__types"]["response"];
+type AppIntegrations = {
+  localDemo: {
+    message: {
+      get: ReturnType<typeof endpoint.get<{ ok: boolean; source: string }>>;
+      post: ReturnType<
+        typeof endpoint.post<{ message: string }, { ok: boolean; source: string }>
+      >;
+    };
+  };
+};
 type IsAny<T> = 0 extends 1 & T ? true : false;
 
 const buildResponse = (data: any, ok = true, status = 200) => ({
@@ -154,5 +165,58 @@ describe("createAPIClient typing", () => {
         },
       },
     );
+  });
+
+  it("adds typed integration namespaces to route API clients", async () => {
+    const api = createAPIClient<APIRouter, AppIntegrations>({ baseURL: "http://example.com" });
+
+    if (false) {
+      const routeResult = await api.hello.get({ query: { name: "Farm" } });
+      const integrationGet = await api.integrations.localDemo.message.get();
+      const integrationPost = await api.integrations.localDemo.message.post({
+        body: {
+          message: "hello",
+        },
+      });
+
+      expectTypeOf(routeResult.data?.message).toEqualTypeOf<string | undefined>();
+      expectTypeOf(integrationGet.data).toEqualTypeOf<
+        { ok: boolean; source: string } | null
+      >();
+      expectTypeOf(integrationPost.data?.source).toEqualTypeOf<string | undefined>();
+
+      // @ts-expect-error integration body schemas require the body wrapper.
+      await api.integrations.localDemo.message.post();
+      // @ts-expect-error unknown integration namespaces are rejected.
+      api.integrations.missing;
+    }
+  });
+
+  it("adds typed integration namespaces to server API clients", async () => {
+    const api = createServerAPIClient<{}, AppIntegrations>({});
+
+    if (false) {
+      expectTypeOf(api.integrations.localDemo.message.get).toBeCallableWith();
+      expectTypeOf(api.integrations.localDemo.message.post).toBeCallableWith({
+        body: {
+          message: "hello",
+        },
+      });
+
+      // @ts-expect-error server integration calls still preserve operation input types.
+      await api.integrations.localDemo.message.post({ body: { nope: "hello" } });
+    }
+  });
+
+  it("allows opting out of the reserved integrations namespace", () => {
+    const api = createAPIClient<APIRouter>({ baseURL: "http://example.com", integrations: false });
+    const serverApi = createServerAPIClient<{}>({}, { integrations: false });
+
+    if (false) {
+      // @ts-expect-error integrations is not present when the namespace is disabled.
+      api.integrations;
+      // @ts-expect-error integrations is not present when the server namespace is disabled.
+      serverApi.integrations;
+    }
   });
 });

--- a/packages/farm/src/__tests__/integration-orm.test.ts
+++ b/packages/farm/src/__tests__/integration-orm.test.ts
@@ -3,9 +3,16 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it } from "vitest";
 import { createIntegrationOrm, farmIntegrationSchemaToOrmSchema } from "../integration-orm";
-import { defineIntegrationSchema } from "../integrations";
+import {
+  defineIntegration,
+  defineIntegrationSchema,
+  dispatchIntegrationRequest,
+  getRegisteredIntegrationRuntime,
+  resolveIntegrationPlugins,
+} from "../integrations";
+import { PluginManager } from "../plugin";
 
 type SqliteDatabase = {
   exec(sql: string): unknown;
@@ -202,6 +209,208 @@ describe("integration ORM storage", () => {
         id: "acct_2",
         ownerId: "user_2",
         status: "active",
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("exposes schema-typed ORM on integration route args", async () => {
+    const dir = await createTempDir("farm-integration-route-orm-");
+    const db = await createSqliteDatabase(path.join(dir, "integration-route.sqlite"));
+
+    try {
+      db.exec(`
+        CREATE TABLE billing_account (
+          id TEXT PRIMARY KEY,
+          owner_id TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'free',
+          seat_quantity INTEGER,
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          UNIQUE(owner_id)
+        );
+
+        INSERT INTO billing_account (
+          id,
+          owner_id,
+          status,
+          seat_quantity
+        ) VALUES (
+          'acct_route_1',
+          'user_route_1',
+          'active',
+          7
+        );
+      `);
+
+      const integration = defineIntegration({
+        category: "custom",
+        type: "typed-storage",
+        instance: {},
+        schema: billingSchema,
+        routes: ({ route }) => [
+          route.get("/api/typed-storage/account", {
+            async handler(_request, context) {
+              const account = await context.args.db.billingAccount.findFirst({
+                where: {
+                  ownerId: "user_route_1",
+                },
+                select: {
+                  status: true,
+                  seatQuantity: true,
+                  createdAt: true,
+                },
+              });
+
+              expectTypeOf(account?.status).toEqualTypeOf<"free" | "active" | undefined>();
+              expectTypeOf(account?.seatQuantity).toEqualTypeOf<number | null | undefined>();
+              expectTypeOf(account?.createdAt).toEqualTypeOf<Date | undefined>();
+
+              return Response.json({
+                status: account?.status,
+                seatQuantity: account?.seatQuantity,
+                createdAtIsDate: account?.createdAt instanceof Date,
+              });
+            },
+          }),
+        ],
+      });
+
+      const manager = new PluginManager({
+        config: {
+          storage: {
+            client: db,
+          },
+          integrations: {
+            typedStorage: integration,
+          },
+        } as any,
+        isDev: true,
+        isProd: false,
+      });
+      manager.addPlugins(
+        resolveIntegrationPlugins({
+          typedStorage: integration,
+        }),
+      );
+      await manager.runHookParallel("init");
+
+      const runtime = getRegisteredIntegrationRuntime("typedStorage");
+      expect(runtime).toBeDefined();
+
+      const response = await dispatchIntegrationRequest(
+        runtime!,
+        new Request("http://localhost/api/typed-storage/account"),
+      );
+
+      expect(response?.status).toBe(200);
+      expect(await response?.json()).toEqual({
+        status: "active",
+        seatQuantity: 7,
+        createdAtIsDate: true,
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("supports endpoint object definitions with schema-typed ORM route args", async () => {
+    const dir = await createTempDir("farm-integration-endpoint-orm-");
+    const db = await createSqliteDatabase(path.join(dir, "integration-endpoint.sqlite"));
+
+    try {
+      db.exec(`
+        CREATE TABLE billing_account (
+          id TEXT PRIMARY KEY,
+          owner_id TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'free',
+          seat_quantity INTEGER,
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          UNIQUE(owner_id)
+        );
+
+        INSERT INTO billing_account (
+          id,
+          owner_id,
+          status,
+          seat_quantity
+        ) VALUES (
+          'acct_endpoint_1',
+          'user_endpoint_1',
+          'active',
+          11
+        );
+      `);
+
+      const integration = defineIntegration({
+        category: "custom",
+        type: "typed-storage-endpoints",
+        instance: {},
+        schema: billingSchema,
+        endpoints: ({ endpoint }) => ({
+          account: endpoint.get("/api/typed-storage/endpoint-account", {
+            async handler(_request, context) {
+              const account = await context.args.db.billingAccount.findFirst({
+                where: {
+                  ownerId: "user_endpoint_1",
+                },
+                select: {
+                  status: true,
+                  seatQuantity: true,
+                  createdAt: true,
+                },
+              });
+
+              expectTypeOf(account?.status).toEqualTypeOf<"free" | "active" | undefined>();
+              expectTypeOf(account?.seatQuantity).toEqualTypeOf<number | null | undefined>();
+              expectTypeOf(account?.createdAt).toEqualTypeOf<Date | undefined>();
+
+              return Response.json({
+                status: account?.status,
+                seatQuantity: account?.seatQuantity,
+                createdAtIsDate: account?.createdAt instanceof Date,
+              });
+            },
+          }),
+        }),
+      });
+
+      const endpointOperation = integration.api.endpointAccount.get;
+      expect(endpointOperation.path).toBe("/api/typed-storage/endpoint-account");
+      expect(integration.routes).toHaveLength(1);
+
+      const manager = new PluginManager({
+        config: {
+          storage: {
+            client: db,
+          },
+          integrations: {
+            typedStorageEndpoints: integration,
+          },
+        } as any,
+        isDev: true,
+        isProd: false,
+      });
+      manager.addPlugins(
+        resolveIntegrationPlugins({
+          typedStorageEndpoints: integration,
+        }),
+      );
+      await manager.runHookParallel("init");
+
+      const runtime = getRegisteredIntegrationRuntime("typedStorageEndpoints");
+      expect(runtime).toBeDefined();
+
+      const response = await dispatchIntegrationRequest(
+        runtime!,
+        new Request("http://localhost/api/typed-storage/endpoint-account"),
+      );
+
+      expect(response?.status).toBe(200);
+      expect(await response?.json()).toEqual({
+        status: "active",
+        seatQuantity: 11,
+        createdAtIsDate: true,
       });
     } finally {
       db.close();

--- a/packages/farm/src/__tests__/integrations.test.ts
+++ b/packages/farm/src/__tests__/integrations.test.ts
@@ -133,6 +133,71 @@ describe("integrations runtime", () => {
     );
   });
 
+  it("runs flat integration config and lifecycle hooks", async () => {
+    const manager = createManager();
+    const calls: string[] = [];
+    const originalSecretKey = process.env.FARM_TEST_STRIPE_SECRET_KEY;
+    process.env.FARM_TEST_STRIPE_SECRET_KEY = "sk_test_lifecycle";
+
+    try {
+      const integration = defineIntegration({
+        category: "payment",
+        type: "stripe-lifecycle",
+        instance: {},
+        config: {
+          schema: z.object({
+            secretKey: z.string(),
+            mode: z.enum(["test", "live"]).default("test"),
+          }),
+          env: {
+            secretKey: "FARM_TEST_STRIPE_SECRET_KEY",
+          },
+        },
+        validate(ctx) {
+          expect(ctx.key).toBe("stripe");
+          expect(ctx.integrationConfig.secretKey).toBe("sk_test_lifecycle");
+          expect(ctx.integrationConfig.mode).toBe("test");
+          expectTypeOf(ctx.integrationConfig.secretKey).toEqualTypeOf<string>();
+          ctx.cleanup(() => {
+            calls.push("cleanup");
+          });
+          calls.push("validate");
+        },
+        async setup(ctx) {
+          expect(ctx.args.db).toBeDefined();
+          expect(ctx.integrationConfig.secretKey).toBe("sk_test_lifecycle");
+          calls.push("setup");
+        },
+        ready(ctx) {
+          expect(ctx.integrationConfig.mode).toBe("test");
+          calls.push("ready");
+        },
+        dispose(ctx) {
+          expect(ctx.reason).toBe("test");
+          calls.push("dispose");
+        },
+      });
+
+      manager.addPlugins(
+        resolveIntegrationPlugins({
+          stripe: integration,
+        }),
+      );
+
+      await manager.runHookParallel("init");
+      await manager.runHookParallel("ready");
+      await manager.runHookParallel("shutdown", { reason: "test" });
+
+      expect(calls).toEqual(["validate", "setup", "ready", "dispose", "cleanup"]);
+    } finally {
+      if (originalSecretKey === undefined) {
+        delete process.env.FARM_TEST_STRIPE_SECRET_KEY;
+      } else {
+        process.env.FARM_TEST_STRIPE_SECRET_KEY = originalSecretKey;
+      }
+    }
+  });
+
   it("registers route integrations as pre-plugins and exposes shared handler context", async () => {
     const log = vi.fn();
     const manager = createManager();

--- a/packages/farm/src/__tests__/integrations.test.ts
+++ b/packages/farm/src/__tests__/integrations.test.ts
@@ -424,6 +424,113 @@ describe("integrations runtime", () => {
     expect(routeMiddleware).toHaveBeenCalledTimes(1);
   });
 
+  it("supports Better Call-style Zod body and query schemas on integration routes", async () => {
+    const beforeHook = vi.fn();
+    const manager = createManager();
+    manager.addPlugins(
+      resolveIntegrationPlugins({
+        localDemo: defineIntegration({
+          category: "custom",
+          type: "local-demo",
+          instance: {},
+          routes: [
+            integrationRoute.post("/api/local-demo/direct-zod", {
+              body: z.object({
+                message: z.string().min(2),
+              }),
+              query: z.object({
+                count: z.coerce.number().int().positive(),
+              }),
+              before: [
+                (_request, context) => {
+                  expectTypeOf(context.input.body).toEqualTypeOf<
+                    | {
+                        message: string;
+                      }
+                    | undefined
+                  >();
+                  expectTypeOf(context.input.query).toEqualTypeOf<
+                    | {
+                        count: number;
+                      }
+                    | undefined
+                  >();
+                  beforeHook(context.input.body?.message, context.input.query?.count);
+                },
+              ],
+              handler(_request, context) {
+                expectTypeOf(context.input.body).toEqualTypeOf<
+                  | {
+                      message: string;
+                    }
+                  | undefined
+                >();
+                expectTypeOf(context.input.query).toEqualTypeOf<
+                  | {
+                      count: number;
+                    }
+                  | undefined
+                >();
+
+                return Response.json({
+                  message: context.input.body?.message,
+                  count: context.input.query?.count,
+                });
+              },
+            }),
+          ],
+        }),
+      }),
+    );
+
+    const invalidReq = createRequest("/api/local-demo/direct-zod?count=bad", "POST");
+    const invalidRes = createResponse();
+    const invalidPromise = manager.runHookParallel(
+      "beforeRequest",
+      invalidReq as any,
+      invalidRes as any,
+    );
+    setImmediate(() => {
+      invalidReq.emit("data", Buffer.from(JSON.stringify({ message: "x" })));
+      invalidReq.emit("end");
+    });
+    const invalidEnded = await invalidPromise;
+
+    expect(invalidEnded).toBe(true);
+    expect(invalidRes.statusCode).toBe(400);
+    expect(JSON.parse(invalidRes.body.toString())).toEqual({
+      error: "Integration route input validation failed",
+      issues: expect.arrayContaining([
+        expect.objectContaining({
+          source: "body",
+          path: ["message"],
+        }),
+        expect.objectContaining({
+          source: "query",
+          path: ["count"],
+        }),
+      ]),
+    });
+    expect(beforeHook).not.toHaveBeenCalled();
+
+    const validReq = createRequest("/api/local-demo/direct-zod?count=3", "POST");
+    const validRes = createResponse();
+    const validPromise = manager.runHookParallel("beforeRequest", validReq as any, validRes as any);
+    setImmediate(() => {
+      validReq.emit("data", Buffer.from(JSON.stringify({ message: "hello" })));
+      validReq.emit("end");
+    });
+    const validEnded = await validPromise;
+
+    expect(validEnded).toBe(true);
+    expect(validRes.statusCode).toBe(200);
+    expect(JSON.parse(validRes.body.toString())).toEqual({
+      message: "hello",
+      count: 3,
+    });
+    expect(beforeHook).toHaveBeenCalledWith("hello", 3);
+  });
+
   it("validates route input schemas during server integration dispatch", async () => {
     const manager = createManager();
     manager.addPlugins(
@@ -533,6 +640,129 @@ describe("integrations runtime", () => {
     expect(JSON.parse(res.body.toString())).toEqual({
       middleware: ["first", "second"],
     });
+  });
+
+  it("runs route before and after hooks around the route handler", async () => {
+    const manager = createManager();
+    const handlerSpy = vi.fn();
+    manager.addPlugins(
+      resolveIntegrationPlugins({
+        localDemo: defineIntegration({
+          category: "custom",
+          type: "local-demo",
+          instance: {},
+          routes: [
+            integrationRoute.get<"/api/local-demo/hooks", { order: string[]; after: boolean }>(
+              "/api/local-demo/hooks",
+              {
+                before: [
+                  (_request, context) => {
+                    expect(context.response).toBeUndefined();
+                    context.requestContext.set("hook-order", ["before"]);
+                  },
+                ],
+                after: [
+                  async (_request, context) => {
+                    expect(context.response?.status).toBe(200);
+                    const body = (await context.response?.clone().json()) as { order: string[] };
+                    return Response.json(
+                      {
+                        order: [...body.order, "after"],
+                        after: true,
+                      },
+                      {
+                        headers: {
+                          "x-integration-after": "yes",
+                        },
+                      },
+                    );
+                  },
+                ],
+                handler(_request, context) {
+                  handlerSpy();
+                  const order = context.requestContext.get<string[]>("hook-order") || [];
+                  return Response.json({
+                    order: [...order, "handler"],
+                    after: false,
+                  });
+                },
+              },
+            ),
+          ],
+        }),
+      }),
+    );
+
+    const req = createRequest("/api/local-demo/hooks");
+    const res = createResponse();
+    const ended = await manager.runHookParallel("beforeRequest", req as any, res as any);
+
+    expect(ended).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(res.getHeader("x-integration-after")).toBe("yes");
+    expect(JSON.parse(res.body.toString())).toEqual({
+      order: ["before", "handler", "after"],
+      after: true,
+    });
+    expect(handlerSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets route before hooks short-circuit and route after hooks inspect that response", async () => {
+    const manager = createManager();
+    const handlerSpy = vi.fn();
+    const integration = defineIntegration({
+      category: "custom",
+      type: "local-demo",
+      instance: {},
+      routes: [
+        integrationRoute.get("/api/local-demo/blocked", {
+          before: [
+            (_request, context) => {
+              context.requestContext.set("blocked", true);
+              return Response.json(
+                {
+                  blocked: context.requestContext.get("blocked"),
+                },
+                {
+                  status: 403,
+                },
+              );
+            },
+          ],
+          after: [
+            (_request, context) => {
+              expect(context.response?.status).toBe(403);
+              context.response?.headers.set("x-integration-after", "blocked");
+            },
+          ],
+          handler() {
+            handlerSpy();
+            return Response.json({ ok: true });
+          },
+        }),
+      ],
+    });
+
+    manager.addPlugins(
+      resolveIntegrationPlugins({
+        localDemo: integration,
+      }),
+    );
+    await manager.runHookParallel("init");
+    const runtime = getRegisteredIntegrationRuntime("localDemo");
+    expect(runtime).toBeDefined();
+
+    const response = await dispatchIntegrationRequest(
+      runtime!,
+      new Request("http://localhost/api/local-demo/blocked"),
+    );
+
+    expect(response?.status).toBe(403);
+    expect(response?.headers.get("x-integration-after")).toBe("blocked");
+    expect(await response?.json()).toEqual({
+      blocked: true,
+    });
+    expect(handlerSpy).not.toHaveBeenCalled();
   });
 
   it("collects document navigation matchers from integrations", () => {

--- a/packages/farm/src/__tests__/integrations.test.ts
+++ b/packages/farm/src/__tests__/integrations.test.ts
@@ -198,6 +198,33 @@ describe("integrations runtime", () => {
     }
   });
 
+  it("validates integration config during init without lifecycle hooks", async () => {
+    const manager = createManager();
+    const integration = defineIntegration({
+      category: "payment",
+      type: "missing-config",
+      instance: {},
+      config: {
+        schema: z.object({
+          secretKey: z.string(),
+        }),
+        env: {
+          secretKey: "FARM_TEST_MISSING_SECRET_KEY",
+        },
+      },
+    });
+
+    manager.addPlugins(
+      resolveIntegrationPlugins({
+        missingConfig: integration,
+      }),
+    );
+
+    await expect(manager.runHookParallel("init")).rejects.toThrow(
+      'Integration "missing-config" config validation failed',
+    );
+  });
+
   it("registers route integrations as pre-plugins and exposes shared handler context", async () => {
     const log = vi.fn();
     const manager = createManager();

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -1,7 +1,33 @@
+import {
+  integrationsClient,
+  integrationsServer,
+  type IntegrationClientOptions,
+  type IntegrationClientRoot,
+  type IntegrationServerClientOptions,
+  type IntegrationServerClientRoot,
+} from "../integration-client";
+
 export type APIClientOptions = {
   baseURL?: string;
   headers?: Record<string, string>;
+  credentials?: RequestCredentials;
   cacheDefaults?: CacheOptions;
+  integrations?: IntegrationClientOptions;
+};
+
+export type APIClientWithoutIntegrationsOptions = Omit<APIClientOptions, "integrations"> & {
+  integrations: false;
+};
+
+export type ServerAPIClientOptions = {
+  integrations?: Omit<IntegrationServerClientOptions, "isServer">;
+};
+
+export type ServerAPIClientWithoutIntegrationsOptions = Omit<
+  ServerAPIClientOptions,
+  "integrations"
+> & {
+  integrations: false;
 };
 
 export type StatusPhase = "idle" | "pending" | "success" | "error" | "revalidating" | "invalidated";
@@ -239,6 +265,18 @@ type RouterToClient<T> = {
       : EndpointMethod<T[K]>;
 };
 
+export type RouteAPIClient<TRouter extends Record<string, any>> = RouterToClient<TRouter>;
+
+export type APIClient<
+  TRouter extends Record<string, any>,
+  TIntegrations extends Record<string, any> = {},
+> = RouteAPIClient<TRouter> & IntegrationClientRoot<TIntegrations>;
+
+export type ServerAPIClient<
+  TEndpoints extends Record<string, any>,
+  TIntegrations extends Record<string, any> = {},
+> = TEndpoints & IntegrationServerClientRoot<TIntegrations>;
+
 /**
  * Create a typed RPC client for Farm.js API routes
  *
@@ -246,13 +284,15 @@ type RouterToClient<T> = {
  * - api.hello.get({ query: { name: 'World' } })
  * - api['auth/login'].post({ body: { email: '...', password: '...' } })
  * - api.users.get({ query: { limit: '10' } })
+ * - api.integrations.billing.checkout({ body: { priceId: 'price_...' } })
  *
  * @example
  * ```typescript
  * import { createAPIClient } from 'farm/client';
  * import type { APIRouter } from '@/api';
+ * import type { AppIntegrations } from '@/lib/integrations';
  *
- * export const api = createAPIClient<APIRouter>();
+ * export const api = createAPIClient<APIRouter, AppIntegrations>();
  *
  * // Use it (nested property access)
  * const result = await api.hello.get({ query: { name: 'World' } });
@@ -263,15 +303,48 @@ type RouterToClient<T> = {
  * const result = await api['auth/login'].post({
  *   body: { email: 'test@example.com', password: 'pass123' }
  * });
+ *
+ * // Integration APIs live under a reserved namespace.
+ * const checkout = await api.integrations.billing.checkout({
+ *   body: { priceId: 'price_123' }
+ * });
  * ```
  */
-export function createAPIClient<TRouter extends Record<string, any>>(
-  options: APIClientOptions = {},
-): RouterToClient<TRouter> {
+export function createAPIClient<
+  TRouter extends Record<string, any>,
+>(options: APIClientWithoutIntegrationsOptions): RouteAPIClient<TRouter>;
+export function createAPIClient<
+  TRouter extends Record<string, any>,
+  TIntegrations extends Record<string, any> = {},
+>(
+  options?: APIClientOptions,
+): APIClient<TRouter, TIntegrations>;
+export function createAPIClient<
+  TRouter extends Record<string, any>,
+  TIntegrations extends Record<string, any> = {},
+>(
+  options: APIClientOptions | APIClientWithoutIntegrationsOptions = {},
+): RouteAPIClient<TRouter> | APIClient<TRouter, TIntegrations> {
+  options ??= {};
   // Auto-detect baseURL
   const baseURL =
     options.baseURL ||
     (typeof window !== "undefined" ? window.location.origin : "http://localhost:3000");
+  const integrationOptions =
+    options.integrations === false
+      ? false
+      : {
+          baseURL: options.baseURL,
+          headers: options.headers,
+          credentials: options.credentials,
+          ...(typeof options.integrations === "object" ? options.integrations : {}),
+        };
+  const rootAliases =
+    integrationOptions === false
+      ? undefined
+      : {
+          integrations: integrationsClient<TIntegrations>(integrationOptions),
+        };
 
   const cacheState = new Map<string, CacheEntry>();
   const inflightState = new Map<string, InflightEntry>();
@@ -603,7 +676,7 @@ export function createAPIClient<TRouter extends Record<string, any>>(
   };
 
   // Return nested proxy (starts with empty path, user adds to it)
-  return createNestedProxy([], request, routeMeta) as RouterToClient<TRouter>;
+  return createNestedProxy([], request, routeMeta, rootAliases) as APIClient<TRouter, TIntegrations>;
 }
 
 /**
@@ -624,13 +697,18 @@ function createNestedProxy(
   path: string[],
   client: any,
   routeMeta: WeakMap<AnyRouteRef, RouteMeta>,
+  rootAliases?: Record<string, unknown>,
 ): any {
   const target = () => {};
   const proxy = new Proxy(target, {
     // When accessing a property (api.hello)
     get(_target, prop: string) {
+      if (path.length === 0 && typeof prop === "string" && rootAliases && prop in rootAliases) {
+        return rootAliases[prop];
+      }
+
       // Add prop to path and return new proxy
-      return createNestedProxy([...path, prop], client, routeMeta);
+      return createNestedProxy([...path, prop], client, routeMeta, rootAliases);
     },
 
     // When calling as a function
@@ -670,12 +748,58 @@ function createNestedProxy(
 
 /**
  * Server-side API client that calls endpoints directly as functions
- * No HTTP overhead, just direct function calls
+ * No HTTP overhead for app endpoints, and registered integration routes can be exposed at
+ * api.integrations.* where Farm can dispatch them directly to the integration handler.
+ *
+ * @example
+ * ```typescript
+ * import { createServerAPIClient } from 'farm/client';
+ * import type { AppIntegrations } from '@/lib/integrations';
+ *
+ * export const api = createServerAPIClient<{}, AppIntegrations>({});
+ *
+ * const result = await api.integrations.billing.status();
+ * ```
  */
 export function createServerAPIClient<TEndpoints extends Record<string, any>>(
   endpoints: TEndpoints,
-): TEndpoints {
-  return endpoints;
+): TEndpoints;
+export function createServerAPIClient<TEndpoints extends Record<string, any>>(
+  endpoints: TEndpoints,
+  options: ServerAPIClientWithoutIntegrationsOptions,
+): TEndpoints;
+export function createServerAPIClient<
+  TEndpoints extends Record<string, any>,
+  TIntegrations extends Record<string, any> = {},
+>(
+  endpoints: TEndpoints,
+  options?: ServerAPIClientOptions,
+): ServerAPIClient<TEndpoints, TIntegrations>;
+export function createServerAPIClient<
+  TEndpoints extends Record<string, any>,
+  TIntegrations extends Record<string, any> = {},
+>(
+  endpoints: TEndpoints,
+  options: ServerAPIClientOptions | ServerAPIClientWithoutIntegrationsOptions = {},
+): TEndpoints | ServerAPIClient<TEndpoints, TIntegrations> {
+  if (
+    options.integrations === false ||
+    Object.prototype.hasOwnProperty.call(endpoints, "integrations")
+  ) {
+    return endpoints;
+  }
+
+  Object.defineProperty(endpoints, "integrations", {
+    get() {
+      return integrationsServer<TIntegrations>(
+        typeof options.integrations === "object" ? options.integrations : {},
+      );
+    },
+    enumerable: false,
+    configurable: true,
+  });
+
+  return endpoints as ServerAPIClient<TEndpoints, TIntegrations>;
 }
 
 type CacheEntry = {

--- a/packages/farm/src/client.ts
+++ b/packages/farm/src/client.ts
@@ -1,5 +1,13 @@
 export { createAPIClient, createServerAPIClient } from "./api/client";
-export type { APIClientOptions } from "./api/client";
+export type {
+  APIClient,
+  APIClientOptions,
+  APIClientWithoutIntegrationsOptions,
+  RouteAPIClient,
+  ServerAPIClient,
+  ServerAPIClientOptions,
+  ServerAPIClientWithoutIntegrationsOptions,
+} from "./api/client";
 export {
   api,
   endpoint,

--- a/packages/farm/src/client/index.ts
+++ b/packages/farm/src/client/index.ts
@@ -14,6 +14,15 @@ export type {
   ExternalHref,
 } from "./link";
 export { useRouter } from "./router";
-export { createAPIClient } from "../api/client";
+export { createAPIClient, createServerAPIClient } from "../api/client";
+export type {
+  APIClient,
+  APIClientOptions,
+  APIClientWithoutIntegrationsOptions,
+  RouteAPIClient,
+  ServerAPIClient,
+  ServerAPIClientOptions,
+  ServerAPIClientWithoutIntegrationsOptions,
+} from "../api/client";
 export { getRouter, navigateTo, prefetch, SPARouter } from "./spa-router";
 export type { PageProps, LayoutProps, Metadata } from "../types";

--- a/packages/farm/src/integration-api.ts
+++ b/packages/farm/src/integration-api.ts
@@ -269,7 +269,11 @@ function normalizeRouteSegment(segment: string): string {
     return segment.slice(0, matcherIndex);
   }
 
-  return segment;
+  return camelCaseRouteSegment(segment);
+}
+
+function camelCaseRouteSegment(segment: string): string {
+  return segment.replace(/-([a-zA-Z0-9])/g, (_match, value: string) => value.toUpperCase());
 }
 
 function getRouteClientSegments(path: string): string[] {

--- a/packages/farm/src/integration-orm.ts
+++ b/packages/farm/src/integration-orm.ts
@@ -1,6 +1,9 @@
 import type {
   AnyFieldBuilder,
   AnyModelDefinition,
+  FieldBuilder,
+  JsonValue,
+  ModelDefinition,
   OrmClient,
   SchemaDefinition,
   SchemaModels,
@@ -20,16 +23,88 @@ export type FarmIntegrationOrmSchema = SchemaDefinition<Record<string, AnyModelD
 
 export type FarmIntegrationOrmClient<TSchema extends FarmIntegrationOrmSchema> = OrmClient<TSchema>;
 
-export interface CreateIntegrationOrmOptions<TClient = unknown> {
-  schema: FarmIntegrationSchema;
+type FarmIntegrationOrmFieldKind<TField extends FarmIntegrationSchemaField> = TField["type"] extends
+  | "id"
+  | "uuid"
+  ? "id"
+  : TField["type"] extends "text"
+    ? "string"
+    : TField["type"] extends "number"
+      ? "decimal"
+      : Extract<TField["type"], "string" | "boolean" | "integer" | "datetime" | "json" | "enum">;
+
+type FarmIntegrationOrmFieldNullable<TField extends FarmIntegrationSchemaField> = TField extends {
+  nullable: true;
+}
+  ? true
+  : TField extends { required: false }
+    ? true
+    : false;
+
+type FarmIntegrationOrmEnumValue<TField extends FarmIntegrationSchemaField> = TField extends {
+  values: readonly (infer TValue extends string)[];
+}
+  ? TValue
+  : string;
+
+type FarmIntegrationOrmFieldValue<TField extends FarmIntegrationSchemaField> =
+  TField["type"] extends "id" | "uuid" | "string" | "text"
+    ? string
+    : TField["type"] extends "boolean"
+      ? boolean
+      : TField["type"] extends "integer"
+        ? number
+        : TField["type"] extends "number"
+          ? string
+          : TField["type"] extends "datetime"
+            ? Date
+            : TField["type"] extends "json"
+              ? JsonValue
+              : TField["type"] extends "enum"
+                ? FarmIntegrationOrmEnumValue<TField>
+                : never;
+
+export type InferFarmIntegrationOrmField<TField extends FarmIntegrationSchemaField> = FieldBuilder<
+  FarmIntegrationOrmFieldKind<TField>,
+  FarmIntegrationOrmFieldNullable<TField>,
+  FarmIntegrationOrmFieldValue<TField>
+>;
+
+export type InferFarmIntegrationOrmFields<TModel extends FarmIntegrationSchemaModel> = {
+  [TFieldKey in keyof TModel["fields"] & string]: InferFarmIntegrationOrmField<
+    Extract<TModel["fields"][TFieldKey], FarmIntegrationSchemaField>
+  >;
+};
+
+export type InferFarmIntegrationOrmSchema<TSchema extends FarmIntegrationSchema> =
+  SchemaDefinition<{
+    [TModelKey in keyof TSchema["models"] & string]: ModelDefinition<
+      InferFarmIntegrationOrmFields<
+        Extract<TSchema["models"][TModelKey], FarmIntegrationSchemaModel>
+      >,
+      {}
+    >;
+  }>;
+
+export type InferFarmIntegrationOrmClient<TSchema extends FarmIntegrationSchema | undefined> =
+  TSchema extends FarmIntegrationSchema ? OrmClient<InferFarmIntegrationOrmSchema<TSchema>> : never;
+
+export interface CreateIntegrationOrmOptions<
+  TClient = unknown,
+  TSchema extends FarmIntegrationSchema = FarmIntegrationSchema,
+> {
+  schema: TSchema;
   config?: Pick<FarmConfig, "storage">;
   storage?: FarmStorageUserConfig;
   client?: TClient | RuntimeClientFactory<TClient>;
 }
 
-export async function createIntegrationOrm<TClient = unknown>(
-  options: CreateIntegrationOrmOptions<TClient>,
-): Promise<FarmIntegrationOrmClient<FarmIntegrationOrmSchema>> {
+export async function createIntegrationOrm<
+  TClient = unknown,
+  TSchema extends FarmIntegrationSchema = FarmIntegrationSchema,
+>(
+  options: CreateIntegrationOrmOptions<TClient, TSchema>,
+): Promise<InferFarmIntegrationOrmClient<TSchema>> {
   const [schema, client] = await Promise.all([
     farmIntegrationSchemaToOrmSchema(options.schema),
     resolveIntegrationOrmRuntimeClient(options),
@@ -45,7 +120,7 @@ export async function createIntegrationOrm<TClient = unknown>(
   return createOrmFromRuntime({
     schema,
     client,
-  }) as Promise<FarmIntegrationOrmClient<FarmIntegrationOrmSchema>>;
+  }) as Promise<InferFarmIntegrationOrmClient<TSchema>>;
 }
 
 export async function resolveIntegrationOrmRuntimeClient<TClient = unknown>(

--- a/packages/farm/src/integrations.ts
+++ b/packages/farm/src/integrations.ts
@@ -1511,6 +1511,8 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
         isProd: context.isProd,
       });
 
+      await createLifecycleContext(context, "validate");
+
       if (integration.validate) {
         await integration.validate(await createLifecycleContext(context, "validate"));
       }

--- a/packages/farm/src/integrations.ts
+++ b/packages/farm/src/integrations.ts
@@ -6,8 +6,10 @@ import type {
   FarmIntegrationAPIMethod,
   FarmIntegrationAPIOperation,
   FarmIntegrationAPIResponseFormat,
+  FarmIntegrationRouteOperationCarrier,
   InferIntegrationAPIFromRoutes,
 } from "./integration-api";
+import type { InferFarmIntegrationOrmClient } from "./integration-orm";
 import type { FarmPlugin, FarmPluginContext } from "./plugin";
 import {
   clearRequestContext,
@@ -115,7 +117,89 @@ export interface FarmIntegrationRequestContextStore {
   snapshot(options?: { exposedOnly?: boolean }): Map<string, unknown>;
 }
 
-export interface FarmIntegrationHandlerContext<TBody = unknown, TQuery = unknown> {
+export type FarmIntegrationRouteDb<TSchema extends FarmIntegrationSchema | undefined> =
+  InferFarmIntegrationOrmClient<TSchema>;
+
+export interface FarmIntegrationRouteStorageArgs<
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> {
+  getClient(): Promise<unknown | undefined>;
+  getOrm(): Promise<FarmIntegrationRouteDb<TSchema>>;
+}
+
+export interface FarmIntegrationRouteArgs<
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> {
+  db: FarmIntegrationRouteDb<TSchema>;
+  getDb(): Promise<FarmIntegrationRouteDb<TSchema>>;
+  storage: FarmIntegrationRouteStorageArgs<TSchema>;
+}
+
+export interface FarmIntegrationConfigContext<
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> {
+  key: string;
+  integration: FarmIntegration<TSchema, any>;
+  appConfig: FarmPluginContext["config"];
+  /** Alias for appConfig. */
+  config: FarmPluginContext["config"];
+  args: FarmIntegrationRouteArgs<TSchema>;
+  env: Record<string, string | undefined>;
+  isDev: boolean;
+  isProd: boolean;
+}
+
+export interface FarmIntegrationConfigDefinition<
+  TConfig = unknown,
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> {
+  schema?: FarmIntegrationInputSchema<TConfig>;
+  env?: Record<string, string | readonly string[]>;
+  defaults?:
+    | Partial<TConfig>
+    | ((context: FarmIntegrationConfigContext<TSchema>) => MaybePromise<Partial<TConfig>>);
+  input?:
+    | Partial<TConfig>
+    | ((context: FarmIntegrationConfigContext<TSchema>) => MaybePromise<Partial<TConfig>>);
+  resolve?(
+    context: FarmIntegrationConfigContext<TSchema>,
+  ): MaybePromise<TConfig | Partial<TConfig> | undefined>;
+}
+
+export type FarmIntegrationConfigInput<
+  TConfig = unknown,
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> = FarmIntegrationInputSchema<TConfig> | FarmIntegrationConfigDefinition<TConfig, TSchema>;
+
+export type FarmIntegrationLifecycleLogLevel = "info" | "warn" | "error";
+
+export interface FarmIntegrationLifecycleLogger {
+  info(message: string, meta?: Record<string, unknown>): void;
+  warn(message: string, meta?: Record<string, unknown>): void;
+  error(message: string, meta?: Record<string, unknown>): void;
+}
+
+export interface FarmIntegrationLifecycleContext<
+  TConfig = unknown,
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> extends FarmIntegrationConfigContext<TSchema> {
+  integration: FarmIntegration<TSchema, TConfig>;
+  integrationConfig: TConfig;
+  log: FarmIntegrationLifecycleLogger;
+  reason?: string;
+  cleanup(callback?: () => MaybePromise<void>): Promise<void>;
+}
+
+export type FarmIntegrationLifecycleHook<
+  TConfig = unknown,
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> = (context: FarmIntegrationLifecycleContext<TConfig, TSchema>) => MaybePromise<void>;
+
+export interface FarmIntegrationHandlerContext<
+  TBody = unknown,
+  TQuery = unknown,
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> {
   request: Request;
   requestId: string;
   url: URL;
@@ -123,6 +207,7 @@ export interface FarmIntegrationHandlerContext<TBody = unknown, TQuery = unknown
   method: string;
   params: FarmIntegrationRouteParams;
   input: FarmIntegrationRouteInput<TBody, TQuery>;
+  args: FarmIntegrationRouteArgs<TSchema>;
   integration: {
     category: FarmIntegrationCategory;
     /** @deprecated Use category instead. */
@@ -144,22 +229,33 @@ export interface FarmIntegrationHandlerContext<TBody = unknown, TQuery = unknown
 export interface FarmIntegrationRouteHookContext<
   TBody = unknown,
   TQuery = unknown,
-> extends FarmIntegrationHandlerContext<TBody, TQuery> {
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> extends FarmIntegrationHandlerContext<TBody, TQuery, TSchema> {
   response?: Response;
 }
 
-export type FarmIntegrationRouteHook<TBody = unknown, TQuery = unknown> = (
-  request: Request,
-  context: FarmIntegrationRouteHookContext<TBody, TQuery>,
-) => Promise<Response | void> | Response | void;
+export type FarmIntegrationRouteHook<
+  TBody = unknown,
+  TQuery = unknown,
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> = {
+  bivarianceHack(
+    request: Request,
+    context: FarmIntegrationRouteHookContext<TBody, TQuery, TSchema>,
+  ): Promise<Response | void> | Response | void;
+}["bivarianceHack"];
 
-export interface FarmIntegrationRoute<TBody = unknown, TQuery = unknown> {
+export interface FarmIntegrationRoute<
+  TBody = unknown,
+  TQuery = unknown,
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> {
   path: string;
   method?: FarmIntegrationRouteMethod;
   methods?: readonly FarmIntegrationRouteMethod[];
-  middleware?: readonly FarmIntegrationRouteMiddleware[];
-  before?: readonly FarmIntegrationRouteHook<TBody, TQuery>[];
-  after?: readonly FarmIntegrationRouteHook<TBody, TQuery>[];
+  middleware?: readonly FarmIntegrationRouteMiddleware<TSchema>[];
+  before?: readonly FarmIntegrationRouteHook<TBody, TQuery, TSchema>[];
+  after?: readonly FarmIntegrationRouteHook<TBody, TQuery, TSchema>[];
   rawBody?: boolean;
   bodyFormat?: FarmIntegrationAPIBodyFormat;
   body?: FarmIntegrationInputSchema<TBody>;
@@ -167,7 +263,7 @@ export interface FarmIntegrationRoute<TBody = unknown, TQuery = unknown> {
   input?: FarmIntegrationRouteInputSchemas<TBody, TQuery>;
   handler(
     request: Request,
-    context: FarmIntegrationHandlerContext<TBody, TQuery>,
+    context: FarmIntegrationHandlerContext<TBody, TQuery, TSchema>,
   ): Promise<Response> | Response;
 }
 
@@ -178,24 +274,29 @@ export interface FarmTypedIntegrationRoute<
   TResponse = unknown,
   TServer extends boolean = false,
   TMethod extends FarmIntegrationAPIMethod = FarmIntegrationAPIMethod,
-> extends FarmIntegrationRoute<TBody, TQuery> {
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> extends FarmIntegrationRoute<TBody, TQuery, TSchema> {
   path: TPath;
   method: TMethod;
   __operation: FarmIntegrationAPIOperation<TBody, TQuery, TResponse, TServer, TMethod>;
 }
 
-export interface FarmIntegrationRouteMiddleware {
+export interface FarmIntegrationRouteMiddleware<
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> {
   handler(
     request: Request,
-    context: FarmIntegrationHandlerContext,
+    context: FarmIntegrationHandlerContext<unknown, unknown, TSchema>,
   ): Promise<Response | void> | Response | void;
 }
 
-export interface FarmIntegrationMiddleware {
+export interface FarmIntegrationMiddleware<
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> {
   matcher?: string | string[];
   handler(
     request: Request,
-    context: FarmIntegrationHandlerContext,
+    context: FarmIntegrationHandlerContext<unknown, unknown, TSchema>,
   ): Promise<Response | void> | Response | void;
 }
 
@@ -296,6 +397,10 @@ export function defineIntegrationSchema<TSchema extends FarmIntegrationSchema>(
 
 export type FarmIntegrationLogPhase =
   | "registered"
+  | "validate"
+  | "setup"
+  | "ready"
+  | "dispose"
   | "request:start"
   | "request:end"
   | "request:error";
@@ -316,12 +421,18 @@ export interface FarmIntegrationLogEvent {
   response?: Response;
   error?: unknown;
   durationMs?: number;
+  level?: FarmIntegrationLifecycleLogLevel;
+  message?: string;
+  meta?: Record<string, unknown>;
   context: Map<string, unknown>;
 }
 
 export type FarmIntegrationLogger = (event: FarmIntegrationLogEvent) => void | Promise<void>;
 
-export interface FarmIntegration {
+export interface FarmIntegration<
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+  TConfig = unknown,
+> {
   readonly kind: "farm-integration";
   category: FarmIntegrationCategory;
   /** @deprecated Use category instead. */
@@ -329,10 +440,16 @@ export interface FarmIntegration {
   type: string;
   instance: unknown;
   api?: FarmIntegrationAPI;
-  schema?: FarmIntegrationSchema;
+  schema?: TSchema;
+  config?: FarmIntegrationConfigInput<TConfig, TSchema>;
+  validate?: FarmIntegrationLifecycleHook<TConfig, TSchema>;
+  setup?: FarmIntegrationLifecycleHook<TConfig, TSchema>;
+  ready?: FarmIntegrationLifecycleHook<TConfig, TSchema>;
+  dispose?: FarmIntegrationLifecycleHook<TConfig, TSchema>;
   log?: FarmIntegrationLogger;
-  routes?: readonly FarmIntegrationRoute[];
-  middleware?: readonly FarmIntegrationMiddleware[];
+  routes?: readonly FarmIntegrationRoute<any, any, TSchema>[];
+  endpoints?: FarmIntegrationEndpoints<TSchema>;
+  middleware?: readonly FarmIntegrationMiddleware<TSchema>[];
   providers?: readonly FarmIntegrationProvider[];
   documentNavigations?: readonly FarmIntegrationDocumentNavigation[];
   plugins?: readonly FarmPlugin[];
@@ -340,10 +457,15 @@ export interface FarmIntegration {
 
 export type FarmIntegrationsUserConfig = Record<string, FarmIntegration | undefined>;
 
-type IntegrationRouteBuilderOptions<TBody, TQuery, TServer extends boolean> = {
-  middleware?: readonly FarmIntegrationRouteMiddleware[];
-  before?: readonly FarmIntegrationRouteHook<TBody, TQuery>[];
-  after?: readonly FarmIntegrationRouteHook<TBody, TQuery>[];
+type IntegrationRouteBuilderOptions<
+  TBody,
+  TQuery,
+  TServer extends boolean,
+  TSchema extends FarmIntegrationSchema | undefined,
+> = {
+  middleware?: readonly FarmIntegrationRouteMiddleware<TSchema>[];
+  before?: readonly FarmIntegrationRouteHook<TBody, TQuery, TSchema>[];
+  after?: readonly FarmIntegrationRouteHook<TBody, TQuery, TSchema>[];
   rawBody?: boolean;
   headers?: Record<string, string>;
   credentials?: RequestCredentials;
@@ -355,7 +477,7 @@ type IntegrationRouteBuilderOptions<TBody, TQuery, TServer extends boolean> = {
   input?: FarmIntegrationRouteInputSchemas<TBody, TQuery>;
   handler(
     request: Request,
-    context: FarmIntegrationHandlerContext<TBody, TQuery>,
+    context: FarmIntegrationHandlerContext<TBody, TQuery, TSchema>,
   ): Promise<Response> | Response;
 };
 
@@ -366,11 +488,12 @@ function defineTypedIntegrationRoute<
   TResponse,
   TServer extends boolean,
   TMethod extends FarmIntegrationAPIMethod,
+  TSchema extends FarmIntegrationSchema | undefined,
 >(
   method: TMethod,
   path: TPath,
-  input: IntegrationRouteBuilderOptions<TBody, TQuery, TServer>,
-): FarmTypedIntegrationRoute<TPath, TBody, TQuery, TResponse, TServer, TMethod> {
+  input: IntegrationRouteBuilderOptions<TBody, TQuery, TServer, TSchema>,
+): FarmTypedIntegrationRoute<TPath, TBody, TQuery, TResponse, TServer, TMethod, TSchema> {
   return {
     path,
     method,
@@ -393,81 +516,53 @@ function defineTypedIntegrationRoute<
   };
 }
 
-export const integrationRoute = {
+export interface FarmIntegrationRouteFactory<
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> {
   get<TPath extends string, TResponse = unknown, TQuery = never, TServer extends boolean = false>(
     path: TPath,
-    input: Omit<IntegrationRouteBuilderOptions<never, TQuery, TServer>, "bodyFormat">,
-  ) {
-    return defineTypedIntegrationRoute<TPath, never, TQuery, TResponse, TServer, "GET">(
-      "GET",
-      path,
-      input,
-    );
-  },
+    input: Omit<IntegrationRouteBuilderOptions<never, TQuery, TServer, TSchema>, "bodyFormat">,
+  ): FarmTypedIntegrationRoute<TPath, never, TQuery, TResponse, TServer, "GET", TSchema>;
   post<
     TPath extends string,
     TBody = never,
     TResponse = unknown,
     TQuery = never,
     TServer extends boolean = false,
-  >(path: TPath, input: IntegrationRouteBuilderOptions<TBody, TQuery, TServer>) {
-    return defineTypedIntegrationRoute<TPath, TBody, TQuery, TResponse, TServer, "POST">(
-      "POST",
-      path,
-      {
-        bodyFormat: "json",
-        ...input,
-      },
-    );
-  },
+  >(
+    path: TPath,
+    input: IntegrationRouteBuilderOptions<TBody, TQuery, TServer, TSchema>,
+  ): FarmTypedIntegrationRoute<TPath, TBody, TQuery, TResponse, TServer, "POST", TSchema>;
   put<
     TPath extends string,
     TBody = never,
     TResponse = unknown,
     TQuery = never,
     TServer extends boolean = false,
-  >(path: TPath, input: IntegrationRouteBuilderOptions<TBody, TQuery, TServer>) {
-    return defineTypedIntegrationRoute<TPath, TBody, TQuery, TResponse, TServer, "PUT">(
-      "PUT",
-      path,
-      {
-        bodyFormat: "json",
-        ...input,
-      },
-    );
-  },
+  >(
+    path: TPath,
+    input: IntegrationRouteBuilderOptions<TBody, TQuery, TServer, TSchema>,
+  ): FarmTypedIntegrationRoute<TPath, TBody, TQuery, TResponse, TServer, "PUT", TSchema>;
   patch<
     TPath extends string,
     TBody = never,
     TResponse = unknown,
     TQuery = never,
     TServer extends boolean = false,
-  >(path: TPath, input: IntegrationRouteBuilderOptions<TBody, TQuery, TServer>) {
-    return defineTypedIntegrationRoute<TPath, TBody, TQuery, TResponse, TServer, "PATCH">(
-      "PATCH",
-      path,
-      {
-        bodyFormat: "json",
-        ...input,
-      },
-    );
-  },
+  >(
+    path: TPath,
+    input: IntegrationRouteBuilderOptions<TBody, TQuery, TServer, TSchema>,
+  ): FarmTypedIntegrationRoute<TPath, TBody, TQuery, TResponse, TServer, "PATCH", TSchema>;
   delete<
     TPath extends string,
     TBody = never,
     TResponse = unknown,
     TQuery = never,
     TServer extends boolean = false,
-  >(path: TPath, input: IntegrationRouteBuilderOptions<TBody, TQuery, TServer>) {
-    return defineTypedIntegrationRoute<TPath, TBody, TQuery, TResponse, TServer, "DELETE">(
-      "DELETE",
-      path,
-      {
-        bodyFormat: "json",
-        ...input,
-      },
-    );
-  },
+  >(
+    path: TPath,
+    input: IntegrationRouteBuilderOptions<TBody, TQuery, TServer, TSchema>,
+  ): FarmTypedIntegrationRoute<TPath, TBody, TQuery, TResponse, TServer, "DELETE", TSchema>;
   options<
     TPath extends string,
     TResponse = unknown,
@@ -475,25 +570,182 @@ export const integrationRoute = {
     TServer extends boolean = false,
   >(
     path: TPath,
-    input: Omit<IntegrationRouteBuilderOptions<never, TQuery, TServer>, "bodyFormat">,
-  ) {
-    return defineTypedIntegrationRoute<TPath, never, TQuery, TResponse, TServer, "OPTIONS">(
-      "OPTIONS",
-      path,
-      input,
-    );
-  },
+    input: Omit<IntegrationRouteBuilderOptions<never, TQuery, TServer, TSchema>, "bodyFormat">,
+  ): FarmTypedIntegrationRoute<TPath, never, TQuery, TResponse, TServer, "OPTIONS", TSchema>;
   head<TPath extends string, TResponse = unknown, TQuery = never, TServer extends boolean = false>(
     path: TPath,
-    input: Omit<IntegrationRouteBuilderOptions<never, TQuery, TServer>, "bodyFormat">,
-  ) {
-    return defineTypedIntegrationRoute<TPath, never, TQuery, TResponse, TServer, "HEAD">(
-      "HEAD",
-      path,
-      input,
-    );
-  },
+    input: Omit<IntegrationRouteBuilderOptions<never, TQuery, TServer, TSchema>, "bodyFormat">,
+  ): FarmTypedIntegrationRoute<TPath, never, TQuery, TResponse, TServer, "HEAD", TSchema>;
+}
+
+export interface FarmIntegrationRoutesFactoryContext<
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> {
+  route: FarmIntegrationRouteFactory<TSchema>;
+  integrationRoute: FarmIntegrationRouteFactory<TSchema>;
+}
+
+export type FarmIntegrationRoutesFactory<
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> = (
+  context: FarmIntegrationRoutesFactoryContext<TSchema>,
+) => readonly FarmIntegrationRoute<any, any, TSchema>[];
+
+export type FarmIntegrationEndpointValue<
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> =
+  | FarmIntegrationRoute<any, any, TSchema>
+  | readonly FarmIntegrationEndpointValue<TSchema>[]
+  | {
+      readonly [key: string]: FarmIntegrationEndpointValue<TSchema> | undefined;
+    };
+
+export type FarmIntegrationEndpoints<
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> = {
+  readonly [key: string]: FarmIntegrationEndpointValue<TSchema> | undefined;
 };
+
+export interface FarmIntegrationEndpointsFactoryContext<
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> extends FarmIntegrationRoutesFactoryContext<TSchema> {
+  endpoint: FarmIntegrationRouteFactory<TSchema>;
+}
+
+export type FarmIntegrationEndpointsFactory<
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> = (context: FarmIntegrationEndpointsFactoryContext<TSchema>) => FarmIntegrationEndpoints<TSchema>;
+
+function createIntegrationRouteFactory<
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+>(): FarmIntegrationRouteFactory<TSchema> {
+  return {
+    get<TPath extends string, TResponse = unknown, TQuery = never, TServer extends boolean = false>(
+      path: TPath,
+      input: Omit<IntegrationRouteBuilderOptions<never, TQuery, TServer, TSchema>, "bodyFormat">,
+    ) {
+      return defineTypedIntegrationRoute<TPath, never, TQuery, TResponse, TServer, "GET", TSchema>(
+        "GET",
+        path,
+        input,
+      );
+    },
+    post<
+      TPath extends string,
+      TBody = never,
+      TResponse = unknown,
+      TQuery = never,
+      TServer extends boolean = false,
+    >(path: TPath, input: IntegrationRouteBuilderOptions<TBody, TQuery, TServer, TSchema>) {
+      return defineTypedIntegrationRoute<TPath, TBody, TQuery, TResponse, TServer, "POST", TSchema>(
+        "POST",
+        path,
+        {
+          bodyFormat: "json",
+          ...input,
+        },
+      );
+    },
+    put<
+      TPath extends string,
+      TBody = never,
+      TResponse = unknown,
+      TQuery = never,
+      TServer extends boolean = false,
+    >(path: TPath, input: IntegrationRouteBuilderOptions<TBody, TQuery, TServer, TSchema>) {
+      return defineTypedIntegrationRoute<TPath, TBody, TQuery, TResponse, TServer, "PUT", TSchema>(
+        "PUT",
+        path,
+        {
+          bodyFormat: "json",
+          ...input,
+        },
+      );
+    },
+    patch<
+      TPath extends string,
+      TBody = never,
+      TResponse = unknown,
+      TQuery = never,
+      TServer extends boolean = false,
+    >(path: TPath, input: IntegrationRouteBuilderOptions<TBody, TQuery, TServer, TSchema>) {
+      return defineTypedIntegrationRoute<
+        TPath,
+        TBody,
+        TQuery,
+        TResponse,
+        TServer,
+        "PATCH",
+        TSchema
+      >("PATCH", path, {
+        bodyFormat: "json",
+        ...input,
+      });
+    },
+    delete<
+      TPath extends string,
+      TBody = never,
+      TResponse = unknown,
+      TQuery = never,
+      TServer extends boolean = false,
+    >(path: TPath, input: IntegrationRouteBuilderOptions<TBody, TQuery, TServer, TSchema>) {
+      return defineTypedIntegrationRoute<
+        TPath,
+        TBody,
+        TQuery,
+        TResponse,
+        TServer,
+        "DELETE",
+        TSchema
+      >("DELETE", path, {
+        bodyFormat: "json",
+        ...input,
+      });
+    },
+    options<
+      TPath extends string,
+      TResponse = unknown,
+      TQuery = never,
+      TServer extends boolean = false,
+    >(
+      path: TPath,
+      input: Omit<IntegrationRouteBuilderOptions<never, TQuery, TServer, TSchema>, "bodyFormat">,
+    ) {
+      return defineTypedIntegrationRoute<
+        TPath,
+        never,
+        TQuery,
+        TResponse,
+        TServer,
+        "OPTIONS",
+        TSchema
+      >("OPTIONS", path, input);
+    },
+    head<
+      TPath extends string,
+      TResponse = unknown,
+      TQuery = never,
+      TServer extends boolean = false,
+    >(
+      path: TPath,
+      input: Omit<IntegrationRouteBuilderOptions<never, TQuery, TServer, TSchema>, "bodyFormat">,
+    ) {
+      return defineTypedIntegrationRoute<TPath, never, TQuery, TResponse, TServer, "HEAD", TSchema>(
+        "HEAD",
+        path,
+        input,
+      );
+    },
+  };
+}
+
+export function createIntegrationRoute<
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+>(_schema?: TSchema): FarmIntegrationRouteFactory<TSchema> {
+  return createIntegrationRouteFactory<TSchema>();
+}
+
+export const integrationRoute = createIntegrationRouteFactory<undefined>();
 
 type RegisteredIntegrationRuntime = {
   integration: FarmIntegration;
@@ -525,8 +777,25 @@ function getIntegrationRuntimeRegistry() {
   return globalState[INTEGRATION_RUNTIME_REGISTRY_KEY]!;
 }
 
-type FarmIntegrationInput = Omit<FarmIntegration, "kind" | "category" | "slot"> &
-  (
+type FarmIntegrationRoutesInput<
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> = readonly FarmIntegrationRoute<any, any, TSchema>[] | FarmIntegrationRoutesFactory<TSchema>;
+
+type FarmIntegrationEndpointsInput<
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+> = FarmIntegrationEndpoints<TSchema> | FarmIntegrationEndpointsFactory<TSchema>;
+
+type FarmIntegrationInput<
+  TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
+  TConfig = unknown,
+> = Omit<
+  FarmIntegration<TSchema, TConfig>,
+  "kind" | "category" | "slot" | "config" | "routes" | "endpoints"
+> & {
+  config?: FarmIntegrationConfigInput<TConfig, TSchema>;
+  routes?: FarmIntegrationRoutesInput<TSchema>;
+  endpoints?: FarmIntegrationEndpointsInput<TSchema>;
+} & (
     | {
         category: FarmIntegrationCategory;
         slot?: FarmIntegrationCategory;
@@ -537,42 +806,164 @@ type FarmIntegrationInput = Omit<FarmIntegration, "kind" | "category" | "slot"> 
       }
   );
 
-type ExtractIntegrationCategory<TIntegration extends FarmIntegrationInput> = TIntegration extends {
-  category: infer TCategory extends FarmIntegrationCategory;
+type FarmIntegrationCategoryInput =
+  | {
+      category: FarmIntegrationCategory;
+      slot?: FarmIntegrationCategory;
+    }
+  | {
+      category?: FarmIntegrationCategory;
+      slot: FarmIntegrationCategory;
+    };
+
+type FarmIntegrationShapeForInference = FarmIntegrationCategoryInput & {
+  api?: FarmIntegrationAPI;
+  schema?: FarmIntegrationSchema;
+  config?: unknown;
+  routes?: unknown;
+  endpoints?: unknown;
+};
+
+type ExtractIntegrationSchema<TIntegration> = TIntegration extends {
+  schema: infer TSchema extends FarmIntegrationSchema;
 }
-  ? TCategory
-  : TIntegration extends { slot: infer TSlot extends FarmIntegrationCategory }
-    ? TSlot
-    : FarmIntegrationCategory;
+  ? TSchema
+  : undefined;
 
-type ExtractDerivedIntegrationAPI<TIntegration extends FarmIntegrationInput> =
-  TIntegration extends { api: infer TAPI extends FarmIntegrationAPI }
-    ? TAPI
-    : TIntegration extends {
-          routes: infer TRoutes extends readonly {
-            path: string;
-            __operation: FarmIntegrationAPIOperation<any, any, any, any, any>;
-          }[];
-        }
-      ? InferIntegrationAPIFromRoutes<TRoutes>
-      : FarmIntegrationAPI | undefined;
+type ResolveIntegrationRoutesInput<TRoutes, TSchema extends FarmIntegrationSchema | undefined> =
+  TRoutes extends FarmIntegrationRoutesFactory<TSchema> ? ReturnType<TRoutes> : TRoutes;
 
-export type DefinedIntegration<TIntegration extends FarmIntegrationInput> = Omit<
+type ResolveIntegrationEndpointsInput<
+  TEndpoints,
+  TSchema extends FarmIntegrationSchema | undefined,
+> =
+  TEndpoints extends FarmIntegrationEndpointsFactory<TSchema> ? ReturnType<TEndpoints> : TEndpoints;
+
+type ExtractIntegrationRoutesFromRoutesInput<
+  TRoutes,
+  TSchema extends FarmIntegrationSchema | undefined,
+> =
+  ResolveIntegrationRoutesInput<TRoutes, TSchema> extends readonly (infer TRoute)[]
+    ? TRoute
+    : never;
+
+type ExtractIntegrationRoutesFromEndpointValue<TValue> =
+  TValue extends FarmIntegrationRouteOperationCarrier<string, any>
+    ? TValue
+    : TValue extends readonly (infer TItem)[]
+      ? ExtractIntegrationRoutesFromEndpointValue<TItem>
+      : TValue extends object
+        ? ExtractIntegrationRoutesFromEndpointValue<TValue[keyof TValue]>
+        : never;
+
+type ExtractIntegrationRoutesFromEndpointsInput<
+  TEndpoints,
+  TSchema extends FarmIntegrationSchema | undefined,
+> = ExtractIntegrationRoutesFromEndpointValue<
+  ResolveIntegrationEndpointsInput<TEndpoints, TSchema>
+>;
+
+type ExtractIntegrationRouteUnion<TIntegration, TSchema extends FarmIntegrationSchema | undefined> =
+  | (TIntegration extends { routes: infer TRoutes }
+      ? ExtractIntegrationRoutesFromRoutesInput<TRoutes, TSchema>
+      : never)
+  | (TIntegration extends { endpoints: infer TEndpoints }
+      ? ExtractIntegrationRoutesFromEndpointsInput<TEndpoints, TSchema>
+      : never);
+
+type ExtractDefinedIntegrationRoutes<
   TIntegration,
-  "kind" | "category" | "slot" | "api"
-> & {
+  TSchema extends FarmIntegrationSchema | undefined,
+> = [ExtractIntegrationRouteUnion<TIntegration, TSchema>] extends [never]
+  ? undefined
+  : readonly ExtractIntegrationRouteUnion<TIntegration, TSchema>[];
+
+type ExtractDefinedIntegrationEndpoints<
+  TIntegration,
+  TSchema extends FarmIntegrationSchema | undefined,
+> = TIntegration extends { endpoints: infer TEndpoints }
+  ? ResolveIntegrationEndpointsInput<TEndpoints, TSchema>
+  : undefined;
+
+type ExtractIntegrationAPIRoutes<
+  TIntegration,
+  TSchema extends FarmIntegrationSchema | undefined,
+> = Extract<
+  ExtractIntegrationRouteUnion<TIntegration, TSchema>,
+  FarmIntegrationRouteOperationCarrier<string, any>
+>;
+
+type ExtractIntegrationCategory<TIntegration extends FarmIntegrationCategoryInput> =
+  TIntegration extends {
+    category: infer TCategory extends FarmIntegrationCategory;
+  }
+    ? TCategory
+    : TIntegration extends { slot: infer TSlot extends FarmIntegrationCategory }
+      ? TSlot
+      : FarmIntegrationCategory;
+
+type ExtractDerivedIntegrationAPI<
+  TIntegration extends FarmIntegrationShapeForInference,
+  TSchema extends FarmIntegrationSchema | undefined = ExtractIntegrationSchema<TIntegration>,
+> = TIntegration extends { api: infer TAPI extends FarmIntegrationAPI }
+  ? TAPI
+  : [ExtractIntegrationAPIRoutes<TIntegration, TSchema>] extends [never]
+    ? FarmIntegrationAPI | undefined
+    : InferIntegrationAPIFromRoutes<readonly ExtractIntegrationAPIRoutes<TIntegration, TSchema>[]>;
+
+export type DefinedIntegration<
+  TIntegration extends FarmIntegrationShapeForInference,
+  TSchema extends FarmIntegrationSchema | undefined = ExtractIntegrationSchema<TIntegration>,
+> = Omit<TIntegration, "kind" | "category" | "slot" | "api" | "routes" | "endpoints"> & {
   readonly kind: "farm-integration";
   category: ExtractIntegrationCategory<TIntegration>;
   slot: ExtractIntegrationCategory<TIntegration>;
-  api: ExtractDerivedIntegrationAPI<TIntegration>;
+  routes: ExtractDefinedIntegrationRoutes<TIntegration, TSchema>;
+  endpoints: ExtractDefinedIntegrationEndpoints<TIntegration, TSchema>;
+  api: ExtractDerivedIntegrationAPI<TIntegration, TSchema>;
 };
 
-export function defineIntegration<TIntegration extends FarmIntegrationInput>(
-  integration: TIntegration,
-): DefinedIntegration<TIntegration>;
-export function defineIntegration<TIntegration extends FarmIntegrationInput>(
-  integration: TIntegration,
-): DefinedIntegration<TIntegration> {
+function isIntegrationEndpointRoute(value: unknown): value is FarmIntegrationRoute {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    typeof (value as { path?: unknown }).path === "string" &&
+    typeof (value as { handler?: unknown }).handler === "function"
+  );
+}
+
+function flattenIntegrationEndpoints(
+  endpoints: FarmIntegrationEndpointValue | FarmIntegrationEndpoints | undefined,
+): FarmIntegrationRoute[] {
+  if (!endpoints) {
+    return [];
+  }
+
+  if (Array.isArray(endpoints)) {
+    return endpoints.flatMap((endpoint) => flattenIntegrationEndpoints(endpoint));
+  }
+
+  if (isIntegrationEndpointRoute(endpoints)) {
+    return [endpoints];
+  }
+
+  if (typeof endpoints === "object") {
+    return Object.values(endpoints).flatMap((endpoint) => flattenIntegrationEndpoints(endpoint));
+  }
+
+  return [];
+}
+
+export function defineIntegration<
+  const TSchema extends FarmIntegrationSchema | undefined,
+  const TConfig,
+  TIntegration extends FarmIntegrationInput<TSchema, TConfig>,
+>(integration: TIntegration): DefinedIntegration<TIntegration, TSchema>;
+export function defineIntegration<
+  const TSchema extends FarmIntegrationSchema | undefined,
+  const TConfig,
+  TIntegration extends FarmIntegrationInput<TSchema, TConfig>,
+>(integration: TIntegration): DefinedIntegration<TIntegration, TSchema> {
   const category = integration.category ?? integration.slot;
 
   if (!category) {
@@ -583,11 +974,33 @@ export function defineIntegration<TIntegration extends FarmIntegrationInput>(
     throw new Error("Integration category and slot must match when both are provided.");
   }
 
+  const routeFactory = createIntegrationRoute(integration.schema);
+  const routes =
+    typeof integration.routes === "function"
+      ? integration.routes({
+          route: routeFactory,
+          integrationRoute: routeFactory,
+        })
+      : integration.routes;
+  const endpoints =
+    typeof integration.endpoints === "function"
+      ? integration.endpoints({
+          endpoint: routeFactory,
+          route: routeFactory,
+          integrationRoute: routeFactory,
+        })
+      : integration.endpoints;
+  const endpointRoutes = flattenIntegrationEndpoints(endpoints);
+  const allRoutes =
+    routes?.length || endpointRoutes.length
+      ? ([...(routes || []), ...endpointRoutes] as readonly FarmIntegrationRoute[])
+      : undefined;
+
   const derivedApi =
     integration.api ||
-    (integration.routes?.length
+    (allRoutes?.length
       ? integrationApi.fromRoutes(
-          integration.routes as unknown as ReadonlyArray<{
+          allRoutes as unknown as ReadonlyArray<{
             path: string;
             __operation: FarmIntegrationAPIOperation<any, any, any, any, any>;
           }>,
@@ -597,10 +1010,12 @@ export function defineIntegration<TIntegration extends FarmIntegrationInput>(
   return {
     kind: "farm-integration",
     ...integration,
+    endpoints,
+    routes: allRoutes,
     api: derivedApi,
     category,
     slot: category,
-  } as unknown as DefinedIntegration<TIntegration>;
+  } as unknown as DefinedIntegration<TIntegration, TSchema>;
 }
 
 export function isFarmIntegration(value: unknown): value is FarmIntegration {
@@ -834,9 +1249,255 @@ export function getRegisteredIntegrationAPIManifest(): Record<string, FarmIntegr
   return Object.fromEntries(manifestEntries);
 }
 
+type IntegrationLifecycleCleanup = () => MaybePromise<void>;
+
+function getIntegrationRuntimeEnv(): Record<string, string | undefined> {
+  return typeof process !== "undefined" ? process.env : {};
+}
+
+function isIntegrationConfigDefinition(
+  value: unknown,
+): value is FarmIntegrationConfigDefinition<unknown> {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    ("schema" in value ||
+      "env" in value ||
+      "defaults" in value ||
+      "input" in value ||
+      "resolve" in value)
+  );
+}
+
+function mergeIntegrationConfigValue(current: unknown, next: unknown): unknown {
+  if (next === undefined) {
+    return current;
+  }
+
+  if (isPlainIntegrationConfigObject(current) && isPlainIntegrationConfigObject(next)) {
+    return {
+      ...current,
+      ...next,
+    };
+  }
+
+  return next;
+}
+
+function isPlainIntegrationConfigObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+async function resolveIntegrationConfigPart<TValue>(
+  value: TValue | ((context: FarmIntegrationConfigContext) => MaybePromise<TValue>) | undefined,
+  context: FarmIntegrationConfigContext,
+): Promise<TValue | undefined> {
+  if (typeof value === "function") {
+    return (value as (context: FarmIntegrationConfigContext) => MaybePromise<TValue>)(context);
+  }
+
+  return value;
+}
+
+function resolveIntegrationEnvConfig(
+  env: Record<string, string | readonly string[]> | undefined,
+): Record<string, string> | undefined {
+  if (!env) {
+    return undefined;
+  }
+
+  const runtimeEnv = getIntegrationRuntimeEnv();
+  const config: Record<string, string> = {};
+
+  for (const [key, names] of Object.entries(env)) {
+    const envNames = Array.isArray(names) ? names : [names];
+    const value = envNames.map((name) => runtimeEnv[name]).find((entry) => entry !== undefined);
+    if (value !== undefined) {
+      config[key] = value;
+    }
+  }
+
+  return config;
+}
+
+async function parseIntegrationConfigSchema<TConfig>(
+  integration: FarmIntegration<any, any>,
+  schema: FarmIntegrationInputSchema<TConfig>,
+  value: unknown,
+): Promise<TConfig> {
+  const parser = schema.safeParseAsync || schema.safeParse;
+  if (parser) {
+    const result = await parser.call(schema, value);
+    if (result.success) {
+      return result.data;
+    }
+
+    throw createIntegrationConfigValidationError(integration, result.error);
+  }
+
+  if (schema["~standard"]?.validate) {
+    const result = await schema["~standard"].validate(value);
+    if ("value" in result) {
+      return result.value;
+    }
+
+    throw createIntegrationConfigValidationError(integration, {
+      issues: result.issues,
+    });
+  }
+
+  if (schema.parse) {
+    try {
+      return await schema.parse(value);
+    } catch (error) {
+      throw createIntegrationConfigValidationError(
+        integration,
+        normalizeIntegrationValidationError(error),
+      );
+    }
+  }
+
+  throw new Error(
+    `Integration "${integration.type}" config schema must expose safeParse, safeParseAsync, parse, or ~standard.validate.`,
+  );
+}
+
+function createIntegrationConfigValidationError(
+  integration: FarmIntegration<any, any>,
+  error: FarmIntegrationValidationErrorLike,
+) {
+  const issues =
+    Array.isArray(error.issues) && error.issues.length > 0
+      ? error.issues
+          .map((issue) => {
+            const path = issue.path?.length ? `${issue.path.join(".")}: ` : "";
+            return `${path}${issue.message || "Invalid config"}`;
+          })
+          .join("; ")
+      : error.message || "Invalid config";
+
+  return new Error(`Integration "${integration.type}" config validation failed: ${issues}`);
+}
+
+async function resolveIntegrationConfig<TConfig>(
+  integration: FarmIntegration<any, TConfig>,
+  context: FarmIntegrationConfigContext,
+): Promise<TConfig> {
+  const config = integration.config;
+  if (!config) {
+    return undefined as TConfig;
+  }
+
+  if (!isIntegrationConfigDefinition(config)) {
+    return parseIntegrationConfigSchema(integration, config, {});
+  }
+
+  let value: unknown = {};
+  value = mergeIntegrationConfigValue(
+    value,
+    await resolveIntegrationConfigPart(config.defaults, context),
+  );
+  value = mergeIntegrationConfigValue(value, resolveIntegrationEnvConfig(config.env));
+  value = mergeIntegrationConfigValue(
+    value,
+    await resolveIntegrationConfigPart(config.input, context),
+  );
+  value = mergeIntegrationConfigValue(value, await config.resolve?.(context));
+
+  return config.schema
+    ? parseIntegrationConfigSchema(integration, config.schema, value)
+    : (value as TConfig);
+}
+
+function createIntegrationLifecycleLogger(
+  integration: FarmIntegration<any, any>,
+  phase: FarmIntegrationLogPhase,
+): FarmIntegrationLifecycleLogger {
+  const write = (
+    level: FarmIntegrationLifecycleLogLevel,
+    message: string,
+    meta?: Record<string, unknown>,
+  ) => {
+    if (!integration.log) {
+      return;
+    }
+
+    void Promise.resolve(
+      integration.log({
+        category: integration.category,
+        slot: integration.category,
+        type: integration.type,
+        phase,
+        level,
+        message,
+        meta,
+        context: new Map(),
+      }),
+    ).catch(() => {});
+  };
+
+  return {
+    info(message, meta) {
+      write("info", message, meta);
+    },
+    warn(message, meta) {
+      write("warn", message, meta);
+    },
+    error(message, meta) {
+      write("error", message, meta);
+    },
+  };
+}
+
 function createIntegrationPlugin(integrationKey: string, integration: FarmIntegration): FarmPlugin {
   const routes = normalizeIntegrationRoutes(integration.routes || []);
   const middleware = [...(integration.middleware || [])];
+  const cleanupCallbacks: IntegrationLifecycleCleanup[] = [];
+  let integrationConfigPromise: Promise<unknown> | undefined;
+
+  const runCleanup = async () => {
+    const callbacks = cleanupCallbacks.splice(0).reverse();
+    for (const callback of callbacks) {
+      await callback();
+    }
+  };
+
+  const createLifecycleContext = async (
+    context: FarmPluginContext,
+    phase: FarmIntegrationLogPhase,
+    options: { reason?: string } = {},
+  ): Promise<FarmIntegrationLifecycleContext> => {
+    const args = createIntegrationRouteArgs({
+      integration,
+      config: context.config,
+    });
+    const configContext: FarmIntegrationConfigContext = {
+      key: integrationKey,
+      integration,
+      appConfig: context.config,
+      config: context.config,
+      args,
+      env: getIntegrationRuntimeEnv(),
+      isDev: context.isDev,
+      isProd: context.isProd,
+    };
+    integrationConfigPromise ??= resolveIntegrationConfig(integration, configContext);
+
+    return {
+      ...configContext,
+      integrationConfig: await integrationConfigPromise,
+      log: createIntegrationLifecycleLogger(integration, phase),
+      reason: options.reason,
+      async cleanup(callback) {
+        if (callback) {
+          cleanupCallbacks.push(callback);
+          return;
+        }
+
+        await runCleanup();
+      },
+    };
+  };
 
   return {
     name: `farm:integration:${integration.category}:${integration.type}`,
@@ -849,6 +1510,14 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
         isDev: context.isDev,
         isProd: context.isProd,
       });
+
+      if (integration.validate) {
+        await integration.validate(await createLifecycleContext(context, "validate"));
+      }
+
+      if (integration.setup) {
+        await integration.setup(await createLifecycleContext(context, "setup"));
+      }
 
       if (!integration.log) {
         return;
@@ -882,6 +1551,26 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
           },
           context: new Map(),
         });
+      }
+    },
+
+    async ready(context) {
+      if (integration.ready) {
+        await integration.ready(await createLifecycleContext(context, "ready"));
+      }
+    },
+
+    async shutdown(payload, context) {
+      try {
+        if (integration.dispose) {
+          await integration.dispose(
+            await createLifecycleContext(context, "dispose", {
+              reason: payload.reason,
+            }),
+          );
+        }
+      } finally {
+        await runCleanup();
       }
     },
 
@@ -1190,6 +1879,10 @@ function createIntegrationHandlerContext(input: {
     method: input.request.method,
     params: input.params,
     input: {},
+    args: createIntegrationRouteArgs({
+      integration: input.integration,
+      config: input.pluginContext.config,
+    }),
     integration: {
       category: input.integration.category,
       slot: input.integration.category,
@@ -1501,6 +2194,107 @@ async function readIntegrationValidationBody(
 
 function getIntegrationRouteBodyFormat(route: NormalizedIntegrationRoute) {
   return route.bodyFormat || route.__operation?.bodyFormat || "json";
+}
+
+function createIntegrationRouteArgs(input: {
+  integration: FarmIntegration;
+  config: FarmPluginContext["config"];
+}): FarmIntegrationRouteArgs {
+  let clientPromise: Promise<unknown | undefined> | undefined;
+  let ormPromise: Promise<unknown> | undefined;
+
+  const getClient = () => {
+    clientPromise ??= import("./storage").then(({ resolveStorageRuntimeClient }) =>
+      resolveStorageRuntimeClient(input.config.storage),
+    );
+    return clientPromise;
+  };
+
+  const getOrm = () => {
+    if (!input.integration.schema) {
+      throw new Error(
+        `Integration "${input.integration.type}" does not define a schema for ctx.args.db.`,
+      );
+    }
+
+    ormPromise ??= import("./integration-orm").then(({ createIntegrationOrm }) =>
+      createIntegrationOrm({
+        schema: input.integration.schema!,
+        config: input.config,
+      }),
+    );
+    return ormPromise;
+  };
+
+  return {
+    db: createLazyIntegrationOrmClient(getOrm) as never,
+    getDb: getOrm as never,
+    storage: {
+      getClient,
+      getOrm: getOrm as never,
+    },
+  };
+}
+
+function createLazyIntegrationOrmClient(resolveOrm: () => Promise<unknown>) {
+  const modelProxyCache = new Map<PropertyKey, unknown>();
+
+  return new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (prop === "then") {
+          return undefined;
+        }
+
+        if (prop === "transaction" || prop === "batch") {
+          return async (...args: unknown[]) => {
+            const orm = (await resolveOrm()) as Record<PropertyKey, unknown>;
+            const member = orm[prop];
+            if (typeof member !== "function") {
+              throw new Error(`Integration ORM does not expose "${String(prop)}".`);
+            }
+            return member.apply(orm, args);
+          };
+        }
+
+        if (prop === "$driver") {
+          return undefined;
+        }
+
+        if (!modelProxyCache.has(prop)) {
+          modelProxyCache.set(prop, createLazyIntegrationOrmModel(resolveOrm, prop));
+        }
+
+        return modelProxyCache.get(prop);
+      },
+    },
+  );
+}
+
+function createLazyIntegrationOrmModel(resolveOrm: () => Promise<unknown>, modelName: PropertyKey) {
+  return new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (prop === "then") {
+          return undefined;
+        }
+
+        return async (...args: unknown[]) => {
+          const orm = (await resolveOrm()) as Record<PropertyKey, Record<PropertyKey, unknown>>;
+          const model = orm[modelName];
+          const member = model?.[prop];
+          if (typeof member !== "function") {
+            throw new Error(
+              `Integration ORM model "${String(modelName)}" does not expose "${String(prop)}".`,
+            );
+          }
+          return member.apply(model, args);
+        };
+      },
+    },
+  );
 }
 
 async function runIntegrationRouteBeforeHooks(
@@ -1909,6 +2703,10 @@ function createServerIntegrationHandlerContext(input: {
     method: input.request.method,
     params: input.params,
     input: {},
+    args: createIntegrationRouteArgs({
+      integration: input.runtime.integration,
+      config: input.runtime.config,
+    }),
     integration: {
       category: input.runtime.integration.category,
       slot: input.runtime.integration.category,

--- a/packages/farm/src/integrations.ts
+++ b/packages/farm/src/integrations.ts
@@ -76,9 +76,29 @@ export type FarmIntegrationValidationResult<TValue> =
       error: FarmIntegrationValidationErrorLike;
     };
 
+export type FarmIntegrationStandardValidationResult<TValue> =
+  | {
+      value: TValue;
+    }
+  | {
+      issues: readonly {
+        path?: readonly (string | number)[];
+        code?: string;
+        message: string;
+      }[];
+    };
+
 export interface FarmIntegrationInputSchema<TValue = unknown> {
+  _output?: TValue;
+  parse?(value: unknown): MaybePromise<TValue>;
   safeParse?(value: unknown): MaybePromise<FarmIntegrationValidationResult<TValue>>;
   safeParseAsync?(value: unknown): Promise<FarmIntegrationValidationResult<TValue>>;
+  "~standard"?: {
+    validate(value: unknown): MaybePromise<FarmIntegrationStandardValidationResult<TValue>>;
+    types?: {
+      output: TValue;
+    };
+  };
 }
 
 export interface FarmIntegrationRouteInputSchemas<TBody = unknown, TQuery = unknown> {
@@ -121,13 +141,29 @@ export interface FarmIntegrationHandlerContext<TBody = unknown, TQuery = unknown
   isProd: boolean;
 }
 
+export interface FarmIntegrationRouteHookContext<
+  TBody = unknown,
+  TQuery = unknown,
+> extends FarmIntegrationHandlerContext<TBody, TQuery> {
+  response?: Response;
+}
+
+export type FarmIntegrationRouteHook<TBody = unknown, TQuery = unknown> = (
+  request: Request,
+  context: FarmIntegrationRouteHookContext<TBody, TQuery>,
+) => Promise<Response | void> | Response | void;
+
 export interface FarmIntegrationRoute<TBody = unknown, TQuery = unknown> {
   path: string;
   method?: FarmIntegrationRouteMethod;
   methods?: readonly FarmIntegrationRouteMethod[];
   middleware?: readonly FarmIntegrationRouteMiddleware[];
+  before?: readonly FarmIntegrationRouteHook<TBody, TQuery>[];
+  after?: readonly FarmIntegrationRouteHook<TBody, TQuery>[];
   rawBody?: boolean;
   bodyFormat?: FarmIntegrationAPIBodyFormat;
+  body?: FarmIntegrationInputSchema<TBody>;
+  query?: FarmIntegrationInputSchema<TQuery>;
   input?: FarmIntegrationRouteInputSchemas<TBody, TQuery>;
   handler(
     request: Request,
@@ -306,12 +342,16 @@ export type FarmIntegrationsUserConfig = Record<string, FarmIntegration | undefi
 
 type IntegrationRouteBuilderOptions<TBody, TQuery, TServer extends boolean> = {
   middleware?: readonly FarmIntegrationRouteMiddleware[];
+  before?: readonly FarmIntegrationRouteHook<TBody, TQuery>[];
+  after?: readonly FarmIntegrationRouteHook<TBody, TQuery>[];
   rawBody?: boolean;
   headers?: Record<string, string>;
   credentials?: RequestCredentials;
   bodyFormat?: FarmIntegrationAPIBodyFormat;
   responseFormat?: FarmIntegrationAPIResponseFormat;
   isServer?: TServer;
+  body?: FarmIntegrationInputSchema<TBody>;
+  query?: FarmIntegrationInputSchema<TQuery>;
   input?: FarmIntegrationRouteInputSchemas<TBody, TQuery>;
   handler(
     request: Request,
@@ -335,9 +375,11 @@ function defineTypedIntegrationRoute<
     path,
     method,
     middleware: input.middleware,
+    before: input.before,
+    after: input.after,
     rawBody: input.rawBody,
     bodyFormat: input.bodyFormat,
-    input: input.input,
+    input: normalizeIntegrationRouteInputSchemas(input),
     handler: input.handler,
     __operation: defineIntegrationAPIOperation<TBody, TQuery, TResponse, TServer, TMethod>({
       path,
@@ -1049,7 +1091,45 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
             }
           }
 
-          const response = await route.handler(request, handlerContext);
+          const beforeResponse = await runIntegrationRouteBeforeHooks(
+            route,
+            request,
+            handlerContext,
+          );
+          if (beforeResponse) {
+            const response = await runIntegrationRouteAfterHooks(
+              route,
+              request,
+              handlerContext,
+              beforeResponse,
+            );
+            await sendWebResponse(res, response);
+            await integration.log?.({
+              category: integration.category,
+              slot: integration.category,
+              type: integration.type,
+              phase: "request:end",
+              route: {
+                kind: "route",
+                path: route.path,
+                methods: route.methods,
+              },
+              request,
+              response,
+              requestId,
+              durationMs: Date.now() - startedAt,
+              context: handlerContext.requestContext.snapshot(),
+            });
+            return;
+          }
+
+          const handlerResponse = await route.handler(request, handlerContext);
+          const response = await runIntegrationRouteAfterHooks(
+            route,
+            request,
+            handlerContext,
+            handlerResponse,
+          );
           await sendWebResponse(res, response);
           await integration.log?.({
             category: integration.category,
@@ -1139,6 +1219,7 @@ function normalizeIntegrationRoutes(
   return routes.map((route) => ({
     ...route,
     methods: normalizeIntegrationRouteMethods(route),
+    input: normalizeIntegrationRouteInputSchemas(route),
   }));
 }
 
@@ -1151,6 +1232,24 @@ function normalizeIntegrationRouteMethods(route: Pick<FarmIntegrationRoute, "met
         : ["ALL"];
 
   return input.map((method) => String(method).toUpperCase());
+}
+
+function normalizeIntegrationRouteInputSchemas<TBody, TQuery>(
+  route: Pick<FarmIntegrationRoute<TBody, TQuery>, "body" | "query" | "input">,
+): FarmIntegrationRouteInputSchemas<TBody, TQuery> | undefined {
+  const input: FarmIntegrationRouteInputSchemas<TBody, TQuery> = {
+    ...route.input,
+  };
+
+  if (route.body) {
+    input.body = route.body;
+  }
+
+  if (route.query) {
+    input.query = route.query;
+  }
+
+  return input.body || input.query ? input : undefined;
 }
 
 type IntegrationRouteInputValidationResult =
@@ -1238,29 +1337,64 @@ async function parseIntegrationInputSchema<TValue>(
     }
 > {
   const parser = schema.safeParseAsync || schema.safeParse;
-  if (!parser) {
+  if (parser) {
+    const result = await parser.call(schema, value);
+    if (result.success) {
+      return {
+        success: true,
+        data: result.data,
+      };
+    }
+
     return {
       success: false,
-      issues: [
-        {
-          source,
-          message: "Input schema must expose safeParse or safeParseAsync.",
-        },
-      ],
+      issues: normalizeIntegrationValidationIssues(source, result.error),
     };
   }
 
-  const result = await parser.call(schema, value);
-  if (result.success) {
+  if (schema["~standard"]?.validate) {
+    const result = await schema["~standard"].validate(value);
+    if ("value" in result) {
+      return {
+        success: true,
+        data: result.value,
+      };
+    }
+
     return {
-      success: true,
-      data: result.data,
+      success: false,
+      issues: normalizeIntegrationValidationIssues(source, {
+        issues: result.issues,
+      }),
     };
+  }
+
+  if (schema.parse) {
+    try {
+      return {
+        success: true,
+        data: await schema.parse(value),
+      };
+    } catch (error) {
+      return {
+        success: false,
+        issues: normalizeIntegrationValidationIssues(
+          source,
+          normalizeIntegrationValidationError(error),
+        ),
+      };
+    }
   }
 
   return {
     success: false,
-    issues: normalizeIntegrationValidationIssues(source, result.error),
+    issues: [
+      {
+        source,
+        message:
+          "Input schema must expose safeParse, safeParseAsync, parse, or ~standard.validate.",
+      },
+    ],
   };
 }
 
@@ -1296,6 +1430,16 @@ function normalizeIntegrationValidationIssues(
       message: error.message || "Invalid input",
     },
   ];
+}
+
+function normalizeIntegrationValidationError(error: unknown): FarmIntegrationValidationErrorLike {
+  if (error && typeof error === "object") {
+    return error as FarmIntegrationValidationErrorLike;
+  }
+
+  return {
+    message: error instanceof Error ? error.message : String(error || "Invalid input"),
+  };
 }
 
 async function readIntegrationValidationBody(
@@ -1357,6 +1501,48 @@ async function readIntegrationValidationBody(
 
 function getIntegrationRouteBodyFormat(route: NormalizedIntegrationRoute) {
   return route.bodyFormat || route.__operation?.bodyFormat || "json";
+}
+
+async function runIntegrationRouteBeforeHooks(
+  route: NormalizedIntegrationRoute,
+  request: Request,
+  context: FarmIntegrationHandlerContext,
+): Promise<Response | undefined> {
+  const hookContext = context as FarmIntegrationRouteHookContext;
+  hookContext.response = undefined;
+
+  for (const hook of route.before || []) {
+    const response = await hook(request, hookContext);
+    if (response) {
+      hookContext.response = response;
+      return response;
+    }
+
+    if (hookContext.response) {
+      return hookContext.response;
+    }
+  }
+
+  return undefined;
+}
+
+async function runIntegrationRouteAfterHooks(
+  route: NormalizedIntegrationRoute,
+  request: Request,
+  context: FarmIntegrationHandlerContext,
+  response: Response,
+): Promise<Response> {
+  const hookContext = context as FarmIntegrationRouteHookContext;
+  let currentResponse = response;
+
+  for (const hook of route.after || []) {
+    hookContext.response = currentResponse;
+    const nextResponse = await hook(request, hookContext);
+    currentResponse = nextResponse || hookContext.response || currentResponse;
+  }
+
+  hookContext.response = currentResponse;
+  return currentResponse;
 }
 
 function createQueryInput(searchParams: URLSearchParams): Record<string, string | string[]> {
@@ -1584,7 +1770,40 @@ export async function dispatchIntegrationRequest(
         }
       }
 
-      const response = await route.handler(request, handlerContext);
+      const beforeResponse = await runIntegrationRouteBeforeHooks(route, request, handlerContext);
+      if (beforeResponse) {
+        const response = await runIntegrationRouteAfterHooks(
+          route,
+          request,
+          handlerContext,
+          beforeResponse,
+        );
+        await integration.log?.({
+          category: integration.category,
+          slot: integration.category,
+          type: integration.type,
+          phase: "request:end",
+          route: {
+            kind: "route",
+            path: route.path,
+            methods: route.methods,
+          },
+          request,
+          response,
+          requestId,
+          durationMs: Date.now() - startedAt,
+          context: handlerContext.requestContext.snapshot(),
+        });
+        return response;
+      }
+
+      const handlerResponse = await route.handler(request, handlerContext);
+      const response = await runIntegrationRouteAfterHooks(
+        route,
+        request,
+        handlerContext,
+        handlerResponse,
+      );
       await integration.log?.({
         category: integration.category,
         slot: integration.category,


### PR DESCRIPTION
## Summary\n- compose integration APIs into createAPIClient under api.integrations.*\n- expose server integration namespaces from createServerAPIClient for in-process handler dispatch\n- export the new composed client/server types and opt-out option types\n- add runtime and type coverage for client, server, and opt-out behavior\n\nCloses #49\n\n## Tests\n- corepack pnpm@8.12.1 --filter @farmjs/core exec vitest run src/__tests__/api-client.test.ts src/__tests__/api-client.typing.test.ts src/__tests__/integration-client.test.ts\n- corepack pnpm@8.12.1 --filter @farmjs/core run build