### PR TITLE
feat: add next image compatibility

### DIFF
--- a/docs/src/app/docs/cli/page.md
+++ b/docs/src/app/docs/cli/page.md
@@ -56,7 +56,7 @@ farm migrate tanstack --write
 
 Framework migrations are deterministic codemods. They inspect the project, print a dry-run plan by default, and only write when `--write` is passed. Existing target files are skipped unless `--force` is passed.
 
-The Next.js migrator copies `app` or `src/app` into Farm's `src/app`, creates `farm.config.ts`, creates a minimal root layout when needed, rewrites supported imports from `next/link`, `next/navigation`, and `next/headers`, and updates package scripts to `farm dev`, `farm build`, and `node .output/server/index.mjs`.
+The Next.js migrator copies `app` or `src/app` into Farm's `src/app`, creates `farm.config.ts`, creates a minimal root layout when needed, rewrites supported imports from `next/link`, `next/image`, `next/navigation`, and `next/headers`, and updates package scripts to `farm dev`, `farm build`, and `node .output/server/index.mjs`.
 
 The TanStack migrator converts file routes from `src/routes` or `routes` into `src/app/**/page.tsx`, maps `$id` to `[id]`, maps `$` to `[...splat]`, and adds a default export for simple `component: ComponentName` route files.
 

--- a/docs/src/app/docs/migrations/page.md
+++ b/docs/src/app/docs/migrations/page.md
@@ -37,12 +37,18 @@ The migrator also creates `farm.config.ts`, creates a minimal root layout when o
 
 ```tsx
 import { Link } from "@farmjs/core/client";
+import { Image } from "@farmjs/core/image";
 import { redirect } from "@farmjs/core/navigation";
 import { cookies } from "@farmjs/core/headers";
 
 export default function Page() {
   if (!cookies().has("session")) redirect("/sign-in");
-  return <Link href="/docs">Docs</Link>;
+  return (
+    <Link href="/docs">
+      <Image src="/hero.png" alt="Docs" width={1200} height={630} />
+      Docs
+    </Link>
+  );
 }
 ```
 
@@ -51,10 +57,11 @@ Supported rewrites include:
 | Next import | Farm import |
 | --- | --- |
 | next/link | @farmjs/core/client |
+| next/image | @farmjs/core/image |
 | next/navigation | @farmjs/core/navigation |
 | next/headers | @farmjs/core/headers |
 
-Some Next.js APIs still need review because they are framework-specific. The migration report calls out `next/image`, `next/font`, `next/server`, Pages Router data functions, and `next.config.*` so the app owner can decide the right Farm equivalent.
+Some Next.js APIs still need review because they are framework-specific. The migration report calls out `next/font`, `next/server`, Pages Router data functions, and `next.config.*` so the app owner can decide the right Farm equivalent.
 
 ## Next compatibility layer
 
@@ -70,8 +77,9 @@ Farm keeps the compatibility layer intentionally small. It covers common App Rou
 | `useSearchParams()` | Client hook for current URL search params. |
 | `headers()` | Server helper that reads the current request headers. |
 | `cookies()` | Server helper that reads current request cookies. |
+| `Image` | Client-safe image component that renders a normal `<img>` and accepts common Next Image props during migration. |
 
-This is not a full Next.js clone. APIs such as image optimization, fonts, server actions, route segment config edge cases, and platform-specific middleware behavior stay explicit migration review items until Farm has native equivalents.
+This is not a full Next.js clone. `@farmjs/core/image` does not optimize images by itself; it preserves the component API shape while you decide whether to serve static images, use a CDN loader, or add a provider-specific optimizer. APIs such as fonts, server actions, route segment config edge cases, and platform-specific middleware behavior stay explicit migration review items until Farm has native equivalents.
 
 ## TanStack Router migration
 

--- a/docs/src/app/docs/reference/page.md
+++ b/docs/src/app/docs/reference/page.md
@@ -14,6 +14,7 @@ A compact map of the main package exports and where to learn more.
 | --- | --- |
 | @farmjs/core | Config, app types, plugins, integrations, routing, OpenAPI, docs, cache. |
 | @farmjs/core/client | Link, router helpers, API client, integration client. |
