### PR TITLE
feat: add cache observability events

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -84,6 +84,25 @@ The first request returns `X-Farm-PPR: miss`; the next matching request returns 
 Cached hits serve the Suspense fallback shell first, then refresh the dynamic island with a
 same-origin bypass request.
 
+### Cache and PPR observability
+
+Farm can emit runtime events for cache, PPR, rendering, routes, APIs, integrations, middleware,
+storage, build, plugins, and errors. This example can enable the default logs or send events to a
+custom handler from `farm.config.ts`:
+
+```ts
+export default defineFarmConfig({
+  observability: {
+    logs: true,
+    onEvent(event) {
+      if (event.type.startsWith("ppr.") || event.type.startsWith("cache.")) {
+        console.log(event);
+      }
+    },
+  },
+});
+```
+
 ### Monorepo note
 
 If you change code in `packages/farm` or `packages/farmjs-plugin`, rebuild the workspace packages before restarting this example:

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -42,6 +42,9 @@
       "markdown": [
         "./dist/markdown.d.ts"
       ],
+      "observability": [
+        "./dist/observability.d.ts"
+      ],
       "api": [
         "./types/api.d.ts",
         "./dist/api.d.ts"
@@ -103,6 +106,11 @@
       "types": "./dist/markdown.d.ts",
       "import": "./dist/markdown.mjs",
       "require": "./dist/markdown.cjs"
+    },
+    "./observability": {
+      "types": "./dist/observability.d.ts",
+      "import": "./dist/observability.mjs",
+      "require": "./dist/observability.cjs"
     },
     "./vite": {
       "types": "./dist/vite.d.ts",

--- a/packages/farm/src/__tests__/cache.test.ts
+++ b/packages/farm/src/__tests__/cache.test.ts
@@ -8,9 +8,15 @@ import {
   unstable_cache,
   updateTag,
 } from "../cache";
+import {
+  configureFarmObservability,
+  resetFarmObservability,
+  type FarmEvent,
+} from "../observability";
 
 describe("server cache primitives", () => {
   afterEach(() => {
+    resetFarmObservability();
     getFarmDataCache().clear();
     vi.useRealTimers();
   });
@@ -69,6 +75,8 @@ describe("server cache primitives", () => {
   });
 
   it("revalidates PPR shell entries through the shared path cache", () => {
+    const events: FarmEvent[] = [];
+    configureFarmObservability({ onEvent: (event) => events.push(event) });
     const cache = getFarmDataCache();
     const key = createFarmCacheKey(["ppr", normalizeRevalidatePath("/dashboard"), ""]);
 
@@ -79,6 +87,21 @@ describe("server cache primitives", () => {
     revalidatePath("/dashboard");
 
     expect(cache.getEntry(key)).toBeUndefined();
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "cache.revalidatePath",
+          path: "/dashboard",
+          count: 1,
+        }),
+        expect.objectContaining({
+          type: "ppr.shell.invalidated",
+          route: "/dashboard",
+          reason: "revalidatePath",
+          count: 1,
+        }),
+      ]),
+    );
   });
 
   it("supports updateTag as immediate tag invalidation", async () => {
@@ -130,6 +153,34 @@ describe("server cache primitives", () => {
     expect(first).toEqual({ calls: 1 });
     expect(second).toEqual({ calls: 1 });
     expect(calls).toBe(1);
+  });
+
+  it("emits hit, miss, set, and tag revalidation observability events", async () => {
+    const events: FarmEvent[] = [];
+    configureFarmObservability({ onEvent: (event) => events.push(event) });
+    let calls = 0;
+    const getProduct = unstable_cache(
+      async (id: string) => {
+        calls++;
+        return { id, calls };
+      },
+      ["observability-product"],
+      { tags: ["products"], revalidate: 60 },
+    );
+
+    await getProduct("a");
+    await getProduct("a");
+    revalidateTag("products", "max");
+
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "cache.miss", level: "debug" }),
+        expect.objectContaining({ type: "cache.set", tags: ["products"], revalidate: 60 }),
+        expect.objectContaining({ type: "cache.hit", tags: ["products"], stale: false }),
+        expect.objectContaining({ type: "cache.revalidateTag", tag: "products", count: 1 }),
+      ]),
+    );
+    expect(events.every((event) => typeof event.timestamp === "number")).toBe(true);
   });
 
   it("normalizes paths and stable cache keys", () => {

--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -74,7 +74,10 @@ describe("loadConfig", () => {
   it("throws when a discovered config file fails to import", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-config-env-"));
 
-    await fs.writeFile(path.join(root, "farm.config.mjs"), "throw new Error('broken config import');");
+    await fs.writeFile(
+      path.join(root, "farm.config.mjs"),
+      "throw new Error('broken config import');",
+    );
 
     await expect(loadConfig(root, undefined, "development")).rejects.toThrow(
       "Failed to load config from farm.config.mjs: broken config import",
@@ -124,6 +127,28 @@ describe("loadConfig", () => {
     expect(config).toMatchObject({
       srcDir: "src",
       deploy: { target: "vercel" },
+    });
+  });
+});
+
+describe("resolveConfig", () => {
+  it("preserves observability config and event callbacks", async () => {
+    const onEvent = () => {};
+    const config = await resolveConfig(
+      {
+        observability: {
+          logs: true,
+          onEvent,
+          events: ["cache.hit", "ppr.shell.cached"],
+        },
+      },
+      "development",
+    );
+
+    expect(config.observability).toMatchObject({
+      logs: true,
+      onEvent,
+      events: ["cache.hit", "ppr.shell.cached"],
     });
   });
 });

--- a/packages/farm/src/__tests__/observability.test.ts
+++ b/packages/farm/src/__tests__/observability.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  configureFarmObservability,
+  emitFarmEvent,
+  onFarmEvent,
+  resetFarmObservability,
+  type FarmEvent,
+} from "../observability";
+
+describe("observability", () => {
+  afterEach(() => {
+    resetFarmObservability();
+    vi.restoreAllMocks();
+  });
+
+  it("emits events to config and runtime handlers", () => {
+    const configEvents: FarmEvent[] = [];
+    const runtimeEvents: FarmEvent[] = [];
+
+    configureFarmObservability({ onEvent: (event) => configEvents.push(event) });
+    const unsubscribe = onFarmEvent((event) => runtimeEvents.push(event));
+
+    emitFarmEvent({ type: "cache.hit", key: "product:1" });
+    unsubscribe();
+    emitFarmEvent({ type: "cache.miss", key: "product:2" });
+
+    expect(configEvents.map((event) => event.type)).toEqual(["cache.hit", "cache.miss"]);
+    expect(runtimeEvents.map((event) => event.type)).toEqual(["cache.hit"]);
+  });
+
+  it("filters events when event types are configured", () => {
+    const events: FarmEvent[] = [];
+
+    configureFarmObservability({
+      events: ["ppr.shell.cached"],
+      onEvent: (event) => events.push(event),
+    });
+
+    emitFarmEvent({ type: "cache.hit", key: "ignored" });
+    emitFarmEvent({ type: "ppr.shell.cached", route: "/dashboard", key: "ppr:dashboard" });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "ppr.shell.cached",
+      route: "/dashboard",
+      level: "info",
+    });
+  });
+
+  it("writes compact logs when observability logs are enabled", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    configureFarmObservability({ logs: true });
+    emitFarmEvent({
+      type: "render.complete",
+      route: "/dashboard",
+      pathname: "/dashboard",
+      status: 200,
+      durationMs: 12,
+    });
+
+    expect(log).toHaveBeenCalledWith(
+      "[farm:info] render.complete route=/dashboard pathname=/dashboard status=200 durationMs=12",
+    );
+  });
+});

