### PR TITLE
feat: add code-first framework migrations

### DIFF
--- a/docs/docs.config.ts
+++ b/docs/docs.config.ts
@@ -240,6 +240,7 @@ const sidebar = [
     label: "Reference",
     icon: "book",
     children: [
+      { label: "Migrations", slug: "migrations", icon: "route" },
       { label: "CLI", slug: "cli", icon: "terminal" },
       { label: "Examples", slug: "examples", icon: "box" },
       { label: "Reference", slug: "reference", icon: "book" },

--- a/docs/src/app/docs/cli/page.md
+++ b/docs/src/app/docs/cli/page.md
@@ -1,12 +1,12 @@
 ---
 title: "CLI"
-description: "Use the Farm CLI to run, build, generate types, deploy output, and add integrations."
+description: "Use the Farm CLI to run, build, generate types, migrate apps, deploy output, and add integrations."
 section: "Reference"
 ---
 
 # CLI
 
-Use the Farm CLI to run, build, generate types, deploy output, and add integrations.
+Use the Farm CLI to run, build, generate types, migrate apps, deploy output, and add integrations.
 
 ## Common commands
 
@@ -16,6 +16,9 @@ Use the Farm CLI to run, build, generate types, deploy output, and add integrati
 | farm build | Build the app for the configured target. |
 | farm preview | Preview the production output. |
 | farm generate | Generate API and route types. |
+| farm migrate inspect | Detect supported framework migration sources. |
+| farm migrate next --write | Apply a deterministic Next.js App Router migration. |
+| farm migrate tanstack --write | Apply a deterministic TanStack Router file-route migration. |
 | farm migrate | Run one-shot schema or provider migration commands. |
 | farm add integration stripe --ui | Add integration wiring and optional UI. |
 
@@ -42,7 +45,24 @@ farm generate
 
 Use this after adding or changing API routes so `api.hello.post(...)`, route params, and `Link` types stay current.
 
-## Run migrations
+## Framework migrations
+
+```bash
+farm migrate inspect
+farm migrate next
+farm migrate next --write
+farm migrate tanstack --write
+```
+
+Framework migrations are deterministic codemods. They inspect the project, print a dry-run plan by default, and only write when `--write` is passed. Existing target files are skipped unless `--force` is passed.
+
+The Next.js migrator copies `app` or `src/app` into Farm's `src/app`, creates `farm.config.ts`, creates a minimal root layout when needed, rewrites `next/link` to Farm's typed client `Link`, and updates package scripts to `farm dev`, `farm build`, and `node .output/server/index.mjs`.
+
+The TanStack migrator converts file routes from `src/routes` or `routes` into `src/app/**/page.tsx`, maps `$id` to `[id]`, maps `$` to `[...splat]`, and adds a default export for simple `component: ComponentName` route files.
+
+Both migrators leave source files in place and print manual review notes for framework-specific APIs.
+
+## Run command migrations
 
 ```bash
 farm migrate

--- a/docs/src/app/docs/cli/page.md
+++ b/docs/src/app/docs/cli/page.md
@@ -56,7 +56,7 @@ farm migrate tanstack --write
 
 Framework migrations are deterministic codemods. They inspect the project, print a dry-run plan by default, and only write when `--write` is passed. Existing target files are skipped unless `--force` is passed.
 
-The Next.js migrator copies `app` or `src/app` into Farm's `src/app`, creates `farm.config.ts`, creates a minimal root layout when needed, rewrites `next/link` to Farm's typed client `Link`, and updates package scripts to `farm dev`, `farm build`, and `node .output/server/index.mjs`.
+The Next.js migrator copies `app` or `src/app` into Farm's `src/app`, creates `farm.config.ts`, creates a minimal root layout when needed, rewrites supported imports from `next/link`, `next/navigation`, and `next/headers`, and updates package scripts to `farm dev`, `farm build`, and `node .output/server/index.mjs`.
 
 The TanStack migrator converts file routes from `src/routes` or `routes` into `src/app/**/page.tsx`, maps `$id` to `[id]`, maps `$` to `[...splat]`, and adds a default export for simple `component: ComponentName` route files.
 

--- a/docs/src/app/docs/migrations/page.md
+++ b/docs/src/app/docs/migrations/page.md
@@ -1,0 +1,106 @@
+---
+title: "Migrations"
+description: "Move existing apps to Farm with deterministic code-first migrations, then run one-shot schema or provider commands."
+section: "Reference"
+---
+
+# Migrations
+
+Move existing apps to Farm with deterministic code-first migrations, then run one-shot schema or provider commands.
+
+## Framework migrations
+
+Framework migrations are code-first codemods. They inspect the current project, prepare a file operation plan, and only write when you opt in with `--write`.
+
+```bash
+farm migrate inspect
+farm migrate next
+farm migrate next --write
+farm migrate tanstack --write
+```
+
+`farm migrate next` and `farm migrate tanstack` are dry-run by default. They print detected framework evidence, planned file writes, warnings, and the manual review list. Use `--force` only when you intentionally want generated files to overwrite existing Farm files.
+
+## Next.js migration
+
+The Next.js migrator focuses on the App Router path because Farm uses the same route-file shape for pages, layouts, loading states, errors, not-found pages, and API route handlers.
+
+| Source | Farm output |
+| --- | --- |
+| app/page.tsx | src/app/page.tsx |
+| app/about/page.tsx | src/app/about/page.tsx |
+| app/api/hello/route.ts | src/app/api/hello/route.ts |
+| middleware.ts | src/app/middleware.ts |
+| package scripts | farm dev, farm build, node .output/server/index.mjs |
+
+The migrator also creates `farm.config.ts`, creates a minimal root layout when one is missing, adds `@farmjs/core` and `@farmjs/cli`, and rewrites `next/link` imports to Farm's typed client `Link`.
+
+```tsx
+import { Link } from "@farmjs/core/client";
+
+export default function Page() {
+  return <Link href="/docs">Docs</Link>;
+}
+```
+
+Some Next.js APIs need review because they are framework-specific. The migration report calls out `next/image`, `next/font`, `next/navigation`, `next/headers`, `next/server`, Pages Router data functions, and `next.config.*` so the app owner can decide the right Farm equivalent.
+
+## TanStack Router migration
+
+The TanStack Router migrator targets file-based routes in `src/routes` or `routes`.
+
+| Source | Farm output |
+| --- | --- |
+| src/routes/index.tsx | src/app/page.tsx |
+| src/routes/about.tsx | src/app/about/page.tsx |
+| src/routes/posts.$postId.tsx | src/app/posts/[postId]/page.tsx |
+| src/routes/docs.$.tsx | src/app/docs/[...splat]/page.tsx |
+
+For simple route files that use `component: ComponentName`, the migrator appends a default export so Farm can render the page module.
+
+```tsx
+export const Route = createFileRoute("/posts/$postId")({
+  component: PostPage,
+});
+
+function PostPage() {
+  return <h1>Post</h1>;
+}
+
+export default PostPage;
+```
+
+The migration report flags loaders, `beforeLoad`, search params, and `Route.use*` calls. Move that logic into Farm page props, server helpers, API routes, middleware, or integrations depending on what the route needs.
+
+## Command migrations
+
+`farm migrate` without a framework source still runs one-shot commands from `migrations.commands` in `farm.config.ts`.
+
+```ts
+import { defineFarmConfig } from "@farmjs/core";
+
+export default defineFarmConfig({
+  migrations: {
+    commands: [
+      {
+        name: "database",
+        command: "pnpm prisma migrate deploy",
+      },
+      {
+        name: "integration schema",
+        command: "farm generate --orm postgres --output ./schema/farm.sql",
+      },
+    ],
+  },
+});
+```
+
+Use command migrations for app-owned database migrations, integration schema setup, provider bootstrap commands, and CI steps that should run before `farm build`.
+
+## Safety model
+
+- Framework migrations never delete source files.
+- Framework migrations default to dry-run and require `--write`.
+- Existing target files are skipped unless `--force` is passed.
+- Package dependencies for the previous framework are left in place until the app owner removes them.
+- The report is part of the feature: unsupported APIs are called out instead of guessed.

--- a/docs/src/app/docs/migrations/page.md
+++ b/docs/src/app/docs/migrations/page.md
@@ -33,17 +33,45 @@ The Next.js migrator focuses on the App Router path because Farm uses the same r
 | middleware.ts | src/app/middleware.ts |
 | package scripts | farm dev, farm build, node .output/server/index.mjs |
 
-The migrator also creates `farm.config.ts`, creates a minimal root layout when one is missing, adds `@farmjs/core` and `@farmjs/cli`, and rewrites `next/link` imports to Farm's typed client `Link`.
+The migrator also creates `farm.config.ts`, creates a minimal root layout when one is missing, adds `@farmjs/core` and `@farmjs/cli`, and rewrites supported Next imports to Farm compatibility entries.
 
 ```tsx
 import { Link } from "@farmjs/core/client";
+import { redirect } from "@farmjs/core/navigation";
+import { cookies } from "@farmjs/core/headers";
 
 export default function Page() {
+  if (!cookies().has("session")) redirect("/sign-in");
   return <Link href="/docs">Docs</Link>;
 }
 ```
 
-Some Next.js APIs need review because they are framework-specific. The migration report calls out `next/image`, `next/font`, `next/navigation`, `next/headers`, `next/server`, Pages Router data functions, and `next.config.*` so the app owner can decide the right Farm equivalent.
+Supported rewrites include:
+
+| Next import | Farm import |
+| --- | --- |
+| next/link | @farmjs/core/client |
+| next/navigation | @farmjs/core/navigation |
+| next/headers | @farmjs/core/headers |
+
+Some Next.js APIs still need review because they are framework-specific. The migration report calls out `next/image`, `next/font`, `next/server`, Pages Router data functions, and `next.config.*` so the app owner can decide the right Farm equivalent.
+
+## Next compatibility layer
+
+Farm keeps the compatibility layer intentionally small. It covers common App Router APIs that map cleanly onto Farm's runtime:
+
+| API | Runtime |
+| --- | --- |
+| `redirect()` | Throws a redirect signal that Farm turns into a redirect response. |
+| `permanentRedirect()` | Same redirect signal with status 308. |
+| `notFound()` | Throws a not-found signal that Farm turns into a 404. |
+| `useRouter()` | Client hook backed by Farm's lightweight router. |
+| `usePathname()` | Client hook for the current pathname. |
+| `useSearchParams()` | Client hook for current URL search params. |
+| `headers()` | Server helper that reads the current request headers. |
+| `cookies()` | Server helper that reads current request cookies. |
+
+This is not a full Next.js clone. APIs such as image optimization, fonts, server actions, route segment config edge cases, and platform-specific middleware behavior stay explicit migration review items until Farm has native equivalents.
 
 ## TanStack Router migration
 

--- a/docs/src/app/docs/page.md
+++ b/docs/src/app/docs/page.md
@@ -75,8 +75,9 @@ Plugin system and lifecycle hooks.
 
 ### Reference
 
-CLI, examples, and package map.
+CLI, migrations, examples, and package map.
 
-- [CLI](/docs/cli): Use the Farm CLI to run, build, generate types, deploy output, and add integrations.
+- [Migrations](/docs/migrations): Move Next.js and TanStack Router apps with dry-run codemods, then run schema/provider commands.
+- [CLI](/docs/cli): Use the Farm CLI to run, build, generate types, migrate apps, deploy output, and add integrations.
 - [Examples](/docs/examples): Use the examples folder as executable docs for routing, RSC, docs, markdown, auth, billing, email, jobs, and API keys.
 - [Reference](/docs/reference): A compact map of the main package exports and where to learn more.

--- a/docs/src/app/docs/reference/page.md
+++ b/docs/src/app/docs/reference/page.md
@@ -14,6 +14,8 @@ A compact map of the main package exports and where to learn more.
 | --- | --- |
 | @farmjs/core | Config, app types, plugins, integrations, routing, OpenAPI, docs, cache. |
 | @farmjs/core/client | Link, router helpers, API client, integration client. |
+| @farmjs/core/navigation | Next-compatible redirect, notFound, and client navigation hooks. |
+| @farmjs/core/headers | Next-compatible request headers and cookies helpers. |
 | @farmjs/core/router | Lightweight route matching, href building, and active-route checks. |
 | @farmjs/core/query | Query and route param types. |
 | @farmjs/core/storage | Storage clients and mount helpers. |
@@ -34,6 +36,8 @@ A compact map of the main package exports and where to learn more.
 | --- | --- |
 | `@farmjs/core` | `defineIntegration`, `integrationRoute`, `defineIntegrationSchema`, `definePlugin`, `defineFarmConfig`. |
 | `@farmjs/core/client` | `createIntegrations`, `createIntegrationClient`, `createIntegrationServerClient`, `endpoint`. |
+| `@farmjs/core/navigation` | `redirect`, `permanentRedirect`, `notFound`, `useRouter`, `usePathname`, `useSearchParams`. |
+| `@farmjs/core/headers` | `headers`, `cookies`. |
 | `@farmjs/core/router` | `createFarmRouter`, `matchFarmRoute`, `buildFarmRoutePath`, `isFarmRouteActive`. |
 | `@farmjs/core/storage` | `sqliteStorage`, `postgresStorage`, `redisStorage`, `createStorageClient`, `defineStorageClient`. |
 | `@farmjs/integrations/stripe` | Stripe billing integration. |

--- a/docs/src/farm-routes.d.ts
+++ b/docs/src/farm-routes.d.ts
@@ -3,7 +3,7 @@
  * Link href is typed automatically via module augmentation. Regenerated on dev start and when routes change.
  * Set suppressLintOnLink: true in farm.config.ts to accept any string on Link href.
  */
-export type RoutePath = "/" | "/docs" | `/docs/${string}`;
+export type RoutePath = "/" | "/docs" | `/docs/${string}` | "/docs/api-client" | "/docs/api-routes" | "/docs/cache-ppr" | "/docs/cli" | "/docs/configuration" | "/docs/deployment" | "/docs/docs-engine" | "/docs/examples" | "/docs/getting-started" | "/docs/integrations" | "/docs/integrations/auth" | "/docs/integrations/auth/auth0" | "/docs/integrations/auth/authjs" | "/docs/integrations/auth/better-auth" | "/docs/integrations/auth/clerk" | "/docs/integrations/auth/supabase" | "/docs/integrations/auth/workos" | "/docs/integrations/autumn" | "/docs/integrations/custom" | "/docs/integrations/email" | "/docs/integrations/inngest" | "/docs/integrations/jobs" | "/docs/integrations/orm-storage" | "/docs/integrations/polar" | "/docs/integrations/stripe" | "/docs/integrations/trigger" | "/docs/integrations/ui-registry" | "/docs/integrations/unkey" | "/docs/layouts" | "/docs/markdown" | "/docs/middleware" | "/docs/migrations" | "/docs/observability" | "/docs/openapi" | "/docs/plugins" | "/docs/plugins/create-plugin" | "/docs/project-structure" | "/docs/query" | "/docs/reference" | "/docs/routing" | "/docs/server-rendering" | "/docs/storage";
 declare module "@farmjs/core/client" {
   interface LinkDefaultRoute {
     _: import("./farm-routes").RoutePath;

--- a/packages/farm-cli/bin/farm.js
+++ b/packages/farm-cli/bin/farm.js
@@ -83,13 +83,15 @@ program
   });
 
 program
-  .command("migrate")
-  .description("Run one-shot migration commands from farm.config.ts")
+  .command("migrate [source]")
+  .description("Run one-shot migration commands or migrate from another framework")
   .option("-r, --root <root>", "Root directory", process.cwd())
   .option("-c, --config <config>", "Path to farm config file")
   .option("--command <command>", "Migration command to run; can be repeated", collectOption, [])
   .option("--dry-run", "Print migration commands without running them")
-  .action(async (options) => {
+  .option("--write", "Apply framework migration changes; framework migrations are dry-run by default")
+  .option("--force", "Overwrite existing files during framework migrations")
+  .action(async (source, options) => {
     try {
       const { migrateFarm } = require("../dist/index.js");
       await migrateFarm({
@@ -97,6 +99,9 @@ program
         configPath: options.config,
         commands: options.command,
         dryRun: options.dryRun,
+        source,
+        write: options.write,
+        force: options.force,
       });
     } catch (error) {
       console.error("Failed to run migrations:", error);

--- a/packages/farm-cli/src/index.ts
+++ b/packages/farm-cli/src/index.ts
@@ -10,4 +10,12 @@ export {
 export { buildFarm } from "./build";
 export { deployFarm } from "./deploy";
 export { generateFarmArtifacts } from "./generate";
-export { migrateFarm } from "./migrate";
+export {
+  createFrameworkMigrationPlan,
+  inspectFrameworkMigrations,
+  migrateFarm,
+  type FarmFrameworkMigrationSource,
+  type FrameworkDetection,
+  type FrameworkMigrationOperation,
+  type FrameworkMigrationPlan,
+} from "./migrate";

--- a/packages/farm-cli/src/migrate.ts
+++ b/packages/farm-cli/src/migrate.ts
@@ -1,5 +1,7 @@
 import { loadConfig, logger } from "@farmjs/core";
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 type FarmMigrationCommand =
@@ -19,6 +21,9 @@ export interface MigrateFarmOptions {
   configPath?: string;
   commands?: string[];
   dryRun?: boolean;
+  source?: FarmFrameworkMigrationSource | "inspect";
+  write?: boolean;
+  force?: boolean;
 }
 
 interface ResolvedMigrationCommand {
@@ -28,8 +33,69 @@ interface ResolvedMigrationCommand {
   env?: Record<string, string | undefined>;
 }
 
+export type FarmFrameworkMigrationSource = "next" | "tanstack";
+
+type MigrationOperationKind = "write-file" | "update-package";
+
+export interface FrameworkDetection {
+  source: FarmFrameworkMigrationSource;
+  confidence: number;
+  evidence: string[];
+}
+
+export interface FrameworkMigrationOperation {
+  kind: MigrationOperationKind;
+  path: string;
+  description: string;
+  content?: string;
+  skipped?: boolean;
+  reason?: string;
+  changes?: string[];
+}
+
+export interface FrameworkMigrationPlan {
+  source: FarmFrameworkMigrationSource;
+  root: string;
+  confidence: number;
+  evidence: string[];
+  operations: FrameworkMigrationOperation[];
+  warnings: string[];
+  manual: string[];
+}
+
 export async function migrateFarm(options: MigrateFarmOptions = {}) {
   const root = path.resolve(options.root || process.cwd());
+
+  if (options.source) {
+    if (options.source === "inspect") {
+      const detections = await inspectFrameworkMigrations(root);
+      printFrameworkInspection(root, detections);
+      return detections;
+    }
+
+    if (!isFrameworkMigrationSource(options.source)) {
+      throw new Error(
+        `Unsupported migration source "${options.source}". Use "inspect", "next", or "tanstack".`,
+      );
+    }
+
+    const plan = await createFrameworkMigrationPlan(root, options.source, {
+      force: options.force,
+    });
+    printFrameworkMigrationPlan(plan, Boolean(options.write && !options.dryRun));
+
+    if (!options.write || options.dryRun) {
+      logger.info(`Dry run only. Re-run with "farm migrate ${options.source} --write" to apply.`);
+      return plan;
+    }
+
+    await applyFrameworkMigrationPlan(plan);
+    logger.success(
+      `Applied ${formatOperationCount(plan.operations.filter((operation) => !operation.skipped).length)}.`,
+    );
+    return plan;
+  }
+
   const cliCommands = options.commands?.filter(Boolean) || [];
   const userConfig = await loadConfig(root, options.configPath, "development");
   const configuredCommands = getConfiguredCommands(userConfig?.migrations);
@@ -125,4 +191,565 @@ function runMigrationCommand(command: ResolvedMigrationCommand) {
 
 function formatCount(count: number) {
   return `${count} migration command${count === 1 ? "" : "s"}`;
+}
+
+function formatOperationCount(count: number) {
+  return `${count} migration operation${count === 1 ? "" : "s"}`;
+}
+
+function isFrameworkMigrationSource(value: string): value is FarmFrameworkMigrationSource {
+  return value === "next" || value === "tanstack";
+}
+
+export async function inspectFrameworkMigrations(root: string): Promise<FrameworkDetection[]> {
+  const packageJson = await readPackageJson(root);
+  const detections = [detectNext(root, packageJson), detectTanStack(root, packageJson)]
+    .filter((entry): entry is FrameworkDetection => entry.confidence > 0)
+    .sort((a, b) => b.confidence - a.confidence);
+
+  return detections;
+}
+
+export async function createFrameworkMigrationPlan(
+  root: string,
+  source: FarmFrameworkMigrationSource,
+  options: { force?: boolean } = {},
+): Promise<FrameworkMigrationPlan> {
+  const detections = await inspectFrameworkMigrations(root);
+  const detection =
+    detections.find((entry) => entry.source === source) ||
+    ({
+      source,
+      confidence: 0,
+      evidence: [`No ${source} markers detected.`],
+    } satisfies FrameworkDetection);
+
+  const packageJson = await readPackageJson(root);
+  const plan: FrameworkMigrationPlan = {
+    source,
+    root,
+    confidence: detection.confidence,
+    evidence: detection.evidence,
+    operations: [],
+    warnings: [],
+    manual: [],
+  };
+
+  if (source === "next") {
+    await planNextMigration(root, packageJson, plan, options);
+  } else {
+    await planTanStackMigration(root, packageJson, plan, options);
+  }
+
+  addSharedFarmFiles(root, packageJson, plan, source, options);
+  return plan;
+}
+
+async function planNextMigration(
+  root: string,
+  packageJson: any,
+  plan: FrameworkMigrationPlan,
+  options: { force?: boolean },
+) {
+  const rootAppDir = path.join(root, "app");
+  const srcAppDir = path.join(root, "src", "app");
+  const sourceAppDir = existsSync(rootAppDir) ? rootAppDir : existsSync(srcAppDir) ? srcAppDir : null;
+
+  if (!sourceAppDir) {
+    plan.warnings.push("No Next App Router directory found at app/ or src/app/.");
+    if (existsSync(path.join(root, "pages"))) {
+      plan.manual.push("Pages Router files in pages/ need manual conversion to src/app/**/page.tsx.");
+    }
+    return;
+  }
+
+  const allFiles = await collectFiles(sourceAppDir);
+  const files = allFiles.filter(isMigratableTextFile);
+  for (const file of allFiles) {
+    if (!isMigratableTextFile(file)) {
+      plan.manual.push(`Move or review non-code app asset ${toPosix(path.relative(root, file))}.`);
+    }
+  }
+
+  for (const file of files) {
+    const relative = path.relative(sourceAppDir, file);
+    const target = path.join(srcAppDir, relative);
+    const content = await readFile(file, "utf8");
+    const transformed = transformNextContent(content);
+
+    collectNextManualNotes(relative, transformed, plan);
+    await addWriteFileOperation(plan, {
+      root,
+      source: file,
+      target,
+      content: transformed,
+      description:
+        sourceAppDir === srcAppDir
+          ? `Update Next-compatible app file ${toPosix(path.join("src/app", relative))}`
+          : `Copy Next App Router file to ${toPosix(path.join("src/app", relative))}`,
+      force: options.force,
+      allowExisting: sourceAppDir === srcAppDir,
+    });
+  }
+
+  const rootMiddleware = ["middleware.ts", "middleware.tsx", "middleware.js", "middleware.jsx"]
+    .map((file) => path.join(root, file))
+    .find((file) => existsSync(file));
+
+  if (rootMiddleware) {
+    const extension = path.extname(rootMiddleware);
+    const target = path.join(srcAppDir, `middleware${extension}`);
+    await addWriteFileOperation(plan, {
+      root,
+      source: rootMiddleware,
+      target,
+      content: await readFile(rootMiddleware, "utf8"),
+      description: `Copy root middleware to ${toPosix(path.join("src/app", `middleware${extension}`))}`,
+      force: options.force,
+    });
+    plan.manual.push(
+      "Review migrated middleware for next/server APIs; Farm middleware uses @farmjs/core/middleware.",
+    );
+  }
+
+  if (existsSync(path.join(root, "next.config.js")) || existsSync(path.join(root, "next.config.mjs"))) {
+    plan.manual.push("Review next.config.* and move equivalent settings into farm.config.ts or Vite config.");
+  }
+
+  if (packageJson) {
+    const migratedPackage = createMigratedPackageJson(packageJson, "next");
+    addPackageOperation(root, plan, migratedPackage);
+  }
+}
+
+async function planTanStackMigration(
+  root: string,
+  packageJson: any,
+  plan: FrameworkMigrationPlan,
+  options: { force?: boolean },
+) {
+  const routesDir = [path.join(root, "src", "routes"), path.join(root, "routes")].find((dir) =>
+    existsSync(dir),
+  );
+
+  if (!routesDir) {
+    plan.warnings.push("No TanStack Router file-route directory found at src/routes/ or routes/.");
+    return;
+  }
+
+  const appDir = path.join(root, "src", "app");
+  const files = (await collectFiles(routesDir)).filter((file) => {
+    const basename = path.basename(file);
+    return (
+      /\.(tsx|ts|jsx|js)$/.test(file) &&
+      basename !== "routeTree.gen.ts" &&
+      basename !== "routeTree.gen.tsx"
+    );
+  });
+
+  for (const file of files) {
+    const target = getTanStackTargetPath(routesDir, file, appDir);
+    if (!target) {
+      plan.manual.push(`Review ${toPosix(path.relative(root, file))}; root routes and route trees are not copied automatically.`);
+      continue;
+    }
+
+    const original = await readFile(file, "utf8");
+    const transformed = transformTanStackContent(original, path.relative(root, file), plan);
+    await addWriteFileOperation(plan, {
+      root,
+      source: file,
+      target,
+      content: transformed,
+      description: `Convert TanStack route to ${toPosix(path.relative(root, target))}`,
+      force: options.force,
+    });
+  }
+
+  plan.manual.push(
+    "Review loaders, beforeLoad hooks, search params, and Route.use* calls; Farm page modules should move that logic into props, API routes, or server helpers.",
+  );
+
+  if (packageJson) {
+    const migratedPackage = createMigratedPackageJson(packageJson, "tanstack");
+    addPackageOperation(root, plan, migratedPackage);
+  }
+}
+
+function addSharedFarmFiles(
+  root: string,
+  packageJson: any,
+  plan: FrameworkMigrationPlan,
+  source: FarmFrameworkMigrationSource,
+  options: { force?: boolean },
+) {
+  const farmConfigPath = ["farm.config.ts", "farm.config.mts", "farm.config.js", "farm.config.mjs"]
+    .map((file) => path.join(root, file))
+    .find((file) => existsSync(file));
+
+  if (!farmConfigPath) {
+    const output =
+      source === "next"
+        ? `import { defineFarmConfig } from "@farmjs/core";
+
+export default defineFarmConfig({
+  srcDir: "src",
+});
+`
+        : `import { defineFarmConfig } from "@farmjs/core";
+
+export default defineFarmConfig({
+  srcDir: "src",
+});
+`;
+
+    plan.operations.push({
+      kind: "write-file",
+      path: path.join(root, "farm.config.ts"),
+      description: "Create farm.config.ts",
+      content: output,
+      skipped: false,
+    });
+  }
+
+  const layoutPath = path.join(root, "src", "app", "layout.tsx");
+  if (!existsSync(layoutPath)) {
+    plan.operations.push({
+      kind: "write-file",
+      path: layoutPath,
+      description: "Create a minimal root layout",
+      content: `import type { LayoutProps } from "@farmjs/core";
+
+export default function Layout({ children }: LayoutProps) {
+  return <>{children}</>;
+}
+`,
+      skipped: false,
+    });
+  }
+
+  if (!packageJson) {
+    plan.warnings.push("No package.json found; add @farmjs/core and @farmjs/cli manually.");
+  }
+}
+
+async function addWriteFileOperation(
+  plan: FrameworkMigrationPlan,
+  options: {
+    root: string;
+    source?: string;
+    target: string;
+    content: string;
+    description: string;
+    force?: boolean;
+    allowExisting?: boolean;
+  },
+) {
+  const exists = existsSync(options.target);
+  const sameFile = options.source && path.resolve(options.source) === path.resolve(options.target);
+  const skipped = exists && !sameFile && !options.allowExisting && !options.force;
+
+  plan.operations.push({
+    kind: "write-file",
+    path: options.target,
+    description: options.description,
+    content: options.content,
+    skipped,
+    reason: skipped
+      ? `${toPosix(path.relative(options.root, options.target))} already exists; pass --force to overwrite.`
+      : undefined,
+  });
+}
+
+function addPackageOperation(
+  root: string,
+  plan: FrameworkMigrationPlan,
+  migrated: { packageJson: any; changes: string[] },
+) {
+  if (!migrated.changes.length) return;
+
+  plan.operations.push({
+    kind: "update-package",
+    path: path.join(root, "package.json"),
+    description: "Update package.json scripts and Farm dependencies",
+    content: `${JSON.stringify(migrated.packageJson, null, 2)}\n`,
+    changes: migrated.changes,
+  });
+}
+
+async function applyFrameworkMigrationPlan(plan: FrameworkMigrationPlan) {
+  for (const operation of plan.operations) {
+    if (operation.skipped) {
+      logger.warn(`Skipped ${toPosix(path.relative(plan.root, operation.path))}: ${operation.reason}`);
+      continue;
+    }
+
+    if (operation.kind === "write-file" || operation.kind === "update-package") {
+      await mkdir(path.dirname(operation.path), { recursive: true });
+      await writeFile(operation.path, operation.content || "", "utf8");
+    }
+  }
+}
+
+function printFrameworkInspection(root: string, detections: FrameworkDetection[]) {
+  logger.info(`Migration inspection for ${root}`);
+
+  if (!detections.length) {
+    logger.warn("No supported framework detected yet. Supported sources: next, tanstack.");
+    return;
+  }
+
+  for (const detection of detections) {
+    logger.info(`${detection.source}: ${detection.confidence}% confidence`);
+    for (const evidence of detection.evidence) {
+      logger.info(`  - ${evidence}`);
+    }
+  }
+}
+
+function printFrameworkMigrationPlan(plan: FrameworkMigrationPlan, willWrite: boolean) {
+  logger.info(
+    `${willWrite ? "Applying" : "Prepared"} ${plan.source} migration plan (${plan.confidence}% confidence):`,
+  );
+
+  for (const evidence of plan.evidence) {
+    logger.info(`  evidence: ${evidence}`);
+  }
+
+  if (!plan.operations.length) {
+    logger.warn("No file operations were planned.");
+  } else {
+    logger.info("Operations:");
+    for (const operation of plan.operations) {
+      const marker = operation.skipped ? "skip" : willWrite ? "write" : "plan";
+      logger.info(`  [${marker}] ${operation.description}`);
+      if (operation.changes?.length) {
+        for (const change of operation.changes) {
+          logger.info(`        - ${change}`);
+        }
+      }
+      if (operation.reason) {
+        logger.info(`        ${operation.reason}`);
+      }
+    }
+  }
+
+  if (plan.warnings.length) {
+    logger.warn("Warnings:");
+    for (const warning of unique(plan.warnings)) {
+      logger.warn(`  - ${warning}`);
+    }
+  }
+
+  if (plan.manual.length) {
+    logger.info("Manual review:");
+    for (const note of unique(plan.manual)) {
+      logger.info(`  - ${note}`);
+    }
+  }
+}
+
+function detectNext(root: string, packageJson: any): FrameworkDetection {
+  const evidence: string[] = [];
+  let confidence = 0;
+
+  if (hasPackage(packageJson, "next")) {
+    confidence += 55;
+    evidence.push("package.json depends on next");
+  }
+  if (existsSync(path.join(root, "app"))) {
+    confidence += 30;
+    evidence.push("app/ directory exists");
+  }
+  if (existsSync(path.join(root, "src", "app"))) {
+    confidence += 25;
+    evidence.push("src/app/ directory exists");
+  }
+  if (existsSync(path.join(root, "next.config.js")) || existsSync(path.join(root, "next.config.mjs"))) {
+    confidence += 15;
+    evidence.push("next.config.* exists");
+  }
+  if (existsSync(path.join(root, "pages"))) {
+    confidence += 10;
+    evidence.push("pages/ directory exists");
+  }
+
+  return { source: "next", confidence: Math.min(confidence, 100), evidence };
+}
+
+function detectTanStack(root: string, packageJson: any): FrameworkDetection {
+  const evidence: string[] = [];
+  let confidence = 0;
+
+  if (hasPackage(packageJson, "@tanstack/react-router")) {
+    confidence += 60;
+    evidence.push("package.json depends on @tanstack/react-router");
+  }
+  if (existsSync(path.join(root, "src", "routes"))) {
+    confidence += 35;
+    evidence.push("src/routes/ directory exists");
+  }
+  if (existsSync(path.join(root, "routes"))) {
+    confidence += 25;
+    evidence.push("routes/ directory exists");
+  }
+  if (existsSync(path.join(root, "src", "routeTree.gen.ts"))) {
+    confidence += 15;
+    evidence.push("src/routeTree.gen.ts exists");
+  }
+
+  return { source: "tanstack", confidence: Math.min(confidence, 100), evidence };
+}
+
+async function collectFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir);
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    if (entry === "node_modules" || entry === ".next" || entry === ".output") continue;
+    const fullPath = path.join(dir, entry);
+    const info = await stat(fullPath);
+
+    if (info.isDirectory()) {
+      files.push(...(await collectFiles(fullPath)));
+    } else if (info.isFile()) {
+      files.push(fullPath);
+    }
+  }
+
+  return files.sort();
+}
+
+function transformNextContent(content: string) {
+  return content.replace(
+    /import\s+([A-Za-z_$][\w$]*)\s+from\s+["']next\/link["'];?/g,
+    (_match, localName) =>
+      localName === "Link"
+        ? `import { Link } from "@farmjs/core/client";`
+        : `import { Link as ${localName} } from "@farmjs/core/client";`,
+  );
+}
+
+function collectNextManualNotes(relative: string, content: string, plan: FrameworkMigrationPlan) {
+  const imports = Array.from(content.matchAll(/from\s+["'](next\/[^"']+)["']/g)).map((match) => match[1]);
+  for (const importId of imports) {
+    plan.manual.push(`Review ${toPosix(relative)}; it still imports ${importId}.`);
+  }
+
+  if (/getServerSideProps|getStaticProps|getInitialProps/.test(content)) {
+    plan.manual.push(`Review ${toPosix(relative)}; Pages Router data functions need manual App Router/Farm conversion.`);
+  }
+}
+
+function isMigratableTextFile(file: string) {
+  return /\.(ts|tsx|js|jsx|mjs|cjs|md|mdx|css|json|txt)$/.test(file);
+}
+
+function getTanStackTargetPath(routesDir: string, file: string, appDir: string) {
+  const relative = toPosix(path.relative(routesDir, file));
+  const withoutExt = relative.replace(/\.(tsx|ts|jsx|js)$/, "");
+  if (withoutExt === "__root" || withoutExt === "routeTree.gen") return null;
+
+  const rawParts = withoutExt
+    .split("/")
+    .flatMap((segment) => segment.split("."))
+    .filter((segment) => segment && !segment.startsWith("_"));
+
+  if (!rawParts.length) return null;
+  const isIndex = rawParts[rawParts.length - 1] === "index";
+  const routeParts = (isIndex ? rawParts.slice(0, -1) : rawParts).map(convertTanStackSegment);
+  return path.join(appDir, ...routeParts, "page.tsx");
+}
+
+function convertTanStackSegment(segment: string) {
+  if (segment === "$") return "[...splat]";
+  if (segment.startsWith("$")) return `[${segment.slice(1)}]`;
+  return segment;
+}
+
+function transformTanStackContent(content: string, relativeFile: string, plan: FrameworkMigrationPlan) {
+  if (/Route\.use[A-Z]/.test(content) || /useLoaderData|beforeLoad|loader:/.test(content)) {
+    plan.manual.push(`Review ${toPosix(relativeFile)}; it uses TanStack route runtime APIs.`);
+  }
+
+  if (/export\s+default\s+/.test(content)) return content;
+
+  const componentName = content.match(/component\s*:\s*([A-Za-z_$][\w$]*)/)?.[1];
+  if (!componentName) {
+    plan.manual.push(`Add a default export to ${toPosix(relativeFile)}; no component: Identifier was found.`);
+    return content;
+  }
+
+  return `${content.trimEnd()}
+
+export default ${componentName};
+`;
+}
+
+function createMigratedPackageJson(packageJson: any, source: FarmFrameworkMigrationSource) {
+  const nextPackageJson = cloneJson(packageJson);
+  const changes: string[] = [];
+  nextPackageJson.scripts = nextPackageJson.scripts || {};
+
+  const scriptReplacements =
+    source === "next"
+      ? [
+          ["dev", "farm dev", /(^|\s)next\s+dev(\s|$)/],
+          ["build", "farm build", /(^|\s)next\s+build(\s|$)/],
+          ["start", "node .output/server/index.mjs", /(^|\s)next\s+start(\s|$)/],
+        ]
+      : [
+          ["dev", "farm dev", /(^|\s)vite(\s|$)|(^|\s)vinxi\s+dev(\s|$)/],
+          ["build", "farm build", /(^|\s)vite\s+build(\s|$)|(^|\s)vinxi\s+build(\s|$)/],
+        ];
+
+  for (const [name, value, matcher] of scriptReplacements as [string, string, RegExp][]) {
+    const existing = nextPackageJson.scripts[name];
+    if (!existing || matcher.test(existing)) {
+      if (existing !== value) {
+        nextPackageJson.scripts[name] = value;
+        changes.push(`scripts.${name} -> ${value}`);
+      }
+    }
+  }
+
+  nextPackageJson.dependencies = nextPackageJson.dependencies || {};
+  if (!nextPackageJson.dependencies["@farmjs/core"]) {
+    nextPackageJson.dependencies["@farmjs/core"] = "latest";
+    changes.push("dependencies.@farmjs/core -> latest");
+  }
+
+  nextPackageJson.devDependencies = nextPackageJson.devDependencies || {};
+  if (!nextPackageJson.devDependencies["@farmjs/cli"]) {
+    nextPackageJson.devDependencies["@farmjs/cli"] = "latest";
+    changes.push("devDependencies.@farmjs/cli -> latest");
+  }
+
+  return { packageJson: nextPackageJson, changes };
+}
+
+async function readPackageJson(root: string) {
+  const packagePath = path.join(root, "package.json");
+  if (!existsSync(packagePath)) return null;
+  return JSON.parse(await readFile(packagePath, "utf8"));
+}
+
+function hasPackage(packageJson: any, packageName: string) {
+  return Boolean(
+    packageJson?.dependencies?.[packageName] ||
+      packageJson?.devDependencies?.[packageName] ||
+      packageJson?.peerDependencies?.[packageName],
+  );
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function unique(values: string[]) {
+  return [...new Set(values)];
+}
+
+function toPosix(value: string) {
+  return value.split(path.sep).join("/");
 }

--- a/packages/farm-cli/src/migrate.ts
+++ b/packages/farm-cli/src/migrate.ts
@@ -621,13 +621,16 @@ async function collectFiles(dir: string): Promise<string[]> {
 }
 
 function transformNextContent(content: string) {
-  return content.replace(
-    /import\s+([A-Za-z_$][\w$]*)\s+from\s+["']next\/link["'];?/g,
-    (_match, localName) =>
-      localName === "Link"
-        ? `import { Link } from "@farmjs/core/client";`
-        : `import { Link as ${localName} } from "@farmjs/core/client";`,
-  );
+  return content
+    .replace(
+      /import\s+([A-Za-z_$][\w$]*)\s+from\s+["']next\/link["'];?/g,
+      (_match, localName) =>
+        localName === "Link"
+          ? `import { Link } from "@farmjs/core/client";`
+          : `import { Link as ${localName} } from "@farmjs/core/client";`,
+    )
+    .replace(/from\s+["']next\/navigation["']/g, `from "@farmjs/core/navigation"`)
+    .replace(/from\s+["']next\/headers["']/g, `from "@farmjs/core/headers"`);
 }
 
 function collectNextManualNotes(relative: string, content: string, plan: FrameworkMigrationPlan) {

--- a/packages/farm-cli/test/migrate.test.mjs
+++ b/packages/farm-cli/test/migrate.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { createRequire } from "node:module";
@@ -9,7 +9,8 @@ import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 
 const require = createRequire(import.meta.url);
-const { migrateFarm } = require("../dist/index.js");
+const { createFrameworkMigrationPlan, inspectFrameworkMigrations, migrateFarm } =
+  require("../dist/index.js");
 const execFileAsync = promisify(execFile);
 const testDir = path.dirname(fileURLToPath(import.meta.url));
 const cliBin = path.resolve(testDir, "../bin/farm.js");
@@ -99,11 +100,147 @@ test("runs farm migrate through the CLI", async () => {
   }
 });
 
-async function createTempProject() {
+test("inspects framework migration sources", async () => {
+  const root = await createTempProject({
+    dependencies: {
+      next: "latest",
+      "@tanstack/react-router": "latest",
+    },
+  });
+
+  try {
+    await mkdir(path.join(root, "app"), { recursive: true });
+    await mkdir(path.join(root, "src", "routes"), { recursive: true });
+
+    const detections = await inspectFrameworkMigrations(root);
+
+    assert.ok(detections.some((entry) => entry.source === "next"));
+    assert.ok(detections.some((entry) => entry.source === "tanstack"));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("runs framework migration inspection through the CLI", async () => {
+  const root = await createTempProject({
+    dependencies: {
+      next: "latest",
+    },
+  });
+
+  try {
+    await mkdir(path.join(root, "app"), { recursive: true });
+
+    const { stdout } = await execFileAsync(process.execPath, [
+      cliBin,
+      "migrate",
+      "inspect",
+      "--root",
+      root,
+    ]);
+
+    assert.match(stdout, /next: \d+% confidence/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("prepares and applies a code-first Next app migration", async () => {
+  const root = await createTempProject({
+    scripts: {
+      dev: "next dev",
+      build: "next build",
+      start: "next start",
+    },
+    dependencies: {
+      next: "latest",
+      react: "latest",
+      "react-dom": "latest",
+    },
+  });
+
+  try {
+    await mkdir(path.join(root, "app", "about"), { recursive: true });
+    await writeFile(
+      path.join(root, "app", "about", "page.tsx"),
+      `import FarmLink from "next/link";
+
+export default function AboutPage() {
+  return <FarmLink href="/">Home</FarmLink>;
+}
+`,
+      "utf8",
+    );
+
+    const dryRunPlan = await createFrameworkMigrationPlan(root, "next");
+    assert.ok(dryRunPlan.operations.some((operation) => operation.description.includes("Copy Next")));
+    await assert.rejects(() => readFile(path.join(root, "src", "app", "about", "page.tsx"), "utf8"));
+
+    await migrateFarm({ root, source: "next", write: true });
+
+    const page = await readFile(path.join(root, "src", "app", "about", "page.tsx"), "utf8");
+    assert.match(page, /import \{ Link as FarmLink \} from "@farmjs\/core\/client";/);
+    assert.match(await readFile(path.join(root, "farm.config.ts"), "utf8"), /defineFarmConfig/);
+
+    const packageJson = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
+    assert.equal(packageJson.scripts.dev, "farm dev");
+    assert.equal(packageJson.scripts.build, "farm build");
+    assert.equal(packageJson.scripts.start, "node .output/server/index.mjs");
+    assert.equal(packageJson.dependencies["@farmjs/core"], "latest");
+    assert.equal(packageJson.devDependencies["@farmjs/cli"], "latest");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("applies a simple TanStack file-route migration", async () => {
+  const root = await createTempProject({
+    scripts: {
+      dev: "vite",
+      build: "vite build",
+    },
+    dependencies: {
+      "@tanstack/react-router": "latest",
+      react: "latest",
+      "react-dom": "latest",
+    },
+  });
+
+  try {
+    await mkdir(path.join(root, "src", "routes"), { recursive: true });
+    await writeFile(
+      path.join(root, "src", "routes", "posts.$postId.tsx"),
+      `import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/posts/$postId")({
+  component: PostPage,
+});
+
+function PostPage() {
+  return <h1>Post</h1>;
+}
+`,
+      "utf8",
+    );
+
+    await migrateFarm({ root, source: "tanstack", write: true });
+
+    const page = await readFile(path.join(root, "src", "app", "posts", "[postId]", "page.tsx"), "utf8");
+    assert.match(page, /export default PostPage;/);
+
+    const packageJson = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
+    assert.equal(packageJson.scripts.dev, "farm dev");
+    assert.equal(packageJson.scripts.build, "farm build");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+async function createTempProject(packageJson = {}) {
   const root = await mkdtemp(path.join(os.tmpdir(), "farm-cli-migrate-"));
   await writeFile(
     path.join(root, "package.json"),
-    JSON.stringify({ type: "module", dependencies: {} }, null, 2),
+    JSON.stringify({ type: "module", dependencies: {}, ...packageJson }, null, 2),
     "utf8",
   );
   return root;

--- a/packages/farm-cli/test/migrate.test.mjs
+++ b/packages/farm-cli/test/migrate.test.mjs
@@ -164,8 +164,13 @@ test("prepares and applies a code-first Next app migration", async () => {
     await writeFile(
       path.join(root, "app", "about", "page.tsx"),
       `import FarmLink from "next/link";
