### PR TITLE
feat: add typed link params prefetch

### DIFF
--- a/packages/farm/src/__tests__/generate-route-types.test.ts
+++ b/packages/farm/src/__tests__/generate-route-types.test.ts
@@ -38,6 +38,7 @@ describe("generateRouteTypes", () => {
 
     const content = fs.readFileSync(outPath, "utf8");
     expect(content).toContain("export type RoutePath =");
+    expect(content).toContain("export type RoutePattern =");
     expect(content).toContain('"/"');
     expect(content).toContain('"/about"');
     expect(content).toContain('"/content"');
@@ -46,9 +47,10 @@ describe("generateRouteTypes", () => {
     expect(content).toContain('declare module "@farmjs/core"');
     expect(content).toContain('declare module "@farmjs/core/dist/client.js"');
     expect(content).toContain('_: import("./farm-routes").RoutePath');
+    expect(content).toContain('pattern: import("./farm-routes").RoutePattern');
   });
 
-  it("when suppressLintOnLink is true, does not augment LinkDefaultRoute and RoutePath is string", async () => {
+  it("when suppressLintOnLink is true, does not augment LinkDefaultRoute and route types are string", async () => {
     const outPath = await generateRouteTypes({
       root: tmpDir,
       srcDir: "src",
@@ -56,6 +58,7 @@ describe("generateRouteTypes", () => {
     });
     const content = fs.readFileSync(outPath, "utf8");
     expect(content).toContain("export type RoutePath = string");
+    expect(content).toContain("export type RoutePattern = string");
     expect(content).not.toContain("declare module");
     expect(content).not.toContain("LinkDefaultRoute");
   });
@@ -85,6 +88,7 @@ describe("generateRouteTypes", () => {
     const content = fs.readFileSync(outPath, "utf8");
     expect(content).toContain('"/docs/reference"');
     expect(content).toContain('"/docs"');
+    expect(content).toContain('"/docs/[...docs]"');
     expect(content).toContain("`/docs/${string}`");
   });
 
@@ -105,6 +109,7 @@ export default defineRoutes(({ page }) => [
     const content = fs.readFileSync(outPath, "utf8");
 
     expect(content).toContain("`/marketing/${string}`");
+    expect(content).toContain('"/marketing/[slug]"');
   });
 
   it("includes literal createRoute paths from normal feature files", async () => {
@@ -129,6 +134,7 @@ export const ProductRoute = createRoute("/products/[id]", {
     const content = fs.readFileSync(outPath, "utf8");
 
     expect(content).toContain("`/products/${string}`");
+    expect(content).toContain('"/products/[id]"');
   });
 
   it("writes a valid empty route union when no pages exist", async () => {
@@ -140,6 +146,7 @@ export const ProductRoute = createRoute("/products/[id]", {
       const content = fs.readFileSync(outPath, "utf8");
 
       expect(content).toContain("export type RoutePath = never;");
+      expect(content).toContain("export type RoutePattern = never;");
     } finally {
       await fs.promises.rm(root, { recursive: true, force: true });
     }

--- a/packages/farm/src/__tests__/link.test.tsx
+++ b/packages/farm/src/__tests__/link.test.tsx
@@ -67,6 +67,20 @@ describe("Link", () => {
       expect(observeForPrefetch).not.toHaveBeenCalled();
     });
 
+    it("prefetches the resolved href for route patterns with params", () => {
+      render(
+        createElement(Link<"/products/[id]">, {
+          href: "/products/[id]",
+          params: { id: "farm shoes" },
+          query: { tab: "reviews" },
+          hash: "details",
+          prefetch: "render",
+        }),
+      );
+
+      expect(prefetch).toHaveBeenCalledWith("/products/farm%20shoes?tab=reviews#details");
+    });
+
     it("prefetch=viewport calls observeForPrefetch", () => {
       const el = render(createElement(Link, { href: "/about", prefetch: "viewport" }));
       expect(observeForPrefetch).toHaveBeenCalledWith(el);
@@ -179,15 +193,42 @@ describe("Link", () => {
       expect(navigate).toHaveBeenCalledWith("/settings", { replace: true, scroll: false });
     });
 
+    it("renders and navigates with resolved route params, query, and hash", () => {
+      const el = render(
+        createElement(Link<"/products/[id]">, {
+          href: "/products/[id]?from=list",
+          params: { id: 123 },
+          query: { tab: "info" },
+          hash: "reviews",
+        }),
+      ) as HTMLAnchorElement;
+
+      expect(el.getAttribute("href")).toBe("/products/123?from=list&tab=info#reviews");
+
+      act(() => {
+        el.dispatchEvent(new MouseEvent("click", { bubbles: true, button: 0, cancelable: true }));
+      });
+
+      expect(navigate).toHaveBeenCalledWith("/products/123?from=list&tab=info#reviews", {
+        replace: false,
+        scroll: true,
+      });
+    });
+
     it("external href has correct attribute and is not intercepted", () => {
-      const el = render(createElement(Link, { href: "https://example.com" })) as HTMLAnchorElement;
+      const onClick = vi.fn((event: React.MouseEvent<HTMLAnchorElement>) => {
+        event.preventDefault();
+      });
+      const el = render(
+        createElement(Link, { href: "https://example.com", onClick }),
+      ) as HTMLAnchorElement;
       expect(el.getAttribute("href")).toBe("https://example.com");
       const clickEvent = new MouseEvent("click", { bubbles: true, button: 0, cancelable: true });
       act(() => {
         el.dispatchEvent(clickEvent);
       });
+      expect(onClick).toHaveBeenCalled();
       expect(navigate).not.toHaveBeenCalled();
-      expect(clickEvent.defaultPrevented).toBe(false);
     });
   });
 
@@ -196,6 +237,28 @@ describe("Link", () => {
       type AppRoutes = "/" | "/about" | "/blog/[slug]";
       const el = render(createElement(Link<AppRoutes>, { href: "/about" }));
       expect(el?.getAttribute("href")).toBe("/about");
+    });
+
+    it("accepts route patterns with inferred params", () => {
+      type AppRoutes = "/" | "/products/[id]" | "/docs/[[...slug]]";
+
+      expectTypeOf<LinkProps<"/products/[id]">["params"]>().toEqualTypeOf<
+        { id: string | number | boolean | readonly (string | number | boolean)[] } | undefined
+      >();
+
+      expectTypeOf<LinkProps<"/docs/[[...slug]]">["params"]>().toEqualTypeOf<
+        | {
+            slug?: string | number | boolean | readonly (string | number | boolean)[] | null;
+          }
+        | undefined
+      >();
+
+      render(
+        createElement(Link<AppRoutes>, {
+          href: "/products/[id]",
+          params: { id: "sku-123" },
+        }),
+      );
     });
 
     it("accepts route hrefs with query strings and hashes", () => {

--- a/packages/farm/src/__tests__/type-artifacts.test.ts
+++ b/packages/farm/src/__tests__/type-artifacts.test.ts
@@ -54,6 +54,7 @@ describe("generateFarmTypeArtifacts", () => {
     expect(existsSync(apiTypesPath)).toBe(true);
     expect(existsSync(envTypesPath)).toBe(true);
     expect(readFileSync(routeTypesPath, "utf8")).toContain("`/users/${string}`");
+    expect(readFileSync(routeTypesPath, "utf8")).toContain('"/users/[id]"');
     expect(readFileSync(routeTypesPath, "utf8")).toContain('"/docs/reference"');
     expect(readFileSync(apiTypesPath, "utf8")).toContain("hello: {");
     expect(readFileSync(apiTypesPath, "utf8")).toContain("post: typeof POST_hello;");

--- a/packages/farm/src/client.ts
+++ b/packages/farm/src/client.ts
@@ -73,5 +73,11 @@ export type {
   PrefetchBehavior,
   LinkDefaultRoute,
   DefaultRoutePath,
+  DefaultRoutePattern,
+  DefaultRouteHref,
   ExternalHref,
+  RouteHref,
+  RouteParamValue,
+  RouteOptionalParamValue,
+  RouteParams,
 } from "./client/link";

--- a/packages/farm/src/client/index.ts
+++ b/packages/farm/src/client/index.ts
@@ -11,7 +11,13 @@ export type {
   PrefetchBehavior,
   LinkDefaultRoute,
   DefaultRoutePath,
+  DefaultRoutePattern,
+  DefaultRouteHref,
   ExternalHref,
+  RouteHref,
+  RouteParamValue,
+  RouteOptionalParamValue,
+  RouteParams,
 } from "./link";
 export { useRouter } from "./router";
 export type { UseRouterOptions } from "./router";

--- a/packages/farm/src/client/link.tsx
+++ b/packages/farm/src/client/link.tsx
@@ -2,6 +2,12 @@
 
 import type React from "react";
 import { forwardRef, useEffect, useRef, useCallback, type AnchorHTMLAttributes } from "react";
+import {
+  buildFarmRoutePath,
+  type FarmRouterBuildOptions,
+  type FarmRouterPathParam,
+  type FarmRouterPathParams,
+} from "../router";
 
 /**
  * Prefetch strategy (TanStack Router–style):
@@ -25,11 +31,25 @@ export type DefaultRoutePath = LinkDefaultRoute extends { _: infer TRoute extend
   ? TRoute
   : string;
 
-type RouteHref<TRoute extends string> =
+export type DefaultRoutePattern = LinkDefaultRoute extends {
+  pattern: infer TRoute extends string;
+}
+  ? TRoute
+  : DefaultRoutePath;
+
+export type DefaultRouteHref = DefaultRoutePath | DefaultRoutePattern;
+
+export type RouteHref<TRoute extends string> =
   | TRoute
   | `${TRoute}?${string}`
   | `${TRoute}#${string}`
   | `${TRoute}?${string}#${string}`;
+
+export type RouteParamValue = Exclude<FarmRouterPathParam, null | undefined>;
+export type RouteOptionalParamValue = FarmRouterPathParam;
+export type RouteParams<TRoute extends string> = string extends TRoute
+  ? FarmRouterPathParams
+  : ExtractRouteParams<StripRouteSuffix<TRoute>>;
 
 /** External URLs; these are never type-checked as routes. */
 export type ExternalHref =
@@ -38,24 +58,87 @@ export type ExternalHref =
   | `//${string}`
   | `mailto:${string}`;
 
-export interface LinkProps<TRoute extends string = DefaultRoutePath> extends Omit<
+type StripRouteSuffix<TRoute extends string> = TRoute extends `${infer Path}?${string}`
+  ? StripRouteSuffix<Path>
+  : TRoute extends `${infer Path}#${string}`
+    ? StripRouteSuffix<Path>
+    : TRoute;
+
+type ExtractRouteParams<TRoute extends string> = Simplify<
+  ExtractOptionalCatchAllParams<TRoute> &
+    ExtractCatchAllParams<TRoute> &
+    ExtractDynamicParams<TRoute>
+>;
+
+type ExtractOptionalCatchAllParams<TRoute extends string> =
+  TRoute extends `${string}[[...${infer Param}]]${infer Rest}`
+    ? { [Key in Param]?: RouteOptionalParamValue } & ExtractOptionalCatchAllParams<Rest>
+    : {};
+
+type ExtractCatchAllParams<TRoute extends string> =
+  TRoute extends `${string}[...${infer Param}]${infer Rest}`
+    ? Param extends `[...${string}`
+      ? ExtractCatchAllParams<Rest>
+      : { [Key in Param]: RouteParamValue } & ExtractCatchAllParams<Rest>
+    : {};
+
+type ExtractDynamicParams<TRoute extends string> =
+  TRoute extends `${string}[${infer Param}]${infer Rest}`
+    ? Param extends `...${string}` | `[...${string}`
+      ? ExtractDynamicParams<Rest>
+      : { [Key in Param]: RouteParamValue } & ExtractDynamicParams<Rest>
+    : {};
+
+type Simplify<T> = { [Key in keyof T]: T[Key] } & {};
+
+type HasRouteParams<TRoute extends string> = keyof RouteParams<TRoute> extends never ? false : true;
+
+type LinkRouteParamsProps<TRoute extends string> = string extends TRoute
+  ? { params?: FarmRouterPathParams }
+  : HasRouteParams<TRoute> extends true
+    ? { params: RouteParams<TRoute> }
+    : { params?: FarmRouterPathParams };
+
+type LinkRouteTargetProps<TRoute extends string> = TRoute extends string
+  ? {
+      /** Internal route path or route pattern. */
+      href: RouteHref<TRoute>;
+    } & LinkRouteParamsProps<TRoute>
+  : never;
+
+type LinkExternalTargetProps = {
+  /** External URL; these are never type-checked as app routes. */
+  href: ExternalHref;
+  params?: never;
+};
+
+type LinkTargetProps<TRoute extends string> =
+  | LinkExternalTargetProps
+  | LinkRouteTargetProps<TRoute>;
+
+export type LinkProps<TRoute extends string = DefaultRouteHref> = Omit<
   AnchorHTMLAttributes<HTMLAnchorElement>,
   "href"
-> {
-  /** Internal route path (typed when route types are generated) or external URL. */
-  href: RouteHref<TRoute> | ExternalHref;
+> &
+  LinkTargetProps<TRoute> & {
   /**
    * When to prefetch. TanStack-style: "intent" (hover+touch), "viewport", "render", or "none".
    * Legacy: true (intent+viewport), "hover" (intent), "viewport", false/"none".
    */
   prefetch?: PrefetchBehavior | PrefetchLegacy;
+  /** Search params appended after route params are resolved. */
+  query?: FarmRouterBuildOptions["query"];
+  /** Hash appended after route params and search params are resolved. */
+  hash?: string;
+  /** Add a trailing slash to the generated internal href. */
+  trailingSlash?: boolean;
   /** Delay in ms before intent-based prefetch (hover/touch). Default 50. */
   prefetchDelay?: number;
   /** Replace current history entry instead of pushing */
   replace?: boolean;
   /** Scroll to top after navigation (default: true) */
   scroll?: boolean;
-}
+};
 
 function isModifierEvent(e: React.MouseEvent): boolean {
   return !!(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey);
@@ -103,9 +186,13 @@ function normalizePrefetch(prefetch: LinkProps["prefetch"]): {
   return { intent: false, viewport: false, render: false };
 }
 
-function LinkInner<TRoute extends string = DefaultRoutePath>(
+function LinkInner<TRoute extends string = DefaultRouteHref>(
   {
     href,
+    params,
+    query,
+    hash,
+    trailingSlash,
     prefetch = true,
     prefetchDelay = 50,
     replace = false,
@@ -126,15 +213,24 @@ function LinkInner<TRoute extends string = DefaultRoutePath>(
   const hasPrefetched = useRef(false);
 
   const { intent, viewport, render } = normalizePrefetch(prefetch);
-  const isExternal = isExternalUrl(href);
+  const resolvedHref = resolveLinkHref(href, params, {
+    query,
+    hash,
+    trailingSlash,
+  });
+  const isExternal = isExternalUrl(resolvedHref);
 
   const doPrefetch = useCallback(() => {
     if (isExternal || hasPrefetched.current) return;
     const router = getRouter();
     if (!router) return;
     hasPrefetched.current = true;
-    router.prefetch(href);
-  }, [href, isExternal]);
+    router.prefetch(resolvedHref);
+  }, [resolvedHref, isExternal]);
+
+  useEffect(() => {
+    hasPrefetched.current = false;
+  }, [resolvedHref]);
 
   useEffect(() => {
     const element = elementRef.current;
@@ -147,7 +243,7 @@ function LinkInner<TRoute extends string = DefaultRoutePath>(
       router.observeForPrefetch(element);
       return () => router.unobserveForPrefetch(element);
     }
-  }, [href, viewport, isExternal]);
+  }, [resolvedHref, viewport, isExternal]);
 
   useEffect(() => {
     if (!render || isExternal) return;
@@ -165,7 +261,7 @@ function LinkInner<TRoute extends string = DefaultRoutePath>(
       }
 
       hasPrefetched.current = true;
-      router.prefetch(href);
+      router.prefetch(resolvedHref);
     };
 
     tryRenderPrefetch();
@@ -176,7 +272,7 @@ function LinkInner<TRoute extends string = DefaultRoutePath>(
         clearTimeout(timeoutId);
       }
     };
-  }, [render, isExternal, href]);
+  }, [render, isExternal, resolvedHref]);
 
   useEffect(() => {
     return () => {
@@ -256,14 +352,14 @@ function LinkInner<TRoute extends string = DefaultRoutePath>(
         event.preventDefault();
         const router = getRouter();
         if (router) {
-          router.navigate(href, { replace, scroll });
+          router.navigate(resolvedHref, { replace, scroll });
         } else {
-          if (replace) window.location.replace(href);
-          else window.location.href = href;
+          if (replace) window.location.replace(resolvedHref);
+          else window.location.href = resolvedHref;
         }
       }
     },
-    [href, replace, scroll, target, isExternal, onClick],
+    [resolvedHref, replace, scroll, target, isExternal, onClick],
   );
 
   const setRefs = useCallback(
@@ -278,7 +374,7 @@ function LinkInner<TRoute extends string = DefaultRoutePath>(
   return (
     <a
       ref={setRefs}
-      href={href}
+      href={resolvedHref}
       target={target}
       onClick={handleClick}
       onMouseEnter={handleMouseEnter}
@@ -294,8 +390,70 @@ function LinkInner<TRoute extends string = DefaultRoutePath>(
 const LinkWithRef = forwardRef(LinkInner);
 LinkWithRef.displayName = "Link";
 
-type LinkComponentType = <TRoute extends string = DefaultRoutePath>(
+type LinkComponentType = <TRoute extends string = DefaultRouteHref>(
   props: LinkProps<TRoute> & { ref?: React.ForwardedRef<HTMLAnchorElement> },
 ) => React.ReactElement;
 
 export const Link = LinkWithRef as unknown as LinkComponentType;
+
+function resolveLinkHref(
+  href: string,
+  params: FarmRouterPathParams | undefined,
+  options: FarmRouterBuildOptions,
+) {
+  if (isExternalUrl(href)) return href;
+
+  if (!params && !options.query && !options.hash && !options.trailingSlash) {
+    return href;
+  }
+
+  const { pathname, query, hash } = splitInternalHref(href);
+
+  return buildFarmRoutePath(pathname, params, {
+    query: mergeQueryParams(query, options.query),
+    hash: options.hash ?? hash,
+    trailingSlash: options.trailingSlash,
+  });
+}
+
+function splitInternalHref(href: string) {
+  try {
+    const url = new URL(href, "http://farm.local");
+    return {
+      pathname: url.pathname || "/",
+      query: url.searchParams,
+      hash: url.hash ? url.hash.slice(1) : undefined,
+    };
+  } catch {
+    const [withoutHash, rawHash] = href.split("#", 2);
+    const [pathname, rawQuery] = withoutHash.split("?", 2);
+    return {
+      pathname: pathname || "/",
+      query: new URLSearchParams(rawQuery || ""),
+      hash: rawHash,
+    };
+  }
+}
+
+function mergeQueryParams(
+  current: URLSearchParams,
+  next: FarmRouterBuildOptions["query"],
+): URLSearchParams | undefined {
+  const merged = new URLSearchParams(current);
+
+  if (next instanceof URLSearchParams) {
+    for (const [key, value] of next.entries()) {
+      merged.append(key, value);
+    }
+  } else if (next) {
+    for (const [key, value] of Object.entries(next)) {
+      const values = Array.isArray(value) ? value : [value];
+      for (const item of values) {
+        if (item == null) continue;
+        merged.append(key, String(item));
+      }
+    }
+  }
+
+  return merged.toString() ? merged : undefined;
+}

--- a/packages/farm/src/routing/generate-route-types.ts
+++ b/packages/farm/src/routing/generate-route-types.ts
@@ -17,6 +17,10 @@ function routePatternToTsTypeLiteral(pattern: string): string {
   return "`/" + parts.join("/") + "`";
 }
 
+function routePatternToRouteLiteral(pattern: string): string {
+  return JSON.stringify(pattern);
+}
+
 function createRoutePattern(route: ParsedRoute): string {
   if (route.segments.length === 0) return "/";
   return (
@@ -86,12 +90,19 @@ export async function generateRouteTypes(options: GenerateRouteTypesOptions): Pr
     patterns.add(route);
   }
 
-  const typeLiterals = Array.from(patterns).sort().map(routePatternToTsTypeLiteral);
+  const sortedPatterns = Array.from(patterns).sort();
+  const typeLiterals = sortedPatterns.map(routePatternToTsTypeLiteral);
+  const patternLiterals = sortedPatterns.map(routePatternToRouteLiteral);
 
   const routePathType = suppressLintOnLink
     ? "string"
     : typeLiterals.length
       ? typeLiterals.join(" | ")
+      : "never";
+  const routePatternType = suppressLintOnLink
+    ? "string"
+    : patternLiterals.length
+      ? patternLiterals.join(" | ")
       : "never";
   const augmentationBlock = suppressLintOnLink
     ? ""
@@ -99,12 +110,14 @@ export async function generateRouteTypes(options: GenerateRouteTypesOptions): Pr
 declare module "@farmjs/core/client" {
   interface LinkDefaultRoute {
     _: import("./farm-routes").RoutePath;
+    pattern: import("./farm-routes").RoutePattern;
   }
 }
 
 declare module "@farmjs/core" {
   interface LinkDefaultRoute {
     _: import("./farm-routes").RoutePath;
+    pattern: import("./farm-routes").RoutePattern;
   }
   // Ensure root import ("@farmjs/core") uses the same typed Link signature as client entry.
   const Link: typeof import("@farmjs/core/client").Link;
@@ -114,6 +127,7 @@ declare module "@farmjs/core" {
 declare module "@farmjs/core/dist/client.js" {
   interface LinkDefaultRoute {
     _: import("./farm-routes").RoutePath;
+    pattern: import("./farm-routes").RoutePattern;
   }
 }
 `;
@@ -123,7 +137,8 @@ declare module "@farmjs/core/dist/client.js" {
  * Link href is typed automatically via module augmentation. Regenerated on dev start and when routes change.
  * Set suppressLintOnLink: true in farm.config.ts to accept any string on Link href.
  */
-export type RoutePath = ${routePathType};${augmentationBlock}
+export type RoutePath = ${routePathType};
+export type RoutePattern = ${routePatternType};${augmentationBlock}
 `;
 
   fs.mkdirSync(path.dirname(outPath), { recursive: true });

--- a/packages/farm/types/client.d.ts
+++ b/packages/farm/types/client.d.ts
@@ -8,7 +8,7 @@
 
 import type {
   AnchorHTMLAttributes,
-  ForwardRefExoticComponent,
+  ReactElement,
   ReactNode,
   RefAttributes,
 } from "react";
@@ -111,25 +111,99 @@ declare module "@farmjs/core/client" {
     ? TRoute
     : string;
 
+  export type DefaultRoutePattern = LinkDefaultRoute extends {
+    pattern: infer TRoute extends string;
+  }
+    ? TRoute
+    : DefaultRoutePath;
+
+  export type DefaultRouteHref = DefaultRoutePath | DefaultRoutePattern;
+
   export type RouteHref<TRoute extends string> =
     | TRoute
     | `${TRoute}?${string}`
     | `${TRoute}#${string}`
     | `${TRoute}?${string}#${string}`;
 
-  export interface LinkProps<TRoute extends string = DefaultRoutePath> extends Omit<
+  export type RouteParamPrimitive = string | number | boolean;
+  export type RouteParamValue = RouteParamPrimitive | readonly RouteParamPrimitive[];
+  export type RouteOptionalParamValue = RouteParamValue | null | undefined;
+  export type RouteQueryValue = RouteParamPrimitive | readonly RouteParamPrimitive[] | null | undefined;
+
+  export type RouteParams<TRoute extends string> = string extends TRoute
+    ? Record<string, RouteOptionalParamValue>
+    : ExtractRouteParams<StripRouteSuffix<TRoute>>;
+
+  export type StripRouteSuffix<TRoute extends string> = TRoute extends `${infer Path}?${string}`
+    ? StripRouteSuffix<Path>
+    : TRoute extends `${infer Path}#${string}`
+      ? StripRouteSuffix<Path>
+      : TRoute;
+
+  export type ExtractRouteParams<TRoute extends string> = Simplify<
+    ExtractOptionalCatchAllParams<TRoute> &
+      ExtractCatchAllParams<TRoute> &
+      ExtractDynamicParams<TRoute>
+  >;
+
+  export type ExtractOptionalCatchAllParams<TRoute extends string> =
+    TRoute extends `${string}[[...${infer Param}]]${infer Rest}`
+      ? { [Key in Param]?: RouteOptionalParamValue } & ExtractOptionalCatchAllParams<Rest>
+      : {};
+
+  export type ExtractCatchAllParams<TRoute extends string> =
+    TRoute extends `${string}[...${infer Param}]${infer Rest}`
+      ? Param extends `[...${string}`
+        ? ExtractCatchAllParams<Rest>
+        : { [Key in Param]: RouteParamValue } & ExtractCatchAllParams<Rest>
+      : {};
+
+  export type ExtractDynamicParams<TRoute extends string> =
+    TRoute extends `${string}[${infer Param}]${infer Rest}`
+      ? Param extends `...${string}` | `[...${string}`
+        ? ExtractDynamicParams<Rest>
+        : { [Key in Param]: RouteParamValue } & ExtractDynamicParams<Rest>
+      : {};
+
+  export type Simplify<T> = { [Key in keyof T]: T[Key] } & {};
+
+  export type LinkRouteParamsProps<TRoute extends string> = string extends TRoute
+    ? { params?: Record<string, RouteOptionalParamValue> }
+    : keyof RouteParams<TRoute> extends never
+      ? { params?: Record<string, RouteOptionalParamValue> }
+      : { params: RouteParams<TRoute> };
+
+  export type LinkRouteTargetProps<TRoute extends string> = TRoute extends string
+    ? {
+        href: RouteHref<TRoute>;
+      } & LinkRouteParamsProps<TRoute>
+    : never;
+
+  export type LinkExternalTargetProps = {
+    href: ExternalHref;
+    params?: never;
+  };
+
+  export type LinkProps<TRoute extends string = DefaultRouteHref> = Omit<
     AnchorHTMLAttributes<HTMLAnchorElement>,
     "href"
-  > {
+  > &
+    (LinkExternalTargetProps | LinkRouteTargetProps<TRoute>) & {
     /** Internal route path (typed when route types are generated) or external URL (never raises route-type errors). */
-    href: RouteHref<TRoute> | ExternalHref;
     prefetch?: PrefetchBehavior | boolean | "hover" | "viewport" | "none";
+    query?: URLSearchParams | Record<string, RouteQueryValue>;
+    hash?: string;
+    trailingSlash?: boolean;
     prefetchDelay?: number;
     replace?: boolean;
     scroll?: boolean;
-  }
+  };
 
-  export const Link: ForwardRefExoticComponent<LinkProps & RefAttributes<HTMLAnchorElement>>;
+  export type LinkComponent = <TRoute extends string = DefaultRouteHref>(
+    props: LinkProps<TRoute> & RefAttributes<HTMLAnchorElement>,
+  ) => ReactElement;
+
+  export const Link: LinkComponent;
 
   export function useRouter(): {
     pathname: string;


### PR DESCRIPTION
## Summary
- add typed route-pattern Link targets with inferred params
- resolve params, query, hash, and trailingSlash before render, prefetch, and navigation
- generate RoutePattern alongside RoutePath for typed Link autocomplete

## Validation
- `corepack pnpm --filter @farmjs/core test -- src/__tests__/link.test.tsx src/__tests__/router.test.ts src/__tests__/generate-route-types.test.ts src/__tests__/type-artifacts.test.ts`
- `corepack pnpm --filter @farmjs/core build`
- attempted `corepack pnpm --filter @farmjs/core type-check` (blocked by existing unrelated Nitro/query-state type errors)