### PR TITLE
fix: harden integration scaffolds and Better Auth setup

### DIFF
--- a/docs/src/app/docs/integrations/auth/better-auth/page.md
+++ b/docs/src/app/docs/integrations/auth/better-auth/page.md
@@ -16,7 +16,9 @@ Use Better Auth when the app should own its auth database, methods, plugins, and
 farm add integration better-auth --ui
 ```
 
-Install `better-auth` plus the database driver or adapter selected by the application.
+The command adds `better-auth` and its SQLite driver, creates a local SQLite-backed server instance, writes
+`.env.example`, and, with `--ui`, adds a working sign-up, sign-in, session, and sign-out screen at
+`/integrations/better-auth`.
 
 ## Create the server instance
 
@@ -24,17 +26,26 @@ Install `better-auth` plus the database driver or adapter selected by the applic
 
 ```ts
 import { betterAuth } from "better-auth";
+import Database from "better-sqlite3";
+import { getMigrations } from "better-auth/db/migration";
 
 export const auth = betterAuth({
+  database: new Database(process.env.BETTER_AUTH_DATABASE_PATH || "better-auth.sqlite"),
   secret: process.env.BETTER_AUTH_SECRET,
   baseURL: process.env.BETTER_AUTH_URL,
   emailAndPassword: {
     enabled: true,
   },
 });
+
+const migrations = await getMigrations(auth.options);
+await migrations.runMigrations();
 ```
 
-Configure the production database, social providers, plugins, and callbacks in this object. They are not duplicated in Farm config.
+The generated SQLite setup is designed to work immediately in local development. Configure a
+persistent production database, managed migrations, social providers, plugins, and callbacks
+before deploying. These settings remain in Better Auth rather than being duplicated in Farm
+config.
 
 ## Register it
 

--- a/examples/better-auth-integration/src/lib/auth.ts
+++ b/examples/better-auth-integration/src/lib/auth.ts
@@ -1,10 +1,18 @@
-
+import Database from "better-sqlite3";
 import { betterAuth } from "better-auth";
+import { getMigrations } from "better-auth/db/migration";
 
 export const auth = betterAuth({
-  secret: "farm-example-secret",
-  baseURL: "http://localhost:3001",
+  database: new Database(process.env.BETTER_AUTH_DATABASE_PATH || "better-auth.sqlite"),
+  secret:
+    process.env.BETTER_AUTH_SECRET ||
+    "farm-example-better-auth-secret-for-local-development-only",
+  baseURL: process.env.BETTER_AUTH_URL || "http://localhost:3000",
+  trustedOrigins: ["http://localhost:3000", "http://127.0.0.1:3000"],
   emailAndPassword: {
     enabled: true,
   },
 });
+
+const migrations = await getMigrations(auth.options);
+await migrations.runMigrations();

--- a/packages/farm-cli/src/add-integration.ts
+++ b/packages/farm-cli/src/add-integration.ts
@@ -84,6 +84,13 @@ interface IntegrationProviderDefinition {
   exportName: string;
   description: string;
   env: readonly string[];
+  dependencies?: Readonly<Record<string, string>>;
+  devDependencies?: Readonly<Record<string, string>>;
+  setupFiles?: readonly {
+    path: string;
+    merge?: "lines";
+    source(): string;
+  }[];
   notes?: readonly string[];
   ui?: UIFeatureDefinition;
   template(): string;
@@ -396,8 +403,57 @@ export const autumnIntegration = autumn({
     fileName: "better-auth",
     exportName: "betterAuthIntegration",
     description: "Better Auth route adapter",
-    env: [],
-    notes: ["This template expects src/lib/auth.ts to export a Better Auth instance named auth."],
+    env: ["BETTER_AUTH_SECRET", "BETTER_AUTH_URL", "BETTER_AUTH_DATABASE_PATH"],
+    dependencies: {
+      "better-auth": "^1.5.5",
+      "better-sqlite3": "^12.6.2",
+    },
+    devDependencies: {
+      "@types/better-sqlite3": "^7.6.13",
+    },
+    notes: [
+      "The generated SQLite database is intended for local development. Configure a persistent production database before deploying.",
+      "Set BETTER_AUTH_SECRET to a high-entropy value of at least 32 characters.",
+    ],
+    setupFiles: [
+      {
+        path: "src/lib/auth.ts",
+        source: () => `import Database from "better-sqlite3";
+import { betterAuth as createBetterAuth } from "better-auth";
+import { getMigrations } from "better-auth/db/migration";
+
+const baseURL = process.env.BETTER_AUTH_URL || "http://localhost:3000";
+export const auth = createBetterAuth({
+  database: new Database(process.env.BETTER_AUTH_DATABASE_PATH || "better-auth.sqlite"),
+  secret: process.env.BETTER_AUTH_SECRET,
+  baseURL,
+  trustedOrigins: [baseURL],
+  emailAndPassword: {
+    enabled: true,
+  },
+});
+
+const migrations = await getMigrations(auth.options);
+await migrations.runMigrations();
+`,
+      },
+      {
+        path: ".env.example",
+        merge: "lines",
+        source: () => `BETTER_AUTH_SECRET=replace-with-at-least-32-random-characters
+BETTER_AUTH_URL=http://localhost:3000
+BETTER_AUTH_DATABASE_PATH=better-auth.sqlite
+`,
+      },
+      {
+        path: ".gitignore",
+        merge: "lines",
+        source: () => `better-auth.sqlite
+better-auth.sqlite-shm
+better-auth.sqlite-wal
+`,
+      },
+    ],
     ui: betterAuthUIFeature(),
     template: () => `import { betterAuth } from "@farmjs/integrations/better-auth";
 import { auth } from "../auth.ts";
