### PR TITLE
feat: return Response from app middleware

### DIFF
--- a/docs/src/app/docs/middleware/page.md
+++ b/docs/src/app/docs/middleware/page.md
@@ -149,6 +149,23 @@ export default defineFarmConfig({
 });
 ```
 
+Middleware handlers can also return a Web `Response`. Returned responses stop the middleware chain and are sent directly.
+
+```ts
+import { defineFarmConfig } from "@farmjs/core";
+
+export default defineFarmConfig({
+  middleware: [
+    {
+      matcher: "/dashboard/:path*",
+      handler(ctx) {
+        return Response.redirect(new URL("/sign-in", ctx.url));
+      },
+    },
+  ],
+});
+```
+
 **src/app/dashboard/page.tsx**
 
 ```tsx

--- a/packages/farm/src/__tests__/middleware.test.ts
+++ b/packages/farm/src/__tests__/middleware.test.ts
@@ -1742,6 +1742,53 @@ describe("Middleware Manager Data Flow", () => {
     expect(res.end).toHaveBeenCalledWith("blocked");
   });
 
+  it("returns handled when config middleware returns a Response", async () => {
+    const manager = new MiddlewareManager("/tmp", undefined, [
+      {
+        matcher: "/dashboard/:path*",
+        handler(ctx) {
+          return Response.redirect(new URL("/sign-in", ctx.url));
+        },
+      },
+    ]);
+
+    const req = createMockRequest("/dashboard/settings");
+    const res = createMockResponse();
+    const handled = await manager.execute(req, res);
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(302);
+    expect(res.setHeader).toHaveBeenCalledWith("location", "http://localhost:3000/sign-in");
+  });
+
+  it("returns handled when file middleware returns a Response", async () => {
+    const manager = new MiddlewareManager("/tmp");
+    (manager as any).middleware = [
+      {
+        path: "/dashboard",
+        filePath: "/tmp/app/dashboard/middleware.ts",
+        handlers: [
+          (ctx: MiddlewareContext) => {
+            return new Response(null, {
+              status: 204,
+              headers: {
+                "x-middleware": ctx.pathname,
+              },
+            });
+          },
+        ],
+      },
+    ];
+
+    const req = createMockRequest("/dashboard/settings");
+    const res = createMockResponse();
+    const handled = await manager.execute(req, res);
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(204);
+    expect(res.setHeader).toHaveBeenCalledWith("x-middleware", "/dashboard/settings");
+  });
+
   it("should share middleware context across middleware chain and expose to page request data", async () => {
     const req = createMockRequest("/docs/getting-started");
     const res = createMockResponse();

--- a/packages/farm/src/__tests__/production-middleware.test.ts
+++ b/packages/farm/src/__tests__/production-middleware.test.ts
@@ -30,6 +30,12 @@ export default {
   },
   middleware: [
     {
+      matcher: "/dashboard/config-response",
+      handler(ctx) {
+        return Response.redirect(new URL("/sign-in", ctx.url));
+      },
+    },
+    {
       matcher: "/dashboard/:path*",
       async handler(ctx, next) {
         ctx.data.set("config.area", "dashboard");
@@ -67,6 +73,14 @@ export default function DashboardPage(props: any) {
 export default async function dashboardMiddleware(ctx: any, next: () => Promise<void>) {
   ctx.data.set("file.area", "dashboard-file");
   ctx.headers.set("x-farm-middleware", "yes");
+  if (ctx.pathname === "/dashboard/file-response") {
+    return new Response("blocked by file middleware", {
+      status: 418,
+      headers: {
+        "x-file-response": "yes",
+      },
+    });
+  }
   await next();
 }
 `.trim(),
@@ -105,6 +119,20 @@ describe("production middleware runtime", () => {
         expect(html).toContain(
           "production middleware: dashboard / settings / dashboard-file / /dashboard/settings",
         );
+
+        const configResponse = await serverModule.default.fetch(
+          new Request("https://example.test/dashboard/config-response"),
+        );
+        expect(configResponse.status).toBe(302);
+        expect(configResponse.headers.get("location")).toBe("https://example.test/sign-in");
+
+        const fileResponse = await serverModule.default.fetch(
+          new Request("https://example.test/dashboard/file-response"),
+        );
+        expect(fileResponse.status).toBe(418);
+        expect(fileResponse.headers.get("x-file-response")).toBe("yes");
+        expect(fileResponse.headers.get("x-farm-middleware")).toBe("yes");
+        await expect(fileResponse.text()).resolves.toBe("blocked by file middleware");
       } finally {
         await fs.rm(root, { recursive: true, force: true });
       }

--- a/packages/farm/src/middleware/chain.ts
+++ b/packages/farm/src/middleware/chain.ts
@@ -10,6 +10,7 @@ import type {
   RateLimitConfig,
   RateLimitStorage,
   RateLimitStatus,
+  MiddlewareResult,
 } from "./types";
 import { getStorage } from "../storage";
 import type { Storage } from "unstorage";
@@ -70,7 +71,7 @@ function createRateLimitMiddleware(config: RateLimitConfig): MiddlewareFunction 
   const windowMs = parseTimeWindow(config.window);
   const storage = config.storage || defaultRateLimitStorage;
 
-  return async (ctx: MiddlewareContext, next: () => Promise<void>) => {
+  return async (ctx: MiddlewareContext, next) => {
     const key = config.keyGenerator
       ? config.keyGenerator(ctx)
       : `${ctx.request.socket.remoteAddress}:${ctx.pathname}`;
@@ -94,8 +95,7 @@ function createRateLimitMiddleware(config: RateLimitConfig): MiddlewareFunction 
         },
         ttlSeconds,
       );
-      await next();
-      return;
+      return next();
     }
 
     if (current.count >= config.requests) {
@@ -116,7 +116,7 @@ function createRateLimitMiddleware(config: RateLimitConfig): MiddlewareFunction 
 
     current.count++;
     await storage.set(key, current, ttlSeconds);
-    await next();
+    return next();
   };
 }
 
@@ -193,28 +193,37 @@ class MiddlewareChainImpl implements MiddlewareChain {
       const shouldRun = typeof condition === "function" ? condition(ctx) : condition;
 
       if (!shouldRun) {
-        await next();
-        return;
+        return next();
       }
 
       if (typeof fn === "function" && fn.length === 2) {
-        await (fn as MiddlewareFunction)(ctx, next);
+        return (fn as MiddlewareFunction)(ctx, next);
       } else {
         const subChain = middleware(this.basePath);
         (fn as (chain: MiddlewareChain) => void)(subChain);
         const { handlers } = subChain.build();
 
         let index = 0;
-        const executeNext = async (): Promise<void> => {
+        let returnedResponse: Response | undefined;
+        const executeNext = async (): Promise<MiddlewareResult> => {
           if (index < handlers.length) {
             const handler = handlers[index++];
-            await handler(ctx, executeNext);
+            const result = await handler(ctx, executeNext);
+            if (result instanceof Response) {
+              returnedResponse = result;
+              return result;
+            }
           } else {
-            await next();
+            const result = await next();
+            if (result instanceof Response) {
+              returnedResponse = result;
+              return result;
+            }
           }
+          return returnedResponse;
         };
 
-        await executeNext();
+        return executeNext();
       }
     };
     this.handlers.push(conditionalMiddleware);
@@ -234,7 +243,7 @@ class MiddlewareChainImpl implements MiddlewareChain {
         ctx.redirect(destination, permanent ? 308 : 307);
         return;
       }
-      await next();
+      return next();
     };
 
     this.handlers.push(redirectMiddleware);
@@ -267,8 +276,7 @@ class MiddlewareChainImpl implements MiddlewareChain {
       if (condition !== undefined) {
         const shouldRewrite = typeof condition === "function" ? condition(ctx) : condition;
         if (!shouldRewrite) {
-          await next();
-          return;
+          return next();
         }
       }
 
@@ -290,7 +298,7 @@ class MiddlewareChainImpl implements MiddlewareChain {
         // Only rewrite if pathname matches exactly (edge case)
         ctx.rewrite(destination);
       }
-      await next();
+      return next();
     };
 
     this.handlers.push(rewriteMiddleware);

--- a/packages/farm/src/middleware/index.ts
+++ b/packages/farm/src/middleware/index.ts
@@ -26,5 +26,6 @@ export type {
   RateLimitStorage,
   RateLimitStatus,
   NextFunction,
+  MiddlewareResult,
   FarmMiddlewareConfig,
 } from "./types";

--- a/packages/farm/src/middleware/manager.ts
+++ b/packages/farm/src/middleware/manager.ts
@@ -15,9 +15,11 @@ import type {
   MiddlewareModule,
   MiddlewareConfig,
   MiddlewareContext,
+  MiddlewareResult,
 } from "./types";
 import { createContext } from "./context";
 import { logger } from "../utils";
+import { sendWebResponse } from "../server/response";
 
 export interface DiscoveredMiddleware {
   path: string;
@@ -25,6 +27,10 @@ export interface DiscoveredMiddleware {
   handlers: MiddlewareFunction[];
   config?: MiddlewareConfig;
   source?: "config" | "file";
+}
+
+function isMiddlewareResponse(value: unknown): value is Response {
+  return value instanceof Response;
 }
 
 /**
@@ -261,14 +267,32 @@ export class MiddlewareManager {
 
       // Execute all handlers in this middleware
       let handlerIndex = 0;
-      const executeNext = async (): Promise<void> => {
+      let returnedResponse: Response | undefined;
+      const executeNext = async (): Promise<MiddlewareResult> => {
         if (handlerIndex < mw.handlers.length) {
           const handler = mw.handlers[handlerIndex++];
-          await handler(ctx, executeNext);
+          const result = await handler(ctx, executeNext);
+          if (isMiddlewareResponse(result)) {
+            returnedResponse = result;
+            return result;
+          }
         }
+        return returnedResponse;
       };
 
-      await executeNext();
+      const result = await executeNext();
+      const response = isMiddlewareResponse(result) ? result : returnedResponse;
+      if (response) {
+        if (!res.headersSent && !res.writableEnded) {
+          for (const [key, value] of ctx.headers) {
+            try {
+              res.setHeader(key, value);
+            } catch (error) {}
+          }
+        }
+        await sendWebResponse(res, response);
+        return true;
+      }
 
       // Check if response has been sent or handled by middleware helpers.
       if (ctx._handled || res.headersSent || res.writableEnded) {

--- a/packages/farm/src/middleware/production-runtime.ts
+++ b/packages/farm/src/middleware/production-runtime.ts
@@ -7,6 +7,7 @@ import type {
   MiddlewareFunction,
   MiddlewareMatcher,
   MiddlewareModule,
+  MiddlewareResult,
 } from "./types";
 
 export interface ProductionMiddlewareModuleEntry {
@@ -125,6 +126,10 @@ function mapToHeaders(map: Map<string, string>): Headers {
 
 function headersToRecord(headers: Map<string, string>): Record<string, string> {
   return Object.fromEntries(headers);
+}
+
+function isMiddlewareResponse(value: unknown): value is Response {
+  return value instanceof Response;
 }
 
 function createResponseShim(headers: Map<string, string>): Record<string, any> {
@@ -546,16 +551,26 @@ function normalizeFileMiddleware(
   return entries;
 }
 
-async function executeHandlers(handlers: MiddlewareFunction[], ctx: MiddlewareContext) {
+async function executeHandlers(
+  handlers: MiddlewareFunction[],
+  ctx: MiddlewareContext,
+): Promise<Response | undefined> {
   let handlerIndex = 0;
-  const executeNext = async (): Promise<void> => {
+  let returnedResponse: Response | undefined;
+  const executeNext = async (): Promise<MiddlewareResult> => {
     if (handlerIndex < handlers.length) {
       const handler = handlers[handlerIndex++];
-      await handler(ctx, executeNext);
+      const result = await handler(ctx, executeNext);
+      if (isMiddlewareResponse(result)) {
+        returnedResponse = result;
+        return result;
+      }
     }
+    return returnedResponse;
   };
 
-  await executeNext();
+  const result = await executeNext();
+  return isMiddlewareResponse(result) ? result : returnedResponse;
 }
 
 function emptyResult(request: Request): ProductionMiddlewareResult {
@@ -628,8 +643,18 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
         ctx.params = { ...ctx.params, ...configMatch.params };
       }
 
-      await executeHandlers(entry.handlers, ctx);
+      const returnedResponse = await executeHandlers(entry.handlers, ctx);
       currentRequest = contextState.getRequest();
+
+      if (returnedResponse) {
+        return {
+          request: currentRequest,
+          response: applyProductionMiddlewareHeaders(returnedResponse, mapToHeaders(ctx.headers)),
+          data: new Map(ctx.data),
+          headers: mapToHeaders(ctx.headers),
+          handled: true,
+        };
+      }
 
       if (ctx._handled) {
         return {

--- a/packages/farm/src/middleware/types.ts
+++ b/packages/farm/src/middleware/types.ts
@@ -10,7 +10,8 @@ import type { ViteDevServer } from "vite";
 /**
  * Next function type for middleware chain
  */
-export type NextFunction = () => Promise<void>;
+export type MiddlewareResult = void | Response;
+export type NextFunction = () => Promise<MiddlewareResult>;
 
 /**
  * Middleware function signature
@@ -18,7 +19,7 @@ export type NextFunction = () => Promise<void>;
 export type MiddlewareFunction = (
   ctx: MiddlewareContext,
   next: NextFunction,
-) => void | Promise<void>;
+) => MiddlewareResult | Promise<MiddlewareResult>;
 
 /**
  * Cookie options


### PR DESCRIPTION
## Summary

- Allow config and app middleware handlers to return a Web `Response` to short-circuit the chain.
- Preserve `ctx.headers` when a returned response is sent in dev and production.
- Document the `Response.redirect(new URL(..., ctx.url))` pattern.

## Validation

- `corepack pnpm --dir packages/farm exec vitest run src/__tests__/middleware.test.ts --config vitest.config.ts`
- `corepack pnpm --dir packages/farm exec vitest run src/__tests__/production-middleware.test.ts --config vitest.config.ts`
- Filtered `corepack pnpm --dir packages/farm run type-check` for touched middleware files produced no touched-file errors. Full type-check still has existing baseline failures outside this PR.