### PR TITLE
feat: expand docs for integrations and plugins

### DIFF
--- a/docs/docs.config.ts
+++ b/docs/docs.config.ts
@@ -135,6 +135,17 @@ const sidebar = [
     children: [
       { label: "Overview", slug: "integrations", icon: "plug" },
       {
+        label: "Build",
+        icon: "braces",
+        children: [
+          {
+            label: "Custom Integrations",
+            slug: "integrations/custom",
+            icon: "braces",
+          },
+        ],
+      },
+      {
         label: "Payment",
         icon: "card",
         children: [

--- a/docs/src/app/docs/integrations/custom/page.md
+++ b/docs/src/app/docs/integrations/custom/page.md
@@ -1,0 +1,579 @@
+---
+title: "Custom Integrations"
+description: "Build a first-class Farm integration with typed APIs, route handlers, lifecycle hooks, config validation, middleware, providers, storage schemas, and runtime logs."
+section: "Integrations"
+---
+
+# Custom Integrations
+
+Use a custom integration when a service is bigger than a helper function. A good integration owns the contract between the app and the service: config, routes, typed callers, storage, lifecycle checks, request behavior, and any UI/provider setup the app needs.
+
+Farm integrations are declared with `defineIntegration`. They are registered in `farm.config.ts`, then Farm turns them into pre-plugins during config resolution.
+
+## Minimal integration
+
+**src/integrations/acme.ts**
+
+```ts
+import { defineIntegration, integrationRoute } from "@farmjs/core";
+
+export const acme = defineIntegration({
+  category: "custom",
+  type: "acme",
+  instance: {},
+  routes: [
+    integrationRoute.get("/api/acme/status", {
+      handler() {
+        return Response.json({
+          ok: true,
+        });
+      },
+    }),
+  ],
+});
+```
+
+**farm.config.ts**
+
+```ts
+import { defineFarmConfig } from "@farmjs/core";
+import { acme } from "./src/integrations/acme";
+
+export default defineFarmConfig({
+  integrations: {
+    acme,
+  },
+});
+```
+
+The route is now mounted at `/api/acme/status`. Because it was created with `integrationRoute.get`, Farm can also derive the callable API shape.
+
+## Full shape
+
+The full interface is intentionally flat. Lifecycle hooks are top-level fields instead of being wrapped in a `lifecycle` object.
+
+```ts
+type IntegrationAuthoringShape = {
+  category: string;
+  type: string;
+  instance: unknown;
+  api?: object;
+  routes?: readonly unknown[];
+  endpoints?: object;
+  middleware?: readonly unknown[];
+  providers?: readonly unknown[];
+  documentNavigations?: readonly unknown[];
+  schema?: object;
+  config?: object;
+  validate?: (ctx: unknown) => void | Promise<void>;
+  setup?: (ctx: unknown) => void | Promise<void>;
+  ready?: (ctx: unknown) => void | Promise<void>;
+  dispose?: (ctx: unknown) => void | Promise<void>;
+  log?: (event: unknown) => void | Promise<void>;
+  plugins?: readonly unknown[];
+};
+```
+
+In normal app code you do not need to write this type by hand. `defineIntegration` preserves the exact route, endpoint, config, and schema types for inference.
+
+## Config validation
+
+Use `config` when an integration needs secrets or user options. Farm resolves config in this order:
+
+1. `defaults`
+2. values loaded from `env`
+3. explicit `input`
+4. `resolve(ctx)`
+5. `schema` validation
+
+**src/integrations/acme.ts**
+
+```ts
+import { defineIntegration } from "@farmjs/core";
+import { z } from "zod";
+
+const acmeConfigSchema = z.object({
+  apiKey: z.string().min(1),
+  webhookSecret: z.string().optional(),
+  mode: z.enum(["test", "live"]).default("test"),
+});
+
+export const acme = defineIntegration({
+  category: "custom",
+  type: "acme",
+  instance: {},
+  config: {
+    schema: acmeConfigSchema,
+    env: {
+      apiKey: "ACME_API_KEY",
+      webhookSecret: "ACME_WEBHOOK_SECRET",
+    },
+    defaults: {
+      mode: "test",
+    },
+  },
+  validate(ctx) {
+    if (ctx.integrationConfig.mode === "live" && !ctx.integrationConfig.webhookSecret) {
+      throw new Error("ACME_WEBHOOK_SECRET is required in live mode.");
+    }
+  },
+});
+```
+
+`ctx.integrationConfig` is the parsed config. If validation fails, the app fails during integration startup instead of later during a request.
+
+## Lifecycle hooks
+
+Lifecycle hooks receive the same base context plus the parsed `integrationConfig`, a `log` helper, and cleanup support.
+
+| Hook | When it runs | Use it for |
+| --- | --- | --- |
+| `validate(ctx)` | During integration init | Check API keys, required URLs, config combinations, and app prerequisites. |
+| `setup(ctx)` | During integration init after validation | Prepare storage, register webhooks, create queues, warm clients, or schedule cleanup. |
+| `ready(ctx)` | When the app/plugin manager is ready | Emit ready logs or start background listeners. |
+| `dispose(ctx)` | During shutdown | Close clients, flush buffers, unregister listeners, or stop workers. |
+
+```ts
+export const acme = defineIntegration({
+  category: "custom",
+  type: "acme",
+  instance: {},
+  config: {
+    schema: acmeConfigSchema,
+    env: {
+      apiKey: "ACME_API_KEY",
+    },
+  },
+  async validate(ctx) {
+    if (!ctx.integrationConfig.apiKey.startsWith("acme_")) {
+      throw new Error("Invalid ACME_API_KEY.");
+    }
+  },
+  async setup(ctx) {
+    const interval = setInterval(() => {
+      ctx.log.info("ACME heartbeat");
+    }, 30_000);
+
+    await ctx.cleanup(() => {
+      clearInterval(interval);
+    });
+  },
+  ready(ctx) {
+    ctx.log.info("ACME integration ready", {
+      key: ctx.key,
+    });
+  },
+  dispose(ctx) {
+    ctx.log.info("ACME integration disposed", {
+      reason: ctx.reason,
+    });
+  },
+});
+```
+
+`ctx.cleanup(callback)` registers cleanup that runs after `dispose`. Calling `ctx.cleanup()` with no callback runs the registered cleanups immediately.
+
+## Typed routes
+
+`integrationRoute` is the route factory. It supports `get`, `post`, `put`, `patch`, `delete`, `options`, and `head`.
+
+```ts
+import { defineIntegration, integrationRoute } from "@farmjs/core";
+import { z } from "zod";
+
+const createCheckoutBody = z.object({
+  priceId: z.string(),
+  successUrl: z.string().url(),
+  cancelUrl: z.string().url(),
+});
+
+export const billing = defineIntegration({
+  category: "payment",
+  type: "acme-billing",
+  instance: {},
+  routes: [
+    integrationRoute.post<
+      "/api/billing/checkout",
+      z.output<typeof createCheckoutBody>,
+      { url: string }
+    >("/api/billing/checkout", {
+      body: createCheckoutBody,
+      async handler(_request, ctx) {
+        const checkout = await createCheckoutSession(ctx.input.body!);
+
+        return Response.json({
+          url: checkout.url,
+        });
+      },
+    }),
+  ],
+});
+```
+
+For body and query validation you can use Zod, any parser with `parse`, any parser with `safeParse` or `safeParseAsync`, or a Standard Schema compatible validator through `~standard.validate`.
+
+## Endpoints object
+
+Use `endpoints` when you want the integration definition to look like the callable API tree. Farm flattens the endpoints into routes and derives the same client namespace.
+
+```ts
+import { z } from "zod";
+
+const checkoutBody = z.object({
+  priceId: z.string(),
+});
+
+export const billing = defineIntegration({
+  category: "payment",
+  type: "acme-billing",
+  instance: {},
+  endpoints: ({ endpoint }) => ({
+    checkout: endpoint.post<
+      "/api/billing/checkout",
+      { priceId: string },
+      { url: string }
+    >("/api/billing/checkout", {
+      body: checkoutBody,
+      handler(_request, ctx) {
+        return Response.json({
+          url: `https://checkout.example/${ctx.input.body?.priceId}`,
+        });
+      },
+    }),
+    status: endpoint.get<"/api/billing/status", { active: boolean }>(
+      "/api/billing/status",
+      {
+        handler() {
+          return Response.json({
+            active: true,
+          });
+        },
+      },
+    ),
+  }),
+});
+```
+
+That produces `api.billing.checkout.post(...)` and `api.billing.status()`.
+
+## Explicit API trees
+
+Use `api` when routes are implemented elsewhere, or when the integration only needs typed callers.
+
+```ts
+import { defineIntegration, endpoint } from "@farmjs/core";
+
+export const acme = defineIntegration({
+  category: "custom",
+  type: "acme",
+  instance: {},
+  api: {
+    profile: endpoint.get<{ id: string }, { id: string; name: string }>("/api/acme/profile", {
+      responseFormat: "json",
+    }),
+    messages: endpoint.route(
+      "/api/acme/messages",
+      endpoint.get<{ items: string[] }>({
+        responseFormat: "json",
+      }),
+      endpoint.post<{ text: string }, { id: string }>({
+        responseFormat: "json",
+      }),
+    ),
+  },
+});
+```
+
+`endpoint.route(path, ...)` is useful when multiple methods share one path. A namespace with one method can be called directly and still keeps the method accessor.
+
+## Hooks around a route
+
+Route-level `middleware`, `before`, and `after` run in this order:
+
+1. Input validation
+2. `route.middleware`
+3. `route.before`
+4. `handler`
+5. `route.after`
+
+```ts
+integrationRoute.get("/api/acme/admin", {
+  middleware: [
+    {
+      handler(_request, ctx) {
+        ctx.requestContext.set("startedAt", Date.now());
+      },
+    },
+  ],
+  before: [
+    (_request, ctx) => {
+      if (!ctx.data.tenantId) {
+        return Response.json(
+          {
+            error: "tenantId is required",
+          },
+          {
+            status: 400,
+          },
+        );
+      }
+    },
+  ],
+  handler() {
+    return Response.json({
+      ok: true,
+    });
+  },
+  after: [
+    (_request, ctx) => {
+      ctx.response?.headers.set("x-integration", ctx.integration.type);
+    },
+  ],
+});
+```
+
+`before` can return a `Response` to short-circuit the handler. `after` receives `ctx.response` for both normal handler responses and short-circuit responses, and can mutate it or return a replacement.
+
+## Integration middleware
+
+Top-level `middleware` is for request behavior that is not tied to one route. It uses a matcher and can short-circuit the request.
+
+```ts
+export const authGate = defineIntegration({
+  category: "auth",
+  type: "auth-gate",
+  instance: {},
+  middleware: [
+    {
+      matcher: "/dashboard/[section]",
+      handler(_request, ctx) {
+        if (!ctx.requestContext.get("user.id")) {
+          return new Response("Unauthorized", {
+            status: 401,
+          });
+        }
+      },
+    },
+  ],
+});
+```
+
+Use top-level middleware for auth gates, tenant loading, rewrites, rate-limit checks, or provider-specific request enrichment.
+
+## Context reference
+
+Route handlers, route middleware, and route hooks receive `ctx` with these fields:
+
+| Field | What it contains |
+| --- | --- |
+| `request` | The web `Request` passed to the handler. |
+| `requestId` | Request ID from headers or Farm-generated fallback. |
+| `url` | Parsed `URL`. |
+| `pathname` | Current pathname. |
+| `method` | HTTP method. |
+| `params` | Dynamic route params, including catch-all arrays. |
+| `input.body` | Parsed and validated body, if a body schema exists. |
+| `input.query` | Parsed and validated query, if a query schema exists. |
+| `args.db` | Lazy ORM client for the integration schema. |
+| `args.getDb()` | Promise-based ORM client resolver. |
+| `args.storage.getClient()` | Raw `storage.client`, if configured. |
+| `data` | Small sanitized metadata from `createIntegrations({ data })` and per-call data. |
+| `integration` | Category, type, slot alias, and original `instance`. |
+| `route` | Route kind, path, and methods. |
+| `requestContext` | Request-scoped key/value store shared with plugins and hooks. |
+| `config` | Resolved Farm config. |
+| `isDev` / `isProd` | Runtime mode flags. |
+
+`ctx.requestContext.set(key, value, { exposeToPage: true })` can expose values to page props. Avoid exposing secrets.
+
+## Storage schema
+
+Declare `schema` when an integration owns data. Farm maps that schema to the integration ORM so route handlers and lifecycle hooks can use `ctx.args.db`.
+
+```ts
+import { defineIntegration, defineIntegrationSchema, integrationRoute } from "@farmjs/core";
+
+const billingSchema = defineIntegrationSchema({
+  models: {
+    billingAccount: {
+      name: "billing_account",
+      fields: {
+        id: {
+          type: "id",
+          primaryKey: true,
+        },
+        ownerId: {
+          type: "string",
+          name: "owner_id",
+          required: true,
+          index: true,
+        },
+        status: {
+          type: "enum",
+          required: true,
+          values: ["free", "active"],
+          default: "free",
+        },
+        createdAt: {
+          type: "datetime",
+          required: true,
+          default: "now",
+        },
+      },
+      constraints: [
+        {
+          type: "unique",
+          fields: ["ownerId"],
+        },
+      ],
+    },
+  },
+});
+
+export const billing = defineIntegration({
+  category: "payment",
+  type: "custom-billing",
+  instance: {},
+  schema: billingSchema,
+  routes: [
+    integrationRoute.get("/api/billing/account", {
+      async handler(_request, ctx) {
+        const account = await ctx.args.db.billingAccount.findFirst({
+          where: {
+            ownerId: String(ctx.data.ownerId),
+          },
+        });
+
+        return Response.json({
+          account,
+        });
+      },
+    }),
+  ],
+});
+```
+
+If an integration does not define `schema`, `ctx.args.db` throws. Use `ctx.args.storage.getClient()` when you only need the app's raw storage client.
+
+## Storage config
+
+The app supplies the storage client once:
+
+**farm.config.ts**
+
+```ts
+import { defineFarmConfig } from "@farmjs/core";
+import { DatabaseSync } from "node:sqlite";
+import { billing } from "./src/integrations/billing";
+
+const sqlite = new DatabaseSync("farm.sqlite");
+
+export default defineFarmConfig({
+  storage: {
+    client: sqlite,
+  },
+  integrations: {
+    billing,
+  },
+});
+```
+
+The integration code still uses `ctx.args.db`, not SQLite-specific APIs. If the app later switches to another supported client, the integration surface stays the same.
+
+## Providers
+
+Use `providers` for client SDKs, context providers, or integration metadata that the app shell can compose.
+
+```tsx
+import type { FarmIntegrationProviderProps } from "@farmjs/core";
+
+function AcmeProvider({ children }: FarmIntegrationProviderProps) {
+  return <>{children}</>;
+}
+
+export const acme = defineIntegration({
+  category: "custom",
+  type: "acme",
+  instance: {},
+  providers: [
+    {
+      name: "acme",
+      type: "client",
+      props: {
+        publishableKey: process.env.ACME_PUBLISHABLE_KEY,
+      },
+      component: AcmeProvider,
+    },
+  ],
+});
+```
+
+Keep provider props public-safe. Secrets belong in server config and lifecycle hooks.
+
+## Logging
+
+The `log` callback receives lifecycle and request events. Use it for observability, tests, and debugging integration behavior.
+
+```ts
+export const acme = defineIntegration({
+  category: "custom",
+  type: "acme",
+  instance: {},
+  log(event) {
+    console.log("[integration]", event.phase, {
+      type: event.type,
+      route: event.route?.path,
+      durationMs: event.durationMs,
+    });
+  },
+});
+```
+
+Common phases are `registered`, `validate`, `setup`, `ready`, `dispose`, `request:start`, `request:end`, and `request:error`.
+
+## Client and server usage
+
+Automatic callers read the registered integration API manifest in the browser and the registered runtime on the server.
+
+```ts
+import { createIntegrations } from "@farmjs/core/client";
+import type { acme } from "../integrations/acme";
+
+type AppIntegrations = {
+  acme: typeof acme;
+};
+
+export const { api, apiClient } = createIntegrations<AppIntegrations>({
+  data: {
+    tenantId: "tenant_123",
+  },
+});
+```
+
+For library tests or isolated packages, pass explicit sources:
+
+```ts
+export const { api, apiClient } = createIntegrations({
+  acme,
+});
+```
+
+## Security checklist
+
+- Validate config during startup with `config.schema` and `validate`.
+- Validate all route body and query input before touching provider SDKs.
+- Treat `ctx.data` as untrusted when it arrives from a browser.
+- Do not expose secrets through provider props, page props, response bodies, or logs.
+- Prefer `responseFormat: "json"` for typed callers and return structured errors.
+- Keep webhook routes strict about method, body format, signature verification, and replay windows.
+- Use `before` or route middleware for authorization checks close to the route they protect.
+- Use `dispose` and `ctx.cleanup` for open handles, background listeners, and timers.
+
+## Production checklist
+
+- Define a stable `category` and `type`.
+- Keep app namespace keys predictable in `farm.config.ts`.
+- Add integration tests for valid input, invalid input, middleware short-circuiting, hooks, and client caller inference.
+- Add storage tests with real data when `schema` is present.
+- Log enough request metadata to debug failures without logging secrets.
+- Document env vars, route paths, API callers, and storage models for app teams.

--- a/docs/src/app/docs/integrations/orm-storage/page.md
+++ b/docs/src/app/docs/integrations/orm-storage/page.md
@@ -6,7 +6,9 @@ section: "Integrations"
 
 # ORM Storage for Integrations
 
-Pass one storage client through farm.config.ts and let integrations use ctx.args.db through the unified farming-labs/orm-style API.
+Farm integrations can declare a schema and then use `ctx.args.db` inside route handlers, middleware, and lifecycle hooks. The app decides which storage client backs the data. The integration only depends on the ORM-shaped API.
+
+This keeps integration code storage agnostic. A Stripe, auth, jobs, email, or custom integration can define models once and work across the supported runtime clients that `@farming-labs/orm` understands.
 
 ## Pass a client
 
@@ -14,31 +16,178 @@ Pass one storage client through farm.config.ts and let integrations use ctx.args
 
 ```ts
 import { defineFarmConfig } from "@farmjs/core";
