### PR TITLE
fix(docs): soften Farm.js brand suffix

### DIFF
--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -268,7 +268,8 @@ describe("createFarmDocsHandler", () => {
     );
     expect(sidebarBrand).not.toContain('data-search-full=""');
     expect(sidebarBrand).toContain('class="sidebar-brand-logo"');
-    expect(sidebarBrand).toContain("<span>Docs</span>");
+    expect(sidebarBrand).toContain('<span class="sidebar-brand-title">Docs</span>');
+    expect(sidebarBrand).not.toContain("sidebar-brand-suffix");
     expect(html).toContain("--fd-nav-height: 44px");
     expect(html).toContain("--omni-content-top: 1rem");
     expect(html).toContain("max-height: calc(100vh - 2rem)");
@@ -648,6 +649,28 @@ describe("createFarmDocsHandler", () => {
     const handler = createFarmDocsHandler({ ...docs, enabled: false }, { root, srcDir: "src" });
 
     await expect(handler(new Request("http://farm.test/docs"))).resolves.toBeNull();
+  });
+
+  it("softens a trailing .js in the sidebar brand title", async () => {
+    const { root, docs } = await createDocsFixture();
+    const handler = createFarmDocsHandler(
+      {
+        ...docs,
+        config: {
+          ...docs.config,
+          nav: { title: "Farm.js" },
+        },
+      },
+      { root, srcDir: "src" },
+    );
+
+    const response = await handler(new Request("http://farm.test/docs"));
+    const html = await response?.text();
+
+    expect(html).toContain(
+      '<span class="sidebar-brand-title">Farm<span class="sidebar-brand-suffix">.js</span></span>',
+    );
+    expect(html).toContain(".sidebar-brand-suffix { opacity: 0.52; }");
   });
 });
 

--- a/packages/farm/src/docs/handler.ts
+++ b/packages/farm/src/docs/handler.ts
@@ -119,6 +119,17 @@ function renderFarmDocsBrandMark(): string {
   </svg>`;
 }
 
+function renderFarmDocsBrandTitle(navTitle: string): string {
+  const suffix = navTitle.match(/\.js$/i)?.[0];
+
+  if (!suffix) {
+    return `<span class="sidebar-brand-title">${escapeHtml(navTitle)}</span>`;
+  }
+
+  const productName = navTitle.slice(0, -suffix.length);
+  return `<span class="sidebar-brand-title">${escapeHtml(productName)}<span class="sidebar-brand-suffix">${escapeHtml(suffix)}</span></span>`;
+}
+
 function isSafeSegment(segment: string): boolean {
   return segment !== ".." && !segment.includes("/") && !segment.includes("\\");
 }
@@ -1669,6 +1680,8 @@ function renderFarmDocsBridgeCss(docs: FarmDocsResolvedConfig): string {
     .sidebar-brand { display: flex; align-items: center; justify-content: space-between; gap: 10px; min-height: var(--fd-nav-height, 44px); margin: 0 calc(-1 * var(--fd-sidebar-edge)) 18px; border-top: 1px solid var(--color-fd-border, hsl(0 0% 15%)); border-bottom: 1px solid var(--color-fd-border, hsl(0 0% 15%)); background: transparent; padding: 0 var(--fd-sidebar-edge); font-family: var(--fd-docs-font-mono); font-size: 12px; letter-spacing: 0.03em; text-transform: uppercase; }
     .sidebar-brand a { display: inline-flex; min-width: 0; align-items: center; gap: 8px; overflow: hidden; text-decoration: none; text-overflow: ellipsis; white-space: nowrap; }
     .sidebar-brand-logo { width: 16px; height: 16px; flex: 0 0 16px; color: var(--color-fd-foreground, oklch(0.985 0.001 106.423)); }
+    .sidebar-brand-title { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .sidebar-brand-suffix { opacity: 0.52; }
     .sidebar-scroll { margin: 0 calc(-1 * var(--fd-sidebar-edge)); overflow: visible; }
     .sidebar-tree { margin-top: 0 !important; }
     .sidebar-tree > a[data-active], .sidebar-folder { border-top: 1px solid var(--color-fd-border, hsl(0 0% 15%)); }
@@ -1858,7 +1871,7 @@ ${renderFarmDocsBridgeCss(docs)}</style>
     <div class="sidebar-backdrop" data-sidebar-backdrop></div>
     <aside id="nd-sidebar">
       <div class="sidebar-brand">
-        <a href="/">${renderFarmDocsBrandMark()}<span>${escapeHtml(navTitle)}</span></a>
+        <a href="/">${renderFarmDocsBrandMark()}${renderFarmDocsBrandTitle(navTitle)}</a>
         <span>/ docs</span>
       </div>
       ${renderPixelNavItems(pages, page.href, docs)}

--- a/packages/farm/src/docs/pixel-border-css.ts
+++ b/packages/farm/src/docs/pixel-border-css.ts
@@ -191,6 +191,17 @@ code:not(pre code) {
   color: var(--color-fd-foreground);
 }
 
+.sidebar-brand-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-brand-suffix {
+  opacity: 0.52;
+}
+
 .sidebar-brand > span {
   flex: 0 0 auto;
   margin-left: auto;


### PR DESCRIPTION
## What changed

- render a trailing `.js` in the docs sidebar brand as a separate suffix
- match the landing-page navbar treatment with 52% opacity
- preserve custom docs titles that do not end in `.js`
- add focused coverage for both branded and generic titles

## Why

PR #221 was merged before this final visual refinement was pushed. The docs sidebar therefore still rendered the full `Farm.js` label at the same brightness, while the homepage navbar uses a quieter `.JS` suffix.

## Impact

This is a presentation-only docs branding change. It does not alter routing, navigation, favicon handling, build behavior, or runtime functionality.

## Validation

- `pnpm --filter @farmjs/core test -- src/__tests__/docs-handler.test.ts` — 18 tests passed
- `pnpm exec oxfmt --check packages/farm/src/docs/handler.ts packages/farm/src/docs/pixel-border-css.ts packages/farm/src/__tests__/docs-handler.test.ts`
- browser verification at `/docs`: `.js` computed opacity is `0.52`, alignment is preserved, and no console errors or error overlays were detected