### PR TITLE
feat: add typed server functions

### DIFF
--- a/examples/rsc-demo/src/actions/user.ts
+++ b/examples/rsc-demo/src/actions/user.ts
@@ -1,7 +1,8 @@
-"use server";
+import { createServerFn } from "@farmjs/core/server-fn";
+import { z } from "zod";
 
-// Server Actions - Functions that run on the server but can be called from the client
-// The "use server" directive marks this file (or function) as server-only
+// Server functions run on the server but can be called from forms and client components.
+// Farm adds the underlying React "use server" boundary for createServerFn exports.
 
 // Simulated database
 const messages: { id: number; name: string; message: string; timestamp: string }[] = [];
@@ -9,33 +10,32 @@ let nextId = 1;
 
 /**
  * Submit a message - Server Action
- * This function runs on the server, even when called from a client component
+ * This function runs on the server, even when called from a client component.
  */
-export async function submitMessage(formData: FormData) {
-  // Simulate network delay
-  await new Promise((resolve) => setTimeout(resolve, 500));
+export const submitMessage = createServerFn({
+  input: z.object({
+    name: z.string().trim().min(1, "Name is required"),
+    message: z.string().trim().min(1, "Message is required"),
+  }),
+  async handler({ input }) {
+    // Simulate network delay
+    await new Promise((resolve) => setTimeout(resolve, 500));
 
-  const name = formData.get("name") as string;
-  const message = formData.get("message") as string;
+    // In a real app, you'd save to a database here
+    const newMessage = {
+      id: nextId++,
+      name: input.name,
+      message: input.message,
+      timestamp: new Date().toISOString(),
+    };
+    messages.push(newMessage);
 
-  if (!name || !message) {
-    return { success: false, error: "Name and message are required" };
-  }
-
-  // In a real app, you'd save to a database here
-  const newMessage = {
-    id: nextId++,
-    name,
-    message,
-    timestamp: new Date().toISOString(),
-  };
-  messages.push(newMessage);
-
-  return {
-    success: true,
-    message: newMessage,
-  };
-}
+    return {
+      success: true,
+      message: newMessage,
+    };
+  },
+});
 
 /**
  * Get all messages - Server Action

--- a/examples/rsc-demo/src/components/MessageForm.tsx
+++ b/examples/rsc-demo/src/components/MessageForm.tsx
@@ -43,8 +43,8 @@ export function MessageForm() {
         Server Action Form
       </h3>
       <p className="text-slate-400 mb-4">
-        This form calls a <code className="text-orange-400">"use server"</code>{" "}
-        function directly. No API route needed!
+        This form calls a <code className="text-orange-400">createServerFn</code>{" "}
+        action directly. No API route needed!
       </p>
 
       <form id="message-form" action={handleSubmit} className="space-y-4">

--- a/examples/rsc-demo/src/form/page.tsx
+++ b/examples/rsc-demo/src/form/page.tsx
@@ -1,5 +1,5 @@
 // Form page - Server Actions Demo
-// Shows how to use "use server" functions from Client Components
+// Shows how to use createServerFn functions from Client Components
 
 import React from "react";
 import { MessageForm } from "../components/MessageForm";
@@ -16,8 +16,8 @@ export default function FormPage() {
       <div className="text-center">
         <h1 className="text-4xl font-bold text-white mb-4">Server Actions</h1>
         <p className="text-lg text-slate-400 max-w-2xl mx-auto">
-          Use <code className="text-orange-400">"use server"</code> to create
-          functions that run on the server but can be called from the client.
+          Use <code className="text-orange-400">createServerFn</code> to create
+          validated functions that run on the server but can be called from forms.
         </p>
       </div>
 
@@ -39,17 +39,16 @@ export default function FormPage() {
               Server Action (actions/user.ts)
             </h4>
             <pre className="bg-slate-900/50 rounded-lg p-4 overflow-x-auto text-sm">
-              <code className="text-slate-300">{`"use server";
-
-export async function submitMessage(formData) {
-  const name = formData.get("name");
-  const message = formData.get("message");
-
-  // Save to database
-  await db.messages.create({ name, message });
-
-  return { success: true };
-}`}</code>
+              <code className="text-slate-300">{`export const submitMessage = createServerFn({
+  input: z.object({
+    name: z.string().min(1),
+    message: z.string().min(1),
+  }),
+  async handler({ input }) {
+    await db.messages.create(input);
+    return { success: true };
+  },
+});`}</code>
             </pre>
           </div>
           <div>

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -60,6 +60,9 @@
       "workflows": [
         "./dist/workflows.d.ts"
       ],
+      "server-fn": [
+        "./dist/server-fn.d.ts"
+      ],
       "api": [
         "./types/api.d.ts",
         "./dist/api.d.ts"
@@ -146,6 +149,11 @@
       "types": "./dist/workflows.d.ts",
       "import": "./dist/workflows.mjs",
       "require": "./dist/workflows.cjs"
+    },
+    "./server-fn": {
+      "types": "./dist/server-fn.d.ts",
+      "import": "./dist/server-fn.mjs",
+      "require": "./dist/server-fn.cjs"
     },
     "./vite": {
       "types": "./dist/vite.d.ts",

--- a/packages/farm/src/__tests__/server-fn.test.ts
+++ b/packages/farm/src/__tests__/server-fn.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment node
+
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+import { z } from "zod";
+import { createServerFn, FARM_SERVER_FN_SYMBOL } from "../server-fn";
+
+describe("createServerFn", () => {
+  it("validates object input before calling the handler", async () => {
+    const handler = vi.fn(async ({ input }: { input: { email: string; password: string } }) => ({
+      ok: true,
+      email: input.email,
+    }));
+
+    const signup = createServerFn({
+      input: z.object({
+        email: z.string().email(),
+        password: z.string().min(8),
+      }),
+      handler,
+    });
+
+    const result = await signup({
+      email: "ada@example.com",
+      password: "correct horse battery staple",
+    });
+
+    expect(result).toEqual({ ok: true, email: "ada@example.com" });
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: {
+          email: "ada@example.com",
+          password: "correct horse battery staple",
+        },
+      }),
+    );
+    expect(
+      (signup as unknown as Record<typeof FARM_SERVER_FN_SYMBOL, boolean>)[FARM_SERVER_FN_SYMBOL],
+    ).toBe(true);
+  });
+
+  it("turns form data into schema input for form actions", async () => {
+    const submitMessage = createServerFn({
+      input: z.object({
+        name: z.string().min(1),
+        message: z.string().min(1),
+      }),
+      async handler({ input, formData }) {
+        return {
+          saved: true,
+          name: input.name,
+          message: input.message,
+          hasFormData: formData instanceof FormData,
+        };
+      },
+    });
+
+    const formData = new FormData();
+    formData.set("name", "Ada");
+    formData.set("message", "Hello from a form");
+
+    await expect(submitMessage(formData)).resolves.toEqual({
+      saved: true,
+      name: "Ada",
+      message: "Hello from a form",
+      hasFormData: true,
+    });
+  });
+
+  it("does not call the handler when validation fails", async () => {
+    const handler = vi.fn();
+    const signup = createServerFn({
+      input: z.object({
+        email: z.string().email(),
+      }),
+      handler,
+    });
+
+    await expect(signup({ email: "nope" })).rejects.toBeTruthy();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("keeps repeated form fields as arrays and drops unsafe metadata keys", async () => {
+    const inspect = createServerFn({
+      handler({ input }) {
+        const data = input as Record<string, unknown>;
+
+        return {
+          tags: data.tag,
+          actionMetadataPresent: Object.prototype.hasOwnProperty.call(data, "$ACTION_ID_123"),
+          protoPresent: Object.prototype.hasOwnProperty.call(data, "__proto__"),
+          constructorPresent: Object.prototype.hasOwnProperty.call(data, "constructor"),
+          polluted: ({} as Record<string, unknown>).polluted,
+        };
+      },
+    });
+
+    const formData = new FormData();
+    formData.append("tag", "rsc");
+    formData.append("tag", "forms");
+    formData.append("$ACTION_ID_123", "secret-action-ref");
+    formData.append("__proto__", "polluted");
+    formData.append("constructor", "polluted");
+
+    await expect(inspect(formData)).resolves.toEqual({
+      tags: ["rsc", "forms"],
+      actionMetadataPresent: false,
+      protoPresent: false,
+      constructorPresent: false,
+      polluted: undefined,
+    });
+  });
+
+  it("allows input-less server functions to be called without an argument", async () => {
+    const getMessages = createServerFn({
+      async handler() {
+        return ["hello"];
+      },
+    });
+
+    await expect(getMessages()).resolves.toEqual(["hello"]);
+    expectTypeOf(getMessages).parameter(0).toEqualTypeOf<unknown | FormData | undefined>();
+  });
+
+  it("infers input and response types from the schema and handler", async () => {
+    const signup = createServerFn({
+      input: z.object({
+        email: z.string().email(),
+      }),
+      async handler({ input }) {
+        expectTypeOf(input.email).toEqualTypeOf<string>();
+        return { ok: true as const };
+      },
+    });
+
+    expectTypeOf(signup).parameter(0).toEqualTypeOf<{ email: string } | FormData>();
+    expectTypeOf(await signup({ email: "ada@example.com" })).toEqualTypeOf<{ ok: true }>();
+  });
+});

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -33,6 +33,7 @@ export * from "./app-markdown";
 export * from "./observability";
 export * from "./workflows";
 export * from "./type-artifacts";
+export * from "./server-fn";
 export { generateRouteTypes } from "./routing/generate-route-types";
 export type { GenerateRouteTypesOptions } from "./routing/generate-route-types";
 export * from "./build/index";

--- a/packages/farm/src/server-fn.ts
+++ b/packages/farm/src/server-fn.ts
@@ -1,0 +1,170 @@
+type MaybePromise<T> = T | Promise<T>;
+
+// Generic schema type that works with Zod v3/v4 and similar validator APIs.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnySchema = {
+  _input?: any;
+  _output?: any;
+  parse?: (data: unknown) => any;
+  parseAsync?: (data: unknown) => Promise<any>;
+  safeParse?: (data: unknown) => any;
+  safeParseAsync?: (data: unknown) => Promise<any>;
+};
+
+type InferInput<T> = T extends { _input: infer I } ? I : unknown;
+type InferOutput<T> = T extends { _output: infer O }
+  ? O
+  : T extends { parse: (data: unknown) => infer R }
+    ? R
+    : unknown;
+
+export type ServerFnFormInput = FormData;
+
+export type ServerFnContext<TInput> = {
+  input: TInput;
+  rawInput: unknown;
+  formData?: FormData;
+};
+
+export type ServerFnHandler<TInput, TResult> = (
+  ctx: ServerFnContext<TInput>,
+) => MaybePromise<TResult>;
+
+export type ServerFnOptions<TSchema extends AnySchema | undefined, TResult> = {
+  input?: TSchema;
+  handler: ServerFnHandler<TSchema extends AnySchema ? InferOutput<TSchema> : unknown, TResult>;
+};
+
+export type ServerFn<TInput, TResult> = ([unknown] extends [TInput]
+  ? (input?: TInput | FormData) => Promise<TResult>
+  : (input: TInput | FormData) => Promise<TResult>) & {
+  readonly __farmServerFn: true;
+  readonly __farmServerFnInput?: unknown;
+};
+
+export const FARM_SERVER_FN_SYMBOL = Symbol.for("farm.server-fn");
+
+const UNSAFE_FORM_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+export function createServerFn<TSchema extends AnySchema, TResult>(
+  options: ServerFnOptions<TSchema, TResult>,
+): ServerFn<InferInput<TSchema>, Awaited<TResult>>;
+export function createServerFn<TResult>(
+  options: ServerFnOptions<undefined, TResult>,
+): ServerFn<unknown, Awaited<TResult>>;
+export function createServerFn(options: ServerFnOptions<AnySchema | undefined, unknown>) {
+  if (!options || typeof options.handler !== "function") {
+    throw new TypeError("createServerFn requires a handler function");
+  }
+
+  const serverFn = async (value: unknown) => {
+    const formData = isFormData(value) ? value : undefined;
+    const rawInput = formData ? formDataToObject(formData) : value;
+    const input = await parseInput(options.input, rawInput);
+
+    return options.handler({
+      input,
+      rawInput,
+      formData,
+    });
+  };
+
+  Object.defineProperties(serverFn, {
+    [FARM_SERVER_FN_SYMBOL]: {
+      value: true,
+      enumerable: false,
+    },
+    __farmServerFn: {
+      value: true,
+      enumerable: false,
+    },
+    __farmServerFnInput: {
+      value: options.input,
+      enumerable: false,
+    },
+  });
+
+  return serverFn as ServerFn<unknown, unknown>;
+}
+
+async function parseInput(schema: AnySchema | undefined, rawInput: unknown) {
+  if (!schema) return rawInput;
+
+  if (typeof schema.safeParseAsync === "function") {
+    const result = await schema.safeParseAsync(rawInput);
+    return unwrapSafeParseResult(result);
+  }
+
+  if (typeof schema.safeParse === "function") {
+    const result = schema.safeParse(rawInput);
+    return unwrapSafeParseResult(await result);
+  }
+
+  if (typeof schema.parseAsync === "function") {
+    return schema.parseAsync(rawInput);
+  }
+
+  if (typeof schema.parse === "function") {
+    return schema.parse(rawInput);
+  }
+
+  throw new TypeError("createServerFn input must provide parse, parseAsync, or safeParse");
+}
+
+function unwrapSafeParseResult(result: unknown) {
+  if (
+    result &&
+    typeof result === "object" &&
+    "success" in result &&
+    (result as { success: boolean }).success === false
+  ) {
+    throw (result as { error?: unknown }).error;
+  }
+
+  if (
+    result &&
+    typeof result === "object" &&
+    "success" in result &&
+    (result as { success: boolean }).success === true
+  ) {
+    return (result as unknown as { data: unknown }).data;
+  }
+
+  return result;
+}
+
+function formDataToObject(formData: FormData) {
+  const output: Record<string, FormDataEntryValue | FormDataEntryValue[]> = Object.create(null);
+
+  for (const [key, value] of formData.entries()) {
+    if (!isSafeFormKey(key)) continue;
+
+    const existing = output[key];
+    if (existing === undefined) {
+      output[key] = value;
+    } else if (Array.isArray(existing)) {
+      existing.push(value);
+    } else {
+      output[key] = [existing, value];
+    }
+  }
+
+  return output;
+}
+
+function isSafeFormKey(key: string) {
+  return !key.startsWith("$ACTION_") && !UNSAFE_FORM_KEYS.has(key);
+}
+
+function isFormData(value: unknown): value is FormData {
+  if (!value || typeof value !== "object") return false;
+
+  if (typeof FormData !== "undefined" && value instanceof FormData) {
+    return true;
+  }
+
+  return (
+    Object.prototype.toString.call(value) === "[object FormData]" &&
+    typeof (value as { entries?: unknown }).entries === "function"
+  );
+}

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     "app-markdown": "src/app-markdown.ts",
     observability: "src/observability.ts",
     workflows: "src/workflows.ts",
+    "server-fn": "src/server-fn.ts",
   },
   format: ["cjs", "esm"],
   dts: true,

--- a/packages/farmjs-plugin/src/rsc/index.ts
+++ b/packages/farmjs-plugin/src/rsc/index.ts
@@ -27,6 +27,7 @@ import type { FarmRscPluginOptions, EntryContext } from "./types.js";
 import { generateRscEntry } from "./entries/rsc.js";
 import { generateSsrEntry } from "./entries/ssr.js";
 import { generateClientEntry } from "./entries/client.js";
+import { transformFarmServerFns } from "./server-fn-transform.js";
 import fs from "fs/promises";
 import path from "path";
 import { pathToFileURL } from "node:url";
@@ -349,7 +350,6 @@ export default function farmRsc(options: FarmRscPluginOptions = {}): Plugin[] {
             ...(farmCorePath
               ? {
                   alias: [
-                    { find: "@farmjs/core", replacement: farmCorePath },
                     {
                       find: "@farmjs/core/middleware",
                       replacement: path.join(farmCorePath, "dist/middleware.mjs"),
@@ -358,6 +358,11 @@ export default function farmRsc(options: FarmRscPluginOptions = {}): Plugin[] {
                       find: "@farmjs/core/api",
                       replacement: path.join(farmCorePath, "dist/api.mjs"),
                     },
+                    {
+                      find: "@farmjs/core/server-fn",
+                      replacement: path.join(farmCorePath, "dist/server-fn.mjs"),
+                    },
+                    { find: "@farmjs/core", replacement: farmCorePath },
                   ],
                 }
               : {}),
@@ -391,6 +396,23 @@ export default function farmRsc(options: FarmRscPluginOptions = {}): Plugin[] {
               resolve: { conditions: ["browser", "import"] },
             },
           },
+        };
+      },
+    },
+
+    {
+      name: "@farmjs/plugin/rsc:server-fn-actions",
+      enforce: "pre",
+
+      transform(code, id) {
+        if (!rscEnabled || !actionsEnabled) return null;
+
+        const result = transformFarmServerFns(code, id);
+        if (!result) return null;
+
+        return {
+          code: result.code,
+          map: null,
         };
       },
     },

--- a/packages/farmjs-plugin/src/rsc/server-fn-transform.ts
+++ b/packages/farmjs-plugin/src/rsc/server-fn-transform.ts
@@ -1,0 +1,181 @@
+const CREATE_SERVER_FN_IMPORT_RE =
+  /\bimport\s+(?:type\s+)?([\s\S]*?)\s+from\s*["']@farmjs\/core(?:\/server-fn)?["']\s*;?/g;
+const EXPORT_CREATE_SERVER_FN_RE =
+  /\bexport\s+(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*([A-Za-z_$][\w$]*)\s*\(/g;
+const MODULE_EXT_RE = /\.[cm]?[jt]sx?$/;
+const DECLARATION_RE = /(^|\n)\s*["']([^"']+)["']\s*;?/g;
+
+export type FarmServerFnTransformResult = {
+  code: string;
+  exports: string[];
+};
+
+export function transformFarmServerFns(
+  code: string,
+  id: string,
+): FarmServerFnTransformResult | null {
+  if (!isTransformableModule(id) || !code.includes("createServerFn")) return null;
+
+  const createServerFnNames = findCreateServerFnImportNames(code);
+  if (createServerFnNames.size === 0) return null;
+
+  const replacements = findServerFnExportReplacements(code, createServerFnNames);
+  if (replacements.length === 0) return null;
+
+  if (hasModuleDirective(code, "use client")) {
+    throw new Error(
+      "createServerFn exports must live in a server module. Move them out of the 'use client' file.",
+    );
+  }
+
+  let output = code;
+  for (const replacement of replacements.sort((a, b) => b.start - a.start)) {
+    output = output.slice(0, replacement.start) + replacement.code + output.slice(replacement.end);
+  }
+
+  if (!hasModuleDirective(output, "use server")) {
+    output = `"use server";\n${output}`;
+  }
+
+  return {
+    code: output,
+    exports: replacements.map((replacement) => replacement.exportName),
+  };
+}
+
+function isTransformableModule(id: string) {
+  const cleanId = id.split("?", 1)[0];
+  return MODULE_EXT_RE.test(cleanId) && !/\.d\.[cm]?ts$/.test(cleanId);
+}
+
+function findCreateServerFnImportNames(code: string) {
+  const names = new Set<string>();
+
+  for (const match of code.matchAll(CREATE_SERVER_FN_IMPORT_RE)) {
+    const importClause = match[1] ?? "";
+    const namedStart = importClause.indexOf("{");
+    const namedEnd = importClause.lastIndexOf("}");
+    if (namedStart === -1 || namedEnd === -1 || namedEnd <= namedStart) continue;
+
+    const namedImports = importClause.slice(namedStart + 1, namedEnd).split(",");
+    for (const specifier of namedImports) {
+      const normalized = specifier.trim().replace(/^type\s+/, "");
+      const specifierMatch = normalized.match(/^createServerFn(?:\s+as\s+([A-Za-z_$][\w$]*))?$/);
+      if (specifierMatch) {
+        names.add(specifierMatch[1] ?? "createServerFn");
+      }
+    }
+  }
+
+  return names;
+}
+
+function findServerFnExportReplacements(code: string, createServerFnNames: Set<string>) {
+  const replacements: Array<{
+    start: number;
+    end: number;
+    code: string;
+    exportName: string;
+  }> = [];
+
+  for (const match of code.matchAll(EXPORT_CREATE_SERVER_FN_RE)) {
+    const exportName = match[1];
+    const calleeName = match[2];
+    if (!exportName || !calleeName || !createServerFnNames.has(calleeName)) continue;
+
+    const openParenIndex = (match.index ?? 0) + match[0].length - 1;
+    const callEnd = findMatchingParen(code, openParenIndex);
+    if (callEnd === -1) continue;
+
+    let declarationEnd = callEnd + 1;
+    while (/\s/.test(code[declarationEnd] ?? "")) declarationEnd++;
+    if (code[declarationEnd] === ";") declarationEnd++;
+
+    const calleeIndex = code.indexOf(calleeName, match.index);
+    const callExpression = code.slice(calleeIndex, callEnd + 1);
+    const privateName = `$$farm_server_fn_${exportName}`;
+
+    replacements.push({
+      start: match.index ?? 0,
+      end: declarationEnd,
+      exportName,
+      code: `const ${privateName} = ${callExpression};\nexport async function ${exportName}(input) {\n  return ${privateName}(input);\n}`,
+    });
+  }
+
+  return replacements;
+}
+
+function hasModuleDirective(code: string, directive: "use client" | "use server") {
+  for (const match of code.matchAll(DECLARATION_RE)) {
+    const value = match[2];
+    if (value === directive) return true;
+    if (value !== "use strict" && value !== "use client" && value !== "use server") return false;
+  }
+
+  return false;
+}
+
+function findMatchingParen(code: string, openParenIndex: number) {
+  let depth = 0;
+  let quote: "'" | '"' | "`" | null = null;
+  let lineComment = false;
+  let blockComment = false;
+  let escaped = false;
+
+  for (let index = openParenIndex; index < code.length; index++) {
+    const char = code[index];
+    const next = code[index + 1];
+
+    if (lineComment) {
+      if (char === "\n" || char === "\r") lineComment = false;
+      continue;
+    }
+
+    if (blockComment) {
+      if (char === "*" && next === "/") {
+        blockComment = false;
+        index++;
+      }
+      continue;
+    }
+
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === "/" && next === "/") {
+      lineComment = true;
+      index++;
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      blockComment = true;
+      index++;
+      continue;
+    }
+    if (char === "'" || char === '"' || char === "`") {
+      quote = char;
+      continue;
+    }
+
+    if (char === "(") depth++;
+    if (char === ")") {
+      depth--;
+      if (depth === 0) return index;
+    }
+  }
+
+  return -1;
+}


### PR DESCRIPTION
## Summary

- add `createServerFn()` to `@farmjs/core` with typed schema input, form-data parsing, and validation before handler execution
- add an RSC transform that turns exported `createServerFn(...)` values into React-compatible server function exports and injects the server boundary automatically
- update the RSC demo to show `createServerFn` instead of a manual `"use server"` action

## Security

- filters React action metadata and prototype-pollution keys from submitted `FormData`
- validates parsed input before calling the server handler
- keeps the handler behind React server references instead of exposing implementation code to client modules

## Checks

- `corepack pnpm --filter @farmjs/core test -- src/__tests__/server-fn.test.ts`
- `corepack pnpm --filter @farmjs/plugin typecheck`
- `corepack pnpm --filter @farmjs/core build`
- `corepack pnpm --filter @farmjs/plugin build`
- `corepack pnpm --filter farm-rsc-demo build`