### PR TITLE
feat: add next compatibility migration layer

### DIFF
--- a/docs/src/app/docs/cli/page.md
+++ b/docs/src/app/docs/cli/page.md
@@ -56,7 +56,7 @@ farm migrate tanstack --write
 
 Framework migrations are deterministic codemods. They inspect the project, print a dry-run plan by default, and only write when `--write` is passed. Existing target files are skipped unless `--force` is passed.
 
-The Next.js migrator copies `app` or `src/app` into Farm's `src/app`, creates `farm.config.ts`, creates a minimal root layout when needed, rewrites `next/link` to Farm's typed client `Link`, and updates package scripts to `farm dev`, `farm build`, and `node .output/server/index.mjs`.
+The Next.js migrator copies `app` or `src/app` into Farm's `src/app`, creates `farm.config.ts`, creates a minimal root layout when needed, rewrites supported imports from `next/link`, `next/navigation`, and `next/headers`, and updates package scripts to `farm dev`, `farm build`, and `node .output/server/index.mjs`.
 
 The TanStack migrator converts file routes from `src/routes` or `routes` into `src/app/**/page.tsx`, maps `$id` to `[id]`, maps `$` to `[...splat]`, and adds a default export for simple `component: ComponentName` route files.
 

--- a/docs/src/app/docs/migrations/page.md
+++ b/docs/src/app/docs/migrations/page.md
@@ -33,17 +33,45 @@ The Next.js migrator focuses on the App Router path because Farm uses the same r
 | middleware.ts | src/app/middleware.ts |
 | package scripts | farm dev, farm build, node .output/server/index.mjs |
 
-The migrator also creates `farm.config.ts`, creates a minimal root layout when one is missing, adds `@farmjs/core` and `@farmjs/cli`, and rewrites `next/link` imports to Farm's typed client `Link`.
+The migrator also creates `farm.config.ts`, creates a minimal root layout when one is missing, adds `@farmjs/core` and `@farmjs/cli`, and rewrites supported Next imports to Farm compatibility entries.
 
 ```tsx
 import { Link } from "@farmjs/core/client";
+import { redirect } from "@farmjs/core/navigation";
+import { cookies } from "@farmjs/core/headers";
 
 export default function Page() {
+  if (!cookies().has("session")) redirect("/sign-in");
   return <Link href="/docs">Docs</Link>;
 }
 ```
 
-Some Next.js APIs need review because they are framework-specific. The migration report calls out `next/image`, `next/font`, `next/navigation`, `next/headers`, `next/server`, Pages Router data functions, and `next.config.*` so the app owner can decide the right Farm equivalent.
+Supported rewrites include:
+
+| Next import | Farm import |
+| --- | --- |
+| next/link | @farmjs/core/client |
+| next/navigation | @farmjs/core/navigation |
+| next/headers | @farmjs/core/headers |
+
+Some Next.js APIs still need review because they are framework-specific. The migration report calls out `next/image`, `next/font`, `next/server`, Pages Router data functions, and `next.config.*` so the app owner can decide the right Farm equivalent.
+
+## Next compatibility layer
+
+Farm keeps the compatibility layer intentionally small. It covers common App Router APIs that map cleanly onto Farm's runtime:
+
+| API | Runtime |
+| --- | --- |
+| `redirect()` | Throws a redirect signal that Farm turns into a redirect response. |
+| `permanentRedirect()` | Same redirect signal with status 308. |
+| `notFound()` | Throws a not-found signal that Farm turns into a 404. |
+| `useRouter()` | Client hook backed by Farm's lightweight router. |
+| `usePathname()` | Client hook for the current pathname. |
+| `useSearchParams()` | Client hook for current URL search params. |
+| `headers()` | Server helper that reads the current request headers. |
+| `cookies()` | Server helper that reads current request cookies. |
+
+This is not a full Next.js clone. APIs such as image optimization, fonts, server actions, route segment config edge cases, and platform-specific middleware behavior stay explicit migration review items until Farm has native equivalents.
 
 ## TanStack Router migration
 

