### PR TITLE
feat: add request-first route middleware

### DIFF
--- a/docs/src/app/docs/middleware/page.md
+++ b/docs/src/app/docs/middleware/page.md
@@ -12,16 +12,17 @@ Run request behavior before routes, pass request-scoped data to pages, and short
 
 Farm runs middleware in development and production builds. For every request, Farm finds matching `farm.config.ts` middleware entries first, then matching `src/app/**/middleware.ts` files from the root segment down to the route segment.
 
-The chain stops when a middleware handler returns a Web `Response` or uses a short-circuit helper such as `ctx.redirect()`. Otherwise, each handler should call `await next()` to continue to the next middleware and route handler.
+The chain stops when a middleware handler returns a Web `Response` or uses a short-circuit helper such as `ctx.redirect()`. Default Farm handlers call `await next()` to continue. A named request-first handler continues automatically when it returns `undefined`.
 
 Data and headers written during middleware are request-scoped:
 
-| API | Result |
-| --- | --- |
-| `ctx.data.set(key, value)` | Passes data to later middleware and page props. |
-| `ctx.headers.set(name, value)` | Adds headers to the final response. |
-| `ctx.params` | Contains params from the matched config matcher or route-scoped middleware path. |
-| `return new Response(...)` | Stops the chain and sends that response immediately. |
+| API                                                                  | Result                                                                                        |
+| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `ctx.data.set(key, value)` or `context.data.set(key, value)`         | Passes serializable, client-safe data to later middleware and page props.                     |
+| `ctx.locals.set(key, value)` or `context.set(key, value)`            | Passes server-only context to later middleware, layouts, pages, and nested Server Components. |
+| `ctx.headers.set(name, value)` or `context.headers.set(name, value)` | Adds headers to the final response.                                                           |
+| `ctx.params` or `context.params`                                     | Contains params from the matched config matcher or route-scoped middleware path.              |
+| `return new Response(...)`                                           | Stops the chain and sends that response immediately.                                          |
 
 ## Route middleware
 
@@ -37,6 +38,68 @@ export default middleware().use(async (ctx, next) => {
   await next();
 });
 ```
+
+### Request-first named export
+
+Farm also supports the request-first named export style familiar from Next middleware. It receives a Web `Request` plus a Farm context, does not need a wrapper, and continues automatically unless it returns a `Response` or uses a response helper.
+
+**src/app/dashboard/middleware.ts**
+
+```ts
+import type { RequestMiddlewareContext } from "@farmjs/core/middleware";
+import { getSession } from "../../session";
+
+export interface DashboardMiddlewareContext {
+  session: Awaited<ReturnType<typeof getSession>>;
+}
+
+export const config = {
+  matcher: "/dashboard/:path*",
+};
+
+export async function middleware(
+  request: Request,
+  context: RequestMiddlewareContext<DashboardMiddlewareContext>,
+) {
+  const session = await getSession(request);
+
+  if (!session.user) {
+    return Response.redirect(new URL("/sign-in", request.url));
+  }
+
+  context.set("session", session);
+  context.headers.set("x-request-area", "dashboard");
+}
+```
+
+Use either a default Farm handler or a named `middleware` export in one file, not both. The exported `config.matcher` uses the same matcher syntax as config middleware.
+
+### Server Component context
+
+Values written with `context.set()` are request-scoped and server-only. A sibling page, layout, loading state, error state, or nested Server Component can read them without prop drilling.
+
+**src/app/dashboard/user-menu.tsx**
+
+```tsx
+import { getMiddlewareContext } from "@farmjs/core/middleware";
+import type { DashboardMiddlewareContext } from "./middleware";
+
+export function UserMenu() {
+  const context = getMiddlewareContext<DashboardMiddlewareContext>();
+  const session = context.get("session");
+
+  return <span>{session?.user.name}</span>;
+}
+```
+
+The legacy chain style can write to the same store with `ctx.locals.set("session", session)`. Nested middleware inherits the parent context, and concurrent requests receive isolated stores.
+
+Keep the two data channels distinct:
+
+| Channel                                 | Read in a Server Component                       | Browser visibility                | Good values                                          |
+| --------------------------------------- | ------------------------------------------------ | --------------------------------- | ---------------------------------------------------- |
+| `context.set()` / `ctx.locals.set()`    | `getMiddlewareContext()`                         | Never added to hydration props    | Full sessions, service clients, authorization state  |
+| `context.data.set()` / `ctx.data.set()` | `getMiddlewareData()` or `props.middleware.data` | Can be serialized with page props | Request IDs, safe user display fields, feature flags |
 
 Dynamic route segments from the middleware file path are available on `ctx.params`.
 
@@ -250,12 +313,12 @@ export default function DashboardPage(props: PageProps) {
 
 Middleware emits observability events in development and production. Subscribe with `observability.onEvent` in `farm.config.ts` or `onFarmEvent` from `@farmjs/core/observability`.
 
-| Event | Emitted when | Useful fields |
-| --- | --- | --- |
-| `middleware.start` | A matching middleware handler starts. | `route`, `pathname`, `name` |
-| `middleware.complete` | A handler calls through and completes. | `route`, `pathname`, `name`, `durationMs` |
-| `middleware.shortCircuit` | A handler returns or creates a response before the route runs. | `route`, `pathname`, `name`, `status` |
-| `middleware.error` | A handler throws. | `route`, `pathname`, `name`, `error` |
+| Event                     | Emitted when                                                   | Useful fields                             |
+| ------------------------- | -------------------------------------------------------------- | ----------------------------------------- |
+| `middleware.start`        | A matching middleware handler starts.                          | `route`, `pathname`, `name`               |
+| `middleware.complete`     | A handler calls through and completes.                         | `route`, `pathname`, `name`, `durationMs` |
+| `middleware.shortCircuit` | A handler returns or creates a response before the route runs. | `route`, `pathname`, `name`, `status`     |
+| `middleware.error`        | A handler throws.                                              | `route`, `pathname`, `name`, `error`      |
 
 ```ts
 import { defineFarmConfig } from "@farmjs/core";
@@ -277,14 +340,14 @@ See `/docs/observability` for the full event model.
 
 The production middleware runtime is easiest to verify with a tiny app fixture that builds the app, imports the generated server entry, and sends real `Request` objects through it. A complete fixture should cover:
 
-| Behavior | What to assert |
-| --- | --- |
-| Config middleware | A `farm.config.ts` matcher runs and writes `ctx.data`. |
-| File middleware | A `src/app/**/middleware.ts` file runs for its route area. |
-| Short-circuiting | A returned `Response` status, body, and headers are preserved. |
-| Data passing | Page props include values written to `ctx.data`. |
-| Route params | Dynamic file middleware sees values such as `ctx.params.id`. |
-| Events | The expected `middleware.*` events are emitted in order. |
+| Behavior          | What to assert                                                 |
+| ----------------- | -------------------------------------------------------------- |
+| Config middleware | A `farm.config.ts` matcher runs and writes `ctx.data`.         |
+| File middleware   | A `src/app/**/middleware.ts` file runs for its route area.     |
+| Short-circuiting  | A returned `Response` status, body, and headers are preserved. |
+| Data passing      | Page props include values written to `ctx.data`.               |
+| Route params      | Dynamic file middleware sees values such as `ctx.params.id`.   |
+| Events            | The expected `middleware.*` events are emitted in order.       |
 
 Farm's own test suite keeps this as a reusable helper at `packages/farm/src/__tests__/fixtures/middleware-production-fixture.ts`.
 
@@ -300,7 +363,10 @@ Farm's own test suite keeps this as a reusable helper at `packages/farm/src/__te
 ## Production notes
 
 - `farm.config.ts` middleware and `src/app/**/middleware.ts` files both run in production builds.
+- Request-first named exports and default Farm handlers use the same matcher, cascading, response, and production runtime.
+- Responses that depend on middleware data or server context are marked private and bypass PPR shell caching.
 - Keep secrets server-only inside middleware.
-- Expose only the page data the route actually needs.
+- Put secrets and non-serializable dependencies in server context; expose only safe page data through `ctx.data` or `context.data`.
+- Middleware is useful for early redirects, but API handlers and server functions must still enforce their own authorization.
 - Prefer integration middleware when a provider owns the behavior, such as auth or API key checks.
 - Keep middleware fast because it runs before the route can render.

