### PR TITLE
perf(build): preload Nitro during bundle compilation

### DIFF
--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -60,6 +60,7 @@ import { adaptTailwindVitePlugin } from "../build/vite-plugin-compat";
 // Type alias for OutputBundle
 type OutputBundle = Rollup.OutputBundle;
 type NitroEsbuildOptions = NonNullable<NonNullable<NitroConfig["esbuild"]>["options"]>;
+type FarmNitroRuntime = typeof import("nitro");
 type UniversalPageRoute = {
   pattern: string;
   modulePath: string;
@@ -93,6 +94,13 @@ type UniversalMiddlewareRoute = {
   path: string;
   filePath: string;
 };
+
+function preloadFarmNitroRuntime(): Promise<PromiseSettledResult<FarmNitroRuntime>> {
+  return import("nitro").then(
+    (value) => ({ status: "fulfilled", value }),
+    (reason) => ({ status: "rejected", reason }),
+  );
+}
 
 // Get __dirname equivalent for ESM
 const _filename = typeof import.meta.url !== "undefined" ? fileURLToPath(import.meta.url) : "";
@@ -582,6 +590,10 @@ export async function buildUniversal(
   const productionViteResultPromise = Promise.allSettled([
     Promise.resolve(options.productionVite ?? loadFarmProductionVite()),
   ]);
+  // Nitro is guaranteed to be needed for every universal production build.
+  // Start resolving it while route metadata and the client/SSR bundles are
+  // prepared, then consume the settled result at the adapter stage.
+  const nitroRuntimeResultPromise = preloadFarmNitroRuntime();
 
   logger.info(`🚜 Building Farm.js application (universal) with preset: ${preset}...`);
 
@@ -733,6 +745,7 @@ export async function buildUniversal(
       clientOutputDir,
       routeRuntimeManifest,
       configuredHeaderRoutes,
+      nitroRuntimeResultPromise,
       lifecyclePluginManager,
     );
 
@@ -5146,12 +5159,18 @@ async function buildNitroUniversal(
   clientOutputDir: string,
   routeRuntimeManifest: FarmRouteRuntimeManifest,
   configuredHeaderRoutes: UniversalConfiguredHeaderRoute[],
+  nitroRuntimeResultPromise: Promise<PromiseSettledResult<FarmNitroRuntime>>,
   pluginManager?: PluginManager,
 ) {
   // Nitro is only needed while producing the deployment artifact. Keeping the
   // import lazy prevents this build-only dependency from leaking into an
   // application's standalone server bundle through @farmjs/core's root entry.
-  const [fs, nitro] = await Promise.all([import("fs/promises"), import("nitro")]);
+  const [fs, nitroRuntimeResult] = await Promise.all([
+    import("fs/promises"),
+    nitroRuntimeResultPromise,
+  ]);
+  if (nitroRuntimeResult.status === "rejected") throw nitroRuntimeResult.reason;
+  const nitro = nitroRuntimeResult.value;
 
   const isVercel = preset === "vercel" || preset === "vercel-edge";
   const isCloudflareWorker = preset === "cloudflare-module";


### PR DESCRIPTION
## Summary

- begin resolving the Nitro build runtime while Farm prepares the client and SSR bundles
- reuse the settled module at the adapter stage instead of starting the import after bundle compilation
- preserve the existing lazy build-only boundary and propagate the original import error if resolution fails

## Performance

Same-machine A/B runs used the repository framework fixture with Node 20.19.1:

```
/usr/local/bin/node benchmarks/frameworks/run.mjs \
  --only farm --runs 7 --requests 30 --warmups 30 --skip-prepare
```

| Revision | Run 1 median | Run 2 median | Average |
| --- | ---: | ---: | ---: |
| `main` (`7cede64`) | 852 ms | 836 ms | 844 ms |
| this branch | 765 ms | 804 ms | 785 ms |

That is about **59 ms / 7.0% faster** for the complete fixture production build. Dev startup, production boot, response latency, and generated HTML size remained effectively unchanged.

## Verification

- `pnpm --filter @farmjs/core build:runtime`
- `pnpm exec oxfmt --check packages/farm/src/nitro/universal-build.ts`
- `pnpm exec oxlint packages/farm/src/nitro/universal-build.ts` (0 errors; 2 pre-existing warnings)
- Core suite: 712 passed, 1 skipped
- CLI suite: 40 passed
- Production prebuilt SSR suite: 16 passed
- Node standalone boot and rendered-route checks passed
- Vercel production middleware/output check passed
- Cloudflare module production output check passed

The full core run initially had one `ENOSPC` infrastructure interruption after 711 passes; the exact interrupted Vercel production test passed when rerun after clearing generated output.