### PR TITLE
feat: add markdown page mirrors

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -56,6 +56,21 @@ export default defineFarmConfig({
 
 No root `vite.config.ts` or `vercel.json` is required for the basic example.
 
+### Markdown page mirrors
+
+This example exposes agent-readable markdown mirrors for a few normal pages:
+
+```ts
+export default defineFarmConfig({
+  md: {
+    expose: ["/", "/about", "/contact"],
+    cache: 60,
+  },
+});
+```
+
+With the dev server running, `/about.md` renders the same `/about` page as `text/markdown`.
+
 ### Monorepo note
 
 If you change code in `packages/farm` or `packages/farmjs-plugin`, rebuild the workspace packages before restarting this example:

--- a/examples/basic/farm.config.ts
+++ b/examples/basic/farm.config.ts
@@ -154,6 +154,11 @@ export default defineFarmConfig({
     entry: '/docs',
   },
 
+  md: {
+    expose: ['/', '/about', '/contact'],
+    cache: 60,
+  },
+
   // Plugins
   plugins: [
     createLoggerPlugin({}),

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -39,6 +39,9 @@
       "docs": [
         "./dist/docs.d.ts"
       ],
+      "markdown": [
+        "./dist/markdown.d.ts"
+      ],
       "api": [
         "./types/api.d.ts",
         "./dist/api.d.ts"
@@ -95,6 +98,11 @@
       "types": "./dist/docs.d.ts",
       "import": "./dist/docs.mjs",
       "require": "./dist/docs.cjs"
+    },
+    "./markdown": {
+      "types": "./dist/markdown.d.ts",
+      "import": "./dist/markdown.mjs",
+      "require": "./dist/markdown.cjs"
     },
     "./vite": {
       "types": "./dist/vite.d.ts",

--- a/packages/farm/src/__tests__/markdown.test.ts
+++ b/packages/farm/src/__tests__/markdown.test.ts
@@ -1,0 +1,205 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { resolveConfig } from "../config";
+import {
+  createMarkdownMirrorResponse,
+  htmlToMarkdown,
+  resolveMarkdownConfig,
+  resolveMarkdownMirrorTarget,
+} from "../markdown";
+
+describe("resolveMarkdownConfig", () => {
+  it("keeps markdown mirrors disabled by default", () => {
+    expect(resolveMarkdownConfig(undefined)).toMatchObject({
+      enabled: false,
+      expose: [],
+      cache: false,
+      includeMetadata: true,
+    });
+  });
+
+  it("normalizes exposed routes and aliases routes to expose", () => {
+    const config = resolveMarkdownConfig({
+      routes: ["/pricing.md", { route: "blog/[slug]", title: "Blog", cache: 60 }],
+      cache: 30,
+    });
+
+    expect(config).toMatchObject({
+      enabled: true,
+      expose: [{ route: "/pricing" }, { route: "/blog/[slug]", title: "Blog", cache: 60 }],
+      cache: 30,
+    });
+  });
+
+  it("supports exposing every existing page route", () => {
+    expect(resolveMarkdownConfig(true)).toMatchObject({
+      enabled: true,
+      expose: true,
+    });
+  });
+});
+
+describe("resolveMarkdownMirrorTarget", () => {
+  it("maps exposed .md URLs back to their page route", () => {
+    const config = resolveMarkdownConfig({
+      expose: ["/pricing", "/blog/[slug]"],
+    });
+
+    expect(resolveMarkdownMirrorTarget(config, "/pricing.md")).toMatchObject({
+      pathname: "/pricing",
+      route: { route: "/pricing" },
+    });
+    expect(resolveMarkdownMirrorTarget(config, "/blog/farm.md")).toMatchObject({
+      pathname: "/blog/farm",
+      route: { route: "/blog/[slug]" },
+    });
+  });
+
+  it("ignores routes that are not exposed", () => {
+    const config = resolveMarkdownConfig({
+      expose: ["/pricing"],
+    });
+
+    expect(resolveMarkdownMirrorTarget(config, "/secret.md")).toBeNull();
+    expect(resolveMarkdownMirrorTarget(config, "/pricing")).toBeNull();
+  });
+});
+
+describe("createMarkdownMirrorResponse", () => {
+  it("renders an exposed page as markdown", async () => {
+    const config = resolveMarkdownConfig({
+      expose: ["/pricing"],
+      cache: 60,
+    });
+
+    const response = await createMarkdownMirrorResponse({
+      request: new Request("http://farm.test/pricing.md"),
+      config,
+      routeExists: (pathname) => pathname === "/pricing",
+      renderPage: () =>
+        new Response(
+          [
+            "<!doctype html>",
+            "<html>",
+            "<head><title>Pricing</title></head>",
+            "<body>",
+            '<div id="root">',
+            "<main>",
+            "<h1>Pricing</h1>",
+            "<p>Simple <strong>plans</strong> for builders.</p>",
+            '<a href="/signup">Start now</a>',
+            "</main>",
+            "</div>",
+            "</body>",
+            "</html>",
+          ].join(""),
+          {
+            headers: {
+              "content-type": "text/html; charset=utf-8",
+            },
+          },
+        ),
+    });
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("content-type")).toContain("text/markdown");
+    expect(response?.headers.get("cache-control")).toBe("public, max-age=60, s-maxage=60");
+    expect(response?.headers.get("x-farm-markdown-route")).toBe("/pricing");
+    const markdown = await response?.text();
+    expect(markdown).toContain("# Pricing");
+    expect(markdown).toContain("**plans**");
+  });
+
+  it("returns null when the target page route does not exist", async () => {
+    const config = resolveMarkdownConfig({
+      expose: ["/pricing"],
+    });
+
+    const response = await createMarkdownMirrorResponse({
+      request: new Request("http://farm.test/pricing.md"),
+      config,
+      routeExists: () => false,
+      renderPage: () => {
+        throw new Error("renderPage should not be called");
+      },
+    });
+
+    expect(response).toBeNull();
+  });
+
+  it("supports HEAD requests without a response body", async () => {
+    const config = resolveMarkdownConfig({
+      expose: ["/pricing"],
+    });
+
+    const response = await createMarkdownMirrorResponse({
+      request: new Request("http://farm.test/pricing.md", { method: "HEAD" }),
+      config,
+      routeExists: () => true,
+      renderPage: () =>
+        new Response("<html><body><h1>Pricing</h1></body></html>", {
+          headers: {
+            "content-type": "text/html",
+          },
+        }),
+    });
+
+    expect(response?.headers.get("content-type")).toContain("text/markdown");
+    await expect(response?.text()).resolves.toBe("");
+  });
+});
+
+describe("htmlToMarkdown", () => {
+  it("converts common page HTML into readable markdown", () => {
+    expect(
+      htmlToMarkdown(
+        [
+          "<html><head><title>Guide</title></head><body>",
+          "<article>",
+          "<h2>Install</h2>",
+          "<p>Run <code>pnpm add @farmjs/core</code>.</p>",
+          '<p><a href="/docs">Read docs</a></p>',
+          "</article>",
+          "</body></html>",
+        ].join(""),
+        { sourcePath: "/guide" },
+      ),
+    ).toContain("[Read docs](/docs)");
+  });
+
+  it("prefers page content over layout chrome", () => {
+    expect(
+      htmlToMarkdown(
+        [
+          "<html><body>",
+          '<div id="root">',
+          "<nav>Home About Contact</nav>",
+          "<main><h1>About</h1><p>Readable page content.</p></main>",
+          "</div>",
+          "</body></html>",
+        ].join(""),
+      ),
+    ).not.toContain("Home About Contact");
+  });
+});
+
+describe("resolveConfig markdown mirrors", () => {
+  it("resolves md config from farm.config options", async () => {
+    const config = await resolveConfig(
+      {
+        md: {
+          expose: ["/pricing"],
+          cache: 60,
+        },
+      },
+      "development",
+    );
+
+    expect(config.md).toMatchObject({
+      enabled: true,
+      expose: [{ route: "/pricing" }],
+      cache: 60,
+    });
+  });
+});

--- a/packages/farm/src/app.ts
+++ b/packages/farm/src/app.ts
@@ -1,5 +1,7 @@
 import type { FarmConfig } from "./types";
 import type { FarmDocsResolvedConfig } from "./docs/types";
+import type { FarmMarkdownResolvedConfig } from "./markdown";
+import { resolveMarkdownConfig } from "./markdown";
 import { resolveAppPath, fileExists, logger } from "./utils";
 import { initStorage } from "./storage";
 import { RouteManager } from "./routing/route-manager";
@@ -9,6 +11,7 @@ import type { ViteDevServer } from "vite";
 
 type NormalizedFarmConfig = Required<FarmConfig> & {
   docs: FarmDocsResolvedConfig;
+  md: FarmMarkdownResolvedConfig;
 };
 
 const defaultDocsConfig: FarmDocsResolvedConfig = {
@@ -78,6 +81,7 @@ export class FarmApp {
       storage: config.storage || {},
       integrations: config.integrations || {},
       docs: isResolvedDocsConfig(config.docs) ? config.docs : defaultDocsConfig,
+      md: resolveMarkdownConfig(config.md),
       suppressLintOnLink: config.suppressLintOnLink ?? false,
       experimental: {
         serverComponents: config.experimental?.serverComponents ?? false,

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -2,12 +2,19 @@ import type { FarmConfig as BaseFarmConfig } from "./types";
 import type { DocsConfig } from "@farming-labs/docs";
 import type { FarmDocsResolvedConfig, FarmDocsUserConfig } from "./docs/types";
 import type { FarmIntegrationsUserConfig } from "./integrations";
+import type { FarmMarkdownResolvedConfig, FarmMarkdownUserConfig } from "./markdown";
 import type { FarmPlugin } from "./plugin";
 import type { UserConfig as ViteUserConfig } from "vite";
 import { resolveIntegrationPlugins } from "./integrations";
+import { resolveMarkdownConfig } from "./markdown";
 import path from "path";
 
 export type { FarmDocsConfigInput, FarmDocsResolvedConfig, FarmDocsUserConfig } from "./docs/types";
+export type {
+  FarmMarkdownResolvedConfig,
+  FarmMarkdownRouteInput,
+  FarmMarkdownUserConfig,
+} from "./markdown";
 
 export interface RedirectConfig {
   source: string;
@@ -117,6 +124,7 @@ export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite" | "docs"> {
   preset?: BaseFarmConfig["preset"];
   deploy?: FarmDeployConfig;
   docs?: FarmDocsUserConfig;
+  md?: FarmMarkdownUserConfig | boolean;
 
   trailingSlash?: boolean;
   redirects?: () => Promise<RedirectConfig[]> | RedirectConfig[];
@@ -159,12 +167,13 @@ export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite" | "docs"> {
 }
 
 export interface ResolvedFarmConfig extends Required<
-  Omit<FarmUserConfig, "plugins" | "vite" | "deploy" | "docs">
+  Omit<FarmUserConfig, "plugins" | "vite" | "deploy" | "docs" | "md">
 > {
   plugins: FarmPlugin[];
   vite: ViteUserConfig;
   deploy: ResolvedFarmDeployConfig;
   docs: FarmDocsResolvedConfig;
+  md: FarmMarkdownResolvedConfig;
 }
 
 export function defineFarmConfig(config: FarmUserConfig): FarmUserConfig {
@@ -513,6 +522,7 @@ export async function resolveConfig(
   const root = userConfig.root || process.cwd();
   const srcDir = userConfig.srcDir || "src";
   const docs = await resolveDocsConfig(userConfig.docs, { root, srcDir });
+  const md = resolveMarkdownConfig(userConfig.md);
 
   const resolved: ResolvedFarmConfig = {
     root,
@@ -522,6 +532,7 @@ export async function resolveConfig(
     preset: deploy.preset || "node-server",
     deploy,
     docs,
+    md,
     storage: userConfig.storage || {},
     suppressLintOnLink: userConfig.suppressLintOnLink ?? false,
     experimental: {

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -26,6 +26,7 @@ export * from "./openapi";
 export * from "./query";
 export * from "./middleware";
 export * from "./docs";
+export * from "./markdown";
 export { generateRouteTypes } from "./routing/generate-route-types";
 export type { GenerateRouteTypesOptions } from "./routing/generate-route-types";
 export * from "./build/index";
@@ -66,6 +67,8 @@ export type {
   FarmDeployTarget,
   FarmDocsResolvedConfig,
   FarmDocsUserConfig,
+  FarmMarkdownResolvedConfig,
+  FarmMarkdownUserConfig,
 } from "./config";
 
 export type { ComponentType, ReactNode, ReactElement, FC, PropsWithChildren } from "react";

--- a/packages/farm/src/markdown.ts
+++ b/packages/farm/src/markdown.ts
@@ -1,0 +1,356 @@
+export type FarmMarkdownRouteInput =
+  | string
+  | {
+      route: string;
+      title?: string;
+      cache?: number | false;
+    };
+
+export interface FarmMarkdownUserConfig {
+  enabled?: boolean;
+  expose?: boolean | FarmMarkdownRouteInput[];
+  routes?: FarmMarkdownRouteInput[];
+  cache?: number | false;
+  includeMetadata?: boolean;
+}
+
+export interface FarmMarkdownResolvedRoute {
+  route: string;
+  title?: string;
+  cache?: number | false;
+}
+
+export interface FarmMarkdownResolvedConfig {
+  enabled: boolean;
+  expose: true | FarmMarkdownResolvedRoute[];
+  cache: number | false;
+  includeMetadata: boolean;
+}
+
+export interface FarmMarkdownMirrorTarget {
+  pathname: string;
+  route: FarmMarkdownResolvedRoute | null;
+}
+
+export interface CreateMarkdownMirrorResponseOptions {
+  request: Request;
+  config?: FarmMarkdownResolvedConfig;
+  routeExists?: (pathname: string) => boolean;
+  renderPage: (request: Request) => Response | Promise<Response>;
+}
+
+export function resolveMarkdownConfig(
+  config: FarmMarkdownUserConfig | boolean | undefined,
+): FarmMarkdownResolvedConfig {
+  if (config === false || config === undefined) {
+    return {
+      enabled: false,
+      expose: [],
+      cache: false,
+      includeMetadata: true,
+    };
+  }
+
+  if (config === true) {
+    return {
+      enabled: true,
+      expose: true,
+      cache: false,
+      includeMetadata: true,
+    };
+  }
+
+  const exposeInput = config.expose ?? config.routes ?? [];
+  const expose =
+    exposeInput === true
+      ? true
+      : Array.isArray(exposeInput)
+        ? exposeInput.map(normalizeMarkdownRouteInput)
+        : [];
+
+  return {
+    enabled: config.enabled !== false && (expose === true || expose.length > 0),
+    expose,
+    cache: config.cache ?? false,
+    includeMetadata: config.includeMetadata ?? true,
+  };
+}
+
+export function resolveMarkdownMirrorTarget(
+  config: FarmMarkdownResolvedConfig | undefined,
+  pathname: string,
+): FarmMarkdownMirrorTarget | null {
+  if (!config?.enabled || !pathname.endsWith(".md")) {
+    return null;
+  }
+
+  const targetPathname = normalizeMarkdownRoute(pathname.slice(0, -".md".length) || "/");
+  const route = findExposedMarkdownRoute(config, targetPathname);
+  if (!route && config.expose !== true) {
+    return null;
+  }
+
+  return {
+    pathname: targetPathname,
+    route,
+  };
+}
+
+export async function createMarkdownMirrorResponse(
+  options: CreateMarkdownMirrorResponseOptions,
+): Promise<Response | null> {
+  if (options.request.method !== "GET" && options.request.method !== "HEAD") {
+    return null;
+  }
+
+  const requestUrl = new URL(options.request.url);
+  const target = resolveMarkdownMirrorTarget(options.config, requestUrl.pathname);
+  if (!target) {
+    return null;
+  }
+
+  if (options.routeExists && !options.routeExists(target.pathname)) {
+    return null;
+  }
+
+  const pageUrl = new URL(options.request.url);
+  pageUrl.pathname = target.pathname;
+  const headers = new Headers(options.request.headers);
+  headers.set("accept", "text/html");
+
+  const pageResponse = await options.renderPage(
+    new Request(pageUrl, {
+      method: "GET",
+      headers,
+    }),
+  );
+
+  if (!isHtmlResponse(pageResponse)) {
+    return null;
+  }
+
+  const html = await pageResponse.text();
+  const markdown = htmlToMarkdown(html, {
+    title: target.route?.title,
+    includeMetadata: options.config?.includeMetadata ?? true,
+    sourcePath: target.pathname,
+  });
+  const headersOut = new Headers({
+    "Content-Type": "text/markdown; charset=utf-8",
+    "X-Farm-Markdown-Route": target.pathname,
+  });
+  const cache = target.route?.cache ?? options.config?.cache ?? false;
+  headersOut.set("Cache-Control", createMarkdownCacheHeader(cache));
+
+  return new Response(options.request.method === "HEAD" ? null : markdown, {
+    status: pageResponse.status,
+    headers: headersOut,
+  });
+}
+
+export function htmlToMarkdown(
+  html: string,
+  options: {
+    title?: string;
+    sourcePath?: string;
+    includeMetadata?: boolean;
+  } = {},
+): string {
+  const title = options.title ?? extractHtmlTitle(html);
+  let source = extractHtmlBody(html)
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "")
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, "")
+    .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi, "")
+    .replace(/<!--[\s\S]*?-->/g, "");
+
+  source = source.replace(/<pre\b[^>]*><code\b[^>]*>([\s\S]*?)<\/code><\/pre>/gi, (_, code) => {
+    return `\n\n\`\`\`\n${decodeHtml(stripTags(code)).trim()}\n\`\`\`\n\n`;
+  });
+  source = source.replace(/<pre\b[^>]*>([\s\S]*?)<\/pre>/gi, (_, code) => {
+    return `\n\n\`\`\`\n${decodeHtml(stripTags(code)).trim()}\n\`\`\`\n\n`;
+  });
+  source = source.replace(/<h([1-6])\b[^>]*>([\s\S]*?)<\/h\1>/gi, (_, level, content) => {
+    return `\n\n${"#".repeat(Number(level))} ${toInlineMarkdown(content).trim()}\n\n`;
+  });
+  source = source.replace(/<p\b[^>]*>([\s\S]*?)<\/p>/gi, (_, content) => {
+    return `\n\n${toInlineMarkdown(content).trim()}\n\n`;
+  });
+  source = source.replace(/<blockquote\b[^>]*>([\s\S]*?)<\/blockquote>/gi, (_, content) => {
+    const quote = htmlToMarkdown(content, { includeMetadata: false })
+      .split("\n")
+      .filter((line) => line.trim().length > 0)
+      .map((line) => `> ${line}`)
+      .join("\n");
+    return `\n\n${quote}\n\n`;
+  });
+  source = source.replace(/<li\b[^>]*>([\s\S]*?)<\/li>/gi, (_, content) => {
+    return `\n- ${toInlineMarkdown(content).trim()}`;
+  });
+  source = source
+    .replace(/<\/?(ul|ol|main|section|article|header|footer|nav|aside|div)\b[^>]*>/gi, "\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<hr\s*\/?>/gi, "\n\n---\n\n");
+
+  let markdown = stripTags(source)
+    .split("\n")
+    .map((line) => line.replace(/[ \t]+$/g, ""))
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
+  if (options.includeMetadata !== false) {
+    const metadata: string[] = [];
+    if (title && !markdown.startsWith("# ")) {
+      metadata.push(`# ${title}`);
+    }
+    if (options.sourcePath) {
+      metadata.push(`Source: ${options.sourcePath}`);
+    }
+    if (metadata.length) {
+      markdown = `${metadata.join("\n\n")}${markdown ? `\n\n${markdown}` : ""}`;
+    }
+  }
+
+  return `${markdown}\n`;
+}
+
+function normalizeMarkdownRouteInput(input: FarmMarkdownRouteInput): FarmMarkdownResolvedRoute {
+  if (typeof input === "string") {
+    return {
+      route: normalizeMarkdownRoute(input),
+    };
+  }
+
+  return {
+    ...input,
+    route: normalizeMarkdownRoute(input.route),
+  };
+}
+
+function normalizeMarkdownRoute(route: string): string {
+  const withoutMarkdownExtension = route.endsWith(".md") ? route.slice(0, -3) : route;
+  const withSlash = withoutMarkdownExtension.startsWith("/")
+    ? withoutMarkdownExtension
+    : `/${withoutMarkdownExtension}`;
+  const normalized = withSlash.replace(/\/+/g, "/").replace(/\/$/g, "");
+  return normalized === "" || normalized === "/index" ? "/" : normalized;
+}
+
+function findExposedMarkdownRoute(
+  config: FarmMarkdownResolvedConfig,
+  pathname: string,
+): FarmMarkdownResolvedRoute | null {
+  if (config.expose === true) {
+    return null;
+  }
+
+  return config.expose.find((route) => routeMatches(route.route, pathname)) ?? null;
+}
+
+function routeMatches(pattern: string, pathname: string): boolean {
+  if (pattern === pathname) {
+    return true;
+  }
+
+  const escaped = pattern
+    .split("/")
+    .map((segment) => {
+      if (/^\[\.\.\.[^\]]+\]$/.test(segment)) {
+        return ".*";
+      }
+      if (/^\[[^\]]+\]$/.test(segment)) {
+        return "[^/]+";
+      }
+      return segment.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    })
+    .join("/");
+
+  return new RegExp(`^${escaped}$`).test(pathname);
+}
+
+function isHtmlResponse(response: Response): boolean {
+  const contentType = response.headers.get("content-type") ?? "";
+  return contentType.includes("text/html");
+}
+
+function createMarkdownCacheHeader(cache: number | false): string {
+  if (cache === false || cache <= 0) {
+    return "no-store";
+  }
+
+  return `public, max-age=${cache}, s-maxage=${cache}`;
+}
+
+function extractHtmlTitle(html: string): string | undefined {
+  const match = html.match(/<title\b[^>]*>([\s\S]*?)<\/title>/i);
+  return match ? decodeHtml(stripTags(match[1])).trim() : undefined;
+}
+
+function extractHtmlBody(html: string): string {
+  const rootMatch = html.match(
+    /<div\b[^>]*id=["']root["'][^>]*>([\s\S]*?)<\/div>\s*(?:<script|<\/body>|$)/i,
+  );
+  const bodyMatch = html.match(/<body\b[^>]*>([\s\S]*?)<\/body>/i);
+  const body = rootMatch ? rootMatch[1] : bodyMatch ? bodyMatch[1] : html;
+  return extractFirstElementContent(body, ["main", "article"]) ?? body;
+}
+
+function extractFirstElementContent(html: string, tagNames: string[]): string | undefined {
+  for (const tagName of tagNames) {
+    const match = html.match(new RegExp(`<${tagName}\\b[^>]*>([\\s\\S]*?)<\\/${tagName}>`, "i"));
+    if (match) {
+      return match[1];
+    }
+  }
+
+  return undefined;
+}
+
+function toInlineMarkdown(html: string): string {
+  let source = html
+    .replace(/<a\b[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi, (_, href, text) => {
+      const label: string = toInlineMarkdown(text).trim() || href;
+      return `[${label}](${decodeHtml(href)})`;
+    })
+    .replace(
+      /<img\b[^>]*src=["']([^"']+)["'][^>]*alt=["']([^"']*)["'][^>]*\/?>/gi,
+      (_, src, alt) => {
+        return `![${decodeHtml(alt)}](${decodeHtml(src)})`;
+      },
+    )
+    .replace(/<strong\b[^>]*>([\s\S]*?)<\/strong>/gi, (_, content) => {
+      return `**${toInlineMarkdown(content).trim()}**`;
+    })
+    .replace(/<b\b[^>]*>([\s\S]*?)<\/b>/gi, (_, content) => {
+      return `**${toInlineMarkdown(content).trim()}**`;
+    })
+    .replace(/<em\b[^>]*>([\s\S]*?)<\/em>/gi, (_, content) => {
+      return `_${toInlineMarkdown(content).trim()}_`;
+    })
+    .replace(/<i\b[^>]*>([\s\S]*?)<\/i>/gi, (_, content) => {
+      return `_${toInlineMarkdown(content).trim()}_`;
+    })
+    .replace(/<code\b[^>]*>([\s\S]*?)<\/code>/gi, (_, content) => {
+      return `\`${decodeHtml(stripTags(content)).trim()}\``;
+    })
+    .replace(/<br\s*\/?>/gi, "\n");
+
+  source = stripTags(source);
+  return decodeHtml(source).replace(/\s+/g, " ");
+}
+
+function stripTags(input: string): string {
+  return input.replace(/<[^>]+>/g, "");
+}
+
+function decodeHtml(input: string): string {
+  return input
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x([0-9a-f]+);/gi, (_, code) => String.fromCodePoint(Number.parseInt(code, 16)))
+    .replace(/&#(\d+);/g, (_, code) => String.fromCodePoint(Number.parseInt(code, 10)));
+}

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1261,6 +1261,9 @@ function generateVirtualEntryCode(
   const docsHandlerImport = config.docs?.enabled
     ? `import { createFarmDocsAPIHandler, createFarmDocsHandler } from "farm/docs";`
     : "";
+  const markdownHandlerImport = config.md?.enabled
+    ? `import { createMarkdownMirrorResponse } from "farm/markdown";`
+    : "";
   const integrationImports = configModulePath
     ? `
 import * as FarmUserConfigModule from "${configModulePath}";
@@ -1317,6 +1320,7 @@ ${layoutImports.join("\n")}
 ${notFoundImport}
 ${apiRouteHelpersImport}
 ${docsHandlerImport}
+${markdownHandlerImport}
 ${integrationImports}
 
 // Custom 404 page component (if provided)
@@ -1327,6 +1331,7 @@ const farmUserConfig = ${
   };
 const configuredIntegrations = farmUserConfig?.integrations || {};
 const integrationRuntimeConfig = farmUserConfig || {};
+const farmMarkdownConfig = ${JSON.stringify(config.md)};
 globalThis.__FARM_DOCS_RUNTIME_CONFIG__ = {
   root: ${JSON.stringify(config.root)},
   srcDir: ${JSON.stringify(config.srcDir)},
@@ -1448,6 +1453,18 @@ async function handleRequest(request) {
     const docsResponse = await farmDocsHandler(request.clone());
     if (docsResponse) {
       return docsResponse;
+    }
+  }
+
+  if (farmMarkdownConfig?.enabled) {
+    const markdownResponse = await createMarkdownMirrorResponse({
+      request: request.clone(),
+      config: farmMarkdownConfig,
+      routeExists: (targetPathname) => Boolean(matchPageRoute(targetPathname)),
+      renderPage: (targetRequest) => handleRequest(targetRequest),
+    });
+    if (markdownResponse) {
+      return markdownResponse;
     }
   }
 

--- a/packages/farm/src/types.ts
+++ b/packages/farm/src/types.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage, ServerResponse } from "http";
 import type { FarmStorageUserConfig } from "./storage/types";
 import type { FarmIntegrationsUserConfig } from "./integrations";
 import type { FarmDocsResolvedConfig, FarmDocsUserConfig } from "./docs/types";
+import type { FarmMarkdownResolvedConfig, FarmMarkdownUserConfig } from "./markdown";
 
 export type NitroPreset =
   | "node-server"
@@ -51,6 +52,7 @@ export interface FarmConfig {
   storage?: FarmStorageUserConfig;
   integrations?: FarmIntegrationsUserConfig;
   docs?: FarmDocsUserConfig | FarmDocsResolvedConfig;
+  md?: FarmMarkdownUserConfig | FarmMarkdownResolvedConfig | boolean;
   /**
    * When true, Link href is not strictly typed (accepts any string).
    * Use when you want to skip route-type errors on Link or don't use generated route types.

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -15,6 +15,7 @@ import {
   getFarmDocsRouteTypeEntries,
   isFarmDocsAPIRequest,
 } from "./docs";
+import { createMarkdownMirrorResponse } from "./markdown";
 import { sendWebResponse } from "./server/response";
 import {
   getClientModuleMetadata,
@@ -280,6 +281,7 @@ export function farmPlugin(
         const requestMethod = req.method || "GET";
         const fullUrl = `http://${req.headers.host || "localhost:3000"}${requestUrl}`;
         const requestPathname = new URL(fullUrl).pathname;
+        const currentConfig = farmApp?.getConfig() ?? options;
 
         // Handle OpenAPI docs route
         if (openAPIManager && req.url === options.openapi?.route) {
@@ -304,7 +306,20 @@ export function farmPlugin(
           return;
         }
 
-        const currentConfig = farmApp?.getConfig() ?? options;
+        const markdownResponse = await createMarkdownMirrorResponse({
+          request: new Request(fullUrl, {
+            method: requestMethod,
+            headers: docsHeaders,
+          }),
+          config: farmApp.getConfig().md,
+          routeExists: (pathname) => Boolean(farmApp.getRouteManager().matchRoute(pathname).route),
+          renderPage: async (request) => fetch(request),
+        });
+        if (markdownResponse) {
+          await sendWebResponse(res, markdownResponse);
+          return;
+        }
+
         const configuredIntegrations = currentConfig.integrations;
 
         const tryConfiguredIntegrationRoute = async () => {

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     storage: "src/storage/index.ts",
     cache: "src/cache.ts",
     docs: "src/docs/index.ts",
+    markdown: "src/markdown.ts",
   },
   format: ["cjs", "esm"],
   dts: true,


### PR DESCRIPTION
## Summary

- add config-driven `md` page mirrors so normal routes can be exposed as `/<route>.md`
- wire markdown mirrors into dev middleware and generated Nitro/server output
- export `farm/markdown`, normalize markdown config in Farm app/config, and document the feature in the basic example
- add focused tests for config resolution, route matching, response behavior, and page-content extraction

## Validation

- `corepack pnpm --filter @farmjs/core test`
- `corepack pnpm --filter @farmjs/core build`
- `corepack pnpm --filter farm-example-basic build`
- live dev smoke: `curl -i http://localhost:3000/about.md` returned `200`, `text/markdown`, and `x-farm-markdown-route: /about`

Note: the core build still prints the existing `import.meta` warning for the CJS output of `src/nitro/universal-build.ts`, but the build completes successfully.