### PR TITLE
feat: add metadata og image routes

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -306,6 +306,69 @@ This page renders at `/about` and exposes source at `/about.md`.
 
 Do not place `page.tsx` and `page.mdx` in the same folder. Farm treats that as a duplicate route and asks you to choose one page source.
 
+## Metadata And OG Images
+
+Export `metadata` for static head tags or `generateMetadata` when the values depend on route params, search params, middleware data, or route data. Farm merges layout metadata from root to leaf, then applies the page metadata last.
+
+**src/app/products/[id]/page.tsx**
+
+```tsx
+import type { PageProps } from "@farmjs/core";
+
+export const metadata = {
+  description: "Product details",
+  openGraph: {
+    siteName: "Acme",
+    type: "website",
+  },
+};
+
+export async function generateMetadata({ params }: PageProps) {
+  const product = await getProduct(params.id);
+
+  return {
+    title: product.name,
+    openGraph: {
+      title: product.name,
+      description: product.summary,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: product.name,
+    },
+  };
+}
+
+export default function ProductPage() {
+  return <main>Product</main>;
+}
+```
+
+Place `opengraph-image.tsx` or `twitter-image.tsx` next to a route segment to create a metadata image endpoint. Farm automatically adds the nearest matching image to the page head when `openGraph.images` or `twitter.images` is not already set.
+
+**src/app/products/[id]/opengraph-image.tsx**
+
+```tsx
+import type { PageProps } from "@farmjs/core";
+
+export const size = { width: 1200, height: 630 };
+export const alt = "Product preview";
+export const contentType = "image/svg+xml";
+
+export default function ProductOpenGraphImage({ params }: PageProps) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+      <rect width="1200" height="630" fill="#111827" />
+      <text x="80" y="340" fill="white" fontSize="72">
+        Product {params.id}
+      </text>
+    </svg>
+  );
+}
+```
+
+For `/products/42`, this file is served at `/products/42/opengraph-image` and Farm emits `og:image`, `og:image:width`, `og:image:height`, and `og:image:alt` tags. The default return value can be a React SVG element, a string, bytes, or a `Response`.
+
 ## File Route States
 
 Use `loading.tsx` and `error.tsx` next to a file route to define route-local loading and error states. Farm picks the nearest matching boundary, so `src/app/dashboard/error.tsx` handles `/dashboard` and nested dashboard pages unless a deeper segment defines its own boundary.

--- a/packages/farm/src/__tests__/route-manager.test.ts
+++ b/packages/farm/src/__tests__/route-manager.test.ts
@@ -203,4 +203,44 @@ describe("RouteManager", () => {
       expect(root?.route.filePath).toBe("error.tsx");
     });
   });
+
+  describe("metadata image routes", () => {
+    it("discovers and matches opengraph-image and twitter-image files", async () => {
+      const { globFiles } = await import("../utils");
+      vi.mocked(globFiles).mockImplementation(async (pattern: string) => {
+        if (pattern.includes("page")) {
+          return ["page.tsx", "blog/[slug]/page.tsx"];
+        }
+        if (pattern.includes("opengraph-image")) {
+          return [
+            "opengraph-image.tsx",
+            "blog/[slug]/opengraph-image.tsx",
+            "blog/[slug]/twitter-image.tsx",
+          ];
+        }
+        return [];
+      });
+
+      await routeManager.discoverRoutes();
+
+      expect(routeManager.getMetadataImages().size).toBe(3);
+
+      const exact = routeManager.matchMetadataImage("/blog/farm/opengraph-image");
+      expect(exact?.image.pattern).toBe("/blog/[slug]");
+      expect(exact?.params).toEqual({ slug: "farm" });
+      expect(exact?.pagePath).toBe("/blog/farm");
+
+      const nearest = routeManager.getMatchingMetadataImage("/blog/farm/comments", "opengraph");
+      expect(nearest?.image.pattern).toBe("/blog/[slug]");
+      expect(routeManager.resolveMetadataImagePath(nearest!.image, nearest!.params)).toBe(
+        "/blog/farm/opengraph-image",
+      );
+
+      const twitter = routeManager.getMatchingMetadataImage("/blog/farm", "twitter");
+      expect(twitter?.image.pattern).toBe("/blog/[slug]");
+      expect(routeManager.resolveMetadataImagePath(twitter!.image, twitter!.params)).toBe(
+        "/blog/farm/twitter-image",
+      );
+    });
+  });
 });

