### PR TITLE
feat: add unified fetcher operations

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -82,6 +82,66 @@ existing API-client cache, retry, invalidation, and optimistic options through `
 `optimistic` state on `useMutation` is separate from an API cache update: it controls
 `mutation.data`, while `request.optimistic` updates shared cached queries.
 
+## Submit without navigation
+
+Use `useFetcher` when a button or form should run an operation without changing the current route.
+It accepts generated API methods, Farm server functions, and ordinary async functions:
+
+```tsx
+"use client";
+
+import { useFetcher } from "@farm.js/core/client";
+import { api } from "@/lib/api-client";
+
+export function CreateProductForm() {
+  const createProduct = useFetcher(api.products.post, {
+    request: {
+      invalidate: [[api.products.get]],
+    },
+  });
+
+  return (
+    <createProduct.Form>
+      <input name="name" required />
+      <input name="category" required />
+      <button disabled={createProduct.pending}>
+        {createProduct.pending ? "Creating..." : "Create product"}
+      </button>
+
+      {createProduct.error ? <p role="alert">{createProduct.error.message}</p> : null}
+      {createProduct.data ? <p>Created {createProduct.data.name}</p> : null}
+    </createProduct.Form>
+  );
+}
+```
+
+The fetcher exposes `state` (`idle` or `submitting`), `status`, `pending`, `data`, `error`,
+`variables`, the active `formData`, `submit`, `submitAsync`, `Form`, and `reset`. It uses the same
+optimistic updates, rollback, callbacks, typed errors, and API-client request options as
+`useMutation`.
+
+Generated API forms map fields to `{ body: ... }` by default, or `{ query: ... }` for GET routes.
+Use `mapFormData` when the validated input needs coercion or a different shape:
+
+```tsx
+const quantity = useFetcher(api.cart.post, {
+  mapFormData(formData) {
+    return {
+      body: {
+        productId: String(formData.get("productId")),
+        quantity: Number(formData.get("quantity")),
+      },
+    };
+  },
+});
+```
+
+After hydration, `<fetcher.Form>` prevents navigation and submits through the typed target. For a
+server function, the function itself remains the native form action, preserving React's
+progressive-enhancement path before JavaScript loads. Generated GET and POST API forms use the
+real endpoint URL as their native fallback; a native fallback navigates to the endpoint response,
+while the hydrated fetcher stays on the page.
+
 ## Client options
 
 - cache: choose cache-first, network-only, or stale-while-revalidate.

--- a/examples/basic/src/app/feature-lab/feature-lab-client.tsx
+++ b/examples/basic/src/app/feature-lab/feature-lab-client.tsx
@@ -4,11 +4,13 @@ import { useEffect, useState } from 'react';
 import {
   Link,
   useBlocker,
+  useFetcher,
   useNavigation,
   usePageState,
   useRouter,
 } from '@farm.js/core/client';
 import { getPublicEnv } from '@farm.js/core/env';
+import { api } from '../../lib/api-client';
 import {
   readClientBoundary,
   readRuntimeBoundary,
@@ -25,6 +27,7 @@ export default function FeatureLabClient() {
   const navigation = useNavigation();
   const pageState = usePageState<FeaturePageState>();
   const router = useRouter();
+  const createUser = useFetcher(api.users.post);
 
   useBlocker({
     when: dirty,
@@ -110,6 +113,27 @@ export default function FeatureLabClient() {
           Client view transition
         </Link>
       </nav>
+
+      <createUser.Form
+        className="grid gap-3 rounded-md border border-slate-200 bg-white p-5"
+        data-testid="fetcher-form"
+      >
+        <label className="grid gap-1">
+          Name
+          <input name="name" defaultValue="Fetcher user" />
+        </label>
+        <label className="grid gap-1">
+          Email
+          <input name="email" type="email" defaultValue="fetcher@example.com" />
+        </label>
+        <button type="submit" disabled={createUser.pending}>
+          {createUser.pending ? 'Creating user' : 'Create user without navigation'}
+        </button>
+        <output data-testid="fetcher-state">{createUser.state}</output>
+        {createUser.data ? (
+          <p data-testid="fetcher-result">{createUser.data.user.email}</p>
+        ) : null}
+      </createUser.Form>
     </section>
   );
 }

--- a/packages/farm/src/__tests__/endpoint-errors.test.ts
+++ b/packages/farm/src/__tests__/endpoint-errors.test.ts
@@ -76,6 +76,25 @@ describe("typed endpoint errors", () => {
     });
   });
 
+  it("validates native urlencoded form submissions", async () => {
+    const response = await invokeAPIRouteEndpoint(
+      createProduct,
+      new Request("https://farm.test/api/products", {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+        },
+        body: "name=From+a+native+form",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      id: "product-2",
+      name: "From a native form",
+    });
+  });
+
   it("preserves the typed failure when an endpoint is called directly", async () => {
     await expect(
       createProduct({

--- a/packages/farm/src/__tests__/fetcher-client.test.tsx
+++ b/packages/farm/src/__tests__/fetcher-client.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import { z } from "zod";
+import { createAPIClient } from "../api/client";
+import { useFetcher, type UseFetcherReturn } from "../fetcher-client";
+import { createServerFn } from "../server-fn";
+
+type APIRouter = {
+  products: {
+    post: {
+      __types: {
+        body: { name: string; intent?: string };
+        query: never;
+        response: { id: string; name: string };
+      };
+    };
+  };
+};
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+describe("useFetcher", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot> | undefined;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    (globalThis as any).window = globalThis;
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount();
+      });
+    }
+    container.remove();
+    root = undefined;
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    delete (globalThis as any).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  it("submits a generated API form without navigating and exposes its lifecycle", async () => {
+    const response = createDeferred<{
+      ok: boolean;
+      status: number;
+      statusText: string;
+      json: () => Promise<{ id: string; name: string }>;
+    }>();
+    globalThis.fetch = vi.fn(() => response.promise) as any;
+    const api = createAPIClient<APIRouter>({
+      baseURL: "https://farm.test",
+    });
+    let fetcher!: UseFetcherReturn<typeof api.products.post>;
+
+    function App() {
+      fetcher = useFetcher(api.products.post);
+      return createElement(
+        fetcher.Form,
+        { "data-state": fetcher.state },
+        createElement("input", { name: "name", defaultValue: "Strata" }),
+        createElement("button", { name: "intent", value: "create", type: "submit" }, "Create"),
+        createElement("output", null, fetcher.data?.name ?? fetcher.status),
+      );
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    const form = container.querySelector("form")!;
+    expect(form.action).toBe("https://farm.test/api/products");
+    expect(form.method).toBe("post");
+
+    await act(async () => {
+      form.dispatchEvent(new SubmitEvent("submit", { bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+
+    expect(form.dataset.state).toBe("submitting");
+    expect(fetcher.formData?.get("name")).toBe("Strata");
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://farm.test/api/products",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ name: "Strata" }),
+      }),
+    );
+
+    response.resolve({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({ id: "product-1", name: "Strata" }),
+    });
+
+    await act(async () => {
+      await response.promise;
+      await Promise.resolve();
+    });
+
+    expect(form.dataset.state).toBe("idle");
+    expect(fetcher.formData).toBeNull();
+    expect(container.querySelector("output")?.textContent).toBe("Strata");
+  });
+
+  it("uses a relative native action for same-origin API clients", () => {
+    const api = createAPIClient<APIRouter>();
+
+    function App() {
+      const fetcher = useFetcher(api.products.post);
+      return createElement(fetcher.Form);
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    const form = container.querySelector("form")!;
+    expect(form.getAttribute("action")).toBe("/api/products");
+    expect(form.method).toBe("post");
+  });
+
+  it("keeps a server function as the native form action and submits FormData", async () => {
+    const save = createServerFn({
+      input: z.object({
+        name: z.string().min(1),
+      }),
+      async handler({ input, formData }) {
+        return {
+          name: input.name,
+          receivedFormData: formData instanceof FormData,
+        };
+      },
+    });
+    let fetcher!: UseFetcherReturn<typeof save>;
+
+    function App() {
+      fetcher = useFetcher(save);
+      return createElement(
+        fetcher.Form,
+        null,
+        createElement("input", { name: "name", defaultValue: "Ada" }),
+        createElement("button", { type: "submit" }, "Save"),
+      );
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    const form = container.querySelector("form")!;
+    await act(async () => {
+      form.dispatchEvent(new SubmitEvent("submit", { bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+
+    expect(fetcher.data).toEqual({
+      name: "Ada",
+      receivedFormData: true,
+    });
+    expectTypeOf(fetcher.data).toEqualTypeOf<{
+      name: string;
+      receivedFormData: boolean;
+    } | null>();
+  });
+
+  it("maps form values into typed variables when a route needs custom input", async () => {
+    const target = vi.fn(async (input: { count: number }) => ({ doubled: input.count * 2 }));
+    let fetcher!: UseFetcherReturn<typeof target>;
+
+    function App() {
+      fetcher = useFetcher(target, {
+        mapFormData(formData, context) {
+          expect(context.form).toBeInstanceOf(HTMLFormElement);
+          return { count: Number(formData.get("count")) };
+        },
+      });
+      return createElement(
+        fetcher.Form,
+        null,
+        createElement("input", { name: "count", defaultValue: "4" }),
+        createElement("button", { type: "submit" }, "Double"),
+      );
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    await act(async () => {
+      container
+        .querySelector("form")!
+        .dispatchEvent(new SubmitEvent("submit", { bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+
+    expect(target).toHaveBeenCalledWith({ count: 4 });
+    expect(fetcher.data).toEqual({ doubled: 8 });
+  });
+});

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -21,6 +21,14 @@ import {
 import type { DefinedCacheKey, InferCacheKeyData, RouteDataCacheKey } from "../cache";
 
 export const FARM_API_ROUTE_REF_SYMBOL: unique symbol = Symbol.for("farm.api.route-ref") as any;
+export const FARM_API_ROUTE_META_SYMBOL: unique symbol = Symbol.for("farm.api.route-meta") as any;
+
+export type APIRouteRefMetadata = {
+  path: string;
+  method: string;
+  baseURL: string;
+  sameOrigin: boolean;
+};
 
 export type APIClientOptions = {
   baseURL?: string;
@@ -747,10 +755,14 @@ export function createAPIClient<
   };
 
   // Return nested proxy (starts with empty path, user adds to it)
-  return createNestedProxy([], request, routeMeta, baseURL, rootAliases) as APIClient<
-    TRouter,
-    TIntegrations
-  >;
+  return createNestedProxy(
+    [],
+    request,
+    routeMeta,
+    baseURL,
+    options.baseURL === undefined,
+    rootAliases,
+  ) as APIClient<TRouter, TIntegrations>;
 }
 
 /**
@@ -772,6 +784,7 @@ function createNestedProxy(
   client: any,
   routeMeta: WeakMap<AnyRouteRef, RouteMeta>,
   baseURL: string,
+  sameOrigin: boolean,
   rootAliases?: Record<string, unknown>,
 ): any {
   const target = () => {};
@@ -780,6 +793,15 @@ function createNestedProxy(
     get(_target, prop: string | symbol) {
       if (prop === FARM_API_ROUTE_REF_SYMBOL) {
         return path.length > 0;
+      }
+      if (prop === FARM_API_ROUTE_META_SYMBOL) {
+        const metadata = resolveRouteMeta({ path, baseURL });
+        return Object.freeze({
+          path: metadata.routePath,
+          method: metadata.method,
+          baseURL,
+          sameOrigin,
+        });
       }
 
       if (path.length === 0 && typeof prop === "string" && rootAliases && prop in rootAliases) {
@@ -791,7 +813,14 @@ function createNestedProxy(
       }
 
       // Add prop to path and return new proxy
-      return createNestedProxy([...path, prop], client, routeMeta, baseURL, rootAliases);
+      return createNestedProxy(
+        [...path, prop],
+        client,
+        routeMeta,
+        baseURL,
+        sameOrigin,
+        rootAliases,
+      );
     },
 
     // When calling as a function
@@ -834,6 +863,31 @@ export function isAPIRouteRef(value: unknown): value is CallableRouteRef {
     typeof value === "function" &&
     (value as { [FARM_API_ROUTE_REF_SYMBOL]?: unknown })[FARM_API_ROUTE_REF_SYMBOL] === true
   );
+}
+
+export function getAPIRouteRefMetadata(value: unknown): APIRouteRefMetadata | null {
+  if (!isAPIRouteRef(value)) return null;
+  const metadata = (value as { [FARM_API_ROUTE_META_SYMBOL]?: unknown })[
+    FARM_API_ROUTE_META_SYMBOL
+  ];
+  if (!metadata || typeof metadata !== "object") return null;
+
+  const candidate = metadata as Partial<APIRouteRefMetadata>;
+  if (
+    typeof candidate.path !== "string" ||
+    typeof candidate.method !== "string" ||
+    typeof candidate.baseURL !== "string" ||
+    typeof candidate.sameOrigin !== "boolean"
+  ) {
+    return null;
+  }
+
+  return {
+    path: candidate.path,
+    method: candidate.method,
+    baseURL: candidate.baseURL,
+    sameOrigin: candidate.sameOrigin,
+  };
 }
 
 /**

--- a/packages/farm/src/api/runtime.ts
+++ b/packages/farm/src/api/runtime.ts
@@ -73,7 +73,7 @@ async function invokeAPIRouteEndpointInContext(
 
   let body: any = undefined;
   if (request.method.toUpperCase() !== "GET" && request.method.toUpperCase() !== "HEAD") {
-    body = await readJSONBody(request);
+    body = await readRequestBody(request);
   }
 
   const headers = Object.fromEntries(request.headers.entries());
@@ -205,17 +205,44 @@ function isFarmContextHandler(endpoint: unknown): boolean {
   return firstParameter === "ctx" || firstParameter === "context" || firstParameter.startsWith("{");
 }
 
-async function readJSONBody(request: Request): Promise<unknown> {
+async function readRequestBody(request: Request): Promise<unknown> {
+  const contentType = request.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
+
   try {
     const text = await request.clone().text();
-    if (text) {
+    if (!text) return undefined;
+    if (contentType === "application/x-www-form-urlencoded") {
+      return searchParamsToObject(new URLSearchParams(text));
+    }
+    if (contentType === "application/json" || contentType?.endsWith("+json")) {
       return JSON.parse(text);
     }
+
+    // Preserve the previous permissive behavior for callers that omit the
+    // content type but still send JSON.
+    return JSON.parse(text);
   } catch {
-    // Body might not be JSON.
+    // The body format is unsupported or malformed. Schema validation below
+    // will turn the missing value into a typed 400 response when applicable.
   }
 
   return undefined;
+}
+
+function searchParamsToObject(searchParams: URLSearchParams): Record<string, string | string[]> {
+  const output: Record<string, string | string[]> = Object.create(null);
+  for (const [key, value] of searchParams) {
+    if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
+    const current = output[key];
+    if (current === undefined) {
+      output[key] = value;
+    } else if (Array.isArray(current)) {
+      current.push(value);
+    } else {
+      output[key] = [current, value];
+    }
+  }
+  return output;
 }
 
 function validateInput(schema: any, value: unknown, error: string): unknown | Response {

--- a/packages/farm/src/client.ts
+++ b/packages/farm/src/client.ts
@@ -11,6 +11,7 @@ export type {
 } from "./api/client";
 export { useMutation } from "./mutation-client";
 export type {
+  AnyMutationTarget,
   InferMutationData,
   InferMutationError,
   InferMutationVariables,
@@ -21,6 +22,16 @@ export type {
   UseMutationOptions,
   UseMutationReturn,
 } from "./mutation-client";
+export { useFetcher } from "./fetcher-client";
+export type {
+  FetcherFormDataContext,
+  FetcherFormProps,
+  FetcherState,
+  FetcherSubmit,
+  FetcherSubmitAsync,
+  UseFetcherOptions,
+  UseFetcherReturn,
+} from "./fetcher-client";
 export { fetchServerQuery, prefetchServerQuery, useServerQuery } from "./server-query-client";
 export type {
   ServerQueryFetchOptions,

--- a/packages/farm/src/client/index.ts
+++ b/packages/farm/src/client/index.ts
@@ -47,6 +47,7 @@ export type {
 } from "../api/client";
 export { useMutation } from "../mutation-client";
 export type {
+  AnyMutationTarget,
   InferMutationData,
   InferMutationError,
   InferMutationVariables,
@@ -57,6 +58,16 @@ export type {
   UseMutationOptions,
   UseMutationReturn,
 } from "../mutation-client";
+export { useFetcher } from "../fetcher-client";
+export type {
+  FetcherFormDataContext,
+  FetcherFormProps,
+  FetcherState,
+  FetcherSubmit,
+  FetcherSubmitAsync,
+  UseFetcherOptions,
+  UseFetcherReturn,
+} from "../fetcher-client";
 export {
   getRouter,
   navigateTo,

--- a/packages/farm/src/fetcher-client.tsx
+++ b/packages/farm/src/fetcher-client.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import {
+  createElement,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type ComponentType,
+  type FormEvent,
+  type FormHTMLAttributes,
+} from "react";
+import { getAPIRouteRefMetadata, isAPIRouteRef } from "./api/client";
+import {
+  useMutation,
+  type AnyMutationTarget,
+  type InferMutationData,
+  type InferMutationError,
+  type InferMutationVariables,
+  type MutationStatus,
+  type UseMutationOptions,
+} from "./mutation-client";
+
+export type FetcherState = "idle" | "submitting";
+
+export type FetcherFormDataContext = {
+  form: HTMLFormElement | null;
+  submitter: HTMLElement | null;
+};
+
+export type UseFetcherOptions<TTarget extends AnyMutationTarget> = UseMutationOptions<
+  InferMutationVariables<TTarget>,
+  InferMutationData<TTarget>,
+  InferMutationError<TTarget>
+> & {
+  /**
+   * Convert browser FormData into the target's typed variables.
+   *
+   * Generated API routes default to `{ body: Object.fromEntries(formData) }`
+   * (or `{ query: ... }` for GET/HEAD). Server functions receive FormData
+   * directly so their input schema remains authoritative.
+   */
+  mapFormData?: (
+    formData: FormData,
+    context: FetcherFormDataContext,
+  ) => InferMutationVariables<TTarget>;
+};
+
+export type FetcherFormProps = Omit<FormHTMLAttributes<HTMLFormElement>, "action" | "onSubmit"> & {
+  /**
+   * Override the native form fallback. By default server functions remain the
+   * action and generated GET/POST API routes use their real URL.
+   */
+  action?: string | ((formData: FormData) => void | Promise<void>);
+  onSubmit?: (event: FormEvent<HTMLFormElement>) => void;
+};
+
+type FetcherInput<TTarget extends AnyMutationTarget> = InferMutationVariables<TTarget> | FormData;
+
+export type FetcherSubmitAsync<TTarget extends AnyMutationTarget> =
+  [] extends Parameters<TTarget>
+    ? (input?: FetcherInput<TTarget>) => Promise<InferMutationData<TTarget>>
+    : (input: FetcherInput<TTarget>) => Promise<InferMutationData<TTarget>>;
+
+export type FetcherSubmit<TTarget extends AnyMutationTarget> =
+  [] extends Parameters<TTarget>
+    ? (input?: FetcherInput<TTarget>) => void
+    : (input: FetcherInput<TTarget>) => void;
+
+export type UseFetcherReturn<TTarget extends AnyMutationTarget> = {
+  state: FetcherState;
+  status: MutationStatus;
+  pending: boolean;
+  data: InferMutationData<TTarget> | null;
+  error: InferMutationError<TTarget> | null;
+  variables: InferMutationVariables<TTarget> | undefined;
+  formData: FormData | null;
+  submit: FetcherSubmit<TTarget>;
+  submitAsync: FetcherSubmitAsync<TTarget>;
+  Form: ComponentType<FetcherFormProps>;
+  reset: () => void;
+};
+
+const formDataContexts = new WeakMap<FormData, FetcherFormDataContext>();
+
+/**
+ * Run a typed server function or generated API operation without navigating.
+ *
+ * `fetcher.Form` progressively keeps a server function as the native form
+ * action, while hydration intercepts submissions into this fetcher lifecycle.
+ */
+export function useFetcher<TTarget extends AnyMutationTarget>(
+  target: TTarget,
+  options: UseFetcherOptions<TTarget> = {},
+): UseFetcherReturn<TTarget> {
+  const targetRef = useRef(target);
+  const optionsRef = useRef(options);
+  const submissionIdRef = useRef(0);
+  const [formData, setFormData] = useState<FormData | null>(null);
+  const mutation = useMutation(target, options);
+
+  targetRef.current = target;
+  optionsRef.current = options;
+
+  const submitAsync = useCallback(
+    async (input?: FetcherInput<TTarget>) => {
+      const submissionId = ++submissionIdRef.current;
+      const submittedFormData = isFormData(input) ? input : null;
+      setFormData(submittedFormData);
+
+      try {
+        const variables = submittedFormData
+          ? mapFetcherFormData(targetRef.current, submittedFormData, optionsRef.current)
+          : input;
+        return await mutation.mutateAsync(variables as InferMutationVariables<TTarget>);
+      } finally {
+        if (submissionId === submissionIdRef.current) {
+          setFormData(null);
+        }
+      }
+    },
+    [mutation.mutateAsync],
+  ) as FetcherSubmitAsync<TTarget>;
+
+  const submit = useCallback(
+    (input?: FetcherInput<TTarget>) => {
+      void submitAsync(input as never).catch(() => {});
+    },
+    [submitAsync],
+  ) as FetcherSubmit<TTarget>;
+
+  const Form = useMemo(() => {
+    const FetcherForm = ({ action, method, encType, onSubmit, ...props }: FetcherFormProps) => {
+      const targetValue = targetRef.current;
+      const metadata = getAPIRouteRefMetadata(targetValue);
+      const nativeAction = action ?? resolveFetcherFormAction(targetValue, metadata);
+      const nativeMethod =
+        method ??
+        (metadata && (metadata.method === "GET" || metadata.method === "POST")
+          ? metadata.method.toLowerCase()
+          : metadata
+            ? "post"
+            : undefined);
+      const functionAction = typeof nativeAction === "function";
+
+      const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+        onSubmit?.(event);
+        if (event.defaultPrevented) return;
+
+        event.preventDefault();
+        const submitter = getSubmitter(event);
+        const nextFormData = createSubmitterFormData(event.currentTarget, submitter);
+        formDataContexts.set(nextFormData, {
+          form: event.currentTarget,
+          submitter,
+        });
+        void submitAsync(nextFormData as never).catch(() => {});
+      };
+
+      return createElement("form", {
+        ...props,
+        action: nativeAction as FormHTMLAttributes<HTMLFormElement>["action"],
+        method: functionAction ? undefined : nativeMethod,
+        encType: functionAction ? undefined : encType,
+        onSubmit: handleSubmit,
+      });
+    };
+
+    FetcherForm.displayName = "FetcherForm";
+    return FetcherForm;
+  }, [submitAsync]);
+
+  const reset = useCallback(() => {
+    submissionIdRef.current += 1;
+    setFormData(null);
+    mutation.reset();
+  }, [mutation.reset]);
+
+  return useMemo(
+    () => ({
+      state: mutation.pending ? "submitting" : "idle",
+      status: mutation.status,
+      pending: mutation.pending,
+      data: mutation.data,
+      error: mutation.error,
+      variables: mutation.variables,
+      formData,
+      submit,
+      submitAsync,
+      Form,
+      reset,
+    }),
+    [
+      Form,
+      formData,
+      mutation.data,
+      mutation.error,
+      mutation.pending,
+      mutation.status,
+      mutation.variables,
+      reset,
+      submit,
+      submitAsync,
+    ],
+  );
+}
+
+function mapFetcherFormData<TTarget extends AnyMutationTarget>(
+  target: TTarget,
+  formData: FormData,
+  options: UseFetcherOptions<TTarget>,
+): InferMutationVariables<TTarget> | FormData {
+  const context = formDataContexts.get(formData) ?? { form: null, submitter: null };
+  if (options.mapFormData) {
+    return options.mapFormData(formData, context);
+  }
+  if (!isAPIRouteRef(target)) {
+    return formData;
+  }
+
+  const values = formDataToObject(formData);
+  const method = getAPIRouteRefMetadata(target)?.method;
+  return (
+    method === "GET" || method === "HEAD" ? { query: values } : { body: values }
+  ) as InferMutationVariables<TTarget>;
+}
+
+function resolveFetcherFormAction(
+  target: AnyMutationTarget,
+  metadata: ReturnType<typeof getAPIRouteRefMetadata>,
+): string | AnyMutationTarget | undefined {
+  if (!metadata) return isProgressiveFormAction(target) ? target : undefined;
+  if (metadata.sameOrigin) return metadata.path;
+
+  return new URL(metadata.path, metadata.baseURL).href;
+}
+
+function formDataToObject(
+  formData: FormData,
+): Record<string, FormDataEntryValue | FormDataEntryValue[]> {
+  const output: Record<string, FormDataEntryValue | FormDataEntryValue[]> = Object.create(null);
+  for (const [key, value] of formData.entries()) {
+    if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
+    const current = output[key];
+    if (current === undefined) {
+      output[key] = value;
+    } else if (Array.isArray(current)) {
+      current.push(value);
+    } else {
+      output[key] = [current, value];
+    }
+  }
+  return output;
+}
+
+function createSubmitterFormData(form: HTMLFormElement, submitter: HTMLElement | null): FormData {
+  try {
+    return new FormData(form, submitter as HTMLElement | undefined);
+  } catch {
+    const formData = new FormData(form);
+    const candidate = submitter as
+      | (HTMLElement & { disabled?: boolean; name?: string; value?: string })
+      | null;
+    if (candidate && !candidate.disabled && candidate.name) {
+      formData.append(candidate.name, candidate.value ?? "");
+    }
+    return formData;
+  }
+}
+
+function getSubmitter(event: FormEvent<HTMLFormElement>): HTMLElement | null {
+  const nativeEvent = event.nativeEvent as SubmitEvent;
+  return nativeEvent.submitter instanceof HTMLElement ? nativeEvent.submitter : null;
+}
+
+function isProgressiveFormAction(target: AnyMutationTarget): boolean {
+  const candidate = target as AnyMutationTarget & {
+    __farmServerFn?: unknown;
+    $$FORM_ACTION?: unknown;
+    $$typeof?: unknown;
+  };
+  return (
+    candidate.__farmServerFn === true ||
+    typeof candidate.$$FORM_ACTION === "function" ||
+    candidate.$$typeof === Symbol.for("react.server.reference")
+  );
+}
+
+function isFormData(value: unknown): value is FormData {
+  if (!value || typeof value !== "object") return false;
+  return (
+    (typeof FormData !== "undefined" && value instanceof FormData) ||
+    (Object.prototype.toString.call(value) === "[object FormData]" &&
+      typeof (value as { entries?: unknown }).entries === "function")
+  );
+}

--- a/packages/farm/src/mutation-client.ts
+++ b/packages/farm/src/mutation-client.ts
@@ -5,7 +5,7 @@ import { isAPIRouteRef, type APIResult, type ClientOptions } from "./api/client"
 
 export type MutationStatus = "idle" | "pending" | "success" | "error";
 
-type AnyMutationTarget = (...args: any[]) => Promise<any>;
+export type AnyMutationTarget = (...args: any[]) => Promise<any>;
 
 export type InferMutationVariables<TTarget extends AnyMutationTarget> =
   Parameters<TTarget> extends [] ? undefined : Parameters<TTarget>[0];

--- a/packages/farm/types/client.d.ts
+++ b/packages/farm/types/client.d.ts
@@ -8,6 +8,9 @@
 
 import type {
   AnchorHTMLAttributes,
+  ComponentType,
+  FormEvent,
+  FormHTMLAttributes,
   ReactElement,
   ReactNode,
   RefObject,
@@ -636,7 +639,7 @@ declare module "@farm.js/core/client" {
 
   export type MutationStatus = "idle" | "pending" | "success" | "error";
 
-  type AnyMutationTarget = (...args: any[]) => Promise<any>;
+  export type AnyMutationTarget = (...args: any[]) => Promise<any>;
 
   export type InferMutationVariables<TTarget extends AnyMutationTarget> =
     Parameters<TTarget> extends [] ? undefined : Parameters<TTarget>[0];
@@ -708,6 +711,63 @@ declare module "@farm.js/core/client" {
       InferMutationError<TTarget>
     >,
   ): UseMutationReturn<TTarget>;
+
+  export type FetcherState = "idle" | "submitting";
+
+  export type FetcherFormDataContext = {
+    form: HTMLFormElement | null;
+    submitter: HTMLElement | null;
+  };
+
+  export type UseFetcherOptions<TTarget extends AnyMutationTarget> = UseMutationOptions<
+    InferMutationVariables<TTarget>,
+    InferMutationData<TTarget>,
+    InferMutationError<TTarget>
+  > & {
+    mapFormData?: (
+      formData: FormData,
+      context: FetcherFormDataContext,
+    ) => InferMutationVariables<TTarget>;
+  };
+
+  export type FetcherFormProps = Omit<
+    FormHTMLAttributes<HTMLFormElement>,
+    "action" | "onSubmit"
+  > & {
+    action?: string | ((formData: FormData) => void | Promise<void>);
+    onSubmit?: (event: FormEvent<HTMLFormElement>) => void;
+  };
+
+  type FetcherInput<TTarget extends AnyMutationTarget> = InferMutationVariables<TTarget> | FormData;
+
+  export type FetcherSubmitAsync<TTarget extends AnyMutationTarget> =
+    [] extends Parameters<TTarget>
+      ? (input?: FetcherInput<TTarget>) => Promise<InferMutationData<TTarget>>
+      : (input: FetcherInput<TTarget>) => Promise<InferMutationData<TTarget>>;
+
+  export type FetcherSubmit<TTarget extends AnyMutationTarget> =
+    [] extends Parameters<TTarget>
+      ? (input?: FetcherInput<TTarget>) => void
+      : (input: FetcherInput<TTarget>) => void;
+
+  export type UseFetcherReturn<TTarget extends AnyMutationTarget> = {
+    state: FetcherState;
+    status: MutationStatus;
+    pending: boolean;
+    data: InferMutationData<TTarget> | null;
+    error: InferMutationError<TTarget> | null;
+    variables: InferMutationVariables<TTarget> | undefined;
+    formData: FormData | null;
+    submit: FetcherSubmit<TTarget>;
+    submitAsync: FetcherSubmitAsync<TTarget>;
+    Form: ComponentType<FetcherFormProps>;
+    reset: () => void;
+  };
+
+  export function useFetcher<TTarget extends AnyMutationTarget>(
+    target: TTarget,
+    options?: UseFetcherOptions<TTarget>,
+  ): UseFetcherReturn<TTarget>;
 
   type RouterToClient<T> = {
     [K in keyof T]: T[K] extends TypedEndpointLike

--- a/tests/e2e/framework-features.spec.ts
+++ b/tests/e2e/framework-features.spec.ts
@@ -150,6 +150,16 @@ test.describe("Framework feature integration", () => {
     await expect(page.getByTestId("client-runtime-boundary")).toHaveText("runtime:client");
   });
 
+  test("submits fetcher forms without navigating", async ({ page }) => {
+    await page.goto("/feature-lab");
+
+    await page.getByRole("button", { name: "Create user without navigation" }).click();
+
+    await expect(page.getByTestId("fetcher-result")).toHaveText("fetcher@example.com");
+    await expect(page.getByTestId("fetcher-state")).toHaveText("idle");
+    await expect(page).toHaveURL(/\/feature-lab$/);
+  });
+
   test("hydrates and navigates optional catch-all routes", async ({ page }) => {
     await page.goto("/optional-catchall/one/two");
     await expect(page.getByTestId("optional-catchall-slug")).toHaveText("one/two");


### PR DESCRIPTION
## Summary

- add `useFetcher` as a typed, non-navigation mutation lifecycle for generated API methods, Farm server functions, and async functions
- add `<fetcher.Form>` with progressive server-function actions and native GET/POST API fallbacks
- support URL-encoded request bodies in the API runtime
- document and exercise the feature in the basic example and framework E2E suite

## Verification

- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter farm-example-basic type-check`
- focused Vitest suite: 5 files, 31 tests
- targeted Playwright fetcher flow: 1 test
- targeted Oxlint: 0 warnings, 0 errors
- `git diff --check`

