### PR TITLE
feat: add navigation pending ui

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -449,6 +449,29 @@ src/app/
 
 The group names are organizational. The URLs are still `/`, `/pricing`, and `/dashboard`.
 
+## Pending Navigation UI
+
+Use `useNavigation()` for global route-transition UI: top progress bars, disabled navigation buttons, optimistic shells, or app-wide busy indicators. It tracks SPA navigations started by `Link` and `navigateTo`.
+
+```tsx
+"use client";
+
+import { useNavigation } from "@farmjs/core/client";
+
+export function TopProgress() {
+  const navigation = useNavigation();
+
+  return (
+    <div
+      data-pending={navigation.pending}
+      aria-hidden={!navigation.pending}
+    />
+  );
+}
+```
+
+`navigation.state` is `"loading"` while route data is being fetched and returns to `"idle"` after the route is committed. `navigation.to` includes the target `pathname`, `search`, `hash`, and full `href`. Use route `loading.tsx` for segment-level Suspense fallbacks, and `useNavigation()` when the surrounding app shell should react to a navigation.
+
 ## Navigation workflow
 
 1. Add or rename route files.

--- a/packages/farm/src/__tests__/navigation-state.test.tsx
+++ b/packages/farm/src/__tests__/navigation-state.test.tsx
@@ -4,7 +4,7 @@
 import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useBlocker, useScrollRestoration } from "../client/router";
