### PR TITLE
feat: add chunk error recovery

### DIFF
--- a/docs/src/app/docs/deployment/page.md
+++ b/docs/src/app/docs/deployment/page.md
@@ -83,6 +83,12 @@ export default defineFarmConfig({
 
 The same shape lives in `examples/deployment-presets` so the preset behavior can be tested from a real app.
 
+## Chunk error recovery
+
+Farm installs client-side chunk recovery automatically in the generated browser runtime. When the browser fails to load a JavaScript or CSS chunk after a deployment, Farm reloads the current page once so the app can pick up the newest asset manifest.
+
+This is meant for stale deploy assets, where a user has an older HTML page open while the server now points at newer chunks. Farm stores a short session guard per page before reloading, so repeated chunk failures do not trap the user in a reload loop. Ordinary runtime errors are left alone and should still be handled with route `error.tsx`, programmatic `error` components, monitoring, and tests.
+
 ## Self-host a Farm app
 
 Use `target: "node"` when you want to run the app on your own server, VPS, container, or platform that expects a long-running Node process. Farm builds the app with Nitro's Node server preset.

--- a/packages/farm/src/__tests__/chunk-recovery.test.ts
+++ b/packages/farm/src/__tests__/chunk-recovery.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { installChunkErrorRecovery, isChunkLoadError } from "../client/chunk-recovery";
+
+class MemoryStorage implements Pick<Storage, "getItem" | "setItem" | "removeItem"> {
+  private values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+}
+
+describe("chunk error recovery", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("detects dynamic import and bundler chunk load failures", () => {
+    expect(
+      isChunkLoadError(
+        new TypeError("Failed to fetch dynamically imported module: /assets/page.abc123.js"),
+      ),
+    ).toBe(true);
+    expect(
+      isChunkLoadError({
+        name: "ChunkLoadError",
+        message: "Loading chunk dashboard failed.",
+      }),
+    ).toBe(true);
+    expect(isChunkLoadError(new Error("User profile request failed"))).toBe(false);
+  });
+
+  it("detects script and css resource load failures", () => {
+    const script = document.createElement("script");
+    script.src = "/assets/app.abc123.js";
+    const scriptEvent = new Event("error");
+    Object.defineProperty(scriptEvent, "target", { value: script });
+
+    const link = document.createElement("link");
+    link.href = "/assets/app.abc123.css";
+    const linkEvent = new Event("error");
+    Object.defineProperty(linkEvent, "target", { value: link });
+
+    expect(isChunkLoadError(scriptEvent)).toBe(true);
+    expect(isChunkLoadError(linkEvent)).toBe(true);
+  });
+
+  it("reloads once for a chunk failure on the current page", () => {
+    const storage = new MemoryStorage();
+    const reload = vi.fn();
+    const onRecover = vi.fn();
+    const cleanup = installChunkErrorRecovery({
+      storage,
+      reload,
+      onRecover,
+      now: () => 1000,
+      location: {
+        pathname: "/products",
+        search: "?tab=reviews",
+        reload,
+      } as any,
+    });
+
+    const event = new Event("unhandledrejection") as PromiseRejectionEvent;
+    Object.defineProperty(event, "reason", {
+      value: new TypeError("Failed to fetch dynamically imported module"),
+    });
+
+    window.dispatchEvent(event);
+    window.dispatchEvent(event);
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(onRecover).toHaveBeenCalledTimes(1);
+    expect(storage.getItem("farm:chunk-recovery:/products?tab=reviews")).toBe("1000");
+
+    cleanup();
+  });
+
+  it("allows recovery again after the guard window expires", () => {
+    const storage = new MemoryStorage();
+    const reload = vi.fn();
+    let now = 1000;
+    const cleanup = installChunkErrorRecovery({
+      storage,
+      reload,
+      now: () => now,
+      maxAgeMs: 10,
+      storageKey: "farm:test-chunk",
+    });
+    const event = new Event("unhandledrejection") as PromiseRejectionEvent;
+    Object.defineProperty(event, "reason", {
+      value: { code: "CSS_CHUNK_LOAD_FAILED" },
+    });
+
+    window.dispatchEvent(event);
+    now = 1011;
+    window.dispatchEvent(event);
+
+    expect(reload).toHaveBeenCalledTimes(2);
+    expect(storage.getItem("farm:test-chunk")).toBe("1011");
+
+    cleanup();
+  });
+});

--- a/packages/farm/src/client.ts
+++ b/packages/farm/src/client.ts
@@ -81,6 +81,7 @@ export {
   readPageState,
   replaceState,
 } from "./client/spa-router";
+export { installChunkErrorRecovery, isChunkLoadError } from "./client/chunk-recovery";
 export type {
   LinkProps,
   PrefetchBehavior,
@@ -94,6 +95,7 @@ export type {
   RouteOptionalParamValue,
   RouteParams,
 } from "./client/link";
+export type { FarmChunkRecoveryOptions } from "./client/chunk-recovery";
 export type {
   UseBlockerOptions,
   UseBlockerReturn,

--- a/packages/farm/src/client/chunk-recovery.ts
+++ b/packages/farm/src/client/chunk-recovery.ts
@@ -1,0 +1,214 @@
+"use client";
+
+export interface FarmChunkRecoveryOptions {
+  /**
+   * How long a page is considered already recovered before another chunk
+   * failure may trigger a reload. Defaults to 30 seconds.
+   */
+  maxAgeMs?: number;
+  /**
+   * Override the storage key. Mostly useful for tests and embedded runtimes.
+   */
+  storageKey?: string;
+  /**
+   * Called right before Farm reloads the page.
+   */
+  onRecover?: (error: unknown) => void;
+  /**
+   * Test hooks for browser globals.
+   */
+  reload?: () => void;
+  storage?: Pick<Storage, "getItem" | "setItem" | "removeItem"> | null;
+  location?: Pick<Location, "pathname" | "search" | "reload">;
+  now?: () => number;
+}
+
+const DEFAULT_MAX_AGE_MS = 30_000;
+const STORAGE_KEY_PREFIX = "farm:chunk-recovery:";
+const CHUNK_ERROR_PATTERNS = [
+  /ChunkLoadError/i,
+  /Loading chunk [\w-]+ failed/i,
+  /Loading CSS chunk [\w-]+ failed/i,
+  /CSS_CHUNK_LOAD_FAILED/i,
+  /failed to fetch dynamically imported module/i,
+  /error loading dynamically imported module/i,
+  /importing a module script failed/i,
+  /unable to preload CSS/i,
+  /module script failed/i,
+];
+
+export function isChunkLoadError(errorLike: unknown): boolean {
+  const values = collectErrorText(errorLike);
+  if (values.some((value) => CHUNK_ERROR_PATTERNS.some((pattern) => pattern.test(value)))) {
+    return true;
+  }
+
+  const targetUrl = getEventTargetAssetUrl(errorLike);
+  return Boolean(targetUrl && /\.(?:m?js|css)(?:[?#].*)?$/i.test(targetUrl));
+}
+
+export function installChunkErrorRecovery(
+  options: FarmChunkRecoveryOptions = {},
+): () => void {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+
+  const recover = (errorLike: unknown) => {
+    if (!isChunkLoadError(errorLike)) {
+      return;
+    }
+    if (!markRecovered(options)) {
+      return;
+    }
+
+    options.onRecover?.(errorLike);
+    getReload(options)();
+  };
+
+  const onError = (event: Event | ErrorEvent) => {
+    recover(getErrorEventPayload(event));
+  };
+  const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+    recover(event.reason);
+  };
+
+  window.addEventListener("error", onError, true);
+  window.addEventListener("unhandledrejection", onUnhandledRejection);
+
+  return () => {
+    window.removeEventListener("error", onError, true);
+    window.removeEventListener("unhandledrejection", onUnhandledRejection);
+  };
+}
+
+function markRecovered(options: FarmChunkRecoveryOptions): boolean {
+  const now = getNow(options);
+  const maxAgeMs = options.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+  const storage = getStorage(options);
+  const key = getStorageKey(options);
+
+  if (!storage) {
+    return true;
+  }
+
+  try {
+    const previous = Number(storage.getItem(key));
+    if (Number.isFinite(previous) && previous > 0 && now - previous < maxAgeMs) {
+      return false;
+    }
+    storage.setItem(key, String(now));
+    return true;
+  } catch {
+    return true;
+  }
+}
+
+function getErrorEventPayload(event: Event | ErrorEvent): unknown {
+  if ("error" in event && event.error) {
+    return event.error;
+  }
+  if ("message" in event && event.message) {
+    return event.message;
+  }
+  return event;
+}
+
+function collectErrorText(value: unknown, seen = new Set<unknown>()): string[] {
+  if (value == null || seen.has(value)) {
+    return [];
+  }
+  seen.add(value);
+
+  if (typeof value === "string") {
+    return [value];
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return [String(value)];
+  }
+  if (typeof value !== "object") {
+    return [];
+  }
+
+  const record = value as Record<string, unknown>;
+  const output: string[] = [];
+
+  for (const key of ["name", "message", "code", "type", "request", "src", "href"]) {
+    const candidate = record[key];
+    if (typeof candidate === "string") {
+      output.push(candidate);
+    }
+  }
+
+  if ("reason" in record) {
+    output.push(...collectErrorText(record.reason, seen));
+  }
+  if ("error" in record) {
+    output.push(...collectErrorText(record.error, seen));
+  }
+
+  return output;
+}
+
+function getEventTargetAssetUrl(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+
+  const target = (value as Event).target as
+    | (EventTarget & { src?: string; href?: string; tagName?: string })
+    | null
+    | undefined;
+  if (!target || typeof target !== "object") {
+    return undefined;
+  }
+
+  const tagName = typeof target.tagName === "string" ? target.tagName.toLowerCase() : "";
+  if (tagName !== "script" && tagName !== "link") {
+    return undefined;
+  }
+
+  return typeof target.src === "string" && target.src
+    ? target.src
+    : typeof target.href === "string" && target.href
+      ? target.href
+      : undefined;
+}
+
+function getStorage(options: FarmChunkRecoveryOptions) {
+  if ("storage" in options) {
+    return options.storage;
+  }
+
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function getStorageKey(options: FarmChunkRecoveryOptions): string {
+  if (options.storageKey) {
+    return options.storageKey;
+  }
+
+  const location = getLocation(options);
+  return `${STORAGE_KEY_PREFIX}${location.pathname}${location.search}`;
+}
+
+function getLocation(options: FarmChunkRecoveryOptions) {
+  return options.location ?? window.location;
+}
+
+function getReload(options: FarmChunkRecoveryOptions): () => void {
+  if (options.reload) {
+    return options.reload;
+  }
+
+  const location = getLocation(options);
+  return () => location.reload();
+}
+
+function getNow(options: FarmChunkRecoveryOptions): number {
+  return options.now ? options.now() : Date.now();
+}

--- a/packages/farm/src/client/index.ts
+++ b/packages/farm/src/client/index.ts
@@ -59,6 +59,8 @@ export {
   replaceState,
   SPARouter,
 } from "./spa-router";
+export { installChunkErrorRecovery, isChunkLoadError } from "./chunk-recovery";
+export type { FarmChunkRecoveryOptions } from "./chunk-recovery";
 export type {
   FarmNavigateOptions,
   FarmNavigationListener,

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -598,6 +598,9 @@ ${cssImport}
 ${layoutImports}
 import React from "react";
 import { createRoot, hydrateRoot } from "react-dom/client";
+import { installChunkErrorRecovery } from "@farmjs/core/client";
+
+installChunkErrorRecovery();
 
 // SPA Router for server-rendered pages (HTML swap)
 const spaRouter = {
@@ -774,8 +777,11 @@ ${cssImport}
 ${layoutImports}
 import React from "react";
 import { createRoot, hydrateRoot } from "react-dom/client";
+import { installChunkErrorRecovery } from "@farmjs/core/client";
 
 ${imports.join("\n")}
+
+installChunkErrorRecovery();
 
 // Client component routes
 const clientRoutes = [

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -1753,6 +1753,7 @@ function generateClientCode(
   return `
 import React from 'react'
 import { hydrateRoot, createRoot } from 'react-dom/client'
+import { installChunkErrorRecovery } from '@farmjs/core/client'
 ${providerImportBlock}
 
 // ⭐ Farm.js SPA Client Runtime (TanStack Start pattern)
@@ -1763,6 +1764,8 @@ ${providerImportBlock}
 window.__FARM_REACT__ = React;
 const integrationProviders = ${JSON.stringify(integrationProviders)};
 const integrationDocumentNavigationMatchers = ${JSON.stringify(documentNavigationMatchers)};
+
+installChunkErrorRecovery();
 
 let reactRoot = null;
 

--- a/packages/farm/types/client.d.ts
+++ b/packages/farm/types/client.d.ts
@@ -244,6 +244,16 @@ declare module "@farmjs/core/client" {
 
   export type FarmNavigationListener = (state: FarmNavigationState) => void;
 
+  export interface FarmChunkRecoveryOptions {
+    maxAgeMs?: number;
+    storageKey?: string;
+    onRecover?: (error: unknown) => void;
+    reload?: () => void;
+    storage?: Pick<Storage, "getItem" | "setItem" | "removeItem"> | null;
+    location?: Pick<Location, "pathname" | "search" | "reload">;
+    now?: () => number;
+  }
+
   export interface UseRouterOptions {
     basePath?: string;
     routes?: Array<string | { path: string; name?: string; meta?: unknown }>;
@@ -285,6 +295,8 @@ declare module "@farmjs/core/client" {
   export function pushState<TState>(state: TState, href?: string): void;
   export function replaceState<TState>(state: TState, href?: string): void;
   export function readPageState<TState = unknown>(): TState | null;
+  export function isChunkLoadError(errorLike: unknown): boolean;
+  export function installChunkErrorRecovery(options?: FarmChunkRecoveryOptions): () => void;
 
   export interface APIClientOptions {
     baseURL?: string;


### PR DESCRIPTION
## What changed
- Adds automatic client-side chunk error recovery for stale JavaScript and CSS assets.
- Installs recovery in the generated Vite and Nitro browser runtimes.
- Guards reloads with session storage so repeated chunk failures do not create a reload loop.
- Documents deployment behavior and validates dynamic import/resource failures.

## Validation
- `corepack pnpm --filter @farmjs/core test -- src/__tests__/chunk-recovery.test.ts src/__tests__/navigation-state.test.tsx src/__tests__/link.test.tsx`
- `corepack pnpm --filter @farmjs/core build`

Merge order: 5/6. Base: `feat/optimistic-form-actions`.