### PR TITLE
fix: polish agent install command

### DIFF
--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -464,6 +464,17 @@
   }
 }
 
+@keyframes farm-agent-command-scroll {
+  0%,
+  8% {
+    transform: translate3d(0, 0, 0);
+  }
+
+  100% {
+    transform: translate3d(-50%, 0, 0);
+  }
+}
+
 @keyframes farm-terminal-command-type {
   0% {
     width: 0;
@@ -744,6 +755,28 @@
   );
 }
 
+.farm-agent-command-viewport {
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent,
+    #000 1rem,
+    #000 calc(100% - 1rem),
+    transparent
+  );
+  mask-image: linear-gradient(
+    to right,
+    transparent,
+    #000 1rem,
+    #000 calc(100% - 1rem),
+    transparent
+  );
+}
+
+.farm-agent-command-track {
+  animation: farm-agent-command-scroll 36s linear infinite;
+  will-change: transform;
+}
+
 .farm-logo-rail {
   animation: farm-logo-rail 24s linear infinite;
   will-change: transform;
@@ -754,6 +787,10 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
+  .farm-agent-command-viewport:hover .farm-agent-command-track {
+    animation-play-state: paused;
+  }
+
   .farm-logo-viewport:hover .farm-logo-rail {
     animation-play-state: paused;
   }
@@ -778,6 +815,15 @@
   }
 
   .farm-logo-rail-copy[aria-hidden="true"] {
+    display: none;
+  }
+
+  .farm-agent-command-track {
+    animation: none;
+    transform: none;
+  }
+
+  .farm-agent-command-copy[aria-hidden="true"] {
     display: none;
   }
 

--- a/docs/src/components/home/install-command.tsx
+++ b/docs/src/components/home/install-command.tsx
@@ -21,7 +21,7 @@ const commands: readonly CommandOption[] = [
   {
     label: "Agent",
     command:
-      "Use Farm.js to build this React product app. Read the project docs first, then follow its app router, typed API, middleware, integration, and deployment conventions.",
+      "Use Farm.js to build this production-ready React product app. Read the project docs first, then follow its App Router, typed APIs, server functions, middleware, integrations, environment boundaries, data loading, and deployment conventions. Preserve existing patterns, validate external input, keep secrets server-only, add focused tests, and run type checks plus a production build before finishing.",
     icon: Bot,
     kind: "agent",
   },
@@ -202,20 +202,35 @@ export function InstallCommand() {
         </span>
         <div className="min-w-0 overflow-hidden">
           <code
-            className={`flex h-full min-w-0 px-2 font-mono text-[9px] tracking-normal text-white/78 sm:px-2.5 sm:text-[10px] ${
-              activeCommand.kind === "agent" ? "items-start py-2 leading-4" : "items-center"
-            }`}
+            className="flex h-full min-w-0 items-center px-2 font-mono text-[9px] tracking-normal text-white/78 sm:px-2.5 sm:text-[10px]"
             title={activeCommand.command}
           >
-            <span
-              aria-hidden
-              className={`mr-2 shrink-0 text-white/28 ${
-                activeCommand.kind === "agent" ? "pt-px" : ""
-              }`}
-            >
+            <span aria-hidden className="mr-2 shrink-0 text-white/28">
               {activeCommand.kind === "agent" ? "AI" : "$"}
             </span>
-            <span className="min-w-0 whitespace-normal break-words">{activeCommand.command}</span>
+            {activeCommand.kind === "agent" ? (
+              <>
+                <span className="sr-only">{activeCommand.command}</span>
+                <span
+                  aria-hidden
+                  className="farm-agent-command-viewport min-w-0 flex-1 overflow-hidden px-3"
+                >
+                  <span className="farm-agent-command-track flex w-max items-center whitespace-nowrap">
+                    {([0, 1] as const).map((copyIndex) => (
+                      <span
+                        key={copyIndex}
+                        aria-hidden={copyIndex === 1 ? true : undefined}
+                        className="farm-agent-command-copy shrink-0 pr-8"
+                      >
+                        {activeCommand.command}
+                      </span>
+                    ))}
+                  </span>
+                </span>
+              </>
+            ) : (
+              <span className="min-w-0 truncate whitespace-nowrap">{activeCommand.command}</span>
+            )}
           </code>
         </div>
         <button


### PR DESCRIPTION
## Summary
- present the Agent instruction as a compact single-line command strip
- add a seamless masked marquee with hover pause and reduced-motion handling
- expand the copied instruction with production, security, testing, and build guidance
- keep the clipboard value canonical without visual prefixes or marquee duplication

## Verification
- corepack pnpm exec oxfmt --check docs/src/components/home/install-command.tsx docs/src/app/globals.css
- corepack pnpm --dir docs exec farm build
- verified desktop and 390px mobile layouts with no overflow or console errors
- verified a trusted Copy action writes the complete 400-character instruction