### PR TITLE
fix: correct homepage code examples

### DIFF
--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -343,9 +343,32 @@
     will-change: transform;
   }
 
-  .farm-terminal-sequence {
+  .farm-terminal-command-text {
+    width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    animation: farm-terminal-command-type 9.6s infinite;
+    will-change: width, opacity;
+  }
+
+  .farm-terminal-command-cursor {
+    margin-left: 0.2em;
+    vertical-align: -0.12em;
+    animation: farm-terminal-cursor-window 9.6s linear infinite;
+  }
+
+  .farm-terminal-command-cursor::before {
+    display: block;
+    width: 0.45em;
+    height: 1.05em;
+    background: rgb(255 255 255 / 0.74);
+    animation: farm-terminal-cursor-blink 0.8s steps(1, end) infinite;
+    content: "";
+  }
+
+  .farm-terminal-output {
     clip-path: inset(0 0 100% 0);
-    animation: farm-terminal-sequence 8.4s infinite;
+    animation: farm-terminal-output 9.6s infinite;
     will-change: clip-path, opacity;
   }
 
@@ -412,14 +435,69 @@
   }
 }
 
-@keyframes farm-terminal-sequence {
+@keyframes farm-terminal-command-type {
   0% {
-    clip-path: inset(0 0 100% 0);
+    width: 0;
     opacity: 1;
-    animation-timing-function: steps(7, end);
   }
 
-  64%,
+  2% {
+    width: 0;
+    opacity: 1;
+    animation-timing-function: steps(8, end);
+  }
+
+  7%,
+  88% {
+    width: 8ch;
+    opacity: 1;
+  }
+
+  94%,
+  99.99% {
+    width: 8ch;
+    opacity: 0;
+  }
+
+  100% {
+    width: 0;
+    opacity: 1;
+  }
+}
+
+@keyframes farm-terminal-cursor-window {
+  0%,
+  12% {
+    opacity: 1;
+  }
+
+  12.01%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes farm-terminal-cursor-blink {
+  0%,
+  48% {
+    opacity: 1;
+  }
+
+  49%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes farm-terminal-output {
+  0%,
+  12% {
+    clip-path: inset(0 0 100% 0);
+    opacity: 1;
+    animation-timing-function: steps(6, start);
+  }
+
+  68%,
   88% {
     clip-path: inset(0);
     opacity: 1;
@@ -583,7 +661,10 @@
   }
 
   .group:hover .farm-migration-row,
-  .group:hover .farm-terminal-sequence,
+  .group:hover .farm-terminal-command-text,
+  .group:hover .farm-terminal-command-cursor,
+  .group:hover .farm-terminal-command-cursor::before,
+  .group:hover .farm-terminal-output,
   .group:hover .farm-migration-source,
   .group:hover .farm-migration-target,
   .group:hover .farm-migration-link,
@@ -618,7 +699,10 @@
   }
 
   .farm-migration-row,
-  .farm-terminal-sequence,
+  .farm-terminal-command-text,
+  .farm-terminal-command-cursor,
+  .farm-terminal-command-cursor::before,
+  .farm-terminal-output,
   .farm-migration-source,
   .farm-migration-target,
   .farm-migration-link,
@@ -626,7 +710,17 @@
     animation: none;
   }
 
-  .farm-terminal-sequence {
+  .farm-terminal-command-text {
+    width: auto;
+    overflow: visible;
+    opacity: 1;
+  }
+
+  .farm-terminal-command-cursor {
+    display: none;
+  }
+
+  .farm-terminal-output {
     clip-path: inset(0);
     opacity: 1;
   }

--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -343,6 +343,12 @@
     will-change: transform;
   }
 
+  .farm-terminal-sequence {
+    clip-path: inset(0 0 100% 0);
+    animation: farm-terminal-sequence 8.4s infinite;
+    will-change: clip-path, opacity;
+  }
+
   .farm-highlighted-code {
     --sh-class: rgb(255 255 255 / 0.86);
     --sh-identifier: rgb(255 255 255 / 0.64);
@@ -403,6 +409,32 @@
   }
   to {
     transform: translate3d(-50%, 0, 0);
+  }
+}
+
+@keyframes farm-terminal-sequence {
+  0% {
+    clip-path: inset(0 0 100% 0);
+    opacity: 1;
+    animation-timing-function: steps(7, end);
+  }
+
+  64%,
+  88% {
+    clip-path: inset(0);
+    opacity: 1;
+    animation-timing-function: linear;
+  }
+
+  94%,
+  99.99% {
+    clip-path: inset(0);
+    opacity: 0;
+  }
+
+  100% {
+    clip-path: inset(0 0 100% 0);
+    opacity: 1;
   }
 }
 
@@ -551,6 +583,7 @@
   }
 
   .group:hover .farm-migration-row,
