### PR TITLE
feat: add integration data context

### DIFF
--- a/packages/farm-integrations/src/farm-core-shim.d.ts
+++ b/packages/farm-integrations/src/farm-core-shim.d.ts
@@ -168,6 +168,10 @@ declare module "@farmjs/core" {
     TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
   > = (context: FarmIntegrationLifecycleContext<TConfig, TSchema>) => MaybePromise<void>;
 
+  /**
+   * Small per-call integration metadata. Values received over HTTP are
+   * client-controlled and should be validated before authorization decisions.
+   */
   export type FarmIntegrationData = Record<string, unknown>;
 
   export interface FarmIntegrationHandlerContext<

--- a/packages/farm-integrations/src/farm-core-shim.d.ts
+++ b/packages/farm-integrations/src/farm-core-shim.d.ts
@@ -168,6 +168,8 @@ declare module "@farmjs/core" {
     TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
   > = (context: FarmIntegrationLifecycleContext<TConfig, TSchema>) => MaybePromise<void>;
 
+  export type FarmIntegrationData = Record<string, unknown>;
+
   export interface FarmIntegrationHandlerContext<
     TBody = unknown,
     TQuery = unknown,
@@ -181,6 +183,7 @@ declare module "@farmjs/core" {
     params: FarmIntegrationRouteParams;
     input: FarmIntegrationRouteInput<TBody, TQuery>;
     args: FarmIntegrationRouteArgs<TSchema>;
+    data: FarmIntegrationData;
     integration: {
       category: FarmIntegrationCategory;
       /** @deprecated Use category instead. */

--- a/packages/farm/src/__tests__/autumn-webhooks.test.ts
+++ b/packages/farm/src/__tests__/autumn-webhooks.test.ts
@@ -41,6 +41,7 @@ function createContext(
     method,
     params: {},
     input: {},
+    data: {},
     integration: {
       category: "payment",
       slot: "payment",

--- a/packages/farm/src/__tests__/integration-client.test.ts
+++ b/packages/farm/src/__tests__/integration-client.test.ts
@@ -234,24 +234,23 @@ describe("integration client", () => {
       },
     };
 
+    const globalData = JSON.parse(
+      '{"tenantId":"tenant_global","plan":"starter","__proto__":{"polluted":true},"nested":{"safe":true,"constructor":{"prototype":{"polluted":true}}}}',
+    ) as Record<string, unknown>;
+    const callData = JSON.parse(
+      '{"tenantId":"tenant_call","locale":"en","prototype":{"polluted":true}}',
+    ) as Record<string, unknown>;
+
     const { apiClient } = createIntegrations<{
       localDemo: {
         data: {
           get: ReturnType<typeof endpoint.get<{ ok: boolean }>>;
         };
       };
-    }>({
-      data: {
-        tenantId: "tenant_global",
-        plan: "starter",
-      },
-    });
+    }>({ data: globalData });
 
     const result = await apiClient.localDemo.data.get(undefined, {
-      data: {
-        tenantId: "tenant_call",
-        locale: "en",
-      },
+      data: callData,
     });
 
     expect(result.error).toBeNull();
@@ -262,7 +261,53 @@ describe("integration client", () => {
       tenantId: "tenant_call",
       plan: "starter",
       locale: "en",
+      nested: {
+        safe: true,
+      },
     });
+    expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+  });
+
+  it("rejects oversized integration data before browser fetches", async () => {
+    stubBrowser();
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+        },
+      }),
+    );
+
+    (window as any).__FARM_INTEGRATION_API_MANIFEST__ = {
+      localDemo: {
+        data: endpoint.route(
+          "/api/local-demo/data",
+          endpoint.get<{ ok: boolean }>({
+            responseFormat: "json",
+          }),
+        ),
+      },
+    };
+
+    const { apiClient } = createIntegrations<{
+      localDemo: {
+        data: {
+          get: ReturnType<typeof endpoint.get<{ ok: boolean }>>;
+        };
+      };
+    }>({
+      data: {
+        blob: "x".repeat(17 * 1024),
+      },
+    });
+
+    const result = await apiClient.localDemo.data.get();
+
+    expect(result.data).toBeNull();
+    expect(result.error?.message).toContain("must be smaller");
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("creates api and apiClient aliases from registered integrations when no sources are passed", async () => {

--- a/packages/farm/src/__tests__/integration-client.test.ts
+++ b/packages/farm/src/__tests__/integration-client.test.ts
@@ -4,6 +4,7 @@ import {
   createIntegrationApi,
   createIntegrationClient,
   createIntegrationClients,
+  createIntegrations,
   createIntegrationServerClient,
   endpoint,
   integrationClients,
@@ -208,6 +209,60 @@ describe("integration client", () => {
 
     expect(result.error).toBeNull();
     expect(result.data?.authenticated).toBe(false);
+  });
+
+  it("serializes createIntegrations data for browser integration calls", async () => {
+    stubBrowser();
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+        },
+      }),
+    );
+
+    (window as any).__FARM_INTEGRATION_API_MANIFEST__ = {
+      localDemo: {
+        data: endpoint.route(
+          "/api/local-demo/data",
+          endpoint.get<{ ok: boolean }>({
+            responseFormat: "json",
+          }),
+        ),
+      },
+    };
+
+    const { apiClient } = createIntegrations<{
+      localDemo: {
+        data: {
+          get: ReturnType<typeof endpoint.get<{ ok: boolean }>>;
+        };
+      };
+    }>({
+      data: {
+        tenantId: "tenant_global",
+        plan: "starter",
+      },
+    });
+
+    const result = await apiClient.localDemo.data.get(undefined, {
+      data: {
+        tenantId: "tenant_call",
+        locale: "en",
+      },
+    });
+
+    expect(result.error).toBeNull();
+    const headers = fetchSpy.mock.calls[0]?.[1]
+      ? new Headers(fetchSpy.mock.calls[0][1]!.headers as HeadersInit)
+      : new Headers();
+    expect(JSON.parse(headers.get("x-farm-integration-data") || "{}")).toEqual({
+      tenantId: "tenant_call",
+      plan: "starter",
+      locale: "en",
+    });
   });
 
   it("creates api and apiClient aliases from registered integrations when no sources are passed", async () => {
@@ -919,6 +974,78 @@ describe("integration client", () => {
 
     expect(clientResult.error).toBeNull();
     expect(clientResult.data?.ok).toBe(true);
+  });
+
+  it("passes createIntegrations data to registered server handlers", async () => {
+    stubServer();
+
+    const integration = defineIntegration({
+      category: "custom",
+      type: "local-demo",
+      instance: {},
+      routes: [
+        integrationRoute.get<
+          "/api/local-demo/data",
+          { data: Record<string, unknown> },
+          never,
+          true
+        >("/api/local-demo/data", {
+          responseFormat: "json",
+          isServer: true,
+          handler(_request, context) {
+            return Response.json({
+              data: context.data,
+            });
+          },
+        }),
+      ],
+    });
+
+    const manager = new PluginManager({
+      config: {
+        integrations: {
+          localDemo: integration,
+        },
+      } as any,
+      isDev: true,
+      isProd: false,
+    });
+    manager.addPlugins(
+      resolveIntegrationPlugins({
+        localDemo: integration,
+      }),
+    );
+    await manager.runHookParallel("init");
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const { api } = createIntegrations<{
+      localDemo: typeof integration;
+    }>({
+      data: {
+        tenantId: "tenant_global",
+        plan: "starter",
+      },
+    });
+
+    await _runWithCurrentRequest(new Request("https://farmjs.dev/server-demo"), async () => {
+      const result = await api.localDemo.data.get(undefined, {
+        data: {
+          tenantId: "tenant_call",
+          locale: "en",
+        },
+      });
+
+      expect(result.error).toBeNull();
+      expect(result.data).toEqual({
+        data: {
+          tenantId: "tenant_call",
+          plan: "starter",
+          locale: "en",
+        },
+      });
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("picks up newly added client manifest operations without rebuilding the root alias", async () => {

--- a/packages/farm/src/__tests__/integrations.test.ts
+++ b/packages/farm/src/__tests__/integrations.test.ts
@@ -734,6 +734,48 @@ describe("integrations runtime", () => {
     });
   });
 
+  it("exposes serialized integration data on HTTP route contexts", async () => {
+    const manager = createManager();
+    manager.addPlugins(
+      resolveIntegrationPlugins({
+        localDemo: defineIntegration({
+          category: "custom",
+          type: "local-demo",
+          instance: {},
+          routes: [
+            integrationRoute.get<"/api/local-demo/data", { data: Record<string, unknown> }>(
+              "/api/local-demo/data",
+              {
+                handler(_request, context) {
+                  return Response.json({
+                    data: context.data,
+                  });
+                },
+              },
+            ),
+          ],
+        }),
+      }),
+    );
+
+    const req = createRequest("/api/local-demo/data");
+    req.headers["x-farm-integration-data"] = JSON.stringify({
+      tenantId: "tenant_browser",
+      locale: "en",
+    });
+    const res = createResponse();
+    const ended = await manager.runHookParallel("beforeRequest", req as any, res as any);
+
+    expect(ended).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body.toString())).toEqual({
+      data: {
+        tenantId: "tenant_browser",
+        locale: "en",
+      },
+    });
+  });
+
   it("runs route before and after hooks around the route handler", async () => {
     const manager = createManager();
     const handlerSpy = vi.fn();

--- a/packages/farm/src/__tests__/integrations.test.ts
+++ b/packages/farm/src/__tests__/integrations.test.ts
@@ -776,6 +776,98 @@ describe("integrations runtime", () => {
     });
   });
 
+  it("sanitizes untrusted integration data headers", async () => {
+    const manager = createManager();
+    manager.addPlugins(
+      resolveIntegrationPlugins({
+        localDemo: defineIntegration({
+          category: "custom",
+          type: "local-demo",
+          instance: {},
+          routes: [
+            integrationRoute.get<"/api/local-demo/data", { data: Record<string, unknown> }>(
+              "/api/local-demo/data",
+              {
+                handler(_request, context) {
+                  return Response.json({
+                    data: context.data,
+                    polluted: ({} as { polluted?: boolean }).polluted ?? null,
+                    hasProto: Object.prototype.hasOwnProperty.call(context.data, "__proto__"),
+                    hasConstructor: Object.prototype.hasOwnProperty.call(
+                      context.data,
+                      "constructor",
+                    ),
+                    hasPrototype: Object.prototype.hasOwnProperty.call(context.data, "prototype"),
+                  });
+                },
+              },
+            ),
+          ],
+        }),
+      }),
+    );
+
+    const req = createRequest("/api/local-demo/data");
+    req.headers["x-farm-integration-data"] =
+      '{"tenantId":"tenant_browser","__proto__":{"polluted":true},"constructor":{"prototype":{"polluted":true}},"prototype":{"polluted":true},"nested":{"safe":true,"constructor":{"prototype":{"polluted":true}}}}';
+    const res = createResponse();
+    const ended = await manager.runHookParallel("beforeRequest", req as any, res as any);
+
+    expect(ended).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body.toString())).toEqual({
+      data: {
+        tenantId: "tenant_browser",
+        nested: {
+          safe: true,
+        },
+      },
+      polluted: null,
+      hasProto: false,
+      hasConstructor: false,
+      hasPrototype: false,
+    });
+    expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+  });
+
+  it("ignores oversized integration data headers", async () => {
+    const manager = createManager();
+    manager.addPlugins(
+      resolveIntegrationPlugins({
+        localDemo: defineIntegration({
+          category: "custom",
+          type: "local-demo",
+          instance: {},
+          routes: [
+            integrationRoute.get<"/api/local-demo/data", { data: Record<string, unknown> }>(
+              "/api/local-demo/data",
+              {
+                handler(_request, context) {
+                  return Response.json({
+                    data: context.data,
+                  });
+                },
+              },
+            ),
+          ],
+        }),
+      }),
+    );
+
+    const req = createRequest("/api/local-demo/data");
+    req.headers["x-farm-integration-data"] = JSON.stringify({
+      blob: "x".repeat(17 * 1024),
+    });
+    const res = createResponse();
+    const ended = await manager.runHookParallel("beforeRequest", req as any, res as any);
+
+    expect(ended).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body.toString())).toEqual({
+      data: {},
+    });
+  });
+
   it("runs route before and after hooks around the route handler", async () => {
     const manager = createManager();
     const handlerSpy = vi.fn();

--- a/packages/farm/src/__tests__/polar-webhooks.test.ts
+++ b/packages/farm/src/__tests__/polar-webhooks.test.ts
@@ -41,6 +41,7 @@ function createContext(
     method,
     params: {},
     input: {},
+    data: {},
     integration: {
       category: "payment",
       slot: "payment",

--- a/packages/farm/src/__tests__/resend-email.test.tsx
+++ b/packages/farm/src/__tests__/resend-email.test.tsx
@@ -43,6 +43,7 @@ function createContext(
     method,
     params: {},
     input: {},
+    data: {},
     integration: {
       category: "email",
       slot: "email",

--- a/packages/farm/src/__tests__/stripe-orm-storage.test.ts
+++ b/packages/farm/src/__tests__/stripe-orm-storage.test.ts
@@ -63,6 +63,7 @@ function createContext(
     method,
     params: {},
     input: {},
+    data: {},
     integration: {
       category: "payment",
       slot: "payment",

--- a/packages/farm/src/__tests__/stripe-trial-hooks.test.ts
+++ b/packages/farm/src/__tests__/stripe-trial-hooks.test.ts
@@ -52,6 +52,7 @@ function createContext(
     method,
     params: {},
     input: {},
+    data: {},
     integration: {
       category: "payment",
       slot: "payment",

--- a/packages/farm/src/__tests__/stripe-webhooks.test.ts
+++ b/packages/farm/src/__tests__/stripe-webhooks.test.ts
@@ -37,6 +37,7 @@ function createContext(
     method,
     params: {},
     input: {},
+    data: {},
     integration: {
       category: "payment",
       slot: "payment",

--- a/packages/farm/src/client.ts
+++ b/packages/farm/src/client.ts
@@ -25,6 +25,7 @@ export { createIntegrationClient, IntegrationClientError } from "./integration-c
 export {
   createIntegrationApi,
   createIntegrationClients,
+  createIntegrations,
   createIntegrationServerClient,
   getIntegrationAPIManifest,
   integrationClients,
@@ -39,6 +40,7 @@ export type {
   IntegrationClientRequestOptions,
   IntegrationAPI,
   IntegrationClients,
+  IntegrationClientData,
   IntegrationOperationResult,
   InferIntegrationOperationBody,
   InferIntegrationOperationQuery,

--- a/packages/farm/src/integration-client.ts
+++ b/packages/farm/src/integration-client.ts
@@ -5,10 +5,13 @@ import type {
 } from "./integration-api";
 import type { FarmIntegration as FarmIntegrationDefinition } from "./integrations";
 
+export type IntegrationClientData = Record<string, unknown>;
+
 export type IntegrationClientOptions = {
   baseURL?: string;
   headers?: Record<string, string>;
   credentials?: RequestCredentials;
+  data?: IntegrationClientData;
   isServer?: false | undefined;
 };
 
@@ -16,6 +19,7 @@ type IntegrationRequestOptionsBase = {
   headers?: Record<string, string>;
   signal?: AbortSignal;
   credentials?: RequestCredentials;
+  data?: IntegrationClientData;
 };
 
 export type IntegrationClientRequestOptions = IntegrationRequestOptionsBase;
@@ -246,7 +250,7 @@ const INTEGRATION_REQUEST_DISPATCHER_KEY = Symbol.for("farm.integrationRequestDi
 type IntegrationRequestDispatcher = (
   runtime: RegisteredIntegrationRuntime,
   request: Request,
-  options?: { currentRequest?: Request },
+  options?: { currentRequest?: Request; data?: IntegrationClientData },
 ) => Promise<Response | null>;
 
 type GlobalWithIntegrationRuntimeRegistry = typeof globalThis & {
@@ -329,6 +333,42 @@ function resolveCurrentRequestLocal(): Request | undefined {
 function resolveIntegrationRequestDispatcherLocal(): IntegrationRequestDispatcher | undefined {
   const globalState = globalThis as GlobalWithIntegrationRuntimeRegistry;
   return globalState[INTEGRATION_REQUEST_DISPATCHER_KEY];
+}
+
+const INTEGRATION_DATA_HEADER = "x-farm-integration-data";
+
+function isIntegrationClientData(value: unknown): value is IntegrationClientData {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function mergeIntegrationClientData(
+  ...values: Array<IntegrationClientData | undefined>
+): IntegrationClientData | undefined {
+  let merged: IntegrationClientData | undefined;
+
+  for (const value of values) {
+    if (!isIntegrationClientData(value)) {
+      continue;
+    }
+
+    merged = {
+      ...(merged || {}),
+      ...value,
+    };
+  }
+
+  return merged && Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function appendIntegrationClientDataHeader(
+  headers: Headers,
+  data: IntegrationClientData | undefined,
+) {
+  if (!data) {
+    return;
+  }
+
+  headers.set(INTEGRATION_DATA_HEADER, JSON.stringify(data));
 }
 
 function resolveAutomaticClientNamespaces(): ResolvedIntegrationNamespace[] {
@@ -576,7 +616,7 @@ async function finalizeOperationResponse(
 async function executeClientOperation(
   operation: FarmIntegrationAPIOperation<any, any, any>,
   input: Record<string, unknown>,
-  options: Pick<IntegrationClientOptions, "baseURL" | "headers" | "credentials">,
+  options: Pick<IntegrationClientOptions, "baseURL" | "headers" | "credentials" | "data">,
   requestOptions?: IntegrationClientRequestOptions,
 ) {
   try {
@@ -605,6 +645,11 @@ async function executeClientOperation(
     if (operation.responseFormat !== "response") {
       headers.set("accept", "application/json");
     }
+
+    appendIntegrationClientDataHeader(
+      headers,
+      mergeIntegrationClientData(options.data, requestOptions?.data),
+    );
 
     const response = await fetch(url.toString(), {
       method: operation.method,
@@ -647,7 +692,7 @@ async function executeServerOperation(
   input: Record<string, unknown>,
   options: Pick<
     IntegrationServerClientOptions,
-    "baseURL" | "headers" | "credentials" | "request" | "forwardHeaders"
+    "baseURL" | "headers" | "credentials" | "data" | "request" | "forwardHeaders"
   >,
   requestOptions?: IntegrationServerClientRequestOptions,
   integrationKey?: string,
@@ -700,6 +745,8 @@ async function executeServerOperation(
       headers.set("accept", "application/json");
     }
 
+    const data = mergeIntegrationClientData(options.data, requestOptions?.data);
+
     if (integrationKey) {
       const runtime =
         "kind" in (source || {}) &&
@@ -724,6 +771,7 @@ async function executeServerOperation(
               }),
               {
                 currentRequest,
+                data,
               },
             )
           : null;
@@ -733,6 +781,8 @@ async function executeServerOperation(
         }
       }
     }
+
+    appendIntegrationClientDataHeader(headers, data);
 
     const response = await fetch(url.toString(), {
       method: operation.method,
@@ -980,6 +1030,34 @@ export function createIntegrationApi<TSources extends Record<string, any>>(
   };
 }
 
+function isIntegrationClientOptionsInput(value: unknown): value is IntegrationClientOptions {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    ("baseURL" in value ||
+      "headers" in value ||
+      "credentials" in value ||
+      "data" in value ||
+      "isServer" in value)
+  );
+}
+
+function resolveIntegrationServerOptions(
+  clientOptions: IntegrationClientOptions = {},
+  serverOptions: Omit<IntegrationServerClientOptions, "isServer"> = {},
+): Omit<IntegrationServerClientOptions, "isServer"> {
+  const data = mergeIntegrationClientData(clientOptions.data, serverOptions.data);
+
+  return {
+    baseURL: clientOptions.baseURL,
+    headers: clientOptions.headers,
+    credentials: clientOptions.credentials,
+    ...serverOptions,
+    ...(data ? { data } : {}),
+  };
+}
+
 export function createIntegrationClients<TSources extends Record<string, any>>(
   clientOptions?: IntegrationClientOptions,
   serverOptions?: Omit<IntegrationServerClientOptions, "isServer">,
@@ -999,10 +1077,18 @@ export function createIntegrationClients<TSources extends Record<string, any>>(
   clientOptions?: IntegrationClientOptions,
   serverOptions?: Omit<IntegrationServerClientOptions, "isServer">,
 ): IntegrationClients<TSources> {
-  if (arguments.length === 0) {
+  if (arguments.length === 0 || isIntegrationClientOptionsInput(sources)) {
+    const automaticClientOptions = isIntegrationClientOptionsInput(sources) ? sources : {};
+    const automaticServerOptions = arguments.length > 1 ? clientOptions : undefined;
+
     return {
-      api: integrationsServer<TSources>(),
-      apiClient: integrationsClient<TSources>(),
+      api: integrationsServer<TSources>(
+        resolveIntegrationServerOptions(
+          automaticClientOptions,
+          automaticServerOptions as Omit<IntegrationServerClientOptions, "isServer"> | undefined,
+        ),
+      ),
+      apiClient: integrationsClient<TSources>(automaticClientOptions),
     };
   }
 
@@ -1014,7 +1100,7 @@ export function createIntegrationClients<TSources extends Record<string, any>>(
       {
         integrations: explicitSources,
       },
-      serverOptions || {},
+      resolveIntegrationServerOptions(clientOptions, serverOptions),
     ) as IntegrationServerClientAliases<TSources>,
     apiClient: createIntegrationClient(
       {
@@ -1023,6 +1109,36 @@ export function createIntegrationClients<TSources extends Record<string, any>>(
       clientOptions,
     ) as IntegrationClientAliases<TSources>,
   };
+}
+
+export function createIntegrations<TSources extends Record<string, any>>(
+  clientOptions?: IntegrationClientOptions,
+  serverOptions?: Omit<IntegrationServerClientOptions, "isServer">,
+): IntegrationClients<TSources>;
+export function createIntegrations<TSources extends Record<string, any>>(
+  sources: TSources,
+  clientOptions?: IntegrationClientOptions,
+  serverOptions?: Omit<IntegrationServerClientOptions, "isServer">,
+): IntegrationClients<TSources>;
+export function createIntegrations<TSources extends Record<string, any>>(
+  sources: { integrations: TSources },
+  clientOptions?: IntegrationClientOptions,
+  serverOptions?: Omit<IntegrationServerClientOptions, "isServer">,
+): IntegrationClients<TSources>;
+export function createIntegrations<TSources extends Record<string, any>>(
+  sources?: TSources | { integrations: TSources } | IntegrationClientOptions,
+  clientOptions?: IntegrationClientOptions,
+  serverOptions?: Omit<IntegrationServerClientOptions, "isServer">,
+): IntegrationClients<TSources> {
+  if (arguments.length === 0) {
+    return createIntegrationClients<TSources>();
+  }
+
+  return createIntegrationClients<TSources>(
+    sources as TSources,
+    clientOptions,
+    serverOptions,
+  ) as IntegrationClients<TSources>;
 }
 
 function createClientSafeIntegrationAPI(

--- a/packages/farm/src/integration-client.ts
+++ b/packages/farm/src/integration-client.ts
@@ -5,6 +5,10 @@ import type {
 } from "./integration-api";
 import type { FarmIntegration as FarmIntegrationDefinition } from "./integrations";
 
+/**
+ * Small per-call integration metadata. When sent from a browser, values are
+ * client-controlled and should be validated before authorization decisions.
+ */
 export type IntegrationClientData = Record<string, unknown>;
 
 export type IntegrationClientOptions = {
@@ -336,9 +340,58 @@ function resolveIntegrationRequestDispatcherLocal(): IntegrationRequestDispatche
 }
 
 const INTEGRATION_DATA_HEADER = "x-farm-integration-data";
+const INTEGRATION_DATA_HEADER_MAX_LENGTH = 16 * 1024;
+const BLOCKED_INTEGRATION_DATA_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
 function isIntegrationClientData(value: unknown): value is IntegrationClientData {
   return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isPlainIntegrationDataObject(value: unknown): value is Record<string, unknown> {
+  if (!isIntegrationClientData(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function sanitizeIntegrationClientDataValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeIntegrationClientDataValue(item));
+  }
+
+  if (!isPlainIntegrationDataObject(value)) {
+    return value;
+  }
+
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (BLOCKED_INTEGRATION_DATA_KEYS.has(key)) {
+      continue;
+    }
+
+    sanitized[key] = sanitizeIntegrationClientDataValue(item);
+  }
+
+  return sanitized;
+}
+
+function normalizeIntegrationClientData(
+  value: IntegrationClientData | undefined,
+): IntegrationClientData | undefined {
+  if (!isIntegrationClientData(value)) {
+    return undefined;
+  }
+
+  const sanitized = sanitizeIntegrationClientDataValue(value);
+  return isIntegrationClientData(sanitized) && Object.keys(sanitized).length > 0
+    ? sanitized
+    : undefined;
+}
+
+function getIntegrationDataHeaderByteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
 }
 
 function mergeIntegrationClientData(
@@ -347,17 +400,29 @@ function mergeIntegrationClientData(
   let merged: IntegrationClientData | undefined;
 
   for (const value of values) {
-    if (!isIntegrationClientData(value)) {
+    const data = normalizeIntegrationClientData(value);
+    if (!data) {
       continue;
     }
 
     merged = {
       ...(merged || {}),
-      ...value,
+      ...data,
     };
   }
 
   return merged && Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function serializeIntegrationClientData(data: IntegrationClientData): string {
+  const serialized = JSON.stringify(data);
+  if (getIntegrationDataHeaderByteLength(serialized) > INTEGRATION_DATA_HEADER_MAX_LENGTH) {
+    throw new Error(
+      `Integration client data must be smaller than ${INTEGRATION_DATA_HEADER_MAX_LENGTH} bytes when sent over HTTP headers.`,
+    );
+  }
+
+  return serialized;
 }
 
 function appendIntegrationClientDataHeader(
@@ -368,7 +433,7 @@ function appendIntegrationClientDataHeader(
     return;
   }
 
-  headers.set(INTEGRATION_DATA_HEADER, JSON.stringify(data));
+  headers.set(INTEGRATION_DATA_HEADER, serializeIntegrationClientData(data));
 }
 
 function resolveAutomaticClientNamespaces(): ResolvedIntegrationNamespace[] {

--- a/packages/farm/src/integrations.ts
+++ b/packages/farm/src/integrations.ts
@@ -195,6 +195,10 @@ export type FarmIntegrationLifecycleHook<
   TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
 > = (context: FarmIntegrationLifecycleContext<TConfig, TSchema>) => MaybePromise<void>;
 
+/**
+ * Small per-call integration metadata. Values received over HTTP are
+ * client-controlled and should be validated before authorization decisions.
+ */
 export type FarmIntegrationData = Record<string, unknown>;
 
 export interface FarmIntegrationHandlerContext<
@@ -1453,9 +1457,54 @@ function createIntegrationLifecycleLogger(
 }
 
 const INTEGRATION_DATA_HEADER = "x-farm-integration-data";
+const INTEGRATION_DATA_HEADER_MAX_LENGTH = 16 * 1024;
+const BLOCKED_INTEGRATION_DATA_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
 function isFarmIntegrationData(value: unknown): value is FarmIntegrationData {
   return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isPlainIntegrationDataObject(value: unknown): value is Record<string, unknown> {
+  if (!isFarmIntegrationData(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function sanitizeIntegrationDataValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeIntegrationDataValue(item));
+  }
+
+  if (!isPlainIntegrationDataObject(value)) {
+    return value;
+  }
+
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (BLOCKED_INTEGRATION_DATA_KEYS.has(key)) {
+      continue;
+    }
+
+    sanitized[key] = sanitizeIntegrationDataValue(item);
+  }
+
+  return sanitized;
+}
+
+function normalizeIntegrationData(value: FarmIntegrationData | undefined): FarmIntegrationData {
+  if (!isFarmIntegrationData(value)) {
+    return {};
+  }
+
+  const sanitized = sanitizeIntegrationDataValue(value);
+  return isFarmIntegrationData(sanitized) ? sanitized : {};
+}
+
+function getIntegrationDataHeaderByteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
 }
 
 function parseIntegrationDataHeader(request: Request): FarmIntegrationData {
@@ -1464,9 +1513,13 @@ function parseIntegrationDataHeader(request: Request): FarmIntegrationData {
     return {};
   }
 
+  if (getIntegrationDataHeaderByteLength(raw) > INTEGRATION_DATA_HEADER_MAX_LENGTH) {
+    return {};
+  }
+
   try {
     const value = JSON.parse(raw);
-    return isFarmIntegrationData(value) ? value : {};
+    return normalizeIntegrationData(value);
   } catch {
     return {};
   }
@@ -1475,7 +1528,7 @@ function parseIntegrationDataHeader(request: Request): FarmIntegrationData {
 function resolveIntegrationData(request: Request, data?: FarmIntegrationData): FarmIntegrationData {
   return {
     ...parseIntegrationDataHeader(request),
-    ...(isFarmIntegrationData(data) ? data : {}),
+    ...normalizeIntegrationData(data),
   };
 }
 

--- a/packages/farm/src/integrations.ts
+++ b/packages/farm/src/integrations.ts
@@ -195,6 +195,8 @@ export type FarmIntegrationLifecycleHook<
   TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
 > = (context: FarmIntegrationLifecycleContext<TConfig, TSchema>) => MaybePromise<void>;
 
+export type FarmIntegrationData = Record<string, unknown>;
+
 export interface FarmIntegrationHandlerContext<
   TBody = unknown,
   TQuery = unknown,
@@ -208,6 +210,7 @@ export interface FarmIntegrationHandlerContext<
   params: FarmIntegrationRouteParams;
   input: FarmIntegrationRouteInput<TBody, TQuery>;
   args: FarmIntegrationRouteArgs<TSchema>;
+  data: FarmIntegrationData;
   integration: {
     category: FarmIntegrationCategory;
     /** @deprecated Use category instead. */
@@ -1449,6 +1452,33 @@ function createIntegrationLifecycleLogger(
   };
 }
 
+const INTEGRATION_DATA_HEADER = "x-farm-integration-data";
+
+function isFarmIntegrationData(value: unknown): value is FarmIntegrationData {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseIntegrationDataHeader(request: Request): FarmIntegrationData {
+  const raw = request.headers.get(INTEGRATION_DATA_HEADER);
+  if (!raw) {
+    return {};
+  }
+
+  try {
+    const value = JSON.parse(raw);
+    return isFarmIntegrationData(value) ? value : {};
+  } catch {
+    return {};
+  }
+}
+
+function resolveIntegrationData(request: Request, data?: FarmIntegrationData): FarmIntegrationData {
+  return {
+    ...parseIntegrationDataHeader(request),
+    ...(isFarmIntegrationData(data) ? data : {}),
+  };
+}
+
 function createIntegrationPlugin(integrationKey: string, integration: FarmIntegration): FarmPlugin {
   const routes = normalizeIntegrationRoutes(integration.routes || []);
   const middleware = [...(integration.middleware || [])];
@@ -1885,6 +1915,7 @@ function createIntegrationHandlerContext(input: {
       integration: input.integration,
       config: input.pluginContext.config,
     }),
+    data: resolveIntegrationData(input.request),
     integration: {
       category: input.integration.category,
       slot: input.integration.category,
@@ -2376,6 +2407,7 @@ export async function dispatchIntegrationRequest(
   request: Request,
   options: {
     currentRequest?: Request;
+    data?: FarmIntegrationData;
   } = {},
 ): Promise<Response | null> {
   const integration = runtime.integration;
@@ -2406,6 +2438,7 @@ export async function dispatchIntegrationRequest(
       pathname,
       requestId,
       currentRequest: options.currentRequest,
+      data: options.data,
     });
     const startedAt = Date.now();
 
@@ -2502,6 +2535,7 @@ export async function dispatchIntegrationRequest(
       pathname,
       requestId,
       currentRequest: options.currentRequest,
+      data: options.data,
     });
     const startedAt = Date.now();
 
@@ -2696,6 +2730,7 @@ function createServerIntegrationHandlerContext(input: {
   pathname: string;
   requestId: string;
   currentRequest?: Request;
+  data?: FarmIntegrationData;
 }): FarmIntegrationHandlerContext {
   return {
     request: input.request,
@@ -2709,6 +2744,7 @@ function createServerIntegrationHandlerContext(input: {
       integration: input.runtime.integration,
       config: input.runtime.config,
     }),
+    data: resolveIntegrationData(input.request, input.data),
     integration: {
       category: input.runtime.integration.category,
       slot: input.runtime.integration.category,

--- a/packages/farm/types/client.d.ts
+++ b/packages/farm/types/client.d.ts
@@ -625,6 +625,10 @@ declare module "@farmjs/core/client" {
 
   export const endpoint: typeof api;
 
+  /**
+   * Small per-call integration metadata. When sent from a browser, values are
+   * client-controlled and should be validated before authorization decisions.
+   */
   export type IntegrationClientData = Record<string, unknown>;
 
   export interface IntegrationClientOptions {

--- a/packages/farm/types/client.d.ts
+++ b/packages/farm/types/client.d.ts
@@ -625,10 +625,13 @@ declare module "@farmjs/core/client" {
 
   export const endpoint: typeof api;
 
+  export type IntegrationClientData = Record<string, unknown>;
+
   export interface IntegrationClientOptions {
     baseURL?: string;
     headers?: Record<string, string>;
     credentials?: RequestCredentials;
+    data?: IntegrationClientData;
     isServer?: false | undefined;
   }
 
@@ -636,6 +639,7 @@ declare module "@farmjs/core/client" {
     headers?: Record<string, string>;
     signal?: AbortSignal;
     credentials?: RequestCredentials;
+    data?: IntegrationClientData;
   }
 
   export interface IntegrationClientRequestOptions extends IntegrationRequestOptionsBase {}
@@ -917,6 +921,23 @@ declare module "@farmjs/core/client" {
   ): IntegrationClients<TSources>;
 
   export function createIntegrationClients<TSources extends Record<string, any>>(
+    sources: { integrations: TSources },
+    clientOptions?: IntegrationClientOptions,
+    serverOptions?: Omit<IntegrationServerClientOptions, "isServer">,
+  ): IntegrationClients<TSources>;
+
+  export function createIntegrations<TSources extends Record<string, any>>(
+    clientOptions?: IntegrationClientOptions,
+    serverOptions?: Omit<IntegrationServerClientOptions, "isServer">,
+  ): IntegrationClients<TSources>;
+
+  export function createIntegrations<TSources extends Record<string, any>>(
+    sources: TSources,
+    clientOptions?: IntegrationClientOptions,
+    serverOptions?: Omit<IntegrationServerClientOptions, "isServer">,
+  ): IntegrationClients<TSources>;
+
+  export function createIntegrations<TSources extends Record<string, any>>(
     sources: { integrations: TSources },
     clientOptions?: IntegrationClientOptions,
     serverOptions?: Omit<IntegrationServerClientOptions, "isServer">,


### PR DESCRIPTION
## Summary
- add `data` to integration client/server options and per-call request options
- expose merged values as `ctx.data` for integration routes, middleware, and hooks
- add `createIntegrations(...)` as the compact helper for paired server/client integration APIs
- harden browser/HTTP data transport by stripping prototype-pollution keys, capping header payload size, and documenting that HTTP data is client-controlled

## Testing
- `corepack pnpm@8.12.1 --filter @farmjs/core exec vitest run src/__tests__/integration-client.test.ts src/__tests__/integrations.test.ts`
- `corepack pnpm@8.12.1 --filter @farmjs/core run build`
- `corepack pnpm@8.12.1 --filter @farmjs/integrations run build`
- `corepack pnpm@8.12.1 exec oxfmt --check ...touched files...`

## Notes
- `corepack pnpm@8.12.1 --filter @farmjs/core run type-check` still fails on existing Nitro/query-state issues unrelated to this change.