### PR TITLE
chore: release v0.1.0-beta.1

### DIFF
--- a/examples/basic/src/app/page.tsx
+++ b/examples/basic/src/app/page.tsx
@@ -18,7 +18,7 @@ export default function HomePage({ params, searchParams }: PageProps) {
     <div className="space-y-8">
       <div className="text-center">
         <h1 className="text-5xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent mb-4">
-          Welcome to Farm.js 0.1.0-beta.0
+          Welcome to Farm.js 0.1.0-beta.1
         </h1>
         
         <p className="text-xl text-gray-600 max-w-2xl mx-auto">

--- a/packages/create-farm-app/package.json
+++ b/packages/create-farm-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/create-app",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "Create a new Farm.js application",
   "keywords": [
     "@farm.js/create-app",

--- a/packages/create-farm-app/templates/basic/package.json
+++ b/packages/create-farm-app/templates/basic/package.json
@@ -10,12 +10,12 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "0.1.0-beta.0",
+    "@farm.js/core": "0.1.0-beta.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.0",
+    "@farm.js/cli": "0.1.0-beta.1",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "tailwindcss": "^4.0.0",

--- a/packages/farm-ai/package.json
+++ b/packages/farm-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/ai",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "Farm.js AI route helpers",
   "license": "MIT",
   "repository": {

--- a/packages/farm-auth0/package.json
+++ b/packages/farm-auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/auth0",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "Auth0 integration for Farm.js",
   "license": "MIT",
   "repository": {

--- a/packages/farm-authjs/package.json
+++ b/packages/farm-authjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/authjs",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "Auth.js integration for Farm.js",
   "license": "MIT",
   "repository": {

--- a/packages/farm-autumn/package.json
+++ b/packages/farm-autumn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/autumn",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "Autumn billing integration for Farm.js",
   "license": "MIT",
   "repository": {

--- a/packages/farm-better-auth/package.json
+++ b/packages/farm-better-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/better-auth",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "Better Auth integration for Farm.js",
   "license": "MIT",
   "repository": {

--- a/packages/farm-cf-agent/package.json
+++ b/packages/farm-cf-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/cf-agent",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "First-class Cloudflare Agents integration for Farm.js",
   "keywords": [
     "agents",

--- a/packages/farm-clerk/package.json
+++ b/packages/farm-clerk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/clerk",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "Clerk integration for Farm.js",
   "license": "MIT",
   "repository": {

--- a/packages/farm-cli/package.json
+++ b/packages/farm-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/cli",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "CLI for Farm.js framework",
   "keywords": [
     "@farm.js/cli",

--- a/packages/farm-email/package.json
+++ b/packages/farm-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/email",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "Email and Resend integration for Farm.js",
   "license": "MIT",
   "repository": {

--- a/packages/farm-eve/package.json
+++ b/packages/farm-eve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/eve",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "First-class Eve agent runtime integration for Farm.js",
   "keywords": [
     "agents",

--- a/packages/farm-integration-utils/package.json
+++ b/packages/farm-integration-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/integration-utils",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "Shared integration utilities for Farm.js",
   "license": "MIT",
   "repository": {

--- a/packages/farm-integrations/package.json
+++ b/packages/farm-integrations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/integrations",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "Compatibility package that re-exports official Farm.js integrations",
   "license": "MIT",
   "repository": {

--- a/packages/farm-jobs/package.json
+++ b/packages/farm-jobs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/jobs",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "Jobs integration primitives for Farm.js",
   "license": "MIT",
   "repository": {

--- a/packages/farm-polar/package.json
+++ b/packages/farm-polar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/polar",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "Polar billing integration for Farm.js",
   "license": "MIT",
   "repository": {

--- a/packages/farm-preview-gateway/package.json
+++ b/packages/farm-preview-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/preview-gateway",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "Farm.js preview gateway for Vercel-hosted instant preview URLs",
   "license": "MIT",
   "repository": {

--- a/packages/farm-stripe/package.json
+++ b/packages/farm-stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/stripe",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "Stripe billing integration for Farm.js",
   "license": "MIT",
   "repository": {

--- a/packages/farm-supabase/package.json
+++ b/packages/farm-supabase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/supabase",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "Supabase integration for Farm.js",
   "license": "MIT",
   "repository": {

--- a/packages/farm-unkey/package.json
+++ b/packages/farm-unkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/unkey",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "Unkey integration for Farm.js",
   "license": "MIT",
   "repository": {

--- a/packages/farm-workos/package.json
+++ b/packages/farm-workos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/workos",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "WorkOS integration for Farm.js",
   "license": "MIT",
   "repository": {

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/core",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "Core Farm.js framework - A modern React meta-framework",
   "keywords": [
     "@farm.js/core",

--- a/packages/farmjs-plugin/package.json
+++ b/packages/farmjs-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/plugin",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "Official plugins for Farm.js framework",
   "license": "MIT",
   "author": "Farm.js Team",

--- a/packages/farmjs-plugin/src/index.ts
+++ b/packages/farmjs-plugin/src/index.ts
@@ -40,7 +40,7 @@
  * ```
  */
 
-export const version = "0.1.0-beta.0";
+export const version = "0.1.0-beta.1";
 
 // Note: Import plugins from their respective subpaths:
 // - @farm.js/plugin/rsc


### PR DESCRIPTION
## Summary

- bump all 22 publishable `@farm.js/*` packages from `0.1.0-beta.0` to `0.1.0-beta.1`
- sync the generated starter versions for `@farm.js/core` and `@farm.js/cli`
- update the plugin version export and the visible basic-example version

## Why

`0.1.0-beta.0` is immutable on npm, and its generated starter omitted required CLI and Tailwind setup. The starter fixes are already on `main`; this coordinated beta bump prepares corrected packages for a new publishable version.

The current release configuration includes `@farm.js/ai`, `@farm.js/integrations`, and the other integration packages in the same 22-package release set. This PR preserves that existing coordinated-release behavior and makes the scope explicit.

## Impact

After merge, `0.1.0-beta.1` can be published under the beta dist-tag. This PR itself does **not** publish any npm packages or create an npm tag.

## Validation

- `pnpm run release:prepare` on Node.js 24
- all 22 package build/test steps passed
- core: 716 passed, 1 skipped
- CLI: 42 passed
- plugin: 26 passed
- create-app generated-starter manifest test: 1 passed
- prior fixed-starter validation on `main`: clean install, type-check, and production build
- prior examples validation on `main`: 26 builds across Node.js 22/24
- prior Chromium E2E validation on `main`: 26 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump all 22 publishable `@farm.js/*` packages to `0.1.0-beta.1`, sync starter template versions, and update the plugin `version` export. Prepares corrected beta packages for publish and updates the basic example banner.

- **Dependencies**
  - `@farm.js/create-app` and the basic template now use `@farm.js/core` and `@farm.js/cli` at `0.1.0-beta.1` to include the required CLI and Tailwind setup.
  - All integration packages (including `@farm.js/integrations`) are bumped to keep the coordinated release set intact.

<sup>Written for commit b0b9b16e4ad846b53731743952889f178ba1fefe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

