### PR TITLE
fix: correct docs dates and query guidance

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -60,6 +60,62 @@ const product = await api.products.get(
 
 Structured keys use Farm's route-data key contract. Default API cache keys include the API origin and remain isolated from other clients.
 
+## Optimistic cache updates
+
+Farm's cache lifecycle is intentionally familiar to React Query and TanStack Query users, but it is
+implemented by Farm's own typed API client and shared cache. A mutation can update an existing
+query result immediately, roll it back after an error, and invalidate it after the server responds.
+
+```ts
+const products = await api.products.get(
+  { query: { category } },
+  {
+    cache: {
+      key: ["products", category],
+      policy: "stale-while-revalidate",
+      staleTime: 30_000,
+    },
+  },
+);
+
+const createProduct = api.products.post(
+  {
+    body: {
+      name,
+      category,
+    },
+  },
+  {
+    optimistic: {
+      update: [
+        [
+          products.key,
+          (current) => ({
+            ...current,
+            products: [
+              { id: "optimistic", name, category },
+              ...(current?.products ?? []),
+            ],
+          }),
+        ],
+      ],
+      rollbackOnError: true,
+    },
+    invalidate: [products.key],
+  },
+);
+
+await createProduct;
+```
+
+The updater runs synchronously before the POST finishes. `products.key` preserves the cached
+response type, so `current` is inferred from `api.products.get`. You can also target a generated
+route directly with `[api.products.get, { query: { category } }, updater]`.
+
+With `rollbackOnError: true`, Farm restores the exact previous cache entry when the mutation fails.
+After the request settles, invalidation marks the key stale so mounted consumers or the next read
+can load the canonical server result.
+
 ## Result shape
 
 API and integration callers return a consistent result object:

--- a/docs/src/app/docs/docs-engine/page.md
+++ b/docs/src/app/docs/docs-engine/page.md
@@ -76,6 +76,24 @@ The docs runtime can serve human pages and machine-readable output from the same
 
 That means docs content only needs to be written once.
 
+## Last updated dates
+
+When `lastUpdated` is enabled, Farm uses the latest Git commit for each markdown page instead of
+trusting deployment file timestamps. Production builds preserve those dates in the bundled docs
+content, so archive or copy metadata cannot turn into a misleading footer date.
+
+Set an explicit date in frontmatter when a page needs editorial control:
+
+```md
+---
+title: "Release Policy"
+lastModified: "2026-07-16"
+---
+```
+
+Explicit frontmatter wins over generated Git metadata. When Git history is unavailable, local docs
+fall back to the source file timestamp and copied production docs fall back to the build date.
+
 ## Override behavior
 
 When `docs.entry` is enabled in `farm.config.ts`, Farm can mount docs pages and docs API routes automatically. Add explicit route wrappers only when the app wants to override default rendering, authentication, or response behavior.

--- a/docs/src/app/docs/server-queries/page.md
+++ b/docs/src/app/docs/server-queries/page.md
@@ -8,6 +8,11 @@ section: "Data and APIs"
 
 `createServerQuery` defines a typed server read with one structured cache key. The same declaration works during server rendering, through a generated browser server reference, with browser prefetch, and in `useServerQuery`.
 
+The browser lifecycle is intentionally familiar to React Query and TanStack Query users: request
+deduplication, prefetching, `staleTime`, stale-while-revalidate, focus and reconnect refresh, shared
+invalidation, and optimistic cache writes. Farm implements this behavior in its own cache and
+generated server references; it does not install or wrap TanStack Query.
+
 ## Declare a query
 
 **src/features/products/queries.ts**
@@ -160,6 +165,50 @@ const result = await api.products.get(
 ```
 
 The route, API caller, and server query now read and invalidate the same canonical key. Default API keys remain isolated by request origin; only an explicit structured key opts into cross-feature sharing.
+
+### Share optimistic updates
+
+API mutations can optimistically update data watched by `useServerQuery` when both features use the
+same structured key and the same data shape:
+
+```ts
+const products = await api.products.get(
+  { query: { category } },
+  {
+    cache: {
+      key: ["products", category],
+      policy: "stale-while-revalidate",
+      staleTime: 30_000,
+    },
+  },
+);
+
+await api.products.post(
+  { body: draft },
+  {
+    optimistic: {
+      update: [
+        [
+          products.key,
+          (current) => ({
+            ...current,
+            products: [
+              { ...draft, id: "optimistic" },
+              ...(current?.products ?? []),
+            ],
+          }),
+        ],
+      ],
+      rollbackOnError: true,
+    },
+    invalidate: [products.key],
+  },
+);
+```
+
+This works through the shared Farm client cache; `useServerQuery` does not expose a separate
+optimistic option. Keep the API response and server-query result contracts identical whenever they
+share a key.
 
 ## Cache lifetime
 

--- a/docs/src/app/docs/server-rendering/page.md
+++ b/docs/src/app/docs/server-rendering/page.md
@@ -37,12 +37,15 @@ Farm also recognizes compact rendering directives at the top of route modules. T
 **src/app/blog/page.tsx**
 
 ```tsx
-"use ppr: 60";
+"use ssg; 60";
 
 export default function BlogPage() {
   return <main>Blog</main>;
 }
 ```
+
+`use ssg; 60` statically generates the route and revalidates it every 60 seconds. Farm also accepts
+`use ssg`, `use dynamic`, and `use ppr; 60` when those rendering modes fit the route.
 
 ## Dynamic rendering
 

--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 
+import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -12,6 +13,10 @@ import {
   getFarmDocsDocumentNavigationMatchers,
   isFarmDocsAPIRequest,
 } from "../docs";
+import {
+  createFarmDocsLastModifiedManifest,
+  FARM_DOCS_LAST_MODIFIED_MANIFEST,
+} from "../docs/last-modified";
 
 describe("getFarmDocsDocumentNavigationMatchers", () => {
   it("routes enabled docs trees through document navigation", () => {
@@ -170,7 +175,7 @@ describe("createFarmDocsHandler", () => {
       },
       { root, srcDir: "src" },
     );
-    return { root, docs };
+    return { root, docs, docsDir };
   }
 
   it("serves docs markdown files as HTML", async () => {
@@ -298,6 +303,74 @@ describe("createFarmDocsHandler", () => {
     expect(html).toContain("Farm docs pixel-border bridge");
     expect(html).toContain('class="toc-scroll"');
     expect(html).toContain('class="toc-empty"');
+  });
+
+  it("uses generated metadata instead of deployment file timestamps", async () => {
+    const { root, docs, docsDir } = await createDocsFixture();
+    const sourcePath = path.join(docsDir, "page.md");
+    const copiedTimestamp = new Date("2018-10-20T12:00:00.000Z");
+    const lastModified = "2026-07-14T12:00:00.000Z";
+
+    await fs.utimes(sourcePath, copiedTimestamp, copiedTimestamp);
+    const manifest = createFarmDocsLastModifiedManifest(docsDir, {
+      fallback: "now",
+      now: new Date(lastModified),
+    });
+    await fs.writeFile(
+      path.join(docsDir, FARM_DOCS_LAST_MODIFIED_MANIFEST),
+      JSON.stringify(manifest),
+    );
+
+    expect(manifest.pages["page.md"]).toBe(lastModified);
+
+    const handler = createFarmDocsHandler(docs, { root, srcDir: "src" });
+    const response = await handler(
+      new Request("http://farm.test/docs", {
+        headers: { accept: "text/html" },
+      }),
+    );
+
+    expect(response?.status).toBe(200);
+    const html = await response?.text();
+    expect(html).toContain(`datetime="${lastModified}"`);
+    expect(html).toContain("July 14, 2026");
+    expect(html).not.toContain("October 20, 2018");
+  });
+
+  it("generates page dates from Git history before file timestamps", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-docs-git-dates-"));
+    const docsDir = path.join(root, "docs");
+    const sourcePath = path.join(docsDir, "page.md");
+    const commitDate = "2026-06-12T09:30:00.000Z";
+
+    await fs.mkdir(docsDir, { recursive: true });
+    await fs.writeFile(sourcePath, "# Git-backed date");
+    execFileSync("git", ["init"], { cwd: root, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "farm@example.com"], {
+      cwd: root,
+      stdio: "ignore",
+    });
+    execFileSync("git", ["config", "user.name", "Farm Docs"], {
+      cwd: root,
+      stdio: "ignore",
+    });
+    execFileSync("git", ["add", "docs/page.md"], { cwd: root, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "docs: add page"], {
+      cwd: root,
+      stdio: "ignore",
+      env: {
+        ...process.env,
+        GIT_AUTHOR_DATE: commitDate,
+        GIT_COMMITTER_DATE: commitDate,
+      },
+    });
+
+    const copiedTimestamp = new Date("2018-10-20T12:00:00.000Z");
+    await fs.utimes(sourcePath, copiedTimestamp, copiedTimestamp);
+
+    const manifest = createFarmDocsLastModifiedManifest(docsDir);
+
+    expect(new Date(manifest.pages["page.md"]).toISOString()).toBe(commitDate);
   });
 
   it("renders docs-style breadcrumbs only for nested docs pages", async () => {

--- a/packages/farm/src/docs/handler.ts
+++ b/packages/farm/src/docs/handler.ts
@@ -23,6 +23,7 @@ import {
 } from "@farming-labs/docs";
 import { marked, Renderer } from "marked";
 import { highlight } from "sugar-high";
+import { resolveFarmDocsPageLastModified } from "./last-modified";
 import type { FarmDocsResolvedConfig } from "./types";
 
 export interface FarmDocsHandlerOptions {
@@ -227,17 +228,6 @@ function titleFromMarkdown(body: string, fallback: string): string {
   return heading || fallback;
 }
 
-function getPageLastModified(sourcePath: string, frontmatter: Record<string, string>): string {
-  const configured =
-    frontmatter.lastModified ||
-    frontmatter.lastmod ||
-    frontmatter.lastUpdated ||
-    frontmatter.updatedAt;
-  if (configured) return configured;
-
-  return statSync(sourcePath).mtime.toISOString();
-}
-
 export function loadFarmDocsPage(
   contentDir: string,
   docs: FarmDocsResolvedConfig,
@@ -257,7 +247,7 @@ export function loadFarmDocsPage(
     description: frontmatter.description,
     href,
     sourcePath,
-    lastModified: getPageLastModified(sourcePath, frontmatter),
+    lastModified: resolveFarmDocsPageLastModified(contentDir, sourcePath, frontmatter),
     frontmatter,
     body,
   };
@@ -322,7 +312,7 @@ export function discoverFarmDocsPages(
         section: frontmatter.section,
         href: createDocsHref(docs.entry, slug),
         sourcePath: absolutePath,
-        lastModified: getPageLastModified(absolutePath, frontmatter),
+        lastModified: resolveFarmDocsPageLastModified(contentDir, absolutePath, frontmatter),
       });
     }
   };

--- a/packages/farm/src/docs/last-modified.ts
+++ b/packages/farm/src/docs/last-modified.ts
@@ -1,0 +1,201 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
+import path from "node:path";
+
+export const FARM_DOCS_LAST_MODIFIED_MANIFEST = ".farm-docs-last-modified.json";
+
+export interface FarmDocsLastModifiedManifest {
+  version: 1;
+  pages: Record<string, string>;
+}
+
+export interface CreateFarmDocsLastModifiedManifestOptions {
+  fallback?: "mtime" | "now";
+  now?: Date;
+}
+
+const COMMIT_MARKER = "__FARM_DOCS_COMMIT__";
+const DOCS_FILE_EXTENSIONS = new Set([".md", ".mdx"]);
+const manifestCache = new Map<
+  string,
+  {
+    signature: string;
+    manifest: FarmDocsLastModifiedManifest;
+  }
+>();
+
+function normalizeRelativePath(value: string): string {
+  return value.replace(/\\/g, "/").replace(/^\.\/+/, "");
+}
+
+function resolveExistingPath(filePath: string): string {
+  try {
+    return realpathSync(filePath);
+  } catch {
+    return path.resolve(filePath);
+  }
+}
+
+function isDocsSourceFile(filePath: string): boolean {
+  return DOCS_FILE_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+}
+
+function discoverDocsSourceFiles(contentDir: string): string[] {
+  const files: string[] = [];
+
+  const visit = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    )) {
+      if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+
+      const absolutePath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        visit(absolutePath);
+      } else if (entry.isFile() && isDocsSourceFile(absolutePath)) {
+        files.push(absolutePath);
+      }
+    }
+  };
+
+  if (existsSync(contentDir)) visit(contentDir);
+  return files;
+}
+
+function getGitLastModifiedDates(contentDir: string): Record<string, string> {
+  try {
+    const gitRoot = execFileSync("git", ["-C", contentDir, "rev-parse", "--show-toplevel"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (!gitRoot) return {};
+
+    const contentPathspec = normalizeRelativePath(path.relative(gitRoot, contentDir)) || ".";
+    const contentPrefix = contentPathspec === "." ? "" : `${contentPathspec}/`;
+    const history = execFileSync(
+      "git",
+      [
+        "-C",
+        gitRoot,
+        "-c",
+        "core.quotePath=false",
+        "log",
+        `--format=${COMMIT_MARKER}%cI`,
+        "--name-only",
+        "--",
+        contentPathspec,
+      ],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+        maxBuffer: 32 * 1024 * 1024,
+      },
+    );
+
+    const pages: Record<string, string> = {};
+    let commitDate: string | undefined;
+
+    for (const rawLine of history.split(/\r?\n/)) {
+      const line = normalizeRelativePath(rawLine.trim());
+      if (!line) continue;
+
+      if (line.startsWith(COMMIT_MARKER)) {
+        commitDate = line.slice(COMMIT_MARKER.length);
+        continue;
+      }
+      if (!commitDate || (contentPrefix && !line.startsWith(contentPrefix))) continue;
+
+      const relativePath = contentPrefix ? line.slice(contentPrefix.length) : line;
+      if (isDocsSourceFile(relativePath) && !pages[relativePath]) {
+        pages[relativePath] = commitDate;
+      }
+    }
+
+    return pages;
+  } catch {
+    return {};
+  }
+}
+
+function readManifest(contentDir: string): FarmDocsLastModifiedManifest | null {
+  const manifestPath = path.join(contentDir, FARM_DOCS_LAST_MODIFIED_MANIFEST);
+  if (!existsSync(manifestPath)) return null;
+
+  try {
+    const parsed = JSON.parse(readFileSync(manifestPath, "utf8")) as Partial<
+      FarmDocsLastModifiedManifest
+    >;
+    if (parsed.version !== 1 || !parsed.pages || typeof parsed.pages !== "object") return null;
+
+    const pages = Object.fromEntries(
+      Object.entries(parsed.pages).filter(
+        (entry): entry is [string, string] =>
+          typeof entry[1] === "string" && entry[1].length > 0,
+      ),
+    );
+    return { version: 1, pages };
+  } catch {
+    return null;
+  }
+}
+
+export function createFarmDocsLastModifiedManifest(
+  contentDir: string,
+  options: CreateFarmDocsLastModifiedManifestOptions = {},
+): FarmDocsLastModifiedManifest {
+  const resolvedContentDir = resolveExistingPath(contentDir);
+  const gitDates = getGitLastModifiedDates(resolvedContentDir);
+  const fallbackDate = (options.now ?? new Date()).toISOString();
+  const pages: Record<string, string> = {};
+
+  for (const sourcePath of discoverDocsSourceFiles(resolvedContentDir)) {
+    const relativePath = normalizeRelativePath(path.relative(resolvedContentDir, sourcePath));
+    pages[relativePath] =
+      gitDates[relativePath] ||
+      (options.fallback === "now" ? fallbackDate : statSync(sourcePath).mtime.toISOString());
+  }
+
+  return { version: 1, pages };
+}
+
+function getLastModifiedManifest(contentDir: string): FarmDocsLastModifiedManifest {
+  const resolvedContentDir = resolveExistingPath(contentDir);
+  const manifestPath = path.join(resolvedContentDir, FARM_DOCS_LAST_MODIFIED_MANIFEST);
+  const manifestStat = existsSync(manifestPath) ? statSync(manifestPath) : null;
+  const signature = manifestStat
+    ? `file:${manifestStat.mtimeMs}:${manifestStat.size}`
+    : "generated";
+  const cached = manifestCache.get(resolvedContentDir);
+  if (cached?.signature === signature) return cached.manifest;
+
+  const manifest =
+    readManifest(resolvedContentDir) ?? createFarmDocsLastModifiedManifest(resolvedContentDir);
+  manifestCache.set(resolvedContentDir, { signature, manifest });
+  return manifest;
+}
+
+export function resolveFarmDocsPageLastModified(
+  contentDir: string,
+  sourcePath: string,
+  frontmatter: Record<string, string>,
+): string {
+  const configured =
+    frontmatter.lastModified ||
+    frontmatter.lastmod ||
+    frontmatter.lastUpdated ||
+    frontmatter.updatedAt;
+  if (configured) return configured;
+
+  const resolvedContentDir = resolveExistingPath(contentDir);
+  const resolvedSourcePath = resolveExistingPath(sourcePath);
+  const relativePath = normalizeRelativePath(path.relative(resolvedContentDir, resolvedSourcePath));
+  const isInsideContentDir =
+    relativePath !== ".." && !relativePath.startsWith("../") && !path.isAbsolute(relativePath);
+
+  if (isInsideContentDir) {
+    const generated = getLastModifiedManifest(resolvedContentDir).pages[relativePath];
+    if (generated) return generated;
+  }
+
+  return statSync(resolvedSourcePath).mtime.toISOString();
+}

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -25,6 +25,10 @@ import {
 import { routeRulesToNitroRouteRules } from "../route-rules";
 import { getFarmAppDirectories } from "../layers";
 import { farmEnvironmentFunctionsPlugin } from "../environment-vite";
+import {
+  createFarmDocsLastModifiedManifest,
+  FARM_DOCS_LAST_MODIFIED_MANIFEST,
+} from "../docs/last-modified";
 
 // Type alias for OutputBundle
 type OutputBundle = Rollup.OutputBundle;
@@ -2754,9 +2758,16 @@ async function copyFarmDocsContentForVercel(
   if (!docsContentDir) return;
 
   const bundledContentDir = path.join(nitroFuncDir, "chunks", "nitro", "farm-docs-content");
+  const lastModifiedManifest = createFarmDocsLastModifiedManifest(docsContentDir, {
+    fallback: "now",
+  });
   await fs.rm(bundledContentDir, { recursive: true, force: true });
   await fs.mkdir(path.dirname(bundledContentDir), { recursive: true });
   await fs.cp(docsContentDir, bundledContentDir, { recursive: true, force: true });
+  await fs.writeFile(
+    path.join(bundledContentDir, FARM_DOCS_LAST_MODIFIED_MANIFEST),
+    `${JSON.stringify(lastModifiedManifest, null, 2)}\n`,
+  );
 
   logger.info(`📚 Bundled docs content for Vercel: ${path.relative(root, docsContentDir)}`);
 }


### PR DESCRIPTION
## Summary

- derive docs page dates from explicit frontmatter or per-page Git history and bundle a stable metadata sidecar for Vercel deployments
- replace the rendering example with the canonical `"use ssg; 60"` directive
- document Farm-native optimistic API cache updates and their shared-key relationship with `createServerQuery`, without claiming a separate query-hook optimistic API

## Verification

- `corepack pnpm --filter @farmjs/core build`
- `vitest run` for docs handler, API client runtime/types, server query client, and SSG: 37 tests passed
- `farm build --preset vercel` and inspected the bundled 50-page last-modified manifest
- local desktop/mobile browser checks for `/docs`, `/docs/docs-engine`, `/docs/server-rendering`, `/docs/api-client`, and `/docs/server-queries`; all returned 200 with no console, page, or request errors

## Note

The package-wide `tsc --noEmit` command still reports existing unrelated Nitro, Rollup, `nuqs`, and Vite typing failures. The package build and declaration generation pass with this change.