### PR TITLE
perf(build): skip DTS in website deployment

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,29 @@ From the repo root:
 pnpm run --filter farmjs-docs build
 ```
 
-Output is in `.farm/.output` (Vercel preset).
+The production Vercel artifact is written to `.vercel/output`.
+
+### Runtime-only core build
+
+The documentation-site build opts into `@farmjs/core`'s runtime-only package build:
+
+```bash
+pnpm --filter @farmjs/core build:runtime
+```
+
+This builds the same ESM, CJS, and source-map artifacts as the default core build, but skips
+TypeScript declaration generation because the deployed website does not consume `.d.ts` files.
+The optimization applies to the complete `farmjs.dev` application, including the landing page and
+documentation routes.
+
+The regular package and release build remains the default and continues to generate declarations:
+
+```bash
+pnpm --filter @farmjs/core build
+```
+
+Use `build:runtime` only for application deployments that need executable runtime artifacts. Do not
+use it for package publishing, release validation, or any workflow that consumes generated types.
 
 ## Structure
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "pnpm --filter @farmjs/core build && pnpm --filter @farmjs/cli build && pnpm run prisma:generate && farm dev",
-    "build": "pnpm --filter @farmjs/core build && pnpm --filter @farmjs/cli build && pnpm run prisma:generate && farm build",
+    "build": "pnpm --filter @farmjs/core build:runtime && pnpm --filter @farmjs/cli build && pnpm run prisma:generate && farm build",
     "preview": "farm preview",
     "prisma:generate": "DATABASE_URL=${DATABASE_URL:-postgresql://user:password@localhost:5432/farmjs} prisma generate",
     "db:push": "prisma db push"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:e2e:rsc": "corepack pnpm --filter @farmjs/core build && corepack pnpm --filter @farmjs/plugin build && FARM_SKIP_NPM_INSTALL=1 NITRO_PRESET=node-server corepack pnpm --filter farm-rsc-demo build && playwright test --config playwright.rsc.config.ts",
     "test:e2e:list": "playwright test --list",
     "docs:dev": "pnpm --filter @farmjs/core build && pnpm --filter farmjs-docs dev",
-    "docs:build": "pnpm --filter @farmjs/core build && pnpm --filter farmjs-docs build",
+    "docs:build": "pnpm --filter farmjs-docs build",
     "benchmark:frameworks": "node benchmarks/frameworks/run.mjs",
     "lint": "oxlint . && oxfmt --check .",
     "format": "oxlint --fix . && oxfmt .",

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -455,6 +455,7 @@
   },
   "scripts": {
     "build": "tsup",
+    "build:runtime": "tsup --config tsup.runtime.config.ts",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:coverage": "vitest --coverage",

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "tsup";
+import { defineConfig, type Options } from "tsup";
 
-export default defineConfig({
+export const farmPackageBuildOptions = {
   entry: {
     index: "src/index.ts",
     server: "src/server.ts",
@@ -80,4 +80,6 @@ export default defineConfig({
   outExtension({ format }) {
     return { js: format === "cjs" ? ".cjs" : ".mjs" };
   },
-});
+} satisfies Options;
+
+export default defineConfig(farmPackageBuildOptions);

--- a/packages/farm/tsup.runtime.config.ts
+++ b/packages/farm/tsup.runtime.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "tsup";
+import { farmPackageBuildOptions } from "./tsup.config";
+
+export default defineConfig({
+  ...farmPackageBuildOptions,
+  dts: false,
+});


### PR DESCRIPTION
## Summary

- add an explicit `@farmjs/core` runtime-only build configuration with declaration generation disabled
- use that opt-in build only for the complete `farmjs.dev` production build
- keep the default package, release, development, example, and test builds unchanged
- remove the redundant core build from the root `docs:build` command
- document the opt-in, its safety boundary, and the Vercel output location in `docs/README.md`

## Why

The Vercel logs showed `@farmjs/core` declaration generation consuming about 47 seconds of the deployment. The website only needs the executable ESM/CJS artifacts at runtime, while package and release builds still need declarations.

## Impact

This keeps DTS generation enabled by default and requires the website to opt into `build:runtime`. The measured Vercel build completed in 39 seconds instead of 87 seconds, and the deployment became live in 51 seconds instead of about 99 seconds.

## Verification

- default core build emitted 150 declaration files and 110 executable ESM/CJS files
- runtime core build emitted zero declaration files and the same 110 executable files
- executable JavaScript and source-map hashes were byte-identical between both modes
- full `pnpm --dir docs build` completed and emitted valid Vercel Build Output API v3 artifacts
- deployed `/`, `/farm-client.css`, `/farm-client.js`, and `/docs/getting-started` all returned HTTP 200
- production artifact verified in-browser for the landing/benchmark page and docs routes
- client navigation from Getting Started to Routing succeeded
- no browser console warnings or errors
- `oxfmt --check` and `git diff --check` passed