### PR TITLE
feat: expand auth and jobs integration guides

### DIFF
--- a/docs/src/app/docs/integrations/auth/auth0/page.md
+++ b/docs/src/app/docs/integrations/auth/auth0/page.md
@@ -1,12 +1,14 @@
 ---
 title: "Auth0 Integration"
-description: "Wire Auth0 login, callback, logout, and session routes from Farm config."
+description: "Add Auth0 login, callback, logout, profile, and protected-route flows to Farm."
 section: "Integrations"
 ---
 
 # Auth0 Integration
 
-Auth0 fits teams that want hosted identity, enterprise providers, and a config-first login and callback flow.
+Use Auth0 when the identity provider should host login and enterprise connections while Farm owns the application-facing OAuth routes and local session.
+
+The built-in flow uses Authorization Code with PKCE, validates signed state, reads the user profile, and stores that profile in a signed HTTP-only cookie.
 
 ## Add Auth0
 
@@ -21,61 +23,133 @@ farm add integration auth0 --ui
 **src/lib/integrations.ts**
 
 ```ts
-import { auth0 } from "@farmjs/integrations/auth";
+import { auth0 } from "@farmjs/integrations/auth0";
 
-export const integrations = {
+export const appIntegrations = {
   auth: auth0({
     domain: process.env.AUTH0_DOMAIN,
     clientId: process.env.AUTH0_CLIENT_ID,
     clientSecret: process.env.AUTH0_CLIENT_SECRET,
-    callbackUrl: "/api/auth/callback",
+    secret: process.env.AUTH0_SECRET,
+    appBaseUrl: process.env.APP_BASE_URL,
+    callbackPath: "/auth/callback",
+    protectedRoutes: ["/dashboard(.*)"],
   }),
-};
+} as const;
+
+export type AppIntegrations = typeof appIntegrations;
 ```
 
-## Use it
+`callbackPath` stays root-relative. Farm combines it with `APP_BASE_URL`, or the incoming request origin, to create the callback URL sent to Auth0.
 
-**Caller**
+You can use `callbackUrl` instead, but it must be absolute:
 
 ```ts
-const login = await api.auth.login.get({
+auth0({
+  callbackUrl: "https://app.example.com/auth/callback",
+});
+```
+
+## Environment variables
+
+| Variable              | Required                  | Purpose                                                                   |
+| --------------------- | ------------------------- | ------------------------------------------------------------------------- |
+| `AUTH0_DOMAIN`        | Yes                       | Tenant domain without a required protocol, such as `tenant.us.auth0.com`. |
+| `AUTH0_CLIENT_ID`     | Yes                       | OAuth application client ID.                                              |
+| `AUTH0_CLIENT_SECRET` | Depends on client type    | Used by confidential clients during code exchange.                        |
+| `AUTH0_SECRET`        | Production                | Signs state and local session cookies.                                    |
+| `APP_BASE_URL`        | Recommended in production | Public app origin used for callbacks and protected-route redirects.       |
+
+Farm provides a development-only fallback for `AUTH0_SECRET`. Production startup fails when no secret is configured.
+
+## Routes and methods
+
+| Method | Default route    | Purpose                                                            |
+| ------ | ---------------- | ------------------------------------------------------------------ |
+| `GET`  | `/auth/login`    | Starts login. Accepts `returnTo`.                                  |
+| `GET`  | `/auth/signup`   | Starts signup with Auth0's signup screen hint.                     |
+| `GET`  | `/auth/callback` | Validates state, exchanges the code, and writes the local session. |
+| `GET`  | `/auth/logout`   | Clears the local session and redirects through Auth0 logout.       |
+| `GET`  | `/auth/profile`  | Returns the current local profile or `401`.                        |
+
+Every path can be changed with `loginPath`, `signUpPath`, `callbackPath`, `logoutPath`, or `profilePath`.
+
+## Start login
+
+Normal document navigation redirects directly:
+
+```tsx
+<a href="/auth/login?returnTo=/dashboard">Sign in</a>
+```
+
+The typed integration client asks for the redirect URL as JSON:
+
+```ts
+const result = await apiClient.auth.login.get({
   query: {
     returnTo: "/dashboard",
   },
 });
 
-if (login.data?.redirectTo) {
-  window.location.href = login.data.redirectTo;
+if (result.data) {
+  window.location.assign(result.data.redirectTo);
 }
 ```
 
-## What Auth0 adds
+Signup uses the same shape through `apiClient.auth.signup.get(...)`.
 
-| Route | Purpose |
-| --- | --- |
-| `/auth/login` | Starts login and returns or performs a redirect. |
-| `/auth/signup` | Starts signup and returns or performs a redirect. |
-| `/auth/callback` | Exchanges the authorization code and writes the session cookie. |
-| `/auth/logout` | Clears the local session and redirects to Auth0 logout. |
-| `/auth/profile` | Reads the local Auth0 session profile. |
+## Read the profile
 
-The route paths can be overridden when the app needs a different URL structure.
+```ts
+const result = await api.auth.profile.get();
 
-## Protected routes
+if (result.error && "status" in result.error && result.error.status === 401) {
+  // No valid local Auth0 session.
+}
+
+const user = result.data?.user;
+```
+
+The session cookie contains the fetched Auth0 profile and an expiry derived from the token response. The integration does not persist refresh tokens, so an expired local session requires a new login.
+
+## Protect app routes
 
 ```ts
 auth0({
-  domain: process.env.AUTH0_DOMAIN,
-  clientId: process.env.AUTH0_CLIENT_ID,
-  clientSecret: process.env.AUTH0_CLIENT_SECRET,
-  secret: process.env.AUTH0_SECRET,
-  protectedRoutes: ["/dashboard(.*)"],
+  protectedRoutes: ["/dashboard(.*)", "/settings(.*)"],
 });
 ```
 
-## Production notes
+A signed-out request is redirected with status `307` to:
 
-- Set `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `AUTH0_SECRET`, and `APP_BASE_URL`.
-- Register the callback URL in the Auth0 dashboard.
-- Use `returnTo` for post-login navigation.
-- Test state validation, callback errors, logout redirects, and expired sessions.
+```text
+/auth/login?returnTo=/the/original/path
+```
+
+Only root-relative `returnTo` values are accepted. Invalid or external values fall back to `/dashboard`.
+
+## Options
+
+| Option                    | Default                | Use                                                                          |
+| ------------------------- | ---------------------- | ---------------------------------------------------------------------------- |
+| `domain`                  | `AUTH0_DOMAIN`         | Auth0 tenant domain.                                                         |
+| `clientId`                | `AUTH0_CLIENT_ID`      | OAuth client ID.                                                             |
+| `clientSecret`            | `AUTH0_CLIENT_SECRET`  | OAuth client secret for confidential clients.                                |
+| `secret`                  | `AUTH0_SECRET`         | Cookie and state signing secret.                                             |
+| `appBaseUrl`              | `APP_BASE_URL`         | Public app origin.                                                           |
+| `callbackUrl`             | None                   | Absolute callback URL.                                                       |
+| `callbackPath`            | `/auth/callback`       | Callback route when `callbackUrl` is not supplied.                           |
+| `audience`                | None                   | Optional Auth0 API audience.                                                 |
+| `scopes`                  | `openid profile email` | Requested OAuth scopes.                                                      |
+| `tokenEndpointAuthMethod` | `auto`                 | `client_secret_basic`, `client_secret_post`, `none`, or automatic selection. |
+| `protectedRoutes`         | None                   | One matcher or a list of matchers.                                           |
+
+Advanced adapters can pass `instance: { middleware, matcher }`. In that mode Farm mounts the supplied middleware and does not create the built-in login, callback, logout, or profile routes.
+
+## Production checklist
+
+- Allow the exact callback URL in Auth0.
+- Allow the app origin as a logout URL.
+- Use a strong `AUTH0_SECRET`.
+- Set `APP_BASE_URL` behind proxies or custom domains.
+- Test bad state, callback errors, expired cookies, login return paths, and logout.

--- a/docs/src/app/docs/integrations/auth/authjs/page.md
+++ b/docs/src/app/docs/integrations/auth/authjs/page.md
@@ -1,12 +1,14 @@
 ---
 title: "Auth.js Integration"
-description: "Mount Auth.js routes and session helpers through Farm's integration API."
+description: "Mount an Auth.js handler at Farm's catch-all auth route and keep using Auth.js native helpers."
 section: "Integrations"
 ---
 
 # Auth.js Integration
 
-Auth.js works well when a project already uses NextAuth-style providers and callbacks but wants Farm to own routing, typed callers, and middleware wiring.
+Use this adapter when Auth.js should own providers, callbacks, cookies, and sessions while Farm mounts its `GET` and `POST` handlers.
+
+Farm creates the catch-all route. It does not reimplement Auth.js or generate a separate Farm auth client.
 
 ## Add Auth.js
 
@@ -16,40 +18,9 @@ Auth.js works well when a project already uses NextAuth-style providers and call
 farm add integration authjs --ui
 ```
 
-## Configure
+Install Auth.js and the provider packages used by the app.
 
-**src/lib/integrations.ts**
-
-```ts
-import { authjs } from "@farmjs/integrations/auth";
-
-export const integrations = {
-  auth: authjs({
-    secret: process.env.AUTH_SECRET,
-    providers: [],
-  }),
-};
-```
-
-## Use it
-
-**Mounted route**
-
-```ts
-const response = await fetch("/api/auth/session", {
-  credentials: "include",
-});
-
-const session = await response.json();
-```
-
-Farm mounts the Auth.js handler at the provider route. Use Auth.js helpers such as `auth()` on the server and the provider client helpers in the browser when you need Auth.js-native session behavior.
-
-## What Auth.js adds
-
-Auth.js is mounted at `/api/auth/[...nextauth]` with `GET` and `POST` handlers. Farm delegates to the `handlers` object created by Auth.js while keeping the integration registered in `farm.config.ts`.
-
-## Full app shape
+## Create the Auth.js instance
 
 **src/lib/auth.ts**
 
