### PR TITLE
feat: support defineConfig for Farm config

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,17 @@ yarn add @farmjs/core react react-dom
 Create a `farm.config.ts`:
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   srcDir: "src",
   deploy: {
     target: "vercel",
   },
 });
 ```
+
+`defineFarmConfig` remains supported as an exact alias of `defineConfig`.
 
 Create your first page in `src/app/page.tsx`:
 
@@ -110,9 +112,9 @@ my-farm-app/
 Farm.js supports a powerful configuration system via `farm.config.ts`:
 
 ```typescript
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   experimental: {
     serverComponents: true,
   },
@@ -172,9 +174,9 @@ src/app/
 Required config:
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   experimental: {
     serverComponents: true,
   },

--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -13,9 +13,9 @@ Use farm.config.ts as the single project control plane for source paths, integra
 **farm.config.ts**
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   srcDir: "src",
   deploy: {
     target: "vercel",
@@ -32,6 +32,26 @@ export default defineFarmConfig({
   },
 });
 ```
+
+`defineConfig` is the concise Farm helper. `defineFarmConfig` is the same typed function and remains fully supported for existing applications.
+
+### Docs config
+
+Use `defineDocs` for docs-specific navigation, search, theme, and metadata in a separate `docs.config.ts`:
+
+```ts
+import { defineDocs } from "@farming-labs/docs";
+
+export default defineDocs({
+  entry: "docs",
+  docsPath: "/docs",
+  nav: {
+    title: "Farm.js Docs",
+  },
+});
+```
+
+`defineConfig` configures the Farm application. `defineDocs` configures the docs experience mounted by that application.
 
 ## Important options
 
@@ -56,7 +76,7 @@ export default defineFarmConfig({
 Use `extends` to compose ordinary Farm-shaped directories and packages. Entries apply from left to right, and project files and configuration have final priority.
 
 ```ts
