### PR TITLE
feat: add config-driven docs search

### DIFF
--- a/docs/docs.config.ts
+++ b/docs/docs.config.ts
@@ -268,7 +268,7 @@ const config = {
     description: "Farm.js framework documentation powered by @farming-labs/docs.",
   },
   nav: {
-    title: "Farm.js Docs",
+    title: "Farm.js",
     url: "/",
   },
   search: {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -18,7 +18,7 @@
     "description": "Farm.js framework documentation powered by @farming-labs/docs."
   },
   "nav": {
-    "title": "Farm.js Docs"
+    "title": "Farm.js"
   },
   "search": {
     "provider": "simple",

--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -72,6 +72,11 @@ agent-readable docs routes. A separate `docs.config.*` or `docs.json` file is op
 only for large serializable configurations; inline values always take priority. See
 [Docs Engine](/docs/docs-engine) for content layout, generated routes, and API overrides.
 
+The same `search` option configures the search provider and the docs interface. When it is enabled,
+Farm adds a search control to the sidebar and opens the search dialog with `Cmd+S` on macOS or
+`Ctrl+S` elsewhere. Set `search: false` or `search.enabled: false` to remove the control, dialog, and
+shortcut together.
+
 ## Important options
 
 | Option        | Use it for                                                                        |

--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -73,9 +73,10 @@ only for large serializable configurations; inline values always take priority. 
 [Docs Engine](/docs/docs-engine) for content layout, generated routes, and API overrides.
 
 The same `search` option configures the search provider and the docs interface. When it is enabled,
-Farm adds a search control to the sidebar and opens the search dialog with `Cmd+S` on macOS or
-`Ctrl+S` elsewhere. Set `search: false` or `search.enabled: false` to remove the control, dialog, and
-shortcut together.
+Farm mounts the shared Omni React search from `@farming-labs/theme`. The sidebar control and
+`Cmd+K` on macOS or `Ctrl+K` elsewhere open the same search interface used by the other Farming Labs
+framework adapters. Set `search: false` or `search.enabled: false` to remove the control, client
+mount, and shortcut together.
 
 ## Important options
 

--- a/docs/src/app/docs/docs-engine/page.md
+++ b/docs/src/app/docs/docs-engine/page.md
@@ -105,10 +105,14 @@ required for a Farm application.
 
 ### Built-in search
 
-Farm follows the Fumadocs search pattern without requiring application-owned UI. The sidebar search
-control and `Cmd+S` / `Ctrl+S` shortcut open one accessible dialog with keyboard navigation. The
-dialog queries `/api/docs?query=<term>`, so `provider`, `maxResults`, and custom provider behavior
-come from the same `docs.search` config used by the docs API.
+Farm uses the existing `DocsCommandSearch` React component from `@farming-labs/theme`, the same Omni
+search used by the Next.js docs adapter. Farm provides its HTML mount and server endpoint; the shared
+component owns the dialog, fuzzy ranking, filters, recent searches, loading and empty states, result
+highlights, and keyboard navigation. The sidebar control and `Cmd+K` / `Ctrl+K` shortcut open it.
+
+The component queries `/api/docs?query=<term>`. That endpoint returns the standard docs search result
+array, so `provider`, `maxResults`, and custom provider behavior come from the same `docs.search`
+config instead of a second client-side search implementation.
 
 Use `search: true` for the built-in simple provider, or configure `provider: "simple"`,
 `"algolia"`, `"typesense"`, `"mcp"`, or `"custom"`. Search result content is rendered as text, and

--- a/docs/src/app/docs/docs-engine/page.md
+++ b/docs/src/app/docs/docs-engine/page.md
@@ -103,6 +103,18 @@ The `docs` object controls the public path, metadata, navigation, search, page a
 theme, icons, reading time, last-updated display, sitemap, and robots output. `defineDocs` is not
 required for a Farm application.
 
+### Built-in search
+
+Farm follows the Fumadocs search pattern without requiring application-owned UI. The sidebar search
+control and `Cmd+S` / `Ctrl+S` shortcut open one accessible dialog with keyboard navigation. The
+dialog queries `/api/docs?query=<term>`, so `provider`, `maxResults`, and custom provider behavior
+come from the same `docs.search` config used by the docs API.
+
+Use `search: true` for the built-in simple provider, or configure `provider: "simple"`,
+`"algolia"`, `"typesense"`, `"mcp"`, or `"custom"`. Search result content is rendered as text, and
+provider credentials remain on the server. Setting `search: false` or `search.enabled: false`
+disables both the endpoint capability and the interface.
+
 ### Optional external config
 
 Large documentation sites may move the serializable docs options into `docs.config.ts`,

--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -208,8 +208,23 @@ describe("createFarmDocsHandler", () => {
     expect(html).toContain("farmDocsNavigating");
     expect(html).toContain("farmDocsRuntimeId");
     expect(html).toContain('class="mobile-topbar"');
-    expect(html).toContain('data-sidebar-toggle');
-    expect(html).toContain('data-sidebar-backdrop');
+    expect(html).toContain("data-sidebar-toggle");
+    expect(html).toContain("data-sidebar-backdrop");
+    expect(html).toContain('class="fd-docs-search-trigger"');
+    expect(html).toContain("data-docs-search-trigger");
+    expect(html).toContain('aria-keyshortcuts="Meta+S Control+S"');
+    expect(html).toContain('id="farm-docs-search-dialog"');
+    expect(html).toContain("data-docs-search-input");
+    expect(html).toContain('aria-label="Search documentation"');
+    expect(html).toContain('role="listbox"');
+    expect(html).toContain("window.__farmDocsSearchRuntime");
+    expect(html).toContain('event.key.toLowerCase()==="s"');
+    expect(html).toContain('fetch("/api/docs?query="+encodeURIComponent(query)');
+    expect(html).toContain("descriptionElement.textContent=description");
+    expect(html).toContain('document.getElementById(id)?.scrollIntoView({block:"start"})');
+    expect(html).toContain(
+      "sidebar.scrollTop+=activeRect.top-sidebarRect.top-(sidebar.clientHeight-activeRect.height)/2",
+    );
     expect(html).toContain("initMobileSidebar");
     expect(html).toContain("closeMobileSidebar");
     expect(html).toContain('data-farm-docs-sidebar="open"');
@@ -226,7 +241,7 @@ describe("createFarmDocsHandler", () => {
     expect(html).toContain("try{await navigator.clipboard.writeText(text);return}catch{}");
     expect(html).toContain("4500");
     expect(html).toContain('url("/assets/GeistMono-Variable-BNLlm6Cd.woff2") format("woff2")');
-    expect(html).toContain("--font-geist-mono: \"Geist Mono\"");
+    expect(html).toContain('--font-geist-mono: "Geist Mono"');
     expect(html).toContain('<link rel="preload" href="/assets/GeistMono-Variable-BNLlm6Cd.woff2"');
     expect(html).toContain('class="fd-page-meta-item">1 min read</span>');
     expect(html).toContain('class="not-prose fd-page-footer"');
@@ -257,19 +272,27 @@ describe("createFarmDocsHandler", () => {
     expect(html).not.toContain(
       '.sidebar-tree a[data-active="true"], .sidebar-tree a[data-active="true"]:hover { color: var(--color-fd-primary, oklch(0.985 0.001 106.423)) !important; font-weight: 600; }',
     );
-    expect(html).toContain(".sidebar-folder-content { position: relative; padding: 8px 0; overflow: hidden; }");
+    expect(html).toContain(
+      ".sidebar-folder-content { position: relative; padding: 8px 0; overflow: hidden; }",
+    );
     expect(html).toContain(
       '.sidebar-folder-content::before { content: ""; position: absolute; left: var(--fd-sidebar-guide-x); top: 0; bottom: 0;',
     );
     expect(html).toContain(
       ".sidebar-folder-content > a[data-active]::after, .sidebar-subgroup-title::after, .sidebar-subgroup-content a[data-active]::after",
     );
-    expect(html).toContain(".sidebar-folder-content > a[data-active]::after { left: calc(var(--fd-sidebar-guide-x) + var(--fd-sidebar-branch-gap));");
-    expect(html).toContain(".sidebar-subgroup-title::after { left: calc(var(--fd-sidebar-guide-x) + var(--fd-sidebar-branch-gap)); width: calc(var(--fd-sidebar-sub-guide-x) - var(--fd-sidebar-guide-x) - var(--fd-sidebar-branch-gap));");
+    expect(html).toContain(
+      ".sidebar-folder-content > a[data-active]::after { left: calc(var(--fd-sidebar-guide-x) + var(--fd-sidebar-branch-gap));",
+    );
+    expect(html).toContain(
+      ".sidebar-subgroup-title::after { left: calc(var(--fd-sidebar-guide-x) + var(--fd-sidebar-branch-gap)); width: calc(var(--fd-sidebar-sub-guide-x) - var(--fd-sidebar-guide-x) - var(--fd-sidebar-branch-gap));",
+    );
     expect(html).toContain(
       ".sidebar-subgroup-content a[data-active]::after { left: var(--fd-sidebar-sub-guide-x);",
     );
-    expect(html).toContain("--fd-sidebar-sub-guide-x: calc(var(--fd-sidebar-link-x) + 7px); --fd-sidebar-sub-link-x: calc(var(--fd-sidebar-sub-guide-x) + 28px);");
+    expect(html).toContain(
+      "--fd-sidebar-sub-guide-x: calc(var(--fd-sidebar-link-x) + 7px); --fd-sidebar-sub-link-x: calc(var(--fd-sidebar-sub-guide-x) + 28px);",
+    );
     expect(html).toContain(
       '.sidebar-folder-content > a[data-active="true"]::after, .sidebar-subgroup-content a[data-active="true"]::after',
     );
@@ -292,7 +315,9 @@ describe("createFarmDocsHandler", () => {
     expect(html).not.toContain('class="page-kicker"');
     expect(html).not.toContain("DOCUMENTATION / OVERVIEW");
     expect(html).toContain("article#nd-page .fd-breadcrumb");
-    expect(html).toContain("article#nd-page .fd-breadcrumb { display: flex; min-width: 0; align-items: center; gap: 0; margin: 0 0 0.5rem; color: var(--color-fd-muted-foreground, hsl(0 0% 55%)); font-family: var(--fd-docs-font-mono);");
+    expect(html).toContain(
+      "article#nd-page .fd-breadcrumb { display: flex; min-width: 0; align-items: center; gap: 0; margin: 0 0 0.5rem; color: var(--color-fd-muted-foreground, hsl(0 0% 55%)); font-family: var(--fd-docs-font-mono);",
+    );
     expect(html).toContain("--fd-docs-font-mono: var(--font-geist-mono");
     expect(html).toContain("text-transform: uppercase");
     expect(html).toContain('id="farm-docs"');
@@ -305,6 +330,30 @@ describe("createFarmDocsHandler", () => {
     expect(html).toContain("Farm docs pixel-border bridge");
     expect(html).toContain('class="toc-scroll"');
     expect(html).toContain('class="toc-empty"');
+  });
+
+  it("hides the search interface and shortcut when docs search is disabled", async () => {
+    const { root, docs } = await createDocsFixture();
+
+    for (const search of [false, { provider: "simple" as const, enabled: false }]) {
+      const handler = createFarmDocsHandler(
+        {
+          ...docs,
+          config: {
+            ...docs.config,
+            search,
+          },
+        },
+        { root, srcDir: "src" },
+      );
+      const response = await handler(new Request("http://farm.test/docs"));
+      const html = await response?.text();
+
+      expect(html).not.toContain("data-docs-search-trigger");
+      expect(html).not.toContain('id="farm-docs-search-root"');
+      expect(html).not.toContain("window.__farmDocsSearchRuntime");
+      expect(html).not.toContain('aria-keyshortcuts="Meta+S Control+S"');
+    }
   });
 
   it("uses generated metadata instead of deployment file timestamps", async () => {

--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -191,6 +191,7 @@ describe("createFarmDocsHandler", () => {
     expect(response?.status).toBe(200);
     expect(response?.headers.get("content-type")).toContain("text/html");
     const html = await response?.text();
+    const htmlText = html || "";
     expect(html).toContain('data-docs-theme="farm-docs"');
     expect(html).toContain('id="nd-docs-layout"');
     expect(html).toContain('id="nd-toc"');
@@ -218,6 +219,27 @@ describe("createFarmDocsHandler", () => {
     expect(html).toContain('data-api="/api/docs"');
     expect(html).toContain('aria-label="Search documentation"');
     expect(html).toContain('<script type="module" src="/farm-client.js"></script>');
+    const topbar = htmlText.slice(
+      htmlText.indexOf('<header class="topbar">'),
+      htmlText.indexOf("</header>", htmlText.indexOf('<header class="topbar">')),
+    );
+    const sidebarBrand = htmlText.slice(
+      htmlText.indexOf('<div class="sidebar-brand">'),
+      htmlText.indexOf("</div>", htmlText.indexOf('<div class="sidebar-brand">')),
+    );
+    const mobileTopbar = htmlText.slice(
+      htmlText.indexOf('<header class="mobile-topbar"'),
+      htmlText.indexOf("</header>", htmlText.indexOf('<header class="mobile-topbar"')),
+    );
+    expect(topbar).toContain('data-search-full=""');
+    expect(topbar.indexOf('data-search-full=""')).toBeLessThan(
+      topbar.indexOf('href="/llms.txt"'),
+    );
+    expect(mobileTopbar.indexOf('data-search-full=""')).toBeLessThan(
+      mobileTopbar.indexOf('href="/llms.txt"'),
+    );
+    expect(sidebarBrand).not.toContain('data-search-full=""');
+    expect(html).toContain("--fd-nav-height: 38px");
     expect(html).not.toContain('id="farm-docs-search-dialog"');
     expect(html).not.toContain("window.__farmDocsSearchRuntime");
     expect(html).toContain("window.__farmDocsHashRuntime");

--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -214,6 +214,7 @@ describe("createFarmDocsHandler", () => {
     expect(html).toContain('class="fd-docs-search-trigger"');
     expect(html).toContain('data-search-full=""');
     expect(html).toContain('aria-keyshortcuts="Meta+K Control+K"');
+    expect(html).toContain("<kbd><span>⌘</span><span>K</span></kbd>");
     expect(html).toContain('id="farm-docs-search-root"');
     expect(html).toContain("data-farm-docs-search-root");
     expect(html).toContain('data-api="/api/docs"');

--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -232,14 +232,14 @@ describe("createFarmDocsHandler", () => {
       htmlText.indexOf("</header>", htmlText.indexOf('<header class="mobile-topbar"')),
     );
     expect(topbar).toContain('data-search-full=""');
-    expect(topbar.indexOf('data-search-full=""')).toBeLessThan(
-      topbar.indexOf('href="/llms.txt"'),
-    );
+    expect(topbar.indexOf('data-search-full=""')).toBeLessThan(topbar.indexOf('href="/llms.txt"'));
     expect(mobileTopbar.indexOf('data-search-full=""')).toBeLessThan(
       mobileTopbar.indexOf('href="/llms.txt"'),
     );
     expect(sidebarBrand).not.toContain('data-search-full=""');
     expect(html).toContain("--fd-nav-height: 38px");
+    expect(html).toContain("--omni-content-top: calc(var(--fd-mobile-nav-height, 56px) + 12px)");
+    expect(html).toContain("max-height: calc(100dvh - var(--omni-content-top) - 12px)");
     expect(html).not.toContain('id="farm-docs-search-dialog"');
     expect(html).not.toContain("window.__farmDocsSearchRuntime");
     expect(html).toContain("window.__farmDocsHashRuntime");

--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -211,16 +211,17 @@ describe("createFarmDocsHandler", () => {
     expect(html).toContain("data-sidebar-toggle");
     expect(html).toContain("data-sidebar-backdrop");
     expect(html).toContain('class="fd-docs-search-trigger"');
-    expect(html).toContain("data-docs-search-trigger");
-    expect(html).toContain('aria-keyshortcuts="Meta+S Control+S"');
-    expect(html).toContain('id="farm-docs-search-dialog"');
-    expect(html).toContain("data-docs-search-input");
+    expect(html).toContain('data-search-full=""');
+    expect(html).toContain('aria-keyshortcuts="Meta+K Control+K"');
+    expect(html).toContain('id="farm-docs-search-root"');
+    expect(html).toContain("data-farm-docs-search-root");
+    expect(html).toContain('data-api="/api/docs"');
     expect(html).toContain('aria-label="Search documentation"');
-    expect(html).toContain('role="listbox"');
-    expect(html).toContain("window.__farmDocsSearchRuntime");
-    expect(html).toContain('event.key.toLowerCase()==="s"');
-    expect(html).toContain('fetch("/api/docs?query="+encodeURIComponent(query)');
-    expect(html).toContain("descriptionElement.textContent=description");
+    expect(html).toContain('<script type="module" src="/farm-client.js"></script>');
+    expect(html).not.toContain('id="farm-docs-search-dialog"');
+    expect(html).not.toContain("window.__farmDocsSearchRuntime");
+    expect(html).toContain("window.__farmDocsHashRuntime");
+    expect(html).toContain('window.addEventListener("load",schedule,{once:true})');
     expect(html).toContain('document.getElementById(id)?.scrollIntoView({block:"start"})');
     expect(html).toContain(
       "sidebar.scrollTop+=activeRect.top-sidebarRect.top-(sidebar.clientHeight-activeRect.height)/2",
@@ -349,10 +350,10 @@ describe("createFarmDocsHandler", () => {
       const response = await handler(new Request("http://farm.test/docs"));
       const html = await response?.text();
 
-      expect(html).not.toContain("data-docs-search-trigger");
+      expect(html).not.toContain('data-search-full=""');
       expect(html).not.toContain('id="farm-docs-search-root"');
-      expect(html).not.toContain("window.__farmDocsSearchRuntime");
-      expect(html).not.toContain('aria-keyshortcuts="Meta+S Control+S"');
+      expect(html).not.toContain('aria-keyshortcuts="Meta+K Control+K"');
+      expect(html).not.toContain('<script type="module" src="/farm-client.js"></script>');
     }
   });
 
@@ -611,11 +612,11 @@ describe("createDocsAPI", () => {
 
     const searchResponse = await handlers.GET(new Request("http://farm.test/api/docs?query=guide"));
     await expect(searchResponse.json()).resolves.toEqual(
-      expect.objectContaining({
-        query: "guide",
-        results: expect.arrayContaining([expect.objectContaining({ title: "Guide" })]),
-      }),
+      expect.arrayContaining([expect.objectContaining({ title: "Guide" })]),
     );
+
+    const emptySearchResponse = await handlers.GET(new Request("http://farm.test/api/docs"));
+    await expect(emptySearchResponse.json()).resolves.toEqual([]);
 
     const pathMarkdownResponse = await handlers.GET(
       new Request("http://farm.test/api/docs/guide.md"),

--- a/packages/farm/src/__tests__/docs-search-client.test.ts
+++ b/packages/farm/src/__tests__/docs-search-client.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import {
+  generateFarmDocsSearchClientRuntime,
+  isFarmDocsSearchEnabled,
+} from "../docs/search-client";
+
+describe("Farm docs search client", () => {
+  it("mounts the shared Omni React search component", () => {
+    const runtime = generateFarmDocsSearchClientRuntime(true, "/theme/docs-command-search.mjs");
+
+    expect(runtime).toContain('import("/theme/docs-command-search.mjs")');
+    expect(runtime).toContain("DocsCommandSearch");
+    expect(runtime).toContain("data-farm-docs-search-root");
+    expect(runtime).toContain("container.dataset.api || '/api/docs'");
+    expect(runtime).toContain("React.createElement");
+    expect(runtime).not.toContain("fetch('/api/docs");
+  });
+
+  it("omits the theme import when docs search is disabled", () => {
+    const runtime = generateFarmDocsSearchClientRuntime(false);
+
+    expect(runtime).not.toContain("@farming-labs/theme");
+    expect(runtime).not.toContain("DocsCommandSearch");
+  });
+
+  it("follows the docs search config", () => {
+    const docs = {
+      enabled: true,
+      entry: "/docs",
+      config: { entry: "docs" },
+    } as const;
+
+    expect(isFarmDocsSearchEnabled(docs)).toBe(true);
+    expect(
+      isFarmDocsSearchEnabled({
+        ...docs,
+        config: { ...docs.config, search: false },
+      }),
+    ).toBe(false);
+    expect(
+      isFarmDocsSearchEnabled({
+        ...docs,
+        config: { ...docs.config, search: { provider: "simple", enabled: false } },
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/farm/src/docs/api.ts
+++ b/packages/farm/src/docs/api.ts
@@ -601,10 +601,8 @@ async function handleDocsAPIGet(request: Request, context: FarmDocsAPIContext): 
   }
 
   const query = url.searchParams.get("query") || url.searchParams.get("q") || "";
-  return json({
-    query,
-    results: await searchDocs(context, request, query),
-  });
+  if (!query.trim()) return json([]);
+  return json(await searchDocs(context, request, query));
 }
 
 export function createDocsAPI(

--- a/packages/farm/src/docs/handler.ts
+++ b/packages/farm/src/docs/handler.ts
@@ -343,6 +343,12 @@ function getDocsTitle(docs: FarmDocsResolvedConfig): string {
     : "Documentation";
 }
 
+function isDocsSearchEnabled(docs: FarmDocsResolvedConfig): boolean {
+  const search = docs.config.search;
+  if (search === false) return false;
+  return !(search && typeof search === "object" && search.enabled === false);
+}
+
 function getDocsDescription(docs: FarmDocsResolvedConfig): string | undefined {
   return docs.config.metadata?.description;
 }
@@ -1501,6 +1507,32 @@ function renderPixelBreadcrumb(page: LoadedFarmDocsPage, docs: FarmDocsResolvedC
 </nav>`;
 }
 
+function renderDocsSearchTrigger(): string {
+  return `<button class="fd-docs-search-trigger" type="button" data-docs-search-trigger aria-label="Search documentation" aria-haspopup="dialog" aria-controls="farm-docs-search-dialog" aria-expanded="false" aria-keyshortcuts="Meta+S Control+S">
+  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><circle cx="11" cy="11" r="7"></circle><path d="m20 20-4-4"></path></svg>
+  <span class="fd-docs-search-trigger-label">Search</span>
+  <kbd><span data-docs-search-modifier>⌘</span>S</kbd>
+</button>`;
+}
+
+function renderDocsSearchDialog(docs: FarmDocsResolvedConfig): string {
+  const title = `Search ${getDocsTitle(docs)}`;
+  return `<div id="farm-docs-search-root" class="fd-docs-search-root" data-docs-search-root hidden>
+  <div class="fd-docs-search-overlay" data-docs-search-close aria-hidden="true"></div>
+  <section id="farm-docs-search-dialog" class="fd-docs-search-dialog" data-docs-search-dialog role="dialog" aria-modal="true" aria-labelledby="farm-docs-search-title" tabindex="-1">
+    <h2 id="farm-docs-search-title" class="fd-docs-search-visually-hidden">${escapeHtml(title)}</h2>
+    <div class="fd-docs-search-header">
+      <svg class="fd-docs-search-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><circle cx="11" cy="11" r="7"></circle><path d="m20 20-4-4"></path></svg>
+      <input type="search" data-docs-search-input role="combobox" aria-label="Search documentation" aria-autocomplete="list" aria-controls="farm-docs-search-results" aria-expanded="true" autocomplete="off" autocapitalize="off" spellcheck="false" placeholder="Search documentation" />
+      <button class="fd-docs-search-close" type="button" data-docs-search-close aria-label="Close search">ESC</button>
+    </div>
+    <div id="farm-docs-search-results" class="fd-docs-search-results" data-docs-search-results role="listbox" aria-label="Search results" hidden></div>
+    <div class="fd-docs-search-status" data-docs-search-status role="status">Search the documentation</div>
+    <div class="fd-docs-search-visually-hidden" data-docs-search-live aria-live="polite"></div>
+  </section>
+</div>`;
+}
+
 function renderPixelToc(items: TocItem[]): string {
   if (items.length === 0) return '<p class="toc-empty">No sections</p>';
   return `<div class="toc-track">
@@ -1518,15 +1550,211 @@ ${items
 
 function renderDocsRuntimeScript(docs: FarmDocsResolvedConfig): string {
   const docsEntry = JSON.stringify(normalizeEntry(docs.entry));
-  return `<script>(()=>{if(window.__farmDocsRuntime)return;window.__farmDocsRuntime=true;document.documentElement.dataset.farmDocsRuntime="true";document.documentElement.dataset.farmDocsRuntimeId=Math.random().toString(36).slice(2);const docsEntry=${docsEntry};let cleanupToc=()=>{};let closeMobileSidebar=()=>{};const normalizePath=(path)=>path.length>1?path.replace(/\\/+$/,""):path;const isDocsPath=(path)=>{const next=normalizePath(path);const entry=normalizePath(docsEntry);if(next.endsWith(".md"))return false;if(entry==="/")return true;return next===entry||next.startsWith(entry+"/")};const initToc=()=>{cleanupToc();const toc=document.getElementById("nd-toc");if(!toc){cleanupToc=()=>{};return}const links=Array.from(toc.querySelectorAll("[data-toc-item]"));const thumb=toc.querySelector("[data-toc-thumb]");const pairs=links.map((link)=>{let id=link.hash.slice(1);try{id=decodeURIComponent(id)}catch{}return{link,heading:document.getElementById(id)}}).filter((item)=>item.heading);const setActive=(active)=>{for(const {link} of pairs)link.dataset.active=link===active.link?"true":"false";if(!thumb)return;const styles=getComputedStyle(active.link);const top=active.link.offsetTop+parseFloat(styles.paddingTop||"0");const bottom=active.link.offsetTop+active.link.clientHeight-parseFloat(styles.paddingBottom||"0");thumb.style.clipPath="polygon(0 "+top+"px,100% "+top+"px,100% "+bottom+"px,0 "+bottom+"px)"};const update=()=>{if(pairs.length===0)return;const offset=Math.min(window.innerHeight*0.3,160);let active=pairs[0];for(const pair of pairs){if(pair.heading.getBoundingClientRect().top<=offset)active=pair;else break}setActive(active)};let frame=0;const schedule=()=>{if(frame)return;frame=requestAnimationFrame(()=>{frame=0;update()})};const onHashChange=()=>setTimeout(schedule,0);window.addEventListener("scroll",schedule,{passive:true});window.addEventListener("resize",schedule);window.addEventListener("hashchange",onHashChange);cleanupToc=()=>{window.removeEventListener("scroll",schedule);window.removeEventListener("resize",schedule);window.removeEventListener("hashchange",onHashChange);if(frame)cancelAnimationFrame(frame);frame=0};update()};const getSidebar=()=>document.getElementById("nd-sidebar");const ensureActiveVisible=()=>{const sidebar=getSidebar();if(!sidebar)return;const active=sidebar.querySelector('a[data-active="true"]');if(!(active instanceof HTMLElement))return;const activeRect=active.getBoundingClientRect();const sidebarRect=sidebar.getBoundingClientRect();if(activeRect.top<sidebarRect.top||activeRect.bottom>sidebarRect.bottom)active.scrollIntoView({block:"center"})};const setSidebarActive=(path)=>{const sidebar=getSidebar();if(!sidebar)return;const current=normalizePath(path);for(const link of Array.from(sidebar.querySelectorAll("a[href]"))){try{link.dataset.active=normalizePath(new URL(link.href,location.href).pathname)===current?"true":"false"}catch{}}ensureActiveVisible()};const initMobileSidebar=()=>{const layout=document.getElementById("nd-docs-layout");const sidebar=getSidebar();const toggle=document.querySelector("[data-sidebar-toggle]");const backdrop=document.querySelector("[data-sidebar-backdrop]");if(!layout||!sidebar||!(toggle instanceof HTMLButtonElement))return;const setOpen=(open)=>{layout.dataset.sidebarOpen=open?"true":"false";document.documentElement.dataset.farmDocsSidebar=open?"open":"closed";toggle.setAttribute("aria-expanded",open?"true":"false");toggle.setAttribute("aria-label",open?"Close menu":"Open menu")};const toggleOpen=()=>setOpen(layout.dataset.sidebarOpen!=="true");closeMobileSidebar=()=>setOpen(false);toggle.addEventListener("click",(event)=>{event.preventDefault();toggleOpen()});backdrop?.addEventListener("click",()=>closeMobileSidebar());document.addEventListener("keydown",(event)=>{if(event.key==="Escape")closeMobileSidebar()});sidebar.addEventListener("click",(event)=>{const target=event.target instanceof Element?event.target.closest("a[href]"):null;if(target)closeMobileSidebar()});closeMobileSidebar()};const initSidebarScroll=()=>{const sidebar=getSidebar();if(!sidebar)return;const key="farmdocs:sidebar-scroll:"+location.origin;const getStorage=()=>{try{return window.sessionStorage}catch{return null}};const readSaved=()=>{try{const raw=getStorage()?.getItem(key);if(!raw)return null;const parsed=JSON.parse(raw);return parsed&&typeof parsed==="object"?parsed:null}catch{return null}};const save=(path=location.pathname)=>{try{getStorage()?.setItem(key,JSON.stringify({path,scrollTop:sidebar.scrollTop}))}catch{}};const saved=readSaved();if(saved?.path===location.pathname&&Number.isFinite(Number(saved.scrollTop)))sidebar.scrollTop=Number(saved.scrollTop);ensureActiveVisible();save();sidebar.addEventListener("scroll",()=>save(),{passive:true});sidebar.addEventListener("click",(event)=>{const target=event.target instanceof Element?event.target.closest("a[href]"):null;if(!target)return;try{save(new URL(target.href,location.href).pathname)}catch{save()}});window.addEventListener("beforeunload",()=>save())};let navigateController=null;const getPageKey=(root)=>{const article=root.getElementById("nd-page");if(!article)return"";return article.querySelector("h1")?.textContent?.trim()||article.textContent?.replace(/\\s+/g," ").trim().slice(0,160)||""};const swapDocsPage=(html,url)=>{const nextDoc=new DOMParser().parseFromString(html,"text/html");const nextArticle=nextDoc.getElementById("nd-page");const currentArticle=document.getElementById("nd-page");if(!nextArticle||!currentArticle)return false;const nextKey=getPageKey(nextDoc);const importedArticle=document.importNode(nextArticle,true);currentArticle.replaceWith(importedArticle);const renderedArticle=document.getElementById("nd-page");if(!renderedArticle||renderedArticle===currentArticle||(nextKey&&getPageKey(document)!==nextKey))return false;const nextToc=nextDoc.getElementById("nd-toc");const currentToc=document.getElementById("nd-toc");if(nextToc&&currentToc)currentToc.replaceWith(document.importNode(nextToc,true));if(nextDoc.title)document.title=nextDoc.title;const nextDescription=nextDoc.querySelector('meta[name="description"]');const currentDescription=document.querySelector('meta[name="description"]');if(nextDescription&&currentDescription)currentDescription.setAttribute("content",nextDescription.getAttribute("content")||"");setSidebarActive(url.pathname);initToc();closeMobileSidebar();return true};const navigateDocs=async(url,{replace=false,scroll=true}={})=>{if(!isDocsPath(url.pathname))return false;if(navigateController)navigateController.abort();const controller=new AbortController();navigateController=controller;document.documentElement.dataset.farmDocsNavigating="true";try{const response=await fetch(url.href,{cache:"no-store",headers:{accept:"text/html","x-farm-docs-navigate":"1"},signal:controller.signal});if(!response.ok||!((response.headers.get("content-type")||"").includes("text/html")))return false;const html=await response.text();if(!swapDocsPage(html,url))return false;if(replace)history.replaceState({farmDocs:true},"",url.href);else history.pushState({farmDocs:true},"",url.href);if(scroll)window.scrollTo({top:0,left:0});return true}catch(error){if(error?.name==="AbortError")return true;return false}finally{if(navigateController===controller){delete document.documentElement.dataset.farmDocsNavigating;navigateController=null}}};const initClientNavigation=()=>{document.addEventListener("click",(event)=>{if(event.defaultPrevented||event.button!==0||event.metaKey||event.ctrlKey||event.shiftKey||event.altKey)return;const target=event.target instanceof Element?event.target.closest("a[href]"):null;if(!target||target.target||target.hasAttribute("download"))return;let url;try{url=new URL(target.href,location.href)}catch{return}if(url.origin!==location.origin||!isDocsPath(url.pathname))return;if(normalizePath(url.pathname)===normalizePath(location.pathname)&&url.hash)return;event.preventDefault();navigateDocs(url).then((handled)=>{if(!handled)location.href=url.href})});window.addEventListener("popstate",()=>{navigateDocs(new URL(location.href),{replace:true,scroll:false}).then((handled)=>{if(!handled)location.reload()})})};const init=()=>{initToc();initMobileSidebar();initSidebarScroll();initClientNavigation()};if(document.readyState==="loading")document.addEventListener("DOMContentLoaded",init,{once:true});else init()})();</script>`;
+  return `<script>(()=>{if(window.__farmDocsRuntime)return;window.__farmDocsRuntime=true;document.documentElement.dataset.farmDocsRuntime="true";document.documentElement.dataset.farmDocsRuntimeId=Math.random().toString(36).slice(2);const docsEntry=${docsEntry};let cleanupToc=()=>{};let closeMobileSidebar=()=>{};const normalizePath=(path)=>path.length>1?path.replace(/\\/+$/,""):path;const isDocsPath=(path)=>{const next=normalizePath(path);const entry=normalizePath(docsEntry);if(next.endsWith(".md"))return false;if(entry==="/")return true;return next===entry||next.startsWith(entry+"/")};const initToc=()=>{cleanupToc();const toc=document.getElementById("nd-toc");if(!toc){cleanupToc=()=>{};return}const links=Array.from(toc.querySelectorAll("[data-toc-item]"));const thumb=toc.querySelector("[data-toc-thumb]");const pairs=links.map((link)=>{let id=link.hash.slice(1);try{id=decodeURIComponent(id)}catch{}return{link,heading:document.getElementById(id)}}).filter((item)=>item.heading);const setActive=(active)=>{for(const {link} of pairs)link.dataset.active=link===active.link?"true":"false";if(!thumb)return;const styles=getComputedStyle(active.link);const top=active.link.offsetTop+parseFloat(styles.paddingTop||"0");const bottom=active.link.offsetTop+active.link.clientHeight-parseFloat(styles.paddingBottom||"0");thumb.style.clipPath="polygon(0 "+top+"px,100% "+top+"px,100% "+bottom+"px,0 "+bottom+"px)"};const update=()=>{if(pairs.length===0)return;const offset=Math.min(window.innerHeight*0.3,160);let active=pairs[0];for(const pair of pairs){if(pair.heading.getBoundingClientRect().top<=offset)active=pair;else break}setActive(active)};let frame=0;const schedule=()=>{if(frame)return;frame=requestAnimationFrame(()=>{frame=0;update()})};const onHashChange=()=>setTimeout(schedule,0);window.addEventListener("scroll",schedule,{passive:true});window.addEventListener("resize",schedule);window.addEventListener("hashchange",onHashChange);cleanupToc=()=>{window.removeEventListener("scroll",schedule);window.removeEventListener("resize",schedule);window.removeEventListener("hashchange",onHashChange);if(frame)cancelAnimationFrame(frame);frame=0};update()};const getSidebar=()=>document.getElementById("nd-sidebar");const ensureActiveVisible=()=>{const sidebar=getSidebar();if(!sidebar)return;const active=sidebar.querySelector('a[data-active="true"]');if(!(active instanceof HTMLElement))return;const activeRect=active.getBoundingClientRect();const sidebarRect=sidebar.getBoundingClientRect();if(activeRect.top<sidebarRect.top||activeRect.bottom>sidebarRect.bottom)sidebar.scrollTop+=activeRect.top-sidebarRect.top-(sidebar.clientHeight-activeRect.height)/2};const setSidebarActive=(path)=>{const sidebar=getSidebar();if(!sidebar)return;const current=normalizePath(path);for(const link of Array.from(sidebar.querySelectorAll("a[href]"))){try{link.dataset.active=normalizePath(new URL(link.href,location.href).pathname)===current?"true":"false"}catch{}}ensureActiveVisible()};const initMobileSidebar=()=>{const layout=document.getElementById("nd-docs-layout");const sidebar=getSidebar();const toggle=document.querySelector("[data-sidebar-toggle]");const backdrop=document.querySelector("[data-sidebar-backdrop]");if(!layout||!sidebar||!(toggle instanceof HTMLButtonElement))return;const setOpen=(open)=>{layout.dataset.sidebarOpen=open?"true":"false";document.documentElement.dataset.farmDocsSidebar=open?"open":"closed";toggle.setAttribute("aria-expanded",open?"true":"false");toggle.setAttribute("aria-label",open?"Close menu":"Open menu")};const toggleOpen=()=>setOpen(layout.dataset.sidebarOpen!=="true");closeMobileSidebar=()=>setOpen(false);toggle.addEventListener("click",(event)=>{event.preventDefault();toggleOpen()});backdrop?.addEventListener("click",()=>closeMobileSidebar());document.addEventListener("keydown",(event)=>{if(event.key==="Escape")closeMobileSidebar()});sidebar.addEventListener("click",(event)=>{const target=event.target instanceof Element?event.target.closest("a[href]"):null;if(target)closeMobileSidebar()});closeMobileSidebar()};const initSidebarScroll=()=>{const sidebar=getSidebar();if(!sidebar)return;const key="farmdocs:sidebar-scroll:"+location.origin;const getStorage=()=>{try{return window.sessionStorage}catch{return null}};const readSaved=()=>{try{const raw=getStorage()?.getItem(key);if(!raw)return null;const parsed=JSON.parse(raw);return parsed&&typeof parsed==="object"?parsed:null}catch{return null}};const save=(path=location.pathname)=>{try{getStorage()?.setItem(key,JSON.stringify({path,scrollTop:sidebar.scrollTop}))}catch{}};const saved=readSaved();if(saved?.path===location.pathname&&Number.isFinite(Number(saved.scrollTop)))sidebar.scrollTop=Number(saved.scrollTop);ensureActiveVisible();save();sidebar.addEventListener("scroll",()=>save(),{passive:true});sidebar.addEventListener("click",(event)=>{const target=event.target instanceof Element?event.target.closest("a[href]"):null;if(!target)return;try{save(new URL(target.href,location.href).pathname)}catch{save()}});window.addEventListener("beforeunload",()=>save())};let navigateController=null;const getPageKey=(root)=>{const article=root.getElementById("nd-page");if(!article)return"";return article.querySelector("h1")?.textContent?.trim()||article.textContent?.replace(/\\s+/g," ").trim().slice(0,160)||""};const swapDocsPage=(html,url)=>{const nextDoc=new DOMParser().parseFromString(html,"text/html");const nextArticle=nextDoc.getElementById("nd-page");const currentArticle=document.getElementById("nd-page");if(!nextArticle||!currentArticle)return false;const nextKey=getPageKey(nextDoc);const importedArticle=document.importNode(nextArticle,true);currentArticle.replaceWith(importedArticle);const renderedArticle=document.getElementById("nd-page");if(!renderedArticle||renderedArticle===currentArticle||(nextKey&&getPageKey(document)!==nextKey))return false;const nextToc=nextDoc.getElementById("nd-toc");const currentToc=document.getElementById("nd-toc");if(nextToc&&currentToc)currentToc.replaceWith(document.importNode(nextToc,true));if(nextDoc.title)document.title=nextDoc.title;const nextDescription=nextDoc.querySelector('meta[name="description"]');const currentDescription=document.querySelector('meta[name="description"]');if(nextDescription&&currentDescription)currentDescription.setAttribute("content",nextDescription.getAttribute("content")||"");setSidebarActive(url.pathname);initToc();closeMobileSidebar();return true};const navigateDocs=async(url,{replace=false,scroll=true}={})=>{if(!isDocsPath(url.pathname))return false;if(navigateController)navigateController.abort();const controller=new AbortController();navigateController=controller;document.documentElement.dataset.farmDocsNavigating="true";try{const response=await fetch(url.href,{cache:"no-store",headers:{accept:"text/html","x-farm-docs-navigate":"1"},signal:controller.signal});if(!response.ok||!((response.headers.get("content-type")||"").includes("text/html")))return false;const html=await response.text();if(!swapDocsPage(html,url))return false;if(replace)history.replaceState({farmDocs:true},"",url.href);else history.pushState({farmDocs:true},"",url.href);if(scroll){if(url.hash){let id=url.hash.slice(1);try{id=decodeURIComponent(id)}catch{}document.getElementById(id)?.scrollIntoView({block:"start"})}else window.scrollTo({top:0,left:0})}return true}catch(error){if(error?.name==="AbortError")return true;return false}finally{if(navigateController===controller){delete document.documentElement.dataset.farmDocsNavigating;navigateController=null}}};const initClientNavigation=()=>{document.addEventListener("click",(event)=>{if(event.defaultPrevented||event.button!==0||event.metaKey||event.ctrlKey||event.shiftKey||event.altKey)return;const target=event.target instanceof Element?event.target.closest("a[href]"):null;if(!target||target.target||target.hasAttribute("download"))return;let url;try{url=new URL(target.href,location.href)}catch{return}if(url.origin!==location.origin||!isDocsPath(url.pathname))return;if(normalizePath(url.pathname)===normalizePath(location.pathname)&&url.hash)return;event.preventDefault();navigateDocs(url).then((handled)=>{if(!handled)location.href=url.href})});window.addEventListener("popstate",()=>{navigateDocs(new URL(location.href),{replace:true,scroll:false}).then((handled)=>{if(!handled)location.reload()})})};const init=()=>{initToc();initMobileSidebar();initSidebarScroll();initClientNavigation()};if(document.readyState==="loading")document.addEventListener("DOMContentLoaded",init,{once:true});else init()})();</script>`;
 }
 
 function renderDocsPageActionsRuntimeScript(): string {
   return `<script>(()=>{if(window.__farmDocsPageActionsRuntime)return;window.__farmDocsPageActionsRuntime=true;const readArticleText=()=>{const article=document.getElementById("nd-page");if(!article)return"";const clone=article.cloneNode(true);if(!(clone instanceof HTMLElement))return article.innerText||"";clone.querySelectorAll("[data-page-actions],.fd-page-footer,.fd-page-nav").forEach((node)=>node.remove());return clone.innerText||""};const withTitle=(content,format,includeTitle)=>{if(!includeTitle)return content;const title=document.querySelector("#nd-page h1")?.textContent?.trim()||document.title.trim();if(!title)return content;const trimmed=content.trimStart();if(trimmed.startsWith(title)||trimmed.startsWith("# "+title))return content;return format==="markdown"?"# "+title+"\\n\\n"+content:title+"\\n\\n"+content};const writeClipboard=async(text)=>{if(navigator.clipboard?.writeText){try{await navigator.clipboard.writeText(text);return}catch{}}const textarea=document.createElement("textarea");textarea.value=text;textarea.setAttribute("readonly","");textarea.style.position="fixed";textarea.style.opacity="0";textarea.style.pointerEvents="none";document.body.appendChild(textarea);textarea.select();document.execCommand("copy");textarea.remove()};const markCopied=(button)=>{const label=button.querySelector("[data-page-action-label]");button.dataset.copied="true";button.setAttribute("aria-label",button.dataset.copiedLabel||"Copied!");button.title=button.dataset.copiedLabel||"Copied!";if(label)label.textContent=button.dataset.copiedLabel||"Copied!";const previous=Number(button.dataset.copyTimeout||0);if(previous)clearTimeout(previous);button.dataset.copyTimeout=String(setTimeout(()=>{button.dataset.copied="false";button.setAttribute("aria-label",button.dataset.copyLabel||"Copy page");button.title=button.dataset.copyLabel||"Copy page";if(label)label.textContent=button.dataset.copyLabel||"Copy page";button.dataset.copyTimeout="0"},4500))};document.addEventListener("click",async(event)=>{const target=event.target instanceof Element?event.target.closest('[data-page-action="copy-markdown"]'):null;if(!(target instanceof HTMLButtonElement))return;event.preventDefault();const format=target.dataset.copyMarkdownFormat==="text"?"text":"markdown";const includeTitle=target.dataset.copyMarkdownIncludeTitle==="true";let content="";target.disabled=true;try{if(format==="markdown"&&target.dataset.markdownUrl){try{const response=await fetch(target.dataset.markdownUrl,{headers:{Accept:"text/markdown"}});if(response.ok)content=await response.text()}catch{}}if(!content)content=readArticleText();content=withTitle(content,format,includeTitle);if(content.trim()){await writeClipboard(content);markCopied(target)}}finally{target.disabled=false}})})();</script>`;
 }
 
+function renderDocsSearchRuntimeScript(): string {
+  return `<script>(()=>{
+  if(window.__farmDocsSearchRuntime)return;
+  window.__farmDocsSearchRuntime=true;
+  const root=document.querySelector("[data-docs-search-root]");
+  if(!(root instanceof HTMLElement))return;
+  const dialog=root.querySelector("[data-docs-search-dialog]");
+  const input=root.querySelector("[data-docs-search-input]");
+  const results=root.querySelector("[data-docs-search-results]");
+  const status=root.querySelector("[data-docs-search-status]");
+  const live=root.querySelector("[data-docs-search-live]");
+  const layout=document.getElementById("nd-docs-layout");
+  if(!(dialog instanceof HTMLElement)||!(input instanceof HTMLInputElement)||!(results instanceof HTMLElement)||!(status instanceof HTMLElement)||!(live instanceof HTMLElement))return;
+
+  let previousFocus=null;
+  let debounceTimer=0;
+  let searchController=null;
+  let activeIndex=-1;
+  let resultLinks=[];
+
+  const getTriggers=()=>Array.from(document.querySelectorAll("[data-docs-search-trigger]")).filter((item)=>item instanceof HTMLButtonElement);
+  const setExpanded=(expanded)=>{for(const trigger of getTriggers())trigger.setAttribute("aria-expanded",expanded?"true":"false")};
+  const setStatus=(message,state)=>{
+    status.textContent=message;
+    status.hidden=false;
+    results.hidden=true;
+    results.replaceChildren();
+    resultLinks=[];
+    activeIndex=-1;
+    input.removeAttribute("aria-activedescendant");
+    root.dataset.searchState=state;
+    live.textContent=message;
+  };
+  const setActive=(index)=>{
+    if(resultLinks.length===0)return;
+    activeIndex=(index+resultLinks.length)%resultLinks.length;
+    for(let itemIndex=0;itemIndex<resultLinks.length;itemIndex++){
+      const link=resultLinks[itemIndex];
+      const selected=itemIndex===activeIndex;
+      link.dataset.active=selected?"true":"false";
+      link.setAttribute("aria-selected",selected?"true":"false");
+    }
+    const active=resultLinks[activeIndex];
+    input.setAttribute("aria-activedescendant",active.id);
+    active.scrollIntoView({block:"nearest"});
+  };
+  const resolveResultHref=(value)=>{
+    if(typeof value!=="string"||!value)return null;
+    try{
+      const url=new URL(value,location.href);
+      if(url.protocol!=="http:"&&url.protocol!=="https:")return null;
+      return url.origin===location.origin?url.pathname+url.search+url.hash:url.href;
+    }catch{return null}
+  };
+  const renderResults=(items)=>{
+    const fragment=document.createDocumentFragment();
+    const links=[];
+    for(const item of items){
+      if(!item||typeof item!=="object")continue;
+      const href=resolveResultHref(typeof item.url==="string"?item.url:item.href);
+      if(!href)continue;
+      const title=typeof item.title==="string"&&item.title.trim()?item.title.trim():typeof item.content==="string"&&item.content.trim()?item.content.trim():"Documentation";
+      const section=typeof item.section==="string"&&item.section.trim()&&item.section.trim()!==title?item.section.trim():"";
+      const description=typeof item.description==="string"?item.description.trim():"";
+      const link=document.createElement("a");
+      link.id="farm-docs-search-result-"+links.length;
+      link.className="fd-docs-search-result";
+      link.href=href;
+      link.setAttribute("role","option");
+      link.setAttribute("aria-selected","false");
+      link.dataset.active="false";
+      const marker=document.createElement("span");
+      marker.className="fd-docs-search-result-marker";
+      marker.setAttribute("aria-hidden","true");
+      marker.textContent=item.type==="heading"?"#":"↗";
+      const content=document.createElement("span");
+      content.className="fd-docs-search-result-content";
+      const heading=document.createElement("span");
+      heading.className="fd-docs-search-result-heading";
+      const titleElement=document.createElement("span");
+      titleElement.className="fd-docs-search-result-title";
+      titleElement.textContent=title;
+      heading.append(titleElement);
+      if(section){
+        const sectionElement=document.createElement("span");
+        sectionElement.className="fd-docs-search-result-section";
+        sectionElement.textContent=section;
+        heading.append(sectionElement);
+      }
+      content.append(heading);
+      if(description){
+        const descriptionElement=document.createElement("span");
+        descriptionElement.className="fd-docs-search-result-description";
+        descriptionElement.textContent=description;
+        content.append(descriptionElement);
+      }
+      link.append(marker,content);
+      const index=links.length;
+      link.addEventListener("pointerenter",()=>setActive(index));
+      links.push(link);
+      fragment.append(link);
+    }
+    if(links.length===0){setStatus("No results found","empty");return}
+    status.hidden=true;
+    results.hidden=false;
+    results.replaceChildren(fragment);
+    resultLinks=links;
+    root.dataset.searchState="results";
+    live.textContent=links.length+" result"+(links.length===1?"":"s")+" found";
+    setActive(0);
+  };
+  const runSearch=async()=>{
+    const query=input.value.trim();
+    if(!query){
+      searchController?.abort();
+      setStatus("Search the documentation","idle");
+      return;
+    }
+    searchController?.abort();
+    const controller=new AbortController();
+    searchController=controller;
+    setStatus("Searching...","loading");
+    try{
+      const response=await fetch("/api/docs?query="+encodeURIComponent(query),{headers:{Accept:"application/json"},signal:controller.signal});
+      if(!response.ok)throw new Error("Search request failed");
+      const payload=await response.json();
+      if(controller.signal.aborted||input.value.trim()!==query)return;
+      renderResults(Array.isArray(payload?.results)?payload.results:[]);
+    }catch(error){
+      if(error?.name!=="AbortError")setStatus("Search is unavailable. Try again.","error");
+    }finally{
+      if(searchController===controller)searchController=null;
+    }
+  };
+  const openSearch=()=>{
+    if(!root.hidden)return;
+    previousFocus=document.activeElement instanceof HTMLElement?document.activeElement:null;
+    root.hidden=false;
+    root.dataset.open="true";
+    document.documentElement.dataset.farmDocsSearch="open";
+    if(layout)layout.inert=true;
+    setExpanded(true);
+    requestAnimationFrame(()=>{input.focus();input.select()});
+  };
+  const closeSearch=(restoreFocus=true)=>{
+    if(root.hidden)return;
+    searchController?.abort();
+    clearTimeout(debounceTimer);
+    delete root.dataset.open;
+    root.hidden=true;
+    delete document.documentElement.dataset.farmDocsSearch;
+    if(layout)layout.inert=false;
+    setExpanded(false);
+    if(restoreFocus)previousFocus?.focus();
+  };
+
+  const isMac=/Mac|iPhone|iPad|iPod/.test(navigator.platform||navigator.userAgent);
+  for(const key of document.querySelectorAll("[data-docs-search-modifier]"))key.textContent=isMac?"⌘":"Ctrl+";
+  document.addEventListener("click",(event)=>{
+    const target=event.target instanceof Element?event.target:null;
+    if(!target)return;
+    const trigger=target.closest("[data-docs-search-trigger]");
+    if(trigger){event.preventDefault();openSearch();return}
+    if(target.closest("[data-docs-search-close]")){event.preventDefault();closeSearch();return}
+    if(target.closest("[data-docs-search-results] a[href]"))closeSearch(false);
+  });
+  input.addEventListener("input",()=>{
+    searchController?.abort();
+    clearTimeout(debounceTimer);
+    debounceTimer=window.setTimeout(runSearch,140);
+  });
+  document.addEventListener("keydown",(event)=>{
+    const shortcut=(event.metaKey||event.ctrlKey)&&!event.altKey&&!event.shiftKey&&event.key.toLowerCase()==="s";
+    if(shortcut){event.preventDefault();root.hidden?openSearch():closeSearch();return}
+    if(root.hidden)return;
+    if(event.key==="Escape"){event.preventDefault();closeSearch();return}
+    if(event.key==="ArrowDown"||event.key==="ArrowUp"){
+      if(resultLinks.length===0||event.isComposing)return;
+      event.preventDefault();
+      setActive(activeIndex+(event.key==="ArrowDown"?1:-1));
+      return;
+    }
+    if(event.key==="Enter"&&!event.isComposing&&activeIndex>=0){event.preventDefault();resultLinks[activeIndex]?.click();return}
+    if(event.key==="Tab"){
+      const focusable=Array.from(dialog.querySelectorAll("input,button,a[href]")).filter((item)=>item instanceof HTMLElement&&!item.hasAttribute("disabled"));
+      if(focusable.length===0)return;
+      const first=focusable[0];
+      const last=focusable[focusable.length-1];
+      if(event.shiftKey&&document.activeElement===first){event.preventDefault();last.focus()}
+      else if(!event.shiftKey&&document.activeElement===last){event.preventDefault();first.focus()}
+    }
+  });
+})();</script>`;
+}
+
 function renderDocsRuntimeScripts(docs: FarmDocsResolvedConfig): string {
   return `${renderDocsRuntimeScript(docs)}
+${isDocsSearchEnabled(docs) ? renderDocsSearchRuntimeScript() : ""}
 ${renderDocsPageActionsRuntimeScript()}`;
 }
 
@@ -1766,6 +1994,7 @@ function renderPixelDocsHtml(
   const description = page.description || docs.config.metadata?.description || "";
   const tocItems = extractTocItems(page.body, getThemeTocDepth(docs));
   const themeName = getThemeName(docs);
+  const searchEnabled = isDocsSearchEnabled(docs);
 
   return `<!DOCTYPE html>
 <html class="dark" lang="en" data-docs-theme="${escapeAttribute(themeName)}">
@@ -1794,6 +2023,7 @@ ${renderFarmDocsBridgeCss(docs)}</style>
     <aside id="nd-sidebar">
       <div class="sidebar-brand">
         <a href="/">${escapeHtml(navTitle)}</a>
+        ${searchEnabled ? renderDocsSearchTrigger() : ""}
         <span>/ docs</span>
       </div>
       ${renderPixelNavItems(pages, page.href, docs)}
@@ -1819,6 +2049,7 @@ ${renderMarkdownHtmlWithTitleMeta(page, docs)}
       </div>
     </nav>
   </div>
+  ${searchEnabled ? renderDocsSearchDialog(docs) : ""}
   ${renderDocsRuntimeScripts(docs)}
 </body>
 </html>`;

--- a/packages/farm/src/docs/handler.ts
+++ b/packages/farm/src/docs/handler.ts
@@ -1507,7 +1507,7 @@ function renderDocsSearchTrigger(): string {
   return `<button class="fd-docs-search-trigger" type="button" data-search-full="" aria-label="Search documentation" aria-haspopup="dialog" aria-keyshortcuts="Meta+K Control+K">
   <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><circle cx="11" cy="11" r="7"></circle><path d="m20 20-4-4"></path></svg>
   <span class="fd-docs-search-trigger-label">Search</span>
-  <kbd>⌘K</kbd>
+  <kbd><span>⌘</span><span>K</span></kbd>
 </button>`;
 }
 

--- a/packages/farm/src/docs/handler.ts
+++ b/packages/farm/src/docs/handler.ts
@@ -24,11 +24,13 @@ import {
 import { marked, Renderer } from "marked";
 import { highlight } from "sugar-high";
 import { resolveFarmDocsPageLastModified } from "./last-modified";
+import { isFarmDocsSearchEnabled } from "./search-client";
 import type { FarmDocsResolvedConfig } from "./types";
 
 export interface FarmDocsHandlerOptions {
   root: string;
   srcDir?: string;
+  clientEntry?: string;
 }
 
 export interface FarmDocsPage {
@@ -341,12 +343,6 @@ function getDocsTitle(docs: FarmDocsResolvedConfig): string {
   return typeof docs.config.nav === "object" && docs.config.nav && "title" in docs.config.nav
     ? String((docs.config.nav as { title?: unknown }).title || "Documentation")
     : "Documentation";
-}
-
-function isDocsSearchEnabled(docs: FarmDocsResolvedConfig): boolean {
-  const search = docs.config.search;
-  if (search === false) return false;
-  return !(search && typeof search === "object" && search.enabled === false);
 }
 
 function getDocsDescription(docs: FarmDocsResolvedConfig): string | undefined {
@@ -1508,29 +1504,16 @@ function renderPixelBreadcrumb(page: LoadedFarmDocsPage, docs: FarmDocsResolvedC
 }
 
 function renderDocsSearchTrigger(): string {
-  return `<button class="fd-docs-search-trigger" type="button" data-docs-search-trigger aria-label="Search documentation" aria-haspopup="dialog" aria-controls="farm-docs-search-dialog" aria-expanded="false" aria-keyshortcuts="Meta+S Control+S">
+  return `<button class="fd-docs-search-trigger" type="button" data-search-full="" aria-label="Search documentation" aria-haspopup="dialog" aria-keyshortcuts="Meta+K Control+K">
   <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><circle cx="11" cy="11" r="7"></circle><path d="m20 20-4-4"></path></svg>
   <span class="fd-docs-search-trigger-label">Search</span>
-  <kbd><span data-docs-search-modifier>⌘</span>S</kbd>
+  <kbd>⌘K</kbd>
 </button>`;
 }
 
-function renderDocsSearchDialog(docs: FarmDocsResolvedConfig): string {
-  const title = `Search ${getDocsTitle(docs)}`;
-  return `<div id="farm-docs-search-root" class="fd-docs-search-root" data-docs-search-root hidden>
-  <div class="fd-docs-search-overlay" data-docs-search-close aria-hidden="true"></div>
-  <section id="farm-docs-search-dialog" class="fd-docs-search-dialog" data-docs-search-dialog role="dialog" aria-modal="true" aria-labelledby="farm-docs-search-title" tabindex="-1">
-    <h2 id="farm-docs-search-title" class="fd-docs-search-visually-hidden">${escapeHtml(title)}</h2>
-    <div class="fd-docs-search-header">
-      <svg class="fd-docs-search-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><circle cx="11" cy="11" r="7"></circle><path d="m20 20-4-4"></path></svg>
-      <input type="search" data-docs-search-input role="combobox" aria-label="Search documentation" aria-autocomplete="list" aria-controls="farm-docs-search-results" aria-expanded="true" autocomplete="off" autocapitalize="off" spellcheck="false" placeholder="Search documentation" />
-      <button class="fd-docs-search-close" type="button" data-docs-search-close aria-label="Close search">ESC</button>
-    </div>
-    <div id="farm-docs-search-results" class="fd-docs-search-results" data-docs-search-results role="listbox" aria-label="Search results" hidden></div>
-    <div class="fd-docs-search-status" data-docs-search-status role="status">Search the documentation</div>
-    <div class="fd-docs-search-visually-hidden" data-docs-search-live aria-live="polite"></div>
-  </section>
-</div>`;
+function renderDocsSearchMount(clientEntry: string): string {
+  return `<div id="farm-docs-search-root" data-farm-docs-search-root data-api="/api/docs"></div>
+  <script type="module" src="${escapeAttribute(clientEntry)}"></script>`;
 }
 
 function renderPixelToc(items: TocItem[]): string {
@@ -1557,204 +1540,13 @@ function renderDocsPageActionsRuntimeScript(): string {
   return `<script>(()=>{if(window.__farmDocsPageActionsRuntime)return;window.__farmDocsPageActionsRuntime=true;const readArticleText=()=>{const article=document.getElementById("nd-page");if(!article)return"";const clone=article.cloneNode(true);if(!(clone instanceof HTMLElement))return article.innerText||"";clone.querySelectorAll("[data-page-actions],.fd-page-footer,.fd-page-nav").forEach((node)=>node.remove());return clone.innerText||""};const withTitle=(content,format,includeTitle)=>{if(!includeTitle)return content;const title=document.querySelector("#nd-page h1")?.textContent?.trim()||document.title.trim();if(!title)return content;const trimmed=content.trimStart();if(trimmed.startsWith(title)||trimmed.startsWith("# "+title))return content;return format==="markdown"?"# "+title+"\\n\\n"+content:title+"\\n\\n"+content};const writeClipboard=async(text)=>{if(navigator.clipboard?.writeText){try{await navigator.clipboard.writeText(text);return}catch{}}const textarea=document.createElement("textarea");textarea.value=text;textarea.setAttribute("readonly","");textarea.style.position="fixed";textarea.style.opacity="0";textarea.style.pointerEvents="none";document.body.appendChild(textarea);textarea.select();document.execCommand("copy");textarea.remove()};const markCopied=(button)=>{const label=button.querySelector("[data-page-action-label]");button.dataset.copied="true";button.setAttribute("aria-label",button.dataset.copiedLabel||"Copied!");button.title=button.dataset.copiedLabel||"Copied!";if(label)label.textContent=button.dataset.copiedLabel||"Copied!";const previous=Number(button.dataset.copyTimeout||0);if(previous)clearTimeout(previous);button.dataset.copyTimeout=String(setTimeout(()=>{button.dataset.copied="false";button.setAttribute("aria-label",button.dataset.copyLabel||"Copy page");button.title=button.dataset.copyLabel||"Copy page";if(label)label.textContent=button.dataset.copyLabel||"Copy page";button.dataset.copyTimeout="0"},4500))};document.addEventListener("click",async(event)=>{const target=event.target instanceof Element?event.target.closest('[data-page-action="copy-markdown"]'):null;if(!(target instanceof HTMLButtonElement))return;event.preventDefault();const format=target.dataset.copyMarkdownFormat==="text"?"text":"markdown";const includeTitle=target.dataset.copyMarkdownIncludeTitle==="true";let content="";target.disabled=true;try{if(format==="markdown"&&target.dataset.markdownUrl){try{const response=await fetch(target.dataset.markdownUrl,{headers:{Accept:"text/markdown"}});if(response.ok)content=await response.text()}catch{}}if(!content)content=readArticleText();content=withTitle(content,format,includeTitle);if(content.trim()){await writeClipboard(content);markCopied(target)}}finally{target.disabled=false}})})();</script>`;
 }
 
-function renderDocsSearchRuntimeScript(): string {
-  return `<script>(()=>{
-  if(window.__farmDocsSearchRuntime)return;
-  window.__farmDocsSearchRuntime=true;
-  const root=document.querySelector("[data-docs-search-root]");
-  if(!(root instanceof HTMLElement))return;
-  const dialog=root.querySelector("[data-docs-search-dialog]");
-  const input=root.querySelector("[data-docs-search-input]");
-  const results=root.querySelector("[data-docs-search-results]");
-  const status=root.querySelector("[data-docs-search-status]");
-  const live=root.querySelector("[data-docs-search-live]");
-  const layout=document.getElementById("nd-docs-layout");
-  if(!(dialog instanceof HTMLElement)||!(input instanceof HTMLInputElement)||!(results instanceof HTMLElement)||!(status instanceof HTMLElement)||!(live instanceof HTMLElement))return;
-
-  let previousFocus=null;
-  let debounceTimer=0;
-  let searchController=null;
-  let activeIndex=-1;
-  let resultLinks=[];
-
-  const getTriggers=()=>Array.from(document.querySelectorAll("[data-docs-search-trigger]")).filter((item)=>item instanceof HTMLButtonElement);
-  const setExpanded=(expanded)=>{for(const trigger of getTriggers())trigger.setAttribute("aria-expanded",expanded?"true":"false")};
-  const setStatus=(message,state)=>{
-    status.textContent=message;
-    status.hidden=false;
-    results.hidden=true;
-    results.replaceChildren();
-    resultLinks=[];
-    activeIndex=-1;
-    input.removeAttribute("aria-activedescendant");
-    root.dataset.searchState=state;
-    live.textContent=message;
-  };
-  const setActive=(index)=>{
-    if(resultLinks.length===0)return;
-    activeIndex=(index+resultLinks.length)%resultLinks.length;
-    for(let itemIndex=0;itemIndex<resultLinks.length;itemIndex++){
-      const link=resultLinks[itemIndex];
-      const selected=itemIndex===activeIndex;
-      link.dataset.active=selected?"true":"false";
-      link.setAttribute("aria-selected",selected?"true":"false");
-    }
-    const active=resultLinks[activeIndex];
-    input.setAttribute("aria-activedescendant",active.id);
-    active.scrollIntoView({block:"nearest"});
-  };
-  const resolveResultHref=(value)=>{
-    if(typeof value!=="string"||!value)return null;
-    try{
-      const url=new URL(value,location.href);
-      if(url.protocol!=="http:"&&url.protocol!=="https:")return null;
-      return url.origin===location.origin?url.pathname+url.search+url.hash:url.href;
-    }catch{return null}
-  };
-  const renderResults=(items)=>{
-    const fragment=document.createDocumentFragment();
-    const links=[];
-    for(const item of items){
-      if(!item||typeof item!=="object")continue;
-      const href=resolveResultHref(typeof item.url==="string"?item.url:item.href);
-      if(!href)continue;
-      const title=typeof item.title==="string"&&item.title.trim()?item.title.trim():typeof item.content==="string"&&item.content.trim()?item.content.trim():"Documentation";
-      const section=typeof item.section==="string"&&item.section.trim()&&item.section.trim()!==title?item.section.trim():"";
-      const description=typeof item.description==="string"?item.description.trim():"";
-      const link=document.createElement("a");
-      link.id="farm-docs-search-result-"+links.length;
-      link.className="fd-docs-search-result";
-      link.href=href;
-      link.setAttribute("role","option");
-      link.setAttribute("aria-selected","false");
-      link.dataset.active="false";
-      const marker=document.createElement("span");
-      marker.className="fd-docs-search-result-marker";
-      marker.setAttribute("aria-hidden","true");
-      marker.textContent=item.type==="heading"?"#":"↗";
-      const content=document.createElement("span");
-      content.className="fd-docs-search-result-content";
-      const heading=document.createElement("span");
-      heading.className="fd-docs-search-result-heading";
-      const titleElement=document.createElement("span");
-      titleElement.className="fd-docs-search-result-title";
-      titleElement.textContent=title;
-      heading.append(titleElement);
-      if(section){
-        const sectionElement=document.createElement("span");
-        sectionElement.className="fd-docs-search-result-section";
-        sectionElement.textContent=section;
-        heading.append(sectionElement);
-      }
-      content.append(heading);
-      if(description){
-        const descriptionElement=document.createElement("span");
-        descriptionElement.className="fd-docs-search-result-description";
-        descriptionElement.textContent=description;
-        content.append(descriptionElement);
-      }
-      link.append(marker,content);
-      const index=links.length;
-      link.addEventListener("pointerenter",()=>setActive(index));
-      links.push(link);
-      fragment.append(link);
-    }
-    if(links.length===0){setStatus("No results found","empty");return}
-    status.hidden=true;
-    results.hidden=false;
-    results.replaceChildren(fragment);
-    resultLinks=links;
-    root.dataset.searchState="results";
-    live.textContent=links.length+" result"+(links.length===1?"":"s")+" found";
-    setActive(0);
-  };
-  const runSearch=async()=>{
-    const query=input.value.trim();
-    if(!query){
-      searchController?.abort();
-      setStatus("Search the documentation","idle");
-      return;
-    }
-    searchController?.abort();
-    const controller=new AbortController();
-    searchController=controller;
-    setStatus("Searching...","loading");
-    try{
-      const response=await fetch("/api/docs?query="+encodeURIComponent(query),{headers:{Accept:"application/json"},signal:controller.signal});
-      if(!response.ok)throw new Error("Search request failed");
-      const payload=await response.json();
-      if(controller.signal.aborted||input.value.trim()!==query)return;
-      renderResults(Array.isArray(payload?.results)?payload.results:[]);
-    }catch(error){
-      if(error?.name!=="AbortError")setStatus("Search is unavailable. Try again.","error");
-    }finally{
-      if(searchController===controller)searchController=null;
-    }
-  };
-  const openSearch=()=>{
-    if(!root.hidden)return;
-    previousFocus=document.activeElement instanceof HTMLElement?document.activeElement:null;
-    root.hidden=false;
-    root.dataset.open="true";
-    document.documentElement.dataset.farmDocsSearch="open";
-    if(layout)layout.inert=true;
-    setExpanded(true);
-    requestAnimationFrame(()=>{input.focus();input.select()});
-  };
-  const closeSearch=(restoreFocus=true)=>{
-    if(root.hidden)return;
-    searchController?.abort();
-    clearTimeout(debounceTimer);
-    delete root.dataset.open;
-    root.hidden=true;
-    delete document.documentElement.dataset.farmDocsSearch;
-    if(layout)layout.inert=false;
-    setExpanded(false);
-    if(restoreFocus)previousFocus?.focus();
-  };
-
-  const isMac=/Mac|iPhone|iPad|iPod/.test(navigator.platform||navigator.userAgent);
-  for(const key of document.querySelectorAll("[data-docs-search-modifier]"))key.textContent=isMac?"⌘":"Ctrl+";
-  document.addEventListener("click",(event)=>{
-    const target=event.target instanceof Element?event.target:null;
-    if(!target)return;
-    const trigger=target.closest("[data-docs-search-trigger]");
-    if(trigger){event.preventDefault();openSearch();return}
-    if(target.closest("[data-docs-search-close]")){event.preventDefault();closeSearch();return}
-    if(target.closest("[data-docs-search-results] a[href]"))closeSearch(false);
-  });
-  input.addEventListener("input",()=>{
-    searchController?.abort();
-    clearTimeout(debounceTimer);
-    debounceTimer=window.setTimeout(runSearch,140);
-  });
-  document.addEventListener("keydown",(event)=>{
-    const shortcut=(event.metaKey||event.ctrlKey)&&!event.altKey&&!event.shiftKey&&event.key.toLowerCase()==="s";
-    if(shortcut){event.preventDefault();root.hidden?openSearch():closeSearch();return}
-    if(root.hidden)return;
-    if(event.key==="Escape"){event.preventDefault();closeSearch();return}
-    if(event.key==="ArrowDown"||event.key==="ArrowUp"){
-      if(resultLinks.length===0||event.isComposing)return;
-      event.preventDefault();
-      setActive(activeIndex+(event.key==="ArrowDown"?1:-1));
-      return;
-    }
-    if(event.key==="Enter"&&!event.isComposing&&activeIndex>=0){event.preventDefault();resultLinks[activeIndex]?.click();return}
-    if(event.key==="Tab"){
-      const focusable=Array.from(dialog.querySelectorAll("input,button,a[href]")).filter((item)=>item instanceof HTMLElement&&!item.hasAttribute("disabled"));
-      if(focusable.length===0)return;
-      const first=focusable[0];
-      const last=focusable[focusable.length-1];
-      if(event.shiftKey&&document.activeElement===first){event.preventDefault();last.focus()}
-      else if(!event.shiftKey&&document.activeElement===last){event.preventDefault();first.focus()}
-    }
-  });
-})();</script>`;
+function renderDocsHashRuntimeScript(): string {
+  return `<script>(()=>{if(window.__farmDocsHashRuntime)return;window.__farmDocsHashRuntime=true;const scrollToHash=()=>{if(!location.hash)return;let id=location.hash.slice(1);try{id=decodeURIComponent(id)}catch{}document.getElementById(id)?.scrollIntoView({block:"start"})};const schedule=()=>requestAnimationFrame(()=>requestAnimationFrame(scrollToHash));if(document.readyState==="loading")document.addEventListener("DOMContentLoaded",schedule,{once:true});else schedule();window.addEventListener("load",schedule,{once:true});window.addEventListener("hashchange",schedule)})();</script>`;
 }
 
 function renderDocsRuntimeScripts(docs: FarmDocsResolvedConfig): string {
   return `${renderDocsRuntimeScript(docs)}
-${isDocsSearchEnabled(docs) ? renderDocsSearchRuntimeScript() : ""}
+${renderDocsHashRuntimeScript()}
 ${renderDocsPageActionsRuntimeScript()}`;
 }
 
@@ -1986,6 +1778,7 @@ function renderPixelDocsHtml(
   pages: FarmDocsPage[],
   docs: FarmDocsResolvedConfig,
   themeCss: string,
+  clientEntry: string,
 ): string {
   const navTitle =
     typeof docs.config.nav === "object" && docs.config.nav && "title" in docs.config.nav
@@ -1994,7 +1787,7 @@ function renderPixelDocsHtml(
   const description = page.description || docs.config.metadata?.description || "";
   const tocItems = extractTocItems(page.body, getThemeTocDepth(docs));
   const themeName = getThemeName(docs);
-  const searchEnabled = isDocsSearchEnabled(docs);
+  const searchEnabled = isFarmDocsSearchEnabled(docs);
 
   return `<!DOCTYPE html>
 <html class="dark" lang="en" data-docs-theme="${escapeAttribute(themeName)}">
@@ -2049,7 +1842,7 @@ ${renderMarkdownHtmlWithTitleMeta(page, docs)}
       </div>
     </nav>
   </div>
-  ${searchEnabled ? renderDocsSearchDialog(docs) : ""}
+  ${searchEnabled ? renderDocsSearchMount(clientEntry) : ""}
   ${renderDocsRuntimeScripts(docs)}
 </body>
 </html>`;
@@ -2095,6 +1888,7 @@ export function createFarmDocsHandler(
         discoverFarmDocsPages(contentDir, docs),
         docs,
         resolvePixelBorderThemeCss(options),
+        options.clientEntry || "/farm-client.js",
       ),
       {
         status: 200,

--- a/packages/farm/src/docs/handler.ts
+++ b/packages/farm/src/docs/handler.ts
@@ -1596,27 +1596,28 @@ function renderFarmDocsBridgeCss(docs: FarmDocsResolvedConfig): string {
   return `
     @font-face { font-family: "Geist Sans"; src: local("Geist Sans"), url("${GEIST_SANS_FONT_URL}") format("woff2"), url("/node_modules/geist/dist/fonts/geist-sans/Geist-Variable.woff2") format("woff2"); font-display: block; font-style: normal; font-weight: 100 900; }
     @font-face { font-family: "Geist Mono"; src: local("Geist Mono"), url("${GEIST_MONO_FONT_URL}") format("woff2"), url("/node_modules/geist/dist/fonts/geist-mono/GeistMono-Variable.woff2") format("woff2"); font-display: block; font-style: normal; font-weight: 100 900; }
-    :root { color-scheme: dark; --font-geist-sans: "Geist Sans"; --font-geist-mono: "Geist Mono"; --fd-sidebar-width: ${sidebarWidth}px; --fd-content-width: ${contentWidth}px; --fd-toc-width: 240px; --fd-docs-height: 100vh; --fd-docs-row-1: var(--fd-nav-height, 56px); --fd-docs-font-sans: var(--font-geist-sans, "Geist Sans", var(--font-sans, system-ui, -apple-system, sans-serif)); --fd-docs-font-mono: var(--font-geist-mono, "Geist Mono", var(--font-mono, ui-monospace, monospace)); --fd-font-sans: var(--fd-docs-font-sans); --fd-font-mono: var(--fd-docs-font-mono); --fd-pixel-rail-width: 12px; --fd-sidebar-edge: calc(var(--fd-pixel-rail-width) + 18px); --fd-sidebar-guide-x: calc(var(--fd-sidebar-edge) + 16px); --fd-sidebar-link-x: calc(var(--fd-sidebar-guide-x) + 22px); --fd-sidebar-sub-guide-x: calc(var(--fd-sidebar-link-x) + 7px); --fd-sidebar-sub-link-x: calc(var(--fd-sidebar-sub-guide-x) + 28px); --fd-sidebar-branch-gap: 0px; --fd-sidebar-nested-icon-gap: 0px; --fd-sidebar-line-color: color-mix(in srgb, var(--color-fd-border, hsl(0 0% 15%)) 88%, transparent); }
+    :root { color-scheme: dark; --font-geist-sans: "Geist Sans"; --font-geist-mono: "Geist Mono"; --fd-sidebar-width: ${sidebarWidth}px; --fd-content-width: ${contentWidth}px; --fd-toc-width: 240px; --fd-docs-height: 100vh; --fd-docs-row-1: var(--fd-nav-height, 38px); --fd-docs-font-sans: var(--font-geist-sans, "Geist Sans", var(--font-sans, system-ui, -apple-system, sans-serif)); --fd-docs-font-mono: var(--font-geist-mono, "Geist Mono", var(--font-mono, ui-monospace, monospace)); --fd-font-sans: var(--fd-docs-font-sans); --fd-font-mono: var(--fd-docs-font-mono); --fd-pixel-rail-width: 12px; --fd-sidebar-edge: calc(var(--fd-pixel-rail-width) + 18px); --fd-sidebar-guide-x: calc(var(--fd-sidebar-edge) + 16px); --fd-sidebar-link-x: calc(var(--fd-sidebar-guide-x) + 22px); --fd-sidebar-sub-guide-x: calc(var(--fd-sidebar-link-x) + 7px); --fd-sidebar-sub-link-x: calc(var(--fd-sidebar-sub-guide-x) + 28px); --fd-sidebar-branch-gap: 0px; --fd-sidebar-nested-icon-gap: 0px; --fd-sidebar-line-color: color-mix(in srgb, var(--color-fd-border, hsl(0 0% 15%)) 88%, transparent); }
     * { box-sizing: border-box; }
-    html { background: var(--color-fd-background, hsl(0 0% 2%)); scroll-padding-top: 76px; }
+    html { background: var(--color-fd-background, hsl(0 0% 2%)); scroll-padding-top: calc(var(--fd-nav-height, 38px) + 24px); }
     html[data-farm-docs-sidebar="open"], html[data-farm-docs-sidebar="open"] body { overflow: hidden; }
     body { margin: 0; min-height: 100vh; background: var(--color-fd-background, hsl(0 0% 2%)); color: var(--color-fd-foreground, oklch(0.985 0.001 106.423)); font-family: var(--fd-docs-font-sans); text-rendering: optimizeLegibility; }
     ::selection { background: var(--color-fd-foreground, #fff); color: var(--color-fd-background, #000); }
     a { color: inherit; }
-    #nd-docs-layout { --fd-sidebar-col: var(--fd-sidebar-width); display: grid; grid-template: "sidebar header header" var(--fd-nav-height, 56px) "sidebar main toc" 1fr / var(--fd-sidebar-width) minmax(0, 1fr) var(--fd-toc-width) !important; min-height: 100vh; border-top: 1px solid var(--color-fd-border, hsl(0 0% 15%)); background: var(--color-fd-background, hsl(0 0% 2%)); }
-    #nd-docs-layout.grid { grid-template: "sidebar header header" var(--fd-nav-height, 56px) "sidebar main toc" 1fr / var(--fd-sidebar-width) minmax(0, 1fr) var(--fd-toc-width) !important; }
+    #nd-docs-layout { --fd-sidebar-col: var(--fd-sidebar-width); display: grid; grid-template: "sidebar header header" var(--fd-nav-height, 38px) "sidebar main toc" 1fr / var(--fd-sidebar-width) minmax(0, 1fr) var(--fd-toc-width) !important; min-height: 100vh; border-top: 1px solid var(--color-fd-border, hsl(0 0% 15%)); background: var(--color-fd-background, hsl(0 0% 2%)); }
+    #nd-docs-layout.grid { grid-template: "sidebar header header" var(--fd-nav-height, 38px) "sidebar main toc" 1fr / var(--fd-sidebar-width) minmax(0, 1fr) var(--fd-toc-width) !important; }
     #nd-docs-layout, #nd-docs-layout * { border-radius: 0 !important; }
-    .topbar { position: sticky; top: 0; z-index: 20; grid-area: header; height: var(--fd-nav-height, 56px); display: flex; align-items: center; justify-content: space-between; gap: 16px; border-bottom: 1px solid var(--color-fd-border, hsl(0 0% 15%)); background: color-mix(in srgb, var(--color-fd-background, hsl(0 0% 2%)) 92%, transparent); backdrop-filter: blur(12px); padding: 0 0 0 28px; font-family: var(--fd-docs-font-mono); font-size: 12px; letter-spacing: 0.03em; text-transform: uppercase; }
+    .topbar { position: sticky; top: 0; z-index: 20; grid-area: header; height: var(--fd-nav-height, 38px); display: flex; align-items: center; justify-content: space-between; gap: 16px; border-bottom: 1px solid var(--color-fd-border, hsl(0 0% 15%)); background: color-mix(in srgb, var(--color-fd-background, hsl(0 0% 2%)) 92%, transparent); backdrop-filter: blur(12px); padding: 0 0 0 22px; font-family: var(--fd-docs-font-mono); font-size: 12px; letter-spacing: 0.03em; text-transform: uppercase; }
     .topbar a { text-decoration: none; color: var(--color-fd-muted-foreground, hsl(0 0% 55%)); }
     .topbar a:hover { color: var(--color-fd-foreground, oklch(0.985 0.001 106.423)); }
-    .topbar a:last-child { display: inline-flex; height: 100%; align-items: center; margin-left: auto; border-left: 1px solid var(--color-fd-border, hsl(0 0% 15%)); padding: 0 28px; }
+    .topbar-actions, .mobile-topbar-actions { display: flex; height: 100%; min-width: 0; align-items: stretch; margin-left: auto; }
+    .topbar-llms-link { display: inline-flex; height: 100%; align-items: center; border-left: 1px solid var(--color-fd-border, hsl(0 0% 15%)); padding: 0 22px; }
     .mobile-topbar { display: none; }
     .sidebar-backdrop { display: none; }
     .fd-mobile-nav-btn { display: inline-flex; width: var(--fd-mobile-nav-height, 56px); height: 100%; flex: 0 0 var(--fd-mobile-nav-height, 56px); align-items: center; justify-content: center; border: 0; border-right: 1px solid var(--color-fd-border, hsl(0 0% 15%)); background: transparent; color: var(--color-fd-foreground, oklch(0.985 0.001 106.423)); cursor: pointer; padding: 0; appearance: none; }
     .fd-mobile-nav-btn svg { width: 19px; height: 19px; fill: none; stroke: currentColor; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
     .mobile-topbar-brand, .mobile-topbar-link { display: inline-flex; height: 100%; min-width: 0; align-items: center; color: var(--color-fd-muted-foreground, hsl(0 0% 55%)); font-family: var(--fd-docs-font-mono); font-size: 12px; letter-spacing: 0.03em; text-decoration: none; text-transform: uppercase; }
     .mobile-topbar-brand { padding: 0 14px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .mobile-topbar-link { margin-left: auto; border-left: 1px solid var(--color-fd-border, hsl(0 0% 15%)); padding: 0 14px; }
+    .mobile-topbar-link { border-left: 1px solid var(--color-fd-border, hsl(0 0% 15%)); padding: 0 14px; }
     #nd-docs-layout .fd-toc { position: sticky; top: var(--fd-docs-row-1); grid-area: toc; display: flex; width: var(--fd-toc-width); height: calc(var(--fd-docs-height) - var(--fd-docs-row-1)); max-height: calc(100vh - var(--fd-docs-row-1)); flex-direction: column; align-self: start; overflow: hidden; padding: 48px 16px 8px 0; }
     #nd-docs-layout .fd-toc-inner { display: flex; min-width: 0; min-height: 0; flex: 1 1 auto; flex-direction: column; }
     #nd-docs-layout .fd-toc-title { display: inline-flex; align-items: center; gap: 0.375rem; margin: 0 0 1rem; color: var(--color-fd-muted-foreground, hsl(0 0% 55%)); font-family: var(--fd-docs-font-sans); font-size: 0.875rem; font-weight: 500; line-height: 1.4; }
@@ -1634,10 +1635,10 @@ function renderFarmDocsBridgeCss(docs: FarmDocsResolvedConfig): string {
     #nd-docs-layout .toc-link[data-active="true"] { color: var(--color-fd-primary, oklch(0.985 0.001 106.423)); }
     #nd-docs-layout .toc-link:hover { color: var(--color-fd-accent-foreground, oklch(0.985 0.001 106.423)); }
     #nd-docs-layout .toc-empty { margin: 0; color: var(--color-fd-muted-foreground, hsl(0 0% 55%)); font-size: 0.875rem; line-height: 1.5; }
-    aside#nd-sidebar { position: sticky; top: 0; grid-area: sidebar; height: 100vh; overflow: auto; isolation: isolate; border-left: 1px solid var(--color-fd-border, hsl(0 0% 15%)); border-right: 1px solid var(--color-fd-border, hsl(0 0% 15%)); background-color: var(--color-fd-background, hsl(0 0% 2%)); background-image: linear-gradient(var(--color-fd-border, hsl(0 0% 15%)), var(--color-fd-border, hsl(0 0% 15%))), linear-gradient(var(--color-fd-border, hsl(0 0% 15%)), var(--color-fd-border, hsl(0 0% 15%))), repeating-linear-gradient(-45deg, color-mix(in srgb, var(--color-fd-border, hsl(0 0% 15%)) 2%, transparent), color-mix(in srgb, var(--color-fd-foreground, #fff) 7%, transparent) 1px, transparent 1px, transparent 6px), repeating-linear-gradient(-45deg, color-mix(in srgb, var(--color-fd-border, hsl(0 0% 15%)) 2%, transparent), color-mix(in srgb, var(--color-fd-foreground, #fff) 7%, transparent) 1px, transparent 1px, transparent 6px); background-size: 1px 100%, 1px 100%, var(--fd-pixel-rail-width) 100%, var(--fd-pixel-rail-width) 100%; background-position: var(--fd-pixel-rail-width) 0, calc(100% - var(--fd-pixel-rail-width)) 0, left top, right top; background-repeat: repeat-y; padding: 18px var(--fd-sidebar-edge); }
+    aside#nd-sidebar { position: sticky; top: 0; grid-area: sidebar; height: 100vh; overflow: auto; isolation: isolate; border-left: 1px solid var(--color-fd-border, hsl(0 0% 15%)); border-right: 1px solid var(--color-fd-border, hsl(0 0% 15%)); background-color: var(--color-fd-background, hsl(0 0% 2%)); background-image: linear-gradient(var(--color-fd-border, hsl(0 0% 15%)), var(--color-fd-border, hsl(0 0% 15%))), linear-gradient(var(--color-fd-border, hsl(0 0% 15%)), var(--color-fd-border, hsl(0 0% 15%))), repeating-linear-gradient(-45deg, color-mix(in srgb, var(--color-fd-border, hsl(0 0% 15%)) 2%, transparent), color-mix(in srgb, var(--color-fd-foreground, #fff) 7%, transparent) 1px, transparent 1px, transparent 6px), repeating-linear-gradient(-45deg, color-mix(in srgb, var(--color-fd-border, hsl(0 0% 15%)) 2%, transparent), color-mix(in srgb, var(--color-fd-foreground, #fff) 7%, transparent) 1px, transparent 1px, transparent 6px); background-size: 1px 100%, 1px 100%, var(--fd-pixel-rail-width) 100%, var(--fd-pixel-rail-width) 100%; background-position: var(--fd-pixel-rail-width) 0, calc(100% - var(--fd-pixel-rail-width)) 0, left top, right top; background-repeat: repeat-y; padding: 0 var(--fd-sidebar-edge) 18px; }
     aside#nd-sidebar::before, aside#nd-sidebar::after { display: none; }
     aside#nd-sidebar > * { position: relative; z-index: 1; }
-    .sidebar-brand { display: flex; align-items: center; justify-content: space-between; gap: 10px; min-height: 38px; margin: -2px calc(-1 * var(--fd-sidebar-edge)) 18px; border-top: 1px solid var(--color-fd-border, hsl(0 0% 15%)); border-bottom: 1px solid var(--color-fd-border, hsl(0 0% 15%)); background: transparent; padding: 0 var(--fd-sidebar-edge); font-family: var(--fd-docs-font-mono); font-size: 12px; letter-spacing: 0.03em; text-transform: uppercase; }
+    .sidebar-brand { display: flex; align-items: center; justify-content: space-between; gap: 10px; min-height: var(--fd-nav-height, 38px); margin: 0 calc(-1 * var(--fd-sidebar-edge)) 18px; border-top: 1px solid var(--color-fd-border, hsl(0 0% 15%)); border-bottom: 1px solid var(--color-fd-border, hsl(0 0% 15%)); background: transparent; padding: 0 var(--fd-sidebar-edge); font-family: var(--fd-docs-font-mono); font-size: 12px; letter-spacing: 0.03em; text-transform: uppercase; }
     .sidebar-brand a { text-decoration: none; }
     .sidebar-scroll { margin: 0 calc(-1 * var(--fd-sidebar-edge)); overflow: visible; }
     .sidebar-tree { margin-top: 0 !important; }
@@ -1752,7 +1753,7 @@ function renderFarmDocsBridgeCss(docs: FarmDocsResolvedConfig): string {
       aside#nd-sidebar { position: fixed; inset: 0 auto 0 0; z-index: 90; width: min(342px, calc(100vw - 42px)); height: 100dvh; max-height: none; overflow-y: auto; overscroll-behavior: contain; border-right: 1px solid var(--color-fd-border, hsl(0 0% 15%)); border-bottom: 0; transform: translate3d(-100%, 0, 0); transition: transform 180ms ease; will-change: transform; }
       #nd-docs-layout[data-sidebar-open="true"] aside#nd-sidebar { transform: translate3d(0, 0, 0); }
       aside#nd-sidebar::before, aside#nd-sidebar::after { display: none; }
-      .sidebar-brand { min-height: 38px; margin-top: -2px; }
+      .sidebar-brand { min-height: 38px; margin-top: 0; }
       main { padding: 34px 20px 64px; }
       article#nd-page { width: 100%; margin: 0; }
       #nd-docs-layout .fd-toc { display: none !important; }
@@ -1810,20 +1811,25 @@ ${renderFarmDocsBridgeCss(docs)}</style>
         <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
       </button>
       <a class="mobile-topbar-brand" href="/">Farm.js</a>
-      <a class="mobile-topbar-link" href="/llms.txt">llms.txt</a>
+      <div class="mobile-topbar-actions">
+        ${searchEnabled ? renderDocsSearchTrigger() : ""}
+        <a class="mobile-topbar-link" href="/llms.txt">llms.txt</a>
+      </div>
     </header>
     <div class="sidebar-backdrop" data-sidebar-backdrop></div>
     <aside id="nd-sidebar">
       <div class="sidebar-brand">
         <a href="/">${escapeHtml(navTitle)}</a>
-        ${searchEnabled ? renderDocsSearchTrigger() : ""}
         <span>/ docs</span>
       </div>
       ${renderPixelNavItems(pages, page.href, docs)}
     </aside>
     <header class="topbar">
       <a href="/">Farm.js</a>
-      <a href="/llms.txt">llms.txt</a>
+      <div class="topbar-actions">
+        ${searchEnabled ? renderDocsSearchTrigger() : ""}
+        <a class="topbar-llms-link" href="/llms.txt">llms.txt</a>
+      </div>
     </header>
     <main>
       <article id="nd-page" class="prose">

--- a/packages/farm/src/docs/pixel-border.css
+++ b/packages/farm/src/docs/pixel-border.css
@@ -14,7 +14,7 @@
   --color-fd-accent-foreground: oklch(0.985 0.001 106.423);
   --color-fd-border: hsl(0 0% 15%);
   --color-fd-ring: hsl(0 0% 30%);
-  --fd-nav-height: 56px;
+  --fd-nav-height: 38px;
   --fd-banner-height: 0px;
   --fd-tocnav-height: 0px;
   --scrollbar-thumb: var(--color-fd-border);
@@ -82,7 +82,12 @@ code:not(pre code) {
   width: 100%;
 }
 
-.topbar a:last-child {
+.topbar-actions,
+.mobile-topbar-actions {
+  display: flex;
+  height: 100%;
+  min-width: 0;
+  align-items: stretch;
   margin-left: auto;
 }
 
@@ -141,7 +146,6 @@ code:not(pre code) {
 }
 
 .mobile-topbar-link {
-  margin-left: auto;
   border-left: 1px solid var(--color-fd-border);
   padding: 0 14px;
 }
@@ -235,6 +239,25 @@ code:not(pre code) {
   font-weight: 500;
   letter-spacing: 0;
   line-height: 1;
+}
+
+.topbar-actions .fd-docs-search-trigger,
+.mobile-topbar-actions .fd-docs-search-trigger {
+  width: auto;
+  min-width: 54px;
+  height: 100%;
+  flex: 0 0 auto;
+  border: 0;
+  border-left: 1px solid var(--color-fd-border);
+  background: transparent;
+  padding: 0 12px;
+}
+
+.topbar-actions .fd-docs-search-trigger:hover,
+.topbar-actions .fd-docs-search-trigger:focus-visible,
+.mobile-topbar-actions .fd-docs-search-trigger:hover,
+.mobile-topbar-actions .fd-docs-search-trigger:focus-visible {
+  background: color-mix(in srgb, var(--color-fd-foreground) 6%, transparent);
 }
 
 .fd-toc {
@@ -589,5 +612,14 @@ code:not(pre code) {
   .fd-page-nav-next {
     align-items: flex-start;
     text-align: left;
+  }
+
+  .mobile-topbar-actions .fd-docs-search-trigger {
+    min-width: 44px;
+    padding: 0 14px;
+  }
+
+  .mobile-topbar-actions .fd-docs-search-trigger kbd {
+    display: none;
   }
 }

--- a/packages/farm/src/docs/pixel-border.css
+++ b/packages/farm/src/docs/pixel-border.css
@@ -229,7 +229,7 @@ code:not(pre code) {
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;
-  gap: 1px;
+  gap: 2px;
   border: 1px solid var(--color-fd-border);
   background: var(--color-fd-background);
   padding: 1px 4px;

--- a/packages/farm/src/docs/pixel-border.css
+++ b/packages/farm/src/docs/pixel-border.css
@@ -67,11 +67,6 @@ html[data-farm-docs-sidebar="open"] body {
   overflow: hidden;
 }
 
-html[data-farm-docs-search="open"],
-html[data-farm-docs-search="open"] body {
-  overflow: hidden;
-}
-
 code:not(pre code) {
   overflow-wrap: break-word;
   word-break: break-word;
@@ -208,8 +203,7 @@ code:not(pre code) {
   outline-offset: 2px;
 }
 
-.fd-docs-search-trigger svg,
-.fd-docs-search-icon {
+.fd-docs-search-trigger svg {
   width: 13px;
   height: 13px;
   flex: 0 0 13px;
@@ -241,239 +235,6 @@ code:not(pre code) {
   font-weight: 500;
   letter-spacing: 0;
   line-height: 1;
-}
-
-.fd-docs-search-root[hidden] {
-  display: none;
-}
-
-.fd-docs-search-root {
-  position: fixed;
-  inset: 0;
-  z-index: 130;
-  display: grid;
-  align-items: start;
-  justify-items: center;
-  overflow: auto;
-  padding: clamp(16px, 8vh, 72px) 8px 16px;
-  font-family: var(--fd-docs-font-sans);
-}
-
-.fd-docs-search-overlay {
-  position: fixed;
-  inset: 0;
-  background: color-mix(in srgb, var(--color-fd-background) 72%, transparent);
-  backdrop-filter: blur(8px);
-}
-
-.fd-docs-search-dialog {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  width: min(640px, calc(100vw - 16px));
-  max-height: min(620px, calc(100dvh - 32px));
-  flex-direction: column;
-  overflow: hidden;
-  border: 1px solid color-mix(in srgb, var(--color-fd-foreground) 22%, transparent);
-  border-radius: 6px;
-  background: var(--color-fd-background);
-  box-shadow: 0 24px 80px rgb(0 0 0 / 58%);
-  color: var(--color-fd-foreground);
-}
-
-.fd-docs-search-header {
-  display: grid;
-  min-height: 54px;
-  grid-template-columns: 18px minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 10px;
-  border-bottom: 1px solid var(--color-fd-border);
-  padding: 8px 10px 8px 14px;
-}
-
-.fd-docs-search-icon {
-  width: 16px;
-  height: 16px;
-  color: var(--color-fd-muted-foreground);
-}
-
-.fd-docs-search-header input {
-  width: 100%;
-  min-width: 0;
-  border: 0;
-  outline: 0;
-  background: transparent;
-  color: var(--color-fd-foreground);
-  padding: 0;
-  font: inherit;
-  font-size: 16px;
-  line-height: 1.4;
-  appearance: none;
-}
-
-.fd-docs-search-header input::-webkit-search-cancel-button {
-  display: none;
-}
-
-.fd-docs-search-header input::placeholder {
-  color: var(--color-fd-muted-foreground);
-}
-
-.fd-docs-search-close {
-  min-width: 36px;
-  height: 24px;
-  border: 1px solid var(--color-fd-border);
-  background: color-mix(in srgb, var(--color-fd-foreground) 4%, transparent);
-  color: var(--color-fd-muted-foreground);
-  cursor: pointer;
-  padding: 0 6px;
-  font-family: var(--fd-docs-font-mono);
-  font-size: 9px;
-  letter-spacing: 0.04em;
-  line-height: 1;
-}
-
-.fd-docs-search-close:hover,
-.fd-docs-search-close:focus-visible {
-  background: color-mix(in srgb, var(--color-fd-foreground) 8%, transparent);
-  color: var(--color-fd-foreground);
-}
-
-.fd-docs-search-close:focus-visible {
-  outline: 1px solid var(--color-fd-foreground);
-  outline-offset: 2px;
-}
-
-.fd-docs-search-results {
-  min-height: 0;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  padding: 6px;
-}
-
-.fd-docs-search-result {
-  display: grid;
-  min-width: 0;
-  grid-template-columns: 24px minmax(0, 1fr);
-  align-items: start;
-  gap: 8px;
-  border-bottom: 1px solid color-mix(in srgb, var(--color-fd-border) 76%, transparent);
-  padding: 11px 10px;
-  color: var(--color-fd-muted-foreground);
-  text-decoration: none;
-  transition:
-    background-color 120ms ease,
-    color 120ms ease;
-}
-
-.fd-docs-search-result:last-child {
-  border-bottom: 0;
-}
-
-.fd-docs-search-result:hover,
-.fd-docs-search-result[data-active="true"] {
-  background: color-mix(in srgb, var(--color-fd-foreground) 7%, transparent);
-  color: var(--color-fd-foreground);
-}
-
-.fd-docs-search-result-marker {
-  display: inline-flex;
-  width: 24px;
-  height: 24px;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--color-fd-border);
-  color: var(--color-fd-muted-foreground);
-  font-family: var(--fd-docs-font-mono);
-  font-size: 11px;
-  line-height: 1;
-}
-
-.fd-docs-search-result[data-active="true"] .fd-docs-search-result-marker {
-  border-color: color-mix(in srgb, var(--color-fd-foreground) 32%, transparent);
-  color: var(--color-fd-foreground);
-}
-
-.fd-docs-search-result-content {
-  display: flex;
-  min-width: 0;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.fd-docs-search-result-heading {
-  display: flex;
-  min-width: 0;
-  align-items: baseline;
-  gap: 7px;
-}
-
-.fd-docs-search-result-title,
-.fd-docs-search-result-section {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.fd-docs-search-result-title {
-  flex: 0 1 auto;
-  color: var(--color-fd-foreground);
-  font-size: 13px;
-  font-weight: 600;
-}
-
-.fd-docs-search-result-section {
-  flex: 1 1 auto;
-  font-size: 12px;
-}
-
-.fd-docs-search-result-section::before {
-  content: "/ ";
-  opacity: 0.5;
-}
-
-.fd-docs-search-result-description {
-  display: -webkit-box;
-  overflow: hidden;
-  color: var(--color-fd-muted-foreground);
-  font-size: 12px;
-  line-height: 1.45;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-}
-
-.fd-docs-search-status {
-  display: grid;
-  min-height: 150px;
-  place-items: center;
-  padding: 24px;
-  color: var(--color-fd-muted-foreground);
-  font-size: 13px;
-  text-align: center;
-}
-
-.fd-docs-search-visually-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  clip-path: inset(50%);
-  margin: -1px;
-  padding: 0;
-  border: 0;
-  white-space: nowrap;
-}
-
-.fd-docs-search-root[data-search-state="loading"] .fd-docs-search-icon {
-  animation: fd-docs-search-pulse 900ms ease-in-out infinite;
-}
-
-@keyframes fd-docs-search-pulse {
-  50% {
-    opacity: 0.35;
-  }
 }
 
 .fd-toc {
@@ -740,14 +501,6 @@ code:not(pre code) {
     display: none !important;
   }
 
-  .fd-docs-search-root {
-    padding-top: 8px;
-  }
-
-  .fd-docs-search-dialog {
-    max-height: calc(100dvh - 16px);
-  }
-
   .sidebar-backdrop {
     position: fixed;
     inset: 0;
@@ -836,11 +589,5 @@ code:not(pre code) {
   .fd-page-nav-next {
     align-items: flex-start;
     text-align: left;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .fd-docs-search-root[data-search-state="loading"] .fd-docs-search-icon {
-    animation: none;
   }
 }

--- a/packages/farm/src/docs/pixel-border.css
+++ b/packages/farm/src/docs/pixel-border.css
@@ -524,6 +524,14 @@ code:not(pre code) {
     display: none !important;
   }
 
+  .omni-overlay {
+    z-index: 100;
+  }
+
+  .omni-content {
+    z-index: 101;
+  }
+
   .sidebar-backdrop {
     position: fixed;
     inset: 0;
@@ -621,5 +629,13 @@ code:not(pre code) {
 
   .mobile-topbar-actions .fd-docs-search-trigger kbd {
     display: none;
+  }
+}
+
+@media (max-width: 639px) {
+  .omni-content {
+    --omni-content-top: calc(var(--fd-mobile-nav-height, 56px) + 12px);
+    top: var(--omni-content-top);
+    max-height: calc(100dvh - var(--omni-content-top) - 12px);
   }
 }

--- a/packages/farm/src/docs/pixel-border.css
+++ b/packages/farm/src/docs/pixel-border.css
@@ -67,6 +67,11 @@ html[data-farm-docs-sidebar="open"] body {
   overflow: hidden;
 }
 
+html[data-farm-docs-search="open"],
+html[data-farm-docs-search="open"] body {
+  overflow: hidden;
+}
+
 code:not(pre code) {
   overflow-wrap: break-word;
   word-break: break-word;
@@ -144,6 +149,331 @@ code:not(pre code) {
   margin-left: auto;
   border-left: 1px solid var(--color-fd-border);
   padding: 0 14px;
+}
+
+.sidebar-brand {
+  justify-content: flex-start;
+}
+
+.sidebar-brand > a {
+  min-width: 0;
+  overflow: hidden;
+  flex: 0 0 auto;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-brand > span {
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+
+.fd-docs-search-trigger {
+  display: inline-flex;
+  width: auto;
+  min-width: 46px;
+  height: 26px;
+  flex: 1 1 auto;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  overflow: hidden;
+  border: 1px solid var(--color-fd-border);
+  background: color-mix(in srgb, var(--color-fd-foreground) 4%, transparent);
+  color: var(--color-fd-muted-foreground);
+  cursor: pointer;
+  padding: 0 5px 0 7px;
+  font-family: var(--fd-docs-font-mono);
+  font-size: 10px;
+  letter-spacing: 0;
+  line-height: 1;
+  text-transform: none;
+  transition:
+    border-color 150ms ease,
+    background-color 150ms ease,
+    color 150ms ease;
+  appearance: none;
+}
+
+.fd-docs-search-trigger:hover,
+.fd-docs-search-trigger:focus-visible,
+.fd-docs-search-trigger[aria-expanded="true"] {
+  border-color: color-mix(in srgb, var(--color-fd-foreground) 28%, transparent);
+  background: color-mix(in srgb, var(--color-fd-foreground) 8%, transparent);
+  color: var(--color-fd-foreground);
+}
+
+.fd-docs-search-trigger:focus-visible {
+  outline: 1px solid var(--color-fd-foreground);
+  outline-offset: 2px;
+}
+
+.fd-docs-search-trigger svg,
+.fd-docs-search-icon {
+  width: 13px;
+  height: 13px;
+  flex: 0 0 13px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+
+.fd-docs-search-trigger-label {
+  display: none;
+}
+
+.fd-docs-search-trigger kbd {
+  display: inline-flex;
+  min-width: 24px;
+  min-height: 16px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
+  border: 1px solid var(--color-fd-border);
+  background: var(--color-fd-background);
+  padding: 1px 4px;
+  color: currentColor;
+  font-family: inherit;
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+.fd-docs-search-root[hidden] {
+  display: none;
+}
+
+.fd-docs-search-root {
+  position: fixed;
+  inset: 0;
+  z-index: 130;
+  display: grid;
+  align-items: start;
+  justify-items: center;
+  overflow: auto;
+  padding: clamp(16px, 8vh, 72px) 8px 16px;
+  font-family: var(--fd-docs-font-sans);
+}
+
+.fd-docs-search-overlay {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in srgb, var(--color-fd-background) 72%, transparent);
+  backdrop-filter: blur(8px);
+}
+
+.fd-docs-search-dialog {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  width: min(640px, calc(100vw - 16px));
+  max-height: min(620px, calc(100dvh - 32px));
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--color-fd-foreground) 22%, transparent);
+  border-radius: 6px;
+  background: var(--color-fd-background);
+  box-shadow: 0 24px 80px rgb(0 0 0 / 58%);
+  color: var(--color-fd-foreground);
+}
+
+.fd-docs-search-header {
+  display: grid;
+  min-height: 54px;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  border-bottom: 1px solid var(--color-fd-border);
+  padding: 8px 10px 8px 14px;
+}
+
+.fd-docs-search-icon {
+  width: 16px;
+  height: 16px;
+  color: var(--color-fd-muted-foreground);
+}
+
+.fd-docs-search-header input {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--color-fd-foreground);
+  padding: 0;
+  font: inherit;
+  font-size: 16px;
+  line-height: 1.4;
+  appearance: none;
+}
+
+.fd-docs-search-header input::-webkit-search-cancel-button {
+  display: none;
+}
+
+.fd-docs-search-header input::placeholder {
+  color: var(--color-fd-muted-foreground);
+}
+
+.fd-docs-search-close {
+  min-width: 36px;
+  height: 24px;
+  border: 1px solid var(--color-fd-border);
+  background: color-mix(in srgb, var(--color-fd-foreground) 4%, transparent);
+  color: var(--color-fd-muted-foreground);
+  cursor: pointer;
+  padding: 0 6px;
+  font-family: var(--fd-docs-font-mono);
+  font-size: 9px;
+  letter-spacing: 0.04em;
+  line-height: 1;
+}
+
+.fd-docs-search-close:hover,
+.fd-docs-search-close:focus-visible {
+  background: color-mix(in srgb, var(--color-fd-foreground) 8%, transparent);
+  color: var(--color-fd-foreground);
+}
+
+.fd-docs-search-close:focus-visible {
+  outline: 1px solid var(--color-fd-foreground);
+  outline-offset: 2px;
+}
+
+.fd-docs-search-results {
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 6px;
+}
+
+.fd-docs-search-result {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: 24px minmax(0, 1fr);
+  align-items: start;
+  gap: 8px;
+  border-bottom: 1px solid color-mix(in srgb, var(--color-fd-border) 76%, transparent);
+  padding: 11px 10px;
+  color: var(--color-fd-muted-foreground);
+  text-decoration: none;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.fd-docs-search-result:last-child {
+  border-bottom: 0;
+}
+
+.fd-docs-search-result:hover,
+.fd-docs-search-result[data-active="true"] {
+  background: color-mix(in srgb, var(--color-fd-foreground) 7%, transparent);
+  color: var(--color-fd-foreground);
+}
+
+.fd-docs-search-result-marker {
+  display: inline-flex;
+  width: 24px;
+  height: 24px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--color-fd-border);
+  color: var(--color-fd-muted-foreground);
+  font-family: var(--fd-docs-font-mono);
+  font-size: 11px;
+  line-height: 1;
+}
+
+.fd-docs-search-result[data-active="true"] .fd-docs-search-result-marker {
+  border-color: color-mix(in srgb, var(--color-fd-foreground) 32%, transparent);
+  color: var(--color-fd-foreground);
+}
+
+.fd-docs-search-result-content {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.fd-docs-search-result-heading {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: 7px;
+}
+
+.fd-docs-search-result-title,
+.fd-docs-search-result-section {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fd-docs-search-result-title {
+  flex: 0 1 auto;
+  color: var(--color-fd-foreground);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.fd-docs-search-result-section {
+  flex: 1 1 auto;
+  font-size: 12px;
+}
+
+.fd-docs-search-result-section::before {
+  content: "/ ";
+  opacity: 0.5;
+}
+
+.fd-docs-search-result-description {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--color-fd-muted-foreground);
+  font-size: 12px;
+  line-height: 1.45;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.fd-docs-search-status {
+  display: grid;
+  min-height: 150px;
+  place-items: center;
+  padding: 24px;
+  color: var(--color-fd-muted-foreground);
+  font-size: 13px;
+  text-align: center;
+}
+
+.fd-docs-search-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  white-space: nowrap;
+}
+
+.fd-docs-search-root[data-search-state="loading"] .fd-docs-search-icon {
+  animation: fd-docs-search-pulse 900ms ease-in-out infinite;
+}
+
+@keyframes fd-docs-search-pulse {
+  50% {
+    opacity: 0.35;
+  }
 }
 
 .fd-toc {
@@ -410,6 +740,14 @@ code:not(pre code) {
     display: none !important;
   }
 
+  .fd-docs-search-root {
+    padding-top: 8px;
+  }
+
+  .fd-docs-search-dialog {
+    max-height: calc(100dvh - 16px);
+  }
+
   .sidebar-backdrop {
     position: fixed;
     inset: 0;
@@ -498,5 +836,11 @@ code:not(pre code) {
   .fd-page-nav-next {
     align-items: flex-start;
     text-align: left;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fd-docs-search-root[data-search-state="loading"] .fd-docs-search-icon {
+    animation: none;
   }
 }

--- a/packages/farm/src/docs/search-client.ts
+++ b/packages/farm/src/docs/search-client.ts
@@ -1,0 +1,85 @@
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import type { FarmDocsResolvedConfig } from "./types";
+
+export function isFarmDocsSearchEnabled(docs: FarmDocsResolvedConfig | undefined): boolean {
+  if (!docs?.enabled) return false;
+
+  const search = docs.config.search;
+  if (search === false) return false;
+  return !(search && typeof search === "object" && search.enabled === false);
+}
+
+export function resolveFarmDocsSearchClientModule(root: string): string {
+  try {
+    const requireFromApp = createRequire(path.join(path.resolve(root), "package.json"));
+    const themeEntry = requireFromApp.resolve("@farming-labs/theme");
+    const commandSearchModule = path.join(path.dirname(themeEntry), "docs-command-search.mjs");
+    if (existsSync(commandSearchModule)) return commandSearchModule;
+  } catch {
+    // The public package entry remains a compatible fallback.
+  }
+
+  return "@farming-labs/theme";
+}
+
+export function generateFarmDocsSearchClientRuntime(
+  enabled: boolean,
+  moduleId = "@farming-labs/theme",
+): string {
+  if (!enabled) {
+    return `
+function isFarmDocsSearchPage() {
+  return false;
+}
+
+async function mountFarmDocsSearch() {
+  return false;
+}
+`;
+  }
+
+  return `
+let farmDocsSearchRoot = null;
+let farmDocsSearchContainer = null;
+let farmDocsSearchModulePromise = null;
+
+function isFarmDocsSearchPage() {
+  return document.querySelector('[data-farm-docs-search-root]') instanceof HTMLElement;
+}
+
+async function mountFarmDocsSearch() {
+  const container = document.querySelector('[data-farm-docs-search-root]');
+  if (!(container instanceof HTMLElement)) return false;
+  if (farmDocsSearchContainer === container && farmDocsSearchRoot) return true;
+
+  try {
+    farmDocsSearchModulePromise ||= import(${JSON.stringify(moduleId)});
+    const { DocsCommandSearch } = await farmDocsSearchModulePromise;
+    if (!container.isConnected) return false;
+
+    if (farmDocsSearchRoot) {
+      try {
+        farmDocsSearchRoot.unmount();
+      } catch {}
+    }
+
+    farmDocsSearchContainer = container;
+    farmDocsSearchRoot = createRoot(container);
+    farmDocsSearchRoot.render(
+      React.createElement(DocsCommandSearch, {
+        api: container.dataset.api || '/api/docs',
+      }),
+    );
+    return true;
+  } catch (error) {
+    farmDocsSearchModulePromise = null;
+    console.error('[Farm.js] Could not load docs search:', error);
+    return false;
+  }
+}
+
+window.__FARM_MOUNT_DOCS_SEARCH__ = mountFarmDocsSearch;
+`;
+}

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -35,6 +35,11 @@ import {
   createFarmDocsLastModifiedManifest,
   FARM_DOCS_LAST_MODIFIED_MANIFEST,
 } from "../docs/last-modified";
+import {
+  generateFarmDocsSearchClientRuntime,
+  isFarmDocsSearchEnabled,
+  resolveFarmDocsSearchClientModule,
+} from "../docs/search-client";
 
 // Type alias for OutputBundle
 type OutputBundle = Rollup.OutputBundle;
@@ -422,7 +427,14 @@ async function buildClient(
   await fs.mkdir(clientEntryRoot, { recursive: true });
   const clientEntryDir = await fs.mkdtemp(path.join(clientEntryRoot, "client-entry-"));
   const clientEntryPath = path.join(clientEntryDir, "farm-client-entry.tsx");
-  const clientHydrationCode = generateClientHydrationEntry(clientPages, layoutRoutes, root, srcDir);
+  const clientHydrationCode = generateClientHydrationEntry(
+    clientPages,
+    layoutRoutes,
+    root,
+    srcDir,
+    isFarmDocsSearchEnabled(config.docs),
+    resolveFarmDocsSearchClientModule(root),
+  );
 
   // Write the client entry to a temporary file
   await fs.writeFile(clientEntryPath, clientHydrationCode);
@@ -616,6 +628,8 @@ function generateClientHydrationEntry(
   layoutRoutes: Array<{ pattern: string; modulePath: string }>,
   root: string,
   srcDir: string,
+  docsSearchEnabled: boolean,
+  docsSearchModuleId: string,
 ): string {
   const toImportPath = (targetPath: string) => targetPath.replace(/\\/g, "/");
 
@@ -647,8 +661,10 @@ ${layoutImports}
 import React from "react";
 import { createRoot, hydrateRoot } from "react-dom/client";
 import { installChunkErrorRecovery } from "@farmjs/core/client";
+${generateFarmDocsSearchClientRuntime(docsSearchEnabled, docsSearchModuleId)}
 
 installChunkErrorRecovery();
+mountFarmDocsSearch();
 
 // SPA Router for server-rendered pages (HTML swap)
 const spaRouter = {
@@ -828,6 +844,7 @@ import { createRoot, hydrateRoot } from "react-dom/client";
 import { installChunkErrorRecovery } from "@farmjs/core/client";
 
 ${imports.join("\n")}
+${generateFarmDocsSearchClientRuntime(docsSearchEnabled, docsSearchModuleId)}
 
 installChunkErrorRecovery();
 
@@ -1192,7 +1209,11 @@ document.addEventListener("click", function(e) {
 });
 
 // Initial hydration
-hydrate();
+if (isFarmDocsSearchPage()) {
+  mountFarmDocsSearch();
+} else {
+  hydrate();
+}
 `.trim();
 }
 
@@ -1804,7 +1825,7 @@ globalThis.__FARM_DOCS_RUNTIME_CONFIG__ = {
 };
 const farmDocsHandler = ${
     config.docs?.enabled
-      ? `createFarmDocsHandler(farmDocsResolvedConfig, { root: farmDocsRuntimeRoot, srcDir: ${JSON.stringify(config.srcDir)} })`
+      ? `createFarmDocsHandler(farmDocsResolvedConfig, { root: farmDocsRuntimeRoot, srcDir: ${JSON.stringify(config.srcDir)}, clientEntry: "/farm-client.js" })`
       : "null"
   };
 const farmDocsAPIHandler = ${

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -21,6 +21,11 @@ import {
   getFarmDocsRouteTypeEntries,
   isFarmDocsAPIRequest,
 } from "./docs";
+import {
+  generateFarmDocsSearchClientRuntime,
+  isFarmDocsSearchEnabled,
+  resolveFarmDocsSearchClientModule,
+} from "./docs/search-client";
 import { createMarkdownMirrorResponse } from "./markdown";
 import { createFarmMarkdownSourceResponse, isFarmMarkdownPageFile } from "./app-markdown";
 import { sendWebResponse } from "./server/response";
@@ -587,6 +592,7 @@ export function farmPlugin(
       const farmDocsHandler = createFarmDocsHandler(farmConfig.docs, {
         root: farmConfig.root,
         srcDir: farmConfig.srcDir,
+        clientEntry: "/@farm/client.js",
       });
       const farmDocsAPIHandler = farmConfig.docs?.enabled
         ? createFarmDocsAPIHandler({
@@ -1398,6 +1404,10 @@ export function farmPlugin(
             ...getIntegrationDocumentNavigationMatchers(integrations),
             ...getFarmDocsDocumentNavigationMatchers(resolvedConfig?.docs),
           ],
+          isFarmDocsSearchEnabled(resolvedConfig?.docs),
+          resolveFarmDocsSearchClientModule(
+            resolvedConfig?.root || server?.config.root || process.cwd(),
+          ),
         );
       }
 
@@ -2164,6 +2174,8 @@ function parseRouteModuleSchema(
 function generateClientCode(
   integrationProviders: Array<{ name: string; type: string; props?: Record<string, unknown> }> = [],
   documentNavigationMatchers: string[] = [],
+  docsSearchEnabled = false,
+  docsSearchModuleId = "@farming-labs/theme",
 ): string {
   const hasClerkProvider = integrationProviders.some((provider) => provider.type === "clerk");
   const providerImportBlock = hasClerkProvider
@@ -2181,6 +2193,7 @@ import {
   isFarmDeploymentMismatchResponse,
 } from '@farmjs/core/deployment'
 ${providerImportBlock}
+${generateFarmDocsSearchClientRuntime(docsSearchEnabled, docsSearchModuleId)}
 
 // ⭐ Farm.js SPA Client Runtime (TanStack Start pattern)
 // Uses manifest-based chunk loading - NO HTML fetching!
@@ -2979,6 +2992,11 @@ async function renderPage(pageData) {
 spaRouter.setNavigationHandler(renderPage);
 
 async function hydrate() {
+  if (isFarmDocsSearchPage()) {
+    await mountFarmDocsSearch();
+    return;
+  }
+
   const rootContainer = document.getElementById('root')
   
   if (!rootContainer) {


### PR DESCRIPTION
## Summary

- add a compact docs search control between the Farm.js brand and the docs label
- open an accessible Fumadocs-style search dialog with Cmd+S or Ctrl+S
- reuse the existing `docs.search` provider and `/api/docs?query=` endpoint
- support keyboard result navigation, cancellation, safe text rendering, focus restoration, and responsive layouts
- hide the search UI and runtime when `search: false` or `search.enabled: false`
- preserve section anchors during client navigation and keep sidebar scrolling isolated from the page
- document configuration, providers, shortcuts, and disabled behavior

## Validation

- `pnpm --filter @farmjs/core test` (64 files, 562 passed, 1 skipped)
- `pnpm --filter @farmjs/core build`
- `pnpm --dir docs build`
- desktop and 390px mobile browser verification
- click, Cmd+S, input focus, loading/results, arrow navigation, Enter, Escape, anchor navigation, and horizontal overflow checks
- no browser console errors