### PR TITLE
feat: secure server functions

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -104,10 +104,9 @@ If an integration operation is marked server-only, call it from `api`, not `apiC
 
 `createServerFn` pairs with `useServerFn` when a mutation is naturally a form action. Use `optimistic` to show the next UI state immediately, then let the server result replace it when the action completes.
 
-```tsx
-"use client";
+**src/actions/todos.ts**
 
-import { useServerFn } from "@farmjs/core/server-fn/client";
+```ts
 import { createServerFn } from "@farmjs/core/server-fn";
 import { z } from "zod";
 
@@ -115,12 +114,22 @@ export const addTodo = createServerFn({
   input: z.object({
     title: z.string().min(1),
   }),
-  async handler({ input }) {
+  async handler({ input, signal }) {
+    signal.throwIfAborted();
     return {
       todos: await db.todo.create({ data: input }),
     };
   },
 });
+```
+
+**src/components/todo-form.tsx**
+
+```tsx
+"use client";
+
+import { useServerFn } from "@farmjs/core/server-fn/client";
+import { addTodo } from "../actions/todos";
 
 export function TodoForm() {
   const action = useServerFn(addTodo, {
@@ -147,6 +156,29 @@ export function TodoForm() {
 
 The optimistic callback receives the raw input, `formData` for form submissions, and the current result. Return `undefined` when a submission should not change the optimistic result. Use `rollbackOnError` for reversible UI state; keep authorization and validation on the server function itself.
 
+When the function is called from the browser, `request` is the underlying Web `Request` and `signal` aborts with that request. A direct server-side call has no `request` and receives a stable, non-aborted signal. Pass `signal` to database or network clients that support cancellation.
+
+Farm validates action origin metadata, accepted form/RSC content types, action ID shape, and request size before decoding an action. Browser calls use same-origin credentials and refuse redirects. Unexpected thrown values are logged on the server but become a generic `ServerActionError` in the browser, so secrets and stack traces are not serialized.
+
+Return typed expected failures instead of throwing messages that the UI needs to display:
+
+```ts
+export const renameProject = createServerFn({
+  input: renameProjectSchema,
+  async handler({ input }) {
+    const session = await requireSession();
+    if (!session.canEdit(input.projectId)) {
+      return { ok: false as const, reason: "forbidden" as const };
+    }
+
+    await updateProject(input);
+    return { ok: true as const };
+  },
+});
+```
+
+Action references identify which function to execute; they are not authorization tokens. Check authentication, roles, tenant ownership, and resource access inside every action that reads or changes private data.
+
 ## Production notes
 
 - Keep generated API types committed or generated during CI.
@@ -154,3 +186,5 @@ The optimistic callback receives the raw input, `formData` for form submissions,
 - Use server callers for secrets, auth cookies, and internal-only provider actions.
 - Use invalidation after mutations that change cached route data.
 - Keep optimistic updates scoped to UI state you can confidently roll back.
+- Keep `serverActions.allowedOrigins` narrow and use API routes for intentionally cross-origin callers.
+- Return typed expected failures; reserve thrown errors for unexpected failures.

--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -35,18 +35,57 @@ export default defineFarmConfig({
 
 ## Important options
 
-| Option | Use it for |
-| --- | --- |
-| srcDir | Changing the app source folder from the default src. |
-| integrations | Registering built-in or custom integrations. |
-| storage | Providing storage clients and mounts for framework and integration code. |
-| migrations | Running one-shot schema/provider commands with `farm migrate`. |
-| docs | Serving the built-in docs runtime and docs API. |
-| md | Exposing markdown mirrors like /pricing.md. |
-| mdx | Rendering `page.md` and `page.mdx` app routes, plus MDX components. |
-| deploy | Selecting a target, preset, and output directory. |
-| routeRules | Applying rendering, cache, redirect, CORS, and header behavior to route patterns. |
-| openapi | Publishing API reference docs. |
+| Option        | Use it for                                                                        |
+| ------------- | --------------------------------------------------------------------------------- |
+| srcDir        | Changing the app source folder from the default src.                              |
+| integrations  | Registering built-in or custom integrations.                                      |
+| storage       | Providing storage clients and mounts for framework and integration code.          |
+| migrations    | Running one-shot schema/provider commands with `farm migrate`.                    |
+| docs          | Serving the built-in docs runtime and docs API.                                   |
+| md            | Exposing markdown mirrors like /pricing.md.                                       |
+| mdx           | Rendering `page.md` and `page.mdx` app routes, plus MDX components.               |
+| deploy        | Selecting a target, preset, and output directory.                                 |
+| routeRules    | Applying rendering, cache, redirect, CORS, and header behavior to route patterns. |
+| serverActions | Restricting trusted action origins and request body size.                         |
+| openapi       | Publishing API reference docs.                                                    |
+
+## Server action security
+
+Server actions are same-origin application RPC endpoints. Farm rejects cross-origin action requests by default and limits the encoded request body to 1 MB.
+
+```ts
+import { defineFarmConfig } from "@farmjs/core";
+
+export default defineFarmConfig({
+  experimental: {
+    serverComponents: true,
+    serverActions: true,
+  },
+
+  serverActions: {
+    allowedOrigins: [],
+    bodySizeLimit: "1mb",
+  },
+});
+```
+
+`allowedOrigins` adds trusted origins when a reverse proxy or multi-origin deployment makes the browser origin differ from the server request origin. Entries can be exact origins, hosts, or leftmost-subdomain wildcards:
+
+```ts
+serverActions: {
+  allowedOrigins: [
+    "https://app.example.com",
+    "proxy.internal:8443",
+    "https://*.preview.example.com",
+  ],
+}
+```
+
+Do not use `allowedOrigins` as a replacement for CORS or as a public API allowlist. Browser action requests must provide a matching `Origin` or `Referer`; Farm accepts `Sec-Fetch-Site: same-origin` when both are unavailable. Explicitly configured origins can cross a trusted proxy boundary.
+
+`bodySizeLimit` accepts bytes or strings such as `"500kb"`, `"2mb"`, and `"2MiB"`. Farm checks `Content-Length` when present and also counts streamed bytes, so chunked requests cannot bypass the limit.
+
+Rejected requests use generic, non-cacheable responses: `403` for origin failures, `413` for oversized bodies, and `415` for unsupported content types. Detailed parsing or execution errors stay in server logs.
 
 ## Next-style route exports
 
@@ -185,4 +224,6 @@ export default defineFarmConfig({
 - Use `docs.entry` when the docs runtime should be mounted automatically.
 - Prefer route-level exports such as `dynamic`, `revalidate`, and `ppr` when behavior belongs to one page.
 - Prefer `routeRules` for broad URL patterns and platform-level cache/header behavior.
+- Keep `serverActions.allowedOrigins` empty unless the deployment has a known proxy-origin mismatch.
+- Treat every server action as a public endpoint and authorize the current user inside the action or middleware.
 - Keep `farm.config.ts` as the single control plane instead of spreading framework behavior across many root files.

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -69,6 +69,9 @@
       "server-fn/client": [
         "./dist/server-fn-client.d.ts"
       ],
+      "server-action-security": [
+        "./dist/server-action-security.d.ts"
+      ],
       "env": [
         "./dist/env.d.ts"
       ],
@@ -171,6 +174,11 @@
       "types": "./dist/server-fn-client.d.ts",
       "import": "./dist/server-fn-client.mjs",
       "require": "./dist/server-fn-client.cjs"
+    },
+    "./server-action-security": {
+      "types": "./dist/server-action-security.d.ts",
+      "import": "./dist/server-action-security.mjs",
+      "require": "./dist/server-action-security.cjs"
     },
     "./env": {
       "types": "./dist/env.d.ts",

--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -142,6 +142,29 @@ describe("loadConfig", () => {
 });
 
 describe("resolveConfig", () => {
+  it("resolves secure server action defaults and overrides", async () => {
+    const defaults = await resolveConfig({}, "production");
+    expect(defaults.serverActions).toEqual({
+      allowedOrigins: [],
+      bodySizeLimit: 1_000_000,
+    });
+
+    const configured = await resolveConfig(
+      {
+        serverActions: {
+          allowedOrigins: ["HTTPS://APP.EXAMPLE.COM/", "*.proxy.example.com"],
+          bodySizeLimit: "2mb",
+        },
+      },
+      "production",
+    );
+
+    expect(configured.serverActions).toEqual({
+      allowedOrigins: ["https://app.example.com", "*.proxy.example.com"],
+      bodySizeLimit: 2_000_000,
+    });
+  });
+
   it("resolves MDX app page config", async () => {
     const config = await resolveConfig(
       {

--- a/packages/farm/src/__tests__/server-action-security.test.ts
+++ b/packages/farm/src/__tests__/server-action-security.test.ts
@@ -1,0 +1,354 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import {
+  ServerActionRequestError,
+  createServerActionRequestErrorResponse,
+  getServerActionExecutionContext,
+  prepareServerActionRequest,
+  resolveServerActionsConfig,
+  runWithServerActionRequest,
+  sanitizeServerActionError,
+  validateServerActionRequest,
+} from "../server-action-security";
+
+const defaultConfig = resolveServerActionsConfig(undefined);
+
+describe("server action security config", () => {
+  it("uses same-origin-only and a 1mb body limit by default", () => {
+    expect(defaultConfig).toEqual({
+      allowedOrigins: [],
+      bodySizeLimit: 1_000_000,
+    });
+  });
+
+  it("parses decimal and binary body size strings", () => {
+    expect(resolveServerActionsConfig({ bodySizeLimit: "500kb" }).bodySizeLimit).toBe(500_000);
+    expect(resolveServerActionsConfig({ bodySizeLimit: "2 MiB" }).bodySizeLimit).toBe(2_097_152);
+  });
+
+  it("normalizes trusted origins and wildcard host patterns", () => {
+    expect(
+      resolveServerActionsConfig({
+        allowedOrigins: ["HTTPS://APP.EXAMPLE.COM/", "*.Proxy.Example.com"],
+      }).allowedOrigins,
+    ).toEqual(["https://app.example.com", "*.proxy.example.com"]);
+  });
+
+  it("rejects unsafe config values", () => {
+    expect(() => resolveServerActionsConfig({ bodySizeLimit: 0 })).toThrow("positive safe integer");
+    expect(() => resolveServerActionsConfig({ bodySizeLimit: "lots" })).toThrow("size string");
+    expect(() =>
+      resolveServerActionsConfig({ allowedOrigins: ["https://example.com/path"] }),
+    ).toThrow("without paths");
+    expect(() => resolveServerActionsConfig({ allowedOrigins: ["*example.com"] })).toThrow(
+      "Invalid",
+    );
+  });
+});
+
+describe("validateServerActionRequest", () => {
+  it("accepts an exact same-origin request", () => {
+    const request = createActionRequest({ origin: "https://app.example.com" });
+    expect(() => validateServerActionRequest(request, defaultConfig)).not.toThrow();
+  });
+
+  it("accepts trusted proxy origins and wildcard subdomains", () => {
+    const exact = createActionRequest({ origin: "https://proxy.example.com" });
+    const wildcard = createActionRequest({ origin: "https://edge.proxy.example.com" });
+    const config = resolveServerActionsConfig({
+      allowedOrigins: ["https://proxy.example.com", "https://*.proxy.example.com"],
+    });
+
+    expect(() => validateServerActionRequest(exact, config)).not.toThrow();
+    expect(() => validateServerActionRequest(wildcard, config)).not.toThrow();
+  });
+
+  it("does not let a wildcard match its root domain or another scheme", () => {
+    const config = resolveServerActionsConfig({
+      allowedOrigins: ["https://*.proxy.example.com"],
+    });
+
+    expect(() =>
+      validateServerActionRequest(
+        createActionRequest({ origin: "https://proxy.example.com" }),
+        config,
+      ),
+    ).toThrow(ServerActionRequestError);
+    expect(() =>
+      validateServerActionRequest(
+        createActionRequest({ origin: "http://edge.proxy.example.com" }),
+        config,
+      ),
+    ).toThrow(ServerActionRequestError);
+  });
+
+  it("matches an explicitly configured default wildcard port", () => {
+    const request = createActionRequest({ origin: "https://edge.proxy.example.com" });
+    const config = resolveServerActionsConfig({
+      allowedOrigins: ["https://*.proxy.example.com:443"],
+    });
+
+    expect(() => validateServerActionRequest(request, config)).not.toThrow();
+  });
+
+  it("rejects cross-origin, opaque-origin, and protocol-downgrade requests", () => {
+    expect(() =>
+      validateServerActionRequest(
+        createActionRequest({ origin: "https://attacker.example" }),
+        defaultConfig,
+      ),
+    ).toThrow(expect.objectContaining({ code: "INVALID_ORIGIN", status: 403 }));
+
+    expect(() =>
+      validateServerActionRequest(createActionRequest({ origin: "null" }), defaultConfig),
+    ).toThrow(expect.objectContaining({ code: "INVALID_ORIGIN", status: 403 }));
+
+    expect(() =>
+      validateServerActionRequest(
+        createActionRequest({ origin: "http://app.example.com" }),
+        defaultConfig,
+      ),
+    ).toThrow(expect.objectContaining({ code: "INVALID_ORIGIN", status: 403 }));
+  });
+
+  it("uses Referer when Origin is unavailable", () => {
+    const request = createActionRequest({
+      origin: null,
+      referer: "https://app.example.com/products/1",
+    });
+
+    expect(() => validateServerActionRequest(request, defaultConfig)).not.toThrow();
+  });
+
+  it("requires browser origin evidence by default", () => {
+    const missing = createActionRequest({ origin: null });
+    expect(() => validateServerActionRequest(missing, defaultConfig)).toThrow(
+      expect.objectContaining({ code: "MISSING_ORIGIN", status: 403 }),
+    );
+
+    const fetchMetadata = createActionRequest({
+      origin: null,
+      fetchSite: "same-origin",
+    });
+    expect(() => validateServerActionRequest(fetchMetadata, defaultConfig)).not.toThrow();
+  });
+
+  it("rejects cross-site Fetch Metadata unless its origin was explicitly trusted", () => {
+    const sameOriginMarkedCrossSite = createActionRequest({
+      origin: "https://app.example.com",
+      fetchSite: "cross-site",
+    });
+    expect(() => validateServerActionRequest(sameOriginMarkedCrossSite, defaultConfig)).toThrow(
+      expect.objectContaining({ code: "INVALID_ORIGIN", status: 403 }),
+    );
+
+    const proxy = createActionRequest({
+      origin: "https://proxy.example.com",
+      fetchSite: "cross-site",
+    });
+    expect(() =>
+      validateServerActionRequest(
+        proxy,
+        resolveServerActionsConfig({ allowedOrigins: ["https://proxy.example.com"] }),
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe("prepareServerActionRequest", () => {
+  it("accepts the React JavaScript action content types", async () => {
+    const text = createActionRequest({ body: "hello", contentType: "text/plain" });
+    await expect(
+      prepareServerActionRequest(text, defaultConfig, "javascript", "action-id"),
+    ).resolves.toMatchObject({ body: "hello", contentType: "text/plain" });
+
+    const binary = createActionRequest({
+      body: "encoded",
+      contentType: "application/octet-stream",
+    });
+    await expect(
+      prepareServerActionRequest(binary, defaultConfig, "javascript", "action-id"),
+    ).resolves.toMatchObject({ body: "encoded", contentType: "application/octet-stream" });
+  });
+
+  it("parses progressive enhancement form bodies after enforcing the limit", async () => {
+    const request = createActionRequest({
+      body: "name=Ada&role=admin",
+      contentType: "application/x-www-form-urlencoded",
+    });
+
+    const prepared = await prepareServerActionRequest(request, defaultConfig, "form");
+    expect(prepared.body).toBeInstanceOf(FormData);
+    expect((prepared.body as FormData).get("name")).toBe("Ada");
+    expect((prepared.body as FormData).get("role")).toBe("admin");
+  });
+
+  it("rejects unsupported content types and invalid action ids", async () => {
+    await expect(
+      prepareServerActionRequest(
+        createActionRequest({ contentType: "application/json" }),
+        defaultConfig,
+        "javascript",
+        "action-id",
+      ),
+    ).rejects.toMatchObject({ code: "UNSUPPORTED_CONTENT_TYPE", status: 415 });
+
+    await expect(
+      prepareServerActionRequest(createActionRequest({}), defaultConfig, "javascript", ""),
+    ).rejects.toMatchObject({ code: "INVALID_ACTION_ID", status: 400 });
+  });
+
+  it("rejects a declared body larger than the configured limit", async () => {
+    const request = createActionRequest({
+      body: "small",
+      contentLength: "100",
+    });
+
+    await expect(
+      prepareServerActionRequest(
+        request,
+        resolveServerActionsConfig({ bodySizeLimit: 10 }),
+        "javascript",
+        "action-id",
+      ),
+    ).rejects.toMatchObject({ code: "BODY_TOO_LARGE", status: 413 });
+  });
+
+  it("enforces the body limit while streaming when Content-Length is absent", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("12345"));
+        controller.enqueue(encoder.encode("67890"));
+        controller.close();
+      },
+    });
+    const request = new Request("https://app.example.com/action", {
+      method: "POST",
+      headers: {
+        "content-type": "text/plain",
+        origin: "https://app.example.com",
+      },
+      body: stream,
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
+
+    await expect(
+      prepareServerActionRequest(
+        request,
+        resolveServerActionsConfig({ bodySizeLimit: 9 }),
+        "javascript",
+        "action-id",
+      ),
+    ).rejects.toMatchObject({ code: "BODY_TOO_LARGE", status: 413 });
+  });
+
+  it("stops before reading an already aborted request", async () => {
+    const controller = new AbortController();
+    controller.abort(new DOMException("cancelled", "AbortError"));
+    const request = createActionRequest({ signal: controller.signal });
+
+    await expect(
+      prepareServerActionRequest(request, defaultConfig, "javascript", "action-id"),
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("cancels an in-flight body read when the request is aborted", async () => {
+    const controller = new AbortController();
+    let bodyCancelled = false;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(streamController) {
+        streamController.enqueue(new TextEncoder().encode("partial"));
+        return new Promise(() => {});
+      },
+      cancel() {
+        bodyCancelled = true;
+      },
+    });
+    const request = new Request("https://app.example.com/action", {
+      method: "POST",
+      headers: {
+        "content-type": "text/plain",
+        origin: "https://app.example.com",
+      },
+      body: stream,
+      duplex: "half",
+      signal: controller.signal,
+    } as RequestInit & { duplex: "half" });
+
+    const prepared = prepareServerActionRequest(request, defaultConfig, "javascript", "action-id");
+    await Promise.resolve();
+    controller.abort(new DOMException("cancelled", "AbortError"));
+
+    await expect(prepared).rejects.toMatchObject({ name: "AbortError" });
+    expect(bodyCancelled).toBe(true);
+  });
+});
+
+describe("server action failures and execution context", () => {
+  it("returns cache-safe generic request rejection responses", async () => {
+    const response = createServerActionRequestErrorResponse(
+      new ServerActionRequestError("INVALID_ORIGIN", 403, "attacker.example did not match"),
+    );
+
+    expect(response?.status).toBe(403);
+    expect(await response?.text()).toBe("Forbidden");
+    expect(response?.headers.get("cache-control")).toBe("no-store");
+    expect(response?.headers.get("x-content-type-options")).toBe("nosniff");
+  });
+
+  it("never exposes thrown error messages or properties", () => {
+    expect(
+      sanitizeServerActionError(
+        Object.assign(new Error("database password leaked"), { secret: "top-secret" }),
+      ),
+    ).toEqual({
+      name: "ServerActionError",
+      message: "Server function failed",
+    });
+  });
+
+  it("makes the request and its cancellation signal available during execution", async () => {
+    const controller = new AbortController();
+    const request = createActionRequest({ signal: controller.signal });
+
+    await runWithServerActionRequest(request, async () => {
+      const context = getServerActionExecutionContext();
+      expect(context?.request).toBe(request);
+      expect(context?.signal).toBe(request.signal);
+      controller.abort();
+      expect(context?.signal.aborted).toBe(true);
+    });
+
+    expect(getServerActionExecutionContext()).toBeUndefined();
+  });
+});
+
+function createActionRequest(options: {
+  body?: BodyInit;
+  contentLength?: string;
+  contentType?: string;
+  fetchSite?: string;
+  origin?: string | null;
+  referer?: string;
+  signal?: AbortSignal;
+}): Request {
+  const headers = new Headers({
+    "content-type": options.contentType ?? "text/plain",
+    host: "app.example.com",
+  });
+  if (options.origin !== null) {
+    headers.set("origin", options.origin ?? "https://app.example.com");
+  }
+  if (options.referer) headers.set("referer", options.referer);
+  if (options.fetchSite) headers.set("sec-fetch-site", options.fetchSite);
+  if (options.contentLength) headers.set("content-length", options.contentLength);
+
+  return new Request("https://app.example.com/action", {
+    method: "POST",
+    headers,
+    body: options.body ?? "action-body",
+    signal: options.signal,
+  });
+}

--- a/packages/farm/src/__tests__/server-fn.test.ts
+++ b/packages/farm/src/__tests__/server-fn.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import { z } from "zod";
 import { createServerFn, FARM_SERVER_FN_SYMBOL } from "../server-fn";
+import { runWithServerActionRequest } from "../server-action-security";
 
 describe("createServerFn", () => {
   it("validates object input before calling the handler", async () => {
@@ -134,5 +135,27 @@ describe("createServerFn", () => {
 
     expectTypeOf(signup).parameter(0).toEqualTypeOf<{ email: string } | FormData>();
     expectTypeOf(await signup({ email: "ada@example.com" })).toEqualTypeOf<{ ok: true }>();
+  });
+
+  it("provides the action request and cancellation signal to handlers", async () => {
+    const controller = new AbortController();
+    const request = new Request("https://app.example.com/action", {
+      signal: controller.signal,
+    });
+    const inspect = createServerFn({
+      handler({ request: currentRequest, signal }) {
+        return {
+          request: currentRequest,
+          signal,
+        };
+      },
+    });
+
+    const result = await runWithServerActionRequest(request, () => inspect());
+
+    expect(result.request).toBe(request);
+    expect(result.signal).toBe(request.signal);
+    controller.abort();
+    expect(result.signal.aborted).toBe(true);
   });
 });

--- a/packages/farm/src/app.ts
+++ b/packages/farm/src/app.ts
@@ -9,6 +9,7 @@ import { resolveAppPath, fileExists, logger } from "./utils";
 import { initStorage } from "./storage";
 import { configureFarmObservability } from "./observability";
 import { normalizeRouteRules } from "./route-rules";
+import { resolveServerActionsConfig } from "./server-action-security";
 import { RouteManager } from "./routing/route-manager";
 import { ServerRenderer } from "./server/renderer";
 import { findProgrammaticRouteFiles } from "./routes.server";
@@ -100,6 +101,7 @@ export class FarmApp {
       middleware: config.middleware || {},
       routeRules: normalizeRouteRules(config.routeRules),
       context: config.context || (() => undefined),
+      serverActions: resolveServerActionsConfig(config.serverActions),
       docs: isResolvedDocsConfig(config.docs) ? config.docs : defaultDocsConfig,
       md: resolveMarkdownConfig(config.md),
       mdx: resolveMdxConfig(config.mdx),

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -30,6 +30,11 @@ import {
   routeRulesToRedirects,
   type FarmRouteRules,
 } from "./route-rules";
+import {
+  resolveServerActionsConfig,
+  type FarmServerActionsConfig,
+  type ResolvedFarmServerActionsConfig,
+} from "./server-action-security";
 import path from "path";
 
 export type {
@@ -59,6 +64,10 @@ export type {
   FarmRouteRuleRenderMode,
   FarmRouteRules,
 } from "./route-rules";
+export type {
+  FarmServerActionsConfig,
+  ResolvedFarmServerActionsConfig,
+} from "./server-action-security";
 
 export interface RedirectConfig {
   source: string;
@@ -186,6 +195,7 @@ export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite" | "docs" | "
   middleware?: FarmMiddlewareConfig;
   routeRules?: FarmRouteRules;
   context?: BaseFarmConfig["context"];
+  serverActions?: FarmServerActionsConfig;
 
   notFound?: NotFoundConfig;
 
@@ -217,7 +227,16 @@ export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite" | "docs" | "
 export interface ResolvedFarmConfig extends Required<
   Omit<
     FarmUserConfig,
-    "plugins" | "vite" | "deploy" | "docs" | "md" | "mdx" | "migrations" | "workflows" | "env"
+    | "plugins"
+    | "vite"
+    | "deploy"
+    | "docs"
+    | "md"
+    | "mdx"
+    | "migrations"
+    | "workflows"
+    | "env"
+    | "serverActions"
   >
 > {
   plugins: FarmPlugin[];
@@ -229,6 +248,7 @@ export interface ResolvedFarmConfig extends Required<
   migrations: ResolvedFarmMigrationsConfig;
   workflows: FarmWorkflowsResolvedConfig;
   env: ResolvedFarmEnv;
+  serverActions: ResolvedFarmServerActionsConfig;
 }
 
 export function defineFarmConfig<const TConfig extends FarmUserConfig>(config: TConfig): TConfig {
@@ -651,6 +671,7 @@ export async function resolveConfig(
     middleware: userConfig.middleware || {},
     notFound: userConfig.notFound || {},
     context: userConfig.context || (() => undefined),
+    serverActions: resolveServerActionsConfig(userConfig.serverActions),
     output: userConfig.output || "standalone",
     distDir: userConfig.distDir || ".farm",
     generateBuildId: userConfig.generateBuildId || (() => `build-${Date.now()}`),

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -92,6 +92,7 @@ export * from "./env-types";
 export * from "./type-artifacts";
 export * from "./server-fn";
 export * from "./server-fn-client";
+export * from "./server-action-security";
 export { generateRouteTypes } from "./routing/generate-route-types";
 export type { GenerateRouteTypesOptions } from "./routing/generate-route-types";
 export * from "./build/index";
@@ -138,6 +139,8 @@ export type {
   RewriteConfig,
   ImageConfig,
   I18nConfig,
+  FarmServerActionsConfig,
+  ResolvedFarmServerActionsConfig,
   OpenAPIConfig,
   MiddlewareConfig,
   FarmDeployConfig,

--- a/packages/farm/src/server-action-security.ts
+++ b/packages/farm/src/server-action-security.ts
@@ -1,0 +1,523 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export const DEFAULT_SERVER_ACTION_BODY_SIZE_LIMIT = 1_000_000;
+
+export interface FarmServerActionsConfig {
+  /** Additional trusted origins or host patterns, such as https://app.example.com. */
+  allowedOrigins?: readonly string[];
+  /** Maximum encoded request body size in bytes or as a size string such as "1mb". */
+  bodySizeLimit?: number | string;
+}
+
+export interface ResolvedFarmServerActionsConfig {
+  allowedOrigins: readonly string[];
+  bodySizeLimit: number;
+}
+
+export type ServerActionRequestKind = "javascript" | "form";
+
+export interface PreparedServerActionRequest {
+  body: string | FormData;
+  contentType: string;
+}
+
+export type SanitizedServerActionError = {
+  name: "ServerActionError";
+  message: "Server function failed";
+};
+
+type ServerActionRequestErrorCode =
+  | "BODY_TOO_LARGE"
+  | "INVALID_ACTION_ID"
+  | "INVALID_BODY"
+  | "INVALID_CONTENT_LENGTH"
+  | "INVALID_METHOD"
+  | "INVALID_ORIGIN"
+  | "MISSING_ORIGIN"
+  | "UNSUPPORTED_CONTENT_TYPE";
+
+export class ServerActionRequestError extends Error {
+  readonly code: ServerActionRequestErrorCode;
+  readonly status: number;
+
+  constructor(code: ServerActionRequestErrorCode, status: number, message: string) {
+    super(message);
+    this.name = "ServerActionRequestError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+type ServerActionExecutionContext = {
+  request: Request;
+  signal: AbortSignal;
+};
+
+const SERVER_ACTION_STORAGE_KEY = Symbol.for("farm.serverActionStorage");
+const FALLBACK_ABORT_CONTROLLER_KEY = Symbol.for("farm.serverActionFallbackAbortController");
+const FORM_ACTION_CONTENT_TYPES = new Set([
+  "application/x-www-form-urlencoded",
+  "multipart/form-data",
+]);
+const JAVASCRIPT_ACTION_CONTENT_TYPES = new Set([
+  "application/octet-stream",
+  "application/x-www-form-urlencoded",
+  "multipart/form-data",
+  "text/plain",
+]);
+
+type GlobalWithServerActionStorage = typeof globalThis & {
+  [SERVER_ACTION_STORAGE_KEY]?: AsyncLocalStorage<ServerActionExecutionContext>;
+  [FALLBACK_ABORT_CONTROLLER_KEY]?: AbortController;
+};
+
+export function resolveServerActionsConfig(
+  config: FarmServerActionsConfig | undefined,
+): ResolvedFarmServerActionsConfig {
+  const allowedOrigins = (config?.allowedOrigins ?? []).map(normalizeAllowedOriginPattern);
+  const bodySizeLimit = parseBodySizeLimit(
+    config?.bodySizeLimit ?? DEFAULT_SERVER_ACTION_BODY_SIZE_LIMIT,
+  );
+
+  return Object.freeze({
+    allowedOrigins: Object.freeze(allowedOrigins),
+    bodySizeLimit,
+  });
+}
+
+export function validateServerActionRequest(
+  request: Request,
+  config: ResolvedFarmServerActionsConfig,
+): void {
+  if (request.method.toUpperCase() !== "POST") {
+    throw new ServerActionRequestError(
+      "INVALID_METHOD",
+      405,
+      "Server actions only accept POST requests",
+    );
+  }
+
+  const requestUrl = new URL(request.url);
+  const sourceOrigin = getRequestSourceOrigin(request);
+  const fetchSite = request.headers.get("sec-fetch-site")?.trim().toLowerCase();
+
+  if (!sourceOrigin) {
+    if (fetchSite !== "same-origin") {
+      throw new ServerActionRequestError(
+        "MISSING_ORIGIN",
+        403,
+        "Server action request is missing same-origin metadata",
+      );
+    }
+    return;
+  }
+
+  const matchesRequest =
+    sourceOrigin === requestUrl.origin || matchesHostHeader(sourceOrigin, request);
+  const matchesConfiguredOrigin = config.allowedOrigins.some((pattern) =>
+    matchesAllowedOrigin(sourceOrigin, pattern),
+  );
+
+  if (!matchesRequest && !matchesConfiguredOrigin) {
+    throw new ServerActionRequestError(
+      "INVALID_ORIGIN",
+      403,
+      "Server action origin does not match the request origin",
+    );
+  }
+
+  if (fetchSite === "cross-site" && !matchesConfiguredOrigin) {
+    throw new ServerActionRequestError(
+      "INVALID_ORIGIN",
+      403,
+      "Cross-site server action request was rejected",
+    );
+  }
+}
+
+export async function prepareServerActionRequest(
+  request: Request,
+  config: ResolvedFarmServerActionsConfig,
+  kind: ServerActionRequestKind,
+  actionId?: string | null,
+): Promise<PreparedServerActionRequest> {
+  validateServerActionRequest(request, config);
+
+  if (kind === "javascript") {
+    validateActionId(actionId);
+  }
+
+  const contentType = getSupportedContentType(request, kind);
+  const bytes = await readBodyWithLimit(request, config.bodySizeLimit);
+
+  if (kind === "form" || contentType === "multipart/form-data") {
+    return {
+      body: await parseFormData(request, bytes),
+      contentType,
+    };
+  }
+
+  return {
+    body: new TextDecoder().decode(bytes),
+    contentType,
+  };
+}
+
+export function createServerActionRequestErrorResponse(error: unknown): Response | null {
+  if (!(error instanceof ServerActionRequestError)) {
+    return null;
+  }
+
+  const headers = new Headers({
+    "cache-control": "no-store",
+    "content-type": "text/plain; charset=utf-8",
+    "x-content-type-options": "nosniff",
+  });
+  if (error.status === 405) {
+    headers.set("allow", "POST");
+  }
+
+  return new Response(getPublicErrorMessage(error.status), {
+    status: error.status,
+    headers,
+  });
+}
+
+export function sanitizeServerActionError(_error: unknown): SanitizedServerActionError {
+  return {
+    name: "ServerActionError",
+    message: "Server function failed",
+  };
+}
+
+export function runWithServerActionRequest<T>(
+  request: Request,
+  callback: () => T | Promise<T>,
+): T | Promise<T> {
+  throwIfAborted(request.signal);
+  return getServerActionStorage().run(
+    {
+      request,
+      signal: request.signal,
+    },
+    callback,
+  );
+}
+
+export function getServerActionExecutionContext(): ServerActionExecutionContext | undefined {
+  return getServerActionStorage().getStore();
+}
+
+export function getServerActionSignal(): AbortSignal {
+  return getServerActionExecutionContext()?.signal ?? getFallbackAbortController().signal;
+}
+
+function getServerActionStorage(): AsyncLocalStorage<ServerActionExecutionContext> {
+  const globalState = globalThis as GlobalWithServerActionStorage;
+  if (!globalState[SERVER_ACTION_STORAGE_KEY]) {
+    globalState[SERVER_ACTION_STORAGE_KEY] = new AsyncLocalStorage<ServerActionExecutionContext>();
+  }
+  return globalState[SERVER_ACTION_STORAGE_KEY]!;
+}
+
+function getFallbackAbortController(): AbortController {
+  const globalState = globalThis as GlobalWithServerActionStorage;
+  if (!globalState[FALLBACK_ABORT_CONTROLLER_KEY]) {
+    globalState[FALLBACK_ABORT_CONTROLLER_KEY] = new AbortController();
+  }
+  return globalState[FALLBACK_ABORT_CONTROLLER_KEY]!;
+}
+
+function parseBodySizeLimit(value: number | string): number {
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+      throw new TypeError("serverActions.bodySizeLimit must be a positive safe integer");
+    }
+    return value;
+  }
+
+  const match = value
+    .trim()
+    .toLowerCase()
+    .match(/^(\d+(?:\.\d+)?)\s*(b|kb|mb|gb|kib|mib|gib)?$/);
+  if (!match) {
+    throw new TypeError(
+      'serverActions.bodySizeLimit must be bytes or a size string such as "500kb" or "1mb"',
+    );
+  }
+
+  const amount = Number(match[1]);
+  const unit = match[2] ?? "b";
+  const multiplier: Record<string, number> = {
+    b: 1,
+    kb: 1_000,
+    mb: 1_000_000,
+    gb: 1_000_000_000,
+    kib: 1_024,
+    mib: 1_048_576,
+    gib: 1_073_741_824,
+  };
+  const bytes = Math.floor(amount * multiplier[unit]);
+
+  if (!Number.isSafeInteger(bytes) || bytes <= 0) {
+    throw new TypeError("serverActions.bodySizeLimit must resolve to a positive safe integer");
+  }
+
+  return bytes;
+}
+
+function normalizeAllowedOriginPattern(value: string): string {
+  const pattern = value.trim().toLowerCase();
+  if (!pattern) {
+    throw new TypeError("serverActions.allowedOrigins cannot contain empty values");
+  }
+
+  if (pattern.includes("*")) {
+    if (!/^(?:https?:\/\/)?\*\.[a-z0-9.-]+(?::\d+)?$/.test(pattern)) {
+      throw new TypeError(`Invalid serverActions.allowedOrigins pattern: ${JSON.stringify(value)}`);
+    }
+    return pattern;
+  }
+
+  if (pattern.includes("://")) {
+    let parsed: URL;
+    try {
+      parsed = new URL(pattern);
+    } catch {
+      throw new TypeError(`Invalid serverActions.allowedOrigins value: ${JSON.stringify(value)}`);
+    }
+
+    if (
+      (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+      parsed.username ||
+      parsed.password ||
+      parsed.pathname !== "/" ||
+      parsed.search ||
+      parsed.hash
+    ) {
+      throw new TypeError(
+        `serverActions.allowedOrigins must contain origins without paths: ${JSON.stringify(value)}`,
+      );
+    }
+    return parsed.origin;
+  }
+
+  if (/[/@?#]/.test(pattern)) {
+    throw new TypeError(
+      `serverActions.allowedOrigins must contain origins or hosts: ${JSON.stringify(value)}`,
+    );
+  }
+
+  try {
+    return new URL(`http://${pattern}`).host;
+  } catch {
+    throw new TypeError(`Invalid serverActions.allowedOrigins value: ${JSON.stringify(value)}`);
+  }
+}
+
+function getRequestSourceOrigin(request: Request): string | null {
+  const origin = request.headers.get("origin")?.trim();
+  if (origin) {
+    return parseSourceOrigin(origin);
+  }
+
+  const referer = request.headers.get("referer")?.trim();
+  if (referer) {
+    return parseSourceOrigin(referer);
+  }
+
+  return null;
+}
+
+function parseSourceOrigin(value: string): string {
+  if (value === "null") {
+    throw new ServerActionRequestError("INVALID_ORIGIN", 403, "Opaque origins are not allowed");
+  }
+
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error("Unsupported protocol");
+    }
+    return parsed.origin;
+  } catch {
+    throw new ServerActionRequestError("INVALID_ORIGIN", 403, "Invalid request origin");
+  }
+}
+
+function matchesHostHeader(sourceOrigin: string, request: Request): boolean {
+  const host = request.headers.get("host")?.trim().toLowerCase();
+  if (!host) return false;
+
+  try {
+    const source = new URL(sourceOrigin);
+    const target = new URL(request.url);
+    return source.protocol === target.protocol && source.host.toLowerCase() === host;
+  } catch {
+    return false;
+  }
+}
+
+function matchesAllowedOrigin(sourceOrigin: string, pattern: string): boolean {
+  const source = new URL(sourceOrigin);
+  if (!pattern.includes("*")) {
+    return pattern.includes("://") ? source.origin === pattern : source.host === pattern;
+  }
+
+  const schemeEnd = pattern.indexOf("://");
+  const scheme = schemeEnd === -1 ? null : pattern.slice(0, schemeEnd + 1);
+  const hostPattern = pattern.slice(schemeEnd === -1 ? 0 : schemeEnd + 3);
+  const [wildcardHost, port] = splitHostAndPort(hostPattern);
+  const baseHost = wildcardHost.slice(2);
+
+  if (scheme && source.protocol !== scheme) return false;
+  if (port && getEffectivePort(source) !== port) return false;
+  if (!port && source.port) return false;
+
+  return source.hostname.endsWith(`.${baseHost}`) && source.hostname !== baseHost;
+}
+
+function splitHostAndPort(value: string): [string, string | null] {
+  const separator = value.lastIndexOf(":");
+  if (separator === -1) return [value, null];
+  return [value.slice(0, separator), value.slice(separator + 1)];
+}
+
+function getEffectivePort(url: URL): string {
+  if (url.port) return url.port;
+  if (url.protocol === "https:") return "443";
+  if (url.protocol === "http:") return "80";
+  return "";
+}
+
+function validateActionId(actionId?: string | null): asserts actionId is string {
+  if (!actionId || actionId.length > 4096 || hasControlCharacters(actionId)) {
+    throw new ServerActionRequestError("INVALID_ACTION_ID", 400, "Invalid server action id");
+  }
+}
+
+function hasControlCharacters(value: string): boolean {
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    if (code <= 31 || code === 127) return true;
+  }
+  return false;
+}
+
+function getSupportedContentType(request: Request, kind: ServerActionRequestKind): string {
+  const header = request.headers.get("content-type")?.trim().toLowerCase();
+  const contentType = header?.split(";", 1)[0]?.trim() ?? "";
+  const supported = kind === "form" ? FORM_ACTION_CONTENT_TYPES : JAVASCRIPT_ACTION_CONTENT_TYPES;
+
+  if (!supported.has(contentType)) {
+    throw new ServerActionRequestError(
+      "UNSUPPORTED_CONTENT_TYPE",
+      415,
+      "Unsupported server action content type",
+    );
+  }
+
+  return contentType;
+}
+
+async function readBodyWithLimit(request: Request, limit: number): Promise<Uint8Array> {
+  const contentLength = request.headers.get("content-length")?.trim();
+  if (contentLength) {
+    if (!/^\d+$/.test(contentLength)) {
+      throw new ServerActionRequestError(
+        "INVALID_CONTENT_LENGTH",
+        400,
+        "Invalid content-length header",
+      );
+    }
+    if (Number(contentLength) > limit) {
+      throw new ServerActionRequestError("BODY_TOO_LARGE", 413, "Server action body is too large");
+    }
+  }
+
+  throwIfAborted(request.signal);
+  if (!request.body) return new Uint8Array();
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  const cancelBodyRead = () => {
+    void reader.cancel(request.signal.reason).catch(() => {});
+  };
+
+  request.signal.addEventListener("abort", cancelBodyRead, { once: true });
+
+  try {
+    while (true) {
+      throwIfAborted(request.signal);
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      total += value.byteLength;
+      if (total > limit) {
+        await reader.cancel("Server action body is too large");
+        throw new ServerActionRequestError(
+          "BODY_TOO_LARGE",
+          413,
+          "Server action body is too large",
+        );
+      }
+      chunks.push(value);
+    }
+  } catch (error) {
+    if (request.signal.aborted) throwIfAborted(request.signal);
+    throw error;
+  } finally {
+    request.signal.removeEventListener("abort", cancelBodyRead);
+    reader.releaseLock();
+  }
+
+  throwIfAborted(request.signal);
+  const body = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body;
+}
+
+async function parseFormData(request: Request, bytes: Uint8Array): Promise<FormData> {
+  const body = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(body).set(bytes);
+  const copy = new Request(request.url, {
+    method: "POST",
+    headers: request.headers,
+    body,
+  });
+
+  try {
+    return await copy.formData();
+  } catch {
+    throw new ServerActionRequestError("INVALID_BODY", 400, "Invalid server action form body");
+  }
+}
+
+function getPublicErrorMessage(status: number): string {
+  switch (status) {
+    case 400:
+      return "Bad Request";
+    case 403:
+      return "Forbidden";
+    case 405:
+      return "Method Not Allowed";
+    case 413:
+      return "Payload Too Large";
+    case 415:
+      return "Unsupported Media Type";
+    default:
+      return "Server Action Request Failed";
+  }
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (!signal.aborted) return;
+  if (signal.reason !== undefined) throw signal.reason;
+  throw new DOMException("The operation was aborted", "AbortError");
+}

