### PR TITLE
feat: route params for file middleware

### DIFF
--- a/docs/src/app/docs/middleware/page.md
+++ b/docs/src/app/docs/middleware/page.md
@@ -23,6 +23,19 @@ export default middleware().use(async (ctx, next) => {
 });
 ```
 
+Dynamic route segments from the middleware file path are available on `ctx.params`.
+
+**src/app/users/[id]/middleware.ts**
+
+```ts
+import { middleware } from "@farmjs/core/middleware";
+
+export default middleware().use(async (ctx, next) => {
+  ctx.data.set("user.id", ctx.params.id);
+  await next();
+});
+```
+
 ## Config middleware
 
 Use farm.config.ts when middleware behavior should be described globally. This is useful for cross-cutting behavior that should be visible from the project control plane, while route middleware files can stay close to the pages or API routes they protect.

--- a/packages/farm/src/__tests__/middleware.test.ts
+++ b/packages/farm/src/__tests__/middleware.test.ts
@@ -1908,6 +1908,29 @@ describe("Middleware Manager Data Flow", () => {
     }
   });
 
+  it("passes dynamic route params to file middleware", async () => {
+    const manager = new MiddlewareManager("/tmp");
+    (manager as any).middleware = [
+      {
+        path: "/users/[id]",
+        filePath: "/tmp/app/users/[id]/middleware.ts",
+        handlers: [
+          async (ctx: MiddlewareContext, next: () => Promise<void>) => {
+            ctx.data.set("userId", ctx.params.id);
+            await next();
+          },
+        ],
+      },
+    ];
+
+    const req = createMockRequest("/users/42/settings");
+    const res = createMockResponse();
+    const handled = await manager.execute(req, res);
+
+    expect(handled).toBe(false);
+    expect((req as any).__FARM_MIDDLEWARE_DATA__.get("userId")).toBe("42");
+  });
+
   it("should share middleware context across middleware chain and expose to page request data", async () => {
     const req = createMockRequest("/docs/getting-started");
     const res = createMockResponse();

--- a/packages/farm/src/__tests__/production-middleware.test.ts
+++ b/packages/farm/src/__tests__/production-middleware.test.ts
@@ -16,6 +16,9 @@ async function createProductionMiddlewareFixture(): Promise<string> {
   await fs.symlink(packageRoot, path.join(root, "node_modules", "@farmjs", "core"), "dir");
 
   await fs.mkdir(path.join(root, "src", "app", "dashboard", "settings"), { recursive: true });
+  await fs.mkdir(path.join(root, "src", "app", "users", "[id]", "settings"), {
+    recursive: true,
+  });
   await fs.writeFile(
     path.join(root, "package.json"),
     JSON.stringify({ type: "module" }, null, 2),
@@ -99,6 +102,29 @@ export default async function dashboardMiddleware(ctx: any, next: () => Promise<
 }
 `.trim(),
   );
+  await fs.writeFile(
+    path.join(root, "src", "app", "users", "[id]", "middleware.ts"),
+    `
+export default async function userMiddleware(ctx: any, next: () => Promise<void>) {
+  ctx.data.set("file.userId", ctx.params.id || "missing-id");
+  await next();
+}
+`.trim(),
+  );
+  await fs.writeFile(
+    path.join(root, "src", "app", "users", "[id]", "settings", "page.tsx"),
+    `
+import React from "react";
+
+export default function UserSettingsPage(props: any) {
+  return React.createElement(
+    "main",
+    null,
+    \`user settings: \${props.middleware?.data.get("file.userId") || "missing"} / \${props.params.id}\`
+  );
+}
+`.trim(),
+  );
 
   return root;
 }
