### PR TITLE
fix: simplify the hero label

### DIFF
--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -509,7 +509,7 @@ function IndexedLabel({
   label,
 }: {
   index: string;
-  icon: LucideIcon;
+  icon?: LucideIcon;
   label: string;
 }) {
   return (
@@ -518,7 +518,7 @@ function IndexedLabel({
       <span aria-hidden className="text-white/18">
         /
       </span>
-      <Icon aria-hidden className="size-3.5 shrink-0" strokeWidth={1.5} />
+      {Icon ? <Icon aria-hidden className="size-3.5 shrink-0" strokeWidth={1.5} /> : null}
       <span className="truncate">{label}</span>
     </span>
   );
@@ -716,7 +716,7 @@ function Hero() {
       />
       <div className="relative z-10 mx-auto flex w-full max-w-[58rem] flex-col items-center px-6 pb-16 pt-11 text-center sm:px-10 sm:pb-20 sm:pt-12 lg:px-12">
         <div className="text-white/42">
-          <IndexedLabel icon={Route} index="00" label="Build / Ship / Scale" />
+          <IndexedLabel index="00" label="Build / Ship / Scale" />
         </div>
         <HeroTitleFrame>
           <h1 className="max-w-full text-[1.125rem] font-medium leading-[1.02] tracking-normal text-white min-[360px]:text-[1.3125rem] min-[380px]:text-[1.4375rem] min-[400px]:text-[1.5rem] min-[420px]:text-[1.625rem] sm:text-[2.25rem] md:text-[2.625rem] lg:text-[3.25rem]">


### PR DESCRIPTION
## What changed

- make the shared `IndexedLabel` icon optional
- omit the icon only from the hero’s `BUILD / SHIP / SCALE` label
- preserve icons in navigation and every other indexed label

## Why

The hero eyebrow was visually busier than needed. Removing its route icon leaves a cleaner `00 / BUILD / SHIP / SCALE` treatment without changing the rest of the landing-page icon system.

## Impact

This is a presentation-only landing-page change. It does not affect framework runtime behavior, dependencies, build configuration, or benchmark data.

## Validation

- `pnpm exec oxfmt --check docs/src/app/page.tsx`
- `pnpm --filter farmjs-docs build`
- visually verified the hero at desktop and mobile widths
- confirmed no browser console warnings or errors