+import { useBlocker, useNavigation, useScrollRestoration } from "../client/router";
 import { navigateTo, pushState, readPageState, replaceState, SPARouter } from "../client/spa-router";
 
 describe("navigation state and blocking", () => {
@@ -41,6 +41,7 @@ describe("navigation state and blocking", () => {
     container.remove();
     root = undefined;
     sessionStorage.clear();
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
     vi.useRealTimers();
     delete (globalThis as any).IS_REACT_ACT_ENVIRONMENT;
@@ -95,6 +96,58 @@ describe("navigation state and blocking", () => {
     expect(window.confirm).toHaveBeenCalledWith("Leave this form?");
     expect(fetch).not.toHaveBeenCalled();
     expect(window.location.pathname).toBe("/");
+  });
+
+  it("exposes pending navigation state while a route transition loads", async () => {
+    let releaseFetch!: () => void;
+    vi.mocked(fetch).mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          releaseFetch = () => {
+            resolve(
+              new Response(
+                JSON.stringify({
+                  props: {},
+                  modulePath: "/src/app/reports/page.tsx",
+                  metadata: { title: "Reports" },
+                }),
+                { status: 200, headers: { "Content-Type": "application/json" } },
+              ),
+            );
+          };
+        }),
+    );
+    vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+
+    function App() {
+      const navigation = useNavigation();
+      return createElement(
+        "output",
+        null,
+        `${navigation.state}:${navigation.to?.pathname ?? ""}:${navigation.action ?? ""}`,
+      );
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    let navigationPromise!: Promise<void>;
+    await act(async () => {
+      navigationPromise = navigateTo("/reports");
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toBe("loading:/reports:push");
+
+    await act(async () => {
+      releaseFetch();
+      await navigationPromise;
+    });
+
+    expect(container.textContent).toBe("idle::");
+    expect(window.location.pathname).toBe("/reports");
   });
 
   it("restores registered nested scroll containers by key", () => {

--- a/packages/farm/src/client.ts
+++ b/packages/farm/src/client.ts
@@ -67,7 +67,13 @@ export type {
 
 // SPA Navigation exports
 export { Link } from "./client/link";
-export { useBlocker, usePageState, useRouter, useScrollRestoration } from "./client/router";
+export {
+  useBlocker,
+  useNavigation,
+  usePageState,
+  useRouter,
+  useScrollRestoration,
+} from "./client/router";
 export {
   navigateTo,
   prefetch,
@@ -97,4 +103,7 @@ export type {
   FarmNavigateOptions,
   FarmNavigationBlocker,
   FarmNavigationBlockerContext,
+  FarmNavigationListener,
+  FarmNavigationLocation,
+  FarmNavigationState,
 } from "./client/spa-router";

--- a/packages/farm/src/client/index.ts
+++ b/packages/farm/src/client/index.ts
@@ -19,7 +19,13 @@ export type {
   RouteOptionalParamValue,
   RouteParams,
 } from "./link";
-export { useBlocker, usePageState, useRouter, useScrollRestoration } from "./router";
+export {
+  useBlocker,
+  useNavigation,
+  usePageState,
+  useRouter,
+  useScrollRestoration,
+} from "./router";
 export type { UseBlockerOptions, UseBlockerReturn, UseRouterOptions } from "./router";
 export { buildFarmRoutePath, createFarmRouter, isFarmRouteActive, matchFarmRoute } from "../router";
 export type {
@@ -55,7 +61,10 @@ export {
 } from "./spa-router";
 export type {
   FarmNavigateOptions,
+  FarmNavigationListener,
+  FarmNavigationLocation,
   FarmNavigationBlocker,
   FarmNavigationBlockerContext,
+  FarmNavigationState,
 } from "./spa-router";
 export type { PageProps, LayoutProps, Metadata } from "../types";

--- a/packages/farm/src/client/router.ts
+++ b/packages/farm/src/client/router.ts
@@ -4,6 +4,7 @@ import {
   getRouter as getSPARouter,
   readPageState,
   type FarmNavigationBlockerContext,
+  type FarmNavigationState,
 } from "./spa-router";
 
 interface RouterState {
@@ -120,6 +121,19 @@ export function usePageState<TState = unknown>(): TState | null {
     handlePopState();
     window.addEventListener("popstate", handlePopState);
     return () => window.removeEventListener("popstate", handlePopState);
+  }, []);
+
+  return state;
+}
+
+export function useNavigation(): FarmNavigationState {
+  const [state, setState] = useState<FarmNavigationState>(() =>
+    getSPARouter().getNavigationState(),
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    return getSPARouter().subscribeNavigation(setState);
   }, []);
 
   return state;

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -49,7 +49,33 @@ export interface FarmNavigateOptions {
   state?: unknown;
 }
 
+export interface FarmNavigationLocation {
+  href: string;
+  pathname: string;
+  search: string;
+  hash: string;
+}
+
+export interface FarmNavigationState {
+  state: "idle" | "loading";
+  pending: boolean;
+  from: string | null;
+  to: FarmNavigationLocation | null;
+  action: FarmNavigationBlockerContext["action"] | null;
+  startedAt: number | null;
+}
+
+export type FarmNavigationListener = (state: FarmNavigationState) => void;
+
 const FARM_PAGE_STATE_KEY = "__farmPageState";
+const IDLE_NAVIGATION_STATE: FarmNavigationState = {
+  state: "idle",
+  pending: false,
+  from: null,
+  to: null,
+  action: null,
+  startedAt: null,
+};
 
 // Global router instance
 let routerInstance: SPARouter | null = null;
@@ -59,6 +85,8 @@ export class SPARouter {
   private prefetchingUrls: Set<string> = new Set();
   private observers: Map<Element, IntersectionObserver> = new Map();
   private blockers: Set<FarmNavigationBlocker> = new Set();
+  private navigationListeners: Set<FarmNavigationListener> = new Set();
+  private navigationState: FarmNavigationState = IDLE_NAVIGATION_STATE;
   private scrollElements: Map<string, HTMLElement> = new Map();
   private options: Required<RouterOptions>;
   private onNavigate?: (data: PageData) => Promise<void>;
@@ -125,6 +153,12 @@ export class SPARouter {
       this.saveScrollPosition(window.location.pathname);
     }
 
+    this.startNavigation({
+      from,
+      to: createNavigationLocation(url),
+      action: replace ? "replace" : "push",
+    });
+
     try {
       // Fetch page data (from cache or server)
       const pageData = await this.fetchPageData(fullPath);
@@ -174,7 +208,10 @@ export class SPARouter {
         // Restore previous scroll position if available
         this.restoreScrollPosition(pathname);
       }
+
+      this.finishNavigation();
     } catch (error) {
+      this.finishNavigation();
       console.error("[Farm.js] Navigation error:", error);
       // Fall back to full page navigation
       window.location.href = href;
@@ -252,6 +289,18 @@ export class SPARouter {
     };
   }
 
+  getNavigationState(): FarmNavigationState {
+    return this.navigationState;
+  }
+
+  subscribeNavigation(listener: FarmNavigationListener): () => void {
+    this.navigationListeners.add(listener);
+    listener(this.navigationState);
+    return () => {
+      this.navigationListeners.delete(listener);
+    };
+  }
+
   registerScrollElement(key: string, element: HTMLElement): () => void {
     this.scrollElements.set(key, element);
     this.restoreScrollElement(window.location.pathname, key, element);
@@ -319,6 +368,12 @@ export class SPARouter {
       return;
     }
 
+    this.startNavigation({
+      from: event.state?.path || path,
+      to: createNavigationLocation(new URL(window.location.href)),
+      action: "pop",
+    });
+
     try {
       const pageData = await this.fetchPageData(path);
 
@@ -336,7 +391,10 @@ export class SPARouter {
       if (this.options.scrollRestoration) {
         this.restoreScrollPosition(window.location.pathname);
       }
+
+      this.finishNavigation();
     } catch (error) {
+      this.finishNavigation();
       console.error("[Farm.js] Popstate navigation error:", error);
       // Reload the page as fallback
       window.location.reload();
@@ -365,6 +423,32 @@ export class SPARouter {
       }
     }
     return false;
+  }
+
+  private startNavigation(options: {
+    from: string;
+    to: FarmNavigationLocation;
+    action: FarmNavigationBlockerContext["action"];
+  }): void {
+    this.setNavigationState({
+      state: "loading",
+      pending: true,
+      from: options.from,
+      to: options.to,
+      action: options.action,
+      startedAt: Date.now(),
+    });
+  }
+
+  private finishNavigation(): void {
+    this.setNavigationState(IDLE_NAVIGATION_STATE);
+  }
+
+  private setNavigationState(state: FarmNavigationState): void {
+    this.navigationState = state;
+    for (const listener of this.navigationListeners) {
+      listener(state);
+    }
   }
 
   private writePageState(action: "push" | "replace", state: unknown, href?: string): void {
@@ -500,6 +584,15 @@ function createHistoryState(path: string, pageState: unknown, currentState?: unk
     ...base,
     path,
     [FARM_PAGE_STATE_KEY]: pageState,
+  };
+}
+
+function createNavigationLocation(url: URL): FarmNavigationLocation {
+  return {
+    href: url.href,
+    pathname: url.pathname,
+    search: url.search,
+    hash: url.hash,
   };
 }
 

--- a/packages/farm/types/client.d.ts
+++ b/packages/farm/types/client.d.ts
@@ -222,6 +222,24 @@ declare module "@farmjs/core/client" {
     state?: unknown;
   }
 
+  export interface FarmNavigationLocation {
+    href: string;
+    pathname: string;
+    search: string;
+    hash: string;
+  }
+
+  export interface FarmNavigationState {
+    state: "idle" | "loading";
+    pending: boolean;
+    from: string | null;
+    to: FarmNavigationLocation | null;
+    action: FarmNavigationBlockerContext["action"] | null;
+    startedAt: number | null;
+  }
+
+  export type FarmNavigationListener = (state: FarmNavigationState) => void;
+
   export interface UseRouterOptions {
     basePath?: string;
     routes?: Array<string | { path: string; name?: string; meta?: unknown }>;
@@ -253,6 +271,7 @@ declare module "@farmjs/core/client" {
   };
 
   export function usePageState<TState = unknown>(): TState | null;
+  export function useNavigation(): FarmNavigationState;
   export function useBlocker(options: UseBlockerOptions): UseBlockerReturn;
   export function useScrollRestoration<TElement extends HTMLElement = HTMLElement>(
     key: string,


### PR DESCRIPTION
## What changed
- Adds navigation state tracking to the SPA router.
- Exposes `useNavigation()` for global pending indicators.
- Keeps navigation state updated for push, replace, and pop navigations.
- Documents pending navigation UI usage.

## Validation
- `corepack pnpm --filter @farmjs/core test -- src/__tests__/navigation-state.test.tsx src/__tests__/link.test.tsx`
- `corepack pnpm --filter @farmjs/core build`

Merge order: 2/6. Base: `feat/metadata-og-routes`.