### PR TITLE
feat: add request-bound ctx.req

### DIFF
--- a/docs/farm.config.ts
+++ b/docs/farm.config.ts
@@ -115,10 +115,10 @@ function createDocsContextDemoPlugin(
       const userFromHeader = Array.isArray(headerUser) ? headerUser[0] : headerUser;
       const requestId = randomUUID();
       const user = userFromHeader || defaultUser;
-      context.requestContext.set(req, "demo.requestId", requestId, { exposeToPage: true });
-      context.requestContext.set(req, "demo.path", pathname, { exposeToPage: true });
-      context.requestContext.set(req, "demo.user", user, { exposeToPage: true });
-      context.requestContext.set(req, "internal.startTs", Date.now());
+      context.req.set("demo.requestId", requestId, { exposeToPage: true });
+      context.req.set("demo.path", pathname, { exposeToPage: true });
+      context.req.set("demo.user", user, { exposeToPage: true });
+      context.req.set("internal.startTs", Date.now());
       options.onBeforeRequest?.({ pathname, user, requestId });
 
       if (log) {
@@ -129,8 +129,8 @@ function createDocsContextDemoPlugin(
     },
     afterResponse(req, res, context) {
       const pathname = req.url ? req.url.split("?")[0] : "/";
-      const user = context.requestContext.get<string>(req, "demo.user") || defaultUser;
-      const requestId = context.requestContext.get<string>(req, "demo.requestId") || "unknown";
+      const user = context.req.get<string>("demo.user") || defaultUser;
+      const requestId = context.req.get<string>("demo.requestId") || "unknown";
       const statusCode = res.statusCode || 200;
       options.onAfterResponse?.({ pathname, user, requestId, statusCode });
       if (log) {

--- a/docs/src/app/docs/integrations/autumn/page.md
+++ b/docs/src/app/docs/integrations/autumn/page.md
@@ -101,13 +101,13 @@ autumn({
   secretKey: process.env.AUTUMN_SECRET_KEY,
   billing: {
     async resolveOwner(ctx) {
-      const organizationId = ctx.requestContext.get<string>("organization.id");
+      const organizationId = ctx.req.get<string>("organization.id");
 
       return organizationId
         ? {
             id: organizationId,
             kind: "organization",
-            email: ctx.requestContext.get<string>("user.email") ?? null,
+            email: ctx.req.get<string>("user.email") ?? null,
           }
         : null;
     },

--- a/docs/src/app/docs/integrations/custom/page.md
+++ b/docs/src/app/docs/integrations/custom/page.md
@@ -578,7 +578,7 @@ integrationRoute.get("/api/acme/admin", {
   middleware: [
     {
       handler(_request, ctx) {
-        ctx.requestContext.set("startedAt", Date.now());
+        ctx.req.set("startedAt", Date.now());
       },
     },
   ],
@@ -624,7 +624,7 @@ export const authGate = defineIntegration({
     {
       matcher: "/dashboard/[section]",
       handler(_request, ctx) {
-        if (!ctx.requestContext.get("user.id")) {
+        if (!ctx.req.get("user.id")) {
           return new Response("Unauthorized", {
             status: 401,
           });
@@ -657,11 +657,12 @@ Route handlers, route middleware, and route hooks receive `ctx` with these field
 | `data` | Small sanitized metadata from `createIntegrations({ data })` and per-call data. |
 | `integration` | Category, type, slot alias, and original `instance`. |
 | `route` | Route kind, path, and methods. |
-| `requestContext` | Request-scoped key/value store shared with plugins and hooks. |
+| `req` | Request-scoped key/value store shared with plugins and hooks. |
 | `config` | Resolved Farm config. |
 | `isDev` / `isProd` | Runtime mode flags. |
 
-`ctx.requestContext.set(key, value, { exposeToPage: true })` can expose values to page props. Avoid exposing secrets.
+`ctx.req.set(key, value, { exposeToPage: true })` can expose values to page props. Avoid exposing secrets.
+`ctx.requestContext` remains as a deprecated compatibility alias for existing integrations.
 
 ## Storage schema
 

--- a/docs/src/app/docs/integrations/stripe/page.md
+++ b/docs/src/app/docs/integrations/stripe/page.md
@@ -114,7 +114,7 @@ stripe({
   webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
   billing: {
     async resolveOwner(ctx) {
-      const userId = ctx.requestContext.get<string>("user.id");
+      const userId = ctx.req.get<string>("user.id");
 
       if (!userId) {
         return null;
@@ -123,7 +123,7 @@ stripe({
       return {
         id: userId,
         kind: "user",
-        email: ctx.requestContext.get<string>("user.email") ?? null,
+        email: ctx.req.get<string>("user.email") ?? null,
       };
     },
   },

--- a/docs/src/app/docs/plugins/create-plugin/page.md
+++ b/docs/src/app/docs/plugins/create-plugin/page.md
@@ -22,7 +22,7 @@ export const requestIdPlugin = definePlugin({
     const header = req.headers["x-request-id"];
     const requestId = Array.isArray(header) ? header[0] : header || randomUUID();
 
-    ctx.requestContext.set(req, "request.id", requestId, {
+    ctx.req.set("request.id", requestId, {
       exposeToPage: true,
     });
   },
@@ -109,7 +109,9 @@ Keep config transforms predictable. If two plugins edit the same field, ordering
 ```ts
 export const apiTracePlugin = definePlugin({
   name: "api-trace",
-  beforeApiHandler(request, api) {
+  beforeApiHandler(request, api, ctx) {
+    ctx.req.set("api.traceId", crypto.randomUUID());
+
     const headers = new Headers(request.headers);
     headers.set("x-farm-route", api.routePath || api.pathname);
 
@@ -128,6 +130,8 @@ export const apiTracePlugin = definePlugin({
   },
 });
 ```
+
+`ctx.req` stays attached when a plugin returns a transformed `Request`, so later plugins and the API handler can read the same request data.
 
 ## Transform HTML
 
@@ -216,12 +220,12 @@ Only explicitly exposed request context values appear on page props.
 ```ts
 export const tracePlugin = definePlugin({
   name: "trace",
-  beforeRequest(req, _res, ctx) {
-    ctx.requestContext.set(req, "traceId", "trace_123", {
+  beforeRequest(_req, _res, ctx) {
+    ctx.req.set("traceId", "trace_123", {
       exposeToPage: true,
     });
 
-    ctx.requestContext.set(req, "secret", "do-not-expose");
+    ctx.req.set("secret", "do-not-expose");
   },
 });
 ```

--- a/docs/src/app/docs/plugins/page.md
+++ b/docs/src/app/docs/plugins/page.md
@@ -93,7 +93,7 @@ export default defineFarmConfig({
 
 Farm orders plugins as `pre`, normal, then `post`. Use `pre` when another plugin must see your request context or config changes. Use `post` when you want to observe final output.
 
-## Request context
+## Request data
 
 Plugins can share request-scoped values with other plugins, integrations, and pages.
 
@@ -103,17 +103,19 @@ import { randomUUID } from "node:crypto";
 
 export const tracePlugin = definePlugin({
   name: "trace",
-  beforeRequest(req, _res, ctx) {
-    ctx.requestContext.set(req, "traceId", randomUUID(), {
+  beforeRequest(_req, _res, ctx) {
+    ctx.req.set("traceId", randomUUID(), {
       exposeToPage: true,
     });
 
-    ctx.requestContext.set(req, "internalToken", "secret");
+    ctx.req.set("internalToken", "secret");
   },
 });
 ```
 
 Only values marked with `exposeToPage: true` are available to page props through `props.context?.data`.
+The store is already bound to the current request, so `ctx.req` never needs the raw request passed again.
+Existing plugins can keep using `ctx.requestContext` during migration, but it is deprecated.
 
 ## Plugin or integration
 

--- a/examples/basic/src/lib/integration-lab.ts
+++ b/examples/basic/src/lib/integration-lab.ts
@@ -28,12 +28,12 @@ export interface IntegrationLabResult {
 const TRACE_KEY = 'integration-lab:trace';
 
 function appendTrace(context: FarmIntegrationHandlerContext, step: string) {
-  const trace = context.requestContext.get<string[]>(TRACE_KEY) || [];
-  context.requestContext.set(TRACE_KEY, [...trace, step]);
+  const trace = context.req.get<string[]>(TRACE_KEY) || [];
+  context.req.set(TRACE_KEY, [...trace, step]);
 }
 
 function readTrace(context: FarmIntegrationHandlerContext) {
-  return context.requestContext.get<string[]>(TRACE_KEY) || [];
+  return context.req.get<string[]>(TRACE_KEY) || [];
 }
 
 function readCaller(context: FarmIntegrationHandlerContext) {

--- a/examples/supabase-integration/src/lib/integrations/local-demo/index.ts
+++ b/examples/supabase-integration/src/lib/integrations/local-demo/index.ts
@@ -74,9 +74,9 @@ function createStatusResponse(
     pathname: context.pathname,
     requestId: context.requestId,
     bootedAt: instance.bootedAt,
-    lastAction: context.requestContext.get("local-demo:last-action"),
+    lastAction: context.req.get("local-demo:last-action"),
     middlewareOrder:
-      context.requestContext.get<string[]>("local-demo:middleware-order") || [],
+      context.req.get<string[]>("local-demo:middleware-order") || [],
     timestamp: new Date().toISOString(),
   });
 }
@@ -86,8 +86,8 @@ function appendMiddlewareStep(
   step: string,
 ) {
   const current =
-    context.requestContext.get<string[]>("local-demo:middleware-order") || [];
-  context.requestContext.set("local-demo:middleware-order", [...current, step]);
+    context.req.get<string[]>("local-demo:middleware-order") || [];
+  context.req.set("local-demo:middleware-order", [...current, step]);
 }
 
 export const localDemoRoutes = [
@@ -99,13 +99,13 @@ export const localDemoRoutes = [
     middleware: [
       {
         handler(_request, context) {
-          context.requestContext.set("local-demo:last-action", "status");
+          context.req.set("local-demo:last-action", "status");
           appendMiddlewareStep(context, "status:first");
         },
       },
       {
         handler(_request, context) {
-          const lists = context.requestContext.get<string[]>("local-demo:middleware-order") || [];
+          const lists = context.req.get<string[]>("local-demo:middleware-order") || [];
           appendMiddlewareStep(context, "status:second");
         },
       },
@@ -128,7 +128,7 @@ export const localDemoRoutes = [
     middleware: [
       {
         handler(_request, context) {
-          context.requestContext.set("local-demo:last-action", "echo");
+          context.req.set("local-demo:last-action", "echo");
           appendMiddlewareStep(context, "echo:first");
         },
       },
@@ -153,7 +153,7 @@ export const localDemoRoutes = [
         );
       }
 
-      context.requestContext.set("local-demo:last-message", message);
+      context.req.set("local-demo:last-message", message);
       return Response.json({
         ok: true,
         message,
@@ -161,9 +161,9 @@ export const localDemoRoutes = [
         length: message.length,
         pathname: context.pathname,
         requestId: context.requestId,
-        lastAction: context.requestContext.get("local-demo:last-action"),
+        lastAction: context.req.get("local-demo:last-action"),
         middlewareOrder:
-          context.requestContext.get<string[]>("local-demo:middleware-order") || [],
+          context.req.get<string[]>("local-demo:middleware-order") || [],
         timestamp: new Date().toISOString(),
       });
     },

--- a/packages/farm-integrations/src/email/index.ts
+++ b/packages/farm-integrations/src/email/index.ts
@@ -307,8 +307,8 @@ export function resend<const TTemplates extends EmailTemplates>(
           }
 
           const [templateId, configuredTemplate] = resolved;
-          context.requestContext.set("email.templateId", templateId);
-          context.requestContext.set("email.data", body.data);
+          context.req.set("email.templateId", templateId);
+          context.req.set("email.data", body.data);
 
           const subject = await resolveTemplateString(configuredTemplate.subject, body.data);
           const previewText = await resolveTemplateString(
@@ -428,9 +428,9 @@ export function resend<const TTemplates extends EmailTemplates>(
           }
 
           const [templateId, configuredTemplate] = resolved;
-          context.requestContext.set("email.templateId", templateId);
-          context.requestContext.set("email.data", body.data);
-          context.requestContext.set("email.when", when);
+          context.req.set("email.templateId", templateId);
+          context.req.set("email.data", body.data);
+          context.req.set("email.when", when);
 
           const subject = await resolveTemplateString(configuredTemplate.subject, body.data);
           const previewText = await resolveTemplateString(
@@ -536,8 +536,8 @@ export function resend<const TTemplates extends EmailTemplates>(
           }
 
           const [templateId, configuredTemplate] = resolved;
-          context.requestContext.set("email.templateId", templateId);
-          context.requestContext.set("email.data", body.data);
+          context.req.set("email.templateId", templateId);
+          context.req.set("email.data", body.data);
 
           const subject = await resolveTemplateString(configuredTemplate.subject, body.data);
           const previewText = await resolveTemplateString(

--- a/packages/farm-integrations/src/farm-core-shim.d.ts
+++ b/packages/farm-integrations/src/farm-core-shim.d.ts
@@ -80,7 +80,7 @@ declare module "@farmjs/core" {
     query?: FarmIntegrationInputSchema<TQuery>;
   }
 
-  export interface FarmIntegrationRequestContextStore {
+  export interface FarmRequestStore {
     get<T = unknown>(key: string): T | undefined;
     set(key: string, value: unknown, options?: { exposeToPage?: boolean }): void;
     has(key: string): boolean;
@@ -88,6 +88,9 @@ declare module "@farmjs/core" {
     clear(): void;
     snapshot(options?: { exposedOnly?: boolean }): Map<string, unknown>;
   }
+
+  /** @deprecated Use FarmRequestStore. */
+  export type FarmIntegrationRequestContextStore = FarmRequestStore;
 
   export const FARM_INTEGRATION_INTERNAL_DISPATCH_CONTEXT_KEY: "farm.integration.internalDispatch";
 
@@ -202,7 +205,9 @@ declare module "@farmjs/core" {
       path: string;
       methods: readonly string[];
     };
-    requestContext: FarmIntegrationRequestContextStore;
+    req: FarmRequestStore;
+    /** @deprecated Use req instead. */
+    requestContext: FarmRequestStore;
     config: Record<string, unknown>;
     isDev: boolean;
     isProd: boolean;

--- a/packages/farm-integrations/src/supabase/index.ts
+++ b/packages/farm-integrations/src/supabase/index.ts
@@ -735,7 +735,7 @@ function renderCheckEmailPage(
 }
 
 function createSupabaseHandler(
-  context: Pick<FarmIntegrationHandlerContext, "request" | "requestContext">,
+  context: Pick<FarmIntegrationHandlerContext, "request" | "req">,
   env: ResolvedSupabaseEnv,
 ) {
   const setCookies: string[] = [];
@@ -753,7 +753,7 @@ function createSupabaseHandler(
         for (const cookie of cookiesToSet) {
           setCookies.push(serializeCookie(cookie.name, cookie.value, cookie.options));
         }
-        context.requestContext.set("supabase:set-cookies", [...setCookies]);
+        context.req.set("supabase:set-cookies", [...setCookies]);
       },
     },
   });

--- a/packages/farm-integrations/src/unkey/index.ts
+++ b/packages/farm-integrations/src/unkey/index.ts
@@ -560,7 +560,7 @@ async function readJsonBody<T>(request: Request): Promise<T> {
 }
 
 function ensureInternalServerCall(context: FarmIntegrationHandlerContext): Response | undefined {
-  if (context.requestContext.get(FARM_INTEGRATION_INTERNAL_DISPATCH_CONTEXT_KEY) === true) {
+  if (context.req.get(FARM_INTEGRATION_INTERNAL_DISPATCH_CONTEXT_KEY) === true) {
     return undefined;
   }
 
@@ -608,19 +608,19 @@ async function verifyProtectedRequest(
 
     if (result.valid) {
       const contextKey = options.contextKey ?? "unkey";
-      context.requestContext.set(contextKey, result, {
+      context.req.set(contextKey, result, {
         exposeToPage: options.exposeToPage,
       });
-      context.requestContext.set("apiKey", result, {
+      context.req.set("apiKey", result, {
         exposeToPage: options.exposeToPage,
       });
       if (result.keyId) {
-        context.requestContext.set("apiKeyId", result.keyId, {
+        context.req.set("apiKeyId", result.keyId, {
           exposeToPage: options.exposeToPage,
         });
       }
       if (result.identity?.externalId) {
-        context.requestContext.set("apiKeyOwnerId", result.identity.externalId, {
+        context.req.set("apiKeyOwnerId", result.identity.externalId, {
           exposeToPage: options.exposeToPage,
         });
       }

--- a/packages/farm/src/__tests__/autumn-webhooks.test.ts
+++ b/packages/farm/src/__tests__/autumn-webhooks.test.ts
@@ -33,6 +33,8 @@ function createContext(
   path: string,
   instance: unknown,
 ): FarmIntegrationHandlerContext {
+  const req = createRequestContextStore();
+
   return {
     request,
     requestId: "req_test",
@@ -53,7 +55,8 @@ function createContext(
       path,
       methods: [method],
     },
-    requestContext: createRequestContextStore(),
+    req,
+    requestContext: req,
     config: {} as FarmIntegrationHandlerContext["config"],
     isDev: true,
     isProd: false,

--- a/packages/farm/src/__tests__/integration-client.test.ts
+++ b/packages/farm/src/__tests__/integration-client.test.ts
@@ -1204,14 +1204,14 @@ describe("integration client", () => {
           middleware: [
             {
               handler(_request, context) {
-                context.requestContext.set("direct-route", "yes");
-                context.requestContext.set("direct-route-order", ["first"]);
+                context.req.set("direct-route", "yes");
+                context.req.set("direct-route-order", ["first"]);
               },
             },
             {
               handler(_request, context) {
-                const order = context.requestContext.get<string[]>("direct-route-order") || [];
-                context.requestContext.set("direct-route-order", [...order, "second"]);
+                const order = context.req.get<string[]>("direct-route-order") || [];
+                context.req.set("direct-route-order", [...order, "second"]);
               },
             },
           ],
@@ -1219,8 +1219,8 @@ describe("integration client", () => {
             handlerSpy();
             return Response.json({
               ok: true,
-              direct: context.requestContext.get("direct-route") === "yes",
-              middlewareOrder: context.requestContext.get<string[]>("direct-route-order") || [],
+              direct: context.req.get("direct-route") === "yes",
+              middlewareOrder: context.req.get<string[]>("direct-route-order") || [],
             });
           },
         }),

--- a/packages/farm/src/__tests__/integrations.test.ts
+++ b/packages/farm/src/__tests__/integrations.test.ts
@@ -231,8 +231,8 @@ describe("integrations runtime", () => {
     manager.addPlugin({
       name: "seed-request-context",
       enforce: "pre",
-      beforeRequest(req, _res, context) {
-        context.requestContext.set(req, "seed", "shared-value");
+      beforeRequest(_req, _res, context) {
+        context.req.set("seed", "shared-value");
       },
     });
     manager.addPlugins(
@@ -260,16 +260,17 @@ describe("integrations runtime", () => {
                 expect(context.integration.slot).toBe("auth");
                 expect(context.integration.type).toBe("better-auth");
                 expect(context.route.kind).toBe("route");
-                expect(context.requestContext.get("seed")).toBe("shared-value");
+                expect(context.req).toBe(context.requestContext);
+                expect(context.req.get("seed")).toBe("shared-value");
 
-                context.requestContext.set("handled", "yes");
+                context.req.set("handled", "yes");
 
                 return Response.json(
                   {
                     provider: context.params.provider,
                     auth: context.params.auth,
-                    handled: context.requestContext.get("handled"),
-                    seeded: context.requestContext.get("seed"),
+                    handled: context.req.get("handled"),
+                    seeded: context.req.get("seed"),
                   },
                   { status: 201 },
                 );
@@ -758,20 +759,19 @@ describe("integrations runtime", () => {
               middleware: [
                 {
                   handler(_request, context) {
-                    context.requestContext.set("route-middleware-order", ["first"]);
+                    context.req.set("route-middleware-order", ["first"]);
                   },
                 },
                 {
                   handler(_request, context) {
-                    const order =
-                      context.requestContext.get<string[]>("route-middleware-order") || [];
-                    context.requestContext.set("route-middleware-order", [...order, "second"]);
+                    const order = context.req.get<string[]>("route-middleware-order") || [];
+                    context.req.set("route-middleware-order", [...order, "second"]);
                   },
                 },
               ],
               handler(_request, context) {
                 return Response.json({
-                  middleware: context.requestContext.get("route-middleware-order"),
+                  middleware: context.req.get("route-middleware-order"),
                 });
               },
             },
@@ -941,7 +941,7 @@ describe("integrations runtime", () => {
                 before: [
                   (_request, context) => {
                     expect(context.response).toBeUndefined();
-                    context.requestContext.set("hook-order", ["before"]);
+                    context.req.set("hook-order", ["before"]);
                   },
                 ],
                 after: [
@@ -963,7 +963,7 @@ describe("integrations runtime", () => {
                 ],
                 handler(_request, context) {
                   handlerSpy();
-                  const order = context.requestContext.get<string[]>("hook-order") || [];
+                  const order = context.req.get<string[]>("hook-order") || [];
                   return Response.json({
                     order: [...order, "handler"],
                     after: false,
@@ -1001,10 +1001,10 @@ describe("integrations runtime", () => {
         integrationRoute.get("/api/local-demo/blocked", {
           before: [
             (_request, context) => {
-              context.requestContext.set("blocked", true);
+              context.req.set("blocked", true);
               return Response.json(
                 {
-                  blocked: context.requestContext.get("blocked"),
+                  blocked: context.req.get("blocked"),
                 },
                 {
                   status: 403,

--- a/packages/farm/src/__tests__/plugin-lifecycle.test.ts
+++ b/packages/farm/src/__tests__/plugin-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { PluginManager, definePlugin } from "../plugin";
-import { getRequestContextSnapshot } from "../request-context";
+import { getRequestContext, getRequestContextSnapshot } from "../request-context";
 import type { PageProps } from "../types";
 
 function createManager() {
@@ -50,8 +50,9 @@ describe("plugin lifecycle hooks", () => {
           seen.push("after-render");
           return html + "<!--after-render-->";
         },
-        beforeApiHandler(request) {
+        beforeApiHandler(request, _api, context) {
           seen.push("before-api");
+          context.req.set("api.phase", "before");
           const headers = new Headers(request.headers);
           headers.set("x-hook", "before");
           return new Request(request, { headers });
@@ -143,6 +144,8 @@ describe("plugin lifecycle hooks", () => {
       routePath: "/api/health",
     });
     expect(modifiedRequest.headers.get("x-hook")).toBe("before");
+    expect(getRequestContext(request, "api.phase")).toBe("before");
+    expect(getRequestContext(modifiedRequest, "api.phase")).toBe("before");
 
     const response = new Response("ok", { status: 200 });
     const modifiedResponse = await manager.runHookSerial("afterApiHandler", response, {
@@ -187,6 +190,48 @@ describe("plugin lifecycle hooks", () => {
     expect(seen).toContain("after-api");
     expect(seen).toContain("before-nitro");
     expect(seen).toContain("shutdown:test");
+  });
+
+  it("keeps ctx.req data across transformed API requests", async () => {
+    const manager = createManager();
+    const observed: string[] = [];
+
+    manager.addPlugin(
+      definePlugin({
+        name: "api-request-writer",
+        beforeApiHandler(request, _api, context) {
+          context.req.set("traceId", "trace-123", { exposeToPage: true });
+          const headers = new Headers(request.headers);
+          headers.set("x-first-plugin", "yes");
+          return new Request(request, { headers });
+        },
+      }),
+    );
+    manager.addPlugin(
+      definePlugin({
+        name: "api-request-reader",
+        beforeApiHandler(request, _api, context) {
+          observed.push(context.req.get<string>("traceId") || "missing");
+          const headers = new Headers(request.headers);
+          headers.set("x-second-plugin", "yes");
+          return new Request(request, { headers });
+        },
+      }),
+    );
+
+    const request = new Request("http://localhost/api/health");
+    const result = await manager.runHookSerial("beforeApiHandler", request, {
+      pathname: "/api/health",
+      method: "GET",
+    });
+
+    expect(observed).toEqual(["trace-123"]);
+    expect(result.headers.get("x-first-plugin")).toBe("yes");
+    expect(result.headers.get("x-second-plugin")).toBe("yes");
+    expect(getRequestContext(result, "traceId")).toBe("trace-123");
+    expect(getRequestContextSnapshot(result, { exposedOnly: true }).get("traceId")).toBe(
+      "trace-123",
+    );
   });
 
   it("keeps enforce ordering for lifecycle hooks", async () => {
@@ -259,16 +304,17 @@ describe("plugin lifecycle hooks", () => {
     expect(second).toHaveBeenCalledTimes(0);
   });
 
-  it("allows plugins to set and read request context with explicit page exposure", async () => {
+  it("provides a bound ctx.req store while preserving the legacy requestContext alias", async () => {
     const manager = createManager();
     const observed: Array<string | undefined> = [];
+    let legacyTraceId: string | undefined;
 
     manager.addPlugin(
       definePlugin({
         name: "setter",
-        beforeRequest(req, _res, context) {
-          context.requestContext.set(req, "traceId", "trace-123", { exposeToPage: true });
-          context.requestContext.set(req, "internalToken", "secret-token");
+        beforeRequest(_req, _res, context) {
+          context.req.set("traceId", "trace-123", { exposeToPage: true });
+          context.req.set("internalToken", "secret-token");
         },
       }),
     );
@@ -277,11 +323,15 @@ describe("plugin lifecycle hooks", () => {
       definePlugin({
         name: "reader",
         beforeRequest(req, _res, context) {
-          observed.push(context.requestContext.get(req, "traceId"));
-          observed.push(context.requestContext.get(req, "internalToken"));
-          const exposed = context.requestContext.getAll(req, { exposedOnly: true });
-          observed.push(exposed.get("traceId"));
-          observed.push(exposed.get("internalToken"));
+          observed.push(context.req.get<string>("traceId"));
+          observed.push(context.req.get<string>("internalToken"));
+          const exposed = context.req.snapshot({ exposedOnly: true });
+          observed.push(exposed.get("traceId") as string | undefined);
+          observed.push(exposed.get("internalToken") as string | undefined);
+          legacyTraceId = context.requestContext.get(req, "traceId");
+        },
+        afterResponse(_req, _res, context) {
+          observed.push(context.req.get<string>("traceId"));
         },
       }),
     );
@@ -289,8 +339,10 @@ describe("plugin lifecycle hooks", () => {
     const req: any = {};
     const res: any = { writableEnded: false };
     await manager.runHookParallel("beforeRequest", req, res);
+    await manager.runHookParallel("afterResponse", req, res);
 
-    expect(observed).toEqual(["trace-123", "secret-token", "trace-123", undefined]);
+    expect(observed).toEqual(["trace-123", "secret-token", "trace-123", undefined, "trace-123"]);
+    expect(legacyTraceId).toBe("trace-123");
 
     const exposedFromStore = getRequestContextSnapshot(req, { exposedOnly: true });
     expect(exposedFromStore.get("traceId")).toBe("trace-123");

--- a/packages/farm/src/__tests__/polar-webhooks.test.ts
+++ b/packages/farm/src/__tests__/polar-webhooks.test.ts
@@ -33,6 +33,8 @@ function createContext(
   path: string,
   instance: unknown,
 ): FarmIntegrationHandlerContext {
+  const req = createRequestContextStore();
+
   return {
     request,
     requestId: "req_test",
@@ -53,7 +55,8 @@ function createContext(
       path,
       methods: [method],
     },
-    requestContext: createRequestContextStore(),
+    req,
+    requestContext: req,
     config: {} as FarmIntegrationHandlerContext["config"],
     isDev: true,
     isProd: false,

--- a/packages/farm/src/__tests__/resend-email.test.tsx
+++ b/packages/farm/src/__tests__/resend-email.test.tsx
@@ -35,6 +35,8 @@ function createContext(
   path: string,
   instance: unknown,
 ): FarmIntegrationHandlerContext {
+  const req = createRequestContextStore();
+
   return {
     request,
     requestId: "req_test",
@@ -55,7 +57,8 @@ function createContext(
       path,
       methods: [method],
     },
-    requestContext: createRequestContextStore(),
+    req,
+    requestContext: req,
     config: {} as FarmIntegrationHandlerContext["config"],
     isDev: true,
     isProd: false,

--- a/packages/farm/src/__tests__/stripe-orm-storage.test.ts
+++ b/packages/farm/src/__tests__/stripe-orm-storage.test.ts
@@ -55,6 +55,8 @@ function createContext(
   instance: unknown,
   config: FarmIntegrationHandlerContext["config"],
 ): FarmIntegrationHandlerContext {
+  const req = createRequestContextStore();
+
   return {
     request,
     requestId: "req_test",
@@ -75,7 +77,8 @@ function createContext(
       path,
       methods: [method],
     },
-    requestContext: createRequestContextStore(),
+    req,
+    requestContext: req,
     config,
     isDev: true,
     isProd: false,

--- a/packages/farm/src/__tests__/stripe-trial-hooks.test.ts
+++ b/packages/farm/src/__tests__/stripe-trial-hooks.test.ts
@@ -44,6 +44,8 @@ function createContext(
   path: string,
   instance: unknown,
 ): FarmIntegrationHandlerContext {
+  const req = createRequestContextStore();
+
   return {
     request,
     requestId: "req_test",
@@ -64,7 +66,8 @@ function createContext(
       path,
       methods: [method],
     },
-    requestContext: createRequestContextStore(),
+    req,
+    requestContext: req,
     config: {} as FarmIntegrationHandlerContext["config"],
     isDev: true,
     isProd: false,

--- a/packages/farm/src/__tests__/stripe-webhooks.test.ts
+++ b/packages/farm/src/__tests__/stripe-webhooks.test.ts
@@ -29,6 +29,8 @@ function createContext(
   path: string,
   instance: unknown,
 ): FarmIntegrationHandlerContext {
+  const req = createRequestContextStore();
+
   return {
     request,
     requestId: "req_test",
@@ -49,7 +51,8 @@ function createContext(
       path,
       methods: [method],
     },
-    requestContext: createRequestContextStore(),
+    req,
+    requestContext: req,
     config: {} as FarmIntegrationHandlerContext["config"],
     isDev: true,
     isProd: false,

--- a/packages/farm/src/client-plugins.ts
+++ b/packages/farm/src/client-plugins.ts
@@ -1,5 +1,10 @@
 // Client-side plugins export (for future client-side plugin support)
-export type { FarmPlugin, FarmPluginContext } from "./plugin";
+export type {
+  FarmPlugin,
+  FarmPluginContext,
+  FarmRequestPluginContext,
+  FarmRequestStore,
+} from "./plugin";
 export { definePlugin } from "./plugin";
 
 // Note: Currently Farm.js plugins are primarily server-side.

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -130,6 +130,8 @@ export type { ReadonlyHeaders, ReadonlyRequestCookies, RequestCookie } from "./h
 export type {
   FarmPlugin,
   FarmPluginContext,
+  FarmRequestPluginContext,
+  FarmRequestStore,
   RouteDiscoveredPayload,
   RoutesGeneratedPayload,
   MiddlewareDiscoveredPayload,

--- a/packages/farm/src/integrations.ts
+++ b/packages/farm/src/integrations.ts
@@ -10,7 +10,7 @@ import type {
   InferIntegrationAPIFromRoutes,
 } from "./integration-api";
 import type { InferFarmIntegrationOrmClient } from "./integration-orm";
-import type { FarmPlugin, FarmPluginContext } from "./plugin";
+import type { FarmPlugin, FarmPluginContext, FarmRequestStore } from "./plugin";
 import {
   clearRequestContext,
   deleteRequestContext,
@@ -114,14 +114,8 @@ export interface FarmIntegrationRouteInputSchemas<TBody = unknown, TQuery = unkn
   query?: FarmIntegrationInputSchema<TQuery>;
 }
 
-export interface FarmIntegrationRequestContextStore {
-  get<T = unknown>(key: string): T | undefined;
-  set(key: string, value: unknown, options?: { exposeToPage?: boolean }): void;
-  has(key: string): boolean;
-  delete(key: string): boolean;
-  clear(): void;
-  snapshot(options?: { exposedOnly?: boolean }): Map<string, unknown>;
-}
+/** @deprecated Use `FarmRequestStore` and access it through `ctx.req`. */
+export type FarmIntegrationRequestContextStore = FarmRequestStore;
 
 export const FARM_INTEGRATION_INTERNAL_DISPATCH_CONTEXT_KEY = "farm.integration.internalDispatch";
 
@@ -235,7 +229,9 @@ export interface FarmIntegrationHandlerContext<
     path: string;
     methods: readonly string[];
   };
-  requestContext: FarmIntegrationRequestContextStore;
+  req: FarmRequestStore;
+  /** @deprecated Use `req` instead. */
+  requestContext: FarmRequestStore;
   config: FarmPluginContext["config"];
   isDev: boolean;
   isProd: boolean;
@@ -1729,7 +1725,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
           },
           request,
           requestId,
-          context: handlerContext.requestContext.snapshot(),
+          context: handlerContext.req.snapshot(),
         });
 
         try {
@@ -1750,7 +1746,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
               response,
               requestId,
               durationMs: Date.now() - startedAt,
-              context: handlerContext.requestContext.snapshot(),
+              context: handlerContext.req.snapshot(),
             });
             return;
           }
@@ -1768,7 +1764,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
             request,
             requestId,
             durationMs: Date.now() - startedAt,
-            context: handlerContext.requestContext.snapshot(),
+            context: handlerContext.req.snapshot(),
           });
         } catch (error) {
           await integration.log?.({
@@ -1785,7 +1781,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
             requestId,
             durationMs: Date.now() - startedAt,
             error,
-            context: handlerContext.requestContext.snapshot(),
+            context: handlerContext.req.snapshot(),
           });
           throw error;
         }
@@ -1827,7 +1823,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
           },
           request,
           requestId,
-          context: handlerContext.requestContext.snapshot(),
+          context: handlerContext.req.snapshot(),
         });
 
         try {
@@ -1848,7 +1844,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
               response: validation.response,
               requestId,
               durationMs: Date.now() - startedAt,
-              context: handlerContext.requestContext.snapshot(),
+              context: handlerContext.req.snapshot(),
             });
             return;
           }
@@ -1872,7 +1868,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
                 response: middlewareResponse,
                 requestId,
                 durationMs: Date.now() - startedAt,
-                context: handlerContext.requestContext.snapshot(),
+                context: handlerContext.req.snapshot(),
               });
               return;
             }
@@ -1905,7 +1901,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
               response,
               requestId,
               durationMs: Date.now() - startedAt,
-              context: handlerContext.requestContext.snapshot(),
+              context: handlerContext.req.snapshot(),
             });
             return;
           }
@@ -1932,7 +1928,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
             response,
             requestId,
             durationMs: Date.now() - startedAt,
-            context: handlerContext.requestContext.snapshot(),
+            context: handlerContext.req.snapshot(),
           });
           return;
         } catch (error) {
@@ -1950,7 +1946,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
             requestId,
             durationMs: Date.now() - startedAt,
             error,
-            context: handlerContext.requestContext.snapshot(),
+            context: handlerContext.req.snapshot(),
           });
           throw error;
         }
@@ -1969,6 +1965,12 @@ function createIntegrationHandlerContext(input: {
   requestId: string;
   pluginContext: FarmPluginContext;
 }): FarmIntegrationHandlerContext {
+  const req = createIntegrationRequestContextStore(
+    input.rawRequest,
+    input.request,
+    input.pluginContext,
+  );
+
   return {
     request: input.request,
     requestId: input.requestId,
@@ -1989,11 +1991,8 @@ function createIntegrationHandlerContext(input: {
       instance: input.integration.instance,
     },
     route: input.route,
-    requestContext: createIntegrationRequestContextStore(
-      input.rawRequest,
-      input.request,
-      input.pluginContext,
-    ),
+    req,
+    requestContext: req,
     config: input.pluginContext.config,
     isDev: input.pluginContext.isDev,
     isProd: input.pluginContext.isProd,
@@ -2532,7 +2531,7 @@ export async function dispatchIntegrationRequest(
       },
       request,
       requestId,
-      context: handlerContext.requestContext.snapshot(),
+      context: handlerContext.req.snapshot(),
     });
 
     try {
@@ -2552,7 +2551,7 @@ export async function dispatchIntegrationRequest(
           response,
           requestId,
           durationMs: Date.now() - startedAt,
-          context: handlerContext.requestContext.snapshot(),
+          context: handlerContext.req.snapshot(),
         });
         return response;
       }
@@ -2570,7 +2569,7 @@ export async function dispatchIntegrationRequest(
         request,
         requestId,
         durationMs: Date.now() - startedAt,
-        context: handlerContext.requestContext.snapshot(),
+        context: handlerContext.req.snapshot(),
       });
     } catch (error) {
       await integration.log?.({
@@ -2587,7 +2586,7 @@ export async function dispatchIntegrationRequest(
         requestId,
         durationMs: Date.now() - startedAt,
         error,
-        context: handlerContext.requestContext.snapshot(),
+        context: handlerContext.req.snapshot(),
       });
       throw error;
     }
@@ -2630,7 +2629,7 @@ export async function dispatchIntegrationRequest(
       },
       request,
       requestId,
-      context: handlerContext.requestContext.snapshot(),
+      context: handlerContext.req.snapshot(),
     });
 
     try {
@@ -2650,7 +2649,7 @@ export async function dispatchIntegrationRequest(
           response: validation.response,
           requestId,
           durationMs: Date.now() - startedAt,
-          context: handlerContext.requestContext.snapshot(),
+          context: handlerContext.req.snapshot(),
         });
         return validation.response;
       }
@@ -2673,7 +2672,7 @@ export async function dispatchIntegrationRequest(
             response: middlewareResponse,
             requestId,
             durationMs: Date.now() - startedAt,
-            context: handlerContext.requestContext.snapshot(),
+            context: handlerContext.req.snapshot(),
           });
           return middlewareResponse;
         }
@@ -2701,7 +2700,7 @@ export async function dispatchIntegrationRequest(
           response,
           requestId,
           durationMs: Date.now() - startedAt,
-          context: handlerContext.requestContext.snapshot(),
+          context: handlerContext.req.snapshot(),
         });
         return response;
       }
@@ -2727,7 +2726,7 @@ export async function dispatchIntegrationRequest(
         response,
         requestId,
         durationMs: Date.now() - startedAt,
-        context: handlerContext.requestContext.snapshot(),
+        context: handlerContext.req.snapshot(),
       });
       return response;
     } catch (error) {
@@ -2745,7 +2744,7 @@ export async function dispatchIntegrationRequest(
         requestId,
         durationMs: Date.now() - startedAt,
         error,
-        context: handlerContext.requestContext.snapshot(),
+        context: handlerContext.req.snapshot(),
       });
       throw error;
     }
@@ -2812,13 +2811,10 @@ function createServerIntegrationHandlerContext(input: {
   data?: FarmIntegrationData;
   internal?: boolean;
 }): FarmIntegrationHandlerContext {
-  const requestContext = createServerIntegrationRequestContextStore(
-    input.request,
-    input.currentRequest,
-  );
+  const req = createServerIntegrationRequestContextStore(input.request, input.currentRequest);
 
   if (input.internal) {
-    requestContext.set(FARM_INTEGRATION_INTERNAL_DISPATCH_CONTEXT_KEY, true);
+    req.set(FARM_INTEGRATION_INTERNAL_DISPATCH_CONTEXT_KEY, true);
   }
 
   return {
@@ -2841,7 +2837,8 @@ function createServerIntegrationHandlerContext(input: {
       instance: input.runtime.integration.instance,
     },
     route: input.route,
-    requestContext,
+    req,
+    requestContext: req,
     config: input.runtime.config,
     isDev: input.runtime.isDev,
     isProd: input.runtime.isProd,

--- a/packages/farm/src/plugin.ts
+++ b/packages/farm/src/plugin.ts
@@ -23,12 +23,27 @@ export interface PluginRequestContext {
   getAll: (target: FarmRequest | Request, options?: { exposedOnly?: boolean }) => Map<string, any>;
 }
 
+export interface FarmRequestStore {
+  set(key: string, value: unknown, options?: { exposeToPage?: boolean }): void;
+  get<T = unknown>(key: string): T | undefined;
+  has(key: string): boolean;
+  delete(key: string): boolean;
+  clear(): void;
+  snapshot(options?: { exposedOnly?: boolean }): Map<string, unknown>;
+}
+
 export interface FarmPluginContext {
   config: FarmConfig;
   viteServer?: ViteDevServer;
   isDev: boolean;
   isProd: boolean;
+  /** @deprecated Use `ctx.req` inside request hooks. */
   requestContext: PluginRequestContext;
+}
+
+export interface FarmRequestPluginContext extends FarmPluginContext {
+  /** Request-scoped values for the current hook invocation. */
+  readonly req: FarmRequestStore;
 }
 
 export interface RouteDiscoveredPayload {
@@ -165,7 +180,7 @@ export interface FarmPlugin {
   beforeApiHandler?: (
     request: Request,
     api: APIHandlerLifecyclePayload,
-    context: FarmPluginContext,
+    context: FarmRequestPluginContext,
   ) => Request | Promise<Request> | void | Promise<void>;
   afterApiHandler?: (
     response: Response,
@@ -189,12 +204,12 @@ export interface FarmPlugin {
   beforeRequest?: (
     req: FarmRequest,
     res: FarmResponse,
-    context: FarmPluginContext,
+    context: FarmRequestPluginContext,
   ) => void | Promise<void>;
   afterResponse?: (
     req: FarmRequest,
     res: FarmResponse,
-    context: FarmPluginContext,
+    context: FarmRequestPluginContext,
   ) => void | Promise<void>;
 
   // Transform hooks
@@ -232,6 +247,61 @@ export class PluginManager {
     };
   }
 
+  private createRequestHookContext(target: FarmRequest | Request): FarmRequestPluginContext {
+    const requestContext = this.context.requestContext;
+
+    return {
+      ...this.context,
+      req: {
+        set(key, value, options) {
+          requestContext.set(target, key, value, options);
+        },
+        get(key) {
+          return requestContext.get(target, key);
+        },
+        has(key) {
+          return requestContext.has(target, key);
+        },
+        delete(key) {
+          return requestContext.delete(target, key);
+        },
+        clear() {
+          requestContext.clear(target);
+        },
+        snapshot(options) {
+          return requestContext.getAll(target, options);
+        },
+      },
+    };
+  }
+
+  private copyRequestStore(source: FarmRequest | Request, target: FarmRequest | Request): void {
+    const requestContext = this.context.requestContext;
+    const values = requestContext.getAll(source);
+    const exposed = requestContext.getAll(source, { exposedOnly: true });
+
+    for (const [key, value] of values) {
+      requestContext.set(target, key, value, {
+        exposeToPage: exposed.has(key),
+      });
+    }
+  }
+
+  private getHookContext(hookName: keyof FarmPlugin, args: any[]): FarmPluginContext {
+    if (
+      hookName === "beforeRequest" ||
+      hookName === "afterResponse" ||
+      hookName === "beforeApiHandler"
+    ) {
+      const target = args[0];
+      if (target && typeof target === "object") {
+        return this.createRequestHookContext(target);
+      }
+    }
+
+    return this.context;
+  }
+
   addPlugin(plugin: FarmPlugin) {
     this.plugins.push(plugin);
   }
@@ -259,7 +329,8 @@ export class PluginManager {
     for (const plugin of plugins) {
       const hook = plugin[hookName];
       if (typeof hook === "function") {
-        const result = await (hook as any).apply(plugin, [...args, this.context]);
+        const hookContext = this.getHookContext(hookName, args);
+        const result = await (hook as any).apply(plugin, [...args, hookContext]);
         if (result !== undefined) {
           return result;
         }
@@ -278,8 +349,20 @@ export class PluginManager {
     for (const plugin of plugins) {
       const hook = plugin[hookName];
       if (typeof hook === "function") {
-        const result = await (hook as any).apply(plugin, [value, ...args, this.context]);
+        const hookArgs = [value, ...args];
+        const hookContext = this.getHookContext(hookName, hookArgs);
+        const result = await (hook as any).apply(plugin, [...hookArgs, hookContext]);
         if (result !== undefined) {
+          if (
+            hookName === "beforeApiHandler" &&
+            result !== value &&
+            value &&
+            result &&
+            typeof value === "object" &&
+            typeof result === "object"
+          ) {
+            this.copyRequestStore(value as FarmRequest | Request, result as FarmRequest | Request);
+          }
           value = result;
         }
       }
@@ -315,7 +398,8 @@ export class PluginManager {
             }
           }
 
-          await (hook as any).apply(plugin, [...args, this.context]);
+          const hookContext = this.getHookContext(hookName, args);
+          await (hook as any).apply(plugin, [...args, hookContext]);
 
           // Check again after plugin execution (only for beforeRequest)
           if (hookName === "beforeRequest") {
@@ -332,7 +416,8 @@ export class PluginManager {
       for (const plugin of plugins) {
         const hook = plugin[hookName];
         if (typeof hook === "function") {
-          promises.push((hook as any).apply(plugin, [...args, this.context]));
+          const hookContext = this.getHookContext(hookName, args);
+          promises.push((hook as any).apply(plugin, [...args, hookContext]));
         }
       }
       await Promise.all(promises);

--- a/packages/farm/src/server-plugins.ts
+++ b/packages/farm/src/server-plugins.ts
@@ -8,5 +8,10 @@ export {
   createLoggerPlugin,
 } from "./plugins";
 
-export type { FarmPlugin, FarmPluginContext } from "./plugin";
+export type {
+  FarmPlugin,
+  FarmPluginContext,
+  FarmRequestPluginContext,
+  FarmRequestStore,
+} from "./plugin";
 export type { RedirectConfig, HeaderConfig, RewriteConfig } from "./config";

--- a/packages/farmjs-plugin/src/context/index.ts
+++ b/packages/farmjs-plugin/src/context/index.ts
@@ -6,14 +6,9 @@ interface RequestLike {
 }
 
 interface PluginContextLike {
-  requestContext: {
-    set: (
-      target: RequestLike,
-      key: string,
-      value: any,
-      options?: { exposeToPage?: boolean },
-    ) => void;
-    get: <T = any>(target: RequestLike, key: string) => T | undefined;
+  req: {
+    set: (key: string, value: any, options?: { exposeToPage?: boolean }) => void;
+    get: <T = any>(key: string) => T | undefined;
   };
 }
 
@@ -95,24 +90,24 @@ export function contextPlugin(options: ContextPluginOptions = {}): ContextPlugin
       const requestId = getHeader(req, requestIdHeader) || randomUUID();
       const locale = getHeader(req, localeHeader) || "en";
 
-      context.requestContext.set(req, "requestId", requestId, { exposeToPage: true });
-      context.requestContext.set(req, "locale", locale, { exposeToPage: true });
+      context.req.set("requestId", requestId, { exposeToPage: true });
+      context.req.set("locale", locale, { exposeToPage: true });
 
       if (exposePathname) {
-        context.requestContext.set(req, "pathname", pathname, { exposeToPage: true });
+        context.req.set("pathname", pathname, { exposeToPage: true });
       }
 
       // Private value stays available only to plugin hooks.
-      context.requestContext.set(req, "internal:requestStart", Date.now());
+      context.req.set("internal:requestStart", Date.now());
       if (beforeRequestCb) {
         beforeRequestCb({ requestId, locale, pathname });
       }
     },
     afterResponse(req, res, context) {
       if (!afterResponseCb) return;
-      const requestId = context.requestContext.get<string>(req, "requestId") || "unknown";
-      const locale = context.requestContext.get<string>(req, "locale") || "en";
-      const started = context.requestContext.get<number>(req, "internal:requestStart");
+      const requestId = context.req.get<string>("requestId") || "unknown";
+      const locale = context.req.get<string>("locale") || "en";
+      const started = context.req.get<number>("internal:requestStart");
       const pathname = req.url || "/";
       const durationMs = typeof started === "number" ? Date.now() - started : 0;
       const statusCode =

--- a/skills/farmjs/SKILL.md
+++ b/skills/farmjs/SKILL.md
@@ -387,7 +387,7 @@ import { definePlugin } from "@farmjs/core";
 export const plugin = definePlugin({
   name: "request-context-demo",
   beforeRequest(req, _res, context) {
-    context.requestContext.set(req, "demo.path", req.url, {
+    context.req.set("demo.path", req.url, {
       exposeToPage: true,
     });
   },


### PR DESCRIPTION
## Summary

- add a request-bound `ctx.req` store to plugin request hooks
- expose the same shorthand to integration handlers while preserving `ctx.requestContext` as a deprecated compatibility alias
- carry request data across transformed API `Request` objects
- migrate first-party integrations, examples, docs, and the Farm skill to the simpler API

## Validation

- `@farmjs/core`: 537 tests passed, 1 skipped
- focused request/integration suite: 52 tests passed
- `@farmjs/core` build and declaration generation
- `@farmjs/integrations` type check and build
- `@farmjs/plugin` type check, build, and 11 tests
- docs production build with the Vercel preset

## Compatibility

Existing `ctx.requestContext` usage continues to work and is marked deprecated, allowing integrations and plugins to migrate without a breaking release.