### PR TITLE
feat: add lightweight router helpers

### DIFF
--- a/docs/src/app/docs/reference/page.md
+++ b/docs/src/app/docs/reference/page.md
@@ -14,6 +14,7 @@ A compact map of the main package exports and where to learn more.
 | --- | --- |
 | @farmjs/core | Config, app types, plugins, integrations, routing, OpenAPI, docs, cache. |
 | @farmjs/core/client | Link, router helpers, API client, integration client. |
+| @farmjs/core/router | Lightweight route matching, href building, and active-route checks. |
 | @farmjs/core/query | Query and route param types. |
 | @farmjs/core/storage | Storage clients and mount helpers. |
 | @farmjs/core/cache | Data cache, revalidation, cache keys. |
@@ -33,6 +34,7 @@ A compact map of the main package exports and where to learn more.
 | --- | --- |
 | `@farmjs/core` | `defineIntegration`, `integrationRoute`, `defineIntegrationSchema`, `definePlugin`, `defineFarmConfig`. |
 | `@farmjs/core/client` | `createIntegrations`, `createIntegrationClient`, `createIntegrationServerClient`, `endpoint`. |
+| `@farmjs/core/router` | `createFarmRouter`, `matchFarmRoute`, `buildFarmRoutePath`, `isFarmRouteActive`. |
 | `@farmjs/core/storage` | `sqliteStorage`, `postgresStorage`, `redisStorage`, `createStorageClient`, `defineStorageClient`. |
 | `@farmjs/integrations/stripe` | Stripe billing integration. |
 | `@farmjs/integrations/auth` | Better Auth, Auth.js, Clerk, Auth0, WorkOS helpers when using the auth barrel. |

