### PR TITLE
docs: sharpen hero product message

### DIFF
--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -716,7 +716,7 @@ function Hero() {
       />
       <div className="relative z-10 mx-auto flex w-full max-w-[58rem] flex-col items-center px-6 pb-16 pt-11 text-center sm:px-10 sm:pb-20 sm:pt-12 lg:px-12">
         <div className="text-white/42">
-          <IndexedLabel icon={Route} index="00" label="App Router / Typed APIs / One Runtime" />
+          <IndexedLabel icon={Route} index="00" label="Build / Ship / Scale" />
         </div>
         <HeroTitleFrame>
           <h1 className="max-w-full text-[1.125rem] font-medium leading-[1.02] tracking-normal text-white min-[360px]:text-[1.3125rem] min-[380px]:text-[1.4375rem] min-[400px]:text-[1.5rem] min-[420px]:text-[1.625rem] sm:text-[2.25rem] md:text-[2.625rem] lg:text-[3.25rem]">


### PR DESCRIPTION
## Summary

- replace the hero kicker `App Router / Typed APIs / One Runtime` with `Build / Ship / Scale`
- keep the existing indexed-label styling, icon, spacing, and hero structure unchanged

## Why

The previous line read like a feature inventory. The new copy is shorter, outcome-oriented, and better matches the hero's compact technical-label rhythm.

## Impact

This is a copy-only landing-page change. It does not modify routing, runtime behavior, layout structure, or application functionality.

## Verification

- verified the hero at 1280px desktop width
- verified the hero at 390px mobile width
- confirmed the label stays on one line with no horizontal overflow
- confirmed no browser console warnings or errors
- `oxfmt --check docs/src/app/page.tsx`
- `git diff --check`