### PR TITLE
feat: add unkey api key integration

### DIFF
--- a/examples/auth0-integration/src/lib/api.ts
+++ b/examples/auth0-integration/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { integrationsClient, integrationsServer } from "@farmjs/core/client";
+import { createIntegrations } from "@farmjs/core/client";
 import { auth0Client } from "@farmjs/integrations/auth0/client";
 
 const auth0Api = {
@@ -20,5 +20,4 @@ type Auth0IntegrationSources = {
   auth: typeof auth0Api;
 };
 
-export const api = integrationsServer<Auth0IntegrationSources>();
-export const apiClient = integrationsClient<Auth0IntegrationSources>();
+export const { api, apiClient } = createIntegrations<Auth0IntegrationSources>();

--- a/examples/autumn-integration/src/lib/api.ts
+++ b/examples/autumn-integration/src/lib/api.ts
@@ -1,5 +1,4 @@
-import { integrationClients } from "@farmjs/core/client";
+import { createIntegrations } from "@farmjs/core/client";
 import type { AppIntegrations } from "./integrations";
 
-export const { api, apiClient } = integrationClients<AppIntegrations>();
-
+export const { api, apiClient } = createIntegrations<AppIntegrations>();

--- a/examples/email-integrations/resend-example/src/lib/api.ts
+++ b/examples/email-integrations/resend-example/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { integrationClients } from "@farmjs/core/client";
+import { createIntegrations } from "@farmjs/core/client";
 import type { AppIntegrations } from "./integrations";
 
-export const { api, apiClient } = integrationClients<AppIntegrations>();
+export const { api, apiClient } = createIntegrations<AppIntegrations>();

--- a/examples/jobs-inngest/src/lib/api.client.ts
+++ b/examples/jobs-inngest/src/lib/api.client.ts
@@ -1,4 +1,4 @@
-import { integrationsClient } from "@farmjs/core/client";
+import { createIntegrations } from "@farmjs/core/client";
 import type { AppIntegrations } from "./integrations";
 
-export const apiClient = integrationsClient<AppIntegrations>();
+export const { apiClient } = createIntegrations<AppIntegrations>();

--- a/examples/jobs-inngest/src/lib/api.server.ts
+++ b/examples/jobs-inngest/src/lib/api.server.ts
@@ -1,4 +1,4 @@
-import { integrationsServer } from "@farmjs/core/client";
+import { createIntegrations } from "@farmjs/core/client";
 import type { AppIntegrations } from "./integrations";
 
-export const api = integrationsServer<AppIntegrations>();
+export const { api } = createIntegrations<AppIntegrations>();

--- a/examples/jobs-integration/src/lib/api.server.ts
+++ b/examples/jobs-integration/src/lib/api.server.ts
@@ -1,4 +1,4 @@
-import { integrationsServer } from "@farmjs/core/client";
+import { createIntegrations } from "@farmjs/core/client";
 import type { AppIntegrations } from "./integrations";
 
-export const api = integrationsServer<AppIntegrations>();
+export const { api } = createIntegrations<AppIntegrations>();

--- a/examples/jobs-trigger/src/lib/api.client.ts
+++ b/examples/jobs-trigger/src/lib/api.client.ts
@@ -1,4 +1,4 @@
-import { integrationsClient } from "@farmjs/core/client";
+import { createIntegrations } from "@farmjs/core/client";
 import type { AppIntegrations } from "./integrations";
 
-export const apiClient = integrationsClient<AppIntegrations>();
+export const { apiClient } = createIntegrations<AppIntegrations>();

--- a/examples/jobs-trigger/src/lib/api.server.ts
+++ b/examples/jobs-trigger/src/lib/api.server.ts
@@ -1,4 +1,4 @@
-import { integrationsServer } from "@farmjs/core/client";
+import { createIntegrations } from "@farmjs/core/client";
 import type { AppIntegrations } from "./integrations";
 
-export const api = integrationsServer<AppIntegrations>();
+export const { api } = createIntegrations<AppIntegrations>();

--- a/examples/polar-integration/src/lib/api.ts
+++ b/examples/polar-integration/src/lib/api.ts
@@ -1,5 +1,4 @@
-import { integrationClients } from "@farmjs/core/client";
+import { createIntegrations } from "@farmjs/core/client";
 import type { AppIntegrations } from "./integrations";
 
-export const { api, apiClient } = integrationClients<AppIntegrations>();
-
+export const { api, apiClient } = createIntegrations<AppIntegrations>();

--- a/examples/stripe-integration/src/lib/api.ts
+++ b/examples/stripe-integration/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { integrationClients } from "@farmjs/core/client";
+import { createIntegrations } from "@farmjs/core/client";
 import type { AppIntegrations } from "./integrations";
 
-export const { api, apiClient } = integrationClients<AppIntegrations>();
+export const { api, apiClient } = createIntegrations<AppIntegrations>();

--- a/examples/stripe-integrations/drizzle/src/lib/api.ts
+++ b/examples/stripe-integrations/drizzle/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { integrationClients } from "@farmjs/core/client";
+import { createIntegrations } from "@farmjs/core/client";
 import type { AppIntegrations } from "./integrations";
 
-export const { api, apiClient } = integrationClients<AppIntegrations>();
+export const { api, apiClient } = createIntegrations<AppIntegrations>();

--- a/examples/stripe-integrations/prisma-org/src/lib/api.ts
+++ b/examples/stripe-integrations/prisma-org/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { integrationClients } from "@farmjs/core/client";
+import { createIntegrations } from "@farmjs/core/client";
 import type { AppIntegrations } from "./integrations";
 
-export const { api, apiClient } = integrationClients<AppIntegrations>();
+export const { api, apiClient } = createIntegrations<AppIntegrations>();

--- a/examples/stripe-integrations/prisma/src/lib/api.ts
+++ b/examples/stripe-integrations/prisma/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { integrationClients } from "@farmjs/core/client";
+import { createIntegrations } from "@farmjs/core/client";
 import type { AppIntegrations } from "./integrations";
 
-export const { api, apiClient } = integrationClients<AppIntegrations>();
+export const { api, apiClient } = createIntegrations<AppIntegrations>();

--- a/examples/stripe-integrations/sqlite/src/lib/api.ts
+++ b/examples/stripe-integrations/sqlite/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { integrationClients } from "@farmjs/core/client";
+import { createIntegrations } from "@farmjs/core/client";
 import type { AppIntegrations } from "./integrations";
 
-export const { api, apiClient } = integrationClients<AppIntegrations>();
+export const { api, apiClient } = createIntegrations<AppIntegrations>();

--- a/examples/supabase-integration/README.md
+++ b/examples/supabase-integration/README.md
@@ -45,11 +45,10 @@ The integration owns:
 Create the shared callers once and reuse them in your pages:
 
 ```ts
-import { integrationsClient, integrationsServer } from "@farmjs/core/client";
+import { createIntegrations } from "@farmjs/core/client";
 import type { AppIntegrations } from "./src/lib/integrations";
 
-export const api = integrationsServer<AppIntegrations>();
-export const apiClient = integrationsClient<AppIntegrations>();
+export const { api, apiClient } = createIntegrations<AppIntegrations>();
 ```
 
 Client usage:

--- a/examples/supabase-integration/src/lib/api.ts
+++ b/examples/supabase-integration/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { integrationsClient, integrationsServer } from "@farmjs/core/client";
+import { createIntegrations } from "@farmjs/core/client";
 import { supabaseClient } from "@farmjs/integrations/supabase/client";
 import type { InferIntegrationAPIFromRoutes } from "@farmjs/core";
 import type { localDemoRoutes } from "./integrations/local-demo/index.ts";
@@ -24,5 +24,4 @@ type SupabaseIntegrationSources = {
   localDemo: InferIntegrationAPIFromRoutes<typeof localDemoRoutes>;
 };
 
-export const api = integrationsServer<SupabaseIntegrationSources>();
-export const apiClient = integrationsClient<SupabaseIntegrationSources>();
+export const { api, apiClient } = createIntegrations<SupabaseIntegrationSources>();

--- a/examples/workos-integration/src/lib/api.ts
+++ b/examples/workos-integration/src/lib/api.ts
@@ -1,5 +1,4 @@
-import { integrationsClient, integrationsServer } from "@farmjs/core/client";
+import { createIntegrations } from "@farmjs/core/client";
 import type { AppIntegrations } from "./integrations";
 
-export const api = integrationsServer<AppIntegrations>();
-export const apiClient = integrationsClient<AppIntegrations>();
+export const { api, apiClient } = createIntegrations<AppIntegrations>();

--- a/packages/farm-integrations/package.json
+++ b/packages/farm-integrations/package.json
@@ -98,6 +98,10 @@
     "./supabase/client": {
       "types": "./dist/supabase/client.d.ts",
       "import": "./dist/supabase/client.js"
+    },
+    "./unkey": {
+      "types": "./dist/unkey/index.d.ts",
+      "import": "./dist/unkey/index.js"
     }
   },
   "scripts": {

--- a/packages/farm-integrations/src/farm-core-shim.d.ts
+++ b/packages/farm-integrations/src/farm-core-shim.d.ts
@@ -89,6 +89,8 @@ declare module "@farmjs/core" {
     snapshot(options?: { exposedOnly?: boolean }): Map<string, unknown>;
   }
 
+  export const FARM_INTEGRATION_INTERNAL_DISPATCH_CONTEXT_KEY: "farm.integration.internalDispatch";
+
   export type FarmIntegrationRouteDb<TSchema extends FarmIntegrationSchema | undefined> = Record<
     string,
     any
@@ -447,7 +449,7 @@ declare module "@farmjs/core" {
   }
 
   export type FarmIntegrationAPI = {
-    [key: string]: FarmIntegrationAPI | FarmIntegrationAPIOperation<any, any, any>;
+    [key: string]: FarmIntegrationAPI | FarmIntegrationAPIOperation<any, any, any, any, any>;
   };
 
   export type FarmIntegrationRouteOperationCarrier<

--- a/packages/farm-integrations/src/index.ts
+++ b/packages/farm-integrations/src/index.ts
@@ -21,6 +21,7 @@ export { workos } from "./workos/index.js";
 export { workosClient } from "./workos/client.js";
 export { supabase } from "./supabase/index.js";
 export { supabaseClient, supabaseAuthFormFields } from "./supabase/client.js";
+export { createUnkeyClient, unkey, UnkeyAPIError } from "./unkey/index.js";
 export {
   drizzleStorageAdapter,
   prismaStorageAdapter,
@@ -28,6 +29,25 @@ export {
   stripe,
   stripeSchema,
 } from "./stripe/index.js";
+export type {
+  UnkeyAPIEnvelope,
+  UnkeyClient,
+  UnkeyClientOptions,
+  UnkeyCreateKeyInput,
+  UnkeyCreateKeyResult,
+  UnkeyCreditsInput,
+  UnkeyDeleteKeyInput,
+  UnkeyIntegrationInput,
+  UnkeyIntegrationPaths,
+  UnkeyProtectionOptions,
+  UnkeyRatelimitRequest,
+  UnkeyRatelimitState,
+  UnkeyRevokeKeyInput,
+  UnkeyUpdateKeyInput,
+  UnkeyVerificationIdentity,
+  UnkeyVerifyKeyInput,
+  UnkeyVerifyKeyResult,
+} from "./unkey/index.js";
 export type {
   AIChatPrepareContext,
   AIChatRequestBody,

--- a/packages/farm-integrations/src/unkey/index.ts
+++ b/packages/farm-integrations/src/unkey/index.ts
@@ -1,0 +1,708 @@
+import {
+  FARM_INTEGRATION_INTERNAL_DISPATCH_CONTEXT_KEY,
+  defineIntegration,
+  integrationRoute,
+  type FarmIntegrationHandlerContext,
+  type FarmIntegrationLogger,
+} from "@farmjs/core";
+import { api as clientApi } from "@farmjs/core/client";
+import { createPathInferredClientApi, integrationConfig } from "../utils/index.js";
+
+const DEFAULT_UNKEY_BASE_URL = "https://api.unkey.com";
+
+export interface UnkeyAPIEnvelope<TData> {
+  meta?: {
+    requestId?: string;
+    [key: string]: unknown;
+  };
+  data: TData;
+}
+
+export interface UnkeyRatelimitRequest {
+  name: string;
+  limit?: number;
+  duration?: number;
+  cost?: number;
+  autoApply?: boolean;
+}
+
+export interface UnkeyCreditsInput {
+  remaining?: number | null;
+  refill?: {
+    interval: "daily" | "monthly";
+    amount: number;
+    refillDay?: number;
+  } | null;
+}
+
+export interface UnkeyCreateKeyInput {
+  apiId?: string;
+  prefix?: string;
+  name?: string;
+  byteLength?: number;
+  externalId?: string;
+  meta?: Record<string, unknown>;
+  roles?: string[];
+  permissions?: string[];
+  expires?: number;
+  credits?: UnkeyCreditsInput;
+  ratelimits?: UnkeyRatelimitRequest[];
+}
+
+export interface UnkeyCreateKeyResult {
+  keyId: string;
+  key: string;
+}
+
+export interface UnkeyVerifyKeyInput {
+  key: string;
+  tags?: string[];
+  permissions?: string;
+  credits?: {
+    cost?: number;
+  };
+  ratelimits?: Array<{
+    name: string;
+    cost?: number;
+    limit?: number;
+    duration?: number;
+  }>;
+  migrationId?: string;
+}
+
+export interface UnkeyVerificationIdentity {
+  id?: string;
+  externalId?: string;
+  meta?: Record<string, unknown>;
+  ratelimits?: UnkeyRatelimitRequest[];
+}
+
+export interface UnkeyRatelimitState {
+  exceeded?: boolean;
+  id?: string;
+  name?: string;
+  limit?: number;
+  duration?: number;
+  reset?: number;
+  remaining?: number;
+  autoApply?: boolean;
+}
+
+export interface UnkeyVerifyKeyResult {
+  valid: boolean;
+  code?: string;
+  keyId?: string;
+  name?: string;
+  meta?: Record<string, unknown>;
+  expires?: number;
+  credits?: number;
+  enabled?: boolean;
+  permissions?: string[];
+  roles?: string[];
+  identity?: UnkeyVerificationIdentity;
+  ratelimits?: UnkeyRatelimitState[];
+}
+
+export interface UnkeyUpdateKeyInput {
+  keyId: string;
+  name?: string | null;
+  externalId?: string | null;
+  meta?: Record<string, unknown> | null;
+  expires?: number | null;
+  credits?: UnkeyCreditsInput | null;
+  ratelimits?: UnkeyRatelimitRequest[] | null;
+  enabled?: boolean;
+  roles?: string[];
+  permissions?: string[];
+}
+
+export interface UnkeyDeleteKeyInput {
+  keyId: string;
+  permanent?: boolean;
+}
+
+export interface UnkeyRevokeKeyInput {
+  keyId: string;
+}
+
+export interface UnkeyClient {
+  createKey(input: UnkeyCreateKeyInput): Promise<UnkeyCreateKeyResult>;
+  verifyKey(input: UnkeyVerifyKeyInput): Promise<UnkeyVerifyKeyResult>;
+  updateKey(input: UnkeyUpdateKeyInput): Promise<Record<string, never>>;
+  revokeKey(input: UnkeyRevokeKeyInput): Promise<Record<string, never>>;
+  deleteKey(input: UnkeyDeleteKeyInput): Promise<Record<string, never>>;
+}
+
+export interface UnkeyClientOptions {
+  rootKey?: string;
+  apiId?: string;
+  baseUrl?: string;
+  fetch?: typeof fetch;
+}
+
+export class UnkeyAPIError<TData = unknown> extends Error {
+  readonly status: number;
+  readonly requestId: string | undefined;
+  readonly data: TData | undefined;
+
+  constructor(message: string, options: { status: number; requestId?: string; data?: TData }) {
+    super(message);
+    this.name = "UnkeyAPIError";
+    this.status = options.status;
+    this.requestId = options.requestId;
+    this.data = options.data;
+  }
+}
+
+export function createUnkeyClient(options: UnkeyClientOptions = {}): UnkeyClient {
+  return new UnkeyHttpClient(options);
+}
+
+class UnkeyHttpClient implements UnkeyClient {
+  private readonly rootKey: string | undefined;
+  private readonly apiId: string | undefined;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: UnkeyClientOptions) {
+    this.rootKey = options.rootKey ?? process.env.UNKEY_ROOT_KEY ?? undefined;
+    this.apiId = options.apiId ?? process.env.UNKEY_API_ID ?? undefined;
+    this.baseUrl = options.baseUrl ?? process.env.UNKEY_BASE_URL ?? DEFAULT_UNKEY_BASE_URL;
+    this.fetchImpl = options.fetch ?? fetch;
+  }
+
+  createKey(input: UnkeyCreateKeyInput): Promise<UnkeyCreateKeyResult> {
+    const apiId = input.apiId ?? this.apiId;
+    if (!apiId) {
+      throw new Error("Unkey createKey requires UNKEY_API_ID, options.apiId, or input.apiId.");
+    }
+
+    return this.request<UnkeyCreateKeyResult>("keys.createKey", {
+      ...input,
+      apiId,
+    });
+  }
+
+  verifyKey(input: UnkeyVerifyKeyInput): Promise<UnkeyVerifyKeyResult> {
+    return this.request<UnkeyVerifyKeyResult>("keys.verifyKey", input);
+  }
+
+  updateKey(input: UnkeyUpdateKeyInput): Promise<Record<string, never>> {
+    return this.request<Record<string, never>>("keys.updateKey", input);
+  }
+
+  revokeKey(input: UnkeyRevokeKeyInput): Promise<Record<string, never>> {
+    return this.updateKey({
+      keyId: input.keyId,
+      enabled: false,
+    });
+  }
+
+  deleteKey(input: UnkeyDeleteKeyInput): Promise<Record<string, never>> {
+    return this.request<Record<string, never>>("keys.deleteKey", input);
+  }
+
+  private async request<TData>(operation: string, body: unknown): Promise<TData> {
+    if (!this.rootKey) {
+      throw new Error("Unkey client requires UNKEY_ROOT_KEY or options.rootKey.");
+    }
+
+    const response = await this.fetchImpl(`${this.baseUrl.replace(/\/+$/, "")}/v2/${operation}`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${this.rootKey}`,
+        "content-type": "application/json",
+        accept: "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    const payload = await parseUnkeyResponse(response);
+    if (!response.ok) {
+      throw createUnkeyError(response, payload);
+    }
+
+    return ((payload as UnkeyAPIEnvelope<TData>).data ?? {}) as TData;
+  }
+}
+
+async function parseUnkeyResponse(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return {
+      message: text,
+    };
+  }
+}
+
+function createUnkeyError(response: Response, payload: unknown): UnkeyAPIError {
+  const data = isRecord(payload) ? payload : undefined;
+  const error = isRecord(data?.error) ? data.error : undefined;
+  const message =
+    getString(error?.message) ||
+    getString(data?.message) ||
+    response.statusText ||
+    "Unkey API request failed.";
+  const requestId =
+    getString(data?.requestId) ||
+    (isRecord(data?.meta) ? getString(data.meta.requestId) : undefined);
+
+  return new UnkeyAPIError(message, {
+    status: response.status,
+    requestId,
+    data,
+  });
+}
+
+export interface UnkeyIntegrationPaths {
+  basePath?: string;
+  create?: string;
+  verify?: string;
+  update?: string;
+  revoke?: string;
+  deleteKey?: string;
+}
+
+interface ResolvedUnkeyPaths {
+  create: string;
+  verify: string;
+  update: string;
+  revoke: string;
+  deleteKey: string;
+}
+
+export interface UnkeyProtectionOptions {
+  matcher?: string | string[];
+  headers?: string | string[];
+  permissions?: string;
+  tags?: string[] | ((request: Request, context: FarmIntegrationHandlerContext) => string[]);
+  contextKey?: string;
+  exposeToPage?: boolean;
+  onVerified?: (
+    request: Request,
+    context: FarmIntegrationHandlerContext,
+    result: UnkeyVerifyKeyResult,
+  ) => Promise<Response | void> | Response | void;
+  onDenied?: (
+    request: Request,
+    context: FarmIntegrationHandlerContext,
+    result: UnkeyVerifyKeyResult | { valid: false; code: "MISSING_KEY" | "VERIFY_ERROR" },
+  ) => Promise<Response | void> | Response | void;
+}
+
+export interface UnkeyIntegrationInput extends UnkeyClientOptions {
+  client?: UnkeyClient;
+  paths?: UnkeyIntegrationPaths;
+  protectedRoutes?: string | string[];
+  protection?: UnkeyProtectionOptions;
+  log?: FarmIntegrationLogger;
+}
+
+interface ResolvedUnkeyConfig {
+  rootKey?: string;
+  apiId?: string;
+  baseUrl: string;
+}
+
+function createUnkeyApi(paths: ResolvedUnkeyPaths) {
+  return createPathInferredClientApi(
+    {
+      path: paths.create,
+      operation: clientApi.post<UnkeyCreateKeyInput, UnkeyCreateKeyResult, never, true>(
+        paths.create,
+        {
+          responseFormat: "json",
+          isServer: true,
+        },
+      ),
+    },
+    {
+      path: paths.verify,
+      operation: clientApi.post<UnkeyVerifyKeyInput, UnkeyVerifyKeyResult, never, true>(
+        paths.verify,
+        {
+          responseFormat: "json",
+          isServer: true,
+        },
+      ),
+    },
+    {
+      path: paths.update,
+      operation: clientApi.post<UnkeyUpdateKeyInput, Record<string, never>, never, true>(
+        paths.update,
+        {
+          responseFormat: "json",
+          isServer: true,
+        },
+      ),
+    },
+    {
+      path: paths.revoke,
+      operation: clientApi.post<UnkeyRevokeKeyInput, Record<string, never>, never, true>(
+        paths.revoke,
+        {
+          responseFormat: "json",
+          isServer: true,
+        },
+      ),
+    },
+    {
+      path: paths.deleteKey,
+      operation: clientApi.post<UnkeyDeleteKeyInput, Record<string, never>, never, true>(
+        paths.deleteKey,
+        {
+          responseFormat: "json",
+          isServer: true,
+        },
+      ),
+    },
+  );
+}
+
+export function unkey(input: UnkeyIntegrationInput = {}) {
+  const config = resolveUnkeyConfig(input);
+  const paths = resolveUnkeyPaths(input.paths);
+  const hasInjectedClient = !!input.client;
+  const client = input.client ?? createUnkeyClient(config);
+  const protection = input.protection;
+  const protectedRoutes = input.protectedRoutes ?? protection?.matcher;
+
+  return defineIntegration({
+    category: "auth",
+    type: "unkey",
+    instance: {
+      apiId: config.apiId,
+      baseUrl: config.baseUrl,
+      client,
+    },
+    api: createUnkeyApi(paths),
+    config: integrationConfig<ResolvedUnkeyConfig>({
+      label: "Unkey integration",
+      env: {
+        rootKey: "UNKEY_ROOT_KEY",
+        apiId: "UNKEY_API_ID",
+        baseUrl: "UNKEY_BASE_URL",
+      },
+      defaults: {
+        baseUrl: DEFAULT_UNKEY_BASE_URL,
+      },
+      input: config,
+      required: hasInjectedClient ? [] : ["rootKey"],
+    }),
+    log: input.log,
+    middleware: protectedRoutes
+      ? [
+          {
+            matcher: protectedRoutes,
+            handler(request, context) {
+              return verifyProtectedRequest(request, context, client, protection);
+            },
+          },
+        ]
+      : undefined,
+    routes: [
+      integrationRoute.post<
+        typeof paths.create,
+        UnkeyCreateKeyInput,
+        UnkeyCreateKeyResult,
+        never,
+        true
+      >(paths.create, {
+        responseFormat: "json",
+        isServer: true,
+        async handler(request, context) {
+          const blocked = ensureInternalServerCall(context);
+          if (blocked) {
+            return blocked;
+          }
+
+          const body = await readJsonBody<UnkeyCreateKeyInput>(request);
+          if (!hasInjectedClient && !body.apiId && !config.apiId) {
+            return Response.json(
+              {
+                error: "Unkey create key requires UNKEY_API_ID, options.apiId, or body.apiId.",
+              },
+              {
+                status: 400,
+              },
+            );
+          }
+
+          return Response.json(
+            await client.createKey({
+              ...body,
+              apiId: body.apiId ?? config.apiId,
+            }),
+          );
+        },
+      }),
+      integrationRoute.post<
+        typeof paths.verify,
+        UnkeyVerifyKeyInput,
+        UnkeyVerifyKeyResult,
+        never,
+        true
+      >(paths.verify, {
+        responseFormat: "json",
+        isServer: true,
+        async handler(request, context) {
+          const blocked = ensureInternalServerCall(context);
+          if (blocked) {
+            return blocked;
+          }
+
+          return Response.json(
+            await client.verifyKey(await readJsonBody<UnkeyVerifyKeyInput>(request)),
+          );
+        },
+      }),
+      integrationRoute.post<
+        typeof paths.update,
+        UnkeyUpdateKeyInput,
+        Record<string, never>,
+        never,
+        true
+      >(paths.update, {
+        responseFormat: "json",
+        isServer: true,
+        async handler(request, context) {
+          const blocked = ensureInternalServerCall(context);
+          if (blocked) {
+            return blocked;
+          }
+
+          return Response.json(
+            await client.updateKey(await readJsonBody<UnkeyUpdateKeyInput>(request)),
+          );
+        },
+      }),
+      integrationRoute.post<
+        typeof paths.revoke,
+        UnkeyRevokeKeyInput,
+        Record<string, never>,
+        never,
+        true
+      >(paths.revoke, {
+        responseFormat: "json",
+        isServer: true,
+        async handler(request, context) {
+          const blocked = ensureInternalServerCall(context);
+          if (blocked) {
+            return blocked;
+          }
+
+          return Response.json(
+            await client.revokeKey(await readJsonBody<UnkeyRevokeKeyInput>(request)),
+          );
+        },
+      }),
+      integrationRoute.post<
+        typeof paths.deleteKey,
+        UnkeyDeleteKeyInput,
+        Record<string, never>,
+        never,
+        true
+      >(paths.deleteKey, {
+        responseFormat: "json",
+        isServer: true,
+        async handler(request, context) {
+          const blocked = ensureInternalServerCall(context);
+          if (blocked) {
+            return blocked;
+          }
+
+          return Response.json(
+            await client.deleteKey(await readJsonBody<UnkeyDeleteKeyInput>(request)),
+          );
+        },
+      }),
+    ],
+  });
+}
+
+function resolveUnkeyConfig(input: UnkeyIntegrationInput): ResolvedUnkeyConfig {
+  return {
+    rootKey: input.rootKey ?? process.env.UNKEY_ROOT_KEY ?? undefined,
+    apiId: input.apiId ?? process.env.UNKEY_API_ID ?? undefined,
+    baseUrl: input.baseUrl ?? process.env.UNKEY_BASE_URL ?? DEFAULT_UNKEY_BASE_URL,
+  };
+}
+
+function resolveUnkeyPaths(paths: UnkeyIntegrationPaths = {}): ResolvedUnkeyPaths {
+  const basePath = normalizePath(paths.basePath ?? "/api/unkey");
+
+  return {
+    create: normalizePath(paths.create ?? `${basePath}/create`),
+    verify: normalizePath(paths.verify ?? `${basePath}/verify`),
+    update: normalizePath(paths.update ?? `${basePath}/update`),
+    revoke: normalizePath(paths.revoke ?? `${basePath}/revoke`),
+    deleteKey: normalizePath(paths.deleteKey ?? `${basePath}/delete-key`),
+  };
+}
+
+function normalizePath(path: string): string {
+  return path.startsWith("/") ? path : `/${path}`;
+}
+
+async function readJsonBody<T>(request: Request): Promise<T> {
+  const text = await request.text();
+  if (!text) {
+    return {} as T;
+  }
+
+  return JSON.parse(text) as T;
+}
+
+function ensureInternalServerCall(context: FarmIntegrationHandlerContext): Response | undefined {
+  if (context.requestContext.get(FARM_INTEGRATION_INTERNAL_DISPATCH_CONTEXT_KEY) === true) {
+    return undefined;
+  }
+
+  return Response.json(
+    {
+      error: "Not found",
+    },
+    {
+      status: 404,
+    },
+  );
+}
+
+async function verifyProtectedRequest(
+  request: Request,
+  context: FarmIntegrationHandlerContext,
+  client: UnkeyClient,
+  options: UnkeyProtectionOptions = {},
+): Promise<Response | void> {
+  const key = getApiKeyFromRequest(request, options.headers);
+  if (!key) {
+    return (
+      (await options.onDenied?.(request, context, {
+        valid: false,
+        code: "MISSING_KEY",
+      })) ||
+      Response.json(
+        {
+          error: "Missing API key",
+          code: "MISSING_KEY",
+        },
+        {
+          status: 401,
+        },
+      )
+    );
+  }
+
+  try {
+    const result = await client.verifyKey({
+      key,
+      permissions: options.permissions,
+      tags: resolveProtectionTags(request, context, options.tags),
+    });
+
+    if (result.valid) {
+      const contextKey = options.contextKey ?? "unkey";
+      context.requestContext.set(contextKey, result, {
+        exposeToPage: options.exposeToPage,
+      });
+      context.requestContext.set("apiKey", result, {
+        exposeToPage: options.exposeToPage,
+      });
+      if (result.keyId) {
+        context.requestContext.set("apiKeyId", result.keyId, {
+          exposeToPage: options.exposeToPage,
+        });
+      }
+      if (result.identity?.externalId) {
+        context.requestContext.set("apiKeyOwnerId", result.identity.externalId, {
+          exposeToPage: options.exposeToPage,
+        });
+      }
+
+      return options.onVerified?.(request, context, result);
+    }
+
+    const override = await options.onDenied?.(request, context, result);
+    if (override) {
+      return override;
+    }
+
+    return Response.json(
+      {
+        error: "Invalid API key",
+        code: result.code ?? "INVALID",
+      },
+      {
+        status: result.code === "RATE_LIMITED" ? 429 : 401,
+      },
+    );
+  } catch {
+    const failure = {
+      valid: false,
+      code: "VERIFY_ERROR" as const,
+    };
+    const override = await options.onDenied?.(request, context, failure);
+    if (override) {
+      return override;
+    }
+
+    return Response.json(
+      {
+        error: "API key verification failed",
+        code: failure.code,
+      },
+      {
+        status: 401,
+      },
+    );
+  }
+}
+
+function getApiKeyFromRequest(
+  request: Request,
+  headers: UnkeyProtectionOptions["headers"],
+): string | undefined {
+  const names = Array.isArray(headers)
+    ? headers
+    : headers
+      ? [headers]
+      : ["authorization", "x-api-key"];
+
+  for (const name of names) {
+    const value = request.headers.get(name);
+    if (!value) {
+      continue;
+    }
+
+    if (name.toLowerCase() === "authorization") {
+      const match = value.match(/^Bearer\s+(.+)$/i);
+      return (match?.[1] || value).trim();
+    }
+
+    return value.trim();
+  }
+
+  return undefined;
+}
+
+function resolveProtectionTags(
+  request: Request,
+  context: FarmIntegrationHandlerContext,
+  tags: UnkeyProtectionOptions["tags"],
+): string[] | undefined {
+  return typeof tags === "function" ? tags(request, context) : tags;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/packages/farm/src/integration-api.ts
+++ b/packages/farm/src/integration-api.ts
@@ -34,7 +34,7 @@ export interface FarmIntegrationAPIOperation<
 }
 
 export type FarmIntegrationAPI = {
-  [key: string]: FarmIntegrationAPI | FarmIntegrationAPIOperation<any, any, any>;
+  [key: string]: FarmIntegrationAPI | FarmIntegrationAPIOperation<any, any, any, any, any>;
 };
 
 export type FarmIntegrationRouteOperationCarrier<

--- a/packages/farm/src/integration-client.ts
+++ b/packages/farm/src/integration-client.ts
@@ -254,7 +254,7 @@ const INTEGRATION_REQUEST_DISPATCHER_KEY = Symbol.for("farm.integrationRequestDi
 type IntegrationRequestDispatcher = (
   runtime: RegisteredIntegrationRuntime,
   request: Request,
-  options?: { currentRequest?: Request; data?: IntegrationClientData },
+  options?: { currentRequest?: Request; data?: IntegrationClientData; internal?: boolean },
 ) => Promise<Response | null>;
 
 type GlobalWithIntegrationRuntimeRegistry = typeof globalThis & {
@@ -837,6 +837,7 @@ async function executeServerOperation(
               {
                 currentRequest,
                 data,
+                internal: true,
               },
             )
           : null;

--- a/packages/farm/src/integrations.ts
+++ b/packages/farm/src/integrations.ts
@@ -117,6 +117,8 @@ export interface FarmIntegrationRequestContextStore {
   snapshot(options?: { exposedOnly?: boolean }): Map<string, unknown>;
 }
 
+export const FARM_INTEGRATION_INTERNAL_DISPATCH_CONTEXT_KEY = "farm.integration.internalDispatch";
+
 export type FarmIntegrationRouteDb<TSchema extends FarmIntegrationSchema | undefined> =
   InferFarmIntegrationOrmClient<TSchema>;
 
@@ -2461,6 +2463,7 @@ export async function dispatchIntegrationRequest(
   options: {
     currentRequest?: Request;
     data?: FarmIntegrationData;
+    internal?: boolean;
   } = {},
 ): Promise<Response | null> {
   const integration = runtime.integration;
@@ -2492,6 +2495,7 @@ export async function dispatchIntegrationRequest(
       requestId,
       currentRequest: options.currentRequest,
       data: options.data,
+      internal: options.internal === true,
     });
     const startedAt = Date.now();
 
@@ -2589,6 +2593,7 @@ export async function dispatchIntegrationRequest(
       requestId,
       currentRequest: options.currentRequest,
       data: options.data,
+      internal: options.internal === true,
     });
     const startedAt = Date.now();
 
@@ -2784,7 +2789,17 @@ function createServerIntegrationHandlerContext(input: {
   requestId: string;
   currentRequest?: Request;
   data?: FarmIntegrationData;
+  internal?: boolean;
 }): FarmIntegrationHandlerContext {
+  const requestContext = createServerIntegrationRequestContextStore(
+    input.request,
+    input.currentRequest,
+  );
+
+  if (input.internal) {
+    requestContext.set(FARM_INTEGRATION_INTERNAL_DISPATCH_CONTEXT_KEY, true);
+  }
+
   return {
     request: input.request,
     requestId: input.requestId,
@@ -2805,7 +2820,7 @@ function createServerIntegrationHandlerContext(input: {
       instance: input.runtime.integration.instance,
     },
     route: input.route,
-    requestContext: createServerIntegrationRequestContextStore(input.request, input.currentRequest),
+    requestContext,
     config: input.runtime.config,
     isDev: input.runtime.isDev,
     isProd: input.runtime.isProd,


### PR DESCRIPTION
## Summary
- add an official Unkey integration with a typed `createUnkeyClient` wrapper for create, verify, update, revoke, and delete key operations
- expose server-only integration APIs under the configured integration namespace while blocking public management-route access with a 404
- add protected-route middleware that verifies `Authorization: Bearer ...` or `x-api-key`, then stores API key details on the Farm request context
- widen the integration API type surface so server-only integration operations are valid generated API entries
- clean up integration examples to use `createIntegrations()` as the primary DX

Closes #63

## Testing
- `corepack pnpm@8.12.1 --filter @farmjs/core run build`
- `corepack pnpm@8.12.1 --filter @farmjs/integrations run build`
- `corepack pnpm@8.12.1 --filter @farmjs/core test -- src/__tests__/integration-client.test.ts src/__tests__/integrations.test.ts`
- `corepack pnpm@8.12.1 --filter @farmjs/core test -- src/__tests__/integration-client.test.ts`
- `git diff --check`
- one-off runtime checks for Unkey client request shape and integration security boundary