### PR TITLE
fix: match dev terminal startup log

### DIFF
--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -943,12 +943,12 @@ function TerminalVisual() {
                 <span aria-hidden className="farm-terminal-command-cursor inline-block" />
               </span>
               <span className="farm-terminal-output mt-1.5 block space-y-1.5">
-                <span className="block text-white">
-                  <span className="font-semibold text-white">[bench]</span> first rendered page{" "}
-                  <span className="text-white/88">
-                    {formatBenchmarkDuration(farmBenchmark.metrics.devFirstPageMs.median)}
-                  </span>{" "}
-                  <span className="text-white/34">median</span>
+                <span className="block whitespace-nowrap">
+                  <span className="font-semibold text-green-400">Farm.js</span>{" "}
+                  <span className="text-white/34">v1.0.0</span>{" "}
+                  <span className="text-white/34">
+                    ready in {formatBenchmarkDuration(farmBenchmark.metrics.devFirstPageMs.median)}
+                  </span>
                 </span>
                 <span className="block whitespace-nowrap text-white/58">
                   <span className="inline-block w-[4.5rem] text-white/82">➜ Local:</span>


### PR DESCRIPTION
## Summary

- remove the benchmark-style `first rendered page ... median` line from the homepage terminal animation
- mirror the real `pnpm dev` startup banner with `Farm.js v1.0.0 ready in {time}ms`
- preserve the existing Local, Network, and request output animation

## Why

The homepage terminal demo used benchmark wording that does not match Farm's actual development server output. This aligns the animated example with the logger implemented by the dev server.

## Validation

- `pnpm exec oxfmt --check docs/src/app/page.tsx`
- `git diff --check`
- `pnpm --dir docs exec farm build`