+  .group:hover .farm-terminal-sequence,
   .group:hover .farm-migration-source,
   .group:hover .farm-migration-target,
   .group:hover .farm-migration-link,
@@ -585,11 +618,17 @@
   }
 
   .farm-migration-row,
+  .farm-terminal-sequence,
   .farm-migration-source,
   .farm-migration-target,
   .farm-migration-link,
   .farm-migration-progress {
     animation: none;
+  }
+
+  .farm-terminal-sequence {
+    clip-path: inset(0);
+    opacity: 1;
   }
 
   .farm-migration-row[data-initial="true"] {

--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -372,6 +372,35 @@
     will-change: clip-path, opacity;
   }
 
+  .farm-build-command-text {
+    width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    animation: farm-build-command-type 10.8s infinite;
+    will-change: width, opacity;
+  }
+
+  .farm-build-command-cursor {
+    margin-left: 0.2em;
+    vertical-align: -0.12em;
+    animation: farm-build-cursor-window 10.8s linear infinite;
+  }
+
+  .farm-build-command-cursor::before {
+    display: block;
+    width: 0.45em;
+    height: 1.05em;
+    background: rgb(255 255 255 / 0.74);
+    animation: farm-terminal-cursor-blink 0.8s steps(1, end) infinite;
+    content: "";
+  }
+
+  .farm-build-output {
+    clip-path: inset(0 0 100% 0);
+    animation: farm-build-output 10.8s infinite;
+    will-change: clip-path, opacity;
+  }
+
   .farm-highlighted-code {
     --sh-class: rgb(255 255 255 / 0.86);
     --sh-identifier: rgb(255 255 255 / 0.64);
@@ -498,6 +527,75 @@
   }
 
   68%,
