### PR TITLE
feat: add typed runtime env

### DIFF
--- a/packages/farm-cli/src/generate.ts
+++ b/packages/farm-cli/src/generate.ts
@@ -1,5 +1,6 @@
 import {
   APITypeGenerator,
+  generateEnvTypes,
   getFarmDocsRouteTypeEntries,
   getIntegrationSchemas,
   generateRouteTypes,
@@ -81,14 +82,24 @@ export async function generateFarmArtifacts(options: GenerateFarmOptions = {}) {
     extraRoutes,
     suppressLintOnLink: resolvedConfig.suppressLintOnLink,
   });
+  await generateEnvTypes({
+    root: resolvedConfig.root,
+    srcDir: resolvedConfig.srcDir,
+    configPath: options.configPath,
+  });
   const appDir = path.join(resolvedConfig.root, resolvedConfig.srcDir, "app");
   const apiGenerator = new APITypeGenerator(appDir);
   const apiRoutes = apiGenerator.scanAPIRoutes();
-  const apiTypesPath = path.join(resolvedConfig.root, resolvedConfig.srcDir, "lib", "api.generated.ts");
+  const apiTypesPath = path.join(
+    resolvedConfig.root,
+    resolvedConfig.srcDir,
+    "lib",
+    "api.generated.ts",
+  );
   await mkdir(path.dirname(apiTypesPath), { recursive: true });
   await writeFile(apiTypesPath, apiGenerator.generateAPIRouter(apiRoutes), "utf8");
   logger.success(
-    `Generated route and API types (${apiRoutes.length} API route${apiRoutes.length === 1 ? "" : "s"}).`,
+    `Generated route, API, and env types (${apiRoutes.length} API route${apiRoutes.length === 1 ? "" : "s"}).`,
   );
 
   const schemas = getIntegrationSchemas(resolvedConfig.integrations);

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -66,6 +66,12 @@
       "server-fn": [
         "./dist/server-fn.d.ts"
       ],
+      "env": [
+        "./dist/env.d.ts"
+      ],
+      "env-types": [
+        "./dist/env-types.d.ts"
+      ],
       "api": [
         "./types/api.d.ts",
         "./dist/api.d.ts"
@@ -157,6 +163,16 @@
       "types": "./dist/server-fn.d.ts",
       "import": "./dist/server-fn.mjs",
       "require": "./dist/server-fn.cjs"
+    },
+    "./env": {
+      "types": "./dist/env.d.ts",
+      "import": "./dist/env.mjs",
+      "require": "./dist/env.cjs"
+    },
+    "./env-types": {
+      "types": "./dist/env-types.d.ts",
+      "import": "./dist/env-types.mjs",
+      "require": "./dist/env-types.cjs"
     },
     "./vite": {
       "types": "./dist/vite.d.ts",

--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -11,10 +11,13 @@ import {
   resolveDocsConfig,
   resolveMigrationsConfig,
 } from "../config";
+import { getResolvedEnv, setEnv } from "../env";
 
 const originalEnv = { ...process.env };
 
 afterEach(() => {
+  setEnv({ server: {}, public: {} });
+
   for (const key of Object.keys(process.env)) {
     if (!(key in originalEnv)) {
       delete process.env[key];
@@ -196,6 +199,66 @@ describe("resolveConfig", () => {
       secretEnv: "WORKFLOW_SECRET",
       secret: undefined,
     });
+  });
+
+  it("validates typed env from process env", async () => {
+    process.env.DATABASE_URL = "postgres://from-process/farm";
+    process.env.PUBLIC_APP_URL = "https://process.example";
+
+    const config = await resolveConfig(
+      {
+        env: {
+          server: {
+            DATABASE_URL: {
+              parse(value: unknown) {
+                if (typeof value !== "string") {
+                  throw new Error("required");
+                }
+
+                return value;
+              },
+            },
+          },
+          public: {
+            PUBLIC_APP_URL: {
+              parse(value: unknown) {
+                return String(value);
+              },
+            },
+          },
+        },
+      },
+      "development",
+    );
+
+    expect(config.env).toEqual({
+      server: { DATABASE_URL: "postgres://from-process/farm" },
+      public: { PUBLIC_APP_URL: "https://process.example" },
+    });
+    expect(getResolvedEnv()).toEqual(config.env);
+  });
+
+  it("throws when typed env validation fails", async () => {
+    await expect(
+      resolveConfig(
+        {
+          env: {
+            server: {
+              DATABASE_URL: {
+                parse(value: unknown) {
+                  if (!value) {
+                    throw new Error("missing database url");
+                  }
+
+                  return String(value);
+                },
+              },
+            },
+          },
+        },
+        "production",
+      ),
+    ).rejects.toThrow('Invalid server env "DATABASE_URL": missing database url');
   });
 });
 

--- a/packages/farm/src/__tests__/env.test.ts
+++ b/packages/farm/src/__tests__/env.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, it } from "vitest";
+import { farmPlugin } from "../vite";
+import {
+  env,
+  getEnv,
+  getPublicEnv,
+  getResolvedEnv,
+  publicEnv,
+  resolveEnv,
+  serverEnv,
+  setEnv,
+} from "../env";
+
+afterEach(() => {
+  setEnv({ server: {}, public: {} });
+});
+
+describe("env", () => {
+  it("validates server and public env from parser schemas", () => {
+    const resolved = resolveEnv(
+      {
+        server: {
+          DATABASE_URL: {
+            parse(value: unknown) {
+              if (typeof value !== "string" || !value.startsWith("postgres://")) {
+                throw new Error("expected postgres url");
+              }
+
+              return value;
+            },
+          },
+        },
+        public: {
+          PUBLIC_APP_URL: {
+            parse(value: unknown) {
+              return String(value);
+            },
+          },
+        },
+      },
+      {
+        DATABASE_URL: "postgres://localhost/farm",
+        PUBLIC_APP_URL: "https://farm.test",
+      },
+    );
+    setEnv(resolved);
+
+    expect(getResolvedEnv()).toEqual({
+      server: { DATABASE_URL: "postgres://localhost/farm" },
+      public: { PUBLIC_APP_URL: "https://farm.test" },
+    });
+    expect(getEnv()).toEqual({ DATABASE_URL: "postgres://localhost/farm" });
+    expect(getEnv("DATABASE_URL")).toBe("postgres://localhost/farm");
+    expect(getPublicEnv()).toEqual({ PUBLIC_APP_URL: "https://farm.test" });
+    expect(getPublicEnv("PUBLIC_APP_URL")).toBe("https://farm.test");
+    expect(env.DATABASE_URL).toBe("postgres://localhost/farm");
+    expect(serverEnv.DATABASE_URL).toBe("postgres://localhost/farm");
+    expect(publicEnv.PUBLIC_APP_URL).toBe("https://farm.test");
+  });
+
+  it("supports parser functions and useful validation errors", () => {
+    const envConfig = {
+      server: {
+        PORT: (value: string | undefined) => {
+          const port = Number(value);
+          if (!Number.isInteger(port)) {
+            throw new Error("expected integer");
+          }
+
+          return port;
+        },
+      },
+    };
+
+    expect(resolveEnv(envConfig, { PORT: "3000" }).server.PORT).toBe(3000);
+    expect(() => resolveEnv(envConfig, { PORT: "nope" })).toThrow(
+      'Invalid server env "PORT": expected integer',
+    );
+  });
+
+  it("only exposes public env to browser bundles", () => {
+    const plugin = farmPlugin({
+      env: {
+        server: { SECRET: "server-only" },
+        public: { PUBLIC_APP_URL: "https://farm.test" },
+      },
+    });
+
+    const browserConfig = (plugin.config as any)?.(
+      {},
+      { command: "build", mode: "production", isSsrBuild: false },
+    );
+    expect(browserConfig.define).toEqual({
+      __FARM_PUBLIC_ENV__: JSON.stringify({ PUBLIC_APP_URL: "https://farm.test" }),
+    });
+
+    const ssrConfig = (plugin.config as any)?.(
+      {},
+      { command: "build", mode: "production", isSsrBuild: true },
+    );
+    expect(ssrConfig.define).toEqual({
+      __FARM_PUBLIC_ENV__: JSON.stringify({ PUBLIC_APP_URL: "https://farm.test" }),
+      __FARM_ENV__: JSON.stringify({
+        server: { SECRET: "server-only" },
+        public: { PUBLIC_APP_URL: "https://farm.test" },
+      }),
+    });
+  });
+});

