### PR TITLE
fix: restore clean docs deployment

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "pnpm --filter @farmjs/core build && pnpm run prisma:generate && farm dev",
-    "build": "pnpm --filter @farmjs/core build && pnpm run prisma:generate && farm build",
+    "dev": "pnpm --filter @farmjs/core build && pnpm --filter @farmjs/cli build && pnpm run prisma:generate && farm dev",
+    "build": "pnpm --filter @farmjs/core build && pnpm --filter @farmjs/cli build && pnpm run prisma:generate && farm build",
     "preview": "farm preview",
     "prisma:generate": "DATABASE_URL=${DATABASE_URL:-postgresql://user:password@localhost:5432/farmjs} prisma generate",
     "db:push": "prisma db push"

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -1,3 +1,10 @@
 import { defineConfig } from "vite";
 
-export default defineConfig({});
+export default defineConfig({
+  resolve: {
+    dedupe: ["react", "react-dom"],
+  },
+  ssr: {
+    noExternal: ["lucide-react"],
+  },
+});

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -434,7 +434,7 @@ export class SPARouter {
   /**
    * Handle browser back/forward navigation
    */
-  private async handlePopState(_event: PopStateEvent): Promise<void> {
+  private async handlePopState(event: PopStateEvent): Promise<void> {
     if (document.documentElement.dataset.farmDocsRuntime === "true") return;
 
     const path = window.location.pathname + window.location.search;


### PR DESCRIPTION
## Summary
- use the actual `PopStateEvent` object during back and forward navigation
- build the workspace CLI before direct docs dev and build commands
- deduplicate the React runtime and bundle Lucide into the docs SSR output

## Why
A clean docs checkout could not generate declarations because the popstate handler referenced the global event, then could not run `farm build` because the local CLI had not been built. Once deployed, externalized Lucide loaded a second React instance and failed during SSR.

## Verification
- clean `pnpm docs:build`
- Vercel preview deployment is Ready
- `https://beta.farmjs.dev/` returns 200 and renders the redesigned homepage
- `https://beta.farmjs.dev/docs/getting-started` returns 200 and renders documentation
- unknown routes return 404
- no browser console errors
- formatting and `git diff --check`
