### PR TITLE
fix: externalize sharp from server bundle

### DIFF
--- a/packages/farm/src/__tests__/production-middleware.test.ts
+++ b/packages/farm/src/__tests__/production-middleware.test.ts
@@ -41,6 +41,20 @@ describe("production middleware runtime", () => {
           ),
         ),
       ).resolves.toBeUndefined();
+      const nitroBundle = await fs.readFile(
+        path.join(
+          root,
+          ".vercel",
+          "output",
+          "functions",
+          "__nitro.func",
+          "chunks",
+          "nitro",
+          "nitro.mjs",
+        ),
+        "utf8",
+      );
+      expect(nitroBundle).not.toContain("@img/sharp-");
       globalThis.fetch = (async (input: URL | RequestInfo, init?: RequestInit) => {
         const url = new URL(input instanceof Request ? input.url : String(input));
         if (url.origin === "https://example.test" && url.pathname.endsWith(productAssetName!)) {

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1492,6 +1492,7 @@ async function buildSSRInMemory(
           // Externalize native modules and Node.js built-ins
           external: [
             "fsevents",
+            "sharp",
             "@prisma/client",
             "@prisma/client/default",
             "@prisma/client/default.js",
@@ -1519,6 +1520,7 @@ async function buildSSRInMemory(
         // These have native binaries that won't work in serverless environments
         external: [
           "fsevents",
+          "sharp",
           "esbuild",
           "lightningcss",
           "rollup",


### PR DESCRIPTION
## Summary

- externalize `sharp` during the first Vite SSR build
- prevent Rollup's CommonJS transform from inlining Sharp's native binary loader
- add regression coverage that rejects bundled `@img/sharp-*` loader code

## Root cause

The Node image runtime imports `farm/image-sharp`, but `sharp` was only externalized during the later Nitro build. By then Vite had already bundled Sharp and replaced its platform-dependent native requires with a throwing CommonJS helper. The generated Vercel function therefore crashed during module initialization with `FUNCTION_INVOCATION_FAILED`, causing every farmjs.dev route to return 500.

## Impact

Vercel will keep Sharp as a runtime dependency and load the Linux native package copied into the function instead of executing Rollup's dynamic-require shim. Image optimization remains enabled.

## Validation

- `pnpm --filter @farmjs/core test -- production-middleware.test.ts`
- `pnpm --dir docs run build`
- imported the generated Vercel function successfully
- invoked generated `/docs` handler: HTTP 200
- confirmed final Nitro bundle contains no `@img/sharp-*` loader code
- `git diff --check`

## Notes

The broader `@farmjs/core` type-check still reports existing unrelated errors in Nitro/query-state typings and missing type dependencies.