--- a/packages/farm/src/__tests__/type-artifacts.test.ts
+++ b/packages/farm/src/__tests__/type-artifacts.test.ts
@@ -12,6 +12,18 @@ describe("generateFarmTypeArtifacts", () => {
     mkdirSync(path.join(appDir, "api", "hello"), { recursive: true });
 
     writeFileSync(
+      path.join(root, "farm.config.ts"),
+      [
+        'import { defineFarmConfig } from "@farmjs/core";',
+        "export default defineFarmConfig({",
+        "  env: {",
+        "    server: { DATABASE_URL: { parse: (value: unknown) => String(value) } },",
+        "    public: { PUBLIC_APP_URL: { parse: (value: unknown) => String(value) } },",
+        "  },",
+        "});",
+      ].join("\n"),
+    );
+    writeFileSync(
       path.join(appDir, "page.tsx"),
       "export default function Home() { return null; }\n",
     );
@@ -32,15 +44,22 @@ describe("generateFarmTypeArtifacts", () => {
 
     const routeTypesPath = path.join(root, "src", "farm-routes.d.ts");
     const apiTypesPath = path.join(root, "src", "lib", "api.generated.ts");
+    const envTypesPath = path.join(root, "src", "farm-env.d.ts");
 
     expect(result.routeTypesPath).toBe(routeTypesPath);
     expect(result.apiTypesPath).toBe(apiTypesPath);
+    expect(result.envTypesPath).toBe(envTypesPath);
     expect(result.apiRoutes).toHaveLength(1);
     expect(existsSync(routeTypesPath)).toBe(true);
     expect(existsSync(apiTypesPath)).toBe(true);
+    expect(existsSync(envTypesPath)).toBe(true);
     expect(readFileSync(routeTypesPath, "utf8")).toContain("`/users/${string}`");
     expect(readFileSync(routeTypesPath, "utf8")).toContain('"/docs/reference"');
     expect(readFileSync(apiTypesPath, "utf8")).toContain("hello: {");
     expect(readFileSync(apiTypesPath, "utf8")).toContain("post: typeof POST_hello;");
+    expect(readFileSync(envTypesPath, "utf8")).toContain(
+      'import type FarmConfig from "../farm.config"',
+    );
+    expect(readFileSync(envTypesPath, "utf8")).toContain('declare module "@farmjs/core/env"');
   });
 });

