### PR TITLE
feat: showcase storage and advanced routes

### DIFF
--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -419,6 +419,10 @@
     color: rgb(255 255 255 / 0.48);
   }
 
+  .farm-highlighted-code--compact .sh__line {
+    min-height: 1.25rem;
+  }
+
   .farm-highlighted-code .sh__token--keyword {
     font-weight: 650;
   }

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -336,32 +336,30 @@ const createRouteHelper = ["create", "Route"].join("");
 
 const routeCodeTabs = [
   {
-    id: "contract",
-    label: "Contract / product.route.tsx",
-    language: "tsx",
-    highlightLines: [1, 2, 3, 4],
+    id: "route",
+    label: "Route / src/farm.route.ts",
+    language: "ts",
+    highlightLines: [4, 5, 6],
     code: `export const ProductRoute = ${createRouteHelper}("/products/[id]", {
-    params: z.object({ id: z.string() }),
-    search: { schema: ProductSearch, stripDefaults: true },
-    guard: ({ context }) => requireUser(context.session),
-    pending: ProductSkeleton,
-    error: ProductError,
-    render: "dynamic",
+    params: ProductParams,
+    data: {
+        before: ({ context }) => requireUser(context.session),
+        main: ({ params, before }) => getProduct(params.id, before.id),
+        after: ({ data }) => recordView(data.id),
+    },
     component: ProductPage,
 });`,
   },
   {
-    id: "data",
-    label: "Data / product.route.tsx",
+    id: "component",
+    label: "Use / product-page.tsx",
     language: "tsx",
-    highlightLines: [2, 3, 4],
-    code: `data: {
-    key: ({ params }) => ["product", params.id],
-    staleTime: "30s",
-    main: async ({ params }) => ({
-        product: await getProduct(params.id),
-    }),
-},`,
+    highlightLines: [2, 4],
+    code: `export function ProductPage({
+    data,
+}: ProductPageProps) {
+    return <h1>{data.name}</h1>;
+}`,
   },
 ] as const satisfies readonly [HighlightedCodeTab, ...HighlightedCodeTab[]];
 
@@ -1172,7 +1170,7 @@ function FoundationGrid() {
         <StorageVisual />
       </FeatureCell>
       <FeatureCell
-        body="Keep validated params and search, guards, cached data, pending and error UI, and rendering policy in one typed route definition."
+        body="Validate params, prepare request data, load the page, and run post-load work in one typed route definition."
         className="border-t border-white/12 lg:border-l"
         icon={Route}
         index="02.6"

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -339,7 +339,7 @@ const routeCodeTabs = [
     id: "route",
     label: "Route / src/farm.route.ts",
     language: "ts",
-    highlightLines: [4, 5, 6],
+    highlightLines: [4, 5, 6, 8, 9],
     code: `export const ProductRoute = ${createRouteHelper}("/products/[id]", {
     params: ProductParams,
     data: {
@@ -347,6 +347,8 @@ const routeCodeTabs = [
         main: ({ params, before }) => getProduct(params.id, before.id),
         after: ({ data }) => recordView(data.id),
     },
+    pending: ProductSkeleton,
+    error: ProductError,
     component: ProductPage,
 });`,
   },
@@ -354,11 +356,16 @@ const routeCodeTabs = [
     id: "component",
     label: "Use / product-page.tsx",
     language: "tsx",
-    highlightLines: [2, 4],
+    highlightLines: [2, 6, 7],
     code: `export function ProductPage({
     data,
 }: ProductPageProps) {
-    return <h1>{data.name}</h1>;
+    return (
+        <main>
+            <h1>{data.name}</h1>
+            <p>{data.description}</p>
+        </main>
+    );
 }`,
   },
 ] as const satisfies readonly [HighlightedCodeTab, ...HighlightedCodeTab[]];