--- a/packages/farm/src/__tests__/server-renderer-route-states.test.tsx
+++ b/packages/farm/src/__tests__/server-renderer-route-states.test.tsx
@@ -14,6 +14,7 @@ type MockResponse = FarmResponse & {
 const routeModulePath = "/test/src/app/dashboard/page.tsx";
 const loadingModulePath = "/test/src/app/dashboard/loading.tsx";
 const errorModulePath = "/test/src/app/dashboard/error.tsx";
+const ogImageModulePath = "/test/src/app/dashboard/opengraph-image.tsx";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -81,10 +82,128 @@ describe("file route loading.tsx and error.tsx", () => {
     expect(response.body).toContain("Dashboard error dashboard exploded /dashboard stats");
     expect(response.body).not.toContain("Internal Server Error");
   });
+
+  it("renders generated metadata and route image file tags", async () => {
+    const response = createMockResponse();
+    const renderer = createRenderer(
+      {
+        [routeModulePath]: {
+          metadata: {
+            description: "Dashboard overview",
+            openGraph: {
+              siteName: "Farm",
+            },
+          },
+          async generateMetadata(props: any) {
+            const search = await props.searchParams;
+            return {
+              title: `Dashboard ${search.tab}`,
+              openGraph: {
+                title: "Dashboard stats",
+              },
+            };
+          },
+          default: function DashboardPage() {
+            return React.createElement("main", null, "Dashboard ready");
+          },
+        },
+        [ogImageModulePath]: {
+          size: { width: 1200, height: 630 },
+          alt: "Dashboard preview",
+          default: function DashboardImage() {
+            return React.createElement(
+              "svg",
+              { xmlns: "http://www.w3.org/2000/svg", viewBox: "0 0 1200 630" },
+              React.createElement("text", null, "Dashboard OG"),
+            );
+          },
+        },
+      },
+      { opengraphImage: true },
+    );
+
+    await renderer.renderPage(createMockRequest("/dashboard?tab=stats"), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toContain("<title>Dashboard stats</title>");
+    expect(response.body).toContain(
+      '<meta name="description" content="Dashboard overview">',
+    );
+    expect(response.body).toContain('<meta property="og:title" content="Dashboard stats">');
+    expect(response.body).toContain('<meta property="og:site_name" content="Farm">');
+    expect(response.body).toContain(
+      '<meta property="og:image" content="/dashboard/opengraph-image">',
+    );
+    expect(response.body).toContain('<meta property="og:image:width" content="1200">');
+    expect(response.body).toContain(
+      '<meta property="og:image:alt" content="Dashboard preview">',
+    );
+  });
+
+  it("serves opengraph-image.tsx as a metadata image endpoint", async () => {
+    const response = createMockResponse();
+    const renderer = createRenderer(
+      {
+        [routeModulePath]: {
+          default: function DashboardPage() {
+            return React.createElement("main", null, "Dashboard ready");
+          },
+        },
+        [ogImageModulePath]: {
+          contentType: "image/svg+xml",
+          default: function DashboardImage(props: any) {
+            return React.createElement(
+              "svg",
+              { xmlns: "http://www.w3.org/2000/svg", viewBox: "0 0 1200 630" },
+              React.createElement("text", null, `OG ${props.path}`),
+            );
+          },
+        },
+      },
+      { opengraphImage: true },
+    );
+
+    await renderer.renderPage(createMockRequest("/dashboard/opengraph-image"), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/svg+xml");
+    expect(response.body).toContain("<svg");
+    expect(response.body).toContain("OG /dashboard");
+  });
 });
 
-function createRenderer(modules: Record<string, any>) {
+function createRenderer(
+  modules: Record<string, any>,
+  options: { opengraphImage?: boolean } = {},
+) {
+  const metadataImageEntry = {
+    pattern: "/dashboard",
+    modulePath: ogImageModulePath,
+    kind: "opengraph",
+    fileName: "opengraph-image",
+    route: {
+      segments: [
+        {
+          segment: "dashboard",
+          isDynamic: false,
+          isCatchAll: false,
+          isOptional: false,
+        },
+      ],
+    },
+  };
   const routeManager = {
+    matchMetadataImage(pathname: string) {
+      if (!options.opengraphImage || pathname !== "/dashboard/opengraph-image") {
+        return null;
+      }
+
+      return {
+        image: metadataImageEntry,
+        params: {},
+        pagePath: "/dashboard",
+      };
+    },
     matchRoute() {
       return {
         route: {
@@ -110,6 +229,19 @@ function createRenderer(modules: Record<string, any>) {
             modulePath: errorModulePath,
           }
         : null;
+    },
+    getMatchingMetadataImage(_pathname: string, kind: string) {
+      if (!options.opengraphImage || kind !== "opengraph") {
+        return null;
+      }
+
+      return {
+        image: metadataImageEntry,
+        params: {},
+      };
+    },
+    resolveMetadataImagePath() {
+      return "/dashboard/opengraph-image";
     },
     async loadRouteModule(modulePath: string) {
       const mod = modules[modulePath];

--- a/packages/farm/src/metadata.ts
+++ b/packages/farm/src/metadata.ts
@@ -1,0 +1,349 @@
+import type { Metadata } from "./types";
+
+export type MetadataImageKind = "opengraph" | "twitter";
+
+export interface FarmMetadataImageReference {
+  kind: MetadataImageKind;
+  href: string;
+  alt?: string;
+  width?: number;
+  height?: number;
+  contentType?: string;
+}
+
+export interface RenderedMetadataHead {
+  title: string;
+  tags: string;
+}
+
+type MetadataRecord = Metadata & Record<string, any>;
+
+export function mergeMetadata(
+  base: MetadataRecord | undefined,
+  next: MetadataRecord | undefined,
+): MetadataRecord {
+  if (!base) return next ? { ...next } : {};
+  if (!next) return { ...base };
+
+  return {
+    ...base,
+    ...next,
+    openGraph: mergeNestedMetadata(base.openGraph, next.openGraph),
+    twitter: mergeNestedMetadata(base.twitter, next.twitter),
+    alternates: mergeNestedMetadata((base as any).alternates, (next as any).alternates),
+    icons: mergeNestedMetadata((base as any).icons, (next as any).icons),
+  };
+}
+
+export function addMetadataImageReference(
+  metadata: MetadataRecord,
+  reference: FarmMetadataImageReference,
+): MetadataRecord {
+  if (reference.kind === "opengraph") {
+    const openGraph = { ...(metadata.openGraph || {}) };
+    if (!hasMetadataImages(openGraph.images) && !hasMetadataImages((openGraph as any).image)) {
+      openGraph.images = [
+        {
+          url: reference.href,
+          width: reference.width,
+          height: reference.height,
+          alt: reference.alt,
+          type: reference.contentType,
+        },
+      ];
+    }
+
+    return {
+      ...metadata,
+      openGraph,
+    };
+  }
+
+  const twitter = { ...(metadata.twitter || {}) };
+  if (!hasMetadataImages(twitter.images)) {
+    twitter.images = [reference.href];
+    twitter.card = twitter.card || "summary_large_image";
+  }
+
+  return {
+    ...metadata,
+    twitter,
+  };
+}
+
+export function renderMetadataHead(metadata: MetadataRecord | undefined): RenderedMetadataHead {
+  const resolvedMetadata = metadata || {};
+  const metadataBase = resolveMetadataBase(resolvedMetadata);
+  const title = resolveMetadataTitle(resolvedMetadata.title) || "Farm.js App";
+  const tags: string[] = [];
+
+  appendMetaName(tags, "description", resolvedMetadata.description);
+  appendMetaName(tags, "keywords", normalizeKeywords(resolvedMetadata.keywords));
+  appendMetaName(tags, "author", (resolvedMetadata as any).author);
+
+  if (Array.isArray(resolvedMetadata.authors)) {
+    for (const author of resolvedMetadata.authors) {
+      appendMetaName(tags, "author", author?.name);
+      if (author?.url) {
+        appendLink(tags, "author", resolveMetadataUrl(author.url, metadataBase));
+      }
+    }
+  }
+
+  appendMetaName(tags, "creator", resolvedMetadata.creator);
+  appendMetaName(tags, "publisher", resolvedMetadata.publisher);
+  appendMetaName(tags, "robots", normalizeRobots(resolvedMetadata.robots));
+
+  const alternates = (resolvedMetadata as any).alternates;
+  if (isRecord(alternates)) {
+    appendLink(tags, "canonical", resolveMetadataUrl(alternates.canonical, metadataBase));
+
+    if (isRecord(alternates.languages)) {
+      for (const [language, href] of Object.entries(alternates.languages)) {
+        appendLink(tags, "alternate", resolveMetadataUrl(href, metadataBase), {
+          hreflang: language,
+        });
+      }
+    }
+  }
+
+  appendIcons(tags, (resolvedMetadata as any).icons, metadataBase);
+
+  if ((resolvedMetadata as any).manifest) {
+    appendLink(
+      tags,
+      "manifest",
+      resolveMetadataUrl((resolvedMetadata as any).manifest, metadataBase),
+    );
+  }
+
+  appendOpenGraph(tags, resolvedMetadata.openGraph, metadataBase);
+  appendTwitter(tags, resolvedMetadata.twitter, metadataBase);
+
+  return {
+    title: escapeText(title),
+    tags: tags.length > 0 ? `\n  ${tags.join("\n  ")}` : "",
+  };
+}
+
+function mergeNestedMetadata(base: unknown, next: unknown): any {
+  if (isRecord(base) && isRecord(next)) {
+    return {
+      ...base,
+      ...next,
+    };
+  }
+
+  return next ?? base;
+}
+
+function appendOpenGraph(tags: string[], openGraph: Metadata["openGraph"], metadataBase?: string) {
+  if (!isRecord(openGraph)) return;
+
+  appendMetaProperty(tags, "og:title", openGraph.title);
+  appendMetaProperty(tags, "og:description", openGraph.description);
+  appendMetaProperty(tags, "og:url", resolveMetadataUrl(openGraph.url, metadataBase));
+  appendMetaProperty(tags, "og:site_name", openGraph.siteName);
+  appendMetaProperty(tags, "og:type", openGraph.type);
+  appendMetaProperty(tags, "og:locale", (openGraph as any).locale);
+
+  const images = normalizeMetadataImages(openGraph.images ?? (openGraph as any).image, metadataBase);
+  for (const image of images) {
+    appendMetaProperty(tags, "og:image", image.url);
+    appendMetaProperty(tags, "og:image:width", image.width);
+    appendMetaProperty(tags, "og:image:height", image.height);
+    appendMetaProperty(tags, "og:image:alt", image.alt);
+    appendMetaProperty(tags, "og:image:type", image.type);
+  }
+}
+
+function appendTwitter(tags: string[], twitter: Metadata["twitter"], metadataBase?: string) {
+  if (!isRecord(twitter)) return;
+
+  appendMetaName(tags, "twitter:card", twitter.card);
+  appendMetaName(tags, "twitter:site", twitter.site);
+  appendMetaName(tags, "twitter:creator", twitter.creator);
+  appendMetaName(tags, "twitter:title", twitter.title);
+  appendMetaName(tags, "twitter:description", twitter.description);
+
+  for (const image of normalizeMetadataImages(twitter.images, metadataBase)) {
+    appendMetaName(tags, "twitter:image", image.url);
+    appendMetaName(tags, "twitter:image:alt", image.alt);
+  }
+}
+
+function appendIcons(tags: string[], icons: unknown, metadataBase?: string) {
+  if (!icons) return;
+
+  if (typeof icons === "string") {
+    appendLink(tags, "icon", resolveMetadataUrl(icons, metadataBase));
+    return;
+  }
+
+  if (!isRecord(icons)) return;
+
+  appendIconList(tags, "icon", icons.icon, metadataBase);
+  appendIconList(tags, "shortcut icon", icons.shortcut, metadataBase);
+  appendIconList(tags, "apple-touch-icon", icons.apple, metadataBase);
+}
+
+function appendIconList(tags: string[], rel: string, value: unknown, metadataBase?: string) {
+  for (const icon of normalizeArray(value)) {
+    if (typeof icon === "string") {
+      appendLink(tags, rel, resolveMetadataUrl(icon, metadataBase));
+      continue;
+    }
+
+    if (!isRecord(icon)) continue;
+    appendLink(tags, rel, resolveMetadataUrl(icon.url, metadataBase), {
+      sizes: icon.sizes,
+      type: icon.type,
+    });
+  }
+}
+
+function appendMetaName(tags: string[], name: string, content: unknown) {
+  const normalized = normalizeContent(content);
+  if (!normalized) return;
+  tags.push(`<meta name="${escapeAttribute(name)}" content="${escapeAttribute(normalized)}">`);
+}
+
+function appendMetaProperty(tags: string[], property: string, content: unknown) {
+  const normalized = normalizeContent(content);
+  if (!normalized) return;
+  tags.push(
+    `<meta property="${escapeAttribute(property)}" content="${escapeAttribute(normalized)}">`,
+  );
+}
+
+function appendLink(
+  tags: string[],
+  rel: string,
+  href: unknown,
+  attrs: Record<string, unknown> = {},
+) {
+  const normalizedHref = normalizeContent(href);
+  if (!normalizedHref) return;
+
+  const attrText = Object.entries(attrs)
+    .map(([key, value]) => {
+      const normalized = normalizeContent(value);
+      return normalized ? ` ${key}="${escapeAttribute(normalized)}"` : "";
+    })
+    .join("");
+
+  tags.push(
+    `<link rel="${escapeAttribute(rel)}" href="${escapeAttribute(normalizedHref)}"${attrText}>`,
+  );
+}
+
+function normalizeMetadataImages(
+  value: unknown,
+  metadataBase?: string,
+): Array<{
+  url: string;
+  width?: number;
+  height?: number;
+  alt?: string;
+  type?: string;
+}> {
+  return normalizeArray(value)
+    .map((item) => {
+      if (typeof item === "string") {
+        return { url: resolveMetadataUrl(item, metadataBase) || item };
+      }
+
+      if (!isRecord(item)) return null;
+      const rawUrl = item.url || item.src;
+      const url = resolveMetadataUrl(rawUrl, metadataBase);
+      if (!url) return null;
+
+      return {
+        url,
+        width: normalizeNumber(item.width),
+        height: normalizeNumber(item.height),
+        alt: typeof item.alt === "string" ? item.alt : undefined,
+        type: typeof item.type === "string" ? item.type : undefined,
+      };
+    })
+    .filter((item): item is NonNullable<typeof item> => item !== null);
+}
+
+function normalizeArray(value: unknown): unknown[] {
+  if (value == null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function hasMetadataImages(value: unknown): boolean {
+  return normalizeMetadataImages(value).length > 0;
+}
+
+function resolveMetadataTitle(title: Metadata["title"]): string | undefined {
+  if (typeof title === "string") return title;
+  if (isRecord(title)) {
+    return normalizeContent(title.default);
+  }
+  return undefined;
+}
+
+function normalizeKeywords(keywords: Metadata["keywords"]): string | undefined {
+  if (Array.isArray(keywords)) return keywords.filter(Boolean).join(", ");
+  return keywords;
+}
+
+function normalizeRobots(robots: Metadata["robots"]): string | undefined {
+  if (typeof robots === "string") return robots;
+  if (!isRecord(robots)) return undefined;
+
+  const values: string[] = [];
+  if (typeof robots.index === "boolean") values.push(robots.index ? "index" : "noindex");
+  if (typeof robots.follow === "boolean") values.push(robots.follow ? "follow" : "nofollow");
+  return values.join(", ") || undefined;
+}
+
+function resolveMetadataBase(metadata: MetadataRecord): string | undefined {
+  const base = metadata.metadataBase;
+  if (!base) return undefined;
+  return String(base);
+}
+
+function resolveMetadataUrl(value: unknown, metadataBase?: string): string | undefined {
+  const normalized = normalizeContent(value);
+  if (!normalized) return undefined;
+  if (!metadataBase) return normalized;
+
+  try {
+    return new URL(normalized, metadataBase).toString();
+  } catch {
+    return normalized;
+  }
+}
+
+function normalizeNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function normalizeContent(value: unknown): string | undefined {
+  if (value == null) return undefined;
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (value instanceof URL) return value.toString();
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function escapeText(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function escapeAttribute(value: string): string {
+  return escapeText(value).replace(/"/g, "&quot;");
+}

--- a/packages/farm/src/routing/route-manager.ts
+++ b/packages/farm/src/routing/route-manager.ts
@@ -28,12 +28,18 @@ import {
 import path from "path";
 import type { ViteDevServer } from "vite";
 import { getClientModuleMetadata } from "../utils/client-component";
+import type { MetadataImageKind } from "../metadata";
 
 interface RouteEntry {
   route: ParsedRoute;
   modulePath: string;
   pattern: string;
   source?: "file" | "programmatic";
+}
+
+interface MetadataImageEntry extends RouteEntry {
+  kind: MetadataImageKind;
+  fileName: "opengraph-image" | "twitter-image";
 }
 
 interface RedirectEntry {
@@ -51,6 +57,7 @@ export class RouteManager {
   private layouts: Map<string, RouteEntry> = new Map();
   private loadings: Map<string, RouteEntry> = new Map();
   private errors: Map<string, RouteEntry> = new Map();
+  private metadataImages: Map<string, MetadataImageEntry> = new Map();
   private redirects: Map<string, RedirectEntry> = new Map();
   private programmaticPages: Map<string, ProgrammaticPageRoute> = new Map();
   private programmaticLayouts: Map<string, ProgrammaticLayoutRoute> = new Map();
@@ -69,6 +76,7 @@ export class RouteManager {
     this.layouts.clear();
     this.loadings.clear();
     this.errors.clear();
+    this.metadataImages.clear();
     this.redirects.clear();
     this.programmaticPages.clear();
     this.programmaticLayouts.clear();
@@ -80,6 +88,10 @@ export class RouteManager {
     const layoutFiles = await safeGlobFiles("**/layout.{ts,tsx,js,jsx}", appDir);
     const loadingFiles = await safeGlobFiles("**/loading.{ts,tsx,js,jsx}", appDir);
     const errorFiles = await safeGlobFiles("**/error.{ts,tsx,js,jsx}", appDir);
+    const metadataImageFiles = await safeGlobFiles(
+      "**/{opengraph-image,twitter-image}.{ts,tsx,js,jsx}",
+      appDir,
+    );
 
     // Silent discovery - only log if verbose mode enabled
     if (process.env.FARM_VERBOSE) {
@@ -146,6 +158,34 @@ export class RouteManager {
         route,
         modulePath,
         pattern,
+        source: "file",
+      });
+    }
+
+    // Process metadata image files
+    for (const file of metadataImageFiles) {
+      const fileBase = path.basename(file).replace(/\.(tsx?|jsx?)$/, "");
+      const kind: MetadataImageKind = fileBase === "twitter-image" ? "twitter" : "opengraph";
+      const fileName = kind === "twitter" ? "twitter-image" : "opengraph-image";
+      const route = parseRoutePath(file);
+      const modulePath = path.join(appDir, file);
+      const pattern = this.createRoutePattern(route);
+      const key = `${kind}:${pattern}`;
+      const existing = this.metadataImages.get(key);
+
+      if (existing) {
+        throw new Error(
+          `Duplicate ${fileName} route "${pattern}". Found both ${existing.modulePath} and ${modulePath}. ` +
+            "Use only one metadata image file per route segment.",
+        );
+      }
+
+      this.metadataImages.set(key, {
+        route,
+        modulePath,
+        pattern,
+        kind,
+        fileName,
         source: "file",
       });
     }
@@ -218,6 +258,10 @@ export class RouteManager {
     return new Map(this.errors);
   }
 
+  getMetadataImages(): Map<string, MetadataImageEntry> {
+    return new Map(this.metadataImages);
+  }
+
   getRedirects(): ProgrammaticRedirectRoute[] {
     return Array.from(this.redirects.values()).map((entry) => entry.definition);
   }
@@ -263,6 +307,82 @@ export class RouteManager {
    */
   getMatchingError(pathname: string): RouteEntry | null {
     return this.findNearestBoundary(pathname, this.errors);
+  }
+
+  matchMetadataImage(pathname: string): {
+    image: MetadataImageEntry;
+    params: Record<string, string>;
+    pagePath: string;
+  } | null {
+    const normalizedPath = pathname === "/" ? "/" : pathname.replace(/\/$/, "");
+    const suffix = getMetadataImageSuffix(normalizedPath);
+    if (!suffix) return null;
+
+    const pagePath = normalizedPath.slice(0, -suffix.fileName.length - 1) || "/";
+
+    for (const imageEntry of this.metadataImages.values()) {
+      if (imageEntry.kind !== suffix.kind) continue;
+
+      const match = matchRoute(pagePath, imageEntry.route.segments);
+      if (!match.matches) continue;
+
+      return {
+        image: imageEntry,
+        params: match.params,
+        pagePath,
+      };
+    }
+
+    return null;
+  }
+
+  getMatchingMetadataImage(
+    pathname: string,
+    kind: MetadataImageKind,
+  ): {
+    image: MetadataImageEntry;
+    params: Record<string, string>;
+  } | null {
+    const normalizedPath = pathname === "/" ? "/" : pathname.replace(/\/$/, "");
+    const pathSegments = normalizedPath.split("/").filter(Boolean);
+    let bestMatch:
+      | {
+          image: MetadataImageEntry;
+          params: Record<string, string>;
+        }
+      | null = null;
+
+    for (const imageEntry of this.metadataImages.values()) {
+      if (imageEntry.kind !== kind) continue;
+      if (imageEntry.route.segments.length > pathSegments.length) continue;
+
+      const candidatePath =
+        imageEntry.route.segments.length === 0
+          ? "/"
+          : `/${pathSegments.slice(0, imageEntry.route.segments.length).join("/")}`;
+      const match = matchRoute(candidatePath, imageEntry.route.segments);
+      if (!match.matches) continue;
+
+      if (
+        !bestMatch ||
+        imageEntry.route.segments.length > bestMatch.image.route.segments.length
+      ) {
+        bestMatch = {
+          image: imageEntry,
+          params: match.params,
+        };
+      }
+    }
+
+    return bestMatch;
+  }
+
+  resolveMetadataImagePath(
+    image: MetadataImageEntry,
+    params: Record<string, string> = {},
+  ): string {
+    const pagePath = routeSegmentsToPath(image.route.segments, params);
+    return pagePath === "/" ? `/${image.fileName}` : `${pagePath}/${image.fileName}`;
   }
 
   /**
@@ -630,6 +750,49 @@ function interpolateRedirectDestination(
   }
 
   return result;
+}
+
+function getMetadataImageSuffix(pathname: string):
+  | {
+      kind: MetadataImageKind;
+      fileName: MetadataImageEntry["fileName"];
+    }
+  | null {
+  if (pathname === "/opengraph-image" || pathname.endsWith("/opengraph-image")) {
+    return { kind: "opengraph", fileName: "opengraph-image" };
+  }
+
+  if (pathname === "/twitter-image" || pathname.endsWith("/twitter-image")) {
+    return { kind: "twitter", fileName: "twitter-image" };
+  }
+
+  return null;
+}
+
+function routeSegmentsToPath(
+  segments: ParsedRoute["segments"],
+  params: Record<string, string>,
+): string {
+  if (segments.length === 0) return "/";
+
+  const parts: string[] = [];
+  for (const segment of segments) {
+    if (!segment.isDynamic) {
+      parts.push(segment.segment);
+      continue;
+    }
+
+    const value = params[segment.segment];
+    if (!value && segment.isOptional) continue;
+    if (!value) {
+      parts.push(`[${segment.segment}]`);
+      continue;
+    }
+
+    parts.push(...value.split("/").map((part) => encodeURIComponent(part)));
+  }
+
+  return `/${parts.join("/")}`;
 }
 
 function replaceAll(input: string, search: string, replacement: string): string {

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import { renderToPipeableStream } from "react-dom/server";
+import { renderToPipeableStream, renderToStaticMarkup } from "react-dom/server";
 import * as fs from "fs";
 import * as path from "path";
 import type {
@@ -23,6 +23,13 @@ import { _runWithCurrentRequest, createWebRequestFromFarmRequest } from "./reque
 import { createFarmCacheKey, getFarmDataCache, normalizeRevalidatePath } from "../cache";
 import { emitFarmEvent } from "../observability";
 import { getFarmRedirectError, isFarmNotFoundError, isFarmRedirectError } from "../navigation";
+import {
+  addMetadataImageReference,
+  mergeMetadata,
+  renderMetadataHead,
+  type FarmMetadataImageReference,
+  type MetadataImageKind,
+} from "../metadata";
 
 let cachedClerkProvider: {
   ClerkProvider: React.ComponentType<{ children?: React.ReactNode } & Record<string, unknown>>;
@@ -79,6 +86,27 @@ function createPreHydrationClickQueueScript(): string {
   return `<script>(function(){if(window.__FARM_PREHYDRATION_CLICK_QUEUE__)return;var queue=[];window.__FARM_PREHYDRATION_CLICK_QUEUE__=queue;window.__FARM_HYDRATED__=false;document.documentElement.dataset.farmHydrated="false";function isModified(event){return !!(event.metaKey||event.altKey||event.ctrlKey||event.shiftKey)}function closestQueuedTarget(target){while(target&&target!==document.documentElement){if(target.matches&&target.matches('button,[role="button"],input[type="button"],input[type="submit"],input[type="reset"]'))return target;target=target.parentElement}return null}document.addEventListener("click",function(event){if(window.__FARM_HYDRATED__)return;if(event.defaultPrevented||event.button!==0||isModified(event))return;var target=closestQueuedTarget(event.target);if(!target||target.closest&&target.closest("a[href]"))return;if(queue.some(function(item){return item.target===target}))return;queue.push({target:target,createdAt:Date.now()});event.preventDefault();event.stopImmediatePropagation()},true);})();</script>`;
 }
 
+function searchParamsToObject(
+  searchParams: URLSearchParams,
+): Record<string, string | string[] | undefined> {
+  const output: Record<string, string | string[] | undefined> = {};
+
+  searchParams.forEach((value, key) => {
+    const existing = output[key];
+    if (existing) {
+      if (Array.isArray(existing)) {
+        existing.push(value);
+      } else {
+        output[key] = [existing, value];
+      }
+    } else {
+      output[key] = value;
+    }
+  });
+
+  return output;
+}
+
 function createDocumentFooter(options: {
   suspenseRevealFallback: string;
   refreshPPR?: boolean;
@@ -99,6 +127,14 @@ function toMiddlewareMap(input: unknown): Map<string, any> {
     return new Map(Object.entries(input as Record<string, any>));
   }
   return new Map<string, any>();
+}
+
+function isWebResponse(value: unknown): value is Response {
+  return (
+    typeof Response !== "undefined" &&
+    value instanceof Response &&
+    typeof value.arrayBuffer === "function"
+  );
 }
 
 class FarmRouteErrorBoundary extends React.Component<
@@ -490,6 +526,18 @@ export class ServerRenderer {
       const url = new URL(req.url || "/", `http://${req.headers.host}`);
       pathname = url.pathname;
       emitFarmEvent({ type: "render.start", route: pathname, pathname });
+      searchParamsObject = searchParamsToObject(url.searchParams);
+
+      const metadataImageMatch = this.routeManager.matchMetadataImage(pathname);
+      if (metadataImageMatch) {
+        await this.renderMetadataImage(req, res, {
+          pathname,
+          searchParamsObject,
+          ...metadataImageMatch,
+        });
+        completeRender(res.statusCode || 200, pathname);
+        return;
+      }
 
       // Check for pre-rendered SSG page first (production only)
       if (process.env.NODE_ENV === "production") {
@@ -528,21 +576,6 @@ export class ServerRenderer {
 
       middlewareMap = toMiddlewareMap((req as any).__FARM_MIDDLEWARE_DATA__);
       pluginExposedContext = getRequestContextSnapshot(req as object, { exposedOnly: true });
-
-      searchParamsObject = {};
-      url.searchParams.forEach((value, key) => {
-        const existing = searchParamsObject[key];
-        if (existing) {
-          // If key already exists, convert to array
-          if (Array.isArray(existing)) {
-            existing.push(value);
-          } else {
-            searchParamsObject[key] = [existing, value];
-          }
-        } else {
-          searchParamsObject[key] = value;
-        }
-      });
 
       // Load route module
       const routeModule = await this.routeManager.loadRouteModule(route.modulePath);
@@ -663,20 +696,12 @@ export class ServerRenderer {
         layouts.map((layout) => this.routeManager.loadLayoutModule(layout.modulePath)),
       );
 
-      // Collect metadata from layouts and page (page metadata overrides layout metadata)
-      let mergedMetadata: Record<string, any> = {};
-
-      // First, collect metadata from layouts (in order, so nested layouts can override)
-      for (const layoutModule of layoutModules) {
-        if ((layoutModule as any).metadata) {
-          mergedMetadata = { ...mergedMetadata, ...(layoutModule as any).metadata };
-        }
-      }
-
-      // Then, page metadata overrides everything
-      if ((routeModule as any).metadata) {
-        mergedMetadata = { ...mergedMetadata, ...(routeModule as any).metadata };
-      }
+      const mergedMetadata = await this.resolveRouteMetadata({
+        layoutModules,
+        routeModule,
+        pageProps,
+        pathname,
+      });
 
       // Store metadata on request for renderWithSSR
       (req as any).__FARM_METADATA__ = mergedMetadata;
@@ -870,6 +895,158 @@ export class ServerRenderer {
     return wrapped;
   }
 
+  private async resolveRouteMetadata(options: {
+    layoutModules: Array<Record<string, any>>;
+    routeModule: RouteModule;
+    pageProps: PageProps;
+    pathname: string;
+  }): Promise<Record<string, any>> {
+    let metadata: Record<string, any> = {};
+
+    for (const layoutModule of options.layoutModules) {
+      metadata = mergeMetadata(metadata, layoutModule.metadata);
+      if (typeof layoutModule.generateMetadata === "function") {
+        metadata = mergeMetadata(
+          metadata,
+          await layoutModule.generateMetadata({ params: options.pageProps.params }),
+        );
+      }
+    }
+
+    metadata = mergeMetadata(metadata, (options.routeModule as any).metadata);
+    if (typeof (options.routeModule as any).generateMetadata === "function") {
+      metadata = mergeMetadata(
+        metadata,
+        await (options.routeModule as any).generateMetadata(options.pageProps),
+      );
+    }
+
+    for (const kind of ["opengraph", "twitter"] as const) {
+      const reference = await this.resolveMetadataImageReference(
+        kind,
+        options.pathname,
+      );
+      if (reference) {
+        metadata = addMetadataImageReference(metadata, reference);
+      }
+    }
+
+    return metadata;
+  }
+
+  private async resolveMetadataImageReference(
+    kind: MetadataImageKind,
+    pathname: string,
+  ): Promise<FarmMetadataImageReference | null> {
+    const match = this.routeManager.getMatchingMetadataImage(pathname, kind);
+    if (!match) return null;
+
+    const href = this.routeManager.resolveMetadataImagePath(match.image, match.params);
+    const reference: FarmMetadataImageReference = {
+      kind,
+      href,
+    };
+
+    try {
+      const imageModule = await this.routeManager.loadRouteModule(match.image.modulePath);
+      const size = (imageModule as any).size;
+      if (size && typeof size === "object") {
+        reference.width = typeof size.width === "number" ? size.width : undefined;
+        reference.height = typeof size.height === "number" ? size.height : undefined;
+      }
+      if (typeof (imageModule as any).alt === "string") {
+        reference.alt = (imageModule as any).alt;
+      }
+      if (typeof (imageModule as any).contentType === "string") {
+        reference.contentType = (imageModule as any).contentType;
+      }
+    } catch (error) {
+      logger.warn(`Failed to read ${kind} image metadata for ${pathname}: ${error}`);
+    }
+
+    return reference;
+  }
+
+  private async renderMetadataImage(
+    req: FarmRequest,
+    res: FarmResponse,
+    options: {
+      pathname: string;
+      pagePath: string;
+      params: Record<string, string>;
+      searchParamsObject: Record<string, string | string[] | undefined>;
+      image: { modulePath: string; kind: MetadataImageKind };
+    },
+  ): Promise<void> {
+    const imageModule = await this.routeManager.loadRouteModule(options.image.modulePath);
+    if (!imageModule.default) {
+      throw new Error(
+        `Metadata image module ${options.image.modulePath} does not export a default component or handler`,
+      );
+    }
+
+    const imageProps: PageProps = {
+      params: options.params,
+      searchParams: Promise.resolve(options.searchParamsObject),
+      path: options.pagePath,
+    };
+    const handlerResult =
+      typeof imageModule.default === "function"
+        ? await (imageModule.default as any)(imageProps)
+        : imageModule.default;
+
+    await this.writeMetadataImageResponse(req, res, handlerResult, imageModule);
+  }
+
+  private async writeMetadataImageResponse(
+    req: FarmRequest,
+    res: FarmResponse,
+    value: unknown,
+    imageModule: RouteModule,
+  ): Promise<void> {
+    if (isWebResponse(value)) {
+      res.statusCode = value.status;
+      value.headers.forEach((headerValue, key) => {
+        res.setHeader(key, headerValue);
+      });
+
+      if (req.method === "HEAD") {
+        res.end();
+        return;
+      }
+
+      const body = Buffer.from(await value.arrayBuffer());
+      res.write(body);
+      res.end();
+      return;
+    }
+
+    const contentType = (imageModule as any).contentType || "image/svg+xml; charset=utf-8";
+    let body: string | Buffer;
+
+    if (typeof value === "string") {
+      body = value;
+    } else if (value instanceof ArrayBuffer) {
+      body = Buffer.from(value);
+    } else if (ArrayBuffer.isView(value)) {
+      body = Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+    } else if (React.isValidElement(value)) {
+      body = renderToStaticMarkup(value);
+    } else {
+      throw new Error("Metadata image must return a Response, string, bytes, or React element");
+    }
+
+    res.statusCode = res.statusCode || 200;
+    res.setHeader("Content-Type", contentType);
+    res.setHeader("Cache-Control", "public, max-age=0, must-revalidate");
+    if (req.method === "HEAD") {
+      res.end();
+      return;
+    }
+    res.write(body);
+    res.end();
+  }
+
   private async renderRouteErrorBoundary(
     req: FarmRequest,
     res: FarmResponse,
@@ -1034,39 +1211,7 @@ window.__FARM_INTEGRATION_API_MANIFEST__ = ${JSON.stringify(getRegisteredIntegra
           ? createPreHydrationClickQueueScript()
           : "";
 
-      // Get metadata from request
-      const metadata = (req as any).__FARM_METADATA__ || {};
-      const title = metadata.title || "Farm.js App";
-      const description = metadata.description || "";
-
-      // Build meta tags
-      let metaTags = "";
-      if (description) {
-        metaTags += `\n  <meta name="description" content="${description.replace(/"/g, "&quot;")}">`;
-      }
-      if (metadata.keywords) {
-        const keywords = Array.isArray(metadata.keywords)
-          ? metadata.keywords.join(", ")
-          : metadata.keywords;
-        metaTags += `\n  <meta name="keywords" content="${keywords.replace(/"/g, "&quot;")}">`;
-      }
-      if (metadata.author) {
-        metaTags += `\n  <meta name="author" content="${metadata.author.replace(/"/g, "&quot;")}">`;
-      }
-      // Open Graph tags
-      if (metadata.openGraph) {
-        const og = metadata.openGraph;
-        if (og.title)
-          metaTags += `\n  <meta property="og:title" content="${og.title.replace(/"/g, "&quot;")}">`;
-        if (og.description)
-          metaTags += `\n  <meta property="og:description" content="${og.description.replace(/"/g, "&quot;")}">`;
-        if (og.image)
-          metaTags += `\n  <meta property="og:image" content="${og.image.replace(/"/g, "&quot;")}">`;
-        if (og.url)
-          metaTags += `\n  <meta property="og:url" content="${og.url.replace(/"/g, "&quot;")}">`;
-        if (og.type)
-          metaTags += `\n  <meta property="og:type" content="${og.type.replace(/"/g, "&quot;")}">`;
-      }
+      const { title, tags: metaTags } = renderMetadataHead((req as any).__FARM_METADATA__);
 
       // React 19: ensure root is a single DOM node so streaming starts early (avoids Fragment delay)
       const streamRoot = React.createElement("div", { style: { display: "contents" } }, element);

--- a/packages/farm/src/types.ts
+++ b/packages/farm/src/types.ts
@@ -328,9 +328,11 @@ export interface LayoutModule {
 }
 
 export interface Metadata {
+  metadataBase?: string | URL;
   title?: string | { default?: string; template?: string };
   description?: string;
   keywords?: string | string[];
+  author?: string;
   authors?: Array<{ name: string; url?: string }>;
   creator?: string;
   publisher?: string;
@@ -340,13 +342,25 @@ export interface Metadata {
     description?: string;
     url?: string;
     siteName?: string;
-    images?: Array<{
-      url: string;
-      width?: number;
-      height?: number;
-      alt?: string;
-    }>;
+    images?:
+      | string
+      | {
+          url: string;
+          width?: number;
+          height?: number;
+          alt?: string;
+          type?: string;
+        }
+      | Array<{
+          url: string;
+          width?: number;
+          height?: number;
+          alt?: string;
+          type?: string;
+        }>;
+    image?: string;
     type?: string;
+    locale?: string;
   };
   twitter?: {
     card?: "summary" | "summary_large_image" | "app" | "player";
@@ -354,8 +368,44 @@ export interface Metadata {
     creator?: string;
     title?: string;
     description?: string;
-    images?: string | string[];
+    images?:
+      | string
+      | {
+          url: string;
+          width?: number;
+          height?: number;
+          alt?: string;
+          type?: string;
+        }
+      | Array<
+          | string
+          | {
+              url: string;
+              width?: number;
+              height?: number;
+              alt?: string;
+              type?: string;
+            }
+        >;
   };
+  alternates?: {
+    canonical?: string;
+    languages?: Record<string, string>;
+  };
+  icons?:
+    | string
+    | {
+        icon?:
+          | string
+          | Array<string | { url: string; sizes?: string; type?: string }>;
+        shortcut?:
+          | string
+          | Array<string | { url: string; sizes?: string; type?: string }>;
+        apple?:
+          | string
+          | Array<string | { url: string; sizes?: string; type?: string }>;
+      };
+  manifest?: string;
 }
 
 export interface FarmRequest extends IncomingMessage {


### PR DESCRIPTION
## What changed
- Adds metadata image route discovery for `opengraph-image` and `twitter-image` files.
- Merges layout/page metadata and auto-injects Open Graph/Twitter image tags when image files exist.
- Serves matched metadata image endpoints through the renderer.
- Documents metadata and OG image file route behavior.

## Validation
- `corepack pnpm --filter @farmjs/core test -- src/__tests__/route-manager.test.ts src/__tests__/server-renderer-route-states.test.tsx`
- `corepack pnpm --filter @farmjs/core build`

Merge order: 1/6. Base: `feat/file-route-states`.