### PR TITLE
feat: add typed endpoint errors

### DIFF
--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -161,6 +161,65 @@ Endpoint middleware is local to one `createEndpoint` declaration and can use its
 >
 > Derive users, roles, tenants, and rate-limit identities from the trusted `Request` or server state. Middleware context is created only on the server and is never accepted from client input. Keep resource-specific permission checks close to the resource query even when shared authentication runs in middleware.
 
+## Typed expected errors
+
+Declare failures that are part of an endpoint's public contract, then return them through the typed
+`fail` function:
+
+```ts
+export const POST = createEndpoint(
+  {
+    method: "POST",
+    body: z.object({
+      name: z.string().min(1),
+    }),
+    errors: {
+      duplicate: {
+        status: 409,
+        message: "A product with this name already exists",
+        schema: z.object({
+          existingId: z.string(),
+        }),
+      },
+      forbidden: {
+        status: 403,
+        schema: z.object({
+          permission: z.string(),
+        }),
+      },
+    },
+  },
+  async ({ body, fail }) => {
+    const existing = await findProductByName(body.name);
+    if (existing) {
+      return fail("duplicate", {
+        existingId: existing.id,
+      });
+    }
+
+    return createProduct(body);
+  },
+);
+```
+
+Error codes and payloads are checked in the handler and carried into the generated API client:
+
+```ts
+const result = await api.products.post({
+  body: { name },
+});
+
+if (result.error?.code === "duplicate") {
+  // existingId is inferred as string.
+  showExistingProduct(result.error.data.existingId);
+}
+```
+
+Farm validates the failure payload before returning a JSON error response. Declared messages and
+payloads are public, so do not include secrets. Undeclared exceptions remain unexpected server
+errors and are not converted into a declared failure. Endpoints without an `errors` declaration
+keep the existing `Error` client type.
+
 ## Client inference
 
 Routes become client namespaces from their path:

--- a/packages/farm/src/__tests__/endpoint-errors.test.ts
+++ b/packages/farm/src/__tests__/endpoint-errors.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+import { z } from "zod";
+import { APIClientError, createAPIClient } from "../api/client";
+import { createEndpoint, EndpointFailure } from "../api/endpoint";
+import { invokeAPIRouteEndpoint } from "../api/runtime";
+
+describe("typed endpoint errors", () => {
+  const createProduct = createEndpoint(
+    "/api/products",
+    {
+      method: "POST",
+      body: z.object({
+        name: z.string(),
+      }),
+      errors: {
+        duplicate: {
+          status: 409,
+          message: "A product with this name already exists",
+          schema: z.object({
+            existingId: z.string(),
+          }),
+        },
+        forbidden: {
+          status: 403,
+          schema: z.object({
+            permission: z.string(),
+          }),
+        },
+      },
+    },
+    async ({ body, fail }) => {
+      if (false) {
+        // @ts-expect-error only declared endpoint error codes are accepted.
+        fail("missing", {});
+        // @ts-expect-error duplicate errors require a string existingId.
+        fail("duplicate", { existingId: 123 });
+      }
+
+      if (body.name === "Existing") {
+        return fail("duplicate", {
+          existingId: "product-1",
+        });
+      }
+
+      return {
+        id: "product-2",
+        name: body.name,
+      };
+    },
+  );
+
+  it("serializes validated expected failures without exposing a stack", async () => {
+    const response = await invokeAPIRouteEndpoint(
+      createProduct,
+      new Request("https://farm.test/api/products", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          name: "Existing",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "duplicate",
+        message: "A product with this name already exists",
+        data: {
+          existingId: "product-1",
+        },
+      },
+    });
+  });
+
+  it("preserves the typed failure when an endpoint is called directly", async () => {
+    await expect(
+      createProduct({
+        body: {
+          name: "Existing",
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: "EndpointFailure",
+      code: "duplicate",
+      status: 409,
+      data: {
+        existingId: "product-1",
+      },
+    });
+
+    try {
+      await createProduct({
+        body: {
+          name: "Existing",
+        },
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(EndpointFailure);
+    }
+  });
+
+  it("infers discriminated client errors from the endpoint contract", async () => {
+    globalThis.fetch = vi.fn(async (url: string, init?: RequestInit) =>
+      invokeAPIRouteEndpoint(createProduct, new Request(url, init)),
+    ) as any;
+    type Router = {
+      products: {
+        post: typeof createProduct;
+      };
+    };
+    const api = createAPIClient<Router>({
+      baseURL: "https://farm.test",
+    });
+
+    const result = await api.products.post({
+      body: {
+        name: "Existing",
+      },
+    });
+
+    expect(result.error).toBeInstanceOf(APIClientError);
+    expect(result.error).toMatchObject({
+      code: "duplicate",
+      status: 409,
+      data: {
+        existingId: "product-1",
+      },
+    });
+
+    if (result.error?.code === "duplicate") {
+      expectTypeOf(result.error.data).toEqualTypeOf<{
+        existingId: string;
+      }>();
+      expectTypeOf(result.error.status).toEqualTypeOf<409>();
+    }
+
+    if (result.error?.code === "forbidden") {
+      expectTypeOf(result.error.data).toEqualTypeOf<{
+        permission: string;
+      }>();
+      expectTypeOf(result.error.status).toEqualTypeOf<403>();
+    }
+  });
+
+  it("validates declared error definitions when the endpoint is created", () => {
+    expect(() =>
+      createEndpoint(
+        {
+          method: "POST",
+          errors: {
+            invalid: {
+              status: 200,
+              schema: z.object({}),
+            },
+          },
+        },
+        async () => ({ ok: true }),
+      ),
+    ).toThrow('Endpoint error "invalid" status must be an integer between 400 and 599');
+  });
+});

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -61,6 +61,38 @@ export type APIResult<TData = unknown, TError = Error> = {
   key: CacheKey<TData>;
 };
 
+export class APIClientError<
+  TCode extends string = string,
+  TData = unknown,
+  TStatus extends number = number,
+> extends Error {
+  readonly code: TCode;
+  readonly data: TData;
+  readonly status: TStatus;
+  readonly response?: Response;
+
+  constructor(
+    code: TCode,
+    data: TData,
+    options: {
+      status: TStatus;
+      message: string;
+      response?: Response;
+    },
+  ) {
+    super(options.message);
+    this.name = "APIClientError";
+    this.code = code;
+    this.data = data;
+    this.status = options.status;
+    this.response = options.response;
+  }
+}
+
+export type APIClientSystemError =
+  | APIClientError<"http_error", unknown, number>
+  | APIClientError<"network_error", unknown, 0>;
+
 export type RequestEvent = {
   requestId: string;
   method: StatusEvent["method"];
@@ -194,6 +226,7 @@ type TypedEndpointLike = {
     body: any;
     query: any;
     response: any;
+    errors?: any;
   };
 };
 
@@ -249,18 +282,37 @@ type InferEndpointOutput<T> = T extends {
   ? R
   : any;
 
+type InferEndpointError<T> = T extends {
+  __types: {
+    errors: infer TErrors;
+  };
+}
+  ? keyof TErrors extends never
+    ? Error
+    :
+        | {
+            [TCode in keyof TErrors]: TErrors[TCode] extends {
+              data: infer TData;
+              status: infer TStatus extends number;
+            }
+              ? APIClientError<TCode & string, TData, TStatus>
+              : never;
+          }[keyof TErrors]
+        | APIClientSystemError
+  : Error;
+
 // Type for a single endpoint method
 type EndpointMethod<T = any> = (<TUpdates extends readonly unknown[] = readonly OptimisticUpdate[]>(
   ...args: HasRequiredKeys<InferEndpointInput<T>> extends true
     ? [
         options: InferEndpointInput<T>,
-        clientOptions?: ClientOptions<InferEndpointOutput<T>, Error, TUpdates>,
+        clientOptions?: ClientOptions<InferEndpointOutput<T>, InferEndpointError<T>, TUpdates>,
       ]
     : [
         options?: InferEndpointInput<T>,
-        clientOptions?: ClientOptions<InferEndpointOutput<T>, Error, TUpdates>,
+        clientOptions?: ClientOptions<InferEndpointOutput<T>, InferEndpointError<T>, TUpdates>,
       ]
-) => Promise<APIResult<InferEndpointOutput<T>, Error>>) &
+) => Promise<APIResult<InferEndpointOutput<T>, InferEndpointError<T>>>) &
   RouteRef<InferEndpointOutput<T>, InferEndpointInput<T>>;
 
 // Type for converting router structure to client structure
@@ -926,14 +978,54 @@ function resolveRouteMeta(meta: RouteMeta): { routePath: string; method: string 
 }
 
 function normalizeError(error: unknown): Error {
-  if (error instanceof Error) return error;
-  return new Error(typeof error === "string" ? error : "Unknown error");
+  if (error instanceof APIClientError) return error;
+
+  const normalized = new APIClientError("network_error", undefined, {
+    status: 0,
+    message:
+      error instanceof Error
+        ? error.message
+        : typeof error === "string"
+          ? error
+          : "Network request failed",
+  });
+  (normalized as Error & { cause?: unknown }).cause = error;
+  return normalized;
 }
 
 function createResponseError(response: Response, data: any): Error {
-  const error = new Error(`HTTP ${response.status}: ${response.statusText}`);
-  (error as any).status = response.status;
-  (error as any).response = response;
-  (error as any).data = data;
-  return error;
+  const expected = readEndpointErrorEnvelope(data);
+  if (expected) {
+    return new APIClientError(expected.code, expected.data, {
+      status: response.status,
+      message: expected.message,
+      response,
+    });
+  }
+
+  return new APIClientError("http_error", data, {
+    status: response.status,
+    message: `HTTP ${response.status}: ${response.statusText}`,
+    response,
+  });
+}
+
+function readEndpointErrorEnvelope(data: unknown): {
+  code: string;
+  message: string;
+  data: unknown;
+} | null {
+  if (!data || typeof data !== "object") return null;
+  const error = (data as { error?: unknown }).error;
+  if (!error || typeof error !== "object") return null;
+
+  const code = (error as { code?: unknown }).code;
+  const message = (error as { message?: unknown }).message;
+  if (typeof code !== "string" || typeof message !== "string") return null;
+
+  return {
+    code,
+    message,
+    data: (error as { data?: unknown }).data,
+  };
 }

--- a/packages/farm/src/api/endpoint.ts
+++ b/packages/farm/src/api/endpoint.ts
@@ -25,6 +25,57 @@ type InferHeadersOutput<T> = [T] extends [never]
     ? InferOutput<T>
     : Record<string, string>;
 
+export type EndpointErrorDefinition<
+  TSchema extends AnySchema = AnySchema,
+  TStatus extends number = number,
+> = {
+  status: TStatus;
+  schema: TSchema;
+  /** Public message safe to expose to API callers. */
+  message?: string;
+};
+
+export type EndpointErrorDefinitions = Record<string, EndpointErrorDefinition<AnySchema, number>>;
+
+export type EndpointErrorContracts<TErrors extends EndpointErrorDefinitions> = {
+  [TCode in keyof TErrors]: {
+    data: InferOutput<TErrors[TCode]["schema"]>;
+    status: TErrors[TCode]["status"];
+  };
+};
+
+export type EndpointFail<TErrors extends EndpointErrorDefinitions> = <
+  TCode extends keyof TErrors & string,
+>(
+  code: TCode,
+  data: InferOutput<TErrors[TCode]["schema"]>,
+) => never;
+
+export class EndpointFailure<TCode extends string = string, TData = unknown> extends Error {
+  readonly code: TCode;
+  readonly data: TData;
+  readonly status: number;
+
+  constructor(
+    code: TCode,
+    data: TData,
+    options: {
+      status: number;
+      message: string;
+    },
+  ) {
+    super(options.message);
+    this.name = "EndpointFailure";
+    this.code = code;
+    this.data = data;
+    this.status = options.status;
+  }
+}
+
+export function isEndpointFailure(value: unknown): value is EndpointFailure<string, unknown> {
+  return value instanceof EndpointFailure;
+}
+
 export type EndpointParamValue = string | string[];
 export type EndpointParams = Record<string, EndpointParamValue>;
 
@@ -104,12 +155,14 @@ export type EndpointOptions<
   TQuery extends AnySchema = never,
   THeaders extends AnySchema = never,
   TMiddlewares extends readonly AnyEndpointMiddleware[] = readonly [],
+  TErrors extends EndpointErrorDefinitions = {},
 > = {
   method?: "GET" | "HEAD" | "POST" | "PUT" | "DELETE" | "PATCH" | "OPTIONS";
   body?: TBody;
   query?: TQuery;
   headers?: THeaders;
   middleware?: TMiddlewares;
+  errors?: TErrors;
   /** @deprecated Use plain functions in `middleware` for Farm endpoint middleware. */
   use?: any[];
 };
@@ -120,6 +173,7 @@ export type EndpointHandler<
   THeaders extends AnySchema = never,
   TResponse = any,
   TContext extends object = {},
+  TErrors extends EndpointErrorDefinitions = {},
 > = (ctx: {
   body: InferOutput<TBody>;
   query: InferOutput<TQuery>;
@@ -127,6 +181,7 @@ export type EndpointHandler<
   request: Request;
   context: Readonly<TContext>;
   params: EndpointParams;
+  fail: EndpointFail<TErrors>;
 }) => Promise<TResponse> | TResponse;
 
 // Type to represent an endpoint with its input/output types
@@ -135,12 +190,14 @@ export type TypedEndpoint<
   TQuery = never,
   TResponse = any,
   THeaders = Record<string, string>,
+  TErrors = never,
 > = {
   __types: {
     body: TBody;
     query: TQuery;
     headers: THeaders;
     response: TResponse;
+    errors: TErrors;
   };
   __path?: string;
   __method?: string;
@@ -151,18 +208,21 @@ type CreatedEndpoint<
   TQuery extends AnySchema,
   THeaders extends AnySchema,
   TResponse,
+  TErrors extends EndpointErrorDefinitions = {},
 > = TypedEndpoint<
   InferOutput<TBody>,
   InferOutput<TQuery>,
   Awaited<TResponse>,
-  InferHeadersOutput<THeaders>
+  InferHeadersOutput<THeaders>,
+  EndpointErrorContracts<TErrors>
 >;
 
 type AnyEndpointOptions = EndpointOptions<
   AnySchema,
   AnySchema,
   AnySchema,
-  readonly AnyEndpointMiddleware[]
+  readonly AnyEndpointMiddleware[],
+  EndpointErrorDefinitions
 >;
 type EndpointBodyFromOptions<TOptions> = TOptions extends {
   body: infer TBody extends AnySchema;
@@ -184,13 +244,19 @@ type EndpointMiddlewaresFromOptions<TOptions> = TOptions extends {
 }
   ? TMiddlewares
   : readonly [];
+type EndpointErrorsFromOptions<TOptions> = TOptions extends {
+  errors: infer TErrors extends EndpointErrorDefinitions;
+}
+  ? TErrors
+  : {};
 type MethodlessEndpointOptions = Omit<AnyEndpointOptions, "method">;
 type EndpointHandlerFromOptions<TOptions, TResponse> = EndpointHandler<
   EndpointBodyFromOptions<TOptions>,
   EndpointQueryFromOptions<TOptions>,
   EndpointHeadersFromOptions<TOptions>,
   TResponse,
-  InferEndpointMiddlewareContext<EndpointMiddlewaresFromOptions<TOptions>>
+  InferEndpointMiddlewareContext<EndpointMiddlewaresFromOptions<TOptions>>,
+  EndpointErrorsFromOptions<TOptions>
 >;
 type ValidatedEndpointHandlerFromOptions<TOptions, TResponse> = EndpointHandlerFromOptions<
   TOptions,
@@ -205,7 +271,8 @@ type CreatedEndpointFromOptions<TOptions, TResponse> = CreatedEndpoint<
   EndpointBodyFromOptions<TOptions>,
   EndpointQueryFromOptions<TOptions>,
   EndpointHeadersFromOptions<TOptions>,
-  TResponse
+  TResponse,
+  EndpointErrorsFromOptions<TOptions>
 >;
 
 /**
@@ -248,16 +315,24 @@ export function createEndpoint<
   handler: EndpointHandler<TBody, TQuery, THeaders, TResponse>,
 ): CreatedEndpoint<TBody, TQuery, THeaders, TResponse>;
 export function createEndpoint(
-  pathOrOptions: string | EndpointOptions<any, any, any, readonly AnyEndpointMiddleware[]>,
+  pathOrOptions:
+    | string
+    | EndpointOptions<any, any, any, readonly AnyEndpointMiddleware[], EndpointErrorDefinitions>,
   optionsOrHandler:
-    | EndpointOptions<any, any, any, readonly AnyEndpointMiddleware[]>
-    | EndpointHandler<any, any, any, any, any>,
-  maybeHandler?: EndpointHandler<any, any, any, any, any>,
+    | EndpointOptions<any, any, any, readonly AnyEndpointMiddleware[], EndpointErrorDefinitions>
+    | EndpointHandler<any, any, any, any, any, EndpointErrorDefinitions>,
+  maybeHandler?: EndpointHandler<any, any, any, any, any, EndpointErrorDefinitions>,
 ): TypedEndpoint<any, any, any, any> {
   // Determine if first arg is path or options
   let path: string;
-  let options: EndpointOptions<any, any, any, readonly AnyEndpointMiddleware[]>;
-  let handler: EndpointHandler<any, any, any, any, any>;
+  let options: EndpointOptions<
+    any,
+    any,
+    any,
+    readonly AnyEndpointMiddleware[],
+    EndpointErrorDefinitions
+  >;
+  let handler: EndpointHandler<any, any, any, any, any, EndpointErrorDefinitions>;
 
   if (typeof pathOrOptions === "string") {
     // createEndpoint('/path', options, handler)
@@ -276,9 +351,11 @@ export function createEndpoint(
   }
 
   const middleware = normalizeEndpointMiddleware(options.middleware);
+  const errors = normalizeEndpointErrors(options.errors);
+  const fail = createEndpointFail(errors);
   const wrappedHandler = ((ctx: EndpointMiddlewareContext<any, any, any, any>) =>
-    runEndpointMiddleware(middleware, ctx, handler)) as typeof handler;
-  const { middleware: _middleware, ...betterCallOptions } = options;
+    runEndpointMiddleware(middleware, ctx, handler, fail)) as typeof handler;
+  const { middleware: _middleware, errors: _errors, ...betterCallOptions } = options;
 
   // Create the endpoint - path will be set later by API plugin if not provided
   // We use a temporary path that will be replaced when the router is created
@@ -296,6 +373,7 @@ export function createEndpoint(
   endpoint.__handler = wrappedHandler; // Used by Farm's route runtime.
   endpoint.__middleware = middleware;
   endpoint.__sourceHandler = handler;
+  endpoint.__errors = errors;
 
   // Store type information for inference
   endpoint.__types = {
@@ -303,6 +381,7 @@ export function createEndpoint(
     query: options.query,
     headers: options.headers,
     response: null as any,
+    errors,
   };
 
   return endpoint as any;
@@ -313,6 +392,59 @@ const EMPTY_ENDPOINT_CONTEXT = Object.freeze(Object.create(null)) as Readonly<
   Record<string | symbol, unknown>
 >;
 const UNSAFE_ENDPOINT_CONTEXT_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+function normalizeEndpointErrors(
+  definitions: EndpointErrorDefinitions | undefined,
+): Readonly<EndpointErrorDefinitions> {
+  if (definitions === undefined) return Object.freeze({});
+  if (!isPlainEndpointContext(definitions)) {
+    throw new TypeError("createEndpoint errors must be an object");
+  }
+
+  const normalized: EndpointErrorDefinitions = Object.create(null);
+  for (const [code, definition] of Object.entries(definitions)) {
+    if (!code.trim()) {
+      throw new TypeError("Endpoint error codes cannot be empty");
+    }
+    if (!definition || typeof definition !== "object") {
+      throw new TypeError(`Endpoint error "${code}" must be an object`);
+    }
+    if (
+      !Number.isInteger(definition.status) ||
+      definition.status < 400 ||
+      definition.status > 599
+    ) {
+      throw new TypeError(`Endpoint error "${code}" status must be an integer between 400 and 599`);
+    }
+    if (!definition.schema || typeof definition.schema.parse !== "function") {
+      throw new TypeError(`Endpoint error "${code}" requires a schema with parse()`);
+    }
+    if (definition.message !== undefined && typeof definition.message !== "string") {
+      throw new TypeError(`Endpoint error "${code}" message must be a string`);
+    }
+
+    normalized[code] = Object.freeze({ ...definition });
+  }
+
+  return Object.freeze(normalized);
+}
+
+function createEndpointFail(
+  definitions: Readonly<EndpointErrorDefinitions>,
+): EndpointFail<EndpointErrorDefinitions> {
+  return ((code: string, data: unknown): never => {
+    const definition = definitions[code];
+    if (!definition) {
+      throw new TypeError(`Endpoint error "${code}" is not declared`);
+    }
+
+    const parsed = definition.schema.parse!(data);
+    throw new EndpointFailure(code, parsed, {
+      status: definition.status,
+      message: definition.message ?? "Request failed",
+    });
+  }) as EndpointFail<EndpointErrorDefinitions>;
+}
 
 function normalizeEndpointMiddleware(
   middleware: readonly AnyEndpointMiddleware[] | undefined,
@@ -335,7 +467,8 @@ function normalizeEndpointMiddleware(
 async function runEndpointMiddleware(
   middleware: readonly AnyEndpointMiddleware[],
   handlerContext: EndpointMiddlewareContext<any, any, any, any>,
-  handler: EndpointHandler<any, any, any, any, any>,
+  handler: EndpointHandler<any, any, any, any, any, EndpointErrorDefinitions>,
+  fail: EndpointFail<EndpointErrorDefinitions>,
 ): Promise<unknown> {
   let context = createInitialEndpointContext(handlerContext.context);
 
@@ -355,7 +488,7 @@ async function runEndpointMiddleware(
     context = mergeEndpointContext(context, result, index);
   }
 
-  return handler({ ...handlerContext, context });
+  return handler({ ...handlerContext, context, fail });
 }
 
 function createInitialEndpointContext(value: unknown) {

--- a/packages/farm/src/api/runtime.ts
+++ b/packages/farm/src/api/runtime.ts
@@ -1,4 +1,5 @@
 import { _runWithCurrentRequest } from "../server/request";
+import { isEndpointFailure, type EndpointFailure } from "./endpoint";
 
 export type APIRouteParamValue = string | string[];
 export type APIRouteParams = Record<string, APIRouteParamValue>;
@@ -88,14 +89,22 @@ async function invokeAPIRouteEndpointInContext(
     return headersValidation;
   }
 
-  const result = await farmHandler({
-    query: queryValidation,
-    body: bodyValidation,
-    headers: headersValidation,
-    request,
-    context: {},
-    params,
-  });
+  let result: unknown;
+  try {
+    result = await farmHandler({
+      query: queryValidation,
+      body: bodyValidation,
+      headers: headersValidation,
+      request,
+      context: {},
+      params,
+    });
+  } catch (error) {
+    if (isEndpointFailure(error)) {
+      return createEndpointFailureResponse(error);
+    }
+    throw error;
+  }
 
   return normalizeRouteResponse(result);
 }
@@ -123,6 +132,25 @@ export function isWebResponse(value: unknown): value is Response {
       "headers" in value &&
       "status" in value &&
       typeof (value as Response).arrayBuffer === "function")
+  );
+}
+
+export function createEndpointFailureResponse(failure: EndpointFailure<string, unknown>): Response {
+  return new Response(
+    JSON.stringify({
+      error: {
+        code: failure.code,
+        message: failure.message,
+        data: failure.data,
+      },
+    }),
+    {
+      status: failure.status,
+      headers: {
+        "cache-control": "no-store",
+        "content-type": "application/json",
+      },
+    },
   );
 }
 

--- a/packages/farm/src/client.ts
+++ b/packages/farm/src/client.ts
@@ -1,7 +1,8 @@
-export { createAPIClient, createServerAPIClient } from "./api/client";
+export { APIClientError, createAPIClient, createServerAPIClient } from "./api/client";
 export type {
   APIClient,
   APIClientOptions,
+  APIClientSystemError,
   APIClientWithoutIntegrationsOptions,
   RouteAPIClient,
   ServerAPIClient,

--- a/packages/farm/src/client/index.ts
+++ b/packages/farm/src/client/index.ts
@@ -34,10 +34,11 @@ export type {
   FarmRouterRoute,
   FarmRouterRouteInput,
 } from "../router";
-export { createAPIClient, createServerAPIClient } from "../api/client";
+export { APIClientError, createAPIClient, createServerAPIClient } from "../api/client";
 export type {
   APIClient,
   APIClientOptions,
+  APIClientSystemError,
   APIClientWithoutIntegrationsOptions,
   RouteAPIClient,
   ServerAPIClient,

--- a/packages/farm/types/client.d.ts
+++ b/packages/farm/types/client.d.ts
@@ -378,6 +378,31 @@ declare module "@farm.js/core/client" {
     key: CacheKey<TData>;
   };
 
+  export class APIClientError<
+    TCode extends string = string,
+    TData = unknown,
+    TStatus extends number = number,
+  > extends Error {
+    readonly code: TCode;
+    readonly data: TData;
+    readonly status: TStatus;
+    readonly response?: Response;
+
+    constructor(
+      code: TCode,
+      data: TData,
+      options: {
+        status: TStatus;
+        message: string;
+        response?: Response;
+      },
+    );
+  }
+
+  export type APIClientSystemError =
+    | APIClientError<"http_error", unknown, number>
+    | APIClientError<"network_error", unknown, 0>;
+
   export type RequestEvent = {
     requestId: string;
     method: StatusEvent["method"];
@@ -516,6 +541,7 @@ declare module "@farm.js/core/client" {
       body: any;
       query: any;
       response: any;
+      errors?: any;
     };
   };
 
@@ -571,19 +597,38 @@ declare module "@farm.js/core/client" {
     ? R
     : any;
 
+  type InferEndpointError<T> = T extends {
+    __types: {
+      errors: infer TErrors;
+    };
+  }
+    ? keyof TErrors extends never
+      ? Error
+      :
+          | {
+              [TCode in keyof TErrors]: TErrors[TCode] extends {
+                data: infer TData;
+                status: infer TStatus extends number;
+              }
+                ? APIClientError<TCode & string, TData, TStatus>
+                : never;
+            }[keyof TErrors]
+          | APIClientSystemError
+    : Error;
+
   type EndpointMethod<T = any> = (<
     TUpdates extends readonly unknown[] = readonly OptimisticUpdate[],
   >(
     ...args: HasRequiredKeys<InferEndpointInput<T>> extends true
       ? [
           options: InferEndpointInput<T>,
-          clientOptions?: ClientOptions<InferEndpointOutput<T>, Error, TUpdates>,
+          clientOptions?: ClientOptions<InferEndpointOutput<T>, InferEndpointError<T>, TUpdates>,
         ]
       : [
           options?: InferEndpointInput<T>,
-          clientOptions?: ClientOptions<InferEndpointOutput<T>, Error, TUpdates>,
+          clientOptions?: ClientOptions<InferEndpointOutput<T>, InferEndpointError<T>, TUpdates>,
         ]
-  ) => Promise<APIResult<InferEndpointOutput<T>, Error>>) &
+  ) => Promise<APIResult<InferEndpointOutput<T>, InferEndpointError<T>>>) &
     RouteRef<InferEndpointOutput<T>, InferEndpointInput<T>>;
 
   type RouterToClient<T> = {


### PR DESCRIPTION
## Summary

- let endpoints declare expected errors with stable codes, HTTP statuses, public messages, and payload schemas
- inject a typed `fail(code, payload)` helper into endpoint handlers
- validate failure payloads and serialize only expected failures as no-store JSON responses
- leave unexpected exceptions on the existing unexpected-error path
- infer discriminated `APIClientError` unions in generated client results
- keep endpoints without error declarations on their existing `Error` client type
- document server and client usage

## Verification

- typed error, endpoint middleware, and API-client suites (24 passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/core build`
- formatting and lint checks on changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add typed endpoint errors so routes can declare public error codes, statuses, and payload schemas, and return them via a new `fail` helper. The API client now exposes discriminated, typed `APIClientError`s for expected, HTTP, and network failures.

- **New Features**
  - Declare endpoint `errors` with stable codes, HTTP status, optional message, and a Zod schema.
  - New `fail(code, payload)` in handlers; payloads are validated and returned as no-store JSON `{ error: { code, message, data } }`.
  - Unexpected exceptions keep the existing unexpected-error path; no behavior change there.
  - Client infers a discriminated union of `APIClientError` from endpoint contracts; endpoints without `errors` keep the `Error` client type.
  - Added and exported `APIClientError` and `APIClientSystemError` (typed `http_error` and `network_error`) from `@farm.js/core/client` and the root client entry.
  - Validates error definitions at endpoint creation (status must be 4xx–5xx). Docs and tests included.

<sup>Written for commit a627fdf3dc25c4c3317c63a882a63ecb05dc8ea4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

