### PR TITLE
feat: add first-class test utilities

### DIFF
--- a/docs/docs.config.ts
+++ b/docs/docs.config.ts
@@ -245,6 +245,7 @@ const sidebar = [
     icon: "book",
     children: [
       { label: "Migrations", slug: "migrations", icon: "route" },
+      { label: "Testing", slug: "testing", icon: "terminal" },
       { label: "CLI", slug: "cli", icon: "terminal" },
       { label: "Examples", slug: "examples", icon: "box" },
       { label: "Reference", slug: "reference", icon: "book" },

--- a/docs/src/app/docs/testing/page.md
+++ b/docs/src/app/docs/testing/page.md
@@ -1,0 +1,176 @@
+---
+title: "Testing"
+description: "Test Farm requests, programmatic routes, API endpoints, and server functions with the real framework runtimes."
+section: "Reference"
+---
+
+# Testing
+
+Farm provides runner-agnostic helpers from `@farmjs/core/testing`. They use Web `Request` and `Response` objects and call the same route data, API endpoint, and server-function runtimes used by the application.
+
+## Create a harness
+
+Set request defaults once for a test file. The `context` callback has the same input and behavior as `context` in `farm.config.ts`.
+
+```ts
+import { afterEach } from "vitest";
+import { createFarmTestHarness } from "@farmjs/core/testing";
+import { getSession } from "../src/session";
+
+export const farm = createFarmTestHarness({
+  origin: "https://app.example.test",
+  headers: { "x-tenant": "acme" },
+  cookies: { session: "test-session" },
+  context: async ({ request }) => ({
+    session: await getSession(request),
+  }),
+});
+
+afterEach(() => {
+  farm.clearCache();
+});
+```
+
+Harness defaults are merged with each call. Per-call headers and cookies win when the same name is provided.
+
+## Test a route
+
+Pass the exported `createRoute` value directly. Farm builds the URL, validates params and search, resolves request context, runs the guard, then runs `data.before`, `data.main`, and `data.after` in production order.
+
+```ts
+import { expect, test } from "vitest";
+import { ProductRoute } from "../src/features/products/page";
+import { farm } from "./farm";
+
+test("loads a product route", async () => {
+  const result = await farm.route(ProductRoute, {
+    params: { id: "product-1" },
+    search: { tab: "reviews" },
+  });
+
+  expect(result.request.url).toBe("https://app.example.test/products/product-1?tab=reviews");
+  expect(result.props.data.product.id).toBe("product-1");
+  expect(result.props.search.tab).toBe("reviews");
+});
+```
+
+`result.props` preserves the route's inferred params, search, and `data.main` result types. It is the safe prop object passed to the page component: private app context is not included. `result.element` is a React element for the route component, while `result.canonicalPath` exposes search cleanup such as stripped defaults or temporary params.
+
+Guards keep their normal control flow, so redirects and not-found signals can be asserted directly:
+
+```ts
+await expect(
+  farm.route(DashboardRoute, {
+    context: { session: { user: null } },
+  }),
+).rejects.toMatchObject({
+  digest: "FARM_REDIRECT;307;/login",
+});
+```
+
+Pass `context` to one route call to override the harness context factory. Use `pluginContext` or `middleware` when the component also needs request-scoped plugin or middleware data.
+
+## Test API routes
+
+Use `api` for a programmatic API route. Dynamic params are interpolated and then matched again by the real API matcher. Endpoint schemas and response normalization still run.
+
+```ts
+import { expect, test } from "vitest";
+import { ProjectApi } from "../src/features/projects/api";
+import { farm } from "./farm";
+
+test("updates a project", async () => {
+  const response = await farm.api(ProjectApi, {
+    method: "PATCH",
+    params: { id: "project-1" },
+    query: { source: "form" },
+    json: { name: "Farm" },
+  });
+
+  expect(response.status).toBe(200);
+  await expect(response.json()).resolves.toMatchObject({
+    id: "project-1",
+    name: "Farm",
+  });
+});
+```
+
+Use `endpoint` for a handler exported by a file route:
+
+```ts
+import { GET } from "../src/app/api/projects/[id]/route";
+
+const response = await farm.endpoint(GET, {
+  path: "/api/projects/project-1",
+  params: { id: "project-1" },
+});
+```
+
+The helpers return JSON 404 and 405 responses just like the API route manager. Thrown handlers become a 500 response by default. Set `throwOnError: true` when a unit test needs to inspect the original error.
+
+## Test server functions
+
+`serverFn` keeps input and return inference, including Zod validation and `FormData` conversion. It also installs the request and cancellation signal that the handler reads.
+
+```ts
+import { expect, test } from "vitest";
+import { signup } from "../src/actions/signup";
+import { farm } from "./farm";
+
+test("signs up a user", async () => {
+  const result = await farm.serverFn(signup, {
+    email: "ada@example.com",
+    password: "correct horse battery staple",
+  });
+
+  expect(result.ok).toBe(true);
+});
+```
+
+Pass a `FormData` value to test form actions, or provide an exact request when the handler reads authorization headers or cookies:
+
+```ts
+const request = farm.request("/actions/signup", {
+  method: "POST",
+  headers: { authorization: "Bearer test-token" },
+});
+
+await farm.serverFn(signup, formData, { request });
+```
+
+Use an aborted signal to test cancellation:
+
+```ts
+const controller = new AbortController();
+controller.abort(new Error("cancelled"));
+
+await expect(farm.serverFn(signup, input, { signal: controller.signal })).rejects.toThrow(
+  "cancelled",
+);
+```
+
+## Build requests
+
+Use `createTestRequest` without a harness, or `farm.request` when you want harness defaults.
+
+```ts
+import { createTestRequest } from "@farmjs/core/testing";
+
+const request = createTestRequest("/api/search", {
+  origin: "https://app.example.test",
+  query: { q: "routing", tag: ["farm", "react"] },
+  cookies: { preview: "enabled" },
+  json: { limit: 10 },
+});
+```
+
+Provide only one of `json`, `form`, or `body`. A body defaults the method to `POST`; explicit `GET` and `HEAD` requests reject non-empty bodies.
+
+## Testing boundaries
+
+- Clear the route data cache in `afterEach` when tests use `data.key`. The cache is process-wide, matching the application runtime.
+- Keep database, storage, email, and provider clients behind context or module boundaries so tests can supply controlled implementations.
+- Use `farm.route` for route contracts and hook flow. Use a React renderer when the assertion concerns component interactions or DOM output.
+- Use `farm.serverFn` for input validation, handler authorization, form conversion, request access, and cancellation.
+- Add an HTTP E2E test for server-action transport security. Direct server-function tests do not exercise Origin/Host checks, Fetch Metadata, action-reference decoding, or payload-size limits.
+- Assert both success and expected failures. A typed result such as `{ ok: false, reason: "forbidden" }` should be tested separately from unexpected thrown errors.

--- a/docs/src/farm-routes.d.ts
+++ b/docs/src/farm-routes.d.ts
@@ -3,16 +3,19 @@
  * Link href is typed automatically via module augmentation. Regenerated on dev start and when routes change.
  * Set suppressLintOnLink: true in farm.config.ts to accept any string on Link href.
  */
-export type RoutePath = "/" | "/docs" | `/docs/${string}` | "/docs/api-client" | "/docs/api-routes" | "/docs/cache-ppr" | "/docs/cli" | "/docs/configuration" | "/docs/deployment" | "/docs/docs-engine" | "/docs/environment-functions" | "/docs/examples" | "/docs/getting-started" | "/docs/integrations" | "/docs/integrations/auth" | "/docs/integrations/auth/auth0" | "/docs/integrations/auth/authjs" | "/docs/integrations/auth/better-auth" | "/docs/integrations/auth/clerk" | "/docs/integrations/auth/supabase" | "/docs/integrations/auth/workos" | "/docs/integrations/autumn" | "/docs/integrations/custom" | "/docs/integrations/email" | "/docs/integrations/inngest" | "/docs/integrations/jobs" | "/docs/integrations/orm-storage" | "/docs/integrations/polar" | "/docs/integrations/stripe" | "/docs/integrations/trigger" | "/docs/integrations/ui-registry" | "/docs/integrations/unkey" | "/docs/layers" | "/docs/layouts" | "/docs/markdown" | "/docs/middleware" | "/docs/migrations" | "/docs/observability" | "/docs/openapi" | "/docs/plugins" | "/docs/plugins/create-plugin" | "/docs/preview" | "/docs/project-structure" | "/docs/query" | "/docs/reference" | "/docs/routing" | "/docs/server-rendering" | "/docs/storage" | "/docs/workflows";
+export type RoutePath = "/" | "/docs" | `/docs/${string}` | "/docs/api-client" | "/docs/api-routes" | "/docs/cache-ppr" | "/docs/cli" | "/docs/configuration" | "/docs/deployment" | "/docs/docs-engine" | "/docs/environment-functions" | "/docs/examples" | "/docs/getting-started" | "/docs/integrations" | "/docs/integrations/auth" | "/docs/integrations/auth/auth0" | "/docs/integrations/auth/authjs" | "/docs/integrations/auth/better-auth" | "/docs/integrations/auth/clerk" | "/docs/integrations/auth/supabase" | "/docs/integrations/auth/workos" | "/docs/integrations/autumn" | "/docs/integrations/custom" | "/docs/integrations/email" | "/docs/integrations/inngest" | "/docs/integrations/jobs" | "/docs/integrations/orm-storage" | "/docs/integrations/polar" | "/docs/integrations/stripe" | "/docs/integrations/trigger" | "/docs/integrations/ui-registry" | "/docs/integrations/unkey" | "/docs/layers" | "/docs/layouts" | "/docs/markdown" | "/docs/middleware" | "/docs/migrations" | "/docs/observability" | "/docs/openapi" | "/docs/plugins" | "/docs/plugins/create-plugin" | "/docs/preview" | "/docs/project-structure" | "/docs/query" | "/docs/reference" | "/docs/routing" | "/docs/server-rendering" | "/docs/storage" | "/docs/testing" | "/docs/workflows";
+export type RoutePattern = "/" | "/docs" | "/docs/[...docs]" | "/docs/api-client" | "/docs/api-routes" | "/docs/cache-ppr" | "/docs/cli" | "/docs/configuration" | "/docs/deployment" | "/docs/docs-engine" | "/docs/environment-functions" | "/docs/examples" | "/docs/getting-started" | "/docs/integrations" | "/docs/integrations/auth" | "/docs/integrations/auth/auth0" | "/docs/integrations/auth/authjs" | "/docs/integrations/auth/better-auth" | "/docs/integrations/auth/clerk" | "/docs/integrations/auth/supabase" | "/docs/integrations/auth/workos" | "/docs/integrations/autumn" | "/docs/integrations/custom" | "/docs/integrations/email" | "/docs/integrations/inngest" | "/docs/integrations/jobs" | "/docs/integrations/orm-storage" | "/docs/integrations/polar" | "/docs/integrations/stripe" | "/docs/integrations/trigger" | "/docs/integrations/ui-registry" | "/docs/integrations/unkey" | "/docs/layers" | "/docs/layouts" | "/docs/markdown" | "/docs/middleware" | "/docs/migrations" | "/docs/observability" | "/docs/openapi" | "/docs/plugins" | "/docs/plugins/create-plugin" | "/docs/preview" | "/docs/project-structure" | "/docs/query" | "/docs/reference" | "/docs/routing" | "/docs/server-rendering" | "/docs/storage" | "/docs/testing" | "/docs/workflows";
 declare module "@farmjs/core/client" {
   interface LinkDefaultRoute {
     _: import("./farm-routes").RoutePath;
+    pattern: import("./farm-routes").RoutePattern;
   }
 }
 
 declare module "@farmjs/core" {
   interface LinkDefaultRoute {
     _: import("./farm-routes").RoutePath;
+    pattern: import("./farm-routes").RoutePattern;
   }
   // Ensure root import ("@farmjs/core") uses the same typed Link signature as client entry.
   const Link: typeof import("@farmjs/core/client").Link;
@@ -22,6 +25,7 @@ declare module "@farmjs/core" {
 declare module "@farmjs/core/dist/client.js" {
   interface LinkDefaultRoute {
     _: import("./farm-routes").RoutePath;
+    pattern: import("./farm-routes").RoutePattern;
   }
 }
 

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -84,6 +84,9 @@
       "environment/vite": [
         "./dist/environment/vite.d.ts"
       ],
+      "testing": [
+        "./dist/testing.d.ts"
+      ],
       "api": [
         "./types/api.d.ts",
         "./dist/api.d.ts"
@@ -265,6 +268,11 @@
       "types": "./dist/routes.d.ts",
       "import": "./dist/routes.mjs",
       "require": "./dist/routes.cjs"
+    },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "import": "./dist/testing.mjs",
+      "require": "./dist/testing.cjs"
     }
   },
   "scripts": {

--- a/packages/farm/src/__tests__/testing.test.ts
+++ b/packages/farm/src/__tests__/testing.test.ts
@@ -1,0 +1,409 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import { z } from "zod";
+import { createEndpoint } from "../api/endpoint";
+import { redirect } from "../navigation";
+import { api, createRoute } from "../routes";
+import { createServerFn } from "../server-fn";
+import { createFarmTestHarness, createTestRequest } from "../testing";
+
+afterEach(() => {
+  createFarmTestHarness().clearCache();
+});
+
+describe("createTestRequest", () => {
+  it("builds JSON requests with query, header, and cookie defaults", async () => {
+    const farm = createFarmTestHarness({
+      origin: "https://app.example.com/base",
+      headers: { "x-tenant": "acme", "x-shared": "default" },
+      cookies: { session: "session value" },
+    });
+
+    const request = farm.request("/api/products?keep=old", {
+      query: {
+        keep: "new",
+        tag: ["rsc", "forms"],
+        preview: true,
+        skipped: undefined,
+      },
+      headers: { "x-shared": "request" },
+      cookies: { theme: "dark" },
+      json: { name: "Farm" },
+    });
+    const url = new URL(request.url);
+
+    expect(request.method).toBe("POST");
+    expect(url.origin).toBe("https://app.example.com");
+    expect(url.pathname).toBe("/api/products");
+    expect(url.searchParams.get("keep")).toBe("new");
+    expect(url.searchParams.getAll("tag")).toEqual(["rsc", "forms"]);
+    expect(url.searchParams.get("preview")).toBe("true");
+    expect(url.searchParams.has("skipped")).toBe(false);
+    expect(request.headers.get("x-tenant")).toBe("acme");
+    expect(request.headers.get("x-shared")).toBe("request");
+    expect(request.headers.get("cookie")).toBe("session=session%20value; theme=dark");
+    expect(request.headers.get("content-type")).toBe("application/json");
+    await expect(request.json()).resolves.toEqual({ name: "Farm" });
+  });
+
+  it("builds repeated form fields", async () => {
+    const request = createTestRequest("/contact", {
+      form: {
+        name: "Ada",
+        topic: ["routing", "testing"],
+      },
+    });
+    const formData = await request.formData();
+
+    expect(request.method).toBe("POST");
+    expect(formData.get("name")).toBe("Ada");
+    expect(formData.getAll("topic")).toEqual(["routing", "testing"]);
+  });
+
+  it("rejects ambiguous bodies, GET bodies, and invalid origins", () => {
+    expect(() =>
+      createTestRequest("/submit", {
+        json: { ok: true },
+        body: "duplicate",
+      }),
+    ).toThrow("only one of json, form, or body");
+
+    expect(() =>
+      createTestRequest("/submit", {
+        method: "GET",
+        json: { ok: true },
+      }),
+    ).toThrow("cannot send a body with GET");
+
+    expect(() => createTestRequest("/", { origin: "file:///tmp/farm" })).toThrow(
+      "must use HTTP(S)",
+    );
+  });
+});
+
+describe("Farm test route harness", () => {
+  it("runs typed schemas, context, guards, and data hooks in runtime order", async () => {
+    const events: string[] = [];
+    const contextFactory = vi.fn(({ request, params, search }) => ({
+      tenant: request.headers.get("x-tenant"),
+      routeId: params.id,
+      rawTab: search.tab,
+    }));
+    const farm = createFarmTestHarness({
+      origin: "https://shop.example.com",
+      headers: { "x-tenant": "tenant-1" },
+      context: contextFactory,
+    });
+
+    const ProductRoute = createRoute("/products/[id]", {
+      params: z.object({ id: z.string().min(1) }),
+      search: {
+        schema: z.object({
+          tab: z.enum(["info", "reviews"]).default("info"),
+          locale: z.string().default("en"),
+          toast: z.string().optional(),
+        }),
+        stripDefaults: true,
+        preserve: ["locale"],
+        temporary: ["toast"],
+      },
+      guard({ context }) {
+        events.push("guard");
+        expect((context as { tenant: string }).tenant).toBe("tenant-1");
+      },
+      data: {
+        before({ params }) {
+          events.push("before");
+          return { token: `token:${params.id}` };
+        },
+        async main({ params, search, before, context }) {
+          events.push("main");
+          return {
+            product: {
+              id: params.id,
+              tab: search.tab,
+              token: before.token,
+              tenant: (context as { tenant: string }).tenant,
+            },
+          };
+        },
+        after({ data }) {
+          events.push("after");
+          expect(data.product.id).toBe("product 1");
+        },
+      },
+      component: function ProductPage() {
+        return null;
+      },
+    });
+    const pluginContext = { data: new Map<string, unknown>([["traceId", "trace-1"]]) };
+
+    const result = await farm.route(ProductRoute, {
+      params: { id: "product 1" },
+      search: { tab: "reviews", locale: "am", toast: "saved" },
+      pluginContext,
+      middleware: { data: new Map([["feature", "catalog"]]) },
+    });
+
+    expect(result.request.url).toBe(
+      "https://shop.example.com/products/product%201?tab=reviews&locale=am&toast=saved",
+    );
+    expect(result.props.params).toEqual({ id: "product 1" });
+    expect(result.props.search).toEqual({ tab: "reviews", locale: "am", toast: "saved" });
+    expect(result.props.data).toEqual({
+      product: {
+        id: "product 1",
+        tab: "reviews",
+        token: "token:product 1",
+        tenant: "tenant-1",
+      },
+    });
+    expect(result.props.context).toBe(pluginContext);
+    expect(result.props.middleware?.data.get("feature")).toBe("catalog");
+    expect(result.props).not.toHaveProperty("pluginContext");
+    expect(result.canonicalPath).toBe("/products/product%201?tab=reviews&locale=am");
+    expect(result.element.type).toBe(ProductRoute.component);
+    expect(events).toEqual(["guard", "before", "main", "after"]);
+    expect(contextFactory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: { id: "product 1" },
+        search: { tab: "reviews", locale: "am", toast: "saved" },
+        path: "/products/product%201",
+      }),
+    );
+
+    expectTypeOf(result.props.params).toEqualTypeOf<{ id: string }>();
+    expectTypeOf(result.props.search.tab).toEqualTypeOf<"info" | "reviews">();
+    expectTypeOf(result.props.data.product.id).toEqualTypeOf<string>();
+  });
+
+  it("lets explicit context override the harness context factory", async () => {
+    const contextFactory = vi.fn(() => ({ role: "viewer" }));
+    const farm = createFarmTestHarness({ context: contextFactory });
+    const DashboardRoute = createRoute("/dashboard", {
+      guard({ context }) {
+        expect(context).toEqual({ role: "admin" });
+      },
+      component: function DashboardPage() {
+        return null;
+      },
+    });
+
+    await farm.route(DashboardRoute, { context: { role: "admin" } });
+
+    expect(contextFactory).not.toHaveBeenCalled();
+  });
+
+  it("surfaces redirects and schema failures", async () => {
+    const farm = createFarmTestHarness();
+    const ProtectedRoute = createRoute("/protected/[id]", {
+      params: z.object({ id: z.string().uuid() }),
+      search: z.object({ access: z.enum(["allowed", "denied"]) }),
+      guard({ search }) {
+        if (search.access === "denied") redirect("/login");
+      },
+      component: function ProtectedPage() {
+        return null;
+      },
+    });
+
+    await expect(
+      farm.route(ProtectedRoute, {
+        params: { id: "550e8400-e29b-41d4-a716-446655440000" },
+        search: { access: "denied" },
+      }),
+    ).rejects.toMatchObject({ digest: "FARM_REDIRECT;307;/login" });
+
+    await expect(
+      farm.route(ProtectedRoute, {
+        params: { id: "not-a-uuid" },
+        search: { access: "allowed" },
+      }),
+    ).rejects.toThrow('Invalid params for route "/protected/[id]"');
+  });
+
+  it("uses the real route data cache and clears it explicitly", async () => {
+    const farm = createFarmTestHarness();
+    const loadProduct = vi.fn(async (id: string) => ({ id }));
+    const ProductRoute = createRoute("/cached/[id]", {
+      params: z.object({ id: z.string() }),
+      data: {
+        key: ({ params }) => ["test-product", params.id],
+        async main({ params }) {
+          return { product: await loadProduct(params.id) };
+        },
+      },
+      component: function CachedProductPage() {
+        return null;
+      },
+    });
+
+    await farm.route(ProductRoute, { params: { id: "42" } });
+    await farm.route(ProductRoute, { params: { id: "42" } });
+    expect(loadProduct).toHaveBeenCalledTimes(1);
+
+    farm.clearCache();
+    await farm.route(ProductRoute, { params: { id: "42" } });
+    expect(loadProduct).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("Farm test API harness", () => {
+  it("invokes programmatic API routes with params and validation", async () => {
+    const farm = createFarmTestHarness({ headers: { "x-tenant": "acme" } });
+    const updateProject = createEndpoint(
+      {
+        method: "PATCH",
+        body: z.object({ name: z.string().min(2) }),
+        query: z.object({ source: z.enum(["form", "api"]) }),
+      },
+      ({ body, query, params, headers }) => ({
+        id: params.id,
+        name: body.name,
+        source: query.source,
+        tenant: headers["x-tenant"],
+      }),
+    );
+    const ProjectApi = api("/api/projects/[id]", { PATCH: updateProject });
+
+    const response = await farm.api(ProjectApi, {
+      method: "PATCH",
+      params: { id: "project 1" },
+      query: { source: "form" },
+      json: { name: "Farm" },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      id: "project 1",
+      name: "Farm",
+      source: "form",
+      tenant: "acme",
+    });
+
+    const invalid = await farm.api(ProjectApi, {
+      method: "PATCH",
+      params: { id: "project-1" },
+      query: { source: "api" },
+      json: { name: "x" },
+    });
+    expect(invalid.status).toBe(400);
+    await expect(invalid.json()).resolves.toMatchObject({ error: "Invalid request body" });
+  });
+
+  it("returns production-style route and handler failures", async () => {
+    const farm = createFarmTestHarness();
+    const ProjectsApi = api("/api/projects", {
+      GET: async () => ({ projects: [] }),
+    });
+
+    const notFound = await farm.api(ProjectsApi, { path: "/api/other" });
+    expect(notFound.status).toBe(404);
+    await expect(notFound.json()).resolves.toEqual({ error: "Not Found" });
+
+    const methodNotAllowed = await farm.api(ProjectsApi, { method: "DELETE" });
+    expect(methodNotAllowed.status).toBe(405);
+    await expect(methodNotAllowed.json()).resolves.toEqual({ error: "Method Not Allowed" });
+
+    const BrokenApi = api("/api/broken", {
+      GET: async () => {
+        throw new Error("database unavailable");
+      },
+    });
+    const failed = await farm.api(BrokenApi);
+    expect(failed.status).toBe(500);
+    await expect(failed.json()).resolves.toEqual({ error: "database unavailable" });
+    await expect(farm.api(BrokenApi, { throwOnError: true })).rejects.toThrow(
+      "database unavailable",
+    );
+  });
+
+  it("invokes file-style endpoints directly", async () => {
+    const farm = createFarmTestHarness();
+    const GET = async (
+      request: Request,
+      { params }: { params: Promise<Record<string, string>> },
+    ) => ({
+      id: (await params).id,
+      mode: new URL(request.url).searchParams.get("mode"),
+    });
+
+    const response = await farm.endpoint(GET, {
+      path: "/api/files/guide",
+      params: { id: "guide" },
+      query: { mode: "raw" },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ id: "guide", mode: "raw" });
+  });
+});
+
+describe("Farm test server function harness", () => {
+  it("keeps schema and result inference while providing request context", async () => {
+    const farm = createFarmTestHarness({
+      origin: "https://actions.example.com",
+      headers: { "x-tenant": "acme" },
+    });
+    const signup = createServerFn({
+      input: z.object({ email: z.string().email() }),
+      async handler({ input, request, signal }) {
+        return {
+          ok: true as const,
+          email: input.email,
+          url: request?.url,
+          tenant: request?.headers.get("x-tenant"),
+          signal,
+        };
+      },
+    });
+
+    const result = await farm.serverFn(signup, { email: "ada@example.com" });
+
+    expect(result).toMatchObject({
+      ok: true,
+      email: "ada@example.com",
+      url: "https://actions.example.com/__farm/test/server-fn",
+      tenant: "acme",
+    });
+    expect(result.signal.aborted).toBe(false);
+    expectTypeOf(result.ok).toEqualTypeOf<true>();
+    expectTypeOf(result.email).toEqualTypeOf<string>();
+
+    await expect(farm.serverFn(signup, { email: "invalid" })).rejects.toBeTruthy();
+  });
+
+  it("supports form input, input-less functions, exact requests, and cancellation", async () => {
+    const farm = createFarmTestHarness();
+    const submit = createServerFn({
+      input: z.object({ title: z.string().min(1) }),
+      handler: ({ input, formData, request }) => ({
+        title: input.title,
+        fromForm: formData instanceof FormData,
+        authorization: request?.headers.get("authorization"),
+      }),
+    });
+    const formData = new FormData();
+    formData.set("title", "Test Farm");
+    const request = createTestRequest("https://app.example.com/actions/submit", {
+      method: "POST",
+      headers: { authorization: "Bearer test" },
+    });
+
+    await expect(farm.serverFn(submit, formData, { request })).resolves.toEqual({
+      title: "Test Farm",
+      fromForm: true,
+      authorization: "Bearer test",
+    });
+
+    const health = createServerFn({ handler: () => ({ ok: true as const }) });
+    await expect(farm.serverFn(health)).resolves.toEqual({ ok: true });
+
+    const controller = new AbortController();
+    controller.abort(new Error("request cancelled"));
+    await expect(
+      farm.serverFn(submit, { title: "cancelled" }, { signal: controller.signal }),
+    ).rejects.toThrow("request cancelled");
+  });
+});

--- a/packages/farm/src/testing.ts
+++ b/packages/farm/src/testing.ts
@@ -1,0 +1,488 @@
+import { createElement, type ReactElement } from "react";
+import { invokeAPIRouteEndpoint, matchAPIRoute, type APIRouteParams } from "./api/route-manager";
+import { getFarmDataCache } from "./cache";
+import { resolveFarmRouteContext, withFarmRouteContext } from "./route-context";
+import {
+  createRouteModuleFromProgrammaticPage,
+  type InferProgrammaticRouteData,
+  type ProgrammaticApiRoute,
+  type ProgrammaticPageRoute,
+  type ProgrammaticRouteComponentProps,
+  type ProgrammaticRouteMethod,
+} from "./routes";
+import {
+  buildFarmRoutePath,
+  matchFarmRoute,
+  type FarmRouterPathParams,
+  type FarmRouterQueryValue,
+} from "./router";
+import { runWithServerActionRequest } from "./server-action-security";
+import type { ServerFn } from "./server-fn";
+import type { FarmContextFactory, MiddlewareProps, PluginContextProps, RouteModule } from "./types";
+
+export type FarmTestQuery = URLSearchParams | Record<string, FarmRouterQueryValue>;
+export type FarmTestPathParams = FarmRouterPathParams;
+export type FarmTestFormValues = Record<string, FormDataEntryValue | readonly FormDataEntryValue[]>;
+
+export interface FarmTestRequestOptions extends Omit<RequestInit, "body" | "headers"> {
+  origin?: string;
+  headers?: HeadersInit;
+  query?: FarmTestQuery;
+  cookies?: Record<string, string>;
+  json?: unknown;
+  form?: FormData | FarmTestFormValues;
+  body?: BodyInit | null;
+}
+
+export interface FarmTestHarnessOptions<TContext = unknown> {
+  origin?: string;
+  headers?: HeadersInit;
+  cookies?: Record<string, string>;
+  context?: FarmContextFactory<TContext>;
+}
+
+type AnyProgrammaticPageRoute = ProgrammaticPageRoute<any, any, any, any>;
+
+export type InferFarmTestRouteParams<TRoute> =
+  TRoute extends ProgrammaticPageRoute<infer TParams, any, any, any> ? TParams : never;
+
+export type InferFarmTestRouteSearch<TRoute> =
+  TRoute extends ProgrammaticPageRoute<any, infer TSearch, any, any> ? TSearch : never;
+
+export type InferFarmTestRouteData<TRoute> =
+  TRoute extends ProgrammaticPageRoute<any, any, infer TDataHooks, any>
+    ? InferProgrammaticRouteData<TDataHooks>
+    : never;
+
+export type FarmTestRouteProps<TRoute extends AnyProgrammaticPageRoute> =
+  ProgrammaticRouteComponentProps<
+    InferFarmTestRouteParams<TRoute>,
+    InferFarmTestRouteSearch<TRoute>,
+    InferFarmTestRouteData<TRoute>
+  >;
+
+type FarmTestRouteParamsInput<TRoute> =
+  InferFarmTestRouteParams<TRoute> extends Record<string, unknown>
+    ? Partial<InferFarmTestRouteParams<TRoute>>
+    : FarmTestPathParams;
+
+type FarmTestRouteSearchInput<TRoute> =
+  InferFarmTestRouteSearch<TRoute> extends Record<string, unknown>
+    ? Partial<InferFarmTestRouteSearch<TRoute>> | URLSearchParams
+    : FarmTestQuery;
+
+export interface FarmTestRouteOptions<
+  TRoute extends AnyProgrammaticPageRoute,
+  TContext = unknown,
+> extends Pick<FarmTestRequestOptions, "origin" | "headers" | "cookies" | "signal"> {
+  path?: string | URL;
+  params?: FarmTestRouteParamsInput<TRoute>;
+  search?: FarmTestRouteSearchInput<TRoute>;
+  context?: TContext;
+  middleware?: MiddlewareProps;
+  pluginContext?: PluginContextProps;
+}
+
+export interface FarmTestRouteResult<TRoute extends AnyProgrammaticPageRoute> {
+  route: TRoute;
+  module: RouteModule;
+  request: Request;
+  props: FarmTestRouteProps<TRoute>;
+  element: ReactElement;
+  canonicalPath?: string;
+}
+
+export interface FarmTestApiOptions extends FarmTestRequestOptions {
+  path?: string | URL;
+  params?: FarmTestPathParams;
+  throwOnError?: boolean;
+}
+
+export interface FarmTestEndpointOptions extends FarmTestRequestOptions {
+  path?: string | URL;
+  params?: APIRouteParams;
+  throwOnError?: boolean;
+}
+
+export interface FarmTestServerFnOptions extends Pick<
+  FarmTestRequestOptions,
+  "origin" | "headers" | "cookies" | "signal"
+> {
+  path?: string | URL;
+  request?: Request;
+}
+
+export type FarmTestServerFnArguments<TInput> = [unknown] extends [TInput]
+  ? [input?: TInput | FormData, options?: FarmTestServerFnOptions]
+  : [input: TInput | FormData, options?: FarmTestServerFnOptions];
+
+export interface FarmTestHarness<TContext = unknown> {
+  request(path?: string | URL, options?: FarmTestRequestOptions): Request;
+  route<TRoute extends AnyProgrammaticPageRoute>(
+    route: TRoute,
+    options?: FarmTestRouteOptions<TRoute, TContext>,
+  ): Promise<FarmTestRouteResult<TRoute>>;
+  api(route: ProgrammaticApiRoute, options?: FarmTestApiOptions): Promise<Response>;
+  endpoint(endpoint: unknown, options?: FarmTestEndpointOptions): Promise<Response>;
+  serverFn<TInput, TResult>(
+    serverFn: ServerFn<TInput, TResult>,
+    ...args: FarmTestServerFnArguments<TInput>
+  ): Promise<TResult>;
+  clearCache(): void;
+}
+
+/** Create a deterministic Web Request without depending on a test runner. */
+export function createTestRequest(
+  path: string | URL = "/",
+  options: FarmTestRequestOptions = {},
+): Request {
+  const url = resolveTestURL(path, options.origin);
+  applyQuery(url.searchParams, options.query);
+
+  const headers = new Headers(options.headers);
+  applyCookies(headers, options.cookies);
+  const { body, hasBody } = resolveRequestBody(options, headers);
+  const method = (options.method ?? (hasBody ? "POST" : "GET")).toUpperCase();
+
+  if ((method === "GET" || method === "HEAD") && body != null) {
+    throw new TypeError(`Farm test requests cannot send a body with ${method}`);
+  }
+
+  const {
+    origin: _origin,
+    query: _query,
+    cookies: _cookies,
+    json: _json,
+    form: _form,
+    body: _body,
+    headers: _headers,
+    ...requestInit
+  } = options;
+
+  return new Request(url, {
+    ...requestInit,
+    method,
+    headers,
+    body,
+  });
+}
+
+/**
+ * Create test helpers that exercise Farm's real route, API, and server-function runtimes.
+ * The harness has no dependency on Vitest, Jest, or a DOM environment.
+ */
+export function createFarmTestHarness<TContext = unknown>(
+  options: FarmTestHarnessOptions<TContext> = {},
+): FarmTestHarness<TContext> {
+  const origin = normalizeOrigin(options.origin);
+
+  const request = (path: string | URL = "/", requestOptions: FarmTestRequestOptions = {}) =>
+    createTestRequest(path, mergeRequestDefaults(options, origin, requestOptions));
+
+  return {
+    request,
+
+    async route<TRoute extends AnyProgrammaticPageRoute>(
+      route: TRoute,
+      routeOptions: FarmTestRouteOptions<TRoute, TContext> = {},
+    ): Promise<FarmTestRouteResult<TRoute>> {
+      const requestPath =
+        routeOptions.path ??
+        buildFarmRoutePath(route.path, (routeOptions.params ?? {}) as FarmRouterPathParams);
+      const routeRequest = request(requestPath, {
+        origin: routeOptions.origin,
+        headers: routeOptions.headers,
+        cookies: routeOptions.cookies,
+        signal: routeOptions.signal,
+        query: routeOptions.search as FarmTestQuery | undefined,
+      });
+      const url = new URL(routeRequest.url);
+      const params = resolvePageParams(route.path, url.pathname, routeOptions.params);
+      const search = readSearchParams(url.searchParams);
+      const routeContext = Object.prototype.hasOwnProperty.call(routeOptions, "context")
+        ? routeOptions.context
+        : await resolveFarmRouteContext(
+            { context: options.context },
+            {
+              request: routeRequest,
+              params,
+              search,
+              path: url.pathname,
+            },
+          );
+      const rawProps = withFarmRouteContext(
+        {
+          params,
+          searchParams: Promise.resolve(search),
+          path: url.pathname,
+          middleware: routeOptions.middleware,
+          context: routeOptions.pluginContext,
+        },
+        routeContext,
+      );
+      const routeModule = createRouteModuleFromProgrammaticPage(route);
+      const resolveProps = (
+        routeModule as RouteModule & {
+          __farmResolveRouteProps?: (props: typeof rawProps) => Promise<Record<string, unknown>>;
+        }
+      ).__farmResolveRouteProps;
+      const resolvedProps = resolveProps
+        ? await resolveProps(rawProps)
+        : { ...rawProps, search, searchParams: Promise.resolve(search) };
+      const canonicalPath = readCanonicalPath(resolvedProps);
+      const componentProps = stripInternalRouteProps(resolvedProps) as FarmTestRouteProps<TRoute>;
+
+      return {
+        route,
+        module: routeModule,
+        request: routeRequest,
+        props: componentProps,
+        element: createElement(route.component, componentProps),
+        canonicalPath,
+      };
+    },
+
+    async api(route, apiOptions = {}) {
+      const requestPath =
+        apiOptions.path ?? buildFarmRoutePath(route.path, apiOptions.params ?? {});
+      const method = apiOptions.method ?? getDefaultApiMethod(route);
+      const apiRequest = request(requestPath, omitApiControlOptions({ ...apiOptions, method }));
+      const match = matchAPIRoute(new Map([[route.path, route]]), new URL(apiRequest.url).pathname);
+
+      if (!match) {
+        return jsonErrorResponse("Not Found", 404);
+      }
+
+      const endpoint = match.route.methods[apiRequest.method as ProgrammaticRouteMethod];
+      if (!endpoint) {
+        return jsonErrorResponse("Method Not Allowed", 405);
+      }
+
+      return invokeTestEndpoint(endpoint, apiRequest, match.params, apiOptions.throwOnError);
+    },
+
+    async endpoint(endpoint, endpointOptions = {}) {
+      const endpointRecord = endpoint as { __method?: string; __path?: string };
+      const endpointPath = endpointOptions.path ?? endpointRecord.__path ?? "/__farm/test/endpoint";
+      const endpointRequest = request(endpointPath, {
+        ...omitEndpointControlOptions(endpointOptions),
+        method: endpointOptions.method ?? endpointRecord.__method ?? "GET",
+      });
+
+      return invokeTestEndpoint(
+        endpoint,
+        endpointRequest,
+        endpointOptions.params,
+        endpointOptions.throwOnError,
+      );
+    },
+
+    async serverFn<TInput, TResult>(
+      serverFn: ServerFn<TInput, TResult>,
+      ...args: FarmTestServerFnArguments<TInput>
+    ): Promise<TResult> {
+      const [input, serverFnOptions = {}] = args;
+      const actionRequest =
+        serverFnOptions.request ??
+        request(serverFnOptions.path ?? "/__farm/test/server-fn", {
+          origin: serverFnOptions.origin,
+          headers: serverFnOptions.headers,
+          cookies: serverFnOptions.cookies,
+          signal: serverFnOptions.signal,
+          method: "POST",
+        });
+
+      return await runWithServerActionRequest(actionRequest, () => serverFn(input as TInput));
+    },
+
+    clearCache() {
+      getFarmDataCache().clear();
+    },
+  };
+}
+
+function resolveTestURL(path: string | URL, origin: string | undefined): URL {
+  const url = path instanceof URL ? new URL(path) : new URL(path, `${normalizeOrigin(origin)}/`);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new TypeError(`Farm test requests require an HTTP(S) URL, received ${url.protocol}`);
+  }
+  return url;
+}
+
+function normalizeOrigin(origin = "http://farm.test"): string {
+  let url: URL;
+  try {
+    url = new URL(origin);
+  } catch {
+    throw new TypeError(`Invalid Farm test origin: ${JSON.stringify(origin)}`);
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new TypeError(`Farm test origins must use HTTP(S), received ${url.protocol}`);
+  }
+
+  return url.origin;
+}
+
+function mergeRequestDefaults<TContext>(
+  harnessOptions: FarmTestHarnessOptions<TContext>,
+  origin: string,
+  requestOptions: FarmTestRequestOptions,
+): FarmTestRequestOptions {
+  const headers = new Headers(harnessOptions.headers);
+  new Headers(requestOptions.headers).forEach((value, key) => headers.set(key, value));
+
+  return {
+    ...requestOptions,
+    origin: requestOptions.origin ?? origin,
+    headers,
+    cookies: {
+      ...harnessOptions.cookies,
+      ...requestOptions.cookies,
+    },
+  };
+}
+
+function applyQuery(searchParams: URLSearchParams, query: FarmTestQuery | undefined): void {
+  if (!query) return;
+
+  if (query instanceof URLSearchParams) {
+    for (const key of new Set(query.keys())) {
+      searchParams.delete(key);
+      for (const value of query.getAll(key)) searchParams.append(key, value);
+    }
+    return;
+  }
+
+  for (const [key, rawValue] of Object.entries(query)) {
+    searchParams.delete(key);
+    const values = Array.isArray(rawValue) ? rawValue : [rawValue];
+    for (const value of values) {
+      if (value == null) continue;
+      if (typeof value !== "string" && typeof value !== "number" && typeof value !== "boolean") {
+        throw new TypeError(`Invalid query value for ${JSON.stringify(key)}`);
+      }
+      searchParams.append(key, String(value));
+    }
+  }
+}
+
+function applyCookies(headers: Headers, cookies: Record<string, string> | undefined): void {
+  if (!cookies || Object.keys(cookies).length === 0) return;
+
+  const value = Object.entries(cookies)
+    .map(([name, cookieValue]) => `${encodeURIComponent(name)}=${encodeURIComponent(cookieValue)}`)
+    .join("; ");
+  const current = headers.get("cookie");
+  headers.set("cookie", current ? `${current}; ${value}` : value);
+}
+
+function resolveRequestBody(
+  options: FarmTestRequestOptions,
+  headers: Headers,
+): { body: BodyInit | null; hasBody: boolean } {
+  const sources = [
+    options.json !== undefined,
+    options.form !== undefined,
+    options.body !== undefined,
+  ];
+  if (sources.filter(Boolean).length > 1) {
+    throw new TypeError("Farm test requests accept only one of json, form, or body");
+  }
+
+  if (options.json !== undefined) {
+    if (!headers.has("content-type")) headers.set("content-type", "application/json");
+    return { body: JSON.stringify(options.json), hasBody: true };
+  }
+
+  if (options.form !== undefined) {
+    const formData = options.form instanceof FormData ? options.form : createFormData(options.form);
+    return { body: formData, hasBody: true };
+  }
+
+  return {
+    body: options.body ?? null,
+    hasBody: options.body !== undefined,
+  };
+}
+
+function createFormData(values: FarmTestFormValues): FormData {
+  const formData = new FormData();
+  for (const [key, rawValue] of Object.entries(values)) {
+    const entries = Array.isArray(rawValue) ? rawValue : [rawValue];
+    for (const value of entries) formData.append(key, value);
+  }
+  return formData;
+}
+
+function resolvePageParams(
+  pattern: string,
+  pathname: string,
+  explicitParams: Record<string, unknown> | undefined,
+): Record<string, string> {
+  const matchedParams = matchFarmRoute(pattern, pathname);
+  if (!matchedParams) {
+    throw new Error(
+      `Path ${JSON.stringify(pathname)} does not match route ${JSON.stringify(pattern)}`,
+    );
+  }
+
+  if (!explicitParams) return matchedParams;
+
+  return Object.fromEntries(
+    Object.entries(explicitParams).map(([key, value]) => [
+      key,
+      Array.isArray(value) ? value.map(String).join("/") : String(value),
+    ]),
+  );
+}
+
+function readSearchParams(searchParams: URLSearchParams): Record<string, string> {
+  const search: Record<string, string> = {};
+  searchParams.forEach((value, key) => {
+    search[key] = value;
+  });
+  return search;
+}
+
+function readCanonicalPath(props: Record<string, unknown>): string | undefined {
+  return typeof props.__farmCanonicalPath === "string" ? props.__farmCanonicalPath : undefined;
+}
+
+function stripInternalRouteProps(props: Record<string, unknown>): Record<string, unknown> {
+  const { __farmRoutePropsResolved, __farmCanonicalPath, ...componentProps } = props;
+  return componentProps;
+}
+
+function getDefaultApiMethod(route: ProgrammaticApiRoute): ProgrammaticRouteMethod {
+  if (route.methods.GET) return "GET";
+  return (Object.keys(route.methods)[0] as ProgrammaticRouteMethod | undefined) ?? "GET";
+}
+
+function omitApiControlOptions(options: FarmTestApiOptions): FarmTestRequestOptions {
+  const { path: _path, params: _params, throwOnError: _throwOnError, ...requestOptions } = options;
+  return requestOptions;
+}
+
+function omitEndpointControlOptions(options: FarmTestEndpointOptions): FarmTestRequestOptions {
+  const { path: _path, params: _params, throwOnError: _throwOnError, ...requestOptions } = options;
+  return requestOptions;
+}
+
+async function invokeTestEndpoint(
+  endpoint: unknown,
+  request: Request,
+  params: APIRouteParams = {},
+  throwOnError = false,
+): Promise<Response> {
+  try {
+    return await invokeAPIRouteEndpoint(endpoint, request, params);
+  } catch (error) {
+    if (throwOnError) throw error;
+    return jsonErrorResponse(error instanceof Error ? error.message : "Internal Server Error", 500);
+  }
+}
+
+function jsonErrorResponse(error: string, status: number): Response {
+  return Response.json({ error }, { status });
+}

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
     "env-types": "src/env-types.ts",
     environment: "src/environment.ts",
     "environment/vite": "src/environment-vite.ts",
+    testing: "src/testing.ts",
   },
   format: ["cjs", "esm"],
   dts: true,


### PR DESCRIPTION
## Summary

- add a runner-agnostic `@farmjs/core/testing` entry with deterministic Web Request construction
- exercise real programmatic route, API endpoint, route cache, context, and server-function runtimes through one typed harness
- cover validation, redirects, dynamic params, HTTP failures, form inputs, request context, and cancellation
- document usage, isolation practices, and transport-security testing boundaries

## Verification

- `corepack pnpm --filter @farmjs/core build`
- `node_modules/.bin/vitest run` from `packages/farm` (54 files, 460 passed, 1 skipped)
- docs Prisma generation and production `farm build`
- ESM and CommonJS package-subpath import checks
- targeted oxlint and format checks