### PR TITLE
fix: space README attribution mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,6 @@ Farm.js is inspired by:
 
 **[Documentation](https://farm.js.dev)** • **[Examples](./examples)** • **[Contributing](CONTRIBUTING.md)**
 
-Made with ❤️ by&nbsp;<a href="https://www.farming-labs.dev"><img src="./.github/assets/farming-labs-mark.svg" alt="" height="18" align="center" />&nbsp;Farming Labs</a> team
+Made with ❤️ by&ensp;<a href="https://www.farming-labs.dev"><img src="./.github/assets/farming-labs-mark.svg" alt="" height="18" align="center" />&nbsp;Farming Labs</a> team
 
 </div>

--- a/README.md
+++ b/README.md
@@ -397,6 +397,6 @@ Farm.js is inspired by:
 
 **[Documentation](https://farm.js.dev)** • **[Examples](./examples)** • **[Contributing](CONTRIBUTING.md)**
 
-Made with ❤️ by <a href="https://www.farming-labs.dev"><img src="./.github/assets/farming-labs-mark.svg" alt="" height="18" align="center" />&nbsp;Farming Labs</a> team
+Made with ❤️ by&nbsp;<a href="https://www.farming-labs.dev"><img src="./.github/assets/farming-labs-mark.svg" alt="" height="18" align="center" />&nbsp;Farming Labs</a> team
 
 </div>


### PR DESCRIPTION
## Summary

- add a modest en-space gap between `by` and the linked Farming Labs mark
- preserve the existing mark-to-name spacing and link boundary

## Validation

- `git diff --check`