+| @farmjs/core/image | Next-compatible Image component that renders a normal img during migration. |
 | @farmjs/core/navigation | Next-compatible redirect, notFound, and client navigation hooks. |
 | @farmjs/core/headers | Next-compatible request headers and cookies helpers. |
 | @farmjs/core/router | Lightweight route matching, href building, and active-route checks. |
@@ -36,6 +37,7 @@ A compact map of the main package exports and where to learn more.
 | --- | --- |
 | `@farmjs/core` | `defineIntegration`, `integrationRoute`, `defineIntegrationSchema`, `definePlugin`, `defineFarmConfig`. |
 | `@farmjs/core/client` | `createIntegrations`, `createIntegrationClient`, `createIntegrationServerClient`, `endpoint`. |
+| `@farmjs/core/image` | `Image`, `ImageProps`, `StaticImageData`, `ImageLoader`. |
 | `@farmjs/core/navigation` | `redirect`, `permanentRedirect`, `notFound`, `useRouter`, `usePathname`, `useSearchParams`. |
 | `@farmjs/core/headers` | `headers`, `cookies`. |
 | `@farmjs/core/router` | `createFarmRouter`, `matchFarmRoute`, `buildFarmRoutePath`, `isFarmRouteActive`. |

--- a/packages/farm-cli/src/migrate.ts
+++ b/packages/farm-cli/src/migrate.ts
@@ -629,6 +629,13 @@ function transformNextContent(content: string) {
           ? `import { Link } from "@farmjs/core/client";`
           : `import { Link as ${localName} } from "@farmjs/core/client";`,
     )
