### PR TITLE
feat: add opt-in integration UI registry

### DIFF
--- a/packages/farm-cli/bin/farm.js
+++ b/packages/farm-cli/bin/farm.js
@@ -90,6 +90,7 @@ addCommand
   .option("--force", "Overwrite an existing generated integration component")
   .option("--dry-run", "Show what would be added without writing files")
   .option("--route-file <file>", "Route file path for route-based integrations")
+  .option("--ui", "Also install the provider's shadcn-based Farm UI feature pack")
   .option("--skip-package-json", "Do not add @farmjs/integrations to package.json")
   .option("--skip-config", "Do not create or update farm.config")
   .option("-l, --list", "List supported integration providers")
@@ -118,6 +119,7 @@ addCommand
         key: options.key,
         integrationsFile: options.file,
         routeFile: options.routeFile,
+        ui: options.ui,
         dryRun: options.dryRun,
         force: options.force,
         skipPackageJson: options.skipPackageJson,
@@ -129,6 +131,13 @@ addCommand
         console.log(`${verb} ${result.provider} route at ${result.routePath || result.routeFile}`);
       } else {
         console.log(`${verb} ${result.provider} integration as appIntegrations.${result.key}`);
+      }
+
+      if (result.ui) {
+        console.log(`UI feature: ${result.ui.feature}`);
+        if (result.ui.components.length) {
+          console.log(`Shadcn components: ${result.ui.components.join(", ")}`);
+        }
       }
 
       if (result.created.length) {

--- a/packages/farm-cli/src/add-integration.ts
+++ b/packages/farm-cli/src/add-integration.ts
@@ -1,6 +1,26 @@
 import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import {
+  aiChatUIFeature,
+  auth0AuthUIFeature,
+  authjsUIFeature,
+  autumnBillingUIFeature,
+  betterAuthUIFeature,
+  clerkAuthUIFeature,
+  installUIFeature,
+  jobsUIFeature,
+  polarBillingUIFeature,
+  resendEmailUIFeature,
+  stripeBillingUIFeature,
+  supabaseAuthUIFeature,
+  unkeyApiKeysUIFeature,
+  workosAuthUIFeature,
+  type AddFarmIntegrationUIResult,
+  type UIFeatureDefinition,
+} from "./ui-feature-registry";
+
+export type { AddFarmIntegrationUIResult } from "./ui-feature-registry";
 
 type PackageManifest = {
   dependencies?: Record<string, string>;
@@ -15,6 +35,7 @@ export interface AddFarmIntegrationOptions {
   key?: string;
   integrationsFile?: string;
   routeFile?: string;
+  ui?: boolean;
   skipPackageJson?: boolean;
   skipConfig?: boolean;
   dryRun?: boolean;
@@ -36,6 +57,7 @@ export interface AddFarmIntegrationResult {
   skipped: string[];
   env: string[];
   notes: string[];
+  ui?: AddFarmIntegrationUIResult;
 }
 
 export type FarmIntegrationProvider =
@@ -51,6 +73,7 @@ export type FarmIntegrationProvider =
   | "resend"
   | "stripe"
   | "supabase"
+  | "unkey"
   | "workos";
 
 interface IntegrationProviderDefinition {
@@ -62,6 +85,7 @@ interface IntegrationProviderDefinition {
   description: string;
   env: readonly string[];
   notes?: readonly string[];
+  ui?: UIFeatureDefinition;
   template(): string;
 }
 
@@ -79,6 +103,7 @@ const PROVIDERS: readonly IntegrationProviderDefinition[] = [
       "Replace model with any AI SDK provider model or Vercel AI Gateway model id.",
       "No farm.config integration wiring is required for this route.",
     ],
+    ui: aiChatUIFeature(),
     template: () => `import { aiChatRoute } from "@farmjs/integrations/ai";
 
 export const POST = aiChatRoute({
@@ -106,6 +131,7 @@ export const stripeIntegration = stripe({
   },
 });
 `,
+    ui: stripeBillingUIFeature(),
   },
   {
     provider: "supabase",
@@ -115,6 +141,7 @@ export const stripeIntegration = stripe({
     exportName: "supabaseIntegration",
     description: "Supabase auth routes and middleware",
     env: ["SUPABASE_URL", "SUPABASE_ANON_KEY", "APP_BASE_URL"],
+    ui: supabaseAuthUIFeature(),
     template: () => `import { supabase } from "@farmjs/integrations/supabase";
 
 export const supabaseIntegration = supabase({
@@ -138,6 +165,7 @@ export const supabaseIntegration = supabase({
     exportName: "workosIntegration",
     description: "WorkOS auth routes and protected route middleware",
     env: ["WORKOS_CLIENT_ID", "WORKOS_API_KEY", "WORKOS_COOKIE_PASSWORD"],
+    ui: workosAuthUIFeature(),
     template: () => `import { workos } from "@farmjs/integrations/workos";
 
 export const workosIntegration = workos({
@@ -156,6 +184,7 @@ export const workosIntegration = workos({
     exportName: "auth0Integration",
     description: "Auth0 login, callback, logout, and profile routes",
     env: ["AUTH0_DOMAIN", "AUTH0_CLIENT_ID", "AUTH0_CLIENT_SECRET", "AUTH0_SECRET"],
+    ui: auth0AuthUIFeature(),
     template: () => `import { auth0 } from "@farmjs/integrations/auth0";
 
 export const auth0Integration = auth0({
@@ -175,6 +204,7 @@ export const auth0Integration = auth0({
     exportName: "clerkIntegration",
     description: "Clerk auth provider and protected route middleware",
     env: ["NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY", "CLERK_SECRET_KEY"],
+    ui: clerkAuthUIFeature(),
     template: () => `import { clerk } from "@farmjs/integrations/clerk";
 
 export const clerkIntegration = clerk({
@@ -195,6 +225,7 @@ export const clerkIntegration = clerk({
     exportName: "resendIntegration",
     description: "Resend email send, preview, schedule, and webhook routes",
     env: ["RESEND_API_KEY", "RESEND_FROM_EMAIL", "RESEND_WEBHOOK_SECRET"],
+    ui: resendEmailUIFeature(),
     template: () => `import { createElement } from "react";
 import { resend, template } from "@farmjs/integrations/email";
 
@@ -240,6 +271,7 @@ export const resendIntegration = resend({
     description: "Jobs integration backed by Inngest",
     env: ["INNGEST_APP_ID", "INNGEST_EVENT_KEY", "INNGEST_SIGNING_KEY"],
     notes: ["Add tasks to jobTasks before using the generated jobs API."],
+    ui: jobsUIFeature("inngest"),
     template: () => `import { defineTasks, inngest, jobs } from "@farmjs/integrations/jobs";
 
 export const jobTasks = defineTasks({});
@@ -266,6 +298,7 @@ export const jobsIntegration = jobs({
     description: "Jobs integration backed by Trigger.dev",
     env: ["TRIGGER_PROJECT_REF", "TRIGGER_SECRET_KEY", "TRIGGER_WEBHOOK_SECRET"],
     notes: ["Add tasks to jobTasks before using the generated jobs API."],
+    ui: jobsUIFeature("trigger"),
     template: () => `import { defineTasks, jobs, trigger } from "@farmjs/integrations/jobs";
 
 export const jobTasks = defineTasks({});
@@ -292,6 +325,7 @@ export const jobsIntegration = jobs({
     description: "Polar billing and checkout routes",
     env: ["POLAR_ACCESS_TOKEN", "POLAR_WEBHOOK_SECRET", "APP_BASE_URL"],
     notes: ["Replace resolveBillingOwner with your app user or organization lookup."],
+    ui: polarBillingUIFeature(),
     template: () => `import type { FarmIntegrationHandlerContext } from "@farmjs/core";
 import { polar } from "@farmjs/integrations/polar";
 
@@ -328,6 +362,7 @@ export const polarIntegration = polar({
     description: "Autumn billing and checkout routes",
     env: ["AUTUMN_SECRET_KEY", "AUTUMN_WEBHOOK_SECRET", "APP_BASE_URL"],
     notes: ["Replace resolveBillingOwner with your app user or organization lookup."],
+    ui: autumnBillingUIFeature(),
     template: () => `import type { FarmIntegrationHandlerContext } from "@farmjs/core";
 import { autumn } from "@farmjs/integrations/autumn";
 
@@ -363,6 +398,7 @@ export const autumnIntegration = autumn({
     description: "Better Auth route adapter",
     env: [],
     notes: ["This template expects src/lib/auth.ts to export a Better Auth instance named auth."],
+    ui: betterAuthUIFeature(),
     template: () => `import { betterAuth } from "@farmjs/integrations/better-auth";
 import { auth } from "../auth.ts";
 
@@ -383,6 +419,7 @@ export const betterAuthIntegration = betterAuth({
     description: "Auth.js route adapter",
     env: [],
     notes: ["This template expects src/lib/auth.ts to export an Auth.js instance named auth."],
+    ui: authjsUIFeature(),
     template: () => `import { authjs } from "@farmjs/integrations/authjs";
 import { auth } from "../auth.ts";
 
@@ -390,6 +427,28 @@ export const authjsIntegration = authjs({
   instance: auth,
   log(event) {
     console.log("[authjs]", event.phase, event.route?.path || "none");
+  },
+});
+`,
+  },
+  {
+    provider: "unkey",
+    aliases: ["api-keys", "apikeys", "keys", "unkey-api-keys"],
+    defaultKey: "apiKeys",
+    fileName: "unkey",
+    exportName: "unkeyIntegration",
+    description: "Unkey API key creation, verification, and route protection",
+    env: ["UNKEY_ROOT_KEY", "UNKEY_API_ID", "UNKEY_BASE_URL"],
+    ui: unkeyApiKeysUIFeature(),
+    template: () => `import { unkey } from "@farmjs/integrations/unkey";
+
+export const unkeyIntegration = unkey({
+  rootKey: process.env.UNKEY_ROOT_KEY,
+  apiId: process.env.UNKEY_API_ID,
+  baseUrl: process.env.UNKEY_BASE_URL,
+  protectedRoutes: ["/api/protected(.*)"],
+  log(event) {
+    console.log("[unkey]", event.phase, event.route?.path || "none");
   },
 });
 `,
@@ -403,6 +462,13 @@ export function listFarmIntegrationProviders() {
     defaultKey: provider.defaultKey,
     description: provider.description,
     env: [...provider.env],
+    ui: provider.ui
+      ? {
+          feature: provider.ui.name,
+          description: provider.ui.description,
+          components: [...provider.ui.components],
+        }
+      : undefined,
   }));
 }
 
@@ -417,6 +483,7 @@ export async function addFarmIntegration(
       root,
       definition,
       routeFile: options.routeFile,
+      ui: options.ui,
       skipPackageJson: options.skipPackageJson,
       dryRun: options.dryRun,
       force: options.force,
@@ -481,6 +548,18 @@ export async function addFarmIntegration(
     });
   }
 
+  if (options.ui) {
+    await installUIFeature({
+      root,
+      definition,
+      key,
+      dryRun: options.dryRun,
+      force: options.force,
+      skipPackageJson: options.skipPackageJson,
+      result,
+    });
+  }
+
   return result;
 }
 
@@ -488,6 +567,7 @@ async function addAIRouteIntegration(input: {
   root: string;
   definition: IntegrationProviderDefinition;
   routeFile?: string;
+  ui?: boolean;
   skipPackageJson?: boolean;
   dryRun?: boolean;
   force?: boolean;
@@ -523,6 +603,18 @@ async function addAIRouteIntegration(input: {
     await updatePackageJson({
       root: input.root,
       dryRun: input.dryRun,
+      result,
+    });
+  }
+
+  if (input.ui) {
+    await installUIFeature({
+      root: input.root,
+      definition: input.definition,
+      key: input.definition.defaultKey,
+      dryRun: input.dryRun,
+      force: input.force,
+      skipPackageJson: input.skipPackageJson,
       result,
     });
   }

--- a/packages/farm-cli/src/index.ts
+++ b/packages/farm-cli/src/index.ts
@@ -4,6 +4,7 @@ export {
   listFarmIntegrationProviders,
   type AddFarmIntegrationOptions,
   type AddFarmIntegrationResult,
+  type AddFarmIntegrationUIResult,
   type FarmIntegrationProvider,
 } from "./add-integration";
 export { buildFarm } from "./build";

--- a/packages/farm-cli/src/ui-feature-registry.ts
+++ b/packages/farm-cli/src/ui-feature-registry.ts
@@ -1,0 +1,1747 @@
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { AddFarmIntegrationResult, FarmIntegrationProvider } from "./add-integration";
+
+type PackageManifest = {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+};
+
+export interface AddFarmIntegrationUIResult {
+  feature: string;
+  components: string[];
+  files: string[];
+}
+
+export type ShadcnComponentName = "badge" | "button" | "card" | "input" | "label";
+
+export interface UIFeatureDefinition {
+  name: string;
+  description: string;
+  components: readonly ShadcnComponentName[];
+  files(input: UIFeatureTemplateInput): readonly UIFeatureFile[];
+  needsApiClient?: boolean;
+  notes?: readonly string[];
+}
+
+interface UIFeatureTemplateInput {
+  key: string;
+  provider: FarmIntegrationProvider;
+}
+
+interface UIFeatureFile {
+  path: string;
+  source: string;
+}
+
+export async function installUIFeature(input: {
+  root: string;
+  definition: { provider: FarmIntegrationProvider; ui?: UIFeatureDefinition };
+  key: string;
+  dryRun?: boolean;
+  force?: boolean;
+  skipPackageJson?: boolean;
+  result: AddFarmIntegrationResult;
+}) {
+  const feature = input.definition.ui;
+  if (!feature) {
+    input.result.notes.push(
+      `No --ui feature pack is available for ${input.definition.provider} yet.`,
+    );
+    return;
+  }
+
+  input.result.ui = {
+    feature: feature.name,
+    components: [...feature.components],
+    files: [],
+  };
+  input.result.notes.push(
+    `Installed ${feature.description} with shadcn-style local source components.`,
+    ...(feature.notes || []),
+  );
+
+  await ensureComponentsJson({
+    root: input.root,
+    dryRun: input.dryRun,
+    result: input.result,
+  });
+  await ensureShadcnGlobals({
+    root: input.root,
+    dryRun: input.dryRun,
+    result: input.result,
+  });
+  await ensureTsconfigAlias({
+    root: input.root,
+    dryRun: input.dryRun,
+    result: input.result,
+  });
+
+  if (!input.skipPackageJson) {
+    await updateUIPackageJson({
+      root: input.root,
+      dryRun: input.dryRun,
+      result: input.result,
+    });
+  }
+
+  await writeGeneratedFile({
+    root: input.root,
+    relativePath: path.join("src", "lib", "utils.ts"),
+    source: shadcnUtilsTemplate(),
+    dryRun: input.dryRun,
+    force: input.force,
+    result: input.result,
+  });
+
+  for (const component of feature.components) {
+    await writeGeneratedFile({
+      root: input.root,
+      relativePath: path.join("src", "components", "ui", `${component}.tsx`),
+      source: shadcnComponentTemplate(component),
+      dryRun: input.dryRun,
+      force: input.force,
+      result: input.result,
+    });
+  }
+
+  if (feature.needsApiClient !== false) {
+    await writeGeneratedFile({
+      root: input.root,
+      relativePath: path.join("src", "lib", "api.ts"),
+      source: apiClientTemplate(),
+      dryRun: input.dryRun,
+      force: input.force,
+      result: input.result,
+    });
+  }
+
+  for (const file of feature.files({
+    key: input.key,
+    provider: input.definition.provider,
+  })) {
+    await writeGeneratedFile({
+      root: input.root,
+      relativePath: file.path,
+      source: file.source,
+      dryRun: input.dryRun,
+      force: input.force,
+      result: input.result,
+    });
+  }
+}
+
+export function stripeBillingUIFeature(): UIFeatureDefinition {
+  return billingUIFeature({
+    provider: "stripe",
+    label: "Stripe",
+  });
+}
+
+export function polarBillingUIFeature(): UIFeatureDefinition {
+  return billingUIFeature({
+    provider: "polar",
+    label: "Polar",
+  });
+}
+
+export function autumnBillingUIFeature(): UIFeatureDefinition {
+  return billingUIFeature({
+    provider: "autumn",
+    label: "Autumn",
+  });
+}
+
+export function aiChatUIFeature(): UIFeatureDefinition {
+  return {
+    name: "ai-chat",
+    description: "AI chat UI",
+    components: ["badge", "button", "card", "input"],
+    needsApiClient: false,
+    notes: ['Open "/integrations/ai" to try the generated chat UI.'],
+    files: () => [
+      componentFile("ai-chat.tsx", aiChatTemplate()),
+      integrationPageFile("ai", "AIChat"),
+    ],
+  };
+}
+
+export function supabaseAuthUIFeature(): UIFeatureDefinition {
+  return {
+    name: "supabase-auth",
+    description: "Supabase auth UI",
+    components: ["badge", "button", "card", "input", "label"],
+    notes: ['Open "/integrations/supabase" to try the generated auth UI.'],
+    files: (input) => [
+      componentFile("supabase-auth-panel.tsx", supabaseAuthTemplate(input.key)),
+      integrationPageFile("supabase", "SupabaseAuthPanel"),
+    ],
+  };
+}
+
+export function workosAuthUIFeature(): UIFeatureDefinition {
+  return {
+    name: "workos-auth",
+    description: "WorkOS auth UI",
+    components: ["badge", "button", "card"],
+    notes: ['Open "/integrations/workos" to try the generated auth UI.'],
+    files: (input) => [
+      componentFile(
+        "workos-auth-panel.tsx",
+        hostedAuthTemplate({
+          key: input.key,
+          provider: "WorkOS",
+          componentName: "WorkOSAuthPanel",
+          statusCall: "session.get",
+          logoutCall: "logout.post",
+          loginHref: "/login?returnTo=/dashboard",
+          signupHref: "/signup?returnTo=/dashboard",
+          statusLabel: "Session",
+        }),
+      ),
+      integrationPageFile("workos", "WorkOSAuthPanel"),
+    ],
+  };
+}
+
+export function auth0AuthUIFeature(): UIFeatureDefinition {
+  return {
+    name: "auth0-auth",
+    description: "Auth0 auth UI",
+    components: ["badge", "button", "card"],
+    notes: ['Open "/integrations/auth0" to try the generated auth UI.'],
+    files: (input) => [
+      componentFile(
+        "auth0-auth-panel.tsx",
+        hostedAuthTemplate({
+          key: input.key,
+          provider: "Auth0",
+          componentName: "Auth0AuthPanel",
+          statusCall: "profile.get",
+          logoutCall: "logout.get",
+          loginHref: "/auth/login?returnTo=/dashboard",
+          signupHref: "/auth/signup?returnTo=/dashboard",
+          statusLabel: "Profile",
+        }),
+      ),
+      integrationPageFile("auth0", "Auth0AuthPanel"),
+    ],
+  };
+}
+
+export function clerkAuthUIFeature(): UIFeatureDefinition {
+  return authRouteShellUIFeature({
+    provider: "clerk",
+    label: "Clerk",
+    componentName: "ClerkAuthPanel",
+    signInHref: "/sign-in",
+    signUpHref: "/sign-up",
+    sessionHref: "/dashboard",
+  });
+}
+
+export function betterAuthUIFeature(): UIFeatureDefinition {
+  return authRouteShellUIFeature({
+    provider: "better-auth",
+    label: "Better Auth",
+    componentName: "BetterAuthPanel",
+    signInHref: "/api/auth/sign-in",
+    signUpHref: "/api/auth/sign-up",
+    sessionHref: "/api/auth/session",
+  });
+}
+
+export function authjsUIFeature(): UIFeatureDefinition {
+  return authRouteShellUIFeature({
+    provider: "authjs",
+    label: "Auth.js",
+    componentName: "AuthJsPanel",
+    signInHref: "/api/auth/signin",
+    signUpHref: "/api/auth/signin",
+    sessionHref: "/api/auth/session",
+  });
+}
+
+export function resendEmailUIFeature(): UIFeatureDefinition {
+  return {
+    name: "resend-email",
+    description: "Resend email console UI",
+    components: ["badge", "button", "card", "input", "label"],
+    notes: ['Open "/integrations/resend" to try the generated email UI.'],
+    files: (input) => [
+      componentFile("resend-email-console.tsx", resendEmailTemplate(input.key)),
+      integrationPageFile("resend", "ResendEmailConsole"),
+    ],
+  };
+}
+
+export function jobsUIFeature(provider: "inngest" | "trigger"): UIFeatureDefinition {
+  const label = provider === "inngest" ? "Inngest" : "Trigger.dev";
+
+  return {
+    name: `${provider}-jobs`,
+    description: `${label} jobs console UI`,
+    components: ["badge", "button", "card", "input", "label"],
+    notes: [`Open "/integrations/jobs-${provider}" to try the generated jobs UI.`],
+    files: (input) => [
+      componentFile(
+        `${provider}-jobs-console.tsx`,
+        jobsConsoleTemplate(input.key, label, provider),
+      ),
+      integrationPageFile(`jobs-${provider}`, `${pascalCase(provider)}JobsConsole`),
+    ],
+  };
+}
+
+export function unkeyApiKeysUIFeature(): UIFeatureDefinition {
+  return {
+    name: "unkey-api-keys",
+    description: "Unkey API key console UI",
+    components: ["badge", "button", "card", "input", "label"],
+    notes: ['Open "/integrations/unkey" to try the generated API key UI.'],
+    files: (input) => [
+      componentFile("unkey-api-keys-console.tsx", unkeyApiKeysTemplate(input.key)),
+      integrationPageFile("unkey", "UnkeyApiKeysConsole"),
+    ],
+  };
+}
+
+function billingUIFeature(input: { provider: "stripe" | "polar" | "autumn"; label: string }) {
+  return {
+    name: `${input.provider}-billing`,
+    description: `${input.label} pricing and checkout UI`,
+    components: ["badge", "button", "card"],
+    notes: [
+      `Open "/integrations/${input.provider}" to try the generated ${input.label} billing UI.`,
+    ],
+    files: (templateInput) => [
+      componentFile(
+        `${input.provider}-billing.tsx`,
+        billingPricingTemplate({
+          key: templateInput.key,
+          provider: input.provider,
+          label: input.label,
+          componentName: `${pascalCase(input.provider)}Billing`,
+        }),
+      ),
+      integrationPageFile(input.provider, `${pascalCase(input.provider)}Billing`),
+    ],
+  };
+}
+
+function authRouteShellUIFeature(input: {
+  provider: "authjs" | "better-auth" | "clerk";
+  label: string;
+  componentName: string;
+  signInHref: string;
+  signUpHref: string;
+  sessionHref: string;
+}): UIFeatureDefinition {
+  return {
+    name: `${input.provider}-auth`,
+    description: `${input.label} auth UI`,
+    components: ["badge", "button", "card"],
+    notes: [`Open "/integrations/${input.provider}" to try the generated auth UI.`],
+    files: () => [
+      componentFile(
+        `${input.provider}-auth-panel.tsx`,
+        authRouteShellTemplate({
+          provider: input.label,
+          componentName: input.componentName,
+          signInHref: input.signInHref,
+          signUpHref: input.signUpHref,
+          sessionHref: input.sessionHref,
+        }),
+      ),
+      integrationPageFile(input.provider, input.componentName),
+    ],
+  };
+}
+
+function componentFile(fileName: string, source: string): UIFeatureFile {
+  return {
+    path: path.join("src", "components", "farm", fileName),
+    source,
+  };
+}
+
+function integrationPageFile(provider: string, componentName: string): UIFeatureFile {
+  const fileName = kebabCase(componentName);
+
+  return {
+    path: path.join("src", "app", "integrations", provider, "page.tsx"),
+    source: `import { ${componentName} } from "@/components/farm/${fileName}";
+
+export default function ${componentName}Page() {
+  return <${componentName} />;
+}
+`,
+  };
+}
+
+async function writeGeneratedFile(input: {
+  root: string;
+  relativePath: string;
+  source: string;
+  dryRun?: boolean;
+  force?: boolean;
+  result: AddFarmIntegrationResult;
+}) {
+  const absolutePath = path.join(input.root, input.relativePath);
+  const exists = existsSync(absolutePath);
+  input.result.ui?.files.push(absolutePath);
+
+  if (exists && !input.force) {
+    pushResultPath(input.result.skipped, absolutePath);
+    return;
+  }
+
+  if (!input.dryRun) {
+    await mkdir(path.dirname(absolutePath), { recursive: true });
+    await writeFile(absolutePath, input.source, "utf8");
+  }
+
+  pushResultPath(exists ? input.result.updated : input.result.created, absolutePath);
+}
+
+async function ensureComponentsJson(input: {
+  root: string;
+  dryRun?: boolean;
+  result: AddFarmIntegrationResult;
+}) {
+  const componentsJsonPath = path.join(input.root, "components.json");
+  input.result.ui?.files.push(componentsJsonPath);
+  const defaults = createComponentsJson();
+
+  if (!existsSync(componentsJsonPath)) {
+    if (!input.dryRun) {
+      await writeFile(componentsJsonPath, `${JSON.stringify(defaults, null, 2)}\n`, "utf8");
+    }
+    pushResultPath(input.result.created, componentsJsonPath);
+    return;
+  }
+
+  let current: Record<string, unknown>;
+  try {
+    current = JSON.parse(await readFile(componentsJsonPath, "utf8")) as Record<string, unknown>;
+  } catch {
+    pushResultPath(input.result.skipped, componentsJsonPath);
+    input.result.notes.push(
+      "components.json could not be parsed. Keep shadcn aliases pointed at src/components and src/lib/utils.",
+    );
+    return;
+  }
+
+  const next = mergeComponentsJson(current, defaults);
+  if (JSON.stringify(current) === JSON.stringify(next)) {
+    pushResultPath(input.result.skipped, componentsJsonPath);
+    return;
+  }
+
+  if (!input.dryRun) {
+    await writeFile(componentsJsonPath, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+  }
+  pushResultPath(input.result.updated, componentsJsonPath);
+}
+
+async function ensureShadcnGlobals(input: {
+  root: string;
+  dryRun?: boolean;
+  result: AddFarmIntegrationResult;
+}) {
+  const globalsPath = path.join(input.root, "src", "app", "globals.css");
+  input.result.ui?.files.push(globalsPath);
+
+  if (!existsSync(globalsPath)) {
+    const source = `@import "tailwindcss";
+
+${SHADCN_THEME_CSS}
+`;
+    if (!input.dryRun) {
+      await mkdir(path.dirname(globalsPath), { recursive: true });
+      await writeFile(globalsPath, source, "utf8");
+    }
+    pushResultPath(input.result.created, globalsPath);
+    return;
+  }
+
+  const source = await readFile(globalsPath, "utf8");
+  if (source.includes("--color-background") || source.includes("--background:")) {
+    pushResultPath(input.result.skipped, globalsPath);
+    return;
+  }
+
+  const nextSource = `${source.trimEnd()}
+
+${SHADCN_THEME_CSS}
+`;
+  if (!input.dryRun) {
+    await writeFile(globalsPath, nextSource, "utf8");
+  }
+  pushResultPath(input.result.updated, globalsPath);
+}
+
+async function ensureTsconfigAlias(input: {
+  root: string;
+  dryRun?: boolean;
+  result: AddFarmIntegrationResult;
+}) {
+  const tsconfigPath = path.join(input.root, "tsconfig.json");
+  input.result.ui?.files.push(tsconfigPath);
+  const defaults = {
+    compilerOptions: {
+      baseUrl: ".",
+      paths: {
+        "@/*": ["./src/*"],
+      },
+    },
+  };
+
+  if (!existsSync(tsconfigPath)) {
+    if (!input.dryRun) {
+      await writeFile(tsconfigPath, `${JSON.stringify(defaults, null, 2)}\n`, "utf8");
+    }
+    pushResultPath(input.result.created, tsconfigPath);
+    return;
+  }
+
+  let tsconfig: Record<string, unknown>;
+  try {
+    tsconfig = JSON.parse(await readFile(tsconfigPath, "utf8")) as Record<string, unknown>;
+  } catch {
+    pushResultPath(input.result.skipped, tsconfigPath);
+    input.result.notes.push(
+      'tsconfig.json could not be parsed. Add paths: { "@/*": ["./src/*"] } manually.',
+    );
+    return;
+  }
+
+  const compilerOptions = readObject(tsconfig.compilerOptions);
+  const paths = readObject(compilerOptions.paths);
+  const nextCompilerOptions = {
+    ...compilerOptions,
+    baseUrl: typeof compilerOptions.baseUrl === "string" ? compilerOptions.baseUrl : ".",
+    paths: {
+      ...paths,
+      "@/*": ["./src/*"],
+    },
+  };
+  const nextTsconfig = {
+    ...tsconfig,
+    compilerOptions: nextCompilerOptions,
+  };
+
+  if (JSON.stringify(tsconfig) === JSON.stringify(nextTsconfig)) {
+    pushResultPath(input.result.skipped, tsconfigPath);
+    return;
+  }
+
+  if (!input.dryRun) {
+    await writeFile(tsconfigPath, `${JSON.stringify(nextTsconfig, null, 2)}\n`, "utf8");
+  }
+  pushResultPath(input.result.updated, tsconfigPath);
+}
+
+async function updateUIPackageJson(input: {
+  root: string;
+  dryRun?: boolean;
+  result: AddFarmIntegrationResult;
+}) {
+  const packageJsonPath = path.join(input.root, "package.json");
+  input.result.ui?.files.push(packageJsonPath);
+  if (!existsSync(packageJsonPath)) {
+    pushResultPath(input.result.skipped, packageJsonPath);
+    return;
+  }
+
+  const source = await readFile(packageJsonPath, "utf8");
+  const manifest = JSON.parse(source) as PackageManifest;
+  let changed = false;
+
+  for (const [dependency, version] of Object.entries(UI_DEPENDENCIES)) {
+    if (hasPackageDependency(manifest, dependency)) {
+      continue;
+    }
+
+    manifest.dependencies = {
+      ...manifest.dependencies,
+      [dependency]: version,
+    };
+    changed = true;
+  }
+
+  if (!changed) {
+    pushResultPath(input.result.skipped, packageJsonPath);
+    return;
+  }
+
+  if (!input.dryRun) {
+    await writeFile(packageJsonPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  }
+  input.result.packageJson = packageJsonPath;
+  pushResultPath(input.result.updated, packageJsonPath);
+}
+
+const UI_DEPENDENCIES = {
+  "class-variance-authority": "^0.7.1",
+  clsx: "^2.1.1",
+  "tailwind-merge": "^3.3.1",
+} as const;
+
+const SHADCN_THEME_CSS = `@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+}
+
+:root {
+  --radius: 0.5rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+
+  body {
+    @apply bg-background text-foreground;
+  }
+}`;
+
+function createComponentsJson() {
+  return {
+    $schema: "https://ui.shadcn.com/schema.json",
+    style: "new-york",
+    rsc: true,
+    tsx: true,
+    tailwind: {
+      config: "",
+      css: "src/app/globals.css",
+      baseColor: "zinc",
+      cssVariables: true,
+    },
+    aliases: {
+      components: "@/components",
+      utils: "@/lib/utils",
+      ui: "@/components/ui",
+      lib: "@/lib",
+      hooks: "@/hooks",
+    },
+    registries: {
+      farm: {
+        url: "https://farmjs.dev/r/{name}.json",
+      },
+    },
+  };
+}
+
+function mergeComponentsJson(
+  current: Record<string, unknown>,
+  defaults: ReturnType<typeof createComponentsJson>,
+) {
+  const aliases = readObject(current.aliases);
+  const tailwind = readObject(current.tailwind);
+  const registries = readObject(current.registries);
+
+  return {
+    ...current,
+    $schema: typeof current.$schema === "string" ? current.$schema : defaults.$schema,
+    style: typeof current.style === "string" ? current.style : defaults.style,
+    rsc: typeof current.rsc === "boolean" ? current.rsc : defaults.rsc,
+    tsx: typeof current.tsx === "boolean" ? current.tsx : defaults.tsx,
+    tailwind: {
+      ...defaults.tailwind,
+      ...tailwind,
+    },
+    aliases: {
+      ...defaults.aliases,
+      ...aliases,
+    },
+    registries: {
+      ...registries,
+      farm: readObject(registries.farm).url ? registries.farm : defaults.registries.farm,
+    },
+  };
+}
+
+function shadcnUtilsTemplate() {
+  return `import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+`;
+}
+
+function apiClientTemplate() {
+  return `import { createIntegrations } from "@farmjs/core/client";
+import type { AppIntegrations } from "./integrations";
+
+export const { api, apiClient } = createIntegrations<AppIntegrations>();
+`;
+}
+
+function shadcnComponentTemplate(component: ShadcnComponentName) {
+  switch (component) {
+    case "badge":
+      return `import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
+        secondary: "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+export function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { badgeVariants };
+`;
+    case "button":
+      return `import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex h-9 items-center justify-center whitespace-nowrap rounded-md px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        outline: "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-8",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <button
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Button.displayName = "Button";
+
+export { buttonVariants };
+`;
+    case "card":
+      return `import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)}
+      {...props}
+    />
+  ),
+);
+Card.displayName = "Card";
+
+export const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+  ),
+);
+CardHeader.displayName = "CardHeader";
+
+export const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn("text-2xl font-semibold leading-none tracking-normal", className)} {...props} />
+  ),
+);
+CardTitle.displayName = "CardTitle";
+
+export const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+  ),
+);
+CardDescription.displayName = "CardDescription";
+
+export const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  ),
+);
+CardContent.displayName = "CardContent";
+
+export const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+  ),
+);
+CardFooter.displayName = "CardFooter";
+`;
+    case "input":
+      return `import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => (
+    <input
+      type={type}
+      className={cn(
+        "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  ),
+);
+Input.displayName = "Input";
+`;
+    case "label":
+      return `import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const Label = React.forwardRef<HTMLLabelElement, React.LabelHTMLAttributes<HTMLLabelElement>>(
+  ({ className, ...props }, ref) => (
+    <label
+      ref={ref}
+      className={cn("text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70", className)}
+      {...props}
+    />
+  ),
+);
+Label.displayName = "Label";
+`;
+  }
+}
+
+function billingPricingTemplate(input: {
+  key: string;
+  provider: "stripe" | "polar" | "autumn";
+  label: string;
+  componentName: string;
+}) {
+  return `"use client";
+
+import * as React from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { apiClient } from "@/lib/api";
+
+type BillingProduct = NonNullable<Awaited<ReturnType<typeof apiClient.${input.key}.products>>["data"]>[number];
+
+export function ${input.componentName}() {
+  const [products, setProducts] = React.useState<BillingProduct[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [checkingOut, setCheckingOut] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let active = true;
+
+    async function loadProducts() {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await apiClient.${input.key}.products();
+        if (response.error) {
+          throw new Error(readErrorMessage(response.error, "${input.label} request failed."));
+        }
+
+        if (active) {
+          setProducts(Array.from(response.data ?? []));
+        }
+      } catch (cause) {
+        if (active) {
+          setError(cause instanceof Error ? cause.message : "Could not load ${input.label} products.");
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadProducts();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  async function startCheckout(product: BillingProduct) {
+    const productId = String(readProductField(product, "id") ?? "");
+    if (!productId) {
+      setError("This Stripe product is missing an id.");
+      return;
+    }
+
+    setCheckingOut(productId);
+    setError(null);
+
+    try {
+      const response = await apiClient.${input.key}.checkout({
+        body: {
+          productId,
+          successPath: "/billing/success",
+          cancelPath: "/integrations/${input.provider}",
+        },
+      });
+      if (response.error) {
+        throw new Error(readErrorMessage(response.error, "${input.label} checkout failed."));
+      }
+
+      const redirectTo = response.data?.redirectTo;
+      if (!redirectTo) {
+        throw new Error("${input.label} checkout did not return a redirect URL.");
+      }
+
+      window.location.assign(redirectTo);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not start ${input.label} checkout.");
+      setCheckingOut(null);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-background px-6 py-12 text-foreground">
+      <section className="mx-auto flex w-full max-w-5xl flex-col gap-8">
+        <div className="max-w-2xl space-y-3">
+          <Badge variant="secondary">${input.label}</Badge>
+          <h1 className="text-3xl font-semibold tracking-normal">${input.label} billing</h1>
+          <p className="text-sm leading-6 text-muted-foreground">
+            Plans, checkout, and customer billing actions in one place.
+          </p>
+        </div>
+
+        {error ? (
+          <div className="rounded-md border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            {error}
+          </div>
+        ) : null}
+
+        {loading ? (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <Card key={index} className="min-h-[220px] animate-pulse" />
+            ))}
+          </div>
+        ) : products.length ? (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {products.map((product) => {
+              const productId = String(readProductField(product, "id") ?? "");
+              const fallbackName = productId || "Product";
+              const name = String(readProductField(product, "name") ?? fallbackName);
+              const description =
+                readProductField(product, "description") ?? "Connected to your Stripe catalog.";
+
+              return (
+                <Card key={productId || name} className="flex min-h-[260px] flex-col">
+                  <CardHeader>
+                    <CardTitle className="text-xl">{name}</CardTitle>
+                    <CardDescription>{String(description)}</CardDescription>
+                  </CardHeader>
+                  <CardContent className="flex-1">
+                    <div className="text-3xl font-semibold">{formatProductPrice(product)}</div>
+                  </CardContent>
+                  <CardFooter>
+                    <Button
+                      className="w-full"
+                      disabled={!productId || checkingOut === productId}
+                      onClick={() => void startCheckout(product)}
+                    >
+                      {checkingOut === productId ? "Starting checkout..." : "Checkout"}
+                    </Button>
+                  </CardFooter>
+                </Card>
+              );
+            })}
+          </div>
+        ) : (
+          <Card>
+            <CardHeader>
+              <CardTitle>No products yet</CardTitle>
+              <CardDescription>
+                Add products to the generated ${input.label} integration template or provider dashboard.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        )}
+      </section>
+    </main>
+  );
+}
+
+function readProductField(product: BillingProduct, field: string) {
+  return (product as Record<string, unknown>)[field];
+}
+
+function formatProductPrice(product: BillingProduct) {
+  const amount = readProductField(product, "amount") ?? readProductField(product, "unitAmount");
+  const currency = String(readProductField(product, "currency") ?? "USD").toUpperCase();
+  const interval = readProductField(product, "interval");
+
+  if (typeof amount === "number" && Number.isFinite(amount)) {
+    const formatted = new Intl.NumberFormat("en", {
+      style: "currency",
+      currency,
+    }).format(amount / 100);
+
+    return interval ? \`\${formatted}/\${String(interval)}\` : formatted;
+  }
+
+  return "Custom";
+}
+
+function readErrorMessage(error: unknown, fallback: string) {
+  if (error && typeof error === "object" && "message" in error) {
+    return String((error as { message?: unknown }).message);
+  }
+
+  return fallback;
+}
+`;
+}
+
+function aiChatTemplate() {
+  return `"use client";
+
+import * as React from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+
+type ChatMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+export function AIChat() {
+  const [messages, setMessages] = React.useState<ChatMessage[]>([]);
+  const [input, setInput] = React.useState("");
+  const [pending, setPending] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  async function sendMessage(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const nextInput = input.trim();
+    if (!nextInput) {
+      return;
+    }
+
+    const nextMessages: ChatMessage[] = [...messages, { role: "user", content: nextInput }];
+    setMessages(nextMessages);
+    setInput("");
+    setPending(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/chat", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          messages: nextMessages.map((message) => ({
+            role: message.role,
+            parts: [{ type: "text", text: message.content }],
+          })),
+        }),
+      });
+
+      const text = await response.text();
+      if (!response.ok) {
+        throw new Error(text || "AI request failed.");
+      }
+
+      setMessages([...nextMessages, { role: "assistant", content: text || "Done." }]);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "AI request failed.");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-background px-6 py-12 text-foreground">
+      <section className="mx-auto flex w-full max-w-3xl flex-col gap-6">
+        <div className="space-y-3">
+          <Badge variant="secondary">AI</Badge>
+          <h1 className="text-3xl font-semibold tracking-normal">Chat</h1>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Conversation</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="min-h-[320px] space-y-3 rounded-md border bg-muted/30 p-4">
+              {messages.length ? (
+                messages.map((message, index) => (
+                  <div
+                    key={index}
+                    className={message.role === "user" ? "ml-auto max-w-[85%] rounded-md bg-primary px-3 py-2 text-sm text-primary-foreground" : "max-w-[85%] rounded-md bg-background px-3 py-2 text-sm"}
+                  >
+                    {message.content}
+                  </div>
+                ))
+              ) : (
+                <p className="text-sm text-muted-foreground">Start a conversation.</p>
+              )}
+            </div>
+
+            {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+            <form className="flex gap-2" onSubmit={sendMessage}>
+              <Input
+                value={input}
+                onChange={(event) => setInput(event.target.value)}
+                placeholder="Ask something..."
+              />
+              <Button disabled={pending} type="submit">
+                {pending ? "Sending..." : "Send"}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      </section>
+    </main>
+  );
+}
+`;
+}
+
+function supabaseAuthTemplate(key: string) {
+  return `"use client";
+
+import * as React from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { apiClient } from "@/lib/api";
+
+export function SupabaseAuthPanel() {
+  const [email, setEmail] = React.useState("");
+  const [password, setPassword] = React.useState("");
+  const [mode, setMode] = React.useState<"login" | "signup">("login");
+  const [pending, setPending] = React.useState(false);
+  const [status, setStatus] = React.useState<string | null>(null);
+
+  async function submit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setPending(true);
+    setStatus(null);
+
+    const response =
+      mode === "login"
+        ? await apiClient.${key}.login.post({ body: { email, password, returnTo: "/dashboard" } })
+        : await apiClient.${key}.signup.post({ body: { email, password, returnTo: "/dashboard" } });
+
+    if (response.error) {
+      setStatus(response.error.message);
+      setPending(false);
+      return;
+    }
+
+    if (response.data?.redirectTo) {
+      window.location.assign(response.data.redirectTo);
+      return;
+    }
+
+    setStatus(response.data?.message ?? "Check your email to continue.");
+    setPending(false);
+  }
+
+  async function loadSession() {
+    const response = await apiClient.${key}.session.get();
+    setStatus(response.error ? response.error.message : response.data?.authenticated ? "Authenticated" : "No active session");
+  }
+
+  async function logout() {
+    const response = await apiClient.${key}.logout.post({ body: { returnTo: "/" } });
+    if (response.data?.redirectTo) {
+      window.location.assign(response.data.redirectTo);
+      return;
+    }
+    setStatus(response.error?.message ?? "Signed out");
+  }
+
+  return (
+    <main className="min-h-screen bg-background px-6 py-12 text-foreground">
+      <section className="mx-auto flex w-full max-w-xl flex-col gap-6">
+        <div className="space-y-3">
+          <Badge variant="secondary">Supabase</Badge>
+          <h1 className="text-3xl font-semibold tracking-normal">Auth</h1>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">{mode === "login" ? "Sign in" : "Create account"}</CardTitle>
+            <CardDescription>Email and password access for this app.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form className="space-y-4" onSubmit={submit}>
+              <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input id="email" value={email} onChange={(event) => setEmail(event.target.value)} type="email" />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="password">Password</Label>
+                <Input id="password" value={password} onChange={(event) => setPassword(event.target.value)} type="password" />
+              </div>
+              {status ? <p className="text-sm text-muted-foreground">{status}</p> : null}
+              <div className="flex flex-wrap gap-2">
+                <Button disabled={pending} type="submit">{pending ? "Working..." : mode === "login" ? "Sign in" : "Sign up"}</Button>
+                <Button type="button" variant="outline" onClick={() => setMode(mode === "login" ? "signup" : "login")}>
+                  {mode === "login" ? "Use sign up" : "Use sign in"}
+                </Button>
+                <Button type="button" variant="ghost" onClick={() => void loadSession()}>Session</Button>
+                <Button type="button" variant="ghost" onClick={() => void logout()}>Logout</Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      </section>
+    </main>
+  );
+}
+`;
+}
+
+function hostedAuthTemplate(input: {
+  key: string;
+  provider: string;
+  componentName: string;
+  statusCall: string;
+  logoutCall: string;
+  loginHref: string;
+  signupHref: string;
+  statusLabel: string;
+}) {
+  return `"use client";
+
+import * as React from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { apiClient } from "@/lib/api";
+
+export function ${input.componentName}() {
+  const [status, setStatus] = React.useState<string>("Idle");
+  const [pending, setPending] = React.useState(false);
+
+  async function refreshStatus() {
+    setPending(true);
+    const response = await apiClient.${input.key}.${input.statusCall}();
+    if (response.error) {
+      setStatus(response.error.message);
+    } else {
+      setStatus(response.data?.authenticated ? "Authenticated" : "No active session");
+    }
+    setPending(false);
+  }
+
+  async function logout() {
+    setPending(true);
+    const response = await apiClient.${input.key}.${input.logoutCall}();
+    if (response.data?.redirectTo) {
+      window.location.assign(response.data.redirectTo);
+      return;
+    }
+    setStatus(response.error?.message ?? "Signed out");
+    setPending(false);
+  }
+
+  return (
+    <main className="min-h-screen bg-background px-6 py-12 text-foreground">
+      <section className="mx-auto flex w-full max-w-3xl flex-col gap-6">
+        <div className="space-y-3">
+          <Badge variant="secondary">${input.provider}</Badge>
+          <h1 className="text-3xl font-semibold tracking-normal">Auth</h1>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">${input.provider} session</CardTitle>
+            <CardDescription>Hosted auth, account session, and sign-out controls.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="rounded-md border bg-muted/30 px-3 py-2 text-sm">{status}</p>
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" onClick={() => window.location.assign("${input.loginHref}")}>Sign in</Button>
+              <Button type="button" variant="outline" onClick={() => window.location.assign("${input.signupHref}")}>Sign up</Button>
+              <Button type="button" variant="ghost" disabled={pending} onClick={() => void refreshStatus()}>Refresh</Button>
+              <Button type="button" variant="ghost" disabled={pending} onClick={() => void logout()}>Logout</Button>
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+    </main>
+  );
+}
+`;
+}
+
+function authRouteShellTemplate(input: {
+  provider: string;
+  componentName: string;
+  signInHref: string;
+  signUpHref: string;
+  sessionHref: string;
+}) {
+  return `"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export function ${input.componentName}() {
+  return (
+    <main className="min-h-screen bg-background px-6 py-12 text-foreground">
+      <section className="mx-auto flex w-full max-w-3xl flex-col gap-6">
+        <div className="space-y-3">
+          <Badge variant="secondary">${input.provider}</Badge>
+          <h1 className="text-3xl font-semibold tracking-normal">Auth</h1>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">${input.provider} routes</CardTitle>
+            <CardDescription>Account entry points and session route.</CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-wrap gap-2">
+            <Button type="button" onClick={() => window.location.assign("${input.signInHref}")}>Sign in</Button>
+            <Button type="button" variant="outline" onClick={() => window.location.assign("${input.signUpHref}")}>Sign up</Button>
+            <Button type="button" variant="ghost" onClick={() => window.location.assign("${input.sessionHref}")}>Session</Button>
+          </CardContent>
+        </Card>
+      </section>
+    </main>
+  );
+}
+`;
+}
+
+function resendEmailTemplate(key: string) {
+  return `"use client";
+
+import * as React from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { apiClient } from "@/lib/api";
+
+export function ResendEmailConsole() {
+  const [to, setTo] = React.useState("");
+  const [name, setName] = React.useState("Ada");
+  const [templateId, setTemplateId] = React.useState("welcome");
+  const [status, setStatus] = React.useState("Idle");
+  const [previewHtml, setPreviewHtml] = React.useState("");
+
+  async function loadTemplates() {
+    const response = await apiClient.${key}.templates.get();
+    setStatus(response.error ? response.error.message : "Templates: " + (response.data ?? []).map((item) => item.id).join(", "));
+  }
+
+  async function preview() {
+    const response = await apiClient.${key}.preview.post({
+      body: {
+        templateId,
+        data: { name },
+      },
+    });
+    if (response.error) {
+      setStatus(response.error.message);
+      return;
+    }
+    setPreviewHtml(response.data?.html ?? "");
+    setStatus(response.data?.subject ?? "Preview loaded");
+  }
+
+  async function send() {
+    const response = await apiClient.${key}.send.post({
+      body: {
+        templateId,
+        to,
+        data: { name },
+      },
+    });
+    setStatus(response.error ? response.error.message : "Sent " + (response.data?.id ?? "email"));
+  }
+
+  return (
+    <main className="min-h-screen bg-background px-6 py-12 text-foreground">
+      <section className="mx-auto flex w-full max-w-3xl flex-col gap-6">
+        <div className="space-y-3">
+          <Badge variant="secondary">Resend</Badge>
+          <h1 className="text-3xl font-semibold tracking-normal">Email console</h1>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Send template</CardTitle>
+            <CardDescription>Template previews and delivery controls.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-4 sm:grid-cols-3">
+              <div className="space-y-2">
+                <Label htmlFor="templateId">Template</Label>
+                <Input id="templateId" value={templateId} onChange={(event) => setTemplateId(event.target.value)} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="to">To</Label>
+                <Input id="to" value={to} onChange={(event) => setTo(event.target.value)} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="name">Name</Label>
+                <Input id="name" value={name} onChange={(event) => setName(event.target.value)} />
+              </div>
+            </div>
+            <p className="rounded-md border bg-muted/30 px-3 py-2 text-sm">{status}</p>
+            {previewHtml ? <div className="max-h-64 overflow-auto rounded-md border p-3 text-sm" dangerouslySetInnerHTML={{ __html: previewHtml }} /> : null}
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" variant="outline" onClick={() => void loadTemplates()}>Templates</Button>
+              <Button type="button" variant="outline" onClick={() => void preview()}>Preview</Button>
+              <Button type="button" onClick={() => void send()}>Send</Button>
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+    </main>
+  );
+}
+`;
+}
+
+function jobsConsoleTemplate(key: string, label: string, provider: "inngest" | "trigger") {
+  const componentName = `${pascalCase(provider)}JobsConsole`;
+
+  return `"use client";
+
+import * as React from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { apiClient } from "@/lib/api";
+
+type JobTask = {
+  key: string;
+  description?: string | null;
+};
+
+export function ${componentName}() {
+  const [tasks, setTasks] = React.useState<JobTask[]>([]);
+  const [taskKey, setTaskKey] = React.useState("");
+  const [runId, setRunId] = React.useState("");
+  const [status, setStatus] = React.useState("Idle");
+
+  async function loadTasks() {
+    const response = await apiClient.${key}.tasks.list();
+    if (response.error) {
+      setStatus(response.error.message);
+      return;
+    }
+    const nextTasks = Array.from(response.data ?? []);
+    setTasks(nextTasks);
+    setTaskKey(nextTasks[0]?.key ?? "");
+    setStatus(nextTasks.length ? "Tasks loaded" : "No tasks registered yet");
+  }
+
+  async function triggerTask() {
+    const task = (apiClient.${key} as Record<string, any>)[taskKey];
+    if (!task?.trigger) {
+      setStatus("Select a task first.");
+      return;
+    }
+    const response = await task.trigger({ body: { input: {} } });
+    setStatus(response.error ? response.error.message : "Triggered " + (response.data?.runId ?? response.data?.id ?? taskKey));
+  }
+
+  async function checkStatus() {
+    const task = (apiClient.${key} as Record<string, any>)[taskKey];
+    if (!task?.status || !runId) {
+      setStatus("Enter a task and run id.");
+      return;
+    }
+    const response = await task.status({ query: { runId } });
+    setStatus(response.error ? response.error.message : JSON.stringify(response.data));
+  }
+
+  return (
+    <main className="min-h-screen bg-background px-6 py-12 text-foreground">
+      <section className="mx-auto flex w-full max-w-4xl flex-col gap-6">
+        <div className="space-y-3">
+          <Badge variant="secondary">${label}</Badge>
+          <h1 className="text-3xl font-semibold tracking-normal">Jobs console</h1>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Tasks</CardTitle>
+            <CardDescription>Task runs and status checks.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="taskKey">Task key</Label>
+                <Input id="taskKey" value={taskKey} onChange={(event) => setTaskKey(event.target.value)} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="runId">Run id</Label>
+                <Input id="runId" value={runId} onChange={(event) => setRunId(event.target.value)} />
+              </div>
+            </div>
+            <p className="rounded-md border bg-muted/30 px-3 py-2 text-sm">{status}</p>
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" variant="outline" onClick={() => void loadTasks()}>Load tasks</Button>
+              <Button type="button" onClick={() => void triggerTask()}>Trigger</Button>
+              <Button type="button" variant="ghost" onClick={() => void checkStatus()}>Status</Button>
+            </div>
+            {tasks.length ? (
+              <div className="grid gap-2">
+                {tasks.map((task) => (
+                  <button key={task.key} className="rounded-md border px-3 py-2 text-left text-sm" onClick={() => setTaskKey(task.key)} type="button">
+                    {task.key}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </CardContent>
+        </Card>
+      </section>
+    </main>
+  );
+}
+`;
+}
+
+function unkeyApiKeysTemplate(key: string) {
+  return `"use client";
+
+import * as React from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { apiClient } from "@/lib/api";
+
+export function UnkeyApiKeysConsole() {
+  const [name, setName] = React.useState("Development key");
+  const [prefix, setPrefix] = React.useState("farm");
+  const [apiKey, setApiKey] = React.useState("");
+  const [status, setStatus] = React.useState("Idle");
+
+  async function createKey() {
+    const response = await apiClient.${key}.createKey.post({
+      body: {
+        name,
+        prefix,
+      },
+    });
+    if (response.error) {
+      setStatus(response.error.message);
+      return;
+    }
+    setApiKey(response.data?.key ?? "");
+    setStatus("Created " + (response.data?.keyId ?? "key"));
+  }
+
+  async function verifyKey() {
+    const response = await apiClient.${key}.verifyKey.post({
+      body: {
+        key: apiKey,
+      },
+    });
+    setStatus(response.error ? response.error.message : response.data?.valid ? "Valid key" : "Invalid key");
+  }
+
+  return (
+    <main className="min-h-screen bg-background px-6 py-12 text-foreground">
+      <section className="mx-auto flex w-full max-w-3xl flex-col gap-6">
+        <div className="space-y-3">
+          <Badge variant="secondary">Unkey</Badge>
+          <h1 className="text-3xl font-semibold tracking-normal">API keys</h1>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Key console</CardTitle>
+            <CardDescription>API key lifecycle controls.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="name">Name</Label>
+                <Input id="name" value={name} onChange={(event) => setName(event.target.value)} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="prefix">Prefix</Label>
+                <Input id="prefix" value={prefix} onChange={(event) => setPrefix(event.target.value)} />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="apiKey">API key</Label>
+              <Input id="apiKey" value={apiKey} onChange={(event) => setApiKey(event.target.value)} />
+            </div>
+            <p className="rounded-md border bg-muted/30 px-3 py-2 text-sm">{status}</p>
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" onClick={() => void createKey()}>Create key</Button>
+              <Button type="button" variant="outline" onClick={() => void verifyKey()}>Verify</Button>
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+    </main>
+  );
+}
+`;
+}
+
+function pascalCase(input: string) {
+  return input
+    .split(/[^A-Za-z0-9]+/g)
+    .filter(Boolean)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join("");
+}
+
+function kebabCase(input: string) {
+  return input
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/[^A-Za-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase();
+}
+
+function hasPackageDependency(manifest: PackageManifest, dependency: string) {
+  return (
+    dependency in (manifest.dependencies || {}) ||
+    dependency in (manifest.devDependencies || {}) ||
+    dependency in (manifest.peerDependencies || {}) ||
+    dependency in (manifest.optionalDependencies || {})
+  );
+}
+
+function readObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function pushResultPath(list: string[], filePath: string) {
+  if (!list.includes(filePath)) {
+    list.push(filePath);
+  }
+}

--- a/packages/farm-cli/test/add-integration.test.mjs
+++ b/packages/farm-cli/test/add-integration.test.mjs
@@ -1,12 +1,18 @@
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
 import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { createRequire } from "node:module";
 import test from "node:test";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
 
 const require = createRequire(import.meta.url);
 const { addFarmIntegration, listFarmIntegrationProviders } = require("../dist/add-integration.js");
+const execFileAsync = promisify(execFile);
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const cliBin = path.resolve(testDir, "../bin/farm.js");
 
 test("lists official integration providers", () => {
   const providers = listFarmIntegrationProviders().map((provider) => provider.name);
@@ -14,7 +20,16 @@ test("lists official integration providers", () => {
   assert.ok(providers.includes("stripe"));
   assert.ok(providers.includes("ai"));
   assert.ok(providers.includes("supabase"));
+  assert.ok(providers.includes("unkey"));
   assert.ok(providers.includes("jobs-inngest"));
+});
+
+test("all official integration providers expose opt-in UI metadata", () => {
+  for (const provider of listFarmIntegrationProviders()) {
+    assert.ok(provider.ui, `${provider.name} should expose a --ui feature pack`);
+    assert.ok(provider.ui.feature, `${provider.name} should name its UI feature pack`);
+    assert.ok(provider.ui.components.length, `${provider.name} should declare shadcn components`);
+  }
 });
 
 test("adds a supabase integration to a new app", async () => {
@@ -107,6 +122,125 @@ export default defineFarmConfig({
     assert.match(config, /import \{ appIntegrations \}/);
     assert.match(config, /integrations: appIntegrations/);
     assert.match(config, /vite:/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("adds a stripe integration with the shadcn UI feature pack", async () => {
+  const root = await createTempProject({
+    packageJson: {
+      type: "module",
+      dependencies: {
+        "@farmjs/core": "workspace:*",
+      },
+    },
+  });
+
+  try {
+    const result = await addFarmIntegration({
+      root,
+      provider: "stripe",
+      ui: true,
+    });
+
+    const packageJson = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
+    const componentsJson = JSON.parse(await readFile(path.join(root, "components.json"), "utf8"));
+    const tsconfig = JSON.parse(await readFile(path.join(root, "tsconfig.json"), "utf8"));
+    const globals = await readFile(path.join(root, "src/app/globals.css"), "utf8");
+    const api = await readFile(path.join(root, "src/lib/api.ts"), "utf8");
+    const pricing = await readFile(
+      path.join(root, "src/components/farm/stripe-billing.tsx"),
+      "utf8",
+    );
+    const button = await readFile(path.join(root, "src/components/ui/button.tsx"), "utf8");
+    const page = await readFile(path.join(root, "src/app/integrations/stripe/page.tsx"), "utf8");
+
+    assert.deepEqual(result.ui, {
+      feature: "stripe-billing",
+      components: ["badge", "button", "card"],
+      files: result.ui.files,
+    });
+    assert.equal(packageJson.dependencies["@farmjs/integrations"], "workspace:*");
+    assert.equal(packageJson.dependencies["class-variance-authority"], "^0.7.1");
+    assert.equal(packageJson.dependencies.clsx, "^2.1.1");
+    assert.equal(packageJson.dependencies["tailwind-merge"], "^3.3.1");
+    assert.equal(componentsJson.aliases.ui, "@/components/ui");
+    assert.equal(componentsJson.registries.farm.url, "https://farmjs.dev/r/{name}.json");
+    assert.deepEqual(tsconfig.compilerOptions.paths["@/*"], ["./src/*"]);
+    assert.match(globals, /--color-background/);
+    assert.match(api, /createIntegrations<AppIntegrations>/);
+    assert.match(pricing, /apiClient\.billing\.products/);
+    assert.match(pricing, /apiClient\.billing\.checkout/);
+    assert.match(pricing, /from "@\/components\/ui\/button"/);
+    assert.match(button, /class-variance-authority/);
+    assert.match(button, /from "@\/lib\/utils"/);
+    assert.match(page, /from "@\/components\/farm\/stripe-billing"/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("prepares UI files for every built-in integration provider", async () => {
+  for (const provider of listFarmIntegrationProviders()) {
+    const root = await createTempProject({
+      packageJson: {
+        type: "module",
+        dependencies: {
+          "@farmjs/core": "workspace:*",
+        },
+      },
+    });
+
+    try {
+      const result = await addFarmIntegration({
+        root,
+        provider: provider.name,
+        ui: true,
+        dryRun: true,
+      });
+
+      assert.ok(result.ui, `${provider.name} should install a UI feature`);
+      assert.equal(result.ui.feature, provider.ui.feature);
+      assert.deepEqual(result.ui.components, provider.ui.components);
+      assert.ok(
+        result.created.some((file) => file.includes(path.join("src", "components", "farm"))),
+        `${provider.name} should prepare a Farm UI component`,
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("runs farm add integration stripe --ui through the CLI", async () => {
+  const root = await createTempProject({
+    packageJson: {
+      type: "module",
+      dependencies: {
+        "@farmjs/core": "workspace:*",
+      },
+    },
+  });
+
+  try {
+    const { stdout } = await execFileAsync(process.execPath, [
+      cliBin,
+      "add",
+      "integration",
+      "stripe",
+      "--ui",
+      "--root",
+      root,
+    ]);
+
+    assert.match(stdout, /Added stripe integration as appIntegrations\.billing/);
+    assert.match(stdout, /UI feature: stripe-billing/);
+    assert.match(stdout, /Shadcn components: badge, button, card/);
+    assert.match(
+      await readFile(path.join(root, "src/components/farm/stripe-billing.tsx"), "utf8"),
+      /apiClient\.billing\.checkout/,
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1178,6 +1178,7 @@ async function buildSSRInMemory(
         : undefined,
       resolve: {
         alias: {
+          "@": path.resolve(root, "src"),
           // Ensure imports can resolve farm modules
           farm: path.resolve(root, "node_modules", "@farmjs", "core", "src"),
         },

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -2032,6 +2032,7 @@ function generateClientManifest(bundle: any): Record<string, any> {
 
 export async function defineConfig(config: FarmVitePluginOptions = {}) {
   const tailwindcss = (await import("@tailwindcss/vite")).default;
+  const appRoot = path.resolve(config.root || process.cwd());
 
   // Node.js built-in module stubs for browser
   const nodeBuiltinStubs: Record<string, string> = {
@@ -2247,6 +2248,7 @@ export async function defineConfig(config: FarmVitePluginOptions = {}) {
       dedupe: ["react", "react-dom", "react/jsx-runtime", "react/jsx-dev-runtime"],
       // Stub out problematic server-only modules during dev mode
       alias: {
+        "@": path.resolve(appRoot, "src"),
         // Nitro internals that should not be resolved in browser
         "supports-color":
           "data:text/javascript,export default false; export const supportsColor = false; export const stdout = false; export const stderr = false;",


### PR DESCRIPTION
## Summary
- add `farm add integration <provider> --ui` and expose provider UI metadata from the integration registry
- add shadcn-based UI feature packs for every built-in CLI integration: AI, auth providers, billing providers, Resend, jobs, Supabase, WorkOS/Auth0/Clerk/Auth.js/Better Auth, and Unkey
- add the missing Unkey CLI provider so the built-in integration package surface is available from `farm add integration unkey --ui`
- add Farm default `@ -> src` aliases for dev and SSR builds so generated shadcn-style imports work without extra app config

Closes #30

## Tests
- `corepack pnpm --filter @farmjs/cli test`
- `corepack pnpm --filter @farmjs/core build`
- `corepack pnpm --filter @farmjs/core test`
- `corepack pnpm --filter @farmjs/core type-check` *(fails on existing unrelated Nitro/query-state type issues; the new alias error is fixed)*