### PR TITLE
feat: refine homepage code examples

### DIFF
--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -410,6 +410,15 @@
     user-select: none;
   }
 
+  .farm-highlighted-code .sh__line--highlighted {
+    background: rgb(255 255 255 / 0.055);
+    box-shadow: inset 2px 0 0 rgb(255 255 255 / 0.68);
+  }
+
+  .farm-highlighted-code .sh__line--highlighted::before {
+    color: rgb(255 255 255 / 0.48);
+  }
+
   .farm-highlighted-code .sh__token--keyword {
     font-weight: 650;
   }

--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -320,48 +320,6 @@
       inset 0 1px 0 rgb(255 255 255 / 0.025);
   }
 
-  .farm-layer-diagram::before {
-    position: absolute;
-    inset: 0;
-    background-image:
-      linear-gradient(rgb(255 255 255 / 0.025) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(255 255 255 / 0.025) 1px, transparent 1px);
-    background-size: 24px 24px;
-    opacity: 0.72;
-    -webkit-mask-image: linear-gradient(to bottom, transparent, black 18%, black 88%, transparent);
-    mask-image: linear-gradient(to bottom, transparent, black 18%, black 88%, transparent);
-    pointer-events: none;
-    content: "";
-  }
-
-  .farm-layer-project-node {
-    border-color: rgb(255 255 255 / 0.26);
-    background: rgb(255 255 255 / 0.065);
-    box-shadow: inset 2px 0 0 rgb(255 255 255 / 0.82);
-  }
-
-  .farm-layer-project-result {
-    background: rgb(255 255 255 / 0.07);
-    box-shadow: inset 2px 0 0 rgb(255 255 255 / 0.88);
-  }
-
-  .farm-layer-signal {
-    opacity: 0;
-    animation: farm-layer-signal 8s linear infinite;
-    will-change: transform, opacity;
-  }
-
-  .farm-layer-output-signal {
-    opacity: 0;
-    animation: farm-layer-output-signal 2s ease-in-out infinite;
-    will-change: transform, opacity;
-  }
-
-  .farm-layer-resolver {
-    animation: farm-layer-resolver 2s ease-in-out infinite;
-    will-change: border-color, color, box-shadow;
-  }
-
   .farm-terminal-command-text {
     width: 0;
     overflow: hidden;
@@ -693,69 +651,6 @@
   }
 }
 
