### PR TITLE
test: add internationalization e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Setup pnpm cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,28 @@ jobs:
         run: |
           cd playground
           pnpm build
+
+  i18n-e2e:
+    name: Internationalization E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run internationalization E2E
+        run: pnpm test:e2e:i18n

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 8
 
@@ -68,7 +68,7 @@ jobs:
           node-version: 20
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 8
 
@@ -94,7 +94,7 @@ jobs:
           node-version: 20
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 8
 
@@ -129,7 +129,7 @@ jobs:
           node-version: 20
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 8
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:ci": "node scripts/run-tests.js",
     "test:e2e": "playwright test",
     "test:e2e:framework": "corepack pnpm --filter @farmjs/core build && playwright test tests/e2e/framework-features.spec.ts",
+    "test:e2e:i18n": "corepack pnpm --filter @farmjs/core build && corepack pnpm --filter @farmjs/cli build && corepack pnpm --filter farm-i18n-example build && playwright test --config playwright.i18n.config.ts",
     "test:e2e:rsc": "corepack pnpm --filter @farmjs/core build && corepack pnpm --filter @farmjs/plugin build && NITRO_PRESET=node-server corepack pnpm --filter farm-rsc-demo build && playwright test --config playwright.rsc.config.ts",
     "test:e2e:list": "playwright test --list",
     "docs:dev": "pnpm --filter @farmjs/core build && pnpm --filter farmjs-docs dev",

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -3353,10 +3353,29 @@ async function buildNitroUniversal(
 import { defineEventHandler } from 'h3'
 import handler from './${ssrEntryFile}'
 
+function mergeVaryHeaders(target, source) {
+  const values = new Set(
+    [target.get('Vary'), source]
+      .filter(Boolean)
+      .flatMap((value) => value.split(','))
+      .map((value) => value.trim())
+      .filter(Boolean),
+  )
+
+  if (values.size > 0) target.set('Vary', Array.from(values).join(', '))
+}
+
 // Export the wrapped handler for Nitro
-export default defineEventHandler((event) => handler.fetch(event.req, {
-  waitUntil: (promise) => event.waitUntil(promise),
-}))
+export default defineEventHandler(async (event) => {
+  const response = await handler.fetch(event.req, {
+    waitUntil: (promise) => event.waitUntil(promise),
+  })
+
+  // Nitro records asset compression negotiation on the event response. Merge
+  // Farm's cache signals there so H3 preserves both sets of Vary values.
+  mergeVaryHeaders(event.res.headers, response.headers.get('Vary'))
+  return response
+})
   `.trim();
 
   await fs.writeFile(nitroEntryPath, nitroEntryCode);

--- a/playwright.i18n.config.ts
+++ b/playwright.i18n.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e-i18n",
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  use: {
+    baseURL: "http://localhost:4175",
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: "NODE_ENV=production PORT=4175 node examples/i18n/.farm/.output/server/index.mjs",
+    url: "http://localhost:4175",
+    reuseExistingServer: false,
+    timeout: 30_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"], channel: "chrome" },
+    },
+  ],
+});

--- a/tests/e2e-i18n/i18n.spec.ts
+++ b/tests/e2e-i18n/i18n.spec.ts
@@ -1,0 +1,155 @@
+import { expect, test } from "@playwright/test";
+
+function expectVaryIncludes(vary: string | undefined, expected: string[]) {
+  const values = new Set(
+    (vary ?? "")
+      .split(",")
+      .map((value) => value.trim().toLowerCase())
+      .filter(Boolean),
+  );
+
+  for (const value of expected) expect(values).toContain(value.toLowerCase());
+}
+
+test.describe("Farm internationalization", () => {
+  test("resolves signals, canonicalizes URLs, and preserves cache boundaries", async ({
+    request,
+  }) => {
+    const browserDetected = await request.get("/", {
+      headers: { "accept-language": "am-ET, en;q=0.8" },
+      maxRedirects: 0,
+    });
+    expect(browserDetected.status()).toBe(307);
+    expect(browserDetected.headers().location).toBe("/am");
+    expect(browserDetected.headers()["cache-control"]).toBe("private, no-store");
+    expectVaryIncludes(browserDetected.headers().vary, [
+      "Accept-Encoding",
+      "Cookie",
+      "Accept-Language",
+    ]);
+    expect(browserDetected.headers()["set-cookie"]).toContain("farm_locale=am");
+
+    const cookieDetected = await request.get("/", {
+      headers: {
+        cookie: "farm_locale=ar",
+        "accept-language": "am",
+      },
+      maxRedirects: 0,
+    });
+    expect(cookieDetected.status()).toBe(307);
+    expect(cookieDetected.headers().location).toBe("/ar");
+
+    const explicitLocale = await request.get("/am", {
+      headers: {
+        cookie: "farm_locale=ar",
+        "accept-language": "en",
+      },
+    });
+    expect(explicitLocale.status()).toBe(200);
+    expect(explicitLocale.headers()["cache-control"]).toContain("public");
+    expectVaryIncludes(explicitLocale.headers().vary, ["Accept-Encoding"]);
+    expect(explicitLocale.headers().vary).not.toContain("Cookie");
+    expect(explicitLocale.headers().vary).not.toContain("Accept-Language");
+    expect(explicitLocale.headers()["set-cookie"]).toBeUndefined();
+
+    const html = await explicitLocale.text();
+    expect(html).toContain('<html lang="am" dir="ltr">');
+    expect(html).toContain("አንድ መተግበሪያ፣ ለሁሉም ቋንቋ");
+    expect(html).toContain('hreflang="en" href="/"');
+    expect(html).toContain('hreflang="am" href="/am"');
+    expect(html).toContain('hreflang="ar" href="/ar"');
+    expect(html).toContain('hreflang="x-default" href="/"');
+
+    const defaultPrefix = await request.get("/en", { maxRedirects: 0 });
+    expect(defaultPrefix.status()).toBe(307);
+    expect(defaultPrefix.headers().location).toBe("/");
+
+    const localeCase = await request.get("/AM", { maxRedirects: 0 });
+    expect(localeCase.status()).toBe(307);
+    expect(localeCase.headers().location).toBe("/am");
+  });
+
+  test("provides localized API context without changing the API URL", async ({ request }) => {
+    const browserDetected = await request.get("/api/locale", {
+      headers: { "accept-language": "am" },
+    });
+    expect(browserDetected.status()).toBe(200);
+    await expect(browserDetected.json()).resolves.toEqual({
+      locale: "am",
+      source: "accept-language",
+      message: expect.stringContaining("ጉብኝቶች"),
+    });
+    expect(browserDetected.headers()["cache-control"]).toBe("private, no-store");
+    expectVaryIncludes(browserDetected.headers().vary, [
+      "Accept-Encoding",
+      "Cookie",
+      "Accept-Language",
+    ]);
+
+    const cookieDetected = await request.get("/api/locale", {
+      headers: {
+        cookie: "farm_locale=ar",
+        "accept-language": "am",
+      },
+    });
+    expect(cookieDetected.status()).toBe(200);
+    await expect(cookieDetected.json()).resolves.toEqual({
+      locale: "ar",
+      source: "cookie",
+      message: expect.stringContaining("زيارات"),
+    });
+  });
+
+  test("hydrates translated content and switches persisted RTL locale", async ({
+    context,
+    page,
+  }) => {
+    const browserErrors: string[] = [];
+    page.on("console", (message) => {
+      if (message.type() === "error") browserErrors.push(message.text());
+    });
+    page.on("pageerror", (error) => browserErrors.push(error.message));
+
+    await page.goto("/");
+
+    await expect(page.locator("html")).toHaveAttribute("lang", "en");
+    await expect(page.locator("html")).toHaveAttribute("dir", "ltr");
+    await expect(page.getByRole("heading", { level: 1 })).toHaveText(
+      "One application, every locale",
+    );
+    await expect(page.getByRole("button", { name: "English" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    await page.getByRole("button", { name: "Amharic" }).click();
+    await expect(page).toHaveURL(/\/am$/);
+    await expect(page.locator("html")).toHaveAttribute("lang", "am");
+    await expect(page.locator("html")).toHaveAttribute("dir", "ltr");
+    await expect(page.getByRole("heading", { level: 1 })).toHaveText("አንድ መተግበሪያ፣ ለሁሉም ቋንቋ");
+    await expect(page.getByRole("button", { name: "አማርኛ" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect.poll(() => page.evaluate(() => window.__FARM_I18N__?.locale)).toBe("am");
+
+    await page.getByRole("button", { name: "ዓረብኛ" }).click();
+    await expect(page).toHaveURL(/\/ar$/);
+    await expect(page.locator("html")).toHaveAttribute("lang", "ar");
+    await expect(page.locator("html")).toHaveAttribute("dir", "rtl");
+    await expect(page.getByRole("heading", { level: 1 })).toHaveText("تطبيق واحد لكل لغة");
+    await expect(page.getByRole("button", { name: "العربية" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect.poll(() => page.evaluate(() => window.__FARM_I18N__?.locale)).toBe("ar");
+
+    const localeCookie = (await context.cookies()).find((cookie) => cookie.name === "farm_locale");
+    expect(localeCookie?.value).toBe("ar");
+
+    await page.goto("/");
+    await expect(page).toHaveURL(/\/ar$/);
+    await expect(page.locator("html")).toHaveAttribute("dir", "rtl");
+    expect(browserErrors).toEqual([]);
+  });
+});

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -12,6 +12,16 @@ Run the framework feature integration suite, including the required framework bu
 pnpm test:e2e:framework
 ```
 
+Run the production internationalization suite with:
+
+```sh
+pnpm test:e2e:i18n
+```
+
+The i18n suite builds the framework and `examples/i18n`, starts the Nitro production server, and
+verifies locale signal precedence, canonical redirects, cache boundaries, localized API context,
+hydration, client locale switching, cookie persistence, and RTL rendering.
+
 ## Framework feature coverage
 
 `framework-features.spec.ts` runs the features together in `examples/basic` and verifies:


### PR DESCRIPTION
## Summary

- add a production Playwright suite for Farm internationalization
- cover locale signal precedence, canonical redirects, cache boundaries, localized API context, hydration, persisted locale switching, and RTL rendering
- run the suite in CI through a dedicated `test:e2e:i18n` command
- preserve Farm locale `Vary` values when Nitro also negotiates compressed responses
- update the CI cache and pnpm setup actions to their current Node 20-based releases

## Why

The merged i18n feature had strong unit coverage but no browser-level production verification. While adding that coverage, the suite found that Nitro's asset middleware could overwrite `Cookie` and `Accept-Language` cache signals with `Accept-Encoding`. The Nitro adapter now merges both sets of values.

## Validation

- `pnpm test:e2e:i18n` (3 tests passed)
- `pnpm --filter @farmjs/core test -- src/__tests__/i18n.test.ts` (16 tests passed)
- `pnpm exec oxfmt --check packages/farm/src/nitro/universal-build.ts tests/e2e-i18n/i18n.spec.ts playwright.i18n.config.ts`
- `actionlint .github/workflows/ci.yml` (0 errors)
- `git diff --check`

## Hosted CI status

GitHub is currently terminating this repository's Actions events with `startup_failure` before it creates any jobs or logs. The same nameless `BuildFailed` event affects recent `main` and unrelated branch runs. The workflow validates locally and its retired action runtimes have been updated, so the remaining repository-wide Actions account state needs to be cleared before the hosted E2E job can execute.