-import { client } from "./src/lib/db";
+import { DatabaseSync } from "node:sqlite";
+import { billing } from "./src/integrations/billing";
+
+const sqlite = new DatabaseSync("farm.sqlite");
 
 export default defineFarmConfig({
   storage: {
-    client,
+    client: sqlite,
+  },
+  integrations: {
+    billing,
+  },
+});
+```
+
+`storage.client` can be a ready runtime client or a lazy factory. Farm storage clients still power Farm's key/value storage. Other objects or functions are treated as runtime clients for schema-backed integration persistence.
+
+## Declare a schema
+
+**src/integrations/billing.ts**
+
+```ts
+import { defineIntegrationSchema } from "@farmjs/core";
+
+export const billingSchema = defineIntegrationSchema({
+  models: {
+    billingAccount: {
+      name: "billing_account",
+      fields: {
+        id: {
+          type: "id",
+          primaryKey: true,
+        },
+        ownerId: {
+          type: "string",
+          name: "owner_id",
+          required: true,
+          index: true,
+        },
+        status: {
+          type: "enum",
+          name: "status",
+          required: true,
+          values: ["free", "active"],
+          default: "free",
+        },
+        seatQuantity: {
+          type: "integer",
+          name: "seat_quantity",
+          nullable: true,
+        },
+        createdAt: {
+          type: "datetime",
+          name: "created_at",
+          required: true,
+          default: "now",
+        },
+      },
+      constraints: [
+        {
+          type: "unique",
+          fields: ["ownerId"],
+          name: "billing_account_owner_unique",
+        },
+      ],
+    },
   },
 });
 ```
 
 ## Use db in integration hooks
 
-**custom integration**
+**src/integrations/billing.ts**
 
 ```ts