-@keyframes farm-layer-signal {
-  0%,
-  4% {
-    opacity: 0;
-    transform: translate3d(0, 0, 0);
-  }
-
-  8% {
-    opacity: 1;
-  }
-
-  18% {
-    opacity: 0.95;
-    transform: translate3d(300%, 0, 0);
-  }
-
-  22%,
-  100% {
-    opacity: 0;
-    transform: translate3d(380%, 0, 0);
-  }
-}
-
-@keyframes farm-layer-output-signal {
-  0%,
-  12% {
-    opacity: 0;
-    transform: translate3d(0, 0, 0);
-  }
-
-  32% {
-    opacity: 1;
-  }
-
-  82% {
-    opacity: 0.9;
-    transform: translate3d(300%, 0, 0);
-  }
-
-  100% {
-    opacity: 0;
-    transform: translate3d(380%, 0, 0);
-  }
-}
-
-@keyframes farm-layer-resolver {
-  0%,
-  100% {
-    color: rgb(255 255 255 / 0.62);
-    border-color: rgb(255 255 255 / 0.18);
-    box-shadow: 0 0 0 4px rgb(0 0 0 / 0.88);
-  }
-
-  46%,
-  62% {
-    color: rgb(255 255 255 / 0.96);
-    border-color: rgb(255 255 255 / 0.44);
-    box-shadow:
-      0 0 0 4px rgb(0 0 0 / 0.88),
-      0 0 20px rgb(255 255 255 / 0.08);
-  }
-}
-
 .farm-logo-viewport {
   -webkit-mask-image: linear-gradient(
     to right,
@@ -784,12 +679,6 @@
 
 @media (hover: hover) and (pointer: fine) {
   .farm-logo-viewport:hover .farm-logo-rail {
-    animation-play-state: paused;
-  }
-
-  .farm-layer-diagram:hover .farm-layer-signal,
-  .farm-layer-diagram:hover .farm-layer-output-signal,
-  .farm-layer-diagram:hover .farm-layer-resolver {
     animation-play-state: paused;
   }
 }
@@ -826,10 +715,7 @@
   .farm-build-command-text,
   .farm-build-command-cursor,
   .farm-build-command-cursor::before,
-  .farm-build-output,
-  .farm-layer-signal,
-  .farm-layer-output-signal,
-  .farm-layer-resolver {
+  .farm-build-output {
     animation: none;
   }
 
@@ -849,15 +735,5 @@
   .farm-build-output {
     clip-path: inset(0);
     opacity: 1;
-  }
-
-  .farm-layer-signal,
-  .farm-layer-output-signal {
-    display: none;
-  }
-
-  .farm-layer-resolver {
-    color: rgb(255 255 255 / 0.86);
-    border-color: rgb(255 255 255 / 0.32);
   }
 }

--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -320,27 +320,46 @@
       inset 0 1px 0 rgb(255 255 255 / 0.025);
   }
 
-  .farm-layer-row {
-    animation: farm-foundation-sequence-three 6s linear infinite;
+  .farm-layer-diagram::before {
+    position: absolute;
+    inset: 0;
+    background-image:
+      linear-gradient(rgb(255 255 255 / 0.025) 1px, transparent 1px),
+      linear-gradient(90deg, rgb(255 255 255 / 0.025) 1px, transparent 1px);
+    background-size: 24px 24px;
+    opacity: 0.72;
+    -webkit-mask-image: linear-gradient(to bottom, transparent, black 18%, black 88%, transparent);
+    mask-image: linear-gradient(to bottom, transparent, black 18%, black 88%, transparent);
+    pointer-events: none;
+    content: "";
   }
 
-  .farm-layer-source,
-  .farm-layer-target {
-    animation: farm-illustration-float 7s ease-in-out infinite;
-    will-change: transform;
+  .farm-layer-project-node {
+    border-color: rgb(255 255 255 / 0.26);
+    background: rgb(255 255 255 / 0.065);
+    box-shadow: inset 2px 0 0 rgb(255 255 255 / 0.82);
   }
 
-  .farm-layer-target {
-    animation-delay: -2.2s;
+  .farm-layer-project-result {
+    background: rgb(255 255 255 / 0.07);
+    box-shadow: inset 2px 0 0 rgb(255 255 255 / 0.88);
   }
 
-  .farm-layer-link {
-    animation: farm-layer-link 3s ease-in-out infinite;
+  .farm-layer-signal {
+    opacity: 0;
+    animation: farm-layer-signal 8s linear infinite;
+    will-change: transform, opacity;
   }
 
-  .farm-layer-progress {
-    animation: farm-layer-progress 6s ease-in-out infinite;
-    will-change: transform;
+  .farm-layer-output-signal {
+    opacity: 0;
+    animation: farm-layer-output-signal 2s ease-in-out infinite;
+    will-change: transform, opacity;
+  }
+
+  .farm-layer-resolver {
+    animation: farm-layer-resolver 2s ease-in-out infinite;
+    will-change: border-color, color, box-shadow;
   }
 
   .farm-terminal-command-text {
@@ -674,57 +693,66 @@
   }
 }
 
-@keyframes farm-foundation-sequence-three {
+@keyframes farm-layer-signal {
   0%,
-  30% {
-    color: rgb(255 255 255 / 0.9);
-    background: rgb(255 255 255 / 0.075);
-    border-color: rgb(255 255 255 / 0.2);
-    box-shadow: inset 2px 0 0 rgb(255 255 255 / 0.76);
-  }
-
-  33.333%,
-  100% {
-    color: rgb(255 255 255 / 0.42);
-    background: transparent;
-    border-color: rgb(255 255 255 / 0.08);
-    box-shadow: inset 2px 0 0 transparent;
-  }
-}
-
-@keyframes farm-illustration-float {
-  0%,
-  100% {
+  4% {
+    opacity: 0;
     transform: translate3d(0, 0, 0);
   }
 
-  50% {
-    transform: translate3d(0, -3px, 0);
-  }
-}
-
-@keyframes farm-layer-link {
-  0%,
-  100% {
-    opacity: 0.38;
-    transform: translate3d(-2px, 0, 0);
-  }
-
-  50% {
-    opacity: 1;
-    transform: translate3d(2px, 0, 0);
-  }
-}
-
-@keyframes farm-layer-progress {
-  0%,
   8% {
-    transform: scaleX(0.08);
+    opacity: 1;
   }
 
-  76%,
+  18% {
+    opacity: 0.95;
+    transform: translate3d(300%, 0, 0);
+  }
+
+  22%,
   100% {
-    transform: scaleX(1);
+    opacity: 0;
+    transform: translate3d(380%, 0, 0);
+  }
+}
+
+@keyframes farm-layer-output-signal {
+  0%,
+  12% {
+    opacity: 0;
+    transform: translate3d(0, 0, 0);
+  }
+
+  32% {
+    opacity: 1;
+  }
+
+  82% {
+    opacity: 0.9;
+    transform: translate3d(300%, 0, 0);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translate3d(380%, 0, 0);
+  }
+}
+
+@keyframes farm-layer-resolver {
+  0%,
+  100% {
+    color: rgb(255 255 255 / 0.62);
+    border-color: rgb(255 255 255 / 0.18);
+    box-shadow: 0 0 0 4px rgb(0 0 0 / 0.88);
+  }
+
+  46%,
+  62% {
+    color: rgb(255 255 255 / 0.96);
+    border-color: rgb(255 255 255 / 0.44);
+    box-shadow:
+      0 0 0 4px rgb(0 0 0 / 0.88),
+      0 0 20px rgb(255 255 255 / 0.08);
   }
 }
 
@@ -759,11 +787,9 @@
     animation-play-state: paused;
   }
 
-  .group:hover .farm-layer-row,
-  .group:hover .farm-layer-source,
-  .group:hover .farm-layer-target,
-  .group:hover .farm-layer-link,
-  .group:hover .farm-layer-progress {
+  .farm-layer-diagram:hover .farm-layer-signal,
+  .farm-layer-diagram:hover .farm-layer-output-signal,
+  .farm-layer-diagram:hover .farm-layer-resolver {
     animation-play-state: paused;
   }
 }
@@ -793,7 +819,6 @@
     transform: none;
   }
 
-  .farm-layer-row,
   .farm-terminal-command-text,
   .farm-terminal-command-cursor,
   .farm-terminal-command-cursor::before,
@@ -802,10 +827,9 @@
   .farm-build-command-cursor,
   .farm-build-command-cursor::before,
   .farm-build-output,
-  .farm-layer-source,
-  .farm-layer-target,
-  .farm-layer-link,
-  .farm-layer-progress {
+  .farm-layer-signal,
+  .farm-layer-output-signal,
+  .farm-layer-resolver {
     animation: none;
   }
 
@@ -827,19 +851,13 @@
     opacity: 1;
   }
 
-  .farm-layer-row[data-initial="true"] {
-    color: rgb(255 255 255 / 0.9);
-    background: rgb(255 255 255 / 0.075);
-    border-color: rgb(255 255 255 / 0.2);
-    box-shadow: inset 2px 0 0 rgb(255 255 255 / 0.76);
-  }
-
-  .farm-layer-progress {
-    opacity: 1;
-    transform: scaleX(1);
-  }
-
-  .farm-layer-link {
+  .farm-layer-signal,
+  .farm-layer-output-signal {
     display: none;
+  }
+
+  .farm-layer-resolver {
+    color: rgb(255 255 255 / 0.86);
+    border-color: rgb(255 255 255 / 0.32);
   }
 }

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -962,104 +962,172 @@ function DocsVisual() {
 }
 
 function LayersVisual() {
-  const layerRows = [
+  const layerSources = [
     { name: "farm-base", detail: "routes + middleware", icon: Layers3 },
     { name: "admin-layer", detail: "auth + admin", icon: ShieldCheck },
-    { name: "commerce", detail: "products + checkout", icon: CreditCard },
+    { name: "commerce", detail: "catalog + checkout", icon: CreditCard },
+    { name: "project", detail: "overrides /products", icon: FolderTree, project: true },
   ] as const;
   const resolvedRows = [
-    { label: "routes + APIs", state: "composed", icon: Route },
-    { label: "middleware + config", state: "merged", icon: Settings2 },
-    { label: "generated types", state: "ready", icon: Braces },
+    { label: "/products", kind: "page", owner: "project", icon: Route, project: true },
+    { label: "/admin", kind: "layout", owner: "admin", icon: ShieldCheck },
+    { label: "/api/cart", kind: "api", owner: "commerce", icon: Braces },
   ] as const;
 
   return (
     <FoundationCanvas interactive>
       <a
         aria-label="Learn how Farm Layers compose an application"
-        className="group/layers absolute inset-0 overflow-hidden focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-white"
+        className="farm-layer-diagram group/layers absolute inset-0 overflow-hidden focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-white"
         href="/docs/layers"
+        id="layers-visual"
         title="Farm Layers documentation"
       >
         <div
           aria-hidden
-          className="farm-layer-source farm-illustration-surface absolute left-6 top-6 z-10 h-[10.5rem] w-[66%] max-w-[23rem] overflow-hidden border border-white/10 bg-black opacity-62 shadow-[0_14px_40px_rgba(0,0,0,0.45)] transition-opacity duration-150 group-hover/layers:opacity-80 sm:left-10 sm:top-8"
+          className="absolute inset-x-6 top-4 flex h-7 items-center justify-between border-y border-white/8 px-2.5 font-mono text-[7.5px] uppercase tracking-normal text-white/38 sm:inset-x-10 sm:top-5 sm:h-8 sm:px-3 sm:text-[8px]"
         >
-          <div className="flex h-9 items-center justify-between border-b border-white/10 px-3 font-mono text-[8px] uppercase text-white/40">
-            <span>extends[3]</span>
-            <span className="text-white/68">low -&gt; high</span>
-          </div>
-          <div className="grid h-[calc(100%-2.25rem)] grid-rows-3">
-            {layerRows.map((row, index) => {
-              const Icon = row.icon;
+          <span className="flex items-center gap-1.5">
+            <Network aria-hidden className="size-3 text-white/58" strokeWidth={1.4} /> composition
+            graph
+          </span>
+          <span className="flex items-center gap-1.5 text-white/58">
+            low <ArrowRight aria-hidden className="size-2.5" strokeWidth={1.4} /> project priority
+          </span>
+        </div>
+
+        <div
+          aria-hidden
+          className="absolute inset-x-6 bottom-5 top-[3.25rem] grid min-w-0 grid-cols-[minmax(0,4.25fr)_2.75rem_minmax(0,5fr)] sm:inset-x-10 sm:bottom-6 sm:top-[3.75rem] sm:grid-cols-[minmax(0,4fr)_4rem_minmax(0,5fr)]"
+        >
+          <div className="relative z-10 grid min-w-0 grid-rows-4 gap-1.5 py-1">
+            {layerSources.map((source, index) => {
+              const Icon = source.icon;
 
               return (
                 <div
-                  key={row.name}
-                  className="farm-layer-row grid min-h-0 min-w-0 grid-cols-[auto_auto_minmax(0,1fr)] items-center gap-2 border border-transparent px-3 font-mono text-[9px] tracking-normal text-white/50 sm:text-[10px]"
-                  data-initial={index === 0 ? "true" : undefined}
-                  style={{ animationDelay: index * 2 + "s" }}
+                  key={source.name}
+                  className={cx(
+                    "farm-layer-source-node relative grid min-h-0 min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-1.5 border border-white/10 bg-black/88 px-2 font-mono tracking-normal transition-[border-color,background-color] duration-150 group-hover/layers:border-white/16 sm:gap-2 sm:px-2.5",
+                    source.project && "farm-layer-project-node",
+                  )}
                 >
-                  <span className="text-[8px] text-white/28">0{index + 1}</span>
-                  <Icon aria-hidden className="size-3.5 shrink-0 text-white/64" strokeWidth={1.4} />
+                  <Icon
+                    aria-hidden
+                    className={cx(
+                      "size-3 shrink-0 text-white/46 sm:size-3.5",
+                      source.project && "text-white/86",
+                    )}
+                    strokeWidth={1.4}
+                  />
                   <span className="min-w-0">
-                    <span className="block truncate text-white/72">{row.name}</span>
-                    <span className="block truncate text-[8px] text-white/34">{row.detail}</span>
+                    <span
+                      className={cx(
+                        "block truncate text-[8.5px] text-white/66 sm:text-[9px]",
+                        source.project && "text-white/94",
+                      )}
+                    >
+                      {source.name}
+                    </span>
+                    <span className="block truncate text-[7px] text-white/32 sm:text-[7.5px]">
+                      {source.detail}
+                    </span>
                   </span>
-                </div>
-              );
-            })}
-          </div>
-        </div>
+                  <span
+                    className={cx(
+                      "text-[7px] text-white/28 sm:text-[7.5px]",
+                      source.project && "text-white/66",
+                    )}
+                  >
+                    {source.project ? "APP" : `0${index + 1}`}
+                  </span>
 
-        <div
-          aria-hidden
-          className="farm-layer-link absolute left-[49%] top-[42%] z-20 flex items-center gap-2 text-white/62 sm:left-[55%] sm:top-[44%]"
-        >
-          <span className="h-px w-8 bg-white/18 sm:w-12" />
-          <Network className="size-5" strokeWidth={1.35} />
-        </div>
-
-        <div
-          aria-hidden
-          className="farm-layer-target farm-illustration-surface absolute -bottom-px -right-px z-30 h-[13rem] w-[74%] max-w-[25rem] overflow-hidden border border-white/14 bg-black shadow-[-24px_-20px_56px_rgba(0,0,0,0.72)] sm:h-[13.5rem] sm:w-[70%]"
-        >
-          <div className="flex h-9 items-center justify-between border-b border-white/10 px-3 font-mono text-[8px] uppercase text-white/40">
-            <span>resolved app</span>
-            <span className="flex items-center gap-1.5 text-white/72">
-              <CircleCheck aria-hidden className="size-3" strokeWidth={1.5} /> project wins
-            </span>
-          </div>
-
-          <div className="grid h-[calc(100%-4.25rem)] grid-rows-3">
-            {resolvedRows.map((row, index) => {
-              const Icon = row.icon;
-
-              return (
-                <div
-                  key={row.label}
-                  className="farm-layer-row grid min-h-0 min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2.5 border border-transparent px-3 font-mono text-[9px] tracking-normal text-white/50 sm:text-[10px]"
-                  data-initial={index === 0 ? "true" : undefined}
-                  style={{ animationDelay: index * 2 + "s" }}
-                >
-                  <Icon aria-hidden className="size-3.5 shrink-0 text-white/66" strokeWidth={1.4} />
-                  <span className="truncate">{row.label}</span>
-                  <span className="flex items-center gap-1 text-[8px] uppercase text-white/62">
-                    {row.state}
-                    <CircleCheck aria-hidden className="size-3" strokeWidth={1.5} />
+                  <span className="farm-layer-wire absolute left-full top-1/2 h-px w-[1.625rem] bg-white/12 sm:w-8">
+                    <span
+                      className="farm-layer-signal absolute -top-px left-0 h-[3px] w-1.5 bg-white"
+                      style={{ animationDelay: `${index * 2}s` }}
+                    />
                   </span>
                 </div>
               );
             })}
           </div>
 
-          <div className="absolute bottom-0 left-0 right-0 flex h-8 items-center gap-3 border-t border-white/10 px-3">
-            <span className="h-px flex-1 overflow-hidden bg-white/10">
-              <span className="farm-layer-progress block h-full origin-left bg-white/76" />
+          <div className="relative min-w-0">
+            <span className="farm-layer-spine absolute bottom-[12%] left-1/2 top-[12%] w-px -translate-x-1/2 bg-white/12" />
+            <span className="absolute left-1/2 right-0 top-1/2 h-px bg-white/12">
+              <span className="farm-layer-output-signal absolute -top-px left-0 h-[3px] w-1.5 bg-white" />
             </span>
-            <span className="font-mono text-[8px] uppercase tracking-normal text-white/56">
-              #layers/* ready
+            <span className="farm-layer-resolver absolute left-1/2 top-1/2 z-10 flex size-9 -translate-x-1/2 -translate-y-1/2 items-center justify-center border border-white/18 bg-black text-white/78 shadow-[0_0_0_4px_rgba(0,0,0,0.88)] sm:size-10">
+              <Network aria-hidden className="size-4" strokeWidth={1.35} />
+              <span className="absolute -bottom-4 font-mono text-[7px] uppercase tracking-normal text-white/34 sm:text-[7.5px]">
+                resolve
+              </span>
             </span>
+          </div>
+
+          <div className="farm-illustration-surface relative z-10 flex min-w-0 flex-col overflow-hidden border border-white/14 bg-black shadow-[-18px_16px_52px_rgba(0,0,0,0.5)] transition-colors duration-150 group-hover/layers:border-white/20">
+            <div className="flex h-8 shrink-0 items-center justify-between border-b border-white/10 px-2 font-mono text-[7px] uppercase tracking-normal text-white/42 sm:h-9 sm:px-3 sm:text-[7.5px]">
+              <span>resolved app</span>
+              <span className="flex items-center gap-1 text-white/68">
+                <CircleCheck aria-hidden className="size-2.5" strokeWidth={1.5} /> project wins
+              </span>
+            </div>
+
+            <div className="grid min-h-0 flex-1 grid-rows-3">
+              {resolvedRows.map((row) => {
+                const Icon = row.icon;
+
+                return (
+                  <div
+                    key={row.label}
+                    className={cx(
+                      "grid min-h-0 min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-1.5 border-b border-white/8 px-2 font-mono tracking-normal text-white/48 last:border-b-0 sm:gap-2 sm:px-3",
+                      row.project && "farm-layer-project-result",
+                    )}
+                  >
+                    <Icon
+                      aria-hidden
+                      className={cx(
+                        "size-3 shrink-0 text-white/42 sm:size-3.5",
+                        row.project && "text-white/90",
+                      )}
+                      strokeWidth={1.4}
+                    />
+                    <span className="min-w-0">
+                      <span
+                        className={cx(
+                          "block truncate text-[8.5px] text-white/70 sm:text-[9px]",
+                          row.project && "text-white",
+                        )}
+                      >
+                        {row.label}
+                      </span>
+                      <span className="block text-[7px] uppercase text-white/30 sm:text-[7.5px]">
+                        {row.kind}
+                      </span>
+                    </span>
+                    <span
+                      className={cx(
+                        "text-[7px] uppercase text-white/36 sm:text-[7.5px]",
+                        row.project && "text-white/76",
+                      )}
+                    >
+                      {row.owner}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+
+            <div className="flex h-7 shrink-0 items-center justify-between border-t border-white/10 px-2 font-mono text-[7px] uppercase tracking-normal text-white/38 sm:h-8 sm:px-3 sm:text-[7.5px]">
+              <span className="flex items-center gap-1.5">
+                <Braces aria-hidden className="size-2.5" strokeWidth={1.4} /> generated types
+              </span>
+              <span className="flex items-center gap-1 text-white/62">
+                ready <CircleCheck aria-hidden className="size-2.5" strokeWidth={1.5} />
+              </span>
+            </div>
           </div>
         </div>
       </a>

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -286,6 +286,7 @@ export default defineConfig({
     id: "consume",
     label: "Consume / app/farm.config.ts",
     language: "ts",
+    highlightLines: [5],
     code: `import { defineFarmConfig } from "@farmjs/core";
 export default defineFarmConfig({
     extends: [

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -897,6 +897,7 @@ function FoundationCodeTabsVisual({
     <div className="farm-feature-spotlight relative flex h-[320px] min-w-0 items-end justify-end overflow-hidden pl-6 sm:h-[328px] sm:pl-10">
       <HighlightedCodeTabs
         className="relative z-10 -mb-px -mr-px flex h-[296px] w-full max-w-full shrink-0 flex-col sm:h-[300px]"
+        id="farm-layers-code"
         tabs={tabs}
         tabsLabel="Farm Layers examples"
       />

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -50,7 +50,8 @@ import viteIconUrl from "simple-icons/icons/vite.svg?url";
 import farmingLabsLogoUrl from "../assets/farming-labs-logo-dark.svg?url";
 import nitroIconUrl from "../assets/nitro.svg?url";
 import { HeroTitleFrame } from "../components/home/hero-title-frame";
-import { HighlightedCode } from "../components/home/highlighted-code";
+import { HighlightedCode, HighlightedCodeTabs } from "../components/home/highlighted-code";
+import type { HighlightedCodeTab } from "../components/home/highlighted-code";
 import { InstallCommand } from "../components/home/install-command";
 import { FileTree } from "../components/ui/file-tree";
 import type { FileTreeNode } from "../components/ui/file-tree";
@@ -269,14 +270,31 @@ export default defineConfig({
     },
 });`;
 
-const layersConfigCode = `import { defineFarmConfig } from "@farmjs/core";
+const layersConfigTabs = [
+  {
+    id: "share",
+    label: "Share / layer/farm.config.ts",
+    language: "ts",
+    code: `import type { FarmLayerConfig } from "@farmjs/core";
+export default {
+    routeRules: {
+        "/products/**": { swr: 300 },
+    },
+} satisfies FarmLayerConfig;`,
+  },
+  {
+    id: "consume",
+    label: "Consume / app/farm.config.ts",
+    language: "ts",
+    code: `import { defineFarmConfig } from "@farmjs/core";
 export default defineFarmConfig({
     extends: [
         "@company/farm-base",
-        "@company/admin-layer",
         "./layers/commerce",
     ],
-});`;
+});`,
+  },
+] as const satisfies readonly [HighlightedCodeTab, ...HighlightedCodeTab[]];
 
 function cx(...classes: Array<string | false | null | undefined>) {
   return classes.filter(Boolean).join(" ");
@@ -860,6 +878,22 @@ function FoundationCodeVisual({
   );
 }
 
+function FoundationCodeTabsVisual({
+  tabs,
+}: {
+  tabs: readonly [HighlightedCodeTab, ...HighlightedCodeTab[]];
+}) {
+  return (
+    <div className="farm-feature-spotlight relative flex h-[320px] min-w-0 items-end justify-end overflow-hidden pl-6 sm:h-[328px] sm:pl-10">
+      <HighlightedCodeTabs
+        className="relative z-10 -mb-px -mr-px flex h-[296px] w-full max-w-full shrink-0 flex-col sm:h-[300px]"
+        tabs={tabs}
+        tabsLabel="Farm Layers examples"
+      />
+    </div>
+  );
+}
+
 function FileTreeVisual() {
   const nodes: readonly FileTreeNode[] = [
     {
@@ -970,7 +1004,7 @@ function DocsVisual() {
 }
 
 function LayersVisual() {
-  return <FoundationCodeVisual code={layersConfigCode} label="farm.config.ts" language="ts" />;
+  return <FoundationCodeTabsVisual tabs={layersConfigTabs} />;
 }
 
 function FoundationGrid() {

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -275,12 +275,12 @@ const layersConfigTabs = [
     id: "share",
     label: "Share / layer/farm.config.ts",
     language: "ts",
-    code: `import type { FarmLayerConfig } from "@farmjs/core";
-export default {
+    code: `import { defineConfig } from "@farmjs/core";
+export default defineConfig({
     routeRules: {
         "/products/**": { swr: 300 },
     },
-} satisfies FarmLayerConfig;`,
+});`,
   },
   {
     id: "consume",

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -6,7 +6,6 @@ import {
   BookOpen,
   BookOpenText,
   Braces,
-  CircleCheck,
   CloudCog,
   CreditCard,
   ExternalLink,
@@ -268,6 +267,15 @@ export default defineConfig({
         search: true,
         mcp: true,
     },
+});`;
+
+const layersConfigCode = `import { defineFarmConfig } from "@farmjs/core";
+export default defineFarmConfig({
+    extends: [
+        "@company/farm-base",
+        "@company/admin-layer",
+        "./layers/commerce",
+    ],
 });`;
 
 function cx(...classes: Array<string | false | null | undefined>) {
@@ -962,177 +970,7 @@ function DocsVisual() {
 }
 
 function LayersVisual() {
-  const layerSources = [
-    { name: "farm-base", detail: "routes + middleware", icon: Layers3 },
-    { name: "admin-layer", detail: "auth + admin", icon: ShieldCheck },
-    { name: "commerce", detail: "catalog + checkout", icon: CreditCard },
-    { name: "project", detail: "overrides /products", icon: FolderTree, project: true },
-  ] as const;
-  const resolvedRows = [
-    { label: "/products", kind: "page", owner: "project", icon: Route, project: true },
-    { label: "/admin", kind: "layout", owner: "admin", icon: ShieldCheck },
-    { label: "/api/cart", kind: "api", owner: "commerce", icon: Braces },
-  ] as const;
-
-  return (
-    <FoundationCanvas interactive>
-      <a
-        aria-label="Learn how Farm Layers compose an application"
-        className="farm-layer-diagram group/layers absolute inset-0 overflow-hidden focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-white"
-        href="/docs/layers"
-        id="layers-visual"
-        title="Farm Layers documentation"
-      >
-        <div
-          aria-hidden
-          className="absolute inset-x-6 top-4 flex h-7 items-center justify-between border-y border-white/8 px-2.5 font-mono text-[7.5px] uppercase tracking-normal text-white/38 sm:inset-x-10 sm:top-5 sm:h-8 sm:px-3 sm:text-[8px]"
-        >
-          <span className="flex items-center gap-1.5">
-            <Network aria-hidden className="size-3 text-white/58" strokeWidth={1.4} /> composition
-            graph
-          </span>
-          <span className="flex items-center gap-1.5 text-white/58">
-            low <ArrowRight aria-hidden className="size-2.5" strokeWidth={1.4} /> project priority
-          </span>
-        </div>
-
-        <div
-          aria-hidden
-          className="absolute inset-x-6 bottom-5 top-[3.25rem] grid min-w-0 grid-cols-[minmax(0,4.25fr)_2.75rem_minmax(0,5fr)] sm:inset-x-10 sm:bottom-6 sm:top-[3.75rem] sm:grid-cols-[minmax(0,4fr)_4rem_minmax(0,5fr)]"
-        >
-          <div className="relative z-10 grid min-w-0 grid-rows-4 gap-1.5 py-1">
-            {layerSources.map((source, index) => {
-              const Icon = source.icon;
-
-              return (
-                <div
-                  key={source.name}
-                  className={cx(
-                    "farm-layer-source-node relative grid min-h-0 min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-1.5 border border-white/10 bg-black/88 px-2 font-mono tracking-normal transition-[border-color,background-color] duration-150 group-hover/layers:border-white/16 sm:gap-2 sm:px-2.5",
-                    source.project && "farm-layer-project-node",
-                  )}
-                >
-                  <Icon
-                    aria-hidden
-                    className={cx(
-                      "size-3 shrink-0 text-white/46 sm:size-3.5",
-                      source.project && "text-white/86",
-                    )}
-                    strokeWidth={1.4}
-                  />
-                  <span className="min-w-0">
-                    <span
-                      className={cx(
-                        "block truncate text-[8.5px] text-white/66 sm:text-[9px]",
-                        source.project && "text-white/94",
-                      )}
-                    >
-                      {source.name}
-                    </span>
-                    <span className="block truncate text-[7px] text-white/32 sm:text-[7.5px]">
-                      {source.detail}
-                    </span>
-                  </span>
-                  <span
-                    className={cx(
-                      "text-[7px] text-white/28 sm:text-[7.5px]",
-                      source.project && "text-white/66",
-                    )}
-                  >
-                    {source.project ? "APP" : `0${index + 1}`}
-                  </span>
-
-                  <span className="farm-layer-wire absolute left-full top-1/2 h-px w-[1.625rem] bg-white/12 sm:w-8">
-                    <span
-                      className="farm-layer-signal absolute -top-px left-0 h-[3px] w-1.5 bg-white"
-                      style={{ animationDelay: `${index * 2}s` }}
-                    />
-                  </span>
-                </div>
-              );
-            })}
-          </div>
-
-          <div className="relative min-w-0">
-            <span className="farm-layer-spine absolute bottom-[12%] left-1/2 top-[12%] w-px -translate-x-1/2 bg-white/12" />
-            <span className="absolute left-1/2 right-0 top-1/2 h-px bg-white/12">
-              <span className="farm-layer-output-signal absolute -top-px left-0 h-[3px] w-1.5 bg-white" />
-            </span>
-            <span className="farm-layer-resolver absolute left-1/2 top-1/2 z-10 flex size-9 -translate-x-1/2 -translate-y-1/2 items-center justify-center border border-white/18 bg-black text-white/78 shadow-[0_0_0_4px_rgba(0,0,0,0.88)] sm:size-10">
-              <Network aria-hidden className="size-4" strokeWidth={1.35} />
-              <span className="absolute -bottom-4 font-mono text-[7px] uppercase tracking-normal text-white/34 sm:text-[7.5px]">
-                resolve
-              </span>
-            </span>
-          </div>
-
-          <div className="farm-illustration-surface relative z-10 flex min-w-0 flex-col overflow-hidden border border-white/14 bg-black shadow-[-18px_16px_52px_rgba(0,0,0,0.5)] transition-colors duration-150 group-hover/layers:border-white/20">
-            <div className="flex h-8 shrink-0 items-center justify-between border-b border-white/10 px-2 font-mono text-[7px] uppercase tracking-normal text-white/42 sm:h-9 sm:px-3 sm:text-[7.5px]">
-              <span>resolved app</span>
-              <span className="flex items-center gap-1 text-white/68">
-                <CircleCheck aria-hidden className="size-2.5" strokeWidth={1.5} /> project wins
-              </span>
-            </div>
-
-            <div className="grid min-h-0 flex-1 grid-rows-3">
-              {resolvedRows.map((row) => {
-                const Icon = row.icon;
-
-                return (
-                  <div
-                    key={row.label}
-                    className={cx(
-                      "grid min-h-0 min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-1.5 border-b border-white/8 px-2 font-mono tracking-normal text-white/48 last:border-b-0 sm:gap-2 sm:px-3",
-                      row.project && "farm-layer-project-result",
-                    )}
-                  >
-                    <Icon
-                      aria-hidden
-                      className={cx(
-                        "size-3 shrink-0 text-white/42 sm:size-3.5",
-                        row.project && "text-white/90",
-                      )}
-                      strokeWidth={1.4}
-                    />
-                    <span className="min-w-0">
-                      <span
-                        className={cx(
-                          "block truncate text-[8.5px] text-white/70 sm:text-[9px]",
-                          row.project && "text-white",
-                        )}
-                      >
-                        {row.label}
-                      </span>
-                      <span className="block text-[7px] uppercase text-white/30 sm:text-[7.5px]">
-                        {row.kind}
-                      </span>
-                    </span>
-                    <span
-                      className={cx(
-                        "text-[7px] uppercase text-white/36 sm:text-[7.5px]",
-                        row.project && "text-white/76",
-                      )}
-                    >
-                      {row.owner}
-                    </span>
-                  </div>
-                );
-              })}
-            </div>
-
-            <div className="flex h-7 shrink-0 items-center justify-between border-t border-white/10 px-2 font-mono text-[7px] uppercase tracking-normal text-white/38 sm:h-8 sm:px-3 sm:text-[7.5px]">
-              <span className="flex items-center gap-1.5">
-                <Braces aria-hidden className="size-2.5" strokeWidth={1.4} /> generated types
-              </span>
-              <span className="flex items-center gap-1 text-white/62">
-                ready <CircleCheck aria-hidden className="size-2.5" strokeWidth={1.5} />
-              </span>
-            </div>
-          </div>
-        </div>
-      </a>
-    </FoundationCanvas>
-  );
+  return <FoundationCodeVisual code={layersConfigCode} label="farm.config.ts" language="ts" />;
 }
 
 function FoundationGrid() {

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -270,6 +270,10 @@ export default defineConfig({
     },
 });`;
 
+const typedApiHighlightLines = [1, 7, 8] as const;
+const integrationHighlightLines = [5] as const;
+const docsHighlightLines = [3, 4] as const;
+
 const layersConfigTabs = [
   {
     id: "share",
@@ -687,6 +691,7 @@ function TypedApiVisual() {
       <HighlightedCode
         className="relative z-10 -mb-px -mr-px flex h-[290px] w-full max-w-full shrink-0 flex-col"
         code={typedApiCode}
+        highlightLines={typedApiHighlightLines}
         label="/api/users"
         language="tsx"
         prefix="GET"
@@ -701,6 +706,7 @@ function IntegrationVisual() {
       <HighlightedCode
         className="relative z-10 -mb-px -mr-px flex h-[290px] w-full max-w-full shrink-0 flex-col"
         code={integrationConfigCode}
+        highlightLines={integrationHighlightLines}
         label="farm.config.ts"
         language="ts"
       />
@@ -860,10 +866,12 @@ function FoundationCanvas({
 
 function FoundationCodeVisual({
   code,
+  highlightLines,
   label,
   language,
 }: {
   code: string;
+  highlightLines?: readonly number[];
   label: string;
   language: string;
 }) {
@@ -872,6 +880,7 @@ function FoundationCodeVisual({
       <HighlightedCode
         className="relative z-10 -mb-px -mr-px flex h-[296px] w-full max-w-full shrink-0 flex-col sm:h-[300px]"
         code={code}
+        highlightLines={highlightLines}
         label={label}
         language={language}
       />
@@ -1001,7 +1010,14 @@ function DeploymentVisual() {
 }
 
 function DocsVisual() {
-  return <FoundationCodeVisual code={docsConfigCode} label="farm.config.ts" language="ts" />;
+  return (
+    <FoundationCodeVisual
+      code={docsConfigCode}
+      highlightLines={docsHighlightLines}
+      label="farm.config.ts"
+      language="ts"
+    />
+  );
 }
 
 function LayersVisual() {
@@ -1080,13 +1096,6 @@ function IntegrationsSection() {
                 icon={<BookOpenText aria-hidden className="size-4" strokeWidth={1.5} />}
               >
                 Explore Integrations
-              </ButtonLink>
-              <ButtonLink
-                href="/docs/integrations/custom"
-                icon={<Plug aria-hidden className="size-4" strokeWidth={1.5} />}
-                variant="secondary"
-              >
-                Custom Integration
               </ButtonLink>
             </div>
           </div>

--- a/docs/src/components/home/highlighted-code.tsx
+++ b/docs/src/components/home/highlighted-code.tsx
@@ -1,4 +1,8 @@
+"use client";
+
 import { Code2 } from "lucide-react";
+import type { KeyboardEvent } from "react";
+import { useId, useRef, useState } from "react";
 import { highlight } from "sugar-high";
 
 interface HighlightedCodeProps {
@@ -9,6 +13,63 @@ interface HighlightedCodeProps {
   prefix?: string;
 }
 
+export interface HighlightedCodeTab {
+  code: string;
+  id: string;
+  label: string;
+  language: string;
+}
+
+interface HighlightedCodeTabsProps {
+  className?: string;
+  tabs: readonly [HighlightedCodeTab, ...HighlightedCodeTab[]];
+  tabsLabel?: string;
+}
+
+function figureClassName(className?: string) {
+  return [
+    "min-w-0 max-w-full overflow-hidden border border-white/10 bg-black shadow-[0_18px_50px_rgba(0,0,0,0.18)]",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+function HighlightedCodeBody({
+  ariaLabel,
+  ariaLabelledBy,
+  code,
+  id,
+  role,
+}: {
+  ariaLabel?: string;
+  ariaLabelledBy?: string;
+  code: string;
+  id?: string;
+  role?: "tabpanel";
+}) {
+  const highlightedCode = highlight(code.trim()).replace(
+    /<\/span>\n<span class="sh__line"/g,
+    '</span><span class="sh__line"',
+  );
+
+  return (
+    <pre
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      className="min-h-0 max-w-full flex-1 overflow-x-auto py-4 font-mono text-[10.5px] leading-6 tracking-normal sm:text-[11px]"
+      id={id}
+      role={role}
+      tabIndex={0}
+    >
+      <code
+        className="farm-highlighted-code block min-w-full"
+        dangerouslySetInnerHTML={{ __html: highlightedCode }}
+      />
+    </pre>
+  );
+}
+
 export function HighlightedCode({
   className,
   code,
@@ -16,20 +77,8 @@ export function HighlightedCode({
   language,
   prefix,
 }: HighlightedCodeProps) {
-  const highlightedCode = highlight(code.trim()).replace(
-    /<\/span>\n<span class="sh__line"/g,
-    '</span><span class="sh__line"',
-  );
-
   return (
-    <figure
-      className={[
-        "min-w-0 max-w-full overflow-hidden border border-white/10 bg-black shadow-[0_18px_50px_rgba(0,0,0,0.18)]",
-        className,
-      ]
-        .filter(Boolean)
-        .join(" ")}
-    >
+    <figure className={figureClassName(className)}>
       <figcaption className="flex h-10 min-w-0 items-center justify-between gap-4 border-b border-white/8 px-4 font-mono text-[9px] tracking-normal text-white/38">
         <span className="flex min-w-0 items-center gap-2">
           <Code2 aria-hidden className="size-3 shrink-0" strokeWidth={1.5} />
@@ -38,16 +87,85 @@ export function HighlightedCode({
         </span>
         <span className="shrink-0 uppercase text-white/24">{language}</span>
       </figcaption>
-      <pre
-        aria-label={`${prefix ? `${prefix} ` : ""}${label} code`}
-        className="min-h-0 max-w-full flex-1 overflow-x-auto py-4 font-mono text-[10.5px] leading-6 tracking-normal sm:text-[11px]"
-        tabIndex={0}
-      >
-        <code
-          className="farm-highlighted-code block min-w-full"
-          dangerouslySetInnerHTML={{ __html: highlightedCode }}
-        />
-      </pre>
+      <HighlightedCodeBody ariaLabel={`${prefix ? `${prefix} ` : ""}${label} code`} code={code} />
+    </figure>
+  );
+}
+
+export function HighlightedCodeTabs({
+  className,
+  tabs,
+  tabsLabel = "Code examples",
+}: HighlightedCodeTabsProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const groupId = useId();
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const activeTab = tabs[activeIndex] ?? tabs[0];
+  const panelId = `${groupId}-panel`;
+
+  function selectTab(index: number) {
+    setActiveIndex(index);
+  }
+
+  function handleTabKeyDown(event: KeyboardEvent<HTMLButtonElement>, index: number) {
+    let nextIndex: number | undefined;
+
+    if (event.key === "ArrowRight") nextIndex = (index + 1) % tabs.length;
+    if (event.key === "ArrowLeft") nextIndex = (index - 1 + tabs.length) % tabs.length;
+    if (event.key === "Home") nextIndex = 0;
+    if (event.key === "End") nextIndex = tabs.length - 1;
+    if (nextIndex === undefined) return;
+
+    event.preventDefault();
+    selectTab(nextIndex);
+    tabRefs.current[nextIndex]?.focus();
+  }
+
+  return (
+    <figure className={figureClassName(className)}>
+      <figcaption className="flex h-10 min-w-0 items-stretch border-b border-white/8 font-mono text-[8px] tracking-normal text-white/38 sm:text-[9px]">
+        <span
+          aria-hidden
+          className="grid w-9 shrink-0 place-items-center border-r border-white/8 text-white/34"
+        >
+          <Code2 className="size-3" strokeWidth={1.5} />
+        </span>
+        <span aria-label={tabsLabel} className="flex min-w-0 flex-1 items-stretch" role="tablist">
+          {tabs.map((tab, index) => {
+            const tabId = `${groupId}-${tab.id}-tab`;
+
+            return (
+              <button
+                key={tab.id}
+                aria-controls={panelId}
+                aria-selected={activeIndex === index}
+                className="relative flex h-full min-w-0 flex-1 items-center justify-center border-r border-white/8 px-2 text-white/34 transition-[background-color,color,box-shadow] duration-150 hover:bg-white/[0.035] hover:text-white/68 focus-visible:z-10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-white aria-selected:bg-white/[0.045] aria-selected:text-white/82 aria-selected:shadow-[inset_0_-1px_0_rgba(255,255,255,0.85)]"
+                id={tabId}
+                onClick={() => selectTab(index)}
+                onKeyDown={(event) => handleTabKeyDown(event, index)}
+                ref={(node) => {
+                  tabRefs.current[index] = node;
+                }}
+                role="tab"
+                tabIndex={activeIndex === index ? 0 : -1}
+                title={tab.label}
+                type="button"
+              >
+                <span className="truncate">{tab.label}</span>
+              </button>
+            );
+          })}
+        </span>
+        <span className="flex shrink-0 items-center px-3 uppercase text-white/24">
+          {activeTab.language}
+        </span>
+      </figcaption>
+      <HighlightedCodeBody
+        ariaLabelledBy={`${groupId}-${activeTab.id}-tab`}
+        code={activeTab.code}
+        id={panelId}
+        role="tabpanel"
+      />
     </figure>
   );
 }

--- a/docs/src/components/home/highlighted-code.tsx
+++ b/docs/src/components/home/highlighted-code.tsx
@@ -2,7 +2,7 @@
 
 import { Code2 } from "lucide-react";
 import type { KeyboardEvent } from "react";
-import { useId, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { highlight } from "sugar-high";
 
 interface HighlightedCodeProps {
@@ -24,6 +24,7 @@ export interface HighlightedCodeTab {
 
 interface HighlightedCodeTabsProps {
   className?: string;
+  id: string;
   tabs: readonly [HighlightedCodeTab, ...HighlightedCodeTab[]];
   tabsLabel?: string;
 }
@@ -108,14 +109,14 @@ export function HighlightedCode({
 
 export function HighlightedCodeTabs({
   className,
+  id,
   tabs,
   tabsLabel = "Code examples",
 }: HighlightedCodeTabsProps) {
   const [activeIndex, setActiveIndex] = useState(0);
-  const groupId = useId();
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const activeTab = tabs[activeIndex] ?? tabs[0];
-  const panelId = `${groupId}-panel`;
+  const panelId = `${id}-panel`;
 
   function selectTab(index: number) {
     setActiveIndex(index);
@@ -146,7 +147,7 @@ export function HighlightedCodeTabs({
         </span>
         <span aria-label={tabsLabel} className="flex min-w-0 flex-1 items-stretch" role="tablist">
           {tabs.map((tab, index) => {
-            const tabId = `${groupId}-${tab.id}-tab`;
+            const tabId = `${id}-${tab.id}-tab`;
 
             return (
               <button
@@ -175,7 +176,7 @@ export function HighlightedCodeTabs({
         </span>
       </figcaption>
       <HighlightedCodeBody
-        ariaLabelledBy={`${groupId}-${activeTab.id}-tab`}
+        ariaLabelledBy={`${id}-${activeTab.id}-tab`}
         code={activeTab.code}
         highlightLines={activeTab.highlightLines}
         id={panelId}

--- a/docs/src/components/home/highlighted-code.tsx
+++ b/docs/src/components/home/highlighted-code.tsx
@@ -8,6 +8,7 @@ import { highlight } from "sugar-high";
 interface HighlightedCodeProps {
   className?: string;
   code: string;
+  highlightLines?: readonly number[];
   label: string;
   language: string;
   prefix?: string;
@@ -15,6 +16,7 @@ interface HighlightedCodeProps {
 
 export interface HighlightedCodeTab {
   code: string;
+  highlightLines?: readonly number[];
   id: string;
   label: string;
   language: string;
@@ -39,19 +41,26 @@ function HighlightedCodeBody({
   ariaLabel,
   ariaLabelledBy,
   code,
+  highlightLines = [],
   id,
   role,
 }: {
   ariaLabel?: string;
   ariaLabelledBy?: string;
   code: string;
+  highlightLines?: readonly number[];
   id?: string;
   role?: "tabpanel";
 }) {
-  const highlightedCode = highlight(code.trim()).replace(
-    /<\/span>\n<span class="sh__line"/g,
-    '</span><span class="sh__line"',
-  );
+  const highlightedLineNumbers = new Set(highlightLines);
+  const highlightedCode = highlight(code.trim())
+    .split("\n")
+    .map((line, index) =>
+      highlightedLineNumbers.has(index + 1)
+        ? line.replace('class="sh__line"', 'class="sh__line sh__line--highlighted"')
+        : line,
+    )
+    .join("");
 
   return (
     <pre
@@ -73,6 +82,7 @@ function HighlightedCodeBody({
 export function HighlightedCode({
   className,
   code,
+  highlightLines,
   label,
   language,
   prefix,
@@ -87,7 +97,11 @@ export function HighlightedCode({
         </span>
         <span className="shrink-0 uppercase text-white/24">{language}</span>
       </figcaption>
-      <HighlightedCodeBody ariaLabel={`${prefix ? `${prefix} ` : ""}${label} code`} code={code} />
+      <HighlightedCodeBody
+        ariaLabel={`${prefix ? `${prefix} ` : ""}${label} code`}
+        code={code}
+        highlightLines={highlightLines}
+      />
     </figure>
   );
 }
@@ -163,6 +177,7 @@ export function HighlightedCodeTabs({
       <HighlightedCodeBody
         ariaLabelledBy={`${groupId}-${activeTab.id}-tab`}
         code={activeTab.code}
+        highlightLines={activeTab.highlightLines}
         id={panelId}
         role="tabpanel"
       />


### PR DESCRIPTION
## Summary

- replace the Farm Layers illustration with accessible Share and Consume code tabs
- highlight the consumed layer and the key lines in typed API, integration, and docs examples
- remove the secondary Custom Integration CTA while keeping the primary integrations path
- use stable tab and panel IDs so the accessible controls hydrate consistently
- keep code blocks responsive, keyboard accessible, and consistent with the homepage visual system

## Verification

- `corepack pnpm exec oxfmt --check docs/src/app/page.tsx docs/src/components/home/highlighted-code.tsx docs/src/app/globals.css`
- `corepack pnpm --dir docs exec farm build`
- verified at 419x814 and 1280x900 with no horizontal overflow
- verified exact highlighted-line content, CTA presence, and cold-start hydration with no browser console errors