### PR TITLE
fix framework version surfaces

### DIFF
--- a/examples/basic/src/app/page.tsx
+++ b/examples/basic/src/app/page.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import type { PageProps, Metadata } from '@farm.js/core'
 import { Link } from '@farm.js/core/client'
 import type { ResolvedRouteHref } from '@farm.js/core/client'
+import { FARM_VERSION } from '@farm.js/core/version'
 
 // Note: This page uses Link components which require hydration
 // SSG is better suited for pages without client-side interactivity
@@ -18,7 +19,7 @@ export default function HomePage({ params, searchParams }: PageProps) {
     <div className="space-y-8">
       <div className="text-center">
         <h1 className="text-5xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent mb-4">
-          Welcome to Farm.js 0.1.0-beta.2
+          Welcome to Farm.js v{FARM_VERSION}
         </h1>
         
         <p className="text-xl text-gray-600 max-w-2xl mx-auto">

--- a/packages/create-farm-app/templates/basic/src/app/page.tsx
+++ b/packages/create-farm-app/templates/basic/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@farm.js/core/client";
+import { FARM_VERSION } from "@farm.js/core/version";
 
 export default function HomePage() {
   return (
@@ -7,7 +8,7 @@ export default function HomePage() {
         <div>
           <h1 className="text-6xl font-bold mb-4">
             <span className="bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
-              🚜 Welcome to Farm.js
+              🚜 Welcome to Farm.js v{FARM_VERSION}
             </span>
           </h1>
 

--- a/packages/create-farm-app/test/create-app.test.mjs
+++ b/packages/create-farm-app/test/create-app.test.mjs
@@ -54,6 +54,9 @@ test("generates a buildable starter dependency manifest", async () => {
       "utf8",
     );
     assert.match(generatedHomePage, /from "@farm\.js\/core\/client"/);
+    assert.match(generatedHomePage, /from "@farm\.js\/core\/version"/);
+    assert.match(generatedHomePage, /Welcome to Farm\.js v\{FARM_VERSION\}/);
+    assert.doesNotMatch(generatedHomePage, /Welcome to Farm\.js v?\d+\.\d+\.\d+/);
     assert.doesNotMatch(generatedHomePage, /from "farm\//);
   } finally {
     await rm(tempDir, { recursive: true, force: true });

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -30,6 +30,9 @@
         "./types/middleware.d.ts",
         "./dist/middleware.d.ts"
       ],
+      "version": [
+        "./dist/version.d.ts"
+      ],
       "router": [
         "./dist/router.d.ts"
       ],
@@ -181,6 +184,11 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs",
       "default": "./dist/index.mjs"
+    },
+    "./version": {
+      "types": "./dist/version.d.ts",
+      "import": "./dist/version.mjs",
+      "require": "./dist/version.cjs"
     },
     "./config": {
       "types": "./dist/config.d.ts",

--- a/packages/farm/src/__tests__/version.test.ts
+++ b/packages/farm/src/__tests__/version.test.ts
@@ -1,0 +1,9 @@
+import packageJson from "../../package.json";
+import { describe, expect, it } from "vitest";
+import { FARM_VERSION } from "../version";
+
+describe("FARM_VERSION", () => {
+  it("matches the published core package version", () => {
+    expect(FARM_VERSION).toBe(packageJson.version);
+  });
+});

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig, type Options } from "tsup";
 export const farmPackageBuildOptions = {
   entry: {
     index: "src/index.ts",
+    version: "src/version.ts",
     server: "src/server.ts",
     client: "src/client.ts",
     vite: "src/vite.ts",


### PR DESCRIPTION
## What changed

- publish `@farm.js/core/version` as a supported ESM/CJS/types subpath
- render `FARM_VERSION` on the generated starter homepage and the basic example homepage
- add regression tests that tie `FARM_VERSION` to the core package manifest and reject hardcoded starter versions

## Why

The published beta banner and homepage could drift because version text was either hardcoded or absent. Both user-visible surfaces now consume the version bundled from `@farm.js/core/package.json`, so release bumps update them together.

## Impact

Fresh apps created from the next beta display the exact installed framework version. For `0.1.0-beta.2`, both the terminal banner and homepage render `v0.1.0-beta.2`.

## Validation

- `@farm.js/core` focused version test
- `@farm.js/core` build and type-check
- `@farm.js/create-app` test and type-check
- basic example type-check and production build
- packed local core/CLI/create-app artifacts installed into a fresh generated project
- fresh project type-check and production build
- browser verification confirmed the homepage and terminal banner both show `v0.1.0-beta.2` with no console warnings or errors
- oxlint, oxfmt, and `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent version drift in user-facing version text by exposing `FARM_VERSION` via `@farm.js/core/version` and using it in the starter and basic example homepages. Release bumps now update these surfaces automatically.

- **Bug Fixes**
  - Publish `@farm.js/core/version` subpath with ESM, CJS, and types.
  - Render `v{FARM_VERSION}` in starter and example homepages.
  - Add tests to ensure `FARM_VERSION` matches `@farm.js/core` package.json and reject hardcoded version strings in the template.

<sup>Written for commit 94dff502e498f6bf10acdc36bbeff0381f24208f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

