### PR TITLE
feat: add server function middleware

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -155,6 +155,62 @@ Output parsing also runs for direct server calls, form actions, and browser call
 reject the function just like invalid input. Keep the output contract narrow for private data;
 do not rely on TypeScript alone to prevent an extra database field from being returned at runtime.
 
+### Composable middleware
+
+Use `createServerMiddleware` for server-only behavior shared by several functions, such as session
+loading, authorization, transactions, rate limits, and auditing. Middleware can depend on other
+middleware, and every context value is inferred by functions that install it.
+
+```ts
+import { createServerFn, createServerMiddleware } from "@farmjs/core/server-fn";
+
+const withSession = createServerMiddleware({
+  async handler({ request, next }) {
+    if (!request) throw new Error("A request is required");
+
+    const session = await getSession(request);
+    if (!session.user) throw new UnauthorizedError();
+
+    return next({ context: { session } });
+  },
+});
+
+const withTransaction = createServerMiddleware({
+  middleware: [withSession],
+  async handler({ context, next }) {
+    return db.transaction((tx) => next({ context: { tx } }));
+  },
+});
+
+export const renameProject = createServerFn({
+  middleware: [withTransaction],
+  input: z.object({ projectId: z.string(), name: z.string().min(1) }),
+  async handler({ input, context }) {
+    // context.session and context.tx are both typed.
+    await requireProjectEditor(context.session, input.projectId);
+    return context.tx.project.update({
+      where: { id: input.projectId },
+      data: { name: input.name },
+    });
+  },
+});
+```
+
+Dependencies run first and are de-duplicated by middleware identity. For
+`middleware: [withTransaction, withAudit]`, a shared `withSession` dependency runs once. The chain
+uses onion ordering: code before `await next()` runs from outer to inner, and code after it unwinds
+from inner to outer.
+
+Every middleware must call `next()` exactly once and return its result. Throw to reject a request;
+middleware cannot silently skip the handler. Input validation finishes before the chain starts,
+while output validation runs after the whole chain unwinds. Context is created on the server,
+shallowly frozen, and never accepted from the browser.
+
+Keep shared authentication in middleware, but still perform resource-specific authorization where
+the resource is loaded. Derive identities, roles, tenant IDs, and rate-limit keys from the trusted
+request or server state, never from unvalidated client fields. Middleware errors use the same
+sanitized server-action error boundary as handler errors.
+
 **src/components/todo-form.tsx**
 
 ```tsx
@@ -188,7 +244,7 @@ export function TodoForm() {
 
 The optimistic callback receives the raw input, `formData` for form submissions, and the current result. Return `undefined` when a submission should not change the optimistic result. Use `rollbackOnError` for reversible UI state; keep authorization and validation on the server function itself.
 
-When the function is called from the browser, `request` is the underlying Web `Request` and `signal` aborts with that request. A direct server-side call has no `request` and receives a stable, non-aborted signal. Pass `signal` to database or network clients that support cancellation.
+When the function is called from the browser, `request` is the underlying Web `Request` and `signal` aborts with that request. A direct call made while rendering can inherit the current render request; a background or direct call outside request scope has no `request` and receives a stable, non-aborted signal. The same values are available to middleware. Pass `signal` to database or network clients that support cancellation.
 
 Farm validates action origin metadata, accepted form/RSC content types, action ID shape, and request size before decoding an action. Browser calls use same-origin credentials and refuse redirects. Unexpected thrown values are logged on the server but become a generic `ServerActionError` in the browser, so secrets and stack traces are not serialized.
 

--- a/docs/src/app/docs/testing/page.md
+++ b/docs/src/app/docs/testing/page.md
@@ -110,7 +110,7 @@ The helpers return JSON 404 and 405 responses just like the API route manager. T
 
 ## Test server functions
 
-`serverFn` keeps input and return inference, including Zod validation and `FormData` conversion. It also installs the request and cancellation signal that the handler reads.
+`serverFn` keeps input and return inference, including Zod validation and `FormData` conversion. It also installs the request and cancellation signal that the handler reads. Any `createServerMiddleware` dependencies run through the same chain as production, including their typed context, ordering, and errors.
 
 ```ts
 import { expect, test } from "vitest";

