### PR TITLE
feat: finish preview command docs

### DIFF
--- a/docs/src/app/docs/cli/page.md
+++ b/docs/src/app/docs/cli/page.md
@@ -101,11 +101,24 @@ Commands run sequentially and stop on the first failure. `--dry-run` prints the 
 farm preview
 farm preview --port 3000
 farm preview --name stripe-webhook
+farm preview --url http://localhost:4319
+farm preview --dry-run
 ```
 
 `farm preview` exposes the app that is already running locally. It does not build or deploy the app. Use it when a teammate, webhook provider, OAuth provider, mobile device, or browser automation tool needs a public URL for the current `farm dev` session.
 
-Farm detects the running app on common local ports, or you can pass `--port` / `--url` when the app is running somewhere specific. By default it connects to the hosted Farm Preview gateway and returns a URL such as `https://stripe-webhook.preview.farming-labs.dev`. App developers do not need to configure Vercel, DNS, Redis, or a local tunnel binary. The command keeps forwarding traffic until you press Ctrl+C.
+Farm detects the running app on common local ports, or you can pass `--port` / `--url` when the app is running somewhere specific. By default it connects to the hosted Farm Preview gateway and returns a URL such as `https://stripe-webhook.preview.farming-labs.dev`.
+
+The preview terminal logs forwarded traffic:
+
+```txt
+GET /api/hello?name=something -> 200 621ms
+POST /api/auth/login -> 200 580ms
+```
+
+The local `farm dev` terminal logs the matched page, API route, and middleware work. Client components hydrate through the same public URL; early button clicks are queued and replayed after hydration so slow dev-mode module loading does not lose the click.
+
+See [Instant Preview](/docs/preview) for webhook setup, custom gateway configuration, troubleshooting, and security notes.
 
 ## Build
 

--- a/docs/src/app/docs/preview/page.md
+++ b/docs/src/app/docs/preview/page.md
@@ -1,40 +1,75 @@
 ---
 title: "Instant Preview"
-description: "Expose the current local Farm app through a public URL for sharing, webhooks, OAuth callbacks, and external testing."
+description: "Expose a running local Farm app through a public URL for sharing, webhook testing, OAuth callbacks, mobile QA, and browser automation."
 section: "Runtime"
 ---
 
 # Instant Preview
 
-Expose the app that is already running on your machine through a public URL.
+Expose the Farm app that is already running on your machine through a temporary public URL.
 
 ```bash
-farm dev
-farm preview
-```
-
-`farm preview` does not build or deploy the app. It connects the current local server to the hosted Farm Preview gateway, so it works well for Stripe webhooks, auth callbacks, mobile device testing, design review, and letting another person try the app without pushing a deployment.
-
-## Usage
-
-```bash
-farm preview
+farm dev --port 3000
 farm preview --port 3000
-farm preview --url http://localhost:4319
-farm preview --name checkout-test
 ```
 
-Farm checks the configured app port, common development ports, and any explicit `--port` or `--url` value. Once a running app is found, Farm opens a preview gateway session and keeps forwarding requests until Ctrl+C.
+`farm preview` is not a deployment command. It does not run `farm build`, upload output, or create a production release. It opens an outbound connection from the CLI to the Farm Preview gateway and forwards public traffic back to your local dev server.
+
+Use it when an external system needs to reach the app you are actively developing:
+
+- Stripe, Clerk, Better Auth, Supabase, Unkey, or custom webhooks.
+- OAuth redirect and callback URLs.
+- Mobile device testing on a real phone.
+- Sharing a local branch with a teammate.
+- Browser automation that needs a public HTTPS origin.
+- Demoing an integration before it is deployed.
+
+## Quick Start
+
+Start the app first:
+
+```bash
+farm dev --port 4324
+```
+
+Open a preview in another terminal:
+
+```bash
+farm preview --port 4324 --name checkout-test
+```
+
+Farm prints the local target, hosted gateway, and public URL:
 
 ```txt
 Creating public preview for the running app...
-Local:  http://localhost:3000
+Local:  http://localhost:4324
 Gateway: https://preview.farming-labs.dev
 Opening Farm preview gateway session...
 Preview URL ready.
 Public: https://checkout-test.preview.farming-labs.dev
-Forwarding requests until Ctrl+C.
+Forwarding requests until Ctrl+C. Remote traffic will be logged below.
 ```
+
+Open the public URL from another browser, device, webhook provider, or test runner:
+
+```txt
+https://checkout-test.preview.farming-labs.dev
+```
+
+Keep both terminals running while you test. Stop the preview with `Ctrl+C`.
+
+## Commands
+
+```bash
+farm preview
+farm preview --port 3000
+farm preview --host 127.0.0.1 --port 3000
+farm preview --url http://localhost:4319
+farm preview --name stripe-webhook
+farm preview --dry-run
+```
+
+When no target is passed, Farm tries to detect a running app from the current project config and common development ports. Pass `--port` or `--url` when the app is running somewhere specific.
 
 ## Options
 
