### PR TITLE
fix: standalone beta examples and Node output

### DIFF
--- a/examples/auth0-integration/package.json
+++ b/examples/auth0-integration/package.json
@@ -9,13 +9,14 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/auth0": "workspace:*",
-    "@farm.js/core": "workspace:*",
+    "@farm.js/auth0": "0.1.0-beta.2",
+    "@farm.js/core": "0.1.0-beta.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
+    "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "typescript": "^5.3.3",

--- a/examples/authjs-integration/package.json
+++ b/examples/authjs-integration/package.json
@@ -9,13 +9,14 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/authjs": "workspace:*",
-    "@farm.js/core": "workspace:*",
+    "@farm.js/authjs": "0.1.0-beta.2",
+    "@farm.js/core": "0.1.0-beta.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
+    "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "typescript": "^5.3.3",

--- a/examples/autumn-integration/package.json
+++ b/examples/autumn-integration/package.json
@@ -10,16 +10,18 @@
     "generate": "farm generate"
   },
   "dependencies": {
-    "@farm.js/autumn": "workspace:*",
-    "@farm.js/better-auth": "workspace:*",
-    "@farm.js/core": "workspace:*",
+    "@farm.js/autumn": "0.1.0-beta.2",
+    "@farm.js/better-auth": "0.1.0-beta.2",
+    "@farm.js/core": "0.1.0-beta.2",
     "better-auth": "^1.5.5",
     "better-sqlite3": "^12.8.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "typescript": "^5.3.3",

--- a/examples/autumn-integration/src/app/dashboard/page.tsx
+++ b/examples/autumn-integration/src/app/dashboard/page.tsx
@@ -603,6 +603,7 @@ export default function DashboardPage() {
       (meterPrice: AutumnCatalogProduct["meterPrices"][number]) => meterPrice.key === "seats",
     ) ?? null;
   const currentOrganizationSeats = activeOrganization?.members.length ?? 0;
+  const currentCharges = billingState.currentCharges;
 
   return (
     <main className="page-shell">
@@ -842,7 +843,7 @@ export default function DashboardPage() {
             <section className="card">
               <h2>Current Cycle Charges</h2>
               {activeOrganization ? (
-                billingState.currentCharges ? (
+                currentCharges ? (
                   <>
                     <p>
                       This is the pending Autumn bill for the active cycle. It combines the base
@@ -852,12 +853,12 @@ export default function DashboardPage() {
                       <div className="session-line">
                         <strong>Billing Period</strong>
                         <span>
-                          {billingState.currentCharges.currentPeriodStart &&
-                          billingState.currentCharges.currentPeriodEnd
+                          {currentCharges.currentPeriodStart &&
+                          currentCharges.currentPeriodEnd
                             ? `${new Date(
-                                billingState.currentCharges.currentPeriodStart,
+                                currentCharges.currentPeriodStart,
                               ).toLocaleDateString()} - ${new Date(
-                                billingState.currentCharges.currentPeriodEnd,
+                                currentCharges.currentPeriodEnd,
                               ).toLocaleDateString()}`
                             : "n/a"}
                         </span>
@@ -866,8 +867,8 @@ export default function DashboardPage() {
                         <strong>Pending Meter Charge</strong>
                         <span>
                           {formatMoney(
-                            billingState.currentCharges.pendingMeterChargeAmount,
-                            billingState.currentCharges.currency,
+                            currentCharges.pendingMeterChargeAmount,
+                            currentCharges.currency,
                           )}
                         </span>
                       </div>
@@ -875,22 +876,22 @@ export default function DashboardPage() {
                         <strong>Estimated Total At Renewal</strong>
                         <span>
                           {formatMoney(
-                            billingState.currentCharges.estimatedTotalAmount,
-                            billingState.currentCharges.currency,
+                            currentCharges.estimatedTotalAmount,
+                            currentCharges.currency,
                           )}
                         </span>
                       </div>
                     </div>
 
-                    {billingState.currentCharges.lineItems.length ? (
+                    {currentCharges.lineItems.length ? (
                       <div className="list-stack">
-                        {billingState.currentCharges.lineItems.map(
+                        {currentCharges.lineItems.map(
                           (line: AutumnBillingCurrentChargesResult["lineItems"][number]) => (
                           <div className="list-item" key={`${line.kind}:${line.key ?? line.label}`}>
                             <div>
                               <strong>
                                 {line.label} ·{" "}
-                                {formatMoney(line.amount, billingState.currentCharges?.currency)}
+                                {formatMoney(line.amount, currentCharges.currency)}
                               </strong>
                               <div className="muted-line">
                                 {line.kind === "metered_usage"
@@ -904,7 +905,7 @@ export default function DashboardPage() {
                                       line.unitAmountDecimal
                                         ? ` × ${formatUnitAmount(
                                             line.unitAmountDecimal,
-                                            billingState.currentCharges?.currency,
+                                            currentCharges.currency,
                                             line.billingUnits,
                                             "tokens",
                                           )}`

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -15,14 +15,14 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "workspace:*",
+    "@farm.js/core": "0.1.0-beta.2",
     "better-call": "^1.0.19",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "zod": "^4.1.12"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "tailwindcss": "^4.0.0",

--- a/examples/better-auth-integration/package.json
+++ b/examples/better-auth-integration/package.json
@@ -10,15 +10,17 @@
   },
   "dependencies": {
     "@better-auth/passkey": "^1.3.1",
-    "@farm.js/better-auth": "workspace:*",
-    "@farm.js/core": "workspace:*",
+    "@farm.js/better-auth": "0.1.0-beta.2",
+    "@farm.js/core": "0.1.0-beta.2",
     "better-auth": "^1.3.1",
     "better-sqlite3": "^12.6.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "typescript": "^5.3.3",

--- a/examples/cf-agent/package.json
+++ b/examples/cf-agent/package.json
@@ -15,15 +15,15 @@
     "verify:worker": "wrangler deploy --dry-run --config .farm-cf-agent.wrangler.jsonc --outdir .farm/cf-agent/wrangler"
   },
   "dependencies": {
-    "@farm.js/cf-agent": "workspace:*",
-    "@farm.js/core": "workspace:*",
+    "@farm.js/cf-agent": "0.1.0-beta.2",
+    "@farm.js/core": "0.1.0-beta.2",
     "agents": "0.17.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^5.20260710.1",
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
     "@types/node": "^20.10.5",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/examples/clerk-integration/package.json
+++ b/examples/clerk-integration/package.json
@@ -11,13 +11,14 @@
   "dependencies": {
     "@clerk/backend": "^3.2.0",
     "@clerk/react": "^6.1.0",
-    "@farm.js/clerk": "workspace:*",
-    "@farm.js/core": "workspace:*",
+    "@farm.js/clerk": "0.1.0-beta.2",
+    "@farm.js/core": "0.1.0-beta.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
+    "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "typescript": "^5.3.3",

--- a/examples/deployment-presets/package.json
+++ b/examples/deployment-presets/package.json
@@ -18,12 +18,12 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "workspace:*",
+    "@farm.js/core": "0.1.0-beta.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "typescript": "^5.3.3",

--- a/examples/docs-integration/package.json
+++ b/examples/docs-integration/package.json
@@ -9,12 +9,12 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "workspace:*",
+    "@farm.js/core": "0.1.0-beta.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "typescript": "^5.5.3",

--- a/examples/email-integrations/resend-example/package.json
+++ b/examples/email-integrations/resend-example/package.json
@@ -9,14 +9,15 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "workspace:*",
-    "@farm.js/email": "workspace:*",
+    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/email": "0.1.0-beta.2",
     "@react-email/components": "^1.0.12",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
+    "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "typescript": "^5.3.3",

--- a/examples/email-integrations/resend-example/tsconfig.json
+++ b/examples/email-integrations/resend-example/tsconfig.json
@@ -24,7 +24,7 @@
         "../../../packages/farm-email/dist/*"
       ],
       "@farm.js/email/schedule": [
-        "../../../packages/farm-integrations/dist/email/schedule.d.ts"
+        "../../../packages/farm-email/dist/schedule.d.ts"
       ]
     },
     "allowImportingTsExtensions": true,

--- a/examples/eve-agent/package.json
+++ b/examples/eve-agent/package.json
@@ -13,15 +13,15 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "workspace:*",
-    "@farm.js/eve": "workspace:*",
+    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/eve": "0.1.0-beta.2",
     "ai": "^7.0.26",
     "eve": "0.24.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "typescript": "^5.3.3",

--- a/examples/i18n/package.json
+++ b/examples/i18n/package.json
@@ -10,12 +10,12 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "workspace:*",
+    "@farm.js/core": "0.1.0-beta.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "typescript": "^5.3.3",

--- a/examples/jobs-inngest/package.json
+++ b/examples/jobs-inngest/package.json
@@ -9,13 +9,14 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "workspace:*",
-    "@farm.js/jobs": "workspace:*",
+    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/jobs": "0.1.0-beta.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
+    "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "typescript": "^5.3.3",

--- a/examples/jobs-integration/package.json
+++ b/examples/jobs-integration/package.json
@@ -9,13 +9,14 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "workspace:*",
-    "@farm.js/jobs": "workspace:*",
+    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/jobs": "0.1.0-beta.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
+    "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "typescript": "^5.3.3",

--- a/examples/jobs-trigger/package.json
+++ b/examples/jobs-trigger/package.json
@@ -9,13 +9,14 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "workspace:*",
-    "@farm.js/jobs": "workspace:*",
+    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/jobs": "0.1.0-beta.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
+    "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "typescript": "^5.3.3",

--- a/examples/polar-integration/package.json
+++ b/examples/polar-integration/package.json
@@ -10,16 +10,18 @@
     "generate": "farm generate"
   },
   "dependencies": {
-    "@farm.js/better-auth": "workspace:*",
-    "@farm.js/core": "workspace:*",
-    "@farm.js/polar": "workspace:*",
+    "@farm.js/better-auth": "0.1.0-beta.2",
+    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/polar": "0.1.0-beta.2",
     "better-auth": "^1.5.5",
     "better-sqlite3": "^12.8.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "typescript": "^5.3.3",

--- a/examples/preview-gateway/package.json
+++ b/examples/preview-gateway/package.json
@@ -5,11 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "vercel dev",
-    "build": "corepack pnpm --filter @farm.js/preview-gateway build",
+    "build": "tsc --noEmit",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/preview-gateway": "workspace:*",
+    "@farm.js/preview-gateway": "0.1.0-beta.2",
     "@vercel/blob": "^2.6.1"
   },
   "devDependencies": {

--- a/examples/preview-gateway/tsconfig.json
+++ b/examples/preview-gateway/tsconfig.json
@@ -1,6 +1,17 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
     "outDir": "./dist",
     "rootDir": ".",
     "types": ["node"]

--- a/examples/preview-gateway/vercel.json
+++ b/examples/preview-gateway/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "corepack pnpm --filter @farm.js/preview-gateway build",
+  "buildCommand": "pnpm run build",
   "regions": ["iad1"],
   "functions": {
     "api/index.ts": {

--- a/examples/rsc-demo/package.json
+++ b/examples/rsc-demo/package.json
@@ -17,7 +17,7 @@
     "deploy:cloudflare": "pnpm run build:cloudflare && npx wrangler pages deploy .output/public --project-name=farm-rsc-demo"
   },
   "dependencies": {
-    "@farm.js/core": "workspace:*",
+    "@farm.js/core": "0.1.0-beta.2",
     "picocolors": "^1.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -25,7 +25,8 @@
     "zod": "^4.1.0"
   },
   "devDependencies": {
-    "@farm.js/plugin": "workspace:*",
+    "@farm.js/plugin": "0.1.0-beta.2",
+    "@rollup/plugin-terser": "^0.4.4",
     "@tailwindcss/vite": "^4.1.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/examples/simple-demo/package.json
+++ b/examples/simple-demo/package.json
@@ -7,8 +7,11 @@
     "dev": "node server.js"
   },
   "dependencies": {
-    "@farm.js/core": "workspace:*",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "@farm.js/core": "0.1.0-beta.2",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "tailwindcss": "^4.0.0"
   }
 }

--- a/examples/simple-demo/src/app/layout.tsx
+++ b/examples/simple-demo/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export default function RootLayout({ children }) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return React.createElement('html', { lang: 'en' },
     React.createElement('head', null,
       React.createElement('meta', { charSet: 'utf-8' }),
@@ -53,4 +53,3 @@ export default function RootLayout({ children }) {
     React.createElement('body', null, children)
   )
 }
-

--- a/examples/ssr-ssg-demo/package.json
+++ b/examples/ssr-ssg-demo/package.json
@@ -14,14 +14,14 @@
     "deploy:netlify": "farm deploy --netlify"
   },
   "dependencies": {
-    "@farm.js/core": "workspace:*",
+    "@farm.js/core": "0.1.0-beta.2",
     "better-call": "^1.0.19",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "tailwindcss": "^4.0.0",

--- a/examples/stripe-integration/package.json
+++ b/examples/stripe-integration/package.json
@@ -9,14 +9,15 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "workspace:*",
-    "@farm.js/stripe": "workspace:*",
+    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/stripe": "0.1.0-beta.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "stripe": "^20.4.1"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
+    "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "typescript": "^5.3.3",

--- a/examples/stripe-integrations/drizzle/package.json
+++ b/examples/stripe-integrations/drizzle/package.json
@@ -11,9 +11,9 @@
   },
   "dependencies": {
     "@better-auth/passkey": "^1.3.1",
-    "@farm.js/better-auth": "workspace:*",
-    "@farm.js/core": "workspace:*",
-    "@farm.js/stripe": "workspace:*",
+    "@farm.js/better-auth": "0.1.0-beta.2",
+    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/stripe": "0.1.0-beta.2",
     "better-auth": "^1.3.1",
     "better-sqlite3": "^12.6.2",
     "drizzle-orm": "^0.44.6",
@@ -22,7 +22,9 @@
     "stripe": "^20.4.1"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "drizzle-kit": "^0.31.4",

--- a/examples/stripe-integrations/prisma-org/package.json
+++ b/examples/stripe-integrations/prisma-org/package.json
@@ -11,9 +11,9 @@
   },
   "dependencies": {
     "@better-auth/passkey": "^1.3.1",
-    "@farm.js/better-auth": "workspace:*",
-    "@farm.js/core": "workspace:*",
-    "@farm.js/stripe": "workspace:*",
+    "@farm.js/better-auth": "0.1.0-beta.2",
+    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/stripe": "0.1.0-beta.2",
     "@prisma/client": "^6.7.0",
     "better-auth": "^1.3.1",
     "better-sqlite3": "^12.6.2",
@@ -22,7 +22,9 @@
     "stripe": "^20.4.1"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "prisma": "^6.7.0",

--- a/examples/stripe-integrations/prisma/package.json
+++ b/examples/stripe-integrations/prisma/package.json
@@ -11,9 +11,9 @@
   },
   "dependencies": {
     "@better-auth/passkey": "^1.3.1",
-    "@farm.js/better-auth": "workspace:*",
-    "@farm.js/core": "workspace:*",
-    "@farm.js/stripe": "workspace:*",
+    "@farm.js/better-auth": "0.1.0-beta.2",
+    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/stripe": "0.1.0-beta.2",
     "@prisma/client": "^6.7.0",
     "better-auth": "^1.3.1",
     "better-sqlite3": "^12.6.2",
@@ -22,7 +22,9 @@
     "stripe": "^20.4.1"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "prisma": "^6.7.0",

--- a/examples/stripe-integrations/sqlite/package.json
+++ b/examples/stripe-integrations/sqlite/package.json
@@ -11,9 +11,9 @@
   },
   "dependencies": {
     "@better-auth/passkey": "^1.3.1",
-    "@farm.js/better-auth": "workspace:*",
-    "@farm.js/core": "workspace:*",
-    "@farm.js/stripe": "workspace:*",
+    "@farm.js/better-auth": "0.1.0-beta.2",
+    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/stripe": "0.1.0-beta.2",
     "better-auth": "^1.3.1",
     "better-sqlite3": "^12.6.2",
     "react": "^19.0.0",
@@ -21,7 +21,9 @@
     "stripe": "^20.4.1"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "typescript": "^5.3.3",

--- a/examples/supabase-integration/package.json
+++ b/examples/supabase-integration/package.json
@@ -9,13 +9,14 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "workspace:*",
-    "@farm.js/supabase": "workspace:*",
+    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/supabase": "0.1.0-beta.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
+    "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "typescript": "^5.3.3",

--- a/examples/workos-integration/package.json
+++ b/examples/workos-integration/package.json
@@ -9,13 +9,14 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "workspace:*",
-    "@farm.js/workos": "workspace:*",
+    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/workos": "0.1.0-beta.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
+    "@farm.js/cli": "0.1.0-beta.2",
+    "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "typescript": "^5.3.3",

--- a/packages/create-farm-app/templates/basic/package.json
+++ b/packages/create-farm-app/templates/basic/package.json
@@ -11,13 +11,13 @@
   },
   "dependencies": {
     "@farm.js/core": "0.1.0-beta.2",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@farm.js/cli": "0.1.0-beta.2",
-    "@types/react": "^18.2.45",
-    "@types/react-dom": "^18.2.18",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.3.3"
   },

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -271,6 +271,7 @@ export default function Page() {
 
   it("boots standalone Node output through the package import mapping", async () => {
     const root = await createProductionFixture();
+    const isolatedRoot = await fs.mkdtemp(path.join(os.tmpdir(), "farm-standalone-prebuilt-"));
 
     try {
       const staticPageDir = path.join(root, "src", "app", "static-page");
@@ -348,7 +349,11 @@ export default function DynamicPage({ params }) {
       expect(clientBundle).toContain("Minified React error");
       expect(clientBundle).not.toContain("Download the React DevTools");
 
-      const serverDir = path.join(root, ".farm", ".output", "server");
+      const isolatedOutput = path.join(isolatedRoot, "output");
+      await fs.cp(path.join(root, ".farm", ".output"), isolatedOutput, {
+        recursive: true,
+      });
+      const serverDir = path.join(isolatedOutput, "server");
       const serverPackage = JSON.parse(
         await fs.readFile(path.join(serverDir, "package.json"), "utf8"),
       );
@@ -422,6 +427,7 @@ export default function DynamicPage({ params }) {
       );
     } finally {
       await fs.rm(root, { recursive: true, force: true });
+      await fs.rm(isolatedRoot, { recursive: true, force: true });
     }
   }, 120_000);
 

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -5259,14 +5259,14 @@ async function buildNitroUniversal(
     await fs.writeFile(filePath, output.type === "chunk" ? output.code : output.source);
   }
 
-  // Create entry that wraps the SSR handler with h3's fromWebHandler
+  // Create the Nitro event handler adapter. Nitro accepts plain event handler
+  // functions, so keep this entry dependency-free for standalone output.
   const nitroEntryPath = path.join(ssrOutputDir, "nitro-entry.mjs");
 
   const nitroEntryCode = `
 // Farm.js Nitro Entry
-// This file imports h3 and the SSR handler, wrapping it for Nitro
+// This file adapts Farm's Web fetch handler to Nitro's event handler contract.
 
-import { defineEventHandler } from 'h3'
 import handler from './${ssrEntryFile}'
 
 function mergeVaryHeaders(target, source) {
@@ -5304,8 +5304,8 @@ function createResponseFinishedHook(event) {
   }
 }
 
-// Export the wrapped handler for Nitro
-export default defineEventHandler(async (event) => {
+// Export the event handler for Nitro
+export default async function farmNitroEventHandler(event) {
   const response = await handler.fetch(event.req, {
     waitUntil: (promise) => event.waitUntil(promise),
     onResponseFinished: createResponseFinishedHook(event),
@@ -5316,7 +5316,7 @@ export default defineEventHandler(async (event) => {
   const farmVary = response.headers.get('Vary')
   if (farmVary) mergeVaryHeaders(event.res.headers, farmVary)
   return response
-})
+}
   `.trim();
 
   await fs.writeFile(nitroEntryPath, nitroEntryCode);

--- a/packages/farm/src/server/create-server.ts
+++ b/packages/farm/src/server/create-server.ts
@@ -15,6 +15,7 @@ import {
   createLoggerPlugin,
 } from "../plugins";
 import { mergeFarmViteConfig } from "./vite-config";
+import { FARM_VERSION } from "../version";
 
 // Farm.js branding plugin for createServer
 function createBrandingPlugin() {
@@ -58,7 +59,7 @@ function createBrandingPlugin() {
           const pc = getColors();
           console.log("");
           console.log(
-            `  ${pc.bold(pc.green("Farm.js"))} ${pc.dim("v1.0.0")} ${pc.dim(`ready in ${elapsed}ms`)}`,
+            `  ${pc.bold(pc.green("Farm.js"))} ${pc.dim(`v${FARM_VERSION}`)} ${pc.dim(`ready in ${elapsed}ms`)}`,
           );
           console.log("");
           console.log(

--- a/packages/farm/src/version.ts
+++ b/packages/farm/src/version.ts
@@ -1,0 +1,3 @@
+import { version } from "../package.json";
+
+export const FARM_VERSION = version;

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -42,6 +42,7 @@ import * as path from "path";
 import type { FarmUserConfig } from "./config";
 import { getFarmAppDirectories, getFarmLayerAliases, getFarmSourceRoots } from "./layers";
 import { farmEnvironmentFunctionsPlugin } from "./environment-vite";
+import { FARM_VERSION } from "./version";
 import { createDeferredDataResponse } from "./deferred";
 import { _withAfterNodeMiddleware } from "./after";
 import {
@@ -3996,7 +3997,7 @@ export async function defineConfig(config: FarmVitePluginOptions = {}) {
 
           console.log("");
           console.log(
-            `  ${pc.bold(pc.green("Farm.js"))} ${pc.dim("v1.0.0")} ${pc.dim(`ready in ${elapsed}ms`)}`,
+            `  ${pc.bold(pc.green("Farm.js"))} ${pc.dim(`v${FARM_VERSION}`)} ${pc.dim(`ready in ${elapsed}ms`)}`,
           );
           console.log("");
           console.log(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,10 +116,10 @@ importers:
   examples/auth0-integration:
     dependencies:
       '@farm.js/auth0':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-auth0
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm
       react:
         specifier: ^19.0.0
@@ -129,8 +129,11 @@ importers:
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-cli
+      '@types/node':
+        specifier: ^20.10.5
+        version: 20.19.21
       '@types/react':
         specifier: ^18.2.45
         version: 18.3.26
@@ -147,10 +150,10 @@ importers:
   examples/authjs-integration:
     dependencies:
       '@farm.js/authjs':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-authjs
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm
       react:
         specifier: ^19.0.0
@@ -160,8 +163,11 @@ importers:
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-cli
+      '@types/node':
+        specifier: ^20.10.5
+        version: 20.19.21
       '@types/react':
         specifier: ^18.2.45
         version: 18.3.26
@@ -178,17 +184,17 @@ importers:
   examples/autumn-integration:
     dependencies:
       '@farm.js/autumn':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-autumn
       '@farm.js/better-auth':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-better-auth
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm
       better-auth:
         specifier: ^1.5.5
-        version: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@7.1.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4)
+        version: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@6.21.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4)
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
@@ -200,8 +206,14 @@ importers:
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-cli
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      '@types/node':
+        specifier: ^20.10.5
+        version: 20.19.21
       '@types/react':
         specifier: ^18.2.45
         version: 18.3.26
@@ -218,7 +230,7 @@ importers:
   examples/basic:
     dependencies:
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm
       better-call:
         specifier: ^1.0.19
@@ -234,7 +246,7 @@ importers:
         version: 4.1.12
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-cli
       '@types/react':
         specifier: ^19.0.0
@@ -258,14 +270,14 @@ importers:
         specifier: ^1.3.1
         version: 1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5)(better-call@1.3.2)(nanostores@1.2.0)
       '@farm.js/better-auth':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-better-auth
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm
       better-auth:
         specifier: ^1.3.1
-        version: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@7.1.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4)
+        version: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@6.21.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4)
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.8.0
@@ -277,8 +289,14 @@ importers:
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-cli
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      '@types/node':
+        specifier: ^20.10.5
+        version: 20.19.21
       '@types/react':
         specifier: ^18.2.45
         version: 18.3.26
@@ -295,10 +313,10 @@ importers:
   examples/cf-agent:
     dependencies:
       '@farm.js/cf-agent':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-cf-agent
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm
       agents:
         specifier: 0.17.4
@@ -314,7 +332,7 @@ importers:
         specifier: ^5.20260710.1
         version: 5.20260716.1
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-cli
       '@types/node':
         specifier: ^20.10.5
@@ -344,10 +362,10 @@ importers:
         specifier: ^6.1.0
         version: 6.1.0(react-dom@19.2.4)(react@19.2.4)
       '@farm.js/clerk':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-clerk
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm
       react:
         specifier: ^19.0.0
@@ -357,8 +375,11 @@ importers:
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-cli
+      '@types/node':
+        specifier: ^20.10.5
+        version: 20.19.21
       '@types/react':
         specifier: ^18.2.45
         version: 18.3.26
@@ -375,7 +396,7 @@ importers:
   examples/deployment-presets:
     dependencies:
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm
       react:
         specifier: ^19.0.0
@@ -385,7 +406,7 @@ importers:
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-cli
       '@types/react':
         specifier: ^18.2.45
@@ -403,7 +424,7 @@ importers:
   examples/docs-integration:
     dependencies:
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm
       react:
         specifier: ^19.0.0
@@ -413,7 +434,7 @@ importers:
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-cli
       '@types/react':
         specifier: ^18.2.45
@@ -431,10 +452,10 @@ importers:
   examples/email-integrations/resend-example:
     dependencies:
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../../packages/farm
       '@farm.js/email':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../../packages/farm-email
       '@react-email/components':
         specifier: ^1.0.12
@@ -447,8 +468,11 @@ importers:
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../../packages/farm-cli
+      '@types/node':
+        specifier: ^20.10.5
+        version: 20.19.21
       '@types/react':
         specifier: ^18.2.45
         version: 18.3.26
@@ -465,10 +489,10 @@ importers:
   examples/eve-agent:
     dependencies:
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm
       '@farm.js/eve':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-eve
       ai:
         specifier: ^7.0.26
@@ -484,7 +508,7 @@ importers:
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-cli
       '@types/react':
         specifier: ^19.0.0
@@ -502,7 +526,7 @@ importers:
   examples/i18n:
     dependencies:
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm
       react:
         specifier: ^19.0.0
@@ -512,7 +536,7 @@ importers:
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-cli
       '@types/react':
         specifier: ^19.0.0
@@ -530,10 +554,10 @@ importers:
   examples/jobs-inngest:
     dependencies:
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm
       '@farm.js/jobs':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-jobs
       react:
         specifier: ^19.0.0
@@ -543,8 +567,11 @@ importers:
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-cli
+      '@types/node':
+        specifier: ^20.10.5
+        version: 20.19.21
       '@types/react':
         specifier: ^18.2.45
         version: 18.3.26
@@ -561,10 +588,10 @@ importers:
   examples/jobs-integration:
     dependencies:
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm
       '@farm.js/jobs':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-jobs
       react:
         specifier: ^19.0.0
@@ -574,8 +601,11 @@ importers:
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-cli
+      '@types/node':
+        specifier: ^20.10.5
+        version: 20.19.21
       '@types/react':
         specifier: ^18.2.45
         version: 18.3.26
@@ -592,10 +622,10 @@ importers:
   examples/jobs-trigger:
     dependencies:
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm
       '@farm.js/jobs':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-jobs
       react:
         specifier: ^19.0.0
@@ -605,8 +635,11 @@ importers:
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-cli
+      '@types/node':
+        specifier: ^20.10.5
+        version: 20.19.21
       '@types/react':
         specifier: ^18.2.45
         version: 18.3.26
@@ -623,17 +656,17 @@ importers:
   examples/polar-integration:
     dependencies:
       '@farm.js/better-auth':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-better-auth
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm
       '@farm.js/polar':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-polar
       better-auth:
         specifier: ^1.5.5
-        version: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@7.1.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4)
+        version: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@6.21.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4)
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
@@ -645,8 +678,14 @@ importers:
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-cli
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      '@types/node':
+        specifier: ^20.10.5
+        version: 20.19.21
       '@types/react':
         specifier: ^18.2.45
         version: 18.3.26
@@ -663,7 +702,7 @@ importers:
   examples/preview-gateway:
     dependencies:
       '@farm.js/preview-gateway':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-preview-gateway
       '@vercel/blob':
         specifier: ^2.6.1
@@ -679,7 +718,7 @@ importers:
   examples/rsc-demo:
     dependencies:
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm
       picocolors:
         specifier: ^1.0.0
@@ -698,8 +737,11 @@ importers:
         version: 4.1.12
     devDependencies:
       '@farm.js/plugin':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farmjs-plugin
+      '@rollup/plugin-terser':
+        specifier: ^0.4.4
+        version: 0.4.4
       '@tailwindcss/vite':
         specifier: ^4.1.0
         version: 4.1.18(vite@6.4.1)
@@ -731,19 +773,23 @@ importers:
   examples/simple-demo:
     dependencies:
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm
       react:
-        specifier: ^18.2.0
-        version: 18.3.1
+        specifier: ^19.0.0
+        version: 19.2.4
       react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      tailwindcss:
+        specifier: ^4.0.0
+        version: 4.1.18
 
   examples/ssr-ssg-demo:
     dependencies:
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm
       better-call:
         specifier: ^1.0.19
@@ -759,7 +805,7 @@ importers:
         version: 3.24.1
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-cli
       '@types/react':
         specifier: ^18.2.45
@@ -780,10 +826,10 @@ importers:
   examples/stripe-integration:
     dependencies:
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm
       '@farm.js/stripe':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-stripe
       react:
         specifier: ^19.0.0
@@ -796,8 +842,11 @@ importers:
         version: 20.4.1(@types/node@20.19.21)
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-cli
+      '@types/node':
+        specifier: ^20.10.5
+        version: 20.19.21
       '@types/react':
         specifier: ^18.2.45
         version: 18.3.26
@@ -817,17 +866,17 @@ importers:
         specifier: ^1.3.1
         version: 1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5)(better-call@1.3.2)(nanostores@1.2.0)
       '@farm.js/better-auth':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../../packages/farm-better-auth
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../../packages/farm
       '@farm.js/stripe':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../../packages/farm-stripe
       better-auth:
         specifier: ^1.3.1
-        version: 1.5.5(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7)(mongodb@7.1.0)(react-dom@19.2.4)(react@19.2.4)
+        version: 1.5.5(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7)(mongodb@6.21.0)(react-dom@19.2.4)(react@19.2.4)
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.8.0
@@ -845,8 +894,14 @@ importers:
         version: 20.4.1(@types/node@20.19.21)
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../../packages/farm-cli
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      '@types/node':
+        specifier: ^20.10.5
+        version: 20.19.21
       '@types/react':
         specifier: ^18.2.45
         version: 18.3.26
@@ -869,20 +924,20 @@ importers:
         specifier: ^1.3.1
         version: 1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5)(better-call@1.3.2)(nanostores@1.2.0)
       '@farm.js/better-auth':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../../packages/farm-better-auth
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../../packages/farm
       '@farm.js/stripe':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../../packages/farm-stripe
       '@prisma/client':
         specifier: ^6.7.0
         version: 6.19.2(prisma@6.19.2)(typescript@5.9.3)
       better-auth:
         specifier: ^1.3.1
-        version: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@7.1.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4)
+        version: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@6.21.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4)
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.8.0
@@ -897,8 +952,14 @@ importers:
         version: 20.4.1(@types/node@20.19.21)
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../../packages/farm-cli
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      '@types/node':
+        specifier: ^20.10.5
+        version: 20.19.21
       '@types/react':
         specifier: ^18.2.45
         version: 18.3.26
@@ -921,20 +982,20 @@ importers:
         specifier: ^1.3.1
         version: 1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5)(better-call@1.3.2)(nanostores@1.2.0)
       '@farm.js/better-auth':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../../packages/farm-better-auth
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../../packages/farm
       '@farm.js/stripe':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../../packages/farm-stripe
       '@prisma/client':
         specifier: ^6.7.0
         version: 6.19.2(prisma@6.19.2)(typescript@5.9.3)
       better-auth:
         specifier: ^1.3.1
-        version: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@7.1.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4)
+        version: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@6.21.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4)
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.8.0
@@ -949,8 +1010,14 @@ importers:
         version: 20.4.1(@types/node@20.19.21)
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../../packages/farm-cli
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      '@types/node':
+        specifier: ^20.10.5
+        version: 20.19.21
       '@types/react':
         specifier: ^18.2.45
         version: 18.3.26
@@ -973,17 +1040,17 @@ importers:
         specifier: ^1.3.1
         version: 1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5)(better-call@1.3.2)(nanostores@1.2.0)
       '@farm.js/better-auth':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../../packages/farm-better-auth
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../../packages/farm
       '@farm.js/stripe':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../../packages/farm-stripe
       better-auth:
         specifier: ^1.3.1
-        version: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@7.1.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4)
+        version: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@6.21.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4)
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.8.0
@@ -998,8 +1065,14 @@ importers:
         version: 20.4.1(@types/node@20.19.21)
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../../packages/farm-cli
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      '@types/node':
+        specifier: ^20.10.5
+        version: 20.19.21
       '@types/react':
         specifier: ^18.2.45
         version: 18.3.26
@@ -1016,10 +1089,10 @@ importers:
   examples/supabase-integration:
     dependencies:
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm
       '@farm.js/supabase':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-supabase
       react:
         specifier: ^19.0.0
@@ -1029,8 +1102,11 @@ importers:
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-cli
+      '@types/node':
+        specifier: ^20.10.5
+        version: 20.19.21
       '@types/react':
         specifier: ^18.2.45
         version: 18.3.26
@@ -1047,10 +1123,10 @@ importers:
   examples/workos-integration:
     dependencies:
       '@farm.js/core':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm
       '@farm.js/workos':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-workos
       react:
         specifier: ^19.0.0
@@ -1060,8 +1136,11 @@ importers:
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@farm.js/cli':
-        specifier: workspace:*
+        specifier: 0.1.0-beta.2
         version: link:../../packages/farm-cli
+      '@types/node':
+        specifier: ^20.10.5
+        version: 20.19.21
       '@types/react':
         specifier: ^18.2.45
         version: 18.3.26
@@ -1548,7 +1627,7 @@ importers:
         version: 2.0.0
       nitro:
         specifier: 3.0.1-alpha.0
-        version: 3.0.1-alpha.0(rolldown@1.2.0)(vite@6.4.1)
+        version: 3.0.1-alpha.0(rolldown@1.2.1)(vite@6.4.1)
       picocolors:
         specifier: ^1.0.0
         version: 1.1.1
@@ -2310,7 +2389,7 @@ packages:
       '@better-auth/utils': 0.3.1
     dev: false
 
-  /@better-auth/mongo-adapter@1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)(mongodb@7.1.0):
+  /@better-auth/mongo-adapter@1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)(mongodb@6.21.0):
     resolution: {integrity: sha512-P1J9ljL5X5k740I8Rx1esPWNgWYPdJR5hf2CY7BwDSrQFPUHuzeCg0YhtEEP55niNateTXhBqGAcy0fVOeamZg==}
     peerDependencies:
       '@better-auth/core': 1.5.5
@@ -2319,7 +2398,7 @@ packages:
     dependencies:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2)(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
-      mongodb: 7.1.0
+      mongodb: 6.21.0
     dev: false
 
   /@better-auth/passkey@1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5)(better-call@1.3.2)(nanostores@1.2.0):
@@ -2337,7 +2416,7 @@ packages:
       '@better-fetch/fetch': 1.1.21
       '@simplewebauthn/browser': 13.3.0
       '@simplewebauthn/server': 13.3.0
-      better-auth: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@7.1.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4)
+      better-auth: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@6.21.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4)
       better-call: 1.3.2(zod@4.3.6)
       nanostores: 1.2.0
       zod: 4.3.6
@@ -2738,6 +2817,14 @@ packages:
       tslib: 2.8.1
     optional: true
 
+  /@emnapi/core@2.0.0-alpha.3:
+    resolution: {integrity: sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==}
+    requiresBuild: true
+    dependencies:
+      '@emnapi/wasi-threads': 2.0.1
+      tslib: 2.8.1
+    optional: true
+
   /@emnapi/runtime@1.11.1:
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
     requiresBuild: true
@@ -2752,8 +2839,22 @@ packages:
       tslib: 2.8.1
     optional: true
 
+  /@emnapi/runtime@2.0.0-alpha.3:
+    resolution: {integrity: sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==}
+    requiresBuild: true
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   /@emnapi/wasi-threads@1.2.2:
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+    requiresBuild: true
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  /@emnapi/wasi-threads@2.0.1:
+    resolution: {integrity: sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==}
     requiresBuild: true
     dependencies:
       tslib: 2.8.1
@@ -2772,14 +2873,6 @@ packages:
     dependencies:
       '@esbuild-kit/core-utils': 3.3.2
       get-tsconfig: 4.12.0
-
-  /@esbuild/aix-ppc64@0.19.12:
-    resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [aix]
-    requiresBuild: true
-    optional: true
 
   /@esbuild/aix-ppc64@0.21.5:
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -2815,14 +2908,6 @@ packages:
 
   /@esbuild/android-arm64@0.18.20:
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/android-arm64@0.19.12:
-    resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -2869,14 +2954,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/android-arm@0.19.12:
-    resolution: {integrity: sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/android-arm@0.21.5:
     resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
     engines: {node: '>=12'}
@@ -2911,14 +2988,6 @@ packages:
 
   /@esbuild/android-x64@0.18.20:
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/android-x64@0.19.12:
-    resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -2965,14 +3034,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.19.12:
-    resolution: {integrity: sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/darwin-arm64@0.21.5:
     resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
     engines: {node: '>=12'}
@@ -3007,14 +3068,6 @@ packages:
 
   /@esbuild/darwin-x64@0.18.20:
     resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/darwin-x64@0.19.12:
-    resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -3061,14 +3114,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.19.12:
-    resolution: {integrity: sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/freebsd-arm64@0.21.5:
     resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
     engines: {node: '>=12'}
@@ -3103,14 +3148,6 @@ packages:
 
   /@esbuild/freebsd-x64@0.18.20:
     resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/freebsd-x64@0.19.12:
-    resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -3157,14 +3194,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-arm64@0.19.12:
-    resolution: {integrity: sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/linux-arm64@0.21.5:
     resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
     engines: {node: '>=12'}
@@ -3199,14 +3228,6 @@ packages:
 
   /@esbuild/linux-arm@0.18.20:
     resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-arm@0.19.12:
-    resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -3253,14 +3274,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-ia32@0.19.12:
-    resolution: {integrity: sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/linux-ia32@0.21.5:
     resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
     engines: {node: '>=12'}
@@ -3295,14 +3308,6 @@ packages:
 
   /@esbuild/linux-loong64@0.18.20:
     resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-loong64@0.19.12:
-    resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -3349,14 +3354,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-mips64el@0.19.12:
-    resolution: {integrity: sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/linux-mips64el@0.21.5:
     resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
     engines: {node: '>=12'}
@@ -3391,14 +3388,6 @@ packages:
 
   /@esbuild/linux-ppc64@0.18.20:
     resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-ppc64@0.19.12:
-    resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -3445,14 +3434,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-riscv64@0.19.12:
-    resolution: {integrity: sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/linux-riscv64@0.21.5:
     resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
     engines: {node: '>=12'}
@@ -3493,14 +3474,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-s390x@0.19.12:
-    resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/linux-s390x@0.21.5:
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
@@ -3535,14 +3508,6 @@ packages:
 
   /@esbuild/linux-x64@0.18.20:
     resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-x64@0.19.12:
-    resolution: {integrity: sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -3613,14 +3578,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/netbsd-x64@0.19.12:
-    resolution: {integrity: sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/netbsd-x64@0.21.5:
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
@@ -3679,14 +3636,6 @@ packages:
 
   /@esbuild/openbsd-x64@0.18.20:
     resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/openbsd-x64@0.19.12:
-    resolution: {integrity: sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -3757,14 +3706,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/sunos-x64@0.19.12:
-    resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/sunos-x64@0.21.5:
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
@@ -3799,14 +3740,6 @@ packages:
 
   /@esbuild/win32-arm64@0.18.20:
     resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/win32-arm64@0.19.12:
-    resolution: {integrity: sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -3853,14 +3786,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/win32-ia32@0.19.12:
-    resolution: {integrity: sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/win32-ia32@0.21.5:
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
@@ -3895,14 +3820,6 @@ packages:
 
   /@esbuild/win32-x64@0.18.20:
     resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/win32-x64@0.19.12:
-    resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -4929,27 +4846,42 @@ packages:
       sparse-bitfield: 3.0.3
     dev: false
 
-  /@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
-    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+  /@napi-rs/wasm-runtime@1.2.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
+    resolution: {integrity: sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
     requiresBuild: true
     peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
+      '@emnapi/core': ^2.0.0-alpha.3
+      '@emnapi/runtime': ^2.0.0-alpha.3
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  /@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2):
-    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+  /@napi-rs/wasm-runtime@1.2.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2):
+    resolution: {integrity: sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
     requiresBuild: true
     peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
+      '@emnapi/core': ^2.0.0-alpha.3
+      '@emnapi/runtime': ^2.0.0-alpha.3
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  /@napi-rs/wasm-runtime@1.2.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3):
+    resolution: {integrity: sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    requiresBuild: true
+    peerDependencies:
+      '@emnapi/core': ^2.0.0-alpha.3
+      '@emnapi/runtime': ^2.0.0-alpha.3
+    dependencies:
+      '@emnapi/core': 2.0.0-alpha.3
+      '@emnapi/runtime': 2.0.0-alpha.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -5058,6 +4990,9 @@ packages:
 
   /@oxc-project/types@0.140.0:
     resolution: {integrity: sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ==}
+
+  /@oxc-project/types@0.142.0:
+    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
 
   /@oxfmt/darwin-arm64@0.27.0:
     resolution: {integrity: sha512-3vwqyzNlVTVFVzHMlrqxb4tgVgHp6FYS0uIxsIZ/SeEDG0azaqiOw/2t8LlJ9f72PKRLWSey+Ak99tiKgpbsnQ==}
@@ -5400,8 +5335,8 @@ packages:
   /@prisma/config@6.7.0(supports-color@10.2.2):
     resolution: {integrity: sha512-di8QDdvSz7DLUi3OOcCHSwxRNeW7jtGRUD2+Z3SdNE3A+pPiNT8WgUJoUyOwJmUr5t+JA2W15P78C/N+8RXrOA==}
     dependencies:
-      esbuild: 0.19.12
-      esbuild-register: 3.6.0(esbuild@0.19.12)(supports-color@10.2.2)
+      esbuild: 0.28.1
+      esbuild-register: 3.6.0(esbuild@0.28.1)(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -6379,6 +6314,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rolldown/binding-android-arm64@1.2.1:
+    resolution: {integrity: sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    optional: true
+
   /@rolldown/binding-darwin-arm64@1.1.5:
     resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6389,6 +6332,14 @@ packages:
 
   /@rolldown/binding-darwin-arm64@1.2.0:
     resolution: {integrity: sha512-pexNaW9ACLUOaBITOpU6qVu4VrsOFIjTv6bzgu0YUATo4eUJx0V605PxwZfndpPOn0ilqGqvGQ0M8UW0IE24jg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
+  /@rolldown/binding-darwin-arm64@1.2.1:
+    resolution: {integrity: sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -6411,6 +6362,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rolldown/binding-darwin-x64@1.2.1:
+    resolution: {integrity: sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
   /@rolldown/binding-freebsd-x64@1.1.5:
     resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6421,6 +6380,14 @@ packages:
 
   /@rolldown/binding-freebsd-x64@1.2.0:
     resolution: {integrity: sha512-3vPoHzh6eBTz9IbB0/qZdSr0Qeks2echn+I4cHu2joV74VriPDdldswksEDzrl1mBB+oPRi+67+3Ib59paxIPQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    optional: true
+
+  /@rolldown/binding-freebsd-x64@1.2.1:
+    resolution: {integrity: sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -6443,6 +6410,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rolldown/binding-linux-arm-gnueabihf@1.2.1:
+    resolution: {integrity: sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@rolldown/binding-linux-arm64-gnu@1.1.5:
     resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6453,6 +6428,14 @@ packages:
 
   /@rolldown/binding-linux-arm64-gnu@1.2.0:
     resolution: {integrity: sha512-D+TgkdgM1vu+7/Fpf8+v0ARW+RXEP9Ccazgm8zQ4JFFd9Q7SrYQ2TakU5S5ihazQDgpKyAgZDOcIFsvoHmTZ8w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rolldown/binding-linux-arm64-gnu@1.2.1:
+    resolution: {integrity: sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -6475,6 +6458,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rolldown/binding-linux-arm64-musl@1.2.1:
+    resolution: {integrity: sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@rolldown/binding-linux-ppc64-gnu@1.1.5:
     resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6485,6 +6476,14 @@ packages:
 
   /@rolldown/binding-linux-ppc64-gnu@1.2.0:
     resolution: {integrity: sha512-9DtF35qR9/NrfhM4oxLplCzVVjE+KKm8Pjemi0i/sdhAWkUasjmSo8WTTubNJClhSHCfyk2yeyoXDQEDPtDAAw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rolldown/binding-linux-ppc64-gnu@1.2.1:
+    resolution: {integrity: sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -6507,6 +6506,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rolldown/binding-linux-s390x-gnu@1.2.1:
+    resolution: {integrity: sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@rolldown/binding-linux-x64-gnu@1.1.5:
     resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6517,6 +6524,14 @@ packages:
 
   /@rolldown/binding-linux-x64-gnu@1.2.0:
     resolution: {integrity: sha512-MK7L0018jjh1jR3mh21G2j1zAVcpscJBlPo2z19pRjv2XOYGRhaV4LyiD8HO6nCDdZln9IFgCMIV5yt4E3klGQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rolldown/binding-linux-x64-gnu@1.2.1:
+    resolution: {integrity: sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -6539,6 +6554,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rolldown/binding-linux-x64-musl@1.2.1:
+    resolution: {integrity: sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@rolldown/binding-openharmony-arm64@1.1.5:
     resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6555,6 +6578,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rolldown/binding-openharmony-arm64@1.2.1:
+    resolution: {integrity: sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+    requiresBuild: true
+    optional: true
+
   /@rolldown/binding-wasm32-wasi@1.1.5:
     resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6563,7 +6594,7 @@ packages:
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.2.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
   /@rolldown/binding-wasm32-wasi@1.2.0:
@@ -6574,7 +6605,17 @@ packages:
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@napi-rs/wasm-runtime': 1.2.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
+  /@rolldown/binding-wasm32-wasi@1.2.1:
+    resolution: {integrity: sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    requiresBuild: true
+    dependencies:
+      '@emnapi/core': 2.0.0-alpha.3
+      '@emnapi/runtime': 2.0.0-alpha.3
+      '@napi-rs/wasm-runtime': 1.2.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
     optional: true
 
   /@rolldown/binding-win32-arm64-msvc@1.1.5:
@@ -6593,6 +6634,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rolldown/binding-win32-arm64-msvc@1.2.1:
+    resolution: {integrity: sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
   /@rolldown/binding-win32-x64-msvc@1.1.5:
     resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6603,6 +6652,14 @@ packages:
 
   /@rolldown/binding-win32-x64-msvc@1.2.0:
     resolution: {integrity: sha512-WfFv6/qGufotqBSBzBYwgpCkJBk8Nj7697LL9vTz/XWc67e0r3oewu8iMRwQj3AUL45GVD7wVsPjCsAAtW66Wg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
+  /@rolldown/binding-win32-x64-msvc@1.2.1:
+    resolution: {integrity: sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -6653,7 +6710,6 @@ packages:
       serialize-javascript: 6.0.2
       smob: 1.5.0
       terser: 5.44.0
-    dev: false
 
   /@rollup/rollup-android-arm-eabi@4.52.4:
     resolution: {integrity: sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==}
@@ -7839,12 +7895,6 @@ packages:
       '@types/webidl-conversions': 7.0.3
     dev: false
 
-  /@types/whatwg-url@13.0.0:
-    resolution: {integrity: sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==}
-    dependencies:
-      '@types/webidl-conversions': 7.0.3
-    dev: false
-
   /@types/ws@8.18.1:
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
     dependencies:
@@ -8775,7 +8825,7 @@ packages:
     resolution: {integrity: sha512-OMu3BGQ4E7P1ErFsIPpbJh0qvDudM/UuJeHgkAvfWe+0HFJCXh+t/l8L6fVLR55RI/UbKrVLnAXZSVwd9ysWYw==}
     hasBin: true
 
-  /better-auth@1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@7.1.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4):
+  /better-auth@1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@6.21.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4):
     resolution: {integrity: sha512-GpVPaV1eqr3mOovKfghJXXk6QvlcVeFbS3z+n+FPDid5rK/2PchnDtiaVCzWyXA9jH2KkirOfl+JhAUvnja0Eg==}
     peerDependencies:
       '@lynx-js/react': '*'
@@ -8841,7 +8891,7 @@ packages:
       '@better-auth/drizzle-adapter': 1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)(drizzle-orm@0.44.7)
       '@better-auth/kysely-adapter': 1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)(kysely@0.28.12)
       '@better-auth/memory-adapter': 1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)
-      '@better-auth/mongo-adapter': 1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)(mongodb@7.1.0)
+      '@better-auth/mongo-adapter': 1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)(mongodb@6.21.0)
       '@better-auth/prisma-adapter': 1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)(@prisma/client@6.19.2)(prisma@6.19.2)
       '@better-auth/telemetry': 1.5.5(@better-auth/core@1.5.5)
       '@better-auth/utils': 0.3.1
@@ -8854,7 +8904,7 @@ packages:
       defu: 6.1.4
       jose: 6.2.1
       kysely: 0.28.12
-      mongodb: 7.1.0
+      mongodb: 6.21.0
       nanostores: 1.2.0
       prisma: 6.19.2(typescript@5.9.3)
       react: 19.2.4
@@ -8864,7 +8914,7 @@ packages:
       - '@cloudflare/workers-types'
     dev: false
 
-  /better-auth@1.5.5(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7)(mongodb@7.1.0)(react-dom@19.2.4)(react@19.2.4):
+  /better-auth@1.5.5(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7)(mongodb@6.21.0)(react-dom@19.2.4)(react@19.2.4):
     resolution: {integrity: sha512-GpVPaV1eqr3mOovKfghJXXk6QvlcVeFbS3z+n+FPDid5rK/2PchnDtiaVCzWyXA9jH2KkirOfl+JhAUvnja0Eg==}
     peerDependencies:
       '@lynx-js/react': '*'
@@ -8930,7 +8980,7 @@ packages:
       '@better-auth/drizzle-adapter': 1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)(drizzle-orm@0.44.7)
       '@better-auth/kysely-adapter': 1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)(kysely@0.28.12)
       '@better-auth/memory-adapter': 1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)
-      '@better-auth/mongo-adapter': 1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)(mongodb@7.1.0)
+      '@better-auth/mongo-adapter': 1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)(mongodb@6.21.0)
       '@better-auth/prisma-adapter': 1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)(@prisma/client@6.19.2)(prisma@6.19.2)
       '@better-auth/telemetry': 1.5.5(@better-auth/core@1.5.5)
       '@better-auth/utils': 0.3.1
@@ -8944,7 +8994,7 @@ packages:
       drizzle-orm: 0.44.7(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.12)
       jose: 6.2.1
       kysely: 0.28.12
-      mongodb: 7.1.0
+      mongodb: 6.21.0
       nanostores: 1.2.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -9065,11 +9115,6 @@ packages:
   /bson@6.10.4:
     resolution: {integrity: sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==}
     engines: {node: '>=16.20.1'}
-    dev: false
-
-  /bson@7.2.0:
-    resolution: {integrity: sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==}
-    engines: {node: '>=20.19.0'}
     dev: false
 
   /buffer-from@1.1.2:
@@ -10075,13 +10120,13 @@ packages:
       vfile-message: 4.0.3
     dev: false
 
-  /esbuild-register@3.6.0(esbuild@0.19.12)(supports-color@10.2.2):
+  /esbuild-register@3.6.0(esbuild@0.28.1)(supports-color@10.2.2):
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
-      esbuild: 0.19.12
+      esbuild: 0.28.1
     transitivePeerDependencies:
       - supports-color
 
@@ -10113,36 +10158,6 @@ packages:
       '@esbuild/win32-arm64': 0.18.20
       '@esbuild/win32-ia32': 0.18.20
       '@esbuild/win32-x64': 0.18.20
-
-  /esbuild@0.19.12:
-    resolution: {integrity: sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.19.12
-      '@esbuild/android-arm': 0.19.12
-      '@esbuild/android-arm64': 0.19.12
-      '@esbuild/android-x64': 0.19.12
-      '@esbuild/darwin-arm64': 0.19.12
-      '@esbuild/darwin-x64': 0.19.12
-      '@esbuild/freebsd-arm64': 0.19.12
-      '@esbuild/freebsd-x64': 0.19.12
-      '@esbuild/linux-arm': 0.19.12
-      '@esbuild/linux-arm64': 0.19.12
-      '@esbuild/linux-ia32': 0.19.12
-      '@esbuild/linux-loong64': 0.19.12
-      '@esbuild/linux-mips64el': 0.19.12
-      '@esbuild/linux-ppc64': 0.19.12
-      '@esbuild/linux-riscv64': 0.19.12
-      '@esbuild/linux-s390x': 0.19.12
-      '@esbuild/linux-x64': 0.19.12
-      '@esbuild/netbsd-x64': 0.19.12
-      '@esbuild/openbsd-x64': 0.19.12
-      '@esbuild/sunos-x64': 0.19.12
-      '@esbuild/win32-arm64': 0.19.12
-      '@esbuild/win32-ia32': 0.19.12
-      '@esbuild/win32-x64': 0.19.12
 
   /esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -12871,14 +12886,6 @@ packages:
       whatwg-url: 14.2.0
     dev: false
 
-  /mongodb-connection-string-url@7.0.1:
-    resolution: {integrity: sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==}
-    engines: {node: '>=20.19.0'}
-    dependencies:
-      '@types/whatwg-url': 13.0.0
-      whatwg-url: 14.2.0
-    dev: false
-
   /mongodb@6.20.0:
     resolution: {integrity: sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==}
     engines: {node: '>=16.20.1'}
@@ -12941,38 +12948,6 @@ packages:
       '@mongodb-js/saslprep': 1.4.6
       bson: 6.10.4
       mongodb-connection-string-url: 3.0.2
-    dev: false
-
-  /mongodb@7.1.0:
-    resolution: {integrity: sha512-kMfnKunbolQYwCIyrkxNJFB4Ypy91pYqua5NargS/f8ODNSJxT03ZU3n1JqL4mCzbSih8tvmMEMLpKTT7x5gCg==}
-    engines: {node: '>=20.19.0'}
-    peerDependencies:
-      '@aws-sdk/credential-providers': ^3.806.0
-      '@mongodb-js/zstd': ^7.0.0
-      gcp-metadata: ^7.0.1
-      kerberos: ^7.0.0
-      mongodb-client-encryption: '>=7.0.0 <7.1.0'
-      snappy: ^7.3.2
-      socks: ^2.8.6
-    peerDependenciesMeta:
-      '@aws-sdk/credential-providers':
-        optional: true
-      '@mongodb-js/zstd':
-        optional: true
-      gcp-metadata:
-        optional: true
-      kerberos:
-        optional: true
-      mongodb-client-encryption:
-        optional: true
-      snappy:
-        optional: true
-      socks:
-        optional: true
-    dependencies:
-      '@mongodb-js/saslprep': 1.4.6
-      bson: 7.2.0
-      mongodb-connection-string-url: 7.0.1
     dev: false
 
   /mongoose@8.24.1(supports-color@10.2.2):
@@ -13283,7 +13258,7 @@ packages:
       - uploadthing
     dev: false
 
-  /nitro@3.0.1-alpha.0(rolldown@1.2.0)(vite@6.4.1):
+  /nitro@3.0.1-alpha.0(rolldown@1.2.1)(vite@6.4.1):
     resolution: {integrity: sha512-lR3RplfXBOZXNlFQf9AJkqFVFhg5/CNbpBijM0dSYhGymb+FthJSdL6crmXVg518h2NVOd40rehhGZaf9ijW9w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
@@ -13311,7 +13286,7 @@ packages:
       ofetch: 1.5.1
       ohash: 2.0.11
       rendu: 0.0.6
-      rolldown: 1.2.0
+      rolldown: 1.2.1
       rollup: 4.52.4
       srvx: 0.8.16
       undici: 7.16.0
@@ -14187,16 +14162,6 @@ packages:
       strip-json-comments: 2.0.1
     dev: false
 
-  /react-dom@18.3.1(react@18.3.1):
-    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
-    peerDependencies:
-      react: ^18.3.1
-    dependencies:
-      loose-envify: 1.4.0
-      react: 18.3.1
-      scheduler: 0.23.2
-    dev: false
-
   /react-dom@19.2.4(react@19.2.4):
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
@@ -14293,13 +14258,6 @@ packages:
       get-nonce: 1.0.1
       react: 19.2.4
       tslib: 2.8.1
-    dev: false
-
-  /react@18.3.1:
-    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      loose-envify: 1.4.0
     dev: false
 
   /react@19.2.4:
@@ -14576,7 +14534,7 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  /rolldown-plugin-dts@0.16.11(rolldown@1.2.0)(supports-color@10.2.2)(typescript@5.9.3):
+  /rolldown-plugin-dts@0.16.11(rolldown@1.2.1)(supports-color@10.2.2)(typescript@5.9.3):
     resolution: {integrity: sha512-9IQDaPvPqTx3RjG2eQCK5GYZITo203BxKunGI80AGYicu1ySFTUyugicAaTZWRzFWh9DSnzkgNeMNbDWBbSs0w==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
@@ -14604,7 +14562,7 @@ packages:
       dts-resolver: 2.1.2
       get-tsconfig: 4.12.0
       magic-string: 0.30.21
-      rolldown: 1.2.0
+      rolldown: 1.2.1
       typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver
@@ -14658,6 +14616,30 @@ packages:
       '@rolldown/binding-wasm32-wasi': 1.2.0
       '@rolldown/binding-win32-arm64-msvc': 1.2.0
       '@rolldown/binding-win32-x64-msvc': 1.2.0
+
+  /rolldown@1.2.1:
+    resolution: {integrity: sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    dependencies:
+      '@oxc-project/types': 0.142.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.1
+      '@rolldown/binding-darwin-arm64': 1.2.1
+      '@rolldown/binding-darwin-x64': 1.2.1
+      '@rolldown/binding-freebsd-x64': 1.2.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.1
+      '@rolldown/binding-linux-arm64-gnu': 1.2.1
+      '@rolldown/binding-linux-arm64-musl': 1.2.1
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.1
+      '@rolldown/binding-linux-s390x-gnu': 1.2.1
+      '@rolldown/binding-linux-x64-gnu': 1.2.1
+      '@rolldown/binding-linux-x64-musl': 1.2.1
+      '@rolldown/binding-openharmony-arm64': 1.2.1
+      '@rolldown/binding-wasm32-wasi': 1.2.1
+      '@rolldown/binding-win32-arm64-msvc': 1.2.1
+      '@rolldown/binding-win32-x64-msvc': 1.2.1
 
   /rollup@4.52.4:
     resolution: {integrity: sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==}
@@ -14749,12 +14731,6 @@ packages:
     dependencies:
       xmlchars: 2.2.0
     dev: true
-
-  /scheduler@0.23.2:
-    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
-    dependencies:
-      loose-envify: 1.4.0
-    dev: false
 
   /scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -15070,7 +15046,6 @@ packages:
 
   /smob@1.5.0:
     resolution: {integrity: sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==}
-    dev: false
 
   /source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -15688,8 +15663,8 @@ packages:
       diff: 8.0.2
       empathic: 2.0.0
       hookable: 5.5.3
-      rolldown: 1.2.0
-      rolldown-plugin-dts: 0.16.11(rolldown@1.2.0)(supports-color@10.2.2)(typescript@5.9.3)
+      rolldown: 1.2.1
+      rolldown-plugin-dts: 0.16.11(rolldown@1.2.1)(supports-color@10.2.2)(typescript@5.9.3)
       semver: 7.7.3
       tinyexec: 1.0.1
       tinyglobby: 0.2.15


### PR DESCRIPTION
## What

- pin all 77 `@farm.js/*` dependency entries in 27 example apps to `0.1.0-beta.2`
- add the type/build dependencies that workspace hoisting had been masking
- make the generated Node adapter dependency-free so standalone Rolldown output no longer imports an unshipped `h3`
- isolate the production-output regression test outside the repository's `node_modules`
- align the simple demo and create-app template with React 19, fix preview-gateway/RSC/example configuration, and report the real core package version in the dev banner

## Why

The examples passed inside the monorepo while relying on hoisted packages. A real registry-style install exposed missing type packages and a Node production output that could fail with `ERR_MODULE_NOT_FOUND: h3` after deployment.

## Validation

- built all 22 beta.2 packages and packed their publish tarballs
- installed the tarballs into a clean standalone workspace (1,192 packages)
- passed all 25 example TypeScript checks across the required Node 22/23/24 runtimes
- passed all 26 example build scripts; the simple demo has no build script and was booted manually
- booted the final core tarball's i18n Rolldown output from an isolated directory with no parent `node_modules`; `/`, `/am`, and `/ar` all returned localized 200 responses
- booted the final simple-demo tarball setup; it returned the SSR page and printed `Farm.js v0.1.0-beta.2`
- passed the core production prebuilt-SSR regression suite (16/16)
- passed create-app type checking and tests
- ran formatting and focused lint checks (0 errors; 4 existing unused-variable warnings in `vite.ts`)

## Limits / release note

- provider-backed live auth/payment/email transactions were not performed; their builds used inert CI fixture values to avoid external side effects
- `v0.1.0-beta.2` already exists as a Git tag, while the beta.2 packages were still returning npm 404 during validation. This PR cannot change that tagged commit, so the standalone runtime fix should ship in a new prerelease after merge rather than silently publishing different contents under the existing beta.2 tag.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix standalone Node SSR and make all example apps install/build cleanly outside the monorepo. Pinned `@farm.js/*` to `0.1.0-beta.2`, added missing type deps, and removed the `h3` requirement from the Nitro entry.

- **Bug Fixes**
  - Made the Nitro event handler adapter dependency-free; Node standalone builds no longer fail with `ERR_MODULE_NOT_FOUND: h3`.
  - Isolated the production SSR regression test to a temp directory to catch missing deps.
  - Fixed preview-gateway build/config for Vercel (local `tsc` build, explicit tsconfig and build command).
  - Dev banner now shows the real `@farm.js/core` version via `FARM_VERSION`.

- **Dependencies**
  - Pinned all example `@farm.js/*` dependencies to `0.1.0-beta.2` and added missing types/build deps previously masked by hoisting.
  - Updated the simple demo, RSC demo, and `create-farm-app` basic template to React 19 and aligned configs.

<sup>Written for commit 4c87cbdae28f14e04ca71090b1f8b7b25420bceb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

