### PR TITLE
feat: add homepage integration examples

### DIFF
--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -269,25 +269,25 @@ data?.users[0]?.name;
 
 const integrationCodeTabs = [
   {
-    id: "providers",
-    label: "Providers",
+    id: "integrations",
+    label: "src/lib/integrations.ts",
     language: "ts",
-    highlightLines: [5, 6, 7, 8],
-    code: `import { betterAuth, jobs, stripe, trigger } from "@farmjs/integrations";
+    highlightLines: [5, 6, 7],
+    code: `import { betterAuth, resend, stripe } from "@farmjs/integrations";
 import { auth } from "./auth";
-import { tasks } from "./jobs";
+import { emailTemplates } from "./email";
 export const integrations = {
     auth: betterAuth({ instance: auth }), // Better Auth
     billing: stripe({ secretKey: process.env.STRIPE_SECRET_KEY }), // Stripe
-    jobs: jobs({ // Trigger.dev
-        runtime: trigger({ apiKey: process.env.TRIGGER_SECRET_KEY }),
-        tasks,
+    email: resend({ // Resend
+        apiKey: process.env.RESEND_API_KEY,
+        templates: emailTemplates,
     }),
 } as const;`,
   },
   {
-    id: "register",
-    label: "Register",
+    id: "config",
+    label: "farm.config.ts",
     language: "ts",
     highlightLines: [4],
     code: `import { defineConfig } from "@farmjs/core";
@@ -916,7 +916,7 @@ function IntegrationVisual() {
         compact
         id="product-integration-examples"
         tabs={integrationCodeTabs}
-        tabsLabel="Product integration examples"
+        tabsLabel="Integration files"
       />
     </div>
   );

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -267,15 +267,36 @@ if (error) throw error;
 data?.users[0]?.name;
 //   ^? string | undefined`;
 
-const integrationConfigCode = `import { defineConfig } from "@farmjs/core";
-import { auth, billing, jobs } from "./src/lib/integrations";
+const integrationCodeTabs = [
+  {
+    id: "providers",
+    label: "Providers",
+    language: "ts",
+    highlightLines: [5, 6, 7, 8],
+    code: `import { betterAuth, jobs, stripe, trigger } from "@farmjs/integrations";
+import { auth } from "./auth";
+import { tasks } from "./jobs";
+export const integrations = {
+    auth: betterAuth({ instance: auth }), // Better Auth
+    billing: stripe({ secretKey: process.env.STRIPE_SECRET_KEY }), // Stripe
+    jobs: jobs({ // Trigger.dev
+        runtime: trigger({ apiKey: process.env.TRIGGER_SECRET_KEY }),
+        tasks,
+    }),
+} as const;`,
+  },
+  {
+    id: "register",
+    label: "Register",
+    language: "ts",
+    highlightLines: [4],
+    code: `import { defineConfig } from "@farmjs/core";
+import { integrations } from "./src/lib/integrations";
 export default defineConfig({
-    extends: ["./layers/commerce"],
-    integrations: { auth, billing, jobs },
-    routeRules: { "/store/**": { swr: 300 } },
-    serverActions: { bodySizeLimit: "1mb" },
-    deploy: { target: "vercel" },
-});`;
+    integrations,
+});`,
+  },
+] as const satisfies readonly [HighlightedCodeTab, ...HighlightedCodeTab[]];
 
 const docsConfigCode = `import { defineConfig } from "@farmjs/core";
 export default defineConfig({
@@ -288,7 +309,6 @@ export default defineConfig({
 });`;
 
 const typedApiHighlightLines = [1, 7, 8] as const;
-const integrationHighlightLines = [5] as const;
 const docsHighlightLines = [3, 4] as const;
 
 const layersConfigTabs = [
@@ -891,12 +911,12 @@ function TypedApiVisual() {
 function IntegrationVisual() {
   return (
     <div className="farm-feature-spotlight relative flex h-[340px] min-w-0 items-end justify-end overflow-hidden pl-6 sm:pl-10">
-      <HighlightedCode
+      <HighlightedCodeTabs
         className="relative z-10 -mb-px -mr-px flex h-[290px] w-full max-w-full shrink-0 flex-col"
-        code={integrationConfigCode}
-        highlightLines={integrationHighlightLines}
-        label="farm.config.ts"
-        language="ts"
+        compact
+        id="product-integration-examples"
+        tabs={integrationCodeTabs}
+        tabsLabel="Product integration examples"
       />
     </div>
   );

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -272,7 +272,7 @@ const integrationCodeTabs = [
     id: "integrations",
     label: "src/lib/integrations.ts",
     language: "ts",
-    highlightLines: [5, 6, 7],
+    highlightLines: [5, 6, 7, 8, 9],
     code: `import { betterAuth, resend, stripe } from "@farmjs/integrations";
 import { auth } from "./auth";
 import { emailTemplates } from "./email";


### PR DESCRIPTION
## Summary

- replace the generic homepage integration snippet with the existing accessible code-tab UI
- show Better Auth, Stripe, and Resend together in one concise `src/lib/integrations.ts` example
- label both tabs with their real filenames: `src/lib/integrations.ts` and `farm.config.ts`
- keep the second file focused on the minimal configuration needed to register the integrations object

## Why

The feature section names Farm.js integrations but did not show how real product providers fit into the integration object. Using auth, billing, and email keeps the example immediately useful and easier to understand than introducing a job runtime.

## Validation

- `corepack pnpm --filter farmjs-docs build`
- `corepack pnpm exec oxlint docs/src/app/page.tsx`
- `corepack pnpm exec oxfmt --check docs/src/app/page.tsx`
- browser QA at desktop and 419px mobile width
- verified both filename tabs, no console errors, no vertical code clipping, and no page-level horizontal overflow
