### PR TITLE
fix: bundle docs search styles

### DIFF
--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -17,6 +17,17 @@ import {
   createFarmDocsLastModifiedManifest,
   FARM_DOCS_LAST_MODIFIED_MANIFEST,
 } from "../docs/last-modified";
+import { farmDocsPixelBorderCss } from "../docs/pixel-border-css";
+
+describe("farmDocsPixelBorderCss", () => {
+  it("bundles the search dialog layout for production adapters", () => {
+    expect(farmDocsPixelBorderCss).toContain(".omni-overlay {\n  position: fixed;");
+    expect(farmDocsPixelBorderCss).toContain(
+      ".omni-content {\n  --omni-content-top: clamp(5rem, 16vh, 7rem);\n  position: fixed;",
+    );
+    expect(farmDocsPixelBorderCss).toContain(".omni-search-input {\n  width: 0;\n  flex: 1;");
+  });
+});
 
 describe("getFarmDocsDocumentNavigationMatchers", () => {
   it("routes enabled docs trees through document navigation", () => {

--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -250,6 +250,8 @@ describe("createFarmDocsHandler", () => {
     expect(html).toContain("font-family: var(--fd-docs-font-mono)");
     expect(html).toContain("width: min(680px, calc(100vw - 32px))");
     expect(html).toContain("width: calc(100vw - 20px)");
+    expect(html).toContain(".omni-overlay {\n  position: fixed;");
+    expect(html).toContain(".omni-content {\n  --omni-content-top:");
     expect(html).toContain(".omni-footer-hints {");
     expect(html).toContain("font-size: 16px");
     expect(html).not.toContain('id="farm-docs-search-dialog"');

--- a/packages/farm/src/docs/handler.ts
+++ b/packages/farm/src/docs/handler.ts
@@ -24,6 +24,7 @@ import {
 import { marked, Renderer } from "marked";
 import { highlight } from "sugar-high";
 import { resolveFarmDocsPageLastModified } from "./last-modified";
+import { farmDocsPixelBorderCss } from "./pixel-border-css";
 import { isFarmDocsSearchEnabled } from "./search-client";
 import type { FarmDocsResolvedConfig } from "./types";
 
@@ -53,30 +54,6 @@ const DOCS_FILE_EXTENSIONS = [".mdx", ".md"];
 const FARM_DOCS_FAVICON =
   "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='black'/%3E%3Cpath d='M7 8h18v3H10v5h12v3H10v5H7z' fill='white'/%3E%3C/svg%3E";
 
-function readFarmDocsPixelBorderCss(): string {
-  const candidates: Array<string | URL> = [];
-  try {
-    candidates.push(new URL("./pixel-border.css", import.meta.url));
-  } catch {
-    // CJS builds fall back to __dirname below.
-  }
-
-  if (typeof __dirname === "string") {
-    candidates.push(path.join(__dirname, "pixel-border.css"));
-  }
-
-  for (const candidate of candidates) {
-    try {
-      return readFileSync(candidate, "utf8");
-    } catch {
-      // Try the next source/dist layout.
-    }
-  }
-
-  return "";
-}
-
-const farmDocsPixelBorderCss = readFarmDocsPixelBorderCss();
 const GEIST_SANS_FONT_URL = "/assets/Geist-Variable-CrgPqtmy.woff2";
 const GEIST_MONO_FONT_URL = "/assets/GeistMono-Variable-BNLlm6Cd.woff2";
 

--- a/packages/farm/src/docs/pixel-border-css.ts
+++ b/packages/farm/src/docs/pixel-border-css.ts
@@ -1,3 +1,4 @@
+export const farmDocsPixelBorderCss = String.raw`
 /* Farm docs pixel-border bridge.
  * This follows the local @farming-labs/docs pixel-border theme while covering
  * the frameworkless HTML emitted by the Farm docs runtime.
@@ -1023,3 +1024,4 @@ code:not(pre code) {
     animation: none;
   }
 }
+`;

--- a/packages/farm/src/docs/pixel-border-css.ts
+++ b/packages/farm/src/docs/pixel-border-css.ts
@@ -676,6 +676,235 @@ code:not(pre code) {
   }
 }
 
+/* Search layout is bundled here because production adapters cannot rely on
+ * resolving @farming-labs/theme files from node_modules at request time. */
+@keyframes omni-fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes omni-scale-in {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(-6px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+}
+
+@keyframes omni-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.omni-spin {
+  animation: omni-spin 1s linear infinite;
+}
+
+.omni-overlay {
+  position: fixed;
+  inset: 0;
+  animation: omni-fade-in 150ms ease-out;
+}
+
+.omni-content {
+  --omni-content-top: clamp(5rem, 16vh, 7rem);
+  position: fixed;
+  top: var(--omni-content-top);
+  left: 50%;
+  display: flex;
+  width: min(720px, calc(100% - 1rem));
+  max-height: calc(100dvh - var(--omni-content-top) - 1rem);
+  transform: translateX(-50%);
+  flex-direction: column;
+  color: var(--color-fd-foreground);
+  outline: none;
+  overscroll-behavior: contain;
+  animation: omni-scale-in 200ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.omni-header {
+  border-bottom: 1px solid var(--color-fd-border);
+}
+
+.omni-search-row {
+  display: flex;
+  align-items: center;
+}
+
+.omni-search-icon {
+  flex-shrink: 0;
+}
+
+.omni-search-input {
+  width: 0;
+  flex: 1;
+  border: 0;
+  background: transparent;
+  color: var(--color-fd-foreground);
+  outline: none;
+}
+
+.omni-search-input::placeholder {
+  color: var(--color-fd-muted-foreground);
+}
+
+.omni-close-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--color-fd-border);
+  background: none;
+  color: var(--color-fd-muted-foreground);
+  cursor: pointer;
+}
+
+.omni-close-btn svg {
+  display: none;
+}
+
+.omni-body {
+  min-height: 0;
+  overflow: auto;
+  flex: 1 1 auto;
+  overscroll-behavior: contain;
+}
+
+.omni-loading {
+  display: flex;
+  align-items: center;
+}
+
+.omni-group {
+  padding: 0;
+}
+
+.omni-group-items {
+  display: flex;
+  flex-direction: column;
+}
+
+.omni-item {
+  position: relative;
+  display: block;
+  width: 100%;
+  flex-shrink: 0;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+
+.omni-item-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.omni-item-icon,
+.omni-item-badge,
+.omni-item-ext,
+.omni-item-chevron {
+  display: none;
+}
+
+.omni-item-text,
+.omni-item-label,
+.omni-item-subtitle,
+.omni-item-description {
+  min-width: 0;
+}
+
+.omni-item-label,
+.omni-item-subtitle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.omni-item-description {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+}
+
+.omni-highlight {
+  padding: 0;
+}
+
+.omni-empty {
+  text-align: center;
+}
+
+.omni-empty-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 0.5rem;
+}
+
+.omni-footer {
+  border-top: 1px solid var(--color-fd-border);
+}
+
+.omni-footer-inner,
+.omni-footer-hints,
+.omni-footer-hint,
+.omni-footer-filter,
+.omni-filter-button,
+.omni-filter-option {
+  display: flex;
+  align-items: center;
+}
+
+.omni-footer-inner {
+  justify-content: space-between;
+}
+
+.omni-footer-hints {
+  flex-wrap: wrap;
+}
+
+.omni-footer-hint,
+.omni-footer-filter {
+  white-space: nowrap;
+}
+
+.omni-footer-filter {
+  position: relative;
+  margin-left: auto;
+}
+
+.omni-filter-button,
+.omni-filter-option {
+  border: 0;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.omni-filter-menu {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 0.5rem);
+  z-index: 1;
+  border: 1px solid var(--color-fd-border);
+}
+
+.omni-filter-option {
+  width: 100%;
+  background: transparent;
+  text-align: left;
+}
+
 /* Docs command search */
 .topbar-actions .fd-docs-search-trigger {
   width: 56px;

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -55,8 +55,6 @@ export default defineConfig({
   sourcemap: true,
   splitting: false,
   treeshake: false,
-  onSuccess:
-    "node -e \"require('fs').copyFileSync('src/docs/pixel-border.css','dist/pixel-border.css')\"",
   esbuildOptions(options) {
     options.keepNames = true;
     return options;


### PR DESCRIPTION
## What changed

- bundle the Farm docs pixel-border CSS directly into the server module
- include the structural search overlay, dialog, input, result, and footer rules in that bundle
- remove the runtime filesystem lookup and post-build CSS copy
- add a regression test against the self-contained CSS module

## Root cause

Local development could resolve theme CSS from `node_modules` and read `pixel-border.css` beside `@farmjs/core/dist/docs.mjs`. Nitro production bundles neither runtime path beside its server chunk. Both reads silently returned empty strings, leaving the search markup without fixed overlay/dialog layout and omitting the true-black theme override.

## Validation

- `pnpm --filter @farmjs/core test -- src/__tests__/docs-handler.test.ts` (15 passed)
- `pnpm exec oxlint ...` (0 warnings, 0 errors)
- `pnpm exec oxfmt --check ...`
- `pnpm --filter @farmjs/core build`
- `pnpm --filter farmjs-docs build`
- confirmed the search layout CSS is embedded in the generated Vercel/Nitro function
- verified the deployed Vercel docs preview on desktop and 390px mobile
- live `storage` query returned 12 results with no console errors or horizontal overflow

The repository-wide core typecheck still reports existing unrelated Nitro/query-state errors; the package and production builds complete successfully.