### PR TITLE
feat: add markdown app pages

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -27,6 +27,9 @@ export default defineFarmConfig({
     expose: ["/", "/pricing"],
     cache: 60,
   },
+  mdx: {
+    components: "./src/markdown-components.tsx",
+  },
 });
 ```
 
@@ -39,6 +42,7 @@ export default defineFarmConfig({
 | storage | Providing storage clients and mounts for framework and integration code. |
 | docs | Serving the built-in docs runtime and docs API. |
 | md | Exposing markdown mirrors like /pricing.md. |
+| mdx | Rendering `page.md` and `page.mdx` app routes, plus MDX components. |
 | deploy | Selecting a target, preset, and output directory. |
 | openapi | Publishing API reference docs. |
 

--- a/docs/src/app/docs/markdown/page.md
+++ b/docs/src/app/docs/markdown/page.md
@@ -8,6 +8,55 @@ section: "Content"
 
 Expose markdown versions of app pages so agents, crawlers, docs tools, and support workflows can read rendered content as text.
 
+Farm supports two markdown flows:
+
+- `page.md` and `page.mdx` are source-authored app pages.
+- `md` mirrors convert rendered `page.tsx` routes back into markdown.
+
+Use source-authored pages for static content such as about pages, policies, changelogs, and content-heavy marketing pages. Use mirrors when the canonical source is a React route.
+
+## Markdown app pages
+
+**src/app/about/page.mdx**
+
+```mdx
+---
+title: About Farm
+description: A markdown-first static page.
+---
+
+# About Farm
+
+<Callout>Farm can render MDX from the app router.</Callout>
+```
+
+This creates `/about` automatically. Because the route is source-authored markdown, Farm also serves the raw source at `/about.md` by default.
+
+## Configure MDX components
+
+**farm.config.ts**
+
+```ts
+export default defineFarmConfig({
+  mdx: {
+    components: "./src/markdown-components.tsx",
+    markdownRoutes: true,
+  },
+});
+```
+
+**src/markdown-components.tsx**
+
+```tsx
+import { Callout } from "./components/callout";
+
+export const components = {
+  Callout,
+};
+```
+
+Set `mdx.markdownRoutes` to `false` when source-authored pages should render as HTML only.
+
 ## Expose pages
 
 **farm.config.ts**
@@ -82,4 +131,5 @@ curl http://localhost:3000/pricing.md
 - Expose only pages that are safe for agents and crawlers.
 - Keep authenticated dashboards out of `md.expose`.
 - Use `cache` for stable public pages.
+- Use `page.md` or `page.mdx` when markdown is the source of truth.
 - Use markdown mirrors for docs, pricing, policies, changelogs, release notes, and help center pages.

--- a/docs/src/app/docs/project-structure/page.md
+++ b/docs/src/app/docs/project-structure/page.md
@@ -44,6 +44,7 @@ Use vite.config.ts only when you need custom Vite behavior. Use platform files o
 | File | Used for |
 | --- | --- |
 | `page.tsx` | The route UI. |
+| `page.md` / `page.mdx` | Markdown-first static app pages. |
 | `layout.tsx` | Shared shell for every child segment. |
 | `loading.tsx` | Pending UI for async route work. |
 | `error.tsx` | Segment-level error UI. |
@@ -65,6 +66,8 @@ my-app/
       dashboard/
         layout.tsx
         page.tsx
+      about/
+        page.mdx
       layout.tsx
       page.tsx
     components/

--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -14,6 +14,7 @@ Farm uses an app directory routing model with static routes, dynamic segments, c
 | --- | --- |
 | src/app/page.tsx | / |
 | src/app/about/page.tsx | /about |
+| src/app/about/page.mdx | /about |
 | src/app/blog/[slug]/page.tsx | /blog/:slug |
 | src/app/docs/[...slug]/page.tsx | /docs/:slug* |
 
@@ -70,6 +71,20 @@ src/app/
 ```
 
 This creates `/`, `/dashboard`, `/dashboard/settings`, `/blog/:slug`, and `/docs/:slug*`.
+
+## Markdown pages
+
+Use `page.md` or `page.mdx` for static content routes. They behave like app pages, participate in layouts, and get route types.
+
+**src/app/about/page.mdx**
+
+```mdx
+# About
+
+This page renders at `/about` and exposes source at `/about.md`.
+```
+
+Do not place `page.tsx` and `page.mdx` in the same folder. Farm treats that as a duplicate route and asks you to choose one page source.
 
 ## Catch-all routes
 