--- a/examples/rsc-demo/src/actions/middleware.ts
+++ b/examples/rsc-demo/src/actions/middleware.ts
@@ -1,0 +1,66 @@
+import { createServerFn, createServerMiddleware } from "@farmjs/core/server-fn";
+import { z } from "zod";
+
+const sessionMiddleware = createServerMiddleware({
+  async handler({ request, next }) {
+    if (!request) {
+      throw new Error("Server function middleware requires a request.");
+    }
+
+    const trace = ["session:before"];
+    const result = await next({
+      context: {
+        requestMethod: request.method,
+        trace,
+        user: { id: "middleware-user" },
+      },
+    });
+    trace.push("session:after");
+    return result;
+  },
+});
+
+const permissionMiddleware = createServerMiddleware({
+  middleware: [sessionMiddleware],
+  async handler({ context, next }) {
+    context.trace.push("permission:before");
+    const result = await next({ context: { permission: "messages:write" as const } });
+    context.trace.push("permission:after");
+    return result;
+  },
+});
+
+const auditMiddleware = createServerMiddleware({
+  middleware: [sessionMiddleware],
+  async handler({ context, next }) {
+    context.trace.push("audit:before");
+    const result = await next();
+    context.trace.push("audit:after");
+    return result;
+  },
+});
+
+export const inspectServerMiddleware = createServerFn({
+  middleware: [permissionMiddleware, auditMiddleware],
+  input: z.object({ message: z.string().trim().min(1) }),
+  output: z.object({
+    message: z.string(),
+    userId: z.string(),
+    permission: z.literal("messages:write"),
+    requestMethod: z.string(),
+    fromForm: z.boolean(),
+    trace: z.array(z.string()),
+  }),
+  async handler({ input, context, formData }) {
+    context.trace.push("handler");
+
+    return {
+      message: input.message,
+      userId: context.user.id,
+      permission: context.permission,
+      requestMethod: context.requestMethod,
+      fromForm: formData instanceof FormData,
+      trace: context.trace,
+    };
+  },
+});

--- a/examples/rsc-demo/src/components/MiddlewareActions.tsx
+++ b/examples/rsc-demo/src/components/MiddlewareActions.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useServerFn } from "@farmjs/core/server-fn/client";
+import { inspectServerMiddleware } from "../actions/middleware";
+
+export function MiddlewareActions() {
+  const action = useServerFn(inspectServerMiddleware);
+
+  return (
+    <section className="space-y-5" aria-labelledby="server-middleware-actions">
+      <h2 id="server-middleware-actions" className="text-xl font-semibold text-orange-400">
+        Action calls
+      </h2>
+
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="button"
+          data-testid="call-server-middleware"
+          onClick={() => action.submit({ message: "browser middleware" })}
+          className="rounded bg-orange-600 px-3 py-2 text-sm font-semibold text-white hover:bg-orange-500"
+        >
+          Call from browser
+        </button>
+
+        <form action={action.formAction} className="flex gap-2">
+          <input type="hidden" name="message" value="form middleware" />
+          <button
+            type="submit"
+            data-testid="submit-server-middleware-form"
+            className="rounded border border-orange-500 px-3 py-2 text-sm font-semibold text-orange-300 hover:bg-orange-950"
+          >
+            Submit form
+          </button>
+        </form>
+      </div>
+
+      <output
+        data-testid="server-middleware-result"
+        className="block min-h-6 break-words text-sm text-slate-300"
+      >
+        {action.error
+          ? JSON.stringify({ error: action.error.message })
+          : action.result
+            ? JSON.stringify(action.result)
+            : action.status}
+      </output>
+    </section>
+  );
+}

