### PR TITLE
feat: add unified mutation lifecycle

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -35,6 +35,53 @@ if (result.error) {
 }
 ```
 
+## Track mutations in React
+
+`useMutation` gives generated API methods and Farm server functions the same pending, result, and
+error lifecycle. API methods keep using the typed HTTP client underneath; they are not converted
+into React Server Actions.
+
+```tsx
+"use client";
+
+import { useMutation } from "@farm.js/core/client";
+import { api } from "@/lib/api-client";
+
+export function CreateProductButton() {
+  const createProduct = useMutation(api.products.post, {
+    request: {
+      invalidate: [[api.products.get]],
+    },
+  });
+
+  return (
+    <button
+      disabled={createProduct.pending}
+      onClick={() =>
+        createProduct.mutate({
+          body: { name: "Strata", category: "tools" },
+        })
+      }
+    >
+      {createProduct.pending ? "Creating..." : "Create product"}
+    </button>
+  );
+}
+```
+
+Use `mutate` for event handlers and `mutateAsync` when later code needs the resolved value:
+
+```ts
+const product = await createProduct.mutateAsync({
+  body: { name, category },
+});
+```
+
+The return value includes `data`, `error`, `variables`, `status`, `pending`, and `reset`. Pass the
+existing API-client cache, retry, invalidation, and optimistic options through `request`. Local
+`optimistic` state on `useMutation` is separate from an API cache update: it controls
+`mutation.data`, while `request.optimistic` updates shared cached queries.
+
 ## Client options
 
 - cache: choose cache-first, network-only, or stale-while-revalidate.

--- a/packages/farm/src/__tests__/mutation-client.test.tsx
+++ b/packages/farm/src/__tests__/mutation-client.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import { z } from "zod";
+import { createAPIClient } from "../api/client";
+import { useMutation, type UseMutationReturn } from "../mutation-client";
+import { createServerFn } from "../server-fn";
+
+type APIRouter = {
+  products: {
+    post: {
+      __types: {
+        body: { name: string };
+        query: never;
+        response: { id: string; name: string };
+      };
+    };
+  };
+};
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+describe("useMutation", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot> | undefined;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    (globalThis as any).window = globalThis;
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount();
+      });
+    }
+    container.remove();
+    root = undefined;
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    delete (globalThis as any).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  it("unwraps generated API route results and tracks their lifecycle", async () => {
+    const response = createDeferred<{
+      ok: boolean;
+      status: number;
+      statusText: string;
+      json: () => Promise<{ id: string; name: string }>;
+    }>();
+    globalThis.fetch = vi.fn(() => response.promise) as any;
+    const api = createAPIClient<APIRouter>({
+      baseURL: "https://farm.test",
+    });
+
+    let mutation!: UseMutationReturn<typeof api.products.post, { id: string; name: string }>;
+
+    function App() {
+      mutation = useMutation(api.products.post);
+      return createElement("output", null, `${mutation.status}:${mutation.data?.name ?? ""}`);
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    let result!: Promise<{ id: string; name: string }>;
+    act(() => {
+      result = mutation.mutateAsync({ body: { name: "Strata" } });
+    });
+
+    expect(container.textContent).toBe("pending:");
+    response.resolve({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({ id: "p1", name: "Strata" }),
+    });
+
+    await act(async () => {
+      await expect(result).resolves.toEqual({
+        id: "p1",
+        name: "Strata",
+      });
+    });
+
+    expect(container.textContent).toBe("success:Strata");
+    expectTypeOf(mutation.data).toEqualTypeOf<{
+      id: string;
+      name: string;
+    } | null>();
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://farm.test/api/products",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ name: "Strata" }),
+      }),
+    );
+  });
+
+  it("uses the same lifecycle for server functions", async () => {
+    const rename = createServerFn({
+      input: z.object({ name: z.string() }),
+      async handler({ input }) {
+        return { saved: input.name };
+      },
+    });
+    let mutation!: UseMutationReturn<typeof rename>;
+
+    function App() {
+      mutation = useMutation(rename);
+      return createElement("output", null, `${mutation.status}:${mutation.data?.saved ?? ""}`);
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    await act(async () => {
+      await mutation.mutateAsync({ name: "Farm" });
+    });
+
+    expect(container.textContent).toBe("success:Farm");
+  });
+
+  it("keeps the latest result after an older concurrent request settles", async () => {
+    const first = createDeferred<string>();
+    const second = createDeferred<string>();
+    const save = vi
+      .fn<(value: string) => Promise<string>>()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    let mutation!: UseMutationReturn<typeof save>;
+
+    function App() {
+      mutation = useMutation(save);
+      return createElement(
+        "output",
+        null,
+        `${mutation.status}:${mutation.pending}:${mutation.data ?? ""}`,
+      );
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    let older!: Promise<string>;
+    let latest!: Promise<string>;
+    act(() => {
+      older = mutation.mutateAsync("older");
+      latest = mutation.mutateAsync("latest");
+    });
+
+    second.resolve("latest");
+    await act(async () => {
+      await latest;
+    });
+    expect(container.textContent).toBe("success:true:latest");
+
+    first.resolve("older");
+    await act(async () => {
+      await older;
+    });
+    expect(container.textContent).toBe("success:false:latest");
+  });
+
+  it("rolls back local optimistic data after API errors", async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 409,
+      statusText: "Conflict",
+      json: async () => ({ message: "Already exists" }),
+    })) as any;
+    const api = createAPIClient<APIRouter>({
+      baseURL: "https://farm.test",
+    });
+    let mutation!: UseMutationReturn<typeof api.products.post>;
+
+    function App() {
+      mutation = useMutation(api.products.post, {
+        initialData: { id: "existing", name: "Existing" },
+        optimistic: ({ variables }) => ({
+          id: "optimistic",
+          name: variables?.body.name ?? "",
+        }),
+        rollbackOnError: true,
+      });
+      return createElement("output", null, `${mutation.status}:${mutation.data?.name ?? ""}`);
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    await act(async () => {
+      await expect(mutation.mutateAsync({ body: { name: "Existing" } })).rejects.toThrow(
+        "HTTP 409: Conflict",
+      );
+    });
+
+    expect(container.textContent).toBe("error:Existing");
+  });
+});

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -14,6 +14,8 @@ import {
   type FarmClientDataCache,
 } from "../client-cache";
 
+export const FARM_API_ROUTE_REF_SYMBOL: unique symbol = Symbol.for("farm.api.route-ref") as any;
+
 export type APIClientOptions = {
   baseURL?: string;
   headers?: Record<string, string>;
@@ -712,9 +714,17 @@ function createNestedProxy(
   const target = () => {};
   const proxy = new Proxy(target, {
     // When accessing a property (api.hello)
-    get(_target, prop: string) {
+    get(_target, prop: string | symbol) {
+      if (prop === FARM_API_ROUTE_REF_SYMBOL) {
+        return path.length > 0;
+      }
+
       if (path.length === 0 && typeof prop === "string" && rootAliases && prop in rootAliases) {
         return rootAliases[prop];
+      }
+
+      if (typeof prop !== "string") {
+        return Reflect.get(_target, prop);
       }
 
       // Add prop to path and return new proxy
@@ -754,6 +764,13 @@ function createNestedProxy(
 
   routeMeta.set(proxy, { path: [...path], baseURL });
   return proxy;
+}
+
+export function isAPIRouteRef(value: unknown): value is CallableRouteRef {
+  return (
+    typeof value === "function" &&
+    (value as { [FARM_API_ROUTE_REF_SYMBOL]?: unknown })[FARM_API_ROUTE_REF_SYMBOL] === true
+  );
 }
 
 /**

--- a/packages/farm/src/client.ts
+++ b/packages/farm/src/client.ts
@@ -8,6 +8,18 @@ export type {
   ServerAPIClientOptions,
   ServerAPIClientWithoutIntegrationsOptions,
 } from "./api/client";
+export { useMutation } from "./mutation-client";
+export type {
+  InferMutationData,
+  InferMutationError,
+  InferMutationVariables,
+  MutationAsync,
+  MutationOptimisticContext,
+  MutationStatus,
+  MutationTrigger,
+  UseMutationOptions,
+  UseMutationReturn,
+} from "./mutation-client";
 export { fetchServerQuery, prefetchServerQuery, useServerQuery } from "./server-query-client";
 export type {
   ServerQueryFetchOptions,

--- a/packages/farm/src/client/index.ts
+++ b/packages/farm/src/client/index.ts
@@ -44,6 +44,18 @@ export type {
   ServerAPIClientOptions,
   ServerAPIClientWithoutIntegrationsOptions,
 } from "../api/client";
+export { useMutation } from "../mutation-client";
+export type {
+  InferMutationData,
+  InferMutationError,
+  InferMutationVariables,
+  MutationAsync,
+  MutationOptimisticContext,
+  MutationStatus,
+  MutationTrigger,
+  UseMutationOptions,
+  UseMutationReturn,
+} from "../mutation-client";
 export {
   getRouter,
   navigateTo,

--- a/packages/farm/src/mutation-client.ts
+++ b/packages/farm/src/mutation-client.ts
@@ -1,0 +1,291 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import { isAPIRouteRef, type APIResult, type ClientOptions } from "./api/client";
+
+export type MutationStatus = "idle" | "pending" | "success" | "error";
+
+type AnyMutationTarget = (...args: any[]) => Promise<any>;
+
+export type InferMutationVariables<TTarget extends AnyMutationTarget> =
+  Parameters<TTarget> extends [] ? undefined : Parameters<TTarget>[0];
+
+export type InferMutationData<TTarget extends AnyMutationTarget> = TTarget extends {
+  readonly __farmRouteData: infer TData;
+}
+  ? TData
+  : Awaited<ReturnType<TTarget>>;
+
+export type InferMutationError<TTarget extends AnyMutationTarget> = TTarget extends (
+  ...args: any[]
+) => Promise<APIResult<any, infer TError>>
+  ? TError
+  : Error;
+
+export type MutationOptimisticContext<TVariables, TData> = {
+  variables: TVariables | undefined;
+  current: TData | null;
+};
+
+export type UseMutationOptions<TVariables, TData, TError = Error> = {
+  initialData?: TData | null;
+  resetOnMutate?: boolean;
+  optimistic?: (context: MutationOptimisticContext<TVariables, TData>) => TData | null | undefined;
+  rollbackOnError?: boolean;
+  /**
+   * Options forwarded to generated `api.route.method` clients.
+   * Server functions ignore this field.
+   */
+  request?: ClientOptions<TData, TError>;
+  onSuccess?: (data: TData, variables: TVariables | undefined) => void;
+  onError?: (error: TError, variables: TVariables | undefined) => void;
+  onSettled?: (data: TData | null, error: TError | null, variables: TVariables | undefined) => void;
+};
+
+type MutationInput<TTarget extends AnyMutationTarget> = InferMutationVariables<TTarget>;
+
+type MutationData<TTarget extends AnyMutationTarget> = InferMutationData<TTarget>;
+
+type MutationError<TTarget extends AnyMutationTarget> = InferMutationError<TTarget>;
+
+export type MutationAsync<TTarget extends AnyMutationTarget, TData = MutationData<TTarget>> =
+  [] extends Parameters<TTarget>
+    ? (variables?: MutationInput<TTarget>) => Promise<TData>
+    : (variables: MutationInput<TTarget>) => Promise<TData>;
+
+export type MutationTrigger<TTarget extends AnyMutationTarget> =
+  [] extends Parameters<TTarget>
+    ? (variables?: MutationInput<TTarget>) => void
+    : (variables: MutationInput<TTarget>) => void;
+
+export type UseMutationReturn<
+  TTarget extends AnyMutationTarget,
+  TData = MutationData<TTarget>,
+  TError = MutationError<TTarget>,
+> = {
+  pending: boolean;
+  status: MutationStatus;
+  data: TData | null;
+  error: TError | null;
+  variables: MutationInput<TTarget> | undefined;
+  mutate: MutationTrigger<TTarget>;
+  mutateAsync: MutationAsync<TTarget, TData>;
+  reset: () => void;
+};
+
+type MutationState<TVariables, TData, TError> = {
+  pendingCount: number;
+  status: MutationStatus;
+  data: TData | null;
+  error: TError | null;
+  variables: TVariables | undefined;
+};
+
+/**
+ * Track a generated API route mutation or a Farm server function with one
+ * React lifecycle.
+ *
+ * API routes keep using their existing fetch transport and request options.
+ * Server functions keep using their configured server-function transport.
+ */
+export function useMutation<TTarget extends AnyMutationTarget>(
+  target: TTarget,
+  options: UseMutationOptions<
+    MutationInput<TTarget>,
+    MutationData<TTarget>,
+    MutationError<TTarget>
+  > = {},
+): UseMutationReturn<TTarget> {
+  type TVariables = MutationInput<TTarget>;
+  type TData = MutationData<TTarget>;
+  type TError = MutationError<TTarget>;
+
+  const initialData = options.initialData ?? null;
+  const optionsRef = useRef(options);
+  const targetRef = useRef(target);
+  const requestIdRef = useRef(0);
+  const initialState: MutationState<TVariables, TData, TError> = {
+    pendingCount: 0,
+    status: "idle",
+    data: initialData,
+    error: null,
+    variables: undefined,
+  };
+  const stateRef = useRef(initialState);
+  const [state, setState] = useState<MutationState<TVariables, TData, TError>>(initialState);
+
+  optionsRef.current = options;
+  targetRef.current = target;
+
+  const setMutationState = useCallback(
+    (
+      value:
+        | MutationState<TVariables, TData, TError>
+        | ((
+            current: MutationState<TVariables, TData, TError>,
+          ) => MutationState<TVariables, TData, TError>),
+    ) => {
+      setState((current) => {
+        const next = typeof value === "function" ? value(current) : value;
+        stateRef.current = next;
+        return next;
+      });
+    },
+    [],
+  );
+
+  const mutateAsync = useCallback(
+    async (variables?: TVariables) => {
+      const requestId = ++requestIdRef.current;
+      const currentOptions = optionsRef.current;
+      const previousData = stateRef.current.data;
+      const optimisticData = currentOptions.optimistic?.({
+        variables,
+        current: previousData,
+      });
+      const hasOptimisticData = optimisticData !== undefined;
+
+      setMutationState((current) => ({
+        pendingCount: current.pendingCount + 1,
+        status: "pending",
+        data: hasOptimisticData
+          ? optimisticData
+          : currentOptions.resetOnMutate === false
+            ? current.data
+            : null,
+        error: null,
+        variables,
+      }));
+
+      try {
+        const mutationTarget = targetRef.current;
+        const rawResult = isAPIRouteRef(mutationTarget)
+          ? await mutationTarget(variables, currentOptions.request)
+          : await mutationTarget(variables);
+        const data = unwrapMutationResult<TData, TError>(rawResult, isAPIRouteRef(mutationTarget));
+        const isLatestRequest = requestId === requestIdRef.current;
+
+        setMutationState((current) => {
+          const pendingCount = Math.max(0, current.pendingCount - 1);
+          if (!isLatestRequest) {
+            return {
+              ...current,
+              pendingCount,
+              status: pendingCount > 0 ? "pending" : current.status,
+            };
+          }
+
+          return {
+            pendingCount,
+            status: "success",
+            data,
+            error: null,
+            variables,
+          };
+        });
+
+        if (isLatestRequest) {
+          currentOptions.onSuccess?.(data, variables);
+          currentOptions.onSettled?.(data, null, variables);
+        }
+
+        return data;
+      } catch (cause) {
+        const error = normalizeMutationError(cause) as TError;
+        const isLatestRequest = requestId === requestIdRef.current;
+
+        setMutationState((current) => {
+          const pendingCount = Math.max(0, current.pendingCount - 1);
+          if (!isLatestRequest) {
+            return {
+              ...current,
+              pendingCount,
+              status: pendingCount > 0 ? "pending" : current.status,
+            };
+          }
+
+          return {
+            pendingCount,
+            status: "error",
+            data:
+              hasOptimisticData && currentOptions.rollbackOnError
+                ? previousData
+                : currentOptions.resetOnMutate === false
+                  ? current.data
+                  : null,
+            error,
+            variables,
+          };
+        });
+
+        if (isLatestRequest) {
+          currentOptions.onError?.(error, variables);
+          currentOptions.onSettled?.(null, error, variables);
+        }
+
+        throw error;
+      }
+    },
+    [setMutationState],
+  ) as MutationAsync<TTarget, TData>;
+
+  const mutate = useCallback(
+    (variables?: TVariables) => {
+      void mutateAsync(variables as never).catch(() => {});
+    },
+    [mutateAsync],
+  ) as MutationTrigger<TTarget>;
+
+  const reset = useCallback(() => {
+    requestIdRef.current += 1;
+    setMutationState({
+      pendingCount: 0,
+      status: "idle",
+      data: optionsRef.current.initialData ?? null,
+      error: null,
+      variables: undefined,
+    });
+  }, [setMutationState]);
+
+  return useMemo(
+    () => ({
+      pending: state.pendingCount > 0,
+      status: state.status,
+      data: state.data,
+      error: state.error,
+      variables: state.variables,
+      mutate,
+      mutateAsync,
+      reset,
+    }),
+    [
+      mutate,
+      mutateAsync,
+      reset,
+      state.data,
+      state.error,
+      state.pendingCount,
+      state.status,
+      state.variables,
+    ],
+  );
+}
+
+function unwrapMutationResult<TData, TError>(result: unknown, apiRoute: boolean): TData {
+  if (!apiRoute) return result as TData;
+
+  const apiResult = result as APIResult<TData, TError>;
+  if (apiResult.error) {
+    throw apiResult.error;
+  }
+
+  return apiResult.data as TData;
+}
+
+function normalizeMutationError(error: unknown): Error {
+  if (error instanceof Error) return error;
+
+  const normalized = new Error(typeof error === "string" ? error : "Mutation failed");
+  (normalized as Error & { cause?: unknown }).cause = error;
+  return normalized;
+}

--- a/packages/farm/types/client.d.ts
+++ b/packages/farm/types/client.d.ts
@@ -586,6 +586,81 @@ declare module "@farm.js/core/client" {
   ) => Promise<APIResult<InferEndpointOutput<T>, Error>>) &
     RouteRef<InferEndpointOutput<T>, InferEndpointInput<T>>;
 
+  export type MutationStatus = "idle" | "pending" | "success" | "error";
+
+  type AnyMutationTarget = (...args: any[]) => Promise<any>;
+
+  export type InferMutationVariables<TTarget extends AnyMutationTarget> =
+    Parameters<TTarget> extends [] ? undefined : Parameters<TTarget>[0];
+
+  export type InferMutationData<TTarget extends AnyMutationTarget> = TTarget extends {
+    readonly __farmRouteData: infer TData;
+  }
+    ? TData
+    : Awaited<ReturnType<TTarget>>;
+
+  export type InferMutationError<TTarget extends AnyMutationTarget> = TTarget extends (
+    ...args: any[]
+  ) => Promise<APIResult<any, infer TError>>
+    ? TError
+    : Error;
+
+  export type MutationOptimisticContext<TVariables, TData> = {
+    variables: TVariables | undefined;
+    current: TData | null;
+  };
+
+  export type UseMutationOptions<TVariables, TData, TError = Error> = {
+    initialData?: TData | null;
+    resetOnMutate?: boolean;
+    optimistic?: (
+      context: MutationOptimisticContext<TVariables, TData>,
+    ) => TData | null | undefined;
+    rollbackOnError?: boolean;
+    request?: ClientOptions<TData, TError>;
+    onSuccess?: (data: TData, variables: TVariables | undefined) => void;
+    onError?: (error: TError, variables: TVariables | undefined) => void;
+    onSettled?: (
+      data: TData | null,
+      error: TError | null,
+      variables: TVariables | undefined,
+    ) => void;
+  };
+
+  export type MutationAsync<TTarget extends AnyMutationTarget, TData = InferMutationData<TTarget>> =
+    [] extends Parameters<TTarget>
+      ? (variables?: InferMutationVariables<TTarget>) => Promise<TData>
+      : (variables: InferMutationVariables<TTarget>) => Promise<TData>;
+
+  export type MutationTrigger<TTarget extends AnyMutationTarget> =
+    [] extends Parameters<TTarget>
+      ? (variables?: InferMutationVariables<TTarget>) => void
+      : (variables: InferMutationVariables<TTarget>) => void;
+
+  export type UseMutationReturn<
+    TTarget extends AnyMutationTarget,
+    TData = InferMutationData<TTarget>,
+    TError = InferMutationError<TTarget>,
+  > = {
+    pending: boolean;
+    status: MutationStatus;
+    data: TData | null;
+    error: TError | null;
+    variables: InferMutationVariables<TTarget> | undefined;
+    mutate: MutationTrigger<TTarget>;
+    mutateAsync: MutationAsync<TTarget, TData>;
+    reset: () => void;
+  };
+
+  export function useMutation<TTarget extends AnyMutationTarget>(
+    target: TTarget,
+    options?: UseMutationOptions<
+      InferMutationVariables<TTarget>,
+      InferMutationData<TTarget>,
+      InferMutationError<TTarget>
+    >,
+  ): UseMutationReturn<TTarget>;
+
   type RouterToClient<T> = {
     [K in keyof T]: T[K] extends TypedEndpointLike
       ? EndpointMethod<T[K]>


### PR DESCRIPTION
## Summary

- add a client-side `useMutation` lifecycle for generated API route methods and Farm server functions
- expose pending, status, data, error, variables, reset, optimistic state, rollback, and lifecycle callbacks
- keep API routes on their existing HTTP transport and forward existing client cache/retry/invalidation options through `request`
- preserve latest-request state during concurrent mutations
- document the new API and its relationship to API routes and server functions

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/mutation-client.test.tsx src/__tests__/api-client.test.ts src/__tests__/api-client.typing.test.ts` (18 passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/core build`
- formatting and lint checks on changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a unified React `useMutation` lifecycle for generated API route methods and Farm server functions, with pending/status/data/error/variables, optimistic updates, rollback, and concurrency safety. API routes keep their HTTP transport and still accept cache/retry/invalidation options via `request`.

- **New Features**
  - Introduced `useMutation` in `@farm.js/core/client` with `pending`, `status`, `data`, `error`, `variables`, `mutate`, `mutateAsync`, and `reset`.
  - Options: `initialData`, `resetOnMutate`, `optimistic`, `rollbackOnError`, and callbacks (`onSuccess`, `onError`, `onSettled`).
  - API routes still use the typed HTTP client; forward cache/retry/invalidation/optimistic via `request`.
  - Handles concurrent calls by keeping the latest request’s result.
  - Added API route-ref detection to distinguish API methods from server functions.
  - Updated docs and types; added tests covering API routes, server functions, optimistic updates, rollbacks, and concurrency.

<sup>Written for commit a139a9c8fc277823ede6ce2334f27a9d931a28ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

