### PR TITLE
feat: add file route states

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -306,6 +306,52 @@ This page renders at `/about` and exposes source at `/about.md`.
 
 Do not place `page.tsx` and `page.mdx` in the same folder. Farm treats that as a duplicate route and asks you to choose one page source.
 
+## File Route States
+
+Use `loading.tsx` and `error.tsx` next to a file route to define route-local loading and error states. Farm picks the nearest matching boundary, so `src/app/dashboard/error.tsx` handles `/dashboard` and nested dashboard pages unless a deeper segment defines its own boundary.
+
+```txt
+src/app/
+  dashboard/
+    page.tsx
+    loading.tsx
+    error.tsx
+```
+
+**src/app/dashboard/loading.tsx**
+
+```tsx
+import type { LoadingProps } from "@farmjs/core";
+
+export default function DashboardLoading(props: LoadingProps) {
+  return <p>Loading {props.path}</p>;
+}
+```
+
+`loading.tsx` is used as the Suspense fallback when the page or nested content suspends while rendering.
+
+**src/app/dashboard/error.tsx**
+
+```tsx
+"use client";
+
+import type { ErrorProps } from "@farmjs/core";
+
+export default function DashboardError({ error, reset }: ErrorProps) {
+  const message = error instanceof Error ? error.message : "Something went wrong";
+
+  return (
+    <section>
+      <h2>Could not load dashboard</h2>
+      <p>{message}</p>
+      <button onClick={reset}>Try again</button>
+    </section>
+  );
+}
+```
+
+`error.tsx` receives `error`, `reset`, `params`, `path`, `search`, `searchParams`, middleware data, and plugin context. The closest route error boundary handles normal render/data failures. Redirects and `notFound()` still escape to Farm's redirect and not-found handling.
+
 ## Catch-all routes
 
 Catch-all routes are useful for docs, CMS content, and nested marketing pages where the page is resolved from content instead of a fixed file for every URL.

