### PR TITLE
feat: add view transition navigation

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -472,6 +472,22 @@ export function TopProgress() {
 
 `navigation.state` is `"loading"` while route data is being fetched and returns to `"idle"` after the route is committed. `navigation.to` includes the target `pathname`, `search`, `hash`, and full `href`. Use route `loading.tsx` for segment-level Suspense fallbacks, and `useNavigation()` when the surrounding app shell should react to a navigation.
 
+## View Transitions
+
+Pass `viewTransition` to `Link` or `navigateTo` when a navigation should use the browser View Transitions API. Farm starts the transition after route data is ready and falls back to normal SPA navigation when the browser does not support it.
+
+```tsx
+import { Link, navigateTo } from "@farmjs/core/client";
+
+export function GalleryLink() {
+  return <Link href="/gallery" viewTransition>Gallery</Link>;
+}
+
+await navigateTo("/gallery", { viewTransition: true });
+```
+
+Use this for image galleries, dashboards that keep the same app shell, settings panes, and modal-to-page flows. Keep important loading states in `loading.tsx` or `useNavigation()`; view transitions are visual polish, not a loading boundary.
+
 ## Navigation workflow
 
 1. Add or rename route files.

--- a/packages/farm/src/__tests__/link.test.tsx
+++ b/packages/farm/src/__tests__/link.test.tsx
@@ -180,7 +180,11 @@ describe("Link", () => {
         el.dispatchEvent(e);
       });
       expect(e.defaultPrevented).toBe(true);
-      expect(navigate).toHaveBeenCalledWith("/dashboard", { replace: false, scroll: true });
+      expect(navigate).toHaveBeenCalledWith("/dashboard", {
+        replace: false,
+        scroll: true,
+        viewTransition: false,
+      });
     });
 
     it("replace and scroll false passed to navigate", () => {
@@ -190,7 +194,25 @@ describe("Link", () => {
       act(() => {
         el.dispatchEvent(new MouseEvent("click", { bubbles: true, button: 0, cancelable: true }));
       });
-      expect(navigate).toHaveBeenCalledWith("/settings", { replace: true, scroll: false });
+      expect(navigate).toHaveBeenCalledWith("/settings", {
+        replace: true,
+        scroll: false,
+        viewTransition: false,
+      });
+    });
+
+    it("passes viewTransition to navigate", () => {
+      const el = render(
+        createElement(Link, { href: "/gallery", viewTransition: true }),
+      ) as HTMLAnchorElement;
+      act(() => {
+        el.dispatchEvent(new MouseEvent("click", { bubbles: true, button: 0, cancelable: true }));
+      });
+      expect(navigate).toHaveBeenCalledWith("/gallery", {
+        replace: false,
+        scroll: true,
+        viewTransition: true,
+      });
     });
 
     it("renders and navigates with resolved route params, query, and hash", () => {
@@ -212,6 +234,7 @@ describe("Link", () => {
       expect(navigate).toHaveBeenCalledWith("/products/123?from=list&tab=info#reviews", {
         replace: false,
         scroll: true,
+        viewTransition: false,
       });
     });
 

--- a/packages/farm/src/__tests__/navigation-state.test.tsx
+++ b/packages/farm/src/__tests__/navigation-state.test.tsx
@@ -44,6 +44,7 @@ describe("navigation state and blocking", () => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     vi.useRealTimers();
+    delete (document as any).startViewTransition;
     delete (globalThis as any).IS_REACT_ACT_ENVIRONMENT;
   });
 
@@ -148,6 +149,35 @@ describe("navigation state and blocking", () => {
 
     expect(container.textContent).toBe("idle::");
     expect(window.location.pathname).toBe("/reports");
+  });
+
+  it("wraps route commits in a view transition when requested", async () => {
+    vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+    const updateCallbacks: Array<() => Promise<void>> = [];
+    const startViewTransition = vi.fn((callback: () => Promise<void>) => {
+      updateCallbacks.push(callback);
+      const updateCallbackDone = callback();
+      return {
+        updateCallbackDone,
+        finished: updateCallbackDone,
+      };
+    });
+    (document as any).startViewTransition = startViewTransition;
+
+    const router = new SPARouter({ scrollRestoration: false });
+    const onNavigate = vi.fn(async () => undefined);
+    router.setNavigationHandler(onNavigate);
+
+    await router.navigate("/gallery", { viewTransition: true, scroll: false });
+
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+    expect(updateCallbacks.length).toBe(1);
+    expect(onNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modulePath: "/src/app/page.tsx",
+      }),
+    );
+    expect(window.location.pathname).toBe("/gallery");
   });
 
   it("restores registered nested scroll containers by key", () => {

--- a/packages/farm/src/client.ts
+++ b/packages/farm/src/client.ts
@@ -106,4 +106,5 @@ export type {
   FarmNavigationListener,
   FarmNavigationLocation,
   FarmNavigationState,
+  FarmViewTransitionMode,
 } from "./client/spa-router";

--- a/packages/farm/src/client/index.ts
+++ b/packages/farm/src/client/index.ts
@@ -66,5 +66,6 @@ export type {
   FarmNavigationBlocker,
   FarmNavigationBlockerContext,
   FarmNavigationState,
+  FarmViewTransitionMode,
 } from "./spa-router";
 export type { PageProps, LayoutProps, Metadata } from "../types";

--- a/packages/farm/src/client/link.tsx
+++ b/packages/farm/src/client/link.tsx
@@ -8,6 +8,7 @@ import {
   type FarmRouterPathParam,
   type FarmRouterPathParams,
 } from "../router";
+import type { FarmViewTransitionMode } from "./spa-router";
 
 /**
  * Prefetch strategy (TanStack Router–style):
@@ -138,6 +139,8 @@ export type LinkProps<TRoute extends string = DefaultRouteHref> = Omit<
   replace?: boolean;
   /** Scroll to top after navigation (default: true) */
   scroll?: boolean;
+  /** Wrap this SPA navigation in a browser View Transition when supported. */
+  viewTransition?: FarmViewTransitionMode;
 };
 
 function isModifierEvent(e: React.MouseEvent): boolean {
@@ -152,7 +155,10 @@ function getRouter(): {
   prefetch(href: string): Promise<void>;
   observeForPrefetch(el: HTMLAnchorElement): void;
   unobserveForPrefetch(el: HTMLAnchorElement): void;
-  navigate(href: string, opts: { replace?: boolean; scroll?: boolean }): void;
+  navigate(
+    href: string,
+    opts: { replace?: boolean; scroll?: boolean; viewTransition?: FarmViewTransitionMode },
+  ): void;
 } | null {
   if (typeof window !== "undefined" && (window as any).__FARM_SPA_ROUTER__) {
     return (window as any).__FARM_SPA_ROUTER__;
@@ -197,6 +203,7 @@ function LinkInner<TRoute extends string = DefaultRouteHref>(
     prefetchDelay = 50,
     replace = false,
     scroll = true,
+    viewTransition = false,
     onClick,
     target,
     onMouseEnter,
@@ -352,14 +359,14 @@ function LinkInner<TRoute extends string = DefaultRouteHref>(
         event.preventDefault();
         const router = getRouter();
         if (router) {
-          router.navigate(resolvedHref, { replace, scroll });
+          router.navigate(resolvedHref, { replace, scroll, viewTransition });
         } else {
           if (replace) window.location.replace(resolvedHref);
           else window.location.href = resolvedHref;
         }
       }
     },
-    [resolvedHref, replace, scroll, target, isExternal, onClick],
+    [resolvedHref, replace, scroll, viewTransition, target, isExternal, onClick],
   );
 
   const setRefs = useCallback(

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -43,10 +43,13 @@ export type FarmNavigationBlocker = (
   context: FarmNavigationBlockerContext,
 ) => boolean | void | Promise<boolean | void>;
 
+export type FarmViewTransitionMode = boolean | "auto";
+
 export interface FarmNavigateOptions {
   replace?: boolean;
   scroll?: boolean;
   state?: unknown;
+  viewTransition?: FarmViewTransitionMode;
 }
 
 export interface FarmNavigationLocation {
@@ -127,7 +130,7 @@ export class SPARouter {
     href: string,
     options: FarmNavigateOptions = {},
   ): Promise<void> {
-    const { replace = false, scroll = true, state } = options;
+    const { replace = false, scroll = true, state, viewTransition = false } = options;
 
     // Parse the URL
     const url = new URL(href, window.location.origin);
@@ -163,51 +166,17 @@ export class SPARouter {
       // Fetch page data (from cache or server)
       const pageData = await this.fetchPageData(fullPath);
 
-      // Update browser history
-      const historyState = createHistoryState(fullPath, state);
-      if (replace) {
-        window.history.replaceState(historyState, "", fullPath);
-      } else {
-        window.history.pushState(historyState, "", fullPath);
-      }
-
-      // Update document title
-      if (pageData.metadata?.title) {
-        document.title = pageData.metadata.title;
-      }
-
-      // Update meta description
-      if (pageData.metadata?.description) {
-        let metaDesc = document.querySelector('meta[name="description"]');
-        if (!metaDesc) {
-          metaDesc = document.createElement("meta");
-          metaDesc.setAttribute("name", "description");
-          document.head.appendChild(metaDesc);
-        }
-        metaDesc.setAttribute("content", pageData.metadata.description);
-      }
-
-      // Call the navigation handler to update React
-      if (this.onNavigate) {
-        await this.onNavigate(pageData);
-      }
-
-      // Handle scroll
-      if (scroll) {
-        if (url.hash) {
-          // Scroll to hash
-          const element = document.querySelector(url.hash);
-          if (element) {
-            element.scrollIntoView();
-          }
-        } else {
-          // Scroll to top
-          window.scrollTo(0, 0);
-        }
-      } else if (this.options.scrollRestoration) {
-        // Restore previous scroll position if available
-        this.restoreScrollPosition(pathname);
-      }
+      await this.runViewTransition(viewTransition, () =>
+        this.commitNavigation({
+          fullPath,
+          pageData,
+          pathname,
+          replace,
+          scroll,
+          state,
+          url,
+        }),
+      );
 
       this.finishNavigation();
     } catch (error) {
@@ -317,6 +286,77 @@ export class SPARouter {
 
   replaceState(state: unknown, href?: string): void {
     this.writePageState("replace", state, href);
+  }
+
+  private async commitNavigation(options: {
+    fullPath: string;
+    pageData: PageData;
+    pathname: string;
+    replace: boolean;
+    scroll: boolean;
+    state: unknown;
+    url: URL;
+  }): Promise<void> {
+    const historyState = createHistoryState(options.fullPath, options.state);
+    if (options.replace) {
+      window.history.replaceState(historyState, "", options.fullPath);
+    } else {
+      window.history.pushState(historyState, "", options.fullPath);
+    }
+
+    if (options.pageData.metadata?.title) {
+      document.title = options.pageData.metadata.title;
+    }
+
+    if (options.pageData.metadata?.description) {
+      let metaDesc = document.querySelector('meta[name="description"]');
+      if (!metaDesc) {
+        metaDesc = document.createElement("meta");
+        metaDesc.setAttribute("name", "description");
+        document.head.appendChild(metaDesc);
+      }
+      metaDesc.setAttribute("content", options.pageData.metadata.description);
+    }
+
+    if (this.onNavigate) {
+      await this.onNavigate(options.pageData);
+    }
+
+    if (options.scroll) {
+      if (options.url.hash) {
+        const element = document.querySelector(options.url.hash);
+        if (element) {
+          element.scrollIntoView();
+        }
+      } else {
+        window.scrollTo(0, 0);
+      }
+    } else if (this.options.scrollRestoration) {
+      this.restoreScrollPosition(options.pathname);
+    }
+  }
+
+  private async runViewTransition(
+    mode: FarmViewTransitionMode,
+    callback: () => Promise<void>,
+  ): Promise<void> {
+    if (!mode || typeof document === "undefined") {
+      await callback();
+      return;
+    }
+
+    const startViewTransition = (document as any).startViewTransition;
+    if (typeof startViewTransition !== "function") {
+      await callback();
+      return;
+    }
+
+    const transition = startViewTransition(() => callback());
+    const updateDone = transition?.updateCallbackDone || transition?.ready;
+    if (updateDone && typeof updateDone.then === "function") {
+      await updateDone;
+    }
+    transition?.finished?.catch?.(() => undefined);
   }
 
   /**

--- a/packages/farm/types/client.d.ts
+++ b/packages/farm/types/client.d.ts
@@ -198,6 +198,7 @@ declare module "@farmjs/core/client" {
     prefetchDelay?: number;
     replace?: boolean;
     scroll?: boolean;
+    viewTransition?: FarmViewTransitionMode;
   };
 
   export type LinkComponent = <TRoute extends string = DefaultRouteHref>(
@@ -216,10 +217,13 @@ declare module "@farmjs/core/client" {
     context: FarmNavigationBlockerContext,
   ) => boolean | void | Promise<boolean | void>;
 
+  export type FarmViewTransitionMode = boolean | "auto";
+
   export interface FarmNavigateOptions {
     replace?: boolean;
     scroll?: boolean;
     state?: unknown;
+    viewTransition?: FarmViewTransitionMode;
   }
 
   export interface FarmNavigationLocation {


### PR DESCRIPTION
## What changed
- Adds `viewTransition` navigation support to router options and `<Link>`.
- Uses `document.startViewTransition` when available and falls back cleanly when unsupported.
- Exports the view transition option types through the client entrypoints.
- Documents link-level view transition usage.

## Validation
- `corepack pnpm --filter @farmjs/core test -- src/__tests__/navigation-state.test.tsx src/__tests__/link.test.tsx`
- `corepack pnpm --filter @farmjs/core build`

Merge order: 3/6. Base: `feat/navigation-pending-ui`.