### PR TITLE
feat: standardize Farm config on defineConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ export default defineConfig({
 });
 ```
 
-`defineFarmConfig` remains supported as an exact alias of `defineConfig`.
+`defineFarmConfig` remains available as a deprecated exact alias of `defineConfig`.
 
 Create your first page in `src/app/page.tsx`:
 

--- a/docs/src/app/docs/cli/page.md
+++ b/docs/src/app/docs/cli/page.md
@@ -77,9 +77,9 @@ farm migrate --command "pnpm prisma migrate deploy"
 **farm.config.ts**
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   migrations: {
     commands: [
       {

--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -33,7 +33,7 @@ export default defineConfig({
 });
 ```
 
-`defineConfig` is the concise Farm helper. `defineFarmConfig` is the same typed function and remains fully supported for existing applications.
+`defineConfig` is the canonical Farm helper. `defineFarmConfig` remains available as a deprecated exact alias for existing applications.
 
 ### Docs config
 

--- a/docs/src/app/docs/deployment/page.md
+++ b/docs/src/app/docs/deployment/page.md
@@ -13,7 +13,7 @@ Build deployable output with Farm's deploy config and Nitro presets. Farm owns r
 **farm.config.ts**
 
 ```ts
-export default defineFarmConfig({
+export default defineConfig({
   deploy: {
     target: "vercel",
     output: ".vercel/output",
@@ -46,11 +46,11 @@ Use `deploy.target` when you want one config file to control the platform output
 **farm.config.ts**
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
 const target = process.env.FARM_DEPLOY_TARGET ?? "vercel";
 
-export default defineFarmConfig({
+export default defineConfig({
   deploy: {
     target,
     cloudflare: {
@@ -106,9 +106,9 @@ Mutation requests are rejected before their action body is decoded or the handle
 Farm resolves the ID from explicit config, `FARM_DEPLOYMENT_ID`, `VERCEL_GIT_COMMIT_SHA`, or `CF_PAGES_COMMIT_SHA`. Otherwise, production uses `generateBuildId` and development uses `"development"`.
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   deploymentId: process.env.RELEASE_ID,
 });
 ```
