### PR TITLE
fix: emit deployed favicon in document head

### DIFF
--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -8,6 +8,9 @@ export const metadata = {
   title: "farmjs.dev - React framework for integrated apps",
   description:
     "Farm.js is an easy and fast React framework that blends app foundations and external services into one flow so teams can ship products faster.",
+  icons: {
+    icon: [{ url: "/favicon.svg", type: "image/svg+xml", sizes: "any" }],
+  },
 };
 
 const fontFaceCss = `
@@ -45,7 +48,6 @@ const fontFaceCss = `
 export default function RootLayout({ children }: LayoutProps) {
   return (
     <>
-      <link rel="icon" href="/favicon.svg" type="image/svg+xml" sizes="any" />
       <link rel="preload" href={geistSansUrl} as="font" type="font/woff2" crossOrigin="anonymous" />
       <link rel="preload" href={geistMonoUrl} as="font" type="font/woff2" crossOrigin="anonymous" />
       <link

--- a/packages/farm/src/__tests__/metadata.test.ts
+++ b/packages/farm/src/__tests__/metadata.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { renderMetadataHead } from "../metadata";
+
+describe("metadata head rendering", () => {
+  it("reports when favicon metadata emits a browser icon", () => {
+    const rendered = renderMetadataHead({
+      icons: {
+        icon: [{ url: "/favicon.svg", type: "image/svg+xml", sizes: "any" }],
+      },
+    });
+
+    expect(rendered.hasFavicon).toBe(true);
+    expect(rendered.tags).toContain(
+      '<link rel="icon" href="/favicon.svg" sizes="any" type="image/svg+xml">',
+    );
+  });
+
+  it("keeps the fallback available when only an Apple touch icon is configured", () => {
+    const rendered = renderMetadataHead({
+      icons: {
+        apple: "/apple-touch-icon.png",
+      },
+    });
+
+    expect(rendered.hasFavicon).toBe(false);
+    expect(rendered.tags).toContain('<link rel="apple-touch-icon" href="/apple-touch-icon.png">');
+  });
+});

--- a/packages/farm/src/metadata.ts
+++ b/packages/farm/src/metadata.ts
@@ -14,6 +14,7 @@ export interface FarmMetadataImageReference {
 export interface RenderedMetadataHead {
   title: string;
   tags: string;
+  hasFavicon: boolean;
 }
 
 type MetadataRecord = Metadata & Record<string, any>;
@@ -107,7 +108,7 @@ export function renderMetadataHead(metadata: MetadataRecord | undefined): Render
     }
   }
 
-  appendIcons(tags, (resolvedMetadata as any).icons, metadataBase);
+  const hasFavicon = appendIcons(tags, (resolvedMetadata as any).icons, metadataBase);
 
   if ((resolvedMetadata as any).manifest) {
     appendLink(
@@ -123,6 +124,7 @@ export function renderMetadataHead(metadata: MetadataRecord | undefined): Render
   return {
     title: escapeText(title),
     tags: tags.length > 0 ? `\n  ${tags.join("\n  ")}` : "",
+    hasFavicon,
   };
 }
 
@@ -147,7 +149,10 @@ function appendOpenGraph(tags: string[], openGraph: Metadata["openGraph"], metad
   appendMetaProperty(tags, "og:type", openGraph.type);
   appendMetaProperty(tags, "og:locale", (openGraph as any).locale);
 
-  const images = normalizeMetadataImages(openGraph.images ?? (openGraph as any).image, metadataBase);
+  const images = normalizeMetadataImages(
+    openGraph.images ?? (openGraph as any).image,
+    metadataBase,
+  );
   for (const image of images) {
     appendMetaProperty(tags, "og:image", image.url);
     appendMetaProperty(tags, "og:image:width", image.width);
@@ -172,19 +177,23 @@ function appendTwitter(tags: string[], twitter: Metadata["twitter"], metadataBas
   }
 }
 
-function appendIcons(tags: string[], icons: unknown, metadataBase?: string) {
-  if (!icons) return;
+function appendIcons(tags: string[], icons: unknown, metadataBase?: string): boolean {
+  if (!icons) return false;
 
   if (typeof icons === "string") {
+    const initialTagCount = tags.length;
     appendLink(tags, "icon", resolveMetadataUrl(icons, metadataBase));
-    return;
+    return tags.length > initialTagCount;
   }
 
-  if (!isRecord(icons)) return;
+  if (!isRecord(icons)) return false;
 
+  const initialTagCount = tags.length;
   appendIconList(tags, "icon", icons.icon, metadataBase);
   appendIconList(tags, "shortcut icon", icons.shortcut, metadataBase);
+  const hasFavicon = tags.length > initialTagCount;
   appendIconList(tags, "apple-touch-icon", icons.apple, metadataBase);
+  return hasFavicon;
 }
 
 function appendIconList(tags: string[], rel: string, value: unknown, metadataBase?: string) {

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -2468,6 +2468,7 @@ async function handleFarmRequest(request) {
         const renderedMetadata = renderMetadataHead(mergedMetadata);
         const title = renderedMetadata.title;
         const metaTags = renderedMetadata.tags;
+        const hasFavicon = renderedMetadata.hasFavicon;
         
         // Check if the layout already rendered a full HTML document
         const trimmedHtml = html.trim();
@@ -2504,7 +2505,7 @@ async function handleFarmRequest(request) {
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" href="data:,">
+  \${hasFavicon ? "" : '<link rel="icon" href="data:,">'}
   <title>\${title}</title>\${metaTags}
   <link rel="stylesheet" href="/farm-client.css">
 </head>

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -1205,9 +1205,7 @@ export class ServerRenderer {
     res.setHeader("X-Content-Type-Options", "nosniff");
     res.setHeader(
       "Cache-Control",
-      isVersioned
-        ? "public, max-age=31536000, immutable"
-        : "public, max-age=0, must-revalidate",
+      isVersioned ? "public, max-age=31536000, immutable" : "public, max-age=0, must-revalidate",
     );
 
     if (req.headers["if-none-match"] === etag) {
@@ -1399,7 +1397,11 @@ window.__FARM_INTEGRATION_API_MANIFEST__ = ${JSON.stringify(getRegisteredIntegra
           ? createPreHydrationClickQueueScript()
           : "";
 
-      const { title, tags: metaTags } = renderMetadataHead((req as any).__FARM_METADATA__);
+      const {
+        title,
+        tags: metaTags,
+        hasFavicon,
+      } = renderMetadataHead((req as any).__FARM_METADATA__);
 
       // React 19: ensure root is a single DOM node so streaming starts early (avoids Fragment delay)
       const streamRoot = React.createElement("div", { style: { display: "contents" } }, element);
@@ -1420,7 +1422,7 @@ window.__FARM_INTEGRATION_API_MANIFEST__ = ${JSON.stringify(getRegisteredIntegra
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="farm-deployment-id" content="${escapeHtmlAttribute(deploymentId)}">
-  <link rel="icon" href="data:,">
+  ${hasFavicon ? "" : '<link rel="icon" href="data:,">'}
   <title>${title}</title>${metaTags}
   <link rel="stylesheet" href="/src/app/globals.css" />
   <script type="module" src="/@vite/client"></script>


### PR DESCRIPTION
## Summary

- declare the docs favicon through Farm metadata so it is emitted in the document head
- report whether metadata rendered a browser favicon and suppress the empty `data:,` fallback in development and Nitro production when it did
- preserve the empty fallback for apps without favicon metadata
- add focused metadata rendering coverage

## Root cause

The deployed page emitted `<link rel="icon" href="data:,">` in `<head>`, while the real SVG favicon was rendered inside the page body. The SVG asset itself deployed correctly, but the browser was left with the empty head favicon.

## Verification

- `pnpm --filter @farmjs/core test -- metadata.test.ts`
- focused `oxlint` and `oxfmt --check` on all changed files
- `pnpm --filter farmjs-docs build`
- executed the generated Vercel handler and confirmed one `/favicon.svg` declaration in `<head>`, with no empty favicon
- confirmed the built static favicon matches `docs/public/favicon.svg`

## Existing repository checks

- repository-wide `pnpm format:check` still reports 49 pre-existing files outside this change
- package type checking still reports existing missing-module and Nitro/Vite typing failures unrelated to this patch