--- a/docs/src/app/docs/reference/page.md
+++ b/docs/src/app/docs/reference/page.md
@@ -14,6 +14,8 @@ A compact map of the main package exports and where to learn more.
 | --- | --- |
 | @farmjs/core | Config, app types, plugins, integrations, routing, OpenAPI, docs, cache. |
 | @farmjs/core/client | Link, router helpers, API client, integration client. |
+| @farmjs/core/navigation | Next-compatible redirect, notFound, and client navigation hooks. |
+| @farmjs/core/headers | Next-compatible request headers and cookies helpers. |
 | @farmjs/core/router | Lightweight route matching, href building, and active-route checks. |
 | @farmjs/core/query | Query and route param types. |
 | @farmjs/core/storage | Storage clients and mount helpers. |
@@ -34,6 +36,8 @@ A compact map of the main package exports and where to learn more.
 | --- | --- |
 | `@farmjs/core` | `defineIntegration`, `integrationRoute`, `defineIntegrationSchema`, `definePlugin`, `defineFarmConfig`. |
 | `@farmjs/core/client` | `createIntegrations`, `createIntegrationClient`, `createIntegrationServerClient`, `endpoint`. |
+| `@farmjs/core/navigation` | `redirect`, `permanentRedirect`, `notFound`, `useRouter`, `usePathname`, `useSearchParams`. |
+| `@farmjs/core/headers` | `headers`, `cookies`. |
 | `@farmjs/core/router` | `createFarmRouter`, `matchFarmRoute`, `buildFarmRoutePath`, `isFarmRouteActive`. |
 | `@farmjs/core/storage` | `sqliteStorage`, `postgresStorage`, `redisStorage`, `createStorageClient`, `defineStorageClient`. |
 | `@farmjs/integrations/stripe` | Stripe billing integration. |