--- a/packages/farm/src/app.ts
+++ b/packages/farm/src/app.ts
@@ -101,6 +101,7 @@ export class FarmApp {
       md: resolveMarkdownConfig(config.md),
       mdx: resolveMdxConfig(config.mdx),
       observability: config.observability ?? false,
+      env: config.env || { server: {}, public: {} },
       suppressLintOnLink: config.suppressLintOnLink ?? false,
       experimental: {
         serverComponents: config.experimental?.serverComponents ?? false,

--- a/packages/farm/src/build/index.ts
+++ b/packages/farm/src/build/index.ts
@@ -207,6 +207,10 @@ async function buildSSR(
         input: ssrEntry,
       },
     },
+    define: {
+      __FARM_ENV__: JSON.stringify(config.env || { server: {}, public: {} }),
+      __FARM_PUBLIC_ENV__: JSON.stringify(config.env?.public || {}),
+    },
     plugins: [farmPlugin(config, pluginManager)],
     mode: "production",
   });
@@ -333,6 +337,7 @@ async function buildNitro(
     farmRegistry.apiRouteManager = apiRouteManager;
     farmRegistry.routeManager = routeManager;
     farmRegistry.serverRenderer = serverRenderer;
+    farmRegistry.env = config.env || { server: {}, public: {} };
 
     // Store route paths for SSR module loading
     const routePaths: Record<string, string> = {};

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -13,10 +13,12 @@ import type { FarmObservabilityUserConfig } from "./observability";
 import type { FarmMiddlewareConfig } from "./middleware/types";
 import type { FarmPlugin } from "./plugin";
 import type { FarmWorkflowsResolvedConfig, FarmWorkflowsUserConfig } from "./workflows";
+import type { FarmEnvConfig, ResolvedFarmEnv } from "./env";
 import type { UserConfig as ViteUserConfig } from "vite";
 import { resolveIntegrationPlugins } from "./integrations";
 import { resolveMarkdownConfig } from "./markdown";
 import { resolveWorkflowsConfig } from "./workflows";
+import { resolveEnv, setEnv } from "./env";
 import {
   resolveMdxConfig,
   type FarmMdxResolvedConfig,
@@ -145,7 +147,7 @@ export interface ResolvedFarmDeployConfig extends Omit<FarmDeployConfig, "output
   outputDir: string;
 }
 
-export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite" | "docs"> {
+export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite" | "docs" | "env"> {
   plugins?: FarmPlugin[];
   integrations?: FarmIntegrationsUserConfig;
   migrations?: FarmMigrationsUserConfig;
@@ -185,7 +187,7 @@ export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite" | "docs"> {
   serverRuntimeConfig?: Record<string, any>;
   publicRuntimeConfig?: Record<string, any>;
 
-  env?: Record<string, string>;
+  env?: FarmEnvConfig<any, any>;
 
   typescript?: {
     tsconfigPath?: string;
@@ -197,13 +199,12 @@ export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite" | "docs"> {
   [key: string]: any;
 }
 
-export interface ResolvedFarmConfig
-  extends Required<
-    Omit<
-      FarmUserConfig,
-      "plugins" | "vite" | "deploy" | "docs" | "md" | "mdx" | "migrations" | "workflows"
-    >
-  > {
+export interface ResolvedFarmConfig extends Required<
+  Omit<
+    FarmUserConfig,
+    "plugins" | "vite" | "deploy" | "docs" | "md" | "mdx" | "migrations" | "workflows" | "env"
+  >
+> {
   plugins: FarmPlugin[];
   vite: ViteUserConfig;
   deploy: ResolvedFarmDeployConfig;
@@ -212,9 +213,10 @@ export interface ResolvedFarmConfig
   mdx: FarmMdxResolvedConfig;
   migrations: ResolvedFarmMigrationsConfig;
   workflows: FarmWorkflowsResolvedConfig;
+  env: ResolvedFarmEnv;
 }
 
-export function defineFarmConfig(config: FarmUserConfig): FarmUserConfig {
+export function defineFarmConfig<const TConfig extends FarmUserConfig>(config: TConfig): TConfig {
   return config;
 }
 
@@ -579,6 +581,8 @@ export async function resolveConfig(
   const docs = await resolveDocsConfig(userConfig.docs, { root, srcDir });
   const md = resolveMarkdownConfig(userConfig.md);
   const mdx = resolveMdxConfig(userConfig.mdx);
+  const env = resolveEnv(userConfig.env, process.env);
+  setEnv(env);
 
   const resolved: ResolvedFarmConfig = {
     root,
@@ -638,7 +642,7 @@ export async function resolveConfig(
     },
     serverRuntimeConfig: userConfig.serverRuntimeConfig || {},
     publicRuntimeConfig: userConfig.publicRuntimeConfig || {},
-    env: { ...process.env, ...userConfig.env },
+    env,
     typescript: {
       tsconfigPath: "tsconfig.json",
       ignoreBuildErrors: false,

--- a/packages/farm/src/env-types.ts
+++ b/packages/farm/src/env-types.ts
@@ -1,0 +1,125 @@
+import * as fs from "fs";
+import * as path from "path";
+
+export interface GenerateEnvTypesOptions {
+  root: string;
+  srcDir?: string;
+  outFile?: string;
+  configPath?: string;
+}
+
+const DEFAULT_OUT_FILE = "farm-env.d.ts";
+const CONFIG_FILENAMES = [
+  "farm.config.ts",
+  "farm.config.tsx",
+  "farm.config.mts",
+  "farm.config.cts",
+  "farm.config.js",
+  "farm.config.jsx",
+  "farm.config.mjs",
+  "farm.config.cjs",
+  "config.ts",
+  "config.tsx",
+  "config.mts",
+  "config.cts",
+  "config.js",
+  "config.jsx",
+  "config.mjs",
+  "config.cjs",
+];
+
+export async function generateEnvTypes(options: GenerateEnvTypesOptions): Promise<string> {
+  const root = path.resolve(options.root);
+  const srcDir = options.srcDir || "src";
+  const outPath = path.join(root, srcDir, options.outFile || DEFAULT_OUT_FILE);
+  const configPath = findConfigPath(root, options.configPath);
+  const content = configPath
+    ? createConfigBackedEnvTypes(outPath, configPath)
+    : createEmptyEnvTypes();
+
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, content, "utf8");
+
+  return outPath;
+}
+
+function findConfigPath(root: string, configPath?: string): string | null {
+  if (configPath) {
+    const resolvedPath = path.isAbsolute(configPath) ? configPath : path.join(root, configPath);
+    return fs.existsSync(resolvedPath) ? resolvedPath : null;
+  }
+
+  for (const filename of CONFIG_FILENAMES) {
+    const resolvedPath = path.join(root, filename);
+    if (fs.existsSync(resolvedPath)) {
+      return resolvedPath;
+    }
+  }
+
+  return null;
+}
+
+function createConfigBackedEnvTypes(outPath: string, configPath: string): string {
+  const configImportPath = toTypeImportPath(outPath, configPath);
+
+  return `/**
+ * Auto-generated env types from farm.config.
+ * Regenerated on dev start, build, and farm generate.
+ */
+import type FarmConfig from ${JSON.stringify(configImportPath)};
+import type { InferEnv } from "@farmjs/core/env";
+
+type FarmConfigEnv = typeof FarmConfig extends { env?: infer TEnv } ? NonNullable<TEnv> : never;
+type FarmResolvedEnv = [FarmConfigEnv] extends [never]
+  ? { server: {}; public: {} }
+  : InferEnv<FarmConfigEnv>;
+
+declare module "@farmjs/core/env" {
+  interface FarmEnvTypes {
+    server: FarmResolvedEnv["server"];
+    public: FarmResolvedEnv["public"];
+  }
+}
+
+declare module "@farmjs/core" {
+  interface FarmEnvTypes {
+    server: FarmResolvedEnv["server"];
+    public: FarmResolvedEnv["public"];
+  }
+}
+
+export {};
+`;
+}
+
+function createEmptyEnvTypes(): string {
+  return `/**
+ * Auto-generated env types from farm.config.
+ * Regenerated on dev start, build, and farm generate.
+ */
+declare module "@farmjs/core/env" {
+  interface FarmEnvTypes {
+    server: {};
+    public: {};
+  }
+}
+
+declare module "@farmjs/core" {
+  interface FarmEnvTypes {
+    server: {};
+    public: {};
+  }
+}
+
+export {};
+`;
+}
+
+function toTypeImportPath(outPath: string, targetPath: string): string {
+  const relativePath = path
+    .relative(path.dirname(outPath), targetPath)
+    .replace(/\\/g, "/")
+    .replace(/\.(tsx?|jsx?|mjs|cjs|mts|cts)$/, "");
+
+  return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
+}

--- a/packages/farm/src/env.ts
+++ b/packages/farm/src/env.ts
@@ -1,0 +1,257 @@
+export interface EnvSchema<TOutput = unknown> {
+  parse(value: unknown): TOutput;
+}
+
+export type EnvParser<TOutput = unknown> =
+  | EnvSchema<TOutput>
+  | ((value: string | undefined, context: { key: string; scope: "server" | "public" }) => TOutput);
+
+export type EnvShape = Record<string, EnvParser<any>>;
+
+export type InferEnvParser<TParser> =
+  TParser extends EnvSchema<infer TOutput>
+    ? TOutput
+    : TParser extends (value: string | undefined, context: any) => infer TOutput
+      ? TOutput
+      : never;
+
+export type InferEnvShape<TShape> = TShape extends EnvShape
+  ? { [K in keyof TShape]: InferEnvParser<TShape[K]> }
+  : {};
+
+export interface FarmEnvConfig<
+  TServer extends EnvShape = EnvShape,
+  TPublic extends EnvShape = EnvShape,
+> {
+  server?: TServer;
+  public?: TPublic;
+}
+
+export interface ResolvedFarmEnv<
+  TServer extends Record<string, any> = Record<string, unknown>,
+  TPublic extends Record<string, any> = Record<string, unknown>,
+> {
+  server: TServer;
+  public: TPublic;
+}
+
+export type InferEnv<TConfig> =
+  TConfig extends FarmEnvConfig<infer TServer, infer TPublic>
+    ? ResolvedFarmEnv<InferEnvShape<TServer>, InferEnvShape<TPublic>>
+    : ResolvedFarmEnv;
+
+/**
+ * Augmented by generated src/farm-env.d.ts for project-specific autocomplete.
+ */
+export interface FarmEnvTypes {}
+
+export type FarmServerEnv = FarmEnvTypes extends { server: infer TServer }
+  ? TServer extends Record<string, any>
+    ? TServer
+    : Record<string, unknown>
+  : Record<string, unknown>;
+
+export type FarmPublicEnv = FarmEnvTypes extends { public: infer TPublic }
+  ? TPublic extends Record<string, any>
+    ? TPublic
+    : Record<string, unknown>
+  : Record<string, unknown>;
+
+export type FarmTypedEnv = ResolvedFarmEnv<FarmServerEnv, FarmPublicEnv>;
+
+declare const __FARM_PUBLIC_ENV__: Record<string, unknown> | undefined;
+declare const __FARM_ENV__: ResolvedFarmEnv | undefined;
+
+let currentEnv: ResolvedFarmEnv = getInitialEnv();
+
+export function resolveEnv<TConfig extends FarmEnvConfig<any, any> | undefined>(
+  config: TConfig,
+  source: Record<string, string | undefined> = getProcessEnv(),
+): InferEnv<NonNullable<TConfig>> {
+  const resolved = {
+    server: resolveEnvScope(config?.server, source, "server"),
+    public: resolveEnvScope(config?.public, source, "public"),
+  } as InferEnv<NonNullable<TConfig>>;
+
+  return resolved;
+}
+
+export function setEnv(env: ResolvedFarmEnv): void {
+  currentEnv = normalizeResolvedEnv(env);
+}
+
+export function getResolvedEnv<TEnv extends ResolvedFarmEnv = FarmTypedEnv>(): TEnv {
+  return currentEnv as TEnv;
+}
+
+export function getEnv<TServer extends Record<string, any> = FarmServerEnv>(): TServer;
+export function getEnv<TKey extends Extract<keyof FarmServerEnv, string>>(
+  key: TKey,
+): FarmServerEnv[TKey];
+export function getEnv(key?: string): unknown {
+  assertServerEnvAccess();
+  if (key === undefined) {
+    return currentEnv.server;
+  }
+
+  return currentEnv.server[key];
+}
+
+export function getPublicEnv<TPublic extends Record<string, any> = FarmPublicEnv>(): TPublic;
+export function getPublicEnv<TKey extends Extract<keyof FarmPublicEnv, string>>(
+  key: TKey,
+): FarmPublicEnv[TKey];
+export function getPublicEnv(key?: string): unknown {
+  if (key === undefined) {
+    return currentEnv.public;
+  }
+
+  return currentEnv.public[key];
+}
+
+export const env = createEnvProxy("server") as FarmServerEnv;
+export const serverEnv = env;
+export const publicEnv = createEnvProxy("public") as FarmPublicEnv;
+
+function resolveEnvScope(
+  shape: EnvShape | undefined,
+  source: Record<string, string | undefined>,
+  scope: "server" | "public",
+): Record<string, unknown> {
+  if (!shape) {
+    return {};
+  }
+
+  const resolved: Record<string, unknown> = {};
+
+  for (const [key, parser] of Object.entries(shape)) {
+    try {
+      resolved[key] = parseEnvValue(parser, source[key], key, scope);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Invalid ${scope} env "${key}": ${message}`);
+    }
+  }
+
+  return resolved;
+}
+
+function parseEnvValue(
+  parser: EnvParser<any>,
+  value: string | undefined,
+  key: string,
+  scope: "server" | "public",
+): unknown {
+  if (typeof parser === "function") {
+    return parser(value, { key, scope });
+  }
+
+  if (parser && typeof parser.parse === "function") {
+    return parser.parse(value);
+  }
+
+  throw new Error("expected a parser function or schema with parse()");
+}
+
+function createEnvProxy(scope: "server" | "public"): Record<string, unknown> {
+  return new Proxy(
+    {},
+    {
+      get(_target, property) {
+        if (typeof property === "symbol") {
+          return undefined;
+        }
+
+        const env = getEnvScope(scope);
+        return env[property];
+      },
+      ownKeys() {
+        return Reflect.ownKeys(getEnvScope(scope));
+      },
+      getOwnPropertyDescriptor(_target, property) {
+        const env = getEnvScope(scope);
+        if (!(property in env)) {
+          return undefined;
+        }
+
+        return {
+          enumerable: true,
+          configurable: true,
+          value: env[property as keyof typeof env],
+        };
+      },
+      has(_target, property) {
+        return property in getEnvScope(scope);
+      },
+    },
+  );
+}
+
+function getEnvScope(scope: "server" | "public"): Record<string, unknown> {
+  if (scope === "server") {
+    assertServerEnvAccess();
+  }
+
+  return currentEnv[scope] || {};
+}
+
+function assertServerEnvAccess(): void {
+  if (typeof window !== "undefined") {
+    throw new Error("Farm server env is not available in the browser. Use publicEnv.");
+  }
+}
+
+function getInitialEnv(): ResolvedFarmEnv {
+  const injectedEnv = getInjectedEnv();
+  if (injectedEnv) {
+    return injectedEnv;
+  }
+
+  return {
+    server: {},
+    public: getInjectedPublicEnv(),
+  };
+}
+
+function getInjectedEnv(): ResolvedFarmEnv | null {
+  try {
+    if (typeof __FARM_ENV__ !== "undefined" && __FARM_ENV__) {
+      return normalizeResolvedEnv(__FARM_ENV__);
+    }
+  } catch {
+    // The compile-time global is only defined in Farm server bundles.
+  }
+
+  return null;
+}
+
+function getInjectedPublicEnv(): Record<string, unknown> {
+  try {
+    if (typeof __FARM_PUBLIC_ENV__ !== "undefined" && __FARM_PUBLIC_ENV__) {
+      return __FARM_PUBLIC_ENV__;
+    }
+  } catch {
+    // The compile-time global is only defined in Farm browser bundles.
+  }
+
+  return {};
+}
+
+function normalizeResolvedEnv(env: ResolvedFarmEnv): ResolvedFarmEnv {
+  return {
+    server: isRecord(env.server) ? env.server : {},
+    public: isRecord(env.public) ? env.public : {},
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function getProcessEnv(): Record<string, string | undefined> {
+  if (typeof process !== "undefined" && process.env) {
+    return process.env;
+  }
+
+  return {};
+}

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -75,6 +75,8 @@ export * from "./markdown";
 export * from "./app-markdown";
 export * from "./observability";
 export * from "./workflows";
+export * from "./env";
+export * from "./env-types";
 export * from "./type-artifacts";
 export * from "./server-fn";
 export { generateRouteTypes } from "./routing/generate-route-types";

--- a/packages/farm/src/nitro/default-entry.ts
+++ b/packages/farm/src/nitro/default-entry.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from "./request-handler";
 import type { RouteManager } from "../routing/route-manager";
 import type { APIRouteManager } from "../api/route-manager";
 import type { ServerRenderer } from "../server/renderer";
+import { setEnv } from "../env";
 
 // Global registry for runtime access (populated at build time)
 declare global {
@@ -11,8 +12,20 @@ declare global {
         routeManager?: RouteManager;
         apiRouteManager?: APIRouteManager;
         serverRenderer?: ServerRenderer;
+        env?: any;
       }
     | undefined;
+}
+
+let envHydrated = false;
+
+function hydrateEnvFromRegistry(): void {
+  if (envHydrated || !globalThis.__FARM_REGISTRY__?.env) {
+    return;
+  }
+
+  setEnv(globalThis.__FARM_REGISTRY__.env);
+  envHydrated = true;
 }
 
 /**
@@ -33,6 +46,7 @@ async function defaultHandler({
   const pathname = url.pathname;
 
   // Get managers from context or global registry
+  hydrateEnvFromRegistry();
   const rm = routeManager || globalThis.__FARM_REGISTRY__?.routeManager;
   const arm = apiRouteManager || globalThis.__FARM_REGISTRY__?.apiRouteManager;
   const sr = serverRenderer || globalThis.__FARM_REGISTRY__?.serverRenderer;

--- a/packages/farm/src/nitro/index.ts
+++ b/packages/farm/src/nitro/index.ts
@@ -79,9 +79,11 @@ export const farmRegistry: {
   apiRouteManager?: any;
   routeManager?: any;
   serverRenderer?: any;
+  env?: any;
   clientManifest?: any;
   routePaths?: Record<string, string>;
 } = {
+  env: ${JSON.stringify(config.env || { server: {}, public: {} }, null, 2)},
   routePaths: ${JSON.stringify(routePaths, null, 2)},
 };
 `,
@@ -643,6 +645,7 @@ export default defineEventHandler(async (event: H3Event) => {
           farmRegistry.apiRouteManager = apiRouteManager;
           farmRegistry.routeManager = routeManager;
           farmRegistry.serverRenderer = serverRenderer;
+          farmRegistry.env = config.env || { server: {}, public: {} };
         };
 
         // Also store in global for runtime access (works in serverless)
@@ -652,6 +655,7 @@ export default defineEventHandler(async (event: H3Event) => {
             apiRouteManager,
             routeManager,
             serverRenderer,
+            env: farmRegistry.env,
             clientManifest: farmRegistry.clientManifest,
             routePaths: farmRegistry.routePaths,
           };

--- a/packages/farm/src/nitro/server-entry.ts
+++ b/packages/farm/src/nitro/server-entry.ts
@@ -9,6 +9,7 @@ import type { RouteManager } from "../routing/route-manager";
 import type { APIRouteManager } from "../api/route-manager";
 import type { ServerRenderer } from "../server/renderer";
 import { getClientModuleMetadata } from "../utils/client-component";
+import { setEnv } from "../env";
 
 // Managers will be available via globalThis.__FARM_REGISTRY__
 // They are injected via Nitro hooks (ready hook) or set during build
@@ -20,9 +21,12 @@ declare global {
         routeManager?: RouteManager;
         apiRouteManager?: APIRouteManager;
         serverRenderer?: ServerRenderer;
+        env?: any;
       }
     | undefined;
 }
+
+let envHydrated = false;
 
 /**
  * Initialize managers from global registry if not already initialized
@@ -36,6 +40,7 @@ function getManagers() {
   // Check global registry (populated at build time or via Nitro hooks)
   if (typeof globalThis !== "undefined" && globalThis.__FARM_REGISTRY__) {
     const registry = globalThis.__FARM_REGISTRY__;
+    hydrateEnvFromRegistry(registry);
     return {
       routeManager: registry.routeManager,
       apiRouteManager: registry.apiRouteManager,
@@ -54,6 +59,15 @@ function getManagers() {
     apiRouteManager: undefined,
     serverRenderer: undefined,
   };
+}
+
+function hydrateEnvFromRegistry(registry: { env?: any }): void {
+  if (envHydrated || !registry.env) {
+    return;
+  }
+
+  setEnv(registry.env);
+  envHydrated = true;
 }
 
 /**

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1352,6 +1352,10 @@ async function buildSSRInMemory(
         // Keep this list minimal for faster builds
         noExternal: ["@farmjs/core", "better-call", "react", "react-dom", "react-dom/server"],
       },
+      define: {
+        __FARM_ENV__: JSON.stringify(config.env || { server: {}, public: {} }),
+        __FARM_PUBLIC_ENV__: JSON.stringify(config.env?.public || {}),
+      },
       plugins: [
         farmPlugin(config, pluginManager),
         {

--- a/packages/farm/src/plugins/env.ts
+++ b/packages/farm/src/plugins/env.ts
@@ -22,16 +22,6 @@ export function createEnvPlugin(
   return {
     name: "farm:env",
 
-    config(config, context) {
-      // Inject environment variables into the config
-      return {
-        ...config,
-        env: {
-          ...(config as any).env,
-          ...env,
-        },
-      } as any;
-    },
     configResolved(config, context) {
       for (const [key, value] of Object.entries(env)) {
         process.env[key] = value;

--- a/packages/farm/src/routes.server.ts
+++ b/packages/farm/src/routes.server.ts
@@ -82,6 +82,7 @@ async function findProgrammaticRouteSourceFiles(srcRoot: string): Promise<string
         "**/node_modules/**",
         "**/.*/**",
         "farm-routes.d.ts",
+        "farm-env.d.ts",
         "lib/api.generated.ts",
       ],
     });

--- a/packages/farm/src/server/create-server.ts
+++ b/packages/farm/src/server/create-server.ts
@@ -10,7 +10,6 @@ import {
   createRedirectsPlugin,
   createHeadersPlugin,
   createRewritesPlugin,
-  createEnvPlugin,
   createCompressionPlugin,
   createLoggerPlugin,
 } from "../plugins";
@@ -153,10 +152,6 @@ export async function createServer(config: FarmConfig = {}) {
 
       if (rewrites.length > 0) {
         pluginManager.addPlugin(createRewritesPlugin(rewrites));
-      }
-
-      if (resolvedConfig.env) {
-        pluginManager.addPlugin(createEnvPlugin(resolvedConfig.env));
       }
 
       if (resolvedConfig.compress) {

--- a/packages/farm/src/type-artifacts.ts
+++ b/packages/farm/src/type-artifacts.ts
@@ -1,10 +1,8 @@
 import { mkdirSync, writeFileSync } from "fs";
 import { dirname, join, resolve } from "path";
 import { APITypeGenerator, type APIRouteInfo } from "./type-generator";
-import {
-  generateRouteTypes,
-  type GenerateRouteTypesOptions,
-} from "./routing/generate-route-types";
+import { generateRouteTypes, type GenerateRouteTypesOptions } from "./routing/generate-route-types";
+import { generateEnvTypes } from "./env-types";
 
 export interface GenerateFarmTypeArtifactsOptions {
   root: string;
@@ -13,13 +11,16 @@ export interface GenerateFarmTypeArtifactsOptions {
   suppressLintOnLink?: boolean;
   routeTypesOutFile?: string;
   apiTypesOutFile?: string;
+  envTypesOutFile?: string;
   routes?: boolean;
   api?: boolean;
+  env?: boolean;
 }
 
 export interface GenerateFarmTypeArtifactsResult {
   routeTypesPath?: string;
   apiTypesPath?: string;
+  envTypesPath?: string;
   apiRoutes: APIRouteInfo[];
 }
 
@@ -30,6 +31,7 @@ export async function generateFarmTypeArtifacts(
   const srcDir = options.srcDir || "src";
   const shouldGenerateRoutes = options.routes !== false;
   const shouldGenerateApi = options.api !== false;
+  const shouldGenerateEnv = options.env !== false;
   const appDir = join(root, srcDir, "app");
 
   const result: GenerateFarmTypeArtifactsResult = {
@@ -64,6 +66,14 @@ export async function generateFarmTypeArtifacts(
 
     result.apiTypesPath = apiTypesPath;
     result.apiRoutes = apiRoutes;
+  }
+
+  if (shouldGenerateEnv) {
+    result.envTypesPath = await generateEnvTypes({
+      root,
+      srcDir,
+      outFile: options.envTypesOutFile,
+    });
   }
 
   return result;

--- a/packages/farm/src/types.ts
+++ b/packages/farm/src/types.ts
@@ -8,6 +8,7 @@ import type { FarmMdxResolvedConfig, FarmMdxUserConfig } from "./app-markdown";
 import type { FarmObservabilityUserConfig } from "./observability";
 import type { FarmMiddlewareConfig } from "./middleware/types";
 import type { FarmWorkflowsUserConfig } from "./workflows";
+import type { FarmEnvConfig, ResolvedFarmEnv } from "./env";
 
 export type NitroPreset =
   | "node-server"
@@ -83,6 +84,7 @@ export interface FarmConfig {
   integrations?: FarmIntegrationsUserConfig;
   migrations?: FarmMigrationsUserConfig;
   workflows?: FarmWorkflowsUserConfig | boolean;
+  env?: FarmEnvConfig<any, any> | ResolvedFarmEnv;
   middleware?: FarmMiddlewareConfig;
   docs?: FarmDocsUserConfig | FarmDocsResolvedConfig;
   md?: FarmMarkdownUserConfig | FarmMarkdownResolvedConfig | boolean;

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -1,4 +1,4 @@
-import type { Plugin, ViteDevServer, HmrContext } from "vite";
+import type { ConfigEnv, Plugin, ViteDevServer, HmrContext } from "vite";
 import type { FarmConfig } from "./types";
 import { FarmApp } from "./app";
 import { logger } from "./utils";
@@ -48,6 +48,76 @@ interface FarmVitePluginOptions extends FarmConfig {
   openapi?: FarmUserConfig["openapi"];
 }
 
+const FARM_CONFIG_FILENAMES = new Set([
+  "farm.config.ts",
+  "farm.config.tsx",
+  "farm.config.mts",
+  "farm.config.cts",
+  "farm.config.js",
+  "farm.config.jsx",
+  "farm.config.mjs",
+  "farm.config.cjs",
+  "config.ts",
+  "config.tsx",
+  "config.mts",
+  "config.cts",
+  "config.js",
+  "config.jsx",
+  "config.mjs",
+  "config.cjs",
+]);
+
+function getPublicEnvDefine(config: FarmVitePluginOptions): Record<string, unknown> {
+  const publicEnv = (config as any).env?.public;
+  if (!isResolvedEnvScope(publicEnv)) {
+    return {};
+  }
+
+  return publicEnv;
+}
+
+function getFullEnvDefine(config: FarmVitePluginOptions): {
+  server: Record<string, unknown>;
+  public: Record<string, unknown>;
+} {
+  const env = (config as any).env;
+  if (!env || typeof env !== "object") {
+    return { server: {}, public: {} };
+  }
+
+  return {
+    server: isResolvedEnvScope(env.server) ? env.server : {},
+    public: isResolvedEnvScope(env.public) ? env.public : {},
+  };
+}
+
+function getEnvDefines(
+  config: FarmVitePluginOptions,
+  configEnv?: ConfigEnv,
+): Record<string, string> {
+  const defines: Record<string, string> = {
+    __FARM_PUBLIC_ENV__: JSON.stringify(getPublicEnvDefine(config)),
+  };
+
+  if (configEnv?.isSsrBuild) {
+    defines.__FARM_ENV__ = JSON.stringify(getFullEnvDefine(config));
+  }
+
+  return defines;
+}
+
+function isResolvedEnvScope(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  return !Object.values(value).some(
+    (entry) =>
+      typeof entry === "function" ||
+      (!!entry && typeof entry === "object" && typeof (entry as any).parse === "function"),
+  );
+}
+
 function isPotentialProgrammaticRouteSourceFile(
   normalizedFile: string,
   srcDirSlug: string,
@@ -57,6 +127,7 @@ function isPotentialProgrammaticRouteSourceFile(
     /\.(ts|tsx|js|jsx)$/.test(normalizedFile) &&
     !/\.d\.ts$/.test(normalizedFile) &&
     !normalizedFile.endsWith("/farm-routes.d.ts") &&
+    !normalizedFile.endsWith("/farm-env.d.ts") &&
     !normalizedFile.endsWith("/lib/api.generated.ts")
   );
 }
@@ -71,6 +142,16 @@ function fileContainsProgrammaticPageRoute(file: string): boolean {
   } catch {
     return false;
   }
+}
+
+function isFarmConfigFile(file: string, root: string): boolean {
+  const normalized = file.replace(/\\/g, "/");
+  const rootSlug = root.replace(/\\/g, "/").replace(/\/+$/, "");
+  const relative = normalized.startsWith(`${rootSlug}/`)
+    ? normalized.slice(rootSlug.length + 1)
+    : normalized;
+
+  return FARM_CONFIG_FILENAMES.has(relative);
 }
 
 export function farmPlugin(
@@ -103,6 +184,12 @@ export function farmPlugin(
 
   return {
     name: "farm",
+
+    config(_userConfig, configEnv) {
+      return {
+        define: getEnvDefines(options, configEnv),
+      };
+    },
 
     async configResolved(config) {
       // Defer initialization until Vite server is available
@@ -163,7 +250,7 @@ export function farmPlugin(
           if (log) {
             logUpdate(
               "TYPE",
-              `${reason} - regenerated route and API types (${result.apiRoutes.length} API route${result.apiRoutes.length === 1 ? "" : "s"})`,
+              `${reason} - regenerated route, API, and env types (${result.apiRoutes.length} API route${result.apiRoutes.length === 1 ? "" : "s"})`,
             );
           }
           if (openAPIManager) {
@@ -202,6 +289,7 @@ export function farmPlugin(
       const isTypeAffectingFile = (file: string, event: string) =>
         isPageFile(file) ||
         isApiRouteFile(file) ||
+        isFarmConfigFile(file, farmConfig.root) ||
         isProgrammaticRouteFile(file) ||
         (isProgrammaticRouteSourceFile(file) &&
           (event === "unlink" || fileContainsProgrammaticPageRoute(file)));
@@ -2797,6 +2885,7 @@ export async function defineConfig(config: FarmVitePluginOptions = {}) {
     },
     define: {
       __FARM_DEV__: JSON.stringify(process.env.NODE_ENV === "development"),
+      __FARM_PUBLIC_ENV__: JSON.stringify(getPublicEnvDefine(config)),
     },
   };
 }

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -27,6 +27,8 @@ export default defineConfig({
     observability: "src/observability.ts",
     workflows: "src/workflows.ts",
     "server-fn": "src/server-fn.ts",
+    env: "src/env.ts",
+    "env-types": "src/env-types.ts",
   },
   format: ["cjs", "esm"],
   dts: true,


### PR DESCRIPTION
## Summary
- add a typed runtime env API with schema/function parsers and server/public accessors
- resolve runtime env from farm config and inject only public env into browser bundles
- hydrate resolved runtime env for SSR/Nitro builds and export @farmjs/core/env

## Tests
- corepack pnpm --filter @farmjs/core test -- src/__tests__/env.test.ts src/__tests__/config.test.ts
- corepack pnpm --filter @farmjs/core build