### PR TITLE
feat: production middleware runtime

### DIFF
--- a/packages/farm/src/__tests__/production-middleware.test.ts
+++ b/packages/farm/src/__tests__/production-middleware.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL, fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { build } from "../build";
+import { loadConfig, resolveConfig } from "../config";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+async function createProductionMiddlewareFixture(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(packageRoot, ".tmp-production-middleware-"));
+
+  await fs.mkdir(path.join(root, "node_modules", "@farmjs"), { recursive: true });
+  await fs.symlink(packageRoot, path.join(root, "node_modules", "@farmjs", "core"), "dir");
+
+  await fs.mkdir(path.join(root, "src", "app", "dashboard", "settings"), { recursive: true });
+  await fs.writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({ type: "module" }, null, 2),
+  );
+  await fs.writeFile(
+    path.join(root, "farm.config.ts"),
+    `
+export default {
+  srcDir: "src",
+  deploy: {
+    target: "vercel",
+  },
+  middleware: [
+    {
+      matcher: "/dashboard/:path*",
+      async handler(ctx, next) {
+        ctx.data.set("config.area", "dashboard");
+        ctx.data.set("config.path", ctx.params.path || "");
+        await next();
+      },
+    },
+  ],
+};
+`.trim(),
+  );
+  await fs.writeFile(path.join(root, "src", "app", "globals.css"), "");
+  await fs.writeFile(
+    path.join(root, "src", "app", "dashboard", "settings", "page.tsx"),
+    `
+import React from "react";
+
+export default function DashboardPage(props: any) {
+  const middlewareData = props.middleware?.data;
+  const configArea = middlewareData?.get("config.area") || "missing-config";
+  const configPath = middlewareData?.get("config.path") || "missing-path";
+  const fileArea = middlewareData?.get("file.area") || "missing-file";
+
+  return React.createElement(
+    "main",
+    null,
+    \`production middleware: \${configArea} / \${configPath} / \${fileArea} / \${props.path}\`
+  );
+}
+`.trim(),
+  );
+  await fs.writeFile(
+    path.join(root, "src", "app", "dashboard", "middleware.ts"),
+    `
+export default async function dashboardMiddleware(ctx: any, next: () => Promise<void>) {
+  ctx.data.set("file.area", "dashboard-file");
+  ctx.headers.set("x-farm-middleware", "yes");
+  await next();
+}
+`.trim(),
+  );
+
+  return root;
+}
+
+describe("production middleware runtime", () => {
+  it(
+    "runs farm.config middleware and app middleware in a production build",
+    async () => {
+      const root = await createProductionMiddlewareFixture();
+
+      try {
+        const userConfig = await loadConfig(root, undefined, "production");
+        const config = await resolveConfig({ ...(userConfig || {}), root }, "production");
+        await build(config, { root, preset: "vercel" });
+
+        const entryPath = path.join(
+          root,
+          ".vercel",
+          "output",
+          "functions",
+          "__nitro.func",
+          "index.mjs",
+        );
+        const serverModule = await import(`${pathToFileURL(entryPath).href}?t=${Date.now()}`);
+        const response = await serverModule.default.fetch(
+          new Request("https://example.test/dashboard/settings"),
+        );
+        const html = await response.text();
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("x-farm-middleware")).toBe("yes");
+        expect(html).toContain(
+          "production middleware: dashboard / settings / dashboard-file / /dashboard/settings",
+        );
+      } finally {
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    },
+    120_000,
+  );
+});

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -151,7 +151,7 @@ export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite" | "docs"> {
   i18n?: I18nConfig;
   openapi?: OpenAPIConfig;
 
-  middleware?: MiddlewareConfig;
+  middleware?: FarmMiddlewareConfig;
 
   notFound?: NotFoundConfig;
 

--- a/packages/farm/src/middleware/index.ts
+++ b/packages/farm/src/middleware/index.ts
@@ -9,6 +9,10 @@ export { createContext } from "./context";
 export { MiddlewareManager } from "./manager";
 export { getMiddlewareData, getMiddlewareValue } from "./server";
 export { unwrapMiddleware, getFromMiddleware, hasMiddlewareData } from "./helpers";