--- a/packages/farm/src/__tests__/fixtures/middleware-production-fixture.ts
+++ b/packages/farm/src/__tests__/fixtures/middleware-production-fixture.ts
@@ -83,6 +83,7 @@ export default defineRoutes(({ api }) => [
     path.join(root, "src", "app", "dashboard", "settings", "page.tsx"),
     `
 import React from "react";
+import { DashboardIdentity } from "../dashboard-identity";
 
 export default function DashboardPage(props: any) {
   const middlewareData = props.middleware?.data;
@@ -93,7 +94,28 @@ export default function DashboardPage(props: any) {
   return React.createElement(
     "main",
     null,
-    \`production middleware: \${configArea} / \${configPath} / \${fileArea} / \${props.path}\`
+    \`production middleware: \${configArea} / \${configPath} / \${fileArea} / \${props.path}\`,
+    React.createElement(DashboardIdentity)
+  );
+}
+`.trim(),
+  );
+  await fs.writeFile(
+    path.join(root, "src", "app", "dashboard", "dashboard-identity.tsx"),
+    `
+import React from "react";
+import { getMiddlewareContext } from "@farmjs/core/middleware";
+import type { DashboardContext } from "./middleware";
+
+export function DashboardIdentity() {
+  const context = getMiddlewareContext<DashboardContext>();
+  const session = context.get("session");
+  const requestPath = context.get("requestPath");
+
+  return React.createElement(
+    "span",
+    null,
+    \` / server context: \${session?.userId || "missing"} / \${requestPath || "missing"}\`
   );
 }
 `.trim(),
@@ -101,10 +123,30 @@ export default function DashboardPage(props: any) {
   await fs.writeFile(
     path.join(root, "src", "app", "dashboard", "middleware.ts"),
     `
-export default async function dashboardMiddleware(ctx: any, next: () => Promise<void>) {
-  ctx.data.set("file.area", "dashboard-file");
-  ctx.headers.set("x-farm-middleware", "yes");
-  if (ctx.pathname === "/dashboard/file-response") {
+import type { RequestMiddlewareContext } from "@farmjs/core/middleware";
+
+export interface DashboardContext {
+  session: { userId: string; secret: string };
+  requestPath: string;
+}
+
+export const config = {
+  matcher: "/dashboard/:path*",
+};
+
+export async function middleware(
+  request: Request,
+  context: RequestMiddlewareContext<DashboardContext>,
+) {
+  const pathname = new URL(request.url).pathname;
+  context.set("session", {
+    userId: "dashboard-user",
+    secret: "never-serialize-this-session-secret",
+  });
+  context.set("requestPath", pathname);
+  context.data.set("file.area", "dashboard-file");
+  context.headers.set("x-farm-middleware", "yes");
+  if (pathname === "/dashboard/file-response") {
     return new Response("blocked by file middleware", {
       status: 418,
       headers: {
@@ -112,7 +154,6 @@ export default async function dashboardMiddleware(ctx: any, next: () => Promise<
       },
     });
   }
-  await next();
 }
 `.trim(),
   );
@@ -121,6 +162,7 @@ export default async function dashboardMiddleware(ctx: any, next: () => Promise<
     `
 export default async function userMiddleware(ctx: any, next: () => Promise<void>) {
   ctx.data.set("file.userId", ctx.params.id || "missing-id");
+  ctx.locals.set("file.userId", ctx.params.id || "missing-id");
   await next();
 }
 `.trim(),
@@ -129,12 +171,14 @@ export default async function userMiddleware(ctx: any, next: () => Promise<void>
     path.join(root, "src", "app", "users", "[id]", "settings", "page.tsx"),
     `
 import React from "react";
+import { getMiddlewareContext } from "@farmjs/core/middleware";
 
 export default function UserSettingsPage(props: any) {
+  const context = getMiddlewareContext<{ "file.userId": string }>();
   return React.createElement(
     "main",
     null,
-    \`user settings: \${props.middleware?.data.get("file.userId") || "missing"} / \${props.params.id}\`
+    \`user settings: \${props.middleware?.data.get("file.userId") || "missing"} / \${context.get("file.userId") || "missing-context"} / \${props.params.id}\`
   );
 }
 `.trim(),

--- a/packages/farm/src/__tests__/middleware.test.ts
+++ b/packages/farm/src/__tests__/middleware.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, expectTypeOf, vi, beforeEach } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { middleware, getRateLimitStatus } from "../middleware/chain";
 import { createContext } from "../middleware/context";
 import { MiddlewareManager } from "../middleware/manager";
@@ -6,10 +9,18 @@ import {
   _setCurrentMiddlewareData,
   _clearCurrentMiddlewareData,
   getMiddlewareData,
+  getMiddlewareContext,
   getMiddlewareValue,
   _runWithMiddlewareData,
+  _runWithMiddlewareContext,
 } from "../middleware/server";
-import type { MiddlewareContext, RateLimitStorage } from "../middleware/types";
+import { normalizeMiddlewareModule } from "../middleware/module";
+import { farmMiddlewarePlugin } from "../middleware/vite-plugin";
+import type {
+  MiddlewareContext,
+  RateLimitStorage,
+  RequestMiddlewareContext,
+} from "../middleware/types";
 import {
   configureFarmObservability,
   resetFarmObservability,
@@ -1584,6 +1595,127 @@ describe("URL Rewriting", () => {
   });
 });
 
+describe("Named request middleware", () => {
+  interface DashboardContext {
+    session: { userId: string };
+    requestPath: string;
+  }
+
+  it("passes a Web Request and typed request context without requiring next", async () => {
+    const normalized = normalizeMiddlewareModule(
+      {
+        async middleware(request: Request, context: RequestMiddlewareContext<DashboardContext>) {
+          context.set("session", { userId: request.headers.get("x-user-id") || "anonymous" });
+          context.set("requestPath", new URL(request.url).pathname);
+          context.data.set("client.theme", "dark");
+          context.headers.set("x-named-middleware", "yes");
+        },
+        config: { matcher: "/dashboard/:path*" },
+      },
+      "/dashboard",
+    );
+
+    expect(normalized?.handlers).toHaveLength(1);
+    expect(normalized?.config).toEqual({ matcher: "/dashboard/:path*" });
+
+    const req = createMockRequest("/dashboard/settings");
+    req.headers["x-user-id"] = "user-42";
+    const ctx = createContext(req, createMockResponse());
+    await normalized!.handlers[0](ctx, async () => {
+      throw new Error("named middleware should continue automatically");
+    });
+
+    expect(ctx.locals.get("session")).toEqual({ userId: "user-42" });
+    expect(ctx.locals.get("requestPath")).toBe("/dashboard/settings");
+    expect(ctx.data.get("client.theme")).toBe("dark");
+    expect(ctx.headers.get("x-named-middleware")).toBe("yes");
+  });
+
+  it("uses the same named-export runtime through the standalone Vite plugin", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-named-middleware-"));
+    const middlewareFile = path.join(root, "src", "app", "dashboard", "middleware.ts");
+    await fs.mkdir(path.dirname(middlewareFile), { recursive: true });
+    await fs.writeFile(middlewareFile, "export {};\n");
+
+    try {
+      const server = {
+        config: { root },
+        hot: undefined,
+        ssrLoadModule: vi.fn().mockResolvedValue({
+          config: { matcher: "/dashboard/:path*" },
+          middleware(request: Request, context: RequestMiddlewareContext<DashboardContext>) {
+            context.set("requestPath", new URL(request.url).pathname);
+            context.set("session", { userId: "vite-user" });
+          },
+        }),
+        moduleGraph: { invalidateModule: vi.fn() },
+        ws: { send: vi.fn() },
+      };
+      const plugin = farmMiddlewarePlugin();
+      (plugin.configureServer as (server: any) => void)(server);
+      await (server as any).__farmMiddleware__.waitForDiscovery();
+
+      const req = createMockRequest("/dashboard/settings");
+      const handled = await (server as any).__farmMiddleware__.execute(req, createMockResponse());
+
+      expect(handled).toBe(false);
+      expect((req as any).__FARM_MIDDLEWARE_CONTEXT__).toEqual(
+        new Map([
+          ["requestPath", "/dashboard/settings"],
+          ["session", { userId: "vite-user" }],
+        ]),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves Response short-circuiting", async () => {
+    const normalized = normalizeMiddlewareModule(
+      {
+        middleware(request: Request) {
+          return new Response(new URL(request.url).pathname, { status: 401 });
+        },
+      },
+      "/dashboard",
+    );
+    const ctx = createContext(createMockRequest("/dashboard/private"), createMockResponse());
+
+    const response = await normalized!.handlers[0](ctx, async () => undefined);
+
+    expect(response).toBeInstanceOf(Response);
+    const webResponse = response as Response;
+    expect(webResponse.status).toBe(401);
+    await expect(webResponse.text()).resolves.toBe("/dashboard/private");
+  });
+
+  it("rejects ambiguous default and named exports", () => {
+    expect(() =>
+      normalizeMiddlewareModule(
+        {
+          default: async () => {},
+          middleware: async () => {},
+        },
+        "/",
+      ),
+    ).toThrow("cannot export both");
+  });
+
+  it("keeps context keys and values correlated in TypeScript", () => {
+    const assertContextTypes = (context: RequestMiddlewareContext<DashboardContext>) => {
+      expectTypeOf(context.get("session")).toEqualTypeOf<{ userId: string } | undefined>();
+      expectTypeOf(context.get("requestPath")).toEqualTypeOf<string | undefined>();
+      context.set("session", { userId: "user-42" });
+      // @ts-expect-error session values must match DashboardContext.
+      context.set("session", { userId: 42 });
+      // @ts-expect-error unknown context keys are rejected.
+      context.get("missing");
+    };
+
+    expectTypeOf(assertContextTypes).toBeFunction();
+  });
+});
+
 describe("Middleware Data Access (getMiddlewareData)", () => {
   it("should retrieve middleware data without props", () => {
     // Set data
@@ -1641,6 +1773,34 @@ describe("Middleware Data Access (getMiddlewareData)", () => {
 
     expect(req1).toBe("req-1");
     expect(req2).toBe("req-2");
+  });
+
+  it("shares server-only context with nested components without crossing requests", async () => {
+    interface DashboardContextSnapshot {
+      session: { userId: string };
+      secret: string;
+    }
+
+    const [req1, req2] = await Promise.all([
+      _runWithMiddlewareContext(
+        { session: { userId: "user-1" }, secret: "first-secret" },
+        async () => {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          return getMiddlewareContext<DashboardContextSnapshot>().get("session")?.userId;
+        },
+      ),
+      _runWithMiddlewareContext(
+        { session: { userId: "user-2" }, secret: "second-secret" },
+        async () => {
+          await new Promise((resolve) => setTimeout(resolve, 1));
+          return getMiddlewareContext<DashboardContextSnapshot>().get("session")?.userId;
+        },
+      ),
+    ]);
+
+    expect(req1).toBe("user-1");
+    expect(req2).toBe("user-2");
+    expect(getMiddlewareContext().size).toBe(0);
   });
 });
 
@@ -1943,6 +2103,7 @@ describe("Middleware Manager Data Flow", () => {
         handlers: [
           async (ctx: MiddlewareContext, next: () => Promise<void>) => {
             ctx.data.set("requestId", "req-abc");
+            ctx.locals.set("session", { userId: "user-42" });
             await next();
           },
         ],
@@ -1953,6 +2114,7 @@ describe("Middleware Manager Data Flow", () => {
         handlers: [
           async (ctx: MiddlewareContext, next: () => Promise<void>) => {
             ctx.data.set("seenRequestId", ctx.data.get("requestId"));
+            ctx.locals.set("seenUserId", ctx.locals.get("session")?.userId);
             await next();
           },
         ],
@@ -1966,6 +2128,10 @@ describe("Middleware Manager Data Flow", () => {
     expect(middlewareData).toBeInstanceOf(Map);
     expect(middlewareData.get("requestId")).toBe("req-abc");
     expect(middlewareData.get("seenRequestId")).toBe("req-abc");
+    const middlewareContext = (req as any).__FARM_MIDDLEWARE_CONTEXT__;
+    expect(middlewareContext).toBeInstanceOf(Map);
+    expect(middlewareContext.get("session")).toEqual({ userId: "user-42" });
+    expect(middlewareContext.get("seenUserId")).toBe("user-42");
   });
 });
 

--- a/packages/farm/src/__tests__/production-middleware.test.ts
+++ b/packages/farm/src/__tests__/production-middleware.test.ts
@@ -36,9 +36,12 @@ describe("production middleware runtime", () => {
 
       expect(response.status).toBe(200);
       expect(response.headers.get("x-farm-middleware")).toBe("yes");
+      expect(response.headers.get("cache-control")).toBe("private, no-store");
       expect(html).toContain(
         "production middleware: dashboard / settings / dashboard-file / /dashboard/settings",
       );
+      expect(html).toContain("server context: dashboard-user / /dashboard/settings");
+      expect(html).not.toContain("never-serialize-this-session-secret");
       expect((globalThis as any).__farmMiddlewareEvents.map((event: any) => event.type)).toEqual([
         "middleware.start",
         "middleware.complete",
@@ -86,7 +89,7 @@ describe("production middleware runtime", () => {
       );
       const userHtml = await userResponse.text();
       expect(userResponse.status).toBe(200);
-      expect(userHtml).toContain("user settings: 42 / 42");
+      expect(userHtml).toContain("user settings: 42 / 42 / 42");
       expect((globalThis as any).__farmMiddlewareEvents[0]).toMatchObject({
         route: "/users/[id]",
         pathname: "/users/42/settings",

--- a/packages/farm/src/middleware/context.ts
+++ b/packages/farm/src/middleware/context.ts
@@ -118,6 +118,7 @@ export function createContext(
   const url = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
   const headers = new Map<string, string>();
   const data = parent?.data ? new Map(parent.data) : new Map<string, any>();
+  const locals = parent?.locals ? new Map(parent.locals) : new Map<string, any>();
   const cookies = new CookieJarImpl(req, res);
 
   // Copy existing headers
@@ -153,6 +154,7 @@ export function createContext(
       server: viteServer,
     },
     data,
+    locals,
     headers,
     cookies,
     _handled: false,

--- a/packages/farm/src/middleware/index.ts
+++ b/packages/farm/src/middleware/index.ts
@@ -7,7 +7,13 @@
 export { middleware, getRateLimitStatus } from "./chain";
 export { createContext } from "./context";
 export { MiddlewareManager } from "./manager";
-export { getMiddlewareData, getMiddlewareValue } from "./server";
+export {
+  getMiddlewareContext,
+  getMiddlewareData,
+  getMiddlewareValue,
+  _runWithMiddlewareContext,
+  _runWithMiddlewareData,
+} from "./server";
 export { unwrapMiddleware, getFromMiddleware, hasMiddlewareData } from "./helpers";
 export {
   createProductionMiddlewareRunner,
@@ -18,6 +24,10 @@ export * from "./vite-plugin";
 export type {
   MiddlewareContext,
   MiddlewareFunction,
+  RequestMiddleware,
+  RequestMiddlewareContext,
+  MiddlewareStore,
+  ReadonlyMiddlewareStore,
   MiddlewareChain,
   MiddlewareConfig,
   CookieJar,

--- a/packages/farm/src/middleware/manager.ts
+++ b/packages/farm/src/middleware/manager.ts
@@ -12,12 +12,12 @@ import type {
   FarmMiddlewareConfig,
   MiddlewareFunction,
   MiddlewareMatcher,
-  MiddlewareModule,
   MiddlewareConfig,
   MiddlewareContext,
   MiddlewareResult,
 } from "./types";
 import { createContext } from "./context";
+import { normalizeMiddlewareModule } from "./module";
 import { logger } from "../utils";
 import { sendWebResponse } from "../server/response";
 import { emitFarmEvent } from "../observability";
@@ -173,34 +173,19 @@ export class MiddlewareManager {
         module = await import(/* @vite-ignore */ fileUrl);
       }
 
-      const middlewareModule = module as MiddlewareModule;
-
-      if (!middlewareModule.default) {
-        logger.warn(`Middleware file ${filePath} does not have a default export`);
+      const normalized = normalizeMiddlewareModule(module, routePath);
+      if (!normalized) {
+        logger.warn(
+          `Middleware file ${filePath} must export a default handler or a named middleware handler`,
+        );
         return null;
-      }
-
-      const defaultExport = middlewareModule.default;
-      let handlers: MiddlewareFunction[] = [];
-
-      // Check if it has a build method (middleware chain object)
-      if (defaultExport && typeof defaultExport === "object" && "build" in defaultExport) {
-        // Set the base path for route-scoped middleware (when/rewrite auto-scoping)
-        if (typeof (defaultExport as any).setBasePath === "function") {
-          (defaultExport as any).setBasePath(routePath);
-        }
-        const built = (defaultExport as any).build();
-        handlers = built.handlers;
-      } else if (typeof defaultExport === "function") {
-        // Plain middleware function
-        handlers = [defaultExport as MiddlewareFunction];
       }
 
       return {
         path: routePath,
         filePath,
-        handlers,
-        config: middlewareModule.config,
+        handlers: normalized.handlers,
+        config: normalized.config,
         source: "file",
       };
     } catch (error) {
@@ -360,6 +345,7 @@ export class MiddlewareManager {
 
       parentData = {
         data: new Map(ctx.data),
+        locals: new Map(ctx.locals),
         headers: Object.fromEntries(ctx.headers),
       };
     }
@@ -373,6 +359,7 @@ export class MiddlewareManager {
     }
 
     (req as any).__FARM_MIDDLEWARE_DATA__ = new Map(ctx.data);
+    (req as any).__FARM_MIDDLEWARE_CONTEXT__ = new Map(ctx.locals);
 
     return false; // Continue to page rendering
   }

--- a/packages/farm/src/middleware/module.ts
+++ b/packages/farm/src/middleware/module.ts
@@ -1,0 +1,150 @@
+import { createWebRequestFromFarmRequest } from "../server/request";
+import type {
+  MiddlewareConfig,
+  MiddlewareContext,
+  MiddlewareFunction,
+  MiddlewareModule,
+  MiddlewareStore,
+  RequestMiddlewareContext,
+} from "./types";
+
+export interface NormalizedMiddlewareModule {
+  handlers: MiddlewareFunction[];
+  config?: MiddlewareConfig;
+}
+
+function isWebRequest(request: unknown): request is Request {
+  return typeof Request !== "undefined" && request instanceof Request;
+}
+
+function toWebRequest(ctx: MiddlewareContext): Request {
+  if (isWebRequest(ctx.request)) {
+    return ctx.request;
+  }
+  return createWebRequestFromFarmRequest(ctx.request);
+}
+
+function createRequestMiddlewareContext(
+  ctx: MiddlewareContext,
+): RequestMiddlewareContext<Record<string, any>, Record<string, any>> {
+  const context = {
+    get url() {
+      return ctx.url;
+    },
+    get pathname() {
+      return ctx.pathname;
+    },
+    get searchParams() {
+      return ctx.searchParams;
+    },
+    get method() {
+      return ctx.method;
+    },
+    get params() {
+      return ctx.params;
+    },
+    get route() {
+      return ctx.route;
+    },
+    get locals() {
+      return ctx.locals as MiddlewareStore<Record<string, any>>;
+    },
+    get data() {
+      return ctx.data as MiddlewareStore<Record<string, any>>;
+    },
+    get headers() {
+      return ctx.headers;
+    },
+    get cookies() {
+      return ctx.cookies;
+    },
+    get(key: string) {
+      return ctx.locals.get(key);
+    },
+    has(key: string) {
+      return ctx.locals.has(key);
+    },
+    set(key: string, value: any) {
+      ctx.locals.set(key, value);
+    },
+    delete(key: string) {
+      return ctx.locals.delete(key);
+    },
+    redirect(url: string, status?: number) {
+      ctx.redirect(url, status);
+    },
+    rewrite(url: string) {
+      ctx.rewrite(url);
+    },
+    json(data: any, status?: number) {
+      ctx.json(data, status);
+    },
+    text(content: string, status?: number) {
+      ctx.text(content, status);
+    },
+    html(content: string, status?: number) {
+      ctx.html(content, status);
+    },
+  } satisfies RequestMiddlewareContext;
+
+  return context;
+}
+
+/**
+ * Normalize the two supported middleware file styles to Farm's internal chain.
+ */
+export function normalizeMiddlewareModule(
+  middlewareModule: MiddlewareModule | Record<string, any>,
+  routePath: string,
+): NormalizedMiddlewareModule | null {
+  const module = middlewareModule as MiddlewareModule;
+  const defaultExport = module.default;
+  const namedExport = module.middleware;
+  const hasNamedExport = typeof namedExport === "function";
+
+  if (namedExport !== undefined && !hasNamedExport) {
+    throw new TypeError("The named middleware export must be a function");
+  }
+
+  if (defaultExport && hasNamedExport) {
+    throw new Error(
+      "A middleware file cannot export both a default handler and a named middleware handler",
+    );
+  }
+
+  if (hasNamedExport) {
+    return {
+      handlers: [
+        async (ctx) => {
+          return namedExport(toWebRequest(ctx), createRequestMiddlewareContext(ctx));
+        },
+      ],
+      config: module.config,
+    };
+  }
+
+  if (defaultExport && typeof defaultExport === "object" && "build" in defaultExport) {
+    if (typeof (defaultExport as any).setBasePath === "function") {
+      (defaultExport as any).setBasePath(routePath);
+    }
+    const built = (defaultExport as any).build();
+    const handlers = Array.isArray(built?.handlers)
+      ? built.handlers.filter((handler: unknown) => typeof handler === "function")
+      : [];
+    return handlers.length > 0
+      ? {
+          handlers,
+          config: module.config || built?.config,
+        }
+      : null;
+  }
+
+  if (typeof defaultExport === "function") {
+    return {
+      handlers: [defaultExport as MiddlewareFunction],
+      config: module.config,
+    };
+  }
+
+  return null;
+}

--- a/packages/farm/src/middleware/production-runtime.ts
+++ b/packages/farm/src/middleware/production-runtime.ts
@@ -10,6 +10,7 @@ import type {
   MiddlewareResult,
 } from "./types";
 import { emitFarmEvent } from "../observability";
+import { normalizeMiddlewareModule } from "./module";
 
 export interface ProductionMiddlewareModuleEntry {
   path: string;
@@ -26,6 +27,7 @@ export interface ProductionMiddlewareResult {
   request: Request;
   response: Response | null;
   data: Map<string, any>;
+  context: Map<string, any>;
   headers: Headers;
   handled: boolean;
 }
@@ -201,6 +203,7 @@ function createWebMiddlewareContext(
   let handledResponse: Response | null = null;
   const url = new URL(currentRequest.url);
   const data = parent?.data ? new Map(parent.data) : new Map<string, any>();
+  const locals = parent?.locals ? new Map(parent.locals) : new Map<string, any>();
   const headers = new Map<string, string>();
 
   if (parent?.headers) {
@@ -224,6 +227,7 @@ function createWebMiddlewareContext(
       hmr: false,
     },
     data,
+    locals,
     headers,
     cookies: new WebCookieJar(currentRequest, headers),
     _handled: false as boolean,
@@ -533,37 +537,16 @@ function normalizeFileMiddleware(
   const entries: ProductionMiddlewareEntry[] = [];
 
   for (const moduleEntry of modules) {
-    const middlewareModule = moduleEntry.module as MiddlewareModule;
-    const defaultExport = middlewareModule.default;
-    const handlers: MiddlewareFunction[] = [];
-    let config = middlewareModule.config;
-
-    if (!defaultExport) {
-      continue;
-    }
-
-    if (typeof defaultExport === "object" && "build" in defaultExport) {
-      if (typeof (defaultExport as any).setBasePath === "function") {
-        (defaultExport as any).setBasePath(moduleEntry.path);
-      }
-      const built = (defaultExport as any).build();
-      if (Array.isArray(built?.handlers)) {
-        handlers.push(...built.handlers);
-      }
-      config = config || built?.config;
-    } else if (typeof defaultExport === "function") {
-      handlers.push(defaultExport as MiddlewareFunction);
-    }
-
-    if (handlers.length === 0) {
+    const normalized = normalizeMiddlewareModule(moduleEntry.module, moduleEntry.path);
+    if (!normalized) {
       continue;
     }
 
     entries.push({
       path: moduleEntry.path,
       filePath: moduleEntry.filePath || moduleEntry.path,
-      handlers,
-      config,
+      handlers: normalized.handlers,
+      config: normalized.config,
       source: "file",
     });
   }
@@ -598,6 +581,7 @@ function emptyResult(request: Request): ProductionMiddlewareResult {
     request,
     response: null,
     data: new Map(),
+    context: new Map(),
     headers: new Headers(),
     handled: false,
   };
@@ -647,6 +631,7 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
         request: currentRequest,
         response: null,
         data: new Map(ctx.data),
+        context: new Map(ctx.locals),
         headers: mapToHeaders(ctx.headers),
         handled: false,
       };
@@ -699,6 +684,7 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
             request: currentRequest,
             response,
             data: new Map(ctx.data),
+            context: new Map(ctx.locals),
             headers: mapToHeaders(ctx.headers),
             handled: true,
           };
@@ -715,6 +701,7 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
             request: currentRequest,
             response,
             data: new Map(ctx.data),
+            context: new Map(ctx.locals),
             headers: mapToHeaders(ctx.headers),
             handled: true,
           };
@@ -736,6 +723,7 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
 
       parentData = {
         data: new Map(ctx.data),
+        locals: new Map(ctx.locals),
         headers: headersToRecord(ctx.headers),
       };
     }
@@ -744,6 +732,7 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
       request: currentRequest,
       response: null,
       data: new Map(ctx.data),
+      context: new Map(ctx.locals),
       headers: mapToHeaders(ctx.headers),
       handled: false,
     };

--- a/packages/farm/src/middleware/server.ts
+++ b/packages/farm/src/middleware/server.ts
@@ -3,9 +3,26 @@
  */
 
 import { AsyncLocalStorage } from "async_hooks";
+import type { ReadonlyMiddlewareStore } from "./types";
 
 type MiddlewareStoreInput = Record<string, any> | Map<string, any>;
-const middlewareStore = new AsyncLocalStorage<Map<string, any>>();
+const MIDDLEWARE_DATA_STORE_KEY = Symbol.for("farm.middlewareDataStore");
+const MIDDLEWARE_CONTEXT_STORE_KEY = Symbol.for("farm.middlewareContextStore");
+
+function getGlobalMiddlewareStore(key: symbol): AsyncLocalStorage<Map<string, any>> {
+  const state = globalThis as typeof globalThis & Record<symbol, unknown>;
+  const existing = state[key];
+  if (existing instanceof AsyncLocalStorage) {
+    return existing as AsyncLocalStorage<Map<string, any>>;
+  }
+
+  const store = new AsyncLocalStorage<Map<string, any>>();
+  state[key] = store;
+  return store;
+}
+
+const middlewareStore = getGlobalMiddlewareStore(MIDDLEWARE_DATA_STORE_KEY);
+const middlewareContextStore = getGlobalMiddlewareStore(MIDDLEWARE_CONTEXT_STORE_KEY);
 
 function toMiddlewareMap(data: MiddlewareStoreInput): Map<string, any> {
   if (data instanceof Map) {
@@ -30,6 +47,11 @@ export function _clearCurrentMiddlewareData(): void {
   middlewareStore.enterWith(new Map());
 }
 
+/** Internal: Clear server-only middleware context after rendering. */
+export function _clearCurrentMiddlewareContext(): void {
+  middlewareContextStore.enterWith(new Map());
+}
+
 /**
  * Internal: Run code with middleware data available
  * This is called by the server renderer
@@ -39,6 +61,14 @@ export async function _runWithMiddlewareData<T>(
   fn: () => T | Promise<T>,
 ): Promise<T> {
   return middlewareStore.run(toMiddlewareMap(data), fn);
+}
+
+/** Internal: Run code with server-only middleware context available. */
+export async function _runWithMiddlewareContext<T>(
+  context: MiddlewareStoreInput,
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  return middlewareContextStore.run(toMiddlewareMap(context), fn);
 }
 
 /**
@@ -84,6 +114,17 @@ export function getMiddlewareData<T extends Record<string, any> = Record<string,
 export function getMiddlewareValue<T = any>(key: string): T | undefined {
   const data = getMiddlewareData();
   return data.get(key);
+}
+
+/**
+ * Read server-only values set by route middleware for the current request.
+ * The returned store is available to the matched page, layouts, and nested
+ * Server Components, but is never added to hydration props.
+ */
+export function getMiddlewareContext<
+  T extends Record<string, any> = Record<string, any>,
+>(): ReadonlyMiddlewareStore<T> {
+  return (middlewareContextStore.getStore() || new Map()) as unknown as ReadonlyMiddlewareStore<T>;
 }
 
 /**

--- a/packages/farm/src/middleware/types.ts
+++ b/packages/farm/src/middleware/types.ts
@@ -13,12 +13,85 @@ import type { ViteDevServer } from "vite";
 export type MiddlewareResult = void | Response;
 export type NextFunction = () => Promise<MiddlewareResult>;
 
+type MiddlewareStoreKey<TValues extends Record<string, any>> = Extract<keyof TValues, string>;
+
+/**
+ * A typed view over the request-scoped maps used by middleware.
+ */
+export interface ReadonlyMiddlewareStore<
+  TValues extends Record<string, any> = Record<string, any>,
+> {
+  readonly size: number;
+  get<TKey extends MiddlewareStoreKey<TValues>>(key: TKey): TValues[TKey] | undefined;
+  has<TKey extends MiddlewareStoreKey<TValues>>(key: TKey): boolean;
+  entries(): IterableIterator<[MiddlewareStoreKey<TValues>, TValues[MiddlewareStoreKey<TValues>]]>;
+  keys(): IterableIterator<MiddlewareStoreKey<TValues>>;
+  values(): IterableIterator<TValues[MiddlewareStoreKey<TValues>]>;
+  forEach(
+    callback: (
+      value: TValues[MiddlewareStoreKey<TValues>],
+      key: MiddlewareStoreKey<TValues>,
+      store: ReadonlyMiddlewareStore<TValues>,
+    ) => void,
+    thisArg?: any,
+  ): void;
+  [Symbol.iterator](): IterableIterator<
+    [MiddlewareStoreKey<TValues>, TValues[MiddlewareStoreKey<TValues>]]
+  >;
+}
+
+export interface MiddlewareStore<
+  TValues extends Record<string, any> = Record<string, any>,
+> extends ReadonlyMiddlewareStore<TValues> {
+  clear(): void;
+  delete<TKey extends MiddlewareStoreKey<TValues>>(key: TKey): boolean;
+  set<TKey extends MiddlewareStoreKey<TValues>>(key: TKey, value: TValues[TKey]): this;
+}
+
 /**
  * Middleware function signature
  */
 export type MiddlewareFunction = (
   ctx: MiddlewareContext,
   next: NextFunction,
+) => MiddlewareResult | Promise<MiddlewareResult>;
+
+/**
+ * Context passed to a named, request-first middleware export.
+ * `locals` and the get/set helpers stay on the server. `data` can be exposed
+ * through page props and should contain only serializable, client-safe values.
+ */
+export interface RequestMiddlewareContext<
+  TLocals extends Record<string, any> = Record<string, any>,
+  TData extends Record<string, any> = Record<string, any>,
+> {
+  readonly url: URL;
+  readonly pathname: string;
+  readonly searchParams: URLSearchParams;
+  readonly method: string;
+  readonly params: Record<string, string>;
+  readonly route: string;
+  readonly locals: MiddlewareStore<TLocals>;
+  readonly data: MiddlewareStore<TData>;
+  readonly headers: Map<string, string>;
+  readonly cookies: CookieJar;
+  get<TKey extends MiddlewareStoreKey<TLocals>>(key: TKey): TLocals[TKey] | undefined;
+  has<TKey extends MiddlewareStoreKey<TLocals>>(key: TKey): boolean;
+  set<TKey extends MiddlewareStoreKey<TLocals>>(key: TKey, value: TLocals[TKey]): void;
+  delete<TKey extends MiddlewareStoreKey<TLocals>>(key: TKey): boolean;
+  redirect(url: string, status?: number): void;
+  rewrite(url: string): void;
+  json(data: any, status?: number): void;
+  text(content: string, status?: number): void;
+  html(content: string, status?: number): void;
+}
+
+export type RequestMiddleware<
+  TLocals extends Record<string, any> = Record<string, any>,
+  TData extends Record<string, any> = Record<string, any>,
+> = (
+  request: Request,
+  context: RequestMiddlewareContext<TLocals, TData>,
 ) => MiddlewareResult | Promise<MiddlewareResult>;
 
 /**
@@ -108,6 +181,7 @@ export interface MiddlewareContext {
   // Parent middleware data (for cascading)
   parent?: {
     data: Map<string, any>;
+    locals?: Map<string, any>;
     headers: Record<string, string>;
   };
 
@@ -120,6 +194,9 @@ export interface MiddlewareContext {
 
   // Data storage between middleware and pages
   data: Map<string, any>;
+
+  // Server-only request context shared with nested middleware and components
+  locals: Map<string, any>;
 
   // Helpers
   headers: Map<string, string>;
@@ -185,6 +262,7 @@ export interface MiddlewareChain {
  * Middleware module export
  */
 export interface MiddlewareModule {
-  default: MiddlewareChain | MiddlewareFunction;
+  default?: MiddlewareChain | MiddlewareFunction;
+  middleware?: RequestMiddleware;
   config?: MiddlewareConfig;
 }

--- a/packages/farm/src/middleware/vite-plugin.ts
+++ b/packages/farm/src/middleware/vite-plugin.ts
@@ -1,284 +1,92 @@
 /**
- * Farm.js Middleware Vite Plugin
- *
- * Standalone middleware support that works with any Vite setup.
- * Discovers and executes middleware.ts files at various path levels.
- *
- * @example
- * ```ts
- * import { farmMiddlewarePlugin } from '@farmjs/core'
- *
- * export default defineConfig({
- *   plugins: [farmMiddlewarePlugin({ srcDir: 'src' })],
- * })
- * ```
+ * Standalone Vite middleware support used by Farm's RSC and API plugins.
  */
 
+import fs from "node:fs";
+import path from "node:path";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Plugin, ViteDevServer } from "vite";
+import { MiddlewareManager } from "./manager";
 
 export interface FarmMiddlewarePluginOptions {
-  /** Source directory (default: 'src') */
+  /** Source directory (default: `src`). */
   srcDir?: string;
-  /** Enable debug logging */
+  /** Enable debug logging. */
   debug?: boolean;
 }
 
-interface MiddlewareEntry {
-  path: string;
-  filePath: string;
-  handler: any;
+function getMiddlewareAppDirectory(root: string, srcDir: string): string {
+  const sourceDirectory = path.join(root, srcDir);
+  const appDirectory = path.join(sourceDirectory, "app");
+  return fs.existsSync(appDirectory) ? appDirectory : sourceDirectory;
 }
 
-/**
- * Farm.js Middleware Vite Plugin
- */
 export function farmMiddlewarePlugin(options: FarmMiddlewarePluginOptions = {}): Plugin {
   const srcDir = options.srcDir ?? "src";
-  const debug = options.debug ?? false;
-
-  // Middleware cache
-  let middlewareCache: Map<string, MiddlewareEntry> = new Map();
+  let manager: MiddlewareManager | null = null;
   let discoveryComplete = false;
   let discoveryPromise: Promise<void> | null = null;
 
-  const log = (_message: string) => {};
+  const discover = async (server: ViteDevServer): Promise<void> => {
+    manager = new MiddlewareManager(getMiddlewareAppDirectory(server.config.root, srcDir), server);
+    await manager.discover();
+    discoveryComplete = true;
+  };
 
   return {
     name: "@farmjs/core:middleware",
     enforce: "pre",
 
-    configureServer(server: ViteDevServer) {
-      const discoverMiddleware = async (): Promise<void> => {
-        const fs = await import("fs");
-        const path = await import("path");
+    configureServer(server) {
+      discoveryPromise = discover(server).catch((error) => {
+        discoveryComplete = true;
+        console.error("[FARM] Middleware discovery error:", error);
+      });
 
-        const appDir = path.join(server.config.root, srcDir);
-        if (!fs.existsSync(appDir)) {
-          log("Source directory not found");
-          return;
-        }
-
-        const findMiddlewareFiles = (dir: string, basePath: string = ""): string[] => {
-          const files: string[] = [];
-          if (!fs.existsSync(dir)) return files;
-
-          const entries = fs.readdirSync(dir, { withFileTypes: true });
-          for (const entry of entries) {
-            const fullPath = path.join(dir, entry.name);
-
-            if (entry.isDirectory()) {
-              if (entry.name === "api") continue;
-
-              const newBasePath = basePath ? `${basePath}/${entry.name}` : entry.name;
-              files.push(...findMiddlewareFiles(fullPath, newBasePath));
-            } else if (
-              entry.name === "middleware.ts" ||
-              entry.name === "middleware.tsx" ||
-              entry.name === "middleware.js"
-            ) {
-              files.push(fullPath);
-            }
-          }
-          return files;
-        };
-
-        const middlewareFiles = findMiddlewareFiles(appDir);
-        middlewareCache.clear();
-
-        for (const filePath of middlewareFiles) {
-          try {
-            const relativePath = path.relative(appDir, path.dirname(filePath));
-            // Convert path: "app/counter" -> "/counter"
-            const routePath = "/" + relativePath.replace(/^app\/?/, "").replace(/\\/g, "/");
-
-            const middlewareModule = await server.ssrLoadModule(filePath);
-            const handler = middlewareModule.middleware || middlewareModule.default;
-
-            if (handler) {
-              middlewareCache.set(routePath === "/" ? "/" : routePath, {
-                path: routePath,
-                filePath,
-                handler,
-              });
-              log(`Middleware discovered: ${routePath}`);
-            }
-          } catch (e: any) {
-            log(`Middleware load failed at ${filePath}: ${e.message}`);
-          }
-        }
-
-        log(`Middleware discovery complete: ${middlewareCache.size} middlewares found`);
-      };
-
-      // Execute middleware chain for a given path
-      const executeMiddleware = async (
-        req: any,
-        res: any,
-        pathname: string,
-        middlewareData: Map<string, any>,
+      const execute = async (
+        req: IncomingMessage,
+        res: ServerResponse,
+        _pathname?: string,
+        sharedData?: Map<string, any>,
       ): Promise<boolean> => {
-        const middlewaresToRun: MiddlewareEntry[] = [];
-
-        // Collect matching middleware (from root to specific path)
-        const pathParts = pathname.split("/").filter(Boolean);
-        let currentPath = "/";
-
-        // Check root middleware
-        const rootMiddleware = middlewareCache.get("/");
-        if (rootMiddleware) {
-          middlewaresToRun.push(rootMiddleware);
+        if (discoveryPromise && !discoveryComplete) {
+          await discoveryPromise;
         }
 
-        // Check path-specific middleware
-        for (const part of pathParts) {
-          currentPath = currentPath === "/" ? `/${part}` : `${currentPath}/${part}`;
-          const pathMiddleware = middlewareCache.get(currentPath);
-          if (pathMiddleware) {
-            middlewaresToRun.push(pathMiddleware);
-          }
-        }
-
-        if (middlewaresToRun.length === 0) {
+        if (!manager) {
           return false;
         }
 
-        // Execute middleware chain
-        for (const middleware of middlewaresToRun) {
-          try {
-            const result = await middleware.handler({
-              request: {
-                method: req.method,
-                url: req.url,
-                headers: req.headers,
-              },
-              params: {},
-              pathname,
-              data: middlewareData,
-              cookies: parseCookies(req.headers.cookie),
-            });
-
-            // Handle middleware result
-            if (result) {
-              if (result.redirect) {
-                res.statusCode = result.status || 302;
-                res.setHeader("Location", result.redirect);
-                res.end();
-                return true;
-              }
-
-              if (result.data) {
-                for (const [key, value] of Object.entries(result.data)) {
-                  middlewareData.set(key, value);
-                }
-              }
-
-              if (result.headers) {
-                for (const [key, value] of Object.entries(result.headers)) {
-                  res.setHeader(key, value as string);
-                }
-              }
-            }
-          } catch (e: any) {
-            log(`Middleware error at ${middleware.path}: ${e.message}`);
+        const handled = await manager.execute(req, res);
+        const middlewareData = (req as any).__FARM_MIDDLEWARE_DATA__;
+        if (sharedData && middlewareData instanceof Map) {
+          for (const [key, value] of middlewareData) {
+            sharedData.set(key, value);
           }
         }
-
-        return false;
+        return handled;
       };
 
-      // Initialize discovery
-      discoveryPromise = discoverMiddleware()
-        .then(() => {
-          discoveryComplete = true;
-        })
-        .catch((e) => {
-          console.error("[FARM] Middleware discovery error:", e);
-        });
-
-      // Expose middleware API for other plugins
       (server as any).__farmMiddleware__ = {
-        getMiddlewares: () => middlewareCache,
-        execute: executeMiddleware,
+        execute,
+        getMiddlewares: () => manager?.getMiddlewares() ?? [],
         isReady: () => discoveryComplete,
         waitForDiscovery: () => discoveryPromise,
       };
     },
 
     async handleHotUpdate({ file, server, modules }) {
-      const fileName = file.split("/").pop() || "";
-
-      if (fileName.startsWith("middleware.")) {
-        log(`Middleware file updated: ${file}`);
-
-        for (const mod of modules) {
-          server.moduleGraph.invalidateModule(mod);
-        }
-
-        let middlewarePathToUpdate: string | null = null;
-        for (const [middlewarePath, middleware] of middlewareCache) {
-          if (middleware.filePath === file) {
-            middlewarePathToUpdate = middlewarePath;
-            break;
-          }
-        }
-
-        if (middlewarePathToUpdate) {
-          try {
-            const middlewareModule = await server.ssrLoadModule(file);
-            const handler = middlewareModule.middleware || middlewareModule.default;
-
-            if (handler) {
-              middlewareCache.set(middlewarePathToUpdate, {
-                path: middlewarePathToUpdate,
-                filePath: file,
-                handler,
-              });
-              log(`Middleware reloaded: ${middlewarePathToUpdate}`);
-            }
-          } catch (e: any) {
-            log(`Middleware HMR failed: ${e.message}`);
-          }
-        } else {
-          // New middleware file
-          try {
-            const path = await import("path");
-            const appDir = path.join(server.config.root, srcDir);
-            const relativePath = path.relative(appDir, path.dirname(file));
-            const routePath = "/" + relativePath.replace(/^app\/?/, "").replace(/\\/g, "/");
-
-            const middlewareModule = await server.ssrLoadModule(file);
-            const handler = middlewareModule.middleware || middlewareModule.default;
-
-            if (handler) {
-              middlewareCache.set(routePath === "/" ? "/" : routePath, {
-                path: routePath,
-                filePath: file,
-                handler,
-              });
-              log(`New middleware discovered: ${routePath}`);
-            }
-          } catch (e: any) {
-            log(`New middleware load failed: ${e.message}`);
-          }
-        }
-
-        return [];
+      if (!/^middleware\.[tj]sx?$/.test(path.basename(file))) {
+        return;
       }
+
+      for (const module of modules) {
+        server.moduleGraph.invalidateModule(module);
+      }
+
+      await manager?.reload();
+      server.ws.send({ type: "full-reload", path: "*" });
+      return [];
     },
   };
-}
-
-// Helper to parse cookies
-function parseCookies(cookieHeader: string | undefined): Record<string, string> {
-  const cookies: Record<string, string> = {};
-  if (!cookieHeader) return cookies;
-
-  cookieHeader.split(";").forEach((cookie) => {
-    const [name, ...rest] = cookie.trim().split("=");
-    if (name) {
-      cookies[name] = rest.join("=");
-    }
-  });
-
-  return cookies;
 }

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -530,7 +530,7 @@ async function buildClient(
           },
           load(id) {
             if (id === "\0empty-module") {
-              return "export default {}; export const getMiddlewareData = () => ({}); export const getMiddlewareValue = () => undefined; export const middleware = () => ({});";
+              return "const emptyMiddlewareStore = new Map(); export default {}; export const getMiddlewareContext = () => emptyMiddlewareStore; export const getMiddlewareData = () => emptyMiddlewareStore; export const getMiddlewareValue = () => undefined; export const middleware = () => ({});";
             }
             if (id === "\0empty-api-route") {
               // Stub for API routes - only used in type context, provide empty exports
@@ -1566,7 +1566,7 @@ function generateVirtualEntryCode(
   const cacheHelpersImport = `import { createFarmCacheKey, getFarmDataCache, normalizeRevalidatePath } from "farm/cache";`;
   const navigationHelpersImport = `import { getFarmRedirectError, isFarmNotFoundError, isFarmRedirectError } from "farm/navigation";`;
   const observabilityHelpersImport = `import { configureFarmObservability, emitFarmEvent } from "farm/observability";`;
-  const middlewareRuntimeImport = `import { applyProductionMiddlewareHeaders, createProductionMiddlewareRunner } from "farm/middleware";`;
+  const middlewareRuntimeImport = `import { _runWithMiddlewareContext, _runWithMiddlewareData, applyProductionMiddlewareHeaders, createProductionMiddlewareRunner } from "farm/middleware";`;
   const docsHandlerImport = config.docs?.enabled
     ? `import { createFarmDocsAPIHandler, createFarmDocsHandler } from "farm/docs";`
     : "";
@@ -1916,12 +1916,14 @@ function resolvePPRConfig(routeModule) {
   return { enabled, revalidate };
 }
 
-function getPPRShellBypassReason(request) {
+function getPPRShellBypassReason(request, middlewareData, middlewareContext) {
   const method = request.method.toUpperCase();
   if (method !== "GET" && method !== "HEAD") return "method";
   if (request.headers.get("cookie")) return "cookie";
   if (request.headers.get("authorization")) return "authorization";
   if (request.headers.get("x-farm-ppr-refresh")) return "refresh";
+  if (middlewareData?.size) return "middleware-data";
+  if (middlewareContext?.size) return "middleware-context";
   return undefined;
 }
 
@@ -2005,6 +2007,7 @@ async function handleRequest(request) {
   }
   request = middlewareResult.request;
   const middlewareData = middlewareResult.data;
+  const middlewareContext = middlewareResult.context;
   const middlewareHeaders = middlewareResult.headers;
   url = new URL(request.url);
   pathname = url.pathname;
@@ -2049,7 +2052,9 @@ async function handleRequest(request) {
     
     try {
       const pprConfig = resolvePPRConfig(route.module);
-      const pprBypassReason = pprConfig.enabled ? getPPRShellBypassReason(request) : undefined;
+      const pprBypassReason = pprConfig.enabled
+        ? getPPRShellBypassReason(request, middlewareData, middlewareContext)
+        : undefined;
       const pprCanCache = pprConfig.enabled && !pprBypassReason;
       const pprCacheKey = pprCanCache ? getPPRShellCacheKey(url) : null;
       if (pprConfig.enabled && pprBypassReason) {
@@ -2123,47 +2128,50 @@ async function handleRequest(request) {
               };
             })();
         
-        // First, render the page content
-        let pageElement;
-        
-        // Check if the component is async
-        if (PageComponent.constructor.name === "AsyncFunction" || PageComponent.toString().includes("async")) {
-          // For async components, execute to get the element
-          try {
-            const result = await PageComponent(pageProps);
-            if (React.isValidElement(result)) {
-              pageElement = result;
+        const html = await _runWithMiddlewareData(middlewareData, () =>
+          _runWithMiddlewareContext(middlewareContext, async () => {
+            // First, render the page content
+            let pageElement;
+
+            // Check if the component is async
+            if (PageComponent.constructor.name === "AsyncFunction" || PageComponent.toString().includes("async")) {
+              // For async components, execute to get the element
+              try {
+                const result = await PageComponent(pageProps);
+                if (React.isValidElement(result)) {
+                  pageElement = result;
+                } else {
+                  pageElement = React.createElement("div", null, String(result));
+                }
+              } catch (asyncError) {
+                if (isFarmRedirectError(asyncError) || isFarmNotFoundError(asyncError)) {
+                  throw asyncError;
+                }
+                // If async rendering fails, try sync rendering as fallback
+                pageElement = React.createElement(PageComponent, pageProps);
+              }
             } else {
-              pageElement = React.createElement("div", null, String(result));
+              // Sync component - create element directly
+              pageElement = React.createElement(PageComponent, pageProps);
             }
-          } catch (asyncError) {
-            if (isFarmRedirectError(asyncError) || isFarmNotFoundError(asyncError)) {
-              throw asyncError;
+
+            // Wrap with layouts (from innermost to outermost)
+            // Layouts are sorted by depth (root first), so we process in reverse
+            let wrappedElement = pageElement;
+            for (let i = applicableLayouts.length - 1; i >= 0; i--) {
+              const layout = applicableLayouts[i];
+              const LayoutComponent = layout.module.default;
+              if (LayoutComponent) {
+                wrappedElement = React.createElement(LayoutComponent, {
+                  children: wrappedElement,
+                  params,
+                });
+              }
             }
-            // If async rendering fails, try sync rendering as fallback
-            pageElement = React.createElement(PageComponent, pageProps);
-          }
-        } else {
-          // Sync component - create element directly
-          pageElement = React.createElement(PageComponent, pageProps);
-        }
-        
-        // Wrap with layouts (from innermost to outermost)
-        // Layouts are sorted by depth (root first), so we process in reverse
-        let wrappedElement = pageElement;
-        for (let i = applicableLayouts.length - 1; i >= 0; i--) {
-          const layout = applicableLayouts[i];
-          const LayoutComponent = layout.module.default;
-          if (LayoutComponent) {
-            wrappedElement = React.createElement(LayoutComponent, {
-              children: wrappedElement,
-              params,
-            });
-          }
-        }
-        
-        // Render to string
-        const html = ReactDOMServer.renderToString(wrappedElement);
+
+            return ReactDOMServer.renderToString(wrappedElement);
+          })
+        );
         
         // Collect metadata from layouts and page (page overrides layouts)
         let mergedMetadata = {};
@@ -2238,9 +2246,14 @@ async function handleRequest(request) {
         // Include client CSS and hydration script
         // Add caching headers for edge caching (Vercel, Cloudflare, etc.)
         // s-maxage: cache at edge for 60s, stale-while-revalidate: serve stale while updating
+        const hasRequestScopedMiddleware = Boolean(
+          middlewareData?.size || middlewareContext?.size
+        );
         const responseHeaders = {
           "Content-Type": "text/html; charset=utf-8",
-          "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+          "Cache-Control": hasRequestScopedMiddleware
+            ? "private, no-store"
+            : "public, s-maxage=60, stale-while-revalidate=300",
           ...(pprConfig.enabled ? getPPRHeaders(pprCanCache ? "miss" : "bypass", pprConfig) : {}),
         };
 

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -15,7 +15,12 @@ import type { RouteManager } from "../routing/route-manager";
 import { logger } from "../utils";
 import { getClientModuleMetadata } from "../utils/client-component";
 import { Writable } from "stream";
-import { _runWithMiddlewareData, _clearCurrentMiddlewareData } from "../middleware/server";
+import {
+  _clearCurrentMiddlewareContext,
+  _clearCurrentMiddlewareData,
+  _runWithMiddlewareContext,
+  _runWithMiddlewareData,
+} from "../middleware/server";
 import { getRequestContextSnapshot } from "../request-context";
 import { matchSSGPage, resolveRouteRenderingConfigFromFile } from "../ssg";
 import { getIntegrationProviders, getRegisteredIntegrationAPIManifest } from "../integrations";
@@ -377,6 +382,7 @@ export class ServerRenderer {
   private getPPRShellBypassReason(
     req: FarmRequest,
     middlewareMap: Map<string, any>,
+    middlewareContext: Map<string, any>,
     pluginExposedContext: Map<string, any>,
   ): string | undefined {
     const method = (req.method || "GET").toUpperCase();
@@ -398,6 +404,10 @@ export class ServerRenderer {
 
     if (middlewareMap.size > 0) {
       return "middleware-data";
+    }
+
+    if (middlewareContext.size > 0) {
+      return "middleware-context";
     }
 
     if (pluginExposedContext.size > 0) {
@@ -544,6 +554,7 @@ export class ServerRenderer {
     let layouts: Array<{ modulePath: string }> = [];
     let searchParamsObject: Record<string, string | string[] | undefined> = {};
     let middlewareMap = new Map<string, any>();
+    let middlewareContext = new Map<string, any>();
     let pluginExposedContext = new Map<string, any>();
     let errorBoundaryEntry: { modulePath: string } | null = null;
     let pprRefreshRoute: string | null = null;
@@ -613,6 +624,7 @@ export class ServerRenderer {
       errorBoundaryEntry = this.routeManager.getMatchingError(pathname);
 
       middlewareMap = toMiddlewareMap((req as any).__FARM_MIDDLEWARE_DATA__);
+      middlewareContext = toMiddlewareMap((req as any).__FARM_MIDDLEWARE_CONTEXT__);
       pluginExposedContext = getRequestContextSnapshot(req as object, { exposedOnly: true });
       const currentRequest = createWebRequestFromFarmRequest(req);
       const routeContext = await this.resolveRouteContext({
@@ -689,7 +701,7 @@ export class ServerRenderer {
         route.modulePath,
       );
       const pprBypassReason = renderingConfig.ppr
-        ? this.getPPRShellBypassReason(req, middlewareMap, pluginExposedContext)
+        ? this.getPPRShellBypassReason(req, middlewareMap, middlewareContext, pluginExposedContext)
         : undefined;
       const canCachePPRShell = renderingConfig.ppr && !pprBypassReason;
       const pprShellOptions: PPRShellCacheOptions | undefined = canCachePPRShell
@@ -799,98 +811,109 @@ export class ServerRenderer {
       const middlewareDataForContext = middlewareMap;
 
       await _runWithMiddlewareData(middlewareDataForContext, async () => {
-        await _runWithCurrentRequest(currentRequest, async () => {
-          let pageElement = React.createElement(
-            PageComponent as React.ComponentType<unknown>,
-            pageProps as React.Attributes,
-          );
-
-          if (LoadingFallbackComponent) {
-            const loadingFallback = React.createElement(LoadingFallbackComponent, {
-              ...createRouteStateProps({
-                params,
-                searchParamsObject,
-                path: pathname,
-                middlewareMap,
-                pluginExposedContext,
-              }),
-            } as React.Attributes);
-
-            pageElement = React.createElement(
-              React.Suspense,
-              { fallback: loadingFallback },
-              pageElement,
+        await _runWithMiddlewareContext(middlewareContext, async () => {
+          await _runWithCurrentRequest(currentRequest, async () => {
+            let pageElement = React.createElement(
+              PageComponent as React.ComponentType<unknown>,
+              pageProps as React.Attributes,
             );
-          }
 
-          // Wrap hydratable pages in a targeted container so the client can attach
-          // without re-hydrating the surrounding layout shell.
-          if (isClientComponent || shouldHydrate) {
-            pageElement = React.createElement(
-              "div",
-              { id: "__farm_page__", "data-farm-client": "true" },
-              pageElement,
-            );
-          }
+            if (LoadingFallbackComponent) {
+              const loadingFallback = React.createElement(LoadingFallbackComponent, {
+                ...createRouteStateProps({
+                  params,
+                  searchParamsObject,
+                  path: pathname,
+                  middlewareMap,
+                  pluginExposedContext,
+                }),
+              } as React.Attributes);
 
-          let wrappedElement: React.ReactElement = pageElement;
-          for (let i = layoutModules.length - 1; i >= 0; i--) {
-            const layoutModule = layoutModules[i];
-            const LayoutComponent = layoutModule.default;
-            wrappedElement = React.createElement(
-              LayoutComponent as React.ComponentType<unknown>,
-              {
-                children: wrappedElement,
-                params,
-              } as React.Attributes,
-            );
-          }
+              pageElement = React.createElement(
+                React.Suspense,
+                { fallback: loadingFallback },
+                pageElement,
+              );
+            }
 
-          if (ErrorFallbackComponent) {
-            wrappedElement = React.createElement(
-              FarmRouteErrorBoundary,
-              {
-                Fallback: ErrorFallbackComponent,
-                fallbackProps: {
-                  ...createRouteStateProps({
-                    params,
-                    searchParamsObject,
-                    path: pathname,
-                    middlewareMap,
-                    pluginExposedContext,
-                  }),
+            // Wrap hydratable pages in a targeted container so the client can attach
+            // without re-hydrating the surrounding layout shell.
+            if (isClientComponent || shouldHydrate) {
+              pageElement = React.createElement(
+                "div",
+                { id: "__farm_page__", "data-farm-client": "true" },
+                pageElement,
+              );
+            }
+
+            let wrappedElement: React.ReactElement = pageElement;
+            for (let i = layoutModules.length - 1; i >= 0; i--) {
+              const layoutModule = layoutModules[i];
+              const LayoutComponent = layoutModule.default;
+              wrappedElement = React.createElement(
+                LayoutComponent as React.ComponentType<unknown>,
+                {
+                  children: wrappedElement,
+                  params,
+                } as React.Attributes,
+              );
+            }
+
+            if (ErrorFallbackComponent) {
+              wrappedElement = React.createElement(
+                FarmRouteErrorBoundary,
+                {
+                  Fallback: ErrorFallbackComponent,
+                  fallbackProps: {
+                    ...createRouteStateProps({
+                      params,
+                      searchParamsObject,
+                      path: pathname,
+                      middlewareMap,
+                      pluginExposedContext,
+                    }),
+                  },
                 },
+                wrappedElement,
+              );
+            }
+
+            const integratedElement = await this.wrapWithIntegrationProviders(wrappedElement);
+            const pprHeaders = renderingConfig.ppr
+              ? this.getPPRHeaders(pprShellOptions ? "miss" : "bypass", renderingConfig.revalidate)
+              : undefined;
+
+            // Render with middleware data available
+            await this.renderWithSSR(
+              integratedElement,
+              req,
+              res,
+              () => {
+                _clearCurrentMiddlewareData();
+                _clearCurrentMiddlewareContext();
               },
-              wrappedElement,
+              {
+                responseHeaders: pprHeaders,
+                captureStaticShell: Boolean(pprShellOptions),
+                observabilityRoute: pathname,
+                onSuspenseHoleDetected: pprShellOptions
+                  ? () => emitFarmEvent({ type: "ppr.suspense.holeDetected", route: pathname })
+                  : undefined,
+                onComplete:
+                  pprShellOptions && req.method !== "HEAD"
+                    ? (html) => this.cachePPRShell(pprShellOptions, html)
+                    : undefined,
+              },
             );
-          }
-
-          const integratedElement = await this.wrapWithIntegrationProviders(wrappedElement);
-          const pprHeaders = renderingConfig.ppr
-            ? this.getPPRHeaders(pprShellOptions ? "miss" : "bypass", renderingConfig.revalidate)
-            : undefined;
-
-          // Render with middleware data available
-          await this.renderWithSSR(integratedElement, req, res, _clearCurrentMiddlewareData, {
-            responseHeaders: pprHeaders,
-            captureStaticShell: Boolean(pprShellOptions),
-            observabilityRoute: pathname,
-            onSuspenseHoleDetected: pprShellOptions
-              ? () => emitFarmEvent({ type: "ppr.suspense.holeDetected", route: pathname })
-              : undefined,
-            onComplete:
-              pprShellOptions && req.method !== "HEAD"
-                ? (html) => this.cachePPRShell(pprShellOptions, html)
-                : undefined,
+            if (pprRefreshRoute) {
+              emitFarmEvent({
+                type: "ppr.refresh.complete",
+                route: pprRefreshRoute,
+                durationMs: Date.now() - renderStartTime,
+              });
+            }
+            completeRender(res.statusCode || 200, pathname);
           });
-          if (pprRefreshRoute) {
-            emitFarmEvent({
-              type: "ppr.refresh.complete",
-              route: pprRefreshRoute,
-              durationMs: Date.now() - renderStartTime,
-            });
-          }
-          completeRender(res.statusCode || 200, pathname);
         });
       });
     } catch (error) {
@@ -944,6 +967,7 @@ export class ServerRenderer {
           layouts,
           searchParamsObject,
           middlewareMap,
+          middlewareContext,
           pluginExposedContext,
           error,
           errorModulePath: errorBoundaryEntry.modulePath,
@@ -1140,6 +1164,7 @@ export class ServerRenderer {
       layouts: Array<{ modulePath: string }>;
       searchParamsObject: Record<string, string | string[] | undefined>;
       middlewareMap: Map<string, any>;
+      middlewareContext: Map<string, any>;
       pluginExposedContext: Map<string, any>;
       error: unknown;
       errorModulePath: string;
@@ -1187,7 +1212,11 @@ export class ServerRenderer {
       }
 
       const ReactDOMServer = await import("react-dom/server");
-      const html = ReactDOMServer.renderToString(wrapped);
+      const html = await _runWithMiddlewareData(options.middlewareMap, () =>
+        _runWithMiddlewareContext(options.middlewareContext, () =>
+          ReactDOMServer.renderToString(wrapped),
+        ),
+      );
       res.statusCode = 500;
       res.setHeader("Content-Type", "text/html; charset=utf-8");
       res.write(this.createFullHTML(html));

--- a/packages/farm/types/middleware.d.ts
+++ b/packages/farm/types/middleware.d.ts
@@ -34,6 +34,32 @@ declare module "@farmjs/core/middleware" {
     getAll(): Record<string, string>;
   }
 
+  type MiddlewareStoreKey<TValues extends Record<string, any>> = Extract<keyof TValues, string>;
+
+  export interface ReadonlyMiddlewareStore<
+    TValues extends Record<string, any> = Record<string, any>,
+  > {
+    readonly size: number;
+    get<TKey extends MiddlewareStoreKey<TValues>>(key: TKey): TValues[TKey] | undefined;
+    has<TKey extends MiddlewareStoreKey<TValues>>(key: TKey): boolean;
+    entries(): IterableIterator<
+      [MiddlewareStoreKey<TValues>, TValues[MiddlewareStoreKey<TValues>]]
+    >;
+    keys(): IterableIterator<MiddlewareStoreKey<TValues>>;
+    values(): IterableIterator<TValues[MiddlewareStoreKey<TValues>]>;
+    [Symbol.iterator](): IterableIterator<
+      [MiddlewareStoreKey<TValues>, TValues[MiddlewareStoreKey<TValues>]]
+    >;
+  }
+
+  export interface MiddlewareStore<
+    TValues extends Record<string, any> = Record<string, any>,
+  > extends ReadonlyMiddlewareStore<TValues> {
+    clear(): void;
+    delete<TKey extends MiddlewareStoreKey<TValues>>(key: TKey): boolean;
+    set<TKey extends MiddlewareStoreKey<TValues>>(key: TKey, value: TValues[TKey]): this;
+  }
+
   /**
    * Middleware context passed to each middleware function
    */
@@ -50,6 +76,8 @@ declare module "@farmjs/core/middleware" {
     cookies: CookieJar;
     /** Key-value data store for passing data between middleware */
     data: Map<string, unknown>;
+    /** Server-only request context shared with Server Components */
+    locals: Map<string, unknown>;
     /** Set a response to short-circuit the middleware chain */
     _response?: Response;
     /** Send a response and stop middleware chain */
@@ -69,6 +97,39 @@ declare module "@farmjs/core/middleware" {
     ctx: MiddlewareContext,
     next: NextFunction,
   ) => void | Promise<void>;
+
+  export interface RequestMiddlewareContext<
+    TLocals extends Record<string, any> = Record<string, any>,
+    TData extends Record<string, any> = Record<string, any>,
+  > {
+    readonly url: URL;
+    readonly pathname: string;
+    readonly searchParams: URLSearchParams;
+    readonly method: string;
+    readonly params: Record<string, string>;
+    readonly route: string;
+    readonly locals: MiddlewareStore<TLocals>;
+    readonly data: MiddlewareStore<TData>;
+    readonly headers: Map<string, string>;
+    readonly cookies: CookieJar;
+    get<TKey extends MiddlewareStoreKey<TLocals>>(key: TKey): TLocals[TKey] | undefined;
+    has<TKey extends MiddlewareStoreKey<TLocals>>(key: TKey): boolean;
+    set<TKey extends MiddlewareStoreKey<TLocals>>(key: TKey, value: TLocals[TKey]): void;
+    delete<TKey extends MiddlewareStoreKey<TLocals>>(key: TKey): boolean;
+    redirect(url: string, status?: number): void;
+    rewrite(url: string): void;
+    json(data: unknown, status?: number): void;
+    text(content: string, status?: number): void;
+    html(content: string, status?: number): void;
+  }
+
+  export type RequestMiddleware<
+    TLocals extends Record<string, any> = Record<string, any>,
+    TData extends Record<string, any> = Record<string, any>,
+  > = (
+    request: Request,
+    context: RequestMiddlewareContext<TLocals, TData>,
+  ) => void | Response | Promise<void | Response>;
 
   /**
    * Rate limit configuration
@@ -160,18 +221,20 @@ declare module "@farmjs/core/middleware" {
   /**
    * Get middleware data from context
    */
-  export function getMiddlewareData<T = unknown>(
-    ctx: MiddlewareContext,
-    key: string,
-  ): T | undefined;
+  export function getMiddlewareData<T extends Record<string, any> = Record<string, any>>(): Map<
+    keyof T,
+    T[keyof T]
+  >;
+
+  /** Get server-only middleware context for the current request. */
+  export function getMiddlewareContext<
+    T extends Record<string, any> = Record<string, any>,
+  >(): ReadonlyMiddlewareStore<T>;
 
   /**
    * Get middleware value (alias for getMiddlewareData)
    */
-  export function getMiddlewareValue<T = unknown>(
-    ctx: MiddlewareContext,
-    key: string,
-  ): T | undefined;
+  export function getMiddlewareValue<T = unknown>(key: string): T | undefined;
 
   /**
    * Get data from middleware context

--- a/packages/farmjs-plugin/src/rsc/entries/rsc.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/rsc.ts
@@ -39,6 +39,11 @@ import {
   createFarmDeploymentMismatchResponse,
   getFarmDeploymentMismatch,
 } from '@farmjs/core/deployment';
+import {
+  _runWithMiddlewareContext,
+  _runWithMiddlewareData,
+  createProductionMiddlewareRunner,
+} from '@farmjs/core/middleware';
 
 const farmDeploymentId = ${JSON.stringify(ctx.deploymentId)};
 `;
@@ -125,6 +130,13 @@ const errors = mergeRouteModules([${routeRoots
 const middlewares = mergeRouteModules([${routeRoots
     .map((root, index) => `{ base: ${JSON.stringify(root.base)}, modules: middlewares${index} }`)
     .join(", ")}]);
+const farmMiddlewareRunner = createProductionMiddlewareRunner({
+  modules: Object.entries(middlewares).map(([filePath, module]) => ({
+    path: middlewarePathToRoute(filePath),
+    filePath,
+    module,
+  })),
+});
 
 debug('Discovered pages:', Object.keys(pages));
 debug('Discovered layouts:', Object.keys(layouts));
@@ -196,163 +208,10 @@ function middlewarePathToRoute(filePath) {
 }
 
 /**
- * Get all applicable middleware for a pathname (from root to most specific)
- */
-function getApplicableMiddleware(pathname) {
-  const applicable = [];
-  const normalizedPath = pathname.replace(/\\/$/, '') || '/';
-  
-  for (const [filePath, module] of Object.entries(middlewares)) {
-    const mwPath = middlewarePathToRoute(filePath);
-    
-    // Root middleware (/) applies to everything
-    // Other middleware applies to their path and sub-paths
-    if (mwPath === '/' || normalizedPath.startsWith(mwPath) || normalizedPath === mwPath) {
-      applicable.push({
-        path: mwPath,
-        filePath,
-        module,
-        config: module.config,
-      });
-    }
-  }
-  
-  // Sort by path depth (root first, then nested)
-  applicable.sort((a, b) => {
-    const depthA = a.path.split('/').filter(Boolean).length;
-    const depthB = b.path.split('/').filter(Boolean).length;
-    return depthA - depthB;
-  });
-  
-  return applicable;
-}
-
-/**
- * Create a middleware context
- */
-function createMiddlewareContext(request, url) {
-  return {
-    method: request.method,
-    url: url.href,
-    pathname: url.pathname,
-    searchParams: url.searchParams,
-    headers: new Map(),
-    data: new Map(),
-    request,
-  };
-}
-
-/**
  * Execute middleware chain for a request
- * Returns { handled: boolean, ctx: context } 
  */
-async function executeMiddleware(request, url) {
-  const applicable = getApplicableMiddleware(url.pathname);
-  
-  if (applicable.length === 0) {
-    return { handled: false, ctx: createMiddlewareContext(request, url) };
-  }
-  
-  const startTime = Date.now();
-  const method = request.method || 'GET';
-  
-  // Log middleware execution in [FARM] [MIDDLEWARE] [METHOD] format
-  try {
-    const picoModule = await import('picocolors');
-    const pico = picoModule.default || picoModule;
-    const pc = typeof pico.createColors === 'function' ? pico.createColors(true) : pico;
-    const logMsg = [
-      pc.dim('[') + pc.bold(pc.blue('FARM')) + pc.dim(']'),
-      pc.dim('[') + pc.bold(pc.magenta('MIDDLEWARE')) + pc.dim(']'),
-      pc.dim('[') + pc.bold(pc.white(method.padEnd(3))) + pc.dim(']'),
-      pc.gray('Executing middleware: '),
-      pc.gray(url.pathname),
-      pc.dim(' (' + applicable.length + ' middleware)'),
-    ].join(' ');
-    console.log(logMsg);
-  } catch {
-    console.log('[FARM] [MIDDLEWARE] [' + method + '] Executing middleware: ' + url.pathname + ' (' + applicable.length + ' middleware)');
-  }
-  
-  let ctx = createMiddlewareContext(request, url);
-  
-  for (const mw of applicable) {
-    const module = mw.module;
-    let handlers = [];
-    
-    // Get handlers from the middleware module
-    if (module.default) {
-      const defaultExport = module.default;
-      
-      // Check if it has a build method (middleware chain object)
-      if (typeof defaultExport === 'object' && 'build' in defaultExport) {
-        if (typeof defaultExport.setBasePath === 'function') {
-          defaultExport.setBasePath(mw.path);
-        }
-        const built = defaultExport.build();
-        handlers = built.handlers || [];
-      } else if (typeof defaultExport === 'function') {
-        handlers = [defaultExport];
-      }
-    }
-    
-    // Execute handlers in sequence
-    for (const handler of handlers) {
-      let nextCalled = false;
-      const next = async () => { nextCalled = true; };
-      
-      try {
-        await handler(ctx, next);
-      } catch (err) {
-        console.error('[Middleware] Error in', mw.path, err);
-        throw err;
-      }
-      
-      // If next() was not called, middleware handled the request
-      if (!nextCalled && ctx._response) {
-        // Log middleware completion
-        const duration = Date.now() - startTime;
-        try {
-          const picoModule2 = await import('picocolors');
-          const pico2 = picoModule2.default || picoModule2;
-          const pc2 = typeof pico2.createColors === 'function' ? pico2.createColors(true) : pico2;
-          const logMsg = [
-            pc2.dim('[') + pc2.bold(pc2.blue('FARM')) + pc2.dim(']'),
-            pc2.dim('[') + pc2.bold(pc2.magenta('MIDDLEWARE')) + pc2.dim(']'),
-            pc2.dim('[') + pc2.bold(pc2.white(method.padEnd(3))) + pc2.dim(']'),
-            pc2.gray('Completed'),
-            pc2.gray(url.pathname),
-            pc2.dim('(' + duration + 'ms)'),
-          ].join(' ');
-          console.log(logMsg);
-        } catch {
-          console.log('[FARM] [MIDDLEWARE] [' + method + '] Completed ' + url.pathname + ' (' + duration + 'ms)');
-        }
-        return { handled: true, ctx, response: ctx._response };
-      }
-    }
-  }
-  
-  // Log middleware completion
-  const duration = Date.now() - startTime;
-  try {
-    const picoModule3 = await import('picocolors');
-    const pico3 = picoModule3.default || picoModule3;
-    const pc3 = typeof pico3.createColors === 'function' ? pico3.createColors(true) : pico3;
-    const logMsg = [
-      pc3.dim('[') + pc3.bold(pc3.blue('FARM')) + pc3.dim(']'),
-      pc3.dim('[') + pc3.bold(pc3.magenta('MIDDLEWARE')) + pc3.dim(']'),
-      pc3.dim('[') + pc3.bold(pc3.white(method.padEnd(3))) + pc3.dim(']'),
-      pc3.gray('Completed'),
-      pc3.gray(url.pathname),
-      pc3.dim('(' + duration + 'ms)'),
-    ].join(' ');
-    console.log(logMsg);
-  } catch {
-    console.log('[FARM] [MIDDLEWARE] [' + method + '] Completed ' + url.pathname + ' (' + duration + 'ms)');
-  }
-  
-  return { handled: false, ctx };
+async function executeMiddleware(request) {
+  return farmMiddlewareRunner(request);
 }
 
 /**
@@ -518,7 +377,7 @@ function getLayout(pageFilePath) {
  * Exported as { fetch: handler } for the RSC/Nitro contract (see vite-plugin-rsc-deploy-example).
  */
 async function handler(request) {
-  const url = new URL(request.url);
+  let url = new URL(request.url);
   try {
   debug('Handling request:', request.method, url.pathname);
 
@@ -549,20 +408,26 @@ async function handler(request) {
   }
 
   // Execute middleware first
-  const middlewareResult = await executeMiddleware(request, url);
+  const middlewareResult = await executeMiddleware(request);
   
   // If middleware handled the request (e.g., redirect, auth), return the response
-  if (middlewareResult.handled && middlewareResult.response) {
+  if (middlewareResult.response) {
     return middlewareResult.response;
   }
-  
+
+  request = middlewareResult.request;
+  url = new URL(request.url);
+
   // Extract middleware data and headers for page rendering
-  const middlewareData = Object.fromEntries(middlewareResult.ctx.data);
-  const middlewareHeaders = new Headers();
-  for (const [key, value] of middlewareResult.ctx.headers) {
-    middlewareHeaders.set(key, value);
+  const middlewareData = Object.fromEntries(middlewareResult.data);
+  const middlewareContext = middlewareResult.context;
+  const middlewareHeaders = new Headers(middlewareResult.headers);
+  if (middlewareResult.data.size || middlewareContext.size) {
+    middlewareHeaders.set('cache-control', 'private, no-store');
   }
-  
+
+  return await _runWithMiddlewareData(middlewareResult.data, () =>
+    _runWithMiddlewareContext(middlewareContext, async () => {
   const glob = '';
 `;
 
@@ -830,6 +695,8 @@ async function handler(request) {
   responseHeaders.set('content-type', 'text/html');
   applyActionResponseHeaders(responseHeaders, request);
   return new Response(html, { headers: responseHeaders });
+    })
+  );
   } catch (err) {
     console.error('[RSC] Handler error:', err);
     if (request.method === 'POST') {

--- a/packages/farmjs-plugin/src/rsc/entries/security.test.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/security.test.ts
@@ -59,6 +59,17 @@ describe("generated server action security", () => {
     expect(entry).not.toContain("throw p.returnValue?.data");
   });
 
+  it("uses the shared middleware runtime and server context during RSC rendering", () => {
+    const entry = generateRscEntry(context);
+
+    expect(entry).toContain("createProductionMiddlewareRunner");
+    expect(entry).toContain("path: middlewarePathToRoute(filePath)");
+    expect(entry).toContain("const middlewareContext = middlewareResult.context");
+    expect(entry).toContain("_runWithMiddlewareData(middlewareResult.data");
+    expect(entry).toContain("_runWithMiddlewareContext(middlewareContext");
+    expect(entry).toContain("middlewareHeaders.set('cache-control', 'private, no-store')");
+  });
+
   it("rejects stale actions before decoding and only reloads safe navigation", () => {
     const serverEntry = generateRscEntry(context);
     const clientEntry = generateClientEntry(context);


### PR DESCRIPTION
## Summary

- support a named request-first `middleware(request, context)` export alongside the existing default Farm middleware chain
- add typed, request-isolated server context shared with nested middleware, layouts, pages, and Server Components
- use the same middleware normalizer across development, universal production, standalone Vite, and generated RSC runtimes
- keep server context out of hydration props and bypass shared caches when request-scoped middleware state is present
- document both styles, context sharing, matcher behavior, and security boundaries

## Verification

- `corepack pnpm --filter @farmjs/core test -- src/__tests__/middleware.test.ts src/__tests__/production-middleware.test.ts` (83 passed)
- `corepack pnpm --filter @farmjs/plugin test -- src/rsc/entries/security.test.ts` (6 passed)
- `corepack pnpm --filter @farmjs/core build`
- `corepack pnpm --filter @farmjs/plugin build`
- full core suite: 511 passed, 1 skipped
- docs production build