### PR TITLE
feat: add route rules config

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -45,6 +45,7 @@ export default defineFarmConfig({
 | md | Exposing markdown mirrors like /pricing.md. |
 | mdx | Rendering `page.md` and `page.mdx` app routes, plus MDX components. |
 | deploy | Selecting a target, preset, and output directory. |
+| routeRules | Applying rendering, cache, redirect, CORS, and header behavior to route patterns. |
 | openapi | Publishing API reference docs. |
 
 ## Next-style route exports
@@ -61,6 +62,33 @@ export default async function BlogPage() {
   return <main>...</main>;
 }
 ```
+
+## Route rules
+
+Use `routeRules` when behavior belongs to a URL pattern instead of one page file. Rules are normalized into Farm redirects/headers and passed to Nitro route rules for production adapters.
+
+```ts
+import { defineFarmConfig } from "@farmjs/core";
+
+export default defineFarmConfig({
+  routeRules: {
+    "/": { prerender: true },
+    "/blog/**": { swr: 3600 },
+    "/admin/**": { render: "dynamic" },
+    "/api/**": { cors: true },
+    "/assets/**": {
+      headers: {
+        "Cache-Control": "public, max-age=31536000, immutable",
+      },
+    },
+    "/old": { redirect: "/new" },
+  },
+});
+```
+
+`render: "static"` maps to prerendering. `render: "dynamic"` forces a dynamic response. `swr` and `isr` accept `true` or a TTL in seconds. `cors: true` applies permissive API CORS headers; pass an object when you need a specific origin, methods, or headers.
+
+Prefer route-level exports when one page owns the behavior. Prefer `routeRules` for broad groups, deployment-facing cache policy, API CORS, static asset headers, and legacy redirects.
 
 ## Minimal project layout
 
@@ -156,4 +184,5 @@ export default defineFarmConfig({
 - Use `migrations.commands` for schema setup that should be explicit in CI.
 - Use `docs.entry` when the docs runtime should be mounted automatically.
 - Prefer route-level exports such as `dynamic`, `revalidate`, and `ppr` when behavior belongs to one page.
+- Prefer `routeRules` for broad URL patterns and platform-level cache/header behavior.
 - Keep `farm.config.ts` as the single control plane instead of spreading framework behavior across many root files.

--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -12,6 +12,7 @@ import {
   resolveMigrationsConfig,
 } from "../config";
 import { getResolvedEnv, setEnv } from "../env";
+import { routeRulesToNitroRouteRules } from "../route-rules";
 
 const originalEnv = { ...process.env };
 
@@ -259,6 +260,73 @@ describe("resolveConfig", () => {
         "production",
       ),
     ).rejects.toThrow('Invalid server env "DATABASE_URL": missing database url');
+  });
+
+  it("normalizes routeRules and derives redirects and headers", async () => {
+    const config = await resolveConfig(
+      {
+        routeRules: {
+          "/": { prerender: true },
+          "blog/**": { swr: 3600 },
+          "/admin/**": { render: "dynamic" },
+          "/api/**": {
+            cors: { origin: "https://app.example", methods: ["GET", "POST"] },
+          },
+          "/old": { redirect: { to: "/new", permanent: true } },
+          "/assets/**": { headers: { "Cache-Control": "public, max-age=31536000" } },
+        },
+      },
+      "production",
+    );
+
+    expect(config.routeRules).toMatchObject({
+      "/": { prerender: true },
+      "/blog/**": { swr: 3600 },
+      "/admin/**": { render: "dynamic" },
+      "/api/**": {
+        cors: { origin: "https://app.example", methods: ["GET", "POST"] },
+      },
+    });
+
+    expect(config.redirects()).toEqual([
+      {
+        source: "/old",
+        destination: "/new",
+        permanent: true,
+        statusCode: 308,
+      },
+    ]);
+    expect(config.headers()).toEqual(
+      expect.arrayContaining([
+        {
+          source: "/api/**",
+          headers: expect.arrayContaining([
+            { key: "Access-Control-Allow-Origin", value: "https://app.example" },
+            { key: "Access-Control-Allow-Methods", value: "GET, POST" },
+            { key: "Access-Control-Allow-Headers", value: "*" },
+          ]),
+        },
+        {
+          source: "/assets/**",
+          headers: [{ key: "Cache-Control", value: "public, max-age=31536000" }],
+        },
+      ]),
+    );
+
+    expect(routeRulesToNitroRouteRules(config.routeRules)).toMatchObject({
+      "/": { prerender: true },
+      "/blog/**": { swr: 3600 },
+      "/admin/**": { prerender: false },
+      "/old": { redirect: "/new" },
+      "/api/**": {
+        cors: true,
+        headers: {
+          "Access-Control-Allow-Origin": "https://app.example",
+          "Access-Control-Allow-Methods": "GET, POST",
+          "Access-Control-Allow-Headers": "*",
+        },
+      },
+    });
   });
 });
 

--- a/packages/farm/src/app.ts
+++ b/packages/farm/src/app.ts
@@ -8,6 +8,7 @@ import { resolveWorkflowsConfig, type FarmWorkflowsResolvedConfig } from "./work
 import { resolveAppPath, fileExists, logger } from "./utils";
 import { initStorage } from "./storage";
 import { configureFarmObservability } from "./observability";
+import { normalizeRouteRules } from "./route-rules";
 import { RouteManager } from "./routing/route-manager";
 import { ServerRenderer } from "./server/renderer";
 import { findProgrammaticRouteFiles } from "./routes.server";
@@ -97,6 +98,7 @@ export class FarmApp {
       migrations: config.migrations || { commands: [] },
       workflows: resolveWorkflowsConfig(config.workflows),
       middleware: config.middleware || {},
+      routeRules: normalizeRouteRules(config.routeRules),
       docs: isResolvedDocsConfig(config.docs) ? config.docs : defaultDocsConfig,
       md: resolveMarkdownConfig(config.md),
       mdx: resolveMdxConfig(config.mdx),

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -24,6 +24,12 @@ import {
   type FarmMdxResolvedConfig,
   type FarmMdxUserConfig,
 } from "./app-markdown";
+import {
+  normalizeRouteRules,
+  routeRulesToHeaders,
+  routeRulesToRedirects,
+  type FarmRouteRules,
+} from "./route-rules";
 import path from "path";
 
 export type {
@@ -46,6 +52,13 @@ export type {
   ResolvedFarmMigrationsConfig,
 } from "./types";
 export type { FarmWorkflowsResolvedConfig, FarmWorkflowsUserConfig } from "./workflows";
+export type {
+  FarmRouteRule,
+  FarmRouteRuleCors,
+  FarmRouteRuleRedirect,
+  FarmRouteRuleRenderMode,
+  FarmRouteRules,
+} from "./route-rules";
 
 export interface RedirectConfig {
   source: string;
@@ -171,6 +184,7 @@ export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite" | "docs" | "
   openapi?: OpenAPIConfig;
 
   middleware?: FarmMiddlewareConfig;
+  routeRules?: FarmRouteRules;
 
   notFound?: NotFoundConfig;
 
@@ -574,6 +588,9 @@ export async function resolveConfig(
     typeof userConfig.headers === "function"
       ? await userConfig.headers()
       : userConfig.headers || [];
+  const routeRules = normalizeRouteRules(userConfig.routeRules);
+  const routeRuleRedirects = routeRulesToRedirects(routeRules);
+  const routeRuleHeaders = routeRulesToHeaders(routeRules);
 
   const deploy = resolveDeployConfig(userConfig);
   const root = userConfig.root || process.cwd();
@@ -607,9 +624,10 @@ export async function resolveConfig(
     plugins: [...resolveIntegrationPlugins(userConfig.integrations), ...(userConfig.plugins || [])],
     integrations: userConfig.integrations || {},
     trailingSlash: userConfig.trailingSlash ?? false,
-    redirects: () => redirects,
+    redirects: () => [...redirects, ...routeRuleRedirects],
     rewrites: () => rewrites,
-    headers: () => headers,
+    headers: () => [...headers, ...routeRuleHeaders],
+    routeRules,
     images: {
       domains: [],
       deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -27,6 +27,7 @@ export * from "./openapi";
 export * from "./query";
 export * from "./middleware";
 export * from "./router";
+export * from "./route-rules";
 export {
   createLayoutModuleFromProgrammaticLayout,
   createRoute,

--- a/packages/farm/src/nitro/index.ts
+++ b/packages/farm/src/nitro/index.ts
@@ -7,6 +7,7 @@ import { createNitroAPIHandler } from "./api-handler";
 import { createNitroSSRHandler } from "./ssr-handler";
 import path from "path";
 import { prepareFarmWorkflowsForNitro } from "../workflows";
+import { routeRulesToNitroRouteRules } from "../route-rules";
 
 // Export universal build functions
 export { buildUniversal } from "./universal-build";
@@ -584,6 +585,7 @@ export default defineEventHandler(async (event: H3Event) => {
       "/**": {
         prerender: false,
       },
+      ...routeRulesToNitroRouteRules(config.routeRules),
     },
 
     // // Exclude certain directories from scanning

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -22,6 +22,7 @@ import {
   prepareFarmWorkflowsForNitro,
   type PreparedFarmWorkflows,
 } from "../workflows";
+import { routeRulesToNitroRouteRules } from "../route-rules";
 
 // Type alias for OutputBundle
 type OutputBundle = Rollup.OutputBundle;
@@ -2552,6 +2553,7 @@ export default fromWebHandler(handler.fetch)
       "/**": {
         prerender: false,
       },
+      ...routeRulesToNitroRouteRules(config.routeRules),
     },
     externals: {
       external: [

--- a/packages/farm/src/route-rules.ts
+++ b/packages/farm/src/route-rules.ts
@@ -1,0 +1,145 @@
+import type { HeaderConfig, RedirectConfig } from "./config";
+
+export type FarmRouteRuleRenderMode = "static" | "dynamic";
+
+export type FarmRouteRuleRedirect =
+  | string
+  | {
+      to: string;
+      statusCode?: number;
+      permanent?: boolean;
+    };
+
+export type FarmRouteRuleCors =
+  | boolean
+  | {
+      origin?: string;
+      methods?: string | readonly string[];
+      headers?: string | readonly string[];
+    };
+
+export interface FarmRouteRule {
+  prerender?: boolean;
+  render?: FarmRouteRuleRenderMode;
+  ssr?: boolean;
+  swr?: boolean | number;
+  isr?: boolean | number;
+  cors?: FarmRouteRuleCors;
+  headers?: Record<string, string>;
+  redirect?: FarmRouteRuleRedirect;
+}
+
+export type FarmRouteRules = Record<string, FarmRouteRule>;
+
+export function normalizeRouteRules(routeRules: FarmRouteRules | undefined): FarmRouteRules {
+  if (!routeRules) return {};
+
+  const normalized: FarmRouteRules = {};
+  for (const [source, rule] of Object.entries(routeRules)) {
+    if (!source || !rule) continue;
+    normalized[normalizeRuleSource(source)] = { ...rule };
+  }
+  return normalized;
+}
+
+export function routeRulesToRedirects(routeRules: FarmRouteRules): RedirectConfig[] {
+  return Object.entries(routeRules)
+    .filter((entry): entry is [string, FarmRouteRule & { redirect: FarmRouteRuleRedirect }] =>
+      Boolean(entry[1].redirect),
+    )
+    .map(([source, rule]) => {
+      const redirect =
+        typeof rule.redirect === "string" ? { to: rule.redirect } : rule.redirect;
+      return {
+        source,
+        destination: redirect.to,
+        permanent: redirect.permanent,
+        statusCode:
+          redirect.statusCode ?? (redirect.permanent === true ? 308 : undefined),
+      };
+    });
+}
+
+export function routeRulesToHeaders(routeRules: FarmRouteRules): HeaderConfig[] {
+  const configs: HeaderConfig[] = [];
+
+  for (const [source, rule] of Object.entries(routeRules)) {
+    const headers = {
+      ...normalizeCorsHeaders(rule.cors),
+      ...(rule.headers || {}),
+    };
+
+    const entries = Object.entries(headers);
+    if (entries.length === 0) continue;
+
+    configs.push({
+      source,
+      headers: entries.map(([key, value]) => ({ key, value })),
+    });
+  }
+
+  return configs;
+}
+
+export function routeRulesToNitroRouteRules(routeRules: FarmRouteRules): Record<string, any> {
+  const nitroRules: Record<string, any> = {};
+
+  for (const [source, rule] of Object.entries(routeRules)) {
+    const nitroRule: Record<string, any> = { ...rule };
+
+    if (rule.render === "static") {
+      nitroRule.prerender = true;
+    } else if (rule.render === "dynamic") {
+      nitroRule.prerender = false;
+    }
+
+    if (rule.redirect && typeof rule.redirect !== "string") {
+      nitroRule.redirect = rule.redirect.to;
+      if (rule.redirect.statusCode) {
+        nitroRule.statusCode = rule.redirect.statusCode;
+      }
+    }
+
+    if (rule.cors) {
+      nitroRule.cors = true;
+      nitroRule.headers = {
+        ...normalizeCorsHeaders(rule.cors),
+        ...(rule.headers || {}),
+      };
+    }
+
+    delete nitroRule.render;
+    nitroRules[source] = nitroRule;
+  }
+
+  return nitroRules;
+}
+
+function normalizeCorsHeaders(cors: FarmRouteRuleCors | undefined): Record<string, string> {
+  if (!cors) return {};
+
+  if (cors === true) {
+    return {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "*",
+      "Access-Control-Allow-Headers": "*",
+    };
+  }
+
+  return {
+    "Access-Control-Allow-Origin": cors.origin ?? "*",
+    "Access-Control-Allow-Methods": normalizeList(cors.methods) ?? "*",
+    "Access-Control-Allow-Headers": normalizeList(cors.headers) ?? "*",
+  };
+}
+
+function normalizeList(value: string | readonly string[] | undefined): string | undefined {
+  if (!value || typeof value === "string") return value;
+  return value.join(", ");
+}
+
+function normalizeRuleSource(source: string): string {
+  const trimmed = source.trim();
+  if (!trimmed) return "/";
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}

--- a/packages/farm/src/types.ts
+++ b/packages/farm/src/types.ts
@@ -9,6 +9,7 @@ import type { FarmObservabilityUserConfig } from "./observability";
 import type { FarmMiddlewareConfig } from "./middleware/types";
 import type { FarmWorkflowsUserConfig } from "./workflows";
 import type { FarmEnvConfig, ResolvedFarmEnv } from "./env";
+import type { FarmRouteRules } from "./route-rules";
 
 export type NitroPreset =
   | "node-server"
@@ -86,6 +87,7 @@ export interface FarmConfig {
   workflows?: FarmWorkflowsUserConfig | boolean;
   env?: FarmEnvConfig<any, any> | ResolvedFarmEnv;
   middleware?: FarmMiddlewareConfig;
+  routeRules?: FarmRouteRules;
   docs?: FarmDocsUserConfig | FarmDocsResolvedConfig;
   md?: FarmMarkdownUserConfig | FarmMarkdownResolvedConfig | boolean;
   mdx?: FarmMdxUserConfig | FarmMdxResolvedConfig;


### PR DESCRIPTION
## Summary
- add `routeRules` to Farm config for prerender/render, SWR/ISR, CORS, headers, and redirects
- normalize route rules into existing redirects/headers and Nitro route rules
- document when to use routeRules versus route-level exports

## Validation
- `corepack pnpm --filter @farmjs/core test -- src/__tests__/cache.test.ts src/__tests__/programmatic-routes.test.ts src/__tests__/config.test.ts src/__tests__/navigation-state.test.tsx src/__tests__/link.test.tsx`
- `corepack pnpm --filter @farmjs/core build`