@@ -57,30 +28,90 @@ Auth.js is mounted at `/api/auth/[...nextauth]` with `GET` and `POST` handlers. 
 import NextAuth from "next-auth";
 import GitHub from "next-auth/providers/github";
 
-export const { handlers, auth } = NextAuth({
+export const authInstance = NextAuth({
   providers: [GitHub],
 });
+
+export const { auth, handlers, signIn, signOut } = authInstance;
 ```
+
+The Farm adapter only requires the `handlers` property, so the normal object returned by `NextAuth(...)` can be passed directly.
+
+## Register it
 
 **src/lib/integrations.ts**
 
 ```ts
-import { authjs } from "@farmjs/integrations/auth";
-import { handlers } from "./auth";
+import { authjs } from "@farmjs/integrations/authjs";
+import { authInstance } from "./auth";
 
-export const integrations = {
+export const appIntegrations = {
   auth: authjs({
-    instance: {
-      handlers,
-    },
+    instance: authInstance,
   }),
-};
+} as const;
 ```
 
-## Production notes
+Farm mounts:
 
-- Set `AUTH_SECRET` and provider credentials.
-- Configure provider callback URLs to match the Farm route.
-- Use Auth.js callbacks for provider-specific account logic.
-- Use Farm route middleware for app-specific page/API protection.
-- Test both `GET` and `POST` auth handler paths.
+```text
+GET  /api/auth/[...nextauth]
+POST /api/auth/[...nextauth]
+```
+
+Requests such as `/api/auth/session`, `/api/auth/signin`, and provider callbacks are handled by that catch-all route and delegated to Auth.js.
+
+## Use Auth.js helpers
+
+Use the native helpers exported from the same instance:
+
+```ts
+import { auth } from "@/lib/auth";
+
+const session = await auth();
+```
+
+Use the browser helpers supplied by the Auth.js client package that matches your installed version. You can also call provider-owned endpoints directly when that fits the Auth.js API:
+
+```ts
+const response = await fetch("/api/auth/session", {
+  credentials: "include",
+});
+```
+
+There is no generated `api.auth.session` operation because the integration mounts a provider catch-all route without declaring a separate Farm caller contract.
+
+## Protect application routes
+
+`authjs(...)` does not accept `protectedRoutes`. Protect pages using the Auth.js `auth()` helper or add [Farm middleware](/docs/middleware) that calls your Auth.js instance.
+
+Keep authentication and authorization separate:
+
+- Auth.js establishes the user session.
+- Your app decides which users can access a project, organization, or resource.
+
+## Handler behavior
+
+| Request                         | Behavior                                               |
+| ------------------------------- | ------------------------------------------------------ |
+| `GET` under the catch-all path  | Delegated to `instance.handlers.GET`.                  |
+| `POST` under the catch-all path | Delegated to `instance.handlers.POST`.                 |
+| Missing matching handler        | Returns `405 Method Not Allowed`.                      |
+| Provider callback               | Auth.js processes it through the same catch-all route. |
+
+## Adapter options
+
+| Option     | Required | Use                                                  |
+| ---------- | -------- | ---------------------------------------------------- |
+| `instance` | Yes      | Object containing Auth.js `GET` and `POST` handlers. |
+| `log`      | No       | Farm integration lifecycle and route logger.         |
+
+All provider credentials, callbacks, adapters, events, and session settings belong in the Auth.js configuration.
+
+## Production checklist
+
+- Set `AUTH_SECRET` and every provider credential required by Auth.js.
+- Register provider callback URLs under `/api/auth/callback/<provider>`.
+- Configure trusted hosts and proxy behavior according to the Auth.js deployment.
+- Test both `GET` and `POST` actions through the Farm production server.
+- Add explicit application authorization around tenant and resource access.

--- a/docs/src/app/docs/integrations/auth/better-auth/page.md
+++ b/docs/src/app/docs/integrations/auth/better-auth/page.md
@@ -1,12 +1,12 @@
 ---
 title: "Better Auth Integration"
-description: "Own Better Auth routes, sessions, and callbacks from Farm's integration layer."
+description: "Mount a Better Auth instance in Farm and use its native client, storage, methods, and plugins."
 section: "Integrations"
 ---
 
 # Better Auth Integration
 
-Better Auth is the local-first auth option for apps that want to own routes, sessions, storage, and callbacks without losing Farm's typed integration API.
+Use Better Auth when the app should own its auth database, methods, plugins, and session policy. Farm mounts the Better Auth handler, while Better Auth remains the source of truth for the auth API.
 
 ## Add Better Auth
 
@@ -16,40 +16,9 @@ Better Auth is the local-first auth option for apps that want to own routes, ses
 farm add integration better-auth --ui
 ```
 
-## Configure
+Install `better-auth` plus the database driver or adapter selected by the application.
 
-**src/lib/integrations.ts**
-
-```ts
-import { betterAuth } from "@farmjs/integrations/auth";
-import { auth } from "./auth";
-
-export const integrations = {
-  auth: betterAuth({
-    instance: auth,
-  }),
-};
-```
-
-## Use it
-
-**Mounted route**
-
-```ts
-const response = await fetch("/api/auth/session", {
-  credentials: "include",
-});
-
-const session = await response.json();
-```
-
-Farm mounts the Better Auth handler and keeps it discoverable in the integration registry. The session shape, sign-in methods, plugins, and adapter behavior still come from your Better Auth instance, so use the Better Auth client helpers when you want the full provider DX.
-
-## What Better Auth adds
-
-Better Auth is mounted at `/api/auth/[...auth]` with `GET` and `POST` handlers. The integration delegates to your Better Auth instance, so providers, sessions, plugins, and storage stay in your Better Auth config while Farm owns registration, route discovery, logging, and typed integration wiring.
-
-## Full app shape
+## Create the server instance
 
 **src/lib/auth.ts**
 
@@ -57,32 +26,96 @@ Better Auth is mounted at `/api/auth/[...auth]` with `GET` and `POST` handlers. 
 import { betterAuth } from "better-auth";
 
 export const auth = betterAuth({
-  database: {
-    provider: "sqlite",
-    url: "file:./auth.sqlite",
-  },
+  secret: process.env.BETTER_AUTH_SECRET,
+  baseURL: process.env.BETTER_AUTH_URL,
   emailAndPassword: {
     enabled: true,
   },
 });
 ```
 
+Configure the production database, social providers, plugins, and callbacks in this object. They are not duplicated in Farm config.
+
+## Register it
+
 **src/lib/integrations.ts**
 
 ```ts
-import { betterAuth } from "@farmjs/integrations/auth";
+import { betterAuth } from "@farmjs/integrations/better-auth";
 import { auth } from "./auth";
 
-export const integrations = {
+export const appIntegrations = {
   auth: betterAuth({
     instance: auth,
   }),
-};
+} as const;
 ```
 
-## Production notes
+Farm mounts the instance handler for both methods:
 
-- Keep the Better Auth secret and database credentials server-only.
-- Let Better Auth own provider callbacks and session persistence.
-- Use Farm middleware or integration route hooks for app-specific authorization.
-- Test sign-in, sign-up, session reads, logout, and callback routes through the Farm dev server.
+```text
+GET  /api/auth/[...auth]
+POST /api/auth/[...auth]
+```
+
+There is no app-local `src/app/api/auth/[...auth]/route.ts` file to maintain.
+
+## Create the browser client
+
+**src/lib/auth-client.ts**
+
+```ts
+import { createAuthClient } from "better-auth/react";
+
+export const authClient = createAuthClient({
+  baseURL: "",
+});
+```
+
+An empty `baseURL` keeps browser calls on the current Farm origin.
+
+## Use Better Auth
+
+```ts
+const result = await authClient.signIn.email({
+  email: "ada@example.com",
+  password: "correct-horse-battery-staple",
+});
+```
+
+```ts
+const session = await authClient.getSession();
+await authClient.signOut();
+```
+
+The available methods and response types come from Better Auth and its plugins. Farm does not generate a parallel `api.auth` caller tree for the catch-all handler.
+
+## Protect application routes
+
+`betterAuth(...)` does not accept `protectedRoutes`. Read the session with Better Auth in server code or call the instance from [Farm middleware](/docs/middleware), then apply your app's authorization rules.
+
+For client-only guards, wait for `authClient.getSession()` before rendering private data, but keep sensitive authorization on the server.
+
+## What Farm owns
+
+| Farm                                              | Better Auth                                                  |
+| ------------------------------------------------- | ------------------------------------------------------------ |
+| Registers the integration in `farm.config.ts`.    | Defines users, accounts, sessions, and verification records. |
+| Mounts `GET` and `POST` on `/api/auth/[...auth]`. | Routes each auth action inside the catch-all handler.        |
+| Adds integration logging around mounted requests. | Owns adapters, providers, plugins, callbacks, and cookies.   |
+| Removes the need for a manual route module.       | Supplies the React client and server APIs.                   |
+
+## Adapter options
+
+| Option     | Required | Use                                                    |
+| ---------- | -------- | ------------------------------------------------------ |
+| `instance` | Yes      | Better Auth instance with a `handler(request)` method. |
+| `log`      | No       | Farm integration lifecycle and route logger.           |
+
+## Production checklist
+
+- Set a strong `BETTER_AUTH_SECRET` and the public `BETTER_AUTH_URL`.
+- Configure a persistent production database and run Better Auth migrations.
+- Keep database and OAuth credentials server-only.
+- Verify trusted origins, cookies, and proxy headers on the deployed origin.
+- Test sign-up, sign-in, session reads, sign-out, provider callbacks, and every enabled plugin.

--- a/docs/src/app/docs/integrations/auth/clerk/page.md
+++ b/docs/src/app/docs/integrations/auth/clerk/page.md
@@ -1,12 +1,14 @@
 ---
 title: "Clerk Integration"
-description: "Use Clerk sessions, protected routes, and provider wrappers through Farm."
+description: "Register ClerkProvider and protect Farm routes with Clerk request authentication."
 section: "Integrations"
 ---
 
 # Clerk Integration
 
-Clerk is the hosted auth path for projects that want prebuilt account UI, organizations, and SDK-backed session helpers while keeping Farm route conventions.
+The Clerk integration connects Clerk's React and backend SDKs to the Farm runtime. Farm wraps the app in `ClerkProvider` and can authenticate matched requests, while Clerk remains responsible for UI, users, sessions, organizations, and account flows.
+
+Farm does not create Clerk login, callback, session, or logout API routes.
 
 ## Add Clerk
 
@@ -21,22 +23,59 @@ farm add integration clerk --ui
 **src/lib/integrations.ts**
 
 ```ts
-import { clerk } from "@farmjs/integrations/auth";
+import { clerk } from "@farmjs/integrations/clerk";
 
-export const integrations = {
+export const appIntegrations = {
   auth: clerk({
-    publishableKey: process.env.CLERK_PUBLISHABLE_KEY,
+    publishableKey: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
     secretKey: process.env.CLERK_SECRET_KEY,
+    signInUrl: "/sign-in",
+    signUpUrl: "/sign-up",
+    protectedRoutes: ["/dashboard(.*)"],
   }),
-};
+} as const;
 ```
 
-## Use it
+The keys can be omitted from the call when the environment variables are set.
 
-**Client UI**
+## Environment variables
+
+| Variable                            | Required    | Purpose                                            |
+| ----------------------------------- | ----------- | -------------------------------------------------- |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Yes         | Preferred publishable key name.                    |
+| `CLERK_PUBLISHABLE_KEY`             | Alternative | Fallback environment name for the publishable key. |
+| `CLERK_SECRET_KEY`                  | Yes         | Used by `@clerk/backend` to authenticate requests. |
+
+Install `@clerk/react` and `@clerk/backend` in the application. Farm loads the React provider at render time and the backend client inside protected-route middleware.
+
+## Create sign-in and sign-up pages
+
+`signInUrl` and `signUpUrl` tell Farm where your Clerk pages live. They do not create those pages.
+
+**src/app/sign-in/[...clerk]/page.tsx**
 
 ```tsx
-import { SignInButton, SignedIn, SignedOut, UserButton } from "@clerk/react";
+"use client";
+
+import { SignIn } from "@clerk/react";
+
+export default function SignInPage() {
+  return (
+    <SignIn path="/sign-in" routing="path" signUpUrl="/sign-up" fallbackRedirectUrl="/dashboard" />
+  );
+}
+```
+
+Create the matching sign-up page with Clerk's `SignUp` component.
+
+## Use Clerk in the app
+
+Because Farm registers `ClerkProvider`, client components can use Clerk directly:
+
+```tsx
+"use client";
+
+import { SignedIn, SignedOut, SignInButton, UserButton } from "@clerk/react";
 
 export function AccountMenu() {
   return (
@@ -52,31 +91,70 @@ export function AccountMenu() {
 }
 ```
 
-Clerk remains the source of truth for users, sessions, organizations, and hosted account UI. Farm registers the provider metadata and middleware behavior so protected routes and integration discovery stay in one place.
+Use Clerk's hooks and backend APIs for session, user, and organization data. There is no `api.auth.session` operation for this integration.
 
-## What Clerk adds
-
-The Clerk integration contributes provider metadata for a Clerk provider wrapper and optional protected route middleware. Clerk remains the source of truth for session state, users, organizations, and hosted account UI.
-
-## Protected routes
+## Protect app routes
 
 ```ts
 clerk({
-  publishableKey: process.env.CLERK_PUBLISHABLE_KEY,
-  secretKey: process.env.CLERK_SECRET_KEY,
-  protectedRoutes: ["/dashboard(.*)", "/api/private/[...path]"],
   signInUrl: "/sign-in",
-  signUpUrl: "/sign-up",
+  protectedRoutes: ["/dashboard(.*)", "/settings(.*)"],
 });
 ```
 
-## App usage
+For a matched request, Farm calls `authenticateRequest` from `@clerk/backend`:
 
-Use Clerk UI and hooks in the client, and keep server-sensitive reads on the server. Farm's role is to register provider metadata, protect matched routes, and keep the auth integration visible alongside other app integrations.
+- authenticated requests continue to the page or API handler;
+- Clerk handshake and cookie responses are forwarded;
+- signed-out requests receive a `307` redirect to `signInUrl`;
+- the original pathname is sent as Clerk's `redirect_url`.
 
-## Production notes
+## Authorized parties
 
-- Set `CLERK_SECRET_KEY` and `CLERK_PUBLISHABLE_KEY`.
-- Keep the secret key out of browser code.
-- Configure sign-in and sign-up URLs consistently in Clerk and Farm.
-- Test signed-out protected routes, signed-in dashboard routes, and organization switching if enabled.
+By default, Clerk accepts the current request origin as an authorized party. Set an explicit list when the app has multiple trusted origins:
+
+```ts
+clerk({
+  authorizedParties: ["https://app.example.com", "https://admin.example.com"],
+});
+```
+
+This is especially useful when protecting against cookie misuse across sibling domains.
+
+## Provider props
+
+Pass additional `ClerkProvider` props through `providerProps`:
+
+```ts
+clerk({
+  providerProps: {
+    appearance: {
+      variables: {
+        colorPrimary: "#111111",
+      },
+    },
+  },
+});
+```
+
+`publishableKey` is supplied automatically and can still be combined with these props.
+
+## Options
+
+| Option              | Default                   | Use                                               |
+| ------------------- | ------------------------- | ------------------------------------------------- |
+| `publishableKey`    | Clerk publishable key env | Client-safe Clerk key.                            |
+| `secretKey`         | `CLERK_SECRET_KEY`        | Server Clerk key.                                 |
+| `signInUrl`         | `/sign-in`                | App-owned Clerk sign-in page.                     |
+| `signUpUrl`         | `/sign-up`                | App-owned Clerk sign-up page.                     |
+| `protectedRoutes`   | None                      | One matcher or a list of matchers.                |
+| `authorizedParties` | Current origin            | Origins accepted by Clerk request authentication. |
+| `providerProps`     | `{}`                      | Additional props for `ClerkProvider`.             |
+
+## Production checklist
+
+- Keep `CLERK_SECRET_KEY` out of client code.
+- Configure Clerk's allowed origins and redirect URLs.
+- Create both sign-in and sign-up catch-all pages.
+- Test Clerk handshake redirects as well as normal signed-out redirects.
+- Verify organization switching on every tenant-scoped route.

--- a/docs/src/app/docs/integrations/auth/page.md
+++ b/docs/src/app/docs/integrations/auth/page.md
@@ -1,45 +1,65 @@
 ---
 title: "Auth Integrations"
-description: "Use Better Auth, Auth.js, Clerk, Auth0, WorkOS, or Supabase without hand-rolling every auth route."
+description: "Choose and configure Better Auth, Auth.js, Clerk, Auth0, WorkOS, or Supabase in a Farm app."
 section: "Integrations"
 ---
 
 # Auth Integrations
 
-Use Better Auth, Auth.js, Clerk, Auth0, WorkOS, or Supabase without hand-rolling every auth route.
+Farm supports two auth integration styles:
 
-## Auth providers
+- **Farm-owned auth flows** create login, callback, logout, and session or profile routes. Auth0, WorkOS, and Supabase use this model.
+- **Provider-owned auth flows** mount a provider handler or app wrapper. Better Auth, Auth.js, and Clerk use this model.
 
-- **Better Auth**: Owns Better Auth routes and can pair with local SQLite in examples.
-- **Auth.js**: Mounts the /api/auth/[...nextauth] style route internally.
-- **Clerk**: Adds provider wrappers, protected route middleware, and SDK-backed auth.
-- **Auth0, WorkOS, Supabase**: Config-first login, callback, logout, session, and protected route flows.
+That distinction determines whether you call auth through Farm's generated `api` clients or through the provider's native SDK.
 
-## Supabase example
+## Choose by ownership
+
+| Provider                                           | Farm owns                                                                                                   | Your app or provider owns                                          |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| [Auth0](/docs/integrations/auth/auth0)             | OAuth routes, PKCE/state validation, local session cookie, profile route, protected-route redirects         | Auth0 tenant, connections, actions, and user records               |
+| [WorkOS](/docs/integrations/auth/workos)           | AuthKit redirects, callback, sealed session cookie, session route, protected-route redirects                | WorkOS organizations, SSO configuration, and user management       |
+| [Supabase](/docs/integrations/auth/supabase)       | Email/password and OAuth routes, SSR cookies, optional auth pages, session route, protected-route redirects | Supabase project, providers, policies, and user data               |
+| [Clerk](/docs/integrations/auth/clerk)             | `ClerkProvider` registration and optional request middleware                                                | Clerk UI, hooks, sessions, organizations, and account flows        |
+| [Auth.js](/docs/integrations/auth/authjs)          | The `/api/auth/[...nextauth]` catch-all route                                                               | Auth.js providers, callbacks, session strategy, and native helpers |
+| [Better Auth](/docs/integrations/auth/better-auth) | The `/api/auth/[...auth]` catch-all route                                                                   | Better Auth storage, plugins, methods, sessions, and native client |
+
+## Register a provider
+
+Keep the integration object in a shared server module so `farm.config.ts` and typed callers can refer to the same shape.
+
+**src/lib/integrations.ts**
+
+```ts
+import { supabase } from "@farmjs/integrations/supabase";
+
+export const appIntegrations = {
+  auth: supabase({
+    appBaseUrl: process.env.APP_BASE_URL,
+    callbackPath: "/auth/callback",
+    protectedRoutes: ["/dashboard(.*)"],
+  }),
+} as const;
+
+export type AppIntegrations = typeof appIntegrations;
+```
 
 **farm.config.ts**
 
 ```ts
 import { defineConfig } from "@farmjs/core";
-import { supabase } from "@farmjs/integrations/supabase";
+import { appIntegrations } from "./src/lib/integrations";
 
 export default defineConfig({
-  integrations: {
-    auth: supabase({
-      url: process.env.SUPABASE_URL,
-      anonKey: process.env.SUPABASE_ANON_KEY,
-      callbackUrl: "http://localhost:3000/auth/callback",
-      protectedRoutes: ["/dashboard(.*)"],
-      pages: {
-        signIn: "/sign-in",
-        signUp: "/sign-up",
-      },
-    }),
-  },
+  integrations: appIntegrations,
 });
 ```
 
-## Server and client callers
+Provider credentials can be passed directly, but every built-in provider also resolves its documented environment variables.
+
+## Farm-owned callers
+
+Auth0, WorkOS, and Supabase expose typed operations for their Farm-owned routes.
 
 **src/lib/api.ts**
 
@@ -48,53 +68,51 @@ import { createIntegrations } from "@farmjs/core/client";
 import type { AppIntegrations } from "./integrations";
 
 export const { api, apiClient } = createIntegrations<AppIntegrations>();
-
-const sessionOnServer = await api.auth.session.get();
-const sessionInBrowser = await apiClient.auth.session.get();
 ```
 
-This explicit session caller is the shape for providers that define Farm-owned session endpoints, such as Supabase. Provider-owned integrations such as Better Auth, Auth.js, and Clerk mount their provider handlers or wrappers and should use that provider's native client/server helpers for session reads.
+Use `api` in server code and `apiClient` in client components:
 
-## What auth integrations share
+```ts
+const serverSession = await api.auth.session.get();
+const browserSession = await apiClient.auth.session.get();
+```
 
-| Area | Details |
-| --- | --- |
-| Routes | Login, callback, logout, session/profile, or provider-owned handler routes, depending on the provider. |
-| Typed callers | Farm-owned routes get browser/server callers; provider-owned handlers use provider helpers. |
-| Middleware | Optional protected route matchers. |
-| Providers | Client provider metadata for hosted auth SDKs. |
-| Navigation | Sign-in/sign-up route matchers for docs and app navigation. |
-| Request context | Session or user data can be exposed to downstream handlers and pages. |
+The available operation names depend on the provider:
 
-## Choosing a provider
+| Provider | Main operations                                                        |
+| -------- | ---------------------------------------------------------------------- |
+| Auth0    | `login.get`, `signup.get`, `logout.get`, `profile.get`                 |
+| WorkOS   | `login.get`, `signup.get`, `logout.post`, `session.get`                |
+| Supabase | `login.post`, `signup.post`, `oauth.get`, `logout.post`, `session.get` |
 
-| Provider | Best when |
-| --- | --- |
-| Better Auth | You want local-first auth and control over storage and callbacks. |
-| Auth.js | You already like the NextAuth/Auth.js provider model. |
-| Clerk | You want hosted account UI, organizations, and polished auth UX quickly. |
-| Auth0 | You need hosted identity with enterprise connections and custom domains. |
-| WorkOS | You need enterprise SSO, organizations, directory sync, or B2B workflows. |
-| Supabase | You want hosted auth plus Postgres-backed app data. |
+Auth.js, Better Auth, and Clerk do not create this Farm auth caller tree. Use their native helpers and clients instead.
 
 ## Protected routes
 
-Most hosted auth integrations accept protected route matchers. The integration can redirect to sign-in or return `401` before the page/API handler runs.
+Auth0, WorkOS, Supabase, and Clerk accept `protectedRoutes`:
 
 ```ts
-supabase({
-  protectedRoutes: ["/dashboard(.*)", "/api/private/[...path]"],
-  pages: {
-    signIn: "/sign-in",
-    signUp: "/sign-up",
-  },
+auth0({
+  protectedRoutes: ["/dashboard(.*)", "/settings(.*)"],
 });
 ```
 
-## Production notes
+When a signed-out request matches, the provider integration redirects it to the configured sign-in route and keeps the current path as a return target. A session or profile endpoint can still return `401` when called directly.
 
-- Keep server secrets out of client components.
-- Set `APP_BASE_URL` when callback URLs need to be absolute.
-- Configure callback URLs in the provider dashboard and in Farm config.
-- Test login, signup, callback, logout, session refresh, and protected-route redirects.
-- Decide whether the source of truth for user metadata is the provider, your database, or both.
+Auth.js and Better Auth only mount their provider handlers. Protect application pages with the provider's server helper or with your own [Farm middleware](/docs/middleware).
+
+## Callback and return URLs
+
+- Auth0 and Supabase accept an absolute `callbackUrl` or a root-relative `callbackPath`.
+- WorkOS accepts `callbackPath` and builds the absolute callback from the request origin.
+- Set `APP_BASE_URL` for Auth0 or Supabase when the public production origin cannot be inferred from the incoming request.
+- Register the same absolute callback URL in the provider dashboard.
+- `returnTo` values are intentionally limited to root-relative app paths. External URLs are ignored.
+
+## Production checklist
+
+- Keep client secrets, cookie passwords, and provider secret keys in server-only environment variables.
+- Use a strong Auth0 `AUTH0_SECRET` or WorkOS `WORKOS_COOKIE_PASSWORD`.
+- Confirm callback, logout, sign-in, and sign-up URLs in both Farm and the provider dashboard.
+- Test expired sessions and direct access to every protected page.
+- Decide which provider fields are copied into your application database and when they are synchronized.

--- a/docs/src/app/docs/integrations/auth/supabase/page.md
+++ b/docs/src/app/docs/integrations/auth/supabase/page.md
@@ -1,12 +1,14 @@
 ---
 title: "Supabase Integration"
-description: "Use Supabase auth sessions, callback routes, and protected Farm routes."
+description: "Use Supabase email/password auth, OAuth, SSR sessions, custom pages, and protected Farm routes."
 section: "Integrations"
 ---
 
 # Supabase Integration
 
-Supabase brings hosted auth, Postgres-backed user data, OAuth providers, magic links, and session helpers into Farm's integration API.
+The Supabase adapter creates a complete server-side auth surface: email/password sign-in and signup, OAuth redirects, callback exchange, SSR cookie updates, logout, session reads, and protected-route redirects.
+
+It uses the Supabase anonymous or publishable key. A service-role key is neither accepted nor needed for these user auth flows.
 
 ## Add Supabase
 
@@ -23,55 +25,72 @@ farm add integration supabase --ui
 ```ts
 import { supabase } from "@farmjs/integrations/supabase";
 
-export const integrations = {
+export const appIntegrations = {
   auth: supabase({
     url: process.env.SUPABASE_URL,
     anonKey: process.env.SUPABASE_ANON_KEY,
-    serviceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY,
-    callbackUrl: "/auth/callback",
+    appBaseUrl: process.env.APP_BASE_URL,
+    callbackPath: "/auth/callback",
+    providers: ["github", "google"],
+    protectedRoutes: ["/dashboard(.*)"],
+    pages: {
+      signIn: "/sign-in",
+      signUp: "/sign-up",
+    },
   }),
-};
+} as const;
+
+export type AppIntegrations = typeof appIntegrations;
 ```
 
-## Use it
+Omit `pages` to use Farm's built-in server-rendered sign-in and sign-up forms. When custom page paths are configured, `GET /auth/login` and `GET /auth/signup` redirect to those pages unless an OAuth provider is being started.
 
-**Caller**
+## Environment variables
 
-```ts
-const session = await api.auth.session.get();
-```
+Farm accepts the standard Supabase URL plus any of these anonymous or publishable key names:
 
-## What Supabase adds
+| Value                 | Accepted variables                                                                                                                                                       |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Project URL           | `SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_URL`                                                                                                                               |
+| Browser-safe auth key | `SUPABASE_ANON_KEY`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_PUBLISHABLE_KEY`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY` |
+| Public app origin     | `APP_BASE_URL`                                                                                                                                                           |
 
-| Route | Purpose |
-| --- | --- |
-| `/auth/login` | Email/password login or OAuth redirect start. |
-| `/auth/signup` | Email/password signup. |
-| `/auth/callback` | OAuth callback/session exchange. |
-| `/auth/logout` | Sign out and clear session state. |
-| `/auth/session` | Read the current session. |
+Keep service-role credentials in separate server code that performs administrative operations. Do not expose them to auth pages or pass them to `supabase(...)`.
 
-Farm derives callers from these paths, so `api.auth.session.get()` reads `/auth/session` and `api.auth.oauth.get(...)` starts OAuth through the login path.
+## Routes and methods
 
-## OAuth login
+| Method        | Default route    | Purpose                                                           |
+| ------------- | ---------------- | ----------------------------------------------------------------- |
+| `GET`         | `/auth/login`    | Renders or redirects to sign-in, or starts OAuth with `provider`. |
+| `POST`        | `/auth/login`    | Signs in with email and password.                                 |
+| `GET`         | `/auth/signup`   | Renders or redirects to sign-up.                                  |
+| `POST`        | `/auth/signup`   | Creates an email/password account.                                |
+| `GET`         | `/auth/callback` | Exchanges a Supabase authorization code for a session.            |
+| `GET`, `POST` | `/auth/logout`   | Signs out, updates cookies, and redirects.                        |
+| `GET`         | `/auth/session`  | Returns the authenticated user or `401`.                          |
 
-```ts
-const oauth = await api.auth.oauth.get({
-  query: {
-    provider: "github",
-    returnTo: "/dashboard",
-  },
-});
-
-if (oauth.data?.redirectTo) {
-  window.location.href = oauth.data.redirectTo;
-}
-```
+Paths can be changed with `loginPath`, `signupPath`, `callbackPath`, `logoutPath`, and `sessionPath`.
 
 ## Email and password
 
 ```ts
-const login = await api.auth.login.post({
+const result = await apiClient.auth.login.post({
+  body: {
+    email: "ada@example.com",
+    password: "correct-horse-battery-staple",
+    returnTo: "/dashboard",
+  },
+});
+
+if (result.data) {
+  window.location.assign(result.data.redirectTo);
+}
+```
+
+Signup uses the same credential shape:
+
+```ts
+const result = await apiClient.auth.signup.post({
   body: {
     email: "ada@example.com",
     password: "correct-horse-battery-staple",
@@ -80,10 +99,78 @@ const login = await api.auth.login.post({
 });
 ```
 
-## Production notes
+When email confirmation is required, the result includes `emailConfirmationRequired`, `email`, and a user-facing `message`, then points back to the sign-in page.
 
-- Set `SUPABASE_URL` and `SUPABASE_ANON_KEY`.
-- Keep `SUPABASE_SERVICE_ROLE_KEY` server-only if the app uses it.
-- Configure OAuth callback URLs in Supabase.
-- Use protected route matchers for dashboards and private API routes.
-- Test email/password, OAuth, callback, logout, and session refresh flows.
+## OAuth
+
+Enable each provider in Supabase and register the Farm callback URL. Include it in `providers` when the built-in form should render a button for it.
+
+```ts
+const result = await apiClient.auth.oauth.get({
+  query: {
+    provider: "github",
+    returnTo: "/dashboard",
+  },
+});
+
+if (result.data) {
+  window.location.assign(result.data.redirectTo);
+}
+```
+
+`defaultProvider` can start one provider when `/auth/login` is opened without a `provider` query.
+
+## Session and logout
+
+```ts
+const session = await api.auth.session.get();
+
+if (session.data?.authenticated) {
+  console.log(session.data.user);
+}
+
+const logout = await apiClient.auth.logout.post({
+  body: {
+    returnTo: "/",
+  },
+});
+```
+
+Every auth request forwards Supabase's updated `Set-Cookie` headers, allowing token refreshes from the server client to reach the browser.
+
+## Protect app routes
+
+```ts
+supabase({
+  protectedRoutes: ["/dashboard(.*)", "/settings(.*)"],
+  pages: {
+    signIn: "/sign-in",
+    signUp: "/sign-up",
+  },
+});
+```
+
+The middleware checks the current Supabase cookie session. Signed-out requests redirect to the configured sign-in page with a root-relative `returnTo`.
+
+## Options
+
+| Option            | Default                       | Use                                          |
+| ----------------- | ----------------------------- | -------------------------------------------- |
+| `url`             | Supabase URL env              | Project URL.                                 |
+| `anonKey`         | Anonymous/publishable key env | Browser-safe project key.                    |
+| `appBaseUrl`      | `APP_BASE_URL`                | Public app origin.                           |
+| `callbackUrl`     | None                          | Absolute callback URL.                       |
+| `callbackPath`    | `/auth/callback`              | Callback route when `callbackUrl` is absent. |
+| `providers`       | `[]`                          | OAuth providers shown by the built-in form.  |
+| `defaultProvider` | None                          | Provider started by a plain login request.   |
+| `pages.signIn`    | Built-in form                 | Custom sign-in page path.                    |
+| `pages.signUp`    | Built-in form                 | Custom sign-up page path.                    |
+| `protectedRoutes` | None                          | One matcher or a list of matchers.           |
+
+## Production checklist
+
+- Register the exact callback URL in Supabase.
+- Use the publishable or anonymous key, never the service-role key.
+- Set `APP_BASE_URL` behind proxies or custom domains.
+- Test projects with and without email confirmation.
+- Test OAuth callback errors, refreshed cookies, logout return paths, and protected routes.

--- a/docs/src/app/docs/integrations/auth/workos/page.md
+++ b/docs/src/app/docs/integrations/auth/workos/page.md
@@ -1,12 +1,14 @@
 ---
 title: "WorkOS Integration"
-description: "Add WorkOS auth, organizations, and enterprise-ready callback flows through Farm."
+description: "Add WorkOS AuthKit login, sealed sessions, logout, and protected routes to Farm."
 section: "Integrations"
 ---
 
 # WorkOS Integration
 
-WorkOS is the enterprise auth option for SSO, organizations, directory sync, and role-aware app flows.
+Use WorkOS for B2B authentication when AuthKit, enterprise SSO, and organization-aware sessions should sit behind Farm-owned routes.
+
+This adapter covers AuthKit sign-in and sealed sessions. Directory Sync and other WorkOS APIs remain separate application integrations.
 
 ## Add WorkOS
 
@@ -21,60 +23,142 @@ farm add integration workos --ui
 **src/lib/integrations.ts**
 
 ```ts
-import { workos } from "@farmjs/integrations/auth";
+import { workos } from "@farmjs/integrations/workos";
 
-export const integrations = {
+export const appIntegrations = {
   auth: workos({
-    apiKey: process.env.WORKOS_API_KEY,
     clientId: process.env.WORKOS_CLIENT_ID,
-    redirectUri: "/api/auth/callback",
+    apiKey: process.env.WORKOS_API_KEY,
+    cookiePassword: process.env.WORKOS_COOKIE_PASSWORD,
+    callbackPath: "/callback",
+    protectedRoutes: ["/dashboard(.*)"],
   }),
-};
+} as const;
+
+export type AppIntegrations = typeof appIntegrations;
 ```
 
-## Use it
+Farm builds the absolute redirect URI from the incoming request origin and `callbackPath`. Register that exact URL in WorkOS, for example `https://app.example.com/callback`.
 
-**Caller**
+## Environment variables
+
+| Variable                      | Required    | Purpose                                        |
+| ----------------------------- | ----------- | ---------------------------------------------- |
+| `WORKOS_CLIENT_ID`            | Yes         | AuthKit client ID.                             |
+| `WORKOS_API_KEY`              | Yes         | Server-side WorkOS API key.                    |
+| `WORKOS_COOKIE_PASSWORD`      | Production  | Encrypts and seals the AuthKit session cookie. |
+| `FARM_WORKOS_COOKIE_PASSWORD` | Alternative | Backward-compatible cookie password name.      |
+
+Development has a local fallback cookie password. Production startup fails without an explicit password.
+
+## Routes and methods
+
+| Method | Default route   | Purpose                                                          |
+| ------ | --------------- | ---------------------------------------------------------------- |
+| `GET`  | `/login`        | Starts AuthKit sign-in.                                          |
+| `GET`  | `/signup`       | Starts AuthKit sign-up.                                          |
+| `GET`  | `/callback`     | Exchanges the code and stores the sealed session.                |
+| `POST` | `/logout`       | Clears the cookie and redirects through WorkOS logout.           |
+| `GET`  | `/auth/session` | Returns the authenticated user, session ID, and organization ID. |
+
+Override these routes with `loginPath`, `signUpPath`, `callbackPath`, `logoutPath`, and `sessionPath`.
+
+## Start an AuthKit flow
+
+Document navigation redirects directly:
+
+```tsx
+<a href="/login?returnTo=/dashboard">Sign in</a>
+<a href="/signup?returnTo=/dashboard">Create account</a>
+```
+
+The typed client returns the provider URL:
 
 ```ts
-const login = await api.auth.login.get({
+const result = await apiClient.auth.login.get({
   query: {
     returnTo: "/dashboard",
   },
 });
 
-if (login.data?.redirectTo) {
-  window.location.href = login.data.redirectTo;
+if (result.data) {
+  window.location.assign(result.data.redirectTo);
 }
 ```
 
-## What WorkOS adds
+## Read the sealed session
 
-| Route | Purpose |
-| --- | --- |
-| `/login` | Starts WorkOS sign-in. |
-| `/signup` | Starts WorkOS sign-up. |
-| `/callback` | Exchanges the authorization code and stores the sealed session. |
-| `/logout` | Clears the local session and redirects through WorkOS logout. |
-| `/auth/session` | Reads the current sealed-session-backed user state. |
+```ts
+const result = await api.auth.session.get();
 
-The route paths can be overridden when the app wants `/auth/login` style URLs.
+if (result.error && "status" in result.error && result.error.status === 401) {
+  // No authenticated WorkOS session.
+}
 
-## Protected routes
+const organizationId = result.data?.organizationId;
+const user = result.data?.user;
+```
+
+An authenticated response contains:
+
+```ts
+{
+  authenticated: true;
+  sessionId?: string;
+  organizationId?: string;
+  user: {
+    id: string;
+    email: string;
+    firstName?: string | null;
+    lastName?: string | null;
+    profilePictureUrl?: string | null;
+  };
+}
+```
+
+The organization ID is useful for looking up your app's tenant record. Authorization roles and permissions still need to be resolved by your application.
+
+## Logout
+
+```ts
+const result = await apiClient.auth.logout.post();
+
+if (result.data) {
+  window.location.assign(result.data.redirectTo);
+}
+```
+
+Farm clears the local cookie first. If a sealed session exists, WorkOS supplies the final logout URL; otherwise the user returns to the app origin.
+
+## Protect app routes
 
 ```ts
 workos({
-  clientId: process.env.WORKOS_CLIENT_ID,
-  apiKey: process.env.WORKOS_API_KEY,
-  cookiePassword: process.env.WORKOS_COOKIE_PASSWORD,
-  protectedRoutes: ["/dashboard(.*)", "/api/private/[...path]"],
+  protectedRoutes: ["/dashboard(.*)", "/settings(.*)"],
 });
 ```
 
-## Production notes
+Signed-out requests receive a `307` redirect to `/login` with the original root-relative path in `returnTo`.
 
-- Set `WORKOS_CLIENT_ID`, `WORKOS_API_KEY`, and `WORKOS_COOKIE_PASSWORD`.
-- Use a strong cookie password in production.
-- Configure redirect URIs in WorkOS to match your Farm callback route.
-- Test sign-in, sign-up, callback, logout, and session reads.
-- Decide how organizations and roles map into your app database.
+## Options
+
+| Option            | Default            | Use                                |
+| ----------------- | ------------------ | ---------------------------------- |
+| `clientId`        | `WORKOS_CLIENT_ID` | AuthKit client ID.                 |
+| `apiKey`          | `WORKOS_API_KEY`   | Server API key.                    |
+| `cookiePassword`  | WorkOS cookie env  | Sealed-session password.           |
+| `cookieName`      | `wos-session`      | Session cookie name.               |
+| `loginPath`       | `/login`           | Sign-in route.                     |
+| `signUpPath`      | `/signup`          | Sign-up route.                     |
+| `callbackPath`    | `/callback`        | AuthKit callback route.            |
+| `logoutPath`      | `/logout`          | Logout route.                      |
+| `sessionPath`     | `/auth/session`    | Session JSON route.                |
+| `protectedRoutes` | None               | One matcher or a list of matchers. |
+
+## Production checklist
+
+- Register the production callback URL in WorkOS.
+- Use a strong `WORKOS_COOKIE_PASSWORD`.
+- Confirm the public request origin is preserved by your proxy.
+- Test personal and organization-backed sessions.
+- Map `organizationId` to an application tenant before authorizing tenant data.

--- a/docs/src/app/docs/integrations/inngest/page.md
+++ b/docs/src/app/docs/integrations/inngest/page.md
@@ -1,12 +1,14 @@
 ---
 title: "Inngest Integration"
-description: "Run Farm tasks through Inngest with durable events, functions, and schedules."
+description: "Send typed events to existing Inngest functions, batch them, and inspect runs from Farm."
 section: "Integrations"
 ---
 
 # Inngest Integration
 
-Inngest is the event-driven workflow runtime for durable functions, retries, fan-out, schedules, and background app flows.
+The Inngest runtime turns each Farm task into an event name, sends single or batched events, and reads function runs by the returned event ID.
+
+The current adapter is intentionally narrower than the Trigger.dev runtime. It supports triggering, batching, status, and idempotent event IDs. It does not currently expose delay, scheduling, cancellation, tags, queues, retries, TTL, or concurrency options.
 
 ## Add Inngest
 
@@ -24,72 +26,165 @@ farm add integration jobs-inngest --ui
 import { inngest, jobs } from "@farmjs/integrations/jobs";
 import { tasks } from "./jobs";
 
-export const integrations = {
+export const appIntegrations = {
   jobs: jobs({
-    tasks,
     runtime: inngest({
+      appId: process.env.INNGEST_APP_ID,
       eventKey: process.env.INNGEST_EVENT_KEY,
       signingKey: process.env.INNGEST_SIGNING_KEY,
     }),
+    tasks,
   }),
-};
+} as const;
 ```
 
-## Use it
+## Environment variables
 
-**Caller**
+| Variable              | Current use                                                    |
+| --------------------- | -------------------------------------------------------------- |
+| `INNGEST_EVENT_KEY`   | Required to send single and batch events.                      |
+| `INNGEST_SIGNING_KEY` | Required to look up runs for an event ID.                      |
+| `INNGEST_APP_ID`      | Optional app identifier recorded in integration configuration. |
 
-```ts
-await api.jobs.syncCustomer.trigger({
-  body: {
-    input: {
-      customerId: "cus_123",
-    },
-  },
-});
-```
+The runtime is reported as configured only when both event and signing keys are available.
 
-## Farm task mapping
+## Match the provider function
 
-Inngest is mounted through the Jobs integration. Define tasks once, then choose `inngest(...)` as the runtime.
+**src/lib/jobs.ts**
 
 ```ts
+import { defineTasks, task } from "@farmjs/integrations/jobs";
+
 export const tasks = defineTasks({
-  syncCustomer: task({
-    id: "sync-customer",
-    description: "Sync one customer after a billing event.",
-    async run(input: { customerId: string }) {
+  importCsv: task({
+    id: "import-csv",
+    description: "Import one uploaded CSV file.",
+    defaults: {
+      idempotencyKey(input: { fileId: string }) {
+        return `import:${input.fileId}`;
+      },
+    },
+    async run(input: { fileId: string }) {
       return {
-        synced: true,
-        customerId: input.customerId,
+        processed: input.fileId.length,
       };
     },
   }),
 });
 ```
 
-The app keeps the same Farm caller shape:
+With the default prefix, Farm sends this event:
+
+```text
+farm/import-csv
+```
+
+Deploy an Inngest function that listens for that exact event name. The event payload is placed in `event.data`, and the computed idempotency key is sent as the event `id`. The typed status caller treats provider output as the local `run` return type without runtime validation.
+
+The local `run` callback supplies TypeScript input/output inference. Farm does not execute or register it as an Inngest function.
+
+## Change the event prefix
 
 ```ts
-const run = await api.jobs.syncCustomer.trigger({
-  body: {
-    input: {
-      customerId: "cus_123",
-    },
-  },
+inngest({
+  eventKey: process.env.INNGEST_EVENT_KEY,
+  signingKey: process.env.INNGEST_SIGNING_KEY,
+  eventNamePrefix: "acme",
 });
+```
 
-await api.jobs.syncCustomer.status({
-  query: {
-    handleId: run.data!.handleId,
+The same task now sends `acme/import-csv`.
+
+## Trigger one event
+
+```ts
+const result = await api.jobs.importCsv.trigger({
+  body: {
+    fileId: "file_123",
   },
 });
 ```
 
-## Production notes
+The returned `handleId` is Inngest's event ID, not a run ID. Farm uses it to ask Inngest for associated function runs.
 
-- Set `INNGEST_EVENT_KEY` and `INNGEST_SIGNING_KEY`.
-- Prefer event-shaped task input when the workflow is driven by product events.
-- Use retries for network/provider calls and idempotency for mutation-heavy jobs.
-- Store handle IDs when the UI needs status reads.
-- Test local development, signing, retries, and scheduled runs before shipping.
+An explicit per-call idempotency key is also supported:
+
+```ts
+await api.jobs.importCsv.trigger({
+  body: {
+    fileId: "file_123",
+    $options: {
+      idempotencyKey: "import:file_123:v2",
+    },
+  },
+});
+```
+
+## Batch events
+
+```ts
+const batch = await api.jobs.importCsv.batchTrigger({
+  body: {
+    items: [{ fileId: "file_123" }, { fileId: "file_456" }, { fileId: "file_789" }],
+  },
+});
+```
+
+Farm sends the event array to the Inngest ingestion endpoint. The result contains one handle per accepted event and `batchId: null`.
+
+## Read status
+
+```ts
+const status = await api.jobs.importCsv.status({
+  query: {
+    handleId: result.data!.handleId,
+  },
+});
+```
+
+If Inngest has accepted the event but no function run is visible yet, Farm returns normalized status `queued` with provider status `EVENT_ACCEPTED`. Once a run exists, the result includes its run ID, normalized state, timestamps, output, error, and raw response.
+
+## Current limitations
+
+The shared Jobs API still contains `schedule` and `cancel`, but the Inngest adapter reports unsupported behavior instead of silently ignoring it:
+
+| Operation or option             | Current result                                  |
+| ------------------------------- | ----------------------------------------------- |
+| `$options.delay`                | `400`                                           |
+| `$options.debounce`             | `400`                                           |
+| `$options.tags`                 | `400`                                           |
+| `api.jobs.<task>.schedule(...)` | `400` because delayed launch is not implemented |
+| `api.jobs.<task>.cancel(...)`   | `501`                                           |
+| `defaults.queue`                | Integration setup error                         |
+| `defaults.retry`                | Integration setup error                         |
+| `defaults.ttl`                  | Integration setup error                         |
+| `defaults.concurrencyKey`       | Integration setup error                         |
+| `defaults.tags`                 | Integration setup error                         |
+
+`defaults.idempotencyKey` and batch triggering are supported.
+
+A cron-shaped `schedule` field on the task is exposed in metadata only. It does not register an Inngest cron function.
+
+## Custom endpoints
+
+The defaults are `https://inn.gs` for event ingestion and `https://api.inngest.com` for run status:
+
+```ts
+inngest({
+  eventKey: process.env.INNGEST_EVENT_KEY,
+  signingKey: process.env.INNGEST_SIGNING_KEY,
+  eventBaseUrl: "https://inngest-ingest.example.com",
+  apiBaseUrl: "https://inngest-api.example.com",
+});
+```
+
+Use these options for compatible proxies, test services, or supported self-hosted endpoints.
+
+## Production checklist
+
+- Deploy a function for every generated event name.
+- Keep task IDs and `eventNamePrefix` stable.
+- Use deterministic idempotency keys for retryable product events.
+- Store the event handle when a later request needs status.
+- Restrict job routes to trusted users or server code.
+- Do not add Trigger-only defaults to tasks mounted with Inngest.

--- a/docs/src/app/docs/integrations/jobs/page.md
+++ b/docs/src/app/docs/integrations/jobs/page.md
@@ -1,14 +1,16 @@
 ---
 title: "Jobs Integration"
-description: "Define typed tasks once and run them through Trigger.dev or Inngest with trigger, schedule, batch, status, and cancel APIs."
+description: "Define typed job contracts and call existing Trigger.dev tasks or Inngest functions through one Farm API."
 section: "Integrations"
 ---
 
 # Jobs Integration
 
-Define typed tasks once and run them through Trigger.dev or Inngest with trigger, schedule, batch, status, and cancel APIs.
+The Jobs integration gives a Farm app typed trigger, batch, status, scheduling, cancellation, and metadata routes over Trigger.dev or Inngest.
 
-## Define tasks
+It is currently a control-plane adapter. Farm sends work to a task or function that already exists in the selected provider and reads provider status back.
+
+## Define the task contract
 
 **src/lib/jobs.ts**
 
@@ -18,13 +20,35 @@ import { defineTasks, task } from "@farmjs/integrations/jobs";
 export const tasks = defineTasks({
   sendWelcomeEmail: task({
     id: "send-welcome-email",
-    async run(input: { userId: string }, context) {
-      context.logger.info("Sending welcome email", input);
-      return { ok: true };
+    description: "Send the first email after signup.",
+    async run(input: { userId: string }) {
+      return {
+        messageId: `msg_${input.userId}`,
+      };
     },
   }),
 });
 ```
+
+The object key, `id`, and `run` return type have different jobs:
+
+| Field                         | Purpose                                                                               |
+| ----------------------------- | ------------------------------------------------------------------------------------- |
+| `sendWelcomeEmail` object key | Creates the `api.jobs.sendWelcomeEmail` caller namespace.                             |
+| `id`                          | Selects the provider-side task or event name. Defaults to the kebab-cased object key. |
+| `run` input                   | Infers the typed trigger payload.                                                     |
+| `run` return value            | Infers the typed `status().data.output` value.                                        |
+
+**Important:** the current adapter does not execute or deploy the local `run` callback. Create matching provider-side code and keep its input/output contract synchronized with this definition.
+
+Provider identity is resolved as follows:
+
+| Runtime     | Provider-side identity for the example |
+| ----------- | -------------------------------------- |
+| Trigger.dev | Task ID `send-welcome-email`           |
+| Inngest     | Event name `farm/send-welcome-email`   |
+
+Inngest's `farm` prefix can be changed with `eventNamePrefix`.
 
 ## Mount a runtime
 
@@ -34,92 +58,192 @@ export const tasks = defineTasks({
 import { jobs, trigger } from "@farmjs/integrations/jobs";
 import { tasks } from "./jobs";
 
-export const integrations = {
+export const appIntegrations = {
   jobs: jobs({
-    tasks,
     runtime: trigger({
       apiKey: process.env.TRIGGER_SECRET_KEY,
       projectRef: process.env.TRIGGER_PROJECT_REF,
     }),
+    tasks,
   }),
-};
+} as const;
+
+export type AppIntegrations = typeof appIntegrations;
 ```
 
-## Trigger work
+Swap `trigger(...)` for `inngest(...)` to keep the same caller namespace with the Inngest runtime. Runtime capabilities are not identical, so check the matrix below before sharing task defaults.
 
-**Caller**
+## Create callers
+
+```ts
+import { createIntegrations } from "@farmjs/core/client";
+import type { AppIntegrations } from "./integrations";
+
+export const { api, apiClient } = createIntegrations<AppIntegrations>();
+```
+
+Use `api` in trusted server code. Only expose `apiClient` to the browser when the application has added its own authorization around job routes.
+
+## Trigger one run
+
+Task input is placed directly in `body`. Farm-specific launch options live under `$options`.
 
 ```ts
 const queued = await api.jobs.sendWelcomeEmail.trigger({
   body: {
     userId: "usr_123",
-    $options: { tags: ["signup"] },
+    $options: {
+      idempotencyKey: "welcome:usr_123",
+      tags: ["signup"],
+    },
   },
 });
 
-await api.jobs.sendWelcomeEmail.status({
-  query: { handleId: queued.data!.handleId },
-});
+const handleId = queued.data!.handleId;
 ```
 
-## What the jobs integration adds
+The older `{ input, options }` body is still accepted, but the inline shape above is the canonical API.
 
-| Area | Details |
-| --- | --- |
-| Metadata | A task list route for dashboards and debugging. |
-| Trigger | Queue one task run with typed input. |
-| Batch trigger | Queue many task runs at once. |
-| Schedule | Queue work for a future time. |
-| Status | Read the provider run state and typed output. |
-| Cancel | Cancel a queued or running job when the runtime supports it. |
-
-## Task options
+## Batch trigger
 
 ```ts
-export const tasks = defineTasks({
-  syncCustomer: task({
-    id: "sync-customer",
-    description: "Sync customer data from the billing provider.",
-    defaults: {
-      queue: "billing",
-      retry: {
-        attempts: 3,
-      },
-      tags: ["billing"],
-    },
-    async run(input: { customerId: string }) {
-      return {
-        synced: true,
-        customerId: input.customerId,
-      };
-    },
-  }),
-});
-```
-
-## Runtime choice
-
-Use Trigger.dev when you want explicit job dashboards, task-oriented developer tooling, and production retry visibility. Use Inngest when the app is event-first and workflows naturally start from durable events.
-
-The Farm caller shape stays the same either way:
-
-```ts
-await api.jobs.syncCustomer.trigger({
+const batch = await api.jobs.sendWelcomeEmail.batchTrigger({
   body: {
-    input: {
-      customerId: "cus_123",
-    },
-    options: {
-      tags: ["manual-sync"],
+    items: [
+      {
+        userId: "usr_123",
+        $options: {
+          idempotencyKey: "welcome:usr_123",
+        },
+      },
+      {
+        userId: "usr_456",
+        $options: {
+          idempotencyKey: "welcome:usr_456",
+        },
+      },
+    ],
+  },
+});
+```
+
+Each result contains an index, provider handle ID, and queue timestamp. Trigger.dev can also return a provider batch ID; Inngest returns `batchId: null`.
+
+## Read status
+
+```ts
+const result = await api.jobs.sendWelcomeEmail.status({
+  query: {
+    handleId,
+  },
+});
+
+if (result.data?.status === "completed") {
+  console.log(result.data.output?.messageId);
+}
+```
+
+Farm normalizes provider states to `queued`, `delayed`, `running`, `waiting`, `completed`, `failed`, `canceled`, `expired`, or `unknown`. The raw provider response remains available as `data.raw`.
+
+## Schedule and cancel
+
+One-off scheduling requires exactly one of `at` or `after`:
+
+```ts
+await api.jobs.sendWelcomeEmail.schedule({
+  body: {
+    userId: "usr_123",
+    $schedule: {
+      after: "10m",
+      idempotencyKey: "welcome:usr_123",
+      tags: ["scheduled"],
     },
   },
 });
 ```
 
-## Production notes
+```ts
+await api.jobs.sendWelcomeEmail.cancel({
+  body: {
+    handleId,
+  },
+});
+```
 
-- Keep task keys stable because they become route and caller names.
-- Use idempotency keys when user actions can submit the same job twice.
-- Store provider handle IDs when the UI needs later status reads.
-- Keep secrets in runtime config, not task input.
-- Test trigger, status, cancellation, retry behavior, and scheduled runs.
+These callers exist in the shared API for both runtimes, but the current Inngest adapter rejects one-off scheduling with `400` and cancellation with `501`. Trigger.dev supports both.
+
+The `schedule` field on `task({...})`, including cron and timezone, is exposed as metadata only. It does not create a provider schedule.
+
+## Task defaults
+
+```ts
+task({
+  defaults: {
+    queue: {
+      name: "email",
+      concurrencyLimit: 2,
+    },
+    retry: {
+      attempts: 3,
+    },
+    ttl: "10m",
+    tags: ["email"],
+    concurrencyKey(input: { userId: string }) {
+      return `user:${input.userId}`;
+    },
+    idempotencyKey(input: { userId: string }) {
+      return `welcome:${input.userId}`;
+    },
+  },
+  async run(input: { userId: string }) {
+    return { messageId: input.userId };
+  },
+});
+```
+
+Trigger.dev maps all of these defaults into launch options. Inngest currently accepts only `idempotencyKey`; defining Trigger-only defaults causes integration setup to fail.
+
+## Runtime capabilities
+
+| Capability                        | Trigger.dev   | Inngest                   |
+| --------------------------------- | ------------- | ------------------------- |
+| Trigger one run                   | Yes           | Yes                       |
+| Batch trigger                     | Yes           | Yes                       |
+| Status polling                    | Yes           | Yes                       |
+| Idempotency key                   | Yes           | Yes, sent as the event ID |
+| Delay and one-off schedule        | Yes           | No                        |
+| Debounce and tags                 | Yes           | No                        |
+| Queue and retry defaults          | Yes           | No                        |
+| TTL and concurrency key           | Yes           | No                        |
+| Cancel                            | Yes           | No                        |
+| Cron `task.schedule` registration | Metadata only | Metadata only             |
+
+## Generated routes
+
+For the `sendWelcomeEmail` key and default `basePath`, Farm mounts:
+
+| Method | Route                                              |
+| ------ | -------------------------------------------------- |
+| `GET`  | `/api/jobs/tasks`                                  |
+| `POST` | `/api/jobs/send-welcome-email/trigger`             |
+| `POST` | `/api/jobs/send-welcome-email/batch-trigger`       |
+| `POST` | `/api/jobs/send-welcome-email/schedule`            |
+| `GET`  | `/api/jobs/send-welcome-email/status?handleId=...` |
+| `POST` | `/api/jobs/send-welcome-email/cancel`              |
+
+Read task IDs, provider IDs, paths, defaults, configuration state, and runtime capabilities with:
+
+```ts
+const metadata = await api.jobs.tasks.list();
+```
+
+Change the route prefix with `jobs({ basePath: "/api/automation", ... })`.
+
+## Production checklist
+
+- Implement and deploy the matching provider task or event function.
+- Keep object keys and provider IDs stable.
+- Restrict browser access to trigger, status, and cancel routes.
+- Use idempotency keys for user-retriable actions.
+- Persist handle IDs when a later request needs status or cancellation.
+- Verify each option against the selected runtime capability matrix.

--- a/docs/src/app/docs/integrations/trigger/page.md
+++ b/docs/src/app/docs/integrations/trigger/page.md
@@ -1,12 +1,14 @@
 ---
 title: "Trigger.dev Integration"
-description: "Run Farm tasks through Trigger.dev with typed trigger, status, and cancel APIs."
+description: "Trigger, schedule, batch, inspect, and cancel existing Trigger.dev tasks through typed Farm callers."
 section: "Integrations"
 ---
 
 # Trigger.dev Integration
 
-Trigger.dev is the workflow runtime for long-running background jobs, retries, schedules, queues, and production task observability.
+The Trigger.dev runtime maps Farm task contracts to existing Trigger.dev task IDs. It supports the complete Jobs integration surface: trigger, batch trigger, one-off scheduling, status, cancellation, queues, retries, TTL, tags, concurrency, idempotency, delay, and debounce.
+
+Farm calls Trigger.dev over its HTTP API. It does not deploy the provider task.
 
 ## Add Trigger.dev
 
@@ -24,70 +26,193 @@ farm add integration jobs-trigger --ui
 import { jobs, trigger } from "@farmjs/integrations/jobs";
 import { tasks } from "./jobs";
 
-export const integrations = {
+export const appIntegrations = {
   jobs: jobs({
-    tasks,
     runtime: trigger({
       apiKey: process.env.TRIGGER_SECRET_KEY,
+      projectRef: process.env.TRIGGER_PROJECT_REF,
+      webhookSecret: process.env.TRIGGER_WEBHOOK_SECRET,
     }),
+    tasks,
   }),
-};
+} as const;
 ```
 
-## Use it
+## Environment variables
 
-**Caller**
+| Variable                 | Current use                                                                                  |
+| ------------------------ | -------------------------------------------------------------------------------------------- |
+| `TRIGGER_SECRET_KEY`     | Required to trigger, batch, read status, and cancel.                                         |
+| `TRIGGER_PROJECT_REF`    | Optional project reference added to Farm's trigger request context.                          |
+| `TRIGGER_WEBHOOK_SECRET` | Reserved in runtime config for future webhook support. It is not used by the current routes. |
 
-```ts
-await api.jobs.sendWelcomeEmail.trigger({
-  body: {
-    input: {
-      userId: "user_123",
-    },
-  },
-});
-```
+`apiKey`, `projectRef`, and `webhookSecret` options override their matching environment variables.
 
-## Farm task mapping
+## Match the provider task
 
-Trigger.dev is mounted through the Jobs integration. Define tasks once with `defineTasks`, then choose `trigger(...)` as the runtime.
+**src/lib/jobs.ts**
 
 ```ts
+import { defineTasks, task } from "@farmjs/integrations/jobs";
+
 export const tasks = defineTasks({
   sendWelcomeEmail: task({
     id: "send-welcome-email",
+    description: "Send the first email after signup.",
+    defaults: {
+      queue: {
+        name: "email",
+        concurrencyLimit: 2,
+      },
+      retry: {
+        attempts: 3,
+      },
+      ttl: "10m",
+      tags: ["email"],
+      idempotencyKey(input: { userId: string }) {
+        return `welcome:${input.userId}`;
+      },
+    },
     async run(input: { userId: string }) {
       return {
-        sent: true,
-        userId: input.userId,
+        messageId: `msg_${input.userId}`,
       };
     },
   }),
 });
 ```
 
-Farm turns `sendWelcomeEmail` into typed callers such as:
+Deploy a Trigger.dev task whose ID is exactly `send-welcome-email`. Farm sends the input as Trigger.dev's `payload` and adds source/task context. The typed status caller treats provider output as the local `run` return type, but Farm does not validate that output at runtime.
+
+The local `run` callback supplies TypeScript input/output inference. The Farm integration route does not execute it.
+
+## Trigger a run
 
 ```ts
-await api.jobs.sendWelcomeEmail.trigger({
+const result = await api.jobs.sendWelcomeEmail.trigger({
   body: {
-    input: {
-      userId: "user_123",
+    userId: "usr_123",
+    $options: {
+      delay: "30s",
+      debounce: {
+        key: "welcome:usr_123",
+        delay: "10s",
+      },
+      tags: ["signup"],
     },
-  },
-});
-
-await api.jobs.sendWelcomeEmail.status({
-  query: {
-    handleId: "run_123",
   },
 });
 ```
 
-## Production notes
+Farm merges task defaults and per-call options before sending the request.
 
-- Set the Trigger.dev secret/project config required by your runtime.
-- Use queues and retry defaults on the task definition for predictable load.
-- Keep task IDs stable because provider dashboards and Farm callers depend on them.
-- Store returned `handleId` when users need status polling.
-- Use batch trigger for bulk work instead of loops from the browser.
+## Option mapping
+
+| Farm definition or call                                | Trigger.dev launch option |
+| ------------------------------------------------------ | ------------------------- |
+| `defaults.queue`                                       | `queue`                   |
+| `defaults.retry.attempts`                              | `maxAttempts`             |
+| `defaults.ttl`                                         | `ttl`                     |
+| `defaults.concurrencyKey`                              | `concurrencyKey`          |
+| `defaults.idempotencyKey` or `$options.idempotencyKey` | `idempotencyKey`          |
+| default and per-call tags                              | merged `tags`             |
+| `$options.delay` or `$schedule` timing                 | `delay`                   |
+| `$options.debounce`                                    | `debounce`                |
+
+Per-call tags are deduplicated with default tags. A per-call idempotency key overrides the computed task default.
+
+## One-off scheduling
+
+Use `after` for a relative delay:
+
+```ts
+await api.jobs.sendWelcomeEmail.schedule({
+  body: {
+    userId: "usr_123",
+    $schedule: {
+      after: "10m",
+      tags: ["scheduled"],
+    },
+  },
+});
+```
+
+Or use `at` with an ISO date string or `Date`:
+
+```ts
+await api.jobs.sendWelcomeEmail.schedule({
+  body: {
+    userId: "usr_123",
+    $schedule: {
+      at: new Date("2026-08-01T09:00:00.000Z"),
+    },
+  },
+});
+```
+
+Exactly one of `at` or `after` is required. Farm sends it through Trigger.dev's task trigger endpoint as `delay`.
+
+A cron-shaped `schedule` on the task definition is metadata only and does not create a Trigger.dev schedule.
+
+## Batch trigger
+
+```ts
+const batch = await api.jobs.sendWelcomeEmail.batchTrigger({
+  body: {
+    items: [
+      {
+        userId: "usr_123",
+        $options: {
+          idempotencyKey: "welcome:usr_123",
+        },
+      },
+      {
+        userId: "usr_456",
+        $options: {
+          idempotencyKey: "welcome:usr_456",
+        },
+      },
+    ],
+  },
+});
+```
+
+Farm calls Trigger.dev's task batch endpoint and returns `batchId` plus each run handle.
+
+## Status and cancellation
+
+```ts
+const status = await api.jobs.sendWelcomeEmail.status({
+  query: {
+    handleId: result.data!.handleId,
+  },
+});
+
+await api.jobs.sendWelcomeEmail.cancel({
+  body: {
+    handleId: result.data!.handleId,
+  },
+});
+```
+
+Status includes normalized and provider-native states, timestamps, output, error, tags, and the raw Trigger.dev response.
+
+## Custom API endpoint
+
+The default base is `https://api.trigger.dev`. Override it for a compatible proxy or test service:
+
+```ts
+trigger({
+  apiKey: process.env.TRIGGER_SECRET_KEY,
+  apiBaseUrl: "https://trigger-proxy.example.com",
+});
+```
+
+## Production checklist
+
+- Deploy a Trigger.dev task for every Farm task ID.
+- Keep task IDs stable after callers ship.
+- Store `handleId` when status or cancellation is needed later.
+- Restrict job routes to trusted users or server code.
+- Verify retry, queue, TTL, and concurrency behavior in the Trigger.dev dashboard.
+- Treat `TRIGGER_WEBHOOK_SECRET` as reserved until webhook handling is implemented.


### PR DESCRIPTION
## Summary

- expand the auth overview and all six provider guides with clear ownership boundaries, exact routes and methods, environment variables, options, caller patterns, and production checks
- replace invalid or stale examples, including nonexistent `@farmjs/integrations/auth` imports, relative `callbackUrl` values, WorkOS `redirectUri`, Supabase `serviceRoleKey`, and unsupported Auth.js/Better Auth configuration
- expand the Jobs overview plus Trigger.dev and Inngest guides with canonical inline request bodies, generated routes, task/provider ID mapping, status behavior, and a runtime capability matrix
- document the current control-plane boundary: provider tasks/functions must already exist, `task.run` supplies TypeScript inference but is not executed or deployed by Farm, cron task schedules are metadata-only, and the current Inngest adapter rejects Trigger-only features

## Why

The shortest integration pages omitted behavior developers need to configure production apps and several snippets did not match the adapter interfaces. The jobs pages also presented Trigger.dev and Inngest as more interchangeable than the current implementation allows.

## Impact

Documentation only. Readers can now tell which routes Farm owns, which provider SDK they should use, which credentials and callback forms are accepted, and which jobs features are available for each runtime.

## Validation

- `corepack pnpm exec oxfmt --check` on all ten changed pages
- `corepack pnpm --filter @farmjs/integrations type-check`
- `corepack pnpm --filter @farmjs/core exec vitest run src/__tests__/jobs-integration.test.ts` (7 passed)
- full docs production build through the pinned Corepack toolchain
- Playwright checks for all ten routes at desktop and mobile widths: HTTP 200, no console errors, no error overlays, and no page-level horizontal overflow