### PR TITLE
perf(dev): lazy-load optional runtimes

### DIFF
--- a/packages/farm-cli/bin/farm.js
+++ b/packages/farm-cli/bin/farm.js
@@ -37,7 +37,7 @@ program
   .option("--cron", "Run configured cron routes in-process during development")
   .action(async (options) => {
     try {
-      const { startDevServer, startFarmCronScheduler } = require("../dist/index.js");
+      const { startDevServer } = require("../dist/dev.js");
       const server = await startDevServer(
         {
           root: options.root,
@@ -45,6 +45,7 @@ program
         parseInt(options.port),
       );
       if (options.cron) {
+        const { startFarmCronScheduler } = require("../dist/index.js");
         const address = server.httpServer?.address();
         const port = typeof address === "object" && address ? address.port : parseInt(options.port);
         const scheduler = await startFarmCronScheduler({
@@ -148,8 +149,16 @@ program
   .option("-p, --port <port>", "Port of the running local app")
   .option("--host <host>", "Host of the running local app", "localhost")
   .option("--url <url>", "Full local URL to expose")
-  .option("--gateway <url>", "Advanced: override the hosted Farm Preview gateway URL", process.env.FARM_PREVIEW_GATEWAY_URL)
-  .option("--provider <provider>", "Advanced: preview provider to use (farm, local)", process.env.FARM_PREVIEW_PROVIDER)
+  .option(
+    "--gateway <url>",
+    "Advanced: override the hosted Farm Preview gateway URL",
+    process.env.FARM_PREVIEW_GATEWAY_URL,
+  )
+  .option(
+    "--provider <provider>",
+    "Advanced: preview provider to use (farm, local)",
+    process.env.FARM_PREVIEW_PROVIDER,
+  )
   .option("--name <name>", "Readable preview URL name")
   .option("--dry-run", "Validate target detection and print the preview plan without opening it")
   .option("--no-probe", "Skip local reachability check when --port is provided")
@@ -181,7 +190,10 @@ program
   .option("-c, --config <config>", "Path to farm config file")
   .option("--command <command>", "Migration command to run; can be repeated", collectOption, [])
   .option("--dry-run", "Print migration commands without running them")
-  .option("--write", "Apply framework migration changes; framework migrations are dry-run by default")
+  .option(
+    "--write",
+    "Apply framework migration changes; framework migrations are dry-run by default",
+  )
   .option("--force", "Overwrite existing files during framework migrations")
   .action(async (source, options) => {
     try {

--- a/packages/farm-cli/src/dev.ts
+++ b/packages/farm-cli/src/dev.ts
@@ -1,0 +1,6 @@
+import type { FarmConfig } from "@farmjs/core";
+
+export async function startDevServer(config: FarmConfig = {}, port = 3000) {
+  const { startDevServer: startFarmDevServer } = await import("@farmjs/core/server");
+  return startFarmDevServer(config, port);
+}

--- a/packages/farm-cli/tsdown.config.ts
+++ b/packages/farm-cli/tsdown.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "tsdown";
 export default defineConfig({
   entry: {
     index: "src/index.ts",
+    dev: "src/dev.ts",
     build: "src/build.ts",
     "add-integration": "src/add-integration.ts",
   },

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -7,7 +7,7 @@ import type { FarmPlugin, FarmPluginRuntimeSession, PluginManager } from "./plug
 import { generateFarmClientPluginEntryCode } from "./client-plugin-build";
 import { HMRManager } from "./hmr";
 import { APIRouteManager } from "./api/route-manager";
-import { OpenAPIManager } from "./openapi/manager";
+import type { OpenAPIManager } from "./openapi/manager";
 import { MiddlewareManager } from "./middleware/manager";
 import { generateFarmTypeArtifacts } from "./type-artifacts";
 import {
@@ -15,18 +15,7 @@ import {
   parseProgrammaticRouteModuleId,
   scanProgrammaticPagePaths,
 } from "./routes";
-import {
-  createFarmDocsAPIHandler,
-  createFarmDocsHandler,
-  getFarmDocsDocumentNavigationMatchers,
-  getFarmDocsRouteTypeEntries,
-  isFarmDocsAPIRequest,
-} from "./docs";
-import {
-  generateFarmDocsSearchClientRuntime,
-  isFarmDocsSearchEnabled,
-  resolveFarmDocsSearchClientModule,
-} from "./docs/search-client";
+import type { FarmDocsAPIHandler } from "./docs";
 import { createMarkdownMirrorResponse } from "./markdown";
 import { createFarmMarkdownSourceResponse, isFarmMarkdownPageFile } from "./app-markdown";
 import { sendWebResponse } from "./server/response";
@@ -41,16 +30,8 @@ import {
   getIntegrationProviders,
   matchIntegrationRoute,
 } from "./integrations";
-import {
-  createFarmWorkflowRequestHandler,
-  discoverFarmWorkflows,
-  resolveWorkflowsConfig,
-  type FarmDiscoveredWorkflow,
-} from "./workflows";
+import type { FarmDiscoveredWorkflow } from "./workflows";
 import { resolveFarmRouteContext, withFarmRouteContext } from "./route-context";
-import { createFarmDevtoolsSnapshot } from "./devtools";
-import { renderFarmDevtoolsHtml } from "./devtools-ui";
-import { generateFarmDevtoolsClientRuntime } from "./devtools-client";
 import {
   FARM_DEVTOOLS_LAUNCH_PARAM,
   FARM_DEVTOOLS_PATH,
@@ -81,6 +62,43 @@ interface FarmVitePluginOptions extends FarmConfig {
 }
 
 const FARM_I18N_CLIENT_BRIDGE_ID = "\0farm-i18n-client-bridge";
+const EMPTY_FARM_DOCS_SEARCH_CLIENT_RUNTIME = `
+function isFarmDocsSearchPage() {
+  return false;
+}
+
+async function mountFarmDocsSearch() {
+  return false;
+}
+`;
+
+function loadFarmDocsDevRuntime() {
+  return import("./docs");
+}
+
+function loadFarmDocsSearchDevRuntime() {
+  return import("./docs/search-client");
+}
+
+function loadFarmOpenAPIDevRuntime() {
+  return import("./openapi/manager");
+}
+
+function loadFarmWorkflowsDevRuntime() {
+  return import("./workflows");
+}
+
+function loadFarmDevtoolsSnapshotRuntime() {
+  return import("./devtools");
+}
+
+function loadFarmDevtoolsUIRuntime() {
+  return import("./devtools-ui");
+}
+
+function loadFarmDevtoolsClientRuntime() {
+  return import("./devtools-client");
+}
 
 export function farmI18nClientBridgePlugin(): Plugin {
   return {
@@ -527,10 +545,11 @@ export function farmPlugin(
             : farmConfig.i18n.messages,
         );
       }
-      const workflowConfig = resolveWorkflowsConfig(farmConfig.workflows);
+      const workflowConfig = farmConfig.workflows;
+      const farmDocsDevRuntime = farmConfig.docs.enabled ? await loadFarmDocsDevRuntime() : null;
       const getExtraRouteTypes = () => [
         ...(options.openapi?.enabled && options.openapi.route ? [options.openapi.route] : []),
-        ...getFarmDocsRouteTypeEntries(farmConfig.docs),
+        ...(farmDocsDevRuntime?.getFarmDocsRouteTypeEntries(farmConfig.docs) ?? []),
       ];
       const appDirSlugs = sourceRoots.map((source) =>
         path.join(source.root, source.srcDir, "app").replace(/\\/g, "/"),
@@ -708,21 +727,31 @@ export function farmPlugin(
         i18n: farmApp.getI18nRuntime(),
       });
       await apiRouteManager.discoverRoutes();
-      const discoveredWorkflows = await discoverFarmWorkflows(
-        { ...farmConfig, workflows: workflowConfig },
-        {
-          loadModule: async (filePath) =>
-            server.ssrLoadModule(filePath) as Promise<Record<string, any>>,
-        },
-      );
-      if (discoveredWorkflows.length > 0) {
-        workflowHandler = createFarmWorkflowRequestHandler({
-          workflows: discoveredWorkflows,
-          config: workflowConfig,
-          loadModule: async (workflow: FarmDiscoveredWorkflow) =>
-            server.ssrLoadModule(workflow.filePath) as Promise<Record<string, any>>,
-        });
-        logger.success(`✅ Discovered ${discoveredWorkflows.length} Farm workflow task(s)`);
+      let discoveredWorkflows: FarmDiscoveredWorkflow[] = [];
+      const hasWorkflowDirectory =
+        workflowConfig.enabled &&
+        workflowConfig.dirs.some((dir) =>
+          fs.existsSync(path.isAbsolute(dir) ? dir : path.join(farmConfig.root, dir)),
+        );
+      if (hasWorkflowDirectory) {
+        const { createFarmWorkflowRequestHandler, discoverFarmWorkflows } =
+          await loadFarmWorkflowsDevRuntime();
+        discoveredWorkflows = await discoverFarmWorkflows(
+          { ...farmConfig, workflows: workflowConfig },
+          {
+            loadModule: async (filePath) =>
+              server.ssrLoadModule(filePath) as Promise<Record<string, any>>,
+          },
+        );
+        if (discoveredWorkflows.length > 0) {
+          workflowHandler = createFarmWorkflowRequestHandler({
+            workflows: discoveredWorkflows,
+            config: workflowConfig,
+            loadModule: async (workflow: FarmDiscoveredWorkflow) =>
+              server.ssrLoadModule(workflow.filePath) as Promise<Record<string, any>>,
+          });
+          logger.success(`✅ Discovered ${discoveredWorkflows.length} Farm workflow task(s)`);
+        }
       }
       if (pm) {
         for (const [, apiRoute] of apiRouteManager.getRoutes()) {
@@ -753,6 +782,7 @@ export function farmPlugin(
 
       // Initialize OpenAPI manager if enabled
       if (options.openapi?.enabled) {
+        const { OpenAPIManager } = await loadFarmOpenAPIDevRuntime();
         openAPIManager = new OpenAPIManager(appDirs, options.openapi);
         await openAPIManager.generateSpec();
         logger.success("✅ OpenAPI documentation enabled");
@@ -773,34 +803,40 @@ export function farmPlugin(
         }
       };
 
-      const farmDocsHandler = createFarmDocsHandler(farmConfig.docs, {
-        root: farmConfig.root,
-        srcDir: farmConfig.srcDir,
-        clientEntry: "/@farm/client.js",
-      });
-      const farmDocsAPIHandler = farmConfig.docs?.enabled
-        ? createFarmDocsAPIHandler({
+      const farmDocsHandler = farmDocsDevRuntime
+        ? farmDocsDevRuntime.createFarmDocsHandler(farmConfig.docs, {
+            root: farmConfig.root,
+            srcDir: farmConfig.srcDir,
+            clientEntry: "/@farm/client.js",
+          })
+        : null;
+      const farmDocsAPIHandler: FarmDocsAPIHandler | null = farmDocsDevRuntime
+        ? farmDocsDevRuntime.createFarmDocsAPIHandler({
             rootDir: farmConfig.root,
             srcDir: farmConfig.srcDir,
             docs: farmConfig.docs,
           })
         : null;
-      const farmDocsFontAssets = new Map([
-        [
-          "/assets/Geist-Variable-CrgPqtmy.woff2",
-          path.join(
-            farmConfig.root,
-            "node_modules/geist/dist/fonts/geist-sans/Geist-Variable.woff2",
-          ),
-        ],
-        [
-          "/assets/GeistMono-Variable-BNLlm6Cd.woff2",
-          path.join(
-            farmConfig.root,
-            "node_modules/geist/dist/fonts/geist-mono/GeistMono-Variable.woff2",
-          ),
-        ],
-      ]);
+      const farmDocsFontAssets = new Map<string, string>(
+        farmDocsDevRuntime
+          ? [
+              [
+                "/assets/Geist-Variable-CrgPqtmy.woff2",
+                path.join(
+                  farmConfig.root,
+                  "node_modules/geist/dist/fonts/geist-sans/Geist-Variable.woff2",
+                ),
+              ],
+              [
+                "/assets/GeistMono-Variable-BNLlm6Cd.woff2",
+                path.join(
+                  farmConfig.root,
+                  "node_modules/geist/dist/fonts/geist-mono/GeistMono-Variable.woff2",
+                ),
+              ],
+            ]
+          : [],
+      );
 
       // Built-in terminal logging (always enabled in development, independent of logger plugin)
       const logRequest = (method: string, urlPath: string, tag: "API" | "PAGE") => {
@@ -932,6 +968,7 @@ export function farmPlugin(
               return;
             }
 
+            const { createFarmDevtoolsSnapshot } = await loadFarmDevtoolsSnapshotRuntime();
             const snapshot = await createFarmDevtoolsSnapshot({
               root: farmConfig.root,
               srcDir: farmConfig.srcDir,
@@ -953,11 +990,12 @@ export function farmPlugin(
                 : "text/html; charset=utf-8",
             );
             res.setHeader("Cache-Control", "no-store");
-            res.end(
-              requestPathname.endsWith(".json")
-                ? JSON.stringify(snapshot, null, 2)
-                : renderFarmDevtoolsHtml(snapshot),
-            );
+            if (requestPathname.endsWith(".json")) {
+              res.end(JSON.stringify(snapshot, null, 2));
+            } else {
+              const { renderFarmDevtoolsHtml } = await loadFarmDevtoolsUIRuntime();
+              res.end(renderFarmDevtoolsHtml(snapshot));
+            }
             return;
           }
 
@@ -973,15 +1011,17 @@ export function farmPlugin(
               docsHeaders.set(key, Array.isArray(value) ? value.join(", ") : value);
             }
           }
-          const docsResponse = await farmDocsHandler(
-            new Request(fullUrl, {
-              method: requestMethod,
-              headers: docsHeaders,
-            }),
-          );
-          if (docsResponse) {
-            await sendWebResponse(res, docsResponse);
-            return;
+          if (farmDocsHandler) {
+            const docsResponse = await farmDocsHandler(
+              new Request(fullUrl, {
+                method: requestMethod,
+                headers: docsHeaders,
+              }),
+            );
+            if (docsResponse) {
+              await sendWebResponse(res, docsResponse);
+              return;
+            }
           }
 
           const markdownSourceResponse = await createFarmMarkdownSourceResponse({
@@ -1287,7 +1327,7 @@ export function farmPlugin(
               }
             }
 
-            if (farmDocsAPIHandler && isFarmDocsAPIRequest(pathname)) {
+            if (farmDocsAPIHandler && farmDocsDevRuntime?.isFarmDocsAPIRequest(pathname)) {
               try {
                 const url = `http://${req.headers.host || "localhost:3000"}${req.url}`;
                 const headers = new Headers();
@@ -1904,20 +1944,37 @@ export function farmPlugin(
       if (id === "/@farm/client" || id === "/@farm/client.js") {
         const resolvedConfig = farmApp?.getConfig();
         const integrations = resolvedConfig?.integrations || options.integrations;
+        const root = resolvedConfig?.root || server?.config.root || process.cwd();
+        const docs = resolvedConfig?.docs;
+        const devtools = resolvedConfig?.devtools ?? resolveFarmDevtoolsConfig(false, "production");
+        const [docsRuntime, docsSearchRuntime, devtoolsClientRuntime] = await Promise.all([
+          docs?.enabled ? loadFarmDocsDevRuntime() : null,
+          docs?.enabled ? loadFarmDocsSearchDevRuntime() : null,
+          devtools.enabled ? loadFarmDevtoolsClientRuntime() : null,
+        ]);
+        const docsSearchEnabled = docsSearchRuntime?.isFarmDocsSearchEnabled(docs) ?? false;
+        const generatedDocsSearchRuntime = docsSearchRuntime
+          ? docsSearchRuntime.generateFarmDocsSearchClientRuntime(
+              docsSearchEnabled,
+              docsSearchEnabled
+                ? docsSearchRuntime.resolveFarmDocsSearchClientModule(root)
+                : undefined,
+            )
+          : EMPTY_FARM_DOCS_SEARCH_CLIENT_RUNTIME;
+        const generatedDevtoolsClientRuntime = devtoolsClientRuntime
+          ? devtoolsClientRuntime.generateFarmDevtoolsClientRuntime(devtools)
+          : "";
 
         return generateClientCode(
           getIntegrationProviders(integrations),
           [
             ...getIntegrationDocumentNavigationMatchers(integrations),
-            ...getFarmDocsDocumentNavigationMatchers(resolvedConfig?.docs),
+            ...(docsRuntime?.getFarmDocsDocumentNavigationMatchers(docs) ?? []),
           ],
-          isFarmDocsSearchEnabled(resolvedConfig?.docs),
-          resolveFarmDocsSearchClientModule(
-            resolvedConfig?.root || server?.config.root || process.cwd(),
-          ),
-          resolvedConfig?.devtools ?? resolveFarmDevtoolsConfig(false, "production"),
+          generatedDocsSearchRuntime,
+          generatedDevtoolsClientRuntime,
           resolvedConfig?.plugins || [],
-          resolvedConfig?.root || server?.config.root || process.cwd(),
+          root,
         );
       }
 
@@ -2683,9 +2740,8 @@ function generateClientCode(
     props?: Record<string, unknown>;
   }> = [],
   documentNavigationMatchers: string[] = [],
-  docsSearchEnabled = false,
-  docsSearchModuleId?: string,
-  devtools = resolveFarmDevtoolsConfig(false, "production"),
+  docsSearchClientRuntime = EMPTY_FARM_DOCS_SEARCH_CLIENT_RUNTIME,
+  devtoolsClientRuntime = "",
   plugins: readonly FarmPlugin[] = [],
   root = process.cwd(),
 ): string {
@@ -2708,8 +2764,8 @@ import {
 } from '@farmjs/core/deployment'
 ${providerImportBlock}
 ${clientPluginEntry.imports}
-${generateFarmDocsSearchClientRuntime(docsSearchEnabled, docsSearchModuleId)}
-${generateFarmDevtoolsClientRuntime(devtools)}
+${docsSearchClientRuntime}
+${devtoolsClientRuntime}
 
 // ⭐ Farm.js SPA Client Runtime (TanStack Start pattern)
 // Uses manifest-based chunk loading - NO HTML fetching!

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -71,7 +71,6 @@ export const farmPackageBuildOptions = {
     /^@farming-labs\/orm/,
   ],
   sourcemap: true,
-  splitting: false,
   treeshake: false,
   esbuildOptions(options) {
     options.keepNames = true;


### PR DESCRIPTION
## Summary

- add a minimal `farm dev` CLI entry that loads only the server runtime needed for normal development
- defer docs, docs search, OpenAPI, workflows, and DevTools modules until the associated feature is enabled or requested
- restore ESM chunk splitting while leaving the CommonJS build unsplit for compatibility
- preserve the existing full CLI runtime for `farm dev --cron`

## Why

The normal dev command entered the full CLI bundle, while the Vite plugin eagerly loaded optional feature code even for a plain application. This made every project pay the parse/evaluation cost of docs, OpenAPI, workflow, and DevTools UI modules during startup.

The new loading boundaries are feature-gated. Enabling any of these features keeps the existing behavior; plain apps avoid loading code they do not use.

## Controlled performance check

Same Apple M1 machine, Node 20.19.1, one discarded burn-in plus seven measured rounds, identical SSR fixture and benchmark harness. These are diagnostic results and do not replace the canonical benchmark files.

| Metric | `main` | This branch | Change |
| --- | ---: | ---: | ---: |
| First dev page | 346 ms | 285 ms | 17.6% faster |
| Warm dev response | 2.23 ms | 2.17 ms | effectively unchanged |
| Fixture production build | 744 ms | 747 ms | effectively unchanged |
| Production boot | 62 ms | 62 ms | unchanged |
| Production response p50 | 0.92 ms | 0.90 ms | effectively unchanged |

## Verification

- `@farmjs/core`: 85 test files passed; 712 tests passed and 1 skipped
- `@farmjs/cli`: 40 tests passed
- core runtime and CLI package builds passed
- CommonJS package import smoke test passed
- plain development fixture rendered successfully
- browser-verified home/about SPA navigation, docs, OpenAPI reference, and DevTools overlay
- workflow discovery, listing, and execution passed through a real dev server
- `farm dev --cron` started successfully and served the fixture
- production SSR fixture built, booted, returned HTTP 200, and rendered all 120 fixture items
- focused formatting and lint completed with no errors (five pre-existing warnings in `vite.ts`)