-export default defineFarmConfig({
+export default defineConfig({
   extends: ["@company/farm-base", "./layers/commerce"],
 });
 ```
@@ -68,9 +88,9 @@ A layer may contain an optional plain `farm.config.ts` plus its own `src/app`, c
 Server actions are same-origin application RPC endpoints. Farm rejects cross-origin action requests by default and limits the encoded request body to 1 MB.
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   experimental: {
     serverComponents: true,
     serverActions: true,
@@ -121,9 +141,9 @@ export default async function BlogPage() {
 Use `routeRules` when behavior belongs to a URL pattern instead of one page file. Rules are normalized into Farm redirects/headers and passed to Nitro route rules for production adapters.
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   routeRules: {
     "/": { prerender: true },
     "/blog/**": { swr: 3600 },
@@ -167,11 +187,11 @@ src/lib/integrations.ts
 ## Integrations in config
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { stripe } from "@farmjs/integrations/stripe";
 import { supabase } from "@farmjs/integrations/supabase";
 
-export default defineFarmConfig({
+export default defineConfig({
   integrations: {
     billing: stripe({
       secretKey: process.env.STRIPE_SECRET_KEY,
@@ -191,9 +211,9 @@ The keys become typed namespaces. `billing` becomes `api.billing`, and `auth` be
 Use `migrations.commands` when the app needs a predictable command before build or deploy. This keeps schema setup close to the storage and integration config without turning the framework into a migration engine.
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   migrations: {
     commands: [
       "pnpm drizzle-kit migrate",
@@ -220,7 +240,7 @@ Each command runs from the project root unless it sets `cwd`. Commands run in or
 ## Deployment config
 
 ```ts
-export default defineFarmConfig({
+export default defineConfig({
   deploy: {
     target: "vercel",
     outputDir: ".vercel/output",
@@ -235,7 +255,7 @@ export default defineFarmConfig({
 Farm assigns one deployment ID to the server and browser output so requests from an older open page can be detected safely.
 
 ```ts
-export default defineFarmConfig({
+export default defineConfig({
   deploymentId: process.env.RELEASE_ID,
 });
 ```
@@ -245,7 +265,7 @@ When `deploymentId` is omitted, Farm checks `FARM_DEPLOYMENT_ID`, `VERCEL_GIT_CO
 For a custom build ID, return one stable value for every instance of the same release:
 
 ```ts
-export default defineFarmConfig({
+export default defineConfig({
   generateBuildId: async () => process.env.GIT_SHA || `build-${Date.now()}`,
 });
 ```

--- a/docs/src/app/docs/docs-engine/page.md
+++ b/docs/src/app/docs/docs-engine/page.md
@@ -13,7 +13,9 @@ Serve a @farming-labs/docs-powered docs runtime from Farm config, including huma
 **farm.config.ts**
 
 ```ts
-export default defineFarmConfig({
+import { defineConfig } from "@farmjs/core";
+
+export default defineConfig({
   docs: {
     entry: "/docs",
   },

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -249,9 +249,9 @@ const typedApiCode = `const user = await api.users.get({
 user.name;
 //   ^? string`;
 
-const integrationConfigCode = `import { defineFarmConfig } from "@farmjs/core";
+const integrationConfigCode = `import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   integrations: [
     auth(),
     billing(),

--- a/packages/create-farm-app/templates/basic/farm.config.ts
+++ b/packages/create-farm-app/templates/basic/farm.config.ts
@@ -1,6 +1,6 @@
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   srcDir: "src",
   deploy: {
     target: "vercel",

--- a/packages/farm-cli/src/add-integration.ts
+++ b/packages/farm-cli/src/add-integration.ts
@@ -801,10 +801,10 @@ async function updateFarmConfig(input: {
   if (!configFile) {
     const newConfigFile = path.join(input.root, "farm.config.ts");
     const importPath = toImportPath(path.relative(input.root, input.registryFile));
-    const source = `import { defineFarmConfig } from "@farmjs/core";
+    const source = `import { defineConfig } from "@farmjs/core";
 import { appIntegrations } from "${importPath}";
 
-export default defineFarmConfig({
+export default defineConfig({
   integrations: appIntegrations,
 });
 `;
@@ -849,8 +849,9 @@ export default defineFarmConfig({
 }
 
 function insertIntegrationsConfig(source: string) {
-  if (/defineFarmConfig\s*\(\s*\{/.test(source)) {
-    return source.replace(/defineFarmConfig\s*\(\s*\{/, (match) => {
+  const defineConfigCall = /\bdefine(?:Farm)?Config\s*\(\s*\{/;
+  if (defineConfigCall.test(source)) {
+    return source.replace(defineConfigCall, (match) => {
       return `${match}\n  integrations: appIntegrations,`;
     });
   }

--- a/packages/farm-cli/test/add-integration.test.mjs
+++ b/packages/farm-cli/test/add-integration.test.mjs
@@ -59,6 +59,8 @@ test("adds a supabase integration to a new app", async () => {
     assert.match(registry, /import \{ supabaseIntegration \}/);
     assert.match(registry, /auth: supabaseIntegration/);
     assert.match(component, /supabase\(\{/);
+    assert.match(config, /import \{ defineConfig \} from "@farmjs\/core"/);
+    assert.match(config, /export default defineConfig\(\{/);
     assert.match(config, /integrations: appIntegrations/);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -122,6 +124,43 @@ export default defineFarmConfig({
     assert.match(config, /import \{ appIntegrations \}/);
     assert.match(config, /integrations: appIntegrations/);
     assert.match(config, /vite:/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("adds an integration to a config using defineConfig", async () => {
+  const root = await createTempProject({
+    packageJson: {
+      type: "module",
+      dependencies: {
+        "@farmjs/core": "workspace:*",
+      },
+    },
+  });
+
+  try {
+    await writeFile(
+      path.join(root, "farm.config.ts"),
+      `import { defineConfig } from "@farmjs/core";
+
+export default defineConfig({
+  srcDir: "src",
+});
+`,
+      "utf8",
+    );
+
+    await addFarmIntegration({
+      root,
+      provider: "stripe",
+    });
+
+    const config = await readFile(path.join(root, "farm.config.ts"), "utf8");
+
+    assert.match(config, /defineConfig\(\{/);
+    assert.match(config, /integrations: appIntegrations/);
+    assert.match(config, /srcDir: "src"/);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -5,6 +5,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  defineConfig,
+  defineFarmConfig,
   loadConfig,
   resolveConfig,
   resolveDeployConfig,
@@ -33,6 +35,19 @@ afterEach(() => {
 
     process.env[key] = value;
   }
+});
+
+describe("config helpers", () => {
+  it("supports concise and framework-specific names", () => {
+    const config = {
+      srcDir: "app",
+      deploy: { target: "vercel" as const },
+    };
+
+    expect(defineConfig).toBe(defineFarmConfig);
+    expect(defineConfig(config)).toBe(config);
+    expect(defineFarmConfig(config)).toBe(config);
+  });
 });
 
 describe("loadConfig", () => {

--- a/packages/farm/src/__tests__/type-artifacts.test.ts
+++ b/packages/farm/src/__tests__/type-artifacts.test.ts
@@ -14,8 +14,8 @@ describe("generateFarmTypeArtifacts", () => {
     writeFileSync(
       path.join(root, "farm.config.ts"),
       [
-        'import { defineFarmConfig } from "@farmjs/core";',
-        "export default defineFarmConfig({",
+        'import { defineConfig } from "@farmjs/core";',
+        "export default defineConfig({",
         "  env: {",
         "    server: { DATABASE_URL: { parse: (value: unknown) => String(value) } },",
         "    public: { PUBLIC_APP_URL: { parse: (value: unknown) => String(value) } },",

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -279,9 +279,13 @@ export type FarmLayerConfig = Omit<
   | "deploymentId"
 >;
 
+/** Define a Farm application config while preserving literal types. */
 export function defineFarmConfig<const TConfig extends FarmUserConfig>(config: TConfig): TConfig {
   return config;
 }
+
+/** Concise alias for {@link defineFarmConfig}. */
+export const defineConfig = defineFarmConfig;
 
 export function normalizeDeployTarget(target?: FarmDeployTarget): FarmDeployTarget | undefined {
   if (!target) return undefined;

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -9,6 +9,7 @@ export { FarmProvider } from "./provider";
 export { getCurrentRequest } from "./server/request";
 export { definePlugin, PluginManager } from "./plugin";
 export {
+  defineConfig,
   defineFarmConfig,
   resolveConfig,
   loadConfig,

--- a/skills/farmjs/SKILL.md
+++ b/skills/farmjs/SKILL.md
@@ -53,13 +53,13 @@ Use `"use client"` when a component uses React hooks, browser APIs, or client-on
 
 ## Config Spec
 
-Farm apps use `defineFarmConfig`:
+Farm apps use `defineConfig`. The older `defineFarmConfig` name is an exact supported alias:
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { appIntegrations } from "./src/lib/integrations.ts";
 
-export default defineFarmConfig({
+export default defineConfig({
   experimental: {
     serverComponents: true,
   },
@@ -363,7 +363,7 @@ const sqlite = sqliteStorage({
   tableName: "app_store",
 });
 
-export default defineFarmConfig({
+export default defineConfig({
   storage: {
     mounts: {
       app: sqlite,


### PR DESCRIPTION
## Summary

- export `defineConfig` as the exact typed alias of `defineFarmConfig`
- keep `defineFarmConfig` fully supported and teach the integration CLI to update configs using either helper
- generate new starter and integration configs with `defineConfig`
- document the distinction between Farm's `defineConfig` and `@farming-labs/docs`'s `defineDocs`

## Compatibility

This is additive. Existing applications using `defineFarmConfig` continue to work without changes.

## Validation

- `corepack pnpm --filter @farmjs/core exec vitest run src/__tests__/config.test.ts src/__tests__/type-artifacts.test.ts` (24 tests)
- `corepack pnpm --filter @farmjs/cli test` (27 tests)
- `corepack pnpm -r --filter './packages/*' build`
- `corepack pnpm --filter farmjs-docs exec farm build`
- changed-file `oxfmt --check` and `oxlint`
