### PR TITLE
feat: add route context

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -216,6 +216,39 @@ export const ProductRoute = createRoute("/products/[id]", {
 
 Cache keys are part of your data security model. If data depends on the current user, role, tenant, locale, or draft mode, include that value in `key` or avoid caching that route. Route cache invalidation improves freshness, but API routes and server functions still need their own authorization checks.
 
+## Route context
+
+Use `context` in `farm.config.ts` for request-scoped dependencies that guards and route data need: sessions, tenants, feature flags, or database clients. The value is available to programmatic route `guard`, `data.before`, `data.main`, cache key functions, and `data.after`.
+
+```ts
+import { defineFarmConfig } from "@farmjs/core";
+import { db } from "./src/db";
+import { getSession } from "./src/session";
+
+export default defineFarmConfig({
+  context: async ({ request }) => ({
+    session: await getSession(request),
+    db,
+  }),
+});
+```
+
+Add a module augmentation when you want autocomplete in route files:
+
+```ts
+import type { db } from "./src/db";
+import type { getSession } from "./src/session";
+
+declare module "@farmjs/core" {
+  interface FarmAppContext {
+    session: Awaited<ReturnType<typeof getSession>>;
+    db: typeof db;
+  }
+}
+```
+
+Route context is server-only. Farm passes it to guards and data hooks without serializing it into browser props, so keep raw database clients and secrets in `context` and return only safe page data from `data.main`.
+
 ## Route guards
 
 Use `guard` when a route should be allowed or blocked before route data loads. Guards run after params/search validation and before `data.before` or `data.main`.
@@ -225,16 +258,14 @@ import { createRoute, redirect } from "@farmjs/core";
 
 export const DashboardRoute = createRoute("/dashboard", {
   guard: async ({ context }) => {
-    const session = context?.data.get("session");
-
-    if (!session?.user) {
+    if (!context.session.user) {
       redirect("/login");
     }
   },
 
   data: {
-    async main() {
-      return { stats: await getDashboardStats() };
+    async main({ context }) {
+      return { stats: await getDashboardStats(context.db) };
     },
   },
 

--- a/packages/farm/src/__tests__/programmatic-routes.test.ts
+++ b/packages/farm/src/__tests__/programmatic-routes.test.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getFarmDataCache, invalidate, revalidatePath } from "../cache";
 import { notFound, redirect } from "../navigation";
+import { FARM_ROUTE_CONTEXT_SYMBOL, resolveFarmRouteContext, withFarmRouteContext } from "../route-context";
 import { createRoute, createRouteModuleFromProgrammaticPage, defineRoutes } from "../routes";
 import { RouteManager } from "../routing/route-manager";
 import type { FarmConfig } from "../types";
@@ -379,6 +380,101 @@ describe("programmatic routes", () => {
       }),
     ).resolves.toMatchObject({ data: { ok: true } });
     expect(main).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes app route context to guards and data without leaking it to components", async () => {
+    function DashboardPage() {
+      return null;
+    }
+
+    const appContext = {
+      session: { user: { id: "user-1" } },
+      db: { label: "database" },
+    };
+    const pluginContext = { data: new Map([["traceId", "trace-1"]]) };
+    const guard = vi.fn(({ context, pluginContext: exposedPlugins }: any) => {
+      expect(context).toBe(appContext);
+      expect(exposedPlugins).toBe(pluginContext);
+      if (!context.session.user) redirect("/login");
+    });
+    const before = vi.fn(({ context }: any) => ({
+      userId: context.session.user.id,
+    }));
+    const key = vi.fn(({ context, before }: any) => ["dashboard", context.session.user.id, before.userId]);
+    const main = vi.fn(({ context, before }: any) => ({
+      userId: before.userId,
+      db: context.db.label,
+    }));
+    const after = vi.fn(({ context, data }: any) => {
+      expect(context).toBe(appContext);
+      expect(data.userId).toBe("user-1");
+    });
+
+    const DashboardRoute = createRoute("/dashboard", {
+      guard,
+      data: {
+        key,
+        before,
+        main,
+        after,
+      },
+      component: DashboardPage as any,
+    });
+    const routeModule = createRouteModuleFromProgrammaticPageForTest(DashboardRoute);
+    const props = withFarmRouteContext(
+      {
+        params: {},
+        searchParams: Promise.resolve({}),
+        path: "/dashboard",
+        context: pluginContext,
+      },
+      appContext,
+    );
+
+    const resolvedProps = await (routeModule as any).__farmResolveRouteProps(props);
+
+    expect(resolvedProps.data).toEqual({ userId: "user-1", db: "database" });
+    expect(resolvedProps.context).toBe(pluginContext);
+    expect(Object.getOwnPropertySymbols(resolvedProps)).not.toContain(FARM_ROUTE_CONTEXT_SYMBOL);
+    expect(guard).toHaveBeenCalledTimes(1);
+    expect(before).toHaveBeenCalledTimes(1);
+    expect(key).toHaveBeenCalledTimes(1);
+    expect(main).toHaveBeenCalledTimes(1);
+    expect(after).toHaveBeenCalledTimes(1);
+
+    const Page = routeModule.default as any;
+    const element = (await Page(props)) as any;
+
+    expect(element.props.context).toBe(pluginContext);
+    expect(element.props.context).not.toBe(appContext);
+    expect(Object.getOwnPropertySymbols(element.props)).not.toContain(FARM_ROUTE_CONTEXT_SYMBOL);
+  });
+
+  it("resolves app route context from config", async () => {
+    const request = new Request("https://example.com/products/123?tab=info");
+    const context = await resolveFarmRouteContext(
+      {
+        context: ({ request, params, search, path }) => ({
+          host: new URL(request.url).host,
+          id: params.id,
+          tab: search.tab,
+          path,
+        }),
+      },
+      {
+        request,
+        params: { id: "123" },
+        search: { tab: "info" },
+        path: "/products/123",
+      },
+    );
+
+    expect(context).toEqual({
+      host: "example.com",
+      id: "123",
+      tab: "info",
+      path: "/products/123",
+    });
   });
 
   it("supports pending, error, and notFound components on programmatic routes", async () => {

--- a/packages/farm/src/app.ts
+++ b/packages/farm/src/app.ts
@@ -99,6 +99,7 @@ export class FarmApp {
       workflows: resolveWorkflowsConfig(config.workflows),
       middleware: config.middleware || {},
       routeRules: normalizeRouteRules(config.routeRules),
+      context: config.context || (() => undefined),
       docs: isResolvedDocsConfig(config.docs) ? config.docs : defaultDocsConfig,
       md: resolveMarkdownConfig(config.md),
       mdx: resolveMdxConfig(config.mdx),

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -185,6 +185,7 @@ export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite" | "docs" | "
 
   middleware?: FarmMiddlewareConfig;
   routeRules?: FarmRouteRules;
+  context?: BaseFarmConfig["context"];
 
   notFound?: NotFoundConfig;
 
@@ -649,6 +650,7 @@ export async function resolveConfig(
     },
     middleware: userConfig.middleware || {},
     notFound: userConfig.notFound || {},
+    context: userConfig.context || (() => undefined),
     output: userConfig.output || "standalone",
     distDir: userConfig.distDir || ".farm",
     generateBuildId: userConfig.generateBuildId || (() => `build-${Date.now()}`),

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -61,6 +61,7 @@ export type {
   ProgrammaticRouteGuardContext,
   ProgrammaticRoutePendingComponentProps,
   ProgrammaticRouteBuilder,
+  ProgrammaticRouteContext,
   ProgrammaticRouteDefinition,
   ProgrammaticRouteFactory,
   ProgrammaticRouteManifest,

--- a/packages/farm/src/nitro/server-entry.ts
+++ b/packages/farm/src/nitro/server-entry.ts
@@ -10,6 +10,7 @@ import type { APIRouteManager } from "../api/route-manager";
 import type { ServerRenderer } from "../server/renderer";
 import { getClientModuleMetadata } from "../utils/client-component";
 import { setEnv } from "../env";
+import { withFarmRouteContext } from "../route-context";
 
 // Managers will be available via globalThis.__FARM_REGISTRY__
 // They are injected via Nitro hooks (ready hook) or set during build
@@ -161,12 +162,23 @@ async function defaultHandler({
       targetUrl.searchParams.forEach((value, key) => {
         searchParams[key] = value;
       });
+      const routeContext = sr
+        ? await sr.resolveRouteContext({
+            request,
+            params,
+            search: searchParams,
+            path: targetUrl.pathname,
+          })
+        : undefined;
       const routeProps = await parseRouteModuleProps(routeModule, {
-        props: {
-          params,
-          searchParams: Promise.resolve(searchParams),
-          path: targetUrl.pathname,
-        },
+        props: withFarmRouteContext(
+          {
+            params,
+            searchParams: Promise.resolve(searchParams),
+            path: targetUrl.pathname,
+          },
+          routeContext,
+        ),
         search: searchParams,
         routePath: route.pattern,
       });

--- a/packages/farm/src/route-context.ts
+++ b/packages/farm/src/route-context.ts
@@ -1,0 +1,43 @@
+import type { FarmConfig, FarmContextFactoryInput } from "./types";
+
+export const FARM_ROUTE_CONTEXT_SYMBOL = Symbol.for("farm.routeContext");
+
+export type FarmRouteContextCarrier<TContext = unknown> = {
+  [FARM_ROUTE_CONTEXT_SYMBOL]?: TContext;
+};
+
+export async function resolveFarmRouteContext(
+  config: Pick<FarmConfig, "context">,
+  input: FarmContextFactoryInput,
+): Promise<unknown> {
+  if (typeof config.context !== "function") {
+    return undefined;
+  }
+
+  return config.context(input);
+}
+
+export function withFarmRouteContext<TProps extends object, TContext>(
+  props: TProps,
+  context: TContext | undefined,
+): TProps & FarmRouteContextCarrier<TContext> {
+  if (context === undefined) {
+    return props as TProps & FarmRouteContextCarrier<TContext>;
+  }
+
+  Object.defineProperty(props, FARM_ROUTE_CONTEXT_SYMBOL, {
+    value: context,
+    enumerable: false,
+    configurable: true,
+  });
+
+  return props as TProps & FarmRouteContextCarrier<TContext>;
+}
+
+export function getFarmRouteContext<TContext = unknown>(props: unknown): TContext | undefined {
+  if (!props || typeof props !== "object") {
+    return undefined;
+  }
+
+  return (props as FarmRouteContextCarrier<TContext>)[FARM_ROUTE_CONTEXT_SYMBOL];
+}

--- a/packages/farm/src/routes.ts
+++ b/packages/farm/src/routes.ts
@@ -6,7 +6,16 @@ import {
   type FarmCacheOptions,
   type RouteDataCacheKey,
 } from "./cache";
-import type { LayoutProps, Metadata, PageProps, ParsedRoute, RouteModule } from "./types";
+import { getFarmRouteContext } from "./route-context";
+import type {
+  FarmAppContext,
+  LayoutProps,
+  Metadata,
+  PageProps,
+  ParsedRoute,
+  PluginContextProps,
+  RouteModule,
+} from "./types";
 
 export type ProgrammaticRouteRenderMode = "static" | "dynamic";
 export type ProgrammaticRouteMethod =
@@ -48,6 +57,9 @@ export type ProgrammaticRouteDataStaleTime =
   | `${number}s`
   | `${number}m`
   | `${number}h`;
+export type ProgrammaticRouteContext = keyof FarmAppContext extends never
+  ? unknown
+  : FarmAppContext;
 
 export type ProgrammaticRouteComponentProps<
   TParams = ProgrammaticRouteParamsFallback,
@@ -62,44 +74,54 @@ export type ProgrammaticRouteComponentProps<
 export type ProgrammaticRouteDataContext<
   TParams = ProgrammaticRouteParamsFallback,
   TSearch = ProgrammaticRouteSearchFallback,
-> = ProgrammaticRouteComponentProps<TParams, TSearch>;
+  TContext = ProgrammaticRouteContext,
+> = Omit<ProgrammaticRouteComponentProps<TParams, TSearch>, "context"> & {
+  context: TContext;
+  pluginContext?: PluginContextProps;
+};
 
 export type ProgrammaticRouteDataCacheContext<
   TParams = ProgrammaticRouteParamsFallback,
   TSearch = ProgrammaticRouteSearchFallback,
   TBefore = unknown,
-> = ProgrammaticRouteDataContext<TParams, TSearch> & { before: TBefore };
+  TContext = ProgrammaticRouteContext,
+> = ProgrammaticRouteDataContext<TParams, TSearch, TContext> & { before: TBefore };
 
 export type ProgrammaticRouteGuardContext<
   TParams = ProgrammaticRouteParamsFallback,
   TSearch = ProgrammaticRouteSearchFallback,
-> = ProgrammaticRouteDataContext<TParams, TSearch>;
+  TContext = ProgrammaticRouteContext,
+> = ProgrammaticRouteDataContext<TParams, TSearch, TContext>;
 
 export type ProgrammaticRouteGuard<
   TParams = ProgrammaticRouteParamsFallback,
   TSearch = ProgrammaticRouteSearchFallback,
-> = (context: ProgrammaticRouteGuardContext<TParams, TSearch>) => ProgrammaticRouteMaybePromise<void>;
+  TContext = ProgrammaticRouteContext,
+> = (
+  context: ProgrammaticRouteGuardContext<TParams, TSearch, TContext>,
+) => ProgrammaticRouteMaybePromise<void>;
 
 export type ProgrammaticRouteErrorComponentProps<
   TParams = ProgrammaticRouteParamsFallback,
   TSearch = ProgrammaticRouteSearchFallback,
-> = Partial<ProgrammaticRouteDataContext<TParams, TSearch>> & {
+> = Partial<ProgrammaticRouteComponentProps<TParams, TSearch>> & {
   error: unknown;
 };
 
 export type ProgrammaticRoutePendingComponentProps<
   TParams = ProgrammaticRouteParamsFallback,
   TSearch = ProgrammaticRouteSearchFallback,
-> = Partial<ProgrammaticRouteDataContext<TParams, TSearch>>;
+> = Partial<ProgrammaticRouteComponentProps<TParams, TSearch>>;
 
 export type ProgrammaticRouteDataCacheKeys<
   TParams = ProgrammaticRouteParamsFallback,
   TSearch = ProgrammaticRouteSearchFallback,
   TBefore = unknown,
+  TContext = ProgrammaticRouteContext,
 > =
   | readonly string[]
   | ((
-      context: ProgrammaticRouteDataCacheContext<TParams, TSearch, TBefore>,
+      context: ProgrammaticRouteDataCacheContext<TParams, TSearch, TBefore, TContext>,
     ) => ProgrammaticRouteMaybePromise<readonly string[]>);
 
 export interface ProgrammaticRouteDataHooks<
@@ -107,21 +129,22 @@ export interface ProgrammaticRouteDataHooks<
   TSearch = ProgrammaticRouteSearchFallback,
   TBefore = unknown,
   TData = unknown,
+  TContext = ProgrammaticRouteContext,
 > {
   key?: (
-    context: ProgrammaticRouteDataCacheContext<TParams, TSearch, TBefore>,
+    context: ProgrammaticRouteDataCacheContext<TParams, TSearch, TBefore, TContext>,
   ) => ProgrammaticRouteMaybePromise<RouteDataCacheKey | null | undefined>;
   staleTime?: ProgrammaticRouteDataStaleTime;
-  tags?: ProgrammaticRouteDataCacheKeys<TParams, TSearch, TBefore>;
-  paths?: ProgrammaticRouteDataCacheKeys<TParams, TSearch, TBefore>;
+  tags?: ProgrammaticRouteDataCacheKeys<TParams, TSearch, TBefore, TContext>;
+  paths?: ProgrammaticRouteDataCacheKeys<TParams, TSearch, TBefore, TContext>;
   before?: (
-    context: ProgrammaticRouteDataContext<TParams, TSearch>,
+    context: ProgrammaticRouteDataContext<TParams, TSearch, TContext>,
   ) => ProgrammaticRouteMaybePromise<TBefore>;
   main: (
-    context: ProgrammaticRouteDataContext<TParams, TSearch> & { before: TBefore },
+    context: ProgrammaticRouteDataContext<TParams, TSearch, TContext> & { before: TBefore },
   ) => ProgrammaticRouteMaybePromise<TData>;
   after?: (
-    context: ProgrammaticRouteDataContext<TParams, TSearch> & {
+    context: ProgrammaticRouteDataContext<TParams, TSearch, TContext> & {
       before: TBefore;
       data: TData;
     },
@@ -136,16 +159,17 @@ export type InferProgrammaticRouteData<TDataHooks> =
 export interface ProgrammaticPageRoute<
   TParams = ProgrammaticRouteParamsFallback,
   TSearch = ProgrammaticRouteSearchFallback,
-  TDataHooks extends ProgrammaticRouteDataHooks<TParams, TSearch, any, any> | undefined =
-    | ProgrammaticRouteDataHooks<TParams, TSearch, any, any>
+  TDataHooks extends ProgrammaticRouteDataHooks<TParams, TSearch, any, any, any> | undefined =
+    | ProgrammaticRouteDataHooks<TParams, TSearch, any, any, any>
     | undefined,
+  TContext = ProgrammaticRouteContext,
 > {
   kind: "page";
   path: string;
   component: ComponentType<any>;
   params?: ProgrammaticRouteSchema<TParams>;
   search?: ProgrammaticRouteSchema<TSearch>;
-  guard?: ProgrammaticRouteGuard<TParams, TSearch>;
+  guard?: ProgrammaticRouteGuard<TParams, TSearch, TContext>;
   data?: TDataHooks;
   pending?: ComponentType<ProgrammaticRoutePendingComponentProps<TParams, TSearch>>;
   error?: ComponentType<ProgrammaticRouteErrorComponentProps<TParams, TSearch>>;
@@ -224,6 +248,7 @@ export type CreateRouteOptions<
     | ProgrammaticRouteDataHooks<
         InferProgrammaticRouteSchema<TParamsSchema, ProgrammaticRouteParamsFallback>,
         InferProgrammaticRouteSchema<TSearchSchema, ProgrammaticRouteSearchFallback>,
+        any,
         any,
         any
       >
@@ -331,6 +356,7 @@ export function createRoute<
     | ProgrammaticRouteDataHooks<
         InferProgrammaticRouteSchema<TParamsSchema, ProgrammaticRouteParamsFallback>,
         InferProgrammaticRouteSchema<TSearchSchema, ProgrammaticRouteSearchFallback>,
+        any,
         any,
         any
       >
@@ -636,31 +662,38 @@ async function resolveProgrammaticRouteProps(
   const rawSearch = await props.searchParams;
   const params = parseProgrammaticSchema(route.params, props.params, "params", route.path);
   const search = parseProgrammaticSchema(route.search, rawSearch, "search", route.path);
+  const routeContextValue = getFarmRouteContext(props);
+  const pluginContext = props.context;
   const baseProps = {
     ...props,
     params,
     search,
     searchParams: Promise.resolve(search),
   };
+  const routeContextProps = {
+    ...baseProps,
+    context: routeContextValue,
+    pluginContext,
+  };
 
   if (route.guard) {
-    await route.guard(baseProps as any);
+    await route.guard(routeContextProps as any);
   }
 
   if (!route.data) {
     return markProgrammaticRoutePropsResolved(baseProps);
   }
 
-  const before = route.data.before ? await route.data.before(baseProps as any) : undefined;
+  const before = route.data.before ? await route.data.before(routeContextProps as any) : undefined;
   const dataContext = {
-    ...(baseProps as any),
+    ...(routeContextProps as any),
     before,
   };
   const data = await resolveProgrammaticRouteData(route, route.data, dataContext);
 
   if (route.data.after) {
     await route.data.after({
-      ...(baseProps as any),
+      ...(routeContextProps as any),
       before,
       data,
     });

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -30,6 +30,7 @@ import {
   type FarmMetadataImageReference,
   type MetadataImageKind,
 } from "../metadata";
+import { resolveFarmRouteContext, withFarmRouteContext } from "../route-context";
 
 let cachedClerkProvider: {
   ClerkProvider: React.ComponentType<{ children?: React.ReactNode } & Record<string, unknown>>;
@@ -250,6 +251,16 @@ export class ServerRenderer {
     this.config = config;
     this.routeManager = routeManager;
     this.loadSSGManifest();
+  }
+
+  async resolveRouteContext(input: {
+    request: Request;
+    rawRequest?: FarmRequest;
+    params: Record<string, string>;
+    search: Record<string, string | string[] | undefined>;
+    path: string;
+  }): Promise<unknown> {
+    return resolveFarmRouteContext(this.config, input);
   }
 
   /**
@@ -576,6 +587,14 @@ export class ServerRenderer {
 
       middlewareMap = toMiddlewareMap((req as any).__FARM_MIDDLEWARE_DATA__);
       pluginExposedContext = getRequestContextSnapshot(req as object, { exposedOnly: true });
+      const currentRequest = createWebRequestFromFarmRequest(req);
+      const routeContext = await this.resolveRouteContext({
+        request: currentRequest,
+        rawRequest: req,
+        params,
+        search: searchParamsObject,
+        path: pathname,
+      });
 
       // Load route module
       const routeModule = await this.routeManager.loadRouteModule(route.modulePath);
@@ -585,13 +604,16 @@ export class ServerRenderer {
       }
 
       // Create page props with searchParams as plain object and middleware data
-      const rawPageProps: PageProps = {
-        params,
-        searchParams: Promise.resolve(searchParamsObject),
-        path: pathname,
-        middleware: middlewareMap.size > 0 ? { data: middlewareMap } : undefined,
-        context: pluginExposedContext.size > 0 ? { data: pluginExposedContext } : undefined,
-      } as PageProps & { search: unknown };
+      const rawPageProps: PageProps = withFarmRouteContext(
+        {
+          params,
+          searchParams: Promise.resolve(searchParamsObject),
+          path: pathname,
+          middleware: middlewareMap.size > 0 ? { data: middlewareMap } : undefined,
+          context: pluginExposedContext.size > 0 ? { data: pluginExposedContext } : undefined,
+        } as PageProps & { search: unknown },
+        routeContext,
+      );
       const pageProps = await parseRouteModuleProps(routeModule, {
         props: rawPageProps,
         search: searchParamsObject,
@@ -708,7 +730,6 @@ export class ServerRenderer {
 
       // Get middleware data for AsyncLocalStorage
       const middlewareDataForContext = middlewareMap;
-      const currentRequest = createWebRequestFromFarmRequest(req);
 
       await _runWithMiddlewareData(middlewareDataForContext, async () => {
         await _runWithCurrentRequest(currentRequest, async () => {

--- a/packages/farm/src/types.ts
+++ b/packages/farm/src/types.ts
@@ -54,6 +54,20 @@ export interface ResolvedFarmMigrationsConfig {
   commands: FarmMigrationCommand[];
 }
 
+export interface FarmContextFactoryInput {
+  request: Request;
+  rawRequest?: FarmRequest;
+  params: Record<string, string>;
+  search: Record<string, string | string[] | undefined>;
+  path: string;
+}
+
+export type FarmContextFactory<TContext = unknown> = (
+  input: FarmContextFactoryInput,
+) => TContext | Promise<TContext>;
+
+export interface FarmAppContext {}
+
 export interface FarmConfig {
   root?: string;
   srcDir?: string;
@@ -88,6 +102,7 @@ export interface FarmConfig {
   env?: FarmEnvConfig<any, any> | ResolvedFarmEnv;
   middleware?: FarmMiddlewareConfig;
   routeRules?: FarmRouteRules;
+  context?: FarmContextFactory<any>;
   docs?: FarmDocsUserConfig | FarmDocsResolvedConfig;
   md?: FarmMarkdownUserConfig | FarmMarkdownResolvedConfig | boolean;
   mdx?: FarmMdxUserConfig | FarmMdxResolvedConfig;

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -40,6 +40,7 @@ import {
   resolveWorkflowsConfig,
   type FarmDiscoveredWorkflow,
 } from "./workflows";
+import { resolveFarmRouteContext, withFarmRouteContext } from "./route-context";
 import * as fs from "fs";
 import * as path from "path";
 import type { FarmUserConfig } from "./config";
@@ -74,6 +75,25 @@ function getPublicEnvDefine(config: FarmVitePluginOptions): Record<string, unkno
   }
 
   return publicEnv;
+}
+
+function createRequestFromNodeRequest(
+  req: { method?: string; headers: Record<string, string | string[] | undefined> },
+  url: URL,
+): Request {
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (Array.isArray(value)) {
+      for (const item of value) headers.append(key, item);
+    } else if (value !== undefined) {
+      headers.set(key, value);
+    }
+  }
+
+  return new Request(url.toString(), {
+    method: req.method || "GET",
+    headers,
+  });
 }
 
 function getFullEnvDefine(config: FarmVitePluginOptions): {
@@ -906,12 +926,21 @@ export function farmPlugin(
             targetUrl.searchParams.forEach((value, key) => {
               searchParams[key] = value;
             });
+            const routeContext = await resolveFarmRouteContext(farmApp.getConfig(), {
+              request: createRequestFromNodeRequest(req, urlObj),
+              params,
+              search: searchParams,
+              path: targetUrl.pathname,
+            });
             const routeProps = await parseRouteModuleProps(routeModule as RouteModuleLike, {
-              props: {
-                params,
-                searchParams: Promise.resolve(searchParams),
-                path: targetUrl.pathname,
-              },
+              props: withFarmRouteContext(
+                {
+                  params,
+                  searchParams: Promise.resolve(searchParams),
+                  path: targetUrl.pathname,
+                },
+                routeContext,
+              ),
               search: searchParams,
               routePath: route.pattern,
             });


### PR DESCRIPTION
## What changed
- Adds `context` to Farm config for request-scoped route dependencies.
- Passes app context into programmatic route guards and data hooks, including cache key helpers.
- Keeps app context server-only by using a hidden symbol carrier and preserving existing plugin `props.context` for components.
- Wires context resolution through initial SSR plus dev and Nitro SPA page-data requests.
- Documents route context usage, autocomplete via module augmentation, and security boundaries.

## Validation
- `corepack pnpm --filter @farmjs/core test -- src/__tests__/programmatic-routes.test.ts src/__tests__/config.test.ts`
- `corepack pnpm --filter @farmjs/core test -- src/__tests__/route-manager.test.ts src/__tests__/server-renderer-route-states.test.tsx src/__tests__/navigation-state.test.tsx src/__tests__/link.test.tsx src/__tests__/server-fn-client.test.tsx src/__tests__/server-fn.test.ts src/__tests__/chunk-recovery.test.ts src/__tests__/programmatic-routes.test.ts src/__tests__/config.test.ts`
- `corepack pnpm --filter @farmjs/core build`

Merge order: 6/6. Base: `feat/chunk-error-recovery`.