### PR TITLE
feat: add ppr static shell caching

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -71,6 +71,17 @@ export default defineFarmConfig({
 
 With the dev server running, `/about.md` renders the same `/about` page as `text/markdown`.
 
+### PPR static shell
+
+The `/ppr-demo` page opts into static-shell caching:
+
+```ts
+export const experimental_ppr = true;
+export const revalidate = 60;
+```
+
+The first request returns `X-Farm-PPR: miss`; the next matching request returns `X-Farm-PPR: hit`.
+
 ### Monorepo note
 
 If you change code in `packages/farm` or `packages/farmjs-plugin`, rebuild the workspace packages before restarting this example:

--- a/examples/basic/src/app/ppr-demo/page.tsx
+++ b/examples/basic/src/app/ppr-demo/page.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+export const experimental_ppr = true;
+export const revalidate = 60;
+
+export const metadata = {
+  title: 'PPR Demo | Farm.js',
+  description: 'Static shell caching demo powered by Farm.js PPR route config',
+};
+
+export default function PPRDemoPage() {
+  const renderedAt = new Date().toISOString();
+
+  return (
+    <main className="max-w-3xl mx-auto space-y-6">
+      <section className="space-y-3">
+        <h1 className="text-4xl font-bold text-gray-900">PPR Static Shell</h1>
+        <p className="text-lg text-gray-600 leading-relaxed">
+          This route opts into the Next-compatible{' '}
+          <code className="rounded bg-gray-100 px-1.5 py-0.5">experimental_ppr</code> export.
+          Farm caches the rendered shell and reuses the shared path revalidation cache.
+        </p>
+      </section>
+
+      <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="text-xl font-semibold text-gray-900">Rendered at</h2>
+        <code className="mt-3 block rounded bg-gray-950 p-4 text-sm text-green-300">
+          {renderedAt}
+        </code>
+      </section>
+    </main>
+  );
+}

--- a/examples/basic/src/farm-routes.d.ts
+++ b/examples/basic/src/farm-routes.d.ts
@@ -3,7 +3,7 @@
  * Link href is typed automatically via module augmentation. Regenerated on dev start and when routes change.
  * Set suppressLintOnLink: true in farm.config.ts to accept any string on Link href.
  */
-export type RoutePath = "/" | "/about" | "/api-demo" | "/api-demo-client" | "/api-demo-client-advanced" | "/boundaries/error" | "/boundaries/loading" | "/boundaries/suspense" | "/contact" | "/docs" | `/docs/${string}` | "/docs/reference" | "/farm-query-client-demo" | "/farm-query-demo" | "/prefetch-e2e" | "/query-demo" | "/storage-demo" | "/store-e2e" | `/users/${string}`;
+export type RoutePath = "/" | "/about" | "/api-demo" | "/api-demo-client" | "/api-demo-client-advanced" | "/boundaries/error" | "/boundaries/loading" | "/boundaries/suspense" | "/contact" | "/docs" | `/docs/${string}` | "/docs/reference" | "/farm-query-client-demo" | "/farm-query-demo" | "/ppr-demo" | "/prefetch-e2e" | "/query-demo" | "/storage-demo" | "/store-e2e" | `/users/${string}`;
 declare module "@farmjs/core/client" {
   interface LinkDefaultRoute {
     _: import("./farm-routes").RoutePath;

--- a/packages/farm/src/__tests__/cache.test.ts
+++ b/packages/farm/src/__tests__/cache.test.ts
@@ -68,6 +68,19 @@ describe("server cache primitives", () => {
     await expect(getDashboard()).resolves.toEqual({ calls: 2 });
   });
 
+  it("revalidates PPR shell entries through the shared path cache", () => {
+    const cache = getFarmDataCache();
+    const key = createFarmCacheKey(["ppr", normalizeRevalidatePath("/dashboard"), ""]);
+
+    cache.set(key, { html: "<html>dashboard</html>" }, { paths: ["/dashboard"], tags: ["ppr"] });
+
+    expect(cache.getEntry<{ html: string }>(key)?.value.html).toContain("dashboard");
+
+    revalidatePath("/dashboard");
+
+    expect(cache.getEntry(key)).toBeUndefined();
+  });
+
   it("supports updateTag as immediate tag invalidation", async () => {
     let calls = 0;
     const getUser = unstable_cache(

--- a/packages/farm/src/__tests__/ssg.test.ts
+++ b/packages/farm/src/__tests__/ssg.test.ts
@@ -54,6 +54,23 @@ describe("route rendering config", () => {
     });
   });
 
+  it("supports PPR and Next-compatible experimental_ppr without forcing SSG", () => {
+    expect(resolveRouteRenderingConfig({ experimental_ppr: true, revalidate: 60 })).toMatchObject({
+      ssg: false,
+      ppr: true,
+      revalidate: 60,
+    });
+    expect(resolveRouteRenderingConfig({ ppr: true })).toMatchObject({
+      ssg: false,
+      ppr: true,
+    });
+    expect(resolveRouteRenderingConfig({ ppr: true, dynamic: "force-dynamic" })).toMatchObject({
+      ssg: false,
+      ppr: false,
+      dynamic: "force-dynamic",
+    });
+  });
+
   it("parses top-of-file rendering directives", () => {
     expect(
       parseRouteRenderingDirective(`
@@ -73,7 +90,14 @@ describe("route rendering config", () => {
 
     expect(parseRouteRenderingDirective(`'use ssr';`)).toMatchObject({
       ssg: false,
+      ppr: false,
       dynamic: "force-dynamic",
+    });
+
+    expect(parseRouteRenderingDirective(`"use ppr; 30";`)).toMatchObject({
+      ssg: false,
+      ppr: true,
+      revalidate: 30,
     });
   });
 

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1258,6 +1258,7 @@ function generateVirtualEntryCode(
     apiRoutes.length > 0
       ? `import { invokeAPIRouteEndpoint, matchAPIRoute } from "farm/api/route-manager";`
       : "";
+  const cacheHelpersImport = `import { createFarmCacheKey, getFarmDataCache, normalizeRevalidatePath } from "farm/cache";`;
   const docsHandlerImport = config.docs?.enabled
     ? `import { createFarmDocsAPIHandler, createFarmDocsHandler } from "farm/docs";`
     : "";
@@ -1319,6 +1320,7 @@ ${pageImports.join("\n")}
 ${layoutImports.join("\n")}
 ${notFoundImport}
 ${apiRouteHelpersImport}
+${cacheHelpersImport}
 ${docsHandlerImport}
 ${markdownHandlerImport}
 ${integrationImports}
@@ -1437,6 +1439,65 @@ function getApplicableLayouts(pathname) {
   return applicable;
 }
 
+const pprShellCache = getFarmDataCache();
+
+function resolvePPRConfig(routeModule) {
+  if (!routeModule || routeModule.dynamic === "force-dynamic") {
+    return { enabled: false };
+  }
+
+  if (routeModule.dynamic === "force-static" || routeModule.dynamic === "error") {
+    return { enabled: false };
+  }
+
+  const enabled = routeModule.ppr === true || routeModule.experimental_ppr === true;
+  const revalidate =
+    typeof routeModule.revalidate === "number" && routeModule.revalidate > 0
+      ? routeModule.revalidate
+      : undefined;
+
+  return { enabled, revalidate };
+}
+
+function canCachePPRShell(request) {
+  const method = request.method.toUpperCase();
+  return (
+    (method === "GET" || method === "HEAD") &&
+    !request.headers.get("cookie") &&
+    !request.headers.get("authorization")
+  );
+}
+
+function getPPRShellCacheKey(url) {
+  return createFarmCacheKey(["ppr", normalizeRevalidatePath(url.pathname), url.search]);
+}
+
+function getPPRHeaders(status, config) {
+  const headers = {
+    "X-Farm-PPR": status,
+  };
+
+  if (status === "bypass") {
+    headers["Cache-Control"] = "private, no-store";
+    return headers;
+  }
+
+  if (typeof config.revalidate === "number" && config.revalidate > 0) {
+    headers["Cache-Control"] = \`s-maxage=\${config.revalidate}, stale-while-revalidate\`;
+  }
+
+  return headers;
+}
+
+function getCachedPPRShell(cacheKey) {
+  const entry = pprShellCache.getEntry(cacheKey);
+  if (!entry) {
+    return null;
+  }
+
+  return entry.value.html;
+}
+
 /**
  * Main request handler - created at runtime with bundled routes
  */
@@ -1494,6 +1555,22 @@ async function handleRequest(request) {
     const { route, params } = matchedRoute;
     
     try {
+      const pprConfig = resolvePPRConfig(route.module);
+      const pprCanCache = pprConfig.enabled && canCachePPRShell(request);
+      const pprCacheKey = pprCanCache ? getPPRShellCacheKey(url) : null;
+      if (pprCacheKey) {
+        const cachedPPRShell = getCachedPPRShell(pprCacheKey);
+        if (cachedPPRShell) {
+          return new Response(cachedPPRShell, {
+            status: 200,
+            headers: {
+              "Content-Type": "text/html; charset=utf-8",
+              ...getPPRHeaders("hit", pprConfig),
+            },
+          });
+        }
+      }
+
       // Get the page component and metadata
       const PageComponent = route.module.default;
       const pageMetadata = route.module.metadata || {};
@@ -1624,14 +1701,29 @@ async function handleRequest(request) {
         // Include client CSS and hydration script
         // Add caching headers for edge caching (Vercel, Cloudflare, etc.)
         // s-maxage: cache at edge for 60s, stale-while-revalidate: serve stale while updating
+        const responseHeaders = {
+          "Content-Type": "text/html; charset=utf-8",
+          "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+          ...(pprConfig.enabled ? getPPRHeaders(pprCanCache ? "miss" : "bypass", pprConfig) : {}),
+        };
+
+        if (pprCacheKey && request.method.toUpperCase() !== "HEAD") {
+          pprShellCache.set(
+            pprCacheKey,
+            { html: fullHtml },
+            {
+              paths: [pathname],
+              tags: ["ppr"],
+              revalidate: pprConfig.revalidate ?? false,
+            }
+          );
+        }
+
         return new Response(
           fullHtml,
           { 
             status: 200, 
-            headers: { 
-              "Content-Type": "text/html; charset=utf-8",
-              "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
-            } 
+            headers: responseHeaders
           }
         );
       }

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -9,7 +9,7 @@ import { getClientModuleMetadata } from "../utils/client-component";
 import { Writable } from "stream";
 import { _runWithMiddlewareData, _clearCurrentMiddlewareData } from "../middleware/server";
 import { getRequestContextSnapshot } from "../request-context";
-import { isSSGModule, matchSSGPage } from "../ssg";
+import { matchSSGPage, resolveRouteRenderingConfigFromFile } from "../ssg";
 import { getIntegrationProviders, getRegisteredIntegrationAPIManifest } from "../integrations";
 import { _runWithCurrentRequest, createWebRequestFromFarmRequest } from "./request";
 import { createFarmCacheKey, getFarmDataCache, normalizeRevalidatePath } from "../cache";
@@ -25,6 +25,16 @@ const importRuntimeModule = new Function("specifier", "return import(specifier);
 interface CachedSSGPage {
   html: string;
   document: boolean;
+}
+
+interface CachedPPRShell {
+  html: string;
+}
+
+interface PPRShellCacheOptions {
+  pathname: string;
+  search: string;
+  revalidate?: number;
 }
 
 function toMiddlewareMap(input: unknown): Map<string, any> {
@@ -115,6 +125,10 @@ export class ServerRenderer {
     return createFarmCacheKey(["ssg", normalizeRevalidatePath(urlPath)]);
   }
 
+  private getPPRCacheKey(pathname: string, search = ""): string {
+    return createFarmCacheKey(["ppr", normalizeRevalidatePath(pathname), search]);
+  }
+
   private getCachedSSGPage(urlPath: string) {
     return this.dataCache.getEntry<CachedSSGPage>(this.getSSGCacheKey(urlPath), {
       allowStale: true,
@@ -136,6 +150,65 @@ export class ServerRenderer {
         revalidate: page.revalidate ?? false,
       },
     );
+  }
+
+  private getCachedPPRShell(pathname: string, search: string) {
+    return this.dataCache.getEntry<CachedPPRShell>(this.getPPRCacheKey(pathname, search));
+  }
+
+  private cachePPRShell(options: PPRShellCacheOptions, html: string): void {
+    this.dataCache.set(
+      this.getPPRCacheKey(options.pathname, options.search),
+      { html },
+      {
+        paths: [options.pathname],
+        tags: ["ppr"],
+        revalidate: options.revalidate ?? false,
+      },
+    );
+  }
+
+  private canCachePPRShell(
+    req: FarmRequest,
+    middlewareMap: Map<string, any>,
+    pluginExposedContext: Map<string, any>,
+  ): boolean {
+    const method = (req.method || "GET").toUpperCase();
+    if (method !== "GET" && method !== "HEAD") {
+      return false;
+    }
+
+    if (req.headers.cookie || req.headers.authorization) {
+      return false;
+    }
+
+    return middlewareMap.size === 0 && pluginExposedContext.size === 0;
+  }
+
+  private getPPRHeaders(status: "hit" | "miss" | "bypass", revalidate?: number) {
+    const headers: Record<string, string> = {
+      "X-Farm-PPR": status,
+    };
+
+    if (status === "bypass") {
+      headers["Cache-Control"] = "private, no-store";
+      return headers;
+    }
+
+    if (typeof revalidate === "number" && revalidate > 0) {
+      headers["Cache-Control"] = `s-maxage=${revalidate}, stale-while-revalidate`;
+    }
+
+    return headers;
+  }
+
+  private serveCachedPPRShell(res: FarmResponse, shell: CachedPPRShell, revalidate?: number): void {
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    for (const [key, value] of Object.entries(this.getPPRHeaders("hit", revalidate))) {
+      res.setHeader(key, value);
+    }
+    res.write(shell.html);
+    res.end();
   }
 
   /**
@@ -312,6 +385,28 @@ export class ServerRenderer {
         throw new Error(`Route module ${route.modulePath} does not export a default component`);
       }
 
+      const renderingConfig = await resolveRouteRenderingConfigFromFile(
+        routeModule,
+        route.modulePath,
+      );
+      const canCachePPRShell =
+        renderingConfig.ppr && this.canCachePPRShell(req, middlewareMap, pluginExposedContext);
+      const pprShellOptions: PPRShellCacheOptions | undefined = canCachePPRShell
+        ? {
+            pathname,
+            search: url.search,
+            revalidate: renderingConfig.revalidate,
+          }
+        : undefined;
+
+      if (pprShellOptions) {
+        const cachedPPRShell = this.getCachedPPRShell(pathname, url.search);
+        if (cachedPPRShell) {
+          this.serveCachedPPRShell(res, cachedPPRShell.value, renderingConfig.revalidate);
+          return;
+        }
+      }
+
       let LoadingFallbackComponent: React.ComponentType<any> | null = null;
       if (loadingBoundaryEntry) {
         const loadingModule = await this.routeManager.loadRouteModule(
@@ -454,9 +549,18 @@ export class ServerRenderer {
           }
 
           const integratedElement = await this.wrapWithIntegrationProviders(wrappedElement);
+          const pprHeaders = renderingConfig.ppr
+            ? this.getPPRHeaders(pprShellOptions ? "miss" : "bypass", renderingConfig.revalidate)
+            : undefined;
 
           // Render with middleware data available
-          await this.renderWithSSR(integratedElement, req, res, _clearCurrentMiddlewareData);
+          await this.renderWithSSR(integratedElement, req, res, _clearCurrentMiddlewareData, {
+            responseHeaders: pprHeaders,
+            onComplete:
+              pprShellOptions && req.method !== "HEAD"
+                ? (html) => this.cachePPRShell(pprShellOptions, html)
+                : undefined,
+          });
         });
       });
     } catch (error) {
@@ -588,10 +692,17 @@ export class ServerRenderer {
     req: FarmRequest,
     res: FarmResponse,
     clearMiddlewareData?: () => void,
+    options: {
+      responseHeaders?: Record<string, string> | undefined;
+      onComplete?: (html: string) => void | Promise<void>;
+    } = {},
   ): Promise<void> {
     return new Promise((resolve, reject) => {
       const streamStartTime = Date.now();
       res.setHeader("Content-Type", "text/html; charset=utf-8");
+      for (const [key, value] of Object.entries(options.responseHeaders || {})) {
+        res.setHeader(key, value);
+      }
       if (typeof res.flushHeaders === "function") {
         res.flushHeaders();
       }
@@ -715,6 +826,7 @@ window.__FARM_INTEGRATION_API_MANIFEST__ = ${JSON.stringify(getRegisteredIntegra
 </head>
 <body class="">
   <div id="root">`;
+          htmlParts.push(shell);
 
           let firstChunk = true;
           const writableStream = new Writable({
@@ -723,6 +835,7 @@ window.__FARM_INTEGRATION_API_MANIFEST__ = ${JSON.stringify(getRegisteredIntegra
                 console.log(`[FARM STREAM] first pipe chunk at ${Date.now() - streamStartTime}ms`);
                 firstChunk = false;
               }
+              htmlParts.push(Buffer.isBuffer(chunk) ? chunk.toString() : String(chunk));
               res.write(chunk, encoding, () => {
                 if (typeof (res as any).flush === "function") (res as any).flush();
                 callback();
@@ -730,15 +843,22 @@ window.__FARM_INTEGRATION_API_MANIFEST__ = ${JSON.stringify(getRegisteredIntegra
             },
             final(callback) {
               const suspenseRevealFallback = `<script>(function(){function moveFragment(srcId,placeholderId){var src=document.getElementById(srcId),ph=document.getElementById(placeholderId);if(!src||!ph||!ph.parentNode)return false;while(src.firstChild)ph.parentNode.insertBefore(src.firstChild,ph);ph.parentNode.removeChild(ph);if(src.parentNode)src.parentNode.removeChild(src);return true}function revealBoundary(boundaryId,sectionId){var boundary=document.getElementById(boundaryId),section=document.getElementById(sectionId);if(!boundary||!section||!boundary.parentNode)return false;var start=boundary.previousSibling;if(!start||start.nodeType!==8)return false;var parent=boundary.parentNode;var node=boundary;var depth=0;while(node){if(node.nodeType===8){var data=node.data;if(data==="/$"||data==="/&"){if(depth===0)break;depth--;}else if(data==="$"||data==="$?"||data==="$~"||data==="$!"||data==="&"){depth++;}}var next=node.nextSibling;parent.removeChild(node);node=next;}while(section.firstChild)parent.insertBefore(section.firstChild,node);if(section.parentNode)section.parentNode.removeChild(section);start.data="$";return true}var tries=0;var timer=setInterval(function(){var changed=false;document.querySelectorAll('div[id^="S:"]').forEach(function(section){var suffix=section.id.slice(2);changed=moveFragment('S:'+suffix,'P:'+suffix)||changed;});document.querySelectorAll('template[id^="B:"]').forEach(function(boundary){var suffix=boundary.id.slice(2);changed=revealBoundary('B:'+suffix,'S:'+suffix)||changed;});tries++;if(tries>80||(!document.querySelector('template[id^="B:"]')&&!document.querySelector('template[id^="P:"]'))){clearInterval(timer);}},50);})();</script>`;
-              res.write(`</div>
+              const footer = `</div>
   ${suspenseRevealFallback}
   <script type="module" src="/@farm/client.js"></script>
 </body>
-</html>`);
+</html>`;
+              htmlParts.push(footer);
+              res.write(footer);
               res.end();
               callback();
               if (clearMiddlewareData) {
                 clearMiddlewareData();
+              }
+              if (!didError && options.onComplete) {
+                Promise.resolve(options.onComplete(htmlParts.join(""))).catch((error) => {
+                  logger.warn(`Failed to cache PPR shell: ${error}`);
+                });
               }
               resolve();
             },

--- a/packages/farm/src/ssg.ts
+++ b/packages/farm/src/ssg.ts
@@ -37,6 +37,10 @@
  * export const dynamic = "force-static";
  * export const revalidate = 60;
  *
+ * // PPR/static-shell route
+ * export const experimental_ppr = true;
+ * export const revalidate = 60;
+ *
  * // Directive config
  * "use ssg; 60";
  * export default function DocsPage() {
@@ -59,6 +63,7 @@ export type RouteRenderingDynamic = NonNullable<RouteModule["dynamic"]>;
 
 export interface RouteRenderingConfig {
   ssg: boolean;
+  ppr: boolean;
   revalidate?: number;
   dynamic?: RouteRenderingDynamic;
   directive?: string;
@@ -66,6 +71,7 @@ export interface RouteRenderingConfig {
 
 interface DirectiveRenderingConfig {
   ssg: boolean;
+  ppr: boolean;
   revalidate?: number;
   dynamic?: RouteRenderingDynamic;
   directive: string;
@@ -81,19 +87,26 @@ export function resolveRouteRenderingConfig(
 ): RouteRenderingConfig {
   const directiveConfig = parseRouteRenderingDirective(source);
   let ssg = directiveConfig?.ssg ?? false;
+  let ppr = directiveConfig?.ppr ?? false;
   let revalidate = directiveConfig?.revalidate;
   const moduleDynamic = normalizeDynamicMode(mod?.dynamic);
   const dynamic = moduleDynamic ?? directiveConfig?.dynamic;
   const hasExplicitSsg = typeof mod?.ssg === "boolean";
+  const hasExplicitPPR =
+    typeof mod?.ppr === "boolean" || typeof mod?.experimental_ppr === "boolean";
 
   if (hasExplicitSsg) {
     ssg = mod!.ssg === true;
   }
 
+  if (hasExplicitPPR) {
+    ppr = mod?.ppr === true || mod?.experimental_ppr === true;
+  }
+
   if (typeof mod?.revalidate === "number") {
     if (mod.revalidate > 0) {
       revalidate = mod.revalidate;
-      if (!hasExplicitSsg) {
+      if (!hasExplicitSsg && !ppr) {
         ssg = true;
       }
     } else {
@@ -108,14 +121,17 @@ export function resolveRouteRenderingConfig(
 
   if (moduleDynamic === "force-static" || moduleDynamic === "error") {
     ssg = true;
+    ppr = false;
   } else if (moduleDynamic === "force-dynamic") {
     ssg = false;
+    ppr = false;
     revalidate = undefined;
   }
 
   return {
     ssg,
-    revalidate: ssg ? revalidate : undefined,
+    ppr: ssg ? false : ppr,
+    revalidate: ssg || ppr ? revalidate : undefined,
     dynamic,
     directive: directiveConfig?.directive,
   };
@@ -148,7 +164,9 @@ export function parseRouteRenderingDirective(
 
 function parseKnownRenderingDirective(directive: string): DirectiveRenderingConfig | undefined {
   const normalized = directive.trim().toLowerCase();
-  const match = normalized.match(/^use\s+(ssg|static|isr|ssr|dynamic)(?:\s*[;:]\s*(\d+))?\s*;?$/);
+  const match = normalized.match(
+    /^use\s+(ssg|static|isr|ssr|dynamic|ppr)(?:\s*[;:]\s*(\d+))?\s*;?$/,
+  );
 
   if (!match?.[1]) {
     return undefined;
@@ -160,13 +178,24 @@ function parseKnownRenderingDirective(directive: string): DirectiveRenderingConf
   if (mode === "ssr" || mode === "dynamic") {
     return {
       ssg: false,
+      ppr: false,
       dynamic: "force-dynamic",
+      directive,
+    };
+  }
+
+  if (mode === "ppr") {
+    return {
+      ssg: false,
+      ppr: true,
+      revalidate: typeof revalidate === "number" && revalidate > 0 ? revalidate : undefined,
       directive,
     };
   }
 
   return {
     ssg: true,
+    ppr: false,
     dynamic: "force-static",
     revalidate: typeof revalidate === "number" && revalidate > 0 ? revalidate : undefined,
     directive,
@@ -378,6 +407,13 @@ export function hasISR(mod: RouteModule | null | undefined): boolean {
  */
 export function getRevalidateInterval(mod: RouteModule | null | undefined): number | undefined {
   return resolveRouteRenderingConfig(mod).revalidate;
+}
+
+/**
+ * Check if a route module has PPR/static-shell caching enabled.
+ */
+export function hasPPR(mod: RouteModule | null | undefined): boolean {
+  return resolveRouteRenderingConfig(mod).ppr;
 }
 
 /**

--- a/packages/farm/src/types.ts
+++ b/packages/farm/src/types.ts
@@ -247,6 +247,12 @@ export interface RouteModule {
    */
   dynamic?: "auto" | "force-static" | "force-dynamic" | "error";
   /**
+   * Opt into Partial Prerendering/static-shell caching for this route.
+   * Compatible with Farm's `ppr` export and Next.js `experimental_ppr`.
+   */
+  ppr?: boolean;
+  experimental_ppr?: boolean;
+  /**
    * Return all paths to pre-render for dynamic SSG routes
    * Required for dynamic routes (e.g., [slug]) when ssg = true
    */


### PR DESCRIPTION
## Summary

Starts #12.

- add route-level PPR/static-shell config via `ppr`, Next-compatible `experimental_ppr`, and the `"use ppr; 30"` directive
- keep PPR routes in SSR mode instead of accidentally collecting them as SSG when `revalidate` is present
- cache rendered PPR shells in the shared Farm data cache for dev/server rendering and generated Nitro output
- attach PPR shell entries to path tags so `revalidatePath("/route")` invalidates them alongside other cached data
- bypass shared PPR caching for cookie/authorization/middleware/context requests and return `Cache-Control: private, no-store`
- add a basic `/ppr-demo` example and route types

## Validation

- `corepack pnpm --filter @farmjs/core test`
- `corepack pnpm --filter @farmjs/core build`
- `corepack pnpm --filter farm-example-basic build`
- live dev smoke for `/ppr-demo`:
  - first request: `X-Farm-PPR: miss`
  - second request: `X-Farm-PPR: hit`
  - cookie request: `X-Farm-PPR: bypass` and `Cache-Control: private, no-store`

Note: this is the first PPR/static-shell foundation. It does not yet implement full React Suspense-hole partial prerendering.