@@ -951,10 +958,12 @@ function FoundationCodeVisual({
 }
 
 function FoundationCodeTabsVisual({
+  compact = false,
   id,
   tabs,
   tabsLabel,
 }: {
+  compact?: boolean;
   id: string;
   tabs: readonly [HighlightedCodeTab, ...HighlightedCodeTab[]];
   tabsLabel: string;
@@ -963,6 +972,7 @@ function FoundationCodeTabsVisual({
     <div className="farm-feature-spotlight relative flex h-[320px] min-w-0 items-end justify-end overflow-hidden pl-6 sm:h-[328px] sm:pl-10">
       <HighlightedCodeTabs
         className="relative z-10 -mb-px -mr-px flex h-[296px] w-full max-w-full shrink-0 flex-col sm:h-[300px]"
+        compact={compact}
         id={id}
         tabs={tabs}
         tabsLabel={tabsLabel}
@@ -1110,6 +1120,7 @@ function StorageVisual() {
 function AdvancedRoutesVisual() {
   return (
     <FoundationCodeTabsVisual
+      compact
       id="farm-advanced-routes-code"
       tabs={routeCodeTabs}
       tabsLabel="Farm advanced route examples"

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -8,6 +8,7 @@ import {
   Braces,
   CloudCog,
   CreditCard,
+  Database,
   ExternalLink,
   FileText,
   FolderTree,
@@ -298,6 +299,69 @@ export default defineConfig({
         "./layers/commerce",
     ],
 });`,
+  },
+] as const satisfies readonly [HighlightedCodeTab, ...HighlightedCodeTab[]];
+
+const storageCodeTabs = [
+  {
+    id: "configure",
+    label: "Configure / farm.config.ts",
+    language: "ts",
+    highlightLines: [4, 5],
+    code: `export default defineConfig({
+    storage: {
+        mounts: {
+            app: sqliteStorage({ path: "./data.sqlite" }),
+            cache: redisStorage({ url: process.env.REDIS_URL! }),
+        },
+    },
+});`,
+  },
+  {
+    id: "use",
+    label: "Use / preferences.ts",
+    language: "ts",
+    highlightLines: [1, 3, 7],
+    code: `const app = getStorage("app");
+
+await app.setItem("settings:1", {
+    theme: "dark",
+});
+
+const settings = await app.getItem<Settings>("settings:1");`,
+  },
+] as const satisfies readonly [HighlightedCodeTab, ...HighlightedCodeTab[]];
+
+const createRouteHelper = ["create", "Route"].join("");
+
+const routeCodeTabs = [
+  {
+    id: "contract",
+    label: "Contract / product.route.tsx",
+    language: "tsx",
+    highlightLines: [1, 2, 3, 4],
+    code: `export const ProductRoute = ${createRouteHelper}("/products/[id]", {
+    params: z.object({ id: z.string() }),
+    search: { schema: ProductSearch, stripDefaults: true },
+    guard: ({ context }) => requireUser(context.session),
+    pending: ProductSkeleton,
+    error: ProductError,
+    render: "dynamic",
+    component: ProductPage,
+});`,
+  },
+  {
+    id: "data",
+    label: "Data / product.route.tsx",
+    language: "tsx",
+    highlightLines: [2, 3, 4],
+    code: `data: {
+    key: ({ params }) => ["product", params.id],
+    staleTime: "30s",
+    main: async ({ params }) => ({
+        product: await getProduct(params.id),
+    }),
+},`,
   },
 ] as const satisfies readonly [HighlightedCodeTab, ...HighlightedCodeTab[]];
 
@@ -889,17 +953,21 @@ function FoundationCodeVisual({
 }
 
 function FoundationCodeTabsVisual({
+  id,
   tabs,
+  tabsLabel,
 }: {
+  id: string;
   tabs: readonly [HighlightedCodeTab, ...HighlightedCodeTab[]];
+  tabsLabel: string;
 }) {
   return (
     <div className="farm-feature-spotlight relative flex h-[320px] min-w-0 items-end justify-end overflow-hidden pl-6 sm:h-[328px] sm:pl-10">
       <HighlightedCodeTabs
         className="relative z-10 -mb-px -mr-px flex h-[296px] w-full max-w-full shrink-0 flex-col sm:h-[300px]"
-        id="farm-layers-code"
+        id={id}
         tabs={tabs}
-        tabsLabel="Farm Layers examples"
+        tabsLabel={tabsLabel}
       />
     </div>
   );
@@ -1022,7 +1090,33 @@ function DocsVisual() {
 }
 
 function LayersVisual() {
-  return <FoundationCodeTabsVisual tabs={layersConfigTabs} />;
+  return (
+    <FoundationCodeTabsVisual
+      id="farm-layers-code"
+      tabs={layersConfigTabs}
+      tabsLabel="Farm Layers examples"
+    />
+  );
+}
+
+function StorageVisual() {
+  return (
+    <FoundationCodeTabsVisual
+      id="farm-storage-code"
+      tabs={storageCodeTabs}
+      tabsLabel="Farm storage examples"
+    />
+  );
+}
+
+function AdvancedRoutesVisual() {
+  return (
+    <FoundationCodeTabsVisual
+      id="farm-advanced-routes-code"
+      tabs={routeCodeTabs}
+      tabsLabel="Farm advanced route examples"
+    />
+  );
 }
 
 function FoundationGrid() {
@@ -1066,6 +1160,26 @@ function FoundationGrid() {
         title="Share architecture, not boilerplate"
       >
         <LayersVisual />
+      </FeatureCell>
+      <FeatureCell
+        body="Mount SQLite, Redis, S3, or any supported driver once, then reuse the storage layer across server code, middleware, rate limits, and integrations."
+        className="border-t border-white/12"
+        icon={Database}
+        index="02.5"
+        label="Storage"
+        title="Storage built into the runtime"
+      >
+        <StorageVisual />
+      </FeatureCell>
+      <FeatureCell
+        body="Keep validated params and search, guards, cached data, pending and error UI, and rendering policy in one typed route definition."
+        className="border-t border-white/12 lg:border-l"
+        icon={Route}
+        index="02.6"
+        label="Advanced routes"
+        title="Configure the whole route in one place"
+      >
+        <AdvancedRoutesVisual />
       </FeatureCell>
     </section>
   );

--- a/docs/src/components/home/highlighted-code.tsx
+++ b/docs/src/components/home/highlighted-code.tsx
@@ -24,6 +24,7 @@ export interface HighlightedCodeTab {
 
 interface HighlightedCodeTabsProps {
   className?: string;
+  compact?: boolean;
   id: string;
   tabs: readonly [HighlightedCodeTab, ...HighlightedCodeTab[]];
   tabsLabel?: string;
@@ -42,6 +43,7 @@ function HighlightedCodeBody({
   ariaLabel,
   ariaLabelledBy,
   code,
+  compact = false,
   highlightLines = [],
   id,
   role,
@@ -49,6 +51,7 @@ function HighlightedCodeBody({
   ariaLabel?: string;
   ariaLabelledBy?: string;
   code: string;
+  compact?: boolean;
   highlightLines?: readonly number[];
   id?: string;
   role?: "tabpanel";
@@ -67,13 +70,23 @@ function HighlightedCodeBody({
     <pre
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledBy}
-      className="min-h-0 max-w-full flex-1 overflow-x-auto py-4 font-mono text-[10.5px] leading-6 tracking-normal sm:text-[11px]"
+      className={[
+        "min-h-0 max-w-full flex-1 overflow-x-auto font-mono tracking-normal",
+        compact
+          ? "py-2 text-[10px] leading-5 sm:text-[10.5px]"
+          : "py-4 text-[10.5px] leading-6 sm:text-[11px]",
+      ].join(" ")}
       id={id}
       role={role}
       tabIndex={0}
     >
       <code
-        className="farm-highlighted-code block min-w-full"
+        className={[
+          "farm-highlighted-code block min-w-full",
+          compact && "farm-highlighted-code--compact",
+        ]
+          .filter(Boolean)
+          .join(" ")}
         dangerouslySetInnerHTML={{ __html: highlightedCode }}
       />
     </pre>
@@ -109,6 +122,7 @@ export function HighlightedCode({
 
 export function HighlightedCodeTabs({
   className,
+  compact = false,
   id,
   tabs,
   tabsLabel = "Code examples",
@@ -178,6 +192,7 @@ export function HighlightedCodeTabs({
       <HighlightedCodeBody
         ariaLabelledBy={`${id}-${activeTab.id}-tab`}
         code={activeTab.code}
+        compact={compact}
         highlightLines={activeTab.highlightLines}
         id={panelId}
         role="tabpanel"


### PR DESCRIPTION
## Summary

- add built-in Storage and Advanced Routes to the homepage foundation grid
- show real configure/use and contract/data examples with the existing accessible code tabs
- keep the rendered `createRoute()` sample from being discovered as an actual programmatic route

## Validation

- `corepack pnpm --filter farmjs-docs build`
- `corepack pnpm exec oxlint docs/src/app/page.tsx`
- `corepack pnpm exec oxfmt --check docs/src/app/page.tsx`
- Playwright checks at 1440px and 390px for rendering, tab interaction, console errors, clipping, and horizontal overflow
- confirmed generated route types do not contain the example `/products/[id]` route