--- a/packages/farm/src/__tests__/server-renderer-route-states.test.tsx
+++ b/packages/farm/src/__tests__/server-renderer-route-states.test.tsx
@@ -1,0 +1,252 @@
+// @vitest-environment node
+
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ServerRenderer } from "../server/renderer";
+import type { FarmConfig, FarmRequest, FarmResponse, LoadingProps, ErrorProps } from "../types";
+import { logger } from "../utils";
+
+type MockResponse = FarmResponse & {
+  body: string;
+  headers: Map<string, string | number | readonly string[]>;
+};
+
+const routeModulePath = "/test/src/app/dashboard/page.tsx";
+const loadingModulePath = "/test/src/app/dashboard/loading.tsx";
+const errorModulePath = "/test/src/app/dashboard/error.tsx";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("file route loading.tsx and error.tsx", () => {
+  it("renders the nearest loading.tsx while a file route suspends", async () => {
+    const release = createDeferred<void>();
+    const response = createMockResponse();
+    const renderer = createRenderer({
+      [routeModulePath]: {
+        default: async function DashboardPage() {
+          await release.promise;
+          return React.createElement("main", null, "Dashboard ready");
+        },
+      },
+      [loadingModulePath]: {
+        default: function DashboardLoading(props: LoadingProps) {
+          return React.createElement(
+            "p",
+            null,
+            `Loading dashboard ${props.path} ${props.search?.tab}`,
+          );
+        },
+      },
+    });
+
+    const renderPromise = renderer.renderPage(createMockRequest("/dashboard?tab=stats"), response);
+    await waitFor(() => response.body.includes("Loading dashboard /dashboard stats"));
+
+    release.resolve();
+    await renderPromise;
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toContain("Loading dashboard /dashboard stats");
+    expect(response.body).toContain("Dashboard ready");
+    expect(response.body).toContain("__FARM_LOADING_MODULE__");
+    expect(response.body).toContain("/src/app/dashboard/loading.tsx");
+  });
+
+  it("renders the nearest error.tsx for file route render failures", async () => {
+    vi.spyOn(logger, "error").mockImplementation(() => {});
+    const response = createMockResponse();
+    const renderer = createRenderer({
+      [routeModulePath]: {
+        default: function DashboardPage() {
+          throw new Error("dashboard exploded");
+        },
+      },
+      [errorModulePath]: {
+        default: function DashboardError(props: ErrorProps) {
+          const message = props.error instanceof Error ? props.error.message : String(props.error);
+          return React.createElement(
+            "section",
+            null,
+            `Dashboard error ${message} ${props.path} ${props.search?.tab}`,
+          );
+        },
+      },
+    });
+
+    await renderer.renderPage(createMockRequest("/dashboard?tab=stats"), response);
+
+    expect(response.statusCode).toBe(500);
+    expect(response.body).toContain("Dashboard error dashboard exploded /dashboard stats");
+    expect(response.body).not.toContain("Internal Server Error");
+  });
+});
+
+function createRenderer(modules: Record<string, any>) {
+  const routeManager = {
+    matchRoute() {
+      return {
+        route: {
+          pattern: "/dashboard",
+          modulePath: routeModulePath,
+        },
+        params: {},
+        layouts: [],
+      };
+    },
+    getMatchingLoading() {
+      return modules[loadingModulePath]
+        ? {
+            pattern: "/dashboard",
+            modulePath: loadingModulePath,
+          }
+        : null;
+    },
+    getMatchingError() {
+      return modules[errorModulePath]
+        ? {
+            pattern: "/dashboard",
+            modulePath: errorModulePath,
+          }
+        : null;
+    },
+    async loadRouteModule(modulePath: string) {
+      const mod = modules[modulePath];
+      if (!mod) throw new Error(`Unknown module ${modulePath}`);
+      return mod;
+    },
+    async loadLayoutModule(modulePath: string) {
+      const mod = modules[modulePath];
+      if (!mod) throw new Error(`Unknown layout ${modulePath}`);
+      return mod;
+    },
+    generateClientManifest() {
+      return {
+        routes: [
+          {
+            pattern: "/dashboard",
+            modulePath: "/src/app/dashboard/page.tsx",
+            shouldHydrate: false,
+            isClientComponent: false,
+            segments: [{ segment: "dashboard", isDynamic: false }],
+          },
+        ],
+        layouts: [],
+      };
+    },
+  };
+
+  return new ServerRenderer(createConfig(), routeManager as any);
+}
+
+function createConfig(): Required<FarmConfig> {
+  return {
+    root: "/test",
+    srcDir: "src",
+    outDir: "dist",
+    basePath: "/",
+    preset: "node-server",
+    deploy: {},
+    storage: {},
+    integrations: {},
+    migrations: { commands: [] },
+    workflows: {
+      enabled: false,
+      workflows: [],
+      tasks: {},
+      scheduledTasks: {},
+      route: "/api/workflows",
+    } as any,
+    env: { server: {}, public: {} },
+    middleware: {},
+    routeRules: {},
+    docs: { enabled: false } as any,
+    md: {} as any,
+    mdx: { markdownRoutes: true, className: "farm-markdown" } as any,
+    observability: false,
+    suppressLintOnLink: false,
+    experimental: {
+      serverComponents: false,
+      serverActions: false,
+    },
+    vite: {},
+  } as Required<FarmConfig>;
+}
+
+function createMockRequest(url: string): FarmRequest {
+  return {
+    url,
+    method: "GET",
+    headers: {
+      host: "farm.test",
+    },
+  } as FarmRequest;
+}
+
+function createMockResponse(): MockResponse {
+  const response = {
+    statusCode: 200,
+    body: "",
+    headers: new Map<string, string | number | readonly string[]>(),
+    headersSent: false,
+    writableEnded: false,
+    setHeader(key: string, value: string | number | readonly string[]) {
+      this.headers.set(key.toLowerCase(), value);
+      return this;
+    },
+    getHeader(key: string) {
+      return this.headers.get(key.toLowerCase());
+    },
+    write(chunk: unknown, _encoding?: BufferEncoding | ((error?: Error | null) => void), cb?: (error?: Error | null) => void) {
+      this.headersSent = true;
+      this.body += Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk ?? "");
+      const callback = typeof _encoding === "function" ? _encoding : cb;
+      callback?.();
+      return true;
+    },
+    end(chunk?: unknown) {
+      if (chunk !== undefined) {
+        this.write(chunk);
+      }
+      this.writableEnded = true;
+      return this;
+    },
+    flush() {},
+    json(data: any) {
+      this.setHeader("Content-Type", "application/json");
+      this.end(JSON.stringify(data));
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    redirect(url: string, status = 302) {
+      this.statusCode = status;
+      this.setHeader("Location", url);
+      this.end();
+    },
+  };
+
+  return response as unknown as MockResponse;
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function waitFor(assertion: () => boolean, timeoutMs = 1000) {
+  const start = Date.now();
+  while (!assertion()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("Timed out waiting for assertion");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -6,6 +6,7 @@ import type {
   FarmConfig,
   FarmRequest,
   FarmResponse,
+  LoadingProps,
   PageProps,
   RouteModule,
   SSGPage,
@@ -183,6 +184,24 @@ function parseRouteModuleSchema(
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Invalid ${label} for route "${routePath}": ${message}`);
   }
+}
+
+function createRouteStateProps(input: {
+  params: Record<string, string>;
+  searchParamsObject: Record<string, string | string[] | undefined>;
+  path: string;
+  middlewareMap: Map<string, any>;
+  pluginExposedContext: Map<string, any>;
+}): LoadingProps {
+  return {
+    params: input.params,
+    search: input.searchParamsObject,
+    searchParams: Promise.resolve(input.searchParamsObject),
+    path: input.path,
+    middleware: input.middlewareMap.size > 0 ? { data: input.middlewareMap } : undefined,
+    context:
+      input.pluginExposedContext.size > 0 ? { data: input.pluginExposedContext } : undefined,
+  };
 }
 
 export class ServerRenderer {
@@ -676,8 +695,13 @@ export class ServerRenderer {
 
           if (LoadingFallbackComponent) {
             const loadingFallback = React.createElement(LoadingFallbackComponent, {
-              params,
-              path: pathname,
+              ...createRouteStateProps({
+                params,
+                searchParamsObject,
+                path: pathname,
+                middlewareMap,
+                pluginExposedContext,
+              }),
             } as React.Attributes);
 
             pageElement = React.createElement(
@@ -716,12 +740,13 @@ export class ServerRenderer {
               {
                 Fallback: ErrorFallbackComponent,
                 fallbackProps: {
-                  params,
-                  path: pathname,
-                  searchParams: Promise.resolve(searchParamsObject),
-                  middleware: middlewareMap.size > 0 ? { data: middlewareMap } : undefined,
-                  context:
-                    pluginExposedContext.size > 0 ? { data: pluginExposedContext } : undefined,
+                  ...createRouteStateProps({
+                    params,
+                    searchParamsObject,
+                    path: pathname,
+                    middlewareMap,
+                    pluginExposedContext,
+                  }),
                 },
               },
               wrappedElement,
@@ -874,15 +899,14 @@ export class ServerRenderer {
 
       const ErrorComponent = errorModule.default as React.ComponentType<unknown>;
       const errorElement = React.createElement(ErrorComponent, {
+        ...createRouteStateProps({
+          params: options.params,
+          searchParamsObject: options.searchParamsObject,
+          path: options.pathname,
+          middlewareMap: options.middlewareMap,
+          pluginExposedContext: options.pluginExposedContext,
+        }),
         error: options.error,
-        params: options.params,
-        path: options.pathname,
-        searchParams: Promise.resolve(options.searchParamsObject),
-        middleware: options.middlewareMap.size > 0 ? { data: options.middlewareMap } : undefined,
-        context:
-          options.pluginExposedContext.size > 0
-            ? { data: options.pluginExposedContext }
-            : undefined,
         reset: () => {},
       } as React.Attributes);
 
@@ -935,9 +959,6 @@ export class ServerRenderer {
       res.setHeader("Content-Type", "text/html; charset=utf-8");
       for (const [key, value] of Object.entries(options.responseHeaders || {})) {
         res.setHeader(key, value);
-      }
-      if (typeof res.flushHeaders === "function") {
-        res.flushHeaders();
       }
 
       const htmlParts: string[] = [];

--- a/packages/farm/src/types.ts
+++ b/packages/farm/src/types.ts
@@ -165,6 +165,21 @@ export interface PageProps {
    */
   context?: PluginContextProps;
 }
+
+export interface LoadingProps {
+  params: Record<string, string>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+  search?: Record<string, string | string[] | undefined>;
+  path: string;
+  middleware?: MiddlewareProps;
+  context?: PluginContextProps;
+}
+
+export interface ErrorProps extends LoadingProps {
+  error: unknown;
+  reset: () => void;
+}
+
 /**
  * Helper type to create typed page props with specific middleware data shape
  *
@@ -198,6 +213,8 @@ export interface LayoutProps {
 
 export type Page = ComponentType<PageProps>;
 export type Layout = ComponentType<LayoutProps>;
+export type Loading = ComponentType<LoadingProps>;
+export type ErrorBoundary = ComponentType<ErrorProps>;
 /**
  * Route module exports for pages
  *


### PR DESCRIPTION
## Summary
- document file-based `loading.tsx` and `error.tsx` route states
- add public `LoadingProps` and `ErrorProps` types for file route state components
- pass consistent route state props into loading and error components
- let early server render failures reach the nearest `error.tsx` boundary before headers flush
- add renderer-level tests for suspending pages and route errors

## Validation
- `corepack pnpm --filter @farmjs/core test -- src/__tests__/server-renderer-route-states.test.tsx src/__tests__/route-manager.test.ts`
- `corepack pnpm --filter @farmjs/core test -- src/__tests__/cache.test.ts src/__tests__/programmatic-routes.test.ts src/__tests__/config.test.ts src/__tests__/navigation-state.test.tsx src/__tests__/link.test.tsx src/__tests__/route-manager.test.ts src/__tests__/server-renderer-route-states.test.tsx`
- `corepack pnpm --filter @farmjs/core build`