### PR TITLE
fix: clarify integration HTTP surfaces

### DIFF
--- a/docs/src/app/docs/integrations/custom/page.md
+++ b/docs/src/app/docs/integrations/custom/page.md
@@ -48,6 +48,114 @@ export default defineFarmConfig({
 
 The route is now mounted at `/api/acme/status`. Because it was created with `integrationRoute.get`, Farm can also derive the callable API shape.
 
+## Choose the HTTP surface
+
+`routes`, `endpoints`, and `api` are not three steps that every integration must configure. They
+describe two different responsibilities:
+
+```text
+typed routes or endpoints -> mount HTTP handlers -> derive api and apiClient callers
+plain route objects       -> mount HTTP handlers only
+api                       -> describe callers only; no HTTP handler is mounted
+```
+
+| Field       | Runtime responsibility                                                       | Caller names come from                                       | Best use                                                                  |
+| ----------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| `routes`    | Mounts a flat list of handlers.                                              | The route URL when you use `integrationRoute.*`.             | Most integrations. Start here.                                            |
+| `endpoints` | Recursively flattens an object of handlers into `routes` and mounts them.    | The route URL when you use `endpoint.*`, not the object key. | Large integrations that are clearer when handlers are grouped by feature. |
+| `api`       | Defines typed operations that call existing URLs. It never mounts a handler. | The keys in the `api` object.                                | Routes implemented elsewhere, or a deliberately customized caller tree.   |
+
+A plain object in `routes` or `endpoints` still mounts its handler. Only the typed
+`integrationRoute.*` and `endpoint.*` builders attach the operation metadata Farm needs to infer
+`api` and `apiClient` request and response types.
+
+For most integrations, define `routes` and stop there:
+
+```ts
+export const billing = defineIntegration({
+  category: "payment",
+  type: "acme-billing",
+  instance: {},
+  routes: [
+    integrationRoute.post<"/api/billing/checkout", { priceId: string }, { url: string }>(
+      "/api/billing/checkout",
+      {
+        handler() {
+          return Response.json({ url: "https://checkout.example/session" });
+        },
+      },
+    ),
+  ],
+});
+```
+
+That one declaration does both jobs:
+
+- It mounts `POST /api/billing/checkout`.
+- It derives `api.billing.checkout.post(...)` and `apiClient.billing.checkout.post(...)` when the
+  integration is registered as `billing`.
+
+Use `endpoints` instead when grouping the same handler definitions makes the integration easier to
+scan:
+
+```ts
+export const billing = defineIntegration({
+  category: "payment",
+  type: "acme-billing",
+  instance: {},
+  endpoints: ({ endpoint }) => ({
+    checkout: endpoint.post<"/api/billing/checkout", { priceId: string }, { url: string }>(
+      "/api/billing/checkout",
+      {
+        handler() {
+          return Response.json({ url: "https://checkout.example/session" });
+        },
+      },
+    ),
+  }),
+});
+```
+
+This mounts and derives the same route as the `routes` example. The key `checkout` is only an
+authoring label. The URL `/api/billing/checkout` determines the derived caller path.
+
+Use `api` by itself when this integration does not own the handler:
+
+```ts
+import { defineIntegration, endpoint } from "@farmjs/core";
+
+export const billing = defineIntegration({
+  category: "payment",
+  type: "acme-billing",
+  instance: {},
+  api: {
+    startCheckout: endpoint.post<{ priceId: string }, { url: string }>("/api/billing/checkout", {
+      responseFormat: "json",
+    }),
+  },
+});
+```
+
+This creates `api.billing.startCheckout(...)`, but it does **not** create
+`POST /api/billing/checkout`. The app or another service must implement that URL.
+
+If you provide `api` together with `routes` or `endpoints`, Farm still mounts the handlers, but the
+explicit `api` object replaces all automatic caller derivation for that integration. Use that
+combination only when you intentionally want caller names or operations that differ from the route
+paths, and keep the declared methods and paths synchronized. Built-in integrations may use this
+advanced combination to keep a stable public caller contract; most application integrations do not
+need it.
+
+There are also two similarly named values on the consuming side:
+
+```ts
+const { api: integrationsServer, apiClient: integrationsClient } =
+  createIntegrations<AppIntegrations>();
+```
+
+The integration's `api:` field is a contract. The returned `api` value is the server caller for that
+contract, while `apiClient` is the browser caller.
+
 ## Full shape
 
 The full interface is intentionally flat. Lifecycle hooks are top-level fields instead of being wrapped in a `lifecycle` object.
@@ -57,9 +165,9 @@ type IntegrationAuthoringShape = {
   category: string;
   type: string;
   instance: unknown;
-  api?: object;
-  routes?: readonly unknown[];
-  endpoints?: object;
+  routes?: readonly unknown[]; // Flat HTTP handler definitions.
+  endpoints?: object; // Grouped HTTP handler definitions.
+  api?: object; // Caller definitions only; does not mount handlers.
   middleware?: readonly unknown[];
   providers?: readonly unknown[];
   documentNavigations?: readonly unknown[];
@@ -214,7 +322,9 @@ For body and query validation you can use Zod, any parser with `parse`, any pars
 
 ## Endpoints object
 
-Use `endpoints` when you want the integration definition to look like the callable API tree. Farm flattens the endpoints into routes and derives the same client namespace.
+Use `endpoints` when you want to organize handler definitions in an object instead of a flat array.
+Farm recursively flattens the object into `routes` and derives callers from each route URL. The
+object keys are organizational; they do not control the caller namespace.
 
 ```ts
 import { z } from "zod";
@@ -254,11 +364,15 @@ export const billing = defineIntegration({
 });
 ```
 
-That produces `api.billing.checkout.post(...)` and `api.billing.status()`.
+The URLs in this example produce `api.billing.checkout.post(...)` and
+`api.billing.status()`. Those names match the object keys because the final URL segments are also
+`checkout` and `status`.
 
 ## Explicit API trees
 
-Use `api` when routes are implemented elsewhere, or when the integration only needs typed callers.
+Use `api` when routes are implemented elsewhere, when the integration only needs typed callers, or
+when you intentionally want caller names that do not follow the URLs. An `api` operation never
+registers an HTTP handler.
 
 ```ts
 import { defineIntegration, endpoint } from "@farmjs/core";
@@ -285,6 +399,9 @@ export const acme = defineIntegration({
 ```
 
 `endpoint.route(path, ...)` is useful when multiple methods share one path. A namespace with one method can be called directly and still keeps the method accessor.
+
+If the integration also declares `routes` or `endpoints`, this explicit tree replaces the caller
+tree Farm would derive from them. It does not replace or remove their HTTP handlers.
 
 ## Hooks around a route
 

--- a/docs/src/app/docs/integrations/custom/page.md
+++ b/docs/src/app/docs/integrations/custom/page.md
@@ -69,9 +69,57 @@ A plain object in `routes` or `endpoints` still mounts its handler. Only the typ
 `integrationRoute.*` and `endpoint.*` builders attach the operation metadata Farm needs to infer
 `api` and `apiClient` request and response types.
 
-For most integrations, define `routes` and stop there:
+The three formats below are alternatives. Each example exports an integration named `billing` and
+uses the same registration and caller setup.
+
+### Shared registration
+
+Register the integration once. The `billing` key becomes the first segment after `api` or
+`apiClient`.
+
+**farm.config.ts**
 
 ```ts
+import { defineFarmConfig } from "@farmjs/core";
+import { billing } from "./src/integrations/billing";
+
+export default defineFarmConfig({
+  integrations: {
+    billing,
+  },
+});
+```
+
+Create the browser and server callers once as well:
+
+**src/lib/integrations.ts**
+
+```ts
+import { createIntegrations } from "@farmjs/core/client";
+import type { billing } from "../integrations/billing";
+
+type AppIntegrations = {
+  billing: typeof billing;
+};
+
+export const { api, apiClient } = createIntegrations<AppIntegrations>();
+```
+
+`apiClient` is the browser caller. `api` is the server caller; it dispatches directly to a
+registered integration handler when possible and falls back to `fetch` when no runtime is
+available.
+
+### 1. `routes`: flat owned handlers
+
+Use `routes` when the integration owns the HTTP handlers and a flat list is easy to read. This is
+the recommended default.
+
+**src/integrations/billing.ts**
+
+```ts
+import { defineIntegration, integrationRoute } from "@farmjs/core";
+import { z } from "zod";
+
 export const billing = defineIntegration({
   category: "payment",
   type: "acme-billing",
@@ -80,8 +128,11 @@ export const billing = defineIntegration({
     integrationRoute.post<"/api/billing/checkout", { priceId: string }, { url: string }>(
       "/api/billing/checkout",
       {
-        handler() {
-          return Response.json({ url: "https://checkout.example/session" });
+        body: z.object({ priceId: z.string() }),
+        handler(_request, ctx) {
+          return Response.json({
+            url: `https://checkout.example/${ctx.input.body!.priceId}`,
+          });
         },
       },
     ),