@@ -44,30 +79,171 @@ Forwarding requests until Ctrl+C.
 | `--host <host>` | Expose a specific local host. Defaults to `localhost`. |
 | `--url <url>` | Expose a full local URL. |
 | `--name <name>` | Request a readable preview URL name. |
-| `--dry-run` | Validate detection and print the preview plan without opening it. |
-| `--no-probe` | Skip local reachability checks when `--port` is provided. |
+| `--dry-run` | Validate target detection and print the preview plan without opening a session. |
+| `--no-probe` | Skip the local reachability check when `--port` is provided. |
 | `--gateway <url>` | Advanced: use a different Farm Preview gateway. |
 | `--provider <provider>` | Advanced: use `farm` for the hosted gateway or `local` for a custom local provider. |
 
-## Hosted Gateway
+## Readable URLs
 
-The default gateway is operated by Farming Labs at `https://preview.farming-labs.dev`. App developers do not need a Vercel account, DNS changes, Redis setup, `cloudflared`, ngrok, or another tunnel binary.
+Use `--name` when the URL needs to be pasted into a provider dashboard.
 
 ```bash
-farm preview --name stripe-webhook
+farm preview --port 4324 --name stripe-webhook
 ```
 
-That returns a URL like:
+Farm normalizes the name into a safe subdomain:
 
 ```txt
 https://stripe-webhook.preview.farming-labs.dev
 ```
 
-The hosted gateway owns the wildcard domain, TLS, Vercel deployment, session store, and request relay. The local CLI only opens outbound HTTPS requests to that gateway and forwards traffic to the local app.
+Names are best treated as temporary handles. Stop and restart the command when you want to rotate the session.
 
-The gateway source lives in `examples/preview-gateway` for Farming Labs maintainers or anyone self-hosting their own gateway. Regular Farm apps do not need to copy or deploy it.
+## Request Logging
 
-## Custom Providers
+Every remote request is visible in the preview terminal:
+
+```txt
+GET /api-demo-client -> 200 1139ms
+GET /@farm/client.js -> 200 1790ms
+GET /src/app/api-demo-client/page.tsx?import -> 200 1074ms
+GET /api/hello?name=something -> 200 621ms
+POST /api/auth/login -> 200 580ms
+POST /api/users -> 200 1014ms
+```
+
+The local `farm dev` terminal also logs the same app-level work:
+
+```txt
+[FARM] [PAGE] [GET] /api-demo-client - 200 (21ms)
+[FARM] [API] [GET] /api/hello?name=something - 200 (5ms)
+[FARM] [API] [POST] /api/auth/login - 200 (5ms)
+```
+
+Use the preview terminal to confirm traffic is reaching the tunnel, and use the dev terminal to confirm Farm handled the route, API handler, middleware, or page render.
+
+## Interaction Model
+
+The hosted preview forwards HTTP requests from the public URL to your local app. Browser interaction works after the client runtime hydrates.
+
+In development, Vite serves many separate modules before hydration completes. Over a public tunnel that can make the first page load feel slower than localhost. Farm queues button clicks that happen before hydration and replays them after React attaches, so an early click on a client component does not silently disappear.
+
+After hydration, normal client-side handlers run in the browser and API calls go through the preview URL:
+
+```tsx
+"use client";
+
+import { api } from "../lib/api-client";
+
+export default function Demo() {
+  return (
+    <button
+      onClick={async () => {
+        const result = await api.hello.get({
+          query: { name: "preview" },
+        });
+        console.log(result.data);
+      }}
+    >
+      Fetch
+    </button>
+  );
+}
+```
+
+That click is visible as `GET /api/hello?name=preview` in both the preview and dev terminals.
+
+## Webhook Testing
+
+Run the local app:
+
+```bash
+farm dev --port 4324
+```
+
+Open a named preview:
+
+```bash
+farm preview --port 4324 --name stripe-local
+```
+
+Use the public route in the provider dashboard:
+
+```txt
+https://stripe-local.preview.farming-labs.dev/api/stripe/webhook
+```
+
+When the provider sends an event, the preview terminal shows the public request and the dev terminal shows the Farm API route. This is the fastest way to test integration routes before deploying them.
+
+## OAuth and Auth Callbacks
+
+For auth providers that require a public redirect URL, use a named preview URL and paste the callback path:
+
+```txt
+https://auth-check.preview.farming-labs.dev/api/auth/callback
+```
+
+Keep the preview running for the whole login test. If you restart with a different name, update the provider callback URL too.
+
+## Hosted Gateway
+
+The default gateway is operated by Farming Labs:
+
+```txt
+https://preview.farming-labs.dev
+```
+
+Regular Farm apps do not need Vercel, DNS, Redis, ngrok, `cloudflared`, or a local tunnel binary. The CLI opens outbound HTTPS requests to the gateway, polls for queued public requests, forwards them to the local app, and uploads the response.
+
+The hosted gateway owns:
+
+- TLS for `*.preview.farming-labs.dev`.
+- Session creation and expiry.
+- Public request queueing.
+- Response relay.
+- Stale session cleanup.
+
+The local CLI owns:
+
+- Local target detection.
+- Local reachability checks.
+- Forwarding requests to `localhost`.
+- Request and response logging.
+- Closing the preview when the local app exits.
+
+## Self-Hosting a Gateway
+
+Most app developers should use the hosted gateway. Self-host only when you are operating a private preview domain or maintaining Farming Labs infrastructure.
+
+The gateway example lives in `examples/preview-gateway`.
+
+```bash
+cd examples/preview-gateway
+pnpm install
+vercel deploy
+```
+
+The Vercel example can use Vercel Blob as the session store. Configure a private Blob store for the Vercel project, then set the public domain:
+
+```bash
+vercel blob create-store farm-preview-gateway --access private --region iad1 --yes
+vercel env add FARM_PREVIEW_DOMAIN production
+```
+
+For a private domain such as `preview.example.com`, configure:
+
+- `preview.example.com` for the gateway root.
+- `*.preview.example.com` as a wildcard domain.
+- `FARM_PREVIEW_DOMAIN=preview.example.com`.
+
+Then point the CLI at it:
+
+```bash
+farm preview --gateway https://preview.example.com --name checkout-test
+```
+
+## Custom Tunnel Providers
 
 If you need to integrate a private tunnel provider, set `FARM_PREVIEW_TUNNEL_COMMAND` to a command template that prints the public HTTPS URL after opening the tunnel.
 
