### PR TITLE
feat: showcase Farm Layers and expanded config

### DIFF
--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -417,7 +417,8 @@
     display: block;
     min-width: max-content;
     min-height: 1.5rem;
-    padding-right: 1.25rem;
+    padding-right: 1.5rem;
+    padding-left: 0.75rem;
     white-space: pre;
     counter-increment: farm-code-line;
   }

--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -320,26 +320,26 @@
       inset 0 1px 0 rgb(255 255 255 / 0.025);
   }
 
-  .farm-migration-row {
+  .farm-layer-row {
     animation: farm-foundation-sequence-three 6s linear infinite;
   }
 
-  .farm-migration-source,
-  .farm-migration-target {
+  .farm-layer-source,
+  .farm-layer-target {
     animation: farm-illustration-float 7s ease-in-out infinite;
     will-change: transform;
   }
 
-  .farm-migration-target {
+  .farm-layer-target {
     animation-delay: -2.2s;
   }
 
-  .farm-migration-link {
-    animation: farm-migration-link 3s ease-in-out infinite;
+  .farm-layer-link {
+    animation: farm-layer-link 3s ease-in-out infinite;
   }
 
-  .farm-migration-progress {
-    animation: farm-migration-progress 6s ease-in-out infinite;
+  .farm-layer-progress {
+    animation: farm-layer-progress 6s ease-in-out infinite;
     will-change: transform;
   }
 
@@ -713,7 +713,7 @@
   }
 }
 
-@keyframes farm-migration-link {
+@keyframes farm-layer-link {
   0%,
   100% {
     opacity: 0.38;
@@ -726,7 +726,7 @@
   }
 }
 
-@keyframes farm-migration-progress {
+@keyframes farm-layer-progress {
   0%,
   8% {
     transform: scaleX(0.08);
@@ -795,11 +795,11 @@
     animation-play-state: paused;
   }
 
-  .group:hover .farm-migration-row,
-  .group:hover .farm-migration-source,
-  .group:hover .farm-migration-target,
-  .group:hover .farm-migration-link,
-  .group:hover .farm-migration-progress {
+  .group:hover .farm-layer-row,
+  .group:hover .farm-layer-source,
+  .group:hover .farm-layer-target,
+  .group:hover .farm-layer-link,
+  .group:hover .farm-layer-progress {
     animation-play-state: paused;
   }
 }
@@ -838,7 +838,7 @@
     transform: none;
   }
 
-  .farm-migration-row,
+  .farm-layer-row,
   .farm-terminal-command-text,
   .farm-terminal-command-cursor,
   .farm-terminal-command-cursor::before,
@@ -847,10 +847,10 @@
   .farm-build-command-cursor,
   .farm-build-command-cursor::before,
   .farm-build-output,
-  .farm-migration-source,
-  .farm-migration-target,
-  .farm-migration-link,
-  .farm-migration-progress {
+  .farm-layer-source,
+  .farm-layer-target,
+  .farm-layer-link,
+  .farm-layer-progress {
     animation: none;
   }
 
@@ -872,19 +872,19 @@
     opacity: 1;
   }
 
-  .farm-migration-row[data-initial="true"] {
+  .farm-layer-row[data-initial="true"] {
     color: rgb(255 255 255 / 0.9);
     background: rgb(255 255 255 / 0.075);
     border-color: rgb(255 255 255 / 0.2);
     box-shadow: inset 2px 0 0 rgb(255 255 255 / 0.76);
   }
 
-  .farm-migration-progress {
+  .farm-layer-progress {
     opacity: 1;
     transform: scaleX(1);
   }
 
-  .farm-migration-link {
+  .farm-layer-link {
     display: none;
   }
 }

--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -465,17 +465,6 @@
   }
 }
 
-@keyframes farm-agent-command-scroll {
-  0%,
-  8% {
-    transform: translate3d(0, 0, 0);
-  }
-
-  100% {
-    transform: translate3d(-50%, 0, 0);
-  }
-}
-
 @keyframes farm-terminal-command-type {
   0% {
     width: 0;
@@ -756,28 +745,6 @@
   );
 }
 
-.farm-agent-command-viewport {
-  -webkit-mask-image: linear-gradient(
-    to right,
-    transparent,
-    #000 1rem,
-    #000 calc(100% - 1rem),
-    transparent
-  );
-  mask-image: linear-gradient(
-    to right,
-    transparent,
-    #000 1rem,
-    #000 calc(100% - 1rem),
-    transparent
-  );
-}
-
-.farm-agent-command-track {
-  animation: farm-agent-command-scroll 36s linear infinite;
-  will-change: transform;
-}
-
 .farm-logo-rail {
   animation: farm-logo-rail 24s linear infinite;
   will-change: transform;
@@ -788,10 +755,6 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .farm-agent-command-viewport:hover .farm-agent-command-track {
-    animation-play-state: paused;
-  }
-
   .farm-logo-viewport:hover .farm-logo-rail {
     animation-play-state: paused;
   }
@@ -816,15 +779,6 @@
   }
 
   .farm-logo-rail-copy[aria-hidden="true"] {
-    display: none;
-  }
-
-  .farm-agent-command-track {
-    animation: none;
-    transform: none;
-  }
-
-  .farm-agent-command-copy[aria-hidden="true"] {
     display: none;
   }
 

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -253,11 +253,11 @@ data?.users[0]?.name;
 const integrationConfigCode = `import { defineConfig } from "@farmjs/core";
 import { auth, billing, jobs } from "./src/lib/integrations";
 export default defineConfig({
-  extends: ["./layers/commerce"],
-  integrations: { auth, billing, jobs },
-  routeRules: { "/store/**": { swr: 300 } },
-  serverActions: { bodySizeLimit: "1mb" },
-  deploy: { target: "vercel" },
+    extends: ["./layers/commerce"],
+    integrations: { auth, billing, jobs },
+    routeRules: { "/store/**": { swr: 300 } },
+    serverActions: { bodySizeLimit: "1mb" },
+    deploy: { target: "vercel" },
 });`;
 
 const docsConfigCode = `import { defineDocs } from "@farming-labs/docs";

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -260,13 +260,14 @@ export default defineConfig({
     deploy: { target: "vercel" },
 });`;
 
-const docsConfigCode = `import { defineDocs } from "@farming-labs/docs";
-
-export default defineDocs({
-  entry: "docs",
-  docsPath: "/docs",
-  search: { enabled: true },
-  pageActions: { copyMarkdown: { enabled: true } },
+const docsConfigCode = `import { defineConfig } from "@farmjs/core";
+export default defineConfig({
+    docs: {
+        enabled: true,
+        entry: "/docs",
+        search: true,
+        mcp: true,
+    },
 });`;
 
 function cx(...classes: Array<string | false | null | undefined>) {
@@ -957,7 +958,7 @@ function DeploymentVisual() {
 }
 
 function DocsVisual() {
-  return <FoundationCodeVisual code={docsConfigCode} label="docs.config.ts" language="ts" />;
+  return <FoundationCodeVisual code={docsConfigCode} label="farm.config.ts" language="ts" />;
 }
 
 function LayersVisual() {
@@ -1089,7 +1090,7 @@ function FoundationGrid() {
         <DeploymentVisual />
       </FeatureCell>
       <FeatureCell
-        body="Write docs once, then serve pages, Markdown, search, and agent-ready endpoints from the same source."
+        body="Enable docs in your app config, then serve pages, Markdown, search, and agent-ready endpoints from the same source."
         className="border-t border-white/12"
         icon={BookOpenText}
         index="02.3"

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -251,10 +251,13 @@ data?.users[0]?.name;
 //   ^? string | undefined`;
 
 const integrationConfigCode = `import { defineConfig } from "@farmjs/core";
-import { appIntegrations } from "./src/lib/integrations";
-
+import { auth, billing, jobs } from "./src/lib/integrations";
 export default defineConfig({
-  integrations: appIntegrations,
+  extends: ["./layers/commerce"],
+  integrations: { auth, billing, jobs },
+  routeRules: { "/store/**": { swr: 300 } },
+  serverActions: { bodySizeLimit: "1mb" },
+  deploy: { target: "vercel" },
 });`;
 
 const docsConfigCode = `import { defineDocs } from "@farming-labs/docs";

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -13,7 +13,6 @@ import {
   FileText,
   FolderTree,
   Gauge,
-  GitCompareArrows,
   GitFork,
   KeyRound,
   Layers3,
@@ -958,80 +957,108 @@ function DocsVisual() {
   return <FoundationCodeVisual code={docsConfigCode} label="docs.config.ts" language="ts" />;
 }
 
-function MigrationVisual() {
-  const rows = [
-    { source: "/dashboard", target: "app/dashboard", icon: FileText },
-    { source: "/api/users", target: "api/users/route", icon: Braces },
-    { source: "middleware", target: "middleware.ts", icon: ShieldCheck },
+function LayersVisual() {
+  const layerRows = [
+    { name: "farm-base", detail: "routes + middleware", icon: Layers3 },
+    { name: "admin-layer", detail: "auth + admin", icon: ShieldCheck },
+    { name: "commerce", detail: "products + checkout", icon: CreditCard },
+  ] as const;
+  const resolvedRows = [
+    { label: "routes + APIs", state: "composed", icon: Route },
+    { label: "middleware + config", state: "merged", icon: Settings2 },
+    { label: "generated types", state: "ready", icon: Braces },
   ] as const;
 
   return (
-    <FoundationCanvas>
-      <div className="farm-migration-source farm-illustration-surface absolute left-6 top-6 z-10 h-[10.5rem] w-[64%] max-w-[22rem] overflow-hidden border border-white/10 bg-black opacity-60 shadow-[0_14px_40px_rgba(0,0,0,0.45)] sm:left-10 sm:top-8">
-        <div className="flex h-9 items-center justify-between border-b border-white/10 px-3 font-mono text-[8px] uppercase text-white/40">
-          <span>source inventory</span>
-          <span className="text-white/68">next.js</span>
-        </div>
-        <div className="grid h-[calc(100%-2.25rem)] grid-rows-3">
-          {rows.map((row, index) => {
-            const Icon = row.icon;
+    <FoundationCanvas interactive>
+      <a
+        aria-label="Learn how Farm Layers compose an application"
+        className="group/layers absolute inset-0 overflow-hidden focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-white"
+        href="/docs/layers"
+        title="Farm Layers documentation"
+      >
+        <div
+          aria-hidden
+          className="farm-layer-source farm-illustration-surface absolute left-6 top-6 z-10 h-[10.5rem] w-[66%] max-w-[23rem] overflow-hidden border border-white/10 bg-black opacity-62 shadow-[0_14px_40px_rgba(0,0,0,0.45)] transition-opacity duration-150 group-hover/layers:opacity-80 sm:left-10 sm:top-8"
+        >
+          <div className="flex h-9 items-center justify-between border-b border-white/10 px-3 font-mono text-[8px] uppercase text-white/40">
+            <span>extends[3]</span>
+            <span className="text-white/68">low -&gt; high</span>
+          </div>
+          <div className="grid h-[calc(100%-2.25rem)] grid-rows-3">
+            {layerRows.map((row, index) => {
+              const Icon = row.icon;
 
-            return (
-              <div
-                key={row.source}
-                className="farm-migration-row flex min-h-0 min-w-0 items-center gap-2.5 border border-transparent px-3 font-mono text-[9px] tracking-normal text-white/50 sm:text-[10px]"
-                data-initial={index === 0 ? "true" : undefined}
-                style={{ animationDelay: index * 2 + "s" }}
-              >
-                <Icon aria-hidden className="size-3.5 shrink-0 text-white/64" strokeWidth={1.4} />
-                <span className="truncate">{row.source}</span>
-              </div>
-            );
-          })}
-        </div>
-      </div>
-
-      <div className="farm-migration-link absolute left-[48%] top-[42%] z-20 flex items-center gap-2 text-white/62 sm:left-[54%] sm:top-[44%]">
-        <span className="h-px w-8 bg-white/18 sm:w-12" />
-        <GitCompareArrows aria-hidden className="size-5" strokeWidth={1.35} />
-      </div>
-
-      <div className="farm-migration-target farm-illustration-surface absolute -bottom-px -right-px z-30 h-[13rem] w-[72%] max-w-[25rem] overflow-hidden border border-white/14 bg-black shadow-[-24px_-20px_56px_rgba(0,0,0,0.72)] sm:h-[13.5rem] sm:w-[70%]">
-        <div className="flex h-9 items-center justify-between border-b border-white/10 px-3 font-mono text-[8px] uppercase text-white/40">
-          <span>farm manifest</span>
-          <span className="flex items-center gap-1.5 text-white/72">
-            <CircleCheck aria-hidden className="size-3" strokeWidth={1.5} /> 0 conflicts
-          </span>
-        </div>
-
-        <div className="grid h-[calc(100%-4.25rem)] grid-rows-3">
-          {rows.map((row, index) => {
-            const Icon = row.icon;
-
-            return (
-              <div
-                key={row.target}
-                className="farm-migration-row grid min-h-0 min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2.5 border border-transparent px-3 font-mono text-[9px] tracking-normal text-white/50 sm:text-[10px]"
-                data-initial={index === 0 ? "true" : undefined}
-                style={{ animationDelay: index * 2 + "s" }}
-              >
-                <Icon aria-hidden className="size-3.5 shrink-0 text-white/66" strokeWidth={1.4} />
-                <span className="truncate">{row.target}</span>
-                <CircleCheck aria-hidden className="size-3 text-white/70" strokeWidth={1.5} />
-              </div>
-            );
-          })}
+              return (
+                <div
+                  key={row.name}
+                  className="farm-layer-row grid min-h-0 min-w-0 grid-cols-[auto_auto_minmax(0,1fr)] items-center gap-2 border border-transparent px-3 font-mono text-[9px] tracking-normal text-white/50 sm:text-[10px]"
+                  data-initial={index === 0 ? "true" : undefined}
+                  style={{ animationDelay: index * 2 + "s" }}
+                >
+                  <span className="text-[8px] text-white/28">0{index + 1}</span>
+                  <Icon aria-hidden className="size-3.5 shrink-0 text-white/64" strokeWidth={1.4} />
+                  <span className="min-w-0">
+                    <span className="block truncate text-white/72">{row.name}</span>
+                    <span className="block truncate text-[8px] text-white/34">{row.detail}</span>
+                  </span>
+                </div>
+              );
+            })}
+          </div>
         </div>
 
-        <div className="absolute bottom-0 left-0 right-0 flex h-8 items-center gap-3 border-t border-white/10 px-3">
-          <span className="h-px flex-1 overflow-hidden bg-white/10">
-            <span className="farm-migration-progress block h-full origin-left bg-white/76" />
-          </span>
-          <span className="font-mono text-[8px] uppercase tracking-normal text-white/56">
-            32 / 32 mapped
-          </span>
+        <div
+          aria-hidden
+          className="farm-layer-link absolute left-[49%] top-[42%] z-20 flex items-center gap-2 text-white/62 sm:left-[55%] sm:top-[44%]"
+        >
+          <span className="h-px w-8 bg-white/18 sm:w-12" />
+          <Network className="size-5" strokeWidth={1.35} />
         </div>
-      </div>
+
+        <div
+          aria-hidden
+          className="farm-layer-target farm-illustration-surface absolute -bottom-px -right-px z-30 h-[13rem] w-[74%] max-w-[25rem] overflow-hidden border border-white/14 bg-black shadow-[-24px_-20px_56px_rgba(0,0,0,0.72)] sm:h-[13.5rem] sm:w-[70%]"
+        >
+          <div className="flex h-9 items-center justify-between border-b border-white/10 px-3 font-mono text-[8px] uppercase text-white/40">
+            <span>resolved app</span>
+            <span className="flex items-center gap-1.5 text-white/72">
+              <CircleCheck aria-hidden className="size-3" strokeWidth={1.5} /> project wins
+            </span>
+          </div>
+
+          <div className="grid h-[calc(100%-4.25rem)] grid-rows-3">
+            {resolvedRows.map((row, index) => {
+              const Icon = row.icon;
+
+              return (
+                <div
+                  key={row.label}
+                  className="farm-layer-row grid min-h-0 min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2.5 border border-transparent px-3 font-mono text-[9px] tracking-normal text-white/50 sm:text-[10px]"
+                  data-initial={index === 0 ? "true" : undefined}
+                  style={{ animationDelay: index * 2 + "s" }}
+                >
+                  <Icon aria-hidden className="size-3.5 shrink-0 text-white/66" strokeWidth={1.4} />
+                  <span className="truncate">{row.label}</span>
+                  <span className="flex items-center gap-1 text-[8px] uppercase text-white/62">
+                    {row.state}
+                    <CircleCheck aria-hidden className="size-3" strokeWidth={1.5} />
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="absolute bottom-0 left-0 right-0 flex h-8 items-center gap-3 border-t border-white/10 px-3">
+            <span className="h-px flex-1 overflow-hidden bg-white/10">
+              <span className="farm-layer-progress block h-full origin-left bg-white/76" />
+            </span>
+            <span className="font-mono text-[8px] uppercase tracking-normal text-white/56">
+              #layers/* ready
+            </span>
+          </div>
+        </div>
+      </a>
     </FoundationCanvas>
   );
 }
@@ -1069,14 +1096,14 @@ function FoundationGrid() {
         <DocsVisual />
       </FeatureCell>
       <FeatureCell
-        body="Preview Next.js and TanStack Router migrations before Farm.js writes any files."
+        body="Compose routes, middleware, integrations, components, and config from local or package layers. Project files always win."
         className="border-t border-white/12 lg:border-l"
-        icon={GitCompareArrows}
+        icon={Layers3}
         index="02.4"
-        label="Migration"
-        title="Migrate without surprises"
+        label="Layers"
+        title="Share architecture, not boilerplate"
       >
-        <MigrationVisual />
+        <LayersVisual />
       </FeatureCell>
     </section>
   );

--- a/docs/src/components/home/install-command.tsx
+++ b/docs/src/components/home/install-command.tsx
@@ -17,6 +17,20 @@ type CommandOption = {
   icon?: LucideIcon;
 };
 
+function copyWithSelection(value: string) {
+  const textarea = document.createElement("textarea");
+  textarea.value = value;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  textarea.style.pointerEvents = "none";
+  document.body.appendChild(textarea);
+  textarea.select();
+  const didCopy = document.execCommand("copy");
+  textarea.remove();
+  return didCopy;
+}
+
 const commands: readonly CommandOption[] = [
   {
     label: "Agent",
@@ -104,6 +118,7 @@ export function InstallCommand() {
     let didCopy = false;
     let clipboardTimer: number | undefined;
     setCopyState("copying");
+    const fallbackCopySucceeded = copyWithSelection(activeCommand.command);
 
     try {
       if (!navigator.clipboard?.writeText) throw new Error("Clipboard API unavailable");
@@ -119,14 +134,7 @@ export function InstallCommand() {
       ]);
       didCopy = true;
     } catch {
-      const textarea = document.createElement("textarea");
-      textarea.value = activeCommand.command;
-      textarea.style.position = "fixed";
-      textarea.style.opacity = "0";
-      document.body.appendChild(textarea);
-      textarea.select();
-      didCopy = document.execCommand("copy");
-      textarea.remove();
+      didCopy = fallbackCopySucceeded;
     } finally {
       window.clearTimeout(clipboardTimer);
     }
@@ -208,29 +216,7 @@ export function InstallCommand() {
             <span aria-hidden className="mr-2 shrink-0 text-white/28">
               {activeCommand.kind === "agent" ? "AI" : "$"}
             </span>
-            {activeCommand.kind === "agent" ? (
-              <>
-                <span className="sr-only">{activeCommand.command}</span>
-                <span
-                  aria-hidden
-                  className="farm-agent-command-viewport min-w-0 flex-1 overflow-hidden px-3"
-                >
-                  <span className="farm-agent-command-track flex w-max items-center whitespace-nowrap">
-                    {([0, 1] as const).map((copyIndex) => (
-                      <span
-                        key={copyIndex}
-                        aria-hidden={copyIndex === 1 ? true : undefined}
-                        className="farm-agent-command-copy shrink-0 pr-8"
-                      >
-                        {activeCommand.command}
-                      </span>
-                    ))}
-                  </span>
-                </span>
-              </>
-            ) : (
-              <span className="min-w-0 truncate whitespace-nowrap">{activeCommand.command}</span>
-            )}
+            <span className="min-w-0 truncate whitespace-nowrap">{activeCommand.command}</span>
           </code>
         </div>
         <button


### PR DESCRIPTION
## Summary
- replace the migration homepage feature with a Farm Layers composition and override visual
- link the complete Layers visual directly to the Layers documentation
- expand the farm.config.ts showcase with named integrations, a local layer, route rules, server-action limits, and deployment
- preserve motion-pausing and reduced-motion behavior

## Commits
- feat: showcase Farm Layers
- feat: expand Farm config showcase

## Verification
- corepack pnpm exec oxfmt --check docs/src/app/page.tsx docs/src/app/globals.css
- corepack pnpm --dir docs exec farm build
- visually checked at desktop and 390px mobile widths
- verified no page overflow or browser console errors