### PR TITLE
feat: expand docs content

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -42,3 +42,68 @@ if (result.error) {
 - invalidate: mark typed route keys stale after mutations.
 - optimistic: update cached query data before the server response returns.
 - onRequest, onResponse, onSuccess, onError, onSettled, and onStatus: observe the full client lifecycle.
+
+## Result shape
+
+API and integration callers return a consistent result object:
+
+```ts
+const result = await api.hello.post({
+  body: {
+    name: "Ada",
+  },
+});
+
+if (result.error) {
+  console.error(result.error.status);
+  return;
+}
+
+console.log(result.data.message);
+```
+
+This makes client components easier to write because failed responses do not need to be caught with `try/catch` unless you want that behavior.
+
+## Server callers
+
+Use server callers when the operation needs cookies, request headers, server-only credentials, or internal integration dispatch.
+
+```ts
+import { createServerAPIClient } from "@farmjs/core/client";
+import type { APIRouter } from "./api.generated";
+
+export async function loader(request: Request) {
+  const api = createServerAPIClient<APIRouter>({
+    request,
+  });
+
+  return await api.hello.post({
+    body: {
+      name: "Ada",
+    },
+  });
+}
+```
+
+## Integration callers
+
+Integrations use the same ergonomic style:
+
+```ts
+const checkout = await apiClient.billing.checkout.post({
+  body: {
+    productId: "pro",
+    successPath: "/dashboard",
+  },
+});
+```
+
+If an integration operation is marked server-only, call it from `api`, not `apiClient`.
+
+## Production notes
+
+- Keep generated API types committed or generated during CI.
+- Prefer typed body/query schemas for mutations.
+- Use server callers for secrets, auth cookies, and internal-only provider actions.
+- Use invalidation after mutations that change cached route data.
+- Keep optimistic updates scoped to UI state you can confidently roll back.

--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -45,3 +45,58 @@ export async function GET() {
 > **Zod and standard schema**
 >
 > Endpoint and integration route inputs can use Zod or compatible standard-schema validators so the handler sees parsed input instead of raw unknown data.
+
+## Route file shape
+
+Farm follows the familiar route-file convention: each route lives in `src/app/api/**/route.ts` and exports one or more HTTP methods.
+
+```txt
+src/app/api/hello/route.ts          -> /api/hello
+src/app/api/users/[id]/route.ts     -> /api/users/:id
+src/app/api/files/[...path]/route.ts -> /api/files/*
+```
+
+Use `createEndpoint` when you want input validation and typed client generation. Use plain `GET`, `POST`, `PATCH`, and friends when you want to handle the raw `Request`.
+
+## Body and query input
+
+```ts
+export const GET = createEndpoint({
+  query: z.object({
+    q: z.string().optional(),
+    page: z.coerce.number().int().positive().default(1),
+  }),
+  async handler({ input }) {
+    return Response.json({
+      q: input.query.q ?? "",
+      page: input.query.page,
+    });
+  },
+});
+```
+
+Farm parses and validates input before the handler runs. Invalid input returns a `400` response with structured validation issues.
+
+## Client inference
+
+Routes become client namespaces from their path:
+
+```ts
+await api.hello.post({
+  body: {
+    name: "Ada",
+  },
+});
+
+await api.users.get({
+  query: {
+    limit: 10,
+  },
+});
+```
+
+The exact generated shape comes from route generation. Body and query schemas become typed caller input, and path segments become the nested `api.users.get` style namespace. Run `farm generate` when you want updated route/API types without a full build.
+
+## When to use integrations instead
+
+Use API routes for app-owned endpoints. Use integrations when a provider or feature needs a package-like surface: config validation, lifecycle hooks, storage schema, middleware, providers, and typed callers bundled together.

--- a/docs/src/app/docs/cache-ppr/page.md
+++ b/docs/src/app/docs/cache-ppr/page.md
@@ -52,3 +52,74 @@ export default function DashboardPage() {
   return <main>Static shell with dynamic sections</main>;
 }
 ```
+
+## Cache keys and tags
+
+Use stable keys for data and broad tags for invalidation. Keys identify one cached value, while tags let multiple values be refreshed together.
+
+```ts
+const key = createFarmCacheKey(["products", productId]);
+
+const product = await cache.getOrSet(
+  key,
+  () => getProduct(productId),
+  {
+    tags: ["products", `product:${productId}`],
+    paths: ["/pricing"],
+    revalidate: 300,
+  },
+);
+```
+
+## Invalidate after writes
+
+After a mutation, invalidate the route path and any data tags that feed the page.
+
+**src/app/api/products/route.ts**
+
+```ts
+import { revalidatePath, revalidateTag } from "@farmjs/core/cache";
+
+export async function POST(request: Request) {
+  const input = await request.json();
+  await updateProduct(input);
+
+  revalidateTag("products");
+  revalidatePath("/pricing");
+
+  return Response.json({ ok: true });
+}
+```
+
+## PPR with Suspense holes
+
+PPR works best when the stable page shell is outside Suspense and request-specific or slow data lives inside Suspense.
+
+```tsx
+import { Suspense } from "react";
+
+export const experimental_ppr = true;
+export const revalidate = 60;
+
+export default function BillingPage() {
+  return (
+    <main>
+      <h1>Billing</h1>
+      <Suspense fallback={<div>Loading subscription...</div>}>
+        <SubscriptionStatus />
+      </Suspense>
+    </main>
+  );
+}
+```
+
+## Observability events
+
+Cache and PPR emit events such as `cache.hit`, `cache.miss`, `cache.stale`, `cache.revalidatePath`, `cache.revalidateTag`, `ppr.shell.hit`, `ppr.shell.cached`, and `ppr.suspense.holeDetected`. Subscribe in `farm.config.ts` when debugging refresh behavior.
+
+## Production notes
+
+- Use tags for data families, such as `products` or `billing`.
+- Use paths for route-level invalidation, such as `/pricing`.
+- Do not cache user-specific secrets in shared keys.
+- Prefer PPR for pages with a mostly stable shell and a few dynamic sections.

--- a/docs/src/app/docs/cli/page.md
+++ b/docs/src/app/docs/cli/page.md
@@ -21,3 +21,38 @@ Use the Farm CLI to run, build, generate types, deploy output, and add integrati
 ## Provider names
 
 The integration generator supports ai, stripe, supabase, workos, auth0, clerk, better-auth, authjs, autumn, polar, resend, jobs-trigger, jobs-inngest, and unkey.
+
+## Add integrations
+
+```bash
+farm add integration stripe
+farm add integration stripe --ui
+farm add integration better-auth --ui
+farm add integration jobs-trigger
+```
+
+Without `--ui`, the CLI installs integration wiring. With `--ui`, it also installs app-owned shadcn-style components for the selected provider.
+
+## Generate types
+
+```bash
+farm generate
+```
+
+Use this after adding or changing API routes so `api.hello.post(...)`, route params, and `Link` types stay current.
+
+## Build and preview
+
+```bash
+farm build
+farm preview
+```
+
+`farm build` respects `deploy.target`, `output`, and provider-specific output options from `farm.config.ts`.
+
+## Production notes
+
+- Run `farm generate` in CI if generated route/API types are not committed.
+- Use `farm build` before deployment to catch docs, API, route, and integration wiring issues.
+- Prefer `farm add integration <name> --ui` only when you want generated UI files.
+- Review generated integration files before committing them.

--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -56,3 +56,67 @@ export default async function BlogPage() {
   return <main>...</main>;
 }
 ```
+
+## Minimal project layout
+
+Farm keeps the base project small:
+
+```txt
+farm.config.ts
+src/
+  app/
+    page.tsx
+```
+
+Add optional files only when the app needs them:
+
+```txt
+docs.config.ts
+docs.json
+src/app/api/**/route.ts
+src/app/**/middleware.ts
+src/lib/integrations.ts
+```
+
+## Integrations in config
+
+```ts
+import { defineFarmConfig } from "@farmjs/core";
+import { stripe } from "@farmjs/integrations/stripe";
+import { supabase } from "@farmjs/integrations/supabase";
+
+export default defineFarmConfig({
+  integrations: {
+    billing: stripe({
+      secretKey: process.env.STRIPE_SECRET_KEY,
+    }),
+    auth: supabase({
+      url: process.env.SUPABASE_URL,
+      anonKey: process.env.SUPABASE_ANON_KEY,
+    }),
+  },
+});
+```
+
+The keys become typed namespaces. `billing` becomes `api.billing`, and `auth` becomes `api.auth`.
+
+## Deployment config
+
+```ts
+export default defineFarmConfig({
+  deploy: {
+    target: "vercel",
+    outputDir: ".vercel/output",
+  },
+});
+```
+
+`deploy.target` selects the deployment provider. Farm resolves that to the matching Nitro preset and output shape unless you override it.
+
+## Production notes
+
+- Keep secrets in environment variables, not committed config.
+- Use `storage.client` when integrations need schema-backed persistence.
+- Use `docs.entry` when the docs runtime should be mounted automatically.
+- Prefer route-level exports such as `dynamic`, `revalidate`, and `ppr` when behavior belongs to one page.
+- Keep `farm.config.ts` as the single control plane instead of spreading framework behavior across many root files.

--- a/docs/src/app/docs/deployment/page.md
+++ b/docs/src/app/docs/deployment/page.md
@@ -39,3 +39,65 @@ pnpm build
 farm build --target vercel
 farm deploy --cloudflare
 ```
+
+## Compact config
+
+Farm reads deployment settings from `farm.config.ts`, so a minimal project does not need `vercel.json`, `wrangler.toml`, or Netlify config just to choose an output target.
+
+**farm.config.ts**
+
+```ts
+import { defineFarmConfig } from "@farmjs/core";
+
+export default defineFarmConfig({
+  deploy: {
+    target: "vercel",
+  },
+});
+```
+
+When `target` is `vercel`, Farm uses the Vercel Nitro preset and writes Build Output API output to `.vercel/output`. Other targets default to `.farm/.output` unless you override `output` or `outputDir`.
+
+## Override output
+
+Use `output` for the compact form or `outputDir` when you want the explicit option name.
+
+```ts
+export default defineFarmConfig({
+  deploy: {
+    target: "netlify",
+    output: ".output",
+  },
+});
+```
+
+## Platform deploys
+
+| Command | What it expects |
+| --- | --- |
+| `farm build --target vercel` | Builds `.vercel/output` for Vercel prebuilt deploys. |
+| `farm deploy --vercel` | Uses `vercel deploy --prebuilt`. |
+| `farm deploy --cloudflare` | Deploys the Cloudflare Pages output with Wrangler. |
+| `farm deploy --netlify` | Deploys the Netlify output with Netlify CLI. |
+
+## Environment variables
+
+Keep environment variables in the platform's environment manager or local `.env` files. Farm config can reference `process.env`, and integrations should validate required provider keys during setup.
+
+```ts
+export default defineFarmConfig({
+  integrations: {
+    billing: stripe({
+      secretKey: process.env.STRIPE_SECRET_KEY,
+    }),
+  },
+});
+```
+
+## Production checklist
+
+- Run `farm build` before `farm deploy`.
+- Confirm the selected target matches `deploy.target` or the CLI flag.
+- Check generated output exists at the resolved output directory.
+- Run provider-specific login commands such as `vercel login`, `wrangler login`, or `netlify login` before deploying.
+- Keep provider secrets out of client bundles and UI registry components.

--- a/docs/src/app/docs/docs-engine/page.md
+++ b/docs/src/app/docs/docs-engine/page.md
@@ -34,3 +34,53 @@ When docs.entry is enabled, Farm can serve the docs entry and /api/docs machine 
 ## Config discovery
 
 Farm scans docs.config.ts, docs.config.js, docs.config.mjs, docs.config.cjs, and docs.json by default. Inline config in farm.config.ts can override discovered values.
+
+## docs.config.ts shape
+
+**docs.config.ts**
+
+```ts
+import { defineDocs } from "@farming-labs/docs";
+import { pixelBorder } from "@farming-labs/theme/pixel-border";
+
+export default defineDocs({
+  entry: "docs",
+  docsPath: "/docs",
+  nav: {
+    title: "Farm.js Docs",
+  },
+  search: {
+    provider: "simple",
+    enabled: true,
+  },
+  pageActions: {
+    copyMarkdown: {
+      enabled: true,
+    },
+  },
+  theme: pixelBorder(),
+});
+```
+
+## Agent-readable output
+
+The docs runtime can serve human pages and machine-readable output from the same markdown source:
+
+- `.md` mirrors for individual pages.
+- `llms.txt` style summary output.
+- Sitemap output.
+- Agent discovery/spec routes.
+- Search metadata.
+
+That means docs content only needs to be written once.
+
+## Override behavior
+
+When `docs.entry` is enabled in `farm.config.ts`, Farm can mount docs pages and docs API routes automatically. Add explicit route wrappers only when the app wants to override default rendering, authentication, or response behavior.
+
+## Production notes
+
+- Keep docs content in markdown so human pages and agent-readable pages stay in sync.
+- Use `docs.config.ts` for navigation, page actions, icons, theme, and metadata.
+- Keep generated docs routes public unless product docs require auth.
+- Verify docs build output before publishing package docs.

--- a/docs/src/app/docs/examples/page.md
+++ b/docs/src/app/docs/examples/page.md
@@ -30,3 +30,27 @@ pnpm --filter @farmjs/core build
 pnpm --dir examples/basic install
 pnpm --dir examples/basic dev
 ```
+
+## What to verify
+
+| Example type | Things to click/test |
+| --- | --- |
+| Basic routing | Navigation, route params, layouts, and route config exports. |
+| API routes | Typed callers, validation errors, success responses, and generated types. |
+| Docs integration | `/docs`, markdown mirrors, docs API routes, page actions, and search. |
+| Stripe | Products, checkout redirect, portal redirect, session/status reads, and webhook handling. |
+| Better Auth | Sign-up, sign-in, session read, logout, and protected routes. |
+| Jobs | Trigger, batch trigger, schedule, status, and cancel calls. |
+| Markdown | `.md` mirrors for public pages and cache headers. |
+
+## Example-driven development
+
+When adding a new framework feature, add or update an example that proves the whole flow works:
+
+1. Config in `farm.config.ts`.
+2. Route/page files under `src/app`.
+3. Client interaction when the feature has UI.
+4. Build or dev-server validation.
+5. Docs content that explains the same shape.
+
+Examples should be small but complete enough that a user can copy the pattern into a real app.

--- a/docs/src/app/docs/getting-started/page.md
+++ b/docs/src/app/docs/getting-started/page.md
@@ -40,3 +40,88 @@ export default function HomePage(_props: PageProps) {
   return <h1>Hello from Farm.js</h1>;
 }
 ```
+
+## Add a layout
+
+Every route can share chrome through `layout.tsx`. Start with a root layout, then add nested layouts only when a section needs its own navigation or data shell.
+
+**src/app/layout.tsx**
+
+```tsx
+import type { LayoutProps } from "@farmjs/core";
+import "./globals.css";
+
+export default function RootLayout({ children }: LayoutProps) {
+  return (
+    <main>
+      <header>Farm.js</header>
+      {children}
+    </main>
+  );
+}
+```
+
+## Add an API route
+
+Farm API routes live beside pages and use the same route tree. Define an endpoint, add Zod input when needed, then call it through the generated API client.
+
+**src/app/api/hello/route.ts**
+
+```ts
+import { createEndpoint } from "@farmjs/core/api";
+import { z } from "zod";
+
+export const POST = createEndpoint({
+  body: z.object({
+    name: z.string().min(1),
+  }),
+  async handler({ input }) {
+    return Response.json({
+      message: `Hello ${input.body.name}`,
+    });
+  },
+});
+```
+
+**src/components/hello-button.tsx**
+
+```tsx
+"use client";
+
+import { apiClient } from "@/lib/api";
+
+export function HelloButton() {
+  return (
+    <button
+      onClick={async () => {
+        const result = await apiClient.hello.post({
+          body: { name: "Ada" },
+        });
+
+        console.log(result.data?.message);
+      }}
+    >
+      Say hello
+    </button>
+  );
+}
+```
+
+## Add integrations later
+
+Keep the first app small. When a feature becomes provider-shaped, add it as an integration:
+
+```bash
+farm add integration stripe --ui
+farm add integration better-auth --ui
+farm add integration unkey
+```
+
+Integrations can contribute typed callers, routes, providers, middleware, storage schema, CLI registry components, config validation, and lifecycle hooks.
+
+## Next steps
+
+- Read Project Structure when you want the compact file layout.
+- Read Routing and Layouts when you start nesting pages.
+- Read API Routes and API Client when you need typed server/client calls.
+- Read Integrations when provider features should be packaged instead of copied route-by-route.

--- a/docs/src/app/docs/integrations/auth/auth0/page.md
+++ b/docs/src/app/docs/integrations/auth/auth0/page.md
@@ -38,5 +38,44 @@ export const integrations = {
 **Caller**
 
 ```ts
-await api.auth.login.get();
+const login = await api.auth.login.get({
+  query: {
+    returnTo: "/dashboard",
+  },
+});
+
+if (login.data?.redirectTo) {
+  window.location.href = login.data.redirectTo;
+}
 ```
+
+## What Auth0 adds
+
+| Route | Purpose |
+| --- | --- |
+| `/auth/login` | Starts login and returns or performs a redirect. |
+| `/auth/signup` | Starts signup and returns or performs a redirect. |
+| `/auth/callback` | Exchanges the authorization code and writes the session cookie. |
+| `/auth/logout` | Clears the local session and redirects to Auth0 logout. |
+| `/auth/profile` | Reads the local Auth0 session profile. |
+
+The route paths can be overridden when the app needs a different URL structure.
+
+## Protected routes
+
+```ts
+auth0({
+  domain: process.env.AUTH0_DOMAIN,
+  clientId: process.env.AUTH0_CLIENT_ID,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET,
+  secret: process.env.AUTH0_SECRET,
+  protectedRoutes: ["/dashboard(.*)"],
+});
+```
+
+## Production notes
+
+- Set `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `AUTH0_SECRET`, and `APP_BASE_URL`.
+- Register the callback URL in the Auth0 dashboard.
+- Use `returnTo` for post-login navigation.
+- Test state validation, callback errors, logout redirects, and expired sessions.

--- a/docs/src/app/docs/integrations/auth/authjs/page.md
+++ b/docs/src/app/docs/integrations/auth/authjs/page.md
@@ -33,8 +33,54 @@ export const integrations = {
 
 ## Use it
 
-**Caller**
+**Mounted route**
 
 ```ts
-const session = await api.auth.session.get();
+const response = await fetch("/api/auth/session", {
+  credentials: "include",
+});
+
+const session = await response.json();
 ```
+
+Farm mounts the Auth.js handler at the provider route. Use Auth.js helpers such as `auth()` on the server and the provider client helpers in the browser when you need Auth.js-native session behavior.
+
+## What Auth.js adds
+
+Auth.js is mounted at `/api/auth/[...nextauth]` with `GET` and `POST` handlers. Farm delegates to the `handlers` object created by Auth.js while keeping the integration registered in `farm.config.ts`.
+
+## Full app shape
+
+**src/lib/auth.ts**
+
+```ts
+import NextAuth from "next-auth";
+import GitHub from "next-auth/providers/github";
+
+export const { handlers, auth } = NextAuth({
+  providers: [GitHub],
+});
+```
+
+**src/lib/integrations.ts**
+
+```ts
+import { authjs } from "@farmjs/integrations/auth";
+import { handlers } from "./auth";
+
+export const integrations = {
+  auth: authjs({
+    instance: {
+      handlers,
+    },
+  }),
+};
+```
+
+## Production notes
+
+- Set `AUTH_SECRET` and provider credentials.
+- Configure provider callback URLs to match the Farm route.
+- Use Auth.js callbacks for provider-specific account logic.
+- Use Farm route middleware for app-specific page/API protection.
+- Test both `GET` and `POST` auth handler paths.

--- a/docs/src/app/docs/integrations/auth/better-auth/page.md
+++ b/docs/src/app/docs/integrations/auth/better-auth/page.md
@@ -33,8 +33,56 @@ export const integrations = {
 
 ## Use it
 
-**Caller**
+**Mounted route**
 
 ```ts
-const session = await api.auth.session.get();
+const response = await fetch("/api/auth/session", {
+  credentials: "include",
+});
+
+const session = await response.json();
 ```
+
+Farm mounts the Better Auth handler and keeps it discoverable in the integration registry. The session shape, sign-in methods, plugins, and adapter behavior still come from your Better Auth instance, so use the Better Auth client helpers when you want the full provider DX.
+
+## What Better Auth adds
+
+Better Auth is mounted at `/api/auth/[...auth]` with `GET` and `POST` handlers. The integration delegates to your Better Auth instance, so providers, sessions, plugins, and storage stay in your Better Auth config while Farm owns registration, route discovery, logging, and typed integration wiring.
+
+## Full app shape
+
+**src/lib/auth.ts**
+
+```ts
+import { betterAuth as createBetterAuth } from "better-auth";
+
+export const auth = createBetterAuth({
+  database: {
+    provider: "sqlite",
+    url: "file:./auth.sqlite",
+  },
+  emailAndPassword: {
+    enabled: true,
+  },
+});
+```
+
+**src/lib/integrations.ts**
+
+```ts
+import { betterAuth } from "@farmjs/integrations/auth";
+import { auth } from "./auth";
+
+export const integrations = {
+  auth: betterAuth({
+    instance: auth,
+  }),
+};
+```
+
+## Production notes
+
+- Keep the Better Auth secret and database credentials server-only.
+- Let Better Auth own provider callbacks and session persistence.
+- Use Farm middleware or integration route hooks for app-specific authorization.
+- Test sign-in, sign-up, session reads, logout, and callback routes through the Farm dev server.

--- a/docs/src/app/docs/integrations/auth/clerk/page.md
+++ b/docs/src/app/docs/integrations/auth/clerk/page.md
@@ -33,8 +33,50 @@ export const integrations = {
 
 ## Use it
 
-**Caller**
+**Client UI**
+
+```tsx
+import { SignInButton, SignedIn, SignedOut, UserButton } from "@clerk/react";
+
+export function AccountMenu() {
+  return (
+    <>
+      <SignedOut>
+        <SignInButton />
+      </SignedOut>
+      <SignedIn>
+        <UserButton />
+      </SignedIn>
+    </>
+  );
+}
+```
+
+Clerk remains the source of truth for users, sessions, organizations, and hosted account UI. Farm registers the provider metadata and middleware behavior so protected routes and integration discovery stay in one place.
+
+## What Clerk adds
+
+The Clerk integration contributes provider metadata for a Clerk provider wrapper and optional protected route middleware. Clerk remains the source of truth for session state, users, organizations, and hosted account UI.
+
+## Protected routes
 
 ```ts
-const user = await api.auth.user.get();
+clerk({
+  publishableKey: process.env.CLERK_PUBLISHABLE_KEY,
+  secretKey: process.env.CLERK_SECRET_KEY,
+  protectedRoutes: ["/dashboard(.*)", "/api/private/[...path]"],
+  signInUrl: "/sign-in",
+  signUpUrl: "/sign-up",
+});
 ```
+
+## App usage
+
+Use Clerk UI and hooks in the client, and keep server-sensitive reads on the server. Farm's role is to register provider metadata, protect matched routes, and keep the auth integration visible alongside other app integrations.
+
+## Production notes
+
+- Set `CLERK_SECRET_KEY` and `CLERK_PUBLISHABLE_KEY`.
+- Keep the secret key out of browser code.
+- Configure sign-in and sign-up URLs consistently in Clerk and Farm.
+- Test signed-out protected routes, signed-in dashboard routes, and organization switching if enabled.

--- a/docs/src/app/docs/integrations/auth/page.md
+++ b/docs/src/app/docs/integrations/auth/page.md
@@ -20,11 +20,14 @@ Use Better Auth, Auth.js, Clerk, Auth0, WorkOS, or Supabase without hand-rolling
 **farm.config.ts**
 
 ```ts
+import { defineFarmConfig } from "@farmjs/core";
 import { supabase } from "@farmjs/integrations/supabase";
 
 export default defineFarmConfig({
   integrations: {
     auth: supabase({
+      url: process.env.SUPABASE_URL,
+      anonKey: process.env.SUPABASE_ANON_KEY,
       callbackUrl: "http://localhost:3000/auth/callback",
       protectedRoutes: ["/dashboard(.*)"],
       pages: {
@@ -41,8 +44,57 @@ export default defineFarmConfig({
 **src/lib/api.ts**
 
 ```ts
+import { createIntegrations } from "@farmjs/core/client";
+import type { AppIntegrations } from "./integrations";
+
 export const { api, apiClient } = createIntegrations<AppIntegrations>();
 
 const sessionOnServer = await api.auth.session.get();
 const sessionInBrowser = await apiClient.auth.session.get();
 ```
+
+This explicit session caller is the shape for providers that define Farm-owned session endpoints, such as Supabase. Provider-owned integrations such as Better Auth, Auth.js, and Clerk mount their provider handlers or wrappers and should use that provider's native client/server helpers for session reads.
+
+## What auth integrations share
+
+| Area | Details |
+| --- | --- |
+| Routes | Login, callback, logout, session/profile, or provider-owned handler routes, depending on the provider. |
+| Typed callers | Farm-owned routes get browser/server callers; provider-owned handlers use provider helpers. |
+| Middleware | Optional protected route matchers. |
+| Providers | Client provider metadata for hosted auth SDKs. |
+| Navigation | Sign-in/sign-up route matchers for docs and app navigation. |
+| Request context | Session or user data can be exposed to downstream handlers and pages. |
+
+## Choosing a provider
+
+| Provider | Best when |
+| --- | --- |
+| Better Auth | You want local-first auth and control over storage and callbacks. |
+| Auth.js | You already like the NextAuth/Auth.js provider model. |
+| Clerk | You want hosted account UI, organizations, and polished auth UX quickly. |
+| Auth0 | You need hosted identity with enterprise connections and custom domains. |
+| WorkOS | You need enterprise SSO, organizations, directory sync, or B2B workflows. |
+| Supabase | You want hosted auth plus Postgres-backed app data. |
+
+## Protected routes
+
+Most hosted auth integrations accept protected route matchers. The integration can redirect to sign-in or return `401` before the page/API handler runs.
+
+```ts
+supabase({
+  protectedRoutes: ["/dashboard(.*)", "/api/private/[...path]"],
+  pages: {
+    signIn: "/sign-in",
+    signUp: "/sign-up",
+  },
+});
+```
+
+## Production notes
+
+- Keep server secrets out of client components.
+- Set `APP_BASE_URL` when callback URLs need to be absolute.
+- Configure callback URLs in the provider dashboard and in Farm config.
+- Test login, signup, callback, logout, session refresh, and protected-route redirects.
+- Decide whether the source of truth for user metadata is the provider, your database, or both.

--- a/docs/src/app/docs/integrations/auth/supabase/page.md
+++ b/docs/src/app/docs/integrations/auth/supabase/page.md
@@ -40,3 +40,50 @@ export const integrations = {
 ```ts
 const session = await api.auth.session.get();
 ```
+
+## What Supabase adds
+
+| Route | Purpose |
+| --- | --- |
+| `/auth/login` | Email/password login or OAuth redirect start. |
+| `/auth/signup` | Email/password signup. |
+| `/auth/callback` | OAuth callback/session exchange. |
+| `/auth/logout` | Sign out and clear session state. |
+| `/auth/session` | Read the current session. |
+
+Farm derives callers from these paths, so `api.auth.session.get()` reads `/auth/session` and `api.auth.oauth.get(...)` starts OAuth through the login path.
+
+## OAuth login
+
+```ts
+const oauth = await api.auth.oauth.get({
+  query: {
+    provider: "github",
+    returnTo: "/dashboard",
+  },
+});
+
+if (oauth.data?.redirectTo) {
+  window.location.href = oauth.data.redirectTo;
+}
+```
+
+## Email and password
+
+```ts
+const login = await api.auth.login.post({
+  body: {
+    email: "ada@example.com",
+    password: "correct-horse-battery-staple",
+    returnTo: "/dashboard",
+  },
+});
+```
+
+## Production notes
+
+- Set `SUPABASE_URL` and `SUPABASE_ANON_KEY`.
+- Keep `SUPABASE_SERVICE_ROLE_KEY` server-only if the app uses it.
+- Configure OAuth callback URLs in Supabase.
+- Use protected route matchers for dashboards and private API routes.
+- Test email/password, OAuth, callback, logout, and session refresh flows.

--- a/docs/src/app/docs/integrations/auth/workos/page.md
+++ b/docs/src/app/docs/integrations/auth/workos/page.md
@@ -37,5 +37,44 @@ export const integrations = {
 **Caller**
 
 ```ts
-const organization = await api.auth.organization.get();
+const login = await api.auth.login.get({
+  query: {
+    returnTo: "/dashboard",
+  },
+});
+
+if (login.data?.redirectTo) {
+  window.location.href = login.data.redirectTo;
+}
 ```
+
+## What WorkOS adds
+
+| Route | Purpose |
+| --- | --- |
+| `/login` | Starts WorkOS sign-in. |
+| `/signup` | Starts WorkOS sign-up. |
+| `/callback` | Exchanges the authorization code and stores the sealed session. |
+| `/logout` | Clears the local session and redirects through WorkOS logout. |
+| `/auth/session` | Reads the current sealed-session-backed user state. |
+
+The route paths can be overridden when the app wants `/auth/login` style URLs.
+
+## Protected routes
+
+```ts
+workos({
+  clientId: process.env.WORKOS_CLIENT_ID,
+  apiKey: process.env.WORKOS_API_KEY,
+  cookiePassword: process.env.WORKOS_COOKIE_PASSWORD,
+  protectedRoutes: ["/dashboard(.*)", "/api/private/[...path]"],
+});
+```
+
+## Production notes
+
+- Set `WORKOS_CLIENT_ID`, `WORKOS_API_KEY`, and `WORKOS_COOKIE_PASSWORD`.
+- Use a strong cookie password in production.
+- Configure redirect URIs in WorkOS to match your Farm callback route.
+- Test sign-in, sign-up, callback, logout, and session reads.
+- Decide how organizations and roles map into your app database.

--- a/docs/src/app/docs/integrations/autumn/page.md
+++ b/docs/src/app/docs/integrations/autumn/page.md
@@ -25,7 +25,7 @@ import { autumn } from "@farmjs/integrations/autumn";
 
 export const integrations = {
   billing: autumn({
-    apiKey: process.env.AUTUMN_API_KEY,
+    secretKey: process.env.AUTUMN_SECRET_KEY,
     webhookSecret: process.env.AUTUMN_WEBHOOK_SECRET,
   }),
 };
@@ -40,7 +40,7 @@ const checkout = await api.billing.checkout.post({
   body: {
     productId: "pro",
     customerId: user.id,
-    successUrl: "/dashboard",
+    successPath: "/dashboard",
   },
 });
 ```
@@ -48,3 +48,77 @@ const checkout = await api.billing.checkout.post({
 ## Storage-aware billing
 
 The integration can persist customer, plan, entitlement, and usage snapshots through ctx.args.db, so the app keeps the same Farm integration surface even when the backing storage client changes.
+
+## What Autumn adds
+
+| Area | Details |
+| --- | --- |
+| Products | Public products for pricing pages. |
+| Status | Current plan, subscription, trial, features, limits, and entitlements. |
+| Checkout | Attach an Autumn product and redirect users when payment or confirmation is required. |
+| Portal | Open the customer portal from a typed caller. |
+| Usage | Meter usage, report usage, check balance, and read current charges. |
+| Webhooks | Verify Autumn events and keep local billing state in sync. |
+
+## Common callers
+
+```ts
+const products = await api.billing.products.get();
+const status = await api.billing.status.get();
+
+const allowed = await api.billing.check.post({
+  body: {
+    key: "ai-generations",
+    amount: 1,
+  },
+});
+```
+
+## Checkout flow
+
+```ts
+const checkout = await api.billing.checkout.post({
+  body: {
+    productId: "pro",
+    successPath: "/dashboard",
+    metadata: {
+      source: "pricing",
+    },
+  },
+});
+
+if (checkout.data?.redirectTo) {
+  window.location.href = checkout.data.redirectTo;
+}
+```
+
+## Owner and entitlements
+
+Autumn needs a billing owner when it checks or attaches customer state. Use the owner resolver to connect Farm auth/session data with Autumn customers.
+
+```ts
+autumn({
+  secretKey: process.env.AUTUMN_SECRET_KEY,
+  billing: {
+    async resolveOwner(ctx) {
+      const organizationId = ctx.requestContext.get<string>("organization.id");
+
+      return organizationId
+        ? {
+            id: organizationId,
+            kind: "organization",
+            email: ctx.requestContext.get<string>("user.email") ?? null,
+          }
+        : null;
+    },
+  },
+});
+```
+
+## Production notes
+
+- Set `AUTUMN_SECRET_KEY`, `AUTUMN_WEBHOOK_SECRET`, and `APP_BASE_URL`.
+- Keep Farm product IDs separate from provider IDs when you want a stable app contract.
+- Use `check` before expensive operations and `reportUsage` after successful work.
+- Treat webhooks as the source of truth for subscription state.
+- Test free-plan reads, checkout redirects, portal redirects, usage limits, and webhook sync.

--- a/docs/src/app/docs/integrations/custom/page.md
+++ b/docs/src/app/docs/integrations/custom/page.md
@@ -183,8 +183,8 @@ import { z } from "zod";
 
 const createCheckoutBody = z.object({
   priceId: z.string(),
-  successUrl: z.string().url(),
-  cancelUrl: z.string().url(),
+  successPath: z.string(),
+  cancelPath: z.string(),
 });
 
 export const billing = defineIntegration({
@@ -195,14 +195,14 @@ export const billing = defineIntegration({
     integrationRoute.post<
       "/api/billing/checkout",
       z.output<typeof createCheckoutBody>,
-      { url: string }
+      { redirectTo: string }
     >("/api/billing/checkout", {
       body: createCheckoutBody,
       async handler(_request, ctx) {
         const checkout = await createCheckoutSession(ctx.input.body!);
 
         return Response.json({
-          url: checkout.url,
+          redirectTo: checkout.url,
         });
       },
     }),

--- a/docs/src/app/docs/integrations/email/page.md
+++ b/docs/src/app/docs/integrations/email/page.md
@@ -42,3 +42,67 @@ await apiClient.email.send.post({
   },
 });
 ```
+
+## What Resend adds
+
+| Area | Details |
+| --- | --- |
+| Templates | Typed React Email templates with subjects, preview text, defaults, and preview props. |
+| Send | A typed `send` route for transactional messages. |
+| Schedule | A typed route for future delivery. |
+| Preview | HTML and text rendering for local previews or admin tools. |
+| Templates index | A route that lists configured templates and preview metadata. |
+| Webhooks | Optional Resend webhook receivers for delivery events. |
+
+## Preview before sending
+
+```ts
+const preview = await api.email.preview.post({
+  body: {
+    templateId: "welcome",
+    data: {
+      name: "Ada",
+    },
+  },
+});
+
+console.log(preview.data?.subject);
+console.log(preview.data?.html);
+```
+
+## Schedule mail
+
+```ts
+await api.email.schedule.post({
+  body: {
+    templateId: "welcome",
+    to: "ada@example.com",
+    when: "tomorrow 9am",
+    data: {
+      name: "Ada",
+    },
+  },
+});
+```
+
+## Template defaults
+
+Templates can supply their own `subject`, `previewText`, `from`, and `replyTo`. The integration also supports global defaults, which keeps common sender details out of every call.
+
+```tsx
+const templates = {
+  invite: template({
+    subject: ({ workspace }: { workspace: string }) => `Join ${workspace}`,
+    previewText: "You were invited to collaborate.",
+    component: ({ workspace }: { workspace: string }) => <p>Join {workspace}</p>,
+  }),
+};
+```
+
+## Production notes
+
+- Set `RESEND_API_KEY` and a verified `RESEND_FROM_EMAIL`.
+- Use idempotency keys for important transactional flows.
+- Preview templates in development before sending them to real recipients.
+- Keep template IDs stable because they are part of the caller contract.
+- Verify webhooks before using delivery events for product logic.

--- a/docs/src/app/docs/integrations/inngest/page.md
+++ b/docs/src/app/docs/integrations/inngest/page.md
@@ -40,7 +40,56 @@ export const integrations = {
 **Caller**
 
 ```ts
-await api.jobs.trigger.post({
-  body: { task: "sync-customer", input: { customerId: "cus_123" } },
+await api.jobs.syncCustomer.trigger({
+  body: {
+    input: {
+      customerId: "cus_123",
+    },
+  },
 });
 ```
+
+## Farm task mapping
+
+Inngest is mounted through the Jobs integration. Define tasks once, then choose `inngest(...)` as the runtime.
+
+```ts
+export const tasks = defineTasks({
+  syncCustomer: task({
+    id: "sync-customer",
+    description: "Sync one customer after a billing event.",
+    async run(input: { customerId: string }) {
+      return {
+        synced: true,
+        customerId: input.customerId,
+      };
+    },
+  }),
+});
+```
+
+The app keeps the same Farm caller shape:
+
+```ts
+const run = await api.jobs.syncCustomer.trigger({
+  body: {
+    input: {
+      customerId: "cus_123",
+    },
+  },
+});
+
+await api.jobs.syncCustomer.status({
+  query: {
+    handleId: run.data!.handleId,
+  },
+});
+```
+
+## Production notes
+
+- Set `INNGEST_EVENT_KEY` and `INNGEST_SIGNING_KEY`.
+- Prefer event-shaped task input when the workflow is driven by product events.
+- Use retries for network/provider calls and idempotency for mutation-heavy jobs.
+- Store handle IDs when the UI needs status reads.
+- Test local development, signing, retries, and scheduled runs before shipping.

--- a/docs/src/app/docs/integrations/jobs/page.md
+++ b/docs/src/app/docs/integrations/jobs/page.md
@@ -38,7 +38,7 @@ export const integrations = {
   jobs: jobs({
     tasks,
     runtime: trigger({
-      secretKey: process.env.TRIGGER_SECRET_KEY,
+      apiKey: process.env.TRIGGER_SECRET_KEY,
       projectRef: process.env.TRIGGER_PROJECT_REF,
     }),
   }),
@@ -61,3 +61,65 @@ await api.jobs.sendWelcomeEmail.status({
   query: { handleId: queued.data!.handleId },
 });
 ```
+
+## What the jobs integration adds
+
+| Area | Details |
+| --- | --- |
+| Metadata | A task list route for dashboards and debugging. |
+| Trigger | Queue one task run with typed input. |
+| Batch trigger | Queue many task runs at once. |
+| Schedule | Queue work for a future time. |
+| Status | Read the provider run state and typed output. |
+| Cancel | Cancel a queued or running job when the runtime supports it. |
+
+## Task options
+
+```ts
+export const tasks = defineTasks({
+  syncCustomer: task({
+    id: "sync-customer",
+    description: "Sync customer data from the billing provider.",
+    defaults: {
+      queue: "billing",
+      retry: {
+        attempts: 3,
+      },
+      tags: ["billing"],
+    },
+    async run(input: { customerId: string }) {
+      return {
+        synced: true,
+        customerId: input.customerId,
+      };
+    },
+  }),
+});
+```
+
+## Runtime choice
+
+Use Trigger.dev when you want explicit job dashboards, task-oriented developer tooling, and production retry visibility. Use Inngest when the app is event-first and workflows naturally start from durable events.
+
+The Farm caller shape stays the same either way:
+
+```ts
+await api.jobs.syncCustomer.trigger({
+  body: {
+    input: {
+      customerId: "cus_123",
+    },
+    options: {
+      tags: ["manual-sync"],
+    },
+  },
+});
+```
+
+## Production notes
+
+- Keep task keys stable because they become route and caller names.
+- Use idempotency keys when user actions can submit the same job twice.
+- Store provider handle IDs when the UI needs later status reads.
+- Keep secrets in runtime config, not task input.
+- Test trigger, status, cancellation, retry behavior, and scheduled runs.

--- a/docs/src/app/docs/integrations/polar/page.md
+++ b/docs/src/app/docs/integrations/polar/page.md
@@ -40,7 +40,7 @@ const checkout = await api.billing.checkout.post({
   body: {
     productId: "pro",
     customerEmail: user.email,
-    successUrl: "/dashboard",
+    successPath: "/dashboard",
   },
 });
 ```
@@ -48,3 +48,54 @@ const checkout = await api.billing.checkout.post({
 ## Storage-aware billing
 
 Polar callbacks can read and write through ctx.args.db, so webhook snapshots, subscription state, and customer entitlement checks share the same storage-agnostic integration layer.
+
+## What Polar adds
+
+| Area | Details |
+| --- | --- |
+| Products | Public product metadata for pricing and account screens. |
+| Checkout | Polar checkout sessions for one-time and subscription products. |
+| Portal | Customer sessions for billing management. |
+| Billing status | Current customer, plan, features, limits, and active product state. |
+| Usage | Meter and entitlement helpers for usage-aware products. |
+| Webhooks | Subscription and order events that update local billing state. |
+
+## Common callers
+
+```ts
+const products = await api.billing.products.get();
+const status = await api.billing.status.get();
+
+const checkout = await api.billing.checkout.post({
+  body: {
+    productId: "pro",
+    successPath: "/dashboard",
+    cancelPath: "/pricing",
+  },
+});
+```
+
+## Portal flow
+
+```ts
+const portal = await api.billing.portal.post({
+  body: {
+    returnTo: "/settings/billing",
+  },
+});
+
+if (portal.data?.redirectTo) {
+  window.location.href = portal.data.redirectTo;
+}
+```
+
+## When Polar is a good fit
+
+Polar works especially well when the product is developer-facing, open-source, sponsor-backed, or selling digital access. The Farm integration keeps the same caller shape as other billing providers, so moving between Stripe, Autumn, and Polar does not force your app UI to learn a new local API style.
+
+## Production notes
+
+- Set `POLAR_ACCESS_TOKEN`, `POLAR_WEBHOOK_SECRET`, `POLAR_SERVER`, and `APP_BASE_URL`.
+- Use sandbox/server config for local testing and production config for live billing.
+- Store the external customer ID with the billing owner so portal and status reads stay stable.
+- Test checkout return URLs, portal return URLs, webhook signatures, and entitlement checks.

--- a/docs/src/app/docs/integrations/stripe/page.md
+++ b/docs/src/app/docs/integrations/stripe/page.md
@@ -46,16 +46,97 @@ export const integrations = {
 const checkout = await apiClient.billing.checkout.post({
   body: {
     productId: "pro",
-    successUrl: "/success",
-    cancelUrl: "/pricing",
+    successPath: "/success",
+    cancelPath: "/pricing",
   },
 });
 
-if (checkout.data?.url) {
-  window.location.href = checkout.data.url;
+if (checkout.data?.redirectTo) {
+  window.location.href = checkout.data.redirectTo;
 }
 ```
 
 ## Storage-aware billing
 
 The Stripe integration can use Farm's integration ORM layer through ctx.args.db, so billing snapshot reads and writes can work across Prisma, Drizzle, SQLite SQL, and other farming-labs/orm compatible clients.
+
+## What Stripe adds
+
+| Area | Details |
+| --- | --- |
+| Catalog | Public product and price metadata for pricing pages. |
+| Checkout | A typed checkout route that can return JSON for callers or redirect for browser navigation. |
+| Customer portal | A typed route for opening Stripe's billing portal. |
+| Billing status | Subscription, trial, seats, cancellation, and plan state. |
+| Entitlements | Feature, limit, usage, meter, and billing checks. |
+| Webhooks | Event verification and snapshot updates for checkout and subscription events. |
+| Storage | Schema-backed billing account snapshots through `ctx.args.db`. |
+
+## Common callers
+
+**Load pricing**
+
+```ts
+const products = await api.billing.products.get();
+```
+
+**Read current billing state**
+
+```ts
+const status = await api.billing.status.get();
+
+if (status.data?.status === "active") {
+  console.log(status.data.planId);
+}
+```
+
+**Open the portal**
+
+```ts
+const portal = await api.billing.portal.post({
+  body: {
+    returnTo: "/settings/billing",
+  },
+});
+
+if (portal.data?.redirectTo) {
+  window.location.href = portal.data.redirectTo;
+}
+```
+
+## Billing owner
+
+Production billing usually needs an owner resolver. That resolver decides whether the billing account belongs to a user, organization, workspace, or team.
+
+```ts
+stripe({
+  secretKey: process.env.STRIPE_SECRET_KEY,
+  webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
+  billing: {
+    async resolveOwner(ctx) {
+      const userId = ctx.requestContext.get<string>("user.id");
+
+      if (!userId) {
+        return null;
+      }
+
+      return {
+        id: userId,
+        kind: "user",
+        email: ctx.requestContext.get<string>("user.email") ?? null,
+      };
+    },
+  },
+});
+```
+
+The same `ctx` includes `ctx.args.db`, `ctx.data`, request params, the raw request, and request-scoped context values from middleware or auth integrations.
+
+## Production notes
+
+- Set `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, and `APP_BASE_URL`.
+- Keep product IDs stable because they become the app-facing contract.
+- Verify webhook signatures before mutating billing state.
+- Store billing snapshots through the integration schema when the app needs fast entitlement reads.
+- Use server callers for admin-only operations and browser callers for checkout/portal redirects.
+- Test checkout success, cancel, webhook replay, portal return, subscription update, and trial edge cases.

--- a/docs/src/app/docs/integrations/trigger/page.md
+++ b/docs/src/app/docs/integrations/trigger/page.md
@@ -39,7 +39,55 @@ export const integrations = {
 **Caller**
 
 ```ts
-await api.jobs.trigger.post({
-  body: { task: "send-welcome-email", input: { userId: "user_123" } },
+await api.jobs.sendWelcomeEmail.trigger({
+  body: {
+    input: {
+      userId: "user_123",
+    },
+  },
 });
 ```
+
+## Farm task mapping
+
+Trigger.dev is mounted through the Jobs integration. Define tasks once with `defineTasks`, then choose `trigger(...)` as the runtime.
+
+```ts
+export const tasks = defineTasks({
+  sendWelcomeEmail: task({
+    id: "send-welcome-email",
+    async run(input: { userId: string }) {
+      return {
+        sent: true,
+        userId: input.userId,
+      };
+    },
+  }),
+});
+```
+
+Farm turns `sendWelcomeEmail` into typed callers such as:
+
+```ts
+await api.jobs.sendWelcomeEmail.trigger({
+  body: {
+    input: {
+      userId: "user_123",
+    },
+  },
+});
+
+await api.jobs.sendWelcomeEmail.status({
+  query: {
+    handleId: "run_123",
+  },
+});
+```
+
+## Production notes
+
+- Set the Trigger.dev secret/project config required by your runtime.
+- Use queues and retry defaults on the task definition for predictable load.
+- Keep task IDs stable because provider dashboards and Farm callers depend on them.
+- Store returned `handleId` when users need status polling.
+- Use batch trigger for bulk work instead of loops from the browser.

--- a/docs/src/app/docs/integrations/ui-registry/page.md
+++ b/docs/src/app/docs/integrations/ui-registry/page.md
@@ -25,3 +25,57 @@ farm add integration jobs-trigger --ui
 - Base components follow shadcn conventions.
 - Feature registries are grouped by provider, such as billing, auth, jobs, email, AI, and API keys.
 - Generated files are app-owned, so users can edit the UI after installation.
+
+## What gets generated
+
+The registry is integration-aware. A billing integration can generate pricing cards, checkout buttons, portal buttons, billing-status panels, and entitlement banners. An auth integration can generate sign-in pages, sign-up pages, session buttons, account menus, and protected dashboard shells. Jobs and API-key integrations can generate task dashboards, run-status views, and key-management screens.
+
+The CLI keeps UI optional:
+
+```bash
+farm add integration stripe
+farm add integration stripe --ui
+```
+
+Without `--ui`, Farm installs wiring only. With `--ui`, it adds app-owned components that already call the typed integration API.
+
+## Example generated usage
+
+```tsx
+"use client";
+
+import { apiClient } from "../lib/api";
+
+export function CheckoutButton() {
+  async function checkout() {
+    const result = await apiClient.billing.checkout.post({
+      body: {
+        productId: "pro",
+        successPath: "/dashboard",
+        cancelPath: "/pricing",
+      },
+    });
+
+    if (result.data?.redirectTo) {
+      window.location.href = result.data.redirectTo;
+    }
+  }
+
+  return <button onClick={checkout}>Upgrade</button>;
+}
+```
+
+## Customizing registry output
+
+- Generated files live in the app, so teams can edit them after installation.
+- Keep provider SDK secrets out of generated client components.
+- Prefer small components that call typed APIs over large opaque templates.
+- Use existing design-system primitives when the app already has them.
+- Keep registry output deterministic so repeated installs are reviewable.
+
+## Production notes
+
+- Generate UI only for flows the app plans to own.
+- Review generated files before shipping.
+- Keep route names and product IDs stable so generated components do not drift.
+- Add tests around the resulting user flow, not just the generated component.

--- a/docs/src/app/docs/integrations/unkey/page.md
+++ b/docs/src/app/docs/integrations/unkey/page.md
@@ -13,6 +13,7 @@ Create, verify, revoke, update, and delete API keys, plus protect routes with ke
 **farm.config.ts**
 
 ```ts
+import { defineFarmConfig } from "@farmjs/core";
 import { unkey } from "@farmjs/integrations/unkey";
 
 export default defineFarmConfig({
@@ -30,14 +31,14 @@ export default defineFarmConfig({
 **Caller**
 
 ```ts
-const created = await api.keys.createKey.post({
+const created = await api.keys.create.post({
   body: {
     name: "Production key",
     permissions: ["documents.read"],
   },
 });
 
-const verified = await api.keys.verifyKey.post({
+const verified = await api.keys.verify.post({
   body: {
     key: created.data!.key,
     permissions: "documents.read",
@@ -50,3 +51,64 @@ const verified = await api.keys.verifyKey.post({
 - API products where customers need their own keys.
 - Internal platform keys for service-to-service requests.
 - Route protection where key validity, permissions, credits, or rate limits matter.
+
+## What Unkey adds
+
+| Area | Details |
+| --- | --- |
+| Create | Server-only route for creating customer or service keys. |
+| Verify | Server-only route for checking validity, permissions, credits, and rate limits. |
+| Update | Server-only route for changing metadata, roles, permissions, credits, and limits. |
+| Revoke | Server-only route for disabling a key without deleting its record. |
+| Delete | Server-only route for deleting a key when the app no longer needs it. |
+| Middleware | Optional protected route matcher that verifies request keys before app code runs. |
+
+## Server-only callers
+
+Unkey mutation and verification callers are marked as server-only. Use `api` from `createIntegrations`, not `apiClient` in browser components.
+
+```ts
+import { api } from "../lib/api";
+
+export async function createCustomerKey(userId: string) {
+  const created = await api.keys.create.post({
+    body: {
+      externalId: userId,
+      permissions: ["documents.read"],
+      ratelimits: [
+        {
+          name: "documents",
+          limit: 1000,
+          duration: 60_000,
+        },
+      ],
+    },
+  });
+
+  return created.data;
+}
+```
+
+## Protect routes
+
+```ts
+unkey({
+  rootKey: process.env.UNKEY_ROOT_KEY,
+  apiId: process.env.UNKEY_API_ID,
+  protectedRoutes: ["/api/public/[...path]"],
+  protection: {
+    header: "authorization",
+    permissions: ["documents.read"],
+  },
+});
+```
+
+When a request matches `protectedRoutes`, the integration verifies the key before the route handler runs.
+
+## Production notes
+
+- Keep `UNKEY_ROOT_KEY` server-only.
+- Use server callers for key creation and verification.
+- Prefer permissions and ratelimits over one global "valid key" check.
+- Revoke keys before deleting them when users may need an audit trail.
+- Test expired keys, missing permissions, exhausted credits, and rate-limit failures.

--- a/docs/src/app/docs/layouts/page.md
+++ b/docs/src/app/docs/layouts/page.md
@@ -50,3 +50,67 @@ export default function DashboardLayout({ children }: LayoutProps) {
 - loading.tsx provides pending UI for a route segment.
 - error.tsx catches render failures in that segment.
 - not-found.tsx renders when the route intentionally returns a 404.
+
+## Loading UI
+
+Use `loading.tsx` when a segment can suspend during data loading. Farm can render the route shell while the segment waits, which pairs well with PPR pages.
+
+**src/app/dashboard/loading.tsx**
+
+```tsx
+export default function DashboardLoading() {
+  return <div aria-busy="true">Loading dashboard...</div>;
+}
+```
+
+## Error UI
+
+Error boundaries should be client components because they need to recover in the browser.
+
+**src/app/dashboard/error.tsx**
+
+```tsx
+"use client";
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  return (
+    <section>
+      <h2>Dashboard failed to load</h2>
+      <p>{error.message}</p>
+      <button onClick={reset}>Try again</button>
+    </section>
+  );
+}
+```
+
+## Not found UI
+
+Use `not-found.tsx` for segment-specific missing states. A docs page might show docs navigation, while an account page might link back to settings.
+
+**src/app/docs/not-found.tsx**
+
+```tsx
+import { Link } from "@farmjs/core/client";
+
+export default function DocsNotFound() {
+  return (
+    <main>
+      <h1>Page not found</h1>
+      <Link href="/docs">Back to docs</Link>
+    </main>
+  );
+}
+```
+
+## Design guidance
+
+- Put global providers in the root layout.
+- Put product area navigation in nested layouts.
+- Keep route boundaries close to the route that owns the failure or loading state.
+- Avoid fetching highly specific page data in a parent layout unless every child needs it.

--- a/docs/src/app/docs/markdown/page.md
+++ b/docs/src/app/docs/markdown/page.md
@@ -34,3 +34,52 @@ export default defineFarmConfig({
 - AI assistants can fetch page content without parsing the full app shell.
 - Pricing, docs, changelog, and policy pages become easy to cite.
 - Teams can keep one source of truth: the actual rendered page.
+
+## Expose every route
+
+Use `md: true` when an internal app or documentation site should expose markdown mirrors for every rendered page.
+
+```ts
+export default defineFarmConfig({
+  md: true,
+});
+```
+
+For public apps, prefer an explicit list so private or account pages are not exposed as markdown.
+
+## Per-route options
+
+Routes can include a display title and cache override.
+
+```ts
+export default defineFarmConfig({
+  md: {
+    expose: [
+      {
+        route: "/pricing",
+        title: "Pricing",
+        cache: 300,
+      },
+      "/docs/[...slug]",
+    ],
+    includeMetadata: true,
+  },
+});
+```
+
+## What gets returned
+
+Markdown mirrors call the rendered page, strip scripts/styles, convert HTML headings, paragraphs, lists, blockquotes, and code blocks into markdown, then return `text/markdown`.
+
+**Terminal**
+
+```bash
+curl http://localhost:3000/pricing.md
+```
+
+## Production notes
+
+- Expose only pages that are safe for agents and crawlers.
+- Keep authenticated dashboards out of `md.expose`.
+- Use `cache` for stable public pages.
+- Use markdown mirrors for docs, pricing, policies, changelogs, release notes, and help center pages.

--- a/docs/src/app/docs/middleware/page.md
+++ b/docs/src/app/docs/middleware/page.md
@@ -30,9 +30,62 @@ Use farm.config.ts when middleware behavior should be described globally.
 **farm.config.ts**
 
 ```ts
+import { defineFarmConfig } from "@farmjs/core";
+
 export default defineFarmConfig({
   middleware: {
     matcher: ["/dashboard/:path*"],
   },
 });
 ```
+
+## Protect a route area
+
+Middleware can short-circuit with a redirect or response before the page/API handler runs.
+
+**src/app/dashboard/middleware.ts**
+
+```ts
+import { defineMiddleware } from "@farmjs/core/middleware";
+
+export default defineMiddleware(async ({ request, next, context }) => {
+  const session = await readSession(request);
+
+  if (!session) {
+    return Response.redirect(new URL("/sign-in", request.url));
+  }
+
+  context.data.set("user.id", session.user.id, {
+    exposeToPage: true,
+  });
+
+  return next(request);
+});
+```
+
+**src/app/dashboard/page.tsx**
+
+```tsx
+import type { PageProps } from "@farmjs/core";
+
+export default function DashboardPage(props: PageProps) {
+  const userId = props.middleware?.data.get("user.id");
+  return <main>User {userId}</main>;
+}
+```
+
+## Common uses
+
+| Use case | Pattern |
+| --- | --- |
+| Auth | Redirect signed-out users or return `401` for private APIs. |
+| Request context | Attach request IDs, user IDs, tenant IDs, and feature flags. |
+| Security | Add headers, block invalid origins, or rate-limit an API area. |
+| Localization | Rewrite to a locale route or expose locale data to pages. |
+
+## Production notes
+
+- Keep secrets server-only inside middleware.
+- Expose only the page data the route actually needs.
+- Prefer integration middleware when a provider owns the behavior, such as auth or API key checks.
+- Keep middleware fast because it runs before the route can render.

--- a/docs/src/app/docs/observability/page.md
+++ b/docs/src/app/docs/observability/page.md
@@ -34,3 +34,59 @@ onFarmEvent((event) => {
 | Integrations | integration.ready, integration.api.call.start, integration.webhook.verified |
 | Storage | storage.query.start, storage.schema.ready |
 | Build | build.start, routes.generated, types.generated, manifest.generated |
+
+## Configure in farm.config.ts
+
+Use config-level observability when an app should log or forward events from startup.
+
+```ts
+import { defineFarmConfig } from "@farmjs/core";
+
+export default defineFarmConfig({
+  observability: {
+    logs: true,
+    events: ["cache.hit", "cache.miss", "ppr.shell.cached"],
+    onEvent(event) {
+      if (event.type === "cache.miss") {
+        console.log("Cache miss", event.key, event.reason);
+      }
+    },
+  },
+});
+```
+
+`events` is optional. Leave it out to receive every emitted event.
+
+## Runtime subscription
+
+Use `onFarmEvent` for tests, local debugging, or integration packages that want to register listeners without owning app config.
+
+```ts
+import { onFarmEvent } from "@farmjs/core/observability";
+
+const unsubscribe = onFarmEvent((event) => {
+  if (event.type === "integration.webhook.failed") {
+    console.error(event.integration, event.reason);
+  }
+});
+
+unsubscribe();
+```
+
+## Useful event types
+
+| Area | Events |
+| --- | --- |
+| Cache | `cache.hit`, `cache.miss`, `cache.set`, `cache.stale`, `cache.bypass`, `cache.invalidated`, `cache.revalidatePath`, `cache.revalidateTag`, `cache.updateTag`, `cache.error` |
+| PPR | `ppr.shell.hit`, `ppr.shell.miss`, `ppr.shell.cached`, `ppr.shell.bypass`, `ppr.shell.invalidated`, `ppr.suspense.holeDetected`, `ppr.refresh.start`, `ppr.refresh.complete`, `ppr.refresh.error` |
+| API | `api.request.start`, `api.request.complete`, `api.validation.failed`, `api.error` |
+| Integrations | `integration.registered`, `integration.config.validated`, `integration.ready`, `integration.disposed`, `integration.api.call.start`, `integration.api.call.complete`, `integration.webhook.verified`, `integration.webhook.failed` |
+| Middleware | `middleware.start`, `middleware.complete`, `middleware.shortCircuit`, `middleware.error` |
+| Storage | `storage.query.start`, `storage.query.complete`, `storage.query.error`, `storage.schema.ready`, `storage.schema.error` |
+
+## Production notes
+
+- Filter high-volume events before shipping them to a log drain.
+- Attach request IDs in middleware so event streams can be correlated.
+- Treat event payloads as operational metadata; do not put secrets in event fields.
+- Watch `api.validation.failed`, `integration.webhook.failed`, `cache.error`, and `ppr.refresh.error` in production.

--- a/docs/src/app/docs/openapi/page.md
+++ b/docs/src/app/docs/openapi/page.md
@@ -26,3 +26,71 @@ export default defineFarmConfig({
 ## Reference route
 
 The OpenAPI route can be included in generated route types so docs navigation and Link hrefs stay aware of the reference page.
+
+## What gets documented
+
+Farm scans API route files and generates an OpenAPI 3.0.3 spec from the discovered routes, methods, route params, query schemas, body schemas, and response metadata it can infer.
+
+**src/app/api/users/route.ts**
+
+```ts
+import { createEndpoint } from "@farmjs/core/api";
+import { z } from "zod";
+
+export const GET = createEndpoint({
+  query: z.object({
+    limit: z.coerce.number().int().positive().default(20),
+  }),
+  async handler({ input }) {
+    return Response.json({
+      users: await listUsers(input.query.limit),
+    });
+  },
+});
+```
+
+The route appears in the generated reference with a typed `limit` query parameter.
+
+## Add metadata
+
+```ts
+export default defineFarmConfig({
+  openapi: {
+    enabled: true,
+    route: "/docs/reference",
+    title: "Acme API",
+    description: "Public and internal API routes for Acme.",
+    version: "1.0.0",
+    servers: [
+      {
+        url: "https://api.acme.com",
+        description: "Production",
+      },
+    ],
+    contact: {
+      name: "API Support",
+      email: "support@acme.com",
+    },
+  },
+});
+```
+
+## Serve the reference
+
+The configured route serves a Scalar-powered reference page with the generated spec embedded in the page. The route can be visited during development and included in production docs.
+
+**Terminal**
+
+```bash
+farm generate
+farm build
+```
+
+`farm generate` keeps route types aware of the reference URL. `farm build` includes the reference route in the app output when OpenAPI is enabled.
+
+## Production notes
+
+- Enable OpenAPI for APIs you want to document publicly or internally.
+- Keep private admin routes out of public docs unless the site is protected.
+- Use Zod schemas on API routes for better generated parameter and body details.
+- Pair OpenAPI with typed callers so server/client code and published docs describe the same route surface.

--- a/docs/src/app/docs/project-structure/page.md
+++ b/docs/src/app/docs/project-structure/page.md
@@ -38,3 +38,64 @@ my-app/
 ## Optional files stay optional
 
 Use vite.config.ts only when you need custom Vite behavior. Use platform files only when a deployment target requires provider-specific settings that Farm cannot infer.
+
+## Route files
+
+| File | Used for |
+| --- | --- |
+| `page.tsx` | The route UI. |
+| `layout.tsx` | Shared shell for every child segment. |
+| `loading.tsx` | Pending UI for async route work. |
+| `error.tsx` | Segment-level error UI. |
+| `not-found.tsx` | Segment-level 404 UI. |
+| `middleware.ts` | Request behavior before the route renders. |
+| `route.ts` | API handlers for the current URL segment. |
+
+## Recommended app layout
+
+**Project**
+
+```txt
+my-app/
+  src/
+    app/
+      api/
+        hello/
+          route.ts
+      dashboard/
+        layout.tsx
+        page.tsx
+      layout.tsx
+      page.tsx
+    components/
+      account-menu.tsx
+    lib/
+      api.ts
+      integrations.ts
+  farm.config.ts
+  package.json
+  tsconfig.json
+```
+
+Keep framework configuration in `farm.config.ts`. Keep application helpers under `src/lib`, and keep UI that is reused across pages under `src/components`.
+
+## Generated files
+
+Farm can generate route and API types from the app tree. Commit generated types when the project relies on them during CI or package publishing.
+
+**Terminal**
+
+```bash
+farm generate
+```
+
+Generated route types make `Link` stricter, and generated API types make `api.hello.post(...)` match the route's body and query schemas.
+
+## When to add root files
+
+| File | Add it when |
+| --- | --- |
+| `vite.config.ts` | You need Vite plugins, aliases, or server settings Farm does not infer. |
+| `vercel.json` | You need platform behavior outside Farm's deploy output. |
+| `tailwind.config.ts` | Your Tailwind version or design system requires an explicit config. |
+| `docs.config.ts` | You enable docs and want navigation, icons, theme, or page actions. |

--- a/docs/src/app/docs/query/page.md
+++ b/docs/src/app/docs/query/page.md
@@ -40,3 +40,82 @@ export function SearchControls() {
   return <input value={q} onChange={(event) => setQ(event.target.value)} />;
 }
 ```
+
+## Multiple query values
+
+Use `useQueryStates` when several controls should update together. This keeps the browser URL as the source of shareable state for filters, pagination, and tabs.
+
+**src/components/product-filters.tsx**
+
+```tsx
+"use client";
+
+import { asInteger, asString, useQueryStates } from "@farmjs/core/query/client";
+
+export function ProductFilters() {
+  const [filters, setFilters] = useQueryStates(
+    {
+      q: asString.withDefault!(""),
+      page: asInteger.withDefault!(1),
+      plan: asString,
+    },
+    {
+      history: "replaceState",
+      shallow: true,
+    },
+  );
+
+  return (
+    <form>
+      <input
+        value={filters.q}
+        onChange={(event) => {
+          setFilters({
+            q: event.target.value,
+            page: 1,
+          });
+        }}
+      />
+    </form>
+  );
+}
+```
+
+## Route params
+
+Use route param parsers when dynamic segments should be typed before they hit your data layer.
+
+**src/app/users/[id]/page.tsx**
+
+```tsx
+import type { PageProps } from "@farmjs/core";
+import { asString, loadRouteParams } from "@farmjs/core/query/server";
+
+export default async function UserPage({ params }: PageProps) {
+  const { id } = await loadRouteParams(params, {
+    id: asString,
+  });
+
+  return <main>User {id}</main>;
+}
+```
+
+## Parser reference
+
+| Parser | Reads |
+| --- | --- |
+| `asString` | Plain strings. |
+| `asInteger` | Integer values for pagination and limits. |
+| `asFloat` | Decimal numbers. |
+| `asBoolean` | Boolean flags. |
+| `asArrayOf(parser)` | Repeated values serialized through another parser. |
+| `asJson` | Structured JSON encoded in the URL. |
+| `asIsoDate` | Date strings. |
+| `asIsoDateTime` | Date-time strings. |
+
+## Production notes
+
+- Parse query on the server before passing values to database queries.
+- Use defaults for values that should always be present in UI state.
+- Use `replaceState` for filters that change often, and `pushState` when each change should be browser-history navigable.
+- Keep large state out of the URL; store only the values users should be able to share.

--- a/docs/src/app/docs/reference/page.md
+++ b/docs/src/app/docs/reference/page.md
@@ -26,3 +26,26 @@ A compact map of the main package exports and where to learn more.
 3. Add API Routes, API Client, and Query.
 4. Choose integrations and storage once your product needs them.
 5. Finish with Deployment, Observability, and Reference.
+
+## Integration exports
+
+| Package | Exports |
+| --- | --- |
+| `@farmjs/core` | `defineIntegration`, `integrationRoute`, `defineIntegrationSchema`, `definePlugin`, `defineFarmConfig`. |
+| `@farmjs/core/client` | `createIntegrations`, `createIntegrationClient`, `createIntegrationServerClient`, `endpoint`. |
+| `@farmjs/core/storage` | `sqliteStorage`, `postgresStorage`, `redisStorage`, `createStorageClient`, `defineStorageClient`. |
+| `@farmjs/integrations/stripe` | Stripe billing integration. |
+| `@farmjs/integrations/auth` | Better Auth, Auth.js, Clerk, Auth0, WorkOS helpers when using the auth barrel. |
+| `@farmjs/integrations/supabase` | Supabase auth integration. |
+| `@farmjs/integrations/email` | Resend integration and email template helper. |
+| `@farmjs/integrations/jobs` | Jobs integration, `task`, `defineTasks`, Trigger.dev runtime, Inngest runtime. |
+| `@farmjs/integrations/unkey` | Unkey API key integration. |
+
+## Mental model
+
+- Pages and layouts are app UI.
+- API routes are app-owned HTTP handlers.
+- API clients are typed callers for app routes.
+- Integrations are provider or feature packages that can own routes, callers, schemas, providers, config, and lifecycle.
+- Plugins are framework-level hooks for request, render, build, and runtime behavior.
+- Storage is the shared place to pass key/value stores and runtime database clients.

--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -47,3 +47,67 @@ export function Nav() {
   );
 }
 ```
+
+## Nested segments
+
+Folders become URL segments. Use normal folders for visible path segments and dynamic folders when the value comes from the URL.
+
+**Route tree**
+
+```txt
+src/app/
+  page.tsx
+  dashboard/
+    page.tsx
+    settings/
+      page.tsx
+  blog/
+    [slug]/
+      page.tsx
+  docs/
+    [...slug]/
+      page.tsx
+```
+
+This creates `/`, `/dashboard`, `/dashboard/settings`, `/blog/:slug`, and `/docs/:slug*`.
+
+## Catch-all routes
+
+Catch-all routes are useful for docs, CMS content, and nested marketing pages where the page is resolved from content instead of a fixed file for every URL.
+
+**src/app/docs/[...slug]/page.tsx**
+
+```tsx
+import type { PageProps } from "@farmjs/core";
+
+export default function DocsPage({ params }: PageProps) {
+  const slug = params.slug?.split("/") ?? [];
+  return <main>Docs path: {slug.join(" / ")}</main>;
+}
+```
+
+## Route groups
+
+Use route groups to organize files without adding URL segments. They are useful when an app has multiple shells.
+
+**Route groups**
+
+```txt
+src/app/
+  (marketing)/
+    page.tsx
+    pricing/
+      page.tsx
+  (app)/
+    dashboard/
+      page.tsx
+```
+
+The group names are organizational. The URLs are still `/`, `/pricing`, and `/dashboard`.
+
+## Navigation workflow
+
+1. Add or rename route files.
+2. Run `farm generate` when you want type updates immediately.
+3. Use `Link` for internal navigation and plain anchors for external URLs.
+4. Keep dynamic route values encoded in the href string, such as `/blog/${slug}`.

--- a/docs/src/app/docs/server-rendering/page.md
+++ b/docs/src/app/docs/server-rendering/page.md
@@ -43,3 +43,80 @@ export default function BlogPage() {
   return <main>Blog</main>;
 }
 ```
+
+## Dynamic rendering
+
+Use dynamic rendering for request-specific pages such as dashboards, account settings, and pages that depend on cookies, headers, or per-user data.
+
+**src/app/dashboard/page.tsx**
+
+```tsx
+export const dynamic = "force-dynamic";
+
+export default async function DashboardPage() {
+  return <main>Dashboard</main>;
+}
+```
+
+## Static rendering
+
+Use static rendering for pages that can be built once and served quickly.
+
+**src/app/about/page.tsx**
+
+```tsx
+export const dynamic = "force-static";
+
+export default function AboutPage() {
+  return <main>About Farm</main>;
+}
+```
+
+## ISR-style revalidation
+
+`revalidate` caches a static response and refreshes it after the configured number of seconds.
+
+**src/app/pricing/page.tsx**
+
+```tsx
+export const dynamic = "force-static";
+export const revalidate = 300;
+
+export default async function PricingPage() {
+  const plans = await loadPlans();
+  return <PricingTable plans={plans} />;
+}
+```
+
+## PPR with Suspense
+
+PPR is for pages with a stable shell and dynamic sections. Put dynamic work behind Suspense boundaries so the shell can be cached while the slower section resolves independently.
+
+**src/app/dashboard/page.tsx**
+
+```tsx
+import { Suspense } from "react";
+
+export const experimental_ppr = true;
+export const revalidate = 60;
+
+export default function DashboardPage() {
+  return (
+    <main>
+      <h1>Dashboard</h1>
+      <Suspense fallback={<RevenueSkeleton />}>
+        <RevenuePanel />
+      </Suspense>
+    </main>
+  );
+}
+```
+
+## Choosing a mode
+
+| Need | Use |
+| --- | --- |
+| User-specific data on every request | `dynamic = "force-dynamic"` |
+| Stable docs, marketing, or policy page | `dynamic = "force-static"` |
+| Stable page with scheduled refresh | `revalidate = 60` |
+| Static shell plus dynamic holes | `experimental_ppr = true` with Suspense |

--- a/docs/src/app/docs/storage/page.md
+++ b/docs/src/app/docs/storage/page.md
@@ -44,3 +44,40 @@ export default defineFarmConfig({
 ## Supported drivers
 
 - memory, local filesystem, SQLite, libSQL, PGlite, Postgres, MySQL, Redis, Upstash Redis, MongoDB, S3, and Vercel KV.
+
+## Runtime clients for integrations
+
+`storage.client` can also carry an app-owned database client for schema-backed integrations.
+
+```ts
+import { defineFarmConfig } from "@farmjs/core";
+import { DatabaseSync } from "node:sqlite";
+
+const db = new DatabaseSync("farm.sqlite");
+
+export default defineFarmConfig({
+  storage: {
+    client: db,
+  },
+});
+```
+
+When an integration defines a schema, Farm exposes a typed ORM layer at `ctx.args.db`. The integration does not need to know whether the app passed SQLite, Postgres, or another supported runtime client.
+
+## Storage client or runtime client
+
+| Config | Use it for |
+| --- | --- |
+| `sqliteStorage(...)` | Farm key/value storage with a Farm storage client. |
+| `redisStorage(...)` | Cache, rate-limit, or queue-like key/value data. |
+| `storage.mounts` | Multiple named key/value stores. |
+| `storage.client` with a Farm storage client | Reuse a created Farm storage client as the root store. |
+| `storage.client` with a DB/runtime object | Give integrations a runtime database client. |
+
+## Production notes
+
+- Use durable storage for production state.
+- Keep local/memory storage for development and tests.
+- Pass one runtime client through config so integrations do not each invent storage options.
+- Create physical tables/migrations that match integration schemas.
+- Close database clients during app shutdown when the underlying driver requires it.


### PR DESCRIPTION
## Summary

Expands the Farm.js docs content after the initial docs framework PR landed.

- Adds deeper usage guidance across API routes, API client, config, deployment, docs engine, examples, storage, cache/PPR, middleware, rendering, routing, query params, observability, OpenAPI, CLI, and reference pages.
- Expands provider docs for Stripe, Autumn, Polar, auth providers, email, jobs, Trigger.dev, Inngest, Unkey, UI registry, and custom integrations.
- Tightens examples to match current API shapes, including `redirectTo`, `successPath`/`cancelPath`, server-only Unkey callers, provider-specific auth session guidance, and jobs task callers.

## Validation

- `git diff --check origin/main...HEAD`
- `DATABASE_URL=${DATABASE_URL:-postgresql://user:password@localhost:5432/farmjs} ./node_modules/.bin/prisma generate && DATABASE_URL=${DATABASE_URL:-postgresql://user:password@localhost:5432/farmjs} ./node_modules/.bin/farm build`