### PR TITLE
feat: add navigation state blocking

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -99,6 +99,69 @@ export function CurrentUserTab() {
 }
 ```
 
+## Navigation blocking
+
+Use `useBlocker` when a client component needs to protect unsaved work before SPA navigation continues.
+
+```tsx
+"use client";
+
+import { useBlocker } from "@farmjs/core/client";
+
+export function ProductForm({ isDirty }: { isDirty: boolean }) {
+  useBlocker({
+    when: isDirty,
+    message: "You have unsaved changes.",
+  });
+
+  return <form>{/* ... */}</form>;
+}
+```
+
+Blockers apply to Farm SPA navigation and browser unload prompts. They improve UX, but they do not replace server-side validation or persistence checks.
+
+## Page state
+
+Use page state for shallow UI state that belongs in browser history but should not reload route data: modals, drawers, selected panels, or temporary filters.
+
+```tsx
+"use client";
+
+import { usePageState, useRouter } from "@farmjs/core/client";
+
+export function ProductToolbar() {
+  const router = useRouter();
+  const page = usePageState<{ modal?: "cart"; drawer?: "filters" }>();
+
+  return (
+    <>
+      <button onClick={() => router.pushState({ modal: "cart" })}>Cart</button>
+      <button onClick={() => router.replaceState({ drawer: "filters" })}>Filters</button>
+      {page?.modal === "cart" ? <CartModal /> : null}
+    </>
+  );
+}
+```
+
+Page state is stored in `history.state`, so back/forward navigation restores the previous state without changing the URL unless you pass an href.
+
+## Scroll restoration
+
+Farm restores window scroll during SPA navigation. Register nested scroll areas when a layout owns its own scroll container.
+
+```tsx
+"use client";
+
+import { useScrollRestoration } from "@farmjs/core/client";
+
+export function DocsSidebar() {
+  const ref = useScrollRestoration<HTMLDivElement>("docs-sidebar");
+  return <div ref={ref}>{/* links */}</div>;
+}
+```
+
+Use stable keys per scroll container. If two elements share a key, the latest mounted element owns that stored position.
+
 ## Route data cache
 
 Programmatic routes can cache the value returned from `data.main`. This is useful for product pages, docs pages, dashboards, and other route data that should be reused during server rendering or prefetching.

--- a/packages/farm/src/__tests__/navigation-state.test.tsx
+++ b/packages/farm/src/__tests__/navigation-state.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useBlocker, useScrollRestoration } from "../client/router";
+import { navigateTo, pushState, readPageState, replaceState, SPARouter } from "../client/spa-router";
+
+describe("navigation state and blocking", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot> | undefined;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    window.history.replaceState(null, "", "/");
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            props: {},
+            modulePath: "/src/app/page.tsx",
+            metadata: { title: "Next" },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount();
+      });
+    }
+
+    container.remove();
+    root = undefined;
+    sessionStorage.clear();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    delete (globalThis as any).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  it("blocks SPA navigation when a blocker returns true", async () => {
+    const router = new SPARouter({ scrollRestoration: false });
+    const blocker = vi.fn(() => true);
+    const onNavigate = vi.fn();
+    router.setNavigationHandler(onNavigate);
+    router.addBlocker(blocker);
+
+    await router.navigate("/blocked");
+
+    expect(blocker).toHaveBeenCalledWith({
+      from: "/",
+      to: "/blocked",
+      action: "push",
+    });
+    expect(fetch).not.toHaveBeenCalled();
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(window.location.pathname).toBe("/");
+  });
+
+  it("stores page state in history without changing route data", () => {
+    pushState({ modal: "cart" });
+    expect(readPageState()).toEqual({ modal: "cart" });
+    expect(window.location.pathname).toBe("/");
+
+    replaceState({ drawer: "filters" }, "/products");
+    expect(readPageState()).toEqual({ drawer: "filters" });
+    expect(window.location.pathname).toBe("/products");
+  });
+
+  it("uses confirm-based blockers from React hooks", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    function App() {
+      useBlocker({ when: true, message: "Leave this form?" });
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    await act(async () => {
+      await navigateTo("/next");
+    });
+
+    expect(window.confirm).toHaveBeenCalledWith("Leave this form?");
+    expect(fetch).not.toHaveBeenCalled();
+    expect(window.location.pathname).toBe("/");
+  });
+
+  it("restores registered nested scroll containers by key", () => {
+    vi.useFakeTimers();
+    sessionStorage.setItem("farm-scroll-/:sidebar", JSON.stringify({ x: 4, y: 120 }));
+
+    function App() {
+      const ref = useScrollRestoration<HTMLDivElement>("sidebar");
+      return createElement("div", { ref });
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    const panel = container.querySelector("div") as HTMLDivElement;
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(panel.scrollLeft).toBe(4);
+    expect(panel.scrollTop).toBe(120);
+  });
+});

--- a/packages/farm/src/client.ts
+++ b/packages/farm/src/client.ts
@@ -67,7 +67,14 @@ export type {
 
 // SPA Navigation exports
 export { Link } from "./client/link";
-export { useRouter } from "./client/router";
+export { useBlocker, usePageState, useRouter, useScrollRestoration } from "./client/router";
+export {
+  navigateTo,
+  prefetch,
+  pushState,
+  readPageState,
+  replaceState,
+} from "./client/spa-router";
 export type {
   LinkProps,
   PrefetchBehavior,
@@ -81,3 +88,13 @@ export type {
   RouteOptionalParamValue,
   RouteParams,
 } from "./client/link";
+export type {
+  UseBlockerOptions,
+  UseBlockerReturn,
+  UseRouterOptions,
+} from "./client/router";
+export type {
+  FarmNavigateOptions,
+  FarmNavigationBlocker,
+  FarmNavigationBlockerContext,
+} from "./client/spa-router";

--- a/packages/farm/src/client/index.ts
+++ b/packages/farm/src/client/index.ts
@@ -19,8 +19,8 @@ export type {
   RouteOptionalParamValue,
   RouteParams,
 } from "./link";
-export { useRouter } from "./router";
-export type { UseRouterOptions } from "./router";
+export { useBlocker, usePageState, useRouter, useScrollRestoration } from "./router";
+export type { UseBlockerOptions, UseBlockerReturn, UseRouterOptions } from "./router";
 export { buildFarmRoutePath, createFarmRouter, isFarmRouteActive, matchFarmRoute } from "../router";
 export type {
   FarmRouter,
@@ -44,5 +44,18 @@ export type {
   ServerAPIClientOptions,
   ServerAPIClientWithoutIntegrationsOptions,
 } from "../api/client";
-export { getRouter, navigateTo, prefetch, SPARouter } from "./spa-router";
+export {
+  getRouter,
+  navigateTo,
+  prefetch,
+  pushState,
+  readPageState,
+  replaceState,
+  SPARouter,
+} from "./spa-router";
+export type {
+  FarmNavigateOptions,
+  FarmNavigationBlocker,
+  FarmNavigationBlockerContext,
+} from "./spa-router";
 export type { PageProps, LayoutProps, Metadata } from "../types";

--- a/packages/farm/src/client/router.ts
+++ b/packages/farm/src/client/router.ts
@@ -1,15 +1,33 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import { createFarmRouter, type FarmRouter, type FarmRouterRouteInput } from "../router";
+import {
+  getRouter as getSPARouter,
+  readPageState,
+  type FarmNavigationBlockerContext,
+} from "./spa-router";
 
 interface RouterState {
   pathname: string;
   searchParams: URLSearchParams;
   params: Record<string, string>;
+  pageState: unknown;
 }
 
 export interface UseRouterOptions {
   basePath?: string;
   routes?: FarmRouterRouteInput[];
+}
+
+export interface UseBlockerOptions {
+  when: boolean | ((context: FarmNavigationBlockerContext) => boolean);
+  message?: string;
+  shouldBlock?: (
+    context: FarmNavigationBlockerContext,
+  ) => boolean | Promise<boolean>;
+}
+
+export interface UseBlockerReturn {
+  active: boolean;
 }
 
 /**
@@ -56,6 +74,16 @@ export function useRouter(options: UseRouterOptions = {}) {
     window.dispatchEvent(new PopStateEvent("popstate"));
   };
 
+  const pushState = <TState,>(pageState: TState, href?: string) => {
+    if (typeof window === "undefined") return;
+    getSPARouter().pushState(pageState, resolveClientHref(href, basePath));
+  };
+
+  const replaceState = <TState,>(pageState: TState, href?: string) => {
+    if (typeof window === "undefined") return;
+    getSPARouter().replaceState(pageState, resolveClientHref(href, basePath));
+  };
+
   const back = () => {
     if (typeof window !== "undefined") {
       window.history.back();
@@ -72,9 +100,75 @@ export function useRouter(options: UseRouterOptions = {}) {
     ...state,
     push,
     replace,
+    pushState,
+    replaceState,
     back,
     forward,
   };
+}
+
+export function usePageState<TState = unknown>(): TState | null {
+  const [state, setState] = useState<TState | null>(() => readPageState<TState>());
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handlePopState = () => {
+      setState(readPageState<TState>());
+    };
+
+    handlePopState();
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, []);
+
+  return state;
+}
+
+export function useBlocker(options: UseBlockerOptions): UseBlockerReturn {
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+  const active = Boolean(options.when);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !active) {
+      return;
+    }
+
+    return getSPARouter().addBlocker(async (context) => {
+      const current = optionsRef.current;
+      const when =
+        typeof current.when === "function" ? current.when(context) : current.when;
+
+      if (!when) return false;
+
+      if (current.shouldBlock && !(await current.shouldBlock(context))) {
+        return false;
+      }
+
+      if (current.message && typeof window.confirm === "function") {
+        return !window.confirm(current.message);
+      }
+
+      return true;
+    });
+  }, [active]);
+
+  return { active };
+}
+
+export function useScrollRestoration<TElement extends HTMLElement = HTMLElement>(
+  key: string,
+): RefObject<TElement> {
+  const ref = useRef<TElement>(null);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+    return getSPARouter().registerScrollElement(key, element);
+  }, [key]);
+
+  return ref;
 }
 
 function readRouterState(basePath: string, routeMatcher: FarmRouter | null): RouterState {
@@ -83,6 +177,7 @@ function readRouterState(basePath: string, routeMatcher: FarmRouter | null): Rou
       pathname: "/",
       searchParams: new URLSearchParams(),
       params: {},
+      pageState: null,
     };
   }
 
@@ -92,6 +187,7 @@ function readRouterState(basePath: string, routeMatcher: FarmRouter | null): Rou
     pathname,
     searchParams: url.searchParams,
     params: routeMatcher?.match(pathname)?.params || {},
+    pageState: readPageState(),
   };
 }
 
@@ -101,4 +197,9 @@ function normalizeClientPathname(pathname: string, basePath: string) {
     normalizedBase && (pathname === normalizedBase || pathname.startsWith(`${normalizedBase}/`));
   const withoutBase = isUnderBase ? pathname.slice(normalizedBase.length) || "/" : pathname;
   return withoutBase || "/";
+}
+
+function resolveClientHref(href: string | undefined, basePath: string): string | undefined {
+  if (!href) return undefined;
+  return href.startsWith("/") ? basePath + href : href;
 }

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -25,12 +25,31 @@ interface PageData {
 interface RouterOptions {
   prefetchTimeout?: number;
   cacheMaxAge?: number;
+  scrollRestoration?: boolean;
 }
 
 interface CacheEntry {
   data: PageData;
   timestamp: number;
 }
+
+export interface FarmNavigationBlockerContext {
+  from: string;
+  to: string;
+  action: "push" | "replace" | "pop";
+}
+
+export type FarmNavigationBlocker = (
+  context: FarmNavigationBlockerContext,
+) => boolean | void | Promise<boolean | void>;
+
+export interface FarmNavigateOptions {
+  replace?: boolean;
+  scroll?: boolean;
+  state?: unknown;
+}
+
+const FARM_PAGE_STATE_KEY = "__farmPageState";
 
 // Global router instance
 let routerInstance: SPARouter | null = null;
@@ -39,6 +58,8 @@ export class SPARouter {
   private cache: Map<string, CacheEntry> = new Map();
   private prefetchingUrls: Set<string> = new Set();
   private observers: Map<Element, IntersectionObserver> = new Map();
+  private blockers: Set<FarmNavigationBlocker> = new Set();
+  private scrollElements: Map<string, HTMLElement> = new Map();
   private options: Required<RouterOptions>;
   private onNavigate?: (data: PageData) => Promise<void>;
 
@@ -46,6 +67,7 @@ export class SPARouter {
     this.options = {
       prefetchTimeout: options.prefetchTimeout ?? 100,
       cacheMaxAge: options.cacheMaxAge ?? 30000, // 30 seconds
+      scrollRestoration: options.scrollRestoration ?? true,
     };
 
     if (typeof window !== "undefined") {
@@ -53,7 +75,11 @@ export class SPARouter {
       window.addEventListener("popstate", this.handlePopState.bind(this));
 
       // Save scroll position before unload
-      window.addEventListener("beforeunload", () => {
+      window.addEventListener("beforeunload", (event) => {
+        if (this.blockers.size > 0) {
+          event.preventDefault();
+          event.returnValue = "";
+        }
         this.saveScrollPosition(window.location.pathname);
       });
     }
@@ -71,9 +97,9 @@ export class SPARouter {
    */
   async navigate(
     href: string,
-    options: { replace?: boolean; scroll?: boolean } = {},
+    options: FarmNavigateOptions = {},
   ): Promise<void> {
-    const { replace = false, scroll = true } = options;
+    const { replace = false, scroll = true, state } = options;
 
     // Parse the URL
     const url = new URL(href, window.location.origin);
@@ -89,18 +115,26 @@ export class SPARouter {
       return;
     }
 
+    const from = window.location.pathname + window.location.search;
+    if (await this.shouldBlockNavigation({ from, to: fullPath, action: replace ? "replace" : "push" })) {
+      return;
+    }
+
     // Save current scroll position
-    this.saveScrollPosition(window.location.pathname);
+    if (this.options.scrollRestoration) {
+      this.saveScrollPosition(window.location.pathname);
+    }
 
     try {
       // Fetch page data (from cache or server)
       const pageData = await this.fetchPageData(fullPath);
 
       // Update browser history
+      const historyState = createHistoryState(fullPath, state);
       if (replace) {
-        window.history.replaceState({ path: fullPath }, "", fullPath);
+        window.history.replaceState(historyState, "", fullPath);
       } else {
-        window.history.pushState({ path: fullPath }, "", fullPath);
+        window.history.pushState(historyState, "", fullPath);
       }
 
       // Update document title
@@ -136,7 +170,7 @@ export class SPARouter {
           // Scroll to top
           window.scrollTo(0, 0);
         }
-      } else {
+      } else if (this.options.scrollRestoration) {
         // Restore previous scroll position if available
         this.restoreScrollPosition(pathname);
       }
@@ -211,6 +245,31 @@ export class SPARouter {
     }
   }
 
+  addBlocker(blocker: FarmNavigationBlocker): () => void {
+    this.blockers.add(blocker);
+    return () => {
+      this.blockers.delete(blocker);
+    };
+  }
+
+  registerScrollElement(key: string, element: HTMLElement): () => void {
+    this.scrollElements.set(key, element);
+    this.restoreScrollElement(window.location.pathname, key, element);
+    return () => {
+      if (this.scrollElements.get(key) === element) {
+        this.scrollElements.delete(key);
+      }
+    };
+  }
+
+  pushState(state: unknown, href?: string): void {
+    this.writePageState("push", state, href);
+  }
+
+  replaceState(state: unknown, href?: string): void {
+    this.writePageState("replace", state, href);
+  }
+
   /**
    * Fetch page data from cache or server
    */
@@ -250,6 +309,16 @@ export class SPARouter {
   private async handlePopState(event: PopStateEvent): Promise<void> {
     const path = window.location.pathname + window.location.search;
 
+    if (
+      await this.shouldBlockNavigation({
+        from: event.state?.path || path,
+        to: path,
+        action: "pop",
+      })
+    ) {
+      return;
+    }
+
     try {
       const pageData = await this.fetchPageData(path);
 
@@ -264,7 +333,9 @@ export class SPARouter {
       }
 
       // Restore scroll position
-      this.restoreScrollPosition(window.location.pathname);
+      if (this.options.scrollRestoration) {
+        this.restoreScrollPosition(window.location.pathname);
+      }
     } catch (error) {
       console.error("[Farm.js] Popstate navigation error:", error);
       // Reload the page as fallback
@@ -287,6 +358,34 @@ export class SPARouter {
     return href.startsWith("http://") || href.startsWith("https://") || href.startsWith("//");
   }
 
+  private async shouldBlockNavigation(context: FarmNavigationBlockerContext): Promise<boolean> {
+    for (const blocker of this.blockers) {
+      if (await blocker(context)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private writePageState(action: "push" | "replace", state: unknown, href?: string): void {
+    if (typeof window === "undefined") return;
+
+    const url = href ? new URL(href, window.location.origin).toString() : window.location.href;
+    const nextState = createHistoryState(
+      new URL(url).pathname + new URL(url).search,
+      state,
+      window.history.state,
+    );
+
+    if (action === "replace") {
+      window.history.replaceState(nextState, "", url);
+    } else {
+      window.history.pushState(nextState, "", url);
+    }
+
+    window.dispatchEvent(new PopStateEvent("popstate", { state: nextState }));
+  }
+
   /**
    * Save scroll position for a path
    */
@@ -296,6 +395,12 @@ export class SPARouter {
         `farm-scroll-${path}`,
         JSON.stringify({ x: window.scrollX, y: window.scrollY }),
       );
+      for (const [key, element] of this.scrollElements) {
+        sessionStorage.setItem(
+          getScrollElementStorageKey(path, key),
+          JSON.stringify({ x: element.scrollLeft, y: element.scrollTop }),
+        );
+      }
     } catch {
       // Ignore storage errors
     }
@@ -311,6 +416,23 @@ export class SPARouter {
         const { x, y } = JSON.parse(saved);
         setTimeout(() => window.scrollTo(x, y), 0);
       }
+      for (const [key, element] of this.scrollElements) {
+        this.restoreScrollElement(path, key, element);
+      }
+    } catch {
+      // Ignore storage errors
+    }
+  }
+
+  private restoreScrollElement(path: string, key: string, element: HTMLElement): void {
+    try {
+      const saved = sessionStorage.getItem(getScrollElementStorageKey(path, key));
+      if (!saved) return;
+      const { x, y } = JSON.parse(saved);
+      setTimeout(() => {
+        element.scrollLeft = x;
+        element.scrollTop = y;
+      }, 0);
     } catch {
       // Ignore storage errors
     }
@@ -345,7 +467,7 @@ export function getRouter(): SPARouter {
  */
 export function navigateTo(
   href: string,
-  options?: { replace?: boolean; scroll?: boolean },
+  options?: FarmNavigateOptions,
 ): Promise<void> {
   return getRouter().navigate(href, options);
 }
@@ -355,4 +477,32 @@ export function navigateTo(
  */
 export function prefetch(href: string): Promise<void> {
   return getRouter().prefetch(href);
+}
+
+export function pushState(state: unknown, href?: string): void {
+  getRouter().pushState(state, href);
+}
+
+export function replaceState(state: unknown, href?: string): void {
+  getRouter().replaceState(state, href);
+}
+
+export function readPageState<TState = unknown>(): TState | null {
+  if (typeof window === "undefined") return null;
+  const state = window.history.state;
+  if (!state || typeof state !== "object") return null;
+  return ((state as Record<string, unknown>)[FARM_PAGE_STATE_KEY] as TState | undefined) ?? null;
+}
+
+function createHistoryState(path: string, pageState: unknown, currentState?: unknown) {
+  const base = currentState && typeof currentState === "object" ? { ...(currentState as object) } : {};
+  return {
+    ...base,
+    path,
+    [FARM_PAGE_STATE_KEY]: pageState,
+  };
+}
+
+function getScrollElementStorageKey(path: string, key: string): string {
+  return `farm-scroll-${path}:${key}`;
 }

--- a/packages/farm/types/client.d.ts
+++ b/packages/farm/types/client.d.ts
@@ -10,6 +10,7 @@ import type {
   AnchorHTMLAttributes,
   ReactElement,
   ReactNode,
+  RefObject,
   RefAttributes,
 } from "react";
 
@@ -205,13 +206,62 @@ declare module "@farmjs/core/client" {
 
   export const Link: LinkComponent;
 
-  export function useRouter(): {
+  export interface FarmNavigationBlockerContext {
+    from: string;
+    to: string;
+    action: "push" | "replace" | "pop";
+  }
+
+  export type FarmNavigationBlocker = (
+    context: FarmNavigationBlockerContext,
+  ) => boolean | void | Promise<boolean | void>;
+
+  export interface FarmNavigateOptions {
+    replace?: boolean;
+    scroll?: boolean;
+    state?: unknown;
+  }
+
+  export interface UseRouterOptions {
+    basePath?: string;
+    routes?: Array<string | { path: string; name?: string; meta?: unknown }>;
+  }
+
+  export interface UseBlockerOptions {
+    when: boolean | ((context: FarmNavigationBlockerContext) => boolean);
+    message?: string;
+    shouldBlock?: (
+      context: FarmNavigationBlockerContext,
+    ) => boolean | Promise<boolean>;
+  }
+
+  export interface UseBlockerReturn {
+    active: boolean;
+  }
+
+  export function useRouter(options?: UseRouterOptions): {
     pathname: string;
     searchParams: URLSearchParams;
     params: Record<string, string>;
-    push: (path: string, opts?: { replace?: boolean; scroll?: boolean }) => void;
+    pageState: unknown;
+    push: (path: string) => void;
     replace: (path: string) => void;
+    pushState: <TState>(state: TState, href?: string) => void;
+    replaceState: <TState>(state: TState, href?: string) => void;
+    back: () => void;
+    forward: () => void;
   };
+
+  export function usePageState<TState = unknown>(): TState | null;
+  export function useBlocker(options: UseBlockerOptions): UseBlockerReturn;
+  export function useScrollRestoration<TElement extends HTMLElement = HTMLElement>(
+    key: string,
+  ): RefObject<TElement>;
+  export function navigateTo(href: string, options?: FarmNavigateOptions): Promise<void>;
+  export function prefetch(href: string): Promise<void>;
+  export function pushState<TState>(state: TState, href?: string): void;
+  export function replaceState<TState>(state: TState, href?: string): void;
+  export function readPageState<TState = unknown>(): TState | null;
 
   export interface APIClientOptions {
     baseURL?: string;


### PR DESCRIPTION
## Summary
- add SPA navigation blockers with `useBlocker`
- add `pushState`, `replaceState`, and `usePageState` for shallow page UI state
- add nested scroll container restoration via `useScrollRestoration`
- document dirty-form blocking, page state, and scroll restoration best practices

## Validation
- `corepack pnpm --filter @farmjs/core test -- src/__tests__/cache.test.ts src/__tests__/programmatic-routes.test.ts src/__tests__/config.test.ts src/__tests__/navigation-state.test.tsx src/__tests__/link.test.tsx`
- `corepack pnpm --filter @farmjs/core build`