@@ -89,16 +140,54 @@ export const billing = defineIntegration({
 });
 ```
 
-That one declaration does both jobs:
+Farm mounts `POST /api/billing/checkout` and derives the caller from that URL.
 
-- It mounts `POST /api/billing/checkout`.
-- It derives `api.billing.checkout.post(...)` and `apiClient.billing.checkout.post(...)` when the
-  integration is registered as `billing`.
+**client code**
 
-Use `endpoints` instead when grouping the same handler definitions makes the integration easier to
-scan:
+```tsx
+"use client";
+
+import { apiClient } from "../lib/integrations";
+
+export async function startCheckout() {
+  const result = await apiClient.billing.checkout.post({
+    body: { priceId: "price_123" },
+  });
+
+  if (result.error) throw result.error;
+  return result.data;
+}
+```
+
+**server code**
 
 ```ts
+import { api } from "../lib/integrations";
+
+export async function startCheckoutOnServer() {
+  const result = await api.billing.checkout.post({
+    body: { priceId: "price_123" },
+  });
+
+  if (result.error) throw result.error;
+  return result.data;
+}
+```
+
+Both calls have typed input, typed `data`, and typed `error`. The Zod body schema also validates the
+incoming request at runtime.
+
+### 2. `endpoints`: grouped owned handlers
+
+Use `endpoints` when the integration still owns the handlers, but an object is easier to organize
+than a flat list.
+
+**src/integrations/billing.ts**
+
+```ts
+import { defineIntegration } from "@farmjs/core";
+import { z } from "zod";
+
 export const billing = defineIntegration({
   category: "payment",
   type: "acme-billing",
@@ -107,8 +196,11 @@ export const billing = defineIntegration({
     checkout: endpoint.post<"/api/billing/checkout", { priceId: string }, { url: string }>(
       "/api/billing/checkout",
       {
-        handler() {
-          return Response.json({ url: "https://checkout.example/session" });
+        body: z.object({ priceId: z.string() }),
+        handler(_request, ctx) {
+          return Response.json({
+            url: `https://checkout.example/${ctx.input.body!.priceId}`,
+          });
         },
       },
     ),
@@ -116,10 +208,51 @@ export const billing = defineIntegration({
 });
 ```
 
-This mounts and derives the same route as the `routes` example. The key `checkout` is only an
-authoring label. The URL `/api/billing/checkout` determines the derived caller path.
+Farm flattens this object into `routes`, mounts the same HTTP handler, and generates the same typed
+callers:
 
-Use `api` by itself when this integration does not own the handler:
+**client code**
+
+```tsx
+"use client";
+
+import { apiClient } from "../lib/integrations";
+
+export async function startCheckout() {
+  const result = await apiClient.billing.checkout.post({
+    body: { priceId: "price_123" },
+  });
+
+  if (result.error) throw result.error;
+  return result.data;
+}
+```
+
+**server code**
+
+```ts
+import { api } from "../lib/integrations";
+
+export async function startCheckoutOnServer() {
+  const result = await api.billing.checkout.post({
+    body: { priceId: "price_123" },
+  });
+
+  if (result.error) throw result.error;
+  return result.data;
+}
+```
+
+The `checkout` object key is only an authoring label. The URL `/api/billing/checkout` determines the
+derived caller path. If the key were `start` but the URL stayed the same, the caller would still be
+`api.billing.checkout.post(...)`.
+
+### 3. `api`: callers for existing handlers
+
+Use `api` when this integration does not own the handler, or when you intentionally want caller
+names that do not follow route URLs.
+
+**src/integrations/billing.ts**
 
 ```ts
 import { defineIntegration, endpoint } from "@farmjs/core";
@@ -136,8 +269,42 @@ export const billing = defineIntegration({
 });
 ```
 
-This creates `api.billing.startCheckout(...)`, but it does **not** create
-`POST /api/billing/checkout`. The app or another service must implement that URL.
+This creates typed callers named `startCheckout`:
+
+**client code**
+
+```tsx
+"use client";
+
+import { apiClient } from "../lib/integrations";
+
+export async function startCheckout() {
+  const result = await apiClient.billing.startCheckout({
+    body: { priceId: "price_123" },
+  });
+
+  if (result.error) throw result.error;
+  return result.data;
+}
+```
+
+**server code**
+
+```ts
+import { api } from "../lib/integrations";
+
+export async function startCheckoutOnServer() {
+  const result = await api.billing.startCheckout({
+    body: { priceId: "price_123" },
+  });
+
+  if (result.error) throw result.error;
+  return result.data;
+}
+```
+
+Unlike `routes` and `endpoints`, `api` does **not** create `POST /api/billing/checkout`. The app or
+another service must implement that URL.
 
 If you provide `api` together with `routes` or `endpoints`, Farm still mounts the handlers, but the
 explicit `api` object replaces all automatic caller derivation for that integration. Use that
@@ -146,15 +313,8 @@ paths, and keep the declared methods and paths synchronized. Built-in integratio
 advanced combination to keep a stable public caller contract; most application integrations do not
 need it.
 
-There are also two similarly named values on the consuming side:
-
-```ts
-const { api: integrationsServer, apiClient: integrationsClient } =
-  createIntegrations<AppIntegrations>();
-```
-
-The integration's `api:` field is a contract. The returned `api` value is the server caller for that
-contract, while `apiClient` is the browser caller.
+The integration's `api:` field is a contract. It is different from the returned `api` value, which
+is the server caller for that contract. `apiClient` is the browser caller.
 
 ## Full shape
 

--- a/docs/src/app/docs/integrations/page.md
+++ b/docs/src/app/docs/integrations/page.md
@@ -54,13 +54,37 @@ export const { api, apiClient } = createIntegrations<AppIntegrations>({
 
 ## Integration surface
 
-An integration can contribute any of these pieces:
+An integration can contribute any of these pieces. The three HTTP fields are alternatives for
+different authoring needs; you normally do not define all three.
+
+| HTTP field  | Handles requests? | Produces typed callers?                    | Use it when                                                                                                                             |
+| ----------- | ----------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `routes`    | Yes               | Yes, when entries use `integrationRoute.*` | The integration owns the handlers and a flat array or route factory is easiest to read. This is the recommended default.                |
+| `endpoints` | Yes               | Yes, when entries use `endpoint.*`         | The integration owns the handlers, but a nested object makes a large set of routes easier to organize. Farm flattens it into `routes`.  |
+| `api`       | No                | Yes                                        | The HTTP handlers already exist elsewhere, or you deliberately need a custom caller tree. It is a caller contract, not a route handler. |
+
+For typed `routes` and `endpoints`, Farm derives the caller tree from each URL. For example,
+`/api/billing/checkout` becomes `api.billing.checkout.post(...)` after the integration is registered
+as `billing`. The object keys inside `endpoints` only organize the source code; they do not rename
+the derived caller.
+
+Plain route objects still mount handlers, but they do not carry typed caller metadata. Use
+`integrationRoute.*` or the `endpoint.*` factory when you want Farm to infer request and response
+types for `api` and `apiClient`.
+
+An explicit `api` field replaces that derived caller tree for the integration. It does not mount an
+HTTP handler, so every operation in it must point to a route implemented by `routes`, `endpoints`,
+the app, or another server.
+
+The `api:` field in an integration definition is the **caller contract**. The `api` returned by
+`createIntegrations` is the **server caller** built from that contract; `apiClient` is its browser
+counterpart. See [Choosing `routes`, `endpoints`, or `api`](/docs/integrations/custom#choose-the-http-surface)
+for side-by-side examples.
+
+Other integration fields are independent of that HTTP choice:
 
 | Surface | What it is for |
 | --- | --- |
-| `api` | A typed client/server callable API tree. |
-| `routes` | HTTP route handlers declared as an array or factory. |
-| `endpoints` | A nested object version of routes that also derives API callers. |
 | `middleware` | Integration-owned request behavior for matchers outside a single endpoint. |
 | `providers` | React provider metadata and optional wrapper components. |
 | `schema` | Storage models used by `ctx.args.db` through the ORM layer. |
@@ -75,7 +99,9 @@ An integration can contribute any of these pieces:
 
 ## Route ownership
 
-Integration routes use the same web primitives as normal route handlers. The handler receives the `Request` and a context object with params, parsed input, request metadata, shared request context, integration metadata, and `args` for storage.
+Integration handlers declared through either `routes` or `endpoints` use the same web primitives as
+normal route handlers. The handler receives the `Request` and a context object with params, parsed
+input, request metadata, shared request context, integration metadata, and `args` for storage.
 
 **src/integrations/local-demo.ts**
 
@@ -115,7 +141,8 @@ Farm validates the body and query before route middleware, `before` hooks, or th
 
 ## Caller shape
 
-Typed routes can derive their caller tree from their path:
+Typed routes derive their caller tree from their path, so this integration does not need an explicit
+`api` field:
 
 **src/lib/api.ts**
 


### PR DESCRIPTION
## Summary

- distinguish `routes`, `endpoints`, and `api` by runtime responsibility
- recommend `routes` as the default and explain when grouped `endpoints` are useful
- show shared registration and typed caller creation
- document declaration, browser usage, and server usage for all three formats
- explain path-derived callers, raw route behavior, and explicit `api` overrides
- clarify the `api:` contract field versus the returned `api` server caller

## Verification

- `corepack pnpm --filter @farmjs/core build`
- docs production build with the Vercel preset
- `vitest run src/__tests__/integrations.test.ts src/__tests__/integration-orm.test.ts src/__tests__/integration-client.test.ts` (50 tests)