### PR TITLE
fix: preserve first docs search interaction

### DIFF
--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -231,6 +231,10 @@ describe("createFarmDocsHandler", () => {
     expect(html).toContain("data-farm-docs-search-root");
     expect(html).toContain('data-api="/api/docs"');
     expect(html).toContain('aria-label="Search documentation"');
+    expect(html).toContain("window.__farmDocsSearchBootstrap");
+    expect(htmlText.indexOf("window.__farmDocsSearchBootstrap")).toBeLessThan(
+      htmlText.indexOf("<body>"),
+    );
     expect(html).toContain('<script type="module" src="/farm-client.js"></script>');
     const topbar = htmlText.slice(
       htmlText.indexOf('<header class="topbar">'),
@@ -404,6 +408,7 @@ describe("createFarmDocsHandler", () => {
       expect(html).not.toContain('data-search-full=""');
       expect(html).not.toContain('id="farm-docs-search-root"');
       expect(html).not.toContain('aria-keyshortcuts="Meta+K Control+K"');
+      expect(html).not.toContain("window.__farmDocsSearchBootstrap");
       expect(html).not.toContain('<script type="module" src="/farm-client.js"></script>');
     }
   });

--- a/packages/farm/src/__tests__/docs-search-client.test.ts
+++ b/packages/farm/src/__tests__/docs-search-client.test.ts
@@ -2,11 +2,22 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  generateFarmDocsSearchBootstrapRuntime,
   generateFarmDocsSearchClientRuntime,
   isFarmDocsSearchEnabled,
 } from "../docs/search-client";
 
 describe("Farm docs search client", () => {
+  it("captures search interactions before the client bundle is ready", () => {
+    const runtime = generateFarmDocsSearchBootstrapRuntime();
+
+    expect(runtime).toContain("__farmDocsSearchBootstrap");
+    expect(runtime).toContain("[data-search-full]");
+    expect(runtime).toContain("__FARM_DOCS_SEARCH_PENDING__");
+    expect(runtime).toContain("__FARM_MOUNT_DOCS_SEARCH__?.()");
+    expect(runtime).toContain('queue("keyboard",event)');
+  });
+
   it("mounts the shared Omni React search component", () => {
     const runtime = generateFarmDocsSearchClientRuntime(true, "/theme/docs-command-search.mjs");
 
@@ -15,6 +26,10 @@ describe("Farm docs search client", () => {
     expect(runtime).toContain("data-farm-docs-search-root");
     expect(runtime).toContain("container.dataset.api || '/api/docs'");
     expect(runtime).toContain("React.createElement");
+    expect(runtime).toContain("__FARM_DOCS_SEARCH_BRIDGE_ACTIVE__");
+    expect(runtime).toContain("FarmDocsSearchBridge");
+    expect(runtime).toContain("queueMicrotask");
+    expect(runtime).toContain("trigger.click()");
     expect(runtime).not.toContain("fetch('/api/docs");
   });
 

--- a/packages/farm/src/docs/handler.ts
+++ b/packages/farm/src/docs/handler.ts
@@ -25,7 +25,7 @@ import { marked, Renderer } from "marked";
 import { highlight } from "sugar-high";
 import { resolveFarmDocsPageLastModified } from "./last-modified";
 import { farmDocsPixelBorderCss } from "./pixel-border-css";
-import { isFarmDocsSearchEnabled } from "./search-client";
+import { generateFarmDocsSearchBootstrapRuntime, isFarmDocsSearchEnabled } from "./search-client";
 import type { FarmDocsResolvedConfig } from "./types";
 
 export interface FarmDocsHandlerOptions {
@@ -1492,6 +1492,10 @@ function renderDocsSearchMount(clientEntry: string): string {
   <script type="module" src="${escapeAttribute(clientEntry)}"></script>`;
 }
 
+function renderDocsSearchBootstrapScript(): string {
+  return `<script>${generateFarmDocsSearchBootstrapRuntime()}</script>`;
+}
+
 function renderPixelToc(items: TocItem[]): string {
   if (items.length === 0) return '<p class="toc-empty">No sections</p>';
   return `<div class="toc-track">
@@ -1788,6 +1792,7 @@ function renderPixelDocsHtml(
   ${description ? `<meta name="description" content="${escapeHtml(description)}">` : ""}
   <style>${themeCss}
 ${renderFarmDocsBridgeCss(docs)}</style>
+  ${searchEnabled ? renderDocsSearchBootstrapScript() : ""}
 </head>
 <body>
   <div id="nd-docs-layout" class="grid">

--- a/packages/farm/src/docs/search-client.ts
+++ b/packages/farm/src/docs/search-client.ts
@@ -24,10 +24,11 @@ export function resolveFarmDocsSearchClientModule(root: string): string | undefi
   return undefined;
 }
 
-export function generateFarmDocsSearchClientRuntime(
-  enabled: boolean,
-  moduleId?: string,
-): string {
+export function generateFarmDocsSearchBootstrapRuntime(): string {
+  return `(()=>{if(window.__farmDocsSearchBootstrap)return;window.__farmDocsSearchBootstrap=true;const queue=(trigger,event)=>{if(window.__FARM_DOCS_SEARCH_BRIDGE_ACTIVE__)return;event.preventDefault();event.stopPropagation();event.stopImmediatePropagation();window.__FARM_DOCS_SEARCH_PENDING__=trigger;window.__FARM_MOUNT_DOCS_SEARCH__?.()};document.addEventListener("click",(event)=>{const target=event.target instanceof Element?event.target.closest("[data-search-full]"):null;if(target)queue("button",event)},true);document.addEventListener("keydown",(event)=>{if((event.metaKey||event.ctrlKey)&&event.key.toLowerCase()==="k")queue("keyboard",event)},true)})();`;
+}
+
+export function generateFarmDocsSearchClientRuntime(enabled: boolean, moduleId?: string): string {
   if (!enabled || !moduleId) {
     return `
 function isFarmDocsSearchPage() {
@@ -44,10 +45,84 @@ async function mountFarmDocsSearch() {
 let farmDocsSearchRoot = null;
 let farmDocsSearchContainer = null;
 let farmDocsSearchModulePromise = null;
+let farmDocsSearchPendingTrigger = window.__FARM_DOCS_SEARCH_PENDING__ === 'keyboard'
+  ? 'keyboard'
+  : window.__FARM_DOCS_SEARCH_PENDING__
+    ? 'button'
+    : null;
+let farmDocsSearchReady = false;
 
 function isFarmDocsSearchPage() {
   return document.querySelector('[data-farm-docs-search-root]') instanceof HTMLElement;
 }
+
+function replayFarmDocsSearchOpen() {
+  const pendingTrigger = farmDocsSearchPendingTrigger;
+  farmDocsSearchPendingTrigger = null;
+  window.__FARM_DOCS_SEARCH_PENDING__ = null;
+  if (!pendingTrigger) return;
+
+  queueMicrotask(() => {
+    if (pendingTrigger === 'keyboard') {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'k',
+          metaKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    } else {
+      const trigger = document.querySelector('[data-search-full]');
+      if (trigger instanceof HTMLElement) trigger.click();
+    }
+  });
+}
+
+function FarmDocsSearchBridge({ component, api }) {
+  React.useEffect(() => {
+    farmDocsSearchReady = true;
+    replayFarmDocsSearchOpen();
+    return () => {
+      farmDocsSearchReady = false;
+    };
+  }, []);
+
+  return React.createElement(component, { api });
+}
+
+function queueFarmDocsSearchOpen(trigger, event) {
+  if (farmDocsSearchReady) return;
+  event.preventDefault();
+  event.stopPropagation();
+  event.stopImmediatePropagation();
+  farmDocsSearchPendingTrigger = trigger;
+  window.__FARM_DOCS_SEARCH_PENDING__ = trigger;
+  void mountFarmDocsSearch();
+}
+
+document.addEventListener(
+  'click',
+  (event) => {
+    const target = event.target instanceof Element
+      ? event.target.closest('[data-search-full]')
+      : null;
+    if (target) queueFarmDocsSearchOpen('button', event);
+  },
+  true,
+);
+
+document.addEventListener(
+  'keydown',
+  (event) => {
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+      queueFarmDocsSearchOpen('keyboard', event);
+    }
+  },
+  true,
+);
+
+window.__FARM_DOCS_SEARCH_BRIDGE_ACTIVE__ = true;
 
 async function mountFarmDocsSearch() {
   const container = document.querySelector('[data-farm-docs-search-root]');
@@ -60,6 +135,7 @@ async function mountFarmDocsSearch() {
     if (!container.isConnected) return false;
 
     if (farmDocsSearchRoot) {
+      farmDocsSearchReady = false;
       try {
         farmDocsSearchRoot.unmount();
       } catch {}
@@ -68,7 +144,8 @@ async function mountFarmDocsSearch() {
     farmDocsSearchContainer = container;
     farmDocsSearchRoot = createRoot(container);
     farmDocsSearchRoot.render(
-      React.createElement(DocsCommandSearch, {
+      React.createElement(FarmDocsSearchBridge, {
+        component: DocsCommandSearch,
         api: container.dataset.api || '/api/docs',
       }),
     );


### PR DESCRIPTION
## Summary

- capture docs search button and keyboard interactions before the client bundle finishes loading
- replay the pending interaction once the Omni search component is mounted
- keep search bootstrap code out of pages where docs search is disabled
- add regression coverage for generated search runtime and docs HTML

## Root cause

The search trigger is server-rendered immediately, but its click and Cmd/Ctrl+K handlers are installed only after the lazy theme module loads and React effects run. On a cold load, the first interaction could arrive during that gap and be lost.

## Impact

The first search click and keyboard shortcut now reliably open the modal on direct docs loads and after navigating from the homepage. Search markup and styling are unchanged.

## Validation

- `pnpm --filter @farmjs/core exec vitest run src/__tests__/docs-search-client.test.ts src/__tests__/docs-handler.test.ts` (20 tests passed)
- targeted `oxlint` (0 warnings, 0 errors)
- `pnpm --filter @farmjs/core build`
- browser verified cold-load click, Cmd+K, and homepage-to-docs navigation with no console errors

## Note

The package-wide typecheck still reports unrelated existing errors in Nitro and query-state modules.