## Notes

- generated API forms map fields to `body` by default, or `query` for GET/HEAD
- custom input coercion is available through `mapFormData`
- file and streaming transports are intentionally left to a separate PR


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `useFetcher` and `<fetcher.Form>` for submitting API operations and server functions without navigating, with progressive enhancement and typed lifecycles. Also supports URL‑encoded request bodies and exposes API route metadata to power native form fallbacks; docs, example, and tests included.

- **New Features**
  - `useFetcher(target, options)`: non-navigation lifecycle with state, status, pending, data, error, variables, formData, submit, submitAsync, Form, reset; reuses `useMutation` options and typed errors.
  - `<fetcher.Form>`: keeps server functions as native actions pre-hydration; for generated API routes uses the real GET/POST endpoint as fallback (relative for same-origin, absolute for cross-origin); supports `mapFormData` for custom coercion.
  - API runtime: parses `application/x-www-form-urlencoded` bodies and handles repeated keys; preserves prior permissive JSON behavior.
  - API client: exposes route metadata for path/method/baseURL/sameOrigin; `useFetcher` uses this to set native form actions.
  - Exports: `useFetcher` and its types from `@farm.js/core/client`; docs updated with examples; example app and E2E/unit tests cover fetcher flows.

<sup>Written for commit b70d7c001800299e4219d1d904f0616877816e4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