--- a/examples/basic/farm.config.ts
+++ b/examples/basic/farm.config.ts
@@ -159,6 +159,10 @@ export default defineFarmConfig({
     cache: 60,
   },
 
+  mdx: {
+    components: './src/markdown-components.tsx',
+  },
+
   // Plugins
   plugins: [
     createLoggerPlugin({}),

--- a/examples/basic/src/app/markdown/page.mdx
+++ b/examples/basic/src/app/markdown/page.mdx
@@ -1,0 +1,12 @@
+---
+title: Markdown App Page
+description: A source-authored MDX page rendered from the Farm app router.
+---
+
+# Markdown app page
+
+This route is authored as `src/app/markdown/page.mdx`, renders at `/markdown`, and exposes the original source at `/markdown.md`.
+
+<Callout>
+  The `Callout` component comes from `mdx.components` in `farm.config.ts`.
+</Callout>

--- a/examples/basic/src/farm-routes.d.ts
+++ b/examples/basic/src/farm-routes.d.ts
@@ -3,7 +3,7 @@
  * Link href is typed automatically via module augmentation. Regenerated on dev start and when routes change.
  * Set suppressLintOnLink: true in farm.config.ts to accept any string on Link href.
  */
-export type RoutePath = "/" | "/about" | "/api-demo" | "/api-demo-client" | "/api-demo-client-advanced" | "/boundaries/error" | "/boundaries/loading" | "/boundaries/suspense" | "/contact" | "/docs" | `/docs/${string}` | "/docs/reference" | "/farm-query-client-demo" | "/farm-query-demo" | "/ppr-demo" | "/prefetch-e2e" | "/query-demo" | "/storage-demo" | "/store-e2e" | `/users/${string}`;
+export type RoutePath = "/" | "/about" | "/api-demo" | "/api-demo-client" | "/api-demo-client-advanced" | "/boundaries/error" | "/boundaries/loading" | "/boundaries/suspense" | "/contact" | "/docs" | `/docs/${string}` | "/docs/getting-started" | "/docs/reference" | "/farm-query-client-demo" | "/farm-query-demo" | "/markdown" | "/ppr-demo" | "/prefetch-e2e" | "/query-demo" | "/storage-demo" | "/store-e2e" | `/users/${string}`;
 declare module "@farmjs/core/client" {
   interface LinkDefaultRoute {
     _: import("./farm-routes").RoutePath;

--- a/examples/basic/src/markdown-components.tsx
+++ b/examples/basic/src/markdown-components.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export const components = {
+  Callout(props: { children: React.ReactNode }) {
+    return (
+      <aside className="rounded-lg border border-emerald-200 bg-emerald-50 p-4 text-emerald-950">
+        {props.children}
+      </aside>
+    );
+  },
+};

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -42,6 +42,9 @@
       "markdown": [
         "./dist/markdown.d.ts"
       ],
+      "app-markdown": [
+        "./dist/app-markdown.d.ts"
+      ],
       "observability": [
         "./dist/observability.d.ts"
       ],
@@ -106,6 +109,11 @@
       "types": "./dist/markdown.d.ts",
       "import": "./dist/markdown.mjs",
       "require": "./dist/markdown.cjs"
+    },
+    "./app-markdown": {
+      "types": "./dist/app-markdown.d.ts",
+      "import": "./dist/app-markdown.mjs",
+      "require": "./dist/app-markdown.cjs"
     },
     "./observability": {
       "types": "./dist/observability.d.ts",
@@ -178,6 +186,7 @@
     "@farming-labs/docs": "^0.2.44",
     "@farming-labs/orm": "0.0.62",
     "@farming-labs/orm-runtime": "0.0.62",
+    "@mdx-js/mdx": "^3.1.1",
     "@scalar/api-reference": "^1.38.1",
     "@scalar/openapi-parser": "^0.22.3",
     "@tailwindcss/vite": "^4.1.0",
@@ -194,6 +203,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-server-dom-webpack": "^18.3.0-canary-670c8dfb8-20231204",
+    "remark-gfm": "^4.0.1",
     "sirv": "^2.0.4",
     "sugar-high": "^0.9.5",
     "supports-color": "^10.2.2",

--- a/packages/farm/src/__tests__/app-markdown.test.ts
+++ b/packages/farm/src/__tests__/app-markdown.test.ts
@@ -1,0 +1,91 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import {
+  createFarmMarkdownRouteModule,
+  createFarmMarkdownSourceResponse,
+  parseMarkdownFrontmatter,
+  resolveMdxConfig,
+} from "../app-markdown";
+
+describe("app markdown pages", () => {
+  it("parses frontmatter from markdown sources", () => {
+    const parsed = parseMarkdownFrontmatter(
+      ["---", 'title: "About"', "description: Static content", "---", "# About"].join("\n"),
+    );
+
+    expect(parsed.frontmatter).toEqual({
+      title: "About",
+      description: "Static content",
+    });
+    expect(parsed.body).toContain("# About");
+  });
+
+  it("handles frontmatter without a trailing body", () => {
+    const parsed = parseMarkdownFrontmatter(["---", "title: Empty", "---"].join("\n"));
+
+    expect(parsed.frontmatter).toEqual({ title: "Empty" });
+    expect(parsed.body).toBe("");
+  });
+
+  it("renders MDX with configured components", async () => {
+    const mod = createFarmMarkdownRouteModule({
+      filePath: "/app/about/page.mdx",
+      source: [
+        "---",
+        "title: About Farm",
+        "---",
+        "# About Farm",
+        "",
+        "<Callout>Markdown-first pages</Callout>",
+      ].join("\n"),
+      components: {
+        Callout: (props) => React.createElement("aside", { className: "callout" }, props.children),
+      },
+      config: resolveMdxConfig({ className: "content" }),
+    });
+
+    const element = await (mod.default as any)({});
+    const html = renderToStaticMarkup(element);
+
+    expect(mod.metadata).toMatchObject({
+      title: "About Farm",
+    });
+    expect(html).toContain('class="content"');
+    expect(html).toContain("<h1>About Farm</h1>");
+    expect(html).toContain('<aside class="callout">Markdown-first pages</aside>');
+  });
+
+  it("serves raw source at the markdown route", async () => {
+    const response = await createFarmMarkdownSourceResponse({
+      request: new Request("https://farm.test/about.md"),
+      config: resolveMdxConfig(undefined),
+      resolveSource(pathname) {
+        expect(pathname).toBe("/about");
+        return {
+          filePath: "/app/about/page.mdx",
+          source: "# About\n\nRaw source.",
+        };
+      },
+    });
+
+    expect(response?.headers.get("content-type")).toContain("text/markdown");
+    expect(response?.headers.get("x-farm-markdown-route")).toBe("/about");
+    await expect(response?.text()).resolves.toBe("# About\n\nRaw source.");
+  });
+
+  it("allows raw markdown routes to be disabled", async () => {
+    const response = await createFarmMarkdownSourceResponse({
+      request: new Request("https://farm.test/about.md"),
+      config: resolveMdxConfig({ markdownRoutes: false }),
+      resolveSource() {
+        return {
+          filePath: "/app/about/page.mdx",
+          source: "# About",
+        };
+      },
+    });
+
+    expect(response).toBeNull();
+  });
+});

--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -132,6 +132,25 @@ describe("loadConfig", () => {
 });
 
 describe("resolveConfig", () => {
+  it("resolves MDX app page config", async () => {
+    const config = await resolveConfig(
+      {
+        mdx: {
+          components: "./src/markdown-components.tsx",
+          markdownRoutes: false,
+          className: "prose",
+        },
+      },
+      "development",
+    );
+
+    expect(config.mdx).toMatchObject({
+      components: "./src/markdown-components.tsx",
+      markdownRoutes: false,
+      className: "prose",
+    });
+  });
+
   it("preserves observability config and event callbacks", async () => {
     const onEvent = () => {};
     const config = await resolveConfig(

--- a/packages/farm/src/__tests__/generate-route-types.test.ts
+++ b/packages/farm/src/__tests__/generate-route-types.test.ts
@@ -11,6 +11,7 @@ describe("generateRouteTypes", () => {
     tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "farm-route-types-"));
     const appDir = path.join(tmpDir, "src", "app");
     await fs.promises.mkdir(path.join(appDir, "about"), { recursive: true });
+    await fs.promises.mkdir(path.join(appDir, "content"), { recursive: true });
     await fs.promises.mkdir(path.join(appDir, "users", "[id]"), { recursive: true });
     await fs.promises.writeFile(
       path.join(appDir, "page.tsx"),
@@ -20,6 +21,7 @@ describe("generateRouteTypes", () => {
       path.join(appDir, "about", "page.tsx"),
       "export default function About() { return null; }",
     );
+    await fs.promises.writeFile(path.join(appDir, "content", "page.mdx"), "# Content");
     await fs.promises.writeFile(
       path.join(appDir, "users", "[id]", "page.tsx"),
       "export default function User() { return null; }",
@@ -38,6 +40,7 @@ describe("generateRouteTypes", () => {
     expect(content).toContain("export type RoutePath =");
     expect(content).toContain('"/"');
     expect(content).toContain('"/about"');
+    expect(content).toContain('"/content"');
     expect(content).toContain("LinkDefaultRoute");
     expect(content).toContain('declare module "@farmjs/core/client"');
     expect(content).toContain('declare module "@farmjs/core"');

--- a/packages/farm/src/__tests__/route-manager.test.ts
+++ b/packages/farm/src/__tests__/route-manager.test.ts
@@ -33,6 +33,10 @@ describe("RouteManager", () => {
         serverComponents: true,
         serverActions: true,
       },
+      mdx: {
+        markdownRoutes: true,
+        className: "farm-markdown",
+      },
       vite: {},
     };
     routeManager = new RouteManager(mockConfig);
@@ -101,7 +105,7 @@ describe("RouteManager", () => {
       const { globFiles } = await import("../utils");
       vi.mocked(globFiles).mockImplementation(async (pattern: string) => {
         if (pattern.includes("page")) {
-          return ["page.tsx", "about/page.tsx"];
+          return ["page.tsx", "about/page.tsx", "docs/page.mdx"];
         }
         if (pattern.includes("layout")) {
           return ["layout.tsx"];
@@ -122,10 +126,23 @@ describe("RouteManager", () => {
       const loadings = routeManager.getLoadings();
       const errors = routeManager.getErrors();
 
-      expect(routes.size).toBe(2);
+      expect(routes.size).toBe(3);
       expect(layouts.size).toBe(1);
       expect(loadings.size).toBe(2);
       expect(errors.size).toBe(2);
+      expect(routes.get("/docs")?.modulePath).toBe("/test/src/app/docs/page.mdx");
+    });
+
+    it("should reject duplicate page files for one route segment", async () => {
+      const { globFiles } = await import("../utils");
+      vi.mocked(globFiles).mockImplementation(async (pattern: string) => {
+        if (pattern.includes("page")) {
+          return ["about/page.tsx", "about/page.mdx"];
+        }
+        return [];
+      });
+
+      await expect(routeManager.discoverRoutes()).rejects.toThrow('Duplicate page route "/about"');
     });
   });
 

--- a/packages/farm/src/app-markdown.ts
+++ b/packages/farm/src/app-markdown.ts
@@ -1,0 +1,254 @@
+import React from "react";
+import { readFile } from "fs/promises";
+import path from "path";
+import { pathToFileURL } from "url";
+import type { Metadata, RouteModule } from "./types";
+
+export type FarmMdxComponent = React.ComponentType<any> | keyof React.JSX.IntrinsicElements;
+export type FarmMdxComponents = Record<string, FarmMdxComponent>;
+
+export interface FarmMdxUserConfig {
+  /**
+   * Component map or module path that exports `components` or a default component map.
+   * Relative paths resolve from the project root.
+   */
+  components?: string | FarmMdxComponents;
+  /**
+   * Serve source-authored markdown pages at `/route.md`.
+   * Enabled by default for `page.md` and `page.mdx`.
+   */
+  markdownRoutes?: boolean;
+  /**
+   * Class name used for the wrapper around rendered markdown content.
+   */
+  className?: string;
+}
+
+export interface FarmMdxResolvedConfig {
+  components?: string | FarmMdxComponents;
+  markdownRoutes: boolean;
+  className: string;
+}
+
+export interface FarmMarkdownPageSource {
+  source: string;
+  filePath: string;
+}
+
+export interface FarmMarkdownPageModuleInput extends FarmMarkdownPageSource {
+  components?: FarmMdxComponents;
+  config?: FarmMdxResolvedConfig;
+}
+
+export function resolveMdxConfig(config: FarmMdxUserConfig | undefined): FarmMdxResolvedConfig {
+  return {
+    components: config?.components,
+    markdownRoutes: config?.markdownRoutes ?? true,
+    className: config?.className ?? "farm-markdown",
+  };
+}
+
+export function isFarmMarkdownPageFile(filePath: string): boolean {
+  return /(^|[/\\])page\.mdx?$/i.test(filePath);
+}
+
+export function normalizeFarmMarkdownRoutePath(pathname: string): string {
+  const withoutExtension = pathname.replace(/\.md$/i, "");
+  const normalized = withoutExtension.startsWith("/") ? withoutExtension : `/${withoutExtension}`;
+  return normalized === "/index" ? "/" : normalized.replace(/\/+$/g, "") || "/";
+}
+
+export function parseMarkdownFrontmatter(source: string): {
+  frontmatter: Record<string, string>;
+  body: string;
+} {
+  if (!source.startsWith("---")) {
+    return { frontmatter: {}, body: source };
+  }
+
+  const endIndex = source.indexOf("\n---", 3);
+  if (endIndex === -1) {
+    return { frontmatter: {}, body: source };
+  }
+
+  const frontmatterSource = source.slice(3, endIndex).trim();
+  const closingFenceEnd = endIndex + "\n---".length;
+  const bodyStart =
+    source.slice(closingFenceEnd, closingFenceEnd + 2) === "\r\n"
+      ? closingFenceEnd + 2
+      : source[closingFenceEnd] === "\n"
+        ? closingFenceEnd + 1
+        : closingFenceEnd;
+  const body = source.slice(bodyStart);
+  const frontmatter: Record<string, string> = {};
+
+  for (const line of frontmatterSource.split(/\r?\n/)) {
+    const separator = line.indexOf(":");
+    if (separator === -1) continue;
+    const key = line.slice(0, separator).trim();
+    const value = line
+      .slice(separator + 1)
+      .trim()
+      .replace(/^["']|["']$/g, "");
+    if (key && value) frontmatter[key] = value;
+  }
+
+  return { frontmatter, body };
+}
+
+export function titleFromMarkdown(body: string, fallback?: string): string | undefined {
+  return body.match(/^#\s+(.+)$/m)?.[1]?.trim() || fallback;
+}
+
+export function createMarkdownMetadata(
+  source: string,
+  filePath: string,
+): (Metadata & Record<string, any>) | undefined {
+  const { frontmatter, body } = parseMarkdownFrontmatter(source);
+  const routeTitle = titleFromMarkdown(body);
+  const title = frontmatter.title || routeTitle;
+  const description = frontmatter.description;
+
+  if (!title && !description) {
+    return undefined;
+  }
+
+  return {
+    ...(title ? { title } : {}),
+    ...(description ? { description } : {}),
+    source: filePath,
+  };
+}
+
+async function evaluateMdxSource(source: string, filePath: string) {
+  const [{ evaluate }, runtime, remarkGfmModule] = await Promise.all([
+    import("@mdx-js/mdx"),
+    import("react/jsx-runtime"),
+    import("remark-gfm"),
+  ]);
+  const remarkGfm = remarkGfmModule.default;
+
+  return evaluate(source, {
+    ...runtime,
+    baseUrl: pathToFileURL(filePath),
+    remarkPlugins: [remarkGfm],
+  });
+}
+
+export function createFarmMarkdownRouteModule(
+  input: FarmMarkdownPageModuleInput,
+): RouteModule & { source: string } {
+  const { body } = parseMarkdownFrontmatter(input.source);
+  const components = input.components || {};
+  const className = input.config?.className || "farm-markdown";
+  let evaluatedPromise: Promise<{ default: React.ComponentType<any> }> | undefined;
+
+  const loadContent = async () => {
+    evaluatedPromise ??= evaluateMdxSource(body, input.filePath) as Promise<{
+      default: React.ComponentType<any>;
+    }>;
+    return evaluatedPromise;
+  };
+
+  async function FarmMarkdownPage(props: any) {
+    const evaluated = await loadContent();
+    const MDXContent = evaluated.default;
+    return React.createElement(
+      "article",
+      { className, "data-farm-markdown-page": "" },
+      React.createElement(MDXContent, {
+        ...props,
+        components: {
+          ...components,
+          ...(props?.components || {}),
+        },
+      }),
+    );
+  }
+
+  return {
+    default: FarmMarkdownPage as unknown as RouteModule["default"],
+    metadata: createMarkdownMetadata(input.source, input.filePath),
+    source: input.source,
+  };
+}
+
+export async function createFarmMarkdownRouteModuleFromFile(
+  filePath: string,
+  options: {
+    components?: FarmMdxComponents;
+    config?: FarmMdxResolvedConfig;
+  } = {},
+) {
+  const source = await readFile(filePath, "utf8");
+  return createFarmMarkdownRouteModule({
+    source,
+    filePath,
+    components: options.components,
+    config: options.config,
+  });
+}
+
+export async function loadFarmMdxComponents(
+  config: FarmMdxResolvedConfig | undefined,
+  options: {
+    root: string;
+    loadModule?: (modulePath: string) => Promise<unknown>;
+  },
+): Promise<FarmMdxComponents> {
+  const configured = config?.components;
+  if (!configured) {
+    return {};
+  }
+
+  if (typeof configured !== "string") {
+    return configured;
+  }
+
+  const modulePath = path.isAbsolute(configured) ? configured : path.join(options.root, configured);
+  const mod = options.loadModule
+    ? await options.loadModule(modulePath)
+    : await import(pathToFileURL(modulePath).href);
+  const maybeModule = mod as {
+    components?: FarmMdxComponents;
+    default?: FarmMdxComponents;
+  };
+
+  return maybeModule.components || maybeModule.default || {};
+}
+
+export async function createFarmMarkdownSourceResponse(options: {
+  request: Request;
+  config?: FarmMdxResolvedConfig;
+  resolveSource: (
+    pathname: string,
+  ) => Promise<FarmMarkdownPageSource | null> | FarmMarkdownPageSource | null;
+}): Promise<Response | null> {
+  if (options.request.method !== "GET" && options.request.method !== "HEAD") {
+    return null;
+  }
+  if (options.config?.markdownRoutes === false) {
+    return null;
+  }
+
+  const url = new URL(options.request.url);
+  if (!url.pathname.endsWith(".md")) {
+    return null;
+  }
+
+  const targetPathname = normalizeFarmMarkdownRoutePath(url.pathname);
+  const source = await options.resolveSource(targetPathname);
+  if (!source) {
+    return null;
+  }
+
+  return new Response(options.request.method === "HEAD" ? null : source.source, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+      "X-Farm-Markdown-Route": targetPathname,
+      "X-Farm-Markdown-Source": source.filePath,
+    },
+  });
+}

--- a/packages/farm/src/app.ts
+++ b/packages/farm/src/app.ts
@@ -1,6 +1,8 @@
 import type { FarmConfig } from "./types";
 import type { FarmDocsResolvedConfig } from "./docs/types";
 import type { FarmMarkdownResolvedConfig } from "./markdown";
+import type { FarmMdxResolvedConfig } from "./app-markdown";
+import { resolveMdxConfig } from "./app-markdown";
 import { resolveMarkdownConfig } from "./markdown";
 import { resolveAppPath, fileExists, logger } from "./utils";
 import { initStorage } from "./storage";
@@ -13,6 +15,7 @@ import type { ViteDevServer } from "vite";
 type NormalizedFarmConfig = Required<FarmConfig> & {
   docs: FarmDocsResolvedConfig;
   md: FarmMarkdownResolvedConfig;
+  mdx: FarmMdxResolvedConfig;
 };
 
 const defaultDocsConfig: FarmDocsResolvedConfig = {
@@ -90,6 +93,7 @@ export class FarmApp {
       integrations: config.integrations || {},
       docs: isResolvedDocsConfig(config.docs) ? config.docs : defaultDocsConfig,
       md: resolveMarkdownConfig(config.md),
+      mdx: resolveMdxConfig(config.mdx),
       observability: config.observability ?? false,
       suppressLintOnLink: config.suppressLintOnLink ?? false,
       experimental: {

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -8,6 +8,11 @@ import type { FarmPlugin } from "./plugin";
 import type { UserConfig as ViteUserConfig } from "vite";
 import { resolveIntegrationPlugins } from "./integrations";
 import { resolveMarkdownConfig } from "./markdown";
+import {
+  resolveMdxConfig,
+  type FarmMdxResolvedConfig,
+  type FarmMdxUserConfig,
+} from "./app-markdown";
 import path from "path";
 
 export type {
@@ -22,6 +27,7 @@ export type {
   FarmMarkdownRouteInput,
   FarmMarkdownUserConfig,
 } from "./markdown";
+export type { FarmMdxComponents, FarmMdxResolvedConfig, FarmMdxUserConfig } from "./app-markdown";
 
 export interface RedirectConfig {
   source: string;
@@ -132,6 +138,7 @@ export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite" | "docs"> {
   deploy?: FarmDeployConfig;
   docs?: FarmDocsUserConfig;
   md?: FarmMarkdownUserConfig | boolean;
+  mdx?: FarmMdxUserConfig;
   observability?: FarmObservabilityUserConfig;
 
   trailingSlash?: boolean;
@@ -175,13 +182,14 @@ export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite" | "docs"> {
 }
 
 export interface ResolvedFarmConfig extends Required<
-  Omit<FarmUserConfig, "plugins" | "vite" | "deploy" | "docs" | "md">
+  Omit<FarmUserConfig, "plugins" | "vite" | "deploy" | "docs" | "md" | "mdx">
 > {
   plugins: FarmPlugin[];
   vite: ViteUserConfig;
   deploy: ResolvedFarmDeployConfig;
   docs: FarmDocsResolvedConfig;
   md: FarmMarkdownResolvedConfig;
+  mdx: FarmMdxResolvedConfig;
 }
 
 export function defineFarmConfig(config: FarmUserConfig): FarmUserConfig {
@@ -540,6 +548,7 @@ export async function resolveConfig(
   const srcDir = userConfig.srcDir || "src";
   const docs = await resolveDocsConfig(userConfig.docs, { root, srcDir });
   const md = resolveMarkdownConfig(userConfig.md);
+  const mdx = resolveMdxConfig(userConfig.mdx);
 
   const resolved: ResolvedFarmConfig = {
     root,
@@ -550,6 +559,7 @@ export async function resolveConfig(
     deploy,
     docs,
     md,
+    mdx,
     observability: userConfig.observability ?? false,
     storage: userConfig.storage || {},
     suppressLintOnLink: userConfig.suppressLintOnLink ?? false,

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -27,6 +27,7 @@ export * from "./query";
 export * from "./middleware";
 export * from "./docs";
 export * from "./markdown";
+export * from "./app-markdown";
 export * from "./observability";
 export { generateRouteTypes } from "./routing/generate-route-types";
 export type { GenerateRouteTypesOptions } from "./routing/generate-route-types";

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -8,15 +8,22 @@ import { build as viteBuild, type Rollup } from "vite";
 import * as nitro from "nitro";
 import os from "os";
 import path from "path";
+import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { builtinModules, createRequire } from "module";
 import { logger } from "../utils";
 import { getClientModuleMetadata } from "../utils/client-component";
+import { isFarmMarkdownPageFile } from "../app-markdown";
 import { virtualBundlePlugin } from "./virtual-bundle-plugin";
 import type { NitroConfig } from "nitro/config";
 
 // Type alias for OutputBundle
 type OutputBundle = Rollup.OutputBundle;
+type UniversalPageRoute = {
+  pattern: string;
+  modulePath: string;
+  source?: string;
+};
 
 // Get __dirname equivalent for ESM
 const _filename = typeof import.meta.url !== "undefined" ? fileURLToPath(import.meta.url) : "";
@@ -136,11 +143,14 @@ export async function buildUniversal(
 
   try {
     // Get page routes first (needed for both client and SSR builds)
-    const pageRoutes: Array<{ pattern: string; modulePath: string }> = [];
+    const pageRoutes: UniversalPageRoute[] = [];
     for (const [pattern, entry] of routeManager.getRoutes()) {
       pageRoutes.push({
         pattern,
         modulePath: entry.modulePath,
+        ...(isFarmMarkdownPageFile(entry.modulePath)
+          ? { source: readFileSync(entry.modulePath, "utf8") }
+          : {}),
       });
     }
     logger.info(`📋 Found ${pageRoutes.length} page routes`);
@@ -231,7 +241,7 @@ async function buildClient(
   root: string,
   srcDir: string,
   outputDir: string,
-  pageRoutes: Array<{ pattern: string; modulePath: string }>,
+  pageRoutes: UniversalPageRoute[],
   layoutRoutes: Array<{ pattern: string; modulePath: string }> = [],
 ) {
   const { farmPlugin } = await import("../vite");
@@ -249,6 +259,9 @@ async function buildClient(
   const clientPages: Array<{ pattern: string; modulePath: string; relativePath: string }> = [];
 
   for (const route of pageRoutes) {
+    if (isFarmMarkdownPageFile(route.modulePath)) {
+      continue;
+    }
     try {
       const metadata = getClientModuleMetadata(route.modulePath, root);
       if (metadata.shouldHydrate) {
@@ -986,11 +999,14 @@ async function buildSSRInMemory(
 
   // Generate route manifest from managers
   // This captures route patterns and module paths
-  const pageRoutes: Array<{ pattern: string; modulePath: string }> = [];
+  const pageRoutes: UniversalPageRoute[] = [];
   for (const [pattern, entry] of routeManager.getRoutes()) {
     pageRoutes.push({
       pattern,
       modulePath: entry.modulePath,
+      ...(isFarmMarkdownPageFile(entry.modulePath)
+        ? { source: await fs.readFile(entry.modulePath, "utf8") }
+        : {}),
     });
   }
 
@@ -1065,8 +1081,11 @@ async function buildSSRInMemory(
     !!config.observability &&
     typeof config.observability === "object" &&
     "onEvent" in config.observability;
+  const hasMdxComponentConfig = Boolean(config.mdx?.components);
   const configModulePath =
-    hasConfiguredIntegrations || hasObservabilityHandler ? await findFarmConfigPath(root) : null;
+    hasConfiguredIntegrations || hasObservabilityHandler || hasMdxComponentConfig
+      ? await findFarmConfigPath(root)
+      : null;
 
   // Generate virtual entry code that imports and bundles all routes
   // This ensures all route handlers are captured in the bundle closure
@@ -1217,7 +1236,7 @@ async function buildSSRInMemory(
  */
 function generateVirtualEntryCode(
   apiRoutes: Array<{ path: string; filePath: string; methods: string[] }>,
-  pageRoutes: Array<{ pattern: string; modulePath: string }>,
+  pageRoutes: UniversalPageRoute[],
   layoutRoutes: Array<{ pattern: string; modulePath: string }>,
   notFoundPath: string | null,
   config: ResolvedFarmConfig,
@@ -1244,6 +1263,24 @@ function generateVirtualEntryCode(
 
   pageRoutes.forEach((route, index) => {
     const varName = `pageRoute${index}`;
+    if (route.source !== undefined || isFarmMarkdownPageFile(route.modulePath)) {
+      pageRegistrations.push(`
+  {
+    pattern: ${JSON.stringify(route.pattern)},
+    module: createFarmMarkdownRouteModule({
+      source: ${JSON.stringify(route.source ?? "")},
+      filePath: ${JSON.stringify(route.modulePath)},
+      components: farmMdxComponents,
+      config: farmMdxConfig,
+    }),
+    markdownSource: {
+      source: ${JSON.stringify(route.source ?? "")},
+      filePath: ${JSON.stringify(route.modulePath)},
+    },
+  }`);
+      return;
+    }
+
     pageImports.push(`import * as ${varName} from "${route.modulePath}";`);
     pageRegistrations.push(`
   {
@@ -1279,6 +1316,16 @@ function generateVirtualEntryCode(
     : "";
   const markdownHandlerImport = config.md?.enabled
     ? `import { createMarkdownMirrorResponse } from "farm/markdown";`
+    : "";
+  const appMarkdownImport = `import { createFarmMarkdownRouteModule, createFarmMarkdownSourceResponse } from "farm/app-markdown";`;
+  const mdxComponentsPath =
+    typeof config.mdx?.components === "string"
+      ? path.isAbsolute(config.mdx.components)
+        ? config.mdx.components
+        : path.join(config.root, config.mdx.components)
+      : null;
+  const mdxComponentsImport = mdxComponentsPath
+    ? `import * as FarmMdxComponentsModule from "${mdxComponentsPath.replace(/\\/g, "/")}";`
     : "";
   const integrationImports = configModulePath
     ? `
@@ -1339,6 +1386,8 @@ ${cacheHelpersImport}
 ${observabilityHelpersImport}
 ${docsHandlerImport}
 ${markdownHandlerImport}
+${appMarkdownImport}
+${mdxComponentsImport}
 ${integrationImports}
 
 // Custom 404 page component (if provided)
@@ -1350,6 +1399,16 @@ const farmUserConfig = ${
 const configuredIntegrations = farmUserConfig?.integrations || {};
 const integrationRuntimeConfig = farmUserConfig || {};
 const farmMarkdownConfig = ${JSON.stringify(config.md)};
+const farmMdxConfig = ${JSON.stringify({
+    ...config.mdx,
+    components: typeof config.mdx?.components === "string" ? config.mdx.components : undefined,
+  })};
+const configuredFarmMdxComponents = farmUserConfig?.mdx?.components;
+const farmMdxComponents = ${
+    mdxComponentsPath
+      ? `(FarmMdxComponentsModule.components || Reflect.get(FarmMdxComponentsModule, "default") || {})`
+      : `(configuredFarmMdxComponents && typeof configuredFarmMdxComponents === "object" ? configuredFarmMdxComponents : {})`
+  };
 const farmObservabilityConfig = farmUserConfig?.observability ?? ${JSON.stringify(
     config.observability ?? false,
   )};
@@ -1536,6 +1595,18 @@ async function handleRequest(request) {
     if (docsResponse) {
       return docsResponse;
     }
+  }
+
+  const markdownSourceResponse = await createFarmMarkdownSourceResponse?.({
+    request: request.clone(),
+    config: farmMdxConfig,
+    resolveSource: (targetPathname) => {
+      const match = matchPageRoute(targetPathname);
+      return match?.route?.markdownSource || null;
+    },
+  });
+  if (markdownSourceResponse) {
+    return markdownSourceResponse;
   }
 
   if (farmMarkdownConfig?.enabled) {

--- a/packages/farm/src/routing/generate-route-types.ts
+++ b/packages/farm/src/routing/generate-route-types.ts
@@ -71,7 +71,10 @@ export type RoutePath = string;
   }
 
   const glob = await import("fast-glob");
-  const pageFiles = await glob.default("**/page.{ts,tsx,js,jsx}", { cwd: appDir, absolute: false });
+  const pageFiles = await glob.default("**/page.{ts,tsx,js,jsx,md,mdx}", {
+    cwd: appDir,
+    absolute: false,
+  });
 
   const patterns = new Set<string>();
   for (const file of pageFiles) {

--- a/packages/farm/src/routing/route-manager.ts
+++ b/packages/farm/src/routing/route-manager.ts
@@ -7,6 +7,12 @@ import type {
 } from "../types";
 import { parseRoutePath, matchRoute, resolveAppPath, globFiles, logger } from "../utils";
 import { collectSSGPages, resolveRouteRenderingConfigFromFile } from "../ssg";
+import {
+  createFarmMarkdownRouteModuleFromFile,
+  isFarmMarkdownPageFile,
+  loadFarmMdxComponents,
+  resolveMdxConfig,
+} from "../app-markdown";
 import path from "path";
 import type { ViteDevServer } from "vite";
 import { getClientModuleMetadata } from "../utils/client-component";
@@ -40,7 +46,7 @@ export class RouteManager {
     const appDir = resolveAppPath(this.config.root, this.config.srcDir, "app");
 
     // Find all page and layout files
-    const pageFiles = await globFiles("**/page.{ts,tsx,js,jsx}", appDir);
+    const pageFiles = await globFiles("**/page.{ts,tsx,js,jsx,md,mdx}", appDir);
     const layoutFiles = await globFiles("**/layout.{ts,tsx,js,jsx}", appDir);
     const loadingFiles = await globFiles("**/loading.{ts,tsx,js,jsx}", appDir);
     const errorFiles = await globFiles("**/error.{ts,tsx,js,jsx}", appDir);
@@ -55,6 +61,14 @@ export class RouteManager {
       const route = parseRoutePath(file);
       const modulePath = path.join(appDir, file);
       const pattern = this.createRoutePattern(route);
+
+      const existing = this.routes.get(pattern);
+      if (existing) {
+        throw new Error(
+          `Duplicate page route "${pattern}". Found both ${existing.modulePath} and ${modulePath}. ` +
+            "Use only one page file per route segment.",
+        );
+      }
 
       this.routes.set(pattern, {
         route,
@@ -240,6 +254,20 @@ export class RouteManager {
    */
   async loadRouteModule(modulePath: string): Promise<RouteModule> {
     try {
+      if (isFarmMarkdownPageFile(modulePath)) {
+        const mdxConfig = resolveMdxConfig(this.config.mdx);
+        const components = await loadFarmMdxComponents(mdxConfig, {
+          root: this.config.root,
+          loadModule: this.viteServer
+            ? (componentModulePath) => this.viteServer!.ssrLoadModule(componentModulePath)
+            : undefined,
+        });
+        return await createFarmMarkdownRouteModuleFromFile(modulePath, {
+          components,
+          config: mdxConfig,
+        });
+      }
+
       if (this.viteServer) {
         const module = await this.viteServer.ssrLoadModule(modulePath);
         return module as RouteModule;

--- a/packages/farm/src/types.ts
+++ b/packages/farm/src/types.ts
@@ -4,6 +4,7 @@ import type { FarmStorageUserConfig } from "./storage/types";
 import type { FarmIntegrationsUserConfig } from "./integrations";
 import type { FarmDocsResolvedConfig, FarmDocsUserConfig } from "./docs/types";
 import type { FarmMarkdownResolvedConfig, FarmMarkdownUserConfig } from "./markdown";
+import type { FarmMdxResolvedConfig, FarmMdxUserConfig } from "./app-markdown";
 import type { FarmObservabilityUserConfig } from "./observability";
 
 export type NitroPreset =
@@ -54,6 +55,7 @@ export interface FarmConfig {
   integrations?: FarmIntegrationsUserConfig;
   docs?: FarmDocsUserConfig | FarmDocsResolvedConfig;
   md?: FarmMarkdownUserConfig | FarmMarkdownResolvedConfig | boolean;
+  mdx?: FarmMdxUserConfig | FarmMdxResolvedConfig;
   observability?: FarmObservabilityUserConfig;
   /**
    * When true, Link href is not strictly typed (accepts any string).
@@ -263,11 +265,13 @@ export interface RouteModule {
    * @deprecated Use getStaticPaths instead
    */
   generateStaticParams?: () => Promise<Record<string, string>[]> | Record<string, string>[];
+  metadata?: Metadata & Record<string, any>;
   generateMetadata?: (props: PageProps) => Promise<Metadata> | Metadata;
 }
 
 export interface LayoutModule {
   default: Layout;
+  metadata?: Metadata & Record<string, any>;
   generateMetadata?: (props: { params: Record<string, string> }) => Promise<Metadata> | Metadata;
 }
 

--- a/packages/farm/src/utils.ts
+++ b/packages/farm/src/utils.ts
@@ -47,7 +47,7 @@ export function parseRoutePath(filePath: string): ParsedRoute {
 }
 
 function getRouteType(fileName: string): ParsedRoute["type"] {
-  const baseName = fileName.replace(/\.(tsx?|jsx?)$/, "");
+  const baseName = fileName.replace(/\.(tsx?|jsx?|mdx?|markdown)$/, "");
 
   switch (baseName) {
     case "page":

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -16,6 +16,7 @@ import {
   isFarmDocsAPIRequest,
 } from "./docs";
 import { createMarkdownMirrorResponse } from "./markdown";
+import { createFarmMarkdownSourceResponse, isFarmMarkdownPageFile } from "./app-markdown";
 import { sendWebResponse } from "./server/response";
 import {
   getClientModuleMetadata,
@@ -126,7 +127,7 @@ export function farmPlugin(
       const appDirSlug = path.join(farmConfig.root, farmConfig.srcDir, "app").replace(/\\/g, "/");
       const isPageFile = (file: string) => {
         const normalized = file.replace(/\\/g, "/");
-        return normalized.includes(appDirSlug) && /page\.(ts|tsx|js|jsx)$/.test(normalized);
+        return normalized.includes(appDirSlug) && /page\.(ts|tsx|js|jsx|md|mdx)$/.test(normalized);
       };
       let routeTypeGenScheduled: ReturnType<typeof setTimeout> | null = null;
       const scheduleRouteTypeGen = () => {
@@ -303,6 +304,28 @@ export function farmPlugin(
         );
         if (docsResponse) {
           await sendWebResponse(res, docsResponse);
+          return;
+        }
+
+        const markdownSourceResponse = await createFarmMarkdownSourceResponse({
+          request: new Request(fullUrl, {
+            method: requestMethod,
+            headers: docsHeaders,
+          }),
+          config: farmApp.getConfig().mdx,
+          resolveSource: async (pathname) => {
+            const match = farmApp.getRouteManager().matchRoute(pathname);
+            if (!match.route || !isFarmMarkdownPageFile(match.route.modulePath)) {
+              return null;
+            }
+            return {
+              source: await fs.promises.readFile(match.route.modulePath, "utf8"),
+              filePath: match.route.modulePath,
+            };
+          },
+        });
+        if (markdownSourceResponse) {
+          await sendWebResponse(res, markdownSourceResponse);
           return;
         }
 

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
     cache: "src/cache.ts",
     docs: "src/docs/index.ts",
     markdown: "src/markdown.ts",
+    "app-markdown": "src/app-markdown.ts",
     observability: "src/observability.ts",
   },
   format: ["cjs", "esm"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -935,6 +935,9 @@ importers:
       '@farming-labs/orm-runtime':
         specifier: 0.0.62
         version: 0.0.62(@mikro-orm/core@7.1.5)(@prisma/client@6.7.0)(@xata.io/client@0.30.1)(db0@0.3.4)(drizzle-orm@0.45.2)(kysely@0.28.17)(mongodb@6.21.0)(mongoose@8.24.1)(sequelize@6.37.8)(surrealdb@2.0.4)(typeorm@0.3.30)
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1(supports-color@10.2.2)
       '@scalar/api-reference':
         specifier: ^1.38.1
         version: 1.38.1(supports-color@10.2.2)(tailwindcss@4.1.18)(typescript@5.9.3)
@@ -983,6 +986,9 @@ importers:
       react-server-dom-webpack:
         specifier: ^18.3.0-canary-670c8dfb8-20231204
         version: 18.3.0-next-fecc288b7-20221025(react-dom@19.2.4)(react@19.2.4)(webpack@5.102.1)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1(supports-color@10.2.2)
       sirv:
         specifier: ^2.0.4
         version: 2.0.4
@@ -4001,6 +4007,38 @@ packages:
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
     dev: false
 
+  /@mdx-js/mdx@3.1.1(supports-color@10.2.2):
+    resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdx': 2.0.14
+      acorn: 8.15.0
+      collapse-white-space: 2.1.0
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      estree-util-scope: 1.0.0
+      estree-walker: 3.0.3
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@10.2.2)
+      markdown-extensions: 2.0.0
+      recma-build-jsx: 1.0.0
+      recma-jsx: 1.0.1(acorn@8.15.0)
+      recma-stringify: 1.0.0
+      rehype-recma: 1.0.0(supports-color@10.2.2)
+      remark-mdx: 3.1.1(supports-color@10.2.2)
+      remark-parse: 11.0.0(supports-color@10.2.2)
+      remark-rehype: 11.1.2
+      source-map: 0.7.6
+      unified: 11.0.5
+      unist-util-position-from-estree: 2.0.0
+      unist-util-stringify-position: 4.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@mikro-orm/core@7.1.5:
     resolution: {integrity: sha512-jYsR65PcFF+YKUlg/qytjP0PTyk558JvTKI1GzD6Vy/nshTkbcqMN5fDm2d5GJuxliPk0C8+M8tDn3GXeCAqow==}
     engines: {node: '>= 22.17.0'}
@@ -6675,6 +6713,10 @@ packages:
       '@types/unist': 3.0.3
     dev: false
 
+  /@types/mdx@2.0.14:
+    resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
+    dev: false
+
   /@types/ms@2.1.0:
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
     dev: false
@@ -7270,6 +7312,14 @@ packages:
     dependencies:
       acorn: 8.15.0
 
+  /acorn-jsx@5.3.2(acorn@8.15.0):
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      acorn: 8.15.0
+    dev: false
+
   /acorn-loose@8.5.2:
     resolution: {integrity: sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==}
     engines: {node: '>=0.4.0'}
@@ -7450,6 +7500,11 @@ packages:
       '@babel/parser': 7.28.4
       pathe: 2.0.3
     dev: true
+
+  /astring@1.9.0:
+    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
+    hasBin: true
+    dev: false
 
   /async-retry@1.3.3:
     resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
@@ -8198,6 +8253,10 @@ packages:
       '@codemirror/view': 6.38.6
     dev: false
 
+  /collapse-white-space@2.1.0:
+    resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
+    dev: false
+
   /color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -8895,6 +8954,24 @@ packages:
       hasown: 2.0.2
     dev: true
 
+  /esast-util-from-estree@2.0.0:
+    resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      unist-util-position-from-estree: 2.0.0
+    dev: false
+
+  /esast-util-from-js@2.0.1:
+    resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      acorn: 8.15.0
+      esast-util-from-estree: 2.0.0
+      vfile-message: 4.0.3
+    dev: false
+
   /esbuild-register@3.6.0(esbuild@0.19.12)(supports-color@10.2.2):
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
     peerDependencies:
@@ -9105,14 +9182,45 @@ packages:
       '@types/estree': 1.0.8
     dev: false
 
+  /estree-util-build-jsx@3.0.1:
+    resolution: {integrity: sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==}
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      estree-walker: 3.0.3
+    dev: false
+
   /estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+    dev: false
+
+  /estree-util-scope@1.0.0:
+    resolution: {integrity: sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==}
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+    dev: false
+
+  /estree-util-to-js@2.0.0:
+    resolution: {integrity: sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==}
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      astring: 1.9.0
+      source-map: 0.7.6
     dev: false
 
   /estree-util-value-to-estree@3.5.0:
     resolution: {integrity: sha512-aMV56R27Gv3QmfmF1MY12GWkGzzeAezAX+UplqHVASfjc9wNzI/X6hC0S9oxq61WT4aQesLGslWP9tKk6ghRZQ==}
     dependencies:
       '@types/estree': 1.0.8
+    dev: false
+
+  /estree-util-visit@2.0.0:
+    resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/unist': 3.0.3
     dev: false
 
   /estree-walker@2.0.2:
@@ -9123,7 +9231,6 @@ packages:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
     dependencies:
       '@types/estree': 1.0.8
-    dev: true
 
   /etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -10771,6 +10878,11 @@ packages:
       semver: 7.7.3
     dev: true
 
+  /markdown-extensions@2.0.0:
+    resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
+    engines: {node: '>=16'}
+    dev: false
+
   /markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
     dev: false
@@ -10976,7 +11088,7 @@ packages:
       mdast-util-to-string: 4.0.0
       micromark-util-classify-character: 2.0.1
       micromark-util-decode-string: 2.0.1
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       zwitch: 2.0.4
     dev: false
 
@@ -11104,6 +11216,67 @@ packages:
       micromark-util-types: 2.0.2
     dev: false
 
+  /micromark-extension-mdx-expression@3.0.1:
+    resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    dev: false
+
+  /micromark-extension-mdx-jsx@3.0.2:
+    resolution: {integrity: sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==}
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+    dev: false
+
+  /micromark-extension-mdx-md@2.0.0:
+    resolution: {integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==}
+    dependencies:
+      micromark-util-types: 2.0.2
+    dev: false
+
+  /micromark-extension-mdxjs-esm@3.0.0:
+    resolution: {integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==}
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+    dev: false
+
+  /micromark-extension-mdxjs@3.0.0:
+    resolution: {integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==}
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      micromark-extension-mdx-expression: 3.0.1
+      micromark-extension-mdx-jsx: 3.0.2
+      micromark-extension-mdx-md: 2.0.0
+      micromark-extension-mdxjs-esm: 3.0.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+    dev: false
+
   /micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
     dependencies:
@@ -11119,6 +11292,20 @@ packages:
       micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
+    dev: false
+
+  /micromark-factory-mdx-expression@2.0.3:
+    resolution: {integrity: sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==}
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
     dev: false
 
   /micromark-factory-space@2.0.1:
@@ -11191,6 +11378,18 @@ packages:
 
   /micromark-util-encode@2.0.1:
     resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+    dev: false
+
+  /micromark-util-events-to-acorn@2.0.3:
+    resolution: {integrity: sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==}
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
     dev: false
 
   /micromark-util-html-tag-name@2.0.1:
@@ -12757,6 +12956,45 @@ packages:
     engines: {node: '>= 20.19.0'}
     dev: false
 
+  /recma-build-jsx@1.0.0:
+    resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-util-build-jsx: 3.0.1
+      vfile: 6.0.3
+    dev: false
+
+  /recma-jsx@1.0.1(acorn@8.15.0):
+    resolution: {integrity: sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      estree-util-to-js: 2.0.0
+      recma-parse: 1.0.0
+      recma-stringify: 1.0.0
+      unified: 11.0.5
+    dev: false
+
+  /recma-parse@1.0.0:
+    resolution: {integrity: sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==}
+    dependencies:
+      '@types/estree': 1.0.8
+      esast-util-from-js: 2.0.1
+      unified: 11.0.5
+      vfile: 6.0.3
+    dev: false
+
+  /recma-stringify@1.0.0:
+    resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-util-to-js: 2.0.0
+      unified: 11.0.5
+      vfile: 6.0.3
+    dev: false
+
   /reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
     dev: false
@@ -12811,6 +13049,16 @@ packages:
       vfile: 6.0.3
     dev: false
 
+  /rehype-recma@1.0.0(supports-color@10.2.2):
+    resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      hast-util-to-estree: 3.1.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /rehype-sanitize@6.0.0:
     resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
     dependencies:
@@ -12835,6 +13083,15 @@ packages:
       remark-parse: 11.0.0(supports-color@10.2.2)
       remark-stringify: 11.0.0
       unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /remark-mdx@3.1.1(supports-color@10.2.2):
+    resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
+    dependencies:
+      mdast-util-mdx: 3.0.0(supports-color@10.2.2)
+      micromark-extension-mdxjs: 3.0.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -13431,7 +13688,6 @@ packages:
   /source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
-    dev: true
 
   /space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -14368,6 +14624,12 @@ packages:
 
   /unist-util-is@6.0.0:
     resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
+    dependencies:
+      '@types/unist': 3.0.3
+    dev: false
+
+  /unist-util-position-from-estree@2.0.0:
+    resolution: {integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==}
     dependencies:
       '@types/unist': 3.0.3
     dev: false


### PR DESCRIPTION
## Summary

- Add source-authored `page.md` and `page.mdx` support to the app router.
- Add `mdx` config for custom MDX components, wrapper class names, and automatic raw `/route.md` source routes.
- Wire markdown app pages through dev, route type generation, and universal production builds.
- Add docs and a basic example at `/markdown` with `/markdown.md` raw source output.

## Validation

- `corepack pnpm --filter @farmjs/core test`
- `corepack pnpm --filter @farmjs/core build`
- `corepack pnpm --filter farm-example-basic build`
- Dev smoke: `curl http://localhost:3000/markdown`, `curl http://localhost:3000/markdown.md`, and `curl -I http://localhost:3000/markdown.md`
- `git diff --check`
- targeted `oxfmt --check`

## Notes

- `corepack pnpm --filter @farmjs/core type-check` still fails on existing Nitro/query-state type issues unrelated to this PR.
- `corepack pnpm --filter farm-example-basic type-check` still fails on the existing async JSX issue in `src/app/ppr-demo/page.tsx`.