+  88% {
+    clip-path: inset(0);
+    opacity: 1;
+    animation-timing-function: linear;
+  }
+
+  94%,
+  99.99% {
+    clip-path: inset(0);
+    opacity: 0;
+  }
+
+  100% {
+    clip-path: inset(0 0 100% 0);
+    opacity: 1;
+  }
+}
+
+@keyframes farm-build-command-type {
+  0% {
+    width: 0;
+    opacity: 1;
+  }
+
+  2% {
+    width: 0;
+    opacity: 1;
+    animation-timing-function: steps(26, end);
+  }
+
+  11%,
+  88% {
+    width: 26ch;
+    opacity: 1;
+  }
+
+  94%,
+  99.99% {
+    width: 26ch;
+    opacity: 0;
+  }
+
+  100% {
+    width: 0;
+    opacity: 1;
+  }
+}
+
+@keyframes farm-build-cursor-window {
+  0%,
+  14% {
+    opacity: 1;
+  }
+
+  14.01%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes farm-build-output {
+  0%,
+  14% {
+    clip-path: inset(0 0 100% 0);
+    opacity: 1;
+    animation-timing-function: steps(5, start);
+  }
+
+  56%,
   88% {
     clip-path: inset(0);
     opacity: 1;
@@ -699,6 +797,10 @@
   .farm-terminal-command-cursor,
   .farm-terminal-command-cursor::before,
   .farm-terminal-output,
+  .farm-build-command-text,
+  .farm-build-command-cursor,
+  .farm-build-command-cursor::before,
+  .farm-build-output,
   .farm-migration-source,
   .farm-migration-target,
   .farm-migration-link,
@@ -706,17 +808,20 @@
     animation: none;
   }
 
-  .farm-terminal-command-text {
+  .farm-terminal-command-text,
+  .farm-build-command-text {
     width: auto;
     overflow: visible;
     opacity: 1;
   }
 
-  .farm-terminal-command-cursor {
+  .farm-terminal-command-cursor,
+  .farm-build-command-cursor {
     display: none;
   }
 
-  .farm-terminal-output {
+  .farm-terminal-output,
+  .farm-build-output {
     clip-path: inset(0);
     opacity: 1;
   }

--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -661,10 +661,6 @@
   }
 
   .group:hover .farm-migration-row,
-  .group:hover .farm-terminal-command-text,
-  .group:hover .farm-terminal-command-cursor,
-  .group:hover .farm-terminal-command-cursor::before,
-  .group:hover .farm-terminal-output,
   .group:hover .farm-migration-source,
   .group:hover .farm-migration-target,
   .group:hover .farm-migration-link,

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -573,6 +573,35 @@ function EcosystemStrip() {
   );
 }
 
+function TerminalRequestLine({
+  type,
+  method,
+  path,
+  duration,
+}: {
+  type: "PAGE" | "API";
+  method: "GET" | "POST";
+  path: string;
+  duration: number;
+}) {
+  const isApi = type === "API";
+
+  return (
+    <span className="block whitespace-nowrap text-white/54">
+      <span className="text-white/28">[</span>
+      <span className="text-white/86">FARM</span>
+      <span className="text-white/28">]</span> <span className="text-white/28">[</span>
+      <span className={isApi ? "text-white/86" : "text-white/62"}>{type}</span>
+      <span className="text-white/28">]</span> <span className="text-white/28">[</span>
+      <span className="text-white/72">{method}</span>
+      <span className="text-white/28">]</span>{" "}
+      <span className={isApi ? "text-white/72" : "text-white/66"}>{path}</span>{" "}
+      <span className="text-white/24">-</span> <span className="text-white/84">200</span>{" "}
+      <span className={isApi ? "text-white/38" : "text-white/34"}>({duration}ms)</span>
+    </span>
+  );
+}
+
 function TerminalVisual() {
   return (
     <div className="farm-feature-spotlight relative flex h-[340px] items-end justify-end overflow-hidden pl-6 sm:pl-10">
@@ -592,23 +621,14 @@ function TerminalVisual() {
             <span className="block text-white/48">$ pnpm dev</span>
             <span className="block text-white">
               <span className="font-semibold text-white">Farm.js</span> v1.0.0 ready in{" "}
-              <span className="text-white/72">386ms</span>
+              <span className="text-white/88">84ms</span>
             </span>
             <span className="block text-white/54">
               <span className="text-white/82">➜ Local:</span> http://localhost:3000/
             </span>
-            <span className="block text-white/54">
-              <span className="text-white/72">[FARM] [PAGE] [GET]</span> /contact - 200{" "}
-              <span className="text-white/36">(8ms)</span>
-            </span>
-            <span className="block text-white/54">
-              <span className="text-white/72">[FARM] [PAGE] [GET]</span> /about - 200{" "}
-              <span className="text-white/36">(6ms)</span>
-            </span>
-            <span className="block text-white/54">
-              <span className="text-white/72">[FARM] [PAGE] [GET]</span> /docs - 200{" "}
-              <span className="text-white/36">(11ms)</span>
-            </span>
+            <TerminalRequestLine duration={8} method="GET" path="/contact" type="PAGE" />
+            <TerminalRequestLine duration={5} method="POST" path="/api/waitlist" type="API" />
+            <TerminalRequestLine duration={11} method="GET" path="/docs" type="PAGE" />
           </code>
         </pre>
       </figure>

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -242,21 +242,20 @@ const footerGroups = [
   },
 ] as const;
 
-const typedApiCode = `const user = await api.users.get({
-  params: { id: "user_123" },
+const typedApiCode = `const { data, error } = await api.users.get({
+  query: { limit: "5" },
 });
 
-user.name;
-//   ^? string`;
+if (error) throw error;
+
+data?.users[0]?.name;
+//   ^? string | undefined`;
 
 const integrationConfigCode = `import { defineConfig } from "@farmjs/core";
+import { appIntegrations } from "./src/lib/integrations";
 
 export default defineConfig({
-  integrations: [
-    auth(),
-    billing(),
-    jobs(),
-  ],
+  integrations: appIntegrations,
 });`;
 
 const docsConfigCode = `import { defineDocs } from "@farming-labs/docs";
@@ -589,18 +588,20 @@ function TerminalVisual() {
           </span>
         </figcaption>
         <pre className="min-h-0 flex-1 overflow-x-auto p-5 font-mono text-[11px] leading-6 tracking-normal sm:text-xs">
-          <code className="block min-w-max">
+          <code className="block min-w-0 whitespace-pre-wrap break-words">
             <span className="block text-white/48">$ pnpm dev</span>
+            <span className="mt-2 block text-white/48">
+              [info] 📦 Enabled built-in Tailwind support (@tailwindcss/vite)
+            </span>
             <span className="mt-2 block text-white">
-              <span className="font-semibold text-white">FARM</span> v0.0.3 ready in 126ms
+              <span className="font-semibold text-white">Farm.js</span> v1.0.0 ready in 386ms
             </span>
             <span className="block text-white/54">
-              <span className="text-white/82">Local</span> http://localhost:3000
+              <span className="text-white/82">➜ Local:</span> http://localhost:3000/
             </span>
             <span className="block text-white/54">
-              <span className="text-white/82">Graph</span> 32 routes / 8 integrations
+              <span className="text-white/82">➜ Network:</span> use --host to expose
             </span>
-            <span className="mt-2 block text-white/32">press h + enter to show help</span>
           </code>
         </pre>
       </figure>
@@ -614,7 +615,7 @@ function TypedApiVisual() {
       <HighlightedCode
         className="relative z-10 -mb-px -mr-px flex h-[290px] w-full max-w-full shrink-0 flex-col"
         code={typedApiCode}
-        label="/api/users/:id"
+        label="/api/users"
         language="tsx"
         prefix="GET"
       />
@@ -645,22 +646,26 @@ function BuildVisual() {
           </span>
           <span>bash</span>
         </figcaption>
-        <pre className="min-h-0 flex-1 overflow-x-auto p-5 font-mono text-[10px] leading-6 tracking-normal text-white/58 sm:text-[11px]">
-          <code className="block min-w-max">
-            <span className="block text-white">$ farm build --target vercel</span>
+        <pre className="min-h-0 flex-1 overflow-x-auto p-5 font-mono text-[10px] leading-5 tracking-normal text-white/58 sm:text-[11px] sm:leading-6">
+          <code className="block min-w-0 whitespace-pre-wrap break-words">
+            <span className="block text-white">$ farm build --preset vercel</span>
             <span className="mt-2 block">
-              <span className="text-white">ok</span> route manifest ........ 44 routes
+              <span className="text-white">[info]</span> 🚜 Building Farm.js application with
+              preset: vercel...
             </span>
             <span className="block">
-              <span className="text-white">ok</span> middleware .............. 6 matchers
+              <span className="text-white">[info]</span> 🔍 Discovering routes and API endpoints...
             </span>
             <span className="block">
-              <span className="text-white">ok</span> generated client ........ 12 APIs
+              <span className="text-white">[info]</span> 📦 Building client and SSR bundles in
+              parallel...
             </span>
             <span className="block">
-              <span className="text-white">ok</span> deployment output ....... .vercel/output
+              <span className="text-white">[success]</span> ✅ Build completed successfully!
             </span>
-            <span className="mt-2 block text-white/78">built in 842ms</span>
+            <span className="block text-white/78">
+              <span className="text-white">[info]</span> 📁 Output directory: .vercel/output
+            </span>
           </code>
         </pre>
       </figure>

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -690,24 +690,33 @@ function BuildVisual() {
         </figcaption>
         <pre className="min-h-0 flex-1 overflow-x-auto p-5 font-mono text-[10px] leading-5 tracking-normal text-white/58 sm:text-[11px] sm:leading-6">
           <code className="block min-w-0 whitespace-pre-wrap break-words">
-            <span className="block text-white">$ farm build --preset vercel</span>
-            <span className="mt-2 block">
-              <span className="text-white">[info]</span> 🚜 Building Farm.js application with
-              preset: vercel...
+            <span className="block h-5 whitespace-nowrap text-white sm:h-6">
+              <span>$ </span>
+              <span className="farm-build-command-text inline-block align-bottom">
+                farm build --preset vercel
+              </span>
+              <span aria-hidden className="farm-build-command-cursor inline-block" />
             </span>
-            <span className="block">
-              <span className="text-white">[info]</span> 🔍 Discovering routes and API endpoints...
-            </span>
-            <span className="block">
-              <span className="text-white">[info]</span> 📦 Building client and SSR bundles in
-              parallel...
-            </span>
-            <span className="block">
-              <span className="text-white">[success]</span> ✅ Build completed in{" "}
-              <span className="font-semibold text-white">1.24s</span>
-            </span>
-            <span className="block text-white/78">
-              <span className="text-white">[info]</span> 📁 Output directory: .vercel/output
+            <span className="farm-build-output mt-2 block">
+              <span className="block whitespace-nowrap">
+                <span className="text-white">[info]</span> 🚜 Building Farm.js application with
+                preset: vercel...
+              </span>
+              <span className="block whitespace-nowrap">
+                <span className="text-white">[info]</span> 🔍 Discovering routes and API
+                endpoints...
+              </span>
+              <span className="block whitespace-nowrap">
+                <span className="text-white">[info]</span> 📦 Building client and SSR bundles in
+                parallel...
+              </span>
+              <span className="block whitespace-nowrap">
+                <span className="text-white">[success]</span> ✅ Build completed in{" "}
+                <span className="font-semibold text-white">1.24s</span>
+              </span>
+              <span className="block whitespace-nowrap text-white/78">
+                <span className="text-white">[info]</span> 📁 Output directory: .vercel/output
+              </span>
             </span>
           </code>
         </pre>

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -618,23 +618,31 @@ function TerminalVisual() {
         </figcaption>
         <pre className="min-h-0 flex-1 overflow-x-auto p-5 font-mono text-[10px] leading-5 tracking-normal sm:text-[11px] sm:leading-6">
           <code className="block min-w-0 whitespace-pre-wrap break-words">
-            <span className="farm-terminal-sequence block min-w-max space-y-1.5">
-              <span className="block text-white/48">$ pnpm dev</span>
-              <span className="block text-white">
-                <span className="font-semibold text-white">Farm.js</span> v1.0.0 ready in{" "}
-                <span className="text-white/88">84ms</span>
+            <span className="block min-w-max">
+              <span className="block h-5 whitespace-nowrap text-white/48 sm:h-6">
+                <span>$ </span>
+                <span className="farm-terminal-command-text inline-block align-bottom">
+                  pnpm dev
+                </span>
+                <span aria-hidden className="farm-terminal-command-cursor inline-block" />
               </span>
-              <span className="block whitespace-nowrap text-white/58">
-                <span className="inline-block w-[5.25rem] text-white/82">➜ Local:</span>
-                http://localhost:3000/
+              <span className="farm-terminal-output mt-1.5 block space-y-1.5">
+                <span className="block text-white">
+                  <span className="font-semibold text-white">Farm.js</span> v1.0.0 ready in{" "}
+                  <span className="text-white/88">84ms</span>
+                </span>
+                <span className="block whitespace-nowrap text-white/58">
+                  <span className="inline-block w-[5.25rem] text-white/82">➜ Local:</span>
+                  http://localhost:3000/
+                </span>
+                <span className="block whitespace-nowrap text-white/48">
+                  <span className="inline-block w-[5.25rem] text-white/68">➜ Network:</span>
+                  http://192.168.1.24:3000/
+                </span>
+                <TerminalRequestLine duration={8} method="GET" path="/contact" type="PAGE" />
+                <TerminalRequestLine duration={5} method="POST" path="/api/waitlist" type="API" />
+                <TerminalRequestLine duration={11} method="GET" path="/docs" type="PAGE" />
               </span>
-              <span className="block whitespace-nowrap text-white/48">
-                <span className="inline-block w-[5.25rem] text-white/68">➜ Network:</span>
-                http://192.168.1.24:3000/
-              </span>
-              <TerminalRequestLine duration={8} method="GET" path="/contact" type="PAGE" />
-              <TerminalRequestLine duration={5} method="POST" path="/api/waitlist" type="API" />
-              <TerminalRequestLine duration={11} method="GET" path="/docs" type="PAGE" />
             </span>
           </code>
         </pre>

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -587,17 +587,27 @@ function TerminalVisual() {
             <Terminal aria-hidden className="size-3" strokeWidth={1.5} /> pnpm dev
           </span>
         </figcaption>
-        <pre className="min-h-0 flex-1 overflow-x-auto p-5 font-mono text-[11px] leading-6 tracking-normal sm:text-xs">
+        <pre className="min-h-0 flex-1 overflow-x-auto p-5 font-mono text-[10px] leading-5 tracking-normal sm:text-[11px] sm:leading-6">
           <code className="block min-w-0 space-y-1.5 whitespace-pre-wrap break-words">
             <span className="block text-white/48">$ pnpm dev</span>
             <span className="block text-white">
-              <span className="font-semibold text-white">Farm.js</span> v1.0.0 ready in 386ms
+              <span className="font-semibold text-white">Farm.js</span> v1.0.0 ready in{" "}
+              <span className="text-white/72">386ms</span>
             </span>
             <span className="block text-white/54">
               <span className="text-white/82">➜ Local:</span> http://localhost:3000/
             </span>
             <span className="block text-white/54">
-              <span className="text-white/82">➜ Network:</span> use --host to expose
+              <span className="text-white/72">[FARM] [PAGE] [GET]</span> /contact - 200{" "}
+              <span className="text-white/36">(8ms)</span>
+            </span>
+            <span className="block text-white/54">
+              <span className="text-white/72">[FARM] [PAGE] [GET]</span> /about - 200{" "}
+              <span className="text-white/36">(6ms)</span>
+            </span>
+            <span className="block text-white/54">
+              <span className="text-white/72">[FARM] [PAGE] [GET]</span> /docs - 200{" "}
+              <span className="text-white/36">(11ms)</span>
             </span>
           </code>
         </pre>
@@ -709,11 +719,11 @@ function DeveloperExperienceGrid() {
   return (
     <section className="farm-full-rule grid w-full lg:grid-cols-2">
       <FeatureCell
-        body="Run pages, APIs, docs, and integrations together in the same development server."
+        body="Start the whole app once, then see every page request and response time as you work."
         icon={Terminal}
         index="01.1"
         label="Development"
-        title="One command runs the app"
+        title="A dev server that starts in milliseconds"
       >
         <TerminalVisual />
       </FeatureCell>

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -758,7 +758,7 @@ function DeveloperExperienceGrid() {
         icon={Terminal}
         index="01.1"
         label="Development"
-        title="A dev server that starts in milliseconds"
+        title="A blazingly fast dev server"
       >
         <TerminalVisual />
       </FeatureCell>

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -588,12 +588,9 @@ function TerminalVisual() {
           </span>
         </figcaption>
         <pre className="min-h-0 flex-1 overflow-x-auto p-5 font-mono text-[11px] leading-6 tracking-normal sm:text-xs">
-          <code className="block min-w-0 whitespace-pre-wrap break-words">
+          <code className="block min-w-0 space-y-1.5 whitespace-pre-wrap break-words">
             <span className="block text-white/48">$ pnpm dev</span>
-            <span className="mt-2 block text-white/48">
-              [info] 📦 Enabled built-in Tailwind support (@tailwindcss/vite)
-            </span>
-            <span className="mt-2 block text-white">
+            <span className="block text-white">
               <span className="font-semibold text-white">Farm.js</span> v1.0.0 ready in 386ms
             </span>
             <span className="block text-white/54">

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -617,18 +617,25 @@ function TerminalVisual() {
           </span>
         </figcaption>
         <pre className="min-h-0 flex-1 overflow-x-auto p-5 font-mono text-[10px] leading-5 tracking-normal sm:text-[11px] sm:leading-6">
-          <code className="block min-w-0 space-y-1.5 whitespace-pre-wrap break-words">
-            <span className="block text-white/48">$ pnpm dev</span>
-            <span className="block text-white">
-              <span className="font-semibold text-white">Farm.js</span> v1.0.0 ready in{" "}
-              <span className="text-white/88">84ms</span>
+          <code className="block min-w-0 whitespace-pre-wrap break-words">
+            <span className="farm-terminal-sequence block min-w-max space-y-1.5">
+              <span className="block text-white/48">$ pnpm dev</span>
+              <span className="block text-white">
+                <span className="font-semibold text-white">Farm.js</span> v1.0.0 ready in{" "}
+                <span className="text-white/88">84ms</span>
+              </span>
+              <span className="block whitespace-nowrap text-white/58">
+                <span className="inline-block w-[5.25rem] text-white/82">➜ Local:</span>
+                http://localhost:3000/
+              </span>
+              <span className="block whitespace-nowrap text-white/48">
+                <span className="inline-block w-[5.25rem] text-white/68">➜ Network:</span>
+                http://192.168.1.24:3000/
+              </span>
+              <TerminalRequestLine duration={8} method="GET" path="/contact" type="PAGE" />
+              <TerminalRequestLine duration={5} method="POST" path="/api/waitlist" type="API" />
+              <TerminalRequestLine duration={11} method="GET" path="/docs" type="PAGE" />
             </span>
-            <span className="block text-white/54">
-              <span className="text-white/82">➜ Local:</span> http://localhost:3000/
-            </span>
-            <TerminalRequestLine duration={8} method="GET" path="/contact" type="PAGE" />
-            <TerminalRequestLine duration={5} method="POST" path="/api/waitlist" type="API" />
-            <TerminalRequestLine duration={11} method="GET" path="/docs" type="PAGE" />
           </code>
         </pre>
       </figure>

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -632,11 +632,11 @@ function TerminalVisual() {
                   <span className="text-white/88">84ms</span>
                 </span>
                 <span className="block whitespace-nowrap text-white/58">
-                  <span className="inline-block w-[5.25rem] text-white/82">➜ Local:</span>
+                  <span className="inline-block w-[4.5rem] text-white/82">➜ Local:</span>
                   http://localhost:3000/
                 </span>
-                <span className="block whitespace-nowrap text-white/48">
-                  <span className="inline-block w-[5.25rem] text-white/68">➜ Network:</span>
+                <span className="!mt-0.5 block whitespace-nowrap text-white/48">
+                  <span className="inline-block w-[4.5rem] text-white/68">➜ Network:</span>
                   http://192.168.1.24:3000/
                 </span>
                 <TerminalRequestLine duration={8} method="GET" path="/contact" type="PAGE" />

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -703,7 +703,8 @@ function BuildVisual() {
               parallel...
             </span>
             <span className="block">
-              <span className="text-white">[success]</span> ✅ Build completed successfully!
+              <span className="text-white">[success]</span> ✅ Build completed in{" "}
+              <span className="font-semibold text-white">1.24s</span>
             </span>
             <span className="block text-white/78">
               <span className="text-white">[info]</span> 📁 Output directory: .vercel/output

--- a/docs/src/components/home/install-command.tsx
+++ b/docs/src/components/home/install-command.tsx
@@ -54,6 +54,8 @@ const commands: readonly CommandOption[] = [
 export function InstallCommand() {
   const [activeIndex, setActiveIndex] = useState(0);
   const [copyState, setCopyState] = useState<"idle" | "copying" | "copied" | "failed">("idle");
+  const [fadeEdges, setFadeEdges] = useState({ left: false, right: false });
+  const commandScrollRef = useRef<HTMLElement | null>(null);
   const resetTimer = useRef<number | undefined>(undefined);
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const activeCommand = commands[activeIndex];
@@ -79,6 +81,37 @@ export function InstallCommand() {
   useEffect(() => {
     return () => window.clearTimeout(resetTimer.current);
   }, []);
+
+  useEffect(() => {
+    const scrollArea = commandScrollRef.current;
+    if (!scrollArea) return;
+
+    scrollArea.scrollLeft = 0;
+
+    function updateFadeEdges() {
+      const maxScrollLeft = Math.max(0, scrollArea.scrollWidth - scrollArea.clientWidth);
+      const nextEdges = {
+        left: scrollArea.scrollLeft > 1,
+        right: scrollArea.scrollLeft < maxScrollLeft - 1,
+      };
+
+      setFadeEdges((currentEdges) =>
+        currentEdges.left === nextEdges.left && currentEdges.right === nextEdges.right
+          ? currentEdges
+          : nextEdges,
+      );
+    }
+
+    updateFadeEdges();
+    scrollArea.addEventListener("scroll", updateFadeEdges, { passive: true });
+    const resizeObserver = new ResizeObserver(updateFadeEdges);
+    resizeObserver.observe(scrollArea);
+
+    return () => {
+      scrollArea.removeEventListener("scroll", updateFadeEdges);
+      resizeObserver.disconnect();
+    };
+  }, [activeIndex]);
 
   function selectCommand(index: number) {
     window.clearTimeout(resetTimer.current);
@@ -200,15 +233,34 @@ export function InstallCommand() {
         >
           <ActiveCommandIcon className="size-2.5" strokeWidth={1.5} />
         </span>
-        <code
-          className="flex min-w-0 items-center overflow-x-auto whitespace-nowrap px-2 font-mono text-[9px] tracking-normal text-white/78 sm:px-2.5 sm:text-[10px]"
-          title={activeCommand.command}
-        >
-          <span aria-hidden className="mr-2 text-white/28">
-            {activeCommand.kind === "agent" ? "AI" : "$"}
-          </span>
-          {activeCommand.command}
-        </code>
+        <div className="relative min-w-0 overflow-hidden">
+          <code
+            className="flex h-full min-w-0 items-center overflow-x-auto whitespace-nowrap px-2 font-mono text-[9px] tracking-normal text-white/78 sm:px-2.5 sm:text-[10px]"
+            ref={commandScrollRef}
+            title={activeCommand.command}
+          >
+            <span aria-hidden className="mr-2 text-white/28">
+              {activeCommand.kind === "agent" ? "AI" : "$"}
+            </span>
+            {activeCommand.command}
+          </code>
+          {activeCommand.kind === "agent" ? (
+            <>
+              <span
+                aria-hidden
+                className={`pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-black via-black/80 to-transparent transition-opacity duration-200 ${
+                  fadeEdges.left ? "opacity-100" : "opacity-0"
+                }`}
+              />
+              <span
+                aria-hidden
+                className={`pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-black via-black/80 to-transparent transition-opacity duration-200 ${
+                  fadeEdges.right ? "opacity-100" : "opacity-0"
+                }`}
+              />
+            </>
+          ) : null}
+        </div>
         <button
           aria-label={`${copyLabel} ${copyTarget}`}
           className="inline-flex min-w-9 shrink-0 items-center justify-center gap-1 border-l border-white/10 bg-white/[0.025] px-1.5 font-mono text-[8px] font-normal uppercase tracking-normal text-white/48 transition-[background-color,color] duration-150 hover:bg-white/[0.075] hover:text-white focus-visible:z-10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-white sm:min-w-[4.25rem] sm:px-2 sm:text-[9px]"

--- a/docs/src/components/home/install-command.tsx
+++ b/docs/src/components/home/install-command.tsx
@@ -25,10 +25,30 @@ const commands: readonly CommandOption[] = [
     icon: Bot,
     kind: "agent",
   },
-  { label: "npm", command: "npm create farm@latest", brand: npmIconUrl, kind: "install" },
-  { label: "Yarn", command: "yarn create farm", brand: yarnIconUrl, kind: "install" },
-  { label: "pnpm", command: "pnpm create farm@latest", brand: pnpmIconUrl, kind: "install" },
-  { label: "Bun", command: "bun create farm", brand: bunIconUrl, kind: "install" },
+  {
+    label: "npm",
+    command: "npx @farmjs/create-app@beta",
+    brand: npmIconUrl,
+    kind: "install",
+  },
+  {
+    label: "Yarn",
+    command: "yarn dlx @farmjs/create-app@beta",
+    brand: yarnIconUrl,
+    kind: "install",
+  },
+  {
+    label: "pnpm",
+    command: "pnpm dlx @farmjs/create-app@beta",
+    brand: pnpmIconUrl,
+    kind: "install",
+  },
+  {
+    label: "Bun",
+    command: "bunx @farmjs/create-app@beta",
+    brand: bunIconUrl,
+    kind: "install",
+  },
 ];
 
 export function InstallCommand() {


### PR DESCRIPTION
## Summary

- replace invented dev/build terminal output with captured Farm CLI output and the supported `--preset` flag
- align the typed API and integration examples with generated router and CLI registry shapes
- point setup tabs at the repository package name and planned `beta` dist-tag
- wrap terminal output on narrow screens without changing the feature layout

## Verification

- `corepack pnpm --filter @farmjs/cli test` (27 passing)
- typed API snippet compiled against `examples/basic` generated `APIRouter`
- `defineDocs` snippet executed against `@farming-labs/docs`
- `corepack pnpm exec farm build` from `docs`
- browser QA at 1440px and 390px with no console errors or page overflow

## Publishing note

The `@farmjs/*` packages are not published on npm yet. The setup commands now match `@farmjs/create-app` and the repository beta release script, so they become executable after the scoped beta is published.