### PR TITLE
fix: align production docs styling

### DIFF
--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -361,6 +361,10 @@ describe("createFarmDocsHandler", () => {
     expect(html).toContain('class="fd-page-nav-title fd-page-nav-title-next"');
     expect(html).toContain('<span class="fd-page-nav-description">Next Page</span>');
     expect(html).not.toContain('class="fd-page-nav-label"');
+    expect(html).toContain("--color-fd-background: #000 !important;");
+    expect(html).toContain("min-height: 98px;");
+    expect(html).toContain("border-radius: 0 !important;");
+    expect(html).toContain("font-size: 0.875rem; font-weight: 500; line-height: 1.5;");
     expect(html).toContain('href="/docs/guide"');
     expect(html).toContain("Farm docs pixel-border bridge");
     expect(html).toContain('class="toc-scroll"');

--- a/packages/farm/src/docs/handler.ts
+++ b/packages/farm/src/docs/handler.ts
@@ -1717,12 +1717,12 @@ function renderFarmDocsBridgeCss(docs: FarmDocsResolvedConfig): string {
     img { max-width: 100%; height: auto; border: 1px solid var(--color-fd-border, hsl(0 0% 15%)); }
     .fd-page-nav { display: grid; width: 100%; max-width: 100%; grid-template-columns: 1fr; gap: 16px; margin-top: 16px; border-top: 0; padding-top: 0; }
     .fd-page-nav:has(.fd-page-nav-prev):has(.fd-page-nav-next) { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-    #nd-docs-layout .fd-page-nav-card { display: flex; min-width: 0; min-height: 95px; flex-direction: column; justify-content: flex-start; gap: 8px; border: 1px solid var(--color-fd-border, hsl(0 0% 15%)); border-radius: 8px !important; background: transparent; padding: 16px; color: var(--color-fd-foreground, oklch(0.985 0.001 106.423)); text-decoration: none; transition: background-color 150ms ease, border-color 150ms ease; }
-    .fd-page-nav-card:hover { border-color: var(--color-fd-border, hsl(0 0% 15%)); background: var(--color-fd-muted, hsl(0 0% 10%)); }
+    #nd-docs-layout .fd-page-nav-card { display: flex; min-width: 0; min-height: 98px; flex-direction: column; justify-content: flex-start; gap: 8px; border: 1px solid var(--color-fd-border, hsl(0 0% 15%)); border-radius: 0 !important; background: transparent; padding: 16px; color: var(--color-fd-foreground, oklch(0.985 0.001 106.423)); text-decoration: none; transition: background-color 150ms ease, border-color 150ms ease; }
+    .fd-page-nav-card:hover { border-color: var(--color-fd-border, hsl(0 0% 15%)); background: color-mix(in srgb, var(--color-fd-muted, hsl(0 0% 10%)) 80%, transparent); }
     .fd-page-nav-next { align-items: flex-end; text-align: right; }
-    .fd-page-nav-title { display: inline-flex; max-width: 100%; min-height: 0; align-items: center; gap: 6px; overflow: hidden; color: var(--color-fd-foreground, oklch(0.985 0.001 106.423)); font-size: 1rem; font-weight: 500; line-height: 1.65; overflow-wrap: anywhere; }
+    .fd-page-nav-title { display: inline-flex; max-width: 100%; min-height: 0; align-items: center; gap: 6px; overflow: hidden; color: var(--color-fd-foreground, oklch(0.985 0.001 106.423)); font-size: 0.875rem; font-weight: 500; line-height: 1.5; overflow-wrap: anywhere; }
     .fd-page-nav-title svg { width: 1rem; height: 1rem; flex-shrink: 0; }
-    .fd-page-nav-description { display: block; max-width: 100%; min-height: 0; overflow: hidden; color: var(--color-fd-muted-foreground, hsl(0 0% 55%)); font-size: 1rem; font-weight: 400; line-height: 1.65; text-overflow: ellipsis; white-space: nowrap; }
+    .fd-page-nav-description { display: block; max-width: 100%; min-height: 0; overflow: hidden; color: var(--color-fd-muted-foreground, hsl(0 0% 55%)); font-size: 15.6px; font-weight: 400; line-height: 1.8; text-overflow: ellipsis; white-space: nowrap; }
     .fd-below-title-block { display: flex; flex-direction: column; align-items: flex-start; gap: 0.625rem; margin: 0 0 1.25rem; }
     .fd-page-actions { display: flex; width: 100%; align-items: center; gap: 0.5rem; }
     .fd-page-actions[data-actions-alignment="right"] { justify-content: flex-end; }

--- a/packages/farm/src/docs/pixel-border.css
+++ b/packages/farm/src/docs/pixel-border.css
@@ -4,7 +4,7 @@
  */
 
 :root {
-  --color-fd-background: hsl(0 0% 2%);
+  --color-fd-background: #000;
   --color-fd-foreground: oklch(0.985 0.001 106.423);
   --color-fd-card: hsl(0 0% 4%);
   --color-fd-card-foreground: oklch(0.985 0.001 106.423);
@@ -23,6 +23,16 @@
   --radius: 0px;
   --font-geist-sans: "Geist Sans";
   --font-geist-mono: "Geist Mono";
+}
+
+.dark {
+  --color-fd-background: #000 !important;
+}
+
+html,
+body,
+#nd-docs-layout {
+  background-color: var(--color-fd-background) !important;
 }
 
 @font-face {


### PR DESCRIPTION
## What changed

- force the generated docs shell to use the same true-black background in development and production
- restore the square, compact previous/next cards used by `oss/docs_/website`
- add renderer assertions for the production theme and pager geometry

## Root cause

The standalone docs theme applied its own `.dark` background variable with `!important`, overriding Farm's bridge value in the deployed bundle. The pager had also drifted to rounded cards and larger typography.

## Validation

- `pnpm --filter @farmjs/core test -- src/__tests__/docs-handler.test.ts` (14 passed)
- `pnpm --filter farmjs-docs build`
- desktop and mobile Playwright screenshots at 1440x1000 and 390x844
- inspected the generated Vercel/Nitro bundle for the black theme and pager rules