### PR TITLE
docs: clarify startup comparison copy

### DIFF
--- a/docs/src/components/home/benchmark-section.tsx
+++ b/docs/src/components/home/benchmark-section.tsx
@@ -974,7 +974,7 @@ export function BenchmarkSection() {
           label="Startup advantage"
           title={
             <AnimatedComparisonTitle
-              lead="Farm opens the benchmark app"
+              lead="Farm gets your first page running"
               metric="devFirstPageMs"
             />
           }


### PR DESCRIPTION
## Summary

- replace the benchmark-specific startup headline with product-facing copy
- keep the rotating framework comparison and measured startup metric unchanged

## Why

“Farm opens the benchmark app” described the test fixture rather than the developer experience being measured. “Farm gets your first page running” reads naturally with every rotating comparison while remaining tied to cold development startup through the first rendered page.

## Impact

The landing-page benchmark card is clearer without changing benchmark values, methodology, layout, or behavior.

## Validation

- production `node-server` docs build with Vite/Rolldown passed
- verified the rendered production HTML contains the new headline and no longer contains the previous wording