--- a/examples/rsc-demo/src/layout.tsx
+++ b/examples/rsc-demo/src/layout.tsx
@@ -46,6 +46,12 @@ export default function RootLayout({
               >
                 Form
               </a>
+              <a
+                href="/server-fn-middleware"
+                className="text-slate-300 hover:text-white transition-colors"
+              >
+                Middleware
+              </a>
             </div>
           </div>
         </div>

--- a/examples/rsc-demo/src/server-fn-middleware/page.tsx
+++ b/examples/rsc-demo/src/server-fn-middleware/page.tsx
@@ -1,0 +1,17 @@
+import { MiddlewareActions } from "../components/MiddlewareActions";
+
+export default function ServerFnMiddlewarePage() {
+  return (
+    <section className="mx-auto max-w-3xl space-y-8 px-6 py-12">
+      <header className="space-y-2">
+        <p className="text-sm font-semibold uppercase text-orange-500">RSC regression application</p>
+        <h1 className="text-3xl font-bold text-white">Server function middleware</h1>
+        <p className="text-slate-400">
+          Shared middleware supplies typed request, session, permission, and audit context.
+        </p>
+      </header>
+
+      <MiddlewareActions />
+    </section>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:ci": "node scripts/run-tests.js",
     "test:e2e": "playwright test",
     "test:e2e:recent": "corepack pnpm --filter @farmjs/core build && playwright test tests/e2e/recent-features.spec.ts",
+    "test:e2e:rsc": "corepack pnpm --filter @farmjs/core build && corepack pnpm --filter @farmjs/plugin build && NITRO_PRESET=node-server corepack pnpm --filter farm-rsc-demo build && playwright test --config playwright.rsc.config.ts",
     "test:e2e:list": "playwright test --list",
     "docs:dev": "pnpm --filter @farmjs/core build && pnpm --filter farmjs-docs dev",
     "docs:build": "pnpm --filter @farmjs/core build && pnpm --filter farmjs-docs build",

--- a/packages/farm/src/__tests__/server-fn.test.ts
+++ b/packages/farm/src/__tests__/server-fn.test.ts
@@ -2,8 +2,9 @@
 
 import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import { z } from "zod";
-import { createServerFn, FARM_SERVER_FN_SYMBOL } from "../server-fn";
+import { createServerFn, createServerMiddleware, FARM_SERVER_FN_SYMBOL } from "../server-fn";
 import { runWithServerActionRequest } from "../server-action-security";
+import { _runWithCurrentRequest } from "../server/request";
 
 describe("createServerFn", () => {
   it("validates object input before calling the handler", async () => {
@@ -229,5 +230,140 @@ describe("createServerFn", () => {
     expect(result.signal).toBe(request.signal);
     controller.abort();
     expect(result.signal.aborted).toBe(true);
+  });
+
+  it("composes middleware dependencies with typed server context", async () => {
+    const trace: string[] = [];
+    const requireUser = createServerMiddleware({
+      async handler({ request, signal, next }) {
+        trace.push("auth:before");
+        expect(request?.headers.get("x-user-id")).toBe("user-1");
+        expect(signal).toBe(request?.signal);
+
+        const result = await next({
+          context: {
+            user: {
+              id: request!.headers.get("x-user-id")!,
+              role: "admin" as const,
+            },
+          },
+        });
+        trace.push("auth:after");
+        return result;
+      },
+    });
+    const requireAdmin = createServerMiddleware({
+      middleware: [requireUser],
+      async handler({ context, next }) {
+        expectTypeOf(context.user).toEqualTypeOf<{
+          id: string;
+          role: "admin";
+        }>();
+        trace.push("admin:before");
+        const result = await next({ context: { permission: "products:write" as const } });
+        trace.push("admin:after");
+        return result;
+      },
+    });
+    const audit = createServerMiddleware({
+      middleware: [requireUser],
+      async handler({ context, next }) {
+        expectTypeOf(context.user.id).toEqualTypeOf<string>();
+        trace.push(`audit:${context.user.id}:before`);
+        const result = await next();
+        trace.push(`audit:${context.user.id}:after`);
+        return result;
+      },
+    });
+    const updateProduct = createServerFn({
+      middleware: [requireAdmin, audit],
+      input: z.object({ id: z.string() }),
+      async handler({ input, context }) {
+        expectTypeOf(context.permission).toEqualTypeOf<"products:write">();
+        expectTypeOf(context.user.role).toEqualTypeOf<"admin">();
+        trace.push("handler");
+        return {
+          id: input.id,
+          userId: context.user.id,
+          permission: context.permission,
+        };
+      },
+    });
+    const request = new Request("https://app.example.com/actions/update-product", {
+      headers: { "x-user-id": "user-1" },
+    });
+
+    const result = await runWithServerActionRequest(request, () =>
+      updateProduct({ id: "product-1" }),
+    );
+
+    expect(result).toEqual({
+      id: "product-1",
+      userId: "user-1",
+      permission: "products:write",
+    });
+    expect(trace).toEqual([
+      "auth:before",
+      "admin:before",
+      "audit:user-1:before",
+      "handler",
+      "audit:user-1:after",
+      "admin:after",
+      "auth:after",
+    ]);
+  });
+
+  it("uses the current render request for direct server calls", async () => {
+    const request = new Request("https://app.example.com/dashboard", {
+      headers: { "x-tenant": "acme" },
+    });
+    const tenant = createServerMiddleware({
+      handler({ request: currentRequest, next }) {
+        return next({
+          context: { tenant: currentRequest?.headers.get("x-tenant") ?? "public" },
+        });
+      },
+    });
+    const inspect = createServerFn({
+      middleware: [tenant],
+      handler({ request: currentRequest, context, signal }) {
+        return {
+          request: currentRequest,
+          tenant: context.tenant,
+          signal,
+        };
+      },
+    });
+
+    const result = await _runWithCurrentRequest(request, () => inspect());
+
+    expect(result.request).toBe(request);
+    expect(result.tenant).toBe("acme");
+    expect(result.signal).toBe(request.signal);
+  });
+
+  it("rejects middleware that skips or calls next more than once", async () => {
+    const skipsNext = createServerMiddleware({
+      handler: (() => Promise.resolve({ ok: false })) as any,
+    });
+    const callsNextTwice = createServerMiddleware({
+      async handler({ next }) {
+        await next();
+        return next();
+      },
+    });
+    const skipped = createServerFn({
+      middleware: [skipsNext],
+      handler: () => ({ ok: true }),
+    });
+    const repeated = createServerFn({
+      middleware: [callsNextTwice],
+      handler: () => ({ ok: true }),
+    });
+
+    await expect(skipped()).rejects.toThrow("Server function middleware must call next()");
+    await expect(repeated()).rejects.toThrow(
+      "Server function middleware next() can only be called once",
+    );
   });
 });

--- a/packages/farm/src/server-fn.ts
+++ b/packages/farm/src/server-fn.ts
@@ -1,4 +1,5 @@
 import { getServerActionExecutionContext, getServerActionSignal } from "./server-action-security";
+import { _resolveCurrentRequest } from "./server/request-bridge";
 
 type MaybePromise<T> = T | Promise<T>;
 
@@ -22,7 +23,37 @@ export type InferServerFnSchemaOutput<T> = T extends { _output: infer O }
 
 export type ServerFnFormInput = FormData;
 
-export type ServerFnContext<TInput> = {
+type Simplify<T> = { [TKey in keyof T]: T[TKey] } & {};
+type AssignContext<TCurrent extends object, TNext extends object> = Simplify<
+  Omit<TCurrent, keyof TNext> & TNext
+>;
+type MiddlewareContext<TMiddleware> =
+  TMiddleware extends ServerFnMiddleware<infer TContext> ? TContext : {};
+
+export type ServerFnMiddlewareContext<
+  TMiddlewares extends readonly AnyServerFnMiddleware[],
+  TContext extends object = {},
+> = TMiddlewares extends readonly [infer TMiddleware, ...infer TRest]
+  ? TMiddleware extends AnyServerFnMiddleware
+    ? TRest extends readonly AnyServerFnMiddleware[]
+      ? ServerFnMiddlewareContext<TRest, AssignContext<TContext, MiddlewareContext<TMiddleware>>>
+      : TContext
+    : TContext
+  : number extends TMiddlewares["length"]
+    ? Simplify<TContext & MiddlewareContext<TMiddlewares[number]>>
+    : Simplify<TContext>;
+
+declare const SERVER_FN_MIDDLEWARE_CONTEXT: unique symbol;
+
+export type ServerFnMiddlewareContinuation<TContext extends object = {}> = {
+  readonly [SERVER_FN_MIDDLEWARE_CONTEXT]: TContext;
+};
+
+export type ServerFnMiddlewareNext = <TContext extends object = {}>(options?: {
+  context?: TContext;
+}) => Promise<ServerFnMiddlewareContinuation<TContext>>;
+
+export type ServerFnContext<TInput, TContext extends object = {}> = {
   input: TInput;
   rawInput: unknown;
   formData?: FormData;
@@ -30,30 +61,72 @@ export type ServerFnContext<TInput> = {
   request?: Request;
   /** Aborts when the underlying action request is cancelled. */
   signal: AbortSignal;
+  /** Context produced by this server function's middleware chain. */
+  context: Readonly<TContext>;
 };
 
-export type ServerFnHandler<TInput, TResult> = (
-  ctx: ServerFnContext<TInput>,
+export type ServerFnHandler<TInput, TResult, TContext extends object = {}> = (
+  ctx: ServerFnContext<TInput, TContext>,
 ) => MaybePromise<TResult>;
 
-export type ServerFnOptions<TSchema extends ServerFnSchema | undefined, TResult> = {
+export type ServerFnMiddlewareHandlerContext<TContext extends object = {}> = ServerFnContext<
+  unknown,
+  TContext
+> & {
+  next: ServerFnMiddlewareNext;
+};
+
+export type ServerFnMiddlewareHandler<
+  TContext extends object = {},
+  TProvidedContext extends object = {},
+> = (
+  ctx: ServerFnMiddlewareHandlerContext<TContext>,
+) => MaybePromise<ServerFnMiddlewareContinuation<TProvidedContext>>;
+
+export type ServerFnMiddleware<TContext extends object = {}> = {
+  readonly __farmServerFnMiddleware: true;
+  readonly __farmServerFnMiddlewareContext?: TContext;
+  readonly middleware: readonly AnyServerFnMiddleware[];
+  readonly handler: ServerFnMiddlewareHandler<any, any>;
+};
+
+export type AnyServerFnMiddleware = ServerFnMiddleware<any>;
+
+export type ServerFnMiddlewareOptions<
+  TMiddlewares extends readonly AnyServerFnMiddleware[],
+  TProvidedContext extends object,
+> = {
+  middleware?: TMiddlewares;
+  handler: ServerFnMiddlewareHandler<ServerFnMiddlewareContext<TMiddlewares>, TProvidedContext>;
+};
+
+export type ServerFnOptions<
+  TSchema extends ServerFnSchema | undefined,
+  TResult,
+  TMiddlewares extends readonly AnyServerFnMiddleware[] = readonly [],
+> = {
   input?: TSchema;
   output?: undefined;
+  middleware?: TMiddlewares;
   handler: ServerFnHandler<
     TSchema extends ServerFnSchema ? InferServerFnSchemaOutput<TSchema> : unknown,
-    TResult
+    TResult,
+    ServerFnMiddlewareContext<TMiddlewares>
   >;
 };
 
 export type ServerFnOutputOptions<
   TInputSchema extends ServerFnSchema | undefined,
   TOutputSchema extends ServerFnSchema,
+  TMiddlewares extends readonly AnyServerFnMiddleware[] = readonly [],
 > = {
   input?: TInputSchema;
   output: TOutputSchema;
+  middleware?: TMiddlewares;
   handler: ServerFnHandler<
     TInputSchema extends ServerFnSchema ? InferServerFnSchemaOutput<TInputSchema> : unknown,
-    unknown
+    unknown,
+    ServerFnMiddlewareContext<TMiddlewares>
   >;
 };
 
@@ -69,47 +142,86 @@ export const FARM_SERVER_FN_SYMBOL = Symbol.for("farm.server-fn");
 
 const UNSAFE_FORM_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
+export function createServerMiddleware<
+  const TMiddlewares extends readonly AnyServerFnMiddleware[] = readonly [],
+  TProvidedContext extends object = {},
+>(
+  options: ServerFnMiddlewareOptions<TMiddlewares, TProvidedContext>,
+): ServerFnMiddleware<AssignContext<ServerFnMiddlewareContext<TMiddlewares>, TProvidedContext>>;
+export function createServerMiddleware(options: {
+  middleware?: readonly AnyServerFnMiddleware[];
+  handler: ServerFnMiddlewareHandler<any, any>;
+}): ServerFnMiddleware<any> {
+  if (!options || typeof options.handler !== "function") {
+    throw new TypeError("createServerMiddleware requires a handler function");
+  }
+
+  const middleware = Object.freeze([...(options.middleware ?? [])]);
+  for (const entry of middleware) {
+    assertServerFnMiddleware(entry);
+  }
+
+  return Object.freeze({
+    __farmServerFnMiddleware: true as const,
+    middleware,
+    handler: options.handler,
+  });
+}
+
 export function createServerFn<
   TInputSchema extends ServerFnSchema,
   TOutputSchema extends ServerFnSchema,
+  const TMiddlewares extends readonly AnyServerFnMiddleware[] = readonly [],
 >(
-  options: ServerFnOutputOptions<TInputSchema, TOutputSchema>,
+  options: ServerFnOutputOptions<TInputSchema, TOutputSchema, TMiddlewares>,
 ): ServerFn<
   InferServerFnSchemaInput<TInputSchema>,
   Awaited<InferServerFnSchemaOutput<TOutputSchema>>
 >;
-export function createServerFn<TOutputSchema extends ServerFnSchema>(
-  options: ServerFnOutputOptions<undefined, TOutputSchema>,
+export function createServerFn<
+  TOutputSchema extends ServerFnSchema,
+  const TMiddlewares extends readonly AnyServerFnMiddleware[] = readonly [],
+>(
+  options: ServerFnOutputOptions<undefined, TOutputSchema, TMiddlewares>,
 ): ServerFn<unknown, Awaited<InferServerFnSchemaOutput<TOutputSchema>>>;
-export function createServerFn<TSchema extends ServerFnSchema, TResult>(
-  options: ServerFnOptions<TSchema, TResult>,
+export function createServerFn<
+  TSchema extends ServerFnSchema,
+  TResult,
+  const TMiddlewares extends readonly AnyServerFnMiddleware[] = readonly [],
+>(
+  options: ServerFnOptions<TSchema, TResult, TMiddlewares>,
 ): ServerFn<InferServerFnSchemaInput<TSchema>, Awaited<TResult>>;
-export function createServerFn<TResult>(
-  options: ServerFnOptions<undefined, TResult>,
-): ServerFn<unknown, Awaited<TResult>>;
+export function createServerFn<
+  TResult,
+  const TMiddlewares extends readonly AnyServerFnMiddleware[] = readonly [],
+>(options: ServerFnOptions<undefined, TResult, TMiddlewares>): ServerFn<unknown, Awaited<TResult>>;
 export function createServerFn(options: {
   input?: ServerFnSchema;
   output?: ServerFnSchema;
+  middleware?: readonly AnyServerFnMiddleware[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  handler: ServerFnHandler<any, any>;
+  handler: ServerFnHandler<any, any, any>;
 }) {
   if (!options || typeof options.handler !== "function") {
     throw new TypeError("createServerFn requires a handler function");
   }
 
+  const middleware = resolveServerFnMiddleware(options.middleware);
   const serverFn = async (value: unknown) => {
     const formData = isFormData(value) ? value : undefined;
     const rawInput = formData ? formDataToObject(formData) : value;
     const input = await parseSchema(options.input, rawInput, "input");
     const executionContext = getServerActionExecutionContext();
-
-    const result = await options.handler({
+    const request = executionContext?.request ?? _resolveCurrentRequest();
+    const signal = executionContext?.signal ?? request?.signal ?? getServerActionSignal();
+    const handlerContext = {
       input,
       rawInput,
       formData,
-      request: executionContext?.request,
-      signal: getServerActionSignal(),
-    });
+      request,
+      signal,
+    };
+    const result = await runServerFnMiddleware(middleware, handlerContext, options.handler);
 
     return parseSchema(options.output, result, "output");
   };
@@ -131,9 +243,105 @@ export function createServerFn(options: {
       value: options.output,
       enumerable: false,
     },
+    __farmServerFnMiddleware: {
+      value: middleware,
+      enumerable: false,
+    },
   });
 
   return serverFn as ServerFn<unknown, unknown>;
+}
+
+type ServerFnBaseContext = Omit<ServerFnContext<unknown, {}>, "context">;
+
+async function runServerFnMiddleware(
+  middleware: readonly AnyServerFnMiddleware[],
+  handlerContext: ServerFnBaseContext,
+  handler: ServerFnHandler<any, any, any>,
+) {
+  const dispatch = async (index: number, context: Readonly<object>): Promise<unknown> => {
+    const current = middleware[index];
+    if (!current) {
+      return handler({ ...handlerContext, context });
+    }
+
+    let nextCalled = false;
+    const result = await current.handler({
+      ...handlerContext,
+      context,
+      next: async (nextOptions) => {
+        if (nextCalled) {
+          throw new Error("Server function middleware next() can only be called once");
+        }
+        nextCalled = true;
+
+        return dispatch(index + 1, mergeServerFnContext(context, nextOptions?.context)) as Promise<
+          ServerFnMiddlewareContinuation<any>
+        >;
+      },
+    });
+
+    if (!nextCalled) {
+      throw new Error("Server function middleware must call next()");
+    }
+
+    return result;
+  };
+
+  return dispatch(0, Object.freeze(Object.create(null)));
+}
+
+function resolveServerFnMiddleware(
+  middleware: readonly AnyServerFnMiddleware[] | undefined,
+): readonly AnyServerFnMiddleware[] {
+  const resolved: AnyServerFnMiddleware[] = [];
+  const seen = new Set<AnyServerFnMiddleware>();
+  const visiting = new Set<AnyServerFnMiddleware>();
+
+  const visit = (entry: AnyServerFnMiddleware) => {
+    assertServerFnMiddleware(entry);
+    if (seen.has(entry)) return;
+    if (visiting.has(entry)) {
+      throw new Error("Server function middleware dependencies cannot contain a cycle");
+    }
+
+    visiting.add(entry);
+    for (const dependency of entry.middleware) {
+      visit(dependency);
+    }
+    visiting.delete(entry);
+    seen.add(entry);
+    resolved.push(entry);
+  };
+
+  for (const entry of middleware ?? []) {
+    visit(entry);
+  }
+
+  return Object.freeze(resolved);
+}
+
+function assertServerFnMiddleware(value: unknown): asserts value is AnyServerFnMiddleware {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    (value as { __farmServerFnMiddleware?: unknown }).__farmServerFnMiddleware !== true ||
+    typeof (value as { handler?: unknown }).handler !== "function" ||
+    !Array.isArray((value as { middleware?: unknown }).middleware)
+  ) {
+    throw new TypeError("createServerFn middleware must be created with createServerMiddleware");
+  }
+}
+
+function mergeServerFnContext(current: Readonly<object>, added: object | undefined) {
+  if (
+    added !== undefined &&
+    (added === null || typeof added !== "object" || Array.isArray(added))
+  ) {
+    throw new TypeError("Server function middleware context must be an object");
+  }
+
+  return Object.freeze(Object.assign(Object.create(null), current, added));
 }
 
 async function parseSchema(

--- a/packages/farmjs-plugin/src/rsc/index.ts
+++ b/packages/farmjs-plugin/src/rsc/index.ts
@@ -345,11 +345,11 @@ export default function farmRsc(options: FarmRscPluginOptions = {}): Plugin[] {
         const configuredRoutesDir =
           options.routesDir === undefined ? "app" : options.routesDir.trim();
         const routeRoots = getFarmSourceRoots(c).map((source) => {
-          const routeDirectory = configuredRoutesDir
-            ? path.join(source.root, source.srcDir, configuredRoutesDir)
-            : path.join(source.root, source.srcDir);
-          const relative = path.relative(entriesDir, routeDirectory).replace(/\\/g, "/");
-          const base = relative.startsWith(".") ? relative : `./${relative}`;
+          const routeSuffix = configuredRoutesDir ? `/${configuredRoutesDir}` : "";
+          const projectSourceDir = source.srcDir.replace(/\\/g, "/").replace(/^\.?\//, "");
+          const base = source.layer
+            ? `#layers/${source.name}${routeSuffix}`
+            : `/${projectSourceDir}${routeSuffix}`;
           return { name: source.name, base, glob: base };
         });
         // Build context for entry generators
@@ -430,26 +430,29 @@ export default function farmRsc(options: FarmRscPluginOptions = {}): Plugin[] {
               ...(farmCorePath
                 ? [
                     {
-                      find: "@farmjs/core/middleware",
+                      find: /^@farmjs\/core\/middleware$/,
                       replacement: path.join(farmCorePath, "dist/middleware.mjs"),
                     },
                     {
-                      find: "@farmjs/core/api",
+                      find: /^@farmjs\/core\/api$/,
                       replacement: path.join(farmCorePath, "dist/api.mjs"),
                     },
                     {
-                      find: "@farmjs/core/server-fn",
+                      find: /^@farmjs\/core\/server-fn$/,
                       replacement: path.join(farmCorePath, "dist/server-fn.mjs"),
                     },
                     {
-                      find: "@farmjs/core/server-action-security",
+                      find: /^@farmjs\/core\/server-action-security$/,
                       replacement: path.join(farmCorePath, "dist/server-action-security.mjs"),
                     },
                     {
                       find: /^@farmjs\/core\/environment$/,
                       replacement: path.join(farmCorePath, "dist/environment.mjs"),
                     },
-                    { find: "@farmjs/core", replacement: farmCorePath },
+                    {
+                      find: /^@farmjs\/core$/,
+                      replacement: path.join(farmCorePath, "dist/index.mjs"),
+                    },
                   ]
                 : []),
             ],

--- a/packages/farmjs-plugin/src/rsc/nitro-build.ts
+++ b/packages/farmjs-plugin/src/rsc/nitro-build.ts
@@ -111,7 +111,7 @@ function writeRscEntryFile(buildDir: string, rendererPath: string, ssrPath?: str
   const code = `
 ${setSsLoader}
 import * as entryExports from "./${relRenderer}";
-import { fromWebHandler } from "h3";
+import { defineEventHandler } from "h3";
 
 function getFetchHandler(exports) {
   const def = exports?.default;
@@ -121,7 +121,35 @@ function getFetchHandler(exports) {
 }
 
 const handler = getFetchHandler(entryExports);
-export default fromWebHandler(handler);
+
+function createRscRequest(event) {
+  const node = event.node;
+  if (!node?.req || !node?.res) return event.req;
+
+  const controller = new AbortController();
+  const cleanup = () => {
+    node.req.off("aborted", abort);
+    node.res.off("close", close);
+    node.res.off("finish", cleanup);
+  };
+  const abort = () => {
+    if (!controller.signal.aborted) controller.abort();
+    cleanup();
+  };
+  const close = () => {
+    if (!node.res.writableEnded) abort();
+    else cleanup();
+  };
+
+  node.req.once("aborted", abort);
+  node.res.once("close", close);
+  node.res.once("finish", cleanup);
+  if (node.req.aborted) abort();
+
+  return new Request(event.req, { signal: controller.signal });
+}
+
+export default defineEventHandler((event) => handler(createRscRequest(event)));
 `.trim();
   const entryPath = path.join(buildDir, "rsc-entry.mjs");
   mkdirSync(buildDir, { recursive: true });

--- a/playwright.rsc.config.ts
+++ b/playwright.rsc.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e-rsc",
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  use: {
+    baseURL: "http://localhost:4174",
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: "NODE_ENV=production PORT=4174 corepack pnpm --dir examples/rsc-demo run preview",
+    url: "http://localhost:4174",
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"], channel: "chrome" },
+    },
+  ],
+});

--- a/tests/e2e-rsc/server-middleware.spec.ts
+++ b/tests/e2e-rsc/server-middleware.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "@playwright/test";
+
+const expectedTrace = [
+  "session:before",
+  "permission:before",
+  "audit:before",
+  "handler",
+  "audit:after",
+  "permission:after",
+  "session:after",
+];
+
+test("server function middleware runs for browser and form calls", async ({ page }) => {
+  await page.goto("/server-fn-middleware");
+
+  const output = page.getByTestId("server-middleware-result");
+
+  await page.getByTestId("call-server-middleware").click();
+  await expect(output).toContainText('"message":"browser middleware"');
+  await expect(output).toContainText('"fromForm":false');
+
+  let result = JSON.parse((await output.textContent()) || "{}");
+  expect(result).toMatchObject({
+    userId: "middleware-user",
+    permission: "messages:write",
+    requestMethod: "POST",
+    trace: expectedTrace,
+  });
+
+  await page.getByTestId("submit-server-middleware-form").click();
+  await expect(output).toContainText('"message":"form middleware"');
+  await expect(output).toContainText('"fromForm":true');
+
+  result = JSON.parse((await output.textContent()) || "{}");
+  expect(result.trace).toEqual(expectedTrace);
+});


### PR DESCRIPTION
## Summary

- add composable, typed server-function middleware with dependencies and onion-style execution
- propagate request, cancellation, parsed input, form data, and server-created context through middleware
- stabilize RSC action routing and request cancellation for browser and native form submissions
- add a production RSC example, Playwright coverage, unit tests, and usage/security documentation

## Behavior

- middleware dependencies run depth-first and are deduplicated by identity
- middleware context is inferred and merged into downstream middleware and handlers
- `next()` must be returned exactly once; cycles, skipped continuations, and duplicate calls fail clearly
- input validation runs before middleware and output validation runs after middleware unwinds
- errors and redirects preserve existing server-function behavior

## Verification

- `pnpm --filter @farmjs/core test` (491 passed, 1 optional database test skipped)
- `pnpm --filter @farmjs/plugin test` (5 passed)
- `pnpm run test:e2e:rsc` (production browser and form-action flow passed)
- core package build
- RSC demo node-server and Vercel builds
- documentation production build
- formatting and `git diff --check`