+export {
+  createProductionMiddlewareRunner,
+  applyProductionMiddlewareHeaders,
+} from "./production-runtime";
 export * from "./vite-plugin";
 
 export type {
@@ -22,4 +26,5 @@ export type {
   RateLimitStorage,
   RateLimitStatus,
   NextFunction,
+  FarmMiddlewareConfig,
 } from "./types";

--- a/packages/farm/src/middleware/production-runtime.ts
+++ b/packages/farm/src/middleware/production-runtime.ts
@@ -1,0 +1,682 @@
+import type {
+  CookieJar,
+  CookieOptions,
+  FarmMiddlewareConfig,
+  MiddlewareConfig,
+  MiddlewareContext,
+  MiddlewareFunction,
+  MiddlewareMatcher,
+  MiddlewareModule,
+} from "./types";
+
+export interface ProductionMiddlewareModuleEntry {
+  path: string;
+  filePath?: string;
+  module: MiddlewareModule | Record<string, any>;
+}
+
+export interface ProductionMiddlewareRunnerOptions {
+  config?: FarmMiddlewareConfig | null;
+  modules?: ProductionMiddlewareModuleEntry[];
+}
+
+export interface ProductionMiddlewareResult {
+  request: Request;
+  response: Response | null;
+  data: Map<string, any>;
+  headers: Headers;
+  handled: boolean;
+}
+
+interface ProductionMiddlewareEntry {
+  path: string;
+  filePath: string;
+  handlers: MiddlewareFunction[];
+  config?: MiddlewareConfig;
+  source: "config" | "file";
+}
+
+interface WebMiddlewareContextState {
+  ctx: MiddlewareContext;
+  getRequest(): Request;
+  getResponse(): Response | null;
+}
+
+function parseCookies(cookieHeader?: string | null): Record<string, string> {
+  if (!cookieHeader) return {};
+
+  return cookieHeader.split(";").reduce(
+    (cookies, cookie) => {
+      const [name, ...rest] = cookie.split("=");
+      const value = rest.join("=").trim();
+      if (name && value) {
+        cookies[name.trim()] = decodeURIComponent(value);
+      }
+      return cookies;
+    },
+    {} as Record<string, string>,
+  );
+}
+
+function serializeCookie(name: string, value: string, options: CookieOptions = {}): string {
+  let cookie = `${encodeURIComponent(name)}=${encodeURIComponent(value)}`;
+
+  if (options.maxAge) cookie += `; Max-Age=${options.maxAge}`;
+  if (options.expires) cookie += `; Expires=${options.expires.toUTCString()}`;
+  cookie += `; Path=${options.path || "/"}`;
+  if (options.domain) cookie += `; Domain=${options.domain}`;
+  if (options.secure) cookie += "; Secure";
+  if (options.httpOnly) cookie += "; HttpOnly";
+  if (options.sameSite) {
+    cookie += `; SameSite=${options.sameSite.charAt(0).toUpperCase()}${options.sameSite.slice(1)}`;
+  }
+
+  return cookie;
+}
+
+class WebCookieJar implements CookieJar {
+  private cookies: Record<string, string>;
+  private setCookies: string[] = [];
+
+  constructor(
+    request: Request,
+    private headers: Map<string, string>,
+  ) {
+    this.cookies = parseCookies(request.headers.get("cookie"));
+  }
+
+  get(name: string): string | undefined {
+    return this.cookies[name];
+  }
+
+  set(name: string, value: string, options: CookieOptions = {}): void {
+    this.cookies[name] = value;
+    const cookieString = serializeCookie(name, value, options);
+    this.setCookies.push(cookieString);
+    this.headers.set("Set-Cookie", this.setCookies.join(", "));
+  }
+
+  delete(name: string): void {
+    delete this.cookies[name];
+    const cookieString = serializeCookie(name, "", {
+      maxAge: 0,
+      expires: new Date(0),
+    });
+    this.setCookies.push(cookieString);
+    this.headers.set("Set-Cookie", this.setCookies.join(", "));
+  }
+
+  getAll(): Record<string, string> {
+    return { ...this.cookies };
+  }
+}
+
+function mapToHeaders(map: Map<string, string>): Headers {
+  const headers = new Headers();
+  for (const [key, value] of map) {
+    if (key.toLowerCase() === "set-cookie") {
+      headers.append(key, value);
+    } else {
+      headers.set(key, value);
+    }
+  }
+  return headers;
+}
+
+function headersToRecord(headers: Map<string, string>): Record<string, string> {
+  return Object.fromEntries(headers);
+}
+
+function createResponseShim(headers: Map<string, string>): Record<string, any> {
+  return {
+    headersSent: false,
+    writableEnded: false,
+    setHeader(name: string, value: string | string[]) {
+      headers.set(name, Array.isArray(value) ? value.join(", ") : String(value));
+    },
+    getHeader(name: string) {
+      return headers.get(name);
+    },
+    writeHead(status: number, responseHeaders?: Record<string, string>) {
+      this.statusCode = status;
+      if (responseHeaders) {
+        for (const [key, value] of Object.entries(responseHeaders)) {
+          headers.set(key, value);
+        }
+      }
+      this.headersSent = true;
+    },
+    end() {
+      this.writableEnded = true;
+    },
+  };
+}
+
+function withNodeRequestShape(request: Request): Request {
+  const requestWithShape = request as Request & {
+    socket?: { remoteAddress?: string };
+  };
+
+  if (!requestWithShape.socket) {
+    const forwardedFor = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+    try {
+      requestWithShape.socket = {
+        remoteAddress: forwardedFor || "127.0.0.1",
+      };
+    } catch {
+      // Some Request implementations may not be extensible.
+    }
+  }
+
+  return requestWithShape;
+}
+
+function createHandledResponse(
+  body: BodyInit | null,
+  init: ResponseInit,
+  headers: Map<string, string>,
+): Response {
+  const responseHeaders = new Headers(init.headers);
+  for (const [key, value] of headers) {
+    if (key.toLowerCase() === "set-cookie") {
+      responseHeaders.append(key, value);
+    } else {
+      responseHeaders.set(key, value);
+    }
+  }
+  return new Response(body, { ...init, headers: responseHeaders });
+}
+
+function createWebMiddlewareContext(
+  request: Request,
+  parent?: MiddlewareContext["parent"],
+): WebMiddlewareContextState {
+  let currentRequest = withNodeRequestShape(request);
+  let handledResponse: Response | null = null;
+  const url = new URL(currentRequest.url);
+  const data = parent?.data ? new Map(parent.data) : new Map<string, any>();
+  const headers = new Map<string, string>();
+
+  if (parent?.headers) {
+    for (const [key, value] of Object.entries(parent.headers)) {
+      headers.set(key, value);
+    }
+  }
+
+  const ctx = {
+    request: currentRequest as any,
+    response: createResponseShim(headers) as any,
+    url,
+    pathname: url.pathname,
+    searchParams: url.searchParams,
+    method: currentRequest.method || "GET",
+    params: {},
+    route: url.pathname,
+    parent,
+    vite: {
+      isDev: false,
+      hmr: false,
+    },
+    data,
+    headers,
+    cookies: new WebCookieJar(currentRequest, headers),
+    _handled: false as boolean,
+    _redirectUrl: undefined as string | undefined,
+    _rewriteUrl: undefined as string | undefined,
+
+    redirect(redirectUrl: string, status = 307): void {
+      ctx._redirectUrl = redirectUrl;
+      ctx._handled = true;
+      handledResponse = createHandledResponse(
+        `Redirecting to ${redirectUrl}`,
+        {
+          status,
+          headers: {
+            Location: redirectUrl,
+            "Content-Type": "text/plain",
+          },
+        },
+        headers,
+      );
+    },
+
+    rewrite(rewriteUrl: string): void {
+      ctx._rewriteUrl = rewriteUrl;
+      const nextUrl = new URL(rewriteUrl, currentRequest.url);
+      currentRequest = withNodeRequestShape(new Request(nextUrl, currentRequest));
+      ctx.request = currentRequest as any;
+      ctx.url = nextUrl;
+      ctx.pathname = nextUrl.pathname;
+      ctx.searchParams = nextUrl.searchParams;
+      ctx.route = nextUrl.pathname;
+    },
+
+    json(jsonData: any, status = 200): void {
+      ctx._handled = true;
+      handledResponse = createHandledResponse(
+        JSON.stringify(jsonData),
+        {
+          status,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        },
+        headers,
+      );
+    },
+
+    text(content: string, status = 200): void {
+      ctx._handled = true;
+      handledResponse = createHandledResponse(
+        content,
+        {
+          status,
+          headers: {
+            "Content-Type": "text/plain",
+          },
+        },
+        headers,
+      );
+    },
+
+    html(content: string, status = 200): void {
+      ctx._handled = true;
+      handledResponse = createHandledResponse(
+        content,
+        {
+          status,
+          headers: {
+            "Content-Type": "text/html",
+          },
+        },
+        headers,
+      );
+    },
+  } satisfies MiddlewareContext;
+
+  return {
+    ctx,
+    getRequest: () => currentRequest,
+    getResponse: () => handledResponse,
+  };
+}
+
+function toMatcherList(matcher: MiddlewareConfig["matcher"]): MiddlewareMatcher[] {
+  if (!matcher) return [];
+  return Array.isArray(matcher) ? matcher : [matcher];
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+}
+
+function parseColonParam(segment: string): { name: string; modifier?: string } {
+  const raw = segment.slice(1);
+  const last = raw[raw.length - 1];
+  const modifier = last === "*" || last === "+" || last === "?" ? last : undefined;
+  return {
+    name: modifier ? raw.slice(0, -1) : raw,
+    modifier,
+  };
+}
+
+function compilePathPattern(pattern: string): { regex: RegExp; params: string[] } {
+  const params: string[] = [];
+  const segments = pattern.split("/").filter(Boolean);
+
+  if (segments.length === 0) {
+    return { regex: /^\/$/, params };
+  }
+
+  const parts = segments.map((segment) => {
+    if (segment === "**") {
+      return "(?:/.*)?";
+    }
+
+    if (segment === "*") {
+      return "/[^/]+";
+    }
+
+    if (segment.startsWith(":")) {
+      const { name, modifier } = parseColonParam(segment);
+      params.push(name);
+
+      if (modifier === "*") {
+        return "(?:/(.*))?";
+      }
+      if (modifier === "+") {
+        return "/(.+)";
+      }
+      return "/([^/]+)";
+    }
+
+    if (segment.startsWith("[...") && segment.endsWith("]")) {
+      params.push(segment.slice(4, -1));
+      return "(?:/(.*))?";
+    }
+
+    if (segment.startsWith("[") && segment.endsWith("]")) {
+      params.push(segment.slice(1, -1));
+      return "/([^/]+)";
+    }
+
+    return `/${escapeRegex(segment).replace(/\\\*/g, "[^/]*")}`;
+  });
+
+  return {
+    regex: new RegExp(`^${parts.join("")}$`),
+    params,
+  };
+}
+
+function matchPattern(
+  pattern: string | RegExp,
+  pathname: string,
+): { matched: boolean; params?: Record<string, string> } {
+  if (pattern instanceof RegExp) {
+    pattern.lastIndex = 0;
+    const match = pattern.exec(pathname);
+    return {
+      matched: !!match,
+      params: match?.groups ? { ...match.groups } : undefined,
+    };
+  }
+
+  if (pattern === "*" || pattern === "/(.*)") {
+    return { matched: true };
+  }
+
+  if (pattern.endsWith("(.*)")) {
+    const prefix = pattern.slice(0, -4);
+    return { matched: pathname === prefix || pathname.startsWith(`${prefix}/`) };
+  }
+
+  const { regex, params } = compilePathPattern(pattern);
+  const match = regex.exec(pathname);
+  if (!match) {
+    return { matched: false };
+  }
+
+  const values: Record<string, string> = {};
+  params.forEach((param, index) => {
+    values[param] = decodeURIComponent(match[index + 1] || "");
+  });
+
+  return {
+    matched: true,
+    params: Object.keys(values).length > 0 ? values : undefined,
+  };
+}
+
+function matchesConfig(
+  pathname: string,
+  config: MiddlewareConfig,
+  ctx: MiddlewareContext,
+): { matched: boolean; params?: Record<string, string> } {
+  if (config.exclude) {
+    for (const pattern of config.exclude) {
+      if (matchPattern(pattern, pathname).matched) {
+        return { matched: false };
+      }
+    }
+  }
+
+  if (config.matcher) {
+    for (const matcher of toMatcherList(config.matcher)) {
+      if (typeof matcher === "string" || matcher instanceof RegExp) {
+        const result = matchPattern(matcher, pathname);
+        if (result.matched) {
+          return result;
+        }
+      } else if (typeof matcher === "function") {
+        return { matched: matcher(ctx) };
+      }
+    }
+    return { matched: false };
+  }
+
+  return { matched: true };
+}
+
+function matchesRoutePath(pathname: string, middlewarePath: string): boolean {
+  if (middlewarePath === "/") return true;
+  return pathname === middlewarePath || pathname.startsWith(`${middlewarePath}/`);
+}
+
+function getConfigHandlers(
+  entry: MiddlewareConfig & {
+    handler?: MiddlewareFunction;
+    handlers?: MiddlewareFunction[];
+  },
+): MiddlewareFunction[] {
+  const handlers: MiddlewareFunction[] = [];
+  if ("handler" in entry && typeof entry.handler === "function") {
+    handlers.push(entry.handler);
+  }
+  if ("handlers" in entry && Array.isArray(entry.handlers)) {
+    handlers.push(...entry.handlers.filter((handler) => typeof handler === "function"));
+  }
+  return handlers;
+}
+
+function toMiddlewareConfig(
+  entry: MiddlewareConfig & {
+    handler?: MiddlewareFunction;
+    handlers?: MiddlewareFunction[];
+  },
+): MiddlewareConfig {
+  const { matcher, exclude, runtime } = entry;
+  return { matcher, exclude, runtime };
+}
+
+function normalizeConfigMiddleware(config?: FarmMiddlewareConfig | null): {
+  entries: ProductionMiddlewareEntry[];
+  globalConfig?: MiddlewareConfig;
+} {
+  const entries: ProductionMiddlewareEntry[] = [];
+  let globalConfig: MiddlewareConfig | undefined;
+
+  if (!config) {
+    return { entries, globalConfig };
+  }
+
+  const configEntries = Array.isArray(config) ? config : [config];
+  for (const [index, entry] of configEntries.entries()) {
+    const handlers = getConfigHandlers(entry);
+    const middlewareConfig = toMiddlewareConfig(entry);
+
+    if (handlers.length === 0) {
+      globalConfig = middlewareConfig;
+      continue;
+    }
+
+    entries.push({
+      path: "/",
+      filePath: `farm.config.ts#middleware-${index}`,
+      handlers,
+      config: middlewareConfig,
+      source: "config",
+    });
+  }
+
+  return { entries, globalConfig };
+}
+
+function normalizeFileMiddleware(
+  modules: ProductionMiddlewareModuleEntry[] = [],
+): ProductionMiddlewareEntry[] {
+  const entries: ProductionMiddlewareEntry[] = [];
+
+  for (const moduleEntry of modules) {
+    const middlewareModule = moduleEntry.module as MiddlewareModule;
+    const defaultExport = middlewareModule.default;
+    const handlers: MiddlewareFunction[] = [];
+    let config = middlewareModule.config;
+
+    if (!defaultExport) {
+      continue;
+    }
+
+    if (typeof defaultExport === "object" && "build" in defaultExport) {
+      if (typeof (defaultExport as any).setBasePath === "function") {
+        (defaultExport as any).setBasePath(moduleEntry.path);
+      }
+      const built = (defaultExport as any).build();
+      if (Array.isArray(built?.handlers)) {
+        handlers.push(...built.handlers);
+      }
+      config = config || built?.config;
+    } else if (typeof defaultExport === "function") {
+      handlers.push(defaultExport as MiddlewareFunction);
+    }
+
+    if (handlers.length === 0) {
+      continue;
+    }
+
+    entries.push({
+      path: moduleEntry.path,
+      filePath: moduleEntry.filePath || moduleEntry.path,
+      handlers,
+      config,
+      source: "file",
+    });
+  }
+
+  return entries;
+}
+
+async function executeHandlers(handlers: MiddlewareFunction[], ctx: MiddlewareContext) {
+  let handlerIndex = 0;
+  const executeNext = async (): Promise<void> => {
+    if (handlerIndex < handlers.length) {
+      const handler = handlers[handlerIndex++];
+      await handler(ctx, executeNext);
+    }
+  };
+
+  await executeNext();
+}
+
+function emptyResult(request: Request): ProductionMiddlewareResult {
+  return {
+    request,
+    response: null,
+    data: new Map(),
+    headers: new Headers(),
+    handled: false,
+  };
+}
+
+export function createProductionMiddlewareRunner(options: ProductionMiddlewareRunnerOptions = {}) {
+  const configMiddleware = normalizeConfigMiddleware(options.config);
+  const fileMiddleware = normalizeFileMiddleware(options.modules);
+  const entries = [...configMiddleware.entries, ...fileMiddleware];
+  const globalConfig = configMiddleware.globalConfig;
+
+  return async function runProductionMiddleware(
+    request: Request,
+  ): Promise<ProductionMiddlewareResult> {
+    if (!globalConfig && entries.length === 0) {
+      return emptyResult(request);
+    }
+
+    let contextState = createWebMiddlewareContext(request);
+    let ctx = contextState.ctx;
+    let currentRequest = contextState.getRequest();
+    const initialPathname = ctx.pathname;
+    let parentData: MiddlewareContext["parent"] | undefined;
+
+    if (globalConfig) {
+      const globalMatch = matchesConfig(initialPathname, globalConfig, ctx);
+      if (!globalMatch.matched) {
+        return emptyResult(request);
+      }
+      if (globalMatch.params) {
+        ctx.params = { ...ctx.params, ...globalMatch.params };
+      }
+    }
+
+    const applicable = entries.filter(
+      (entry) => entry.source === "config" || matchesRoutePath(initialPathname, entry.path),
+    );
+
+    if (applicable.length === 0) {
+      return {
+        request: currentRequest,
+        response: null,
+        data: new Map(ctx.data),
+        headers: mapToHeaders(ctx.headers),
+        handled: false,
+      };
+    }
+
+    for (const entry of applicable) {
+      const configMatch = entry.config
+        ? matchesConfig(initialPathname, entry.config, ctx)
+        : { matched: true };
+      if (!configMatch.matched) {
+        continue;
+      }
+
+      if (parentData) {
+        contextState = createWebMiddlewareContext(currentRequest, parentData);
+        ctx = contextState.ctx;
+      }
+
+      if (configMatch.params) {
+        ctx.params = { ...ctx.params, ...configMatch.params };
+      }
+
+      await executeHandlers(entry.handlers, ctx);
+      currentRequest = contextState.getRequest();
+
+      if (ctx._handled) {
+        return {
+          request: currentRequest,
+          response: contextState.getResponse() || new Response(null),
+          data: new Map(ctx.data),
+          headers: mapToHeaders(ctx.headers),
+          handled: true,
+        };
+      }
+
+      parentData = {
+        data: new Map(ctx.data),
+        headers: headersToRecord(ctx.headers),
+      };
+    }
+
+    return {
+      request: currentRequest,
+      response: null,
+      data: new Map(ctx.data),
+      headers: mapToHeaders(ctx.headers),
+      handled: false,
+    };
+  };
+}
+
+export function applyProductionMiddlewareHeaders(
+  response: Response,
+  middlewareHeaders?: Headers | null,
+): Response {
+  if (!middlewareHeaders || Array.from(middlewareHeaders.keys()).length === 0) {
+    return response;
+  }
+
+  const headers = new Headers(response.headers);
+  for (const [key, value] of middlewareHeaders) {
+    if (key.toLowerCase() === "set-cookie") {
+      headers.append(key, value);
+    } else {
+      headers.set(key, value);
+    }
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -24,6 +24,10 @@ type UniversalPageRoute = {
   modulePath: string;
   source?: string;
 };
+type UniversalMiddlewareRoute = {
+  path: string;
+  filePath: string;
+};
 
 // Get __dirname equivalent for ESM
 const _filename = typeof import.meta.url !== "undefined" ? fileURLToPath(import.meta.url) : "";
@@ -136,6 +140,62 @@ async function findFarmConfigPath(root: string): Promise<string | null> {
   }
 
   return null;
+}
+
+function hasFarmMiddlewareConfig(config: ResolvedFarmConfig["middleware"]): boolean {
+  if (!config) return false;
+  if (Array.isArray(config)) return config.length > 0;
+
+  const configRecord = config as Record<string, unknown>;
+  return Boolean(
+    configRecord.matcher ||
+      configRecord.exclude ||
+      configRecord.runtime ||
+      configRecord.handler ||
+      (Array.isArray(configRecord.handlers) && configRecord.handlers.length > 0),
+  );
+}
+
+async function discoverMiddlewareRoutes(appDir: string): Promise<UniversalMiddlewareRoute[]> {
+  const fs = await import("fs/promises");
+  const routes: UniversalMiddlewareRoute[] = [];
+
+  async function walk(dir: string, routePath: string): Promise<void> {
+    let entries: import("fs").Dirent[];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    const middlewareFile = entries.find(
+      (entry) => entry.isFile() && /^middleware\.(tsx?|jsx?)$/.test(entry.name),
+    );
+
+    if (middlewareFile) {
+      routes.push({
+        path: routePath,
+        filePath: path.join(dir, middlewareFile.name),
+      });
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name.startsWith(".") || entry.name.startsWith("_")) {
+        continue;
+      }
+
+      const childRoutePath = routePath === "/" ? `/${entry.name}` : `${routePath}/${entry.name}`;
+      await walk(path.join(dir, entry.name), childRoutePath);
+    }
+  }
+
+  await walk(appDir, "/");
+
+  return routes.sort((a, b) => {
+    const depthA = a.path.split("/").filter(Boolean).length;
+    const depthB = b.path.split("/").filter(Boolean).length;
+    return depthA - depthB || a.path.localeCompare(b.path);
+  });
 }
 
 /**
@@ -1115,8 +1175,8 @@ async function buildSSRInMemory(
 
   // Discover layout files by scanning the source directory
   const layoutRoutes: Array<{ pattern: string; modulePath: string }> = [];
-  const fsSync = await import("fs");
   const appDir = path.join(root, srcDir, "app");
+  const middlewareRoutes = await discoverMiddlewareRoutes(appDir);
 
   async function findLayouts(dir: string, routePrefix: string = "/"): Promise<void> {
     try {
@@ -1166,7 +1226,7 @@ async function buildSSRInMemory(
   });
 
   logger.info(
-    `📋 Found ${pageRoutes.length} page routes, ${layoutRoutes.length} layouts, and ${apiRoutes.length} API routes`,
+    `📋 Found ${pageRoutes.length} page routes, ${layoutRoutes.length} layouts, ${apiRoutes.length} API routes, and ${middlewareRoutes.length} middleware files`,
   );
 
   const hasConfiguredIntegrations = Object.keys(config.integrations || {}).length > 0;
@@ -1175,8 +1235,9 @@ async function buildSSRInMemory(
     typeof config.observability === "object" &&
     "onEvent" in config.observability;
   const hasMdxComponentConfig = Boolean(config.mdx?.components);
+  const hasMiddlewareConfig = hasFarmMiddlewareConfig(config.middleware);
   const configModulePath =
-    hasConfiguredIntegrations || hasObservabilityHandler || hasMdxComponentConfig
+    hasConfiguredIntegrations || hasObservabilityHandler || hasMdxComponentConfig || hasMiddlewareConfig
       ? await findFarmConfigPath(root)
       : null;
 
@@ -1186,6 +1247,7 @@ async function buildSSRInMemory(
     apiRoutes,
     pageRoutes,
     layoutRoutes,
+    middlewareRoutes,
     notFoundPath,
     config,
     configModulePath,
@@ -1331,6 +1393,7 @@ function generateVirtualEntryCode(
   apiRoutes: Array<{ path: string; filePath: string; methods: string[] }>,
   pageRoutes: UniversalPageRoute[],
   layoutRoutes: Array<{ pattern: string; modulePath: string }>,
+  middlewareRoutes: UniversalMiddlewareRoute[],
   notFoundPath: string | null,
   config: ResolvedFarmConfig,
   configModulePath: string | null,
@@ -1396,6 +1459,21 @@ function generateVirtualEntryCode(
   }`);
   });
 
+  // Generate imports for all app middleware files
+  const middlewareImports: string[] = [];
+  const middlewareRegistrations: string[] = [];
+
+  middlewareRoutes.forEach((middlewareRoute, index) => {
+    const varName = `fileMiddleware${index}`;
+    middlewareImports.push(`import * as ${varName} from "${middlewareRoute.filePath}";`);
+    middlewareRegistrations.push(`
+  {
+    path: ${JSON.stringify(middlewareRoute.path)},
+    filePath: ${JSON.stringify(middlewareRoute.filePath)},
+    module: ${varName},
+  }`);
+  });
+
   // Generate import for custom not-found page if exists
   const notFoundImport = notFoundPath ? `import * as CustomNotFound from "${notFoundPath}";` : "";
   const apiRouteHelpersImport =
@@ -1404,6 +1482,7 @@ function generateVirtualEntryCode(
       : "";
   const cacheHelpersImport = `import { createFarmCacheKey, getFarmDataCache, normalizeRevalidatePath } from "farm/cache";`;
   const observabilityHelpersImport = `import { configureFarmObservability, emitFarmEvent } from "farm/observability";`;
+  const middlewareRuntimeImport = `import { applyProductionMiddlewareHeaders, createProductionMiddlewareRunner } from "farm/middleware";`;
   const docsHandlerImport = config.docs?.enabled
     ? `import { createFarmDocsAPIHandler, createFarmDocsHandler } from "farm/docs";`
     : "";
@@ -1478,10 +1557,12 @@ async function handleAPIRequest(request) {
 ${apiImports.join("\n")}
 ${pageImports.join("\n")}
 ${layoutImports.join("\n")}
+${middlewareImports.join("\n")}
 ${notFoundImport}
 ${apiRouteHelpersImport}
 ${cacheHelpersImport}
 ${observabilityHelpersImport}
+${middlewareRuntimeImport}
 ${docsHandlerImport}
 ${docsRuntimeImport}
 ${markdownHandlerImport}
@@ -1571,6 +1652,15 @@ const pageRoutes = [${pageRegistrations.join(",")}
 // Layout routes bundled at build time (sorted by depth, root first)
 const layoutRoutes = [${layoutRegistrations.join(",")}
 ];
+
+// App middleware files bundled at build time (sorted by depth, root first)
+const fileMiddlewareModules = [${middlewareRegistrations.join(",")}
+];
+
+const farmMiddlewareRunner = createProductionMiddlewareRunner({
+  config: farmUserConfig?.middleware,
+  modules: fileMiddlewareModules,
+});
 
 ${apiHandlerCode}
 
@@ -1712,8 +1802,8 @@ function getCachedPPRShell(cacheKey) {
  * Main request handler - created at runtime with bundled routes
  */
 async function handleRequest(request) {
-  const url = new URL(request.url);
-  const pathname = url.pathname;
+  let url = new URL(request.url);
+  let pathname = url.pathname;
   const requestStartTime = Date.now();
 
   const integrationResponse = await handleIntegrationRequest(request.clone());
@@ -1752,24 +1842,34 @@ async function handleRequest(request) {
     }
   }
 
+  const middlewareResult = await farmMiddlewareRunner(request);
+  if (middlewareResult.response) {
+    return middlewareResult.response;
+  }
+  request = middlewareResult.request;
+  const middlewareData = middlewareResult.data;
+  const middlewareHeaders = middlewareResult.headers;
+  url = new URL(request.url);
+  pathname = url.pathname;
+
   // Handle API routes
   if (pathname.startsWith("/api/")) {
     const apiResponse = await handleAPIRequest(request.clone());
     if (apiResponse) {
-      return apiResponse;
+      return applyProductionMiddlewareHeaders(apiResponse, middlewareHeaders);
     }
 
     if (farmDocsAPIHandler) {
       const docsAPIResponse = await farmDocsAPIHandler(request.clone());
       if (docsAPIResponse) {
-        return docsAPIResponse;
+        return applyProductionMiddlewareHeaders(docsAPIResponse, middlewareHeaders);
       }
     }
 
-    return new Response(
+    return applyProductionMiddlewareHeaders(new Response(
       JSON.stringify({ error: "API route not found", pathname }),
       { status: 404, headers: { "Content-Type": "application/json" } }
-    );
+    ), middlewareHeaders);
   }
 
   // Handle page routes (SSR)
@@ -1802,13 +1902,13 @@ async function handleRequest(request) {
             status: 200,
             durationMs: Date.now() - requestStartTime,
           });
