### PR TITLE
fix: make inline docs config canonical

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -37,21 +37,40 @@ export default defineConfig({
 
 ### Docs config
 
-Use `defineDocs` for docs-specific navigation, search, theme, and metadata in a separate `docs.config.ts`:
+Configure the docs runtime directly in `farm.config.ts`:
 
 ```ts
-import { defineDocs } from "@farming-labs/docs";
+import { defineConfig } from "@farmjs/core";
 
-export default defineDocs({
-  entry: "docs",
-  docsPath: "/docs",
-  nav: {
-    title: "Farm.js Docs",
+export default defineConfig({
+  docs: {
+    entry: "/docs",
+    metadata: {
+      description: "Product guides and API reference.",
+    },
+    nav: {
+      title: "Acme Docs",
+    },
+    search: {
+      provider: "simple",
+      enabled: true,
+    },
+    pageActions: {
+      copyMarkdown: {
+        enabled: true,
+      },
+    },
+    llmsTxt: true,
+    sitemap: true,
+    robots: true,
   },
 });
 ```
 
-`defineConfig` configures the Farm application. `defineDocs` configures the docs experience mounted by that application.
+This single property enables human-readable pages, markdown mirrors, search metadata, and
+agent-readable docs routes. A separate `docs.config.*` or `docs.json` file is optional and intended
+only for large serializable configurations; inline values always take priority. See
+[Docs Engine](/docs/docs-engine) for content layout, generated routes, and API overrides.
 
 ## Important options
 
@@ -178,8 +197,8 @@ src/
 Add optional files only when the app needs them:
 
 ```txt
-docs.config.ts
-docs.json
+docs.config.ts              # Optional split for a large docs configuration
+docs.json                   # Optional serializable docs configuration
 src/app/api/**/route.ts
 src/app/**/middleware.ts
 src/lib/integrations.ts

--- a/docs/src/app/docs/docs-engine/page.md
+++ b/docs/src/app/docs/docs-engine/page.md
@@ -18,13 +18,43 @@ import { defineConfig } from "@farmjs/core";
 export default defineConfig({
   docs: {
     entry: "/docs",
+    metadata: {
+      description: "Product guides and API reference.",
+    },
+    nav: {
+      title: "Acme Docs",
+    },
   },
 });
 ```
 
+Farm uses `src/app/docs` for content when `entry` is `/docs`. Add markdown pages using the normal
+app directory structure:
+
+```txt
+src/app/docs/
+  page.md
+  getting-started/
+    page.md
+  api-reference/
+    page.md
+```
+
+Use frontmatter for page metadata:
+
+```md
+---
+title: "Getting Started"
+description: "Install Farm and create your first application."
+---
+
+# Getting Started
+```
+
 ## Automatic docs routes
 
-When docs.entry is enabled, Farm can serve the docs entry and /api/docs machine endpoints automatically. Route wrappers are only needed when you want to override the default behavior.
+When `docs.entry` is enabled, Farm serves the docs entry and `/api/docs` machine endpoints
+automatically. Route wrappers are only needed when you want to override the default behavior.
 
 - /docs
 - /docs/getting-started
@@ -33,36 +63,52 @@ When docs.entry is enabled, Farm can serve the docs entry and /api/docs machine 
 - /api/docs?format=sitemap-xml
 - /api/docs/agent/spec
 
-## Config discovery
+## Configure the docs experience
 
-Farm scans docs.config.ts, docs.config.js, docs.config.mjs, docs.config.cjs, and docs.json by default. Inline config in farm.config.ts can override discovered values.
+Keep docs configuration alongside the rest of the application in `farm.config.ts`:
 
-## docs.config.ts shape
-
-**docs.config.ts**
+**farm.config.ts**
 
 ```ts
-import { defineDocs } from "@farming-labs/docs";
-import { pixelBorder } from "@farming-labs/theme/pixel-border";
+import { defineConfig } from "@farmjs/core";
 
-export default defineDocs({
-  entry: "docs",
-  docsPath: "/docs",
-  nav: {
-    title: "Farm.js Docs",
-  },
-  search: {
-    provider: "simple",
-    enabled: true,
-  },
-  pageActions: {
-    copyMarkdown: {
-      enabled: true,
+export default defineConfig({
+  docs: {
+    entry: "/docs",
+    nav: {
+      title: "Acme Docs",
+      url: "/",
     },
+    search: {
+      provider: "simple",
+      enabled: true,
+      maxResults: 10,
+    },
+    pageActions: {
+      copyMarkdown: {
+        enabled: true,
+      },
+    },
+    llmsTxt: {
+      enabled: true,
+      siteTitle: "Acme Docs",
+    },
+    sitemap: true,
+    robots: true,
   },
-  theme: pixelBorder(),
 });
 ```
+
+The `docs` object controls the public path, metadata, navigation, search, page actions, agent output,
+theme, icons, reading time, last-updated display, sitemap, and robots output. `defineDocs` is not
+required for a Farm application.
+
+### Optional external config
+
+Large documentation sites may move the serializable docs options into `docs.config.ts`,
+`docs.config.js`, `docs.config.mjs`, `docs.config.cjs`, or `docs.json`. Farm discovers those files
+automatically. Values declared in `farm.config.ts` take priority, so applications can still override
+the entry or any shared setting.
 
 ## Agent-readable output
 
@@ -98,9 +144,20 @@ fall back to the source file timestamp and copied production docs fall back to t
 
 When `docs.entry` is enabled in `farm.config.ts`, Farm can mount docs pages and docs API routes automatically. Add explicit route wrappers only when the app wants to override default rendering, authentication, or response behavior.
 
+```ts
+// src/app/api/docs/route.ts
+import { createDocsAPI } from "@farmjs/core/docs";
+
+export const { GET, POST } = createDocsAPI();
+```
+
+Add the same exports to `src/app/api/docs/[...docs]/route.ts` when the override should also own
+path-style machine routes. Most applications do not need either wrapper.
+
 ## Production notes
 
 - Keep docs content in markdown so human pages and agent-readable pages stay in sync.
-- Use `docs.config.ts` for navigation, page actions, icons, theme, and metadata.
+- Keep the canonical docs configuration in the `docs` property of `farm.config.ts`.
+- Use an external docs config only when a large navigation or theme definition is easier to maintain separately.
 - Keep generated docs routes public unless product docs require auth.
 - Verify docs build output before publishing package docs.

--- a/docs/src/app/docs/project-structure/page.md
+++ b/docs/src/app/docs/project-structure/page.md
@@ -27,14 +27,14 @@ my-app/
 
 ## Common folders
 
-| Path | Purpose |
-| --- | --- |
-| src/app | Pages, nested layouts, API routes, route boundaries, middleware. |
-| src/lib | Shared server and client utilities. |
-| src/components | Reusable UI and client components. |
-| layers | Optional local Farm layers consumed through `extends`. |
-| src/farm-routes.d.ts | Generated typed route union for Link. |
-| farm.config.ts | Framework config, integrations, docs, storage, deployment. |
+| Path                 | Purpose                                                          |
+| -------------------- | ---------------------------------------------------------------- |
+| src/app              | Pages, nested layouts, API routes, route boundaries, middleware. |
+| src/lib              | Shared server and client utilities.                              |
+| src/components       | Reusable UI and client components.                               |
+| layers               | Optional local Farm layers consumed through `extends`.           |
+| src/farm-routes.d.ts | Generated typed route union for Link.                            |
+| farm.config.ts       | Framework config, integrations, docs, storage, deployment.       |
 
 ## Optional files stay optional
 
@@ -42,16 +42,16 @@ Use vite.config.ts only when you need custom Vite behavior. Use platform files o
 
 ## Route files
 
-| File | Used for |
-| --- | --- |
-| `page.tsx` | The route UI. |
-| `page.md` / `page.mdx` | Markdown-first static app pages. |
-| `layout.tsx` | Shared shell for every child segment. |
-| `loading.tsx` | Pending UI for async route work. |
-| `error.tsx` | Segment-level error UI. |
-| `not-found.tsx` | Segment-level 404 UI. |
-| `middleware.ts` | Request behavior before the route renders. |
-| `route.ts` | API handlers for the current URL segment. |
+| File                   | Used for                                   |
+| ---------------------- | ------------------------------------------ |
+| `page.tsx`             | The route UI.                              |
+| `page.md` / `page.mdx` | Markdown-first static app pages.           |
+| `layout.tsx`           | Shared shell for every child segment.      |
+| `loading.tsx`          | Pending UI for async route work.           |
+| `error.tsx`            | Segment-level error UI.                    |
+| `not-found.tsx`        | Segment-level 404 UI.                      |
+| `middleware.ts`        | Request behavior before the route renders. |
+| `route.ts`             | API handlers for the current URL segment.  |
 
 ## Recommended app layout
 
@@ -99,9 +99,9 @@ Generated route types make `Link` stricter, and generated API types make `api.he
 
 ## When to add root files
 
-| File | Add it when |
-| --- | --- |
-| `vite.config.ts` | You need Vite plugins, aliases, or server settings Farm does not infer. |
-| `vercel.json` | You need platform behavior outside Farm's deploy output. |
-| `tailwind.config.ts` | Your Tailwind version or design system requires an explicit config. |
-| `docs.config.ts` | You enable docs and want navigation, icons, theme, or page actions. |
+| File                 | Add it when                                                                                                 |
+| -------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `vite.config.ts`     | You need Vite plugins, aliases, or server settings Farm does not infer.                                     |
+| `vercel.json`        | You need platform behavior outside Farm's deploy output.                                                    |
+| `tailwind.config.ts` | Your Tailwind version or design system requires an explicit config.                                         |
+| `docs.config.ts`     | A large docs configuration is easier to maintain outside the canonical `docs` property in `farm.config.ts`. |

--- a/examples/basic/docs.json
+++ b/examples/basic/docs.json
@@ -1,9 +1,0 @@
-{
-  "entry": "docs",
-  "metadata": {
-    "description": "Farm.js example documentation"
-  },
-  "nav": {
-    "title": "Farm Docs"
-  }
-}

--- a/examples/basic/farm.config.ts
+++ b/examples/basic/farm.config.ts
@@ -197,6 +197,12 @@ export default defineConfig({
 
   docs: {
     entry: '/docs',
+    metadata: {
+      description: 'Farm.js example documentation',
+    },
+    nav: {
+      title: 'Farm Docs',
+    },
   },
 
   md: {

--- a/examples/basic/src/app/docs/page.md
+++ b/examples/basic/src/app/docs/page.md
@@ -7,6 +7,6 @@ description: Local docs served by the Farm docs integration.
 
 This page is served from Markdown through the built-in Farm docs integration.
 
-- It uses `docs: { entry: "/docs" }` in `farm.config.ts`.
-- It can also read shared docs settings from `docs.json`.
+- It keeps the entry, metadata, and navigation settings in the `docs` property of `farm.config.ts`.
+- Large sites can optionally move serializable settings to `docs.config.*` or `docs.json`.
 - Markdown can be fetched directly from `/docs.md`.

--- a/examples/docs-integration/README.md
+++ b/examples/docs-integration/README.md
@@ -11,9 +11,32 @@ import { defineConfig } from '@farmjs/core';
 export default defineConfig({
   docs: {
     entry: '/docs',
+    metadata: {
+      description: 'Farm docs integration example',
+    },
+    nav: {
+      title: 'Farm Docs',
+    },
+    search: {
+      provider: 'simple',
+      enabled: true,
+    },
+    pageActions: {
+      copyMarkdown: {
+        enabled: true,
+      },
+    },
+    llmsTxt: true,
+    sitemap: true,
+    robots: true,
   },
 });
 ```
+
+Place markdown in `src/app/docs`. The folder structure becomes the docs URL structure, so
+`src/app/docs/getting-started/page.md` is served at `/docs/getting-started` and
+`/docs/getting-started.md`. A separate `docs.config.*` or `docs.json` file is supported for large
+serializable configurations but is not required.
 
 You only need app route wrappers when you want to override the default handler:
 

--- a/examples/docs-integration/docs.json
+++ b/examples/docs-integration/docs.json
@@ -1,9 +1,0 @@
-{
-  "entry": "docs",
-  "metadata": {
-    "description": "Farm docs integration example"
-  },
-  "nav": {
-    "title": "Farm Docs"
-  }
-}

--- a/examples/docs-integration/farm.config.ts
+++ b/examples/docs-integration/farm.config.ts
@@ -7,5 +7,23 @@ export default defineConfig({
   },
   docs: {
     entry: '/docs',
+    metadata: {
+      description: 'Farm docs integration example',
+    },
+    nav: {
+      title: 'Farm Docs',
+    },
+    search: {
+      provider: 'simple',
+      enabled: true,
+    },
+    pageActions: {
+      copyMarkdown: {
+        enabled: true,
+      },
+    },
+    llmsTxt: true,
+    sitemap: true,
+    robots: true,
   },
 });


### PR DESCRIPTION
## Summary

- make the `docs` property in `farm.config.ts` the canonical configuration path
- document content placement, generated human and agent routes, and optional API overrides
- describe `docs.config.*` and `docs.json` as optional splits for large serializable configurations
- move docs metadata and navigation into the basic and docs-integration examples
- remove the examples' hidden `docs.json` dependency

## Why

The implementation already supports the complete docs configuration inline, but several guides still directed readers to a separate `docs.config.ts`. The examples also depended on `docs.json`, so the visible `farm.config.ts` did not fully explain the resulting docs experience.

This aligns the guides and executable examples around one copyable workflow while preserving external config discovery for larger sites.

## Validation

- `corepack pnpm exec oxfmt --check ...`
- `corepack pnpm --filter @farmjs/core exec vitest run src/__tests__/config.test.ts src/__tests__/docs-handler.test.ts` (36 tests)
- `corepack pnpm --filter farm-docs-integration-example type-check`
- `corepack pnpm --filter farm-example-basic type-check`
- production docs build with Farm's Vercel preset
