### PR TITLE
feat: improve middleware runtime behavior

### DIFF
--- a/docs/src/app/docs/middleware/page.md
+++ b/docs/src/app/docs/middleware/page.md
@@ -8,6 +8,21 @@ section: "Core"
 
 Run request behavior before routes, pass request-scoped data to pages, and short-circuit with redirects or responses.
 
+## Runtime behavior
+
+Farm runs middleware in development and production builds. For every request, Farm finds matching `farm.config.ts` middleware entries first, then matching `src/app/**/middleware.ts` files from the root segment down to the route segment.
+
+The chain stops when a middleware handler returns a Web `Response` or uses a short-circuit helper such as `ctx.redirect()`. Otherwise, each handler should call `await next()` to continue to the next middleware and route handler.
+
+Data and headers written during middleware are request-scoped:
+
+| API | Result |
+| --- | --- |
+| `ctx.data.set(key, value)` | Passes data to later middleware and page props. |
+| `ctx.headers.set(name, value)` | Adds headers to the final response. |
+| `ctx.params` | Contains params from the matched config matcher or route-scoped middleware path. |
+| `return new Response(...)` | Stops the chain and sends that response immediately. |
+
 ## Route middleware
 
 Middleware can live near the routes it protects. Use it for auth, request metadata, A/B flags, rate limit checks, or headers that belong to an area of the app.
