### PR TITLE
fix: secure RSC package alignment

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -17,8 +17,8 @@
     "@prisma/client": "6.7.0",
     "better-call": "^1.0.19",
     "lucide-react": "1.23.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
     "simple-icons": "16.25.0",
     "sugar-high": "0.9.5",
     "zod": "^4.3.6"

--- a/examples/auth0-integration/package.json
+++ b/examples/auth0-integration/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@farm.js/auth0": "workspace:*",
     "@farm.js/core": "workspace:*",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@farm.js/cli": "workspace:*",

--- a/examples/authjs-integration/package.json
+++ b/examples/authjs-integration/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@farm.js/authjs": "workspace:*",
     "@farm.js/core": "workspace:*",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@farm.js/cli": "workspace:*",

--- a/examples/autumn-integration/package.json
+++ b/examples/autumn-integration/package.json
@@ -15,8 +15,8 @@
     "@farm.js/core": "workspace:*",
     "better-auth": "^1.5.5",
     "better-sqlite3": "^12.8.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@farm.js/cli": "workspace:*",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -17,8 +17,8 @@
   "dependencies": {
     "@farm.js/core": "workspace:*",
     "better-call": "^1.0.19",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/examples/better-auth-integration/package.json
+++ b/examples/better-auth-integration/package.json
@@ -14,8 +14,8 @@
     "@farm.js/core": "workspace:*",
     "better-auth": "^1.3.1",
     "better-sqlite3": "^12.6.2",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@farm.js/cli": "workspace:*",

--- a/examples/cf-agent/package.json
+++ b/examples/cf-agent/package.json
@@ -18,8 +18,8 @@
     "@farm.js/cf-agent": "workspace:*",
     "@farm.js/core": "workspace:*",
     "agents": "0.17.4",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^5.20260710.1",

--- a/examples/clerk-integration/package.json
+++ b/examples/clerk-integration/package.json
@@ -13,8 +13,8 @@
     "@clerk/react": "^6.1.0",
     "@farm.js/clerk": "workspace:*",
     "@farm.js/core": "workspace:*",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@farm.js/cli": "workspace:*",

--- a/examples/deployment-presets/package.json
+++ b/examples/deployment-presets/package.json
@@ -19,8 +19,8 @@
   },
   "dependencies": {
     "@farm.js/core": "workspace:*",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@farm.js/cli": "workspace:*",

--- a/examples/docs-integration/package.json
+++ b/examples/docs-integration/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@farm.js/core": "workspace:*",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@farm.js/cli": "workspace:*",

--- a/examples/email-integrations/resend-example/package.json
+++ b/examples/email-integrations/resend-example/package.json
@@ -12,8 +12,8 @@
     "@farm.js/core": "workspace:*",
     "@farm.js/email": "workspace:*",
     "@react-email/components": "^1.0.12",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@farm.js/cli": "workspace:*",

--- a/examples/eve-agent/package.json
+++ b/examples/eve-agent/package.json
@@ -17,8 +17,8 @@
     "@farm.js/eve": "workspace:*",
     "ai": "^7.0.26",
     "eve": "0.24.6",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@farm.js/cli": "workspace:*",

--- a/examples/i18n/package.json
+++ b/examples/i18n/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@farm.js/core": "workspace:*",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@farm.js/cli": "workspace:*",

--- a/examples/jobs-inngest/package.json
+++ b/examples/jobs-inngest/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@farm.js/core": "workspace:*",
     "@farm.js/jobs": "workspace:*",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@farm.js/cli": "workspace:*",

--- a/examples/jobs-integration/package.json
+++ b/examples/jobs-integration/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@farm.js/core": "workspace:*",
     "@farm.js/jobs": "workspace:*",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@farm.js/cli": "workspace:*",

--- a/examples/jobs-trigger/package.json
+++ b/examples/jobs-trigger/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@farm.js/core": "workspace:*",
     "@farm.js/jobs": "workspace:*",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@farm.js/cli": "workspace:*",

--- a/examples/polar-integration/package.json
+++ b/examples/polar-integration/package.json
@@ -15,8 +15,8 @@
     "@farm.js/polar": "workspace:*",
     "better-auth": "^1.5.5",
     "better-sqlite3": "^12.8.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@farm.js/cli": "workspace:*",

--- a/examples/rsc-demo/README.md
+++ b/examples/rsc-demo/README.md
@@ -2,6 +2,32 @@
 
 Demo app for Farm.js with RSC, deployed via Nitro to Vercel.
 
+## RSC package compatibility
+
+Farm pins React's framework-level RSC APIs to one tested combination:
+
+```text
+react                        19.2.8
+react-dom                    19.2.8
+react-server-dom-webpack     19.2.8
+@vitejs/plugin-rsc           0.5.32
+```
+
+The RSC plugin stops startup with an actionable error when an application resolves a missing or
+different version. This prevents React, its Flight renderer/decoder and the Vite integration from
+silently drifting apart.
+
+RSC rendering does not enable Server Actions by itself. This demo opts in because `/form` exercises
+the action protocol:
+
+```ts
+experimental: {
+  serverActions: true,
+}
+```
+
+Keep Server Actions disabled when an RSC application does not need client-callable React actions.
+
 ## Experimental optimized boundary
 
 The `/static-content` route compares a normal React host-element tree with the same typed document

--- a/examples/rsc-demo/package.json
+++ b/examples/rsc-demo/package.json
@@ -19,9 +19,9 @@
   "dependencies": {
     "@farm.js/core": "workspace:*",
     "picocolors": "^1.0.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-server-dom-webpack": "^19.2.4",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
+    "react-server-dom-webpack": "19.2.8",
     "zod": "^4.1.0"
   },
   "devDependencies": {
@@ -30,7 +30,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.2.1",
-    "@vitejs/plugin-rsc": "^0.5.18",
+    "@vitejs/plugin-rsc": "0.5.32",
     "rsc-html-stream": "^0.0.4",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.5.3",

--- a/examples/rsc-demo/vite.config.ts
+++ b/examples/rsc-demo/vite.config.ts
@@ -13,10 +13,10 @@ export default defineConfig({
   port: 3000,
   debug: false,
   experimental: {
+    // Server Actions are a separate, explicit opt-in from RSC rendering.
+    serverActions: true,
     optimizedBoundary: true,
   },
-  // RSC/Server Actions are opt-in.
-  // Set experimental.serverComponents/serverActions in farm config when using core runtime.
   plugins: [
     tailwindcss(),
     rsc({

--- a/examples/simple-demo/package.json
+++ b/examples/simple-demo/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "@farm.js/core": "0.1.0-beta.2",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
   },
   "devDependencies": {
     "tailwindcss": "^4.0.0"

--- a/examples/ssr-ssg-demo/package.json
+++ b/examples/ssr-ssg-demo/package.json
@@ -16,8 +16,8 @@
   "dependencies": {
     "@farm.js/core": "workspace:*",
     "better-call": "^1.0.19",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/examples/stripe-integration/package.json
+++ b/examples/stripe-integration/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@farm.js/core": "workspace:*",
     "@farm.js/stripe": "workspace:*",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
     "stripe": "^20.4.1"
   },
   "devDependencies": {

--- a/examples/stripe-integrations/drizzle/package.json
+++ b/examples/stripe-integrations/drizzle/package.json
@@ -17,8 +17,8 @@
     "better-auth": "^1.3.1",
     "better-sqlite3": "^12.6.2",
     "drizzle-orm": "^0.44.6",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
     "stripe": "^20.4.1"
   },
   "devDependencies": {

--- a/examples/stripe-integrations/prisma-org/package.json
+++ b/examples/stripe-integrations/prisma-org/package.json
@@ -17,8 +17,8 @@
     "@prisma/client": "^6.7.0",
     "better-auth": "^1.3.1",
     "better-sqlite3": "^12.6.2",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
     "stripe": "^20.4.1"
   },
   "devDependencies": {

--- a/examples/stripe-integrations/prisma/package.json
+++ b/examples/stripe-integrations/prisma/package.json
@@ -17,8 +17,8 @@
     "@prisma/client": "^6.7.0",
     "better-auth": "^1.3.1",
     "better-sqlite3": "^12.6.2",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
     "stripe": "^20.4.1"
   },
   "devDependencies": {

--- a/examples/stripe-integrations/sqlite/package.json
+++ b/examples/stripe-integrations/sqlite/package.json
@@ -16,8 +16,8 @@
     "@farm.js/stripe": "workspace:*",
     "better-auth": "^1.3.1",
     "better-sqlite3": "^12.6.2",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
     "stripe": "^20.4.1"
   },
   "devDependencies": {

--- a/examples/supabase-integration/package.json
+++ b/examples/supabase-integration/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@farm.js/core": "workspace:*",
     "@farm.js/supabase": "workspace:*",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@farm.js/cli": "workspace:*",

--- a/examples/workos-integration/package.json
+++ b/examples/workos-integration/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@farm.js/core": "workspace:*",
     "@farm.js/workos": "workspace:*",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@farm.js/cli": "workspace:*",

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -489,9 +489,6 @@
     "nitro": "3.0.1-alpha.0",
     "pg": "^8.20.0",
     "picocolors": "^1.0.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-server-dom-webpack": "^18.3.0-canary-670c8dfb8-20231204",
     "remark-gfm": "^4.0.1",
     "sirv": "^2.0.4",
     "sugar-high": "^0.9.5",
@@ -507,6 +504,8 @@
     "@types/react-dom": "^18.2.18",
     "@vitest/coverage-v8": "^1.1.0",
     "jsdom": "^25.0.0",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
     "tsup": "^8.3.5",
     "typescript": "^5.3.3",
     "vitest": "^1.1.0"

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -53,27 +53,21 @@ export default function Page() {
 }
 
 async function linkReact18(root: string): Promise<void> {
-  const pnpmStore = path.resolve(packageRoot, "../../node_modules/.pnpm");
-  const entries = await fs.readdir(pnpmStore);
-  const reactEntry = entries.find((entry) => /^react@18\.\d+\.\d+$/.test(entry));
-  const reactDOMEntry = entries.find((entry) =>
-    /^react-dom@18\.\d+\.\d+_react@18\.\d+\.\d+$/.test(entry),
-  );
+  const fixtureModules = path.resolve(packageRoot, "../../examples/simple-demo/node_modules");
+  let reactPath: string;
+  let reactDOMPath: string;
 
-  if (!reactEntry || !reactDOMEntry) {
-    throw new Error("React 18 test dependencies are missing from the pnpm store");
+  try {
+    [reactPath, reactDOMPath] = await Promise.all([
+      fs.realpath(path.join(fixtureModules, "react")),
+      fs.realpath(path.join(fixtureModules, "react-dom")),
+    ]);
+  } catch {
+    throw new Error("React 18 compatibility fixture dependencies are missing");
   }
 
-  await fs.symlink(
-    path.join(pnpmStore, reactEntry, "node_modules", "react"),
-    path.join(root, "node_modules", "react"),
-    "dir",
-  );
-  await fs.symlink(
-    path.join(pnpmStore, reactDOMEntry, "node_modules", "react-dom"),
-    path.join(root, "node_modules", "react-dom"),
-    "dir",
-  );
+  await fs.symlink(reactPath, path.join(root, "node_modules", "react"), "dir");
+  await fs.symlink(reactDOMPath, path.join(root, "node_modules", "react-dom"), "dir");
 }
 
 async function getAvailablePort(): Promise<number> {

--- a/packages/farmjs-plugin/package.json
+++ b/packages/farmjs-plugin/package.json
@@ -73,7 +73,10 @@
     "@types/node": "^20.19.21",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "@vitejs/plugin-rsc": "^0.5.18",
+    "@vitejs/plugin-rsc": "0.5.32",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
+    "react-server-dom-webpack": "19.2.8",
     "tsdown": "^0.15.7",
     "typescript": "^5.5.3",
     "vite": "^6.0.0",
@@ -81,13 +84,17 @@
   },
   "peerDependencies": {
     "@farm.js/core": "workspace:*",
-    "@vitejs/plugin-rsc": ">=0.5.0",
-    "react": ">=19.0.0",
-    "react-dom": ">=19.0.0",
+    "@vitejs/plugin-rsc": "0.5.32",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
+    "react-server-dom-webpack": "19.2.8",
     "vite": ">=6.0.0"
   },
   "peerDependenciesMeta": {
     "@vitejs/plugin-rsc": {
+      "optional": true
+    },
+    "react-server-dom-webpack": {
       "optional": true
     }
   }

--- a/packages/farmjs-plugin/src/rsc/compatibility.test.ts
+++ b/packages/farmjs-plugin/src/rsc/compatibility.test.ts
@@ -1,0 +1,105 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { assertRscPackageCompatibility } from "./compatibility.js";
+import farmRsc, { defineConfig } from "./index.js";
+
+const EXPECTED_PACKAGES = {
+  react: "19.2.8",
+  "react-dom": "19.2.8",
+  "react-server-dom-webpack": "19.2.8",
+  "@vitejs/plugin-rsc": "0.5.32",
+} as const;
+
+const temporaryRoots: string[] = [];
+
+function createProject(packages: Partial<Record<keyof typeof EXPECTED_PACKAGES, string>>): string {
+  const root = mkdtempSync(path.join(tmpdir(), "farm-rsc-compatibility-"));
+  temporaryRoots.push(root);
+
+  for (const [packageName, version] of Object.entries(packages)) {
+    const packageRoot = path.join(root, "node_modules", packageName);
+    mkdirSync(packageRoot, { recursive: true });
+    writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: packageName, version }),
+    );
+  }
+
+  return root;
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("RSC package compatibility", () => {
+  it("accepts the exact supported package set", () => {
+    const root = createProject(EXPECTED_PACKAGES);
+    expect(() => assertRscPackageCompatibility(root)).not.toThrow();
+  });
+
+  it("rejects vulnerable or missing RSC packages with an actionable message", () => {
+    const root = createProject({
+      react: "19.2.4",
+      "react-dom": "19.2.4",
+      "react-server-dom-webpack": "19.2.4",
+      "@vitejs/plugin-rsc": "0.5.18",
+    });
+
+    expect(() => assertRscPackageCompatibility(root)).toThrowError(
+      /react: expected 19\.2\.8, found 19\.2\.4[\s\S]*react-server-dom-webpack: expected 19\.2\.8, found 19\.2\.4[\s\S]*@vitejs\/plugin-rsc: expected 0\.5\.32, found 0\.5\.18/,
+    );
+  });
+
+  it("keeps Server Actions disabled until an RSC application opts in", () => {
+    const config = defineConfig();
+    expect(config.experimental).toEqual({
+      serverComponents: true,
+      serverActions: false,
+      optimizedBoundary: false,
+    });
+  });
+
+  it("does not require the RSC package set when RSC is disabled", async () => {
+    const root = createProject({});
+    const configPlugin = farmRsc().find((plugin) => plugin.name === "@farm.js/plugin/rsc:config");
+    const configHook = configPlugin?.config as (
+      config: Record<string, unknown>,
+      env: { command: "build"; mode: string },
+    ) => Promise<unknown>;
+
+    await expect(
+      configHook(
+        {
+          root,
+          experimental: { serverComponents: false },
+        },
+        { command: "build", mode: "production" },
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("keeps the package manifest and ordinary core dependency graph aligned", () => {
+    const pluginManifest = JSON.parse(
+      readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+    ) as {
+      devDependencies: Record<string, string>;
+      peerDependencies: Record<string, string>;
+    };
+    const coreManifest = JSON.parse(
+      readFileSync(new URL("../../../farm/package.json", import.meta.url), "utf8"),
+    ) as {
+      dependencies: Record<string, string>;
+    };
+
+    for (const [packageName, version] of Object.entries(EXPECTED_PACKAGES)) {
+      expect(pluginManifest.devDependencies[packageName]).toBe(version);
+      expect(pluginManifest.peerDependencies[packageName]).toBe(version);
+    }
+    expect(coreManifest.dependencies).not.toHaveProperty("react-server-dom-webpack");
+  });
+});

--- a/packages/farmjs-plugin/src/rsc/compatibility.ts
+++ b/packages/farmjs-plugin/src/rsc/compatibility.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const RSC_PACKAGE_VERSIONS = {
+  react: "19.2.8",
+  "react-dom": "19.2.8",
+  "react-server-dom-webpack": "19.2.8",
+  "@vitejs/plugin-rsc": "0.5.32",
+} as const;
+
+type RscPackageName = keyof typeof RSC_PACKAGE_VERSIONS;
+
+interface PackageManifest {
+  version?: unknown;
+}
+
+function readPackageVersion(
+  projectRequire: NodeRequire,
+  packageName: RscPackageName,
+): string | undefined {
+  const manifestPath = projectRequire.resolve(`${packageName}/package.json`);
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as PackageManifest;
+  return typeof manifest.version === "string" ? manifest.version : undefined;
+}
+
+/**
+ * React's framework-level RSC APIs do not follow semver. Keep the complete
+ * renderer/decoder toolchain on the exact combination exercised by Farm's
+ * integration tests instead of accepting a potentially incompatible or
+ * vulnerable package resolution.
+ */
+export function assertRscPackageCompatibility(root: string): void {
+  const projectRequire = createRequire(path.join(path.resolve(root), "__farm_rsc_check__.cjs"));
+  const problems: string[] = [];
+
+  for (const [packageName, expectedVersion] of Object.entries(RSC_PACKAGE_VERSIONS) as Array<
+    [RscPackageName, string]
+  >) {
+    try {
+      const actualVersion = readPackageVersion(projectRequire, packageName);
+      if (actualVersion !== expectedVersion) {
+        problems.push(
+          `${packageName}: expected ${expectedVersion}, found ${actualVersion ?? "unknown"}`,
+        );
+      }
+    } catch {
+      problems.push(`${packageName}: expected ${expectedVersion}, package is not installed`);
+    }
+  }
+
+  if (problems.length === 0) return;
+
+  throw new Error(
+    [
+      "[Farm.js] Unsupported React Server Components package combination.",
+      ...problems.map((problem) => `- ${problem}`),
+      "",
+      "Farm pins the framework-level RSC APIs to one supported, integration-tested combination.",
+      "Install the supported versions with:",
+      "pnpm add react@19.2.8 react-dom@19.2.8 react-server-dom-webpack@19.2.8",
+      "pnpm add -D @vitejs/plugin-rsc@0.5.32",
+    ].join("\n"),
+  );
+}

--- a/packages/farmjs-plugin/src/rsc/index.ts
+++ b/packages/farmjs-plugin/src/rsc/index.ts
@@ -33,6 +33,7 @@ import { generateSsrEntry } from "./entries/ssr.js";
 import { generateClientEntry } from "./entries/client.js";
 import { transformFarmServerFns } from "./server-fn-transform.js";
 import { resolveRscBuildOutputPath } from "./build-paths.js";
+import { assertRscPackageCompatibility } from "./compatibility.js";
 import fs from "fs/promises";
 import path from "path";
 import { pathToFileURL } from "node:url";
@@ -68,7 +69,15 @@ export interface FarmRscConfig {
   basePath?: string;
   port?: number;
   experimental?: {
+    /**
+     * Enable React Server Components rendering.
+     * @default true
+     */
     serverComponents?: boolean;
+    /**
+     * Enable React Server Actions and their public POST decoder.
+     * @default false
+     */
     serverActions?: boolean;
     /**
      * Enable server-only optimized boundaries through
@@ -106,7 +115,7 @@ export function defineConfig(config: FarmRscConfig = {}): UserConfig {
     // Core Farm RSC settings
     experimental: {
       serverComponents: config.experimental?.serverComponents ?? true,
-      serverActions: config.experimental?.serverActions ?? true,
+      serverActions: config.experimental?.serverActions ?? false,
       optimizedBoundary: config.experimental?.optimizedBoundary ?? false,
     },
     srcDir: config.srcDir ?? "src",
@@ -624,6 +633,7 @@ export default function farmRsc(options: FarmRscPluginOptions = {}): Plugin[] {
         }
 
         const root = c.root ?? process.cwd();
+        assertRscPackageCompatibility(root);
         if (optimizedBoundaryEnabled) {
           registerRscNitroRuntimePackage(
             root,
@@ -757,7 +767,7 @@ export default function farmRsc(options: FarmRscPluginOptions = {}): Plugin[] {
               }
             : {}),
           resolve: {
-            dedupe: ["react", "react-dom"],
+            dedupe: ["react", "react-dom", "react-server-dom-webpack"],
             alias: [
               ...Object.entries(layerAliases).map(([find, replacement]) => ({
                 find,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -776,11 +776,11 @@ importers:
         specifier: 0.1.0-beta.2
         version: link:../../packages/farm
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 18.3.1
+        version: 18.3.1
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
     devDependencies:
       tailwindcss:
         specifier: ^4.0.0
@@ -12169,6 +12169,13 @@ packages:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
     dev: false
 
+  /loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+    dependencies:
+      js-tokens: 4.0.0
+    dev: false
+
   /loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
     dependencies:
@@ -14195,13 +14202,14 @@ packages:
       strip-json-comments: 2.0.1
     dev: false
 
-  /react-dom@19.2.4(react@19.2.4):
-    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
+  /react-dom@18.3.1(react@18.3.1):
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
-      react: ^19.2.4
+      react: ^18.3.1
     dependencies:
-      react: 19.2.4
-      scheduler: 0.27.0
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
     dev: false
 
   /react-dom@19.2.8(react@19.2.4):
@@ -14293,6 +14301,13 @@ packages:
       get-nonce: 1.0.1
       react: 19.2.8
       tslib: 2.8.1
+    dev: false
+
+  /react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
     dev: false
 
   /react@19.2.4:
@@ -14771,6 +14786,12 @@ packages:
     dependencies:
       xmlchars: 2.2.0
     dev: true
+
+  /scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: false
 
   /scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,10 +53,10 @@ importers:
         version: link:../packages/farm
       '@farming-labs/docs':
         specifier: ^0.2.44
-        version: 0.2.44(react@19.2.4)(supports-color@10.2.2)
+        version: 0.2.44(react@19.2.8)(supports-color@10.2.2)
       '@farming-labs/theme':
         specifier: ^0.2.44
-        version: 0.2.44(@farming-labs/docs@0.2.44)(@types/react-dom@18.3.7)(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.4)(react@19.2.4)(supports-color@10.2.2)(tailwindcss@3.4.18)
+        version: 0.2.44(@farming-labs/docs@0.2.44)(@types/react-dom@18.3.7)(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(tailwindcss@3.4.18)
       '@prisma/client':
         specifier: 6.7.0
         version: 6.7.0(prisma@6.7.0)(typescript@5.9.3)
@@ -65,13 +65,13 @@ importers:
         version: 1.0.19
       lucide-react:
         specifier: 1.23.0
-        version: 1.23.0(react@19.2.4)
+        version: 1.23.0(react@19.2.8)
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       simple-icons:
         specifier: 16.25.0
         version: 16.25.0
@@ -122,11 +122,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/farm
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
         specifier: workspace:*
@@ -153,11 +153,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/farm
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
         specifier: workspace:*
@@ -188,16 +188,16 @@ importers:
         version: link:../../packages/farm
       better-auth:
         specifier: ^1.5.5
-        version: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@7.1.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4)
+        version: 1.5.5(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7)(mongodb@7.1.0)(react-dom@19.2.8)(react@19.2.8)
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
         specifier: workspace:*
@@ -224,11 +224,11 @@ importers:
         specifier: ^1.0.19
         version: 1.0.19
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       zod:
         specifier: ^4.1.12
         version: 4.1.12
@@ -265,16 +265,16 @@ importers:
         version: link:../../packages/farm
       better-auth:
         specifier: ^1.3.1
-        version: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@7.1.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4)
+        version: 1.5.5(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7)(mongodb@7.1.0)(react-dom@19.2.8)(react@19.2.8)
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.8.0
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
         specifier: workspace:*
@@ -302,13 +302,13 @@ importers:
         version: link:../../packages/farm
       agents:
         specifier: 0.17.4
-        version: 0.17.4(@babel/core@8.0.1)(@cloudflare/workers-types@5.20260716.1)(react@19.2.4)(rolldown@1.2.0)(supports-color@10.2.2)(vite@8.1.5)(zod@4.3.6)
+        version: 0.17.4(@babel/core@8.0.1)(@cloudflare/workers-types@5.20260716.1)(react@19.2.8)(rolldown@1.2.0)(supports-color@10.2.2)(vite@8.1.5)(zod@4.3.6)
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^5.20260710.1
@@ -339,10 +339,10 @@ importers:
     dependencies:
       '@clerk/backend':
         specifier: ^3.2.0
-        version: 3.2.0(react-dom@19.2.4)(react@19.2.4)
+        version: 3.2.0(react-dom@19.2.8)(react@19.2.8)
       '@clerk/react':
         specifier: ^6.1.0
-        version: 6.1.0(react-dom@19.2.4)(react@19.2.4)
+        version: 6.1.0(react-dom@19.2.8)(react@19.2.8)
       '@farm.js/clerk':
         specifier: workspace:*
         version: link:../../packages/farm-clerk
@@ -350,11 +350,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/farm
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
         specifier: workspace:*
@@ -378,11 +378,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/farm
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
         specifier: workspace:*
@@ -406,11 +406,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/farm
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
         specifier: workspace:*
@@ -438,13 +438,13 @@ importers:
         version: link:../../../packages/farm-email
       '@react-email/components':
         specifier: ^1.0.12
-        version: 1.0.12(react-dom@19.2.4)(react@19.2.4)
+        version: 1.0.12(react-dom@19.2.8)(react@19.2.8)
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
         specifier: workspace:*
@@ -477,11 +477,11 @@ importers:
         specifier: 0.24.6
         version: 0.24.6(ai@7.0.30)(vite@8.1.5)
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
         specifier: workspace:*
@@ -505,11 +505,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/farm
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
         specifier: workspace:*
@@ -536,11 +536,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/farm-jobs
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
         specifier: workspace:*
@@ -567,11 +567,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/farm-jobs
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
         specifier: workspace:*
@@ -598,11 +598,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/farm-jobs
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
         specifier: workspace:*
@@ -633,16 +633,16 @@ importers:
         version: link:../../packages/farm-polar
       better-auth:
         specifier: ^1.5.5
-        version: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@7.1.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4)
+        version: 1.5.5(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7)(mongodb@7.1.0)(react-dom@19.2.8)(react@19.2.8)
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
         specifier: workspace:*
@@ -685,14 +685,14 @@ importers:
         specifier: ^1.0.0
         version: 1.1.1
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       react-server-dom-webpack:
-        specifier: ^19.2.4
-        version: 19.2.4(react-dom@19.2.4)(react@19.2.4)(webpack@5.102.1)
+        specifier: 19.2.8
+        version: 19.2.8(react-dom@19.2.8)(react@19.2.8)(webpack@5.102.1)
       zod:
         specifier: ^4.1.0
         version: 4.1.12
@@ -713,8 +713,8 @@ importers:
         specifier: ^4.2.1
         version: 4.7.0(supports-color@10.2.2)(vite@6.4.1)
       '@vitejs/plugin-rsc':
-        specifier: ^0.5.18
-        version: 0.5.18(react-dom@19.2.4)(react-server-dom-webpack@19.2.4)(react@19.2.4)(vite@6.4.1)
+        specifier: 0.5.32
+        version: 0.5.32(react-dom@19.2.8)(react-server-dom-webpack@19.2.8)(react@19.2.8)(vite@6.4.1)
       rsc-html-stream:
         specifier: ^0.0.4
         version: 0.0.4
@@ -749,11 +749,11 @@ importers:
         specifier: ^1.0.19
         version: 1.0.19
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       zod:
         specifier: ^3.22.4
         version: 3.24.1
@@ -786,11 +786,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/farm-stripe
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       stripe:
         specifier: ^20.4.1
         version: 20.4.1(@types/node@20.19.21)
@@ -827,7 +827,7 @@ importers:
         version: link:../../../packages/farm-stripe
       better-auth:
         specifier: ^1.3.1
-        version: 1.5.5(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7)(mongodb@7.1.0)(react-dom@19.2.4)(react@19.2.4)
+        version: 1.5.5(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7)(mongodb@7.1.0)(react-dom@19.2.8)(react@19.2.8)
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.8.0
@@ -835,11 +835,11 @@ importers:
         specifier: ^0.44.6
         version: 0.44.7(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.12)
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       stripe:
         specifier: ^20.4.1
         version: 20.4.1(@types/node@20.19.21)
@@ -882,16 +882,16 @@ importers:
         version: 6.19.2(prisma@6.19.2)(typescript@5.9.3)
       better-auth:
         specifier: ^1.3.1
-        version: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@7.1.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4)
+        version: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@7.1.0)(prisma@6.19.2)(react-dom@19.2.8)(react@19.2.8)
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.8.0
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       stripe:
         specifier: ^20.4.1
         version: 20.4.1(@types/node@20.19.21)
@@ -934,16 +934,16 @@ importers:
         version: 6.19.2(prisma@6.19.2)(typescript@5.9.3)
       better-auth:
         specifier: ^1.3.1
-        version: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@7.1.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4)
+        version: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@7.1.0)(prisma@6.19.2)(react-dom@19.2.8)(react@19.2.8)
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.8.0
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       stripe:
         specifier: ^20.4.1
         version: 20.4.1(@types/node@20.19.21)
@@ -983,16 +983,16 @@ importers:
         version: link:../../../packages/farm-stripe
       better-auth:
         specifier: ^1.3.1
-        version: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@7.1.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4)
+        version: 1.5.5(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7)(mongodb@7.1.0)(react-dom@19.2.8)(react@19.2.8)
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.8.0
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       stripe:
         specifier: ^20.4.1
         version: 20.4.1(@types/node@20.19.21)
@@ -1022,11 +1022,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/farm-supabase
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
         specifier: workspace:*
@@ -1053,11 +1053,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/farm-workos
       react:
-        specifier: ^19.0.0
-        version: 19.2.4
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
         specifier: workspace:*
@@ -1104,7 +1104,7 @@ importers:
     dependencies:
       '@farming-labs/docs':
         specifier: ^0.2.44
-        version: 0.2.44(react@19.2.4)(supports-color@10.2.2)
+        version: 0.2.44(react@19.2.8)(supports-color@10.2.2)
       '@farming-labs/orm':
         specifier: 0.0.62
         version: 0.0.62
@@ -1162,15 +1162,6 @@ importers:
       picocolors:
         specifier: ^1.0.0
         version: 1.1.1
-      react:
-        specifier: ^19.0.0
-        version: 19.2.4
-      react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
-      react-server-dom-webpack:
-        specifier: ^18.3.0-canary-670c8dfb8-20231204
-        version: 18.3.0-next-fecc288b7-20221025(react-dom@19.2.4)(react@19.2.4)(webpack@5.102.1)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1(supports-color@10.2.2)
@@ -1208,7 +1199,7 @@ importers:
     devDependencies:
       '@clerk/react':
         specifier: ^6.1.0
-        version: 6.1.0(react-dom@19.2.4)(react@19.2.4)
+        version: 6.1.0(react-dom@19.2.8)(react@19.2.8)
       '@types/react':
         specifier: ^18.2.45
         version: 18.3.26
@@ -1221,6 +1212,12 @@ importers:
       jsdom:
         specifier: ^25.0.0
         version: 25.0.1(supports-color@10.2.2)
+      react:
+        specifier: 19.2.8
+        version: 19.2.8
+      react-dom:
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       tsup:
         specifier: ^8.3.5
         version: 8.5.1(supports-color@10.2.2)(typescript@5.9.3)
@@ -1296,7 +1293,7 @@ importers:
         version: 20.19.21
       agents:
         specifier: 0.17.4
-        version: 0.17.4(@babel/core@8.0.1)(@cloudflare/workers-types@4.20260702.1)(react@19.2.4)(rolldown@1.2.0)(supports-color@10.2.2)(zod@4.3.6)
+        version: 0.17.4(@babel/core@8.0.1)(@cloudflare/workers-types@4.20260702.1)(react@19.2.8)(rolldown@1.2.0)(supports-color@10.2.2)(zod@4.3.6)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(supports-color@10.2.2)(typescript@5.9.3)
@@ -1314,10 +1311,10 @@ importers:
     dependencies:
       '@clerk/backend':
         specifier: ^3.2.0
-        version: 3.2.0(react-dom@19.2.4)(react@19.2.4)
+        version: 3.2.0(react-dom@18.3.1)(react@19.2.4)
       '@clerk/react':
         specifier: ^6.1.0
-        version: 6.1.0(react-dom@19.2.4)(react@19.2.4)
+        version: 6.1.0(react-dom@18.3.1)(react@19.2.4)
       '@farm.js/core':
         specifier: workspace:*
         version: link:../farm
@@ -1363,7 +1360,7 @@ importers:
         version: link:../farm-integration-utils
       '@react-email/render':
         specifier: 2.0.6
-        version: 2.0.6(react-dom@19.2.4)(react@19.2.4)
+        version: 2.0.6(react-dom@18.3.1)(react@19.2.4)
       react:
         specifier: ^18.2.0 || ^19.0.0
         version: 19.2.4
@@ -1539,7 +1536,7 @@ importers:
         version: link:../farm
       '@farming-labs/strata':
         specifier: 0.1.2
-        version: 0.1.2(react@19.2.4)
+        version: 0.1.2(react@19.2.8)
       better-call:
         specifier: ^1.0.19
         version: 1.0.19
@@ -1548,16 +1545,10 @@ importers:
         version: 2.0.0
       nitro:
         specifier: 3.0.1-alpha.0
-        version: 3.0.1-alpha.0(rolldown@1.2.0)(vite@6.4.1)
+        version: 3.0.1-alpha.0(rolldown@1.2.1)(vite@6.4.1)
       picocolors:
         specifier: ^1.0.0
         version: 1.1.1
-      react:
-        specifier: '>=19.0.0'
-        version: 19.2.4
-      react-dom:
-        specifier: '>=19.0.0'
-        version: 19.2.4(react@19.2.4)
       rsc-html-stream:
         specifier: ^0.0.4
         version: 0.0.4
@@ -1572,8 +1563,17 @@ importers:
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.13)
       '@vitejs/plugin-rsc':
-        specifier: ^0.5.18
-        version: 0.5.18(react-dom@19.2.4)(react-server-dom-webpack@19.2.4)(react@19.2.4)(vite@6.4.1)
+        specifier: 0.5.32
+        version: 0.5.32(react-dom@19.2.8)(react-server-dom-webpack@19.2.8)(react@19.2.8)(vite@6.4.1)
+      react:
+        specifier: 19.2.8
+        version: 19.2.8
+      react-dom:
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
+      react-server-dom-webpack:
+        specifier: 19.2.8
+        version: 19.2.8(react-dom@19.2.8)(react@19.2.8)(webpack@5.102.1)
       tsdown:
         specifier: ^0.15.7
         version: 0.15.7(supports-color@10.2.2)(typescript@5.9.3)
@@ -2337,7 +2337,7 @@ packages:
       '@better-fetch/fetch': 1.1.21
       '@simplewebauthn/browser': 13.3.0
       '@simplewebauthn/server': 13.3.0
-      better-auth: 1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@7.1.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4)
+      better-auth: 1.5.5(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7)(mongodb@7.1.0)(react-dom@19.2.8)(react@19.2.8)
       better-call: 1.3.2(zod@4.3.6)
       nanostores: 1.2.0
       zod: 4.3.6
@@ -2406,11 +2406,11 @@ packages:
       sisteransi: 1.0.5
     dev: false
 
-  /@clerk/backend@3.2.0(react-dom@19.2.4)(react@19.2.4):
+  /@clerk/backend@3.2.0(react-dom@18.3.1)(react@19.2.4):
     resolution: {integrity: sha512-3APNJ5jt5Db9f441FPVTjgzvPxjLhekygomkMOhsvPpItRNNEHgFZM/bGXYetgcOtUrO6vWcuhf1rlNSTRelhg==}
     engines: {node: '>=20.9.0'}
     dependencies:
-      '@clerk/shared': 4.3.0(react-dom@19.2.4)(react@19.2.4)
+      '@clerk/shared': 4.3.0(react-dom@18.3.1)(react@19.2.4)
       standardwebhooks: 1.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -2418,19 +2418,44 @@ packages:
       - react-dom
     dev: false
 
-  /@clerk/react@6.1.0(react-dom@19.2.4)(react@19.2.4):
+  /@clerk/backend@3.2.0(react-dom@19.2.8)(react@19.2.8):
+    resolution: {integrity: sha512-3APNJ5jt5Db9f441FPVTjgzvPxjLhekygomkMOhsvPpItRNNEHgFZM/bGXYetgcOtUrO6vWcuhf1rlNSTRelhg==}
+    engines: {node: '>=20.9.0'}
+    dependencies:
+      '@clerk/shared': 4.3.0(react-dom@19.2.8)(react@19.2.8)
+      standardwebhooks: 1.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+    dev: false
+
+  /@clerk/react@6.1.0(react-dom@18.3.1)(react@19.2.4):
     resolution: {integrity: sha512-xHFvpQGBZGuuAp/d7+n2LAPoaeqPsqrG5ValR0//Ol6gRGCttnjJ0CVk806dlIzs7JZNLO68+i/MZanowCjEMw==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
     dependencies:
-      '@clerk/shared': 4.3.0(react-dom@19.2.4)(react@19.2.4)
+      '@clerk/shared': 4.3.0(react-dom@18.3.1)(react@19.2.4)
       react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react-dom: 18.3.1(react@19.2.4)
+      tslib: 2.8.1
+    dev: false
+
+  /@clerk/react@6.1.0(react-dom@19.2.8)(react@19.2.8):
+    resolution: {integrity: sha512-xHFvpQGBZGuuAp/d7+n2LAPoaeqPsqrG5ValR0//Ol6gRGCttnjJ0CVk806dlIzs7JZNLO68+i/MZanowCjEMw==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+    dependencies:
+      '@clerk/shared': 4.3.0(react-dom@19.2.8)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       tslib: 2.8.1
 
-  /@clerk/shared@4.3.0(react-dom@19.2.4)(react@19.2.4):
+  /@clerk/shared@4.3.0(react-dom@18.3.1)(react@19.2.4):
     resolution: {integrity: sha512-Ydt8YGohNXEs6aBBLnti80OJT551yYWVTugFTO8Ee+uIZpStyqXF+ufBtJleuhfxs1D5KjtpIxc+hTqkZtqMyQ==}
     engines: {node: '>=20.9.0'}
     requiresBuild: true
@@ -2448,7 +2473,29 @@ packages:
       glob-to-regexp: 0.4.1
       js-cookie: 3.0.5
       react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react-dom: 18.3.1(react@19.2.4)
+      std-env: 3.9.0
+    dev: false
+
+  /@clerk/shared@4.3.0(react-dom@19.2.8)(react@19.2.8):
+    resolution: {integrity: sha512-Ydt8YGohNXEs6aBBLnti80OJT551yYWVTugFTO8Ee+uIZpStyqXF+ufBtJleuhfxs1D5KjtpIxc+hTqkZtqMyQ==}
+    engines: {node: '>=20.9.0'}
+    requiresBuild: true
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@tanstack/query-core': 5.90.16
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.5
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       std-env: 3.9.0
 
   /@cloudflare/codemode@0.4.3(@modelcontextprotocol/sdk@1.29.0)(zod@4.3.6):
@@ -2738,6 +2785,14 @@ packages:
       tslib: 2.8.1
     optional: true
 
+  /@emnapi/core@2.0.0-alpha.3:
+    resolution: {integrity: sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==}
+    requiresBuild: true
+    dependencies:
+      '@emnapi/wasi-threads': 2.0.1
+      tslib: 2.8.1
+    optional: true
+
   /@emnapi/runtime@1.11.1:
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
     requiresBuild: true
@@ -2752,8 +2807,22 @@ packages:
       tslib: 2.8.1
     optional: true
 
+  /@emnapi/runtime@2.0.0-alpha.3:
+    resolution: {integrity: sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==}
+    requiresBuild: true
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   /@emnapi/wasi-threads@1.2.2:
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+    requiresBuild: true
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  /@emnapi/wasi-threads@2.0.1:
+    resolution: {integrity: sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==}
     requiresBuild: true
     dependencies:
       tslib: 2.8.1
@@ -3941,7 +4010,7 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@farming-labs/docs@0.2.44(react@19.2.4)(supports-color@10.2.2):
+  /@farming-labs/docs@0.2.44(react@19.2.8)(supports-color@10.2.2):
     resolution: {integrity: sha512-Y+qC2lC4sG36QeMAUXUQE8hYseNpFhkA2bCWjCxXdGAT4Mhw3pf1WwiT1umZFc2jvluN9ywVW1ShyN/BVMQxVA==}
     hasBin: true
     peerDependencies:
@@ -3957,7 +4026,7 @@ packages:
       gray-matter: 4.0.3
       jiti: 2.6.1
       picocolors: 1.1.1
-      react: 19.2.4
+      react: 19.2.8
       zod: 4.3.6
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -4283,7 +4352,7 @@ packages:
     dev: false
     optional: true
 
-  /@farming-labs/strata@0.1.2(react@19.2.4):
+  /@farming-labs/strata@0.1.2(react@19.2.8):
     resolution: {integrity: sha512-3aedtp19SMokPIdwwKgQgFUTT1czevL6cIGooA+a04MOv0sx/sN2AR2t6yiosE2fK2KUEFatVIokAzkvJiNYsg==}
     engines: {node: '>=20.17.0'}
     peerDependencies:
@@ -4292,7 +4361,7 @@ packages:
       react:
         optional: true
     dependencies:
-      react: 19.2.4
+      react: 19.2.8
     optionalDependencies:
       '@farming-labs/strata-darwin-arm64': 0.1.2
       '@farming-labs/strata-darwin-x64': 0.1.2
@@ -4304,7 +4373,7 @@ packages:
       '@farming-labs/strata-win32-x64-msvc': 0.1.2
     dev: false
 
-  /@farming-labs/theme@0.2.44(@farming-labs/docs@0.2.44)(@types/react-dom@18.3.7)(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.4)(react@19.2.4)(supports-color@10.2.2)(tailwindcss@3.4.18):
+  /@farming-labs/theme@0.2.44(@farming-labs/docs@0.2.44)(@types/react-dom@18.3.7)(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(tailwindcss@3.4.18):
     resolution: {integrity: sha512-sNvbpaCkh+qiaaWjeVZZ0XyC/90FsDvrKfgz/auW+BsoTtG2xhgGRYabGvnkp42CEX0fLtu7JGw2TOLdZQxNlg==}
     peerDependencies:
       '@farming-labs/docs': '>=0.0.1'
@@ -4312,13 +4381,13 @@ packages:
       react: '>=19.2.0'
       react-dom: '>=19.2.0'
     dependencies:
-      '@farming-labs/docs': 0.2.44(react@19.2.4)(supports-color@10.2.2)
-      fumadocs-core: 16.7.16(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.4)(react@19.2.4)(supports-color@10.2.2)(zod@4.3.6)
-      fumadocs-ui: 16.7.16(@types/react-dom@18.3.7)(@types/react@18.3.26)(fumadocs-core@16.7.16)(next@16.2.4)(react-dom@19.2.4)(react@19.2.4)(tailwindcss@3.4.18)
+      '@farming-labs/docs': 0.2.44(react@19.2.8)(supports-color@10.2.2)
+      fumadocs-core: 16.7.16(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(zod@4.3.6)
+      fumadocs-ui: 16.7.16(@types/react-dom@18.3.7)(@types/react@18.3.26)(fumadocs-core@16.7.16)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(tailwindcss@3.4.18)
       gray-matter: 4.0.3
-      next: 16.2.4(@playwright/test@1.58.2)(react-dom@19.2.4)(react@19.2.4)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      next: 16.2.4(@playwright/test@1.58.2)(react-dom@19.2.8)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       sugar-high: 0.9.5
       zod: 4.3.6
     transitivePeerDependencies:
@@ -4371,15 +4440,15 @@ packages:
       '@floating-ui/utils': 0.2.11
     dev: false
 
-  /@floating-ui/react-dom@2.1.8(react-dom@19.2.4)(react@19.2.4):
+  /@floating-ui/react-dom@2.1.8(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
       '@floating-ui/dom': 1.7.6
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     dev: false
 
   /@floating-ui/utils@0.2.10:
@@ -4929,27 +4998,42 @@ packages:
       sparse-bitfield: 3.0.3
     dev: false
 
-  /@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
-    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+  /@napi-rs/wasm-runtime@1.2.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
+    resolution: {integrity: sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
     requiresBuild: true
     peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
+      '@emnapi/core': ^2.0.0-alpha.3
+      '@emnapi/runtime': ^2.0.0-alpha.3
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  /@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2):
-    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+  /@napi-rs/wasm-runtime@1.2.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2):
+    resolution: {integrity: sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
     requiresBuild: true
     peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
+      '@emnapi/core': ^2.0.0-alpha.3
+      '@emnapi/runtime': ^2.0.0-alpha.3
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  /@napi-rs/wasm-runtime@1.2.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3):
+    resolution: {integrity: sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    requiresBuild: true
+    peerDependencies:
+      '@emnapi/core': ^2.0.0-alpha.3
+      '@emnapi/runtime': ^2.0.0-alpha.3
+    dependencies:
+      '@emnapi/core': 2.0.0-alpha.3
+      '@emnapi/runtime': 2.0.0-alpha.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -5058,6 +5142,9 @@ packages:
 
   /@oxc-project/types@0.140.0:
     resolution: {integrity: sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ==}
+
+  /@oxc-project/types@0.142.0:
+    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
 
   /@oxfmt/darwin-arm64@0.27.0:
     resolution: {integrity: sha512-3vwqyzNlVTVFVzHMlrqxb4tgVgHp6FYS0uIxsIZ/SeEDG0azaqiOw/2t8LlJ9f72PKRLWSey+Ak99tiKgpbsnQ==}
@@ -5473,7 +5560,7 @@ packages:
     resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
     dev: false
 
-  /@radix-ui/react-accordion@1.2.15(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4):
+  /@radix-ui/react-accordion@1.2.15(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-24Zz/0SYx8F2bSVThBnQrdJs2VbKelyuJordcFRRdA0fRAhrq/wSegGCqaQz34VQoiWqSMGYCYXEhynLSlyQlg==}
     peerDependencies:
       '@types/react': '*'
@@ -5487,21 +5574,21 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collapsible': 1.1.15(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-collection': 1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-direction': 1.1.2(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-id': 1.1.2(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.26)(react@19.2.4)
+      '@radix-ui/react-collapsible': 1.1.15(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-collection': 1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-context': 1.1.4(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-direction': 1.1.2(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-id': 1.1.2(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.26)(react@19.2.8)
       '@types/react': 18.3.26
       '@types/react-dom': 18.3.7(@types/react@18.3.26)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     dev: false
 
-  /@radix-ui/react-arrow@1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4):
+  /@radix-ui/react-arrow@1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-Kdil9BB1rIFC/khmf4hC35bn8701AJcizTU7G7cUbEbk5XqqbjDuHW60uUfKqO5WojjZcbAW51Q7P0hRmMLw8A==}
     peerDependencies:
       '@types/react': '*'
@@ -5514,14 +5601,14 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
       '@types/react': 18.3.26
       '@types/react-dom': 18.3.7(@types/react@18.3.26)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     dev: false
 
-  /@radix-ui/react-collapsible@1.1.15(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4):
+  /@radix-ui/react-collapsible@1.1.15(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-8A1zibu5skAQ+UVbaeNH5hVMibiFCRJzgMuM14LTWGttnTZKQL9jwYnhAbHRuxrtCqPXa4JvvnVUq1pTNgyZYw==}
     peerDependencies:
       '@types/react': '*'
@@ -5535,20 +5622,20 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-id': 1.1.2(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.26)(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-context': 1.1.4(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-id': 1.1.2(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.26)(react@19.2.8)
       '@types/react': 18.3.26
       '@types/react-dom': 18.3.7(@types/react@18.3.26)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     dev: false
 
-  /@radix-ui/react-collection@1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4):
+  /@radix-ui/react-collection@1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-djW9+zeg137KQdlPtmE8xnaD+K2rcXXMWFrSg0hsmYZ6HRbdTA7tDHFgpaW9+huWVEu0RCabL+985T4TA0BE7g==}
     peerDependencies:
       '@types/react': '*'
@@ -5561,17 +5648,17 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-slot': 1.3.0(@types/react@18.3.26)(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-context': 1.1.4(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-slot': 1.3.0(@types/react@18.3.26)(react@19.2.8)
       '@types/react': 18.3.26
       '@types/react-dom': 18.3.7(@types/react@18.3.26)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     dev: false
 
-  /@radix-ui/react-compose-refs@1.1.3(@types/react@18.3.26)(react@19.2.4):
+  /@radix-ui/react-compose-refs@1.1.3(@types/react@18.3.26)(react@19.2.8):
     resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
     peerDependencies:
       '@types/react': '*'
@@ -5581,10 +5668,10 @@ packages:
         optional: true
     dependencies:
       '@types/react': 18.3.26
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@radix-ui/react-context@1.1.4(@types/react@18.3.26)(react@19.2.4):
+  /@radix-ui/react-context@1.1.4(@types/react@18.3.26)(react@19.2.8):
     resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
     peerDependencies:
       '@types/react': '*'
@@ -5594,10 +5681,10 @@ packages:
         optional: true
     dependencies:
       '@types/react': 18.3.26
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@radix-ui/react-dialog@1.1.18(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4):
+  /@radix-ui/react-dialog@1.1.18(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-apa28mldjMgORmE6g/w3sCcA0Y9UAVeeDVoozN4i7kOw12mLl9RBchfzK3Nn6qxOWjrZhK1Lfy7f07kyzxtnBw==}
     peerDependencies:
       '@types/react': '*'
@@ -5611,26 +5698,26 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-focus-guards': 1.1.4(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-focus-scope': 1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-id': 1.1.2(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-portal': 1.1.13(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-slot': 1.3.0(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.26)(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-context': 1.1.4(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-focus-scope': 1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-id': 1.1.2(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-portal': 1.1.13(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-slot': 1.3.0(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.26)(react@19.2.8)
       '@types/react': 18.3.26
       '@types/react-dom': 18.3.7(@types/react@18.3.26)
       aria-hidden: 1.2.6
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      react-remove-scroll: 2.7.2(@types/react@18.3.26)(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-remove-scroll: 2.7.2(@types/react@18.3.26)(react@19.2.8)
     dev: false
 
-  /@radix-ui/react-direction@1.1.2(@types/react@18.3.26)(react@19.2.4):
+  /@radix-ui/react-direction@1.1.2(@types/react@18.3.26)(react@19.2.8):
     resolution: {integrity: sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==}
     peerDependencies:
       '@types/react': '*'
@@ -5640,10 +5727,10 @@ packages:
         optional: true
     dependencies:
       '@types/react': 18.3.26
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@radix-ui/react-dismissable-layer@1.1.14(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4):
+  /@radix-ui/react-dismissable-layer@1.1.14(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-4lUhWTWAjbDIqFrAPWJ3WqBOpO5YchVZ88X3nh6H9Lu5AFi5nCUeTPj3D8FSDmabmFeRe9ME0BDA4MwKTha5GQ==}
     peerDependencies:
       '@types/react': '*'
@@ -5657,17 +5744,17 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@18.3.26)(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@18.3.26)(react@19.2.8)
       '@types/react': 18.3.26
       '@types/react-dom': 18.3.7(@types/react@18.3.26)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     dev: false
 
-  /@radix-ui/react-focus-guards@1.1.4(@types/react@18.3.26)(react@19.2.4):
+  /@radix-ui/react-focus-guards@1.1.4(@types/react@18.3.26)(react@19.2.8):
     resolution: {integrity: sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==}
     peerDependencies:
       '@types/react': '*'
@@ -5677,10 +5764,10 @@ packages:
         optional: true
     dependencies:
       '@types/react': 18.3.26
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@radix-ui/react-focus-scope@1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4):
+  /@radix-ui/react-focus-scope@1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-Mn88Vg2whaRocGJNOH+DKFqYm6ySFPQaiwHNxZPyjn99B52KAEJWWY9NP83+nWdk2HM3rdov+STu9AG471Rt9w==}
     peerDependencies:
       '@types/react': '*'
@@ -5693,16 +5780,16 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.3.26)(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.3.26)(react@19.2.8)
       '@types/react': 18.3.26
       '@types/react-dom': 18.3.7(@types/react@18.3.26)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     dev: false
 
-  /@radix-ui/react-id@1.1.2(@types/react@18.3.26)(react@19.2.4):
+  /@radix-ui/react-id@1.1.2(@types/react@18.3.26)(react@19.2.8):
     resolution: {integrity: sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==}
     peerDependencies:
       '@types/react': '*'
@@ -5711,12 +5798,12 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.26)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.26)(react@19.2.8)
       '@types/react': 18.3.26
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@radix-ui/react-navigation-menu@1.2.17(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4):
+  /@radix-ui/react-navigation-menu@1.2.17(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-fYeYQvbeNn5AQk2RBbpO7koLm2YbS00UYxC/IL2sgLlninEH5UNIv+X3E0KJ1Vy4WIo+dhN9w8GNqSHhbHWCIg==}
     peerDependencies:
       '@types/react': '*'
@@ -5730,26 +5817,26 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-direction': 1.1.2(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-id': 1.1.2(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-use-previous': 1.1.2(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-visually-hidden': 1.2.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
+      '@radix-ui/react-collection': 1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-context': 1.1.4(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-direction': 1.1.2(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-id': 1.1.2(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-visually-hidden': 1.2.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
       '@types/react': 18.3.26
       '@types/react-dom': 18.3.7(@types/react@18.3.26)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     dev: false
 
-  /@radix-ui/react-popover@1.1.18(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4):
+  /@radix-ui/react-popover@1.1.18(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-qdXDes+eHlnMUGlBAAAe5EG7oOQvqsXuq4mq585diMudg80iB+jHbsSeG3+Q4eWNsogNyhqU2p/3i+Y0iEepqg==}
     peerDependencies:
       '@types/react': '*'
@@ -5763,27 +5850,27 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-focus-guards': 1.1.4(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-focus-scope': 1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-id': 1.1.2(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-popper': 1.3.2(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-portal': 1.1.13(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-slot': 1.3.0(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.26)(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-context': 1.1.4(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-focus-scope': 1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-id': 1.1.2(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-popper': 1.3.2(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-portal': 1.1.13(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-slot': 1.3.0(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.26)(react@19.2.8)
       '@types/react': 18.3.26
       '@types/react-dom': 18.3.7(@types/react@18.3.26)
       aria-hidden: 1.2.6
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      react-remove-scroll: 2.7.2(@types/react@18.3.26)(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-remove-scroll: 2.7.2(@types/react@18.3.26)(react@19.2.8)
     dev: false
 
-  /@radix-ui/react-popper@1.3.2(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4):
+  /@radix-ui/react-popper@1.3.2(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-3QXNeMkdshed1MR3LNoiCirBywRFPkD8ETJa/HlPuLwSajaQixf2ro+isoDNJlGABg9ug41XuZpINZJIle4XWg==}
     peerDependencies:
       '@types/react': '*'
@@ -5796,23 +5883,23 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-arrow': 1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-use-rect': 1.1.2(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-use-size': 1.1.2(@types/react@18.3.26)(react@19.2.4)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-arrow': 1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-context': 1.1.4(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-use-rect': 1.1.2(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@18.3.26)(react@19.2.8)
       '@radix-ui/rect': 1.1.2
       '@types/react': 18.3.26
       '@types/react-dom': 18.3.7(@types/react@18.3.26)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     dev: false
 
-  /@radix-ui/react-portal@1.1.13(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4):
+  /@radix-ui/react-portal@1.1.13(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-z3oXfmaHLJTF1wktbjgD6cn9jiEbq3WSondB10LIuIt2m2Ym4iJlrW04/euMwENDdWDdE7z+OuY7Qyp1YpRSwA==}
     peerDependencies:
       '@types/react': '*'
@@ -5825,15 +5912,15 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.26)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.26)(react@19.2.8)
       '@types/react': 18.3.26
       '@types/react-dom': 18.3.7(@types/react@18.3.26)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     dev: false
 
-  /@radix-ui/react-presence@1.1.6(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4):
+  /@radix-ui/react-presence@1.1.6(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==}
     peerDependencies:
       '@types/react': '*'
@@ -5846,14 +5933,14 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.26)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.26)(react@19.2.8)
       '@types/react': 18.3.26
       '@types/react-dom': 18.3.7(@types/react@18.3.26)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     dev: false
 
-  /@radix-ui/react-primitive@2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4):
+  /@radix-ui/react-primitive@2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==}
     peerDependencies:
       '@types/react': '*'
@@ -5866,14 +5953,14 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/react-slot': 1.3.0(@types/react@18.3.26)(react@19.2.4)
+      '@radix-ui/react-slot': 1.3.0(@types/react@18.3.26)(react@19.2.8)
       '@types/react': 18.3.26
       '@types/react-dom': 18.3.7(@types/react@18.3.26)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     dev: false
 
-  /@radix-ui/react-roving-focus@1.1.14(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4):
+  /@radix-ui/react-roving-focus@1.1.14(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-8Qcnx9447tx/aCBgw6Jenfqg4Skq+vqab9mCBmuGNipIS5YXvL275wbKEu7+ICYHIlAPgCduUMJH1XOYewKF6Q==}
     peerDependencies:
       '@types/react': '*'
@@ -5887,21 +5974,21 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-direction': 1.1.2(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-id': 1.1.2(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.26)(react@19.2.4)
+      '@radix-ui/react-collection': 1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-context': 1.1.4(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-direction': 1.1.2(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-id': 1.1.2(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.26)(react@19.2.8)
       '@types/react': 18.3.26
       '@types/react-dom': 18.3.7(@types/react@18.3.26)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     dev: false
 
-  /@radix-ui/react-scroll-area@1.2.13(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4):
+  /@radix-ui/react-scroll-area@1.2.13(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-7tncSubo2G0UY1e8rk+72qe3XRzrGnOLtZQ1PL1KoBfRUNX0NrJT5akb+0kfwSCc3gVR4wdHqyhAQBDpDNOwDw==}
     peerDependencies:
       '@types/react': '*'
@@ -5916,20 +6003,20 @@ packages:
     dependencies:
       '@radix-ui/number': 1.1.2
       '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-direction': 1.1.2(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.26)(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-context': 1.1.4(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-direction': 1.1.2(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.26)(react@19.2.8)
       '@types/react': 18.3.26
       '@types/react-dom': 18.3.7(@types/react@18.3.26)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     dev: false
 
-  /@radix-ui/react-slot@1.3.0(@types/react@18.3.26)(react@19.2.4):
+  /@radix-ui/react-slot@1.3.0(@types/react@18.3.26)(react@19.2.8):
     resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
     peerDependencies:
       '@types/react': '*'
@@ -5938,12 +6025,12 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.26)(react@19.2.8)
       '@types/react': 18.3.26
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@radix-ui/react-tabs@1.1.16(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4):
+  /@radix-ui/react-tabs@1.1.16(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-v3Ab2l7z6U7tRB4xA0IyKdq0OsqaO1o9ZjsIEoKKnSZ/l96mZz8aCTX0NCXw+YVHJXr8Km4d+Mn6/Q8YjXa+gw==}
     peerDependencies:
       '@types/react': '*'
@@ -5957,20 +6044,20 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-context': 1.1.4(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-direction': 1.1.2(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-id': 1.1.2(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-roving-focus': 1.1.14(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.26)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.4(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-direction': 1.1.2(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-id': 1.1.2(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-roving-focus': 1.1.14(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.26)(react@19.2.8)
       '@types/react': 18.3.26
       '@types/react-dom': 18.3.7(@types/react@18.3.26)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     dev: false
 
-  /@radix-ui/react-use-callback-ref@1.1.2(@types/react@18.3.26)(react@19.2.4):
+  /@radix-ui/react-use-callback-ref@1.1.2(@types/react@18.3.26)(react@19.2.8):
     resolution: {integrity: sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==}
     peerDependencies:
       '@types/react': '*'
@@ -5980,10 +6067,10 @@ packages:
         optional: true
     dependencies:
       '@types/react': 18.3.26
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@radix-ui/react-use-controllable-state@1.2.3(@types/react@18.3.26)(react@19.2.4):
+  /@radix-ui/react-use-controllable-state@1.2.3(@types/react@18.3.26)(react@19.2.8):
     resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
     peerDependencies:
       '@types/react': '*'
@@ -5992,13 +6079,13 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.26)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.26)(react@19.2.8)
       '@types/react': 18.3.26
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@radix-ui/react-use-effect-event@0.0.3(@types/react@18.3.26)(react@19.2.4):
+  /@radix-ui/react-use-effect-event@0.0.3(@types/react@18.3.26)(react@19.2.8):
     resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
     peerDependencies:
       '@types/react': '*'
@@ -6007,12 +6094,12 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.26)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.26)(react@19.2.8)
       '@types/react': 18.3.26
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@radix-ui/react-use-layout-effect@1.1.2(@types/react@18.3.26)(react@19.2.4):
+  /@radix-ui/react-use-layout-effect@1.1.2(@types/react@18.3.26)(react@19.2.8):
     resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
     peerDependencies:
       '@types/react': '*'
@@ -6022,10 +6109,10 @@ packages:
         optional: true
     dependencies:
       '@types/react': 18.3.26
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@radix-ui/react-use-previous@1.1.2(@types/react@18.3.26)(react@19.2.4):
+  /@radix-ui/react-use-previous@1.1.2(@types/react@18.3.26)(react@19.2.8):
     resolution: {integrity: sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==}
     peerDependencies:
       '@types/react': '*'
@@ -6035,10 +6122,10 @@ packages:
         optional: true
     dependencies:
       '@types/react': 18.3.26
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@radix-ui/react-use-rect@1.1.2(@types/react@18.3.26)(react@19.2.4):
+  /@radix-ui/react-use-rect@1.1.2(@types/react@18.3.26)(react@19.2.8):
     resolution: {integrity: sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==}
     peerDependencies:
       '@types/react': '*'
@@ -6049,10 +6136,10 @@ packages:
     dependencies:
       '@radix-ui/rect': 1.1.2
       '@types/react': 18.3.26
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@radix-ui/react-use-size@1.1.2(@types/react@18.3.26)(react@19.2.4):
+  /@radix-ui/react-use-size@1.1.2(@types/react@18.3.26)(react@19.2.8):
     resolution: {integrity: sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==}
     peerDependencies:
       '@types/react': '*'
@@ -6061,12 +6148,12 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.26)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.26)(react@19.2.8)
       '@types/react': 18.3.26
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@radix-ui/react-visually-hidden@1.2.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4):
+  /@radix-ui/react-visually-hidden@1.2.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-1wNZBggTDK3GRuuQ6nP4k2yi7a6l7I5qbMPbZcRsrGsGVead/f/d5FhEzUvqFs0bcrDLx7n1zKQ3JvLR6whaaw==}
     peerDependencies:
       '@types/react': '*'
@@ -6079,186 +6166,186 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
       '@types/react': 18.3.26
       '@types/react-dom': 18.3.7(@types/react@18.3.26)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     dev: false
 
   /@radix-ui/rect@1.1.2:
     resolution: {integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==}
     dev: false
 
-  /@react-email/body@0.3.0(react@19.2.4):
+  /@react-email/body@0.3.0(react@19.2.8):
     resolution: {integrity: sha512-uGo0BOOzjbMUo3lu+BIDWayvn5o6Xyfmnlla5VGf05n8gHMvO1ll7U4FtzWe3hxMLwt53pmc4iE0M+B5slG+Ug==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
     dependencies:
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@react-email/button@0.2.1(react@19.2.4):
+  /@react-email/button@0.2.1(react@19.2.8):
     resolution: {integrity: sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
     dependencies:
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@react-email/code-block@0.2.1(react@19.2.4):
+  /@react-email/code-block@0.2.1(react@19.2.8):
     resolution: {integrity: sha512-M3B7JpVH4ytgn83/ujRR1k1DQHvTeABiDM61OvAbjLRPhC/5KLHU5KkzIbbuGIrjWwxAbL1kSQzU8MhLEtSxyw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
     dependencies:
       prismjs: 1.30.0
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@react-email/code-inline@0.0.6(react@19.2.4):
+  /@react-email/code-inline@0.0.6(react@19.2.8):
     resolution: {integrity: sha512-jfhebvv3dVsp3OdPgKXnk8+e2pBiDVZejDOBFzBa/IblrAJ9cQDkN6rBD5IyEg8hTOxwbw3iaI/yZFmDmIguIA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
     dependencies:
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@react-email/column@0.0.14(react@19.2.4):
+  /@react-email/column@0.0.14(react@19.2.8):
     resolution: {integrity: sha512-f+W+Bk2AjNO77zynE33rHuQhyqVICx4RYtGX9NKsGUg0wWjdGP0qAuIkhx9Rnmk4/hFMo1fUrtYNqca9fwJdHg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
     dependencies:
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@react-email/components@1.0.12(react-dom@19.2.4)(react@19.2.4):
+  /@react-email/components@1.0.12(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-tH18JhPDWgE+3jnYkzyB6ZrZdfNnEsFe4PwmuXmlOw4NGIysP8wPY5aXZg++pTG9qUabXg1nzX/FGHGkObH8xQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
     dependencies:
-      '@react-email/body': 0.3.0(react@19.2.4)
-      '@react-email/button': 0.2.1(react@19.2.4)
-      '@react-email/code-block': 0.2.1(react@19.2.4)
-      '@react-email/code-inline': 0.0.6(react@19.2.4)
-      '@react-email/column': 0.0.14(react@19.2.4)
-      '@react-email/container': 0.0.16(react@19.2.4)
-      '@react-email/font': 0.0.10(react@19.2.4)
-      '@react-email/head': 0.0.13(react@19.2.4)
-      '@react-email/heading': 0.0.16(react@19.2.4)
-      '@react-email/hr': 0.0.12(react@19.2.4)
-      '@react-email/html': 0.0.12(react@19.2.4)
-      '@react-email/img': 0.0.12(react@19.2.4)
-      '@react-email/link': 0.0.13(react@19.2.4)
-      '@react-email/markdown': 0.0.18(react@19.2.4)
-      '@react-email/preview': 0.0.14(react@19.2.4)
-      '@react-email/render': 2.0.6(react-dom@19.2.4)(react@19.2.4)
-      '@react-email/row': 0.0.13(react@19.2.4)
-      '@react-email/section': 0.0.17(react@19.2.4)
-      '@react-email/tailwind': 2.0.7(@react-email/body@0.3.0)(@react-email/button@0.2.1)(@react-email/code-block@0.2.1)(@react-email/code-inline@0.0.6)(@react-email/container@0.0.16)(@react-email/heading@0.0.16)(@react-email/hr@0.0.12)(@react-email/img@0.0.12)(@react-email/link@0.0.13)(@react-email/preview@0.0.14)(@react-email/text@0.1.6)(react@19.2.4)
-      '@react-email/text': 0.1.6(react@19.2.4)
-      react: 19.2.4
+      '@react-email/body': 0.3.0(react@19.2.8)
+      '@react-email/button': 0.2.1(react@19.2.8)
+      '@react-email/code-block': 0.2.1(react@19.2.8)
+      '@react-email/code-inline': 0.0.6(react@19.2.8)
+      '@react-email/column': 0.0.14(react@19.2.8)
+      '@react-email/container': 0.0.16(react@19.2.8)
+      '@react-email/font': 0.0.10(react@19.2.8)
+      '@react-email/head': 0.0.13(react@19.2.8)
+      '@react-email/heading': 0.0.16(react@19.2.8)
+      '@react-email/hr': 0.0.12(react@19.2.8)
+      '@react-email/html': 0.0.12(react@19.2.8)
+      '@react-email/img': 0.0.12(react@19.2.8)
+      '@react-email/link': 0.0.13(react@19.2.8)
+      '@react-email/markdown': 0.0.18(react@19.2.8)
+      '@react-email/preview': 0.0.14(react@19.2.8)
+      '@react-email/render': 2.0.6(react-dom@19.2.8)(react@19.2.8)
+      '@react-email/row': 0.0.13(react@19.2.8)
+      '@react-email/section': 0.0.17(react@19.2.8)
+      '@react-email/tailwind': 2.0.7(@react-email/body@0.3.0)(@react-email/button@0.2.1)(@react-email/code-block@0.2.1)(@react-email/code-inline@0.0.6)(@react-email/container@0.0.16)(@react-email/heading@0.0.16)(@react-email/hr@0.0.12)(@react-email/img@0.0.12)(@react-email/link@0.0.13)(@react-email/preview@0.0.14)(@react-email/text@0.1.6)(react@19.2.8)
+      '@react-email/text': 0.1.6(react@19.2.8)
+      react: 19.2.8
     transitivePeerDependencies:
       - react-dom
     dev: false
 
-  /@react-email/container@0.0.16(react@19.2.4):
+  /@react-email/container@0.0.16(react@19.2.8):
     resolution: {integrity: sha512-QWBB56RkkU0AJ9h+qy33gfT5iuZknPC7Un/IjZv9B0QmMIK+WWacc0cH6y2SV5Cv/b99hU94fjEMOOO4enpkbQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
     dependencies:
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@react-email/font@0.0.10(react@19.2.4):
+  /@react-email/font@0.0.10(react@19.2.8):
     resolution: {integrity: sha512-0urVSgCmQIfx5r7Xc586miBnQUVnGp3OTYUm8m5pwtQRdTRO5XrTtEfNJ3JhYhSOruV0nD8fd+dXtKXobum6tA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
     dependencies:
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@react-email/head@0.0.13(react@19.2.4):
+  /@react-email/head@0.0.13(react@19.2.8):
     resolution: {integrity: sha512-AJg6le/08Gz4tm+6MtKXqtNNyKHzmooOCdmtqmWxD7FxoAdU1eVcizhtQ0gcnVaY6ethEyE/hnEzQxt1zu5Kog==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
     dependencies:
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@react-email/heading@0.0.16(react@19.2.4):
+  /@react-email/heading@0.0.16(react@19.2.8):
     resolution: {integrity: sha512-jmsKnQm1ykpBzw4hCYHwBkt5pW2jScXffPeEH5ZRF5tZeF5b1pvlFTO9han7C0pCkZYo1kEvWiRtx69yfCIwuw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
     dependencies:
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@react-email/hr@0.0.12(react@19.2.4):
+  /@react-email/hr@0.0.12(react@19.2.8):
     resolution: {integrity: sha512-TwmOmBDibavUQpXBxpmZYi2Iks/yeZOzFYh+di9EltMSnEabH8dMZXrl+pxNXzCgZ2XE8HY7VmUL65Lenfu5PA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
     dependencies:
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@react-email/html@0.0.12(react@19.2.4):
+  /@react-email/html@0.0.12(react@19.2.8):
     resolution: {integrity: sha512-KTShZesan+UsreU7PDUV90afrZwU5TLwYlALuCSU0OT+/U8lULNNbAUekg+tGwCnOfIKYtpDPKkAMRdYlqUznw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
     dependencies:
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@react-email/img@0.0.12(react@19.2.4):
+  /@react-email/img@0.0.12(react@19.2.8):
     resolution: {integrity: sha512-sRCpEARNVTf3FQhZOC+JTvu5r6ubiYWkT0ucYXg8ctkyi4G8QG+jgYPiNUqVeTLA2STOfmPM/nrk1nb84y6CPQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
     dependencies:
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@react-email/link@0.0.13(react@19.2.4):
+  /@react-email/link@0.0.13(react@19.2.8):
     resolution: {integrity: sha512-lkWc/NjOcefRZMkQoSDDbuKBEBDES9aXnFEOuPH845wD3TxPwh+QTf0fStuzjoRLUZWpHnio4z7qGGRYusn/sw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
     dependencies:
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@react-email/markdown@0.0.18(react@19.2.4):
+  /@react-email/markdown@0.0.18(react@19.2.8):
     resolution: {integrity: sha512-gSuYK5fsMbGk87jDebqQ6fa2fKcWlkf2Dkva8kMONqLgGCq8/0d+ZQYMEJsdidIeBo3kmsnHZPrwdFB4HgjUXg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
     dependencies:
       marked: 15.0.12
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@react-email/preview@0.0.14(react@19.2.4):
+  /@react-email/preview@0.0.14(react@19.2.8):
     resolution: {integrity: sha512-aYK8q0IPkBXyMsbpMXgxazwHxYJxTrXrV95GFuu2HbEiIToMwSyUgb8HDFYwPqqfV03/jbwqlsXmFxsOd+VNaw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
     dependencies:
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@react-email/render@2.0.6(react-dom@19.2.4)(react@19.2.4):
+  /@react-email/render@2.0.6(react-dom@18.3.1)(react@19.2.4):
     resolution: {integrity: sha512-xOzaYkH3jLZKqN5MqrTXYnmqBYUnZSVbkxdb5PGGmDcK6sKDVMliaDiSwfXajRC9JtSHTcGc2tmGLHWuCgVpog==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
@@ -6268,28 +6355,41 @@ packages:
       html-to-text: 9.0.5
       prettier: 3.8.2
       react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react-dom: 18.3.1(react@19.2.4)
     dev: false
 
-  /@react-email/row@0.0.13(react@19.2.4):
+  /@react-email/render@2.0.6(react-dom@19.2.8)(react@19.2.8):
+    resolution: {integrity: sha512-xOzaYkH3jLZKqN5MqrTXYnmqBYUnZSVbkxdb5PGGmDcK6sKDVMliaDiSwfXajRC9JtSHTcGc2tmGLHWuCgVpog==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+    dependencies:
+      html-to-text: 9.0.5
+      prettier: 3.8.2
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    dev: false
+
+  /@react-email/row@0.0.13(react@19.2.8):
     resolution: {integrity: sha512-bYnOac40vIKCId7IkwuLAAsa3fKfSfqCvv6epJKmPE0JBuu5qI4FHFCl9o9dVpIIS08s/ub+Y/txoMt0dYziGw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
     dependencies:
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@react-email/section@0.0.17(react@19.2.4):
+  /@react-email/section@0.0.17(react@19.2.8):
     resolution: {integrity: sha512-qNl65ye3W0Rd5udhdORzTV9ezjb+GFqQQSae03NDzXtmJq6sqVXNWNiVolAjvJNypim+zGXmv6J9TcV5aNtE/w==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
     dependencies:
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
-  /@react-email/tailwind@2.0.7(@react-email/body@0.3.0)(@react-email/button@0.2.1)(@react-email/code-block@0.2.1)(@react-email/code-inline@0.0.6)(@react-email/container@0.0.16)(@react-email/heading@0.0.16)(@react-email/hr@0.0.12)(@react-email/img@0.0.12)(@react-email/link@0.0.13)(@react-email/preview@0.0.14)(@react-email/text@0.1.6)(react@19.2.4):
+  /@react-email/tailwind@2.0.7(@react-email/body@0.3.0)(@react-email/button@0.2.1)(@react-email/code-block@0.2.1)(@react-email/code-inline@0.0.6)(@react-email/container@0.0.16)(@react-email/heading@0.0.16)(@react-email/hr@0.0.12)(@react-email/img@0.0.12)(@react-email/link@0.0.13)(@react-email/preview@0.0.14)(@react-email/text@0.1.6)(react@19.2.8):
     resolution: {integrity: sha512-kGw80weVFXikcnCXbigTGXGWQ0MRCSYNCudcdkWxebkWYd0FG6/NPoN3V1p/u68/4+NxZwYPVi2fhnp0x23HdA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
@@ -6327,28 +6427,28 @@ packages:
       '@react-email/preview':
         optional: true
     dependencies:
-      '@react-email/body': 0.3.0(react@19.2.4)
-      '@react-email/button': 0.2.1(react@19.2.4)
-      '@react-email/code-block': 0.2.1(react@19.2.4)
-      '@react-email/code-inline': 0.0.6(react@19.2.4)
-      '@react-email/container': 0.0.16(react@19.2.4)
-      '@react-email/heading': 0.0.16(react@19.2.4)
-      '@react-email/hr': 0.0.12(react@19.2.4)
-      '@react-email/img': 0.0.12(react@19.2.4)
-      '@react-email/link': 0.0.13(react@19.2.4)
-      '@react-email/preview': 0.0.14(react@19.2.4)
-      '@react-email/text': 0.1.6(react@19.2.4)
-      react: 19.2.4
+      '@react-email/body': 0.3.0(react@19.2.8)
+      '@react-email/button': 0.2.1(react@19.2.8)
+      '@react-email/code-block': 0.2.1(react@19.2.8)
+      '@react-email/code-inline': 0.0.6(react@19.2.8)
+      '@react-email/container': 0.0.16(react@19.2.8)
+      '@react-email/heading': 0.0.16(react@19.2.8)
+      '@react-email/hr': 0.0.12(react@19.2.8)
+      '@react-email/img': 0.0.12(react@19.2.8)
+      '@react-email/link': 0.0.13(react@19.2.8)
+      '@react-email/preview': 0.0.14(react@19.2.8)
+      '@react-email/text': 0.1.6(react@19.2.8)
+      react: 19.2.8
       tailwindcss: 4.1.18
     dev: false
 
-  /@react-email/text@0.1.6(react@19.2.4):
+  /@react-email/text@0.1.6(react@19.2.8):
     resolution: {integrity: sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
     dependencies:
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
   /@replit/codemirror-css-color-picker@6.3.0(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.6):
@@ -6379,6 +6479,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rolldown/binding-android-arm64@1.2.1:
+    resolution: {integrity: sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    optional: true
+
   /@rolldown/binding-darwin-arm64@1.1.5:
     resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6389,6 +6497,14 @@ packages:
 
   /@rolldown/binding-darwin-arm64@1.2.0:
     resolution: {integrity: sha512-pexNaW9ACLUOaBITOpU6qVu4VrsOFIjTv6bzgu0YUATo4eUJx0V605PxwZfndpPOn0ilqGqvGQ0M8UW0IE24jg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
+  /@rolldown/binding-darwin-arm64@1.2.1:
+    resolution: {integrity: sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -6411,6 +6527,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rolldown/binding-darwin-x64@1.2.1:
+    resolution: {integrity: sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
   /@rolldown/binding-freebsd-x64@1.1.5:
     resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6421,6 +6545,14 @@ packages:
 
   /@rolldown/binding-freebsd-x64@1.2.0:
     resolution: {integrity: sha512-3vPoHzh6eBTz9IbB0/qZdSr0Qeks2echn+I4cHu2joV74VriPDdldswksEDzrl1mBB+oPRi+67+3Ib59paxIPQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    optional: true
+
+  /@rolldown/binding-freebsd-x64@1.2.1:
+    resolution: {integrity: sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -6443,6 +6575,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rolldown/binding-linux-arm-gnueabihf@1.2.1:
+    resolution: {integrity: sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@rolldown/binding-linux-arm64-gnu@1.1.5:
     resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6453,6 +6593,14 @@ packages:
 
   /@rolldown/binding-linux-arm64-gnu@1.2.0:
     resolution: {integrity: sha512-D+TgkdgM1vu+7/Fpf8+v0ARW+RXEP9Ccazgm8zQ4JFFd9Q7SrYQ2TakU5S5ihazQDgpKyAgZDOcIFsvoHmTZ8w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rolldown/binding-linux-arm64-gnu@1.2.1:
+    resolution: {integrity: sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -6475,6 +6623,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rolldown/binding-linux-arm64-musl@1.2.1:
+    resolution: {integrity: sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@rolldown/binding-linux-ppc64-gnu@1.1.5:
     resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6485,6 +6641,14 @@ packages:
 
   /@rolldown/binding-linux-ppc64-gnu@1.2.0:
     resolution: {integrity: sha512-9DtF35qR9/NrfhM4oxLplCzVVjE+KKm8Pjemi0i/sdhAWkUasjmSo8WTTubNJClhSHCfyk2yeyoXDQEDPtDAAw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rolldown/binding-linux-ppc64-gnu@1.2.1:
+    resolution: {integrity: sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -6507,6 +6671,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rolldown/binding-linux-s390x-gnu@1.2.1:
+    resolution: {integrity: sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@rolldown/binding-linux-x64-gnu@1.1.5:
     resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6517,6 +6689,14 @@ packages:
 
   /@rolldown/binding-linux-x64-gnu@1.2.0:
     resolution: {integrity: sha512-MK7L0018jjh1jR3mh21G2j1zAVcpscJBlPo2z19pRjv2XOYGRhaV4LyiD8HO6nCDdZln9IFgCMIV5yt4E3klGQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rolldown/binding-linux-x64-gnu@1.2.1:
+    resolution: {integrity: sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -6539,6 +6719,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rolldown/binding-linux-x64-musl@1.2.1:
+    resolution: {integrity: sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@rolldown/binding-openharmony-arm64@1.1.5:
     resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6555,6 +6743,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rolldown/binding-openharmony-arm64@1.2.1:
+    resolution: {integrity: sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+    requiresBuild: true
+    optional: true
+
   /@rolldown/binding-wasm32-wasi@1.1.5:
     resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6563,7 +6759,7 @@ packages:
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.2.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
   /@rolldown/binding-wasm32-wasi@1.2.0:
@@ -6574,7 +6770,17 @@ packages:
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@napi-rs/wasm-runtime': 1.2.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
+  /@rolldown/binding-wasm32-wasi@1.2.1:
+    resolution: {integrity: sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    requiresBuild: true
+    dependencies:
+      '@emnapi/core': 2.0.0-alpha.3
+      '@emnapi/runtime': 2.0.0-alpha.3
+      '@napi-rs/wasm-runtime': 1.2.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
     optional: true
 
   /@rolldown/binding-win32-arm64-msvc@1.1.5:
@@ -6593,6 +6799,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rolldown/binding-win32-arm64-msvc@1.2.1:
+    resolution: {integrity: sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
   /@rolldown/binding-win32-x64-msvc@1.1.5:
     resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6603,6 +6817,14 @@ packages:
 
   /@rolldown/binding-win32-x64-msvc@1.2.0:
     resolution: {integrity: sha512-WfFv6/qGufotqBSBzBYwgpCkJBk8Nj7697LL9vTz/XWc67e0r3oewu8iMRwQj3AUL45GVD7wVsPjCsAAtW66Wg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
+  /@rolldown/binding-win32-x64-msvc@1.2.1:
+    resolution: {integrity: sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -6633,10 +6855,6 @@ packages:
 
   /@rolldown/pluginutils@1.0.0-beta.27:
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
-
-  /@rolldown/pluginutils@1.0.0-rc.2:
-    resolution: {integrity: sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==}
-    dev: true
 
   /@rolldown/pluginutils@1.0.1:
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
@@ -7980,8 +8198,8 @@ packages:
       - supports-color
     dev: true
 
-  /@vitejs/plugin-rsc@0.5.18(react-dom@19.2.4)(react-server-dom-webpack@19.2.4)(react@19.2.4)(vite@6.4.1):
-    resolution: {integrity: sha512-/BuPW2s+nSWsBcU2DI2eSmXBol6dWJJmEZdvWd8SEjGnah1kVErkjOREyR9WAoYFC0qhwT+atyhAz7A6iPQPwQ==}
+  /@vitejs/plugin-rsc@0.5.32(react-dom@19.2.8)(react-server-dom-webpack@19.2.8)(react@19.2.8)(vite@6.4.1):
+    resolution: {integrity: sha512-9lKCNZ3gSV46CA6/r+0ONjUXfGuwIJeGcm60VapwWCEuCrhO0f9IBw3pLv+2usZtE2NztxQq5Rlum6b3XESRgw==}
     peerDependencies:
       react: '*'
       react-dom: '*'
@@ -7991,19 +8209,18 @@ packages:
       react-server-dom-webpack:
         optional: true
     dependencies:
-      '@rolldown/pluginutils': 1.0.0-rc.2
-      es-module-lexer: 2.0.0
+      '@rolldown/pluginutils': 1.0.1
+      es-module-lexer: 2.3.1
       estree-walker: 3.0.3
       magic-string: 0.30.21
-      periscopic: 4.0.2
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      react-server-dom-webpack: 19.2.4(react-dom@19.2.4)(react@19.2.4)(webpack@5.102.1)
-      srvx: 0.10.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-server-dom-webpack: 19.2.8(react-dom@19.2.8)(react@19.2.8)(webpack@5.102.1)
+      srvx: 0.12.4
       strip-literal: 3.1.0
-      turbo-stream: 3.1.0
+      turbo-stream: 3.2.0
       vite: 6.4.1(@types/node@20.19.21)
-      vitefu: 1.1.1(vite@6.4.1)
+      vitefu: 1.1.3(vite@6.4.1)
     dev: true
 
   /@vitest/coverage-v8@1.6.1(supports-color@10.2.2)(vitest@1.6.1):
@@ -8387,7 +8604,7 @@ packages:
     resolution: {integrity: sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==}
     engines: {node: '>=0.4.0'}
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.17.0
 
   /acorn-walk@8.3.4:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
@@ -8395,12 +8612,6 @@ packages:
     dependencies:
       acorn: 8.15.0
     dev: true
-
-  /acorn@6.4.2:
-    resolution: {integrity: sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-    dev: false
 
   /acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
@@ -8417,7 +8628,7 @@ packages:
     engines: {node: '>= 14'}
     dev: true
 
-  /agents@0.17.4(@babel/core@8.0.1)(@cloudflare/workers-types@4.20260702.1)(react@19.2.4)(rolldown@1.2.0)(supports-color@10.2.2)(zod@4.3.6):
+  /agents@0.17.4(@babel/core@8.0.1)(@cloudflare/workers-types@4.20260702.1)(react@19.2.8)(rolldown@1.2.0)(supports-color@10.2.2)(zod@4.3.6):
     resolution: {integrity: sha512-K6YRbpD3VcwdTOPBlDgI4dILAwkhXo5cdxTlVF0IvUwQEKfMPawmH8E/QMXTN8CPGHqVYgYFACxTyk6nKlK+vg==}
     hasBin: true
     peerDependencies:
@@ -8459,8 +8670,8 @@ packages:
       mimetext: 3.0.28
       nanoid: 5.1.16
       partyserver: 0.5.8(@cloudflare/workers-types@4.20260702.1)
-      partysocket: 1.3.0(react@19.2.4)
-      react: 19.2.4
+      partysocket: 1.3.0(react@19.2.8)
+      react: 19.2.8
       yaml: 2.9.0
       yargs: 18.0.0
       zod: 4.3.6
@@ -8473,7 +8684,7 @@ packages:
       - supports-color
     dev: true
 
-  /agents@0.17.4(@babel/core@8.0.1)(@cloudflare/workers-types@5.20260716.1)(react@19.2.4)(rolldown@1.2.0)(supports-color@10.2.2)(vite@8.1.5)(zod@4.3.6):
+  /agents@0.17.4(@babel/core@8.0.1)(@cloudflare/workers-types@5.20260716.1)(react@19.2.8)(rolldown@1.2.0)(supports-color@10.2.2)(vite@8.1.5)(zod@4.3.6):
     resolution: {integrity: sha512-K6YRbpD3VcwdTOPBlDgI4dILAwkhXo5cdxTlVF0IvUwQEKfMPawmH8E/QMXTN8CPGHqVYgYFACxTyk6nKlK+vg==}
     hasBin: true
     peerDependencies:
@@ -8515,8 +8726,8 @@ packages:
       mimetext: 3.0.28
       nanoid: 5.1.16
       partyserver: 0.5.8(@cloudflare/workers-types@5.20260716.1)
-      partysocket: 1.3.0(react@19.2.4)
-      react: 19.2.4
+      partysocket: 1.3.0(react@19.2.8)
+      react: 19.2.8
       vite: 8.1.5(@types/node@20.19.21)(esbuild@0.28.1)
       yaml: 2.9.0
       yargs: 18.0.0
@@ -8775,7 +8986,7 @@ packages:
     resolution: {integrity: sha512-OMu3BGQ4E7P1ErFsIPpbJh0qvDudM/UuJeHgkAvfWe+0HFJCXh+t/l8L6fVLR55RI/UbKrVLnAXZSVwd9ysWYw==}
     hasBin: true
 
-  /better-auth@1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@7.1.0)(prisma@6.19.2)(react-dom@19.2.4)(react@19.2.4):
+  /better-auth@1.5.5(@prisma/client@6.19.2)(better-sqlite3@12.8.0)(mongodb@7.1.0)(prisma@6.19.2)(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-GpVPaV1eqr3mOovKfghJXXk6QvlcVeFbS3z+n+FPDid5rK/2PchnDtiaVCzWyXA9jH2KkirOfl+JhAUvnja0Eg==}
     peerDependencies:
       '@lynx-js/react': '*'
@@ -8857,14 +9068,14 @@ packages:
       mongodb: 7.1.0
       nanostores: 1.2.0
       prisma: 6.19.2(typescript@5.9.3)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       zod: 4.3.6
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
     dev: false
 
-  /better-auth@1.5.5(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7)(mongodb@7.1.0)(react-dom@19.2.4)(react@19.2.4):
+  /better-auth@1.5.5(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7)(mongodb@7.1.0)(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-GpVPaV1eqr3mOovKfghJXXk6QvlcVeFbS3z+n+FPDid5rK/2PchnDtiaVCzWyXA9jH2KkirOfl+JhAUvnja0Eg==}
     peerDependencies:
       '@lynx-js/react': '*'
@@ -8946,8 +9157,8 @@ packages:
       kysely: 0.28.12
       mongodb: 7.1.0
       nanostores: 1.2.0
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       zod: 4.3.6
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -10040,6 +10251,11 @@ packages:
 
   /es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+    dev: false
+
+  /es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+    dev: true
 
   /es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -10695,7 +10911,7 @@ packages:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
     dev: true
 
-  /framer-motion@12.42.2(react-dom@19.2.4)(react@19.2.4):
+  /framer-motion@12.42.2(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
@@ -10711,8 +10927,8 @@ packages:
     dependencies:
       motion-dom: 12.42.2
       motion-utils: 12.39.0
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       tslib: 2.8.1
     dev: false
 
@@ -10742,7 +10958,7 @@ packages:
     requiresBuild: true
     optional: true
 
-  /fumadocs-core@16.7.16(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.4)(react@19.2.4)(supports-color@10.2.2)(zod@4.3.6):
+  /fumadocs-core@16.7.16(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(zod@4.3.6):
     resolution: {integrity: sha512-OXZMJPS/HVAfCw8/VEgsOEQNWUXq7+U2v1A/DbKmI0Vbb08uPCUpbIqVSj4kmGr46L+Pa/PZgG596Z7iPhlbCg==}
     peerDependencies:
       '@mdx-js/mdx': '*'
@@ -10808,12 +11024,12 @@ packages:
       github-slugger: 2.0.0
       hast-util-to-estree: 3.1.3(supports-color@10.2.2)
       hast-util-to-jsx-runtime: 2.3.6(supports-color@10.2.2)
-      lucide-react: 1.23.0(react@19.2.4)
+      lucide-react: 1.23.0(react@19.2.8)
       mdast-util-mdx: 3.0.0(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
-      next: 16.2.4(@playwright/test@1.58.2)(react-dom@19.2.4)(react@19.2.4)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      next: 16.2.4(@playwright/test@1.58.2)(react-dom@19.2.8)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       remark: 15.0.1(supports-color@10.2.2)
       remark-gfm: 4.0.1(supports-color@10.2.2)
       remark-rehype: 11.1.2
@@ -10828,7 +11044,7 @@ packages:
       - supports-color
     dev: false
 
-  /fumadocs-ui@16.7.16(@types/react-dom@18.3.7)(@types/react@18.3.26)(fumadocs-core@16.7.16)(next@16.2.4)(react-dom@19.2.4)(react@19.2.4)(tailwindcss@3.4.18):
+  /fumadocs-ui@16.7.16(@types/react-dom@18.3.7)(@types/react@18.3.26)(fumadocs-core@16.7.16)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(tailwindcss@3.4.18):
     resolution: {integrity: sha512-NFWH8GuVV0O6OQnGb0TCS6jsdgyB7/5phQm8YjtIkyjkxAkERwA76N5RYCpS27p41NdtWdQw4eFIEve1Aq9Siw==}
     peerDependencies:
       '@takumi-rs/image-response': '*'
@@ -10849,26 +11065,26 @@ packages:
         optional: true
     dependencies:
       '@fumadocs/tailwind': 0.0.5(tailwindcss@3.4.18)
-      '@radix-ui/react-accordion': 1.2.15(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-collapsible': 1.1.15(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-dialog': 1.1.18(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-direction': 1.1.2(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-navigation-menu': 1.2.17(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-popover': 1.1.18(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-scroll-area': 1.2.13(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
-      '@radix-ui/react-slot': 1.3.0(@types/react@18.3.26)(react@19.2.4)
-      '@radix-ui/react-tabs': 1.1.16(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.4)(react@19.2.4)
+      '@radix-ui/react-accordion': 1.2.15(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-collapsible': 1.1.15(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-dialog': 1.1.18(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-direction': 1.1.2(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-navigation-menu': 1.2.17(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-popover': 1.1.18(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-scroll-area': 1.2.13(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-slot': 1.3.0(@types/react@18.3.26)(react@19.2.8)
+      '@radix-ui/react-tabs': 1.1.16(@types/react-dom@18.3.7)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)
       '@types/react': 18.3.26
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.7.16(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.4)(react@19.2.4)(supports-color@10.2.2)(zod@4.3.6)
-      lucide-react: 1.23.0(react@19.2.4)
-      motion: 12.42.2(react-dom@19.2.4)(react@19.2.4)
-      next: 16.2.4(@playwright/test@1.58.2)(react-dom@19.2.4)(react@19.2.4)
-      next-themes: 0.4.6(react-dom@19.2.4)(react@19.2.4)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      react-remove-scroll: 2.7.2(@types/react@18.3.26)(react@19.2.4)
+      fumadocs-core: 16.7.16(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(zod@4.3.6)
+      lucide-react: 1.23.0(react@19.2.8)
+      motion: 12.42.2(react-dom@19.2.8)(react@19.2.8)
+      next: 16.2.4(@playwright/test@1.58.2)(react-dom@19.2.8)(react@19.2.8)
+      next-themes: 0.4.6(react-dom@19.2.8)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-remove-scroll: 2.7.2(@types/react@18.3.26)(react@19.2.8)
       rehype-raw: 7.0.0
       scroll-into-view-if-needed: 3.1.0
       shiki: 4.3.1
@@ -10894,7 +11110,7 @@ packages:
     peerDependencies:
       next: '>=13.2.0'
     dependencies:
-      next: 16.2.4(@playwright/test@1.58.2)(react-dom@19.2.4)(react@19.2.4)
+      next: 16.2.4(@playwright/test@1.58.2)(react-dom@19.2.8)(react@19.2.8)
     dev: true
 
   /gensync@1.0.0-beta.2:
@@ -11609,12 +11825,6 @@ packages:
   /is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
-  /is-reference@3.0.3:
-    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
-    dependencies:
-      '@types/estree': 1.0.8
-    dev: true
-
   /is-regexp@3.1.0:
     resolution: {integrity: sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==}
     engines: {node: '>=12'}
@@ -12139,12 +12349,12 @@ packages:
     dependencies:
       yallist: 3.1.1
 
-  /lucide-react@1.23.0(react@19.2.4):
+  /lucide-react@1.23.0(react@19.2.8):
     resolution: {integrity: sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
     dependencies:
-      react: 19.2.4
+      react: 19.2.8
     dev: false
 
   /magic-string@0.30.19:
@@ -13007,7 +13217,7 @@ packages:
     resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
     dev: false
 
-  /motion@12.42.2(react-dom@19.2.4)(react@19.2.4):
+  /motion@12.42.2(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
@@ -13021,9 +13231,9 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      framer-motion: 12.42.2(react-dom@19.2.4)(react@19.2.4)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      framer-motion: 12.42.2(react-dom@19.2.8)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       tslib: 2.8.1
     dev: false
 
@@ -13093,17 +13303,17 @@ packages:
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  /next-themes@0.4.6(react-dom@19.2.4)(react@19.2.4):
+  /next-themes@0.4.6(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
     peerDependencies:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
     dependencies:
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     dev: false
 
-  /next@16.2.4(@playwright/test@1.58.2)(react-dom@19.2.4)(react@19.2.4):
+  /next@16.2.4(@playwright/test@1.58.2)(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==}
     engines: {node: '>=20.9.0'}
     hasBin: true
@@ -13130,9 +13340,9 @@ packages:
       baseline-browser-mapping: 2.10.21
       caniuse-lite: 1.0.30001750
       postcss: 8.4.31
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      styled-jsx: 5.1.6(react@19.2.8)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.4
       '@next/swc-darwin-x64': 16.2.4
@@ -13283,7 +13493,7 @@ packages:
       - uploadthing
     dev: false
 
-  /nitro@3.0.1-alpha.0(rolldown@1.2.0)(vite@6.4.1):
+  /nitro@3.0.1-alpha.0(rolldown@1.2.1)(vite@6.4.1):
     resolution: {integrity: sha512-lR3RplfXBOZXNlFQf9AJkqFVFhg5/CNbpBijM0dSYhGymb+FthJSdL6crmXVg518h2NVOd40rehhGZaf9ijW9w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
@@ -13311,7 +13521,7 @@ packages:
       ofetch: 1.5.1
       ohash: 2.0.11
       rendu: 0.0.6
-      rolldown: 1.2.0
+      rolldown: 1.2.1
       rollup: 4.52.4
       srvx: 0.8.16
       undici: 7.16.0
@@ -13668,7 +13878,7 @@ packages:
       nanoid: 5.1.16
     dev: false
 
-  /partysocket@1.3.0(react@19.2.4):
+  /partysocket@1.3.0(react@19.2.8):
     resolution: {integrity: sha512-1zToNyolZFK/7nuAw/K2bZrNzFqaZyRoCEkS+9vG6WSC5ikrN6qWRe96q6ImU51uptz2r+dAwSkwhJVdQi4LiA==}
     peerDependencies:
       react: '>=17'
@@ -13677,7 +13887,7 @@ packages:
         optional: true
     dependencies:
       event-target-polyfill: 0.0.4
-      react: 19.2.4
+      react: 19.2.8
 
   /path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -13731,14 +13941,6 @@ packages:
   /perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
     dev: false
-
-  /periscopic@4.0.2:
-    resolution: {integrity: sha512-sqpQDUy8vgB7ycLkendSKS6HnVz1Rneoc3Rc+ZBUCe2pbqlVuCC5vF52l0NJ1aiMg/r1qfYF9/myz8CZeI2rjA==}
-    dependencies:
-      '@types/estree': 1.0.8
-      is-reference: 3.0.3
-      zimmerframe: 1.1.4
-    dev: true
 
   /pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
@@ -14197,12 +14399,22 @@ packages:
       scheduler: 0.23.2
     dev: false
 
-  /react-dom@19.2.4(react@19.2.4):
-    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
+  /react-dom@18.3.1(react@19.2.4):
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
-      react: ^19.2.4
+      react: ^18.3.1
     dependencies:
+      loose-envify: 1.4.0
       react: 19.2.4
+      scheduler: 0.23.2
+    dev: false
+
+  /react-dom@19.2.8(react@19.2.8):
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
+    peerDependencies:
+      react: ^19.2.8
+    dependencies:
+      react: 19.2.8
       scheduler: 0.27.0
 
   /react-is@18.3.1:
@@ -14213,7 +14425,7 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
-  /react-remove-scroll-bar@2.3.8(@types/react@18.3.26)(react@19.2.4):
+  /react-remove-scroll-bar@2.3.8(@types/react@18.3.26)(react@19.2.8):
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -14224,12 +14436,12 @@ packages:
         optional: true
     dependencies:
       '@types/react': 18.3.26
-      react: 19.2.4
-      react-style-singleton: 2.2.3(@types/react@18.3.26)(react@19.2.4)
+      react: 19.2.8
+      react-style-singleton: 2.2.3(@types/react@18.3.26)(react@19.2.8)
       tslib: 2.8.1
     dev: false
 
-  /react-remove-scroll@2.7.2(@types/react@18.3.26)(react@19.2.4):
+  /react-remove-scroll@2.7.2(@types/react@18.3.26)(react@19.2.8):
     resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -14240,46 +14452,30 @@ packages:
         optional: true
     dependencies:
       '@types/react': 18.3.26
-      react: 19.2.4
-      react-remove-scroll-bar: 2.3.8(@types/react@18.3.26)(react@19.2.4)
-      react-style-singleton: 2.2.3(@types/react@18.3.26)(react@19.2.4)
+      react: 19.2.8
+      react-remove-scroll-bar: 2.3.8(@types/react@18.3.26)(react@19.2.8)
+      react-style-singleton: 2.2.3(@types/react@18.3.26)(react@19.2.8)
       tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@18.3.26)(react@19.2.4)
-      use-sidecar: 1.1.3(@types/react@18.3.26)(react@19.2.4)
+      use-callback-ref: 1.3.3(@types/react@18.3.26)(react@19.2.8)
+      use-sidecar: 1.1.3(@types/react@18.3.26)(react@19.2.8)
     dev: false
 
-  /react-server-dom-webpack@18.3.0-next-fecc288b7-20221025(react-dom@19.2.4)(react@19.2.4)(webpack@5.102.1):
-    resolution: {integrity: sha512-7KdRDi/vm9iCs0eZqae+vSTHGKsKcbRtG0SCRrlHx+CDI+xxyscFFITo6PY/w9W79Eh4FnuPe52F1FiIaiprGg==}
+  /react-server-dom-webpack@19.2.8(react-dom@19.2.8)(react@19.2.8)(webpack@5.102.1):
+    resolution: {integrity: sha512-rFO1VJZ+cH9ZH6hGy9+qmIsmZHZpCMKJZXhWHqT71UnSfg+w+W+gwrwp58MVzMqdFquG8GF1c6C8q0OGphkEdg==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
-      react: 18.3.0-next-fecc288b7-20221025
-      react-dom: 18.3.0-next-fecc288b7-20221025
-      webpack: ^5.59.0
-    dependencies:
-      acorn: 6.4.2
-      loose-envify: 1.4.0
-      neo-async: 2.6.2
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      webpack: 5.102.1(esbuild@0.28.1)
-    dev: false
-
-  /react-server-dom-webpack@19.2.4(react-dom@19.2.4)(react@19.2.4)(webpack@5.102.1):
-    resolution: {integrity: sha512-zEhkWv6RhXDctC2N7yEUHg3751nvFg81ydHj8LTTZuukF/IF1gcOKqqAL6Ds+kS5HtDVACYPik0IvzkgYXPhlQ==}
-    engines: {node: '>=0.10.0'}
-    peerDependencies:
-      react: ^19.2.4
-      react-dom: ^19.2.4
+      react: ^19.2.8
+      react-dom: ^19.2.8
       webpack: ^5.59.0
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       webpack: 5.102.1
       webpack-sources: 3.3.3
 
-  /react-style-singleton@2.2.3(@types/react@18.3.26)(react@19.2.4):
+  /react-style-singleton@2.2.3(@types/react@18.3.26)(react@19.2.8):
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -14291,7 +14487,7 @@ packages:
     dependencies:
       '@types/react': 18.3.26
       get-nonce: 1.0.1
-      react: 19.2.4
+      react: 19.2.8
       tslib: 2.8.1
     dev: false
 
@@ -14304,6 +14500,11 @@ packages:
 
   /react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
 
   /read-cache@1.0.0:
@@ -14541,7 +14742,7 @@ packages:
       '@react-email/render':
         optional: true
     dependencies:
-      '@react-email/render': 2.0.6(react-dom@19.2.4)(react@19.2.4)
+      '@react-email/render': 2.0.6(react-dom@18.3.1)(react@19.2.4)
       postal-mime: 2.7.4
       svix: 1.88.0
     dev: false
@@ -14576,7 +14777,7 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  /rolldown-plugin-dts@0.16.11(rolldown@1.2.0)(supports-color@10.2.2)(typescript@5.9.3):
+  /rolldown-plugin-dts@0.16.11(rolldown@1.2.1)(supports-color@10.2.2)(typescript@5.9.3):
     resolution: {integrity: sha512-9IQDaPvPqTx3RjG2eQCK5GYZITo203BxKunGI80AGYicu1ySFTUyugicAaTZWRzFWh9DSnzkgNeMNbDWBbSs0w==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
@@ -14604,7 +14805,7 @@ packages:
       dts-resolver: 2.1.2
       get-tsconfig: 4.12.0
       magic-string: 0.30.21
-      rolldown: 1.2.0
+      rolldown: 1.2.1
       typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver
@@ -14658,6 +14859,30 @@ packages:
       '@rolldown/binding-wasm32-wasi': 1.2.0
       '@rolldown/binding-win32-arm64-msvc': 1.2.0
       '@rolldown/binding-win32-x64-msvc': 1.2.0
+
+  /rolldown@1.2.1:
+    resolution: {integrity: sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    dependencies:
+      '@oxc-project/types': 0.142.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.1
+      '@rolldown/binding-darwin-arm64': 1.2.1
+      '@rolldown/binding-darwin-x64': 1.2.1
+      '@rolldown/binding-freebsd-x64': 1.2.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.1
+      '@rolldown/binding-linux-arm64-gnu': 1.2.1
+      '@rolldown/binding-linux-arm64-musl': 1.2.1
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.1
+      '@rolldown/binding-linux-s390x-gnu': 1.2.1
+      '@rolldown/binding-linux-x64-gnu': 1.2.1
+      '@rolldown/binding-linux-x64-musl': 1.2.1
+      '@rolldown/binding-openharmony-arm64': 1.2.1
+      '@rolldown/binding-wasm32-wasi': 1.2.1
+      '@rolldown/binding-win32-arm64-msvc': 1.2.1
+      '@rolldown/binding-win32-x64-msvc': 1.2.1
 
   /rollup@4.52.4:
     resolution: {integrity: sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==}
@@ -15118,16 +15343,16 @@ packages:
     engines: {node: '>=14'}
     dev: false
 
-  /srvx@0.10.1:
-    resolution: {integrity: sha512-A//xtfak4eESMWWydSRFUVvCTQbSwivnGCEf8YGPe2eHU0+Z6znfUTCPF0a7oV3sObSOcrXHlL6Bs9vVctfXdg==}
-    engines: {node: '>=20.16.0'}
-    hasBin: true
-    dev: true
-
   /srvx@0.11.22:
     resolution: {integrity: sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==}
     engines: {node: '>=20.16.0'}
     hasBin: true
+
+  /srvx@0.12.4:
+    resolution: {integrity: sha512-RixzFlMn3dvzDTpKIAXhXrqL4cy6vScNCP0VVwgVbUBU94o+DiXLsFnAZetbyKAEnK6Ox3hzHXWGsyv/Iibv7g==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+    dev: true
 
   /srvx@0.8.16:
     resolution: {integrity: sha512-hmcGW4CgroeSmzgF1Ihwgl+Ths0JqAJ7HwjP2X7e3JzY7u4IydLMcdnlqGQiQGUswz+PO9oh/KtCpOISIvs9QQ==}
@@ -15288,7 +15513,7 @@ packages:
       inline-style-parser: 0.2.7
     dev: false
 
-  /styled-jsx@5.1.6(react@19.2.4):
+  /styled-jsx@5.1.6(react@19.2.8):
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -15302,7 +15527,7 @@ packages:
         optional: true
     dependencies:
       client-only: 0.0.1
-      react: 19.2.4
+      react: 19.2.8
 
   /sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
@@ -15448,31 +15673,6 @@ packages:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
-    dev: false
-
-  /terser-webpack-plugin@5.3.14(esbuild@0.28.1)(webpack@5.102.1):
-    resolution: {integrity: sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@swc/core': '*'
-      esbuild: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      esbuild:
-        optional: true
-      uglify-js:
-        optional: true
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      esbuild: 0.28.1
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
-      terser: 5.44.0
-      webpack: 5.102.1(esbuild@0.28.1)
     dev: false
 
   /terser-webpack-plugin@5.3.14(webpack@5.102.1):
@@ -15688,8 +15888,8 @@ packages:
       diff: 8.0.2
       empathic: 2.0.0
       hookable: 5.5.3
-      rolldown: 1.2.0
-      rolldown-plugin-dts: 0.16.11(rolldown@1.2.0)(supports-color@10.2.2)(typescript@5.9.3)
+      rolldown: 1.2.1
+      rolldown-plugin-dts: 0.16.11(rolldown@1.2.1)(supports-color@10.2.2)(typescript@5.9.3)
       semver: 7.7.3
       tinyexec: 1.0.1
       tinyglobby: 0.2.15
@@ -15810,8 +16010,8 @@ packages:
     dev: true
     optional: true
 
-  /turbo-stream@3.1.0:
-    resolution: {integrity: sha512-tVI25WEXl4fckNEmrq70xU1XumxUwEx/FZD5AgEcV8ri7Wvrg2o7GEq8U7htrNx3CajciGm+kDyhRf5JB6t7/A==}
+  /turbo-stream@3.2.0:
+    resolution: {integrity: sha512-EK+bZ9UVrVh7JLslVFOV0GEMsociOqVOvEMTAd4ixMyffN5YNIEdLZWXUx5PJqDbTxSIBWw04HS9gCY4frYQDQ==}
     dev: true
 
   /turbo-windows-64@1.13.4:
@@ -16408,7 +16608,7 @@ packages:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  /use-callback-ref@1.3.3(@types/react@18.3.26)(react@19.2.4):
+  /use-callback-ref@1.3.3(@types/react@18.3.26)(react@19.2.8):
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -16419,11 +16619,11 @@ packages:
         optional: true
     dependencies:
       '@types/react': 18.3.26
-      react: 19.2.4
+      react: 19.2.8
       tslib: 2.8.1
     dev: false
 
-  /use-sidecar@1.1.3(@types/react@18.3.26)(react@19.2.4):
+  /use-sidecar@1.1.3(@types/react@18.3.26)(react@19.2.8):
     resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -16435,7 +16635,7 @@ packages:
     dependencies:
       '@types/react': 18.3.26
       detect-node-es: 1.1.0
-      react: 19.2.4
+      react: 19.2.8
       tslib: 2.8.1
     dev: false
 
@@ -16662,10 +16862,10 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
 
-  /vitefu@1.1.1(vite@6.4.1):
-    resolution: {integrity: sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==}
+  /vitefu@1.1.3(vite@6.4.1):
+    resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
     peerDependencies:
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       vite:
         optional: true
@@ -16848,47 +17048,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-
-  /webpack@5.102.1(esbuild@0.28.1):
-    resolution: {integrity: sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    peerDependencies:
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.17.0
-      acorn-import-phases: 1.0.4(acorn@8.17.0)
-      browserslist: 4.26.3
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.20.0
-      es-module-lexer: 1.7.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.3.14(esbuild@0.28.1)(webpack@5.102.1)
-      watchpack: 2.4.4
-      webpack-sources: 3.3.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-    dev: false
 
   /whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -17164,10 +17323,6 @@ packages:
   /zhead@2.2.4:
     resolution: {integrity: sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag==}
     dev: false
-
-  /zimmerframe@1.1.4:
-    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
-    dev: true
 
   /zod-to-json-schema@3.25.2(zod@4.3.6):
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}


### PR DESCRIPTION
## Summary

- pin the supported RSC toolchain to `react@19.2.8`, `react-dom@19.2.8`, `react-server-dom-webpack@19.2.8`, and `@vitejs/plugin-rsc@0.5.32`
- remove the obsolete React 18 Flight dependency from `@farm.js/core`
- add an RSC startup guard that rejects missing, mismatched, or vulnerable package combinations
- make React Server Actions an explicit opt-in while keeping RSC rendering available independently
- deduplicate the Flight runtime and align React 19 workspace applications on the patched release
- document the supported package combination and add compatibility regression tests

## Why

The RSC demo resolved `react-server-dom-webpack@19.2.4`. That release is affected by later React Server Components denial-of-service advisories and is superseded by patched releases. The ordinary core package also depended on a years-old experimental React 18 Flight build while advertising React 19 support.

Broad dependency ranges allowed React, the Flight renderer/decoder, and the Vite RSC integration to drift independently. The standalone RSC configuration also enabled the public Server Action POST decoder implicitly.

This change establishes one integration-tested package set and fails early when an RSC application resolves anything else.

Relevant React advisories:

- https://github.com/facebook/react/security/advisories/GHSA-479c-33wc-g2pg
- https://github.com/facebook/react/security/advisories/GHSA-rv78-f8rc-xrxh

## Developer impact

Non-RSC applications no longer install `react-server-dom-webpack` through `@farm.js/core`.

Standalone RSC applications must install the supported exact versions. Applications that use React Server Actions must now enable them explicitly:

```ts
experimental: {
  serverActions: true,
}
```

The RSC demo opts in explicitly so the production action flow remains covered.

## Validation

- `@farm.js/core`: 716 tests passed, 1 existing skip
- `@farm.js/plugin`: 31 tests passed
- plugin TypeScript check passed
- RSC production E2E: 11/11 passed
- general production framework E2E: 26/26 passed
- RSC production build and Nitro output passed
- RSC development server smoke test returned HTTP 200
- frozen-lockfile installation passed
- dependency graph contains only `react-server-dom-webpack@19.2.8`
- repository lint and format checks passed with zero errors


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks the RSC toolchain to tested versions and adds a startup guard to block vulnerable or mismatched installs, with Server Actions now opt-in. Removes the old React 18 Flight path and aligns the workspace and plugin on the React 19 stack.

- **Dependencies**
  - Pin `react@19.2.8`, `react-dom@19.2.8`, `react-server-dom-webpack@19.2.8`, `@vitejs/plugin-rsc@0.5.32`.
  - Remove the React 18 `react-server-dom-webpack` from `@farm.js/core`.
  - Set exact plugin peers and dedupe `react`, `react-dom`, `react-server-dom-webpack` in Vite.
  - Update examples/docs to the pinned versions.

- **Migration**
  - RSC apps must install the exact set: `pnpm add react@19.2.8 react-dom@19.2.8 react-server-dom-webpack@19.2.8 && pnpm add -D @vitejs/plugin-rsc@0.5.32`.
  - Enable Server Actions explicitly if needed:
    - `experimental: { serverActions: true }`
  - Non-RSC apps no longer depend on `react-server-dom-webpack`.

<sup>Written for commit 4fe9feecde70de8e9818684ffbba355e53088297. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

