### PR TITLE
feat: add optional typed cache keys

### DIFF
--- a/docs/src/app/docs/server-queries/page.md
+++ b/docs/src/app/docs/server-queries/page.md
@@ -137,6 +137,27 @@ During a browser server-action call, Farm carries structured invalidations back 
 
 Server queries use the existing route-data cache namespace and tag. They do not create a separate server cache.
 
+For a key used in several features, keep its factory in a module that is safe to import from both
+the browser and server. Plain string and array keys remain the default and require no helper:
+
+```ts
+export const productKey = (id: string) => ["product", id] as const;
+```
+
+Use `defineCacheKey` only when you want TypeScript to carry the value stored under that key into
+optimistic cache updaters:
+
+```ts
+import { defineCacheKey } from "@farm.js/core/cache";
+import type { Product } from "./types";
+
+export const productKey = defineCacheKey<Product>()((id: string) => ["product", id] as const);
+```
+
+The helper adds no wrapper object or runtime cache format. `productKey("123")` is still the raw
+`["product", "123"]` array, so typed and untyped keys interoperate and existing applications do
+not need to migrate.
+
 Use the same structured key in programmatic route data:
 
 ```ts

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createAPIClient, createServerAPIClient } from "../api/client";
+import { defineCacheKey } from "../cache";
 import { getFarmClientDataCache } from "../client-cache";
 import { endpoint } from "../integration-api";
 import { defineIntegration, integrationRoute, resolveIntegrationPlugins } from "../integrations";
@@ -72,6 +73,75 @@ describe("createAPIClient", () => {
 
     expect(cached.data).toEqual({ id: "1", name: "Alice" });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses defined structured keys directly for optimistic updates and invalidation", async () => {
+    let getCount = 0;
+    const mutationResponse = createDeferred<any>();
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if ((init?.method ?? "GET").toUpperCase() === "POST") {
+        return mutationResponse.promise;
+      }
+
+      getCount += 1;
+      return buildResponse({
+        users: [{ id: String(getCount), name: `User ${getCount}` }],
+        total: getCount,
+        limit: 5,
+        offset: 0,
+      });
+    });
+    globalThis.fetch = fetchMock as any;
+
+    type UsersData = APIRouter["users"]["get"]["__types"]["response"];
+    const usersKey = defineCacheKey<UsersData>()(
+      (limit: string) => ["users", "list", { limit }] as const,
+    )("5");
+    const api = createAPIClient<APIRouter>({
+      baseURL: "http://example.com",
+    });
+    const input = { query: { limit: "5" } };
+    const cache = {
+      key: usersKey,
+      policy: "cache-first" as const,
+      staleTime: 10_000,
+    };
+
+    await api.users.get(input, { cache });
+    const mutation = api.users.post(
+      { body: { name: "Ada", email: "ada@example.com" } },
+      {
+        optimistic: {
+          update: [
+            [
+              usersKey,
+              (current) => ({
+                ...current!,
+                users: [{ id: "optimistic", name: "Ada" }, ...(current?.users ?? [])],
+              }),
+            ],
+          ],
+          rollbackOnError: true,
+        },
+        invalidate: [usersKey],
+      },
+    );
+
+    const optimistic = await api.users.get(input, { cache });
+    expect(optimistic.data?.users[0]).toEqual({
+      id: "optimistic",
+      name: "Ada",
+    });
+
+    mutationResponse.resolve(buildResponse({ success: true }));
+    await mutation;
+
+    const refreshed = await api.users.get(input, { cache });
+    expect(refreshed.data?.users[0]).toEqual({
+      id: "2",
+      name: "User 2",
+    });
+    expect(getCount).toBe(2);
   });
 
   it("keeps default cache keys isolated by API origin", async () => {

--- a/packages/farm/src/__tests__/api-client.typing.test.ts
+++ b/packages/farm/src/__tests__/api-client.typing.test.ts
@@ -1,5 +1,6 @@
 import { describe, expectTypeOf, it, vi } from "vitest";
 import { createAPIClient, createServerAPIClient, type CacheKey } from "../api/client";
+import { defineCacheKey } from "../cache";
 import { endpoint } from "../integration-api";
 
 type APIRouter = {
@@ -160,6 +161,80 @@ describe("createAPIClient typing", () => {
               },
             ] as const,
           ] as const,
+        },
+      },
+    );
+  });
+
+  it("accepts optional defined cache keys without changing raw key support", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      buildResponse({
+        users: [],
+        total: 0,
+        limit: 5,
+        offset: 0,
+      }),
+    ) as any;
+
+    const api = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
+    const usersKey = defineCacheKey<UsersListResponse>()(
+      (limit: string) => ["users", "list", { limit }] as const,
+    );
+    const key = usersKey("5");
+
+    await api.users.get(
+      { query: { limit: "5" } },
+      {
+        cache: {
+          key,
+          policy: "cache-first",
+        },
+      },
+    );
+
+    await api.users.post(
+      { body: { name: "Ada", email: "ada@example.com" } },
+      {
+        invalidate: [key],
+        optimistic: {
+          update: [
+            [
+              key,
+              (prev) => {
+                expectTypeOf(prev).toEqualTypeOf<UsersListResponse | undefined>();
+                return {
+                  users: [{ id: "optimistic", name: "Ada" }, ...(prev?.users ?? [])],
+                  total: (prev?.total ?? 0) + 1,
+                  limit: prev?.limit ?? 5,
+                  offset: prev?.offset ?? 0,
+                };
+              },
+            ] as const,
+          ] as const,
+        },
+      },
+    );
+
+    if (false) {
+      await api.users.post(
+        { body: { name: "Ada", email: "ada@example.com" } },
+        {
+          optimistic: {
+            update: [
+              // @ts-expect-error defined key updaters must return the key's data contract.
+              [key, () => ({ success: true })] as const,
+            ],
+          },
+        },
+      );
+    }
+
+    await api.users.get(
+      { query: { limit: "5" } },
+      {
+        // Existing untyped structured keys remain supported.
+        cache: {
+          key: ["users", "list", { limit: "5" }],
         },
       },
     );

--- a/packages/farm/src/__tests__/cache.test.ts
+++ b/packages/farm/src/__tests__/cache.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createFarmCacheKey,
   createRouteDataCacheTag,
+  defineCacheKey,
   getFarmDataCache,
   invalidate,
   invalidateRouteData,
@@ -30,6 +31,25 @@ describe("server cache primitives", () => {
 
   it("shares the cache across server module instances", () => {
     expect((globalThis as any)[Symbol.for("farm.dataCache")]).toBe(getFarmDataCache());
+  });
+
+  it("keeps defined cache keys runtime-compatible with structured arrays", () => {
+    const productKey = defineCacheKey<{ id: string; name: string }>()(
+      (id: string) => ["product", "detail", id] as const,
+    );
+
+    expect(productKey("123")).toEqual(["product", "detail", "123"]);
+    expect(createFarmCacheKey(productKey("123"))).toBe(
+      createFarmCacheKey(["product", "detail", "123"]),
+    );
+  });
+
+  it("rejects invalid values returned by defined cache key factories", () => {
+    const invalidKey = defineCacheKey<unknown>()((() => ({ scope: "product" })) as any);
+
+    expect(() => invalidKey()).toThrow(
+      "A defined cache key factory must return a string or structured array.",
+    );
   });
 
   it("caches unstable_cache results by key parts and arguments", async () => {

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -13,6 +13,7 @@ import {
   type FarmClientCacheKey,
   type FarmClientDataCache,
 } from "../client-cache";
+import type { DefinedCacheKey, InferCacheKeyData, RouteDataCacheKey } from "../cache";
 
 export type APIClientOptions = {
   baseURL?: string;
@@ -102,7 +103,7 @@ export type RetryOptions = {
 };
 
 export type InvalidateTarget =
-  | string
+  | FarmClientCacheKey
   | {
       key: FarmClientCacheKey;
     }
@@ -122,7 +123,7 @@ export type InvalidateOptions =
 
 export type OptimisticUpdate =
   | [CallableRouteRef<any>, unknown, (prev: any) => any]
-  | [CacheKey<any> | string, (prev: any) => any];
+  | [CacheKey<any> | DefinedCacheKey<any> | string, (prev: any) => any];
 
 export type OptimisticOptions<TUpdates extends readonly unknown[] = readonly OptimisticUpdate[]> = {
   update: TUpdates & NormalizeOptimisticUpdates<TUpdates>;
@@ -178,11 +179,13 @@ type NormalizeOptimisticUpdate<TUpdate> = TUpdate extends readonly [
       ]
     : never
   : TUpdate extends readonly [infer TKey, (prev: any) => any]
-    ? TKey extends CacheKey<infer TData>
-      ? [TKey, (prev: TData | undefined) => TData]
-      : TKey extends string
-        ? [TKey, (prev: unknown) => unknown]
-        : never
+    ? TKey extends DefinedCacheKey<any, RouteDataCacheKey>
+      ? [TKey, (prev: InferCacheKeyData<TKey> | undefined) => InferCacheKeyData<TKey>]
+      : TKey extends CacheKey<infer TData>
+        ? [TKey, (prev: TData | undefined) => TData]
+        : TKey extends string
+          ? [TKey, (prev: unknown) => unknown]
+          : never
     : never;
 
 type NormalizeOptimisticUpdates<TUpdates extends readonly unknown[]> = {
@@ -896,7 +899,10 @@ function resolveTargetKey(
 
   if (Array.isArray(target)) {
     const [route, routeInput] = target;
-    return resolveTargetKey(routeMeta, route, routeInput, baseURL);
+    if (typeof route === "function") {
+      return resolveTargetKey(routeMeta, route, routeInput, baseURL);
+    }
+    return normalizeFarmClientCacheKey(target);
   }
 
   if ("key" in target) return normalizeFarmClientCacheKey(target.key);

--- a/packages/farm/src/cache.ts
+++ b/packages/farm/src/cache.ts
@@ -36,6 +36,54 @@ export interface FarmCacheSetOptions extends FarmCacheOptions {
 
 export type RouteDataCacheKey = string | readonly unknown[];
 
+declare const FARM_DEFINED_CACHE_KEY_DATA: unique symbol;
+
+/**
+ * A regular Farm cache key carrying the data shape stored under that key.
+ *
+ * The brand exists only in TypeScript. At runtime the value remains the
+ * original string or structured array, so all existing cache APIs continue to
+ * accept untyped keys.
+ */
+export type DefinedCacheKey<TData, TKey extends RouteDataCacheKey = RouteDataCacheKey> = TKey & {
+  readonly [FARM_DEFINED_CACHE_KEY_DATA]: TData;
+};
+
+export type CacheKeyFactory<
+  TData,
+  TArguments extends readonly unknown[],
+  TKey extends RouteDataCacheKey = RouteDataCacheKey,
+> = (...args: TArguments) => DefinedCacheKey<TData, TKey>;
+
+export type InferCacheKeyData<TKey> =
+  TKey extends DefinedCacheKey<infer TData, RouteDataCacheKey> ? TData : unknown;
+
+/**
+ * Optionally add a data type to an existing string/array cache-key factory.
+ *
+ * This helper does not introduce a new runtime key representation. Calling the
+ * returned factory produces the exact key returned by `factory`.
+ */
+export function defineCacheKey<TData>() {
+  return <const TArguments extends readonly unknown[], const TKey extends RouteDataCacheKey>(
+    factory: (...args: TArguments) => TKey,
+  ): CacheKeyFactory<TData, TArguments, TKey> => {
+    if (typeof factory !== "function") {
+      throw new TypeError("defineCacheKey expects a key factory function.");
+    }
+
+    return ((...args: TArguments) => {
+      const key = factory(...args);
+      if (typeof key !== "string" && !Array.isArray(key)) {
+        throw new TypeError(
+          "A defined cache key factory must return a string or structured array.",
+        );
+      }
+      return key as DefinedCacheKey<TData, TKey>;
+    }) as CacheKeyFactory<TData, TArguments, TKey>;
+  };
+}
+
 export interface FarmCacheEntry<T = unknown> {
   key: string;
   value: T;

--- a/packages/farm/types/client.d.ts
+++ b/packages/farm/types/client.d.ts
@@ -13,6 +13,7 @@ import type {
   RefObject,
   RefAttributes,
 } from "react";
+import type { DefinedCacheKey, InferCacheKeyData, RouteDataCacheKey } from "@farm.js/core/cache";
 
 declare module "@farm.js/core/client" {
   export interface MiddlewareProps {
@@ -406,7 +407,7 @@ declare module "@farm.js/core/client" {
   export type CachePolicy = "cache-first" | "network-only" | "stale-while-revalidate";
 
   export type CacheOptions = {
-    key?: string;
+    key?: RouteDataCacheKey;
     policy?: CachePolicy;
     staleTime?: number;
     gcTime?: number;
@@ -419,9 +420,9 @@ declare module "@farm.js/core/client" {
   };
 
   export type InvalidateTarget =
-    | string
+    | RouteDataCacheKey
     | {
-        key: string;
+        key: RouteDataCacheKey;
       }
     | {
         path: string;
@@ -439,7 +440,7 @@ declare module "@farm.js/core/client" {
 
   export type OptimisticUpdate =
     | [CallableRouteRef<any>, unknown, (prev: any) => any]
-    | [CacheKey<any> | string, (prev: any) => any];
+    | [CacheKey<any> | DefinedCacheKey<any> | string, (prev: any) => any];
 
   export type OptimisticOptions<TUpdates extends readonly unknown[] = readonly OptimisticUpdate[]> =
     {
@@ -452,7 +453,7 @@ declare module "@farm.js/core/client" {
     TError = unknown,
     TUpdates extends readonly unknown[] = readonly OptimisticUpdate[],
   > = {
-    key?: CacheKey<TData> | string;
+    key?: CacheKey<TData> | RouteDataCacheKey;
     cache?: CacheOptions;
     retry?: RetryOptions;
     invalidate?: InvalidateOptions;
@@ -496,11 +497,13 @@ declare module "@farm.js/core/client" {
         ]
       : never
     : TUpdate extends readonly [infer TKey, (prev: any) => any]
-      ? TKey extends CacheKey<infer TData>
-        ? [TKey, (prev: TData | undefined) => TData]
-        : TKey extends string
-          ? [TKey, (prev: unknown) => unknown]
-          : never
+      ? TKey extends DefinedCacheKey<any, RouteDataCacheKey>
+        ? [TKey, (prev: InferCacheKeyData<TKey> | undefined) => InferCacheKeyData<TKey>]
+        : TKey extends CacheKey<infer TData>
+          ? [TKey, (prev: TData | undefined) => TData]
+          : TKey extends string
+            ? [TKey, (prev: unknown) => unknown]
+            : never
       : never;
 
   type NormalizeOptimisticUpdates<TUpdates extends readonly unknown[]> = {


### PR DESCRIPTION
## Summary

- add optional `defineCacheKey<T>()` factories that carry the cached data type through TypeScript
- keep runtime keys as the exact same strings or structured arrays
- preserve all existing untyped string and array key APIs without migration
- accept structured keys directly in API invalidation targets
- infer cached data in optimistic update callbacks when a defined key is used
- document the helper as an opt-in type-safety layer

## Verification

- focused cache and API-client suites (30 passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/core build`
- formatting and lint checks on changed files

## Full-suite environment note

The isolated worktree run reached 690 passing core tests. The remaining failures require built optional workspace packages (`@farm.js/ai`, Stripe, email, jobs, and related integrations) plus the React 18 compatibility fixture, which are not present in the isolated worktree. Feature-related suites are green; normal CI workspace setup should provide the authoritative full run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional typed cache keys via `defineCacheKey<T>()` without changing runtime keys. This improves type-safety for optimistic updates and lets you pass structured keys directly to invalidation.

- **New Features**
  - Added `defineCacheKey<T>()` that brands existing string/array keys while keeping runtime values unchanged.
  - Optimistic update callbacks now infer the cached data type when using a defined key.
  - `invalidate` and cache options accept structured keys; existing untyped string/array keys still work.

- **Migration**
  - Optional: wrap current key factories with `defineCacheKey<T>()`, e.g. `defineCacheKey<Product>()((id) => ['product', id] as const)`. No other changes needed.

<sup>Written for commit 3d339b0db211966c65aba6bd327c986aa9ba3ff8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

