### PR TITLE
feat: add migration dry run diffs

### DIFF
--- a/docs/src/app/docs/cli/page.md
+++ b/docs/src/app/docs/cli/page.md
@@ -50,11 +50,12 @@ Use this after adding or changing API routes so `api.hello.post(...)`, route par
 ```bash
 farm migrate inspect
 farm migrate next
+farm migrate next --diff
 farm migrate next --write
 farm migrate tanstack --write
 ```
 
-Framework migrations are deterministic codemods. They inspect the project, print a dry-run plan by default, and only write when `--write` is passed. Existing target files are skipped unless `--force` is passed.
+Framework migrations are deterministic codemods. They inspect the project, print a dry-run plan by default, and only write when `--write` is passed. Use `--diff` to include a compact generated-file diff in that dry-run output. Existing target files are skipped unless `--force` is passed.
 
 The Next.js migrator copies `app` or `src/app` into Farm's `src/app`, creates `farm.config.ts`, creates a minimal root layout when needed, rewrites `next/link` to Farm's typed client `Link`, and updates package scripts to `farm dev`, `farm build`, and `node .output/server/index.mjs`.
 

--- a/docs/src/app/docs/migrations/page.md
+++ b/docs/src/app/docs/migrations/page.md
@@ -15,11 +15,23 @@ Framework migrations are code-first codemods. They inspect the current project, 
 ```bash
 farm migrate inspect
 farm migrate next
+farm migrate next --diff
 farm migrate next --write
 farm migrate tanstack --write
 ```
 
-`farm migrate next` and `farm migrate tanstack` are dry-run by default. They print detected framework evidence, planned file writes, warnings, and the manual review list. Use `--force` only when you intentionally want generated files to overwrite existing Farm files.
+`farm migrate next` and `farm migrate tanstack` are dry-run by default. They print detected framework evidence, planned file writes, warnings, and the manual review list. Add `--diff` when you want to inspect the exact generated file contents before applying the plan. Use `--force` only when you intentionally want generated files to overwrite existing Farm files.
+
+## Dry-run diffs
+
+Use `--diff` to preview the concrete edits Farm would make while still leaving the app untouched.
+
+```bash
+farm migrate next --diff
+farm migrate tanstack --diff
+```
+
+The diff includes generated app files, `farm.config.ts`, root layout scaffolding, and `package.json` script/dependency updates. Skipped files are not diffed because Farm will not write them unless you pass `--force`.
 
 ## Next.js migration
 
@@ -101,6 +113,7 @@ Use command migrations for app-owned database migrations, integration schema set
 
 - Framework migrations never delete source files.
 - Framework migrations default to dry-run and require `--write`.
+- `--diff` prints generated file content during dry-runs without writing to disk.
 - Existing target files are skipped unless `--force` is passed.
 - Package dependencies for the previous framework are left in place until the app owner removes them.
 - The report is part of the feature: unsupported APIs are called out instead of guessed.

--- a/packages/farm-cli/bin/farm.js
+++ b/packages/farm-cli/bin/farm.js
@@ -89,6 +89,7 @@ program
   .option("-c, --config <config>", "Path to farm config file")
   .option("--command <command>", "Migration command to run; can be repeated", collectOption, [])
   .option("--dry-run", "Print migration commands without running them")