+import { defineIntegration, integrationRoute } from "@farmjs/core";
+import { billingSchema } from "./billing-schema";
+
 export const billing = defineIntegration({
   category: "payment",
   type: "custom-billing",
+  instance: {},
   schema: billingSchema,
   async setup(ctx) {
     const db = await ctx.args.getDb();
+
     await db.billingAccount.findMany();
+  },
+  routes: [
+    integrationRoute.get("/api/billing/account", {
+      async handler(_request, ctx) {
+        const account = await ctx.args.db.billingAccount.findFirst({
+          where: {
+            ownerId: String(ctx.data.ownerId),
+          },
+          select: {
+            status: true,
+            seatQuantity: true,
+            createdAt: true,
+          },
+        });
+
+        return Response.json({
+          account,
+        });
+      },
+    }),
+  ],
+});
+```
+
+`ctx.args.db` is lazy, so you can access it like a property in handlers. `ctx.args.getDb()` is useful in setup code when you want to await the ORM client directly.
+
+## SQLite shape
+
+For SQLite, create the database client in app code and pass the instance through `storage.client`.
+
+```ts
+import { defineFarmConfig } from "@farmjs/core";
+import { DatabaseSync } from "node:sqlite";
+
+const sqlite = new DatabaseSync("farm.sqlite");
+
+sqlite.exec(`
+  CREATE TABLE IF NOT EXISTS billing_account (
+    id TEXT PRIMARY KEY,
+    owner_id TEXT NOT NULL UNIQUE,
+    status TEXT NOT NULL DEFAULT 'free',
+    seat_quantity INTEGER,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+  );
+`);
+
+export default defineFarmConfig({
+  storage: {
+    client: sqlite,
   },
 });
 ```
 
-## SQLite shape
+Integration code stays the same if the app moves to a different supported client. The schema is the contract; the storage client is an app-level deployment choice.
 
-For SQLite, the app owns the SQLite-compatible client instance and Farm passes it through storage.client. Integrations only depend on ctx.args.db, so the provider can change without rewriting integration code.
+## What gets typed
+
+The schema controls the type of `ctx.args.db`:
+
+- Model names become properties such as `ctx.args.db.billingAccount`.
+- Field names become typed input and output fields.
+- Enum values become string unions.
+- Nullable fields include `null`.
+- Datetime fields read as `Date`.
+- Unique constraints can be used in `findUnique` and `where` shapes when the ORM supports them.
+
+## Raw storage access
+
+Use raw storage access when an integration needs the app's client directly:
+
+```ts
+async setup(ctx) {
+  const client = await ctx.args.storage.getClient();
+
+  if (!client) {
+    ctx.log.warn("No runtime storage client configured.");
+  }
+}
+```
+
+Prefer `ctx.args.db` for schema-backed records. Use `ctx.args.storage.getClient()` for provider-specific operations that cannot be represented through the integration schema.
+
+## Failure modes
+
+- If an integration does not define `schema`, `ctx.args.db` throws with a clear error.
+- If `storage.client` is missing, the ORM layer cannot create a runtime-backed integration DB.
+- If the physical tables do not match the schema, the database client will fail at query time.
+- If a model method does not exist on the underlying ORM client, Farm raises an integration ORM method error.

--- a/docs/src/app/docs/integrations/page.md
+++ b/docs/src/app/docs/integrations/page.md
@@ -6,7 +6,9 @@ section: "Integrations"
 
 # Integrations
 
-Register services once, get owned routes, typed callers, providers, middleware, storage access, lifecycle hooks, and validation.
+Integrations are the Farm layer for connecting product services to your app. A payment provider, auth system, email service, job runner, API-key platform, UI registry, or internal company SDK can register everything it owns in one place: route handlers, typed client/server callers, request middleware, React providers, storage schemas, lifecycle hooks, and runtime logs.
+
+Farm treats every integration as a small server plugin. That means an integration can participate in framework startup and shutdown, own HTTP routes, and still expose a compact typed API to the rest of the app.
 
 ## Register integrations
 
@@ -15,18 +17,25 @@ Register services once, get owned routes, typed callers, providers, middleware, 
 ```ts
 import { defineFarmConfig } from "@farmjs/core";
 import { stripe } from "@farmjs/integrations/stripe";
