### PR TITLE
feat: add optimistic form actions

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -100,6 +100,53 @@ const checkout = await apiClient.billing.checkout.post({
 
 If an integration operation is marked server-only, call it from `api`, not `apiClient`.
 
+## Server Function Form Actions
+
+`createServerFn` pairs with `useServerFn` when a mutation is naturally a form action. Use `optimistic` to show the next UI state immediately, then let the server result replace it when the action completes.
+
+```tsx
+"use client";
+
+import { useServerFn } from "@farmjs/core/server-fn/client";
+import { createServerFn } from "@farmjs/core/server-fn";
+import { z } from "zod";
+
+export const addTodo = createServerFn({
+  input: z.object({
+    title: z.string().min(1),
+  }),
+  async handler({ input }) {
+    return {
+      todos: await db.todo.create({ data: input }),
+    };
+  },
+});
+
+export function TodoForm() {
+  const action = useServerFn(addTodo, {
+    initialResult: { todos: [] },
+    rollbackOnError: true,
+    optimistic({ current, formData }) {
+      return {
+        todos: [
+          ...(current?.todos ?? []),
+          { id: "draft", title: String(formData?.get("title") ?? "") },
+        ],
+      };
+    },
+  });
+
+  return (
+    <form action={action.formAction}>
+      <input name="title" />
+      <button disabled={action.pending}>Add</button>
+    </form>
+  );
+}
+```
+
+The optimistic callback receives the raw input, `formData` for form submissions, and the current result. Return `undefined` when a submission should not change the optimistic result. Use `rollbackOnError` for reversible UI state; keep authorization and validation on the server function itself.
+
 ## Production notes
 
 - Keep generated API types committed or generated during CI.

--- a/packages/farm/src/__tests__/server-fn-client.test.tsx
+++ b/packages/farm/src/__tests__/server-fn-client.test.tsx
@@ -168,6 +168,127 @@ describe("useServerFn", () => {
     expect(onError).toHaveBeenCalledWith(action.error);
   });
 
+  it("applies optimistic results for form actions before the server settles", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const saveMessage = createServerFn({
+      input: z.object({
+        message: z.string().min(1),
+      }),
+      async handler({ input }) {
+        await gate;
+        return {
+          messages: [`Saved:${input.message}`],
+        };
+      },
+    });
+
+    let action!: UseServerFnReturn<{ message: string }, { messages: string[] }>;
+
+    function App() {
+      action = useServerFn(saveMessage, {
+        initialResult: { messages: ["Existing"] },
+        optimistic({ current, formData }) {
+          return {
+            messages: [
+              ...(current?.messages ?? []),
+              `Draft:${String(formData?.get("message") ?? "")}`,
+            ],
+          };
+        },
+      });
+
+      return createElement("output", null, action.result?.messages.join("|") ?? action.status);
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    const formData = new FormData();
+    formData.set("message", "Hello");
+
+    let promise!: Promise<void>;
+    await act(async () => {
+      promise = action.formAction(formData);
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toBe("Existing|Draft:Hello");
+
+    await act(async () => {
+      release();
+      await promise;
+    });
+
+    expect(container.textContent).toBe("Saved:Hello");
+  });
+
+  it("rolls optimistic form results back when the server action fails", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const saveMessage = createServerFn({
+      input: z.object({
+        message: z.string().min(1),
+      }),
+      async handler() {
+        await gate;
+        throw new Error("save failed");
+      },
+    });
+
+    let action!: UseServerFnReturn<{ message: string }, { messages: string[] }>;
+
+    function App() {
+      action = useServerFn(saveMessage, {
+        initialResult: { messages: ["Existing"] },
+        rollbackOnError: true,
+        optimistic({ current, formData }) {
+          return {
+            messages: [
+              ...(current?.messages ?? []),
+              `Draft:${String(formData?.get("message") ?? "")}`,
+            ],
+          };
+        },
+      });
+
+      return createElement(
+        "output",
+        null,
+        `${action.status}:${action.result?.messages.join("|") ?? ""}:${action.error?.message ?? ""}`,
+      );
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    const formData = new FormData();
+    formData.set("message", "Hello");
+
+    let promise!: Promise<void>;
+    await act(async () => {
+      promise = action.formAction(formData);
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toBe("pending:Existing|Draft:Hello:");
+
+    await act(async () => {
+      release();
+      await promise;
+    });
+
+    expect(container.textContent).toBe("error:Existing:save failed");
+  });
+
   it("resets action state and ignores stale submissions", async () => {
     let release!: () => void;
     const gate = new Promise<void>((resolve) => {

--- a/packages/farm/src/server-fn-client.ts
+++ b/packages/farm/src/server-fn-client.ts
@@ -9,10 +9,22 @@ export type ServerFnSubmit<TInput, TResult> = [unknown] extends [TInput]
   ? (input?: TInput | FormData) => Promise<TResult>
   : (input: TInput | FormData) => Promise<TResult>;
 
-export type UseServerFnOptions<TResult, TError extends Error = Error> = {
+export type ServerFnOptimisticContext<TInput, TResult> = {
+  input: TInput | FormData | undefined;
+  formData?: FormData;
+  current: TResult | null;
+};
+
+export type UseServerFnOptions<
+  TResult,
+  TError extends Error = Error,
+  TInput = unknown,
+> = {
   initialResult?: TResult | null;
   resetOnSubmit?: boolean;
   throwOnFormError?: boolean;
+  optimistic?: (context: ServerFnOptimisticContext<TInput, TResult>) => TResult | null | undefined;
+  rollbackOnError?: boolean;
   onSuccess?: (result: TResult) => void;
   onError?: (error: TError) => void;
   onSettled?: (result: TResult | null, error: TError | null) => void;
@@ -36,23 +48,41 @@ type ServerFnActionState<TResult, TError extends Error> = {
 };
 
 type ServerFnActionCallbacks<TResult, TError extends Error> = Pick<
-  UseServerFnOptions<TResult, TError>,
+  UseServerFnOptions<TResult, TError, unknown>,
   "onError" | "onSettled" | "onSuccess" | "throwOnFormError"
 >;
 
 export function useServerFn<TInput, TResult, TError extends Error = Error>(
   serverFn: ServerFn<TInput, TResult>,
-  options: UseServerFnOptions<TResult, TError> = {},
+  options: UseServerFnOptions<TResult, TError, TInput> = {},
 ): UseServerFnReturn<TInput, TResult, TError> {
   const { initialResult = null, resetOnSubmit = true } = options;
   const callbacksRef = useRef<ServerFnActionCallbacks<TResult, TError>>({});
   const requestIdRef = useRef(0);
-  const [state, setState] = useState<ServerFnActionState<TResult, TError>>({
+  const initialState: ServerFnActionState<TResult, TError> = {
     pendingCount: 0,
     status: "idle",
     result: initialResult,
     error: null,
-  });
+  };
+  const stateRef = useRef<ServerFnActionState<TResult, TError>>(initialState);
+  const [state, setState] = useState<ServerFnActionState<TResult, TError>>(initialState);
+  const setActionState = useCallback(
+    (
+      value:
+        | ServerFnActionState<TResult, TError>
+        | ((
+            current: ServerFnActionState<TResult, TError>,
+          ) => ServerFnActionState<TResult, TError>),
+    ) => {
+      setState((current) => {
+        const next = typeof value === "function" ? value(current) : value;
+        stateRef.current = next;
+        return next;
+      });
+    },
+    [],
+  );
 
   callbacksRef.current = {
     onError: options.onError,
@@ -64,11 +94,23 @@ export function useServerFn<TInput, TResult, TError extends Error = Error>(
   const submit = useCallback(
     async (input?: TInput | FormData) => {
       const requestId = ++requestIdRef.current;
+      const formData = isFormData(input) ? input : undefined;
+      const previousResult = stateRef.current.result;
+      const optimisticResult = options.optimistic?.({
+        input,
+        formData,
+        current: previousResult,
+      });
+      const hasOptimisticResult = optimisticResult !== undefined;
 
-      setState((current) => ({
+      setActionState((current) => ({
         pendingCount: current.pendingCount + 1,
         status: "pending",
-        result: resetOnSubmit ? null : current.result,
+        result: hasOptimisticResult
+          ? optimisticResult
+          : resetOnSubmit
+            ? null
+            : current.result,
         error: null,
       }));
 
@@ -76,7 +118,7 @@ export function useServerFn<TInput, TResult, TError extends Error = Error>(
         const result = await serverFn(input as TInput | FormData);
         const isLatestRequest = requestId === requestIdRef.current;
 
-        setState((current) => {
+        setActionState((current) => {
           const pendingCount = Math.max(0, current.pendingCount - 1);
 
           if (!isLatestRequest) {
@@ -105,7 +147,7 @@ export function useServerFn<TInput, TResult, TError extends Error = Error>(
         const error = normalizeServerFnError(cause) as TError;
         const isLatestRequest = requestId === requestIdRef.current;
 
-        setState((current) => {
+        setActionState((current) => {
           const pendingCount = Math.max(0, current.pendingCount - 1);
 
           if (!isLatestRequest) {
@@ -119,7 +161,12 @@ export function useServerFn<TInput, TResult, TError extends Error = Error>(
           return {
             pendingCount,
             status: pendingCount > 0 ? "pending" : "error",
-            result: resetOnSubmit ? null : current.result,
+            result:
+              hasOptimisticResult && options.rollbackOnError
+                ? previousResult
+                : resetOnSubmit
+                  ? null
+                  : current.result,
             error,
           };
         });
@@ -132,7 +179,7 @@ export function useServerFn<TInput, TResult, TError extends Error = Error>(
         throw error;
       }
     },
-    [resetOnSubmit, serverFn],
+    [options.optimistic, options.rollbackOnError, resetOnSubmit, serverFn, setActionState],
   ) as ServerFnSubmit<TInput, TResult>;
 
   const formAction = useCallback(
@@ -150,13 +197,13 @@ export function useServerFn<TInput, TResult, TError extends Error = Error>(
 
   const reset = useCallback(() => {
     requestIdRef.current += 1;
-    setState({
+    setActionState({
       pendingCount: 0,
       status: "idle",
       result: initialResult,
       error: null,
     });
-  }, [initialResult]);
+  }, [initialResult, setActionState]);
 
   return useMemo(
     () => ({
@@ -178,4 +225,17 @@ function normalizeServerFnError(error: unknown) {
   const normalized = new Error(typeof error === "string" ? error : "Server function failed");
   (normalized as Error & { cause?: unknown }).cause = error;
   return normalized;
+}
+
+function isFormData(value: unknown): value is FormData {
+  if (!value || typeof value !== "object") return false;
+
+  if (typeof FormData !== "undefined" && value instanceof FormData) {
+    return true;
+  }
+
+  return (
+    Object.prototype.toString.call(value) === "[object FormData]" &&
+    typeof (value as { entries?: unknown }).entries === "function"
+  );
 }


### PR DESCRIPTION
## What changed
- Adds optimistic result support to `useServerFn` actions.
- Supports rollback on latest action failure while keeping successful actions stable.
- Extends server function form-action docs with optimistic and rollback examples.
- Covers optimistic success and error rollback behavior in tests.

## Validation
- `corepack pnpm --filter @farmjs/core test -- src/__tests__/server-fn-client.test.tsx src/__tests__/server-fn.test.ts`
- `corepack pnpm --filter @farmjs/core build`

Merge order: 4/6. Base: `feat/view-transitions`.