### PR TITLE
feat: add middleware behavior

### DIFF
--- a/docs/src/app/docs/middleware/page.md
+++ b/docs/src/app/docs/middleware/page.md
@@ -8,6 +8,21 @@ section: "Core"
 
 Run request behavior before routes, pass request-scoped data to pages, and short-circuit with redirects or responses.
 
+## Runtime behavior
+
+Farm runs middleware in development and production builds. For every request, Farm finds matching `farm.config.ts` middleware entries first, then matching `src/app/**/middleware.ts` files from the root segment down to the route segment.
+
+The chain stops when a middleware handler returns a Web `Response` or uses a short-circuit helper such as `ctx.redirect()`. Otherwise, each handler should call `await next()` to continue to the next middleware and route handler.
+
+Data and headers written during middleware are request-scoped:
+
+| API | Result |
+| --- | --- |
+| `ctx.data.set(key, value)` | Passes data to later middleware and page props. |
+| `ctx.headers.set(name, value)` | Adds headers to the final response. |
+| `ctx.params` | Contains params from the matched config matcher or route-scoped middleware path. |
+| `return new Response(...)` | Stops the chain and sends that response immediately. |
+
 ## Route middleware
 
 Middleware can live near the routes it protects. Use it for auth, request metadata, A/B flags, rate limit checks, or headers that belong to an area of the app.
@@ -40,7 +55,7 @@ export default middleware().use(async (ctx, next) => {
 
 Use farm.config.ts when middleware behavior should be described globally. This is useful for cross-cutting behavior that should be visible from the project control plane, while route middleware files can stay close to the pages or API routes they protect.
 
-Config middleware supports two shapes:
+Config middleware supports matcher-only gates and handler entries. A matcher can be a single matcher or a list of matchers. When a matcher meets the request path, Farm calls that entry's handler.
 
 | Shape                                | Behavior                                                               |
 | ------------------------------------ | ---------------------------------------------------------------------- |
@@ -60,6 +75,31 @@ export default defineFarmConfig({
       matcher: ["/dashboard/:path*"],
       async handler(ctx, next) {
         ctx.data.set("area", "dashboard");
+        await next();
+      },
+    },
+  ],
+});
+```
+
+Multiple config middleware entries can match the same request. They run in array order before file middleware.
+
+```ts
+import { defineFarmConfig } from "@farmjs/core";
+
+export default defineFarmConfig({
+  middleware: [
+    {
+      matcher: ["/dashboard/:path*", "/account/:path*"],
+      async handler(ctx, next) {
+        ctx.data.set("area", "private");
+        await next();
+      },
+    },
+    {
+      matcher: "/dashboard/reports/:path*",
+      async handler(ctx, next) {
+        ctx.data.set("reports", true);
         await next();
       },
     },
@@ -179,6 +219,22 @@ export default defineFarmConfig({
 });
 ```
 
+This works from route-scoped middleware too.
+
+**src/app/dashboard/middleware.ts**
+
+```ts
+export default async function dashboardMiddleware(ctx: any, next: () => Promise<void>) {
+  const session = await readSession(ctx.request);
+
+  if (!session) {
+    return Response.redirect(new URL("/sign-in", ctx.url));
+  }
+
+  await next();
+}
+```
+
 **src/app/dashboard/page.tsx**
 
 ```tsx
@@ -189,6 +245,48 @@ export default function DashboardPage(props: PageProps) {
   return <main>User {userId}</main>;
 }
 ```
+
+## Observability events
+
+Middleware emits observability events in development and production. Subscribe with `observability.onEvent` in `farm.config.ts` or `onFarmEvent` from `@farmjs/core/observability`.
+
+| Event | Emitted when | Useful fields |
+| --- | --- | --- |
+| `middleware.start` | A matching middleware handler starts. | `route`, `pathname`, `name` |
+| `middleware.complete` | A handler calls through and completes. | `route`, `pathname`, `name`, `durationMs` |
+| `middleware.shortCircuit` | A handler returns or creates a response before the route runs. | `route`, `pathname`, `name`, `status` |
+| `middleware.error` | A handler throws. | `route`, `pathname`, `name`, `error` |
+
+```ts
+import { defineFarmConfig } from "@farmjs/core";
+
+export default defineFarmConfig({
+  observability: {
+    onEvent(event) {
+      if (event.type.startsWith("middleware.")) {
+        console.log(event.type, event.pathname, event.name);
+      }
+    },
+  },
+});
+```
+
+See `/docs/observability` for the full event model.
+
+## Test fixture pattern
+
+The production middleware runtime is easiest to verify with a tiny app fixture that builds the app, imports the generated server entry, and sends real `Request` objects through it. A complete fixture should cover:
+
+| Behavior | What to assert |
+| --- | --- |
+| Config middleware | A `farm.config.ts` matcher runs and writes `ctx.data`. |
+| File middleware | A `src/app/**/middleware.ts` file runs for its route area. |
+| Short-circuiting | A returned `Response` status, body, and headers are preserved. |
+| Data passing | Page props include values written to `ctx.data`. |
+| Route params | Dynamic file middleware sees values such as `ctx.params.id`. |
+| Events | The expected `middleware.*` events are emitted in order. |
+
+Farm's own test suite keeps this as a reusable helper at `packages/farm/src/__tests__/fixtures/middleware-production-fixture.ts`.
 
 ## Common uses
 
@@ -201,6 +299,7 @@ export default function DashboardPage(props: PageProps) {
 
 ## Production notes
 
+- `farm.config.ts` middleware and `src/app/**/middleware.ts` files both run in production builds.
 - Keep secrets server-only inside middleware.
 - Expose only the page data the route actually needs.
 - Prefer integration middleware when a provider owns the behavior, such as auth or API key checks.

--- a/docs/src/app/docs/observability/page.md
+++ b/docs/src/app/docs/observability/page.md
@@ -87,6 +87,31 @@ unsubscribe();
 
 Middleware events include the matched middleware route, request pathname, middleware file/config name, duration for completes, status for short circuits, and the thrown error for failures.
 
+## Middleware event payloads
+
+Middleware events are emitted for both `farm.config.ts` middleware entries and `src/app/**/middleware.ts` files in development and production.
+
+| Event | Payload |
+| --- | --- |
+| `middleware.start` | `route`, `pathname`, `name` |
+| `middleware.complete` | `route`, `pathname`, `name`, `durationMs` |
+| `middleware.shortCircuit` | `route`, `pathname`, `name`, `status` |
+| `middleware.error` | `route`, `pathname`, `name`, `error` |
+
+```ts
+import { defineFarmConfig } from "@farmjs/core";
+
+export default defineFarmConfig({
+  observability: {
+    onEvent(event) {
+      if (event.type === "middleware.shortCircuit") {
+        console.log(event.pathname, event.status);
+      }
+    },
+  },
+});
+```
+
 ## Production notes
 
 - Filter high-volume events before shipping them to a log drain.


### PR DESCRIPTION
## Summary

- Document the full middleware runtime behavior across development and production builds.
- Clarify config middleware matcher lists, handler ordering, returned `Response` short-circuiting, middleware data/headers, and route params.
- Add middleware observability event payload details and a production fixture testing checklist.

## Validation

- `PATH=/opt/homebrew/bin:$PATH corepack pnpm --dir docs build`

Note: `corepack pnpm --dir docs build` initially picked up a pnpm 11 binary from the runtime inside nested scripts and failed before docs validation. Re-running with the Corepack shim path first used the repo's `pnpm@8.12.1` and passed.