### PR TITLE
feat: add typed endpoint middleware

### DIFF
--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -18,14 +18,17 @@ API route modules export HTTP methods. Farm discovers them, runs the route pipel
 import { createEndpoint } from "@farmjs/core/api";
 import { z } from "zod";
 
-export const POST = createEndpoint({
-  body: z.object({
-    name: z.string().min(1),
-  }),
-  async handler({ input }) {
-    return Response.json({ message: "Hello " + input.body.name });
+export const POST = createEndpoint(
+  {
+    method: "POST",
+    body: z.object({
+      name: z.string().min(1),
+    }),
   },
-});
+  async ({ body }) => {
+    return Response.json({ message: "Hello " + body.name });
+  },
+);
 ```
 
 ## Next-style exports
@@ -61,21 +64,102 @@ Use `createEndpoint` when you want input validation and typed client generation.
 ## Body and query input
 
 ```ts
-export const GET = createEndpoint({
-  query: z.object({
-    q: z.string().optional(),
-    page: z.coerce.number().int().positive().default(1),
-  }),
-  async handler({ input }) {
+export const GET = createEndpoint(
+  {
+    method: "GET",
+    query: z.object({
+      q: z.string().optional(),
+      page: z.coerce.number().int().positive().default(1),
+    }),
+  },
+  async ({ query }) => {
     return Response.json({
-      q: input.query.q ?? "",
-      page: input.query.page,
+      q: query.q ?? "",
+      page: query.page,
     });
   },
-});
+);
 ```
 
-Farm parses and validates input before the handler runs. Invalid input returns a `400` response with structured validation issues.
+Farm parses and validates `body`, `query`, and `headers` before middleware or handler code runs. Header schema keys use the lower-case names exposed by the Fetch `Headers` API. Invalid input returns a `400` response with structured validation issues.
+
+## Endpoint middleware
+
+Put plain async functions in `middleware`. There is no middleware factory and no `next()` callback. Functions run in declaration order after endpoint input validation.
+
+**src/app/api/projects/[id]/route.ts**
+
+```ts
+import { createEndpoint, type EndpointMiddlewareContext } from "@farmjs/core/api";
+import { z } from "zod";
+
+type Session = {
+  user: { id: string; roles: string[] };
+};
+
+async function requireAuth({ request }: EndpointMiddlewareContext) {
+  const session = await getSession(request);
+
+  if (!session?.user) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  return { session: session as Session };
+}
+
+const requireRole =
+  (role: string) =>
+  async ({ context }: EndpointMiddlewareContext<{ session: Session }>) => {
+    return context.session.user.roles.includes(role);
+  };
+
+async function loadProject({
+  body,
+  context,
+  params,
+}: EndpointMiddlewareContext<{ session: Session }, { name: string }>) {
+  const project = await db.project.findUniqueOrThrow({
+    where: {
+      id: String(params.id),
+      ownerId: context.session.user.id,
+    },
+  });
+
+  return { project };
+}
+
+export const PATCH = createEndpoint(
+  {
+    method: "PATCH",
+    body: z.object({ name: z.string().min(1) }),
+    middleware: [requireAuth, requireRole("admin"), loadProject],
+  },
+  async ({ body, context }) => {
+    // context.session and context.project are inferred from middleware returns.
+    return db.project.update({
+      where: { id: context.project.id },
+      data: { name: body.name },
+    });
+  },
+);
+```
+
+Middleware return values have deliberate control-flow meaning:
+
+| Return value | Result                                                                                   |
+| ------------ | ---------------------------------------------------------------------------------------- |
+| Plain object | Shallow-merges its properties into typed `context` for later middleware and the handler. |
+| `true`       | Continues without adding context.                                                        |
+| `false`      | Stops and returns Farm's JSON `403 Forbidden` response.                                  |
+| `Response`   | Stops and returns that response unchanged. Use this for custom status, body, or headers. |
+
+Only literal `false` is the default denial signal. Returning `null`, `undefined`, an array, or another value is an error, which catches forgotten returns instead of silently skipping authorization. Context is shallowly frozen, duplicate keys are rejected, and `__proto__`, `constructor`, and `prototype` cannot be provided as context keys.
+
+Endpoint middleware is local to one `createEndpoint` declaration and can use its validated input. Use `src/app/**/middleware.ts` for path-level behavior shared by many routes, such as request tracing, common headers, or an early rewrite before endpoint parsing.
+
+> **Authorization boundary**
+>
+> Derive users, roles, tenants, and rate-limit identities from the trusted `Request` or server state. Middleware context is created only on the server and is never accepted from client input. Keep resource-specific permission checks close to the resource query even when shared authentication runs in middleware.
 
 ## Client inference
 

--- a/docs/src/app/docs/getting-started/page.md
+++ b/docs/src/app/docs/getting-started/page.md
@@ -71,16 +71,19 @@ Farm API routes live beside pages and use the same route tree. Define an endpoin
 import { createEndpoint } from "@farmjs/core/api";
 import { z } from "zod";
 
-export const POST = createEndpoint({
-  body: z.object({
-    name: z.string().min(1),
-  }),
-  async handler({ input }) {
+export const POST = createEndpoint(
+  {
+    method: "POST",
+    body: z.object({
+      name: z.string().min(1),
+    }),
+  },
+  async ({ body }) => {
     return Response.json({
-      message: `Hello ${input.body.name}`,
+      message: `Hello ${body.name}`,
     });
   },
-});
+);
 ```
 
 **src/components/hello-button.tsx**

--- a/docs/src/app/docs/openapi/page.md
+++ b/docs/src/app/docs/openapi/page.md
@@ -37,16 +37,19 @@ Farm scans API route files and generates an OpenAPI 3.0.3 spec from the discover
 import { createEndpoint } from "@farmjs/core/api";
 import { z } from "zod";
 
-export const GET = createEndpoint({
-  query: z.object({
-    limit: z.coerce.number().int().positive().default(20),
-  }),
-  async handler({ input }) {
+export const GET = createEndpoint(
+  {
+    method: "GET",
+    query: z.object({
+      limit: z.coerce.number().int().positive().default(20),
+    }),
+  },
+  async ({ query }) => {
     return Response.json({
-      users: await listUsers(input.query.limit),
+      users: await listUsers(query.limit),
     });
   },
-});
+);
 ```
 
 The route appears in the generated reference with a typed `limit` query parameter.

--- a/examples/ssr-ssg-demo/src/app/api-demo/page.tsx
+++ b/examples/ssr-ssg-demo/src/app/api-demo/page.tsx
@@ -148,17 +148,20 @@ export default function ApiDemoPage() {
 import { createEndpoint } from "@farmjs/core/api";
 import { z } from "zod";
 
-export const GET = createEndpoint({
-  query: z.object({
-    name: z.string().optional(),
-  }),
-  handler: async ({ query }) => {
+export const GET = createEndpoint(
+  {
+    method: "GET",
+    query: z.object({
+      name: z.string().optional(),
+    }),
+  },
+  async ({ query }) => {
     return {
       message: \`Hello, \${query.name || "World"}!\`,
       timestamp: new Date().toISOString(),
     };
   },
-});`}
+);`}
         </pre>
       </div>
     </div>

--- a/packages/farm/src/__tests__/api-route-manager.test.ts
+++ b/packages/farm/src/__tests__/api-route-manager.test.ts
@@ -181,9 +181,11 @@ describe("APIRouteManager", () => {
             {
               method: "GET",
               query: z.object({ view: z.enum(["summary", "details"]) }),
+              middleware: [({ params }) => ({ projectId: params.id })],
             },
             async (ctx) => ({
               id: ctx.params.id,
+              middlewareProjectId: ctx.context.projectId,
               view: ctx.query.view,
               hasRequest: ctx.request instanceof Request,
             }),
@@ -202,6 +204,7 @@ describe("APIRouteManager", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
       id: "farm",
+      middlewareProjectId: "farm",
       view: "details",
       hasRequest: true,
     });

--- a/packages/farm/src/__tests__/endpoint-middleware.test.ts
+++ b/packages/farm/src/__tests__/endpoint-middleware.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+import { z } from "zod";
+import {
+  createEndpoint,
+  POST,
+  type EndpointMiddlewareContext,
+  type TypedEndpoint,
+} from "../api/endpoint";
+import { invokeAPIRouteEndpoint } from "../api/route-manager";
+
+type Session = {
+  user: {
+    id: string;
+    roles: string[];
+  };
+};
+
+interface AuditContext {
+  auditId: string;
+}
+
+const withAudit = async (): Promise<AuditContext> => ({ auditId: "audit-1" });
+
+const returnsNothing = async () => {};
+
+// @ts-expect-error Middleware must continue, deny, respond, or provide context.
+const invalidEndpoint = createEndpoint(
+  {
+    method: "GET",
+    middleware: [returnsNothing],
+  },
+  () => ({ ok: true }),
+);
+void invalidEndpoint;
+
+const withSession = async ({ request }: EndpointMiddlewareContext) => {
+  const userId = request.headers.get("x-user-id");
+  if (!userId) {
+    return Response.json(
+      { error: "Unauthorized" },
+      { status: 401, headers: { "x-auth-required": "true" } },
+    );
+  }
+
+  const session: Session = {
+    user: {
+      id: userId,
+      roles: ["admin"],
+    },
+  };
+  return { session };
+};
+
+describe("createEndpoint middleware", () => {
+  it("passes validated input and accumulated typed context to the handler", async () => {
+    const trace: string[] = [];
+    const loadProject = async ({
+      body,
+      context,
+    }: EndpointMiddlewareContext<{ session: Session }, { projectId: string }>) => {
+      expectTypeOf(context.session.user.id).toEqualTypeOf<string>();
+      trace.push(`project:${body.projectId}:${context.session.user.id}`);
+      return {
+        project: {
+          id: body.projectId,
+          ownerId: context.session.user.id,
+        },
+      };
+    };
+    const endpoint = createEndpoint(
+      {
+        method: "PATCH",
+        body: z.object({ projectId: z.string().min(1) }),
+        query: z.object({ source: z.enum(["form", "api"]) }),
+        headers: z.object({ "x-user-id": z.string().min(1) }),
+        middleware: [withSession, loadProject, withAudit, () => true],
+      },
+      ({ body, query, headers, context }) => {
+        expectTypeOf(context.session).toEqualTypeOf<Session>();
+        expectTypeOf(context.project).toEqualTypeOf<{
+          id: string;
+          ownerId: string;
+        }>();
+        expectTypeOf(context.auditId).toEqualTypeOf<string>();
+        expectTypeOf(body.projectId).toEqualTypeOf<string>();
+        expectTypeOf(query.source).toEqualTypeOf<"form" | "api">();
+        expectTypeOf(headers["x-user-id"]).toEqualTypeOf<string>();
+        expect(Object.isFrozen(context)).toBe(true);
+        trace.push("handler");
+
+        return {
+          id: context.project.id,
+          userId: context.session.user.id,
+          auditId: context.auditId,
+          source: query.source,
+        };
+      },
+    );
+
+    expectTypeOf(endpoint).toMatchTypeOf<
+      TypedEndpoint<
+        { projectId: string },
+        { source: "form" | "api" },
+        { id: string; userId: string; auditId: string; source: "form" | "api" },
+        { "x-user-id": string }
+      >
+    >();
+
+    const response = await invokeAPIRouteEndpoint(
+      endpoint,
+      new Request("https://app.example.com/api/projects/42?source=form", {
+        method: "PATCH",
+        headers: {
+          "content-type": "application/json",
+          "x-user-id": "user-1",
+        },
+        body: JSON.stringify({ projectId: "42" }),
+      }),
+      { id: "42" },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      id: "42",
+      userId: "user-1",
+      auditId: "audit-1",
+      source: "form",
+    });
+    expect(trace).toEqual(["project:42:user-1", "handler"]);
+  });
+
+  it("validates all endpoint input before middleware runs", async () => {
+    const middleware = vi.fn(withSession);
+    const handler = vi.fn(() => ({ ok: true }));
+    const endpoint = createEndpoint(
+      {
+        method: "POST",
+        body: z.object({ name: z.string().min(2) }),
+        headers: z.object({ "x-user-id": z.string().min(1) }),
+        middleware: [middleware],
+      },
+      handler,
+    );
+
+    const response = await invokeAPIRouteEndpoint(
+      endpoint,
+      new Request("https://app.example.com/api/projects", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "Farm" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: "Invalid request headers" });
+    expect(middleware).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("uses a returned Response as the exact short-circuit result", async () => {
+    const later = vi.fn(() => true as const);
+    const handler = vi.fn(() => ({ ok: true }));
+    const endpoint = createEndpoint(
+      {
+        method: "GET",
+        middleware: [withSession, later],
+      },
+      handler,
+    );
+
+    const response = await invokeAPIRouteEndpoint(
+      endpoint,
+      new Request("https://app.example.com/api/private"),
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("x-auth-required")).toBe("true");
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(later).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("turns false into a 403 and does not call later middleware or the handler", async () => {
+    const later = vi.fn(() => ({ loaded: true }));
+    const handler = vi.fn(() => ({ ok: true }));
+    const endpoint = createEndpoint(
+      {
+        method: "GET",
+        middleware: [() => true as const, () => false as const, later],
+      },
+      handler,
+    );
+
+    const response = await invokeAPIRouteEndpoint(
+      endpoint,
+      new Request("https://app.example.com/api/admin"),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "Forbidden" });
+    expect(later).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["null", null],
+    ["an array", []],
+  ])("rejects %s middleware returns", async (_label, result) => {
+    const endpoint = createEndpoint(
+      {
+        method: "GET",
+        middleware: [(() => result) as any],
+      },
+      () => ({ ok: true }),
+    );
+
+    await expect(
+      invokeAPIRouteEndpoint(endpoint, new Request("https://app.example.com/api/invalid")),
+    ).rejects.toThrow("must return an object, true, false, or a Response");
+  });
+
+  it("rejects duplicate and unsafe context keys", async () => {
+    const duplicate = createEndpoint(
+      {
+        method: "GET",
+        middleware: [() => ({ session: { id: "one" } }), () => ({ session: { id: "two" } })],
+      },
+      () => ({ ok: true }),
+    );
+
+    await expect(
+      invokeAPIRouteEndpoint(duplicate, new Request("https://app.example.com/api/duplicate")),
+    ).rejects.toThrow('cannot replace the existing context key "session"');
+
+    const unsafeContext = Object.create(null) as Record<string, unknown>;
+    unsafeContext.__proto__ = "unsafe";
+    const unsafe = createEndpoint(
+      {
+        method: "GET",
+        middleware: [() => unsafeContext],
+      },
+      () => ({ ok: true }),
+    );
+
+    await expect(
+      invokeAPIRouteEndpoint(unsafe, new Request("https://app.example.com/api/unsafe")),
+    ).rejects.toThrow('unsafe context key "__proto__"');
+  });
+
+  it("copies the middleware list when the endpoint is created", async () => {
+    const first = vi.fn(() => true as const);
+    const addedLater = vi.fn(() => false as const);
+    const middleware: Array<() => boolean> = [first];
+    const endpoint = createEndpoint({ method: "GET", middleware }, () => ({ ok: true }));
+    middleware.push(addedLater);
+
+    const response = await invokeAPIRouteEndpoint(
+      endpoint,
+      new Request("https://app.example.com/api/stable"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(first).toHaveBeenCalledOnce();
+    expect(addedLater).not.toHaveBeenCalled();
+  });
+
+  it("preserves middleware context inference in method helpers", async () => {
+    const endpoint = POST(
+      {
+        body: z.object({ name: z.string() }),
+        middleware: [withSession],
+      },
+      ({ body, context }) => {
+        expectTypeOf(body.name).toEqualTypeOf<string>();
+        expectTypeOf(context.session).toEqualTypeOf<Session>();
+        return { name: body.name, userId: context.session.user.id };
+      },
+    );
+
+    const response = await invokeAPIRouteEndpoint(
+      endpoint,
+      new Request("https://app.example.com/api/projects", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-user-id": "user-2",
+        },
+        body: JSON.stringify({ name: "Farm" }),
+      }),
+    );
+
+    await expect(response.json()).resolves.toEqual({ name: "Farm", userId: "user-2" });
+  });
+
+  it("runs the same middleware for direct server endpoint calls", async () => {
+    const endpoint = createEndpoint(
+      "/api/direct",
+      {
+        method: "GET",
+        middleware: [() => ({ source: "middleware" as const })],
+      },
+      ({ context }) => ({ source: context.source }),
+    );
+
+    await expect(endpoint()).resolves.toEqual({ source: "middleware" });
+  });
+});

--- a/packages/farm/src/__tests__/testing.test.ts
+++ b/packages/farm/src/__tests__/testing.test.ts
@@ -257,12 +257,13 @@ describe("Farm test API harness", () => {
         method: "PATCH",
         body: z.object({ name: z.string().min(2) }),
         query: z.object({ source: z.enum(["form", "api"]) }),
+        middleware: [({ headers }) => ({ tenant: headers["x-tenant"] })],
       },
-      ({ body, query, params, headers }) => ({
+      ({ body, query, params, context }) => ({
         id: params.id,
         name: body.name,
         source: query.source,
-        tenant: headers["x-tenant"],
+        tenant: context.tenant,
       }),
     );
     const ProjectApi = api("/api/projects/[id]", { PATCH: updateProject });

--- a/packages/farm/src/api/endpoint.ts
+++ b/packages/farm/src/api/endpoint.ts
@@ -4,6 +4,14 @@ import { createEndpoint as betterCallEndpoint } from "better-call";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySchema = { _output?: any; _input?: any; parse?: (data: unknown) => any };
 
+type MaybePromise<T> = T | Promise<T>;
+type Simplify<T> = { [TKey in keyof T]: T[TKey] } & {};
+type UnionToIntersection<T> = (T extends unknown ? (value: T) => void : never) extends (
+  value: infer TIntersection,
+) => void
+  ? TIntersection
+  : never;
+
 // Infer output type from schema (works with Zod v3 and v4)
 type InferOutput<T> = T extends { _output: infer O }
   ? O
@@ -11,18 +19,98 @@ type InferOutput<T> = T extends { _output: infer O }
     ? R
     : unknown;
 
+type InferHeadersOutput<T> = [T] extends [never]
+  ? Record<string, string>
+  : T extends AnySchema
+    ? InferOutput<T>
+    : Record<string, string>;
+
 export type EndpointParamValue = string | string[];
 export type EndpointParams = Record<string, EndpointParamValue>;
+
+export type EndpointMiddlewareContext<
+  TContext extends object = {},
+  TBody = unknown,
+  TQuery = unknown,
+  THeaders = Record<string, string>,
+> = {
+  body: TBody;
+  query: TQuery;
+  headers: THeaders;
+  request: Request;
+  /** Context accumulated from middleware that ran earlier in the chain. */
+  context: Readonly<TContext>;
+  params: EndpointParams;
+};
+
+export type EndpointMiddlewareResult<TProvidedContext extends object = object> =
+  | TProvidedContext
+  | true
+  | false
+  | Response;
+
+/** A plain async function. No wrapper or `next()` callback is required. */
+export type EndpointMiddleware<
+  TProvidedContext extends object = object,
+  TContext extends object = {},
+  TBody = unknown,
+  TQuery = unknown,
+  THeaders = Record<string, string>,
+> = (
+  ctx: EndpointMiddlewareContext<TContext, TBody, TQuery, THeaders>,
+) => MaybePromise<EndpointMiddlewareResult<TProvidedContext>>;
+
+export type AnyEndpointMiddleware = (ctx: EndpointMiddlewareContext<any, any, any, any>) => unknown;
+
+type ValidateEndpointMiddlewares<TMiddlewares extends readonly AnyEndpointMiddleware[]> = {
+  readonly [TIndex in keyof TMiddlewares]: TMiddlewares[TIndex] extends AnyEndpointMiddleware
+    ? [Awaited<ReturnType<TMiddlewares[TIndex]>>] extends [EndpointMiddlewareResult<object>]
+      ? TMiddlewares[TIndex]
+      : never
+    : never;
+};
+
+type ContextFromMiddlewareResult<TResult> =
+  Exclude<TResult, Response | boolean> extends infer TContext
+    ? [TContext] extends [never]
+      ? {}
+      : TContext extends object
+        ? TContext
+        : {}
+    : {};
+
+type ContextFromMiddleware<TMiddleware> = TMiddleware extends (...args: any[]) => infer TResult
+  ? ContextFromMiddlewareResult<Awaited<TResult>>
+  : {};
+
+export type InferEndpointMiddlewareContext<
+  TMiddlewares extends readonly ((...args: any[]) => any)[],
+  TContext extends object = {},
+> = TMiddlewares extends readonly [infer TMiddleware, ...infer TRest]
+  ? TMiddleware extends (...args: any[]) => any
+    ? TRest extends readonly ((...args: any[]) => any)[]
+      ? InferEndpointMiddlewareContext<
+          TRest,
+          Simplify<TContext & ContextFromMiddleware<TMiddleware>>
+        >
+      : Simplify<TContext>
+    : Simplify<TContext>
+  : number extends TMiddlewares["length"]
+    ? Simplify<TContext & UnionToIntersection<ContextFromMiddleware<TMiddlewares[number]>>>
+    : Simplify<TContext>;
 
 export type EndpointOptions<
   TBody extends AnySchema = never,
   TQuery extends AnySchema = never,
   THeaders extends AnySchema = never,
+  TMiddlewares extends readonly AnyEndpointMiddleware[] = readonly [],
 > = {
   method?: "GET" | "HEAD" | "POST" | "PUT" | "DELETE" | "PATCH" | "OPTIONS";
   body?: TBody;
   query?: TQuery;
   headers?: THeaders;
+  middleware?: TMiddlewares;
+  /** @deprecated Use plain functions in `middleware` for Farm endpoint middleware. */
   use?: any[];
 };
 
@@ -31,25 +119,94 @@ export type EndpointHandler<
   TQuery extends AnySchema = never,
   THeaders extends AnySchema = never,
   TResponse = any,
+  TContext extends object = {},
 > = (ctx: {
   body: InferOutput<TBody>;
   query: InferOutput<TQuery>;
-  headers: THeaders extends AnySchema ? InferOutput<THeaders> : Record<string, string>;
+  headers: InferHeadersOutput<THeaders>;
   request: Request;
-  context: any;
+  context: Readonly<TContext>;
   params: EndpointParams;
 }) => Promise<TResponse> | TResponse;
 
 // Type to represent an endpoint with its input/output types
-export type TypedEndpoint<TBody = never, TQuery = never, TResponse = any> = {
+export type TypedEndpoint<
+  TBody = never,
+  TQuery = never,
+  TResponse = any,
+  THeaders = Record<string, string>,
+> = {
   __types: {
     body: TBody;
     query: TQuery;
+    headers: THeaders;
     response: TResponse;
   };
   __path?: string;
   __method?: string;
 } & ((options?: { body?: TBody; query?: TQuery }) => Promise<TResponse>);
+
+type CreatedEndpoint<
+  TBody extends AnySchema,
+  TQuery extends AnySchema,
+  THeaders extends AnySchema,
+  TResponse,
+> = TypedEndpoint<
+  InferOutput<TBody>,
+  InferOutput<TQuery>,
+  Awaited<TResponse>,
+  InferHeadersOutput<THeaders>
+>;
+
+type AnyEndpointOptions = EndpointOptions<
+  AnySchema,
+  AnySchema,
+  AnySchema,
+  readonly AnyEndpointMiddleware[]
+>;
+type EndpointBodyFromOptions<TOptions> = TOptions extends {
+  body: infer TBody extends AnySchema;
+}
+  ? TBody
+  : never;
+type EndpointQueryFromOptions<TOptions> = TOptions extends {
+  query: infer TQuery extends AnySchema;
+}
+  ? TQuery
+  : never;
+type EndpointHeadersFromOptions<TOptions> = TOptions extends {
+  headers: infer THeaders extends AnySchema;
+}
+  ? THeaders
+  : never;
+type EndpointMiddlewaresFromOptions<TOptions> = TOptions extends {
+  middleware: infer TMiddlewares extends readonly AnyEndpointMiddleware[];
+}
+  ? TMiddlewares
+  : readonly [];
+type MethodlessEndpointOptions = Omit<AnyEndpointOptions, "method">;
+type EndpointHandlerFromOptions<TOptions, TResponse> = EndpointHandler<
+  EndpointBodyFromOptions<TOptions>,
+  EndpointQueryFromOptions<TOptions>,
+  EndpointHeadersFromOptions<TOptions>,
+  TResponse,
+  InferEndpointMiddlewareContext<EndpointMiddlewaresFromOptions<TOptions>>
+>;
+type ValidatedEndpointHandlerFromOptions<TOptions, TResponse> = EndpointHandlerFromOptions<
+  TOptions,
+  TResponse
+> &
+  (EndpointMiddlewaresFromOptions<TOptions> extends ValidateEndpointMiddlewares<
+    EndpointMiddlewaresFromOptions<TOptions>
+  >
+    ? unknown
+    : never);
+type CreatedEndpointFromOptions<TOptions, TResponse> = CreatedEndpoint<
+  EndpointBodyFromOptions<TOptions>,
+  EndpointQueryFromOptions<TOptions>,
+  EndpointHeadersFromOptions<TOptions>,
+  TResponse
+>;
 
 /**
  * Create a Farm.js API endpoint
@@ -62,41 +219,73 @@ export type TypedEndpoint<TBody = never, TQuery = never, TResponse = any> = {
  * 2. Explicit path (for routes.ts at project root):
  *    `createEndpoint('/api/hello', { method: 'GET', query: z.object({...}) }, handler)`
  */
+export function createEndpoint<const TOptions extends AnyEndpointOptions, TResponse = any>(
+  options: TOptions,
+  handler: ValidatedEndpointHandlerFromOptions<TOptions, TResponse>,
+): CreatedEndpointFromOptions<TOptions, TResponse>;
+export function createEndpoint<const TOptions extends AnyEndpointOptions, TResponse = any>(
+  path: string,
+  options: TOptions,
+  handler: ValidatedEndpointHandlerFromOptions<TOptions, TResponse>,
+): CreatedEndpointFromOptions<TOptions, TResponse>;
 export function createEndpoint<
   TBody extends AnySchema = never,
   TQuery extends AnySchema = never,
   THeaders extends AnySchema = never,
   TResponse = any,
 >(
-  pathOrOptions: string | EndpointOptions<TBody, TQuery, THeaders>,
+  options: EndpointOptions<TBody, TQuery, THeaders, readonly []>,
+  handler: EndpointHandler<TBody, TQuery, THeaders, TResponse>,
+): CreatedEndpoint<TBody, TQuery, THeaders, TResponse>;
+export function createEndpoint<
+  TBody extends AnySchema = never,
+  TQuery extends AnySchema = never,
+  THeaders extends AnySchema = never,
+  TResponse = any,
+>(
+  path: string,
+  options: EndpointOptions<TBody, TQuery, THeaders, readonly []>,
+  handler: EndpointHandler<TBody, TQuery, THeaders, TResponse>,
+): CreatedEndpoint<TBody, TQuery, THeaders, TResponse>;
+export function createEndpoint(
+  pathOrOptions: string | EndpointOptions<any, any, any, readonly AnyEndpointMiddleware[]>,
   optionsOrHandler:
-    | EndpointOptions<TBody, TQuery, THeaders>
-    | EndpointHandler<TBody, TQuery, THeaders, TResponse>,
-  maybeHandler?: EndpointHandler<TBody, TQuery, THeaders, TResponse>,
-): TypedEndpoint<InferOutput<TBody>, InferOutput<TQuery>, TResponse> {
+    | EndpointOptions<any, any, any, readonly AnyEndpointMiddleware[]>
+    | EndpointHandler<any, any, any, any, any>,
+  maybeHandler?: EndpointHandler<any, any, any, any, any>,
+): TypedEndpoint<any, any, any, any> {
   // Determine if first arg is path or options
   let path: string;
-  let options: EndpointOptions<TBody, TQuery, THeaders>;
-  let handler: EndpointHandler<TBody, TQuery, THeaders, TResponse>;
+  let options: EndpointOptions<any, any, any, readonly AnyEndpointMiddleware[]>;
+  let handler: EndpointHandler<any, any, any, any, any>;
 
   if (typeof pathOrOptions === "string") {
     // createEndpoint('/path', options, handler)
     path = pathOrOptions;
-    options = optionsOrHandler as EndpointOptions<TBody, TQuery, THeaders>;
-    handler = maybeHandler as EndpointHandler<TBody, TQuery, THeaders, TResponse>;
+    options = optionsOrHandler as typeof options;
+    handler = maybeHandler as typeof handler;
   } else {
     // createEndpoint(options, handler) - path will be set by API plugin from file location
     path = "";
     options = pathOrOptions;
-    handler = optionsOrHandler as EndpointHandler<TBody, TQuery, THeaders, TResponse>;
+    handler = optionsOrHandler as typeof handler;
   }
+
+  if (typeof handler !== "function") {
+    throw new TypeError("createEndpoint requires a handler function");
+  }
+
+  const middleware = normalizeEndpointMiddleware(options.middleware);
+  const wrappedHandler = ((ctx: EndpointMiddlewareContext<any, any, any, any>) =>
+    runEndpointMiddleware(middleware, ctx, handler)) as typeof handler;
+  const { middleware: _middleware, ...betterCallOptions } = options;
 
   // Create the endpoint - path will be set later by API plugin if not provided
   // We use a temporary path that will be replaced when the router is created
   const endpoint = betterCallEndpoint(
     path || "/__farm_auto_path__",
-    options as any,
-    handler as any,
+    betterCallOptions as any,
+    wrappedHandler as any,
   ) as any;
 
   // Store the path and type information on the endpoint for later access
@@ -104,32 +293,147 @@ export function createEndpoint<
   endpoint.__path = path || undefined;
   endpoint.__method = options.method || "GET";
   endpoint.__autoPath = !path; // Flag to indicate path should be auto-inferred
-  endpoint.__handler = handler; // Store original handler for direct invocation
+  endpoint.__handler = wrappedHandler; // Used by Farm's route runtime.
+  endpoint.__middleware = middleware;
+  endpoint.__sourceHandler = handler;
 
   // Store type information for inference
   endpoint.__types = {
     body: options.body,
     query: options.query,
+    headers: options.headers,
     response: null as any,
   };
 
   return endpoint as any;
 }
 
+const EMPTY_ENDPOINT_MIDDLEWARE = Object.freeze([]) as readonly AnyEndpointMiddleware[];
+const EMPTY_ENDPOINT_CONTEXT = Object.freeze(Object.create(null)) as Readonly<
+  Record<string | symbol, unknown>
+>;
+const UNSAFE_ENDPOINT_CONTEXT_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+function normalizeEndpointMiddleware(
+  middleware: readonly AnyEndpointMiddleware[] | undefined,
+): readonly AnyEndpointMiddleware[] {
+  if (middleware === undefined) return EMPTY_ENDPOINT_MIDDLEWARE;
+  if (!Array.isArray(middleware)) {
+    throw new TypeError("createEndpoint middleware must be an array of functions");
+  }
+
+  const normalized = [...middleware];
+  for (const entry of normalized) {
+    if (typeof entry !== "function") {
+      throw new TypeError("createEndpoint middleware entries must be functions");
+    }
+  }
+
+  return Object.freeze(normalized);
+}
+
+async function runEndpointMiddleware(
+  middleware: readonly AnyEndpointMiddleware[],
+  handlerContext: EndpointMiddlewareContext<any, any, any, any>,
+  handler: EndpointHandler<any, any, any, any, any>,
+): Promise<unknown> {
+  let context = createInitialEndpointContext(handlerContext.context);
+
+  for (let index = 0; index < middleware.length; index++) {
+    const result = await middleware[index]({ ...handlerContext, context });
+
+    if (isEndpointResponse(result)) return result;
+    if (result === false) return forbiddenEndpointResponse();
+    if (result === true) continue;
+
+    if (!isPlainEndpointContext(result)) {
+      throw new TypeError(
+        `Endpoint middleware ${index + 1} must return an object, true, false, or a Response`,
+      );
+    }
+
+    context = mergeEndpointContext(context, result, index);
+  }
+
+  return handler({ ...handlerContext, context });
+}
+
+function createInitialEndpointContext(value: unknown) {
+  if (value === undefined || value === null) return EMPTY_ENDPOINT_CONTEXT;
+  if (!isPlainEndpointContext(value)) {
+    throw new TypeError("Endpoint context must be a plain object");
+  }
+
+  return mergeEndpointContext(EMPTY_ENDPOINT_CONTEXT, value);
+}
+
+function mergeEndpointContext(
+  current: Readonly<Record<string | symbol, unknown>>,
+  added: object,
+  middlewareIndex?: number,
+) {
+  const next = Object.assign(Object.create(null), current) as Record<string | symbol, unknown>;
+
+  for (const key of Reflect.ownKeys(added)) {
+    if (!Object.prototype.propertyIsEnumerable.call(added, key)) continue;
+    if (typeof key === "string" && UNSAFE_ENDPOINT_CONTEXT_KEYS.has(key)) {
+      throw new TypeError(`Endpoint middleware cannot provide the unsafe context key "${key}"`);
+    }
+    if (Object.prototype.hasOwnProperty.call(current, key)) {
+      const source =
+        middlewareIndex === undefined
+          ? "Endpoint context"
+          : `Endpoint middleware ${middlewareIndex + 1}`;
+      throw new TypeError(`${source} cannot replace the existing context key "${String(key)}"`);
+    }
+    next[key] = (added as Record<string | symbol, unknown>)[key];
+  }
+
+  return Object.freeze(next);
+}
+
+function isPlainEndpointContext(value: unknown): value is object {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isEndpointResponse(value: unknown): value is Response {
+  return (
+    value instanceof Response ||
+    (typeof value === "object" &&
+      value !== null &&
+      "headers" in value &&
+      "status" in value &&
+      typeof (value as Response).arrayBuffer === "function")
+  );
+}
+
+function forbiddenEndpointResponse() {
+  return new Response(JSON.stringify({ error: "Forbidden" }), {
+    status: 403,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
 /**
  * Convenience method for GET requests
  */
 export function GET<T = any>(
-  handler: EndpointHandler<any, any, any, T>,
-): ReturnType<typeof createEndpoint>;
+  handler: EndpointHandler<never, never, never, T>,
+): CreatedEndpoint<never, never, never, T>;
+export function GET<const TOptions extends MethodlessEndpointOptions, TResponse = any>(
+  options: TOptions,
+  handler: ValidatedEndpointHandlerFromOptions<TOptions, TResponse>,
+): CreatedEndpointFromOptions<TOptions, TResponse>;
 export function GET<
   TQuery extends AnySchema = never,
   THeaders extends AnySchema = never,
   TResponse = any,
 >(
-  options: Omit<EndpointOptions<any, TQuery, THeaders>, "method">,
-  handler: EndpointHandler<any, TQuery, THeaders, TResponse>,
-): ReturnType<typeof createEndpoint>;
+  options: Omit<EndpointOptions<never, TQuery, THeaders, readonly []>, "method">,
+  handler: EndpointHandler<never, TQuery, THeaders, TResponse>,
+): CreatedEndpoint<never, TQuery, THeaders, TResponse>;
 export function GET(...args: any[]): any {
   if (args.length === 1) {
     return createEndpoint("", { method: "GET" }, args[0]);
@@ -141,16 +445,20 @@ export function GET(...args: any[]): any {
  * Convenience method for HEAD requests
  */
 export function HEAD<T = any>(
-  handler: EndpointHandler<any, any, any, T>,
-): ReturnType<typeof createEndpoint>;
+  handler: EndpointHandler<never, never, never, T>,
+): CreatedEndpoint<never, never, never, T>;
+export function HEAD<const TOptions extends MethodlessEndpointOptions, TResponse = any>(
+  options: TOptions,
+  handler: ValidatedEndpointHandlerFromOptions<TOptions, TResponse>,
+): CreatedEndpointFromOptions<TOptions, TResponse>;
 export function HEAD<
-  TQuery extends AnySchema = any,
-  THeaders extends AnySchema = any,
+  TQuery extends AnySchema = never,
+  THeaders extends AnySchema = never,
   TResponse = any,
 >(
-  options: Omit<EndpointOptions<any, TQuery, THeaders>, "method">,
-  handler: EndpointHandler<any, TQuery, THeaders, TResponse>,
-): ReturnType<typeof createEndpoint>;
+  options: Omit<EndpointOptions<never, TQuery, THeaders, readonly []>, "method">,
+  handler: EndpointHandler<never, TQuery, THeaders, TResponse>,
+): CreatedEndpoint<never, TQuery, THeaders, TResponse>;
 export function HEAD(...args: any[]): any {
   if (args.length === 1) {
     return createEndpoint("", { method: "HEAD" }, args[0]);
@@ -162,17 +470,21 @@ export function HEAD(...args: any[]): any {
  * Convenience method for POST requests
  */
 export function POST<T = any>(
-  handler: EndpointHandler<any, any, any, T>,
-): ReturnType<typeof createEndpoint>;
+  handler: EndpointHandler<never, never, never, T>,
+): CreatedEndpoint<never, never, never, T>;
+export function POST<const TOptions extends MethodlessEndpointOptions, TResponse = any>(
+  options: TOptions,
+  handler: ValidatedEndpointHandlerFromOptions<TOptions, TResponse>,
+): CreatedEndpointFromOptions<TOptions, TResponse>;
 export function POST<
   TBody extends AnySchema = never,
   TQuery extends AnySchema = never,
   THeaders extends AnySchema = never,
   TResponse = any,
 >(
-  options: Omit<EndpointOptions<TBody, TQuery, THeaders>, "method">,
+  options: Omit<EndpointOptions<TBody, TQuery, THeaders, readonly []>, "method">,
   handler: EndpointHandler<TBody, TQuery, THeaders, TResponse>,
-): ReturnType<typeof createEndpoint>;
+): CreatedEndpoint<TBody, TQuery, THeaders, TResponse>;
 export function POST(...args: any[]): any {
   if (args.length === 1) {
     return createEndpoint("", { method: "POST" }, args[0]);
@@ -184,17 +496,21 @@ export function POST(...args: any[]): any {
  * Convenience method for PUT requests
  */
 export function PUT<T = any>(
-  handler: EndpointHandler<any, any, any, T>,
-): ReturnType<typeof createEndpoint>;
+  handler: EndpointHandler<never, never, never, T>,
+): CreatedEndpoint<never, never, never, T>;
+export function PUT<const TOptions extends MethodlessEndpointOptions, TResponse = any>(
+  options: TOptions,
+  handler: ValidatedEndpointHandlerFromOptions<TOptions, TResponse>,
+): CreatedEndpointFromOptions<TOptions, TResponse>;
 export function PUT<
   TBody extends AnySchema = never,
   TQuery extends AnySchema = never,
   THeaders extends AnySchema = never,
   TResponse = any,
 >(
-  options: Omit<EndpointOptions<TBody, TQuery, THeaders>, "method">,
+  options: Omit<EndpointOptions<TBody, TQuery, THeaders, readonly []>, "method">,
   handler: EndpointHandler<TBody, TQuery, THeaders, TResponse>,
-): ReturnType<typeof createEndpoint>;
+): CreatedEndpoint<TBody, TQuery, THeaders, TResponse>;
 export function PUT(...args: any[]): any {
   if (args.length === 1) {
     return createEndpoint("", { method: "PUT" }, args[0]);
@@ -206,17 +522,21 @@ export function PUT(...args: any[]): any {
  * Convenience method for DELETE requests
  */
 export function DELETE<T = any>(
-  handler: EndpointHandler<any, any, any, T>,
-): ReturnType<typeof createEndpoint>;
+  handler: EndpointHandler<never, never, never, T>,
+): CreatedEndpoint<never, never, never, T>;
+export function DELETE<const TOptions extends MethodlessEndpointOptions, TResponse = any>(
+  options: TOptions,
+  handler: ValidatedEndpointHandlerFromOptions<TOptions, TResponse>,
+): CreatedEndpointFromOptions<TOptions, TResponse>;
 export function DELETE<
   TBody extends AnySchema = never,
   TQuery extends AnySchema = never,
   THeaders extends AnySchema = never,
   TResponse = any,
 >(
-  options: Omit<EndpointOptions<TBody, TQuery, THeaders>, "method">,
+  options: Omit<EndpointOptions<TBody, TQuery, THeaders, readonly []>, "method">,
   handler: EndpointHandler<TBody, TQuery, THeaders, TResponse>,
-): ReturnType<typeof createEndpoint>;
+): CreatedEndpoint<TBody, TQuery, THeaders, TResponse>;
 export function DELETE(...args: any[]): any {
   if (args.length === 1) {
     return createEndpoint("", { method: "DELETE" }, args[0]);
@@ -228,17 +548,21 @@ export function DELETE(...args: any[]): any {
  * Convenience method for PATCH requests
  */
 export function PATCH<T = any>(
-  handler: EndpointHandler<any, any, any, T>,
-): ReturnType<typeof createEndpoint>;
+  handler: EndpointHandler<never, never, never, T>,
+): CreatedEndpoint<never, never, never, T>;
+export function PATCH<const TOptions extends MethodlessEndpointOptions, TResponse = any>(
+  options: TOptions,
+  handler: ValidatedEndpointHandlerFromOptions<TOptions, TResponse>,
+): CreatedEndpointFromOptions<TOptions, TResponse>;
 export function PATCH<
   TBody extends AnySchema = never,
   TQuery extends AnySchema = never,
   THeaders extends AnySchema = never,
   TResponse = any,
 >(
-  options: Omit<EndpointOptions<TBody, TQuery, THeaders>, "method">,
+  options: Omit<EndpointOptions<TBody, TQuery, THeaders, readonly []>, "method">,
   handler: EndpointHandler<TBody, TQuery, THeaders, TResponse>,
-): ReturnType<typeof createEndpoint>;
+): CreatedEndpoint<TBody, TQuery, THeaders, TResponse>;
 export function PATCH(...args: any[]): any {
   if (args.length === 1) {
     return createEndpoint("", { method: "PATCH" }, args[0]);
@@ -250,17 +574,21 @@ export function PATCH(...args: any[]): any {
  * Convenience method for OPTIONS requests
  */
 export function OPTIONS<T = any>(
-  handler: EndpointHandler<any, any, any, T>,
-): ReturnType<typeof createEndpoint>;
+  handler: EndpointHandler<never, never, never, T>,
+): CreatedEndpoint<never, never, never, T>;
+export function OPTIONS<const TOptions extends MethodlessEndpointOptions, TResponse = any>(
+  options: TOptions,
+  handler: ValidatedEndpointHandlerFromOptions<TOptions, TResponse>,
+): CreatedEndpointFromOptions<TOptions, TResponse>;
 export function OPTIONS<
   TBody extends AnySchema = never,
   TQuery extends AnySchema = never,
   THeaders extends AnySchema = never,
   TResponse = any,
 >(
-  options: Omit<EndpointOptions<TBody, TQuery, THeaders>, "method">,
+  options: Omit<EndpointOptions<TBody, TQuery, THeaders, readonly []>, "method">,
   handler: EndpointHandler<TBody, TQuery, THeaders, TResponse>,
-): ReturnType<typeof createEndpoint>;
+): CreatedEndpoint<TBody, TQuery, THeaders, TResponse>;
 export function OPTIONS(...args: any[]): any {
   if (args.length === 1) {
     return createEndpoint("", { method: "OPTIONS" }, args[0]);

--- a/packages/farm/src/api/route-manager.ts
+++ b/packages/farm/src/api/route-manager.ts
@@ -392,10 +392,15 @@ export async function invokeAPIRouteEndpoint(
     return bodyValidation;
   }
 
+  const headersValidation = validateInput(types.headers, headers, "Invalid request headers");
+  if (headersValidation instanceof Response) {
+    return headersValidation;
+  }
+
   const result = await farmHandler({
     query: queryValidation,
     body: bodyValidation,
-    headers,
+    headers: headersValidation,
     request,
     context: {},
     params,


### PR DESCRIPTION
## Summary

- add plain-function middleware arrays to `createEndpoint` and the HTTP method helpers
- infer middleware-provided values into a readonly handler `context`
- support object, `true`, `false`, and `Response` control-flow returns
- run the same chain for file routes, programmatic routes, the test harness, and direct server endpoint calls
- validate header schemas before middleware and handlers
- reject missing/invalid returns, duplicate context keys, unsafe prototype keys, and middleware list mutation
- document endpoint middleware, authorization guidance, and the difference from path-level `middleware.ts`
- correct existing docs examples to use the supported `createEndpoint(options, handler)` signature

## Validation

- `pnpm --filter @farmjs/core test` (57 files, 505 passed, 1 skipped)
- strict focused TypeScript compile for endpoint, route-manager, and test-harness coverage
- `pnpm --filter @farmjs/core build`
- `pnpm --filter farmjs-docs build`
- focused Oxlint and Oxfmt checks

The repository-wide core `type-check` still reports existing errors on `main` in Nitro and query-state dependencies; the changed source and type tests compile cleanly.