--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -49,6 +49,56 @@ export function Nav() {
 }
 ```
 
+## Lightweight router helpers
+
+Use the lightweight router when client components, layouts, breadcrumbs, tabs, or tests need to match app routes without adding a separate routing library.
+
+**src/lib/router.ts**
+
+```ts
+import { createFarmRouter } from "@farmjs/core/router";
+
+export const router = createFarmRouter([
+  "/",
+  "/dashboard",
+  "/users/[id]",
+  "/docs/[[...slug]]",
+]);
+```
+
+```ts
+const match = router.match("/users/ada?tab=settings");
+
+if (match) {
+  console.log(match.route.path); // /users/[id]
+  console.log(match.params.id); // ada
+}
+```
+
+Build hrefs from the same route patterns:
+
+```ts
+const href = router.build("/docs/[[...slug]]", {
+  slug: ["core", "routing"],
+});
+```
+
+This returns `/docs/core/routing`. Optional catch-all params can be omitted, static routes win over dynamic routes, and route groups such as `(marketing)` do not appear in the URL.
+
+Client components can pass the same route list to `useRouter` when they want current route params:
+
+```tsx
+import { useRouter } from "@farmjs/core/client";
+
+export function CurrentUserTab() {
+  const router = useRouter({
+    routes: ["/users/[id]", "/users/[id]/settings"],
+  });
+
+  return <span>{router.params.id}</span>;
+}
+```
+
 ## Nested segments
 
 Folders become URL segments. Use normal folders for visible path segments and dynamic folders when the value comes from the URL.

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -30,6 +30,9 @@
         "./types/middleware.d.ts",
         "./dist/middleware.d.ts"
       ],
+      "router": [
+        "./dist/router.d.ts"
+      ],
       "storage": [
         "./dist/storage.d.ts"
       ],
@@ -169,6 +172,11 @@
       "types": "./dist/api.d.ts",
       "import": "./dist/api.mjs",
       "require": "./dist/api.cjs"
+    },
+    "./router": {
+      "types": "./dist/router.d.ts",
+      "import": "./dist/router.mjs",
+      "require": "./dist/router.cjs"
     }
   },
   "scripts": {

--- a/packages/farm/src/__tests__/router.test.ts
+++ b/packages/farm/src/__tests__/router.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { buildFarmRoutePath, createFarmRouter, isFarmRouteActive, matchFarmRoute } from "../router";
+
+describe("createFarmRouter", () => {
+  it("matches static, dynamic, and catch-all routes", () => {
+    const router = createFarmRouter(["/", "/about", "/users/[id]", "/docs/[...slug]"]);
+
+    expect(router.match("/")?.params).toEqual({});
+    expect(router.match("/about?from=nav")?.route.path).toBe("/about");
+    expect(router.match("/users/ada")?.params).toEqual({ id: "ada" });
+    expect(router.match("/docs/core/routing")?.params).toEqual({
+      slug: "core/routing",
+    });
+  });
+
+  it("prefers more specific routes before dynamic routes", () => {
+    const router = createFarmRouter(["/users/[id]", "/users/settings"]);
+
+    expect(router.match("/users/settings")?.route.path).toBe("/users/settings");
+    expect(router.match("/users/123")?.route.path).toBe("/users/[id]");
+  });
+
+  it("supports optional catch-all and route group patterns", () => {
+    const router = createFarmRouter(["/(marketing)/docs/[[...slug]]"]);
+
+    expect(router.match("/docs")?.params).toEqual({ slug: "" });
+    expect(router.match("/docs/getting-started")?.params).toEqual({
+      slug: "getting-started",
+    });
+  });
+});
+
+describe("route helpers", () => {
+  it("matches one route pattern", () => {
+    expect(matchFarmRoute("/blog/[slug]", "/blog/hello%20farm")).toEqual({
+      slug: "hello farm",
+    });
+    expect(matchFarmRoute("/blog/[slug]", "/blog")).toBeNull();
+  });
+
+  it("builds paths with params, query, hash, and optional catch-all params", () => {
+    expect(
+      buildFarmRoutePath(
+        "/blog/[slug]",
+        { slug: "hello farm" },
+        {
+          query: {
+            from: "docs",
+            tag: ["farm", "router"],
+          },
+          hash: "intro",
+        },
+      ),
+    ).toBe("/blog/hello%20farm?from=docs&tag=farm&tag=router#intro");
+
+    expect(buildFarmRoutePath("/docs/[[...slug]]")).toBe("/docs");
+    expect(buildFarmRoutePath("/docs/[[...slug]]", { slug: ["core", "routing"] })).toBe(
+      "/docs/core/routing",
+    );
+  });
+
+  it("checks active routes exactly or by static prefix", () => {
+    expect(isFarmRouteActive("/docs", "/docs")).toBe(true);
+    expect(isFarmRouteActive("/docs", "/docs/routing")).toBe(false);
+    expect(isFarmRouteActive("/docs", "/docs/routing", { exact: false })).toBe(true);
+  });
+});

--- a/packages/farm/src/client/index.ts
+++ b/packages/farm/src/client/index.ts
@@ -14,6 +14,20 @@ export type {
   ExternalHref,
 } from "./link";
 export { useRouter } from "./router";
+export type { UseRouterOptions } from "./router";
+export { buildFarmRoutePath, createFarmRouter, isFarmRouteActive, matchFarmRoute } from "../router";
+export type {
+  FarmRouter,
+  FarmRouterActiveOptions,
+  FarmRouterBuildOptions,
+  FarmRouterMatch,
+  FarmRouterParams,
+  FarmRouterPathParam,
+  FarmRouterPathParams,
+  FarmRouterQueryValue,
+  FarmRouterRoute,
+  FarmRouterRouteInput,
+} from "../router";
 export { createAPIClient, createServerAPIClient } from "../api/client";
 export type {
   APIClient,

--- a/packages/farm/src/client/router.ts
+++ b/packages/farm/src/client/router.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { createFarmRouter, type FarmRouter, type FarmRouterRouteInput } from "../router";
 
 interface RouterState {
   pathname: string;
@@ -6,45 +7,38 @@ interface RouterState {
   params: Record<string, string>;
 }
 
+export interface UseRouterOptions {
+  basePath?: string;
+  routes?: FarmRouterRouteInput[];
+}
+
 /**
  * Hook for accessing router state and navigation
  */
-export function useRouter() {
-  // Base path is typically "/" for most apps
-  // TODO: Support configurable base path via context
-  const basePath = "";
+export function useRouter(options: UseRouterOptions = {}) {
+  const basePath = options.basePath || "";
+  const routes = options.routes;
+  const routeKey =
+    routes?.map((route) => (typeof route === "string" ? route : route.path)).join("\n") || "";
+  const routeMatcher = useMemo(
+    () => (routeKey ? createFarmRouter(routeKey.split("\n")) : null),
+    [routeKey],
+  );
   const [state, setState] = useState<RouterState>(() => {
-    if (typeof window === "undefined") {
-      return {
-        pathname: "/",
-        searchParams: new URLSearchParams(),
-        params: {},
-      };
-    }
-
-    const url = new URL(window.location.href);
-    return {
-      pathname: url.pathname.replace(basePath, "") || "/",
-      searchParams: url.searchParams,
-      params: {}, // This would be populated by the route matcher
-    };
+    return readRouterState(basePath, routeMatcher);
   });
 
   useEffect(() => {
     if (typeof window === "undefined") return;
 
     const handlePopState = () => {
-      const url = new URL(window.location.href);
-      setState({
-        pathname: url.pathname.replace(basePath, "") || "/",
-        searchParams: url.searchParams,
-        params: {}, // This would be populated by the route matcher
-      });
+      setState(readRouterState(basePath, routeMatcher));
     };
 
+    handlePopState();
     window.addEventListener("popstate", handlePopState);
     return () => window.removeEventListener("popstate", handlePopState);
-  }, [basePath]);
+  }, [basePath, routeMatcher]);
 
   const push = (href: string) => {
     if (typeof window === "undefined") return;
@@ -81,4 +75,30 @@ export function useRouter() {
     back,
     forward,
   };
+}
+
+function readRouterState(basePath: string, routeMatcher: FarmRouter | null): RouterState {
+  if (typeof window === "undefined") {
+    return {
+      pathname: "/",
+      searchParams: new URLSearchParams(),
+      params: {},
+    };
+  }
+
+  const url = new URL(window.location.href);
+  const pathname = normalizeClientPathname(url.pathname, basePath);
+  return {
+    pathname,
+    searchParams: url.searchParams,
+    params: routeMatcher?.match(pathname)?.params || {},
+  };
+}
+
+function normalizeClientPathname(pathname: string, basePath: string) {
+  const normalizedBase = basePath.replace(/\/+$/, "");
+  const isUnderBase =
+    normalizedBase && (pathname === normalizedBase || pathname.startsWith(`${normalizedBase}/`));
+  const withoutBase = isUnderBase ? pathname.slice(normalizedBase.length) || "/" : pathname;
+  return withoutBase || "/";
 }

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -25,6 +25,7 @@ export { APITypeGenerator } from "./type-generator";
 export * from "./openapi";
 export * from "./query";
 export * from "./middleware";
+export * from "./router";
 export * from "./docs";
 export * from "./markdown";
 export * from "./app-markdown";

--- a/packages/farm/src/router.ts
+++ b/packages/farm/src/router.ts
@@ -1,0 +1,327 @@
+export type FarmRouterPrimitiveParam = string | number | boolean;
+export type FarmRouterPathParam =
+  | FarmRouterPrimitiveParam
+  | readonly FarmRouterPrimitiveParam[]
+  | null
+  | undefined;
+export type FarmRouterPathParams = Record<string, FarmRouterPathParam>;
+export type FarmRouterParams = Record<string, string>;
+
+export interface FarmRouterRoute<TMeta = unknown> {
+  path: string;
+  name?: string;
+  meta?: TMeta;
+}
+
+export type FarmRouterRouteInput<TMeta = unknown> = string | FarmRouterRoute<TMeta>;
+
+export interface FarmRouterMatch<TMeta = unknown> {
+  route: FarmRouterRoute<TMeta>;
+  pathname: string;
+  params: FarmRouterParams;
+}
+
+export type FarmRouterQueryValue =
+  | FarmRouterPrimitiveParam
+  | readonly FarmRouterPrimitiveParam[]
+  | null
+  | undefined;
+
+export interface FarmRouterBuildOptions {
+  query?: URLSearchParams | Record<string, FarmRouterQueryValue>;
+  hash?: string;
+  trailingSlash?: boolean;
+}
+
+export interface FarmRouterActiveOptions {
+  exact?: boolean;
+}
+
+export interface FarmRouter<TMeta = unknown> {
+  routes: FarmRouterRoute<TMeta>[];
+  match(pathname: string): FarmRouterMatch<TMeta> | null;
+  build(pattern: string, params?: FarmRouterPathParams, options?: FarmRouterBuildOptions): string;
+  isActive(pattern: string, pathname: string, options?: FarmRouterActiveOptions): boolean;
+}
+
+type RouterSegment =
+  | {
+      type: "static";
+      value: string;
+    }
+  | {
+      type: "dynamic";
+      name: string;
+      catchAll: boolean;
+      optional: boolean;
+    };
+
+interface NormalizedRouterRoute<TMeta> {
+  route: FarmRouterRoute<TMeta>;
+  segments: RouterSegment[];
+  score: number;
+  index: number;
+}
+
+export function createFarmRouter<TMeta = unknown>(
+  routes: FarmRouterRouteInput<TMeta>[],
+): FarmRouter<TMeta> {
+  const normalizedRoutes = routes.map(normalizeRouteInput).sort(compareRoutes);
+
+  return {
+    routes: normalizedRoutes.map((entry) => entry.route),
+    match(pathname) {
+      const normalizedPathname = normalizePathname(pathname);
+
+      for (const entry of normalizedRoutes) {
+        const params = matchSegments(entry.segments, normalizedPathname);
+        if (params) {
+          return {
+            route: entry.route,
+            pathname: normalizedPathname,
+            params,
+          };
+        }
+      }
+
+      return null;
+    },
+    build: buildFarmRoutePath,
+    isActive: isFarmRouteActive,
+  };
+}
+
+export function matchFarmRoute(pattern: string, pathname: string): FarmRouterParams | null {
+  return matchSegments(parseRoutePattern(pattern), normalizePathname(pathname));
+}
+
+export function buildFarmRoutePath(
+  pattern: string,
+  params: FarmRouterPathParams = {},
+  options: FarmRouterBuildOptions = {},
+): string {
+  const parts: string[] = [];
+
+  for (const segment of parseRoutePattern(pattern)) {
+    if (segment.type === "static") {
+      parts.push(encodePathSegment(segment.value));
+      continue;
+    }
+
+    const value = params[segment.name];
+    const values = Array.isArray(value) ? value : value == null ? [] : [value];
+
+    if (values.length === 0) {
+      if (segment.optional) continue;
+      throw new Error(`Missing route param "${segment.name}" for ${pattern}.`);
+    }
+
+    if (!segment.catchAll && values.length > 1) {
+      throw new Error(`Route param "${segment.name}" for ${pattern} expects a single value.`);
+    }
+
+    parts.push(...values.map((item) => encodePathSegment(String(item))));
+  }
+
+  let pathname = parts.length ? `/${parts.join("/")}` : "/";
+
+  if (options.trailingSlash && pathname !== "/") {
+    pathname = `${pathname}/`;
+  }
+
+  return appendQueryAndHash(pathname, options);
+}
+
+export function isFarmRouteActive(
+  pattern: string,
+  pathname: string,
+  options: FarmRouterActiveOptions = {},
+): boolean {
+  const normalizedPathname = normalizePathname(pathname);
+  if (matchFarmRoute(pattern, normalizedPathname)) return true;
+  if (options.exact !== false) return false;
+
+  const normalizedPattern = normalizePathname(pattern);
+  if (normalizedPattern === "/") return normalizedPathname === "/";
+  return normalizedPathname.startsWith(`${normalizedPattern}/`);
+}
+
+function normalizeRouteInput<TMeta>(
+  input: FarmRouterRouteInput<TMeta>,
+  index: number,
+): NormalizedRouterRoute<TMeta> {
+  const route = typeof input === "string" ? { path: input } : input;
+  const path = normalizePathname(route.path);
+  const segments = parseRoutePattern(path);
+
+  return {
+    route: {
+      ...route,
+      path,
+    },
+    segments,
+    score: scoreSegments(segments),
+    index,
+  };
+}
+
+function parseRoutePattern(pattern: string): RouterSegment[] {
+  return splitPathname(pattern)
+    .filter((part) => !isRouteGroup(part))
+    .map((part) => {
+      const optionalCatchAll = part.match(/^\[\[\.\.\.([A-Za-z0-9_$-]+)\]\]$/);
+      if (optionalCatchAll) {
+        return {
+          type: "dynamic",
+          name: optionalCatchAll[1],
+          catchAll: true,
+          optional: true,
+        };
+      }
+
+      const catchAll = part.match(/^\[\.\.\.([A-Za-z0-9_$-]+)\]$/);
+      if (catchAll) {
+        return {
+          type: "dynamic",
+          name: catchAll[1],
+          catchAll: true,
+          optional: false,
+        };
+      }
+
+      const dynamic = part.match(/^\[([A-Za-z0-9_$-]+)\]$/) || part.match(/^:([A-Za-z0-9_$-]+)$/);
+      if (dynamic) {
+        return {
+          type: "dynamic",
+          name: dynamic[1],
+          catchAll: false,
+          optional: false,
+        };
+      }
+
+      const star = part.match(/^\*([A-Za-z0-9_$-]+)(\?)?$/);
+      if (star) {
+        return {
+          type: "dynamic",
+          name: star[1],
+          catchAll: true,
+          optional: !!star[2],
+        };
+      }
+
+      return {
+        type: "static",
+        value: decodePathSegment(part),
+      };
+    });
+}
+
+function matchSegments(segments: RouterSegment[], pathname: string): FarmRouterParams | null {
+  const parts = splitPathname(pathname);
+  const params: FarmRouterParams = {};
+
+  if (segments.length === 0) {
+    return parts.length === 0 ? params : null;
+  }
+
+  let pathIndex = 0;
+
+  for (const segment of segments) {
+    if (segment.type === "static") {
+      if (decodePathSegment(parts[pathIndex] || "") !== segment.value) return null;
+      pathIndex++;
+      continue;
+    }
+
+    if (segment.catchAll) {
+      const remaining = parts.slice(pathIndex).map(decodePathSegment);
+      if (remaining.length === 0 && !segment.optional) return null;
+      params[segment.name] = remaining.join("/");
+      pathIndex = parts.length;
+      continue;
+    }
+
+    const value = parts[pathIndex];
+    if (!value) return null;
+    params[segment.name] = decodePathSegment(value);
+    pathIndex++;
+  }
+
+  return pathIndex === parts.length ? params : null;
+}
+
+function compareRoutes<TMeta>(
+  left: NormalizedRouterRoute<TMeta>,
+  right: NormalizedRouterRoute<TMeta>,
+) {
+  if (right.score !== left.score) return right.score - left.score;
+  return left.index - right.index;
+}
+
+function scoreSegments(segments: RouterSegment[]) {
+  return segments.reduce((score, segment) => {
+    if (segment.type === "static") return score + 100;
+    if (!segment.catchAll) return score + 50;
+    return score + (segment.optional ? 5 : 10);
+  }, segments.length);
+}
+
+function normalizePathname(value: string) {
+  const raw = value || "/";
+  let pathname = raw;
+
+  try {
+    pathname = new URL(raw, "http://farm.local").pathname;
+  } catch {
+    pathname = raw.split(/[?#]/, 1)[0] || "/";
+  }
+
+  pathname = pathname.replace(/\\/g, "/").replace(/\/+/g, "/");
+  if (!pathname.startsWith("/")) pathname = `/${pathname}`;
+  if (pathname.length > 1) pathname = pathname.replace(/\/+$/, "");
+  return pathname || "/";
+}
+
+function splitPathname(pathname: string) {
+  return normalizePathname(pathname).split("/").filter(Boolean);
+}
+
+function isRouteGroup(part: string) {
+  return part.startsWith("(") && part.endsWith(")");
+}
+
+function decodePathSegment(value: string) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function encodePathSegment(value: string) {
+  return encodeURIComponent(value);
+}
+
+function appendQueryAndHash(pathname: string, options: FarmRouterBuildOptions) {
+  const search = createSearchParams(options.query);
+  const hash = options.hash ? `#${options.hash.replace(/^#/, "")}` : "";
+  const query = search.toString();
+  return `${pathname}${query ? `?${query}` : ""}${hash}`;
+}
+
+function createSearchParams(query: FarmRouterBuildOptions["query"]) {
+  if (query instanceof URLSearchParams) return query;
+
+  const search = new URLSearchParams();
+  if (!query) return search;
+
+  for (const [key, value] of Object.entries(query)) {
+    const values = Array.isArray(value) ? value : [value];
+    for (const item of values) {
+      if (item == null) continue;
+      search.append(key, String(item));
+    }
+  }
+
+  return search;
+}

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     "query/server": "src/query/server.ts",
     middleware: "src/middleware/index.ts",
     api: "src/api/index.ts",
+    router: "src/router.ts",
     plugin: "src/plugin.ts",
     storage: "src/storage/index.ts",
     cache: "src/cache.ts",


### PR DESCRIPTION
Closes #28

## Summary
- add dependency-free `@farmjs/core/router` helpers for matching routes, building hrefs, and active-route checks
- export router helpers from root, client, and the new router subpath
- allow `useRouter({ routes })` to populate params from Farm route patterns
- document lightweight router usage in Routing and Reference docs

## Tests
- `corepack pnpm --filter @farmjs/core test -- router`
- `corepack pnpm --filter @farmjs/core build`
- `DATABASE_URL=${DATABASE_URL:-postgresql://user:password@localhost:5432/farmjs} ./node_modules/.bin/prisma generate && ./node_modules/.bin/farm build` in `docs`