@@ -40,7 +55,7 @@ export default middleware().use(async (ctx, next) => {
 
 Use farm.config.ts when middleware behavior should be described globally. This is useful for cross-cutting behavior that should be visible from the project control plane, while route middleware files can stay close to the pages or API routes they protect.
 
-Config middleware supports two shapes:
+Config middleware supports matcher-only gates and handler entries. A matcher can be a single matcher or a list of matchers. When a matcher meets the request path, Farm calls that entry's handler.
 
 | Shape                                | Behavior                                                               |
 | ------------------------------------ | ---------------------------------------------------------------------- |
@@ -60,6 +75,31 @@ export default defineFarmConfig({
       matcher: ["/dashboard/:path*"],
       async handler(ctx, next) {
         ctx.data.set("area", "dashboard");
+        await next();
+      },
+    },
+  ],
+});
+```
+
+Multiple config middleware entries can match the same request. They run in array order before file middleware.
+
+```ts
+import { defineFarmConfig } from "@farmjs/core";
+
+export default defineFarmConfig({
+  middleware: [
+    {
+      matcher: ["/dashboard/:path*", "/account/:path*"],
+      async handler(ctx, next) {
+        ctx.data.set("area", "private");
+        await next();
+      },
+    },
+    {
+      matcher: "/dashboard/reports/:path*",
+      async handler(ctx, next) {
+        ctx.data.set("reports", true);
         await next();
       },
     },
@@ -179,6 +219,22 @@ export default defineFarmConfig({
 });
 ```
 
+This works from route-scoped middleware too.
+
+**src/app/dashboard/middleware.ts**
+
+```ts
+export default async function dashboardMiddleware(ctx: any, next: () => Promise<void>) {
+  const session = await readSession(ctx.request);
+
+  if (!session) {
+    return Response.redirect(new URL("/sign-in", ctx.url));
+  }
+
+  await next();
+}
+```
+
 **src/app/dashboard/page.tsx**
 
 ```tsx
@@ -189,6 +245,48 @@ export default function DashboardPage(props: PageProps) {
   return <main>User {userId}</main>;
 }
 ```
+
+## Observability events
+
+Middleware emits observability events in development and production. Subscribe with `observability.onEvent` in `farm.config.ts` or `onFarmEvent` from `@farmjs/core/observability`.
+
+| Event | Emitted when | Useful fields |
+| --- | --- | --- |
+| `middleware.start` | A matching middleware handler starts. | `route`, `pathname`, `name` |
+| `middleware.complete` | A handler calls through and completes. | `route`, `pathname`, `name`, `durationMs` |
+| `middleware.shortCircuit` | A handler returns or creates a response before the route runs. | `route`, `pathname`, `name`, `status` |
+| `middleware.error` | A handler throws. | `route`, `pathname`, `name`, `error` |
+
+```ts
+import { defineFarmConfig } from "@farmjs/core";
+
+export default defineFarmConfig({
+  observability: {
+    onEvent(event) {
+      if (event.type.startsWith("middleware.")) {
+        console.log(event.type, event.pathname, event.name);
+      }
+    },
+  },
+});
+```
+
+See `/docs/observability` for the full event model.
+
+## Test fixture pattern
+
+The production middleware runtime is easiest to verify with a tiny app fixture that builds the app, imports the generated server entry, and sends real `Request` objects through it. A complete fixture should cover:
+
+| Behavior | What to assert |
+| --- | --- |
+| Config middleware | A `farm.config.ts` matcher runs and writes `ctx.data`. |
+| File middleware | A `src/app/**/middleware.ts` file runs for its route area. |
+| Short-circuiting | A returned `Response` status, body, and headers are preserved. |
+| Data passing | Page props include values written to `ctx.data`. |
+| Route params | Dynamic file middleware sees values such as `ctx.params.id`. |
+| Events | The expected `middleware.*` events are emitted in order. |
+
+Farm's own test suite keeps this as a reusable helper at `packages/farm/src/__tests__/fixtures/middleware-production-fixture.ts`.
 
 ## Common uses
 
@@ -201,6 +299,7 @@ export default function DashboardPage(props: PageProps) {
 
 ## Production notes
 
+- `farm.config.ts` middleware and `src/app/**/middleware.ts` files both run in production builds.
 - Keep secrets server-only inside middleware.
 - Expose only the page data the route actually needs.
 - Prefer integration middleware when a provider owns the behavior, such as auth or API key checks.

--- a/docs/src/app/docs/middleware/page.md
+++ b/docs/src/app/docs/middleware/page.md
@@ -23,6 +23,19 @@ export default middleware().use(async (ctx, next) => {
 });
 ```
 
+Dynamic route segments from the middleware file path are available on `ctx.params`.
+
+**src/app/users/[id]/middleware.ts**
+
+```ts
+import { middleware } from "@farmjs/core/middleware";
+
+export default middleware().use(async (ctx, next) => {
+  ctx.data.set("user.id", ctx.params.id);
+  await next();
+});
+```
+
 ## Config middleware
 
 Use farm.config.ts when middleware behavior should be described globally. This is useful for cross-cutting behavior that should be visible from the project control plane, while route middleware files can stay close to the pages or API routes they protect.

--- a/docs/src/app/docs/middleware/page.md
+++ b/docs/src/app/docs/middleware/page.md
@@ -149,6 +149,23 @@ export default defineFarmConfig({
 });
 ```
 
+Middleware handlers can also return a Web `Response`. Returned responses stop the middleware chain and are sent directly.
+
+```ts
+import { defineFarmConfig } from "@farmjs/core";
+
+export default defineFarmConfig({
+  middleware: [
+    {
+      matcher: "/dashboard/:path*",
+      handler(ctx) {
+        return Response.redirect(new URL("/sign-in", ctx.url));
+      },
+    },
+  ],
+});
+```
+
 **src/app/dashboard/page.tsx**
 
 ```tsx

--- a/docs/src/app/docs/observability/page.md
+++ b/docs/src/app/docs/observability/page.md
@@ -87,6 +87,31 @@ unsubscribe();
 
 Middleware events include the matched middleware route, request pathname, middleware file/config name, duration for completes, status for short circuits, and the thrown error for failures.
 
+## Middleware event payloads
+
+Middleware events are emitted for both `farm.config.ts` middleware entries and `src/app/**/middleware.ts` files in development and production.
+
+| Event | Payload |
+| --- | --- |
+| `middleware.start` | `route`, `pathname`, `name` |
+| `middleware.complete` | `route`, `pathname`, `name`, `durationMs` |
+| `middleware.shortCircuit` | `route`, `pathname`, `name`, `status` |
+| `middleware.error` | `route`, `pathname`, `name`, `error` |
+
+```ts
+import { defineFarmConfig } from "@farmjs/core";
+
+export default defineFarmConfig({
+  observability: {
+    onEvent(event) {
+      if (event.type === "middleware.shortCircuit") {
+        console.log(event.pathname, event.status);
+      }
+    },
+  },
+});
+```
+
 ## Production notes
 
 - Filter high-volume events before shipping them to a log drain.

--- a/docs/src/app/docs/observability/page.md
+++ b/docs/src/app/docs/observability/page.md
@@ -31,6 +31,7 @@ onFarmEvent((event) => {
 | Rendering | render.start, render.complete, render.stream.shellReady, render.error |
 | Cache | cache.hit, cache.miss, cache.set, cache.revalidateTag |
 | PPR | ppr.shell.hit, ppr.shell.cached, ppr.shell.invalidated |
+| Middleware | middleware.start, middleware.complete, middleware.shortCircuit, middleware.error |
 | Integrations | integration.ready, integration.api.call.start, integration.webhook.verified |
 | Storage | storage.query.start, storage.schema.ready |
 | Build | build.start, routes.generated, types.generated, manifest.generated |
@@ -83,6 +84,8 @@ unsubscribe();
 | Integrations | `integration.registered`, `integration.config.validated`, `integration.ready`, `integration.disposed`, `integration.api.call.start`, `integration.api.call.complete`, `integration.webhook.verified`, `integration.webhook.failed` |
 | Middleware | `middleware.start`, `middleware.complete`, `middleware.shortCircuit`, `middleware.error` |
 | Storage | `storage.query.start`, `storage.query.complete`, `storage.query.error`, `storage.schema.ready`, `storage.schema.error` |
+
+Middleware events include the matched middleware route, request pathname, middleware file/config name, duration for completes, status for short circuits, and the thrown error for failures.
 
 ## Production notes
 

--- a/packages/farm/src/__tests__/fixtures/middleware-production-fixture.ts
+++ b/packages/farm/src/__tests__/fixtures/middleware-production-fixture.ts
@@ -1,0 +1,129 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+
+export async function createMiddlewareProductionFixture(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(packageRoot, ".tmp-production-middleware-"));
+
+  await fs.mkdir(path.join(root, "node_modules", "@farmjs"), { recursive: true });
+  await fs.symlink(packageRoot, path.join(root, "node_modules", "@farmjs", "core"), "dir");
+
+  await fs.mkdir(path.join(root, "src", "app", "dashboard", "settings"), { recursive: true });
+  await fs.mkdir(path.join(root, "src", "app", "users", "[id]", "settings"), {
+    recursive: true,
+  });
+  await fs.writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({ type: "module" }, null, 2),
+  );
+  await fs.writeFile(
+    path.join(root, "farm.config.ts"),
+    `
+export default {
+  srcDir: "src",
+  deploy: {
+    target: "vercel",
+  },
+  observability: {
+    onEvent(event) {
+      if (!event.type.startsWith("middleware.")) return;
+      globalThis.__farmMiddlewareEvents ||= [];
+      globalThis.__farmMiddlewareEvents.push({
+        type: event.type,
+        route: event.route,
+        pathname: event.pathname,
+        name: event.name,
+        status: event.status,
+        durationMs: event.durationMs,
+      });
+    },
+  },
+  middleware: [
+    {
+      matcher: "/dashboard/config-response",
+      handler(ctx) {
+        return Response.redirect(new URL("/sign-in", ctx.url));
+      },
+    },
+    {
+      matcher: "/dashboard/:path*",
+      async handler(ctx, next) {
+        ctx.data.set("config.area", "dashboard");
+        ctx.data.set("config.path", ctx.params.path || "");
+        await next();
+      },
+    },
+  ],
+};
+`.trim(),
+  );
+  await fs.writeFile(path.join(root, "src", "app", "globals.css"), "");
+  await fs.writeFile(
+    path.join(root, "src", "app", "dashboard", "settings", "page.tsx"),
+    `
+import React from "react";
+
+export default function DashboardPage(props: any) {
+  const middlewareData = props.middleware?.data;
+  const configArea = middlewareData?.get("config.area") || "missing-config";
+  const configPath = middlewareData?.get("config.path") || "missing-path";
+  const fileArea = middlewareData?.get("file.area") || "missing-file";
+
+  return React.createElement(
+    "main",
+    null,
+    \`production middleware: \${configArea} / \${configPath} / \${fileArea} / \${props.path}\`
+  );
+}
+`.trim(),
+  );
+  await fs.writeFile(
+    path.join(root, "src", "app", "dashboard", "middleware.ts"),
+    `
+export default async function dashboardMiddleware(ctx: any, next: () => Promise<void>) {
+  ctx.data.set("file.area", "dashboard-file");
+  ctx.headers.set("x-farm-middleware", "yes");
+  if (ctx.pathname === "/dashboard/file-response") {
+    return new Response("blocked by file middleware", {
+      status: 418,
+      headers: {
+        "x-file-response": "yes",
+      },
+    });
+  }
+  await next();
+}
+`.trim(),
+  );
+  await fs.writeFile(
+    path.join(root, "src", "app", "users", "[id]", "middleware.ts"),
+    `
+export default async function userMiddleware(ctx: any, next: () => Promise<void>) {
+  ctx.data.set("file.userId", ctx.params.id || "missing-id");
+  await next();
+}
+`.trim(),
+  );
+  await fs.writeFile(
+    path.join(root, "src", "app", "users", "[id]", "settings", "page.tsx"),
+    `
+import React from "react";
+
+export default function UserSettingsPage(props: any) {
+  return React.createElement(
+    "main",
+    null,
+    \`user settings: \${props.middleware?.data.get("file.userId") || "missing"} / \${props.params.id}\`
+  );
+}
+`.trim(),
+  );
+
+  return root;
+}
+
+export async function cleanupMiddlewareProductionFixture(root: string): Promise<void> {
+  await fs.rm(root, { recursive: true, force: true });
+}

--- a/packages/farm/src/__tests__/middleware.test.ts
+++ b/packages/farm/src/__tests__/middleware.test.ts
@@ -10,6 +10,11 @@ import {
   _runWithMiddlewareData,
 } from "../middleware/server";
 import type { MiddlewareContext, RateLimitStorage } from "../middleware/types";
+import {
+  configureFarmObservability,
+  resetFarmObservability,
+  type FarmEvent,
+} from "../observability";
 import { IncomingMessage, ServerResponse } from "http";
 import { Socket } from "net";
 
@@ -1787,6 +1792,120 @@ describe("Middleware Manager Data Flow", () => {
     expect(handled).toBe(true);
     expect(res.statusCode).toBe(204);
     expect(res.setHeader).toHaveBeenCalledWith("x-middleware", "/dashboard/settings");
+  });
+
+  it("emits middleware observability events", async () => {
+    const events: FarmEvent[] = [];
+    configureFarmObservability({ onEvent: (event) => events.push(event) });
+
+    try {
+      const manager = new MiddlewareManager("/tmp", undefined, [
+        {
+          matcher: "/dashboard/:path*",
+          async handler(ctx, next) {
+            ctx.data.set("fromConfig", "yes");
+            await next();
+          },
+        },
+      ]);
+
+      (manager as any).middleware = [
+        {
+          path: "/dashboard",
+          filePath: "/tmp/app/dashboard/middleware.ts",
+          handlers: [
+            async (ctx: MiddlewareContext, next: () => Promise<void>) => {
+              ctx.data.set("fromFile", "yes");
+              await next();
+            },
+          ],
+        },
+      ];
+
+      const handled = await manager.execute(
+        createMockRequest("/dashboard/settings"),
+        createMockResponse(),
+      );
+
+      expect(handled).toBe(false);
+      expect(events.map((event) => event.type)).toEqual([
+        "middleware.start",
+        "middleware.complete",
+        "middleware.start",
+        "middleware.complete",
+      ]);
+      expect(events[0]).toMatchObject({
+        route: "/",
+        pathname: "/dashboard/settings",
+        name: "farm.config.ts#middleware-0",
+      });
+      expect(events[1]).toMatchObject({
+        route: "/",
+        pathname: "/dashboard/settings",
+        name: "farm.config.ts#middleware-0",
+        durationMs: expect.any(Number),
+      });
+      expect(events[2]).toMatchObject({
+        route: "/dashboard",
+        pathname: "/dashboard/settings",
+        name: "/tmp/app/dashboard/middleware.ts",
+      });
+    } finally {
+      resetFarmObservability();
+    }
+  });
+
+  it("emits shortCircuit and error middleware observability events", async () => {
+    const events: FarmEvent[] = [];
+    configureFarmObservability({ onEvent: (event) => events.push(event) });
+
+    try {
+      const shortCircuitManager = new MiddlewareManager("/tmp", undefined, [
+        {
+          matcher: "/dashboard/:path*",
+          handler(ctx) {
+            return Response.redirect(new URL("/sign-in", ctx.url));
+          },
+        },
+      ]);
+
+      const handled = await shortCircuitManager.execute(
+        createMockRequest("/dashboard/settings"),
+        createMockResponse(),
+      );
+      expect(handled).toBe(true);
+      expect(events.map((event) => event.type)).toEqual([
+        "middleware.start",
+        "middleware.shortCircuit",
+      ]);
+      expect(events[1]).toMatchObject({
+        status: 302,
+        route: "/",
+      });
+
+      events.length = 0;
+      const error = new Error("middleware failed");
+      const errorManager = new MiddlewareManager("/tmp", undefined, [
+        {
+          matcher: "/dashboard/:path*",
+          handler() {
+            throw error;
+          },
+        },
+      ]);
+
+      await expect(
+        errorManager.execute(createMockRequest("/dashboard/settings"), createMockResponse()),
+      ).rejects.toThrow("middleware failed");
+
+      expect(events.map((event) => event.type)).toEqual(["middleware.start", "middleware.error"]);
+      expect(events[1]).toMatchObject({
+        error,
+        route: "/",
+      });
+    } finally {
+      resetFarmObservability();
+    }
   });
 
   it("should share middleware context across middleware chain and expose to page request data", async () => {

--- a/packages/farm/src/__tests__/middleware.test.ts
+++ b/packages/farm/src/__tests__/middleware.test.ts
@@ -1742,6 +1742,53 @@ describe("Middleware Manager Data Flow", () => {
     expect(res.end).toHaveBeenCalledWith("blocked");
   });
 
+  it("returns handled when config middleware returns a Response", async () => {
+    const manager = new MiddlewareManager("/tmp", undefined, [
+      {
+        matcher: "/dashboard/:path*",
+        handler(ctx) {
+          return Response.redirect(new URL("/sign-in", ctx.url));
+        },
+      },
+    ]);
+
+    const req = createMockRequest("/dashboard/settings");
+    const res = createMockResponse();
+    const handled = await manager.execute(req, res);
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(302);
+    expect(res.setHeader).toHaveBeenCalledWith("location", "http://localhost:3000/sign-in");
+  });
+
+  it("returns handled when file middleware returns a Response", async () => {
+    const manager = new MiddlewareManager("/tmp");
+    (manager as any).middleware = [
+      {
+        path: "/dashboard",
+        filePath: "/tmp/app/dashboard/middleware.ts",
+        handlers: [
+          (ctx: MiddlewareContext) => {
+            return new Response(null, {
+              status: 204,
+              headers: {
+                "x-middleware": ctx.pathname,
+              },
+            });
+          },
+        ],
+      },
+    ];
+
+    const req = createMockRequest("/dashboard/settings");
+    const res = createMockResponse();
+    const handled = await manager.execute(req, res);
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(204);
+    expect(res.setHeader).toHaveBeenCalledWith("x-middleware", "/dashboard/settings");
+  });
+
   it("should share middleware context across middleware chain and expose to page request data", async () => {
     const req = createMockRequest("/docs/getting-started");
     const res = createMockResponse();

--- a/packages/farm/src/__tests__/middleware.test.ts
+++ b/packages/farm/src/__tests__/middleware.test.ts
@@ -1908,6 +1908,29 @@ describe("Middleware Manager Data Flow", () => {
     }
   });
 
+  it("passes dynamic route params to file middleware", async () => {
+    const manager = new MiddlewareManager("/tmp");
+    (manager as any).middleware = [
+      {
+        path: "/users/[id]",
+        filePath: "/tmp/app/users/[id]/middleware.ts",
+        handlers: [
+          async (ctx: MiddlewareContext, next: () => Promise<void>) => {
+            ctx.data.set("userId", ctx.params.id);
+            await next();
+          },
+        ],
+      },
+    ];
+
+    const req = createMockRequest("/users/42/settings");
+    const res = createMockResponse();
+    const handled = await manager.execute(req, res);
+
+    expect(handled).toBe(false);
+    expect((req as any).__FARM_MIDDLEWARE_DATA__.get("userId")).toBe("42");
+  });
+
   it("should share middleware context across middleware chain and expose to page request data", async () => {
     const req = createMockRequest("/docs/getting-started");
     const res = createMockResponse();

--- a/packages/farm/src/__tests__/production-middleware.test.ts
+++ b/packages/farm/src/__tests__/production-middleware.test.ts
@@ -28,6 +28,20 @@ export default {
   deploy: {
     target: "vercel",
   },
+  observability: {
+    onEvent(event) {
+      if (!event.type.startsWith("middleware.")) return;
+      globalThis.__farmMiddlewareEvents ||= [];
+      globalThis.__farmMiddlewareEvents.push({
+        type: event.type,
+        route: event.route,
+        pathname: event.pathname,
+        name: event.name,
+        status: event.status,
+        durationMs: event.durationMs,
+      });
+    },
+  },
   middleware: [
     {
       matcher: "/dashboard/config-response",
@@ -109,6 +123,7 @@ describe("production middleware runtime", () => {
           "index.mjs",
         );
         const serverModule = await import(`${pathToFileURL(entryPath).href}?t=${Date.now()}`);
+        (globalThis as any).__farmMiddlewareEvents = [];
         const response = await serverModule.default.fetch(
           new Request("https://example.test/dashboard/settings"),
         );
@@ -119,13 +134,30 @@ describe("production middleware runtime", () => {
         expect(html).toContain(
           "production middleware: dashboard / settings / dashboard-file / /dashboard/settings",
         );
+        expect(
+          (globalThis as any).__farmMiddlewareEvents.map((event: any) => event.type),
+        ).toEqual([
+          "middleware.start",
+          "middleware.complete",
+          "middleware.start",
+          "middleware.complete",
+        ]);
 
+        (globalThis as any).__farmMiddlewareEvents = [];
         const configResponse = await serverModule.default.fetch(
           new Request("https://example.test/dashboard/config-response"),
         );
         expect(configResponse.status).toBe(302);
         expect(configResponse.headers.get("location")).toBe("https://example.test/sign-in");
+        expect(
+          (globalThis as any).__farmMiddlewareEvents.map((event: any) => event.type),
+        ).toEqual(["middleware.start", "middleware.shortCircuit"]);
+        expect((globalThis as any).__farmMiddlewareEvents[1]).toMatchObject({
+          route: "/",
+          status: 302,
+        });
 
+        (globalThis as any).__farmMiddlewareEvents = [];
         const fileResponse = await serverModule.default.fetch(
           new Request("https://example.test/dashboard/file-response"),
         );
@@ -133,7 +165,20 @@ describe("production middleware runtime", () => {
         expect(fileResponse.headers.get("x-file-response")).toBe("yes");
         expect(fileResponse.headers.get("x-farm-middleware")).toBe("yes");
         await expect(fileResponse.text()).resolves.toBe("blocked by file middleware");
+        expect(
+          (globalThis as any).__farmMiddlewareEvents.map((event: any) => event.type),
+        ).toEqual([
+          "middleware.start",
+          "middleware.complete",
+          "middleware.start",
+          "middleware.shortCircuit",
+        ]);
+        expect((globalThis as any).__farmMiddlewareEvents[3]).toMatchObject({
+          route: "/dashboard",
+          status: 418,
+        });
       } finally {
+        delete (globalThis as any).__farmMiddlewareEvents;
         await fs.rm(root, { recursive: true, force: true });
       }
     },

--- a/packages/farm/src/__tests__/production-middleware.test.ts
+++ b/packages/farm/src/__tests__/production-middleware.test.ts
@@ -30,6 +30,12 @@ export default {
   },
   middleware: [
     {
+      matcher: "/dashboard/config-response",
+      handler(ctx) {
+        return Response.redirect(new URL("/sign-in", ctx.url));
+      },
+    },
+    {
       matcher: "/dashboard/:path*",
       async handler(ctx, next) {
         ctx.data.set("config.area", "dashboard");
@@ -67,6 +73,14 @@ export default function DashboardPage(props: any) {
 export default async function dashboardMiddleware(ctx: any, next: () => Promise<void>) {
   ctx.data.set("file.area", "dashboard-file");
   ctx.headers.set("x-farm-middleware", "yes");
+  if (ctx.pathname === "/dashboard/file-response") {
+    return new Response("blocked by file middleware", {
+      status: 418,
+      headers: {
+        "x-file-response": "yes",
+      },
+    });
+  }
   await next();
 }
 `.trim(),
@@ -105,6 +119,20 @@ describe("production middleware runtime", () => {
         expect(html).toContain(
           "production middleware: dashboard / settings / dashboard-file / /dashboard/settings",
         );
+
+        const configResponse = await serverModule.default.fetch(
+          new Request("https://example.test/dashboard/config-response"),
+        );
+        expect(configResponse.status).toBe(302);
+        expect(configResponse.headers.get("location")).toBe("https://example.test/sign-in");
+
+        const fileResponse = await serverModule.default.fetch(
+          new Request("https://example.test/dashboard/file-response"),
+        );
+        expect(fileResponse.status).toBe(418);
+        expect(fileResponse.headers.get("x-file-response")).toBe("yes");
+        expect(fileResponse.headers.get("x-farm-middleware")).toBe("yes");
+        await expect(fileResponse.text()).resolves.toBe("blocked by file middleware");
       } finally {
         await fs.rm(root, { recursive: true, force: true });
       }

--- a/packages/farm/src/__tests__/production-middleware.test.ts
+++ b/packages/farm/src/__tests__/production-middleware.test.ts
@@ -16,6 +16,9 @@ async function createProductionMiddlewareFixture(): Promise<string> {
   await fs.symlink(packageRoot, path.join(root, "node_modules", "@farmjs", "core"), "dir");
 
   await fs.mkdir(path.join(root, "src", "app", "dashboard", "settings"), { recursive: true });
+  await fs.mkdir(path.join(root, "src", "app", "users", "[id]", "settings"), {
+    recursive: true,
+  });
   await fs.writeFile(
     path.join(root, "package.json"),
     JSON.stringify({ type: "module" }, null, 2),
@@ -99,6 +102,29 @@ export default async function dashboardMiddleware(ctx: any, next: () => Promise<
 }
 `.trim(),
   );
+  await fs.writeFile(
+    path.join(root, "src", "app", "users", "[id]", "middleware.ts"),
+    `
+export default async function userMiddleware(ctx: any, next: () => Promise<void>) {
+  ctx.data.set("file.userId", ctx.params.id || "missing-id");
+  await next();
+}
+`.trim(),
+  );
+  await fs.writeFile(
+    path.join(root, "src", "app", "users", "[id]", "settings", "page.tsx"),
+    `
+import React from "react";
+
+export default function UserSettingsPage(props: any) {
+  return React.createElement(
+    "main",
+    null,
+    \`user settings: \${props.middleware?.data.get("file.userId") || "missing"} / \${props.params.id}\`
+  );
+}
+`.trim(),
+  );
 
   return root;
 }
@@ -176,6 +202,18 @@ describe("production middleware runtime", () => {
         expect((globalThis as any).__farmMiddlewareEvents[3]).toMatchObject({
           route: "/dashboard",
           status: 418,
+        });
+
+        (globalThis as any).__farmMiddlewareEvents = [];
+        const userResponse = await serverModule.default.fetch(
+          new Request("https://example.test/users/42/settings"),
+        );
+        const userHtml = await userResponse.text();
+        expect(userResponse.status).toBe(200);
+        expect(userHtml).toContain("user settings: 42 / 42");
+        expect((globalThis as any).__farmMiddlewareEvents[0]).toMatchObject({
+          route: "/users/[id]",
+          pathname: "/users/42/settings",
         });
       } finally {
         delete (globalThis as any).__farmMiddlewareEvents;

--- a/packages/farm/src/__tests__/production-middleware.test.ts
+++ b/packages/farm/src/__tests__/production-middleware.test.ts
@@ -1,139 +1,20 @@
 // @vitest-environment node
 
-import fs from "node:fs/promises";
 import path from "node:path";
-import { pathToFileURL, fileURLToPath } from "node:url";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import { build } from "../build";
 import { loadConfig, resolveConfig } from "../config";
-
-const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
-
-async function createProductionMiddlewareFixture(): Promise<string> {
-  const root = await fs.mkdtemp(path.join(packageRoot, ".tmp-production-middleware-"));
-
-  await fs.mkdir(path.join(root, "node_modules", "@farmjs"), { recursive: true });
-  await fs.symlink(packageRoot, path.join(root, "node_modules", "@farmjs", "core"), "dir");
-
-  await fs.mkdir(path.join(root, "src", "app", "dashboard", "settings"), { recursive: true });
-  await fs.mkdir(path.join(root, "src", "app", "users", "[id]", "settings"), {
-    recursive: true,
-  });
-  await fs.writeFile(
-    path.join(root, "package.json"),
-    JSON.stringify({ type: "module" }, null, 2),
-  );
-  await fs.writeFile(
-    path.join(root, "farm.config.ts"),
-    `
-export default {
-  srcDir: "src",
-  deploy: {
-    target: "vercel",
-  },
-  observability: {
-    onEvent(event) {
-      if (!event.type.startsWith("middleware.")) return;
-      globalThis.__farmMiddlewareEvents ||= [];
-      globalThis.__farmMiddlewareEvents.push({
-        type: event.type,
-        route: event.route,
-        pathname: event.pathname,
-        name: event.name,
-        status: event.status,
-        durationMs: event.durationMs,
-      });
-    },
-  },
-  middleware: [
-    {
-      matcher: "/dashboard/config-response",
-      handler(ctx) {
-        return Response.redirect(new URL("/sign-in", ctx.url));
-      },
-    },
-    {
-      matcher: "/dashboard/:path*",
-      async handler(ctx, next) {
-        ctx.data.set("config.area", "dashboard");
-        ctx.data.set("config.path", ctx.params.path || "");
-        await next();
-      },
-    },
-  ],
-};
-`.trim(),
-  );
-  await fs.writeFile(path.join(root, "src", "app", "globals.css"), "");
-  await fs.writeFile(
-    path.join(root, "src", "app", "dashboard", "settings", "page.tsx"),
-    `
-import React from "react";
-
-export default function DashboardPage(props: any) {
-  const middlewareData = props.middleware?.data;
-  const configArea = middlewareData?.get("config.area") || "missing-config";
-  const configPath = middlewareData?.get("config.path") || "missing-path";
-  const fileArea = middlewareData?.get("file.area") || "missing-file";
-
-  return React.createElement(
-    "main",
-    null,
-    \`production middleware: \${configArea} / \${configPath} / \${fileArea} / \${props.path}\`
-  );
-}
-`.trim(),
-  );
-  await fs.writeFile(
-    path.join(root, "src", "app", "dashboard", "middleware.ts"),
-    `
-export default async function dashboardMiddleware(ctx: any, next: () => Promise<void>) {
-  ctx.data.set("file.area", "dashboard-file");
-  ctx.headers.set("x-farm-middleware", "yes");
-  if (ctx.pathname === "/dashboard/file-response") {
-    return new Response("blocked by file middleware", {
-      status: 418,
-      headers: {
-        "x-file-response": "yes",
-      },
-    });
-  }
-  await next();
-}
-`.trim(),
-  );
-  await fs.writeFile(
-    path.join(root, "src", "app", "users", "[id]", "middleware.ts"),
-    `
-export default async function userMiddleware(ctx: any, next: () => Promise<void>) {
-  ctx.data.set("file.userId", ctx.params.id || "missing-id");
-  await next();
-}
-`.trim(),
-  );
-  await fs.writeFile(
-    path.join(root, "src", "app", "users", "[id]", "settings", "page.tsx"),
-    `
-import React from "react";
-
-export default function UserSettingsPage(props: any) {
-  return React.createElement(
-    "main",
-    null,
-    \`user settings: \${props.middleware?.data.get("file.userId") || "missing"} / \${props.params.id}\`
-  );
-}
-`.trim(),
-  );
-
-  return root;
-}
+import {
+  cleanupMiddlewareProductionFixture,
+  createMiddlewareProductionFixture,
+} from "./fixtures/middleware-production-fixture";
 
 describe("production middleware runtime", () => {
   it(
     "runs farm.config middleware and app middleware in a production build",
     async () => {
-      const root = await createProductionMiddlewareFixture();
+      const root = await createMiddlewareProductionFixture();
 
       try {
         const userConfig = await loadConfig(root, undefined, "production");
@@ -217,7 +98,7 @@ describe("production middleware runtime", () => {
         });
       } finally {
         delete (globalThis as any).__farmMiddlewareEvents;
-        await fs.rm(root, { recursive: true, force: true });
+        await cleanupMiddlewareProductionFixture(root);
       }
     },
     120_000,

--- a/packages/farm/src/middleware/chain.ts
+++ b/packages/farm/src/middleware/chain.ts
@@ -10,6 +10,7 @@ import type {
   RateLimitConfig,
   RateLimitStorage,
   RateLimitStatus,
+  MiddlewareResult,
 } from "./types";
 import { getStorage } from "../storage";
 import type { Storage } from "unstorage";
@@ -70,7 +71,7 @@ function createRateLimitMiddleware(config: RateLimitConfig): MiddlewareFunction 
   const windowMs = parseTimeWindow(config.window);
   const storage = config.storage || defaultRateLimitStorage;
 
-  return async (ctx: MiddlewareContext, next: () => Promise<void>) => {
+  return async (ctx: MiddlewareContext, next) => {
     const key = config.keyGenerator
       ? config.keyGenerator(ctx)
       : `${ctx.request.socket.remoteAddress}:${ctx.pathname}`;
@@ -94,8 +95,7 @@ function createRateLimitMiddleware(config: RateLimitConfig): MiddlewareFunction 
         },
         ttlSeconds,
       );
-      await next();
-      return;
+      return next();
     }
 
     if (current.count >= config.requests) {
@@ -116,7 +116,7 @@ function createRateLimitMiddleware(config: RateLimitConfig): MiddlewareFunction 
 
     current.count++;
     await storage.set(key, current, ttlSeconds);
-    await next();
+    return next();
   };
 }
 
@@ -193,28 +193,37 @@ class MiddlewareChainImpl implements MiddlewareChain {
       const shouldRun = typeof condition === "function" ? condition(ctx) : condition;
 
       if (!shouldRun) {
-        await next();
-        return;
+        return next();
       }
 
       if (typeof fn === "function" && fn.length === 2) {
-        await (fn as MiddlewareFunction)(ctx, next);
+        return (fn as MiddlewareFunction)(ctx, next);
       } else {
         const subChain = middleware(this.basePath);
         (fn as (chain: MiddlewareChain) => void)(subChain);
         const { handlers } = subChain.build();
 
         let index = 0;
-        const executeNext = async (): Promise<void> => {
+        let returnedResponse: Response | undefined;
+        const executeNext = async (): Promise<MiddlewareResult> => {
           if (index < handlers.length) {
             const handler = handlers[index++];
-            await handler(ctx, executeNext);
+            const result = await handler(ctx, executeNext);
+            if (result instanceof Response) {
+              returnedResponse = result;
+              return result;
+            }
           } else {
-            await next();
+            const result = await next();
+            if (result instanceof Response) {
+              returnedResponse = result;
+              return result;
+            }
           }
+          return returnedResponse;
         };
 
-        await executeNext();
+        return executeNext();
       }
     };
     this.handlers.push(conditionalMiddleware);
@@ -234,7 +243,7 @@ class MiddlewareChainImpl implements MiddlewareChain {
         ctx.redirect(destination, permanent ? 308 : 307);
         return;
       }
-      await next();
+      return next();
     };
 
     this.handlers.push(redirectMiddleware);
@@ -267,8 +276,7 @@ class MiddlewareChainImpl implements MiddlewareChain {
       if (condition !== undefined) {
         const shouldRewrite = typeof condition === "function" ? condition(ctx) : condition;
         if (!shouldRewrite) {
-          await next();
-          return;
+          return next();
         }
       }
 
@@ -290,7 +298,7 @@ class MiddlewareChainImpl implements MiddlewareChain {
         // Only rewrite if pathname matches exactly (edge case)
         ctx.rewrite(destination);
       }
-      await next();
+      return next();
     };
 
     this.handlers.push(rewriteMiddleware);

--- a/packages/farm/src/middleware/index.ts
+++ b/packages/farm/src/middleware/index.ts
@@ -26,5 +26,6 @@ export type {
   RateLimitStorage,
   RateLimitStatus,
   NextFunction,
+  MiddlewareResult,
   FarmMiddlewareConfig,
 } from "./types";

--- a/packages/farm/src/middleware/manager.ts
+++ b/packages/farm/src/middleware/manager.ts
@@ -15,9 +15,11 @@ import type {
   MiddlewareModule,
   MiddlewareConfig,
   MiddlewareContext,
+  MiddlewareResult,
 } from "./types";
 import { createContext } from "./context";
 import { logger } from "../utils";
+import { sendWebResponse } from "../server/response";
 
 export interface DiscoveredMiddleware {
   path: string;
@@ -25,6 +27,10 @@ export interface DiscoveredMiddleware {
   handlers: MiddlewareFunction[];
   config?: MiddlewareConfig;
   source?: "config" | "file";
+}
+
+function isMiddlewareResponse(value: unknown): value is Response {
+  return value instanceof Response;
 }
 
 /**
@@ -261,14 +267,32 @@ export class MiddlewareManager {
 
       // Execute all handlers in this middleware
       let handlerIndex = 0;
-      const executeNext = async (): Promise<void> => {
+      let returnedResponse: Response | undefined;
+      const executeNext = async (): Promise<MiddlewareResult> => {
         if (handlerIndex < mw.handlers.length) {
           const handler = mw.handlers[handlerIndex++];
-          await handler(ctx, executeNext);
+          const result = await handler(ctx, executeNext);
+          if (isMiddlewareResponse(result)) {
+            returnedResponse = result;
+            return result;
+          }
         }
+        return returnedResponse;
       };
 
-      await executeNext();
+      const result = await executeNext();
+      const response = isMiddlewareResponse(result) ? result : returnedResponse;
+      if (response) {
+        if (!res.headersSent && !res.writableEnded) {
+          for (const [key, value] of ctx.headers) {
+            try {
+              res.setHeader(key, value);
+            } catch (error) {}
+          }
+        }
+        await sendWebResponse(res, response);
+        return true;
+      }
 
       // Check if response has been sent or handled by middleware helpers.
       if (ctx._handled || res.headersSent || res.writableEnded) {

--- a/packages/farm/src/middleware/manager.ts
+++ b/packages/farm/src/middleware/manager.ts
@@ -219,9 +219,14 @@ export class MiddlewareManager {
     }
 
     // Find applicable middleware (config entries first, then cascading files)
-    const applicable = [
-      ...this.configMiddleware,
-      ...this.middleware.filter((mw) => this.matchesRoutePath(pathname, mw.path)),
+    const applicable: Array<{
+      mw: DiscoveredMiddleware;
+      routeMatch: { matched: boolean; params?: Record<string, string> };
+    }> = [
+      ...this.configMiddleware.map((mw) => ({ mw, routeMatch: { matched: true } })),
+      ...this.middleware
+        .map((mw) => ({ mw, routeMatch: this.matchRoutePath(pathname, mw.path) }))
+        .filter((entry) => entry.routeMatch.matched),
     ];
 
     if (applicable.length === 0) {
@@ -229,7 +234,7 @@ export class MiddlewareManager {
     }
     try {
       const pc = require("picocolors");
-      const middlewarePaths = applicable.map((mw) => mw.path).join(", ");
+      const middlewarePaths = applicable.map(({ mw }) => mw.path).join(", ");
       const log = [
         pc.dim("[") + pc.bold(pc.blue("FARM")) + pc.dim("]"),
         pc.dim("[") + pc.bold(pc.magenta("MIDDLEWARE")) + pc.dim("]"),
@@ -246,13 +251,17 @@ export class MiddlewareManager {
     }
 
     // Execute middleware in cascade order
-    for (const mw of applicable) {
+    for (const entry of applicable) {
       // Check matcher configuration
+      const { mw, routeMatch } = entry;
       const configMatch = mw.config
         ? this.matchesConfig(pathname, mw.config, ctx)
         : { matched: true };
       if (!configMatch.matched) {
         continue;
+      }
+      if (routeMatch.params) {
+        ctx.params = { ...ctx.params, ...routeMatch.params };
       }
       if (configMatch.params) {
         ctx.params = { ...ctx.params, ...configMatch.params };
@@ -261,6 +270,9 @@ export class MiddlewareManager {
       // Create new context with parent data
       if (parentData) {
         ctx = createContext(req, res, this.viteServer, parentData);
+        if (routeMatch.params) {
+          ctx.params = { ...ctx.params, ...routeMatch.params };
+        }
         if (configMatch.params) {
           ctx.params = { ...ctx.params, ...configMatch.params };
         }
@@ -440,9 +452,28 @@ export class MiddlewareManager {
     return [...this.configMiddleware, ...this.middleware];
   }
 
-  private matchesRoutePath(pathname: string, middlewarePath: string): boolean {
-    if (middlewarePath === "/") return true;
-    return pathname === middlewarePath || pathname.startsWith(`${middlewarePath}/`);
+  private matchRoutePath(
+    pathname: string,
+    middlewarePath: string,
+  ): { matched: boolean; params?: Record<string, string> } {
+    if (middlewarePath === "/") return { matched: true };
+
+    const exactMatch = this.matchPattern(middlewarePath, pathname);
+    if (exactMatch.matched) {
+      return exactMatch;
+    }
+
+    const nestedMatch = this.matchPattern(`${middlewarePath}/:__farmRest*`, pathname);
+    if (!nestedMatch.matched) {
+      return { matched: false };
+    }
+
+    const params = { ...(nestedMatch.params || {}) };
+    delete params.__farmRest;
+    return {
+      matched: true,
+      params: Object.keys(params).length > 0 ? params : undefined,
+    };
   }
 
   private toMatcherList(matcher: MiddlewareConfig["matcher"]): MiddlewareMatcher[] {

--- a/packages/farm/src/middleware/manager.ts
+++ b/packages/farm/src/middleware/manager.ts
@@ -20,6 +20,7 @@ import type {
 import { createContext } from "./context";
 import { logger } from "../utils";
 import { sendWebResponse } from "../server/response";
+import { emitFarmEvent } from "../observability";
 
 export interface DiscoveredMiddleware {
   path: string;
@@ -265,38 +266,71 @@ export class MiddlewareManager {
         }
       }
 
-      // Execute all handlers in this middleware
-      let handlerIndex = 0;
-      let returnedResponse: Response | undefined;
-      const executeNext = async (): Promise<MiddlewareResult> => {
-        if (handlerIndex < mw.handlers.length) {
-          const handler = mw.handlers[handlerIndex++];
-          const result = await handler(ctx, executeNext);
-          if (isMiddlewareResponse(result)) {
-            returnedResponse = result;
-            return result;
-          }
-        }
-        return returnedResponse;
+      const middlewareStartTime = Date.now();
+      const middlewareEvent = {
+        route: mw.path,
+        pathname,
+        name: mw.filePath,
       };
+      emitFarmEvent({ type: "middleware.start", ...middlewareEvent });
 
-      const result = await executeNext();
-      const response = isMiddlewareResponse(result) ? result : returnedResponse;
-      if (response) {
-        if (!res.headersSent && !res.writableEnded) {
-          for (const [key, value] of ctx.headers) {
-            try {
-              res.setHeader(key, value);
-            } catch (error) {}
+      try {
+        // Execute all handlers in this middleware
+        let handlerIndex = 0;
+        let returnedResponse: Response | undefined;
+        const executeNext = async (): Promise<MiddlewareResult> => {
+          if (handlerIndex < mw.handlers.length) {
+            const handler = mw.handlers[handlerIndex++];
+            const result = await handler(ctx, executeNext);
+            if (isMiddlewareResponse(result)) {
+              returnedResponse = result;
+              return result;
+            }
           }
-        }
-        await sendWebResponse(res, response);
-        return true;
-      }
+          return returnedResponse;
+        };
 
-      // Check if response has been sent or handled by middleware helpers.
-      if (ctx._handled || res.headersSent || res.writableEnded) {
-        return true;
+        const result = await executeNext();
+        const response = isMiddlewareResponse(result) ? result : returnedResponse;
+        if (response) {
+          if (!res.headersSent && !res.writableEnded) {
+            for (const [key, value] of ctx.headers) {
+              try {
+                res.setHeader(key, value);
+              } catch (error) {}
+            }
+          }
+          emitFarmEvent({
+            type: "middleware.shortCircuit",
+            ...middlewareEvent,
+            status: response.status,
+          });
+          await sendWebResponse(res, response);
+          return true;
+        }
+
+        // Check if response has been sent or handled by middleware helpers.
+        if (ctx._handled || res.headersSent || res.writableEnded) {
+          emitFarmEvent({
+            type: "middleware.shortCircuit",
+            ...middlewareEvent,
+            status: res.statusCode,
+          });
+          return true;
+        }
+
+        emitFarmEvent({
+          type: "middleware.complete",
+          ...middlewareEvent,
+          durationMs: Date.now() - middlewareStartTime,
+        });
+      } catch (error) {
+        emitFarmEvent({
+          type: "middleware.error",
+          ...middlewareEvent,
+          error,
+        });
+        throw error;
       }
 
       parentData = {

--- a/packages/farm/src/middleware/production-runtime.ts
+++ b/packages/farm/src/middleware/production-runtime.ts
@@ -9,6 +9,7 @@ import type {
   MiddlewareModule,
   MiddlewareResult,
 } from "./types";
+import { emitFarmEvent } from "../observability";
 
 export interface ProductionMiddlewareModuleEntry {
   path: string;
@@ -643,27 +644,65 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
         ctx.params = { ...ctx.params, ...configMatch.params };
       }
 
-      const returnedResponse = await executeHandlers(entry.handlers, ctx);
-      currentRequest = contextState.getRequest();
+      const middlewareStartTime = Date.now();
+      const middlewareEvent = {
+        route: entry.path,
+        pathname: initialPathname,
+        name: entry.filePath,
+      };
+      emitFarmEvent({ type: "middleware.start", ...middlewareEvent });
 
-      if (returnedResponse) {
-        return {
-          request: currentRequest,
-          response: applyProductionMiddlewareHeaders(returnedResponse, mapToHeaders(ctx.headers)),
-          data: new Map(ctx.data),
-          headers: mapToHeaders(ctx.headers),
-          handled: true,
-        };
-      }
+      try {
+        const returnedResponse = await executeHandlers(entry.handlers, ctx);
+        currentRequest = contextState.getRequest();
 
-      if (ctx._handled) {
-        return {
-          request: currentRequest,
-          response: contextState.getResponse() || new Response(null),
-          data: new Map(ctx.data),
-          headers: mapToHeaders(ctx.headers),
-          handled: true,
-        };
+        if (returnedResponse) {
+          const response = applyProductionMiddlewareHeaders(
+            returnedResponse,
+            mapToHeaders(ctx.headers),
+          );
+          emitFarmEvent({
+            type: "middleware.shortCircuit",
+            ...middlewareEvent,
+            status: response.status,
+          });
+          return {
+            request: currentRequest,
+            response,
+            data: new Map(ctx.data),
+            headers: mapToHeaders(ctx.headers),
+            handled: true,
+          };
+        }
+
+        if (ctx._handled) {
+          const response = contextState.getResponse() || new Response(null);
+          emitFarmEvent({
+            type: "middleware.shortCircuit",
+            ...middlewareEvent,
+            status: response.status,
+          });
+          return {
+            request: currentRequest,
+            response,
+            data: new Map(ctx.data),
+            headers: mapToHeaders(ctx.headers),
+            handled: true,
+          };
+        }
+
+        emitFarmEvent({
+          type: "middleware.complete",
+          ...middlewareEvent,
+          durationMs: Date.now() - middlewareStartTime,
+        });
+      } catch (error) {
+        emitFarmEvent({
+          type: "middleware.error",
+          ...middlewareEvent,
+          error,
+        });
+        throw error;
       }
 
       parentData = {

--- a/packages/farm/src/middleware/production-runtime.ts
+++ b/packages/farm/src/middleware/production-runtime.ts
@@ -7,6 +7,7 @@ import type {
   MiddlewareFunction,
   MiddlewareMatcher,
   MiddlewareModule,
+  MiddlewareResult,
 } from "./types";
 
 export interface ProductionMiddlewareModuleEntry {
@@ -125,6 +126,10 @@ function mapToHeaders(map: Map<string, string>): Headers {
 
 function headersToRecord(headers: Map<string, string>): Record<string, string> {
   return Object.fromEntries(headers);
+}
+
+function isMiddlewareResponse(value: unknown): value is Response {
+  return value instanceof Response;
 }
 
 function createResponseShim(headers: Map<string, string>): Record<string, any> {
@@ -546,16 +551,26 @@ function normalizeFileMiddleware(
   return entries;
 }
 
-async function executeHandlers(handlers: MiddlewareFunction[], ctx: MiddlewareContext) {
+async function executeHandlers(
+  handlers: MiddlewareFunction[],
+  ctx: MiddlewareContext,
+): Promise<Response | undefined> {
   let handlerIndex = 0;
-  const executeNext = async (): Promise<void> => {
+  let returnedResponse: Response | undefined;
+  const executeNext = async (): Promise<MiddlewareResult> => {
     if (handlerIndex < handlers.length) {
       const handler = handlers[handlerIndex++];
-      await handler(ctx, executeNext);
+      const result = await handler(ctx, executeNext);
+      if (isMiddlewareResponse(result)) {
+        returnedResponse = result;
+        return result;
+      }
     }
+    return returnedResponse;
   };
 
-  await executeNext();
+  const result = await executeNext();
+  return isMiddlewareResponse(result) ? result : returnedResponse;
 }
 
 function emptyResult(request: Request): ProductionMiddlewareResult {
@@ -628,8 +643,18 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
         ctx.params = { ...ctx.params, ...configMatch.params };
       }
 
-      await executeHandlers(entry.handlers, ctx);
+      const returnedResponse = await executeHandlers(entry.handlers, ctx);
       currentRequest = contextState.getRequest();
+
+      if (returnedResponse) {
+        return {
+          request: currentRequest,
+          response: applyProductionMiddlewareHeaders(returnedResponse, mapToHeaders(ctx.headers)),
+          data: new Map(ctx.data),
+          headers: mapToHeaders(ctx.headers),
+          handled: true,
+        };
+      }
 
       if (ctx._handled) {
         return {

--- a/packages/farm/src/middleware/production-runtime.ts
+++ b/packages/farm/src/middleware/production-runtime.ts
@@ -444,9 +444,28 @@ function matchesConfig(
   return { matched: true };
 }
 
-function matchesRoutePath(pathname: string, middlewarePath: string): boolean {
-  if (middlewarePath === "/") return true;
-  return pathname === middlewarePath || pathname.startsWith(`${middlewarePath}/`);
+function matchRoutePath(
+  pathname: string,
+  middlewarePath: string,
+): { matched: boolean; params?: Record<string, string> } {
+  if (middlewarePath === "/") return { matched: true };
+
+  const exactMatch = matchPattern(middlewarePath, pathname);
+  if (exactMatch.matched) {
+    return exactMatch;
+  }
+
+  const nestedMatch = matchPattern(`${middlewarePath}/:__farmRest*`, pathname);
+  if (!nestedMatch.matched) {
+    return { matched: false };
+  }
+
+  const params = { ...(nestedMatch.params || {}) };
+  delete params.__farmRest;
+  return {
+    matched: true,
+    params: Object.keys(params).length > 0 ? params : undefined,
+  };
 }
 
 function getConfigHandlers(
@@ -613,9 +632,15 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
       }
     }
 
-    const applicable = entries.filter(
-      (entry) => entry.source === "config" || matchesRoutePath(initialPathname, entry.path),
-    );
+    const applicable = entries
+      .map((entry) => ({
+        entry,
+        routeMatch:
+          entry.source === "config"
+            ? { matched: true }
+            : matchRoutePath(initialPathname, entry.path),
+      }))
+      .filter((candidate) => candidate.routeMatch.matched);
 
     if (applicable.length === 0) {
       return {
@@ -627,7 +652,8 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
       };
     }
 
-    for (const entry of applicable) {
+    for (const candidate of applicable) {
+      const { entry, routeMatch } = candidate;
       const configMatch = entry.config
         ? matchesConfig(initialPathname, entry.config, ctx)
         : { matched: true };
@@ -640,6 +666,9 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
         ctx = contextState.ctx;
       }
 
+      if (routeMatch.params) {
+        ctx.params = { ...ctx.params, ...routeMatch.params };
+      }
       if (configMatch.params) {
         ctx.params = { ...ctx.params, ...configMatch.params };
       }

--- a/packages/farm/src/middleware/types.ts
+++ b/packages/farm/src/middleware/types.ts
@@ -10,7 +10,8 @@ import type { ViteDevServer } from "vite";
 /**
  * Next function type for middleware chain
  */
-export type NextFunction = () => Promise<void>;
+export type MiddlewareResult = void | Response;
+export type NextFunction = () => Promise<MiddlewareResult>;
 
 /**
  * Middleware function signature
@@ -18,7 +19,7 @@ export type NextFunction = () => Promise<void>;
 export type MiddlewareFunction = (
   ctx: MiddlewareContext,
   next: NextFunction,
-) => void | Promise<void>;
+) => MiddlewareResult | Promise<MiddlewareResult>;
 
 /**
  * Cookie options


### PR DESCRIPTION
## Summary

- adds the production middleware runtime path
- allows app/config middleware to return `Response` for short-circuit behavior
- passes route params into file middleware
- emits middleware observability events for execution, short-circuit, and error cases
- documents the middleware behavior in the docs

## Validation

- `corepack pnpm --filter @farmjs/core test -- middleware`
