### PR TITLE
feat: declare endpoint cache invalidation

### DIFF
--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -181,6 +181,45 @@ await api.users.get({
 
 The exact generated shape comes from route generation. Body and query schemas become typed caller input, and path segments become the nested `api.users.get` style namespace. During `farm dev`, Farm regenerates route/API types when page or API route files are added, changed, or removed. Run `farm generate` when you want the same refresh outside the dev server.
 
+## Declare invalidation with the mutation
+
+When every caller of a mutation makes the same data stale, declare that relationship on the
+endpoint instead of repeating client-side invalidation:
+
+```ts
+export const PATCH = createEndpoint(
+  {
+    method: "PATCH",
+    body: z.object({
+      id: z.string(),
+      name: z.string().min(1),
+    }),
+    invalidates: ({ body }) => [
+      { key: ["product", body.id] },
+      { key: ["products", "list"] },
+      { path: "/products" },
+    ],
+  },
+  async ({ body }) => {
+    return db.product.update({
+      where: { id: body.id },
+      data: { name: body.name },
+    });
+  },
+);
+```
+
+Farm applies declared keys and paths to the server cache after the handler succeeds. Normal
+`api.products.patch(...)` callers also receive the key invalidations through response metadata, so
+matching browser queries become stale without repeating an `invalidate` option. A response with a
+status of 400 or higher, or middleware that stops before the handler, does not invalidate.
+
+The resolver receives validated body, query, and headers plus the accumulated typed middleware
+context. Invalidation is declarative rather than inferred: database writes do not reliably reveal
+every affected query. Existing client-side `invalidate` options remain supported for
+caller-specific cache relationships, and handlers can continue calling `invalidate(...)` or
+`revalidatePath(...)` directly.
+
 ## When to use integrations instead
 
 Use API routes for app-owned endpoints. Use integrations when a provider or feature needs a package-like surface: config validation, lifecycle hooks, storage schema, middleware, providers, and typed callers bundled together.

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createAPIClient, createServerAPIClient } from "../api/client";
+import {
+  encodeFarmCacheInvalidations,
+  FARM_CACHE_INVALIDATION_HEADER,
+} from "../cache-invalidation";
 import { getFarmClientDataCache } from "../client-cache";
 import { endpoint } from "../integration-api";
 import { defineIntegration, integrationRoute, resolveIntegrationPlugins } from "../integrations";
@@ -55,6 +59,34 @@ beforeEach(() => {
 });
 
 describe("createAPIClient", () => {
+  it("applies invalidations declared by the server response", async () => {
+    const key = '["products","list"]';
+    const cache = getFarmClientDataCache();
+    cache.set(key, {
+      data: { products: [{ id: "1" }] },
+      updatedAt: Date.now(),
+      staleAt: Date.now() + 10_000,
+    });
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({
+        [FARM_CACHE_INVALIDATION_HEADER]: encodeFarmCacheInvalidations([key])!,
+      }),
+      json: async () => ({ success: true }),
+    })) as any;
+    const api = createAPIClient<APIRouter>({
+      baseURL: "http://example.com",
+    });
+
+    await api.users.post({
+      body: { name: "Ada", email: "ada@example.com" },
+    });
+
+    expect(cache.isStale(key)).toBe(true);
+  });
+
   it("shares structured cache keys across API client instances", async () => {
     const fetchMock = vi.fn(async () => buildResponse({ id: "1", name: "Alice" }));
     globalThis.fetch = fetchMock as any;

--- a/packages/farm/src/__tests__/endpoint-invalidations.test.ts
+++ b/packages/farm/src/__tests__/endpoint-invalidations.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, expectTypeOf, it } from "vitest";
+import { z } from "zod";
+import {
+  createFarmCacheKey,
+  createRouteDataCacheKey,
+  createRouteDataCacheTag,
+  getFarmDataCache,
+} from "../cache";
+import {
+  decodeFarmCacheInvalidations,
+  FARM_CACHE_INVALIDATION_HEADER,
+} from "../cache-invalidation";
+import { createEndpoint } from "../api/endpoint";
+import { invokeAPIRouteEndpoint } from "../api/runtime";
+
+describe("endpoint invalidations", () => {
+  afterEach(() => {
+    getFarmDataCache().clear();
+  });
+
+  it("invalidates server keys and paths and exposes client key metadata", async () => {
+    const productKey = ["product", "123"] as const;
+    const routeCacheKey = createFarmCacheKey(["route-data", productKey]);
+    const pathCacheKey = "products-page";
+    const cache = getFarmDataCache();
+
+    cache.set(
+      routeCacheKey,
+      { id: "123", name: "Old" },
+      {
+        tags: [createRouteDataCacheTag(productKey)],
+      },
+    );
+    cache.set(pathCacheKey, "<html>old</html>", {
+      paths: ["/products"],
+    });
+
+    const withTenant = async () => ({
+      tenantId: "tenant-1",
+    });
+    const endpoint = createEndpoint(
+      {
+        method: "PATCH",
+        body: z.object({
+          id: z.string(),
+          name: z.string(),
+        }),
+        middleware: [withTenant],
+        invalidates: ({ body, context, result }) => {
+          expectTypeOf(body).toEqualTypeOf<{
+            id: string;
+            name: string;
+          }>();
+          expectTypeOf(context.tenantId).toEqualTypeOf<string>();
+          expectTypeOf(result).toEqualTypeOf<unknown>();
+          expect(context.tenantId).toBe("tenant-1");
+
+          return [{ key: ["product", body.id] }, { path: "/products" }];
+        },
+      },
+      async ({ body }) => ({
+        id: body.id,
+        name: body.name,
+      }),
+    );
+
+    const response = await invokeAPIRouteEndpoint(
+      endpoint,
+      new Request("https://farm.test/api/products/123", {
+        method: "PATCH",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          id: "123",
+          name: "New",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(cache.getEntry(routeCacheKey)).toBeUndefined();
+    expect(cache.getEntry(pathCacheKey)).toBeUndefined();
+    expect(
+      decodeFarmCacheInvalidations(response.headers.get(FARM_CACHE_INVALIDATION_HEADER)),
+    ).toEqual([createRouteDataCacheKey(productKey)]);
+  });
+
+  it("does not invalidate when middleware prevents handler execution", async () => {
+    const endpoint = createEndpoint(
+      {
+        method: "POST",
+        middleware: [async () => false],
+        invalidates: [{ key: ["products"] }],
+      },
+      async () => ({ created: true }),
+    );
+
+    const response = await invokeAPIRouteEndpoint(
+      endpoint,
+      new Request("https://farm.test/api/products", {
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get(FARM_CACHE_INVALIDATION_HEADER)).toBeNull();
+  });
+
+  it("does not invalidate after an error response", async () => {
+    const endpoint = createEndpoint(
+      {
+        method: "POST",
+        invalidates: [{ key: ["products"] }],
+      },
+      async () =>
+        new Response(JSON.stringify({ error: "Conflict" }), {
+          status: 409,
+          headers: {
+            "content-type": "application/json",
+          },
+        }),
+    );
+
+    const response = await invokeAPIRouteEndpoint(
+      endpoint,
+      new Request("https://farm.test/api/products", {
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(response.headers.get(FARM_CACHE_INVALIDATION_HEADER)).toBeNull();
+  });
+
+  it("applies declared invalidations for direct server endpoint calls", async () => {
+    const key = ["products", "list"] as const;
+    const cacheKey = createFarmCacheKey(["route-data", key]);
+    const cache = getFarmDataCache();
+    cache.set(cacheKey, [{ id: "old" }], {
+      tags: [createRouteDataCacheTag(key)],
+    });
+    const endpoint = createEndpoint(
+      "/api/products",
+      {
+        method: "POST",
+        invalidates: [{ key }],
+      },
+      async () => ({ created: true }),
+    );
+
+    await expect(endpoint()).resolves.toEqual({ created: true });
+    expect(cache.getEntry(cacheKey)).toBeUndefined();
+  });
+});

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -13,6 +13,11 @@ import {
   type FarmClientCacheKey,
   type FarmClientDataCache,
 } from "../client-cache";
+import {
+  applyFarmCacheInvalidations,
+  decodeFarmCacheInvalidations,
+  FARM_CACHE_INVALIDATION_HEADER,
+} from "../cache-invalidation";
 
 export type APIClientOptions = {
   baseURL?: string;
@@ -385,6 +390,9 @@ export function createAPIClient<
     }
 
     const response = await fetch(url.toString(), fetchOptions);
+    applyFarmCacheInvalidations(
+      decodeFarmCacheInvalidations(response.headers?.get?.(FARM_CACHE_INVALIDATION_HEADER)),
+    );
     let data: any = undefined;
     if (response.status !== 204 && response.status !== 205) {
       data = await response.json();

--- a/packages/farm/src/api/endpoint.ts
+++ b/packages/farm/src/api/endpoint.ts
@@ -1,4 +1,10 @@
 import { createEndpoint as betterCallEndpoint } from "better-call";
+import {
+  createRouteDataCacheKey,
+  invalidate,
+  revalidatePath,
+  type RouteDataCacheKey,
+} from "../cache";
 
 // Generic schema type that works with both Zod v3 and v4
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -62,6 +68,35 @@ export type EndpointMiddleware<
 
 export type AnyEndpointMiddleware = (ctx: EndpointMiddlewareContext<any, any, any, any>) => unknown;
 
+export type EndpointInvalidationTarget =
+  | {
+      key: RouteDataCacheKey;
+    }
+  | {
+      path: string;
+    };
+
+export type EndpointInvalidationContext<
+  TContext extends object = {},
+  TBody = unknown,
+  TQuery = unknown,
+  THeaders = Record<string, string>,
+> = EndpointMiddlewareContext<TContext, TBody, TQuery, THeaders> & {
+  /** The raw value returned by the endpoint handler. */
+  result: unknown;
+};
+
+export type EndpointInvalidations<
+  TContext extends object = {},
+  TBody = unknown,
+  TQuery = unknown,
+  THeaders = Record<string, string>,
+> =
+  | readonly EndpointInvalidationTarget[]
+  | ((
+      context: EndpointInvalidationContext<TContext, TBody, TQuery, THeaders>,
+    ) => readonly EndpointInvalidationTarget[] | Promise<readonly EndpointInvalidationTarget[]>);
+
 type ValidateEndpointMiddlewares<TMiddlewares extends readonly AnyEndpointMiddleware[]> = {
   readonly [TIndex in keyof TMiddlewares]: TMiddlewares[TIndex] extends AnyEndpointMiddleware
     ? [Awaited<ReturnType<TMiddlewares[TIndex]>>] extends [EndpointMiddlewareResult<object>]
@@ -110,6 +145,16 @@ export type EndpointOptions<
   query?: TQuery;
   headers?: THeaders;
   middleware?: TMiddlewares;
+  /**
+   * Cache keys and route paths made stale after a successful handler result.
+   * The resolver receives validated input and middleware context.
+   */
+  invalidates?: EndpointInvalidations<
+    InferEndpointMiddlewareContext<TMiddlewares>,
+    InferOutput<TBody>,
+    InferOutput<TQuery>,
+    InferHeadersOutput<THeaders>
+  >;
   /** @deprecated Use plain functions in `middleware` for Farm endpoint middleware. */
   use?: any[];
 };
@@ -276,9 +321,11 @@ export function createEndpoint(
   }
 
   const middleware = normalizeEndpointMiddleware(options.middleware);
-  const wrappedHandler = ((ctx: EndpointMiddlewareContext<any, any, any, any>) =>
-    runEndpointMiddleware(middleware, ctx, handler)) as typeof handler;
-  const { middleware: _middleware, ...betterCallOptions } = options;
+  const wrappedHandler = (async (ctx: EndpointMiddlewareContext<any, any, any, any>) => {
+    const execution = await runEndpointMiddleware(middleware, ctx, handler, options.invalidates);
+    return execution.result;
+  }) as typeof handler;
+  const { middleware: _middleware, invalidates: _invalidates, ...betterCallOptions } = options;
 
   // Create the endpoint - path will be set later by API plugin if not provided
   // We use a temporary path that will be replaced when the router is created
@@ -294,8 +341,11 @@ export function createEndpoint(
   endpoint.__method = options.method || "GET";
   endpoint.__autoPath = !path; // Flag to indicate path should be auto-inferred
   endpoint.__handler = wrappedHandler; // Used by Farm's route runtime.
+  endpoint.__farmInvoke = (ctx: EndpointMiddlewareContext<any, any, any, any>) =>
+    runEndpointMiddleware(middleware, ctx, handler, options.invalidates);
   endpoint.__middleware = middleware;
   endpoint.__sourceHandler = handler;
+  endpoint.__invalidates = options.invalidates;
 
   // Store type information for inference
   endpoint.__types = {
@@ -336,14 +386,34 @@ async function runEndpointMiddleware(
   middleware: readonly AnyEndpointMiddleware[],
   handlerContext: EndpointMiddlewareContext<any, any, any, any>,
   handler: EndpointHandler<any, any, any, any, any>,
-): Promise<unknown> {
+  invalidations: EndpointInvalidations<any, any, any, any> | undefined,
+): Promise<{
+  result: unknown;
+  context: Readonly<Record<string | symbol, unknown>>;
+  handlerExecuted: boolean;
+  invalidations: readonly string[];
+}> {
   let context = createInitialEndpointContext(handlerContext.context);
 
   for (let index = 0; index < middleware.length; index++) {
     const result = await middleware[index]({ ...handlerContext, context });
 
-    if (isEndpointResponse(result)) return result;
-    if (result === false) return forbiddenEndpointResponse();
+    if (isEndpointResponse(result)) {
+      return {
+        result,
+        context,
+        handlerExecuted: false,
+        invalidations: [],
+      };
+    }
+    if (result === false) {
+      return {
+        result: forbiddenEndpointResponse(),
+        context,
+        handlerExecuted: false,
+        invalidations: [],
+      };
+    }
     if (result === true) continue;
 
     if (!isPlainEndpointContext(result)) {
@@ -355,7 +425,70 @@ async function runEndpointMiddleware(
     context = mergeEndpointContext(context, result, index);
   }
 
-  return handler({ ...handlerContext, context });
+  const result = await handler({ ...handlerContext, context });
+  return {
+    result,
+    context,
+    handlerExecuted: true,
+    invalidations: await applyEndpointInvalidations(
+      invalidations,
+      {
+        ...handlerContext,
+        context,
+        result,
+      },
+      result,
+    ),
+  };
+}
+
+async function applyEndpointInvalidations(
+  declaration: EndpointInvalidations<any, any, any, any> | undefined,
+  context: EndpointInvalidationContext<any, any, any, any>,
+  result: unknown,
+): Promise<readonly string[]> {
+  if (!declaration || (isEndpointResponse(result) && result.status >= 400)) {
+    return [];
+  }
+
+  const targets = typeof declaration === "function" ? await declaration(context) : declaration;
+  if (!Array.isArray(targets)) {
+    throw new TypeError(
+      "Endpoint invalidates must resolve to an array of { key } or { path } targets",
+    );
+  }
+
+  const clientKeys: string[] = [];
+  for (const target of targets) {
+    assertEndpointInvalidationTarget(target);
+    if ("key" in target) {
+      invalidate(target.key);
+      clientKeys.push(createRouteDataCacheKey(target.key));
+    } else {
+      revalidatePath(target.path);
+    }
+  }
+
+  return Array.from(new Set(clientKeys));
+}
+
+function assertEndpointInvalidationTarget(
+  target: unknown,
+): asserts target is EndpointInvalidationTarget {
+  if (!target || typeof target !== "object") {
+    throw new TypeError("Endpoint invalidation targets must be { key } or { path } objects");
+  }
+
+  if ("key" in target) {
+    const key = (target as { key?: unknown }).key;
+    if (typeof key === "string" || Array.isArray(key)) return;
+  } else if ("path" in target && typeof (target as { path?: unknown }).path === "string") {
+    return;
+  }
+
+  throw new TypeError(
+    "Endpoint invalidation targets must contain a string/array key or a path string",
+  );
 }
 
 function createInitialEndpointContext(value: unknown) {

--- a/packages/farm/src/api/runtime.ts
+++ b/packages/farm/src/api/runtime.ts
@@ -1,4 +1,9 @@
 import { _runWithCurrentRequest } from "../server/request";
+import {
+  decodeFarmCacheInvalidations,
+  encodeFarmCacheInvalidations,
+  FARM_CACHE_INVALIDATION_HEADER,
+} from "../cache-invalidation";
 
 export type APIRouteParamValue = string | string[];
 export type APIRouteParams = Record<string, APIRouteParamValue>;
@@ -88,16 +93,26 @@ async function invokeAPIRouteEndpointInContext(
     return headersValidation;
   }
 
-  const result = await farmHandler({
+  const handlerContext = {
     query: queryValidation,
     body: bodyValidation,
     headers: headersValidation,
     request,
     context: {},
     params,
-  });
+  };
+  const execution =
+    typeof endpoint.__farmInvoke === "function"
+      ? await endpoint.__farmInvoke(handlerContext)
+      : {
+          result: await farmHandler(handlerContext),
+          context: handlerContext.context,
+          handlerExecuted: true,
+          invalidations: [],
+        };
+  const response = normalizeRouteResponse(execution.result);
 
-  return normalizeRouteResponse(result);
+  return attachEndpointInvalidations(response, execution.invalidations);
 }
 
 export function normalizeRouteResponse(result: unknown): Response {
@@ -124,6 +139,22 @@ export function isWebResponse(value: unknown): value is Response {
       "status" in value &&
       typeof (value as Response).arrayBuffer === "function")
   );
+}
+
+function attachEndpointInvalidations(response: Response, keys: readonly string[]): Response {
+  const existing = decodeFarmCacheInvalidations(
+    response.headers.get(FARM_CACHE_INVALIDATION_HEADER),
+  );
+  const encoded = encodeFarmCacheInvalidations([...existing, ...keys]);
+  if (!encoded) return response;
+
+  const headers = new Headers(response.headers);
+  headers.set(FARM_CACHE_INVALIDATION_HEADER, encoded);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
 }
 
 function isFarmContextHandler(endpoint: unknown): boolean {

--- a/packages/farm/src/cache-invalidation.ts
+++ b/packages/farm/src/cache-invalidation.ts
@@ -1,5 +1,7 @@
 export type FarmCacheInvalidationListener = (key: string) => void;
 
+export const FARM_CACHE_INVALIDATION_HEADER = "x-farm-cache-invalidations";
+
 type FarmCacheInvalidationState = {
   listeners: Set<FarmCacheInvalidationListener>;
 };
@@ -30,6 +32,29 @@ export function applyFarmCacheInvalidations(keys: unknown): void {
     if (typeof key === "string") {
       notifyFarmCacheInvalidation(key);
     }
+  }
+}
+
+export function encodeFarmCacheInvalidations(keys: readonly string[]): string | null {
+  const normalized = Array.from(
+    new Set(keys.filter((key) => typeof key === "string" && key.length > 0)),
+  );
+  if (normalized.length === 0) return null;
+  return encodeURIComponent(JSON.stringify(normalized));
+}
+
+export function decodeFarmCacheInvalidations(value: string | null | undefined): readonly string[] {
+  if (!value) return [];
+
+  try {
+    const parsed = JSON.parse(decodeURIComponent(value));
+    return Array.isArray(parsed)
+      ? Array.from(
+          new Set(parsed.filter((key): key is string => typeof key === "string" && key.length > 0)),
+        )
+      : [];
+  } catch {
+    return [];
   }
 }
 

--- a/packages/farmjs-plugin/src/api/index.ts
+++ b/packages/farmjs-plugin/src/api/index.ts
@@ -24,6 +24,7 @@
 
 import type { Plugin, ViteDevServer } from "vite";
 import { _withAfterNodeMiddleware } from "@farm.js/core/after";
+import { invokeAPIRouteEndpoint } from "@farm.js/core/api/runtime";
 
 export interface FarmApiOptions {
   /** Source directory containing the api folder (default: 'src') */
@@ -121,94 +122,7 @@ export default function farmApi(options: FarmApiOptions = {}): Plugin {
         }
 
         try {
-          // Parse query params
-          const queryObj: Record<string, string> = {};
-          url.searchParams.forEach((value, key) => {
-            queryObj[key] = value;
-          });
-
-          // Parse body for non-GET requests
-          let bodyObj: any = {};
-          if (method !== "GET" && method !== "HEAD") {
-            try {
-              const bodyText = await request.text();
-              if (bodyText) {
-                bodyObj = JSON.parse(bodyText);
-              }
-            } catch {
-              // Body parsing failed, use empty object
-            }
-          }
-
-          // Parse headers
-          const headersObj: Record<string, string> = {};
-          request.headers.forEach((value, key) => {
-            headersObj[key] = value;
-          });
-
-          // Validate with Zod if schemas are defined
-          const types = endpoint.__types || {};
-          let validatedQuery = queryObj;
-          let validatedBody = bodyObj;
-
-          if (types.query && typeof types.query.parse === "function") {
-            try {
-              validatedQuery = types.query.parse(queryObj);
-            } catch (e: any) {
-              return new Response(
-                JSON.stringify({
-                  error: "Invalid query parameters",
-                  details: e.errors || e.message,
-                }),
-                {
-                  status: 400,
-                  headers: { "Content-Type": "application/json" },
-                },
-              );
-            }
-          }
-
-          if (types.body && typeof types.body.parse === "function") {
-            try {
-              validatedBody = types.body.parse(bodyObj);
-            } catch (e: any) {
-              return new Response(
-                JSON.stringify({
-                  error: "Invalid request body",
-                  details: e.errors || e.message,
-                }),
-                {
-                  status: 400,
-                  headers: { "Content-Type": "application/json" },
-                },
-              );
-            }
-          }
-
-          // Build context object
-          const ctx = {
-            query: validatedQuery,
-            body: validatedBody,
-            headers: headersObj,
-            request,
-            context: {},
-            params: {},
-          };
-
-          // Call the handler (use __handler if available, otherwise the endpoint itself)
-          const handlerFn = endpoint.__handler || endpoint;
-          const result = await handlerFn(ctx);
-
-          // If result is already a Response, return it
-          if (result instanceof Response) {
-            return result;
-          }
-
-          // Otherwise, serialize to JSON
-          return new Response(JSON.stringify(result), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          });
+          return await invokeAPIRouteEndpoint(endpoint, request);
         } catch (error: any) {
           return new Response(JSON.stringify({ error: error.message || "Internal Server Error" }), {
             status: 500,


### PR DESCRIPTION
## Summary

- add declarative `invalidates` metadata to `createEndpoint`
- resolve invalidation targets from validated input and typed middleware context
- invalidate server cache keys and paths only after successful handler execution
- carry key invalidations to generated browser clients through response metadata
- keep caller-specific client invalidation and direct cache APIs fully supported
- route the standalone API plugin through the shared core endpoint runtime
- document static and computed invalidation behavior

## Verification

- endpoint invalidation, middleware, and API-client suites (25 passed)
- complete `@farm.js/plugin` suite (31 passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/plugin typecheck`
- core and plugin builds
- formatting and lint checks on changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds declarative cache invalidation to API endpoints and propagates invalidation keys to clients so queries become stale automatically after successful mutations. The `@farm.js/plugin` API now runs through the shared `@farm.js/core` runtime for consistent validation and invalidation.

- **New Features**
  - Add `invalidates` to `createEndpoint` to declare cache keys or paths; resolver gets validated input and middleware context.
  - Apply invalidations only after a successful handler; 4xx/5xx or middleware short-circuits do not invalidate.
  - Responses include `x-farm-cache-invalidations`; `createAPIClient` decodes and updates the client cache automatically.
  - Supports direct server endpoint calls; existing caller-specific `invalidate` options and direct cache APIs remain supported.
  - Docs updated with static and computed invalidation examples.

- **Refactors**
  - Route the standalone API plugin through the shared `@farm.js/core` endpoint runtime.
  - Centralize parsing/validation and response normalization, including attaching invalidation headers.

<sup>Written for commit bd4d41510fb3bfc79af5fd32101afcfa4191e2c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

