### PR TITLE
fix: update README team attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,6 @@ Farm.js is inspired by:
 
 **[Documentation](https://farm.js.dev)** • **[Examples](./examples)** • **[Contributing](CONTRIBUTING.md)**
 
-Made with ❤️ by the Farm.js team
+Made with ❤️ by the [Farming Labs team](https://www.farming-labs.dev)
 
 </div>


### PR DESCRIPTION
## Summary

- replace the README footer attribution from the Farm.js team to the Farming Labs team
- link the Farming Labs team name to https://www.farming-labs.dev

## Validation

- `git diff --check`