### PR TITLE
feat: add config middleware handlers

### DIFF
--- a/docs/src/app/docs/middleware/page.md
+++ b/docs/src/app/docs/middleware/page.md
@@ -15,17 +15,17 @@ Middleware can live near the routes it protects. Use it for auth, request metada
 **src/app/dashboard/middleware.ts**
 
 ```ts
-import { defineMiddleware } from "@farmjs/core/middleware";
+import { middleware } from "@farmjs/core/middleware";
 
-export default defineMiddleware(async ({ request, next, context }) => {
-  context.data.set("request.startedAt", Date.now(), { exposeToPage: true });
-  return next(request);
+export default middleware().use(async (ctx, next) => {
+  ctx.data.set("request.startedAt", Date.now());
+  await next();
 });
 ```
 
 ## Config matchers
 
-Use farm.config.ts when middleware behavior should be described globally.
+Use farm.config.ts when middleware behavior should be described globally. A matcher-only object gates discovered middleware files; a list of entries can pair matchers with handlers.
 
 **farm.config.ts**
 
@@ -33,9 +33,15 @@ Use farm.config.ts when middleware behavior should be described globally.
 import { defineFarmConfig } from "@farmjs/core";
 
 export default defineFarmConfig({
-  middleware: {
-    matcher: ["/dashboard/:path*"],
-  },
+  middleware: [
+    {
+      matcher: ["/dashboard/:path*"],
+      async handler(ctx, next) {
+        ctx.data.set("area", "dashboard");
+        await next();
+      },
+    },
+  ],
 });
 ```
 
@@ -46,20 +52,19 @@ Middleware can short-circuit with a redirect or response before the page/API han
 **src/app/dashboard/middleware.ts**
 
 ```ts
-import { defineMiddleware } from "@farmjs/core/middleware";
+import { middleware } from "@farmjs/core/middleware";
 
