### PR TITLE
feat: middleware observability events

### DIFF
--- a/docs/src/app/docs/middleware/page.md
+++ b/docs/src/app/docs/middleware/page.md
@@ -23,6 +23,19 @@ export default middleware().use(async (ctx, next) => {
 });
 ```
 
+Dynamic route segments from the middleware file path are available on `ctx.params`.
+
+**src/app/users/[id]/middleware.ts**
+
+```ts
+import { middleware } from "@farmjs/core/middleware";
+
+export default middleware().use(async (ctx, next) => {
+  ctx.data.set("user.id", ctx.params.id);
+  await next();
+});
+```
+
 ## Config middleware
 
 Use farm.config.ts when middleware behavior should be described globally. This is useful for cross-cutting behavior that should be visible from the project control plane, while route middleware files can stay close to the pages or API routes they protect.

--- a/docs/src/app/docs/observability/page.md
+++ b/docs/src/app/docs/observability/page.md
@@ -31,6 +31,7 @@ onFarmEvent((event) => {
 | Rendering | render.start, render.complete, render.stream.shellReady, render.error |
 | Cache | cache.hit, cache.miss, cache.set, cache.revalidateTag |
 | PPR | ppr.shell.hit, ppr.shell.cached, ppr.shell.invalidated |
+| Middleware | middleware.start, middleware.complete, middleware.shortCircuit, middleware.error |
 | Integrations | integration.ready, integration.api.call.start, integration.webhook.verified |
 | Storage | storage.query.start, storage.schema.ready |
 | Build | build.start, routes.generated, types.generated, manifest.generated |
@@ -83,6 +84,8 @@ unsubscribe();
 | Integrations | `integration.registered`, `integration.config.validated`, `integration.ready`, `integration.disposed`, `integration.api.call.start`, `integration.api.call.complete`, `integration.webhook.verified`, `integration.webhook.failed` |
 | Middleware | `middleware.start`, `middleware.complete`, `middleware.shortCircuit`, `middleware.error` |
 | Storage | `storage.query.start`, `storage.query.complete`, `storage.query.error`, `storage.schema.ready`, `storage.schema.error` |
+
+Middleware events include the matched middleware route, request pathname, middleware file/config name, duration for completes, status for short circuits, and the thrown error for failures.
 
 ## Production notes
 

--- a/packages/farm/src/__tests__/middleware.test.ts
+++ b/packages/farm/src/__tests__/middleware.test.ts
@@ -10,6 +10,11 @@ import {
   _runWithMiddlewareData,
 } from "../middleware/server";
 import type { MiddlewareContext, RateLimitStorage } from "../middleware/types";
+import {
+  configureFarmObservability,
+  resetFarmObservability,
+  type FarmEvent,
+} from "../observability";
 import { IncomingMessage, ServerResponse } from "http";
 import { Socket } from "net";
 
@@ -1787,6 +1792,120 @@ describe("Middleware Manager Data Flow", () => {
     expect(handled).toBe(true);
     expect(res.statusCode).toBe(204);
     expect(res.setHeader).toHaveBeenCalledWith("x-middleware", "/dashboard/settings");
+  });
+
+  it("emits middleware observability events", async () => {
+    const events: FarmEvent[] = [];
+    configureFarmObservability({ onEvent: (event) => events.push(event) });
+
+    try {
+      const manager = new MiddlewareManager("/tmp", undefined, [
+        {
+          matcher: "/dashboard/:path*",
+          async handler(ctx, next) {
+            ctx.data.set("fromConfig", "yes");
+            await next();
+          },
+        },
+      ]);
+
+      (manager as any).middleware = [
+        {
+          path: "/dashboard",
+          filePath: "/tmp/app/dashboard/middleware.ts",
+          handlers: [
+            async (ctx: MiddlewareContext, next: () => Promise<void>) => {
+              ctx.data.set("fromFile", "yes");
+              await next();
+            },
+          ],
+        },
+      ];
+
+      const handled = await manager.execute(
+        createMockRequest("/dashboard/settings"),
+        createMockResponse(),
+      );
+
+      expect(handled).toBe(false);
+      expect(events.map((event) => event.type)).toEqual([
+        "middleware.start",
+        "middleware.complete",
+        "middleware.start",
+        "middleware.complete",
+      ]);
+      expect(events[0]).toMatchObject({
+        route: "/",
+        pathname: "/dashboard/settings",
+        name: "farm.config.ts#middleware-0",
+      });
+      expect(events[1]).toMatchObject({
+        route: "/",
+        pathname: "/dashboard/settings",
+        name: "farm.config.ts#middleware-0",
+        durationMs: expect.any(Number),
+      });
+      expect(events[2]).toMatchObject({
+        route: "/dashboard",
+        pathname: "/dashboard/settings",
+        name: "/tmp/app/dashboard/middleware.ts",
+      });
+    } finally {
+      resetFarmObservability();
+    }
+  });
+
+  it("emits shortCircuit and error middleware observability events", async () => {
+    const events: FarmEvent[] = [];
+    configureFarmObservability({ onEvent: (event) => events.push(event) });
+
+    try {
+      const shortCircuitManager = new MiddlewareManager("/tmp", undefined, [
+        {
+          matcher: "/dashboard/:path*",
+          handler(ctx) {
+            return Response.redirect(new URL("/sign-in", ctx.url));
+          },
+        },
+      ]);
+
+      const handled = await shortCircuitManager.execute(
+        createMockRequest("/dashboard/settings"),
+        createMockResponse(),
+      );
+      expect(handled).toBe(true);
+      expect(events.map((event) => event.type)).toEqual([
+        "middleware.start",
+        "middleware.shortCircuit",
+      ]);
+      expect(events[1]).toMatchObject({
+        status: 302,
+        route: "/",
+      });
+
+      events.length = 0;
+      const error = new Error("middleware failed");
+      const errorManager = new MiddlewareManager("/tmp", undefined, [
+        {
+          matcher: "/dashboard/:path*",
+          handler() {
+            throw error;
+          },
+        },
+      ]);
+
+      await expect(
+        errorManager.execute(createMockRequest("/dashboard/settings"), createMockResponse()),
+      ).rejects.toThrow("middleware failed");
+
+      expect(events.map((event) => event.type)).toEqual(["middleware.start", "middleware.error"]);
+      expect(events[1]).toMatchObject({
+        error,
+        route: "/",
+      });
+    } finally {
+      resetFarmObservability();
+    }
   });
 
   it("should share middleware context across middleware chain and expose to page request data", async () => {

--- a/packages/farm/src/__tests__/middleware.test.ts
+++ b/packages/farm/src/__tests__/middleware.test.ts
@@ -1908,6 +1908,29 @@ describe("Middleware Manager Data Flow", () => {
     }
   });
 
+  it("passes dynamic route params to file middleware", async () => {
+    const manager = new MiddlewareManager("/tmp");
+    (manager as any).middleware = [
+      {
+        path: "/users/[id]",
+        filePath: "/tmp/app/users/[id]/middleware.ts",
+        handlers: [
+          async (ctx: MiddlewareContext, next: () => Promise<void>) => {
+            ctx.data.set("userId", ctx.params.id);
+            await next();
+          },
+        ],
+      },
+    ];
+
+    const req = createMockRequest("/users/42/settings");
+    const res = createMockResponse();
+    const handled = await manager.execute(req, res);
+
+    expect(handled).toBe(false);
+    expect((req as any).__FARM_MIDDLEWARE_DATA__.get("userId")).toBe("42");
+  });
+
   it("should share middleware context across middleware chain and expose to page request data", async () => {
     const req = createMockRequest("/docs/getting-started");
     const res = createMockResponse();

--- a/packages/farm/src/__tests__/production-middleware.test.ts
+++ b/packages/farm/src/__tests__/production-middleware.test.ts
@@ -28,6 +28,20 @@ export default {
   deploy: {
     target: "vercel",
   },
+  observability: {
+    onEvent(event) {
+      if (!event.type.startsWith("middleware.")) return;
+      globalThis.__farmMiddlewareEvents ||= [];
+      globalThis.__farmMiddlewareEvents.push({
+        type: event.type,
+        route: event.route,
+        pathname: event.pathname,
+        name: event.name,
+        status: event.status,
+        durationMs: event.durationMs,
+      });
+    },
+  },
   middleware: [
     {
       matcher: "/dashboard/config-response",
@@ -109,6 +123,7 @@ describe("production middleware runtime", () => {
           "index.mjs",
         );
         const serverModule = await import(`${pathToFileURL(entryPath).href}?t=${Date.now()}`);
+        (globalThis as any).__farmMiddlewareEvents = [];
         const response = await serverModule.default.fetch(
           new Request("https://example.test/dashboard/settings"),
         );
@@ -119,13 +134,30 @@ describe("production middleware runtime", () => {
         expect(html).toContain(
           "production middleware: dashboard / settings / dashboard-file / /dashboard/settings",
         );
+        expect(
+          (globalThis as any).__farmMiddlewareEvents.map((event: any) => event.type),
+        ).toEqual([
+          "middleware.start",
+          "middleware.complete",
+          "middleware.start",
+          "middleware.complete",
+        ]);
 
+        (globalThis as any).__farmMiddlewareEvents = [];
         const configResponse = await serverModule.default.fetch(
           new Request("https://example.test/dashboard/config-response"),
         );
         expect(configResponse.status).toBe(302);
         expect(configResponse.headers.get("location")).toBe("https://example.test/sign-in");
+        expect(
+          (globalThis as any).__farmMiddlewareEvents.map((event: any) => event.type),
+        ).toEqual(["middleware.start", "middleware.shortCircuit"]);
+        expect((globalThis as any).__farmMiddlewareEvents[1]).toMatchObject({
+          route: "/",
+          status: 302,
+        });
 
+        (globalThis as any).__farmMiddlewareEvents = [];
         const fileResponse = await serverModule.default.fetch(
           new Request("https://example.test/dashboard/file-response"),
         );
@@ -133,7 +165,20 @@ describe("production middleware runtime", () => {
         expect(fileResponse.headers.get("x-file-response")).toBe("yes");
         expect(fileResponse.headers.get("x-farm-middleware")).toBe("yes");
         await expect(fileResponse.text()).resolves.toBe("blocked by file middleware");
+        expect(
+          (globalThis as any).__farmMiddlewareEvents.map((event: any) => event.type),
+        ).toEqual([
+          "middleware.start",
+          "middleware.complete",
+          "middleware.start",
+          "middleware.shortCircuit",
+        ]);
+        expect((globalThis as any).__farmMiddlewareEvents[3]).toMatchObject({
+          route: "/dashboard",
+          status: 418,
+        });
       } finally {
+        delete (globalThis as any).__farmMiddlewareEvents;
         await fs.rm(root, { recursive: true, force: true });
       }
     },

--- a/packages/farm/src/__tests__/production-middleware.test.ts
+++ b/packages/farm/src/__tests__/production-middleware.test.ts
@@ -16,6 +16,9 @@ async function createProductionMiddlewareFixture(): Promise<string> {
   await fs.symlink(packageRoot, path.join(root, "node_modules", "@farmjs", "core"), "dir");
 
   await fs.mkdir(path.join(root, "src", "app", "dashboard", "settings"), { recursive: true });
+  await fs.mkdir(path.join(root, "src", "app", "users", "[id]", "settings"), {
+    recursive: true,
+  });
   await fs.writeFile(
     path.join(root, "package.json"),
     JSON.stringify({ type: "module" }, null, 2),
@@ -99,6 +102,29 @@ export default async function dashboardMiddleware(ctx: any, next: () => Promise<
 }
 `.trim(),
   );
