### PR TITLE
fix(rsc): emit global styles in production

### DIFF
--- a/packages/farmjs-plugin/src/rsc/entries/client.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/client.ts
@@ -13,7 +13,16 @@ import type { EntryContext } from "../types.js";
  */
 export function generateClientEntry(ctx: EntryContext): string {
   const debugLog = `// Debug disabled`;
+  const routesDir = ctx.routesDir === undefined ? "app" : ctx.routesDir.trim();
+  const routesPath = routesDir ? `/${routesDir}` : "";
+  const globalsCssPath = `/${ctx.srcDir}${routesPath}/globals.css`;
   let imports = `
+const farmGlobalStylesheets = import.meta.glob(${JSON.stringify(globalsCssPath)}, {
+  eager: true,
+  import: 'default',
+  query: '?url',
+});
+export const farmGlobalStylesheet = Object.values(farmGlobalStylesheets)[0];
 import React from 'react';
 import { hydrateRoot } from 'react-dom/client';
 import { createFromReadableStream } from '@vitejs/plugin-rsc/browser';

--- a/packages/farmjs-plugin/src/rsc/entries/security.test.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/security.test.ts
@@ -59,6 +59,22 @@ describe("generated server action security", () => {
     expect(entry).not.toContain("throw p.returnValue?.data");
   });
 
+  it("emits the global stylesheet URL for every routes directory shape", () => {
+    const defaultEntry = generateClientEntry({ ...context, routesDir: undefined });
+    const customEntry = generateClientEntry({ ...context, routesDir: " routes " });
+    const rootEntry = generateClientEntry({ ...context, routesDir: "" });
+
+    expect(defaultEntry).toContain(
+      'const farmGlobalStylesheets = import.meta.glob("/src/app/globals.css", {',
+    );
+    expect(customEntry).toContain('import.meta.glob("/src/routes/globals.css", {');
+    expect(rootEntry).toContain('import.meta.glob("/src/globals.css", {');
+    expect(defaultEntry).toContain("eager: true");
+    expect(defaultEntry).toContain("import: 'default'");
+    expect(defaultEntry).toContain("query: '?url'");
+    expect(defaultEntry).toContain("export const farmGlobalStylesheet");
+  });
+
   it("uses the shared middleware runtime and server context during RSC rendering", () => {
     const entry = generateRscEntry(context);
 


### PR DESCRIPTION
## Summary

- make the generated RSC browser entry eagerly resolve `src/app/globals.css` as a Vite asset URL
- preserve missing-stylesheet behavior while ensuring production builds retain and emit the CSS asset
- support the default `app`, custom, and empty route-directory layouts

## Regression

The RSC production example rendered and its functionality tests passed, but the generated page requested `/src/globals.css`, which is a source path unavailable in production. The browser entry did not otherwise reference the stylesheet, so Vite could omit it from the client output.

The exact `import.meta.glob` with `query: '?url'` makes the stylesheet part of the production asset graph without injecting a second development style tag. The rebuilt example emits `assets/globals-BVChuT5h.css`.

## Validation

- `@farmjs/plugin` tests: 12/12 passed
- `@farmjs/plugin` production build passes
- RSC example production build passes
- RSC example emits the global stylesheet asset
- prior RSC production interaction suite: 3/3 passed
- no generated example output is included in this PR
