### PR TITLE
feat: add framework E2E coverage to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,45 @@ jobs:
           cd playground
           pnpm build
 
+  framework-e2e:
+    name: Framework E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Verify general framework features
+        run: pnpm test:e2e:framework
+
+      - name: Upload Playwright failure artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: framework-e2e-playwright
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
   rsc-e2e:
     name: RSC E2E
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,13 +113,49 @@ jobs:
       - name: Verify docs and SSR/SSG production output
         run: pnpm test:e2e:production:sites:run
 
-      - name: Verify RSC production output
-        run: pnpm test:e2e:rsc
-
       - name: Build playground
         run: |
           cd playground
           pnpm build
+
+  rsc-e2e:
+    name: RSC E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Verify RSC framework features
+        run: pnpm test:e2e:rsc
+
+      - name: Upload Playwright failure artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: rsc-e2e-playwright
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: ignore
+          retention-days: 7
 
   i18n-e2e:
     name: Internationalization E2E

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:e2e:production:run": "playwright test --config playwright.production.config.ts",
     "test:e2e:production:sites": "corepack pnpm --filter @farmjs/core build && corepack pnpm --filter @farmjs/cli build && corepack pnpm test:e2e:production:sites:run",
     "test:e2e:production:sites:run": "corepack pnpm --dir docs run prisma:generate && FARM_VITE_BUILDER=rolldown corepack pnpm --dir docs exec farm build --preset node-server && FARM_VITE_BUILDER=rolldown corepack pnpm --dir examples/ssr-ssg-demo exec farm build --preset node-server && playwright test --config playwright.production-sites.config.ts",
-    "test:e2e:framework": "corepack pnpm --filter @farmjs/core build && playwright test tests/e2e/framework-features.spec.ts",
+    "test:e2e:framework": "corepack pnpm --filter @farmjs/core build && playwright test --config playwright.config.ts",
     "test:e2e:i18n": "corepack pnpm --filter @farmjs/core build && corepack pnpm --filter @farmjs/cli build && corepack pnpm --filter farm-i18n-example build && playwright test --config playwright.i18n.config.ts",
     "test:e2e:rsc": "corepack pnpm --filter @farmjs/core build && corepack pnpm --filter @farmjs/plugin build && FARM_SKIP_NPM_INSTALL=1 NITRO_PRESET=node-server corepack pnpm --filter farm-rsc-demo build && playwright test --config playwright.rsc.config.ts",
     "test:e2e:list": "playwright test --list",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,7 +11,8 @@ export default defineConfig({
   retries: 0,
   use: {
     baseURL: "http://localhost:4173",
-    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
   },
   webServer: {
     command: "corepack pnpm --dir examples/basic run dev --port 4173",

--- a/playwright.rsc.config.ts
+++ b/playwright.rsc.config.ts
@@ -11,10 +11,12 @@ export default defineConfig({
   retries: 0,
   use: {
     baseURL: "http://localhost:4174",
-    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
   },
   webServer: {
-    command: "NODE_ENV=production PORT=4174 corepack pnpm --dir examples/rsc-demo run preview",
+    command:
+      "NODE_ENV=production PORT=4174 corepack pnpm --dir examples/rsc-demo run preview",
     url: "http://localhost:4174",
     reuseExistingServer: false,
     timeout: 120_000,

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -6,11 +6,16 @@ Run the complete browser suite with:
 pnpm test:e2e
 ```
 
-Run the framework feature integration suite, including the required framework build, with:
+Run the complete general framework browser suite, including the required framework build, with:
 
 ```sh
 pnpm test:e2e:framework
 ```
+
+This is the CI entry point for every spec under `tests/e2e`. It exercises framework routing,
+rendering, hydration, navigation, route boundaries, prefetch controls, and global state against
+`examples/basic`. Specialized production, internationalization, and RSC suites remain separate so
+their failures are reported independently.
 
 Run the production internationalization suite with:
 


### PR DESCRIPTION
## Summary

- run the complete 26-test general framework browser suite as a dedicated `Framework E2E` CI check
- keep the 11-test RSC production suite as an independent specialized check
- retain Playwright traces and failure screenshots, and upload artifacts when either job fails
- document the general and specialized E2E entry points

## Coverage

The general framework check exercises routing and route data, rendering and hydration, SPA navigation, route boundaries, prefetch controls, environment boundaries, plugins, integrations, metadata routes, workflows, and global state against `examples/basic`.

Production sites and internationalization remain independent existing checks so each framework area reports failures clearly.

## Validation

- `pnpm test:e2e:framework` — 26/26 passed
- `pnpm test:e2e:rsc` — 11/11 passed
- Prettier checks passed for changed files
- `actionlint .github/workflows/ci.yml` passed
- `git diff --check` passed