### PR TITLE
feat: add server fn action state helper

### DIFF
--- a/examples/rsc-demo/src/components/MessageForm.tsx
+++ b/examples/rsc-demo/src/components/MessageForm.tsx
@@ -3,39 +3,22 @@
 // Client Component that calls a Server Action
 // Forms can call server actions directly without needing an API route!
 
-import React, { useState, useTransition } from "react";
+import React from "react";
+import { useServerFn } from "@farmjs/core/server-fn/client";
 import { submitMessage } from "../actions/user";
 
 export function MessageForm() {
-  const [isPending, startTransition] = useTransition();
-  const [result, setResult] = useState<{
-    success: boolean;
-    message?: { name: string };
-    error?: string;
-  } | null>(null);
-
-  async function handleSubmit(formData: FormData) {
-    startTransition(async () => {
-      try {
-        const result = await submitMessage(formData);
-        setResult(result);
-
-        // Clear form and notify messages list to refresh
-        if (result?.success) {
-          const form = document.getElementById("message-form") as HTMLFormElement;
-          form?.reset();
-          
-          // Dispatch custom event to refresh messages list
-          window.dispatchEvent(new CustomEvent("messages-updated"));
-        }
-      } catch (err) {
-        setResult({
-          success: false,
-          error: err instanceof Error ? err.message : String(err),
-        });
+  const submitMessageAction = useServerFn(submitMessage, {
+    onSuccess(result) {
+      if (result?.success) {
+        const form = document.getElementById("message-form") as HTMLFormElement;
+        form?.reset();
+        window.dispatchEvent(new CustomEvent("messages-updated"));
       }
-    });
-  }
+    },
+  });
+
+  const result = submitMessageAction.result;
 
   return (
     <div className="bg-slate-800/50 rounded-xl p-6 border border-orange-700/50">
@@ -47,7 +30,7 @@ export function MessageForm() {
         action directly. No API route needed!
       </p>
 
-      <form id="message-form" action={handleSubmit} className="space-y-4">
+      <form id="message-form" action={submitMessageAction.formAction} className="space-y-4">
         <div>
           <label htmlFor="name" className="block text-sm text-slate-400 mb-1">
             Name
@@ -81,17 +64,17 @@ export function MessageForm() {
 
         <button
           type="submit"
-          disabled={isPending}
+          disabled={submitMessageAction.pending}
           className="w-full px-4 py-2 bg-orange-600 hover:bg-orange-500 disabled:bg-orange-800 disabled:cursor-not-allowed rounded-lg font-semibold transition-colors"
         >
-          {isPending ? "Submitting..." : "Submit Message"}
+          {submitMessageAction.pending ? "Submitting..." : "Submit Message"}
         </button>
       </form>
 
-      {result && (
+      {(result || submitMessageAction.error) && (
         <div
           className={`mt-4 p-4 rounded-lg ${
-            result.success
+            result?.success
               ? "bg-green-900/30 border border-green-700/50"
               : "bg-red-900/30 border border-red-700/50"
           }`}
@@ -101,7 +84,9 @@ export function MessageForm() {
               ✓ Message from "{result.message?.name}" saved on the server!
             </p>
           ) : (
-            <p className="text-red-400">✗ {result.error}</p>
+            <p className="text-red-400">
+              ✗ {result?.error ?? submitMessageAction.error?.message}
+            </p>
           )}
         </div>
       )}

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -66,6 +66,9 @@
       "server-fn": [
         "./dist/server-fn.d.ts"
       ],
+      "server-fn/client": [
+        "./dist/server-fn-client.d.ts"
+      ],
       "env": [
         "./dist/env.d.ts"
       ],
@@ -163,6 +166,11 @@
       "types": "./dist/server-fn.d.ts",
       "import": "./dist/server-fn.mjs",
       "require": "./dist/server-fn.cjs"
+    },
+    "./server-fn/client": {
+      "types": "./dist/server-fn-client.d.ts",
+      "import": "./dist/server-fn-client.mjs",
+      "require": "./dist/server-fn-client.cjs"
     },
     "./env": {
       "types": "./dist/env.d.ts",

--- a/packages/farm/src/__tests__/server-fn-client.test.tsx
+++ b/packages/farm/src/__tests__/server-fn-client.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import { z } from "zod";
+import { createServerFn } from "../server-fn";
+import { useServerFn, type UseServerFnReturn } from "../server-fn-client";
+
+describe("useServerFn", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot> | undefined;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    (globalThis as any).window = globalThis;
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount();
+      });
+    }
+
+    container.remove();
+    root = undefined;
+    delete (globalThis as any).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  it("tracks pending, result, and callbacks for imperative submissions", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const onSuccess = vi.fn();
+    const onSettled = vi.fn();
+    const signup = createServerFn({
+      input: z.object({
+        email: z.string().email(),
+      }),
+      async handler({ input }) {
+        await gate;
+        return { ok: true as const, email: input.email };
+      },
+    });
+
+    let action!: UseServerFnReturn<{ email: string }, { ok: true; email: string }>;
+
+    function App() {
+      action = useServerFn(signup, { onSuccess, onSettled });
+
+      return createElement(
+        "output",
+        null,
+        `${action.pending}:${action.status}:${action.result?.email ?? ""}:${action.error?.message ?? ""}`,
+      );
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    expect(container.textContent).toBe("false:idle::");
+
+    let promise!: Promise<{ ok: true; email: string }>;
+    act(() => {
+      promise = action.submit({ email: "ada@example.com" });
+    });
+
+    expect(container.textContent).toBe("true:pending::");
+
+    await act(async () => {
+      release();
+      await promise;
+    });
+
+    expect(container.textContent).toBe("false:success:ada@example.com:");
+    expect(onSuccess).toHaveBeenCalledWith({ ok: true, email: "ada@example.com" });
+    expect(onSettled).toHaveBeenCalledWith({ ok: true, email: "ada@example.com" }, null);
+  });
+
+  it("accepts form actions and stores the returned result", async () => {
+    const saveMessage = createServerFn({
+      input: z.object({
+        name: z.string().min(1),
+        message: z.string().min(1),
+      }),
+      async handler({ input, formData }) {
+        return {
+          saved: true as const,
+          name: input.name,
+          message: input.message,
+          hasFormData: formData instanceof FormData,
+        };
+      },
+    });
+
+    let action!: UseServerFnReturn<
+      { name: string; message: string },
+      { saved: true; name: string; message: string; hasFormData: boolean }
+    >;
+
+    function App() {
+      action = useServerFn(saveMessage);
+      return createElement("output", null, action.result?.name ?? action.status);
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    const formData = new FormData();
+    formData.set("name", "Ada");
+    formData.set("message", "Hello");
+
+    await act(async () => {
+      await action.formAction(formData);
+    });
+
+    expect(action.status).toBe("success");
+    expect(action.result).toEqual({
+      saved: true,
+      name: "Ada",
+      message: "Hello",
+      hasFormData: true,
+    });
+    expect(container.textContent).toBe("Ada");
+  });
+
+  it("keeps form action errors in state without throwing by default", async () => {
+    const handler = vi.fn();
+    const onError = vi.fn();
+    const signup = createServerFn({
+      input: z.object({
+        email: z.string().email(),
+      }),
+      handler,
+    });
+
+    let action!: UseServerFnReturn<{ email: string }, unknown>;
+
+    function App() {
+      action = useServerFn(signup, { onError });
+      return createElement("output", null, action.status);
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    const formData = new FormData();
+    formData.set("email", "not-an-email");
+
+    await act(async () => {
+      await expect(action.formAction(formData)).resolves.toBeUndefined();
+    });
+
+    expect(action.status).toBe("error");
+    expect(action.error).toBeInstanceOf(Error);
+    expect(handler).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(action.error);
+  });
+
+  it("resets action state and ignores stale submissions", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const loadProfile = createServerFn({
+      async handler() {
+        await gate;
+        return { name: "Ada" };
+      },
+    });
+
+    let action!: UseServerFnReturn<unknown, { name: string }>;
+
+    function App() {
+      action = useServerFn(loadProfile, { initialResult: { name: "Grace" } });
+      return createElement("output", null, `${action.status}:${action.result?.name ?? ""}`);
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    let promise!: Promise<{ name: string }>;
+    act(() => {
+      promise = action.submit();
+    });
+
+    expect(container.textContent).toBe("pending:");
+
+    act(() => {
+      action.reset();
+    });
+
+    expect(container.textContent).toBe("idle:Grace");
+
+    await act(async () => {
+      release();
+      await promise;
+    });
+
+    expect(container.textContent).toBe("idle:Grace");
+  });
+
+  it("infers input and result types", () => {
+    const signup = createServerFn({
+      input: z.object({
+        email: z.string().email(),
+      }),
+      async handler({ input }) {
+        return { ok: true as const, email: input.email };
+      },
+    });
+
+    function App() {
+      const action = useServerFn(signup);
+
+      expectTypeOf(action.submit).parameter(0).toEqualTypeOf<{ email: string } | FormData>();
+      expectTypeOf(action.result).toEqualTypeOf<{ ok: true; email: string } | null>();
+      expectTypeOf(action.error).toEqualTypeOf<Error | null>();
+
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+  });
+});

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -79,6 +79,7 @@ export * from "./env";
 export * from "./env-types";
 export * from "./type-artifacts";
 export * from "./server-fn";
+export * from "./server-fn-client";
 export { generateRouteTypes } from "./routing/generate-route-types";
 export type { GenerateRouteTypesOptions } from "./routing/generate-route-types";
 export * from "./build/index";

--- a/packages/farm/src/server-fn-client.ts
+++ b/packages/farm/src/server-fn-client.ts
@@ -1,0 +1,181 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import type { ServerFn } from "./server-fn";
+
+export type ServerFnActionStatus = "idle" | "pending" | "success" | "error";
+
+export type ServerFnSubmit<TInput, TResult> = [unknown] extends [TInput]
+  ? (input?: TInput | FormData) => Promise<TResult>
+  : (input: TInput | FormData) => Promise<TResult>;
+
+export type UseServerFnOptions<TResult, TError extends Error = Error> = {
+  initialResult?: TResult | null;
+  resetOnSubmit?: boolean;
+  throwOnFormError?: boolean;
+  onSuccess?: (result: TResult) => void;
+  onError?: (error: TError) => void;
+  onSettled?: (result: TResult | null, error: TError | null) => void;
+};
+
+export type UseServerFnReturn<TInput, TResult, TError extends Error = Error> = {
+  pending: boolean;
+  status: ServerFnActionStatus;
+  result: TResult | null;
+  error: TError | null;
+  submit: ServerFnSubmit<TInput, TResult>;
+  formAction: (formData: FormData) => Promise<void>;
+  reset: () => void;
+};
+
+type ServerFnActionState<TResult, TError extends Error> = {
+  pendingCount: number;
+  status: ServerFnActionStatus;
+  result: TResult | null;
+  error: TError | null;
+};
+
+type ServerFnActionCallbacks<TResult, TError extends Error> = Pick<
+  UseServerFnOptions<TResult, TError>,
+  "onError" | "onSettled" | "onSuccess" | "throwOnFormError"
+>;
+
+export function useServerFn<TInput, TResult, TError extends Error = Error>(
+  serverFn: ServerFn<TInput, TResult>,
+  options: UseServerFnOptions<TResult, TError> = {},
+): UseServerFnReturn<TInput, TResult, TError> {
+  const { initialResult = null, resetOnSubmit = true } = options;
+  const callbacksRef = useRef<ServerFnActionCallbacks<TResult, TError>>({});
+  const requestIdRef = useRef(0);
+  const [state, setState] = useState<ServerFnActionState<TResult, TError>>({
+    pendingCount: 0,
+    status: "idle",
+    result: initialResult,
+    error: null,
+  });
+
+  callbacksRef.current = {
+    onError: options.onError,
+    onSettled: options.onSettled,
+    onSuccess: options.onSuccess,
+    throwOnFormError: options.throwOnFormError,
+  };
+
+  const submit = useCallback(
+    async (input?: TInput | FormData) => {
+      const requestId = ++requestIdRef.current;
+
+      setState((current) => ({
+        pendingCount: current.pendingCount + 1,
+        status: "pending",
+        result: resetOnSubmit ? null : current.result,
+        error: null,
+      }));
+
+      try {
+        const result = await serverFn(input as TInput | FormData);
+        const isLatestRequest = requestId === requestIdRef.current;
+
+        setState((current) => {
+          const pendingCount = Math.max(0, current.pendingCount - 1);
+
+          if (!isLatestRequest) {
+            return {
+              ...current,
+              pendingCount,
+              status: pendingCount > 0 ? "pending" : current.status,
+            };
+          }
+
+          return {
+            pendingCount,
+            status: pendingCount > 0 ? "pending" : "success",
+            result,
+            error: null,
+          };
+        });
+
+        if (isLatestRequest) {
+          callbacksRef.current.onSuccess?.(result);
+          callbacksRef.current.onSettled?.(result, null);
+        }
+
+        return result;
+      } catch (cause) {
+        const error = normalizeServerFnError(cause) as TError;
+        const isLatestRequest = requestId === requestIdRef.current;
+
+        setState((current) => {
+          const pendingCount = Math.max(0, current.pendingCount - 1);
+
+          if (!isLatestRequest) {
+            return {
+              ...current,
+              pendingCount,
+              status: pendingCount > 0 ? "pending" : current.status,
+            };
+          }
+
+          return {
+            pendingCount,
+            status: pendingCount > 0 ? "pending" : "error",
+            result: resetOnSubmit ? null : current.result,
+            error,
+          };
+        });
+
+        if (isLatestRequest) {
+          callbacksRef.current.onError?.(error);
+          callbacksRef.current.onSettled?.(null, error);
+        }
+
+        throw error;
+      }
+    },
+    [resetOnSubmit, serverFn],
+  ) as ServerFnSubmit<TInput, TResult>;
+
+  const formAction = useCallback(
+    async (formData: FormData) => {
+      try {
+        await submit(formData as TInput | FormData);
+      } catch (error) {
+        if (callbacksRef.current.throwOnFormError) {
+          throw error;
+        }
+      }
+    },
+    [submit],
+  );
+
+  const reset = useCallback(() => {
+    requestIdRef.current += 1;
+    setState({
+      pendingCount: 0,
+      status: "idle",
+      result: initialResult,
+      error: null,
+    });
+  }, [initialResult]);
+
+  return useMemo(
+    () => ({
+      pending: state.pendingCount > 0,
+      status: state.status,
+      result: state.result,
+      error: state.error,
+      submit,
+      formAction,
+      reset,
+    }),
+    [formAction, reset, state.error, state.pendingCount, state.result, state.status, submit],
+  );
+}
+
+function normalizeServerFnError(error: unknown) {
+  if (error instanceof Error) return error;
+
+  const normalized = new Error(typeof error === "string" ? error : "Server function failed");
+  (normalized as Error & { cause?: unknown }).cause = error;
+  return normalized;
+}

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
     observability: "src/observability.ts",
     workflows: "src/workflows.ts",
     "server-fn": "src/server-fn.ts",
+    "server-fn-client": "src/server-fn-client.ts",
     env: "src/env.ts",
     "env-types": "src/env-types.ts",
   },


### PR DESCRIPTION
## Summary
- add a client-side `useServerFn` helper with `pending`, `status`, `result`, `error`, `submit`, `formAction`, and `reset`
- expose the helper through `@farmjs/core/server-fn/client` and the root package export
- update the RSC demo form to use the new helper instead of hand-rolled action state

## Validation
- `corepack pnpm --filter @farmjs/core test -- src/__tests__/server-fn.test.ts src/__tests__/server-fn-client.test.tsx`
- `corepack pnpm --filter @farmjs/core build`
- `corepack pnpm --filter farm-rsc-demo build`