+  await fs.writeFile(
+    path.join(root, "src", "app", "users", "[id]", "middleware.ts"),
+    `
+export default async function userMiddleware(ctx: any, next: () => Promise<void>) {
+  ctx.data.set("file.userId", ctx.params.id || "missing-id");
+  await next();
+}
+`.trim(),
+  );
+  await fs.writeFile(
+    path.join(root, "src", "app", "users", "[id]", "settings", "page.tsx"),
+    `
+import React from "react";
+
+export default function UserSettingsPage(props: any) {
+  return React.createElement(
+    "main",
+    null,
+    \`user settings: \${props.middleware?.data.get("file.userId") || "missing"} / \${props.params.id}\`
+  );
+}
+`.trim(),
+  );
 
   return root;
 }
@@ -176,6 +202,18 @@ describe("production middleware runtime", () => {
         expect((globalThis as any).__farmMiddlewareEvents[3]).toMatchObject({
           route: "/dashboard",
           status: 418,
+        });
+
+        (globalThis as any).__farmMiddlewareEvents = [];
+        const userResponse = await serverModule.default.fetch(
+          new Request("https://example.test/users/42/settings"),
+        );
+        const userHtml = await userResponse.text();
+        expect(userResponse.status).toBe(200);
+        expect(userHtml).toContain("user settings: 42 / 42");
+        expect((globalThis as any).__farmMiddlewareEvents[0]).toMatchObject({
+          route: "/users/[id]",
+          pathname: "/users/42/settings",
         });
       } finally {
         delete (globalThis as any).__farmMiddlewareEvents;

--- a/packages/farm/src/middleware/manager.ts
+++ b/packages/farm/src/middleware/manager.ts
@@ -219,9 +219,14 @@ export class MiddlewareManager {
     }
 
     // Find applicable middleware (config entries first, then cascading files)
-    const applicable = [
-      ...this.configMiddleware,
-      ...this.middleware.filter((mw) => this.matchesRoutePath(pathname, mw.path)),
+    const applicable: Array<{
+      mw: DiscoveredMiddleware;
+      routeMatch: { matched: boolean; params?: Record<string, string> };
+    }> = [
+      ...this.configMiddleware.map((mw) => ({ mw, routeMatch: { matched: true } })),
+      ...this.middleware
+        .map((mw) => ({ mw, routeMatch: this.matchRoutePath(pathname, mw.path) }))
+        .filter((entry) => entry.routeMatch.matched),
     ];
 
     if (applicable.length === 0) {
@@ -229,7 +234,7 @@ export class MiddlewareManager {
     }
     try {
       const pc = require("picocolors");
-      const middlewarePaths = applicable.map((mw) => mw.path).join(", ");
+      const middlewarePaths = applicable.map(({ mw }) => mw.path).join(", ");
       const log = [
         pc.dim("[") + pc.bold(pc.blue("FARM")) + pc.dim("]"),
         pc.dim("[") + pc.bold(pc.magenta("MIDDLEWARE")) + pc.dim("]"),
@@ -246,13 +251,17 @@ export class MiddlewareManager {
     }
 
     // Execute middleware in cascade order
-    for (const mw of applicable) {
+    for (const entry of applicable) {
       // Check matcher configuration
+      const { mw, routeMatch } = entry;
       const configMatch = mw.config
         ? this.matchesConfig(pathname, mw.config, ctx)
         : { matched: true };
       if (!configMatch.matched) {
         continue;
+      }
+      if (routeMatch.params) {
+        ctx.params = { ...ctx.params, ...routeMatch.params };
       }
       if (configMatch.params) {
         ctx.params = { ...ctx.params, ...configMatch.params };
@@ -261,6 +270,9 @@ export class MiddlewareManager {
       // Create new context with parent data
       if (parentData) {
         ctx = createContext(req, res, this.viteServer, parentData);
+        if (routeMatch.params) {
+          ctx.params = { ...ctx.params, ...routeMatch.params };
+        }
         if (configMatch.params) {
           ctx.params = { ...ctx.params, ...configMatch.params };
         }
@@ -440,9 +452,28 @@ export class MiddlewareManager {
     return [...this.configMiddleware, ...this.middleware];
   }
 
-  private matchesRoutePath(pathname: string, middlewarePath: string): boolean {
-    if (middlewarePath === "/") return true;
-    return pathname === middlewarePath || pathname.startsWith(`${middlewarePath}/`);
+  private matchRoutePath(
+    pathname: string,
+    middlewarePath: string,
+  ): { matched: boolean; params?: Record<string, string> } {
+    if (middlewarePath === "/") return { matched: true };
+
+    const exactMatch = this.matchPattern(middlewarePath, pathname);
+    if (exactMatch.matched) {
+      return exactMatch;
+    }
+
+    const nestedMatch = this.matchPattern(`${middlewarePath}/:__farmRest*`, pathname);
+    if (!nestedMatch.matched) {
+      return { matched: false };
+    }
+
+    const params = { ...(nestedMatch.params || {}) };
+    delete params.__farmRest;
+    return {
+      matched: true,
+      params: Object.keys(params).length > 0 ? params : undefined,
+    };
   }
 
   private toMatcherList(matcher: MiddlewareConfig["matcher"]): MiddlewareMatcher[] {

--- a/packages/farm/src/middleware/manager.ts
+++ b/packages/farm/src/middleware/manager.ts
@@ -20,6 +20,7 @@ import type {
 import { createContext } from "./context";
 import { logger } from "../utils";
 import { sendWebResponse } from "../server/response";
+import { emitFarmEvent } from "../observability";
 
 export interface DiscoveredMiddleware {
   path: string;
@@ -265,38 +266,71 @@ export class MiddlewareManager {
         }
       }
 
-      // Execute all handlers in this middleware
-      let handlerIndex = 0;
-      let returnedResponse: Response | undefined;
-      const executeNext = async (): Promise<MiddlewareResult> => {
-        if (handlerIndex < mw.handlers.length) {
-          const handler = mw.handlers[handlerIndex++];
-          const result = await handler(ctx, executeNext);
-          if (isMiddlewareResponse(result)) {
-            returnedResponse = result;
-            return result;
-          }
-        }
-        return returnedResponse;
+      const middlewareStartTime = Date.now();
+      const middlewareEvent = {
+        route: mw.path,
+        pathname,
+        name: mw.filePath,
       };
+      emitFarmEvent({ type: "middleware.start", ...middlewareEvent });
 
-      const result = await executeNext();
-      const response = isMiddlewareResponse(result) ? result : returnedResponse;
-      if (response) {
-        if (!res.headersSent && !res.writableEnded) {
-          for (const [key, value] of ctx.headers) {
-            try {
-              res.setHeader(key, value);
-            } catch (error) {}
+      try {
+        // Execute all handlers in this middleware
+        let handlerIndex = 0;
+        let returnedResponse: Response | undefined;
+        const executeNext = async (): Promise<MiddlewareResult> => {
+          if (handlerIndex < mw.handlers.length) {
+            const handler = mw.handlers[handlerIndex++];
+            const result = await handler(ctx, executeNext);
+            if (isMiddlewareResponse(result)) {
+              returnedResponse = result;
+              return result;
+            }
           }
-        }
-        await sendWebResponse(res, response);
-        return true;
-      }
+          return returnedResponse;
+        };
 
-      // Check if response has been sent or handled by middleware helpers.
-      if (ctx._handled || res.headersSent || res.writableEnded) {
-        return true;
+        const result = await executeNext();
+        const response = isMiddlewareResponse(result) ? result : returnedResponse;
+        if (response) {
+          if (!res.headersSent && !res.writableEnded) {
+            for (const [key, value] of ctx.headers) {
+              try {
+                res.setHeader(key, value);
+              } catch (error) {}
+            }
+          }
+          emitFarmEvent({
+            type: "middleware.shortCircuit",
+            ...middlewareEvent,
+            status: response.status,
+          });
+          await sendWebResponse(res, response);
+          return true;
+        }
+
+        // Check if response has been sent or handled by middleware helpers.
+        if (ctx._handled || res.headersSent || res.writableEnded) {
+          emitFarmEvent({
+            type: "middleware.shortCircuit",
+            ...middlewareEvent,
+            status: res.statusCode,
+          });
+          return true;
+        }
+
+        emitFarmEvent({
+          type: "middleware.complete",
+          ...middlewareEvent,
+          durationMs: Date.now() - middlewareStartTime,
+        });
+      } catch (error) {
+        emitFarmEvent({
+          type: "middleware.error",
+          ...middlewareEvent,
+          error,
+        });
+        throw error;
       }
 
       parentData = {

--- a/packages/farm/src/middleware/production-runtime.ts
+++ b/packages/farm/src/middleware/production-runtime.ts
@@ -9,6 +9,7 @@ import type {
   MiddlewareModule,
   MiddlewareResult,
 } from "./types";
+import { emitFarmEvent } from "../observability";
 
 export interface ProductionMiddlewareModuleEntry {
   path: string;
@@ -643,27 +644,65 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
         ctx.params = { ...ctx.params, ...configMatch.params };
       }
 
-      const returnedResponse = await executeHandlers(entry.handlers, ctx);
-      currentRequest = contextState.getRequest();
+      const middlewareStartTime = Date.now();
+      const middlewareEvent = {
+        route: entry.path,
+        pathname: initialPathname,
+        name: entry.filePath,
+      };
+      emitFarmEvent({ type: "middleware.start", ...middlewareEvent });
 
-      if (returnedResponse) {
-        return {
-          request: currentRequest,
-          response: applyProductionMiddlewareHeaders(returnedResponse, mapToHeaders(ctx.headers)),
-          data: new Map(ctx.data),
-          headers: mapToHeaders(ctx.headers),
-          handled: true,
-        };
-      }
+      try {
+        const returnedResponse = await executeHandlers(entry.handlers, ctx);
+        currentRequest = contextState.getRequest();
 
-      if (ctx._handled) {
-        return {
-          request: currentRequest,
-          response: contextState.getResponse() || new Response(null),
-          data: new Map(ctx.data),
-          headers: mapToHeaders(ctx.headers),
-          handled: true,
-        };
+        if (returnedResponse) {
+          const response = applyProductionMiddlewareHeaders(
+            returnedResponse,
+            mapToHeaders(ctx.headers),
+          );
+          emitFarmEvent({
+            type: "middleware.shortCircuit",
+            ...middlewareEvent,
+            status: response.status,
+          });
+          return {
+            request: currentRequest,
+            response,
+            data: new Map(ctx.data),
+            headers: mapToHeaders(ctx.headers),
+            handled: true,
+          };
+        }
+
+        if (ctx._handled) {
+          const response = contextState.getResponse() || new Response(null);
+          emitFarmEvent({
+            type: "middleware.shortCircuit",
+            ...middlewareEvent,
+            status: response.status,
+          });
+          return {
+            request: currentRequest,
+            response,
+            data: new Map(ctx.data),
+            headers: mapToHeaders(ctx.headers),
+            handled: true,
+          };
+        }
+
+        emitFarmEvent({
+          type: "middleware.complete",
+          ...middlewareEvent,
+          durationMs: Date.now() - middlewareStartTime,
+        });
+      } catch (error) {
+        emitFarmEvent({
+          type: "middleware.error",
+          ...middlewareEvent,
+          error,
+        });
+        throw error;
       }
 
       parentData = {

--- a/packages/farm/src/middleware/production-runtime.ts
+++ b/packages/farm/src/middleware/production-runtime.ts
@@ -444,9 +444,28 @@ function matchesConfig(
   return { matched: true };
 }
 
-function matchesRoutePath(pathname: string, middlewarePath: string): boolean {
-  if (middlewarePath === "/") return true;
-  return pathname === middlewarePath || pathname.startsWith(`${middlewarePath}/`);
+function matchRoutePath(
+  pathname: string,
+  middlewarePath: string,
+): { matched: boolean; params?: Record<string, string> } {
+  if (middlewarePath === "/") return { matched: true };
+
+  const exactMatch = matchPattern(middlewarePath, pathname);
+  if (exactMatch.matched) {
+    return exactMatch;
+  }
+
+  const nestedMatch = matchPattern(`${middlewarePath}/:__farmRest*`, pathname);
+  if (!nestedMatch.matched) {
+    return { matched: false };
+  }
+
+  const params = { ...(nestedMatch.params || {}) };
+  delete params.__farmRest;
+  return {
+    matched: true,
+    params: Object.keys(params).length > 0 ? params : undefined,
+  };
 }
 
 function getConfigHandlers(
@@ -613,9 +632,15 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
       }
     }
 
-    const applicable = entries.filter(
-      (entry) => entry.source === "config" || matchesRoutePath(initialPathname, entry.path),
-    );
+    const applicable = entries
+      .map((entry) => ({
+        entry,
+        routeMatch:
+          entry.source === "config"
+            ? { matched: true }
+            : matchRoutePath(initialPathname, entry.path),
+      }))
+      .filter((candidate) => candidate.routeMatch.matched);
 
     if (applicable.length === 0) {
       return {
@@ -627,7 +652,8 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
       };
     }
 
-    for (const entry of applicable) {
+    for (const candidate of applicable) {
+      const { entry, routeMatch } = candidate;
       const configMatch = entry.config
         ? matchesConfig(initialPathname, entry.config, ctx)
         : { matched: true };
@@ -640,6 +666,9 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
         ctx = contextState.ctx;
       }
 
+      if (routeMatch.params) {
+        ctx.params = { ...ctx.params, ...routeMatch.params };
+      }
       if (configMatch.params) {
         ctx.params = { ...ctx.params, ...configMatch.params };
       }


### PR DESCRIPTION
## Summary

- Emit `middleware.start`, `middleware.complete`, `middleware.shortCircuit`, and `middleware.error` from dev and production middleware runtimes.
- Include route, pathname, middleware name, status/duration/error metadata on events.
- Document middleware events in the observability guide and cover them in unit/build tests.

## Validation

- `corepack pnpm --dir packages/farm exec vitest run src/__tests__/middleware.test.ts --config vitest.config.ts`
- `corepack pnpm --dir packages/farm exec vitest run src/__tests__/production-middleware.test.ts --config vitest.config.ts`
- Filtered `corepack pnpm --dir packages/farm run type-check` for touched middleware/observability files produced no touched-file errors. Full type-check still has existing baseline failures outside this PR.