### PR TITLE
fix(build): incomplete Rolldown client output

### DIFF
--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { build } from "../build";
+import { loadFarmProductionVite, type FarmProductionViteRuntime } from "../build/production-vite";
 import { resolveConfig } from "../config";
 import { defineIntegration } from "../integrations";
 import { definePlugin } from "../plugin";
@@ -201,6 +202,73 @@ async function expectNitroFallback(root: string): Promise<void> {
 }
 
 describe("production prebuilt SSR output", () => {
+  it("retries an incomplete Rolldown client bundle after the parallel SSR build", async () => {
+    const root = await createProductionFixture();
+
+    try {
+      await fs.writeFile(
+        path.join(root, "src", "app", "globals.css"),
+        ".client-output-marker { color: red; }",
+      );
+      await fs.writeFile(
+        path.join(root, "src", "app", "page.tsx"),
+        `
+"use client";
+
+export default function Page() {
+  return <main className="client-output-marker">client output retry</main>;
+}
+`.trim(),
+      );
+
+      const config = await resolveConfig(
+        {
+          root,
+          srcDir: "src",
+          images: { provider: "none" },
+          generateBuildId: () => "client-output-retry-test",
+        },
+        "production",
+      );
+      const productionVite = await loadFarmProductionVite();
+      let clientBuildAttempts = 0;
+      const buildWithIncompleteFirstClient = (async (inlineConfig: any) => {
+        if (!inlineConfig.build?.ssr) {
+          clientBuildAttempts++;
+          if (clientBuildAttempts === 1) {
+            const outputDir = path.resolve(inlineConfig.root, inlineConfig.build.outDir);
+            await fs.mkdir(outputDir, { recursive: true });
+            await fs.writeFile(path.join(outputDir, "farm-client.js"), "");
+            return { output: [] };
+          }
+        }
+
+        return productionVite.build(inlineConfig);
+      }) as FarmProductionViteRuntime["build"];
+      const retryingProductionVite: FarmProductionViteRuntime = {
+        ...productionVite,
+        build: buildWithIncompleteFirstClient,
+        builder: "rolldown",
+      };
+
+      await build(config, {
+        root,
+        preset: "node-server",
+        productionVite: retryingProductionVite,
+      });
+
+      expect(clientBuildAttempts).toBe(2);
+      await expect(
+        fs.readFile(path.join(root, ".farm", "client", "farm-client.js"), "utf8"),
+      ).resolves.not.toBe("");
+      await expect(
+        fs.readFile(path.join(root, ".farm", "client", "farm-client.css"), "utf8"),
+      ).resolves.toContain(".client-output-marker");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }, 120_000);
+
   it("boots standalone Node output through the package import mapping", async () => {
     const root = await createProductionFixture();
 

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -683,8 +683,29 @@ export async function buildUniversal(
     if (routeRuntimeManifestResult.status === "rejected") {
       throw routeRuntimeManifestResult.reason;
     }
-    if (clientBuildResult.status === "rejected") throw clientBuildResult.reason;
     if (ssrBuildResult.status === "rejected") throw ssrBuildResult.reason;
+    if (clientBuildResult.status === "rejected") {
+      if (
+        productionVite.builder !== "rolldown" ||
+        !(clientBuildResult.reason instanceof IncompleteClientBuildOutputError)
+      ) {
+        throw clientBuildResult.reason;
+      }
+
+      // Rolldown can very rarely complete a parallel client build without
+      // traversing its entry graph. Preserve the fast parallel path, then
+      // recover only that invalid result once the SSR graph is fully drained.
+      logger.warn("Client bundle was incomplete; retrying after the SSR build...");
+      await buildClient(
+        productionVite,
+        config,
+        root,
+        srcDir,
+        clientOutputDir,
+        pageRoutes,
+        layoutRoutes,
+      );
+    }
 
     const ssrResult = ssrBuildResult.value;
     const routeRuntimeManifest = routeRuntimeManifestResult.value;
@@ -746,6 +767,60 @@ async function writeSSRAssetsToClient(bundle: OutputBundle, outputDir: string): 
     const filePath = path.join(outputDir, fileName);
     await fs.mkdir(path.dirname(filePath), { recursive: true });
     await fs.writeFile(filePath, output.source);
+  }
+}
+
+class IncompleteClientBuildOutputError extends Error {
+  constructor(detail: string) {
+    super(`Farm client build produced incomplete output: ${detail}`);
+    this.name = "IncompleteClientBuildOutputError";
+  }
+}
+
+async function validateClientBuildOutput(
+  root: string,
+  srcDir: string,
+  outputDir: string,
+): Promise<void> {
+  const fs = await import("fs/promises");
+  const clientEntryPath = path.join(outputDir, "farm-client.js");
+  let clientEntrySize = 0;
+
+  try {
+    const clientEntry = await fs.stat(clientEntryPath);
+    if (clientEntry.isFile()) clientEntrySize = clientEntry.size;
+  } catch {
+    // Report the missing entry through the shared incomplete-output diagnostic.
+  }
+
+  if (clientEntrySize === 0) {
+    throw new IncompleteClientBuildOutputError("farm-client.js is missing or empty");
+  }
+
+  const clientCssPath = path.join(outputDir, "farm-client.css");
+  const globalsCssPath = path.join(root, srcDir, "app", "globals.css");
+  let expectsCss = false;
+  try {
+    const globalsCss = await fs.readFile(globalsCssPath, "utf8");
+    expectsCss = globalsCss.replace(/\/\*[\s\S]*?\*\//g, "").trim().length > 0;
+  } catch {
+    // Vite reports a missing imported stylesheet before output validation.
+  }
+
+  try {
+    const clientCss = await fs.stat(clientCssPath);
+    if (expectsCss && (!clientCss.isFile() || clientCss.size === 0)) {
+      throw new IncompleteClientBuildOutputError("farm-client.css is empty");
+    }
+  } catch (error) {
+    if (error instanceof IncompleteClientBuildOutputError) throw error;
+    if (expectsCss) {
+      throw new IncompleteClientBuildOutputError("farm-client.css is missing");
+    }
+
+    // Farm's HTML always references this stable path. Keep intentionally
+    // style-free applications from receiving an unnecessary 404.
+    await fs.writeFile(clientCssPath, "");
   }
 }
 
@@ -1003,6 +1078,7 @@ async function buildClient(
         ],
       },
     });
+    await validateClientBuildOutput(root, srcDir, outputDir);
   } finally {
     // Clean up temporary entry file
     try {


### PR DESCRIPTION
## What changed

- validate the generated browser bundle before packaging deployment output
- keep client and SSR builds parallel on the normal path
- retry the Rolldown client build once, after SSR completes, only when the first result is missing or empty
- ensure intentionally style-free apps still receive the stable `farm-client.css` path
- add regression coverage that simulates the zero-byte client bundle seen on Vercel

## Root cause

The same source tree produced a healthy Vercel preview and a broken production deployment. In the broken build, the parallel Rolldown client build transformed only 2 modules and emitted a zero-byte `farm-client.js` with no CSS, while the SSR build succeeded and allowed Vercel to mark the deployment ready.

## Performance impact

Healthy builds remain parallel and do not retry. The verified docs build completed both client and SSR bundles in about 1.13 seconds, and its 56,371-byte CSS and 320,931-byte JavaScript outputs were byte-for-byte identical to the healthy deployment.

## Verification

- targeted Vitest regression passes
- changed files pass formatting and lint with no new errors
- real docs `vercel` preset build passes with 1,827 client modules
- generated CSS returns 200 (`56,371` bytes)
- generated JavaScript returns 200 (`320,931` bytes)
- production artifact renders the homepage and routed docs page with no browser errors or overlays

Note: the repository-wide core type-check still reports existing unrelated errors in Nitro and query-state files; neither changed file appears in that error list.