@@ -176,6 +202,18 @@ describe("production middleware runtime", () => {
         expect((globalThis as any).__farmMiddlewareEvents[3]).toMatchObject({
           route: "/dashboard",
           status: 418,
+        });
+
+        (globalThis as any).__farmMiddlewareEvents = [];
+        const userResponse = await serverModule.default.fetch(
+          new Request("https://example.test/users/42/settings"),
+        );
+        const userHtml = await userResponse.text();
+        expect(userResponse.status).toBe(200);
+        expect(userHtml).toContain("user settings: 42 / 42");
+        expect((globalThis as any).__farmMiddlewareEvents[0]).toMatchObject({
+          route: "/users/[id]",
+          pathname: "/users/42/settings",
         });
       } finally {
         delete (globalThis as any).__farmMiddlewareEvents;

--- a/packages/farm/src/middleware/manager.ts
+++ b/packages/farm/src/middleware/manager.ts
@@ -219,9 +219,14 @@ export class MiddlewareManager {
     }
 
     // Find applicable middleware (config entries first, then cascading files)
-    const applicable = [
-      ...this.configMiddleware,
-      ...this.middleware.filter((mw) => this.matchesRoutePath(pathname, mw.path)),
+    const applicable: Array<{
+      mw: DiscoveredMiddleware;
+      routeMatch: { matched: boolean; params?: Record<string, string> };
+    }> = [
+      ...this.configMiddleware.map((mw) => ({ mw, routeMatch: { matched: true } })),
+      ...this.middleware
+        .map((mw) => ({ mw, routeMatch: this.matchRoutePath(pathname, mw.path) }))
+        .filter((entry) => entry.routeMatch.matched),
     ];
 
     if (applicable.length === 0) {
@@ -229,7 +234,7 @@ export class MiddlewareManager {
     }
     try {
       const pc = require("picocolors");
-      const middlewarePaths = applicable.map((mw) => mw.path).join(", ");
+      const middlewarePaths = applicable.map(({ mw }) => mw.path).join(", ");
       const log = [
         pc.dim("[") + pc.bold(pc.blue("FARM")) + pc.dim("]"),
         pc.dim("[") + pc.bold(pc.magenta("MIDDLEWARE")) + pc.dim("]"),
@@ -246,13 +251,17 @@ export class MiddlewareManager {
     }
 
     // Execute middleware in cascade order
-    for (const mw of applicable) {
+    for (const entry of applicable) {
       // Check matcher configuration
+      const { mw, routeMatch } = entry;
       const configMatch = mw.config
         ? this.matchesConfig(pathname, mw.config, ctx)
         : { matched: true };
       if (!configMatch.matched) {
         continue;
+      }
+      if (routeMatch.params) {
+        ctx.params = { ...ctx.params, ...routeMatch.params };
       }
       if (configMatch.params) {
         ctx.params = { ...ctx.params, ...configMatch.params };
@@ -261,6 +270,9 @@ export class MiddlewareManager {
       // Create new context with parent data
       if (parentData) {
         ctx = createContext(req, res, this.viteServer, parentData);
+        if (routeMatch.params) {
+          ctx.params = { ...ctx.params, ...routeMatch.params };
+        }
         if (configMatch.params) {
           ctx.params = { ...ctx.params, ...configMatch.params };
         }
@@ -440,9 +452,28 @@ export class MiddlewareManager {
     return [...this.configMiddleware, ...this.middleware];
   }
 
-  private matchesRoutePath(pathname: string, middlewarePath: string): boolean {
-    if (middlewarePath === "/") return true;
-    return pathname === middlewarePath || pathname.startsWith(`${middlewarePath}/`);
+  private matchRoutePath(
+    pathname: string,
+    middlewarePath: string,
+  ): { matched: boolean; params?: Record<string, string> } {
+    if (middlewarePath === "/") return { matched: true };
+
+    const exactMatch = this.matchPattern(middlewarePath, pathname);
+    if (exactMatch.matched) {
+      return exactMatch;
+    }
+
+    const nestedMatch = this.matchPattern(`${middlewarePath}/:__farmRest*`, pathname);
+    if (!nestedMatch.matched) {
+      return { matched: false };
+    }
+
+    const params = { ...(nestedMatch.params || {}) };
+    delete params.__farmRest;
+    return {
+      matched: true,
+      params: Object.keys(params).length > 0 ? params : undefined,
+    };
   }
 
   private toMatcherList(matcher: MiddlewareConfig["matcher"]): MiddlewareMatcher[] {

--- a/packages/farm/src/middleware/production-runtime.ts
+++ b/packages/farm/src/middleware/production-runtime.ts
@@ -444,9 +444,28 @@ function matchesConfig(
   return { matched: true };
 }
 
-function matchesRoutePath(pathname: string, middlewarePath: string): boolean {
-  if (middlewarePath === "/") return true;
-  return pathname === middlewarePath || pathname.startsWith(`${middlewarePath}/`);
+function matchRoutePath(
+  pathname: string,
+  middlewarePath: string,
+): { matched: boolean; params?: Record<string, string> } {
+  if (middlewarePath === "/") return { matched: true };
+
+  const exactMatch = matchPattern(middlewarePath, pathname);
+  if (exactMatch.matched) {
+    return exactMatch;
+  }
+
+  const nestedMatch = matchPattern(`${middlewarePath}/:__farmRest*`, pathname);
+  if (!nestedMatch.matched) {
+    return { matched: false };
+  }
+
+  const params = { ...(nestedMatch.params || {}) };
+  delete params.__farmRest;
+  return {
+    matched: true,
+    params: Object.keys(params).length > 0 ? params : undefined,
+  };
 }
 
 function getConfigHandlers(
@@ -613,9 +632,15 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
       }
     }
 
-    const applicable = entries.filter(
-      (entry) => entry.source === "config" || matchesRoutePath(initialPathname, entry.path),
-    );
+    const applicable = entries
+      .map((entry) => ({
+        entry,
+        routeMatch:
+          entry.source === "config"
+            ? { matched: true }
+            : matchRoutePath(initialPathname, entry.path),
+      }))
+      .filter((candidate) => candidate.routeMatch.matched);
 
     if (applicable.length === 0) {
       return {
@@ -627,7 +652,8 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
       };
     }
 
-    for (const entry of applicable) {
+    for (const candidate of applicable) {
+      const { entry, routeMatch } = candidate;
       const configMatch = entry.config
         ? matchesConfig(initialPathname, entry.config, ctx)
         : { matched: true };
@@ -640,6 +666,9 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
         ctx = contextState.ctx;
       }
 
+      if (routeMatch.params) {
+        ctx.params = { ...ctx.params, ...routeMatch.params };
+      }
       if (configMatch.params) {
         ctx.params = { ...ctx.params, ...configMatch.params };
       }


### PR DESCRIPTION
## Summary

- Extract params from dynamic file middleware routes such as `src/app/users/[id]/middleware.ts`.
- Apply those params in both dev and production middleware runtimes, including nested paths below the middleware route.
- Document `ctx.params` for route-scoped middleware and cover it in unit/build tests.

## Validation

- `corepack pnpm --dir packages/farm exec vitest run src/__tests__/middleware.test.ts --config vitest.config.ts`
- `corepack pnpm --dir packages/farm exec vitest run src/__tests__/production-middleware.test.ts --config vitest.config.ts`
- Filtered `corepack pnpm --dir packages/farm run type-check` for touched middleware files produced no touched-file errors. Full type-check still has existing baseline failures outside this PR.