@@ -136,9 +136,9 @@ Use `target: "node"` when you want to run the app on your own server, VPS, conta
 **farm.config.ts**
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   deploy: {
     target: "node",
     output: ".output",
@@ -173,9 +173,9 @@ Farm can also build for any Nitro preset that Nitro can resolve. Use `deploy.pre
 **farm.config.ts**
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   deploy: {
     preset: process.env.NITRO_PRESET || "node-server",
     output: ".output",
@@ -224,9 +224,9 @@ Farm reads deployment settings from `farm.config.ts`, so a minimal project does 
 **farm.config.ts**
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   deploy: {
     target: "vercel",
   },
@@ -240,7 +240,7 @@ When `target` is `vercel`, Farm uses the Vercel Nitro preset and writes Build Ou
 Use `output` for the compact form or `outputDir` when you want the explicit option name.
 
 ```ts
-export default defineFarmConfig({
+export default defineConfig({
   deploy: {
     target: "netlify",
     output: ".output",
@@ -266,7 +266,7 @@ For other Nitro presets, use the host's documented deploy command or CI workflow
 Keep environment variables in the platform's environment manager or local `.env` files. Farm config can reference `process.env`, and integrations should validate required provider keys during setup.
 
 ```ts
-export default defineFarmConfig({
+export default defineConfig({
   integrations: {
     billing: stripe({
       secretKey: process.env.STRIPE_SECRET_KEY,

--- a/docs/src/app/docs/integrations/auth/page.md
+++ b/docs/src/app/docs/integrations/auth/page.md
@@ -20,10 +20,10 @@ Use Better Auth, Auth.js, Clerk, Auth0, WorkOS, or Supabase without hand-rolling
 **farm.config.ts**
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { supabase } from "@farmjs/integrations/supabase";
 
-export default defineFarmConfig({
+export default defineConfig({
   integrations: {
     auth: supabase({
       url: process.env.SUPABASE_URL,

--- a/docs/src/app/docs/integrations/custom/page.md
+++ b/docs/src/app/docs/integrations/custom/page.md
@@ -36,10 +36,10 @@ export const acme = defineIntegration({
 **farm.config.ts**
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { acme } from "./src/integrations/acme";
 
-export default defineFarmConfig({
+export default defineConfig({
   integrations: {
     acme,
   },
@@ -80,10 +80,10 @@ Register the integration once. The `billing` key becomes the first segment after
 **farm.config.ts**
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { billing } from "./src/integrations/billing";
 
-export default defineFarmConfig({
+export default defineConfig({
   integrations: {
     billing,
   },
@@ -740,13 +740,13 @@ The app supplies the storage client once:
 **farm.config.ts**
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { DatabaseSync } from "node:sqlite";
 import { billing } from "./src/integrations/billing";
 
 const sqlite = new DatabaseSync("farm.sqlite");
 
-export default defineFarmConfig({
+export default defineConfig({
   storage: {
     client: sqlite,
   },

--- a/docs/src/app/docs/integrations/orm-storage/page.md
+++ b/docs/src/app/docs/integrations/orm-storage/page.md
@@ -15,13 +15,13 @@ This keeps integration code storage agnostic. A Stripe, auth, jobs, email, or cu
 **farm.config.ts**
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { DatabaseSync } from "node:sqlite";
 import { billing } from "./src/integrations/billing";
 
 const sqlite = new DatabaseSync("farm.sqlite");
 
-export default defineFarmConfig({
+export default defineConfig({
   storage: {
     client: sqlite,
   },
@@ -134,7 +134,7 @@ export const billing = defineIntegration({
 For SQLite, create the database client in app code and pass the instance through `storage.client`.
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { DatabaseSync } from "node:sqlite";
 
 const sqlite = new DatabaseSync("farm.sqlite");
@@ -149,7 +149,7 @@ sqlite.exec(`
   );
 `);
 
-export default defineFarmConfig({
+export default defineConfig({
   storage: {
     client: sqlite,
   },

--- a/docs/src/app/docs/integrations/page.md
+++ b/docs/src/app/docs/integrations/page.md
@@ -15,11 +15,11 @@ Farm treats every integration as a small server plugin. That means an integratio
 **farm.config.ts**
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { stripe } from "@farmjs/integrations/stripe";
 import { betterAuth } from "@farmjs/integrations/better-auth";
 
-export default defineFarmConfig({
+export default defineConfig({
   integrations: {
     billing: stripe({
       secretKey: process.env.STRIPE_SECRET_KEY,

--- a/docs/src/app/docs/integrations/unkey/page.md
+++ b/docs/src/app/docs/integrations/unkey/page.md
@@ -13,10 +13,10 @@ Create, verify, revoke, update, and delete API keys, plus protect routes with ke
 **farm.config.ts**
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { unkey } from "@farmjs/integrations/unkey";
 
-export default defineFarmConfig({
+export default defineConfig({
   integrations: {
     keys: unkey({
       rootKey: process.env.UNKEY_ROOT_KEY,

--- a/docs/src/app/docs/layers/page.md
+++ b/docs/src/app/docs/layers/page.md
@@ -13,9 +13,9 @@ A layer does not call a special registration function. The consuming application
 ## Consume layers
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   extends: ["@company/farm-base", "@company/admin-layer", "./layers/commerce"],
 });
 ```
@@ -59,7 +59,7 @@ export default {
 } satisfies FarmLayerConfig;
 ```
 
-`FarmLayerConfig` is an optional type-only helper. A plain default object works without importing anything, and the existing `defineFarmConfig` helper also works. There is no `defineFarmLayer` API.
+`FarmLayerConfig` is an optional type-only helper. A plain default object works without importing anything, and `defineConfig` works too. There is no `defineFarmLayer` API.
 
 ## Override layer files
 

--- a/docs/src/app/docs/markdown/page.md
+++ b/docs/src/app/docs/markdown/page.md
@@ -37,7 +37,7 @@ This creates `/about` automatically. Because the route is source-authored markdo
 **farm.config.ts**
 
 ```ts
-export default defineFarmConfig({
+export default defineConfig({
   mdx: {
     components: "./src/markdown-components.tsx",
     markdownRoutes: true,
@@ -62,7 +62,7 @@ Set `mdx.markdownRoutes` to `false` when source-authored pages should render as 
 **farm.config.ts**
 
 ```ts
-export default defineFarmConfig({
+export default defineConfig({
   md: {
     expose: ["/", "/pricing", "/docs"],
     cache: 60,
@@ -89,7 +89,7 @@ export default defineFarmConfig({
 Use `md: true` when an internal app or documentation site should expose markdown mirrors for every rendered page.
 
 ```ts
-export default defineFarmConfig({
+export default defineConfig({
   md: true,
 });
 ```
@@ -101,7 +101,7 @@ For public apps, prefer an explicit list so private or account pages are not exp
 Routes can include a display title and cache override.
 
 ```ts
-export default defineFarmConfig({
+export default defineConfig({
   md: {
     expose: [
       {

--- a/docs/src/app/docs/middleware/page.md
+++ b/docs/src/app/docs/middleware/page.md
@@ -130,9 +130,9 @@ Config-defined handlers run before discovered route middleware. Data placed in `
 **farm.config.ts**
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   middleware: [
     {
       matcher: ["/dashboard/:path*"],
@@ -148,9 +148,9 @@ export default defineFarmConfig({
 Multiple config middleware entries can match the same request. They run in array order before file middleware.
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   middleware: [
     {
       matcher: ["/dashboard/:path*", "/account/:path*"],
@@ -186,9 +186,9 @@ Matchers can be strings, regular expressions, or functions. String matchers supp
 When a matcher has params, the handler can read them from `ctx.params`.
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   middleware: [
     {
       matcher: "/dashboard/:path*",
@@ -206,9 +206,9 @@ export default defineFarmConfig({
 Use a matcher-only config when you want every discovered middleware file to run only inside a route area.
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   middleware: {
     matcher: "/dashboard/:path*",
   },
@@ -243,9 +243,9 @@ export default middleware().use(async (ctx, next) => {
 The same protection can live in config when the rule should be managed globally.
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   middleware: [
     {
       matcher: "/dashboard/:path*",
@@ -268,9 +268,9 @@ export default defineFarmConfig({
 Middleware handlers can also return a Web `Response`. Returned responses stop the middleware chain and are sent directly.
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   middleware: [
     {
       matcher: "/dashboard/:path*",
@@ -321,9 +321,9 @@ Middleware emits observability events in development and production. Subscribe w
 | `middleware.error`        | A handler throws.                                              | `route`, `pathname`, `name`, `error`      |
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   observability: {
     onEvent(event) {
       if (event.type.startsWith("middleware.")) {

--- a/docs/src/app/docs/migrations/page.md
+++ b/docs/src/app/docs/migrations/page.md
@@ -105,9 +105,9 @@ The migration report flags loaders, `beforeLoad`, search params, and `Route.use*
 `farm migrate` without a framework source still runs one-shot commands from `migrations.commands` in `farm.config.ts`.
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   migrations: {
     commands: [
       {

--- a/docs/src/app/docs/observability/page.md
+++ b/docs/src/app/docs/observability/page.md
@@ -41,9 +41,9 @@ onFarmEvent((event) => {
 Use config-level observability when an app should log or forward events from startup.
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   observability: {
     logs: true,
     events: ["cache.hit", "cache.miss", "ppr.shell.cached"],
@@ -99,9 +99,9 @@ Middleware events are emitted for both `farm.config.ts` middleware entries and `
 | `middleware.error` | `route`, `pathname`, `name`, `error` |
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   observability: {
     onEvent(event) {
       if (event.type === "middleware.shortCircuit") {

--- a/docs/src/app/docs/openapi/page.md
+++ b/docs/src/app/docs/openapi/page.md
@@ -13,7 +13,7 @@ Generate and publish API reference docs from Farm API route metadata, with Scala
 **farm.config.ts**
 
 ```ts
-export default defineFarmConfig({
+export default defineConfig({
   openapi: {
     enabled: true,
     route: "/docs/reference",
@@ -57,7 +57,7 @@ The route appears in the generated reference with a typed `limit` query paramete
 ## Add metadata
 
 ```ts
-export default defineFarmConfig({
+export default defineConfig({
   openapi: {
     enabled: true,
     route: "/docs/reference",

--- a/docs/src/app/docs/plugins/create-plugin/page.md
+++ b/docs/src/app/docs/plugins/create-plugin/page.md
@@ -34,10 +34,10 @@ export const requestIdPlugin = definePlugin({
 **farm.config.ts**
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { requestIdPlugin } from "./src/lib/request-id-plugin";
 
-export default defineFarmConfig({
+export default defineConfig({
   plugins: [requestIdPlugin],
 });
 ```

--- a/docs/src/app/docs/plugins/page.md
+++ b/docs/src/app/docs/plugins/page.md
@@ -15,10 +15,10 @@ Integrations are built on top of plugins. If you are wrapping Stripe, Auth, Rese
 **farm.config.ts**
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { createCompressionPlugin, createLoggerPlugin } from "@farmjs/core/plugin/server";
 
-export default defineFarmConfig({
+export default defineConfig({
   plugins: [
     createLoggerPlugin({}),
     createCompressionPlugin({}),
@@ -74,7 +74,7 @@ Hooks that return a value can transform the current value when Farm runs them se
 Plugins can set `enforce`:
 
 ```ts
-export default defineFarmConfig({
+export default defineConfig({
   plugins: [
     {
       name: "early",

--- a/docs/src/app/docs/reference/page.md
+++ b/docs/src/app/docs/reference/page.md
@@ -35,7 +35,7 @@ A compact map of the main package exports and where to learn more.
 
 | Package | Exports |
 | --- | --- |
-| `@farmjs/core` | `defineIntegration`, `integrationRoute`, `defineIntegrationSchema`, `definePlugin`, `defineFarmConfig`. |
+| `@farmjs/core` | `defineIntegration`, `integrationRoute`, `defineIntegrationSchema`, `definePlugin`, `defineConfig`. |
 | `@farmjs/core/workflows` | `defineCron`, `defineWorkflow`, `defineTask` for lightweight scheduled and manually-triggered server workflows. |
 | `@farmjs/core/client` | `createIntegrations`, `createIntegrationClient`, `createIntegrationServerClient`, `endpoint`. |
 | `@farmjs/core/navigation` | `redirect`, `permanentRedirect`, `notFound`, `useRouter`, `usePathname`, `useSearchParams`. |

--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -322,11 +322,11 @@ Use this for tab state, pagination defaults, locale/tenant preservation, preview
 Use `context` in `farm.config.ts` for request-scoped dependencies that guards and route data need: sessions, tenants, feature flags, or database clients. The value is available to programmatic route `guard`, `data.before`, `data.main`, cache key functions, and `data.after`.
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { db } from "./src/db";
 import { getSession } from "./src/session";
 
-export default defineFarmConfig({
+export default defineConfig({
   context: async ({ request }) => ({
     session: await getSession(request),
     db,

--- a/docs/src/app/docs/storage/page.md
+++ b/docs/src/app/docs/storage/page.md
@@ -28,10 +28,10 @@ await appStorage.setItem("settings", { theme: "light" });
 **farm.config.ts**
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { redisStorage, sqliteStorage } from "@farmjs/core/storage";
 
-export default defineFarmConfig({
+export default defineConfig({
   storage: {
     mounts: {
       app: sqliteStorage({ path: "./.farm/storage/app.sqlite" }),
@@ -50,12 +50,12 @@ export default defineFarmConfig({
 `storage.client` can also carry an app-owned database client for schema-backed integrations.
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { DatabaseSync } from "node:sqlite";
 
 const db = new DatabaseSync("farm.sqlite");
 
-export default defineFarmConfig({
+export default defineConfig({
   storage: {
     client: db,
   },
@@ -71,9 +71,9 @@ Farm can generate integration schema artifacts with `farm generate`, then run yo
 **farm.config.ts**
 
 ```ts
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   storage: {
     client: db,
   },

--- a/docs/src/app/docs/workflows/page.md
+++ b/docs/src/app/docs/workflows/page.md
@@ -84,9 +84,9 @@ curl -X POST https://app.example.com/api/_farm/workflows/sync-cms \
 The default config is enough for most apps.
 
 ```ts title="farm.config.ts"
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   workflows: true,
 });
 ```
@@ -94,9 +94,9 @@ export default defineFarmConfig({
 Customize the scanned directory, route, or secret env when needed.
 
 ```ts title="farm.config.ts"
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   workflows: {
     dir: "src/background",
     route: "/api/internal/workflows",

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -291,8 +291,8 @@ export default defineConfig({
     label: "Consume / app/farm.config.ts",
     language: "ts",
     highlightLines: [5],
-    code: `import { defineFarmConfig } from "@farmjs/core";
-export default defineFarmConfig({
+    code: `import { defineConfig } from "@farmjs/core";
+export default defineConfig({
     extends: [
         "@company/farm-base",
         "./layers/commerce",

--- a/examples/auth0-integration/farm.config.ts
+++ b/examples/auth0-integration/farm.config.ts
@@ -1,7 +1,7 @@
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { appIntegrations } from "./src/lib/integrations.ts";
 
-export default defineFarmConfig({
+export default defineConfig({
   experimental: {
     serverComponents: true,
   },

--- a/examples/authjs-integration/farm.config.ts
+++ b/examples/authjs-integration/farm.config.ts
@@ -1,8 +1,8 @@
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { authjs } from "@farmjs/integrations/authjs";
 import { nextAuth } from "./auth.ts";
 
-export default defineFarmConfig({
+export default defineConfig({
   experimental: {
     serverComponents: true,
   },

--- a/examples/autumn-integration/farm.config.ts
+++ b/examples/autumn-integration/farm.config.ts
@@ -1,7 +1,7 @@
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { appIntegrations } from "./src/lib/integrations.ts";
 
-export default defineFarmConfig({
+export default defineConfig({
   experimental: {
     serverComponents: true,
   },

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -31,7 +31,7 @@ This example enables route-level `loading.tsx` and `error.tsx` boundaries with:
 
 ```ts
 // examples/basic/farm.config.ts
-export default defineFarmConfig({
+export default defineConfig({
   experimental: {
     serverComponents: true,
     serverActions: true,
@@ -44,7 +44,7 @@ export default defineFarmConfig({
 The example also keeps deployment and Vite tweaks in the same file:
 
 ```ts
-export default defineFarmConfig({
+export default defineConfig({
   deploy: {
     target: "vercel",
   },
@@ -61,7 +61,7 @@ No root `vite.config.ts` or `vercel.json` is required for the basic example.
 This example exposes agent-readable markdown mirrors for a few normal pages:
 
 ```ts
-export default defineFarmConfig({
+export default defineConfig({
   md: {
     expose: ["/", "/about", "/contact"],
     cache: 60,
@@ -91,7 +91,7 @@ storage, build, plugins, and errors. This example can enable the default logs or
 custom handler from `farm.config.ts`:
 
 ```ts
-export default defineFarmConfig({
+export default defineConfig({
   observability: {
     logs: true,
     onEvent(event) {

--- a/examples/basic/farm.config.ts
+++ b/examples/basic/farm.config.ts
@@ -1,4 +1,4 @@
-import { defineFarmConfig, type FarmPlugin } from '@farmjs/core';
+import { defineConfig, type FarmPlugin } from '@farmjs/core';
 import { createLoggerPlugin, createEnvPlugin } from '@farmjs/core/plugin/server';
 import { z } from 'zod';
 import { storageDemoClients, STORAGE_DEMO_MOUNTS } from './src/lib/storage-demo.ts';
@@ -19,7 +19,7 @@ const myCustomPlugin: FarmPlugin = {
   },
 };
 
-export default defineFarmConfig({
+export default defineConfig({
   extends: ['./layers/recent-features'],
   srcDir: 'src',
   outDir: 'dist',

--- a/examples/basic/src/app/storage-demo/page.tsx
+++ b/examples/basic/src/app/storage-demo/page.tsx
@@ -113,7 +113,7 @@ export const redis = redisStorage({
 
 await sqlite.setItem("settings", { theme: "light" });
 
-export default defineFarmConfig({
+export default defineConfig({
   storage: {
     mounts: {
       app: sqlite,

--- a/examples/better-auth-integration/farm.config.ts
+++ b/examples/better-auth-integration/farm.config.ts
@@ -1,8 +1,8 @@
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { betterAuth } from "@farmjs/integrations/better-auth";
 import { auth } from "./src/lib/auth.ts";
 
-export default defineFarmConfig({
+export default defineConfig({
   experimental: {
     serverComponents: true,
   },

--- a/examples/clerk-integration/farm.config.ts
+++ b/examples/clerk-integration/farm.config.ts
@@ -1,7 +1,7 @@
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { clerk } from "@farmjs/integrations/clerk";
 
-export default defineFarmConfig({
+export default defineConfig({
   experimental: {
     serverComponents: true,
   },

--- a/examples/deployment-presets/farm.config.ts
+++ b/examples/deployment-presets/farm.config.ts
@@ -1,10 +1,10 @@
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 
 const preset = process.env.NITRO_PRESET;
 const target = preset ? undefined : process.env.FARM_DEPLOY_TARGET || "vercel";
 const isSelfHosted = target === "node";
 
-export default defineFarmConfig({
+export default defineConfig({
   deploy: {
     target,
     preset,

--- a/examples/docs-integration/README.md
+++ b/examples/docs-integration/README.md
@@ -6,9 +6,9 @@ entry and `/api/docs/*` machine routes.
 
 ```ts
 // farm.config.ts
-import { defineFarmConfig } from '@farmjs/core';
+import { defineConfig } from '@farmjs/core';
 
-export default defineFarmConfig({
+export default defineConfig({
   docs: {
     entry: '/docs',
   },

--- a/examples/docs-integration/farm.config.ts
+++ b/examples/docs-integration/farm.config.ts
@@ -1,6 +1,6 @@
-import { defineFarmConfig } from '@farmjs/core';
+import { defineConfig } from '@farmjs/core';
 
-export default defineFarmConfig({
+export default defineConfig({
   srcDir: 'src',
   deploy: {
     target: 'vercel',

--- a/examples/docs-integration/src/app/docs/page.md
+++ b/examples/docs-integration/src/app/docs/page.md
@@ -9,9 +9,9 @@ This page is loaded from `src/app/docs/page.md` through the Farm docs integratio
 machine API route is registered automatically when docs are enabled in `farm.config.ts`:
 
 ```ts
-import { defineFarmConfig } from '@farmjs/core';
+import { defineConfig } from '@farmjs/core';
 
-export default defineFarmConfig({
+export default defineConfig({
   docs: {
     entry: '/docs',
   },

--- a/examples/docs-integration/src/app/docs/server-wrapper/page.md
+++ b/examples/docs-integration/src/app/docs/server-wrapper/page.md
@@ -8,9 +8,9 @@ description: How Farm registers the docs API while keeping a Next-style override
 Farm registers the docs API automatically from `farm.config.ts`:
 
 ```ts
-import { defineFarmConfig } from '@farmjs/core';
+import { defineConfig } from '@farmjs/core';
 
-export default defineFarmConfig({
+export default defineConfig({
   docs: {
     entry: '/docs',
   },

--- a/examples/email-integrations/resend-example/farm.config.ts
+++ b/examples/email-integrations/resend-example/farm.config.ts
@@ -1,7 +1,7 @@
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { appIntegrations } from "./src/lib/integrations.ts";
 
-export default defineFarmConfig({
+export default defineConfig({
   experimental: {
     serverComponents: true,
   },

--- a/examples/jobs-inngest/farm.config.ts
+++ b/examples/jobs-inngest/farm.config.ts
@@ -1,7 +1,7 @@
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { appIntegrations } from "./src/lib/integrations.ts";
 
-export default defineFarmConfig({
+export default defineConfig({
   experimental: {
     serverComponents: true,
   },

--- a/examples/jobs-integration/farm.config.ts
+++ b/examples/jobs-integration/farm.config.ts
@@ -1,7 +1,7 @@
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { appIntegrations } from "./src/lib/integrations.ts";
 
-export default defineFarmConfig({
+export default defineConfig({
   experimental: {
     serverComponents: true,
   },

--- a/examples/jobs-trigger/farm.config.ts
+++ b/examples/jobs-trigger/farm.config.ts
@@ -1,7 +1,7 @@
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { appIntegrations } from "./src/lib/integrations.ts";
 
-export default defineFarmConfig({
+export default defineConfig({
   experimental: {
     serverComponents: true,
   },

--- a/examples/polar-integration/farm.config.ts
+++ b/examples/polar-integration/farm.config.ts
@@ -1,7 +1,7 @@
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { appIntegrations } from "./src/lib/integrations.ts";
 
-export default defineFarmConfig({
+export default defineConfig({
   experimental: {
     serverComponents: true,
   },

--- a/examples/ssr-ssg-demo/farm.config.ts
+++ b/examples/ssr-ssg-demo/farm.config.ts
@@ -1,7 +1,7 @@
-import { defineFarmConfig } from '@farmjs/core';
+import { defineConfig } from '@farmjs/core';
 import { createLoggerPlugin } from '@farmjs/core/plugin/server';
 
-export default defineFarmConfig({
+export default defineConfig({
   srcDir: 'src',
   deploy: {
     target: 'vercel',

--- a/examples/stripe-integration/farm.config.ts
+++ b/examples/stripe-integration/farm.config.ts
@@ -1,7 +1,7 @@
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { appIntegrations } from "./src/lib/integrations.ts";
 
-export default defineFarmConfig({
+export default defineConfig({
   experimental: {
     serverComponents: true,
   },

--- a/examples/stripe-integrations/drizzle/farm.config.ts
+++ b/examples/stripe-integrations/drizzle/farm.config.ts
@@ -1,7 +1,7 @@
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { appIntegrations } from "./src/lib/integrations.ts";
 
-export default defineFarmConfig({
+export default defineConfig({
   experimental: {
     serverComponents: true,
   },

--- a/examples/stripe-integrations/prisma-org/farm.config.ts
+++ b/examples/stripe-integrations/prisma-org/farm.config.ts
@@ -1,7 +1,7 @@
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { appIntegrations } from "./src/lib/integrations.ts";
 
-export default defineFarmConfig({
+export default defineConfig({
   experimental: {
     serverComponents: true,
   },

--- a/examples/stripe-integrations/prisma/farm.config.ts
+++ b/examples/stripe-integrations/prisma/farm.config.ts
@@ -1,7 +1,7 @@
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { appIntegrations } from "./src/lib/integrations.ts";
 
-export default defineFarmConfig({
+export default defineConfig({
   experimental: {
     serverComponents: true,
   },

--- a/examples/stripe-integrations/sqlite/farm.config.ts
+++ b/examples/stripe-integrations/sqlite/farm.config.ts
@@ -1,7 +1,7 @@
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { appIntegrations } from "./src/lib/integrations.ts";
 
-export default defineFarmConfig({
+export default defineConfig({
   experimental: {
     serverComponents: true,
   },

--- a/examples/supabase-integration/README.md
+++ b/examples/supabase-integration/README.md
@@ -79,7 +79,7 @@ the ones published by Farm:
 ```ts
 import { localDemo } from "./src/lib/integrations/local-demo/index.ts";
 
-export default defineFarmConfig({
+export default defineConfig({
   integrations: {
     auth: supabase(...),
     localDemo: localDemo(),

--- a/examples/supabase-integration/farm.config.ts
+++ b/examples/supabase-integration/farm.config.ts
@@ -1,7 +1,7 @@
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { appIntegrations } from "./src/lib/integrations.ts";
 
-export default defineFarmConfig({
+export default defineConfig({
   experimental: {
     serverComponents: true,
   },

--- a/examples/workos-integration/farm.config.ts
+++ b/examples/workos-integration/farm.config.ts
@@ -1,7 +1,7 @@
-import { defineFarmConfig } from "@farmjs/core";
+import { defineConfig } from "@farmjs/core";
 import { appIntegrations } from "./src/lib/integrations.ts";
 
-export default defineFarmConfig({
+export default defineConfig({
   experimental: {
     serverComponents: true,
   },

--- a/packages/farm-cli/src/migrate.ts
+++ b/packages/farm-cli/src/migrate.ts
@@ -390,15 +390,15 @@ function addSharedFarmFiles(
   if (!farmConfigPath) {
     const output =
       source === "next"
-        ? `import { defineFarmConfig } from "@farmjs/core";
+        ? `import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   srcDir: "src",
 });
 `
-        : `import { defineFarmConfig } from "@farmjs/core";
+        : `import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   srcDir: "src",
 });
 `;

--- a/packages/farm-cli/test/add-integration.test.mjs
+++ b/packages/farm-cli/test/add-integration.test.mjs
@@ -93,9 +93,9 @@ export type AppIntegrations = typeof appIntegrations;
     );
     await writeFile(
       path.join(root, "farm.config.ts"),
-      `import { defineFarmConfig } from "@farmjs/core";
+      `import { defineConfig } from "@farmjs/core";
 
-export default defineFarmConfig({
+export default defineConfig({
   vite: {
     server: {
       port: 3000,

--- a/packages/farm-cli/test/migrate.test.mjs
+++ b/packages/farm-cli/test/migrate.test.mjs
@@ -227,7 +227,9 @@ export default function AboutPage() {
     assert.match(page, /from "@farmjs\/core\/navigation";/);
     assert.match(page, /from "@farmjs\/core\/headers";/);
     assert.doesNotMatch(page, /from "next\//);
-    assert.match(await readFile(path.join(root, "farm.config.ts"), "utf8"), /defineFarmConfig/);
+    const farmConfig = await readFile(path.join(root, "farm.config.ts"), "utf8");
+    assert.match(farmConfig, /defineConfig/);
+    assert.doesNotMatch(farmConfig, /defineFarmConfig/);
 
     const packageJson = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
     assert.equal(packageJson.scripts.dev, "farm dev");

--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -38,7 +38,7 @@ afterEach(() => {
 });
 
 describe("config helpers", () => {
-  it("supports concise and framework-specific names", () => {
+  it("keeps defineFarmConfig as an exact compatibility alias", () => {
     const config = {
       srcDir: "app",
       deploy: { target: "vercel" as const },

--- a/packages/farm/src/__tests__/layers.test.ts
+++ b/packages/farm/src/__tests__/layers.test.ts
@@ -34,8 +34,8 @@ describe("Farm layers", () => {
     writeFileSync(
       path.join(root, "farm.config.ts"),
       `
-        import { defineFarmConfig } from "@farmjs/core";
-        export default defineFarmConfig({
+        import { defineConfig } from "@farmjs/core";
+        export default defineConfig({
           extends: ["./layers/commerce"],
           routeRules: { "/shop/checkout": { render: "dynamic" } }
         });

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -280,12 +280,12 @@ export type FarmLayerConfig = Omit<
 >;
 
 /** Define a Farm application config while preserving literal types. */
-export function defineFarmConfig<const TConfig extends FarmUserConfig>(config: TConfig): TConfig {
+export function defineConfig<const TConfig extends FarmUserConfig>(config: TConfig): TConfig {
   return config;
 }
 
-/** Concise alias for {@link defineFarmConfig}. */
-export const defineConfig = defineFarmConfig;
+/** @deprecated Use {@link defineConfig}. */
+export const defineFarmConfig = defineConfig;
 
 export function normalizeDeployTarget(target?: FarmDeployTarget): FarmDeployTarget | undefined {
   if (!target) return undefined;

--- a/packages/farmjs-plugin/src/context/index.ts
+++ b/packages/farmjs-plugin/src/context/index.ts
@@ -61,7 +61,7 @@ function getHeader(req: RequestLike, name: string): string | undefined {
  * ```ts
  * import { contextPlugin } from "@farmjs/plugin/context";
  *
- * export default defineFarmConfig({
+ * export default defineConfig({
  *   plugins: [contextPlugin()],
  * });
  * ```

--- a/skills/farmjs/SKILL.md
+++ b/skills/farmjs/SKILL.md
@@ -53,7 +53,7 @@ Use `"use client"` when a component uses React hooks, browser APIs, or client-on
 
 ## Config Spec
 
-Farm apps use `defineConfig`. The older `defineFarmConfig` name is an exact supported alias:
+Farm apps use `defineConfig`. The older `defineFarmConfig` name remains available as a deprecated exact alias:
 
 ```ts
 import { defineConfig } from "@farmjs/core";


### PR DESCRIPTION
## Summary

- make `defineConfig` the canonical typed Farm config helper
- retain `defineFarmConfig` as a deprecated exact compatibility alias
- update migration-generated configs and CLI fixtures to emit `defineConfig`
- migrate every docs snippet, homepage example, first-party example app, README, and Farm skill to the canonical spelling

## Validation

- `@farmjs/core`: 537 tests passed, 1 skipped
- focused config and layer suite: 33 tests passed
- `@farmjs/cli`: 27 tests passed
- `@farmjs/core` build and declaration generation
- `@farmjs/plugin` type check
- all 20 modified example packages with type-check scripts
- SSR/SSG example Vercel production build
- docs Vercel production build with 51 routes
- repository scan confirms legacy usage remains only for compatibility export, tests, and migration notes

## Compatibility

Existing imports of `defineFarmConfig` continue to work with identical runtime and generic typing behavior. The alias is now marked deprecated so editors guide new code toward `defineConfig`.

## Existing baseline

The standalone CLI type-check still reports its pre-existing `replaceAll` target and UI feature registry typing errors in untouched files; the same errors reproduce on the base checkout.