@@ -522,6 +578,13 @@ export async function addFarmIntegration(
     dryRun: options.dryRun,
     result,
   });
+  await writeIntegrationSetupFiles({
+    root,
+    definition,
+    force: options.force,
+    dryRun: options.dryRun,
+    result,
+  });
   await writeIntegrationRegistry({
     path: registryFile,
     integrationFile,
@@ -534,6 +597,7 @@ export async function addFarmIntegration(
   if (!options.skipPackageJson) {
     await updatePackageJson({
       root,
+      definition,
       dryRun: options.dryRun,
       result,
     });
@@ -602,6 +666,7 @@ async function addAIRouteIntegration(input: {
   if (!input.skipPackageJson) {
     await updatePackageJson({
       root: input.root,
+      definition: input.definition,
       dryRun: input.dryRun,
       result,
     });
@@ -757,8 +822,51 @@ export type AppIntegrations = typeof appIntegrations;
   });
 }
 
+async function writeIntegrationSetupFiles(input: {
+  root: string;
+  definition: IntegrationProviderDefinition;
+  force?: boolean;
+  dryRun?: boolean;
+  result: AddFarmIntegrationResult;
+}) {
+  for (const file of input.definition.setupFiles || []) {
+    const absolutePath = path.join(input.root, file.path);
+    const exists = existsSync(absolutePath);
+    if (exists && !input.force) {
+      if (file.merge === "lines") {
+        const source = await readFile(absolutePath, "utf8");
+        const additions = file
+          .source()
+          .split(/\r?\n/)
+          .filter((line) => line && !source.split(/\r?\n/).includes(line));
+        if (!additions.length) {
+          input.result.skipped.push(absolutePath);
+          continue;
+        }
+
+        if (!input.dryRun) {
+          await writeFile(absolutePath, `${source.trimEnd()}\n${additions.join("\n")}\n`, "utf8");
+        }
+        input.result.updated.push(absolutePath);
+        continue;
+      }
+
+      input.result.skipped.push(absolutePath);
+      continue;
+    }
+
+    if (!input.dryRun) {
+      await mkdir(path.dirname(absolutePath), { recursive: true });
+      await writeFile(absolutePath, file.source(), "utf8");
+    }
+
+    input.result[exists ? "updated" : "created"].push(absolutePath);
+  }
+}
+
 async function updatePackageJson(input: {
   root: string;
+  definition: IntegrationProviderDefinition;
   dryRun?: boolean;
   result: AddFarmIntegrationResult;
 }) {
@@ -771,23 +879,44 @@ async function updatePackageJson(input: {
   const source = await readFile(packageJsonPath, "utf8");
   const manifest = JSON.parse(source) as PackageManifest;
 
-  if (hasPackageDependency(manifest, "@farmjs/integrations")) {
+  const dependencies = missingDependencies(manifest, input.definition.dependencies);
+  const devDependencies = missingDependencies(manifest, input.definition.devDependencies);
+  manifest.dependencies = {
+    ...manifest.dependencies,
+    ...(hasPackageDependency(manifest, "@farmjs/integrations")
+      ? {}
+      : { "@farmjs/integrations": getFarmIntegrationsVersion(manifest) }),
+    ...dependencies,
+  };
+  if (Object.keys(devDependencies).length) {
+    manifest.devDependencies = {
+      ...manifest.devDependencies,
+      ...devDependencies,
+    };
+  }
+
+  const nextSource = `${JSON.stringify(manifest, null, 2)}\n`;
+  if (source === nextSource) {
     input.result.packageJson = packageJsonPath;
     input.result.skipped.push(packageJsonPath);
     return;
   }
 
-  manifest.dependencies = {
-    ...manifest.dependencies,
-    "@farmjs/integrations": getFarmIntegrationsVersion(manifest),
-  };
-
   if (!input.dryRun) {
-    await writeFile(packageJsonPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+    await writeFile(packageJsonPath, nextSource, "utf8");
   }
 
   input.result.packageJson = packageJsonPath;
   input.result.updated.push(packageJsonPath);
+}
+
+function missingDependencies(
+  manifest: PackageManifest,
+  dependencies: Readonly<Record<string, string>> | undefined,
+) {
+  return Object.fromEntries(
+    Object.entries(dependencies || {}).filter(([name]) => !hasPackageDependency(manifest, name)),
+  );
 }
 
 async function updateFarmConfig(input: {

--- a/packages/farm-cli/src/ui-feature-registry.ts
+++ b/packages/farm-cli/src/ui-feature-registry.ts
@@ -244,14 +244,21 @@ export function clerkAuthUIFeature(): UIFeatureDefinition {
 }
 
 export function betterAuthUIFeature(): UIFeatureDefinition {
-  return authRouteShellUIFeature({
-    provider: "better-auth",
-    label: "Better Auth",
-    componentName: "BetterAuthPanel",
-    signInHref: "/api/auth/sign-in",
-    signUpHref: "/api/auth/sign-up",
-    sessionHref: "/api/auth/session",
-  });
+  return {
+    name: "better-auth-auth",
+    description: "Better Auth email and password UI",
+    components: ["badge", "button", "card", "input", "label"],
+    needsApiClient: false,
+    notes: ['Open "/integrations/better-auth" to try the generated auth UI.'],
+    files: () => [
+      {
+        path: path.join("src", "lib", "auth-client.ts"),
+        source: betterAuthClientTemplate(),
+      },
+      componentFile("better-auth-panel.tsx", betterAuthPanelTemplate()),
+      integrationPageFile("better-auth", "BetterAuthPanel"),
+    ],
+  };
 }
 
 export function authjsUIFeature(): UIFeatureDefinition {
@@ -392,6 +399,7 @@ async function writeGeneratedFile(input: {
 }) {
   const absolutePath = path.join(input.root, input.relativePath);
   const exists = existsSync(absolutePath);
+  const source = resolveGeneratedAliases(input.source, input.relativePath);
   input.result.ui?.files.push(absolutePath);
 
   if (exists && !input.force) {
@@ -401,10 +409,23 @@ async function writeGeneratedFile(input: {
 
   if (!input.dryRun) {
     await mkdir(path.dirname(absolutePath), { recursive: true });
-    await writeFile(absolutePath, input.source, "utf8");
+    await writeFile(absolutePath, source, "utf8");
   }
 
   pushResultPath(exists ? input.result.updated : input.result.created, absolutePath);
+}
+
+function resolveGeneratedAliases(source: string, relativePath: string) {
+  const sourceDirectory = path.dirname(relativePath);
+
+  return source.replace(/(["'])@\/([^"']+)\1/g, (_match, quote: string, target: string) => {
+    const relativeTarget = path
+      .relative(sourceDirectory, path.join("src", target))
+      .split(path.sep)
+      .join("/");
+    const importPath = relativeTarget.startsWith(".") ? relativeTarget : `./${relativeTarget}`;
+    return `${quote}${importPath}${quote}`;
+  });
 }
 
 async function ensureComponentsJson(input: {
@@ -469,15 +490,21 @@ ${SHADCN_THEME_CSS}
   }
 
   const source = await readFile(globalsPath, "utf8");
-  if (source.includes("--color-background") || source.includes("--background:")) {
+  const hasTailwindImport = source.includes('@import "tailwindcss"');
+  const hasTheme = source.includes("--color-background") || source.includes("--background:");
+  if (hasTailwindImport && hasTheme) {
     pushResultPath(input.result.skipped, globalsPath);
     return;
   }
 
-  const nextSource = `${source.trimEnd()}
+  const nextSource = `${hasTailwindImport ? "" : '@import "tailwindcss";\n\n'}${source.trimEnd()}${
+    hasTheme
+      ? "\n"
+      : `
 
 ${SHADCN_THEME_CSS}
-`;
+`
+  }`;
   if (!input.dryRun) {
     await writeFile(globalsPath, nextSource, "utf8");
   }
@@ -589,6 +616,7 @@ const UI_DEPENDENCIES = {
   "class-variance-authority": "^0.7.1",
   clsx: "^2.1.1",
   "tailwind-merge": "^3.3.1",
+  tailwindcss: "^4.1.18",
 } as const;
 
 const SHADCN_THEME_CSS = `@custom-variant dark (&:is(.dark *));
@@ -1423,6 +1451,186 @@ export function ${input.componentName}() {
             <Button type="button" onClick={() => window.location.assign("${input.signInHref}")}>Sign in</Button>
             <Button type="button" variant="outline" onClick={() => window.location.assign("${input.signUpHref}")}>Sign up</Button>
             <Button type="button" variant="ghost" onClick={() => window.location.assign("${input.sessionHref}")}>Session</Button>
+          </CardContent>
+        </Card>
+      </section>
+    </main>
+  );
+}
+`;
+}
+
+function betterAuthClientTemplate() {
+  return `import { createAuthClient } from "better-auth/react";
+
+export const authClient = createAuthClient({
+  baseURL: "",
+});
+`;
+}
+
+function betterAuthPanelTemplate() {
+  return `"use client";
+
+import * as React from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { authClient } from "@/lib/auth-client";
+
+type Mode = "sign-in" | "sign-up";
+
+export function BetterAuthPanel() {
+  const [mode, setMode] = React.useState<Mode>("sign-in");
+  const [pending, setPending] = React.useState(false);
+  const [message, setMessage] = React.useState("Ready");
+  const [sessionEmail, setSessionEmail] = React.useState<string | null>(null);
+
+  async function submit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setPending(true);
+    setMessage(mode === "sign-in" ? "Signing in…" : "Creating account…");
+
+    const form = new FormData(event.currentTarget);
+    const email = String(form.get("email") || "");
+    const password = String(form.get("password") || "");
+    const name = String(form.get("name") || "");
+    try {
+      const response =
+        mode === "sign-in"
+          ? await authClient.signIn.email({ email, password })
+          : await authClient.signUp.email({ email, password, name });
+
+      if (response.error) {
+        setMessage(response.error.message || "Authentication failed.");
+        return;
+      }
+
+      setSessionEmail(email);
+      setMessage(mode === "sign-in" ? "Signed in." : "Account created.");
+    } catch (cause) {
+      setMessage(cause instanceof Error ? cause.message : "Could not reach the auth server.");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function refreshSession() {
+    setPending(true);
+    try {
+      const response = await authClient.getSession();
+      setSessionEmail(response.data?.user.email || null);
+      setMessage(response.error?.message || (response.data ? "Session active." : "No active session."));
+    } catch (cause) {
+      setMessage(cause instanceof Error ? cause.message : "Could not read the session.");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function signOut() {
+    setPending(true);
+    try {
+      const response = await authClient.signOut();
+      if (response.error) {
+        setMessage(response.error.message || "Could not sign out.");
+        return;
+      }
+      setSessionEmail(null);
+      setMessage("Signed out.");
+    } catch (cause) {
+      setMessage(cause instanceof Error ? cause.message : "Could not reach the auth server.");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-background px-5 py-12 text-foreground sm:px-8">
+      <section className="mx-auto grid w-full max-w-5xl gap-8 lg:grid-cols-[1fr_420px] lg:items-start">
+        <div className="space-y-5 py-4">
+          <Badge variant="secondary">Better Auth × Farm.js</Badge>
+          <div className="space-y-3">
+            <h1 className="max-w-xl text-4xl font-semibold tracking-tight sm:text-5xl">
+              Authentication that starts ready.
+            </h1>
+            <p className="max-w-xl text-base leading-7 text-muted-foreground">
+              Test account creation, email sign-in, session reads, and sign-out through Farm’s
+              generated Better Auth integration.
+            </p>
+          </div>
+          <div aria-live="polite" className="border-l-2 border-primary pl-4 text-sm">
+            <p className="font-medium">{message}</p>
+            <p className="mt-1 text-muted-foreground">
+              {sessionEmail ? \`Signed in as \${sessionEmail}\` : "No authenticated user"}
+            </p>
+          </div>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>{mode === "sign-in" ? "Welcome back" : "Create an account"}</CardTitle>
+            <CardDescription>
+              {mode === "sign-in"
+                ? "Enter your credentials to start a secure session."
+                : "Use an email and password to create your local account."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form className="space-y-4" onSubmit={submit}>
+              {mode === "sign-up" ? (
+                <div className="space-y-2">
+                  <Label htmlFor="name">Name</Label>
+                  <Input autoComplete="name" id="name" name="name" required />
+                </div>
+              ) : null}
+              <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input autoComplete="email" id="email" name="email" required type="email" />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="password">Password</Label>
+                <Input
+                  autoComplete={mode === "sign-in" ? "current-password" : "new-password"}
+                  id="password"
+                  minLength={8}
+                  name="password"
+                  required
+                  type="password"
+                />
+              </div>
+              <Button className="w-full" disabled={pending} type="submit">
+                {pending ? "Working…" : mode === "sign-in" ? "Sign in" : "Create account"}
+              </Button>
+            </form>
+
+            <div className="mt-4 grid gap-2 sm:grid-cols-2">
+              <Button
+                disabled={pending}
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setMode(mode === "sign-in" ? "sign-up" : "sign-in");
+                  setMessage("Ready");
+                }}
+              >
+                {mode === "sign-in" ? "Create account" : "Use sign in"}
+              </Button>
+              <Button disabled={pending} type="button" variant="outline" onClick={() => void refreshSession()}>
+                Check session
+              </Button>
+            </div>
+            <Button
+              className="mt-2 w-full"
+              disabled={pending || !sessionEmail}
+              type="button"
+              variant="ghost"
+              onClick={() => void signOut()}
+            >
+              Sign out
+            </Button>
           </CardContent>
         </Card>
       </section>

--- a/packages/farm-cli/test/add-integration.test.mjs
+++ b/packages/farm-cli/test/add-integration.test.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 
 const require = createRequire(import.meta.url);
 const { addFarmIntegration, listFarmIntegrationProviders } = require("../dist/add-integration.js");
+const ts = require("typescript");
 const execFileAsync = promisify(execFile);
 const testDir = path.dirname(fileURLToPath(import.meta.url));
 const cliBin = path.resolve(testDir, "../bin/farm.js");
@@ -177,6 +178,8 @@ test("adds a stripe integration with the shadcn UI feature pack", async () => {
   });
 
   try {
+    await mkdir(path.join(root, "src/app"), { recursive: true });
+    await writeFile(path.join(root, "src/app/globals.css"), "body { margin: 0; }\n", "utf8");
     const result = await addFarmIntegration({
       root,
       provider: "stripe",
@@ -204,17 +207,20 @@ test("adds a stripe integration with the shadcn UI feature pack", async () => {
     assert.equal(packageJson.dependencies["class-variance-authority"], "^0.7.1");
     assert.equal(packageJson.dependencies.clsx, "^2.1.1");
     assert.equal(packageJson.dependencies["tailwind-merge"], "^3.3.1");
+    assert.equal(packageJson.dependencies.tailwindcss, "^4.1.18");
     assert.equal(componentsJson.aliases.ui, "@/components/ui");
     assert.equal(componentsJson.registries.farm.url, "https://farmjs.dev/r/{name}.json");
     assert.deepEqual(tsconfig.compilerOptions.paths["@/*"], ["./src/*"]);
     assert.match(globals, /--color-background/);
+    assert.match(globals, /^@import "tailwindcss";/);
+    assert.match(globals, /body \{ margin: 0; \}/);
     assert.match(api, /createIntegrations<AppIntegrations>/);
     assert.match(pricing, /apiClient\.billing\.products/);
     assert.match(pricing, /apiClient\.billing\.checkout/);
-    assert.match(pricing, /from "@\/components\/ui\/button"/);
+    assert.match(pricing, /from "\.\.\/ui\/button"/);
     assert.match(button, /class-variance-authority/);
-    assert.match(button, /from "@\/lib\/utils"/);
-    assert.match(page, /from "@\/components\/farm\/stripe-billing"/);
+    assert.match(button, /from "\.\.\/\.\.\/lib\/utils"/);
+    assert.match(page, /from "\.\.\/\.\.\/\.\.\/components\/farm\/stripe-billing"/);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -249,6 +255,109 @@ test("prepares UI files for every built-in integration provider", async () => {
     } finally {
       await rm(root, { recursive: true, force: true });
     }
+  }
+});
+
+test("writes syntactically valid integration and UI files for every provider", async () => {
+  for (const provider of listFarmIntegrationProviders()) {
+    const root = await createTempProject({
+      packageJson: {
+        type: "module",
+        dependencies: {
+          "@farmjs/core": "workspace:*",
+        },
+      },
+    });
+
+    try {
+      const result = await addFarmIntegration({
+        root,
+        provider: provider.name,
+        ui: true,
+      });
+      const packageJson = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
+
+      assert.equal(
+        packageJson.dependencies["@farmjs/integrations"],
+        "workspace:*",
+        `${provider.name} should install @farmjs/integrations`,
+      );
+
+      for (const file of result.created.filter((file) => /\.[cm]?[jt]sx?$/.test(file))) {
+        const source = await readFile(file, "utf8");
+        assertTypeScriptSyntax(source, file);
+        assert.doesNotMatch(source, /(["'])@\//, `${file} should use portable relative imports`);
+      }
+
+      if (result.mode === "integration") {
+        assert.match(
+          await readFile(result.registryFile, "utf8"),
+          new RegExp(`${result.key}:`),
+          `${provider.name} should register its integration`,
+        );
+        assert.match(
+          await readFile(result.configFile, "utf8"),
+          /integrations: appIntegrations/,
+          `${provider.name} should wire farm.config`,
+        );
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("scaffolds a working Better Auth starter with its UI dependencies", async () => {
+  const root = await createTempProject({
+    packageJson: {
+      type: "module",
+      dependencies: {
+        "@farmjs/core": "workspace:*",
+      },
+    },
+  });
+
+  try {
+    await writeFile(path.join(root, ".env.example"), "EXISTING_VALUE=kept\n", "utf8");
+    await writeFile(path.join(root, ".gitignore"), "node_modules\n", "utf8");
+    const result = await addFarmIntegration({
+      root,
+      provider: "better-auth",
+      ui: true,
+    });
+    const packageJson = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
+    const auth = await readFile(path.join(root, "src/lib/auth.ts"), "utf8");
+    const authClient = await readFile(path.join(root, "src/lib/auth-client.ts"), "utf8");
+    const panel = await readFile(
+      path.join(root, "src/components/farm/better-auth-panel.tsx"),
+      "utf8",
+    );
+    const env = await readFile(path.join(root, ".env.example"), "utf8");
+    const gitignore = await readFile(path.join(root, ".gitignore"), "utf8");
+
+    assert.equal(packageJson.dependencies["better-auth"], "^1.5.5");
+    assert.equal(packageJson.dependencies["better-sqlite3"], "^12.6.2");
+    assert.equal(packageJson.devDependencies["@types/better-sqlite3"], "^7.6.13");
+    assert.match(auth, /emailAndPassword:/);
+    assert.match(auth, /BETTER_AUTH_SECRET/);
+    assert.match(auth, /getMigrations/);
+    assert.match(auth, /runMigrations/);
+    assert.match(authClient, /createAuthClient/);
+    assert.match(panel, /authClient\.signIn\.email/);
+    assert.match(panel, /authClient\.signUp\.email/);
+    assert.match(panel, /authClient\.getSession/);
+    assert.match(panel, /authClient\.signOut/);
+    assert.match(env, /BETTER_AUTH_SECRET=/);
+    assert.match(env, /EXISTING_VALUE=kept/);
+    assert.match(gitignore, /node_modules/);
+    assert.match(gitignore, /better-auth\.sqlite/);
+    assert.deepEqual(result.env, [
+      "BETTER_AUTH_SECRET",
+      "BETTER_AUTH_URL",
+      "BETTER_AUTH_DATABASE_PATH",
+    ]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
   }
 });
 
@@ -362,4 +471,25 @@ async function createTempProject(input) {
     "utf8",
   );
   return root;
+}
+
+function assertTypeScriptSyntax(source, fileName) {
+  const result = ts.transpileModule(source, {
+    compilerOptions: {
+      jsx: ts.JsxEmit.ReactJSX,
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2022,
+    },
+    fileName,
+    reportDiagnostics: true,
+  });
+  const errors = (result.diagnostics || []).filter(
+    (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error,
+  );
+
+  assert.deepEqual(
+    errors.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n")),
+    [],
+    `${fileName} should contain valid TypeScript`,
+  );
 }


### PR DESCRIPTION
## Summary
- validate the actual generated files for every official integration provider
- make generated UI build-portable with relative imports and safe Tailwind CSS dependency/import merging
- turn the Better Auth scaffold into a working SQLite-backed starter with migrations, environment setup, gitignore merging, and responsive auth UI
- align the Better Auth example and documentation with the generated setup

## Why
The provider-wide tests previously inspected only dry-run plans. Actual generated UI could fail because Farm did not resolve `@/` aliases, existing stylesheets could miss the Tailwind import, and `tailwindcss` was not declared. Better Auth also generated an adapter that referenced a missing auth instance and a route-link shell instead of a working auth flow.

## Impact
`farm add integration better-auth --ui` now produces a locally runnable sign-up, sign-in, session, and sign-out starter while preserving existing application configuration. Other providers gain actual generation and syntax coverage plus build-safe generated UI imports and styles.

## Validation
- `pnpm --filter @farmjs/cli test` — 42 passing
- `pnpm --filter farm-example-better-auth-integration type-check`
- `pnpm --filter farm-example-better-auth-integration build`
- `pnpm --filter @farmjs/integrations build`
- generated Better Auth fixture production build
- live Better Auth HTTP sign-up → get-session → sign-out flow
- desktop and mobile browser QA with no console errors
- formatter check and `git diff --check`

Credentialed third-party integrations were scaffold/contract-tested and syntax-checked, but were not exercised against live external accounts.