@@ -77,10 +253,47 @@ FARM_PREVIEW_TUNNEL_COMMAND='farm-preview-agent tunnel --url {url} --hostname {h
 
 Available template values are `{url}`, `{port}`, `{host}`, `{name}`, and `{hostname}`.
 
+Use this path only when the hosted Farm gateway is not appropriate for your environment.
+
+## Environment Variables
+
+| Variable | Purpose |
+| --- | --- |
+| `FARM_PREVIEW_GATEWAY_URL` | Override the hosted gateway URL. |
+| `FARM_PREVIEW_DOMAIN` | Override the preview domain used for generated hostnames. |
+| `FARM_PREVIEW_NAME` | Provide a default readable preview name. |
+| `FARM_PREVIEW_PROVIDER` | Select `farm` or `local`. |
+| `FARM_PREVIEW_TUNNEL_COMMAND` | Command template for a custom local tunnel provider. |
+
+## Troubleshooting
+
+| Symptom | Check |
+| --- | --- |
+| `No active Farm preview is running` | The CLI session stopped, expired, or the local app exited. Restart `farm preview`. |
+| `The local Farm preview did not respond before the gateway timed out` | Confirm `farm dev` is still running and the local route is not hanging. |
+| Public page loads, but clicks feel delayed | Wait for the first hydration pass. Dev-mode Vite modules are forwarded through the tunnel. Early button clicks are queued and replayed. |
+| No traffic appears in the preview terminal | The browser may still be loading modules, the URL may be stale, or the request may be blocked before reaching the gateway. |
+| Traffic appears in preview terminal but not `farm dev` | The local target may be wrong. Re-run with `--port` or `--url`. |
+| HMR websocket errors appear in the browser console | The hosted preview currently forwards HTTP traffic. Vite HMR websocket forwarding is not part of the hosted gateway yet. |
+| Webhook provider receives a non-2xx response | Check the local dev terminal for the actual Farm API route error. |
+
 ## Security
 
-The preview URL forwards traffic to your local app. Treat it like a temporary public deployment:
+The preview URL forwards public internet traffic to your local app. Treat it like a temporary public deployment:
 
-- Stop the command when the review or webhook test is done.
-- Do not expose apps with local-only admin screens or secrets unless you trust the audience.
-- Use short preview names for webhook and OAuth callback URLs you need to paste into providers.
+- Stop the command when testing is finished.
+- Do not expose admin-only routes, local dashboards, or secret-bearing pages unless you trust the audience.
+- Do not paste a preview URL into untrusted systems.
+- Rotate preview names after sharing sensitive routes.
+- Keep provider secrets in environment variables, not client code.
+- Remember that anyone with the URL can send requests while the session is active.
+
+## Production Deployments
+
+Use `farm preview` for temporary access to a running local app. Use `farm build` and the deployment guide for production releases.
+
+```bash
+farm build
+```
+
+Preview is for the branch you are holding in your editor. Deployment is for the version you want to keep online.

--- a/examples/preview-gateway/README.md
+++ b/examples/preview-gateway/README.md
@@ -24,9 +24,18 @@ Vercel will show the DNS records it expects. After DNS is verified, Vercel handl
 
 ## Required environment for production
 
-Use a shared Redis-compatible REST store so all Vercel function invocations see the same sessions and queued requests.
+Use a shared store so all Vercel function invocations see the same sessions and queued requests.
 
