### PR TITLE
feat: add missing docs sidebar icons

### DIFF
--- a/docs/docs.config.ts
+++ b/docs/docs.config.ts
@@ -68,6 +68,7 @@ const icons = {
     '<path d="M8 3H7a2 2 0 0 0-2 2v3a2 2 0 0 1-2 2 2 2 0 0 1 2 2v3a2 2 0 0 0 2 2h1"></path><path d="M16 3h1a2 2 0 0 1 2 2v3a2 2 0 0 0 2 2 2 2 0 0 0-2 2v3a2 2 0 0 1-2 2h-1"></path>',
   card: '<rect x="2" y="5" width="20" height="14" rx="2"></rect><path d="M2 10h20"></path>',
   cloud: '<path d="M17.5 19H8a6 6 0 1 1 5.5-8.5A4.5 4.5 0 1 1 17.5 19Z"></path>',
+  code: '<path d="m8 9-4 3 4 3"></path><path d="m16 9 4 3-4 3"></path><path d="m14 5-4 14"></path>',
   database:
     '<ellipse cx="12" cy="5" rx="8" ry="3"></ellipse><path d="M4 5v6c0 1.7 3.6 3 8 3s8-1.3 8-3V5"></path><path d="M4 11v6c0 1.7 3.6 3 8 3s8-1.3 8-3v-6"></path>',
   file: '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><path d="M14 2v6h6"></path>',
@@ -98,6 +99,8 @@ const icons = {
   sparkles:
     '<path d="M12 3l1.5 4.5L18 9l-4.5 1.5L12 15l-1.5-4.5L6 9l4.5-1.5Z"></path><path d="M19 15l.8 2.2L22 18l-2.2.8L19 21l-.8-2.2L16 18l2.2-.8Z"></path>',
   terminal: '<path d="m4 17 6-6-6-6"></path><path d="M12 19h8"></path>',
+  timer:
+    '<circle cx="12" cy="13" r="8"></circle><path d="M12 9v4l2 2"></path><path d="M9 2h6"></path><path d="M12 2v3"></path>',
   wrench: '<path d="M14.7 6.3a4 4 0 0 0 5 5L10 21l-5-5 9.7-9.7Z"></path>',
   zap: '<path d="M13 2 3 14h8l-1 8 10-12h-8z"></path>',
 };


### PR DESCRIPTION
## Summary

- register the missing `code` icon used by Environment Functions
- register the missing `timer` icon used by Cron
- keep both icons aligned with the existing 24px outline icon language

## Why

The sidebar entries referenced icon keys that were not present in the docs icon registry, so those items rendered without icons.

## Impact

Environment Functions and Cron now display consistent icons in the docs sidebar. All sidebar icon references resolve to registered SVG definitions.

## Validation

- `pnpm exec oxfmt --check docs/docs.config.ts`
- verified all 70 sidebar icon references have matching definitions
- `git diff --check`

The full docs typecheck currently reports pre-existing asset module and React type compatibility errors unrelated to this change.