--- a/packages/farm/src/app.ts
+++ b/packages/farm/src/app.ts
@@ -4,6 +4,7 @@ import type { FarmMarkdownResolvedConfig } from "./markdown";
 import { resolveMarkdownConfig } from "./markdown";
 import { resolveAppPath, fileExists, logger } from "./utils";
 import { initStorage } from "./storage";
+import { configureFarmObservability } from "./observability";
 import { RouteManager } from "./routing/route-manager";
 import { ServerRenderer } from "./server/renderer";
 import path from "path";
@@ -21,7 +22,13 @@ const defaultDocsConfig: FarmDocsResolvedConfig = {
 };
 
 function isResolvedDocsConfig(value: FarmConfig["docs"]): value is FarmDocsResolvedConfig {
-  return !!value && typeof value === "object" && "enabled" in value && "entry" in value && "config" in value;
+  return (
+    !!value &&
+    typeof value === "object" &&
+    "enabled" in value &&
+    "entry" in value &&
+    "config" in value
+  );
 }
 
 export class FarmApp {
@@ -32,6 +39,7 @@ export class FarmApp {
 
   constructor(config: FarmConfig = {}, viteServer?: ViteDevServer) {
     this.config = this.normalizeConfig(config);
+    configureFarmObservability(this.config.observability);
     this.viteServer = viteServer;
     this.routeManager = new RouteManager(this.config, viteServer);
     this.serverRenderer = new ServerRenderer(this.config, this.routeManager);
@@ -82,6 +90,7 @@ export class FarmApp {
       integrations: config.integrations || {},
       docs: isResolvedDocsConfig(config.docs) ? config.docs : defaultDocsConfig,
       md: resolveMarkdownConfig(config.md),
+      observability: config.observability ?? false,
       suppressLintOnLink: config.suppressLintOnLink ?? false,
       experimental: {
         serverComponents: config.experimental?.serverComponents ?? false,

--- a/packages/farm/src/cache.ts
+++ b/packages/farm/src/cache.ts
@@ -1,3 +1,5 @@
+import { emitFarmEvent } from "./observability";
+
 export type RevalidateTagProfile =
   | "max"
   | "default"
@@ -77,10 +79,34 @@ export class FarmDataCache {
     options: GetFarmCacheEntryOptions = {},
   ): FarmCacheEntry<T> | undefined {
     const entry = this.entries.get(key) as InternalFarmCacheEntry<T> | undefined;
-    if (!entry) return undefined;
-    if (!options.allowStale && this.isStale(entry, options.now)) {
+    if (!entry) {
+      emitFarmEvent({ type: "cache.miss", key });
       return undefined;
     }
+
+    const stale = this.isStale(entry, options.now);
+    if (stale) {
+      emitFarmEvent({
+        type: "cache.stale",
+        key,
+        tags: Array.from(entry.tags),
+        revalidate: entry.revalidate,
+      });
+    }
+
+    if (!options.allowStale && stale) {
+      emitFarmEvent({ type: "cache.miss", key, reason: "stale" });
+      return undefined;
+    }
+
+    emitFarmEvent({
+      type: "cache.hit",
+      key,
+      tags: Array.from(entry.tags),
+      revalidate: entry.revalidate,
+      stale,
+    });
+
     return this.toPublicEntry(entry);
   }
 
@@ -103,18 +129,28 @@ export class FarmDataCache {
     };
 
     this.entries.set(key, entry);
+    emitFarmEvent({
+      type: "cache.set",
+      key,
+      tags: Array.from(tags),
+      revalidate: entry.revalidate,
+    });
     return this.toPublicEntry(entry);
   }
 
   delete(key: string): boolean {
-    return this.entries.delete(key);
+    const deleted = this.entries.delete(key);
+    emitFarmEvent({ type: "cache.delete", key, deleted });
+    return deleted;
   }
 
   clear(): void {
+    const count = this.entries.size;
     this.entries.clear();
     this.inflight.clear();
     this.invalidatedTagVersions.clear();
     this.version = 0;
+    emitFarmEvent({ type: "cache.clear", count });
   }
 
   isStale(entry: FarmCacheStaleEntry, now = Date.now()): boolean {
@@ -140,14 +176,37 @@ export class FarmDataCache {
     return false;
   }
 
-  revalidateTag(tag: string): number {
+  revalidateTag(
+    tag: string,
+    options: { source?: "revalidateTag" | "updateTag"; profile?: RevalidateTagProfile } = {},
+  ): number {
     const normalized = normalizeCacheTag(tag);
-    this.invalidatedTagVersions.set(normalized, ++this.version);
-    return this.countEntriesForTag(normalized);
+    const count = this.invalidateTag(normalized);
+    emitFarmEvent(
+      options.source === "updateTag"
+        ? { type: "cache.updateTag", tag: normalized, count }
+        : { type: "cache.revalidateTag", tag: normalized, profile: options.profile, count },
+    );
+    return count;
   }
 
   revalidatePath(routePath: string): number {
-    return this.revalidateTag(createPathCacheTag(routePath));
+    const normalizedPath = normalizeRevalidatePath(routePath);
+    const pathTag = createPathCacheTag(normalizedPath);
+    const pprCount = this.countEntriesForTags([pathTag, "ppr"]);
+    const count = this.invalidateTag(pathTag);
+    emitFarmEvent({ type: "cache.revalidatePath", path: normalizedPath, count });
+
+    if (pprCount > 0) {
+      emitFarmEvent({
+        type: "ppr.shell.invalidated",
+        route: normalizedPath,
+        reason: "revalidatePath",
+        count: pprCount,
+      });
+    }
+
+    return count;
   }
 
   async getOrSet<T>(
@@ -162,6 +221,7 @@ export class FarmDataCache {
 
     const inflight = this.inflight.get(key) as Promise<T> | undefined;
     if (inflight) {
+      emitFarmEvent({ type: "cache.dedupe", key });
       return inflight;
     }
 
@@ -170,6 +230,10 @@ export class FarmDataCache {
       .then((value) => {
         this.set(key, value, options);
         return value;
+      })
+      .catch((error) => {
+        emitFarmEvent({ type: "cache.error", key, operation: "set", error });
+        throw error;
       })
       .finally(() => {
         this.inflight.delete(key);
@@ -187,6 +251,21 @@ export class FarmDataCache {
       }
     }
     return count;
+  }
+
+  private countEntriesForTags(tags: readonly string[]): number {
+    let count = 0;
+    for (const entry of this.entries.values()) {
+      if (tags.every((tag) => entry.tags.has(tag))) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private invalidateTag(normalizedTag: string): number {
+    this.invalidatedTagVersions.set(normalizedTag, ++this.version);
+    return this.countEntriesForTag(normalizedTag);
   }
 
   private toPublicEntry<T>(entry: InternalFarmCacheEntry<T>): FarmCacheEntry<T> {
@@ -226,11 +305,14 @@ export function unstable_cache<Args extends unknown[], Result>(
 }
 
 export function revalidateTag(_tag: string, _profile?: RevalidateTagProfile): void {
-  getFarmDataCache().revalidateTag(_tag);
+  getFarmDataCache().revalidateTag(_tag, {
+    source: "revalidateTag",
+    profile: _profile,
+  });
 }
 
 export function updateTag(tag: string): void {
-  getFarmDataCache().revalidateTag(tag);
+  getFarmDataCache().revalidateTag(tag, { source: "updateTag" });
 }
 
 export function revalidatePath(routePath: string): void {

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -3,6 +3,7 @@ import type { DocsConfig } from "@farming-labs/docs";
 import type { FarmDocsResolvedConfig, FarmDocsUserConfig } from "./docs/types";
 import type { FarmIntegrationsUserConfig } from "./integrations";
 import type { FarmMarkdownResolvedConfig, FarmMarkdownUserConfig } from "./markdown";
+import type { FarmObservabilityUserConfig } from "./observability";
 import type { FarmPlugin } from "./plugin";
 import type { UserConfig as ViteUserConfig } from "vite";
 import { resolveIntegrationPlugins } from "./integrations";
@@ -125,6 +126,7 @@ export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite" | "docs"> {
   deploy?: FarmDeployConfig;
   docs?: FarmDocsUserConfig;
   md?: FarmMarkdownUserConfig | boolean;
+  observability?: FarmObservabilityUserConfig;
 
   trailingSlash?: boolean;
   redirects?: () => Promise<RedirectConfig[]> | RedirectConfig[];
@@ -283,7 +285,11 @@ export const DOCS_CONFIG_FILENAMES = [
 function normalizeDocsRoute(value: string | undefined, fallback = "/docs"): string {
   const raw = (value || fallback).trim();
   if (!raw || raw === "/") return "/";
-  const normalized = raw.replace(/\\/g, "/").replace(/\/+/g, "/").replace(/^\/?/, "/").replace(/\/+$/, "");
+  const normalized = raw
+    .replace(/\\/g, "/")
+    .replace(/\/+/g, "/")
+    .replace(/^\/?/, "/")
+    .replace(/\/+$/, "");
   return normalized || "/";
 }
 
@@ -339,7 +345,10 @@ function sanitizeDocsConfig(config: Partial<DocsConfig>): Partial<DocsConfig> {
   return cloneSerializable(config) || {};
 }
 
-export async function findDocsConfigPath(rootDir: string, configPath?: string): Promise<string | undefined> {
+export async function findDocsConfigPath(
+  rootDir: string,
+  configPath?: string,
+): Promise<string | undefined> {
   const { existsSync } = await import("fs");
   const root = rootDir || process.cwd();
 
@@ -472,8 +481,10 @@ export async function resolveDocsConfig(
   };
 
   const explicitRoute = typeof docsOptions.entry === "string" ? docsOptions.entry : undefined;
-  const configuredDocsPath = typeof mergedDocsConfig.docsPath === "string" ? mergedDocsConfig.docsPath : undefined;
-  const configuredEntry = typeof mergedDocsConfig.entry === "string" ? mergedDocsConfig.entry : undefined;
+  const configuredDocsPath =
+    typeof mergedDocsConfig.docsPath === "string" ? mergedDocsConfig.docsPath : undefined;
+  const configuredEntry =
+    typeof mergedDocsConfig.entry === "string" ? mergedDocsConfig.entry : undefined;
   const entryRoute = normalizeDocsRoute(
     configuredDocsPath || explicitRoute || (configuredEntry ? `/${configuredEntry}` : undefined),
   );
@@ -533,6 +544,7 @@ export async function resolveConfig(
     deploy,
     docs,
     md,
+    observability: userConfig.observability ?? false,
     storage: userConfig.storage || {},
     suppressLintOnLink: userConfig.suppressLintOnLink ?? false,
     experimental: {

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -27,6 +27,7 @@ export * from "./query";
 export * from "./middleware";
 export * from "./docs";
 export * from "./markdown";
+export * from "./observability";
 export { generateRouteTypes } from "./routing/generate-route-types";
 export type { GenerateRouteTypesOptions } from "./routing/generate-route-types";
 export * from "./build/index";

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -84,7 +84,16 @@ function hasProjectPostcssConfig(root: string): boolean {
 
 async function findFarmConfigPath(root: string): Promise<string | null> {
   const fs = await import("fs/promises");
-  const candidates = ["farm.config.ts", "farm.config.js", "farm.config.mjs"];
+  const candidates = [
+    "farm.config.ts",
+    "farm.config.mts",
+    "farm.config.js",
+    "farm.config.mjs",
+    "config.ts",
+    "config.mts",
+    "config.js",
+    "config.mjs",
+  ];
 
   for (const candidate of candidates) {
     const resolvedPath = path.join(root, candidate);
@@ -1052,7 +1061,12 @@ async function buildSSRInMemory(
   );
 
   const hasConfiguredIntegrations = Object.keys(config.integrations || {}).length > 0;
-  const configModulePath = hasConfiguredIntegrations ? await findFarmConfigPath(root) : null;
+  const hasObservabilityHandler =
+    !!config.observability &&
+    typeof config.observability === "object" &&
+    "onEvent" in config.observability;
+  const configModulePath =
+    hasConfiguredIntegrations || hasObservabilityHandler ? await findFarmConfigPath(root) : null;
 
   // Generate virtual entry code that imports and bundles all routes
   // This ensures all route handlers are captured in the bundle closure
@@ -1259,6 +1273,7 @@ function generateVirtualEntryCode(
       ? `import { invokeAPIRouteEndpoint, matchAPIRoute } from "farm/api/route-manager";`
       : "";
   const cacheHelpersImport = `import { createFarmCacheKey, getFarmDataCache, normalizeRevalidatePath } from "farm/cache";`;
+  const observabilityHelpersImport = `import { configureFarmObservability, emitFarmEvent } from "farm/observability";`;
   const docsHandlerImport = config.docs?.enabled
     ? `import { createFarmDocsAPIHandler, createFarmDocsHandler } from "farm/docs";`
     : "";
@@ -1321,6 +1336,7 @@ ${layoutImports.join("\n")}
 ${notFoundImport}
 ${apiRouteHelpersImport}
 ${cacheHelpersImport}
+${observabilityHelpersImport}
 ${docsHandlerImport}
 ${markdownHandlerImport}
 ${integrationImports}
@@ -1334,6 +1350,10 @@ const farmUserConfig = ${
 const configuredIntegrations = farmUserConfig?.integrations || {};
 const integrationRuntimeConfig = farmUserConfig || {};
 const farmMarkdownConfig = ${JSON.stringify(config.md)};
+const farmObservabilityConfig = farmUserConfig?.observability ?? ${JSON.stringify(
+    config.observability ?? false,
+  )};
+configureFarmObservability(farmObservabilityConfig);
 globalThis.__FARM_DOCS_RUNTIME_CONFIG__ = {
   root: ${JSON.stringify(config.root)},
   srcDir: ${JSON.stringify(config.srcDir)},
@@ -1459,14 +1479,13 @@ function resolvePPRConfig(routeModule) {
   return { enabled, revalidate };
 }
 
-function canCachePPRShell(request) {
+function getPPRShellBypassReason(request) {
   const method = request.method.toUpperCase();
-  return (
-    (method === "GET" || method === "HEAD") &&
-    !request.headers.get("cookie") &&
-    !request.headers.get("authorization") &&
-    !request.headers.get("x-farm-ppr-refresh")
-  );
+  if (method !== "GET" && method !== "HEAD") return "method";
+  if (request.headers.get("cookie")) return "cookie";
+  if (request.headers.get("authorization")) return "authorization";
+  if (request.headers.get("x-farm-ppr-refresh")) return "refresh";
+  return undefined;
 }
 
 function getPPRShellCacheKey(url) {
@@ -1505,6 +1524,7 @@ function getCachedPPRShell(cacheKey) {
 async function handleRequest(request) {
   const url = new URL(request.url);
   const pathname = url.pathname;
+  const requestStartTime = Date.now();
 
   const integrationResponse = await handleIntegrationRequest(request.clone());
   if (integrationResponse) {
@@ -1551,17 +1571,35 @@ async function handleRequest(request) {
   }
 
   // Handle page routes (SSR)
+  emitFarmEvent({ type: "render.start", route: pathname, pathname });
   const matchedRoute = matchPageRoute(pathname);
   if (matchedRoute) {
     const { route, params } = matchedRoute;
+    emitFarmEvent({ type: "route.matched", pathname, route: route.pattern, params });
     
     try {
       const pprConfig = resolvePPRConfig(route.module);
-      const pprCanCache = pprConfig.enabled && canCachePPRShell(request);
+      const pprBypassReason = pprConfig.enabled ? getPPRShellBypassReason(request) : undefined;
+      const pprCanCache = pprConfig.enabled && !pprBypassReason;
       const pprCacheKey = pprCanCache ? getPPRShellCacheKey(url) : null;
+      if (pprConfig.enabled && pprBypassReason) {
+        emitFarmEvent({ type: "ppr.shell.bypass", route: pathname, reason: pprBypassReason });
+        emitFarmEvent({ type: "cache.bypass", route: pathname, reason: pprBypassReason });
+        if (pprBypassReason === "refresh") {
+          emitFarmEvent({ type: "ppr.refresh.start", route: pathname });
+        }
+      }
       if (pprCacheKey) {
         const cachedPPRShell = getCachedPPRShell(pprCacheKey);
         if (cachedPPRShell) {
+          emitFarmEvent({ type: "ppr.shell.hit", route: pathname, key: pprCacheKey });
+          emitFarmEvent({
+            type: "render.complete",
+            route: pathname,
+            pathname,
+            status: 200,
+            durationMs: Date.now() - requestStartTime,
+          });
           return new Response(cachedPPRShell, {
             status: 200,
             headers: {
@@ -1570,6 +1608,7 @@ async function handleRequest(request) {
             },
           });
         }
+        emitFarmEvent({ type: "ppr.shell.miss", route: pathname, key: pprCacheKey });
       }
 
       // Get the page component and metadata
@@ -1718,7 +1757,29 @@ async function handleRequest(request) {
               revalidate: pprConfig.revalidate ?? false,
             }
           );
+          emitFarmEvent({
+            type: "ppr.shell.cached",
+            route: pathname,
+            key: pprCacheKey,
+            revalidate: pprConfig.revalidate,
+          });
         }
+
+        if (pprBypassReason === "refresh") {
+          emitFarmEvent({
+            type: "ppr.refresh.complete",
+            route: pathname,
+            durationMs: Date.now() - requestStartTime,
+          });
+        }
+
+        emitFarmEvent({
+          type: "render.complete",
+          route: pathname,
+          pathname,
+          status: 200,
+          durationMs: Date.now() - requestStartTime,
+        });
 
         return new Response(
           fullHtml,
@@ -1729,6 +1790,7 @@ async function handleRequest(request) {
         );
       }
     } catch (error) {
+      emitFarmEvent({ type: "render.error", route: pathname, error });
       console.error("SSR Error:", error);
       return new Response(
         \`<html><body><h1>Error</h1><p>\${error.message}</p><pre>\${error.stack}</pre></body></html>\`,
@@ -1738,6 +1800,7 @@ async function handleRequest(request) {
   }
 
   // 404 fallback - render proper HTML page
+  emitFarmEvent({ type: "route.notFound", pathname });
   try {
     const ReactDOMServer = await import("react-dom/server");
     const React = await import("react");
@@ -1863,6 +1926,14 @@ async function handleRequest(request) {
 </html>\`;
     }
     
+    emitFarmEvent({
+      type: "render.complete",
+      route: pathname,
+      pathname,
+      status: 404,
+      durationMs: Date.now() - requestStartTime,
+    });
+
     return new Response(fullHtml, {
       status: 404,
       headers: { "Content-Type": "text/html; charset=utf-8" }

--- a/packages/farm/src/observability.ts
+++ b/packages/farm/src/observability.ts
@@ -1,0 +1,433 @@
+export type FarmEventLevel = "debug" | "info" | "warn" | "error";
+
+export interface FarmEventBase {
+  type: string;
+  timestamp: number;
+  level: FarmEventLevel;
+  requestId?: string;
+  route?: string;
+  pathname?: string;
+}
+
+export type FarmServerEvent =
+  | (FarmEventBase & {
+      type: "server.start";
+      mode: "dev" | "preview" | "production";
+      port?: number;
+    })
+  | (FarmEventBase & { type: "server.ready"; url?: string })
+  | (FarmEventBase & { type: "server.shutdown"; reason?: string });
+
+export type FarmRouteEvent =
+  | (FarmEventBase & { type: "route.discovered"; route: string; filePath: string })
+  | (FarmEventBase & {
+      type: "route.matched";
+      pathname: string;
+      route: string;
+      params?: Record<string, string>;
+    })
+  | (FarmEventBase & { type: "route.notFound"; pathname: string })
+  | (FarmEventBase & { type: "route.redirect"; from: string; to: string; status?: number })
+  | (FarmEventBase & { type: "route.rewrite"; from: string; to: string });
+
+export type FarmRenderEvent =
+  | (FarmEventBase & { type: "render.start"; route: string; pathname?: string })
+  | (FarmEventBase & {
+      type: "render.complete";
+      route: string;
+      durationMs: number;
+      status?: number;
+    })
+  | (FarmEventBase & { type: "render.error"; route?: string; error: unknown })
+  | (FarmEventBase & { type: "render.stream.start"; route: string })
+  | (FarmEventBase & { type: "render.stream.shellReady"; route: string; durationMs: number })
+  | (FarmEventBase & { type: "render.stream.complete"; route: string; durationMs: number });
+
+export type FarmCacheEvent =
+  | (FarmEventBase & {
+      type: "cache.hit";
+      key: string;
+      route?: string;
+      tags?: readonly string[];
+      revalidate?: number | false;
+      stale?: boolean;
+    })
+  | (FarmEventBase & { type: "cache.miss"; key: string; route?: string; reason?: string })
+  | (FarmEventBase & {
+      type: "cache.set";
+      key: string;
+      route?: string;
+      tags?: readonly string[];
+      revalidate?: number | false;
+    })
+  | (FarmEventBase & { type: "cache.dedupe"; key: string })
+  | (FarmEventBase & { type: "cache.bypass"; key?: string; route?: string; reason: string })
+  | (FarmEventBase & {
+      type: "cache.stale";
+      key: string;
+      route?: string;
+      tags?: readonly string[];
+      revalidate?: number | false;
+    })
+  | (FarmEventBase & { type: "cache.revalidatePath"; path: string; count: number })
+  | (FarmEventBase & {
+      type: "cache.revalidateTag";
+      tag: string;
+      profile?: unknown;
+      count: number;
+    })
+  | (FarmEventBase & { type: "cache.updateTag"; tag: string; count: number })
+  | (FarmEventBase & {
+      type: "cache.invalidated";
+      key?: string;
+      route?: string;
+      tag?: string;
+      reason?: string;
+      count?: number;
+    })
+  | (FarmEventBase & { type: "cache.delete"; key: string; deleted: boolean })
+  | (FarmEventBase & { type: "cache.clear"; count: number })
+  | (FarmEventBase & {
+      type: "cache.error";
+      key?: string;
+      operation: "get" | "set" | "delete" | "revalidate";
+      error: unknown;
+    });
+
+export type FarmPPREvent =
+  | (FarmEventBase & { type: "ppr.shell.hit"; route: string; key: string })
+  | (FarmEventBase & { type: "ppr.shell.miss"; route: string; key: string })
+  | (FarmEventBase & {
+      type: "ppr.shell.cached";
+      route: string;
+      key: string;
+      revalidate?: number;
+    })
+  | (FarmEventBase & { type: "ppr.shell.bypass"; route: string; reason: string })
+  | (FarmEventBase & {
+      type: "ppr.shell.invalidated";
+      route: string;
+      reason?: string;
+      count?: number;
+    })
+  | (FarmEventBase & { type: "ppr.suspense.holeDetected"; route: string })
+  | (FarmEventBase & { type: "ppr.refresh.start"; route: string })
+  | (FarmEventBase & { type: "ppr.refresh.complete"; route: string; durationMs: number })
+  | (FarmEventBase & { type: "ppr.refresh.error"; route: string; error: unknown });
+
+export type FarmAPIEvent =
+  | (FarmEventBase & { type: "api.request.start"; route: string; method: string })
+  | (FarmEventBase & {
+      type: "api.request.complete";
+      route: string;
+      method: string;
+      status: number;
+      durationMs: number;
+    })
+  | (FarmEventBase & {
+      type: "api.validation.failed";
+      route: string;
+      method: string;
+      issues?: unknown;
+    })
+  | (FarmEventBase & { type: "api.error"; route: string; method: string; error: unknown });
+
+export type FarmIntegrationEvent =
+  | (FarmEventBase & { type: "integration.registered"; name: string })
+  | (FarmEventBase & { type: "integration.config.validated"; name: string })
+  | (FarmEventBase & { type: "integration.ready"; name: string })
+  | (FarmEventBase & { type: "integration.disposed"; name: string })
+  | (FarmEventBase & {
+      type: "integration.api.call.start";
+      integration: string;
+      operation: string;
+    })
+  | (FarmEventBase & {
+      type: "integration.api.call.complete";
+      integration: string;
+      operation: string;
+      durationMs: number;
+    })
+  | (FarmEventBase & {
+      type: "integration.api.call.error";
+      integration: string;
+      operation: string;
+      error: unknown;
+    })
+  | (FarmEventBase & { type: "integration.webhook.received"; integration: string; event?: string })
+  | (FarmEventBase & { type: "integration.webhook.verified"; integration: string; event?: string })
+  | (FarmEventBase & { type: "integration.webhook.failed"; integration: string; reason: string });
+
+export type FarmMiddlewareEvent =
+  | (FarmEventBase & { type: "middleware.start"; route?: string; name?: string })
+  | (FarmEventBase & {
+      type: "middleware.complete";
+      route?: string;
+      name?: string;
+      durationMs: number;
+    })
+  | (FarmEventBase & {
+      type: "middleware.shortCircuit";
+      route?: string;
+      name?: string;
+      status?: number;
+    })
+  | (FarmEventBase & { type: "middleware.error"; route?: string; name?: string; error: unknown });
+
+export type FarmStorageEvent =
+  | (FarmEventBase & { type: "storage.query.start"; integration?: string; operation: string })
+  | (FarmEventBase & {
+      type: "storage.query.complete";
+      integration?: string;
+      operation: string;
+      durationMs: number;
+    })
+  | (FarmEventBase & {
+      type: "storage.query.error";
+      integration?: string;
+      operation: string;
+      error: unknown;
+    })
+  | (FarmEventBase & { type: "storage.schema.ready"; integration?: string })
+  | (FarmEventBase & { type: "storage.schema.error"; integration?: string; error: unknown });
+
+export type FarmBuildEvent =
+  | (FarmEventBase & { type: "build.start"; target?: string })
+  | (FarmEventBase & { type: "build.complete"; target?: string; durationMs: number })
+  | (FarmEventBase & { type: "build.error"; target?: string; error: unknown })
+  | (FarmEventBase & { type: "routes.generated"; pageCount: number; apiCount?: number })
+  | (FarmEventBase & { type: "types.generated"; filePath: string })
+  | (FarmEventBase & { type: "manifest.generated"; routeCount: number });
+
+export type FarmPluginEvent =
+  | (FarmEventBase & { type: "plugin.hook.start"; plugin: string; hook: string })
+  | (FarmEventBase & {
+      type: "plugin.hook.complete";
+      plugin: string;
+      hook: string;
+      durationMs: number;
+    })
+  | (FarmEventBase & { type: "plugin.hook.error"; plugin: string; hook: string; error: unknown });
+
+export type FarmErrorEvent = FarmEventBase & {
+  type: "error";
+  source: string;
+  error: unknown;
+  route?: string;
+};
+
+export type FarmEvent =
+  | FarmServerEvent
+  | FarmRouteEvent
+  | FarmRenderEvent
+  | FarmCacheEvent
+  | FarmPPREvent
+  | FarmAPIEvent
+  | FarmIntegrationEvent
+  | FarmMiddlewareEvent
+  | FarmStorageEvent
+  | FarmBuildEvent
+  | FarmPluginEvent
+  | FarmErrorEvent;
+
+export type FarmEventType = FarmEvent["type"];
+export type FarmEventHandler = (event: FarmEvent) => void | Promise<void>;
+
+export type FarmEventInput = FarmEvent extends infer T
+  ? T extends FarmEvent
+    ? Omit<T, "timestamp" | "level"> & Partial<Pick<T, "timestamp" | "level">>
+    : never
+  : never;
+
+export type FarmObservabilityUserConfig =
+  | boolean
+  | {
+      logs?: boolean;
+      onEvent?: FarmEventHandler | readonly FarmEventHandler[];
+      events?: readonly FarmEventType[];
+    };
+
+export interface FarmResolvedObservabilityConfig {
+  logs: boolean;
+  handlers: FarmEventHandler[];
+  events?: Set<FarmEventType>;
+}
+
+const runtimeHandlers = new Set<FarmEventHandler>();
+let observabilityState: FarmResolvedObservabilityConfig = {
+  logs: false,
+  handlers: [],
+};
+
+export function configureFarmObservability(config: FarmObservabilityUserConfig | undefined): void {
+  observabilityState = normalizeFarmObservabilityConfig(config);
+}
+
+export function normalizeFarmObservabilityConfig(
+  config: FarmObservabilityUserConfig | undefined,
+): FarmResolvedObservabilityConfig {
+  if (config === undefined || config === false) {
+    return { logs: false, handlers: [] };
+  }
+
+  if (config === true) {
+    return { logs: true, handlers: [] };
+  }
+
+  const handlers = config.onEvent
+    ? Array.isArray(config.onEvent)
+      ? [...config.onEvent]
+      : [config.onEvent]
+    : [];
+
+  return {
+    logs: config.logs ?? false,
+    handlers,
+    events: config.events ? new Set(config.events) : undefined,
+  };
+}
+
+export function onFarmEvent(handler: FarmEventHandler): () => void {
+  runtimeHandlers.add(handler);
+  return () => {
+    runtimeHandlers.delete(handler);
+  };
+}
+
+export function resetFarmObservability(): void {
+  runtimeHandlers.clear();
+  observabilityState = {
+    logs: false,
+    handlers: [],
+  };
+}
+
+export function emitFarmEvent(input: FarmEventInput): FarmEvent {
+  const event = {
+    timestamp: Date.now(),
+    level: inferFarmEventLevel(input.type),
+    ...input,
+  } as FarmEvent;
+
+  if (!shouldEmitFarmEvent(event)) {
+    return event;
+  }
+
+  if (observabilityState.logs) {
+    logFarmEvent(event);
+  }
+
+  for (const handler of [...observabilityState.handlers, ...runtimeHandlers]) {
+    try {
+      Promise.resolve(handler(event)).catch((error) => {
+        console.warn(`[farm:observability] event handler failed: ${formatError(error)}`);
+      });
+    } catch (error) {
+      console.warn(`[farm:observability] event handler failed: ${formatError(error)}`);
+    }
+  }
+
+  return event;
+}
+
+function shouldEmitFarmEvent(event: FarmEvent): boolean {
+  if (
+    !observabilityState.logs &&
+    observabilityState.handlers.length === 0 &&
+    runtimeHandlers.size === 0
+  ) {
+    return false;
+  }
+
+  if (observabilityState.events && !observabilityState.events.has(event.type)) {
+    return false;
+  }
+
+  return true;
+}
+
+function inferFarmEventLevel(type: FarmEventType): FarmEventLevel {
+  if (type === "error" || type.endsWith(".error") || type.endsWith(".failed")) {
+    return "error";
+  }
+  if (
+    type.endsWith(".bypass") ||
+    type.endsWith(".invalidated") ||
+    type.endsWith(".stale") ||
+    type.endsWith(".notFound")
+  ) {
+    return "warn";
+  }
+  if (
+    type.endsWith(".hit") ||
+    type.endsWith(".miss") ||
+    type.endsWith(".start") ||
+    type.endsWith(".shellReady")
+  ) {
+    return "debug";
+  }
+  return "info";
+}
+
+function logFarmEvent(event: FarmEvent): void {
+  const message = `[farm:${event.level}] ${event.type}${formatFarmEventDetails(event)}`;
+  switch (event.level) {
+    case "error":
+      console.error(message);
+      break;
+    case "warn":
+      console.warn(message);
+      break;
+    default:
+      console.log(message);
+      break;
+  }
+}
+
+function formatFarmEventDetails(event: FarmEvent): string {
+  const details: string[] = [];
+  const record = event as unknown as Record<string, unknown>;
+
+  for (const key of [
+    "route",
+    "pathname",
+    "method",
+    "status",
+    "key",
+    "tag",
+    "path",
+    "reason",
+    "durationMs",
+    "integration",
+    "operation",
+    "plugin",
+    "hook",
+    "target",
+    "count",
+  ]) {
+    const value = record[key];
+    if (value !== undefined) {
+      details.push(`${key}=${formatDetailValue(value)}`);
+    }
+  }
+
+  return details.length > 0 ? ` ${details.join(" ")}` : "";
+}
+
+function formatDetailValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -13,6 +13,7 @@ import { matchSSGPage, resolveRouteRenderingConfigFromFile } from "../ssg";
 import { getIntegrationProviders, getRegisteredIntegrationAPIManifest } from "../integrations";
 import { _runWithCurrentRequest, createWebRequestFromFarmRequest } from "./request";
 import { createFarmCacheKey, getFarmDataCache, normalizeRevalidatePath } from "../cache";
+import { emitFarmEvent } from "../observability";
 
 let cachedClerkProvider: {
   ClerkProvider: React.ComponentType<{ children?: React.ReactNode } & Record<string, unknown>>;
@@ -197,8 +198,9 @@ export class ServerRenderer {
   }
 
   private cachePPRShell(options: PPRShellCacheOptions, html: string): void {
+    const key = this.getPPRCacheKey(options.pathname, options.search);
     this.dataCache.set(
-      this.getPPRCacheKey(options.pathname, options.search),
+      key,
       { html },
       {
         paths: [options.pathname],
@@ -206,27 +208,45 @@ export class ServerRenderer {
         revalidate: options.revalidate ?? false,
       },
     );
+    emitFarmEvent({
+      type: "ppr.shell.cached",
+      route: options.pathname,
+      key,
+      revalidate: options.revalidate,
+    });
   }
 
-  private canCachePPRShell(
+  private getPPRShellBypassReason(
     req: FarmRequest,
     middlewareMap: Map<string, any>,
     pluginExposedContext: Map<string, any>,
-  ): boolean {
+  ): string | undefined {
     const method = (req.method || "GET").toUpperCase();
     if (method !== "GET" && method !== "HEAD") {
-      return false;
+      return "method";
     }
 
-    if (req.headers.cookie || req.headers.authorization) {
-      return false;
+    if (req.headers.cookie) {
+      return "cookie";
+    }
+
+    if (req.headers.authorization) {
+      return "authorization";
     }
 
     if (hasRequestHeader(req, "x-farm-ppr-refresh")) {
-      return false;
+      return "refresh";
     }
 
-    return middlewareMap.size === 0 && pluginExposedContext.size === 0;
+    if (middlewareMap.size > 0) {
+      return "middleware-data";
+    }
+
+    if (pluginExposedContext.size > 0) {
+      return "plugin-context";
+    }
+
+    return undefined;
   }
 
   private getPPRHeaders(status: "hit" | "miss" | "bypass", revalidate?: number) {
@@ -360,6 +380,7 @@ export class ServerRenderer {
   }
 
   async renderPage(req: FarmRequest, res: FarmResponse): Promise<void> {
+    const renderStartTime = Date.now();
     let pathname = "/";
     let params: Record<string, string> = {};
     let layouts: Array<{ modulePath: string }> = [];
@@ -367,17 +388,32 @@ export class ServerRenderer {
     let middlewareMap = new Map<string, any>();
     let pluginExposedContext = new Map<string, any>();
     let errorBoundaryEntry: { modulePath: string } | null = null;
+    let pprRefreshRoute: string | null = null;
+
+    const completeRender = (status = res.statusCode || 200, route = pathname) => {
+      emitFarmEvent({
+        type: "render.complete",
+        route,
+        pathname,
+        status,
+        durationMs: Date.now() - renderStartTime,
+      });
+    };
 
     try {
       const url = new URL(req.url || "/", `http://${req.headers.host}`);
       pathname = url.pathname;
+      emitFarmEvent({ type: "render.start", route: pathname, pathname });
 
       // Check for pre-rendered SSG page first (production only)
       if (process.env.NODE_ENV === "production") {
         const ssgPage = this.shouldServeSSG(pathname);
         if (ssgPage) {
           const served = await this.serveSSGPage(req, res, ssgPage);
-          if (served) return;
+          if (served) {
+            completeRender(res.statusCode || 200, ssgPage.urlPath);
+            return;
+          }
         }
       }
 
@@ -388,9 +424,18 @@ export class ServerRenderer {
       layouts = match.layouts;
 
       if (!route) {
+        emitFarmEvent({ type: "route.notFound", pathname });
         await this.render404(req, res);
+        completeRender(404);
         return;
       }
+
+      emitFarmEvent({
+        type: "route.matched",
+        pathname,
+        route: route.pattern,
+        params,
+      });
 
       const loadingBoundaryEntry = this.routeManager.getMatchingLoading(pathname);
       errorBoundaryEntry = this.routeManager.getMatchingError(pathname);
@@ -433,8 +478,10 @@ export class ServerRenderer {
         routeModule,
         route.modulePath,
       );
-      const canCachePPRShell =
-        renderingConfig.ppr && this.canCachePPRShell(req, middlewareMap, pluginExposedContext);
+      const pprBypassReason = renderingConfig.ppr
+        ? this.getPPRShellBypassReason(req, middlewareMap, pluginExposedContext)
+        : undefined;
+      const canCachePPRShell = renderingConfig.ppr && !pprBypassReason;
       const pprShellOptions: PPRShellCacheOptions | undefined = canCachePPRShell
         ? {
             pathname,
@@ -443,12 +490,26 @@ export class ServerRenderer {
           }
         : undefined;
 
+      if (renderingConfig.ppr && pprBypassReason) {
+        emitFarmEvent({ type: "ppr.shell.bypass", route: pathname, reason: pprBypassReason });
+        emitFarmEvent({ type: "cache.bypass", route: pathname, reason: pprBypassReason });
+
+        if (pprBypassReason === "refresh") {
+          pprRefreshRoute = pathname;
+          emitFarmEvent({ type: "ppr.refresh.start", route: pathname });
+        }
+      }
+
       if (pprShellOptions) {
+        const pprCacheKey = this.getPPRCacheKey(pathname, url.search);
         const cachedPPRShell = this.getCachedPPRShell(pathname, url.search);
         if (cachedPPRShell) {
+          emitFarmEvent({ type: "ppr.shell.hit", route: pathname, key: pprCacheKey });
           this.serveCachedPPRShell(res, cachedPPRShell.value, renderingConfig.revalidate);
+          completeRender(res.statusCode || 200, pathname);
           return;
         }
+        emitFarmEvent({ type: "ppr.shell.miss", route: pathname, key: pprCacheKey });
       }
 
       let LoadingFallbackComponent: React.ComponentType<any> | null = null;
@@ -601,14 +662,30 @@ export class ServerRenderer {
           await this.renderWithSSR(integratedElement, req, res, _clearCurrentMiddlewareData, {
             responseHeaders: pprHeaders,
             captureStaticShell: Boolean(pprShellOptions),
+            observabilityRoute: pathname,
+            onSuspenseHoleDetected: pprShellOptions
+              ? () => emitFarmEvent({ type: "ppr.suspense.holeDetected", route: pathname })
+              : undefined,
             onComplete:
               pprShellOptions && req.method !== "HEAD"
                 ? (html) => this.cachePPRShell(pprShellOptions, html)
                 : undefined,
           });
+          if (pprRefreshRoute) {
+            emitFarmEvent({
+              type: "ppr.refresh.complete",
+              route: pprRefreshRoute,
+              durationMs: Date.now() - renderStartTime,
+            });
+          }
+          completeRender(res.statusCode || 200, pathname);
         });
       });
     } catch (error) {
+      emitFarmEvent({ type: "render.error", route: pathname, error });
+      if (pprRefreshRoute) {
+        emitFarmEvent({ type: "ppr.refresh.error", route: pprRefreshRoute, error });
+      }
       logger.error(`Error rendering page: ${error}`);
 
       if (res.headersSent || (res as any).writableEnded) {
@@ -741,10 +818,15 @@ export class ServerRenderer {
       responseHeaders?: Record<string, string> | undefined;
       onComplete?: (html: string) => void | Promise<void>;
       captureStaticShell?: boolean;
+      observabilityRoute?: string;
+      onSuspenseHoleDetected?: () => void;
     } = {},
   ): Promise<void> {
     return new Promise((resolve, reject) => {
       const streamStartTime = Date.now();
+      const observabilityRoute =
+        options.observabilityRoute || (req as any).__FARM_ROUTE__ || req.url || "/";
+      emitFarmEvent({ type: "render.stream.start", route: observabilityRoute });
       res.setHeader("Content-Type", "text/html; charset=utf-8");
       for (const [key, value] of Object.entries(options.responseHeaders || {})) {
         res.setHeader(key, value);
@@ -756,6 +838,7 @@ export class ServerRenderer {
       const htmlParts: string[] = [];
       const staticShellParts: string[] | undefined = options.captureStaticShell ? [] : undefined;
       let staticShellClosed = false;
+      let suspenseHoleEmitted = false;
       let didError = false;
 
       // Get the page path for client-side hydration
@@ -858,6 +941,11 @@ window.__FARM_INTEGRATION_API_MANIFEST__ = ${JSON.stringify(getRegisteredIntegra
       const { pipe, abort } = renderToPipeableStream(streamRoot, {
         onShellReady() {
           const shellReadyMs = Date.now() - streamStartTime;
+          emitFarmEvent({
+            type: "render.stream.shellReady",
+            route: observabilityRoute,
+            durationMs: shellReadyMs,
+          });
           if (process.env.FARM_VERBOSE) {
             console.log(`[FARM STREAM] onShellReady at ${shellReadyMs}ms`);
           }
@@ -894,6 +982,10 @@ window.__FARM_INTEGRATION_API_MANIFEST__ = ${JSON.stringify(getRegisteredIntegra
                     staticShellParts.push(chunkText.slice(0, dynamicIndex));
                   }
                   staticShellClosed = true;
+                  if (!suspenseHoleEmitted) {
+                    suspenseHoleEmitted = true;
+                    options.onSuspenseHoleDetected?.();
+                  }
                 } else {
                   staticShellParts.push(chunkText);
                 }
@@ -931,6 +1023,11 @@ window.__FARM_INTEGRATION_API_MANIFEST__ = ${JSON.stringify(getRegisteredIntegra
                   logger.warn(`Failed to cache PPR shell: ${error}`);
                 });
               }
+              emitFarmEvent({
+                type: "render.stream.complete",
+                route: observabilityRoute,
+                durationMs: Date.now() - streamStartTime,
+              });
               resolve();
             },
           });
@@ -947,6 +1044,7 @@ window.__FARM_INTEGRATION_API_MANIFEST__ = ${JSON.stringify(getRegisteredIntegra
         onShellError(error) {
           didError = true;
           logger.error(`SSR shell error: ${error}`);
+          emitFarmEvent({ type: "render.error", route: observabilityRoute, error });
 
           if (clearMiddlewareData) {
             clearMiddlewareData();
@@ -957,6 +1055,7 @@ window.__FARM_INTEGRATION_API_MANIFEST__ = ${JSON.stringify(getRegisteredIntegra
         onError(error) {
           didError = true;
           logger.error(`SSR streaming error: ${error}`);
+          emitFarmEvent({ type: "render.error", route: observabilityRoute, error });
         },
       });
     });

--- a/packages/farm/src/types.ts
+++ b/packages/farm/src/types.ts
@@ -4,6 +4,7 @@ import type { FarmStorageUserConfig } from "./storage/types";
 import type { FarmIntegrationsUserConfig } from "./integrations";
 import type { FarmDocsResolvedConfig, FarmDocsUserConfig } from "./docs/types";
 import type { FarmMarkdownResolvedConfig, FarmMarkdownUserConfig } from "./markdown";
+import type { FarmObservabilityUserConfig } from "./observability";
 
 export type NitroPreset =
   | "node-server"
@@ -53,6 +54,7 @@ export interface FarmConfig {
   integrations?: FarmIntegrationsUserConfig;
   docs?: FarmDocsUserConfig | FarmDocsResolvedConfig;
   md?: FarmMarkdownUserConfig | FarmMarkdownResolvedConfig | boolean;
+  observability?: FarmObservabilityUserConfig;
   /**
    * When true, Link href is not strictly typed (accepts any string).
    * Use when you want to skip route-type errors on Link or don't use generated route types.

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
     cache: "src/cache.ts",
     docs: "src/docs/index.ts",
     markdown: "src/markdown.ts",
+    observability: "src/observability.ts",
   },
   format: ["cjs", "esm"],
   dts: true,


### PR DESCRIPTION
## Summary

Refs #59 and #23.

- add a typed Farm observability event model covering server, routes, render, cache, PPR, API, integrations, middleware, storage, build, plugins, and errors
- add `observability` config with `logs`, `onEvent`, and event-type filtering, plus runtime `onFarmEvent` subscriptions
- emit cache hit/miss/set/stale/dedupe/revalidate events from the shared data cache
- emit PPR shell hit/miss/bypass/cached/invalidated, Suspense-hole, refresh, route, and render stream events from the dev renderer and generated Nitro handler
- expose `@farmjs/core/observability` and document the config shape in the basic example

## Validation

- `corepack pnpm exec oxfmt --check packages/farm/src/observability.ts packages/farm/src/cache.ts packages/farm/src/server/renderer.ts packages/farm/src/nitro/universal-build.ts packages/farm/src/app.ts packages/farm/src/config.ts packages/farm/src/types.ts packages/farm/src/index.ts packages/farm/src/__tests__/cache.test.ts packages/farm/src/__tests__/config.test.ts packages/farm/src/__tests__/observability.test.ts packages/farm/tsup.config.ts`
- `git diff --check`
- `corepack pnpm --filter @farmjs/core build`
- `corepack pnpm --filter @farmjs/core test`
- `corepack pnpm --filter farm-example-basic build`
