### PR TITLE
feat: add server function output contracts

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -114,6 +114,14 @@ export const addTodo = createServerFn({
   input: z.object({
     title: z.string().min(1),
   }),
+  output: z.object({
+    todos: z.array(
+      z.object({
+        id: z.string(),
+        title: z.string(),
+      }),
+    ),
+  }),
   async handler({ input, signal }) {
     signal.throwIfAborted();
     return {
@@ -122,6 +130,30 @@ export const addTodo = createServerFn({
   },
 });
 ```
+
+`input` validates values before the handler runs. An optional `output` schema validates the
+resolved handler result before it crosses the server-function boundary. Its parsed type becomes
+the function's return type, and schema transforms are supported:
+
+```ts
+const PublicUser = z.object({
+  id: z.string(),
+  email: z.string().email(),
+});
+
+export const getUser = createServerFn({
+  input: z.object({ id: z.string() }),
+  output: PublicUser,
+  async handler({ input }) {
+    // PublicUser strips passwordHash before this result can reach the browser.
+    return db.user.findUniqueOrThrow({ where: { id: input.id } });
+  },
+});
+```
+
+Output parsing also runs for direct server calls, form actions, and browser calls. Invalid results
+reject the function just like invalid input. Keep the output contract narrow for private data;
+do not rely on TypeScript alone to prevent an extra database field from being returned at runtime.
 
 **src/components/todo-form.tsx**
 
@@ -188,3 +220,4 @@ Action references identify which function to execute; they are not authorization
 - Keep optimistic updates scoped to UI state you can confidently roll back.
 - Keep `serverActions.allowedOrigins` narrow and use API routes for intentionally cross-origin callers.
 - Return typed expected failures; reserve thrown errors for unexpected failures.
+- Add narrow output schemas to functions that return private database records.

--- a/examples/rsc-demo/src/actions/user.ts
+++ b/examples/rsc-demo/src/actions/user.ts
@@ -8,6 +8,13 @@ import { z } from "zod";
 const messages: { id: number; name: string; message: string; timestamp: string }[] = [];
 let nextId = 1;
 
+const publicMessageSchema = z.object({
+  id: z.number().int(),
+  name: z.string(),
+  message: z.string(),
+  timestamp: z.string(),
+});
+
 /**
  * Submit a message - Server Action
  * This function runs on the server, even when called from a client component.
@@ -16,6 +23,10 @@ export const submitMessage = createServerFn({
   input: z.object({
     name: z.string().trim().min(1, "Name is required"),
     message: z.string().trim().min(1, "Message is required"),
+  }),
+  output: z.object({
+    success: z.literal(true),
+    message: publicMessageSchema,
   }),
   async handler({ input }) {
     // Simulate network delay

--- a/examples/rsc-demo/src/components/MessageForm.tsx
+++ b/examples/rsc-demo/src/components/MessageForm.tsx
@@ -15,7 +15,7 @@ export function MessageForm() {
       if (!name || !message) return undefined;
 
       return {
-        success: true,
+        success: true as const,
         message: {
           id: -1,
           name,

--- a/packages/farm/src/__tests__/server-fn.test.ts
+++ b/packages/farm/src/__tests__/server-fn.test.ts
@@ -137,6 +137,78 @@ describe("createServerFn", () => {
     expectTypeOf(await signup({ email: "ada@example.com" })).toEqualTypeOf<{ ok: true }>();
   });
 
+  it("validates and filters handler results with an output schema", async () => {
+    const publicUserSchema = z.object({
+      id: z.string(),
+      email: z.string().email(),
+    });
+    const getUser = createServerFn({
+      input: z.object({ id: z.string() }),
+      output: publicUserSchema,
+      async handler({ input }) {
+        const databaseUser = {
+          id: input.id,
+          email: "ada@example.com",
+          passwordHash: "must-not-cross-the-action-boundary",
+        };
+
+        return databaseUser;
+      },
+    });
+
+    const result = await getUser({ id: "user-1" });
+
+    expect(result).toEqual({ id: "user-1", email: "ada@example.com" });
+    expect(result).not.toHaveProperty("passwordHash");
+    expectTypeOf(result).toEqualTypeOf<{ id: string; email: string }>();
+    expect(getUser.__farmServerFnOutput).toBe(publicUserSchema);
+    expect(Object.keys(getUser)).not.toContain("__farmServerFnOutput");
+  });
+
+  it("returns the transformed output type from asynchronous handlers", async () => {
+    const formatCount = createServerFn({
+      input: z.object({ count: z.number().int() }),
+      output: z.object({ count: z.number() }).transform(({ count }) => `count:${count}`),
+      async handler({ input }) {
+        expectTypeOf(input).toEqualTypeOf<{ count: number }>();
+        return { count: input.count };
+      },
+    });
+
+    expectTypeOf(formatCount).parameter(0).toEqualTypeOf<{ count: number } | FormData>();
+    const result = await formatCount({ count: 3 });
+    expect(result).toBe("count:3");
+    expectTypeOf(result).toEqualTypeOf<string>();
+  });
+
+  it("rejects results that fail the output contract", async () => {
+    const getProfile = createServerFn({
+      output: z.object({ displayName: z.string().min(1) }),
+      handler() {
+        return { displayName: 42 } as unknown as { displayName: string };
+      },
+    });
+
+    await expect(getProfile()).rejects.toBeTruthy();
+  });
+
+  it("reports invalid output parser contracts precisely", async () => {
+    const invalidOutput = {} as {
+      _input: { ok: boolean };
+      _output: { ok: boolean };
+    };
+    const action = createServerFn({
+      output: invalidOutput,
+      handler() {
+        return { ok: true };
+      },
+    });
+
+    await expect(action()).rejects.toThrow(
+      "createServerFn output must provide parse, parseAsync, or safeParse",
+    );
+  });
+
   it("provides the action request and cancellation signal to handlers", async () => {
     const controller = new AbortController();
     const request = new Request("https://app.example.com/action", {

--- a/packages/farm/src/server-fn.ts
+++ b/packages/farm/src/server-fn.ts
@@ -53,17 +53,17 @@ export type ServerFnOutputOptions<
   output: TOutputSchema;
   handler: ServerFnHandler<
     TInputSchema extends ServerFnSchema ? InferServerFnSchemaOutput<TInputSchema> : unknown,
-    InferServerFnSchemaInput<TOutputSchema>
+    unknown
   >;
 };
 
 export type ServerFn<TInput, TResult> = ([unknown] extends [TInput]
   ? (input?: TInput | FormData) => Promise<TResult>
   : (input: TInput | FormData) => Promise<TResult>) & {
-    readonly __farmServerFn: true;
-    readonly __farmServerFnInput?: unknown;
-    readonly __farmServerFnOutput?: unknown;
-  };
+  readonly __farmServerFn: true;
+  readonly __farmServerFnInput?: unknown;
+  readonly __farmServerFnOutput?: unknown;
+};
 
 export const FARM_SERVER_FN_SYMBOL = Symbol.for("farm.server-fn");
 
@@ -161,9 +161,7 @@ async function parseSchema(
     return schema.parse(value);
   }
 
-  throw new TypeError(
-    `createServerFn ${contract} must provide parse, parseAsync, or safeParse`,
-  );
+  throw new TypeError(`createServerFn ${contract} must provide parse, parseAsync, or safeParse`);
 }
 
 function unwrapSafeParseResult(result: unknown) {

--- a/packages/farm/src/server-fn.ts
+++ b/packages/farm/src/server-fn.ts
@@ -4,7 +4,7 @@ type MaybePromise<T> = T | Promise<T>;
 
 // Generic schema type that works with Zod v3/v4 and similar validator APIs.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnySchema = {
+export type ServerFnSchema = {
   _input?: any;
   _output?: any;
   parse?: (data: unknown) => any;
@@ -13,8 +13,8 @@ type AnySchema = {
   safeParseAsync?: (data: unknown) => Promise<any>;
 };
 
-type InferInput<T> = T extends { _input: infer I } ? I : unknown;
-type InferOutput<T> = T extends { _output: infer O }
+export type InferServerFnSchemaInput<T> = T extends { _input: infer I } ? I : unknown;
+export type InferServerFnSchemaOutput<T> = T extends { _output: infer O }
   ? O
   : T extends { parse: (data: unknown) => infer R }
     ? R
@@ -36,29 +36,63 @@ export type ServerFnHandler<TInput, TResult> = (
   ctx: ServerFnContext<TInput>,
 ) => MaybePromise<TResult>;
 
-export type ServerFnOptions<TSchema extends AnySchema | undefined, TResult> = {
+export type ServerFnOptions<TSchema extends ServerFnSchema | undefined, TResult> = {
   input?: TSchema;
-  handler: ServerFnHandler<TSchema extends AnySchema ? InferOutput<TSchema> : unknown, TResult>;
+  output?: undefined;
+  handler: ServerFnHandler<
+    TSchema extends ServerFnSchema ? InferServerFnSchemaOutput<TSchema> : unknown,
+    TResult
+  >;
+};
+
+export type ServerFnOutputOptions<
+  TInputSchema extends ServerFnSchema | undefined,
+  TOutputSchema extends ServerFnSchema,
+> = {
+  input?: TInputSchema;
+  output: TOutputSchema;
+  handler: ServerFnHandler<
+    TInputSchema extends ServerFnSchema ? InferServerFnSchemaOutput<TInputSchema> : unknown,
+    InferServerFnSchemaInput<TOutputSchema>
+  >;
 };
 
 export type ServerFn<TInput, TResult> = ([unknown] extends [TInput]
   ? (input?: TInput | FormData) => Promise<TResult>
   : (input: TInput | FormData) => Promise<TResult>) & {
-  readonly __farmServerFn: true;
-  readonly __farmServerFnInput?: unknown;
-};
+    readonly __farmServerFn: true;
+    readonly __farmServerFnInput?: unknown;
+    readonly __farmServerFnOutput?: unknown;
+  };
 
 export const FARM_SERVER_FN_SYMBOL = Symbol.for("farm.server-fn");
 
 const UNSAFE_FORM_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
-export function createServerFn<TSchema extends AnySchema, TResult>(
+export function createServerFn<
+  TInputSchema extends ServerFnSchema,
+  TOutputSchema extends ServerFnSchema,
+>(
+  options: ServerFnOutputOptions<TInputSchema, TOutputSchema>,
+): ServerFn<
+  InferServerFnSchemaInput<TInputSchema>,
+  Awaited<InferServerFnSchemaOutput<TOutputSchema>>
+>;
+export function createServerFn<TOutputSchema extends ServerFnSchema>(
+  options: ServerFnOutputOptions<undefined, TOutputSchema>,
+): ServerFn<unknown, Awaited<InferServerFnSchemaOutput<TOutputSchema>>>;
+export function createServerFn<TSchema extends ServerFnSchema, TResult>(
   options: ServerFnOptions<TSchema, TResult>,
-): ServerFn<InferInput<TSchema>, Awaited<TResult>>;
+): ServerFn<InferServerFnSchemaInput<TSchema>, Awaited<TResult>>;
 export function createServerFn<TResult>(
   options: ServerFnOptions<undefined, TResult>,
 ): ServerFn<unknown, Awaited<TResult>>;
-export function createServerFn(options: ServerFnOptions<AnySchema | undefined, unknown>) {
+export function createServerFn(options: {
+  input?: ServerFnSchema;
+  output?: ServerFnSchema;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handler: ServerFnHandler<any, any>;
+}) {
   if (!options || typeof options.handler !== "function") {
     throw new TypeError("createServerFn requires a handler function");
   }
@@ -66,16 +100,18 @@ export function createServerFn(options: ServerFnOptions<AnySchema | undefined, u
   const serverFn = async (value: unknown) => {
     const formData = isFormData(value) ? value : undefined;
     const rawInput = formData ? formDataToObject(formData) : value;
-    const input = await parseInput(options.input, rawInput);
+    const input = await parseSchema(options.input, rawInput, "input");
     const executionContext = getServerActionExecutionContext();
 
-    return options.handler({
+    const result = await options.handler({
       input,
       rawInput,
       formData,
       request: executionContext?.request,
       signal: getServerActionSignal(),
     });
+
+    return parseSchema(options.output, result, "output");
   };
 
   Object.defineProperties(serverFn, {
@@ -91,33 +127,43 @@ export function createServerFn(options: ServerFnOptions<AnySchema | undefined, u
       value: options.input,
       enumerable: false,
     },
+    __farmServerFnOutput: {
+      value: options.output,
+      enumerable: false,
+    },
   });
 
   return serverFn as ServerFn<unknown, unknown>;
 }
 
-async function parseInput(schema: AnySchema | undefined, rawInput: unknown) {
-  if (!schema) return rawInput;
+async function parseSchema(
+  schema: ServerFnSchema | undefined,
+  value: unknown,
+  contract: "input" | "output",
+) {
+  if (!schema) return value;
 
   if (typeof schema.safeParseAsync === "function") {
-    const result = await schema.safeParseAsync(rawInput);
+    const result = await schema.safeParseAsync(value);
     return unwrapSafeParseResult(result);
   }
 
   if (typeof schema.safeParse === "function") {
-    const result = schema.safeParse(rawInput);
+    const result = schema.safeParse(value);
     return unwrapSafeParseResult(await result);
   }
 
   if (typeof schema.parseAsync === "function") {
-    return schema.parseAsync(rawInput);
+    return schema.parseAsync(value);
   }
 
   if (typeof schema.parse === "function") {
-    return schema.parse(rawInput);
+    return schema.parse(value);
   }
 
-  throw new TypeError("createServerFn input must provide parse, parseAsync, or safeParse");
+  throw new TypeError(
+    `createServerFn ${contract} must provide parse, parseAsync, or safeParse`,
+  );
 }
 
 function unwrapSafeParseResult(result: unknown) {


### PR DESCRIPTION
## Summary
- add optional `output` schemas to `createServerFn`
- validate, filter, and transform resolved handler results before they cross the action boundary
- infer the public function return type from the output schema while preserving existing inference without one
- expose non-enumerable output-contract metadata for framework introspection
- document the security model and use it in the RSC form example

## Why
Input validation alone does not prevent an action from returning an unexpected database field or malformed payload. Output contracts make the network boundary explicit and runtime-enforced without changing existing server functions.

## Verification
- 53 core test files passed: 452 tests passed, 1 skipped
- server-function tests passed with strict isolated TypeScript compilation
- `@farmjs/core` CJS, ESM, and declaration builds passed
- RSC demo type-check passed
- changed-file formatting and `git diff --check` passed