-export default defineMiddleware(async ({ request, next, context }) => {
-  const session = await readSession(request);
+export default middleware().use(async (ctx, next) => {
+  const session = await readSession(ctx.request);
 
   if (!session) {
-    return Response.redirect(new URL("/sign-in", request.url));
+    ctx.redirect("/sign-in");
+    return;
   }
 
-  context.data.set("user.id", session.user.id, {
-    exposeToPage: true,
-  });
+  ctx.data.set("user.id", session.user.id);
 
-  return next(request);
+  await next();
 });
 ```
 
@@ -76,12 +81,12 @@ export default function DashboardPage(props: PageProps) {
 
 ## Common uses
 
-| Use case | Pattern |
-| --- | --- |
-| Auth | Redirect signed-out users or return `401` for private APIs. |
-| Request context | Attach request IDs, user IDs, tenant IDs, and feature flags. |
-| Security | Add headers, block invalid origins, or rate-limit an API area. |
-| Localization | Rewrite to a locale route or expose locale data to pages. |
+| Use case        | Pattern                                                        |
+| --------------- | -------------------------------------------------------------- |
+| Auth            | Redirect signed-out users or return `401` for private APIs.    |
+| Request context | Attach request IDs, user IDs, tenant IDs, and feature flags.   |
+| Security        | Add headers, block invalid origins, or rate-limit an API area. |
+| Localization    | Rewrite to a locale route or expose locale data to pages.      |
 
 ## Production notes
 

--- a/packages/farm/src/__tests__/middleware.test.ts
+++ b/packages/farm/src/__tests__/middleware.test.ts
@@ -1640,6 +1640,108 @@ describe("Middleware Data Access (getMiddlewareData)", () => {
 });
 
 describe("Middleware Manager Data Flow", () => {
+  it("executes farm.config middleware entries when their matcher matches", async () => {
+    const seen: string[] = [];
+    const manager = new MiddlewareManager("/tmp", undefined, [
+      {
+        matcher: "/dashboard/:path*",
+        async handler(ctx, next) {
+          seen.push(`config:${ctx.params.path}`);
+          ctx.data.set("fromConfig", "yes");
+          await next();
+        },
+      },
+    ]);
+
+    (manager as any).middleware = [
+      {
+        path: "/dashboard",
+        filePath: "/tmp/app/dashboard/middleware.ts",
+        handlers: [
+          async (ctx: MiddlewareContext, next: () => Promise<void>) => {
+            seen.push(`file:${ctx.data.get("fromConfig")}`);
+            ctx.data.set("fromFile", "yes");
+            await next();
+          },
+        ],
+      },
+    ];
+
+    const req = createMockRequest("/dashboard/settings");
+    const res = createMockResponse();
+    const handled = await manager.execute(req, res);
+
+    expect(handled).toBe(false);
+    expect(seen).toEqual(["config:settings", "file:yes"]);
+    expect((req as any).__FARM_MIDDLEWARE_DATA__.get("fromFile")).toBe("yes");
+  });
+
+  it("skips farm.config middleware entries when their matcher does not match", async () => {
+    const seen: string[] = [];
+    const manager = new MiddlewareManager("/tmp", undefined, [
+      {
+        matcher: "/dashboard/:path*",
+        async handler(ctx, next) {
+          seen.push("config");
+          await next();
+        },
+      },
+    ]);
+
+    const req = createMockRequest("/marketing");
+    const res = createMockResponse();
+    const handled = await manager.execute(req, res);
+
+    expect(handled).toBe(false);
+    expect(seen).toEqual([]);
+  });
+
+  it("uses a matcher-only farm.config middleware object as a global gate", async () => {
+    const seen: string[] = [];
+    const manager = new MiddlewareManager("/tmp", undefined, {
+      matcher: "/dashboard/:path*",
+    });
+
+    (manager as any).middleware = [
+      {
+        path: "/",
+        filePath: "/tmp/app/middleware.ts",
+        handlers: [
+          async (ctx: MiddlewareContext, next: () => Promise<void>) => {
+            seen.push(ctx.params.path);
+            await next();
+          },
+        ],
+      },
+    ];
+
+    await manager.execute(createMockRequest("/marketing"), createMockResponse());
+    await manager.execute(createMockRequest("/dashboard/reports/weekly"), createMockResponse());
+
+    expect(seen).toEqual(["reports/weekly"]);
+  });
+
+  it("returns handled when config middleware short-circuits the response", async () => {
+    const manager = new MiddlewareManager("/tmp", undefined, [
+      {
+        matcher: "/dashboard/:path*",
+        handler(ctx) {
+          ctx.text("blocked", 401);
+        },
+      },
+    ]);
+
+    const req = createMockRequest("/dashboard/settings");
+    const res = createMockResponse();
+    const handled = await manager.execute(req, res);
+
+    expect(handled).toBe(true);
+    expect(res.writeHead).toHaveBeenCalledWith(401, {
+      "Content-Type": "text/plain",
+    });
+    expect(res.end).toHaveBeenCalledWith("blocked");
+  });
+
   it("should share middleware context across middleware chain and expose to page request data", async () => {
     const req = createMockRequest("/docs/getting-started");
     const res = createMockResponse();

--- a/packages/farm/src/app.ts
+++ b/packages/farm/src/app.ts
@@ -91,6 +91,7 @@ export class FarmApp {
       deploy: config.deploy || {},
       storage: config.storage || {},
       integrations: config.integrations || {},
+      middleware: config.middleware || {},
       docs: isResolvedDocsConfig(config.docs) ? config.docs : defaultDocsConfig,
       md: resolveMarkdownConfig(config.md),
       mdx: resolveMdxConfig(config.mdx),

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -4,6 +4,7 @@ import type { FarmDocsResolvedConfig, FarmDocsUserConfig } from "./docs/types";
 import type { FarmIntegrationsUserConfig } from "./integrations";
 import type { FarmMarkdownResolvedConfig, FarmMarkdownUserConfig } from "./markdown";
 import type { FarmObservabilityUserConfig } from "./observability";
+import type { FarmMiddlewareConfig } from "./middleware/types";
 import type { FarmPlugin } from "./plugin";
 import type { UserConfig as ViteUserConfig } from "vite";
 import { resolveIntegrationPlugins } from "./integrations";
@@ -84,9 +85,7 @@ export interface OpenAPIConfig {
   };
 }
 
-export interface MiddlewareConfig {
-  matcher?: string | string[];
-}
+export type MiddlewareConfig = FarmMiddlewareConfig;
 
 export interface NotFoundConfig {
   /** Path to a custom 404 page component (e.g., "./src/app/not-found.tsx") */

--- a/packages/farm/src/middleware/manager.ts
+++ b/packages/farm/src/middleware/manager.ts
@@ -9,7 +9,9 @@ import * as path from "path";
 import type { ViteDevServer } from "vite";
 import type { IncomingMessage, ServerResponse } from "http";
 import type {
+  FarmMiddlewareConfig,
   MiddlewareFunction,
+  MiddlewareMatcher,
   MiddlewareModule,
   MiddlewareConfig,
   MiddlewareContext,
@@ -22,6 +24,7 @@ export interface DiscoveredMiddleware {
   filePath: string;
   handlers: MiddlewareFunction[];
   config?: MiddlewareConfig;
+  source?: "config" | "file";
 }
 
 /**
@@ -29,13 +32,44 @@ export interface DiscoveredMiddleware {
  */
 export class MiddlewareManager {
   private middleware: DiscoveredMiddleware[] = [];
+  private configMiddleware: DiscoveredMiddleware[] = [];
+  private globalConfig?: MiddlewareConfig;
   private viteServer?: ViteDevServer;
 
   constructor(
     private appDir: string,
     viteServer?: ViteDevServer,
+    config?: FarmMiddlewareConfig,
   ) {
     this.viteServer = viteServer;
+    this.configure(config);
+  }
+
+  configure(config?: FarmMiddlewareConfig): void {
+    this.configMiddleware = [];
+    this.globalConfig = undefined;
+
+    if (!config) return;
+
+    const entries = Array.isArray(config) ? config : [config];
+
+    for (const [index, entry] of entries.entries()) {
+      const handlers = this.getConfigHandlers(entry);
+      const middlewareConfig = this.toMiddlewareConfig(entry);
+
+      if (handlers.length === 0) {
+        this.globalConfig = middlewareConfig;
+        continue;
+      }
+
+      this.configMiddleware.push({
+        path: "/",
+        filePath: `farm.config.ts#middleware-${index}`,
+        handlers,
+        config: middlewareConfig,
+        source: "config",
+      });
+    }
   }
 
   /**
@@ -147,6 +181,7 @@ export class MiddlewareManager {
         filePath,
         handlers,
         config: middlewareModule.config,
+        source: "file",
       };
     } catch (error) {
       logger.error(`Failed to load middleware ${filePath}: ${error}`);
@@ -162,14 +197,25 @@ export class MiddlewareManager {
     const pathname = url.pathname;
     const method = req.method || "GET";
     const startTime = Date.now();
-    // Find applicable middleware (cascading from root to specific)
-    const applicable = this.middleware.filter((mw) => {
-      // Root middleware (/) applies to everything
-      if (mw.path === "/") return true;
 
-      // Middleware applies to its path and all sub-paths
-      return pathname.startsWith(mw.path) || pathname === mw.path;
-    });
+    let parentData: MiddlewareContext["parent"] | undefined;
+    let ctx = createContext(req, res, this.viteServer);
+
+    if (this.globalConfig) {
+      const globalMatch = this.matchesConfig(pathname, this.globalConfig, ctx);
+      if (!globalMatch.matched) {
+        return false;
+      }
+      if (globalMatch.params) {
+        ctx.params = { ...ctx.params, ...globalMatch.params };
+      }
+    }
+
+    // Find applicable middleware (config entries first, then cascading files)
+    const applicable = [
+      ...this.configMiddleware,
+      ...this.middleware.filter((mw) => this.matchesRoutePath(pathname, mw.path)),
+    ];
 
     if (applicable.length === 0) {
       return false; // No middleware to run
@@ -191,20 +237,26 @@ export class MiddlewareManager {
         `[FARM] [MIDDLEWARE] [${method}] Executing ${pathname} (${applicable.length} middleware)`,
       );
     }
-    // Create root context
-    let parentData: MiddlewareContext["parent"] | undefined;
-    let ctx = createContext(req, res, this.viteServer);
 
     // Execute middleware in cascade order
     for (const mw of applicable) {
       // Check matcher configuration
-      if (mw.config?.matcher && !this.matchesConfig(pathname, mw.config)) {
+      const configMatch = mw.config
+        ? this.matchesConfig(pathname, mw.config, ctx)
+        : { matched: true };
+      if (!configMatch.matched) {
         continue;
+      }
+      if (configMatch.params) {
+        ctx.params = { ...ctx.params, ...configMatch.params };
       }
 
       // Create new context with parent data
       if (parentData) {
         ctx = createContext(req, res, this.viteServer, parentData);
+        if (configMatch.params) {
+          ctx.params = { ...ctx.params, ...configMatch.params };
+        }
       }
 
       // Execute all handlers in this middleware
@@ -218,8 +270,8 @@ export class MiddlewareManager {
 
       await executeNext();
 
-      // Check if response has been sent (auto-detect, no need for ctx._handled)
-      if (res.headersSent || res.writableEnded) {
+      // Check if response has been sent or handled by middleware helpers.
+      if (ctx._handled || res.headersSent || res.writableEnded) {
         return true;
       }
 
@@ -245,52 +297,78 @@ export class MiddlewareManager {
   /**
    * Check if pathname matches middleware config
    */