+import { betterAuth } from "@farmjs/integrations/better-auth";
 
 export default defineFarmConfig({
   integrations: {
     billing: stripe({
       secretKey: process.env.STRIPE_SECRET_KEY,
-      products: [],
+      webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
+    }),
+    auth: betterAuth({
+      baseURL: process.env.BETTER_AUTH_URL,
+      secret: process.env.BETTER_AUTH_SECRET,
     }),
   },
 });
 ```
 
-## Create shared callers
+The object key is the application namespace. If you register Stripe as `billing`, the typed caller lives at `api.billing`. If you register it as `stripe`, it lives at `api.stripe`.
+
+## Create callers
 
 **src/lib/api.ts**
 
@@ -41,21 +50,180 @@ export const { api, apiClient } = createIntegrations<AppIntegrations>({
 });
 ```
 
-## What an integration can contribute
+`apiClient` is the browser caller. `api` is the server caller. Both preserve the same integration namespace so a route like `/api/billing/checkout` can become `api.billing.checkout.post(...)`, and a single-method endpoint can be called directly when there is only one method.
 
-- api: typed client and server callable operations.
-- routes and endpoints: HTTP handlers with zod or standard-schema input validation.
-- middleware: request behavior for protected routes, rate limits, webhooks, and redirects.
-- providers: app wrappers for client SDKs or context providers.
-- schema: models used by Farm's integration ORM layer.
-- config, validate, setup, ready, dispose: lifecycle and configuration validation.
+## Integration surface
+
+An integration can contribute any of these pieces:
+
+| Surface | What it is for |
+| --- | --- |
+| `api` | A typed client/server callable API tree. |
+| `routes` | HTTP route handlers declared as an array or factory. |
+| `endpoints` | A nested object version of routes that also derives API callers. |
+| `middleware` | Integration-owned request behavior for matchers outside a single endpoint. |
+| `providers` | React provider metadata and optional wrapper components. |
+| `schema` | Storage models used by `ctx.args.db` through the ORM layer. |
+| `config` | Schema-validated config from defaults, env, input, and resolver output. |
+| `validate` | Early checks before the integration starts. |
+| `setup` | Bootstrapping work such as storage checks or webhook registration. |
+| `ready` | Post-start work once the app is ready. |
+| `dispose` | Shutdown cleanup. |
+| `log` | Runtime events for registration, request start, request end, request error, and lifecycle messages. |
+| `plugins` | Extra Farm plugins that ship with the integration. |
+| `documentNavigations` | Route matchers that tell docs/navigation systems where the integration owns pages. |
+
+## Route ownership
+
+Integration routes use the same web primitives as normal route handlers. The handler receives the `Request` and a context object with params, parsed input, request metadata, shared request context, integration metadata, and `args` for storage.
+
+**src/integrations/local-demo.ts**
+
+```ts
+import { defineIntegration, integrationRoute } from "@farmjs/core";
+import { z } from "zod";
+
+export const localDemo = defineIntegration({
+  category: "custom",
+  type: "local-demo",
+  instance: {},
+  routes: [
+    integrationRoute.post<
+      "/api/local-demo/messages",
+      { message: string },
+      { message: string; count: number },
+      { count: number }
+    >("/api/local-demo/messages", {
+      body: z.object({
+        message: z.string().min(2),
+      }),
+      query: z.object({
+        count: z.coerce.number().int().positive(),
+      }),
+      handler(_request, ctx) {
+        return Response.json({
+          message: ctx.input.body?.message,
+          count: ctx.input.query?.count ?? 1,
+        });
+      },
+    }),
+  ],
+});
+```
+
+Farm validates the body and query before route middleware, `before` hooks, or the handler run. Invalid input returns a `400` response with validation issues.
+
+## Caller shape
+
+Typed routes can derive their caller tree from their path:
+
+**src/lib/api.ts**
+
+```ts
+import { createIntegrations } from "@farmjs/core/client";
+import { localDemo } from "../integrations/local-demo";
+
+export const { api, apiClient } = createIntegrations({
+  localDemo,
+});
+```
+
+**client component**
+
+```tsx
+"use client";
+
+import { apiClient } from "../lib/api";
+
+export function SendMessageButton() {
+  async function send() {
+    const result = await apiClient.localDemo.messages.post({
+      body: {
+        message: "hello",
+      },
+      query: {
+        count: 2,
+      },
+    });
+
+    if (result.error) {
+      throw result.error;
+    }
+
+    console.log(result.data.message);
+  }
+
+  return <button onClick={send}>Send</button>;
+}
+```
+
+**server code**
+
+```ts
+import { api } from "../lib/api";
+
+export async function loadMessage() {
+  const result = await api.localDemo.messages.post({
+    body: {
+      message: "server hello",
+    },
+  });
+
+  return result.data;
+}
+```
+
+On the server, Farm first tries to dispatch to the registered integration runtime directly. If no runtime is available, it falls back to `fetch` with forwarded request headers.
+
+## Shared data
+
+`createIntegrations({ data })` adds small per-call metadata to integration requests. It is useful for tenant IDs, locale, analytics context, or feature flags.
+
+```ts
+export const { apiClient } = createIntegrations<AppIntegrations>({
+  data: {
+    tenantId: "tenant_123",
+    locale: "en",
+  },
+});
+
+await apiClient.billing.checkout.post(
+  {
+    body: {
+      priceId: "price_123",
+    },
+  },
+  {
+    data: {
+      source: "settings-page",
+    },
+  },
+);
+```
+
+The route reads that value from `ctx.data`. Browser-provided data is client controlled, size limited, and sanitized before it reaches the handler. Validate it before using it for authorization.
 
 ## Built-in groups
 
