### PR TITLE
feat: auto-generate type artifacts

### DIFF
--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -95,7 +95,7 @@ await api.users.get({
 });
 ```
 
-The exact generated shape comes from route generation. Body and query schemas become typed caller input, and path segments become the nested `api.users.get` style namespace. Run `farm generate` when you want updated route/API types without a full build.
+The exact generated shape comes from route generation. Body and query schemas become typed caller input, and path segments become the nested `api.users.get` style namespace. During `farm dev`, Farm regenerates route/API types when page or API route files are added, changed, or removed. Run `farm generate` when you want the same refresh outside the dev server.
 
 ## When to use integrations instead
 

--- a/docs/src/app/docs/cli/page.md
+++ b/docs/src/app/docs/cli/page.md
@@ -15,7 +15,7 @@ Use the Farm CLI to run, build, generate types, migrate apps, deploy output, and
 | farm dev | Start the dev server. |
 | farm build | Build the app for the configured target. |
 | farm preview | Create a public URL for a running local app. |
-| farm generate | Generate API and route types. |
+| farm generate | Generate route/API types and integration schema artifacts. |
 | farm migrate inspect | Detect supported framework migration sources. |
 | farm migrate next --write | Apply a deterministic Next.js App Router migration. |
 | farm migrate tanstack --write | Apply a deterministic TanStack Router file-route migration. |
@@ -43,7 +43,9 @@ Without `--ui`, the CLI installs integration wiring. With `--ui`, it also instal
 farm generate
 ```
 
-Use this after adding or changing API routes so `api.hello.post(...)`, route params, and `Link` types stay current.
+`farm dev` refreshes generated route/API types automatically when page and API route files change. Use `farm generate` when you want to refresh the same files outside the dev server, such as in CI, before publishing a package, or after moving files while the dev server was stopped.
+
+When integration storage schemas are configured, `farm generate` also writes schema artifacts if Farm can detect the data layer. Pass `--orm` and `--output` when you want explicit schema output for a migration step.
 
 ## Framework migrations
 

--- a/docs/src/app/docs/openapi/page.md
+++ b/docs/src/app/docs/openapi/page.md
@@ -86,7 +86,7 @@ farm generate
 farm build
 ```
 
-`farm generate` keeps route types aware of the reference URL. `farm build` includes the reference route in the app output when OpenAPI is enabled.
+`farm dev` and `farm generate` keep route types aware of the reference URL. `farm build` includes the reference route in the app output when OpenAPI is enabled.
 
 ## Production notes
 

--- a/docs/src/app/docs/project-structure/page.md
+++ b/docs/src/app/docs/project-structure/page.md
@@ -84,7 +84,7 @@ Keep framework configuration in `farm.config.ts`. Keep application helpers under
 
 ## Generated files
 
-Farm can generate route and API types from the app tree. Commit generated types when the project relies on them during CI or package publishing.
+Farm generates route and API types from the app tree. `farm dev` keeps them current as page and API route files change; run the command manually when the dev server is not running.
 
 **Terminal**
 

--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -173,6 +173,8 @@ The group names are organizational. The URLs are still `/`, `/pricing`, and `/da
 ## Navigation workflow
 
 1. Add or rename route files.
-2. Run `farm generate` when you want type updates immediately.
+2. Keep `farm dev` running; Farm regenerates route and API types when route files change.
 3. Use `Link` for internal navigation and plain anchors for external URLs.
 4. Keep dynamic route values encoded in the href string, such as `/blog/${slug}`.
+
+Run `farm generate` when you want to refresh generated types outside the dev server, such as in CI or after a large file move.

--- a/packages/farm-cli/bin/farm.js
+++ b/packages/farm-cli/bin/farm.js
@@ -57,7 +57,7 @@ program
 
 program
   .command("generate")
-  .description("Generate integration schema artifacts for the detected data layer")
+  .description("Generate route/API types and integration schema artifacts")
   .option("-r, --root <root>", "Root directory", process.cwd())
   .option("-c, --config <config>", "Path to farm config file")
   .option(
@@ -77,7 +77,7 @@ program
         output: options.output,
       });
     } catch (error) {
-      console.error("Failed to generate integration schema artifacts:", error);
+      console.error("Failed to generate Farm artifacts:", error);
       process.exit(1);
     }
   });