+  .option("--diff", "Show a compact file diff for framework migration dry-runs")
   .option("--write", "Apply framework migration changes; framework migrations are dry-run by default")
   .option("--force", "Overwrite existing files during framework migrations")
   .action(async (source, options) => {
@@ -99,6 +100,7 @@ program
         configPath: options.config,
         commands: options.command,
         dryRun: options.dryRun,
+        diff: options.diff,
         source,
         write: options.write,
         force: options.force,

--- a/packages/farm-cli/src/index.ts
+++ b/packages/farm-cli/src/index.ts
@@ -11,10 +11,12 @@ export { buildFarm } from "./build";
 export { deployFarm } from "./deploy";
 export { generateFarmArtifacts } from "./generate";
 export {
+  createFrameworkMigrationDiff,
   createFrameworkMigrationPlan,
   inspectFrameworkMigrations,
   migrateFarm,
   type FarmFrameworkMigrationSource,
+  type FrameworkMigrationDiffOptions,
   type FrameworkDetection,
   type FrameworkMigrationOperation,
   type FrameworkMigrationPlan,

--- a/packages/farm-cli/src/migrate.ts
+++ b/packages/farm-cli/src/migrate.ts
@@ -21,6 +21,7 @@ export interface MigrateFarmOptions {
   configPath?: string;
   commands?: string[];
   dryRun?: boolean;
+  diff?: boolean;
   source?: FarmFrameworkMigrationSource | "inspect";
   write?: boolean;
   force?: boolean;
@@ -63,6 +64,11 @@ export interface FrameworkMigrationPlan {
   manual: string[];
 }
 
+export interface FrameworkMigrationDiffOptions {
+  contextLines?: number;
+  maxLinesPerFile?: number;
+}
+
 export async function migrateFarm(options: MigrateFarmOptions = {}) {
   const root = path.resolve(options.root || process.cwd());
 
@@ -85,6 +91,9 @@ export async function migrateFarm(options: MigrateFarmOptions = {}) {
     printFrameworkMigrationPlan(plan, Boolean(options.write && !options.dryRun));
 
     if (!options.write || options.dryRun) {
+      if (options.diff) {
+        await printFrameworkMigrationDiff(plan);
+      }
       logger.info(`Dry run only. Re-run with "farm migrate ${options.source} --write" to apply.`);
       return plan;
     }
@@ -491,6 +500,36 @@ async function applyFrameworkMigrationPlan(plan: FrameworkMigrationPlan) {
   }
 }
 
+export async function createFrameworkMigrationDiff(
+  plan: FrameworkMigrationPlan,
+  options: FrameworkMigrationDiffOptions = {},
+) {
+  const chunks: string[] = [];
+  const contextLines = options.contextLines ?? 3;
+  const maxLinesPerFile = options.maxLinesPerFile ?? 120;
+
+  for (const operation of plan.operations) {
+    if (operation.skipped || operation.content === undefined) continue;
+
+    const exists = existsSync(operation.path);
+    const before = exists ? await readFile(operation.path, "utf8") : "";
+    if (before === operation.content) continue;
+
+    chunks.push(
+      createFileDiff({
+        before,
+        after: operation.content,
+        exists,
+        maxLines: maxLinesPerFile,
+        path: toPosix(path.relative(plan.root, operation.path)),
+        contextLines,
+      }),
+    );
+  }
+
+  return chunks.filter(Boolean).join("\n");
+}
+
 function printFrameworkInspection(root: string, detections: FrameworkDetection[]) {
   logger.info(`Migration inspection for ${root}`);
 
@@ -504,6 +543,19 @@ function printFrameworkInspection(root: string, detections: FrameworkDetection[]
     for (const evidence of detection.evidence) {
       logger.info(`  - ${evidence}`);
     }
+  }
+}
+
+async function printFrameworkMigrationDiff(plan: FrameworkMigrationPlan) {
+  const diff = await createFrameworkMigrationDiff(plan);
+  if (!diff.trim()) {
+    logger.info("Diff: no file content changes to show.");
+    return;
+  }
+
+  logger.info("Diff:");
+  for (const line of diff.split("\n")) {
+    logger.info(line);
   }
 }
 
@@ -547,6 +599,75 @@ function printFrameworkMigrationPlan(plan: FrameworkMigrationPlan, willWrite: bo
       logger.info(`  - ${note}`);
     }
   }
+}
+
+function createFileDiff(options: {
+  path: string;
+  before: string;
+  after: string;
+  exists: boolean;
+  contextLines: number;
+  maxLines: number;
+}) {
+  const beforeLines = splitDiffLines(options.before);
+  const afterLines = splitDiffLines(options.after);
+  const header = [`--- ${options.exists ? options.path : "/dev/null"}`, `+++ ${options.path}`];
+
+  if (!options.exists) {
+    return limitDiffLines([...header, ...afterLines.map((line) => `+${line}`)], options.maxLines).join(
+      "\n",
+    );
+  }
+
+  let prefix = 0;
+  while (
+    prefix < beforeLines.length &&
+    prefix < afterLines.length &&
+    beforeLines[prefix] === afterLines[prefix]
+  ) {
+    prefix++;
+  }
+
+  let suffix = 0;
+  while (
+    suffix < beforeLines.length - prefix &&
+    suffix < afterLines.length - prefix &&
+    beforeLines[beforeLines.length - suffix - 1] === afterLines[afterLines.length - suffix - 1]
+  ) {
+    suffix++;
+  }
+
+  const beforeEnd = beforeLines.length - suffix;
+  const afterEnd = afterLines.length - suffix;
+  const contextStart = Math.max(0, prefix - options.contextLines);
+  const contextEnd = Math.min(beforeLines.length, beforeEnd + options.contextLines);
+
+  const lines = [
+    ...header,
+    "@@",
+    ...beforeLines.slice(contextStart, prefix).map((line) => ` ${line}`),
+    ...beforeLines.slice(prefix, beforeEnd).map((line) => `-${line}`),
+    ...afterLines.slice(prefix, afterEnd).map((line) => `+${line}`),
+    ...beforeLines.slice(beforeEnd, contextEnd).map((line) => ` ${line}`),
+  ];
+
+  return limitDiffLines(lines, options.maxLines).join("\n");
+}
+
+function splitDiffLines(value: string) {
+  const lines = value.replace(/\r\n/g, "\n").split("\n");
+  if (lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+  return lines;
+}
+
+function limitDiffLines(lines: string[], maxLines: number) {
+  if (lines.length <= maxLines) return lines;
+  return [
+    ...lines.slice(0, maxLines),
+    `... diff truncated (${lines.length - maxLines} more line${lines.length - maxLines === 1 ? "" : "s"})`,
+  ];
 }
 
 function detectNext(root: string, packageJson: any): FrameworkDetection {

--- a/packages/farm-cli/test/migrate.test.mjs
+++ b/packages/farm-cli/test/migrate.test.mjs
@@ -9,7 +9,7 @@ import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 
 const require = createRequire(import.meta.url);
-const { createFrameworkMigrationPlan, inspectFrameworkMigrations, migrateFarm } =
+const { createFrameworkMigrationDiff, createFrameworkMigrationPlan, inspectFrameworkMigrations, migrateFarm } =
   require("../dist/index.js");
 const execFileAsync = promisify(execFile);
 const testDir = path.dirname(fileURLToPath(import.meta.url));
@@ -174,6 +174,9 @@ export default function AboutPage() {
 
     const dryRunPlan = await createFrameworkMigrationPlan(root, "next");
     assert.ok(dryRunPlan.operations.some((operation) => operation.description.includes("Copy Next")));
+    const diff = await createFrameworkMigrationDiff(dryRunPlan, { maxLinesPerFile: 80 });
+    assert.match(diff, /\+\+\+ src\/app\/about\/page\.tsx/);
+    assert.match(diff, /\+import \{ Link as FarmLink \} from "@farmjs\/core\/client";/);
     await assert.rejects(() => readFile(path.join(root, "src", "app", "about", "page.tsx"), "utf8"));
 
     await migrateFarm({ root, source: "next", write: true });
@@ -188,6 +191,46 @@ export default function AboutPage() {
     assert.equal(packageJson.scripts.start, "node .output/server/index.mjs");
     assert.equal(packageJson.dependencies["@farmjs/core"], "latest");
     assert.equal(packageJson.devDependencies["@farmjs/cli"], "latest");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("prints framework migration diffs through the CLI", async () => {
+  const root = await createTempProject({
+    dependencies: {
+      next: "latest",
+      react: "latest",
+      "react-dom": "latest",
+    },
+  });
+
+  try {
+    await mkdir(path.join(root, "app"), { recursive: true });
+    await writeFile(
+      path.join(root, "app", "page.tsx"),
+      `import Link from "next/link";
+
+export default function Page() {
+  return <Link href="/docs">Docs</Link>;
+}
+`,
+      "utf8",
+    );
+
+    const { stdout } = await execFileAsync(process.execPath, [
+      cliBin,
+      "migrate",
+      "next",
+      "--root",
+      root,
+      "--diff",
+    ]);
+
+    assert.match(stdout, /Diff:/);
+    assert.match(stdout, /\+\+\+ src\/app\/page\.tsx/);
+    assert.match(stdout, /\+import \{ Link \} from "@farmjs\/core\/client";/);
+    await assert.rejects(() => readFile(path.join(root, "src", "app", "page.tsx"), "utf8"));
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- add `createFrameworkMigrationDiff()` for generated framework migration previews
- add `farm migrate <source> --diff` for dry-run file diffs
- document the dry-run diff workflow for framework migrations

## Notes
- diffs are generated only for operations Farm would write
- skipped files remain listed in the plan but are not diffed unless the user reruns with `--force`

## Validation
- `corepack pnpm --filter @farmjs/cli test`
- `corepack pnpm --filter @farmjs/core build && corepack pnpm --filter farmjs-docs build` reached the docs wrapper but failed because the nested script picked up global pnpm 11 against a pnpm 8 lockfile
- `DATABASE_URL=${DATABASE_URL:-postgresql://user:password@localhost:5432/farmjs} corepack pnpm --filter farmjs-docs prisma:generate`
- `corepack pnpm --filter farmjs-docs exec farm build`