+    .replace(
+      /import\s+([A-Za-z_$][\w$]*)\s+from\s+["']next\/image["'];?/g,
+      (_match, localName) =>
+        localName === "Image"
+          ? `import { Image } from "@farmjs/core/image";`
+          : `import { Image as ${localName} } from "@farmjs/core/image";`,
+    )
     .replace(/from\s+["']next\/navigation["']/g, `from "@farmjs/core/navigation"`)
     .replace(/from\s+["']next\/headers["']/g, `from "@farmjs/core/headers"`);
 }

--- a/packages/farm-cli/test/migrate.test.mjs
+++ b/packages/farm-cli/test/migrate.test.mjs
@@ -164,6 +164,7 @@ test("prepares and applies a code-first Next app migration", async () => {
     await writeFile(
       path.join(root, "app", "about", "page.tsx"),
       `import FarmLink from "next/link";
+import NextImage from "next/image";
 import { redirect, usePathname } from "next/navigation";
 import { cookies, headers } from "next/headers";
 
@@ -171,7 +172,7 @@ export default function AboutPage() {
   if (cookies().has("session")) redirect("/dashboard");
   const pathname = usePathname();
   headers().get("x-demo");
-  return <FarmLink href="/">Home</FarmLink>;
+  return <FarmLink href="/"><NextImage src="/hero.png" alt={pathname} width={1200} height={630} />Home</FarmLink>;
 }
 `,
       "utf8",
@@ -185,6 +186,7 @@ export default function AboutPage() {
 
     const page = await readFile(path.join(root, "src", "app", "about", "page.tsx"), "utf8");
     assert.match(page, /import \{ Link as FarmLink \} from "@farmjs\/core\/client";/);
+    assert.match(page, /import \{ Image as NextImage \} from "@farmjs\/core\/image";/);
     assert.match(page, /from "@farmjs\/core\/navigation";/);
     assert.match(page, /from "@farmjs\/core\/headers";/);
     assert.doesNotMatch(page, /from "next\//);

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -45,6 +45,9 @@
       "headers": [
         "./dist/headers.d.ts"
       ],
+      "image": [
+        "./dist/image.d.ts"
+      ],
       "docs": [
         "./dist/docs.d.ts"
       ],
@@ -118,6 +121,11 @@
       "types": "./dist/headers.d.ts",
       "import": "./dist/headers.mjs",
       "require": "./dist/headers.cjs"
+    },
+    "./image": {
+      "types": "./dist/image.d.ts",
+      "import": "./dist/image.mjs",
+      "require": "./dist/image.cjs"
     },
     "./docs": {
       "types": "./dist/docs.d.ts",

--- a/packages/farm/src/__tests__/image.test.tsx
+++ b/packages/farm/src/__tests__/image.test.tsx
@@ -1,0 +1,50 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { Image } from "../image";
+
+describe("Next-compatible Image", () => {
+  it("renders a normal img with explicit dimensions", () => {
+    const markup = renderToStaticMarkup(
+      <Image src="/hero.png" alt="Hero" width={640} height={320} />,
+    );
+
+    expect(markup).toContain('src="/hero.png"');
+    expect(markup).toContain('alt="Hero"');
+    expect(markup).toContain('width="640"');
+    expect(markup).toContain('height="320"');
+    expect(markup).toContain('loading="lazy"');
+  });
+
+  it("maps priority to eager loading and high fetch priority", () => {
+    const markup = renderToStaticMarkup(<Image src="/hero.png" alt="Hero" priority />);
+
+    expect(markup).toContain('loading="eager"');
+    expect(markup).toContain('fetchPriority="high"');
+  });
+
+  it("supports fill layout styles", () => {
+    const markup = renderToStaticMarkup(<Image src="/hero.png" alt="Hero" fill objectFit="cover" />);
+
+    expect(markup).not.toContain('width="');
+    expect(markup).not.toContain('height="');
+    expect(markup).toContain("position:absolute");
+    expect(markup).toContain("width:100%");
+    expect(markup).toContain("height:100%");
+    expect(markup).toContain("object-fit:cover");
+  });
+
+  it("supports static image objects and custom loaders", () => {
+    const markup = renderToStaticMarkup(
+      <Image
+        src={{ src: "/hero.png", width: 1200, height: 630 }}
+        alt="Hero"
+        loader={({ src, width, quality }) => `/cdn${src}?w=${width}&q=${quality}`}
+        quality={80}
+      />,
+    );
+
+    expect(markup).toContain('src="/cdn/hero.png?w=1200&amp;q=80"');
+    expect(markup).toContain('width="1200"');
+    expect(markup).toContain('height="630"');
+  });
+});

--- a/packages/farm/src/image.ts
+++ b/packages/farm/src/image.ts
@@ -1,0 +1,132 @@
+import { createElement, forwardRef } from "react";
+import type { CSSProperties, ImgHTMLAttributes, Ref } from "react";
+
+export interface StaticImageData {
+  src: string;
+  width?: number;
+  height?: number;
+  blurDataURL?: string;
+}
+
+export interface ImageLoaderProps {
+  src: string;
+  width: number;
+  quality?: number;
+}
+
+export type ImageLoader = (props: ImageLoaderProps) => string;
+export type ImageSource = string | StaticImageData;
+
+export interface ImageProps
+  extends Omit<ImgHTMLAttributes<HTMLImageElement>, "alt" | "height" | "loading" | "src" | "srcSet" | "width"> {
+  src: ImageSource;
+  alt: string;
+  width?: number | `${number}`;
+  height?: number | `${number}`;
+  fill?: boolean;
+  quality?: number | `${number}`;
+  priority?: boolean;
+  loading?: "eager" | "lazy";
+  placeholder?: "empty" | "blur";
+  blurDataURL?: string;
+  loader?: ImageLoader;
+  unoptimized?: boolean;
+  objectFit?: CSSProperties["objectFit"];
+  objectPosition?: CSSProperties["objectPosition"];
+}
+
+type ImgProps = ImgHTMLAttributes<HTMLImageElement> & {
+  fetchPriority?: "high" | "low" | "auto";
+  ref?: Ref<HTMLImageElement>;
+};
+
+export const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
+  {
+    src,
+    alt,
+    width,
+    height,
+    fill = false,
+    quality,
+    priority = false,
+    loading,
+    placeholder = "empty",
+    blurDataURL,
+    loader,
+    unoptimized: _unoptimized,
+    objectFit,
+    objectPosition,
+    style,
+    ...rest
+  },
+  ref,
+) {
+  const source = resolveImageSource(src);
+  const numericWidth = toNumber(width ?? source.width);
+  const numericHeight = toNumber(height ?? source.height);
+  const numericQuality = toNumber(quality);
+  const resolvedSrc = loader
+    ? loader({
+        src: source.src,
+        width: numericWidth ?? 0,
+        quality: numericQuality,
+      })
+    : source.src;
+
+  const placeholderImage = placeholder === "blur" ? blurDataURL || source.blurDataURL : undefined;
+  const imageStyle: CSSProperties = {
+    ...(placeholderImage
+      ? {
+          backgroundImage: `url(${placeholderImage})`,
+          backgroundPosition: "center",
+          backgroundSize: "cover",
+        }
+      : null),
+    ...(fill
+      ? {
+          height: "100%",
+          inset: 0,
+          objectFit,
+          objectPosition,
+          position: "absolute",
+          width: "100%",
+        }
+      : null),
+    ...style,
+  };
+
+  const imgProps: ImgProps = {
+    ...rest,
+    alt,
+    decoding: rest.decoding || "async",
+    height: fill ? undefined : numericHeight,
+    loading: priority ? "eager" : loading || "lazy",
+    ref,
+    sizes: rest.sizes,
+    src: resolvedSrc,
+    style: Object.keys(imageStyle).length ? imageStyle : undefined,
+    width: fill ? undefined : numericWidth,
+  };
+
+  if (priority) {
+    imgProps.fetchPriority = "high";
+  }
+
+  return createElement("img", imgProps);
+});
+
+export default Image;
+
+function resolveImageSource(src: ImageSource): StaticImageData {
+  if (typeof src === "string") {
+    return { src };
+  }
+
+  return src;
+}
+
+function toNumber(value: number | `${number}` | undefined) {
+  if (value === undefined) return undefined;
+  const numeric = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(numeric) ? numeric : undefined;
+}

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -31,6 +31,8 @@ export * from "./docs";
 export * from "./markdown";
 export * from "./app-markdown";
 export * from "./observability";
+export { Image } from "./image";
+export type { ImageLoader, ImageLoaderProps, ImageProps, ImageSource, StaticImageData } from "./image";
 export { generateRouteTypes } from "./routing/generate-route-types";
 export type { GenerateRouteTypesOptions } from "./routing/generate-route-types";
 export * from "./build/index";

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -513,6 +513,7 @@ async function buildClient(
                 "// Farm.js Client Exports - Safe for browser bundling",
                 'export { Link } from "@farmjs/core/client";',
                 'export { useRouter } from "@farmjs/core/client";',
+                'export { Image } from "@farmjs/core/image";',
                 'export { usePathname, useSearchParams } from "@farmjs/core/navigation";',
                 'export { createAPIClient } from "@farmjs/core/client";',
               ].join("\n");

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     cache: "src/cache.ts",
     navigation: "src/navigation.ts",
     headers: "src/headers.ts",
+    image: "src/image.ts",
     docs: "src/docs/index.ts",
     markdown: "src/markdown.ts",
     "app-markdown": "src/app-markdown.ts",


### PR DESCRIPTION
## Summary
- add a compact `@farmjs/core/image` compatibility entry for common `next/image` migrations
- export `Image` from the root client-safe bundle and package export map
- rewrite default `next/image` imports during Next migration and document the behavior

## Notes
- this intentionally renders a normal `<img>`; it does not add hidden image optimization
- custom loaders, static image objects, `priority`, and `fill` are supported for migration ergonomics

## Validation
- `corepack pnpm --filter @farmjs/core test -- src/__tests__/image.test.tsx src/__tests__/navigation.test.ts src/__tests__/headers.test.ts`
- `corepack pnpm --filter @farmjs/core build`
- `corepack pnpm --filter @farmjs/cli test`