-- Payment: Stripe, Autumn, and Polar integrations share checkout, subscription, portal, webhook, entitlement, and billing snapshot patterns.
-- Auth: Better Auth, Auth.js, Clerk, Auth0, WorkOS, and Supabase expose routes, providers, and typed session helpers.
-- Messaging: Resend renders React Email templates, sends transactional mail, previews messages, and receives provider webhooks.
-- Workflows: Trigger.dev and Inngest runtimes expose trigger, schedule, batch, status, and cancel APIs for task backends.
-- API Keys: Unkey integrations create, verify, revoke, update, and delete customer or service keys.
-- Interface: UI registry entries can scaffold shadcn-style screens for built-in integrations when `--ui` is enabled.
-- Storage: ORM storage keeps integration schema reads and writes behind ctx.args.db.
+| Group | Built-ins |
+| --- | --- |
+| Payment | Stripe, Autumn, and Polar expose checkout, subscription, portal, webhook, entitlement, and billing snapshot patterns. |
+| Auth | Better Auth, Auth.js, Clerk, Auth0, WorkOS, and Supabase expose routes, providers, session helpers, and auth middleware. |
+| Messaging | Resend sends transactional mail, previews templates, and receives provider webhooks. |
+| Workflows | Trigger.dev and Inngest expose trigger, schedule, batch, status, and cancel APIs. |
+| API Keys | Unkey can create, verify, revoke, update, and delete customer or service keys. |
+| Interface | UI registry entries scaffold shadcn-style integration screens when `--ui` is enabled. |
+| Storage | ORM storage gives schema-backed integrations a provider-neutral `ctx.args.db`. |
+
+## When to build your own
+
+Create a custom integration when a service needs one or more of these:
+
+- Routes or webhooks that should be mounted automatically.
+- Typed client/server functions that should not be hand-written in each app.
+- Config validation that should fail during startup.
+- Storage models shared by routes, hooks, and built-in UI.
+- Request middleware that belongs to the service.
+- Setup or teardown work such as webhook registration, queue consumers, or health checks.
+
+For the full authoring interface, see [Custom Integrations](/docs/integrations/custom).