--- a/packages/farm-cli/src/generate.ts
+++ b/packages/farm-cli/src/generate.ts
@@ -1,7 +1,11 @@
 import {
+  APITypeGenerator,
+  getFarmDocsRouteTypeEntries,
   getIntegrationSchemas,
+  generateRouteTypes,
   loadConfig,
   logger,
+  resolveConfig,
   type FarmIntegrationSchema,
   type FarmIntegrationSchemaField,
   type FarmIntegrationSchemaModel,
@@ -60,22 +64,65 @@ export async function generateFarmArtifacts(options: GenerateFarmOptions = {}) {
   const root = path.resolve(options.root || process.cwd());
   const userConfig = await loadConfig(root, options.configPath, "development");
 
-  if (!userConfig) {
+  if (!userConfig && hasSchemaOptions(options)) {
     throw new Error("No Farm config found. Please create farm.config.ts or config.ts.");
   }
 
-  const schemas = getIntegrationSchemas(userConfig.integrations);
+  const resolvedConfig = await resolveConfig({ root, ...(userConfig || {}) }, "development");
+  const extraRoutes = [
+    ...(resolvedConfig.openapi?.enabled && resolvedConfig.openapi.route
+      ? [resolvedConfig.openapi.route]
+      : []),
+    ...getFarmDocsRouteTypeEntries(resolvedConfig.docs),
+  ];
+  await generateRouteTypes({
+    root: resolvedConfig.root,
+    srcDir: resolvedConfig.srcDir,
+    extraRoutes,
+    suppressLintOnLink: resolvedConfig.suppressLintOnLink,
+  });
+  const appDir = path.join(resolvedConfig.root, resolvedConfig.srcDir, "app");
+  const apiGenerator = new APITypeGenerator(appDir);
+  const apiRoutes = apiGenerator.scanAPIRoutes();
+  const apiTypesPath = path.join(resolvedConfig.root, resolvedConfig.srcDir, "lib", "api.generated.ts");
+  await mkdir(path.dirname(apiTypesPath), { recursive: true });
+  await writeFile(apiTypesPath, apiGenerator.generateAPIRouter(apiRoutes), "utf8");
+  logger.success(
+    `Generated route and API types (${apiRoutes.length} API route${apiRoutes.length === 1 ? "" : "s"}).`,
+  );
+
+  const schemas = getIntegrationSchemas(resolvedConfig.integrations);
   const schemaEntries = Object.entries(schemas);
 
   if (!schemaEntries.length) {
-    logger.warn("No integration schemas were found in the current Farm config.");
+    if (hasSchemaOptions(options)) {
+      logger.warn("No integration schemas were found in the current Farm config.");
+    }
     return;
   }
 
   const packageManifest = await readPackageManifest(root);
-  const orm = options.orm ?? (await detectSchemaTarget(root, packageManifest));
+  const schemaOptionsExplicit = hasSchemaOptions(options);
+  let orm: GenerateFarmSchemaTarget | null = null;
+  try {
+    orm = options.orm ?? (await detectSchemaTarget(root, packageManifest));
+  } catch (error) {
+    if (schemaOptionsExplicit) {
+      throw error;
+    }
+    logger.warn(
+      `Integration schemas were found, but Farm could not choose a schema target automatically: ${(error as Error).message}`,
+    );
+    return;
+  }
 
   if (!orm) {
+    if (!schemaOptionsExplicit) {
+      logger.warn(
+        "Integration schemas were found, but no data layer was detected. Pass --orm prisma|drizzle|postgres|mysql|sqlite|mongodb to generate schema artifacts.",
+      );
+      return;
+    }
     throw new Error(
       "Could not auto-detect a schema target. Pass one explicitly with --orm prisma|drizzle|postgres|mysql|sqlite|mongodb.",
     );
@@ -140,6 +187,10 @@ export async function generateFarmArtifacts(options: GenerateFarmOptions = {}) {
       return;
     }
   }
+}
+
+function hasSchemaOptions(options: GenerateFarmOptions) {
+  return Boolean(options.orm || options.output || options.dialect);
 }
 
 async function readPackageManifest(root: string): Promise<PackageManifest | null> {

--- a/packages/farm-cli/test/migrate.test.mjs
+++ b/packages/farm-cli/test/migrate.test.mjs
@@ -9,8 +9,12 @@ import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 
 const require = createRequire(import.meta.url);
-const { createFrameworkMigrationPlan, inspectFrameworkMigrations, migrateFarm } =
-  require("../dist/index.js");
+const {
+  createFrameworkMigrationPlan,
+  generateFarmArtifacts,
+  inspectFrameworkMigrations,
+  migrateFarm,
+} = require("../dist/index.js");
 const execFileAsync = promisify(execFile);
 const testDir = path.dirname(fileURLToPath(import.meta.url));
 const cliBin = path.resolve(testDir, "../bin/farm.js");
@@ -75,6 +79,41 @@ test("loads migration commands from farm.config", async () => {
     await migrateFarm({ root });
 
     assert.equal(await readFile(path.join(root, "configured.txt"), "utf8"), "configured");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("generates route and API types", async () => {
+  const root = await createTempProject();
+
+  try {
+    await mkdir(path.join(root, "src", "app", "about"), { recursive: true });
+    await mkdir(path.join(root, "src", "app", "api", "hello"), { recursive: true });
+    await writeFile(
+      path.join(root, "src", "app", "page.tsx"),
+      "export default function Home() { return null; }\n",
+      "utf8",
+    );
+    await writeFile(
+      path.join(root, "src", "app", "about", "page.tsx"),
+      "export default function About() { return null; }\n",
+      "utf8",
+    );
+    await writeFile(
+      path.join(root, "src", "app", "api", "hello", "route.ts"),
+      "export const POST = async () => Response.json({ ok: true });\n",
+      "utf8",
+    );
+
+    await generateFarmArtifacts({ root });
+
+    const routeTypes = await readFile(path.join(root, "src", "farm-routes.d.ts"), "utf8");
+    const apiTypes = await readFile(path.join(root, "src", "lib", "api.generated.ts"), "utf8");
+
+    assert.ok(routeTypes.includes('"/about"'));
+    assert.ok(apiTypes.includes("hello: {"));
+    assert.ok(apiTypes.includes("post: typeof POST_hello;"));
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/farm/src/__tests__/generate-route-types.test.ts
+++ b/packages/farm/src/__tests__/generate-route-types.test.ts
@@ -87,4 +87,18 @@ describe("generateRouteTypes", () => {
     expect(content).toContain('"/docs"');
     expect(content).toContain("`/docs/${string}`");
   });
+
+  it("writes a valid empty route union when no pages exist", async () => {
+    const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "farm-empty-route-types-"));
+    try {
+      await fs.promises.mkdir(path.join(root, "src", "app"), { recursive: true });
+
+      const outPath = await generateRouteTypes({ root, srcDir: "src" });
+      const content = fs.readFileSync(outPath, "utf8");
+
+      expect(content).toContain("export type RoutePath = never;");
+    } finally {
+      await fs.promises.rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/farm/src/__tests__/type-artifacts.test.ts
+++ b/packages/farm/src/__tests__/type-artifacts.test.ts
@@ -1,0 +1,46 @@
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { generateFarmTypeArtifacts } from "../type-artifacts";
+
+describe("generateFarmTypeArtifacts", () => {
+  it("generates route and API type files from the app tree", async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "farm-type-artifacts-"));
+    const appDir = path.join(root, "src", "app");
+    mkdirSync(path.join(appDir, "users", "[id]"), { recursive: true });
+    mkdirSync(path.join(appDir, "api", "hello"), { recursive: true });
+
+    writeFileSync(
+      path.join(appDir, "page.tsx"),
+      "export default function Home() { return null; }\n",
+    );
+    writeFileSync(
+      path.join(appDir, "users", "[id]", "page.tsx"),
+      "export default function User() { return null; }\n",
+    );
+    writeFileSync(
+      path.join(appDir, "api", "hello", "route.ts"),
+      "export const POST = async () => Response.json({ ok: true });\n",
+    );
+
+    const result = await generateFarmTypeArtifacts({
+      root,
+      srcDir: "src",
+      extraRoutes: ["/docs/reference"],
+    });
+
+    const routeTypesPath = path.join(root, "src", "farm-routes.d.ts");
+    const apiTypesPath = path.join(root, "src", "lib", "api.generated.ts");
+
+    expect(result.routeTypesPath).toBe(routeTypesPath);
+    expect(result.apiTypesPath).toBe(apiTypesPath);
+    expect(result.apiRoutes).toHaveLength(1);
+    expect(existsSync(routeTypesPath)).toBe(true);
+    expect(existsSync(apiTypesPath)).toBe(true);
+    expect(readFileSync(routeTypesPath, "utf8")).toContain("`/users/${string}`");
+    expect(readFileSync(routeTypesPath, "utf8")).toContain('"/docs/reference"');
+    expect(readFileSync(apiTypesPath, "utf8")).toContain("hello: {");
+    expect(readFileSync(apiTypesPath, "utf8")).toContain("post: typeof POST_hello;");
+  });
+});

--- a/packages/farm/src/__tests__/type-generator.test.ts
+++ b/packages/farm/src/__tests__/type-generator.test.ts
@@ -38,4 +38,30 @@ describe("APITypeGenerator", () => {
     expect(existsSync(outputPath)).toBe(true);
     expect(readFileSync(outputPath, "utf8")).toContain("Auto-generated API router types");
   });
+
+  it("detects function-style handlers and JavaScript route files", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "farm-api-types-"));
+    const appDir = path.join(root, "src", "app");
+    const statusRouteDir = path.join(appDir, "api", "status");
+    const profileRouteDir = path.join(appDir, "api", "profile");
+    mkdirSync(statusRouteDir, { recursive: true });
+    mkdirSync(profileRouteDir, { recursive: true });
+
+    writeFileSync(
+      path.join(statusRouteDir, "route.ts"),
+      "export async function GET() { return Response.json({ ok: true }); }\n",
+    );
+    writeFileSync(
+      path.join(profileRouteDir, "route.js"),
+      "export function POST() { return Response.json({ ok: true }); }\n",
+    );
+
+    const generator = new APITypeGenerator(appDir);
+    const content = generator.generateAPIRouter(generator.scanAPIRoutes());
+
+    expect(content).toContain("import type { GET as GET_status }");
+    expect(content).toContain("import type { POST as POST_profile }");
+    expect(content).toContain("status: {");
+    expect(content).toContain("profile: {");
+  });
 });

--- a/packages/farm/src/build/index.ts
+++ b/packages/farm/src/build/index.ts
@@ -10,7 +10,7 @@ import { APIRouteManager } from "../api/route-manager";
 import { resolveAppPath } from "../utils";
 import { buildUniversal } from "../nitro/universal-build";
 import { getFarmDocsRouteTypeEntries } from "../docs";
-import { generateRouteTypes } from "../routing/generate-route-types";
+import { generateFarmTypeArtifacts } from "../type-artifacts";
 import { PluginManager } from "../plugin";
 
 interface BuildOptions {
@@ -57,7 +57,7 @@ export async function build(config: ResolvedFarmConfig, options: BuildOptions = 
     const serverRenderer = farmApp.getServerRenderer();
 
     try {
-      await generateRouteTypes({
+      await generateFarmTypeArtifacts({
         root,
         srcDir,
         extraRoutes: [

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -32,6 +32,7 @@ export * from "./markdown";
 export * from "./app-markdown";
 export * from "./observability";
 export * from "./workflows";
+export * from "./type-artifacts";
 export { generateRouteTypes } from "./routing/generate-route-types";
 export type { GenerateRouteTypesOptions } from "./routing/generate-route-types";
 export * from "./build/index";

--- a/packages/farm/src/routing/generate-route-types.ts
+++ b/packages/farm/src/routing/generate-route-types.ts
@@ -93,7 +93,11 @@ export type RoutePath = string;
 
   const typeLiterals = Array.from(patterns).sort().map(routePatternToTsTypeLiteral);
 
-  const routePathType = suppressLintOnLink ? "string" : typeLiterals.join(" | ");
+  const routePathType = suppressLintOnLink
+    ? "string"
+    : typeLiterals.length
+      ? typeLiterals.join(" | ")
+      : "never";
   const augmentationBlock = suppressLintOnLink
     ? ""
     : `

--- a/packages/farm/src/type-artifacts.ts
+++ b/packages/farm/src/type-artifacts.ts
@@ -1,0 +1,70 @@
+import { mkdirSync, writeFileSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { APITypeGenerator, type APIRouteInfo } from "./type-generator";
+import {
+  generateRouteTypes,
+  type GenerateRouteTypesOptions,
+} from "./routing/generate-route-types";
+
+export interface GenerateFarmTypeArtifactsOptions {
+  root: string;
+  srcDir?: string;
+  extraRoutes?: string[];
+  suppressLintOnLink?: boolean;
+  routeTypesOutFile?: string;
+  apiTypesOutFile?: string;
+  routes?: boolean;
+  api?: boolean;
+}
+
+export interface GenerateFarmTypeArtifactsResult {
+  routeTypesPath?: string;
+  apiTypesPath?: string;
+  apiRoutes: APIRouteInfo[];
+}
+
+export async function generateFarmTypeArtifacts(
+  options: GenerateFarmTypeArtifactsOptions,
+): Promise<GenerateFarmTypeArtifactsResult> {
+  const root = resolve(options.root);
+  const srcDir = options.srcDir || "src";
+  const shouldGenerateRoutes = options.routes !== false;
+  const shouldGenerateApi = options.api !== false;
+  const appDir = join(root, srcDir, "app");
+
+  const result: GenerateFarmTypeArtifactsResult = {
+    apiRoutes: [],
+  };
+
+  if (shouldGenerateRoutes) {
+    const routeOptions: GenerateRouteTypesOptions = {
+      root,
+      srcDir,
+      extraRoutes: options.extraRoutes || [],
+      suppressLintOnLink: options.suppressLintOnLink,
+    };
+
+    if (options.routeTypesOutFile) {
+      routeOptions.outFile = options.routeTypesOutFile;
+    }
+
+    result.routeTypesPath = await generateRouteTypes(routeOptions);
+  }
+
+  if (shouldGenerateApi) {
+    const generator = new APITypeGenerator(appDir);
+    const apiRoutes = generator.scanAPIRoutes();
+    const apiTypesPath = options.apiTypesOutFile
+      ? resolve(root, options.apiTypesOutFile)
+      : join(root, srcDir, "lib", "api.generated.ts");
+    const content = generator.generateAPIRouter(apiRoutes);
+
+    mkdirSync(dirname(apiTypesPath), { recursive: true });
+    writeFileSync(apiTypesPath, content, "utf-8");
+
+    result.apiTypesPath = apiTypesPath;
+    result.apiRoutes = apiRoutes;
+  }
+
+  return result;
+}

--- a/packages/farm/src/type-generator.ts
+++ b/packages/farm/src/type-generator.ts
@@ -40,7 +40,7 @@ export class APITypeGenerator {
       if (item.isDirectory()) {
         const newBasePath = basePath ? `${basePath}/${item.name}` : item.name;
         this.scanDirectory(fullPath, routes, newBasePath);
-      } else if (item.name === "route.ts" || item.name === "route.tsx") {
+      } else if (/^route\.(ts|tsx|js|jsx)$/.test(item.name)) {
         const routeInfo = this.extractRouteInfo(fullPath, basePath);
         if (routeInfo) {
           routes.push(routeInfo);
@@ -81,6 +81,7 @@ export class APITypeGenerator {
       // Look for export const METHOD = or export { METHOD }
       const patterns = [
         new RegExp(`export\\s+const\\s+${method}\\s*=`, "g"),
+        new RegExp(`export\\s+(?:async\\s+)?function\\s+${method}\\s*\\(`, "g"),
         new RegExp(`export\\s*{\\s*${method}\\s*}`, "g"),
         new RegExp(`export\\s*{\\s*${method}\\s*as\\s+\\w+\\s*}`, "g"),
       ];
@@ -118,9 +119,9 @@ export class APITypeGenerator {
 
     for (const [path, routeList] of routeGroups) {
       const route = routeList[0];
-      const importPath = route.relativePath.replace(/\\/g, "/").replace(/\.(ts|tsx)$/, "");
+      const importPath = route.relativePath.replace(/\\/g, "/").replace(/\.(ts|tsx|js|jsx)$/, "");
       const routeName = this.pathToRouteName(route.path);
-      const cleanPath = path.replace(/^\/api\//, "");
+      const cleanPath = path === "/api" ? "" : path.replace(/^\/api\//, "");
       const parts = cleanPath ? cleanPath.split("/") : [];
 
       // Collect all methods for this route
@@ -132,24 +133,32 @@ export class APITypeGenerator {
         imports.push(`import type { ${method} as ${importName} } from '../app/${importPath}';`);
       }
 
-      // Build nested object
-      let current = nestedStructure;
-      for (let i = 0; i < parts.length; i++) {
-        const part = parts[i];
-        if (i === parts.length - 1) {
-          // Last part - add methods
-          current[part] = {};
-          for (const method of allMethods) {
-            const importName = `${method}_${routeName}`;
-            const methodName = method.toLowerCase();
-            current[part][methodName] = `typeof ${importName}`;
-          }
-        } else {
-          // Intermediate part - create nested object
-          if (!current[part]) {
+      if (parts.length === 0) {
+        for (const method of allMethods) {
+          const importName = `${method}_${routeName}`;
+          const methodName = method.toLowerCase();
+          nestedStructure[methodName] = `typeof ${importName}`;
+        }
+      } else {
+        // Build nested object
+        let current = nestedStructure;
+        for (let i = 0; i < parts.length; i++) {
+          const part = parts[i];
+          if (i === parts.length - 1) {
+            // Last part - add methods
             current[part] = {};
+            for (const method of allMethods) {
+              const importName = `${method}_${routeName}`;
+              const methodName = method.toLowerCase();
+              current[part][methodName] = `typeof ${importName}`;
+            }
+          } else {
+            // Intermediate part - create nested object
+            if (!current[part]) {
+              current[part] = {};
+            }
+            current = current[part];
           }
-          current = current[part];
         }
       }
     }
@@ -176,8 +185,7 @@ ${typeExports}
   }
 
   private pathToRouteName(path: string): string {
-    return path
-      .replace(/^\/api\//, "")
+    return (path === "/api" ? "root" : path.replace(/^\/api\//, ""))
       .replace(/\//g, "_")
       .replace(/[^a-zA-Z0-9_]/g, "");
   }

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -8,7 +8,7 @@ import { HMRManager } from "./hmr";
 import { APIRouteManager } from "./api/route-manager";
 import { OpenAPIManager } from "./openapi/manager";
 import { MiddlewareManager } from "./middleware/manager";
-import { generateRouteTypes } from "./routing/generate-route-types";
+import { generateFarmTypeArtifacts } from "./type-artifacts";
 import {
   createFarmDocsAPIHandler,
   createFarmDocsHandler,
@@ -57,7 +57,7 @@ export function farmPlugin(
     | ((request: Request) => Promise<Response | null>)
     | null = null;
   const pluginManager: PluginManager | undefined = initialPluginManager;
-  const logUpdate = (tag: "PAGE" | "API" | "MIDDLEWARE", message: string) => {
+  const logUpdate = (tag: "PAGE" | "API" | "MIDDLEWARE" | "TYPE", message: string) => {
     try {
       const pc = require("picocolors");
       const log = [
@@ -122,39 +122,59 @@ export function farmPlugin(
         ...(options.openapi?.enabled && options.openapi.route ? [options.openapi.route] : []),
         ...getFarmDocsRouteTypeEntries(farmConfig.docs),
       ];
-      try {
-        await generateRouteTypes({
-          root: farmConfig.root,
-          srcDir: farmConfig.srcDir,
-          extraRoutes: getExtraRouteTypes(),
-          suppressLintOnLink: farmConfig.suppressLintOnLink,
-        });
-      } catch (e) {
-        if (process.env.FARM_VERBOSE)
-          logger.warn("Route type generation failed: " + (e as Error).message);
-      }
-
       const appDirSlug = path.join(farmConfig.root, farmConfig.srcDir, "app").replace(/\\/g, "/");
-      const isPageFile = (file: string) => {
-        const normalized = file.replace(/\\/g, "/");
-        return normalized.includes(appDirSlug) && /page\.(ts|tsx|js|jsx|md|mdx)$/.test(normalized);
-      };
-      let routeTypeGenScheduled: ReturnType<typeof setTimeout> | null = null;
-      const scheduleRouteTypeGen = () => {
-        if (routeTypeGenScheduled) return;
-        routeTypeGenScheduled = setTimeout(() => {
-          routeTypeGenScheduled = null;
-          generateRouteTypes({
+      const generateTypeArtifacts = async (reason: string, log = false) => {
+        try {
+          const result = await generateFarmTypeArtifacts({
             root: farmConfig.root,
             srcDir: farmConfig.srcDir,
             extraRoutes: getExtraRouteTypes(),
             suppressLintOnLink: farmConfig.suppressLintOnLink,
-          }).catch(() => {});
+          });
+          if (log) {
+            logUpdate(
+              "TYPE",
+              `${reason} - regenerated route and API types (${result.apiRoutes.length} API route${result.apiRoutes.length === 1 ? "" : "s"})`,
+            );
+          }
+          if (openAPIManager) {
+            await openAPIManager.invalidateCache();
+          }
+        } catch (e) {
+          if (process.env.FARM_VERBOSE) {
+            logger.warn("Type artifact generation failed: " + (e as Error).message);
+          }
+          if (pm) {
+            await emitPluginError("type-artifact-generation", e, { reason });
+          }
+        }
+      };
+      await generateTypeArtifacts("startup");
+
+      const isPageFile = (file: string) => {
+        const normalized = file.replace(/\\/g, "/");
+        return normalized.includes(appDirSlug) && /page\.(ts|tsx|js|jsx|md|mdx)$/.test(normalized);
+      };
+      const isApiRouteFile = (file: string) => {
+        const normalized = file.replace(/\\/g, "/");
+        return (
+          normalized.includes(`${appDirSlug}/api/`) &&
+          /route\.(ts|tsx|js|jsx)$/.test(normalized)
+        );
+      };
+      const isTypeAffectingFile = (file: string) => isPageFile(file) || isApiRouteFile(file);
+      let typeArtifactGenScheduled: ReturnType<typeof setTimeout> | null = null;
+      const scheduleTypeArtifactGen = (file: string, event: string) => {
+        if (typeArtifactGenScheduled) return;
+        typeArtifactGenScheduled = setTimeout(() => {
+          typeArtifactGenScheduled = null;
+          const shortPath = file.split("/app/")[1] || file;
+          generateTypeArtifacts(`${event} ${shortPath}`, true).catch(() => {});
         }, 100);
       };
       ["add", "change", "unlink"].forEach((ev) => {
         server.watcher.on(ev as "add", (file: string) => {
-          if (isPageFile(file)) scheduleRouteTypeGen();
+          if (isTypeAffectingFile(file)) scheduleTypeArtifactGen(file, ev);
         });
       });
 
@@ -162,7 +182,7 @@ export function farmPlugin(
       hmrManager = new HMRManager(server);
 
       // Initialize API route manager
-      const appDir = path.join(server.config.root, "src/app");
+      const appDir = path.join(farmConfig.root, farmConfig.srcDir, "app");
       const routeManager = farmApp.getRouteManager();
       const discoveredRoutes: Array<{
         kind: "page" | "layout";
@@ -1230,41 +1250,6 @@ if (import.meta.hot) {
           }
 
           return [];
-        }
-
-        // Auto-generate types when API routes change
-        if (file.includes("/api/") && file.includes("/route.")) {
-          const shortPath = file.split("/app/")[1] || file;
-          logUpdate("API", `updated ${shortPath} - regenerating types...`);
-
-          // Dynamically regenerate API types
-          try {
-            const { APITypeGenerator } = await import("./type-generator.js");
-            const { join } = await import("path");
-            const { fileURLToPath } = await import("url");
-
-            const appDir = file.substring(0, file.indexOf("/app/") + 4);
-            const outputPath = join(appDir, "../lib/api.generated.ts");
-
-            const generator = new APITypeGenerator(appDir);
-            generator.generateAPIIndex(outputPath);
-            logger.success("✅ API types regenerated!");
-
-            // Regenerate OpenAPI spec if enabled
-            if (openAPIManager) {
-              await openAPIManager.invalidateCache();
-              logger.success("✅ OpenAPI spec regenerated!");
-            }
-          } catch (error) {
-            if (initialPluginManager) {
-              await initialPluginManager.runHookParallel("onError", {
-                phase: "api-type-regeneration",
-                error,
-                meta: { file },
-              });
-            }
-            logger.warn(`Failed to regenerate API types: ${error}`);
-          }
         }
 
         if (file.includes("page.") || file.includes("layout.")) {


### PR DESCRIPTION
## Summary

- Generate route and API type artifacts together from one shared core helper.
- Refresh generated types automatically during `farm dev` on page/API route file add, change, and unlink events.
- Make `farm generate` refresh route/API types by default while preserving integration schema artifact generation.
- Improve API route type discovery for function-style handlers, JS/JSX route files, and root `/api` handlers.
- Update docs and tests for the automatic generation workflow.

## Validation

- `pnpm --filter @farmjs/core test`
- `pnpm --filter @farmjs/cli test`
- `git diff --check`