-          return new Response(cachedPPRShell, {
+          return applyProductionMiddlewareHeaders(new Response(cachedPPRShell, {
             status: 200,
             headers: {
               "Content-Type": "text/html; charset=utf-8",
               ...getPPRHeaders("hit", pprConfig),
             },
-          });
+          }), middlewareHeaders);
         }
         emitFarmEvent({ type: "ppr.shell.miss", route: pathname, key: pprCacheKey });
       }
@@ -1832,7 +1932,12 @@ async function handleRequest(request) {
         const searchParams = Promise.resolve(searchParamsObj);
         
         // Render the page component
-        const pageProps = { params, searchParams };
+        const pageProps = {
+          params,
+          searchParams,
+          path: pathname,
+          ...(middlewareData?.size ? { middleware: { data: middlewareData } } : {}),
+        };
         
         // First, render the page content
         let pageElement;
@@ -1983,21 +2088,21 @@ async function handleRequest(request) {
           durationMs: Date.now() - requestStartTime,
         });
 
-        return new Response(
+        return applyProductionMiddlewareHeaders(new Response(
           fullHtml,
           { 
             status: 200, 
             headers: responseHeaders
           }
-        );
+        ), middlewareHeaders);
       }
     } catch (error) {
       emitFarmEvent({ type: "render.error", route: pathname, error });
       console.error("SSR Error:", error);
-      return new Response(
+      return applyProductionMiddlewareHeaders(new Response(
         \`<html><body><h1>Error</h1><p>\${error.message}</p><pre>\${error.stack}</pre></body></html>\`,
         { status: 500, headers: { "Content-Type": "text/html" } }
-      );
+      ), middlewareHeaders);
     }
   }
 
@@ -2136,16 +2241,16 @@ async function handleRequest(request) {
       durationMs: Date.now() - requestStartTime,
     });
 
-    return new Response(fullHtml, {
+    return applyProductionMiddlewareHeaders(new Response(fullHtml, {
       status: 404,
       headers: { "Content-Type": "text/html; charset=utf-8" }
-    });
+    }), middlewareHeaders);
   } catch (error) {
     console.error("404 render error:", error);
-    return new Response(
+    return applyProductionMiddlewareHeaders(new Response(
       \`<!DOCTYPE html><html><head><title>404</title></head><body><h1>404 - Page Not Found</h1><p>The page \${pathname} doesn't exist.</p><a href="/">Go Home</a></body></html>\`,
       { status: 404, headers: { "Content-Type": "text/html" } }
-    );
+    ), middlewareHeaders);
   }
 }
 


### PR DESCRIPTION
## Summary

- Add a production middleware runner for `farm.config.ts` middleware entries and bundled `src/app/**/middleware.ts` modules.
- Discover app middleware during the universal production build and pass middleware data/headers into built API/page responses.
- Add a production Vercel-output regression test that builds the app and verifies `/dashboard/:path*` config middleware plus route middleware run.

## Validation

- `corepack pnpm --dir packages/farm exec vitest run src/__tests__/production-middleware.test.ts --config vitest.config.ts`
- `corepack pnpm --dir packages/farm run type-check` currently fails on existing baseline errors in Nitro/query-state dependencies; the filtered touched-file check reported no new type errors.