### PR TITLE
fix: compact mobile docs code blocks

### DIFF
--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -524,6 +524,9 @@ describe("createFarmDocsHandler", () => {
     expect(html).toContain(
       "#nd-docs-layout figure.shiki.code-block > .code-copy-floating { opacity: 0.72;",
     );
+    expect(html).toContain("@media (max-width: 640px)");
+    expect(html).toContain(".code-block-header { min-height: 22px;");
+    expect(html).toContain("padding: 10px !important; font-size: 11px;");
     expect(html).toContain("text-transform: lowercase");
     expect(html).toContain('.code-copy[data-copied="true"] .code-copy-check { display: block; }');
     expect(html).not.toContain('<span class="code-block-title">bash</span>');

--- a/packages/farm/src/docs/handler.ts
+++ b/packages/farm/src/docs/handler.ts
@@ -1769,6 +1769,15 @@ function renderFarmDocsBridgeCss(docs: FarmDocsResolvedConfig): string {
       .fd-page-footer { align-items: flex-start; flex-direction: column; }
       .fd-page-footer .fd-last-updated-footer { margin-left: 0; }
     }
+    @media (max-width: 640px) {
+      .code-block-header { min-height: 22px; padding: 1px 4px 1px 7px; }
+      .code-block-title { font-size: 9px; }
+      .code-copy { width: 20px; height: 20px; }
+      .code-copy svg { width: 12px; height: 12px; }
+      .code-copy-floating { top: 5px; right: 5px; }
+      #nd-docs-layout figure.shiki.code-block pre, .code-block pre { padding: 10px !important; font-size: 11px; line-height: 1.55; }
+      .sh__line { min-height: 1.55em; }
+    }
 ${farmDocsPixelBorderCss}
   `;
 }

--- a/packages/farm/src/docs/pixel-border.css
+++ b/packages/farm/src/docs/pixel-border.css
@@ -628,6 +628,43 @@ code:not(pre code) {
   }
 }
 
+@media (max-width: 640px) {
+  .code-block-header {
+    min-height: 22px;
+    padding: 1px 4px 1px 7px;
+  }
+
+  .code-block-title {
+    font-size: 9px;
+  }
+
+  .code-copy {
+    width: 20px;
+    height: 20px;
+  }
+
+  .code-copy svg {
+    width: 12px;
+    height: 12px;
+  }
+
+  .code-copy-floating {
+    top: 5px;
+    right: 5px;
+  }
+
+  #nd-docs-layout figure.shiki.code-block pre,
+  .code-block pre {
+    padding: 10px !important;
+    font-size: 11px;
+    line-height: 1.55;
+  }
+
+  .sh__line {
+    min-height: 1.55em;
+  }
+}
+
 /* Docs command search */
 .topbar-actions .fd-docs-search-trigger {
   width: 56px;


### PR DESCRIPTION
## Summary

- tighten titled code-block headers on phone-sized viewports
- align titled and untitled code bodies with the same compact type and padding
- cover the mobile CSS contract in the docs renderer test

## Verification

- `corepack pnpm exec vitest run src/__tests__/docs-handler.test.ts` (14 passed)
- `corepack pnpm --filter @farmjs/core build`
- verified `/docs/images` at 419px with no console errors or horizontal overflow