-  private matchesConfig(pathname: string, config: MiddlewareConfig): boolean {
+  private matchesConfig(
+    pathname: string,
+    config: MiddlewareConfig,
+    ctx: MiddlewareContext,
+  ): { matched: boolean; params?: Record<string, string> } {
     // Check exclusions
     if (config.exclude) {
       for (const pattern of config.exclude) {
-        if (this.matchPattern(pattern, pathname)) {
-          return false;
+        if (this.matchPattern(pattern, pathname).matched) {
+          return { matched: false };
         }
       }
     }
 
     // Check matchers
     if (config.matcher) {
-      for (const matcher of config.matcher) {
+      for (const matcher of this.toMatcherList(config.matcher)) {
         if (typeof matcher === "string" || matcher instanceof RegExp) {
-          if (this.matchPattern(matcher, pathname)) {
-            return true;
+          const result = this.matchPattern(matcher, pathname);
+          if (result.matched) {
+            return result;
           }
         } else if (typeof matcher === "function") {
-          // For function matchers, we'd need the full context
-          // For now, allow it through
-          return true;
+          return { matched: matcher(ctx) };
         }
       }
-      return false;
+      return { matched: false };
     }
 
-    return true;
+    return { matched: true };
   }
 
   /**
    * Match a pattern against pathname
    */
-  private matchPattern(pattern: string | RegExp, pathname: string): boolean {
+  private matchPattern(
+    pattern: string | RegExp,
+    pathname: string,
+  ): { matched: boolean; params?: Record<string, string> } {
     if (pattern instanceof RegExp) {
-      return pattern.test(pathname);
+      pattern.lastIndex = 0;
+      const match = pattern.exec(pathname);
+      return {
+        matched: !!match,
+        params: match?.groups ? { ...match.groups } : undefined,
+      };
     }
 
-    // Convert glob-style pattern to regex
-    const regexPattern = pattern
-      .replace(/\*\*/g, "__DOUBLE_STAR__")
-      .replace(/\*/g, "[^/]+")
-      .replace(/__DOUBLE_STAR__/g, ".*")
-      .replace(/\//g, "\\/");
+    if (pattern === "*" || pattern === "/(.*)") {
+      return { matched: true };
+    }
 
-    const regex = new RegExp(`^${regexPattern}$`);
-    return regex.test(pathname);
+    if (pattern.endsWith("(.*)")) {
+      const prefix = pattern.slice(0, -4);
+      return { matched: pathname === prefix || pathname.startsWith(`${prefix}/`) };
+    }
+
+    const { regex, params } = this.compilePathPattern(pattern);
+    const match = regex.exec(pathname);
+    if (!match) {
+      return { matched: false };
+    }
+
+    const values: Record<string, string> = {};
+    params.forEach((param, index) => {
+      values[param] = decodeURIComponent(match[index + 1] || "");
+    });
+
+    return {
+      matched: true,
+      params: Object.keys(values).length > 0 ? values : undefined,
+    };
   }
 
   /**
@@ -301,6 +379,107 @@ export class MiddlewareManager {
   }
 
   getMiddlewares(): DiscoveredMiddleware[] {
-    return [...this.middleware];
+    return [...this.configMiddleware, ...this.middleware];
+  }
+
+  private matchesRoutePath(pathname: string, middlewarePath: string): boolean {
+    if (middlewarePath === "/") return true;
+    return pathname === middlewarePath || pathname.startsWith(`${middlewarePath}/`);
+  }
+
+  private toMatcherList(matcher: MiddlewareConfig["matcher"]): MiddlewareMatcher[] {
+    if (!matcher) return [];
+    return Array.isArray(matcher) ? matcher : [matcher];
+  }
+
+  private getConfigHandlers(
+    entry:
+      | MiddlewareConfig
+      | (MiddlewareConfig & {
+          handler?: MiddlewareFunction;
+          handlers?: MiddlewareFunction[];
+        }),
+  ): MiddlewareFunction[] {
+    const handlers: MiddlewareFunction[] = [];
+    if ("handler" in entry && typeof entry.handler === "function") {
+      handlers.push(entry.handler);
+    }
+    if ("handlers" in entry && Array.isArray(entry.handlers)) {
+      handlers.push(...entry.handlers.filter((handler) => typeof handler === "function"));
+    }
+    return handlers;
+  }
+
+  private toMiddlewareConfig(
+    entry: MiddlewareConfig & {
+      handler?: MiddlewareFunction;
+      handlers?: MiddlewareFunction[];
+    },
+  ): MiddlewareConfig {
+    const { matcher, exclude, runtime } = entry;
+    return { matcher, exclude, runtime };
+  }
+
+  private compilePathPattern(pattern: string): { regex: RegExp; params: string[] } {
+    const params: string[] = [];
+    const segments = pattern.split("/").filter(Boolean);
+
+    if (segments.length === 0) {
+      return { regex: /^\/$/, params };
+    }
+
+    const parts = segments.map((segment) => {
+      if (segment === "**") {
+        return "(?:/.*)?";
+      }
+
+      if (segment === "*") {
+        return "/[^/]+";
+      }
+
+      if (segment.startsWith(":")) {
+        const { name, modifier } = this.parseColonParam(segment);
+        params.push(name);
+
+        if (modifier === "*") {
+          return "(?:/(.*))?";
+        }
+        if (modifier === "+") {
+          return "/(.+)";
+        }
+        return "/([^/]+)";
+      }
+
+      if (segment.startsWith("[...") && segment.endsWith("]")) {
+        params.push(segment.slice(4, -1));
+        return "(?:/(.*))?";
+      }
+
+      if (segment.startsWith("[") && segment.endsWith("]")) {
+        params.push(segment.slice(1, -1));
+        return "/([^/]+)";
+      }
+
+      return `/${this.escapeRegex(segment).replace(/\\\*/g, "[^/]*")}`;
+    });
+
+    return {
+      regex: new RegExp(`^${parts.join("")}$`),
+      params,
+    };
+  }
+
+  private parseColonParam(segment: string): { name: string; modifier?: string } {
+    const raw = segment.slice(1);
+    const last = raw[raw.length - 1];
+    const modifier = last === "*" || last === "+" || last === "?" ? last : undefined;
+    return {
+      name: modifier ? raw.slice(0, -1) : raw,
+      modifier,
+    };
+  }
+
+  private escapeRegex(value: string): string {
+    return value.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
   }
 }

--- a/packages/farm/src/middleware/types.ts
+++ b/packages/farm/src/middleware/types.ts
@@ -6,7 +6,6 @@
 
 import type { IncomingMessage, ServerResponse } from "http";
 import type { ViteDevServer } from "vite";
-import type { FarmConfig } from "../types";
 
 /**
  * Next function type for middleware chain
@@ -71,11 +70,23 @@ export interface RateLimitStatus {
 /**
  * Middleware configuration
  */
+export type MiddlewareMatcher = string | RegExp | ((ctx: MiddlewareContext) => boolean);
+
 export interface MiddlewareConfig {
-  matcher?: (string | RegExp | ((ctx: MiddlewareContext) => boolean))[];
+  matcher?: MiddlewareMatcher | MiddlewareMatcher[];
   exclude?: (string | RegExp)[];
   runtime?: "nodejs" | "edge";
 }
+
+export interface MiddlewareConfigEntry extends MiddlewareConfig {
+  handler?: MiddlewareFunction;
+  handlers?: MiddlewareFunction[];
+}
+
+export type FarmMiddlewareConfig =
+  | MiddlewareConfig
+  | MiddlewareConfigEntry
+  | MiddlewareConfigEntry[];
 
 /**
  * Middleware context - the main object passed to middleware functions

--- a/packages/farm/src/types.ts
+++ b/packages/farm/src/types.ts
@@ -6,6 +6,7 @@ import type { FarmDocsResolvedConfig, FarmDocsUserConfig } from "./docs/types";
 import type { FarmMarkdownResolvedConfig, FarmMarkdownUserConfig } from "./markdown";
 import type { FarmMdxResolvedConfig, FarmMdxUserConfig } from "./app-markdown";
 import type { FarmObservabilityUserConfig } from "./observability";
+import type { FarmMiddlewareConfig } from "./middleware/types";
 
 export type NitroPreset =
   | "node-server"
@@ -53,6 +54,7 @@ export interface FarmConfig {
   };
   storage?: FarmStorageUserConfig;
   integrations?: FarmIntegrationsUserConfig;
+  middleware?: FarmMiddlewareConfig;
   docs?: FarmDocsUserConfig | FarmDocsResolvedConfig;
   md?: FarmMarkdownUserConfig | FarmMarkdownResolvedConfig | boolean;
   mdx?: FarmMdxUserConfig | FarmMdxResolvedConfig;

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -188,7 +188,7 @@ export function farmPlugin(
         }
       }
 
-      middlewareManager = new MiddlewareManager(appDir, server);
+      middlewareManager = new MiddlewareManager(appDir, server, options.middleware);
       await middlewareManager.discover();
       if (pm) {
         for (const middleware of middlewareManager.getMiddlewares()) {


### PR DESCRIPTION
## Summary

Adds config-level middleware handler entries so `farm.config.ts` can define a list of `{ matcher, handler }` middleware rules, while preserving the existing matcher-only object as a global gate for discovered `middleware.ts` files.

## What changed

- Extends middleware config types to support `handler` and `handlers` entries.
- Wires resolved `options.middleware` into `MiddlewareManager` during Vite setup.
- Normalizes config middleware entries into the existing middleware execution flow.
- Adds matcher support for `:param`, `:path*`, bracket params, catch-all params, glob-style patterns, regex, and function matchers.
- Updates middleware docs to show the new config-level handler list and current middleware chain API.
- Adds focused middleware manager tests for config entries, matcher-only global gates, params, non-matches, and short-circuit responses.

## Validation

- `corepack pnpm --filter @farmjs/core test -- middleware.test.ts`
- `corepack pnpm --filter @farmjs/core test -- config.test.ts`
- `corepack pnpm exec oxfmt --check packages/farm/src/middleware/types.ts packages/farm/src/middleware/manager.ts packages/farm/src/config.ts packages/farm/src/types.ts packages/farm/src/app.ts packages/farm/src/vite.ts docs/src/app/docs/middleware/page.md`
- `git diff --check`

## Notes

`corepack pnpm --filter @farmjs/core type-check` still fails on existing unrelated Nitro/query-state issues, including missing `rollup`, `pathe`, `nuqs`, and nullable Nitro event errors.

Replaces #91 so the head branch follows the requested `feat/...` naming.