-The gateway reads either set of variables:
+The hosted Farming Labs gateway uses Vercel Blob. Create and link it once:
+
+```bash
+vercel blob create-store farm-preview-gateway --access private --region iad1 --yes
+```
+
+When the project is linked, Vercel connects the store and injects the Blob env automatically.
+
+If you prefer a Redis-compatible REST store, the reusable gateway package also reads either set of variables:
+
 
 ```txt
 UPSTASH_REDIS_REST_URL
@@ -47,7 +56,7 @@ FARM_PREVIEW_DOMAIN=preview.farming-labs.dev
 FARM_PREVIEW_GATEWAY_URL=https://preview.farming-labs.dev
 ```
 
-Without Redis REST env vars, the gateway falls back to in-memory storage. That is useful for local development, but not reliable for production Vercel traffic because requests can be handled by different function instances.
+Without Blob or Redis REST env vars, the gateway falls back to in-memory storage. That is useful for local development, but not reliable for production Vercel traffic because requests can be handled by different function instances.
 
 ## CLI usage
 

--- a/examples/preview-gateway/api/index.ts
+++ b/examples/preview-gateway/api/index.ts
@@ -1,4 +1,204 @@
-import { createNodePreviewGatewayHandler } from "@farmjs/preview-gateway";
+import {
+  createNodePreviewGatewayHandler,
+  type PreviewGatewayRequest,
+  type PreviewGatewayResponse,
+  type PreviewGatewaySession,
+  type PreviewGatewayStore,
+} from "@farmjs/preview-gateway";
+import { del, get, list, put } from "@vercel/blob";
+
+interface ExpiringValue<T> {
+  expiresAt: number;
+  value: T;
+}
+
+const BLOB_PREFIX = "farm-preview";
+const BLOB_ACCESS = "private";
+
+class VercelBlobPreviewGatewayStore implements PreviewGatewayStore {
+  async createSession(session: PreviewGatewaySession, ttlMs: number): Promise<void> {
+    await Promise.all([
+      this.write(this.sessionKey(session.id), session, ttlMs),
+      this.write(this.nameKey(session.name), session.id, ttlMs),
+    ]);
+  }
+
+  async getSessionByName(name: string): Promise<PreviewGatewaySession | undefined> {
+    const id = await this.read<string>(this.nameKey(name));
+    return id ? this.getSessionById(id) : undefined;
+  }
+
+  async getSessionById(id: string): Promise<PreviewGatewaySession | undefined> {
+    return await this.read<PreviewGatewaySession>(this.sessionKey(id));
+  }
+
+  async touchSession(session: PreviewGatewaySession, ttlMs: number): Promise<void> {
+    const nextSession = {
+      ...session,
+      expiresAt: Date.now() + ttlMs,
+    };
+    await Promise.all([
+      this.write(this.sessionKey(session.id), nextSession, ttlMs),
+      this.write(this.nameKey(session.name), session.id, ttlMs),
+    ]);
+  }
+
+  async enqueueRequest(
+    sessionId: string,
+    request: PreviewGatewayRequest,
+    ttlMs: number,
+  ): Promise<void> {
+    await this.write(this.requestKey(sessionId, request), request, ttlMs);
+  }
+
+  async takeRequests(sessionId: string, limit: number): Promise<PreviewGatewayRequest[]> {
+    const prefix = this.queuePrefix(sessionId);
+    const values: PreviewGatewayRequest[] = [];
+    let cursor: string | undefined;
+
+    while (values.length < limit) {
+      const result = await list({
+        prefix,
+        cursor,
+        limit: Math.max(limit * 4, 24),
+      });
+      const blobs = [...result.blobs].sort((a, b) => a.pathname.localeCompare(b.pathname));
+
+      for (const blob of blobs) {
+        if (values.length >= limit) break;
+
+        const request = await this.read<PreviewGatewayRequest>(blob.pathname);
+        await this.deletePath(blob.pathname);
+
+        if (request) {
+          values.push(request);
+        }
+      }
+
+      if (!result.hasMore || !result.cursor) break;
+      cursor = result.cursor;
+    }
+
+    return values;
+  }
+
+  async saveResponse(
+    sessionId: string,
+    requestId: string,
+    response: PreviewGatewayResponse,
+    ttlMs: number,
+  ): Promise<void> {
+    await this.write(this.responseKey(sessionId, requestId), response, ttlMs);
+  }
+
+  async getResponse(
+    sessionId: string,
+    requestId: string,
+  ): Promise<PreviewGatewayResponse | undefined> {
+    return await this.read<PreviewGatewayResponse>(this.responseKey(sessionId, requestId));
+  }
+
+  async deleteResponse(sessionId: string, requestId: string): Promise<void> {
+    await this.deletePath(this.responseKey(sessionId, requestId));
+  }
+
+  async deleteSession(session: PreviewGatewaySession): Promise<void> {
+    await Promise.all([
+      this.deletePath(this.sessionKey(session.id)),
+      this.deletePath(this.nameKey(session.name)),
+      this.deletePrefix(this.queuePrefix(session.id)),
+      this.deletePrefix(this.responsesPrefix(session.id)),
+    ]);
+  }
+
+  private async write<T>(pathname: string, value: T, ttlMs: number) {
+    const payload: ExpiringValue<T> = {
+      expiresAt: Date.now() + ttlMs,
+      value,
+    };
+    await put(pathname, JSON.stringify(payload), {
+      access: BLOB_ACCESS,
+      allowOverwrite: true,
+      contentType: "application/json",
+    });
+  }
+
+  private async read<T>(pathname: string): Promise<T | undefined> {
+    const blob = await get(pathname, {
+      access: BLOB_ACCESS,
+      useCache: false,
+    }).catch((error: unknown) => {
+      if (isMissingBlobError(error)) return null;
+      throw error;
+    });
+    if (!blob || blob.statusCode !== 200 || !blob.stream) return undefined;
+
+    const payload = JSON.parse(await new Response(blob.stream).text()) as ExpiringValue<T>;
+    if (payload.expiresAt <= Date.now()) {
+      await this.deletePath(pathname);
+      return undefined;
+    }
+    return payload.value;
+  }
+
+  private async deletePath(pathname: string) {
+    await del(pathname).catch(() => undefined);
+  }
+
+  private async deletePrefix(prefix: string) {
+    let cursor: string | undefined;
+    do {
+      const result = await list({ prefix, cursor, limit: 1000 });
+      if (result.blobs.length) {
+        await del(result.blobs.map((blob) => blob.pathname)).catch(() => undefined);
+      }
+      cursor = result.cursor;
+      if (!result.hasMore) break;
+    } while (cursor);
+  }
+
+  private key(path: string) {
+    return `${BLOB_PREFIX}/${path}`;
+  }
+
+  private sessionKey(id: string) {
+    return this.key(`sessions/${id}.json`);
+  }
+
+  private nameKey(name: string) {
+    return this.key(`names/${name}.json`);
+  }
+
+  private queuePrefix(sessionId: string) {
+    return this.key(`queues/${sessionId}/`);
+  }
+
+  private requestKey(sessionId: string, request: PreviewGatewayRequest) {
+    return `${this.queuePrefix(sessionId)}${request.createdAt}-${request.id}.json`;
+  }
+
+  private responsesPrefix(sessionId: string) {
+    return this.key(`responses/${sessionId}/`);
+  }
+
+  private responseKey(sessionId: string, requestId: string) {
+    return `${this.responsesPrefix(sessionId)}${requestId}.json`;
+  }
+}
+
+function createVercelBlobStore() {
+  if (!process.env.BLOB_READ_WRITE_TOKEN && !process.env.BLOB_STORE_ID) return undefined;
+  return new VercelBlobPreviewGatewayStore();
+}
+
+function isMissingBlobError(error: unknown) {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.name === "BlobNotFoundError" ||
+    error.message.includes("404") ||
+    error.message.includes("400 Bad Request")
+  );
+}
 
 export const config = {
   maxDuration: 60,
@@ -7,4 +207,6 @@ export const config = {
 export default createNodePreviewGatewayHandler({
   domain: process.env.FARM_PREVIEW_DOMAIN || "preview.farming-labs.dev",
   baseUrl: process.env.FARM_PREVIEW_GATEWAY_URL,
+  clientHeartbeatTimeoutMs: 1000 * 60 * 30,
+  store: createVercelBlobStore(),
 });

--- a/examples/preview-gateway/package.json
+++ b/examples/preview-gateway/package.json
@@ -9,7 +9,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farmjs/preview-gateway": "workspace:*"
+    "@farmjs/preview-gateway": "workspace:*",
+    "@vercel/blob": "^2.6.1"
   },
   "devDependencies": {
     "@types/node": "^20.10.5",

--- a/examples/preview-gateway/vercel.json
+++ b/examples/preview-gateway/vercel.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "corepack pnpm --filter @farmjs/preview-gateway build",
+  "regions": ["iad1"],
   "functions": {
     "api/index.ts": {
       "maxDuration": 60

--- a/packages/farm-cli/src/preview-gateway.ts
+++ b/packages/farm-cli/src/preview-gateway.ts
@@ -41,6 +41,7 @@ export interface RunPreviewGatewayOptions {
   localProbeIntervalMs?: number;
   localProbeTimeoutMs?: number;
   maxRequests?: number;
+  maxConcurrentRequests?: number;
 }
 
 const DEFAULT_GATEWAY_URL = "https://preview.farming-labs.dev";
@@ -48,6 +49,7 @@ const DEFAULT_PREVIEW_DOMAIN = "preview.farming-labs.dev";
 const DEFAULT_POLL_TIMEOUT_MS = 15000;
 const DEFAULT_LOCAL_PROBE_INTERVAL_MS = 2000;
 const DEFAULT_LOCAL_PROBE_TIMEOUT_MS = 1000;
+const DEFAULT_MAX_CONCURRENT_REQUESTS = 25;
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
   "content-length",
@@ -89,6 +91,11 @@ export async function runPreviewGateway(
   const session = await createGatewaySession(plan, options.timeoutMs ?? 30000);
   const controller = new AbortController();
   let handledRequests = 0;
+  const inFlightRequests = new Set<Promise<void>>();
+  const maxConcurrentRequests = Math.max(
+    1,
+    options.maxConcurrentRequests ?? DEFAULT_MAX_CONCURRENT_REQUESTS,
+  );
   const localTargetWatch = watchLocalPreviewTarget(plan.target, controller, {
     intervalMs: options.localProbeIntervalMs ?? DEFAULT_LOCAL_PROBE_INTERVAL_MS,
     timeoutMs: options.localProbeTimeoutMs ?? DEFAULT_LOCAL_PROBE_TIMEOUT_MS,
@@ -100,30 +107,51 @@ export async function runPreviewGateway(
 
   logger.success("Preview URL ready.");
   logger.info(`Public: ${session.publicUrl}`);
-  logger.info("Forwarding requests until Ctrl+C.");
+  logger.info("Forwarding requests until Ctrl+C. Remote traffic will be logged below.");
+
+  const waitForAvailableRequestSlot = async () => {
+    while (!controller.signal.aborted && inFlightRequests.size >= maxConcurrentRequests) {
+      await Promise.race(inFlightRequests);
+    }
+  };
+
+  const handleRequest = async (request: PreviewGatewayRequest) => {
+    const startedAt = Date.now();
+
+    try {
+      const response = await forwardGatewayRequest(plan.target, request);
+      await sendGatewayResponse(plan, session, request.id, response, controller.signal);
+      handledRequests += 1;
+      logger.info(
+        `${request.method.toUpperCase()} ${formatRequestPath(request.path)} -> ${response.status} ${Date.now() - startedAt}ms`,
+      );
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      logger.warn(
+        `Local preview target ${plan.target.localUrl} is no longer reachable. Closing preview session.`,
+      );
+      controller.abort(error);
+    }
+  };
 
   try {
     while (!controller.signal.aborted) {
+      await waitForAvailableRequestSlot();
+      if (controller.signal.aborted) break;
+
       const requests = await pollGatewayRequests(plan, session, {
         signal: controller.signal,
         pollTimeoutMs: options.pollTimeoutMs ?? DEFAULT_POLL_TIMEOUT_MS,
       });
 
-      await Promise.all(
-        requests.map(async (request) => {
-          try {
-            const response = await forwardGatewayRequest(plan.target, request);
-            await sendGatewayResponse(plan, session, request.id, response, controller.signal);
-            handledRequests += 1;
-          } catch (error) {
-            if (controller.signal.aborted) return;
-            logger.warn(
-              `Local preview target ${plan.target.localUrl} is no longer reachable. Closing preview session.`,
-            );
-            controller.abort(error);
-          }
-        }),
-      );
+      for (const request of requests) {
+        await waitForAvailableRequestSlot();
+        if (controller.signal.aborted) break;
+
+        const promise = handleRequest(request);
+        inFlightRequests.add(promise);
+        promise.finally(() => inFlightRequests.delete(promise));
+      }
 
       if (options.maxRequests && handledRequests >= options.maxRequests) {
         break;
@@ -133,6 +161,7 @@ export async function runPreviewGateway(
     process.removeListener("SIGINT", cleanup);
     process.removeListener("SIGTERM", cleanup);
     controller.abort();
+    await Promise.allSettled(inFlightRequests);
     await localTargetWatch.catch(() => undefined);
     await closeGatewaySession(plan, session).catch(() => undefined);
   }
@@ -319,6 +348,14 @@ export function formatGatewayPlan(plan: PreviewGatewayPlan) {
     `Local:   ${plan.target.localUrl}`,
     `Public:  ${plan.requestedPublicUrl}`,
   ].join("\n");
+}
+
+function formatRequestPath(path: string) {
+  if (path.length <= 96) {
+    return path;
+  }
+
+  return `${path.slice(0, 93)}...`;
 }
 
 function normalizeGatewayUrl(value: string) {

--- a/packages/farm-preview-gateway/src/index.ts
+++ b/packages/farm-preview-gateway/src/index.ts
@@ -78,6 +78,7 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 25000;
 const DEFAULT_POLL_TIMEOUT_MS = 15000;
 const DEFAULT_POLL_INTERVAL_MS = 100;
 const DEFAULT_MAX_BODY_BYTES = 1024 * 1024 * 5;
+const DEFAULT_POLL_REQUEST_LIMIT = 50;
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
   "content-encoding",
@@ -432,7 +433,7 @@ async function pollSessionRequests(
   await markSessionOnline(store, config, session);
 
   while (Date.now() < deadline) {
-    const requests = await store.takeRequests(session.id, 10);
+    const requests = await store.takeRequests(session.id, DEFAULT_POLL_REQUEST_LIMIT);
     if (requests.length) {
       await markSessionOnline(store, config, session);
       return json({ requests });

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -71,6 +71,10 @@ function createPPRRefreshScript(): string {
   return `<script>(function(){if(window.__FARM_PPR_REFRESHING__)return;window.__FARM_PPR_REFRESHING__=true;function replaceRoot(html){var doc=new DOMParser().parseFromString(html,"text/html");var next=doc.getElementById("root");var current=document.getElementById("root");if(!next||!current)return;current.innerHTML=next.innerHTML;}fetch(window.location.href,{credentials:"same-origin",headers:{"x-farm-ppr-refresh":"1"}}).then(function(response){return response.ok?response.text():null;}).then(function(html){if(html)replaceRoot(html);}).catch(function(){});})();</script>`;
 }
 
+function createPreHydrationClickQueueScript(): string {
+  return `<script>(function(){if(window.__FARM_PREHYDRATION_CLICK_QUEUE__)return;var queue=[];window.__FARM_PREHYDRATION_CLICK_QUEUE__=queue;window.__FARM_HYDRATED__=false;document.documentElement.dataset.farmHydrated="false";function isModified(event){return !!(event.metaKey||event.altKey||event.ctrlKey||event.shiftKey)}function closestQueuedTarget(target){while(target&&target!==document.documentElement){if(target.matches&&target.matches('button,[role="button"],input[type="button"],input[type="submit"],input[type="reset"]'))return target;target=target.parentElement}return null}document.addEventListener("click",function(event){if(window.__FARM_HYDRATED__)return;if(event.defaultPrevented||event.button!==0||isModified(event))return;var target=closestQueuedTarget(event.target);if(!target||target.closest&&target.closest("a[href]"))return;if(queue.some(function(item){return item.target===target}))return;queue.push({target:target,createdAt:Date.now()});event.preventDefault();event.stopImmediatePropagation()},true);})();</script>`;
+}
+
 function createDocumentFooter(options: {
   suspenseRevealFallback: string;
   refreshPPR?: boolean;
@@ -936,6 +940,10 @@ window.__FARM_LOADING_MODULE__ = ${JSON.stringify(
 window.__FARM_MANIFEST__ = ${JSON.stringify(clientManifest)};
 window.__FARM_INTEGRATION_API_MANIFEST__ = ${JSON.stringify(getRegisteredIntegrationAPIManifest())};
 </script>`;
+      const hydrationClickQueueScript =
+        isClientComponent || (req as any).__FARM_SHOULD_HYDRATE__ === true
+          ? createPreHydrationClickQueueScript()
+          : "";
 
       // Get metadata from request
       const metadata = (req as any).__FARM_METADATA__ || {};
@@ -994,6 +1002,7 @@ window.__FARM_INTEGRATION_API_MANIFEST__ = ${JSON.stringify(getRegisteredIntegra
   <link rel="stylesheet" href="/src/app/globals.css" />
   <script type="module" src="/@vite/client"></script>
   ${propsScript}
+  ${hydrationClickQueueScript}
 </head>
 <body class="">
   <div id="root">`;

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -1615,6 +1615,24 @@ function normalizeServerProps(rawProps) {
   return props;
 }
 
+function replayPreHydrationClicks() {
+  window.__FARM_HYDRATED__ = true;
+  document.documentElement.dataset.farmHydrated = 'true';
+
+  const queue = Array.isArray(window.__FARM_PREHYDRATION_CLICK_QUEUE__)
+    ? window.__FARM_PREHYDRATION_CLICK_QUEUE__
+    : [];
+  if (queue.length === 0) return;
+
+  const queuedClicks = queue.splice(0, queue.length);
+  for (const queuedClick of queuedClicks) {
+    const target = queuedClick?.target;
+    if (!target || typeof target.click !== 'function') continue;
+    if (target.isConnected === false) continue;
+    setTimeout(() => target.click(), 0);
+  }
+}
+
 async function buildClientHydrationElement(PageComponent, pageProps) {
   let element = React.createElement(PageComponent, pageProps);
   const loadingModulePath = window.__FARM_LOADING_MODULE__;
@@ -1964,6 +1982,7 @@ async function hydrate() {
     ).catch(() => false);
 
     if (hydrated) {
+      replayPreHydrationClicks();
       console.log('[Farm.js] ✅ Hydrated:', modulePath);
       return;
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -545,6 +545,9 @@ importers:
       '@farmjs/preview-gateway':
         specifier: workspace:*
         version: link:../../packages/farm-preview-gateway
+      '@vercel/blob':
+        specifier: ^2.6.1
+        version: 2.6.1
     devDependencies:
       '@types/node':
         specifier: ^20.10.5
@@ -6909,9 +6912,44 @@ packages:
       vue: 3.5.22(typescript@5.9.3)
     dev: false
 
+  /@vercel/blob@2.6.1:
+    resolution: {integrity: sha512-KTJytw85j1XQBxjN5d6UXI7fIWNQe1jotn4nWN+0hePqLs+Qi1B3jHdQcSKFGF0m2rsy9uhPT6GOXMtHe3qNzg==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@vercel/oidc': 3.8.0
+      async-retry: 1.3.3
+      is-buffer: 2.0.5
+      is-node-process: 1.2.0
+      throttleit: 2.1.0
+      undici: 6.27.0
+    dev: false
+
+  /@vercel/cli-config@0.2.0:
+    resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==}
+    dependencies:
+      xdg-app-paths: 5.1.0
+      zod: 4.1.11
+    dev: false
+
+  /@vercel/cli-exec@1.0.0:
+    resolution: {integrity: sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==}
+    engines: {node: '>= 18'}
+    dependencies:
+      execa: 5.1.1
+    dev: false
+
   /@vercel/oidc@3.2.0:
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
+    dev: false
+
+  /@vercel/oidc@3.8.0:
+    resolution: {integrity: sha512-r00laGW6Pv778RoR6M2NxX91ycSj+PBwVo+fOb9Bif+F0IyUKt25zrvBzfEzQpeAzbqOgPZyQibEWDdDFApd+A==}
+    engines: {node: '>= 20'}
+    dependencies:
+      '@vercel/cli-config': 0.2.0
+      '@vercel/cli-exec': 1.0.0
+      jose: 5.10.0
     dev: false
 
   /@vercel/sandbox@2.4.0:
@@ -9314,6 +9352,21 @@ packages:
       eventsource-parser: 3.1.0
     dev: false
 
+  /execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+    dev: false
+
   /execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
@@ -9813,6 +9866,11 @@ packages:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  /get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+    dev: false
+
   /get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
@@ -10298,6 +10356,11 @@ packages:
     hasBin: true
     dev: true
 
+  /human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+    dev: false
+
   /human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
@@ -10397,6 +10460,11 @@ packages:
     dependencies:
       binary-extensions: 2.3.0
 
+  /is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
+    dev: false
+
   /is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
@@ -10435,6 +10503,10 @@ packages:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
     dev: false
 
+  /is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+    dev: false
+
   /is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -10466,6 +10538,11 @@ packages:
   /is-regexp@3.1.0:
     resolution: {integrity: sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==}
     engines: {node: '>=12'}
+    dev: false
+
+  /is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
     dev: false
 
   /is-stream@3.0.0:
@@ -10554,6 +10631,10 @@ packages:
   /jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  /jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
+    dev: false
 
   /jose@6.2.1:
     resolution: {integrity: sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==}
@@ -11539,6 +11620,11 @@ packages:
       mime-db: 1.54.0
     dev: false
 
+  /mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+    dev: false
+
   /mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
@@ -12106,6 +12192,13 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+    dependencies:
+      path-key: 3.1.1
+    dev: false
+
   /npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -12167,6 +12260,13 @@ packages:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
+
+  /onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+    dependencies:
+      mimic-fn: 2.1.0
+    dev: false
 
   /onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
@@ -13686,6 +13786,10 @@ packages:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
     dev: true
 
+  /signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+    dev: false
+
   /signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -13883,6 +13987,11 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
     dev: true
+
+  /strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+    dev: false
 
   /strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
@@ -14186,6 +14295,11 @@ packages:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
     dependencies:
       any-promise: 1.3.0
+
+  /throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
+    dev: false
 
   /tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -14626,6 +14740,11 @@ packages:
 
   /undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  /undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
+    engines: {node: '>=18.17'}
+    dev: false
 
   /undici@7.16.0:
     resolution: {integrity: sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==}


### PR DESCRIPTION
## What changed

- Expands the Instant Preview docs into a full guide covering quick start, command options, named URLs, request logging, webhooks, OAuth callbacks, hosted gateway behavior, self-hosting, custom providers, env vars, troubleshooting, security, and production-vs-preview usage.
- Updates the CLI docs so `farm preview` shows `--url`, `--dry-run`, forwarded request logging, and the hydration behavior users should expect.
- Hardens the preview CLI by logging forwarded traffic and allowing concurrent forwarded requests instead of serially waiting on each polled batch.
- Adds pre-hydration button-click replay for hydratable pages so slow dev-mode preview loads do not silently drop an early click.
- Updates the Vercel gateway example to use Vercel Blob as a private shared session store and documents the current `vercel blob create-store` setup path.

## Why

`farm preview` should feel like a complete ngrok-style local sharing workflow: a public URL, clear logs, webhook/OAuth guidance, and a production-ready hosted gateway path without asking app developers to wire DNS or tunneling tools themselves.

## Validation

- `git diff --check`
- `corepack pnpm --filter @farmjs/cli test`
- `corepack pnpm --filter @farmjs/preview-gateway test`
- `corepack pnpm --filter farm-preview-gateway-vercel type-check`
- `corepack pnpm --filter @farmjs/core build`
- `DATABASE_URL=${DATABASE_URL:-postgresql://user:password@localhost:5432/farmjs} corepack pnpm exec prisma generate` from `docs/`
- `node ../packages/farm-cli/bin/farm.js build` from `docs/`

Manual preview smoke check from the basic example was already verified through `https://interactive-check.preview.farming-labs.dev/api-demo-client`, including early click replay plus `GET /api/hello`, `GET /api/users`, `POST /api/auth/login`, and `POST /api/users` traffic through the hosted preview URL.