--- a/packages/farm/src/server-fn.ts
+++ b/packages/farm/src/server-fn.ts
@@ -1,3 +1,5 @@
+import { getServerActionExecutionContext, getServerActionSignal } from "./server-action-security";
+
 type MaybePromise<T> = T | Promise<T>;
 
 // Generic schema type that works with Zod v3/v4 and similar validator APIs.
@@ -24,6 +26,10 @@ export type ServerFnContext<TInput> = {
   input: TInput;
   rawInput: unknown;
   formData?: FormData;
+  /** The action request when invoked across the network. Undefined for direct server calls. */
+  request?: Request;
+  /** Aborts when the underlying action request is cancelled. */
+  signal: AbortSignal;
 };
 
 export type ServerFnHandler<TInput, TResult> = (
@@ -61,11 +67,14 @@ export function createServerFn(options: ServerFnOptions<AnySchema | undefined, u
     const formData = isFormData(value) ? value : undefined;
     const rawInput = formData ? formDataToObject(formData) : value;
     const input = await parseInput(options.input, rawInput);
+    const executionContext = getServerActionExecutionContext();
 
     return options.handler({
       input,
       rawInput,
       formData,
+      request: executionContext?.request,
+      signal: getServerActionSignal(),
     });
   };
 

--- a/packages/farm/src/server.ts
+++ b/packages/farm/src/server.ts
@@ -8,3 +8,4 @@ export * from "./storage";
 export * from "./cache";
 export { createServer, startDevServer } from "./server/create-server";
 export { getCurrentRequest } from "./server/request";
+export * from "./server-action-security";

--- a/packages/farm/src/types.ts
+++ b/packages/farm/src/types.ts
@@ -10,6 +10,7 @@ import type { FarmMiddlewareConfig } from "./middleware/types";
 import type { FarmWorkflowsUserConfig } from "./workflows";
 import type { FarmEnvConfig, ResolvedFarmEnv } from "./env";
 import type { FarmRouteRules } from "./route-rules";
+import type { FarmServerActionsConfig } from "./server-action-security";
 
 export type NitroPreset =
   | "node-server"
@@ -103,6 +104,7 @@ export interface FarmConfig {
   middleware?: FarmMiddlewareConfig;
   routeRules?: FarmRouteRules;
   context?: FarmContextFactory<any>;
+  serverActions?: FarmServerActionsConfig;
   docs?: FarmDocsUserConfig | FarmDocsResolvedConfig;
   md?: FarmMarkdownUserConfig | FarmMarkdownResolvedConfig | boolean;
   mdx?: FarmMdxUserConfig | FarmMdxResolvedConfig;

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
     workflows: "src/workflows.ts",
     "server-fn": "src/server-fn.ts",
     "server-fn-client": "src/server-fn-client.ts",
+    "server-action-security": "src/server-action-security.ts",
     env: "src/env.ts",
     "env-types": "src/env-types.ts",
   },

--- a/packages/farmjs-plugin/package.json
+++ b/packages/farmjs-plugin/package.json
@@ -46,7 +46,7 @@
     "build": "tsc && node scripts/build.js",
     "dev": "tsc --watch",
     "typecheck": "tsc --noEmit",
-    "test": "echo 'No tests in this package (boundary-matching tested via @farmjs/core)'"
+    "test": "vitest run"
   },
   "dependencies": {
     "@farmjs/core": "workspace:*",
@@ -62,7 +62,8 @@
     "@vitejs/plugin-rsc": "^0.5.18",
     "tsdown": "^0.15.7",
     "typescript": "^5.5.3",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^1.1.0"
   },
   "peerDependencies": {
     "@farmjs/core": "workspace:*",

--- a/packages/farmjs-plugin/src/rsc/entries/client.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/client.ts
@@ -48,7 +48,14 @@ setServerCallback(async (id, args) => {
   };
   if (typeof body === 'string') headers['Content-Type'] = 'text/plain; charset=utf-8';
   else if (!(body instanceof FormData)) headers['Content-Type'] = 'application/octet-stream';
-  const res = await fetch(location.href, { method: 'POST', headers, body });
+  const res = await fetch(location.href, {
+    method: 'POST',
+    headers,
+    body,
+    cache: 'no-store',
+    credentials: 'same-origin',
+    redirect: 'error',
+  });
   if (!res.ok) {
     const text = await res.text();
     console.error('[Farm.js] Server action request failed:', res.status, text);
@@ -69,7 +76,9 @@ setServerCallback(async (id, args) => {
   setPayloadRef.current?.(p);
   if (!p.returnValue || !p.returnValue.ok) {
     debug('Server action failed:', id);
-    throw p.returnValue?.data;
+    const error = new Error(p.returnValue?.data?.message || 'Server function failed');
+    error.name = 'ServerActionError';
+    throw error;
   }
   return p.returnValue.data;
 });

--- a/packages/farmjs-plugin/src/rsc/entries/rsc.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/rsc.ts
@@ -32,12 +32,31 @@ import {
   }
   code += `} from '@vitejs/plugin-rsc/rsc';
 `;
+  if (ctx.actionsEnabled) {
+    code += `import {
+  createServerActionRequestErrorResponse,
+  prepareServerActionRequest,
+  runWithServerActionRequest,
+  sanitizeServerActionError,
+  validateServerActionRequest,
+} from '@farmjs/core/server-action-security';
+
+const serverActionSecurity = ${JSON.stringify(ctx.serverActions)};
+`;
+  }
 
   // Auto-discover pages, layouts, and middleware using Vite's glob import
   code += `
 // Debug logging helper
 function debug(...args) {
   ${debugLog}
+}
+
+function applyActionResponseHeaders(headers, request) {
+  if (${ctx.actionsEnabled ? "true" : "false"} && request.method === 'POST') {
+    headers.set('cache-control', 'no-store');
+    headers.set('x-content-type-options', 'nosniff');
+  }
 }
 
 // Auto-discover all page, layout, and middleware files
@@ -440,9 +459,30 @@ function getLayout(pageFilePath) {
  * Exported as { fetch: handler } for the RSC/Nitro contract (see vite-plugin-rsc-deploy-example).
  */
 async function handler(request) {
-  try {
   const url = new URL(request.url);
+  try {
   debug('Handling request:', request.method, url.pathname);
+
+  ${
+    ctx.actionsEnabled
+      ? `if (request.method === 'POST') {
+    try {
+      validateServerActionRequest(request, serverActionSecurity);
+    } catch (error) {
+      const rejection = createServerActionRequestErrorResponse(error);
+      if (rejection) return rejection;
+      return new Response('Bad Request', {
+        status: 400,
+        headers: {
+          'Cache-Control': 'no-store',
+          'Content-Type': 'text/plain; charset=utf-8',
+          'X-Content-Type-Options': 'nosniff',
+        },
+      });
+    }
+  }`
+      : ""
+  }
 
   // Execute middleware first
   const middlewareResult = await executeMiddleware(request, url);
@@ -471,38 +511,103 @@ async function handler(request) {
   // Handle POST requests (server actions)
   if (request.method === 'POST') {
     const actionId = request.headers.get('x-farm-action-id');
+    let preparedActionRequest;
+
+    try {
+      preparedActionRequest = await prepareServerActionRequest(
+        request,
+        serverActionSecurity,
+        actionId ? 'javascript' : 'form',
+        actionId,
+      );
+    } catch (error) {
+      if (request.signal.aborted) {
+        return new Response(null, { status: 499, headers: { 'Cache-Control': 'no-store' } });
+      }
+      const rejection = createServerActionRequestErrorResponse(error);
+      if (rejection) return rejection;
+      console.error('[Farm.js] Failed to read server action request:', error);
+      return new Response('Bad Request', {
+        status: 400,
+        headers: {
+          'Cache-Control': 'no-store',
+          'Content-Type': 'text/plain; charset=utf-8',
+          'X-Content-Type-Options': 'nosniff',
+        },
+      });
+    }
     
     if (actionId) {
       // Action called via JavaScript (after hydration)
       debug('Executing server action:', actionId);
       temporaryReferences = createTemporaryReferenceSet();
+      let args, action;
+
       try {
-        const contentType = request.headers.get('content-type') || '';
-        const body = contentType.includes('multipart/form-data')
-          ? await request.formData()
-          : await request.text();
-        const args = await decodeReply(body, { temporaryReferences });
-        const action = await loadServerAction(actionId);
-        const data = await action.apply(null, args);
+        args = await decodeReply(preparedActionRequest.body, { temporaryReferences });
+        action = await loadServerAction(actionId);
+      } catch (error) {
+        console.error('[Farm.js] Invalid server action request:', error);
+        return new Response('Bad Request', {
+          status: 400,
+          headers: {
+            'Cache-Control': 'no-store',
+            'Content-Type': 'text/plain; charset=utf-8',
+            'X-Content-Type-Options': 'nosniff',
+          },
+        });
+      }
+
+      try {
+        const data = await runWithServerActionRequest(request, () => action.apply(null, args));
         returnValue = { ok: true, data };
         debug('Server action succeeded:', actionId);
       } catch (e) {
-        returnValue = { ok: false, data: e };
+        if (request.signal.aborted) {
+          return new Response(null, { status: 499, headers: { 'Cache-Control': 'no-store' } });
+        }
+        console.error('[Farm.js] Server action failed:', e);
+        returnValue = { ok: false, data: sanitizeServerActionError(e) };
         debug('Server action failed:', actionId, e);
       }
     } else {
       // Progressive enhancement (form submitted before JS loaded)
       debug('Handling progressive enhancement form submission');
-      
-      const formData = await request.formData();
-      const decoded = await decodeAction(formData);
+      const formData = preparedActionRequest.body;
+      let decoded;
+
+      try {
+        decoded = await decodeAction(formData);
+        if (typeof decoded !== 'function') throw new Error('Missing form action');
+      } catch (error) {
+        console.error('[Farm.js] Invalid form action request:', error);
+        return new Response('Bad Request', {
+          status: 400,
+          headers: {
+            'Cache-Control': 'no-store',
+            'Content-Type': 'text/plain; charset=utf-8',
+            'X-Content-Type-Options': 'nosniff',
+          },
+        });
+      }
       
       try {
-        const result = await decoded();
+        const result = await runWithServerActionRequest(request, () => decoded());
         formState = await decodeFormState(result, formData);
       } catch (e) {
+        if (request.signal.aborted) {
+          return new Response(null, { status: 499, headers: { 'Cache-Control': 'no-store' } });
+        }
+        console.error('[Farm.js] Form action failed:', e);
         debug('Form action failed:', e);
-        return new Response('Action Failed', { status: 500 });
+        return new Response('Server function failed', {
+          status: 500,
+          headers: {
+            'Cache-Control': 'no-store',
+            'Content-Type': 'text/plain; charset=utf-8',
+            'X-Content-Type-Options': 'nosniff',
+          },
+        });
       }
     }
   }
@@ -613,6 +718,7 @@ async function handler(request) {
       // Merge middleware headers with response headers
       const responseHeaders = new Headers(middlewareHeaders);
       responseHeaders.set('content-type', 'text/x-component');
+      applyActionResponseHeaders(responseHeaders, request);
       return new Response(rscStream, { headers: responseHeaders });
     }
 
@@ -632,6 +738,7 @@ async function handler(request) {
       // Merge middleware headers with response headers
       const responseHeaders = new Headers(middlewareHeaders);
       responseHeaders.set('content-type', 'text/html');
+      applyActionResponseHeaders(responseHeaders, request);
       return new Response(html, { headers: responseHeaders });
     }
   }
@@ -657,9 +764,23 @@ async function handler(request) {
   // Merge middleware headers with response headers
   const responseHeaders = new Headers(middlewareHeaders);
   responseHeaders.set('content-type', 'text/html');
+  applyActionResponseHeaders(responseHeaders, request);
   return new Response(html, { headers: responseHeaders });
   } catch (err) {
     console.error('[RSC] Handler error:', err);
+    if (request.method === 'POST') {
+      if (request.signal.aborted) {
+        return new Response(null, { status: 499, headers: { 'Cache-Control': 'no-store' } });
+      }
+      return new Response('Server function failed', {
+        status: 500,
+        headers: {
+          'Cache-Control': 'no-store',
+          'Content-Type': 'text/plain; charset=utf-8',
+          'X-Content-Type-Options': 'nosniff',
+        },
+      });
+    }
     // If route has error.tsx, render it (Next.js-style: SSR error goes to route error boundary)
     const pathname = url.pathname.replace(/\\/$/, '') || '/';
     const ErrorComponent = getMatchingError(pathname, glob);

--- a/packages/farmjs-plugin/src/rsc/entries/security.test.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/security.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
+import type { EntryContext } from "../types.js";
+import { generateClientEntry } from "./client.js";
+import { generateRscEntry } from "./rsc.js";
+
+const context: EntryContext = {
+  srcDir: "src",
+  outDir: "dist",
+  basePath: "/",
+  routesDir: "app",
+  actionsEnabled: true,
+  serverActions: {
+    allowedOrigins: ["https://proxy.example.com"],
+    bodySizeLimit: 500_000,
+  },
+  debug: false,
+};
+
+describe("generated server action security", () => {
+  it("validates and bounds requests before decoding or executing actions", () => {
+    const entry = generateRscEntry(context);
+
+    expect(entry).toContain("from '@farmjs/core/server-action-security'");
+    expect(entry).toContain(
+      'const serverActionSecurity = {"allowedOrigins":["https://proxy.example.com"],"bodySizeLimit":500000};',
+    );
+    expect(entry).toContain("await prepareServerActionRequest(");
+    expect(entry.indexOf("validateServerActionRequest(request")).toBeLessThan(
+      entry.indexOf("const middlewareResult = await executeMiddleware(request"),
+    );
+    expect(entry.indexOf("await prepareServerActionRequest(")).toBeLessThan(
+      entry.indexOf("await decodeReply("),
+    );
+    expect(entry).toContain("await runWithServerActionRequest(request");
+    expect(entry).toContain("sanitizeServerActionError(e)");
+    expect(entry).toContain("headers.set('cache-control', 'no-store')");
+    const outerCatch = entry.lastIndexOf("} catch (err) {");
+    const sanitizedPostFailure = entry.indexOf(
+      "return new Response('Server function failed'",
+      outerCatch,
+    );
+    expect(outerCatch).toBeGreaterThan(-1);
+    expect(sanitizedPostFailure).toBeGreaterThan(outerCatch);
+    expect(entry.slice(outerCatch, sanitizedPostFailure)).toContain(
+      "if (request.method === 'POST')",
+    );
+    expect(entry).not.toContain("returnValue = { ok: false, data: e }");
+  });
+
+  it("keeps browser action requests same-origin and turns failures into Errors", () => {
+    const entry = generateClientEntry(context);
+
+    expect(entry).toContain("credentials: 'same-origin'");
+    expect(entry).toContain("redirect: 'error'");
+    expect(entry).toContain("cache: 'no-store'");
+    expect(entry).toContain("error.name = 'ServerActionError'");
+    expect(entry).not.toContain("throw p.returnValue?.data");
+  });
+
+  it("emits syntactically valid RSC and browser entries", async () => {
+    await expect(
+      transformWithEsbuild(generateRscEntry(context), "entry.rsc.tsx", { loader: "tsx" }),
+    ).resolves.toMatchObject({ code: expect.any(String) });
+    await expect(
+      transformWithEsbuild(generateClientEntry(context), "entry.browser.tsx", { loader: "tsx" }),
+    ).resolves.toMatchObject({ code: expect.any(String) });
+  });
+});

--- a/packages/farmjs-plugin/src/rsc/index.ts
+++ b/packages/farmjs-plugin/src/rsc/index.ts
@@ -24,6 +24,7 @@
 
 import type { Plugin, UserConfig, ViteDevServer } from "vite";
 import type { FarmRscPluginOptions, EntryContext } from "./types.js";
+import type { FarmServerActionsConfig } from "@farmjs/core/server-action-security";
 import { generateRscEntry } from "./entries/rsc.js";
 import { generateSsrEntry } from "./entries/ssr.js";
 import { generateClientEntry } from "./entries/client.js";
@@ -37,6 +38,9 @@ const require_ = createRequire(import.meta.url);
 const { farmApiPlugin, farmMiddlewarePlugin } = require_(
   "@farmjs/core",
 ) as typeof import("@farmjs/core");
+const { resolveServerActionsConfig } = require_(
+  "@farmjs/core/server-action-security",
+) as typeof import("@farmjs/core/server-action-security");
 
 export type { FarmRscPluginOptions, EntryContext };
 export { buildRscNitro, waitForRscManifest, waitForRscOutputs } from "./nitro-build.js";
@@ -56,6 +60,7 @@ export interface FarmRscConfig {
   };
   debug?: boolean;
   encryptActions?: boolean;
+  serverActions?: FarmServerActionsConfig;
   routesDir?: string;
   entries?: {
     rsc?: string;
@@ -83,6 +88,7 @@ export function defineConfig(config: FarmRscConfig = {}): UserConfig {
     srcDir: config.srcDir ?? "src",
     outDir: config.outDir ?? "dist",
     basePath: config.basePath ?? "/",
+    serverActions: config.serverActions,
 
     // Vite server configuration
     server: {
@@ -105,6 +111,7 @@ export function defineConfig(config: FarmRscConfig = {}): UserConfig {
       farmRsc({
         debug,
         encryptActions: config.encryptActions,
+        serverActions: config.serverActions,
         routesDir: config.routesDir,
         entries: config.entries,
       }),
@@ -273,6 +280,7 @@ export default function farmRsc(options: FarmRscPluginOptions = {}): Plugin[] {
           outDir?: string;
           basePath?: string;
           root?: string;
+          serverActions?: FarmServerActionsConfig;
         };
         // Check if user enabled RSC in their config
         rscEnabled = c.experimental?.serverComponents === true;
@@ -298,6 +306,12 @@ export default function farmRsc(options: FarmRscPluginOptions = {}): Plugin[] {
           basePath: c.basePath ?? "/",
           routesDir: options.routesDir,
           actionsEnabled,
+          serverActions: resolveServerActionsConfig({
+            ...c.serverActions,
+            ...options.serverActions,
+            allowedOrigins:
+              options.serverActions?.allowedOrigins ?? c.serverActions?.allowedOrigins,
+          }),
           debug,
         };
 
@@ -361,6 +375,10 @@ export default function farmRsc(options: FarmRscPluginOptions = {}): Plugin[] {
                     {
                       find: "@farmjs/core/server-fn",
                       replacement: path.join(farmCorePath, "dist/server-fn.mjs"),
+                    },
+                    {
+                      find: "@farmjs/core/server-action-security",
+                      replacement: path.join(farmCorePath, "dist/server-action-security.mjs"),
                     },
                     { find: "@farmjs/core", replacement: farmCorePath },
                   ],
@@ -533,11 +551,20 @@ setServerCallback(async (id, args) => {
   const headers = { 'x-farm-action-id': id, 'Accept': 'text/x-component' };
   if (typeof body === 'string') headers['Content-Type'] = 'text/plain; charset=utf-8';
   else if (!(body instanceof FormData)) headers['Content-Type'] = 'application/octet-stream';
-  const res = await fetch(location.href, { method: 'POST', headers, body });
+  const res = await fetch(location.href, {
+    method: 'POST',
+    headers,
+    body,
+    cache: 'no-store',
+    credentials: 'same-origin',
+    redirect: 'error',
+  });
   if (!res.ok) throw new Error('Server action failed: ' + res.status);
   const p = await createFromReadableStream(res.body, { temporaryReferences: refs });
   if (p?.returnValue?.ok) return p.returnValue.data;
-  throw p?.returnValue?.data;
+  const error = new Error(p?.returnValue?.data?.message || 'Server function failed');
+  error.name = 'ServerActionError';
+  throw error;
 });
 `
             : "";

--- a/packages/farmjs-plugin/src/rsc/types.ts
+++ b/packages/farmjs-plugin/src/rsc/types.ts
@@ -1,7 +1,15 @@
+import type {
+  FarmServerActionsConfig,
+  ResolvedFarmServerActionsConfig,
+} from "@farmjs/core/server-action-security";
+
 /**
  * Configuration options for the Farm.js RSC plugin.
  */
 export interface FarmRscPluginOptions {
+  /** Security policy applied to server action requests. */
+  serverActions?: FarmServerActionsConfig;
+
   /**
    * Override the auto-generated virtual entries with custom files.
    * If not provided, virtual entries are generated automatically based on
@@ -62,6 +70,9 @@ export interface EntryContext {
 
   /** Whether server actions are enabled */
   actionsEnabled: boolean;
+
+  /** Normalized server action request security policy. */
+  serverActions: ResolvedFarmServerActionsConfig;
 
   /** Whether debug mode is enabled */
   debug: boolean;

--- a/packages/farmjs-plugin/vitest.config.ts
+++ b/packages/farmjs-plugin/vitest.config.ts
@@ -1,0 +1,15 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  root: path.resolve(__dirname),
+  css: {
+    postcss: {
+      plugins: [],
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1214,6 +1214,9 @@ importers:
       vite:
         specifier: ^6.0.0
         version: 6.4.1(@types/node@20.19.21)
+      vitest:
+        specifier: ^1.1.0
+        version: 1.6.1(@types/node@20.19.21)(supports-color@10.2.2)
 
 packages:
 
@@ -15341,6 +15344,63 @@ packages:
       jsdom: 25.0.1(supports-color@10.2.2)
       local-pkg: 0.5.1
       magic-string: 0.30.19
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.9.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.20(@types/node@20.19.21)
+      vite-node: 1.6.1(@types/node@20.19.21)(supports-color@10.2.2)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vitest@1.6.1(@types/node@20.19.21)(supports-color@10.2.2):
+    resolution: {integrity: sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.6.1
+      '@vitest/ui': 1.6.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 20.19.21
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.4
+      chai: 4.5.0
+      debug: 4.4.3(supports-color@10.2.2)
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.21
       pathe: 1.1.2
       picocolors: 1.1.1
       std-env: 3.9.0


### PR DESCRIPTION
## Summary

- add typed `serverActions` configuration for trusted origins and request body limits
- enforce same-origin checks, Fetch Metadata validation, safe content types, bounded streaming reads, and action ID validation
- propagate the request and cancellation signal into `createServerFn` handlers
- sanitize server-function failures and apply no-store/nosniff response headers
- harden generated browser action requests and document configuration and security best practices

## Security behavior

Server functions now reject untrusted or malformed POST requests before application middleware and action decoding. The default policy permits same-origin requests only; deployments behind trusted proxies can opt into exact origins or wildcard subdomains through `serverActions.allowedOrigins`.

Payload limits are enforced against both `Content-Length` and actual streamed bytes. Request cancellation stops body consumption and is exposed to handlers through `signal`. Unexpected server errors are logged on the server while clients receive a generic failure.

## Validation

- 48 focused core tests passed
- 3 generated RSC/client entry tests passed
- plugin TypeScript check passed
- core and plugin builds passed
- live progressive form submission passed
- adversarial HTTP checks covered cross-origin requests, unsafe content types, missing origin metadata, malformed action IDs, and oversized streamed bodies

## Notes

The repository-wide core typecheck still reports existing Nitro and query-state diagnostics outside this change. The broader core test run has one existing production-middleware fixture resolution failure; the remaining 420 tests passed with 1 skipped.