+import { redirect, usePathname } from "next/navigation";
+import { cookies, headers } from "next/headers";
 
 export default function AboutPage() {
+  if (cookies().has("session")) redirect("/dashboard");
+  const pathname = usePathname();
+  headers().get("x-demo");
   return <FarmLink href="/">Home</FarmLink>;
 }
 `,
@@ -180,6 +185,9 @@ export default function AboutPage() {
 
     const page = await readFile(path.join(root, "src", "app", "about", "page.tsx"), "utf8");
     assert.match(page, /import \{ Link as FarmLink \} from "@farmjs\/core\/client";/);
+    assert.match(page, /from "@farmjs\/core\/navigation";/);
+    assert.match(page, /from "@farmjs\/core\/headers";/);
+    assert.doesNotMatch(page, /from "next\//);
     assert.match(await readFile(path.join(root, "farm.config.ts"), "utf8"), /defineFarmConfig/);
 
     const packageJson = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -39,6 +39,12 @@
       "cache": [
         "./dist/cache.d.ts"
       ],
+      "navigation": [
+        "./dist/navigation.d.ts"
+      ],
+      "headers": [
+        "./dist/headers.d.ts"
+      ],
       "docs": [
         "./dist/docs.d.ts"
       ],
@@ -102,6 +108,16 @@
       "types": "./dist/cache.d.ts",
       "import": "./dist/cache.mjs",
       "require": "./dist/cache.cjs"
+    },
+    "./navigation": {
+      "types": "./dist/navigation.d.ts",
+      "import": "./dist/navigation.mjs",
+      "require": "./dist/navigation.cjs"
+    },
+    "./headers": {
+      "types": "./dist/headers.d.ts",
+      "import": "./dist/headers.mjs",
+      "require": "./dist/headers.cjs"
     },
     "./docs": {
       "types": "./dist/docs.d.ts",

--- a/packages/farm/src/__tests__/headers.test.ts
+++ b/packages/farm/src/__tests__/headers.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { cookies, headers } from "../headers";
+import { _runWithCurrentRequest } from "../server/request";
+
+describe("Next-compatible header helpers", () => {
+  it("reads headers from the current server request", async () => {
+    const request = new Request("https://farmjs.dev/dashboard", {
+      headers: {
+        "x-farm-test": "ok",
+      },
+    });
+
+    await _runWithCurrentRequest(request, () => {
+      const requestHeaders = headers();
+      expect(requestHeaders.get("x-farm-test")).toBe("ok");
+      expect(requestHeaders.has("x-farm-test")).toBe(true);
+    });
+  });
+
+  it("reads request cookies from the current server request", async () => {
+    const request = new Request("https://farmjs.dev/dashboard", {
+      headers: {
+        cookie: "session=abc123; theme=dark",
+      },
+    });
+
+    await _runWithCurrentRequest(request, () => {
+      const requestCookies = cookies();
+      expect(requestCookies.get("session")).toEqual({ name: "session", value: "abc123" });
+      expect(requestCookies.has("theme")).toBe(true);
+      expect(requestCookies.getAll()).toEqual([
+        { name: "session", value: "abc123" },
+        { name: "theme", value: "dark" },
+      ]);
+      expect(requestCookies.toString()).toBe("session=abc123; theme=dark");
+    });
+  });
+});

--- a/packages/farm/src/__tests__/navigation.test.ts
+++ b/packages/farm/src/__tests__/navigation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  getFarmRedirectError,
+  isFarmNotFoundError,
+  isFarmRedirectError,
+  notFound,
+  permanentRedirect,
+  redirect,
+} from "../navigation";
+
+describe("Next-compatible navigation helpers", () => {
+  it("throws a redirect signal with location and status", () => {
+    try {
+      redirect("/sign-in");
+    } catch (error) {
+      expect(isFarmRedirectError(error)).toBe(true);
+      expect(getFarmRedirectError(error)).toEqual({
+        url: "/sign-in",
+        status: 307,
+      });
+    }
+  });
+
+  it("supports permanent redirects", () => {
+    try {
+      permanentRedirect("/new-home");
+    } catch (error) {
+      expect(getFarmRedirectError(error)).toEqual({
+        url: "/new-home",
+        status: 308,
+      });
+    }
+  });
+
+  it("throws a not-found signal", () => {
+    try {
+      notFound();
+    } catch (error) {
+      expect(isFarmNotFoundError(error)).toBe(true);
+      expect(isFarmRedirectError(error)).toBe(false);
+    }
+  });
+});

--- a/packages/farm/src/headers.ts
+++ b/packages/farm/src/headers.ts
@@ -1,0 +1,81 @@
+import { getCurrentRequest } from "./server/request";
+
+export interface RequestCookie {
+  name: string;
+  value: string;
+}
+
+export interface ReadonlyHeaders extends Iterable<[string, string]> {
+  get(name: string): string | null;
+  has(name: string): boolean;
+  forEach(callbackfn: (value: string, key: string, parent: Headers) => void, thisArg?: any): void;
+  entries(): IterableIterator<[string, string]>;
+  keys(): IterableIterator<string>;
+  values(): IterableIterator<string>;
+}
+
+export interface ReadonlyRequestCookies extends Iterable<RequestCookie> {
+  get(name: string): RequestCookie | undefined;
+  getAll(name?: string): RequestCookie[];
+  has(name: string): boolean;
+  toString(): string;
+}
+
+export function headers(): ReadonlyHeaders {
+  return new Headers(getCurrentRequest().headers) as ReadonlyHeaders;
+}
+
+export function cookies(): ReadonlyRequestCookies {
+  const cookieHeader = getCurrentRequest().headers.get("cookie") || "";
+  const parsed = parseCookieHeader(cookieHeader);
+
+  return {
+    get(name) {
+      return parsed.find((cookie) => cookie.name === name);
+    },
+    getAll(name) {
+      return name ? parsed.filter((cookie) => cookie.name === name) : [...parsed];
+    },
+    has(name) {
+      return parsed.some((cookie) => cookie.name === name);
+    },
+    toString() {
+      return cookieHeader;
+    },
+    [Symbol.iterator]() {
+      return parsed[Symbol.iterator]();
+    },
+  };
+}
+
+function parseCookieHeader(header: string): RequestCookie[] {
+  if (!header.trim()) return [];
+
+  return header
+    .split(";")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => {
+      const separatorIndex = part.indexOf("=");
+      if (separatorIndex === -1) {
+        return {
+          name: decodeCookiePart(part),
+          value: "",
+        };
+      }
+
+      return {
+        name: decodeCookiePart(part.slice(0, separatorIndex).trim()),
+        value: decodeCookiePart(part.slice(separatorIndex + 1).trim()),
+      };
+    })
+    .filter((cookie) => cookie.name.length > 0);
+}
+
+function decodeCookiePart(value: string) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -37,6 +37,19 @@ export * from "./build/index";
 export * from "./client";
 export * from "./ssg";
 export * from "./cache";
+export {
+  getFarmRedirectError,
+  isFarmNotFoundError,
+  isFarmRedirectError,
+  notFound,
+  permanentRedirect,
+  redirect,
+  usePathname,
+  useSearchParams,
+} from "./navigation";
+export type { FarmRedirectSignal, FarmRedirectStatus } from "./navigation";
+export { cookies, headers } from "./headers";
+export type { ReadonlyHeaders, ReadonlyRequestCookies, RequestCookie } from "./headers";
 export type {
   FarmPlugin,
   FarmPluginContext,

--- a/packages/farm/src/navigation.ts
+++ b/packages/farm/src/navigation.ts
@@ -1,0 +1,102 @@
+import { useRouter as useFarmRouter } from "./client/router";
+
+export type FarmRedirectStatus = 301 | 302 | 303 | 307 | 308;
+
+export interface FarmRedirectSignal {
+  url: string;
+  status: FarmRedirectStatus;
+}
+
+const REDIRECT_ERROR_CODE = "FARM_REDIRECT";
+const NOT_FOUND_ERROR_CODE = "FARM_NOT_FOUND";
+const REDIRECT_ERROR_SYMBOL = Symbol.for("farm.navigation.redirect");
+const NOT_FOUND_ERROR_SYMBOL = Symbol.for("farm.navigation.notFound");
+
+type FarmNavigationError = Error & {
+  digest: string;
+  [REDIRECT_ERROR_SYMBOL]?: FarmRedirectSignal;
+  [NOT_FOUND_ERROR_SYMBOL]?: true;
+};
+
+export function redirect(url: string, status: FarmRedirectStatus = 307): never {
+  throw createRedirectError(url, status);
+}
+
+export function permanentRedirect(url: string): never {
+  redirect(url, 308);
+}
+
+export function notFound(): never {
+  const error = new Error(NOT_FOUND_ERROR_CODE) as FarmNavigationError;
+  error.digest = NOT_FOUND_ERROR_CODE;
+  error[NOT_FOUND_ERROR_SYMBOL] = true;
+  throw error;
+}
+
+export function isFarmRedirectError(error: unknown): boolean {
+  return Boolean(getFarmRedirectError(error));
+}
+
+export function getFarmRedirectError(error: unknown): FarmRedirectSignal | null {
+  if (!error || typeof error !== "object") return null;
+  const candidate = error as Partial<FarmNavigationError>;
+  if (candidate[REDIRECT_ERROR_SYMBOL]) {
+    return candidate[REDIRECT_ERROR_SYMBOL] as FarmRedirectSignal;
+  }
+
+  if (typeof candidate.digest === "string" && candidate.digest.startsWith(`${REDIRECT_ERROR_CODE};`)) {
+    const [, status, ...urlParts] = candidate.digest.split(";");
+    const parsedStatus = Number(status);
+    if (isRedirectStatus(parsedStatus)) {
+      return {
+        status: parsedStatus,
+        url: urlParts.join(";"),
+      };
+    }
+  }
+
+  return null;
+}
+
+export function isFarmNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as Partial<FarmNavigationError>;
+  return Boolean(candidate[NOT_FOUND_ERROR_SYMBOL] || candidate.digest === NOT_FOUND_ERROR_CODE);
+}
+
+export function useRouter() {
+  const router = useFarmRouter();
+  return {
+    push: router.push,
+    replace: router.replace,
+    back: router.back,
+    forward: router.forward,
+    refresh() {
+      if (typeof window !== "undefined") {
+        window.location.reload();
+      }
+    },
+    prefetch(_href: string) {
+      return Promise.resolve();
+    },
+  };
+}
+
+export function usePathname(): string {
+  return useFarmRouter().pathname;
+}
+
+export function useSearchParams(): URLSearchParams {
+  return useFarmRouter().searchParams;
+}
+
+function createRedirectError(url: string, status: FarmRedirectStatus): FarmNavigationError {
+  const error = new Error(`${REDIRECT_ERROR_CODE};${status};${url}`) as FarmNavigationError;
+  error.digest = `${REDIRECT_ERROR_CODE};${status};${url}`;
+  error[REDIRECT_ERROR_SYMBOL] = { url, status };
+  return error;
+}
+
+function isRedirectStatus(status: number): status is FarmRedirectStatus {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -471,6 +471,7 @@ async function buildClient(
               id === "@farmjs/core/server" ||
               id === "@farmjs/core/api" ||
               id === "@farmjs/core/middleware" ||
+              id === "@farmjs/core/headers" ||
               id === "@farmjs/core/config" ||
               id.includes("@farmjs/core/middleware") ||
               id.includes("@farmjs/core/query/server")
@@ -512,6 +513,7 @@ async function buildClient(
                 "// Farm.js Client Exports - Safe for browser bundling",
                 'export { Link } from "@farmjs/core/client";',
                 'export { useRouter } from "@farmjs/core/client";',
+                'export { usePathname, useSearchParams } from "@farmjs/core/navigation";',
                 'export { createAPIClient } from "@farmjs/core/client";',
               ].join("\n");
             }
@@ -532,7 +534,12 @@ async function buildClient(
       },
       // Optimize dependencies - exclude server-side code from client bundle
       optimizeDeps: {
-        exclude: ["@farmjs/core/server", "@farmjs/core/api", "@farmjs/core/middleware"],
+        exclude: [
+          "@farmjs/core/server",
+          "@farmjs/core/api",
+          "@farmjs/core/middleware",
+          "@farmjs/core/headers",
+        ],
       },
     });
   } finally {
@@ -1481,6 +1488,7 @@ function generateVirtualEntryCode(
       ? `import { invokeAPIRouteEndpoint, matchAPIRoute } from "farm/api/route-manager";`
       : "";
   const cacheHelpersImport = `import { createFarmCacheKey, getFarmDataCache, normalizeRevalidatePath } from "farm/cache";`;
+  const navigationHelpersImport = `import { getFarmRedirectError, isFarmNotFoundError, isFarmRedirectError } from "farm/navigation";`;
   const observabilityHelpersImport = `import { configureFarmObservability, emitFarmEvent } from "farm/observability";`;
   const middlewareRuntimeImport = `import { applyProductionMiddlewareHeaders, createProductionMiddlewareRunner } from "farm/middleware";`;
   const docsHandlerImport = config.docs?.enabled
@@ -1561,6 +1569,7 @@ ${middlewareImports.join("\n")}
 ${notFoundImport}
 ${apiRouteHelpersImport}
 ${cacheHelpersImport}
+${navigationHelpersImport}
 ${observabilityHelpersImport}
 ${middlewareRuntimeImport}
 ${docsHandlerImport}
@@ -1953,6 +1962,9 @@ async function handleRequest(request) {
               pageElement = React.createElement("div", null, String(result));
             }
           } catch (asyncError) {
+            if (isFarmRedirectError(asyncError) || isFarmNotFoundError(asyncError)) {
+              throw asyncError;
+            }
             // If async rendering fails, try sync rendering as fallback
             pageElement = React.createElement(PageComponent, pageProps);
           }
@@ -2097,6 +2109,44 @@ async function handleRequest(request) {
         ), middlewareHeaders);
       }
     } catch (error) {
+      if (isFarmRedirectError(error)) {
+        const redirect = getFarmRedirectError(error);
+        emitFarmEvent({
+          type: "route.redirect",
+          from: pathname,
+          to: redirect.url,
+          status: redirect.status,
+        });
+        emitFarmEvent({
+          type: "render.complete",
+          route: pathname,
+          pathname,
+          status: redirect.status,
+          durationMs: Date.now() - requestStartTime,
+        });
+        return applyProductionMiddlewareHeaders(new Response(null, {
+          status: redirect.status,
+          headers: {
+            Location: redirect.url,
+          },
+        }), middlewareHeaders);
+      }
+
+      if (isFarmNotFoundError(error)) {
+        emitFarmEvent({ type: "route.notFound", pathname });
+        emitFarmEvent({
+          type: "render.complete",
+          route: pathname,
+          pathname,
+          status: 404,
+          durationMs: Date.now() - requestStartTime,
+        });
+        return applyProductionMiddlewareHeaders(new Response("Not Found", {
+          status: 404,
+          headers: { "Content-Type": "text/plain; charset=utf-8" },
+        }), middlewareHeaders);
+      }
+
       emitFarmEvent({ type: "render.error", route: pathname, error });
       console.error("SSR Error:", error);
       return applyProductionMiddlewareHeaders(new Response(

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -14,6 +14,11 @@ import { getIntegrationProviders, getRegisteredIntegrationAPIManifest } from "..
 import { _runWithCurrentRequest, createWebRequestFromFarmRequest } from "./request";
 import { createFarmCacheKey, getFarmDataCache, normalizeRevalidatePath } from "../cache";
 import { emitFarmEvent } from "../observability";
+import {
+  getFarmRedirectError,
+  isFarmNotFoundError,
+  isFarmRedirectError,
+} from "../navigation";
 
 let cachedClerkProvider: {
   ClerkProvider: React.ComponentType<{ children?: React.ReactNode } & Record<string, unknown>>;
@@ -682,6 +687,36 @@ export class ServerRenderer {
         });
       });
     } catch (error) {
+      if (isFarmRedirectError(error)) {
+        const redirect = getFarmRedirectError(error)!;
+        emitFarmEvent({
+          type: "route.redirect",
+          from: pathname,
+          to: redirect.url,
+          status: redirect.status,
+        });
+        if (!res.headersSent && !(res as any).writableEnded) {
+          res.statusCode = redirect.status;
+          res.setHeader("Location", redirect.url);
+          res.end();
+        } else if (!(res as any).writableEnded) {
+          res.end();
+        }
+        completeRender(redirect.status, pathname);
+        return;
+      }
+
+      if (isFarmNotFoundError(error)) {
+        emitFarmEvent({ type: "route.notFound", pathname });
+        if (!res.headersSent && !(res as any).writableEnded) {
+          await this.render404(req, res);
+        } else if (!(res as any).writableEnded) {
+          res.end();
+        }
+        completeRender(404, pathname);
+        return;
+      }
+
       emitFarmEvent({ type: "render.error", route: pathname, error });
       if (pprRefreshRoute) {
         emitFarmEvent({ type: "ppr.refresh.error", route: pprRefreshRoute, error });
@@ -1043,8 +1078,10 @@ window.__FARM_INTEGRATION_API_MANIFEST__ = ${JSON.stringify(getRegisteredIntegra
         },
         onShellError(error) {
           didError = true;
-          logger.error(`SSR shell error: ${error}`);
-          emitFarmEvent({ type: "render.error", route: observabilityRoute, error });
+          if (!isFarmRedirectError(error) && !isFarmNotFoundError(error)) {
+            logger.error(`SSR shell error: ${error}`);
+            emitFarmEvent({ type: "render.error", route: observabilityRoute, error });
+          }
 
           if (clearMiddlewareData) {
             clearMiddlewareData();
@@ -1054,8 +1091,10 @@ window.__FARM_INTEGRATION_API_MANIFEST__ = ${JSON.stringify(getRegisteredIntegra
         },
         onError(error) {
           didError = true;
-          logger.error(`SSR streaming error: ${error}`);
-          emitFarmEvent({ type: "render.error", route: observabilityRoute, error });
+          if (!isFarmRedirectError(error) && !isFarmNotFoundError(error)) {
+            logger.error(`SSR streaming error: ${error}`);
+            emitFarmEvent({ type: "render.error", route: observabilityRoute, error });
+          }
         },
       });
     });

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -18,6 +18,8 @@ export default defineConfig({
     plugin: "src/plugin.ts",
     storage: "src/storage/index.ts",
     cache: "src/cache.ts",
+    navigation: "src/navigation.ts",
+    headers: "src/headers.ts",
     docs: "src/docs/index.ts",
     markdown: "src/markdown.ts",
     "app-markdown": "src/app-markdown.ts",


### PR DESCRIPTION
## Summary
- adds deterministic framework migration mode to `farm migrate` with `inspect`, `next`, and `tanstack` sources
- keeps existing one-shot command migrations working unchanged
- adds dry-run-by-default plans, `--write`, `--force`, package/config/layout updates, Next App Router copying, `next/link` rewrite, and TanStack file-route conversion
- documents the migration flow and adds the docs sidebar entry

## Tests
- `corepack pnpm --filter @farmjs/cli test`
- `DATABASE_URL=postgresql://user:password@localhost:5432/farmjs ./node_modules/.bin/prisma generate && ./node_modules/.bin/farm build` from `docs`

## Notes
- `corepack pnpm --filter @farmjs/cli type-check` still fails on existing `src/ui-feature-registry.ts` shadcn component typing issues; the migrator-specific type error from this branch is fixed.