--- a/docs/src/app/docs/plugins/create-plugin/page.md
+++ b/docs/src/app/docs/plugins/create-plugin/page.md
@@ -6,7 +6,7 @@ section: "Extending"
 
 # Create a Plugin
 
-Build a plugin with definePlugin when app behavior belongs in reusable framework lifecycle hooks.
+Build a plugin when the behavior belongs to the framework runtime instead of one product integration. Plugins are good for instrumentation, HTML transforms, request IDs, security headers, build adapters, custom route discovery reporting, and runtime debugging.
 
 ## Define a plugin
 
@@ -18,8 +18,11 @@ import { randomUUID } from "node:crypto";
 
 export const requestIdPlugin = definePlugin({
   name: "request-id",
-  beforeRequest(req, _res, context) {
-    context.requestContext.set(req, "request.id", randomUUID(), {
+  beforeRequest(req, _res, ctx) {
+    const header = req.headers["x-request-id"];
+    const requestId = Array.isArray(header) ? header[0] : header || randomUUID();
+
+    ctx.requestContext.set(req, "request.id", requestId, {
       exposeToPage: true,
     });
   },
@@ -31,9 +34,222 @@ export const requestIdPlugin = definePlugin({
 **farm.config.ts**
 
 ```ts
+import { defineFarmConfig } from "@farmjs/core";
 import { requestIdPlugin } from "./src/lib/request-id-plugin";
 
 export default defineFarmConfig({
   plugins: [requestIdPlugin],
 });
 ```
+
+## Add options
+
+Make plugins factory functions when users should configure them.
+
+**src/lib/security-headers-plugin.ts**
+
+```ts
+import { definePlugin } from "@farmjs/core";
+
+type SecurityHeadersOptions = {
+  frameAncestors?: string;
+};
+
+export function securityHeadersPlugin(options: SecurityHeadersOptions = {}) {
+  return definePlugin({
+    name: "security-headers",
+    afterApiHandler(response) {
+      const headers = new Headers(response.headers);
+
+      headers.set("x-content-type-options", "nosniff");
+      headers.set("x-frame-options", "DENY");
+
+      if (options.frameAncestors) {
+        headers.set("content-security-policy", `frame-ancestors ${options.frameAncestors}`);
+      }
+
+      return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+      });
+    },
+  });
+}
+```
+
+## Transform config
+
+Use `config` to modify config before it is resolved. Return the updated config.
+
+```ts
+export const observabilityDefaults = definePlugin({
+  name: "observability-defaults",
+  config(config) {
+    return {
+      ...config,
+      observability: config.observability ?? {
+        events: true,
+        runtime: true,
+      },
+    };
+  },
+  configResolved(config) {
+    console.log("Observability enabled:", Boolean(config.observability));
+  },
+});
+```
+
+Keep config transforms predictable. If two plugins edit the same field, ordering matters.
+
+## Transform API requests
+
+`beforeApiHandler` can return a new `Request`. `afterApiHandler` can return a new `Response`.
+
+```ts
+export const apiTracePlugin = definePlugin({
+  name: "api-trace",
+  beforeApiHandler(request, api) {
+    const headers = new Headers(request.headers);
+    headers.set("x-farm-route", api.routePath || api.pathname);
+
+    return new Request(request, {
+      headers,
+    });
+  },
+  afterApiHandler(response) {
+    const headers = new Headers(response.headers);
+    headers.set("x-powered-by", "farm");
+
+    return new Response(response.body, {
+      status: response.status,
+      headers,
+    });
+  },
+});
+```
+
+## Transform HTML
+
+Use `afterRender` when you need route-aware HTML changes. Use `transformHTML` for a general HTML transform.
+
+```ts
+export const htmlMarkerPlugin = definePlugin({
+  name: "html-marker",
+  afterRender(html, render) {
+    if (render.pathname.startsWith("/docs")) {
+      return html.replace("</body>", '<meta name="docs-runtime" content="farm"></body>');
+    }
+  },
+});
+```
+
+## Observe routes and builds
+
+Plugins can gather metadata from route discovery and build hooks.
+
+```ts
+export const routeManifestPlugin = definePlugin({
+  name: "route-manifest",
+  routesGenerated(payload) {
+    console.log("Pages:", payload.pageCount);
+    console.log("Layouts:", payload.layoutCount);
+  },
+  apiRouteDiscovered(route) {
+    console.log("API route:", route.path, route.methods);
+  },
+  beforeBundle(bundle) {
+    console.log("Bundling for:", bundle.preset);
+  },
+  afterBundle(result) {
+    console.log("Bundle success:", result.success);
+  },
+});
+```
+
+## Handle HMR
+
+In development, `hmrUpdate` receives changed file and module IDs.
+
+```ts
+export const hmrDebugPlugin = definePlugin({
+  name: "hmr-debug",
+  hmrUpdate(update) {
+    console.log("Updated file:", update.file);
+    console.log("Modules:", update.modules);
+  },
+});
+```
+
+## Shutdown cleanup
+
+Use `shutdown` for long-lived resources.
+
+```ts
+export function intervalPlugin() {
+  let interval: ReturnType<typeof setInterval> | undefined;
+
+  return definePlugin({
+    name: "interval",
+    ready() {
+      interval = setInterval(() => {
+        console.log("tick");
+      }, 30_000);
+    },
+    shutdown(payload) {
+      if (interval) {
+        clearInterval(interval);
+      }
+
+      console.log("shutdown reason:", payload.reason);
+    },
+  });
+}
+```
+
+## Expose data to pages
+
+Only explicitly exposed request context values appear on page props.
+
+**src/lib/trace-plugin.ts**
+
+```ts
+export const tracePlugin = definePlugin({
+  name: "trace",
+  beforeRequest(req, _res, ctx) {
+    ctx.requestContext.set(req, "traceId", "trace_123", {
+      exposeToPage: true,
+    });
+
+    ctx.requestContext.set(req, "secret", "do-not-expose");
+  },
+});
+```
+
+**src/app/dashboard/page.tsx**
+
+```tsx
+import type { PageProps } from "@farmjs/core";
+
+export default function DashboardPage(props: PageProps) {
+  const traceId = props.context?.data.get("traceId");
+
+  return <p>{traceId}</p>;
+}
+```
+
+## Hook behavior
+
+- `config`, `beforeApiHandler`, `afterApiHandler`, `afterRender`, `beforeNitroBuild`, `transformHTML`, and `transformPage` can return transformed values.
+- `beforeRequest` and `afterResponse` run sequentially because they work with mutable Node request and response objects.
+- `beforeRequest` can short-circuit by ending the response.
+- Other observational hooks can run in parallel.
+- `enforce: "pre"` runs before normal plugins. `enforce: "post"` runs after normal plugins.
+
+## Testing checklist
+
+- Test hook order when using `enforce`.
+- Test transformed requests, responses, HTML, or config values.
+- Test request context exposure with and without `exposeToPage`.
+- Test cleanup by running the `shutdown` hook.
+- Test that request hooks do not run unnecessary work after a response is already ended.

--- a/docs/src/app/docs/plugins/page.md
+++ b/docs/src/app/docs/plugins/page.md
@@ -6,13 +6,16 @@ section: "Extending"
 
 # Plugin Ecosystem
 
-Use server plugins to extend config, request handling, routing, rendering, bundling, HMR, and lifecycle hooks.
+Plugins are the low-level extension surface for Farm itself. Use them when you need to participate in framework lifecycle events: config resolution, route discovery, request handling, rendering, API handlers, HMR, bundling, Nitro output, errors, and shutdown.
+
+Integrations are built on top of plugins. If you are wrapping Stripe, Auth, Resend, Inngest, a UI registry, or a company service, start with an integration. If you are changing how Farm handles requests, pages, builds, or runtime behavior globally, use a plugin.
 
 ## Use plugins
 
 **farm.config.ts**
 
 ```ts
+import { defineFarmConfig } from "@farmjs/core";
 import { createCompressionPlugin, createLoggerPlugin } from "@farmjs/core/plugin/server";
 
 export default defineFarmConfig({
@@ -23,13 +26,109 @@ export default defineFarmConfig({
 });
 ```
 
+Integration plugins are added before user plugins during config resolution. Every integration is registered as an `enforce: "pre"` plugin, then any extra integration plugins are added, then `farm.config.ts` plugins run.
+
 ## Built-in plugins
 
-- Logger for request and lifecycle logging.
-- Compression for production response encoding.
-- Redirects, rewrites, and headers from farm.config.ts.
-- Env helpers for loading and exposing configuration.
+| Plugin | What it handles |
+| --- | --- |
+| Logger | Request and lifecycle logging. |
+| Compression | Production response encoding. |
+| Redirects | Redirect rules from config. |
+| Rewrites | Rewrite rules from config. |
+| Headers | Response header rules from config. |
+| Env helpers | Loading and exposing runtime configuration. |
 
 ## Lifecycle surface
 
-Plugins can observe config resolution, route discovery, route matching, render start and completion, API handlers, bundle steps, Nitro build, HMR updates, errors, and shutdown.
+Plugins can observe or transform these phases:
+
+| Hook | Purpose |
+| --- | --- |
+| `init` | Initialize plugin state. |
+| `ready` | Run after the plugin manager is ready. |
+| `devServerCreated` | Access the Vite dev server. |
+| `config` | Return a modified Farm config. |
+| `configResolved` | Observe the final resolved config. |
+| `buildStart` / `buildEnd` | Run around Farm build work. |
+| `routeDiscovered` | Observe every discovered page or layout. |
+| `routesGenerated` | Observe the final route graph summary. |
+| `middlewareDiscovered` | Observe discovered middleware files. |
+| `apiRouteDiscovered` | Observe discovered API route files and methods. |
+| `beforeRouteMatch` / `afterRouteMatch` | Observe runtime page route matching. |
+| `beforeRender` / `afterRender` | Observe or transform rendered HTML. |
+| `beforeApiHandler` / `afterApiHandler` | Transform API `Request` or `Response`. |
+| `beforeRequest` / `afterResponse` | Work with Node request/response objects. |
+| `hmrUpdate` | Observe hot module updates. |
+| `beforeBundle` / `afterBundle` | Run around bundling. |
+| `beforeNitroBuild` / `afterNitroBuild` | Modify or observe Nitro build output. |
+| `onError` | Capture framework lifecycle errors. |
+| `shutdown` | Release resources. |
+| `transformHTML` | Transform HTML output. |
+| `transformPage` | Transform page components. |
+
+Hooks that return a value can transform the current value when Farm runs them serially. Request hooks that can short-circuit run in deterministic plugin order.
+
+## Ordering
+
+Plugins can set `enforce`:
+
+```ts
+export default defineFarmConfig({
+  plugins: [
+    {
+      name: "early",
+      enforce: "pre",
+    },
+    {
+      name: "normal",
+    },
+    {
+      name: "late",
+      enforce: "post",
+    },
+  ],
+});
+```
+
+Farm orders plugins as `pre`, normal, then `post`. Use `pre` when another plugin must see your request context or config changes. Use `post` when you want to observe final output.
+
+## Request context
+
+Plugins can share request-scoped values with other plugins, integrations, and pages.
+
+```ts
+import { definePlugin } from "@farmjs/core";
+import { randomUUID } from "node:crypto";
+
+export const tracePlugin = definePlugin({
+  name: "trace",
+  beforeRequest(req, _res, ctx) {
+    ctx.requestContext.set(req, "traceId", randomUUID(), {
+      exposeToPage: true,
+    });
+
+    ctx.requestContext.set(req, "internalToken", "secret");
+  },
+});
+```
+
+Only values marked with `exposeToPage: true` are available to page props through `props.context?.data`.
+
+## Plugin or integration
+
+| Choose | When |
+| --- | --- |
+| Integration | You are wrapping a product/service and need routes, typed callers, config validation, storage schema, or providers. |
+| Plugin | You are changing framework behavior, rendering, routing, request handling, HMR, build output, or global app instrumentation. |
+| Both | A product integration needs low-level hooks in addition to its routes and API. Put the product API in the integration and ship extra hooks through `plugins`. |
+
+## Production checklist
+
+- Give every plugin a stable `name`.
+- Use `enforce` only when ordering matters.
+- Keep request hooks fast because they run on every matching request.
+- Do not expose secrets through request context.
+- Return transformed `Request`, `Response`, HTML, or config only from hooks that support transforms.
+- Release timers, sockets, file watchers, and background workers in `shutdown`.
+- Add tests for hook order and transformed output when a plugin changes behavior.


### PR DESCRIPTION
## Summary
- Adds a new Custom Integrations guide covering the integration shape, config validation, lifecycle hooks, typed routes/endpoints, middleware, storage schemas, providers, logging, client/server usage, and production/security checklists.
- Expands the integrations overview and ORM storage docs with concrete examples and clearer API/storage guidance.
- Expands plugin docs with lifecycle tables, ordering, request context, transform hooks, cleanup, and testing guidance.

## Validation
- `corepack pnpm --filter @farmjs/core build`
- `DATABASE_URL=${DATABASE_URL:-postgresql://user:password@localhost:5432/farmjs} ./node_modules/.bin/prisma generate && ./node_modules/.bin/farm build` from `docs/`
- `git diff --check`
- `./node_modules/.bin/oxfmt --check docs/docs.config.ts`
- HTTP-rendered checks for `/docs/integrations/custom`, `/docs/integrations`, `/docs/plugins`, and `/docs/plugins/create-plugin`