--- a/packages/farm-cli/src/migrate.ts
+++ b/packages/farm-cli/src/migrate.ts
@@ -621,13 +621,16 @@ async function collectFiles(dir: string): Promise<string[]> {
 }
 
 function transformNextContent(content: string) {
-  return content.replace(
-    /import\s+([A-Za-z_$][\w$]*)\s+from\s+["']next\/link["'];?/g,
-    (_match, localName) =>
-      localName === "Link"
-        ? `import { Link } from "@farmjs/core/client";`
-        : `import { Link as ${localName} } from "@farmjs/core/client";`,
-  );
+  return content
+    .replace(
+      /import\s+([A-Za-z_$][\w$]*)\s+from\s+["']next\/link["'];?/g,
+      (_match, localName) =>
+        localName === "Link"
+          ? `import { Link } from "@farmjs/core/client";`
+          : `import { Link as ${localName} } from "@farmjs/core/client";`,
+    )
+    .replace(/from\s+["']next\/navigation["']/g, `from "@farmjs/core/navigation"`)
+    .replace(/from\s+["']next\/headers["']/g, `from "@farmjs/core/headers"`);
 }
 
 function collectNextManualNotes(relative: string, content: string, plan: FrameworkMigrationPlan) {

--- a/packages/farm-cli/test/migrate.test.mjs
+++ b/packages/farm-cli/test/migrate.test.mjs
@@ -164,8 +164,13 @@ test("prepares and applies a code-first Next app migration", async () => {
     await writeFile(
       path.join(root, "app", "about", "page.tsx"),
       `import FarmLink from "next/link";
+import { redirect, usePathname } from "next/navigation";
+import { cookies, headers } from "next/headers";
 
 export default function AboutPage() {
+  if (cookies().has("session")) redirect("/dashboard");
+  const pathname = usePathname();
+  headers().get("x-demo");
   return <FarmLink href="/">Home</FarmLink>;
 }
 `,
@@ -180,6 +185,9 @@ export default function AboutPage() {
 
     const page = await readFile(path.join(root, "src", "app", "about", "page.tsx"), "utf8");
     assert.match(page, /import \{ Link as FarmLink \} from "@farmjs\/core\/client";/);
+    assert.match(page, /from "@farmjs\/core\/navigation";/);
+    assert.match(page, /from "@farmjs\/core\/headers";/);
+    assert.doesNotMatch(page, /from "next\//);
     assert.match(await readFile(path.join(root, "farm.config.ts"), "utf8"), /defineFarmConfig/);
 
     const packageJson = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -39,6 +39,12 @@
       "cache": [
         "./dist/cache.d.ts"
       ],
+      "navigation": [
+        "./dist/navigation.d.ts"
+      ],
+      "headers": [
+        "./dist/headers.d.ts"
+      ],
       "docs": [
         "./dist/docs.d.ts"
       ],
@@ -102,6 +108,16 @@
       "types": "./dist/cache.d.ts",
       "import": "./dist/cache.mjs",
       "require": "./dist/cache.cjs"
+    },
+    "./navigation": {
+      "types": "./dist/navigation.d.ts",
+      "import": "./dist/navigation.mjs",
+      "require": "./dist/navigation.cjs"
+    },
+    "./headers": {
+      "types": "./dist/headers.d.ts",
+      "import": "./dist/headers.mjs",
+      "require": "./dist/headers.cjs"
     },
     "./docs": {
       "types": "./dist/docs.d.ts",

--- a/packages/farm/src/__tests__/headers.test.ts
+++ b/packages/farm/src/__tests__/headers.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { cookies, headers } from "../headers";
+import { _runWithCurrentRequest } from "../server/request";
+
+describe("Next-compatible header helpers", () => {
+  it("reads headers from the current server request", async () => {
+    const request = new Request("https://farmjs.dev/dashboard", {
+      headers: {
+        "x-farm-test": "ok",
+      },
+    });
+
+    await _runWithCurrentRequest(request, () => {
+      const requestHeaders = headers();
+      expect(requestHeaders.get("x-farm-test")).toBe("ok");
+      expect(requestHeaders.has("x-farm-test")).toBe(true);
+    });
+  });
+
+  it("reads request cookies from the current server request", async () => {
+    const request = new Request("https://farmjs.dev/dashboard", {
+      headers: {
+        cookie: "session=abc123; theme=dark",
+      },
+    });
+
+    await _runWithCurrentRequest(request, () => {
+      const requestCookies = cookies();
+      expect(requestCookies.get("session")).toEqual({ name: "session", value: "abc123" });
+      expect(requestCookies.has("theme")).toBe(true);
+      expect(requestCookies.getAll()).toEqual([
+        { name: "session", value: "abc123" },
+        { name: "theme", value: "dark" },
+      ]);
+      expect(requestCookies.toString()).toBe("session=abc123; theme=dark");
+    });
+  });
+});

--- a/packages/farm/src/__tests__/navigation.test.ts
+++ b/packages/farm/src/__tests__/navigation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  getFarmRedirectError,
+  isFarmNotFoundError,
+  isFarmRedirectError,
+  notFound,
+  permanentRedirect,
+  redirect,
+} from "../navigation";
+
+describe("Next-compatible navigation helpers", () => {
+  it("throws a redirect signal with location and status", () => {
+    try {
+      redirect("/sign-in");
+    } catch (error) {
+      expect(isFarmRedirectError(error)).toBe(true);
+      expect(getFarmRedirectError(error)).toEqual({
+        url: "/sign-in",
+        status: 307,
+      });
+    }
+  });
+
+  it("supports permanent redirects", () => {
+    try {
+      permanentRedirect("/new-home");
+    } catch (error) {
+      expect(getFarmRedirectError(error)).toEqual({
+        url: "/new-home",
+        status: 308,
+      });
+    }
+  });
+
+  it("throws a not-found signal", () => {
+    try {
+      notFound();
+    } catch (error) {
+      expect(isFarmNotFoundError(error)).toBe(true);
+      expect(isFarmRedirectError(error)).toBe(false);
+    }
+  });
+});

--- a/packages/farm/src/headers.ts
+++ b/packages/farm/src/headers.ts
@@ -1,0 +1,81 @@
+import { getCurrentRequest } from "./server/request";
+
+export interface RequestCookie {
+  name: string;
+  value: string;
+}
+
+export interface ReadonlyHeaders extends Iterable<[string, string]> {
+  get(name: string): string | null;
+  has(name: string): boolean;
+  forEach(callbackfn: (value: string, key: string, parent: Headers) => void, thisArg?: any): void;
+  entries(): IterableIterator<[string, string]>;
+  keys(): IterableIterator<string>;
+  values(): IterableIterator<string>;
+}
+
+export interface ReadonlyRequestCookies extends Iterable<RequestCookie> {
+  get(name: string): RequestCookie | undefined;
+  getAll(name?: string): RequestCookie[];
+  has(name: string): boolean;
+  toString(): string;
+}
+
+export function headers(): ReadonlyHeaders {
+  return new Headers(getCurrentRequest().headers) as ReadonlyHeaders;
+}
+
+export function cookies(): ReadonlyRequestCookies {
+  const cookieHeader = getCurrentRequest().headers.get("cookie") || "";
+  const parsed = parseCookieHeader(cookieHeader);
+
+  return {
+    get(name) {
+      return parsed.find((cookie) => cookie.name === name);
+    },
+    getAll(name) {
+      return name ? parsed.filter((cookie) => cookie.name === name) : [...parsed];
+    },
+    has(name) {
+      return parsed.some((cookie) => cookie.name === name);
+    },
+    toString() {
+      return cookieHeader;
+    },
+    [Symbol.iterator]() {
+      return parsed[Symbol.iterator]();
+    },
+  };
+}
+
+function parseCookieHeader(header: string): RequestCookie[] {
+  if (!header.trim()) return [];
+
+  return header
+    .split(";")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => {
+      const separatorIndex = part.indexOf("=");
+      if (separatorIndex === -1) {
+        return {
+          name: decodeCookiePart(part),
+          value: "",
+        };
+      }
+
+      return {
+        name: decodeCookiePart(part.slice(0, separatorIndex).trim()),
+        value: decodeCookiePart(part.slice(separatorIndex + 1).trim()),
+      };
+    })
+    .filter((cookie) => cookie.name.length > 0);
+}
+
+function decodeCookiePart(value: string) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -37,6 +37,19 @@ export * from "./build/index";
 export * from "./client";
 export * from "./ssg";
 export * from "./cache";
+export {
+  getFarmRedirectError,
+  isFarmNotFoundError,
+  isFarmRedirectError,
+  notFound,
+  permanentRedirect,
+  redirect,
+  usePathname,
+  useSearchParams,
+} from "./navigation";
+export type { FarmRedirectSignal, FarmRedirectStatus } from "./navigation";
+export { cookies, headers } from "./headers";
+export type { ReadonlyHeaders, ReadonlyRequestCookies, RequestCookie } from "./headers";
 export type {
   FarmPlugin,
   FarmPluginContext,

--- a/packages/farm/src/navigation.ts
+++ b/packages/farm/src/navigation.ts
@@ -1,0 +1,102 @@
+import { useRouter as useFarmRouter } from "./client/router";
+
+export type FarmRedirectStatus = 301 | 302 | 303 | 307 | 308;
+
+export interface FarmRedirectSignal {
+  url: string;
+  status: FarmRedirectStatus;
+}
+
+const REDIRECT_ERROR_CODE = "FARM_REDIRECT";
+const NOT_FOUND_ERROR_CODE = "FARM_NOT_FOUND";
+const REDIRECT_ERROR_SYMBOL = Symbol.for("farm.navigation.redirect");
+const NOT_FOUND_ERROR_SYMBOL = Symbol.for("farm.navigation.notFound");
+
+type FarmNavigationError = Error & {
+  digest: string;
+  [REDIRECT_ERROR_SYMBOL]?: FarmRedirectSignal;
+  [NOT_FOUND_ERROR_SYMBOL]?: true;
+};
+
+export function redirect(url: string, status: FarmRedirectStatus = 307): never {
+  throw createRedirectError(url, status);
+}
+
+export function permanentRedirect(url: string): never {
+  redirect(url, 308);
+}
+
+export function notFound(): never {
+  const error = new Error(NOT_FOUND_ERROR_CODE) as FarmNavigationError;
+  error.digest = NOT_FOUND_ERROR_CODE;
+  error[NOT_FOUND_ERROR_SYMBOL] = true;
+  throw error;
+}
+
+export function isFarmRedirectError(error: unknown): boolean {
+  return Boolean(getFarmRedirectError(error));
+}
+
+export function getFarmRedirectError(error: unknown): FarmRedirectSignal | null {
+  if (!error || typeof error !== "object") return null;
+  const candidate = error as Partial<FarmNavigationError>;
+  if (candidate[REDIRECT_ERROR_SYMBOL]) {
+    return candidate[REDIRECT_ERROR_SYMBOL] as FarmRedirectSignal;
+  }
+
+  if (typeof candidate.digest === "string" && candidate.digest.startsWith(`${REDIRECT_ERROR_CODE};`)) {
+    const [, status, ...urlParts] = candidate.digest.split(";");
+    const parsedStatus = Number(status);
+    if (isRedirectStatus(parsedStatus)) {
+      return {
+        status: parsedStatus,
+        url: urlParts.join(";"),
+      };
+    }
+  }
+
+  return null;
+}
+
+export function isFarmNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as Partial<FarmNavigationError>;
+  return Boolean(candidate[NOT_FOUND_ERROR_SYMBOL] || candidate.digest === NOT_FOUND_ERROR_CODE);
+}
+
+export function useRouter() {
+  const router = useFarmRouter();
+  return {
+    push: router.push,
+    replace: router.replace,
+    back: router.back,
+    forward: router.forward,
+    refresh() {
+      if (typeof window !== "undefined") {
+        window.location.reload();
+      }
+    },
+    prefetch(_href: string) {
+      return Promise.resolve();
+    },
+  };
+}
+
+export function usePathname(): string {
+  return useFarmRouter().pathname;
+}
+
+export function useSearchParams(): URLSearchParams {
+  return useFarmRouter().searchParams;
+}
+
+function createRedirectError(url: string, status: FarmRedirectStatus): FarmNavigationError {
+  const error = new Error(`${REDIRECT_ERROR_CODE};${status};${url}`) as FarmNavigationError;
+  error.digest = `${REDIRECT_ERROR_CODE};${status};${url}`;
+  error[REDIRECT_ERROR_SYMBOL] = { url, status };
+  return error;
+}
+
+function isRedirectStatus(status: number): status is FarmRedirectStatus {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -471,6 +471,7 @@ async function buildClient(
               id === "@farmjs/core/server" ||
               id === "@farmjs/core/api" ||
               id === "@farmjs/core/middleware" ||
+              id === "@farmjs/core/headers" ||
               id === "@farmjs/core/config" ||
               id.includes("@farmjs/core/middleware") ||
               id.includes("@farmjs/core/query/server")
@@ -512,6 +513,7 @@ async function buildClient(
                 "// Farm.js Client Exports - Safe for browser bundling",
                 'export { Link } from "@farmjs/core/client";',
                 'export { useRouter } from "@farmjs/core/client";',
+                'export { usePathname, useSearchParams } from "@farmjs/core/navigation";',
                 'export { createAPIClient } from "@farmjs/core/client";',
               ].join("\n");
             }
@@ -532,7 +534,12 @@ async function buildClient(
       },
       // Optimize dependencies - exclude server-side code from client bundle
       optimizeDeps: {
-        exclude: ["@farmjs/core/server", "@farmjs/core/api", "@farmjs/core/middleware"],
+        exclude: [
+          "@farmjs/core/server",
+          "@farmjs/core/api",
+          "@farmjs/core/middleware",
+          "@farmjs/core/headers",
+        ],
       },
     });
   } finally {
@@ -1481,6 +1488,7 @@ function generateVirtualEntryCode(
       ? `import { invokeAPIRouteEndpoint, matchAPIRoute } from "farm/api/route-manager";`
       : "";
   const cacheHelpersImport = `import { createFarmCacheKey, getFarmDataCache, normalizeRevalidatePath } from "farm/cache";`;
+  const navigationHelpersImport = `import { getFarmRedirectError, isFarmNotFoundError, isFarmRedirectError } from "farm/navigation";`;
   const observabilityHelpersImport = `import { configureFarmObservability, emitFarmEvent } from "farm/observability";`;
   const middlewareRuntimeImport = `import { applyProductionMiddlewareHeaders, createProductionMiddlewareRunner } from "farm/middleware";`;
   const docsHandlerImport = config.docs?.enabled
@@ -1561,6 +1569,7 @@ ${middlewareImports.join("\n")}
 ${notFoundImport}
 ${apiRouteHelpersImport}
 ${cacheHelpersImport}
+${navigationHelpersImport}
 ${observabilityHelpersImport}
 ${middlewareRuntimeImport}
 ${docsHandlerImport}
@@ -1953,6 +1962,9 @@ async function handleRequest(request) {
               pageElement = React.createElement("div", null, String(result));
             }
           } catch (asyncError) {
+            if (isFarmRedirectError(asyncError) || isFarmNotFoundError(asyncError)) {
+              throw asyncError;
+            }
             // If async rendering fails, try sync rendering as fallback
             pageElement = React.createElement(PageComponent, pageProps);
           }
@@ -2097,6 +2109,44 @@ async function handleRequest(request) {
         ), middlewareHeaders);
       }
     } catch (error) {
+      if (isFarmRedirectError(error)) {
+        const redirect = getFarmRedirectError(error);
+        emitFarmEvent({
+          type: "route.redirect",
+          from: pathname,
+          to: redirect.url,
+          status: redirect.status,
+        });
+        emitFarmEvent({
+          type: "render.complete",
+          route: pathname,
+          pathname,
+          status: redirect.status,
+          durationMs: Date.now() - requestStartTime,
+        });
+        return applyProductionMiddlewareHeaders(new Response(null, {
+          status: redirect.status,
+          headers: {
+            Location: redirect.url,
+          },
+        }), middlewareHeaders);
+      }
+
+      if (isFarmNotFoundError(error)) {
+        emitFarmEvent({ type: "route.notFound", pathname });
+        emitFarmEvent({
+          type: "render.complete",
+          route: pathname,
+          pathname,
+          status: 404,
+          durationMs: Date.now() - requestStartTime,
+        });
+        return applyProductionMiddlewareHeaders(new Response("Not Found", {
+          status: 404,
+          headers: { "Content-Type": "text/plain; charset=utf-8" },
+        }), middlewareHeaders);
+      }
+
       emitFarmEvent({ type: "render.error", route: pathname, error });
       console.error("SSR Error:", error);
       return applyProductionMiddlewareHeaders(new Response(

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -14,6 +14,11 @@ import { getIntegrationProviders, getRegisteredIntegrationAPIManifest } from "..
 import { _runWithCurrentRequest, createWebRequestFromFarmRequest } from "./request";
 import { createFarmCacheKey, getFarmDataCache, normalizeRevalidatePath } from "../cache";
 import { emitFarmEvent } from "../observability";
+import {
+  getFarmRedirectError,
+  isFarmNotFoundError,
+  isFarmRedirectError,
+} from "../navigation";
 
 let cachedClerkProvider: {
   ClerkProvider: React.ComponentType<{ children?: React.ReactNode } & Record<string, unknown>>;
@@ -682,6 +687,36 @@ export class ServerRenderer {
         });
       });
     } catch (error) {
+      if (isFarmRedirectError(error)) {
+        const redirect = getFarmRedirectError(error)!;
+        emitFarmEvent({
+          type: "route.redirect",
+          from: pathname,
+          to: redirect.url,
+          status: redirect.status,
+        });
+        if (!res.headersSent && !(res as any).writableEnded) {
+          res.statusCode = redirect.status;
+          res.setHeader("Location", redirect.url);
+          res.end();
+        } else if (!(res as any).writableEnded) {
+          res.end();
+        }
+        completeRender(redirect.status, pathname);
+        return;
+      }
+
+      if (isFarmNotFoundError(error)) {
+        emitFarmEvent({ type: "route.notFound", pathname });
+        if (!res.headersSent && !(res as any).writableEnded) {
+          await this.render404(req, res);
+        } else if (!(res as any).writableEnded) {
+          res.end();
+        }
+        completeRender(404, pathname);
+        return;
+      }
+
       emitFarmEvent({ type: "render.error", route: pathname, error });
       if (pprRefreshRoute) {
         emitFarmEvent({ type: "ppr.refresh.error", route: pprRefreshRoute, error });
@@ -1043,8 +1078,10 @@ window.__FARM_INTEGRATION_API_MANIFEST__ = ${JSON.stringify(getRegisteredIntegra
         },
         onShellError(error) {
           didError = true;
-          logger.error(`SSR shell error: ${error}`);
-          emitFarmEvent({ type: "render.error", route: observabilityRoute, error });
+          if (!isFarmRedirectError(error) && !isFarmNotFoundError(error)) {
+            logger.error(`SSR shell error: ${error}`);
+            emitFarmEvent({ type: "render.error", route: observabilityRoute, error });
+          }
 
           if (clearMiddlewareData) {
             clearMiddlewareData();
@@ -1054,8 +1091,10 @@ window.__FARM_INTEGRATION_API_MANIFEST__ = ${JSON.stringify(getRegisteredIntegra
         },
         onError(error) {
           didError = true;
-          logger.error(`SSR streaming error: ${error}`);
-          emitFarmEvent({ type: "render.error", route: observabilityRoute, error });
+          if (!isFarmRedirectError(error) && !isFarmNotFoundError(error)) {
+            logger.error(`SSR streaming error: ${error}`);
+            emitFarmEvent({ type: "render.error", route: observabilityRoute, error });
+          }
         },
       });
     });

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -18,6 +18,8 @@ export default defineConfig({
     plugin: "src/plugin.ts",
     storage: "src/storage/index.ts",
     cache: "src/cache.ts",
+    navigation: "src/navigation.ts",
+    headers: "src/headers.ts",
     docs: "src/docs/index.ts",
     markdown: "src/markdown.ts",
     "app-markdown": "src/app-markdown.ts",


### PR DESCRIPTION
## Summary
- adds compact Next-compatible Farm entries for `@farmjs/core/navigation` and `@farmjs/core/headers`
- supports `redirect`, `permanentRedirect`, `notFound`, `useRouter`, `usePathname`, `useSearchParams`, `headers`, and read-only `cookies`
- wires redirect/not-found signals through dev/server rendering and universal Nitro output
- teaches `farm migrate next` to rewrite supported `next/navigation` and `next/headers` imports, while keeping unsupported APIs as manual review items
- documents the compatibility scope without claiming full Next parity

## Tests
- `corepack pnpm --filter @farmjs/core test -- src/__tests__/navigation.test.ts src/__tests__/headers.test.ts`
- `corepack pnpm --filter @farmjs/core build`
- `corepack pnpm --filter @farmjs/cli test`
- `DATABASE_URL=postgresql://user:password@localhost:5432/farmjs ./node_modules/.bin/prisma generate && ./node_modules/.bin/farm build` from `docs`

## Notes
- Stacked on #105 / `feat/code-first-migrations`.
- `corepack pnpm --filter @farmjs/core type-check` still fails on existing Nitro/nuqs-related repo errors; the branch-specific root export ambiguity found during build was fixed.