### PR TITLE
feat: add typed upload and stream transports

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -35,6 +35,40 @@ if (result.error) {
 }
 ```
 
+## Upload files and consume progress streams
+
+`toFormData()` retains the endpoint's body shape while sending files as real multipart fields. When
+an endpoint returns `jsonStream()`, the generated client exposes a typed, single-consumer async
+iterable:
+
+```ts
+import { toFormData } from "@farm.js/core/api";
+
+const result = await api.imports.post({
+  body: toFormData({
+    title: "Quarterly report",
+    file,
+  }),
+});
+
+if (result.error) {
+  throw result.error;
+}
+
+for await (const event of result.data) {
+  if (event.phase === "accepted") {
+    console.log(`Uploading ${event.bytes} bytes`);
+  } else {
+    console.log(`Imported ${event.imported} rows`);
+  }
+}
+```
+
+Farm passes the `FormData` object directly to `fetch`, allowing the runtime to generate the required
+multipart boundary. Do not set `Content-Type` manually. Stream items are decoded only as the
+consumer advances the iterator, and `result.data.cancel()` aborts the response reader when the UI
+no longer needs progress.
+
 ## Track mutations in React
 
 `useMutation` gives generated API methods and Farm server functions the same pending, result, and

--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -83,6 +83,46 @@ export const GET = createEndpoint(
 
 Farm parses and validates `body`, `query`, and `headers` before middleware or handler code runs. Header schema keys use the lower-case names exposed by the Fetch `Headers` API. Invalid input returns a `400` response with structured validation issues.
 
+## Uploads and streaming results
+
+Use `multipart()` when an endpoint accepts files. Farm parses the request as `FormData`, preserves
+`Blob`/`File` values and repeated fields, then runs the same body-schema validation used for JSON:
+
+```ts
+import { createEndpoint, jsonStream, multipart } from "@farm.js/core/api";
+import { z } from "zod";
+
+const importBody = multipart(
+  z.object({
+    title: z.string().min(1),
+    file: z.custom<Blob>((value) => value instanceof Blob),
+  }),
+);
+
+type ImportEvent = { phase: "accepted"; bytes: number } | { phase: "complete"; imported: number };
+
+export const POST = createEndpoint(
+  {
+    method: "POST",
+    body: importBody,
+  },
+  async ({ body }) => {
+    async function* importEvents(): AsyncGenerator<ImportEvent> {
+      yield { phase: "accepted", bytes: body.file.size };
+      const imported = await importRows(body.file);
+      yield { phase: "complete", imported };
+    }
+
+    return jsonStream(importEvents());
+  },
+);
+```
+
+`jsonStream()` uses newline-delimited JSON (`application/x-ndjson`). It sends each typed event as
+soon as the source yields it, respects response backpressure, cancels the source when the reader
+disconnects, and defaults to `Cache-Control: no-store`. Use ordinary `Response` objects for binary
+downloads or protocols that are not JSON event streams.
+
 ## Endpoint middleware
 
 Put plain async functions in `middleware`. There is no middleware factory and no `next()` callback. Functions run in declaration order after endpoint input validation.

--- a/examples/basic/src/app/api/transport-lab/route.ts
+++ b/examples/basic/src/app/api/transport-lab/route.ts
@@ -1,0 +1,43 @@
+import { createEndpoint, jsonStream, multipart } from '@farm.js/core/api';
+import { z } from 'zod';
+
+const uploadBody = multipart(
+  z.object({
+    title: z.string().min(1),
+    file: z.custom<Blob>((value) => value instanceof Blob),
+    tags: z
+      .union([z.string(), z.array(z.string())])
+      .transform((value) => (Array.isArray(value) ? value : [value])),
+  }),
+);
+
+type ImportEvent =
+  | {
+      phase: 'accepted';
+      title: string;
+      bytes: number;
+    }
+  | {
+      phase: 'complete';
+      tags: string[];
+    };
+
+export const POST = createEndpoint(
+  {
+    method: 'POST',
+    body: uploadBody,
+  },
+  async ({ body }) => {
+    return jsonStream<ImportEvent>([
+      {
+        phase: 'accepted',
+        title: body.title,
+        bytes: body.file.size,
+      },
+      {
+        phase: 'complete',
+        tags: body.tags,
+      },
+    ]);
+  },
+);

--- a/examples/basic/src/lib/api.generated.ts
+++ b/examples/basic/src/lib/api.generated.ts
@@ -17,6 +17,7 @@ import type { GET as GET_storagedemo } from "../app/api/storage-demo/route";
 import type { POST as POST_storagedemo } from "../app/api/storage-demo/route";
 import type { DELETE as DELETE_storagedemo } from "../app/api/storage-demo/route";
 import type { GET as GET_test } from "../app/api/test/route";
+import type { POST as POST_transportlab } from "../app/api/transport-lab/route";
 import type { GET as GET_users } from "../app/api/users/route";
 import type { POST as POST_users } from "../app/api/users/route";
 import type { DELETE as DELETE_users } from "../app/api/users/route";
@@ -54,6 +55,9 @@ export type APIRouter = {
   };
   test: {
     get: typeof GET_test;
+  };
+  "transport-lab": {
+    post: typeof POST_transportlab;
   };
   users: {
     get: typeof GET_users;

--- a/packages/farm/src/__tests__/api-client-transport.test.ts
+++ b/packages/farm/src/__tests__/api-client-transport.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import { createAPIClient } from "../api/client";
+import {
+  jsonStream,
+  toFormData,
+  type FarmAPIStream,
+  type FarmStreamResponse,
+  type TypedFormData,
+} from "../api/transport";
+
+type UploadBody = {
+  title: string;
+  attachment: Blob;
+};
+
+type UploadEvent = { phase: "accepted"; title: string } | { phase: "complete"; assetId: string };
+
+type APIRouter = {
+  uploads: {
+    post: {
+      __types: {
+        body: UploadBody;
+        inputBody: TypedFormData<UploadBody>;
+        query: never;
+        response: FarmStreamResponse<UploadEvent>;
+      };
+    };
+  };
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("API client transports", () => {
+  it("sends FormData directly and exposes a typed async response stream", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonStream<UploadEvent>([
+        { phase: "accepted", title: "Farm report" },
+        { phase: "complete", assetId: "asset-1" },
+      ]),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+    const api = createAPIClient<APIRouter>({
+      baseURL: "https://farm.test",
+    });
+
+    const result = await api.uploads.post({
+      body: toFormData({
+        title: "Farm report",
+        attachment: new Blob(["report"]),
+      }),
+    });
+    expectTypeOf(result.data).toEqualTypeOf<FarmAPIStream<UploadEvent> | undefined>();
+
+    const events = [];
+    for await (const event of result.data!) events.push(event);
+
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = init?.headers as Record<string, string>;
+    expect(init?.body).toBeInstanceOf(FormData);
+    expect(Object.keys(headers).map((key) => key.toLowerCase())).not.toContain("content-type");
+    expect(events).toEqual([
+      { phase: "accepted", title: "Farm report" },
+      { phase: "complete", assetId: "asset-1" },
+    ]);
+  });
+});

--- a/packages/farm/src/__tests__/api-transport.test.ts
+++ b/packages/farm/src/__tests__/api-transport.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  isJSONStreamResponse,
+  jsonStream,
+  multipart,
+  readJSONStream,
+  toFormData,
+} from "../api/transport";
+
+describe("API transports", () => {
+  it("encodes typed multipart values without converting blobs to JSON", async () => {
+    const attachment = new Blob(["hello"], { type: "text/plain" });
+    const formData = toFormData({
+      attachment,
+      count: 2,
+      enabled: true,
+      tags: ["one", "two"],
+      skipped: undefined,
+    });
+
+    expect(formData.get("attachment")).toBeInstanceOf(Blob);
+    expect(formData.get("count")).toBe("2");
+    expect(formData.get("enabled")).toBe("true");
+    expect(formData.getAll("tags")).toEqual(["one", "two"]);
+    expect(formData.has("skipped")).toBe(false);
+  });
+
+  it("marks schemas as multipart without changing their parser", () => {
+    const schema = {
+      parse(value: unknown) {
+        return { value };
+      },
+    };
+    const marked = multipart(schema);
+
+    expect(marked).toBe(schema);
+    expect(marked.__farmMultipartSchema).toBe(true);
+    expect(marked.parse("farm")).toEqual({ value: "farm" });
+  });
+
+  it("streams and decodes typed JSON items incrementally", async () => {
+    async function* events() {
+      yield { phase: "accepted" as const, progress: 0 };
+      yield { phase: "complete" as const, progress: 100 };
+    }
+
+    const response = jsonStream(events());
+    const stream = readJSONStream<
+      { phase: "accepted"; progress: number } | { phase: "complete"; progress: number }
+    >(response);
+    const received = [];
+
+    expect(isJSONStreamResponse(response)).toBe(true);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+
+    for await (const event of stream) received.push(event);
+
+    expect(received).toEqual([
+      { phase: "accepted", progress: 0 },
+      { phase: "complete", progress: 100 },
+    ]);
+    expect(() => stream[Symbol.asyncIterator]()).toThrow(
+      "Farm API streams can only be consumed once",
+    );
+  });
+
+  it("cancels the source when the client no longer needs progress", async () => {
+    let released = false;
+    async function* events() {
+      try {
+        yield { progress: 10 };
+        await new Promise(() => {});
+      } finally {
+        released = true;
+      }
+    }
+
+    const stream = readJSONStream<{ progress: number }>(jsonStream(events()));
+    const iterator = stream[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { progress: 10 },
+    });
+    await stream.cancel("view closed");
+
+    expect(released).toBe(true);
+  });
+});

--- a/packages/farm/src/__tests__/endpoint-transport.test.ts
+++ b/packages/farm/src/__tests__/endpoint-transport.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { z } from "zod";
+import type { RouteAPIClient } from "../api/client";
+import { createEndpoint } from "../api/endpoint";
+import { invokeAPIRouteEndpoint } from "../api/runtime";
+import {
+  jsonStream,
+  multipart,
+  readJSONStream,
+  toFormData,
+  type FarmAPIStream,
+  type FarmStreamResponse,
+  type TypedFormData,
+} from "../api/transport";
+
+const uploadSchema = multipart(
+  z.object({
+    title: z.string().min(1),
+    attachment: z.custom<Blob>((value) => value instanceof Blob),
+    tags: z.array(z.string()),
+  }),
+);
+
+type UploadBody = z.output<typeof uploadSchema>;
+type UploadEvent =
+  | { phase: "accepted"; title: string; bytes: number }
+  | { phase: "complete"; tags: string[] };
+
+const uploadEndpoint = createEndpoint(
+  {
+    method: "POST",
+    body: uploadSchema,
+  },
+  async ({ body }): Promise<FarmStreamResponse<UploadEvent>> => {
+    expectTypeOf(body).toEqualTypeOf<z.output<typeof uploadSchema>>();
+
+    return jsonStream([
+      {
+        phase: "accepted",
+        title: body.title,
+        bytes: body.attachment.size,
+      },
+      {
+        phase: "complete",
+        tags: body.tags,
+      },
+    ] satisfies UploadEvent[]);
+  },
+);
+
+type UploadClient = RouteAPIClient<{
+  uploads: {
+    post: typeof uploadEndpoint;
+  };
+}>;
+type UploadClientInput = Parameters<UploadClient["uploads"]["post"]>[0];
+type UploadClientData = Awaited<ReturnType<UploadClient["uploads"]["post"]>>["data"];
+
+describe("endpoint multipart and stream transport", () => {
+  it("validates multipart uploads and preserves repeated fields", async () => {
+    const body = toFormData({
+      title: "Quarterly import",
+      attachment: new Blob(["farm"], { type: "text/plain" }),
+      tags: ["reports", "finance"],
+    });
+    expectTypeOf(body).toEqualTypeOf<TypedFormData<UploadBody>>();
+    expectTypeOf<UploadClientInput>().toEqualTypeOf<{
+      body: TypedFormData<UploadBody>;
+    }>();
+    expectTypeOf<UploadClientData>().toEqualTypeOf<FarmAPIStream<UploadEvent> | undefined>();
+
+    const request = new Request("https://farm.test/api/uploads", {
+      method: "POST",
+      body,
+    });
+    const response = await invokeAPIRouteEndpoint(uploadEndpoint, request);
+    const stream = readJSONStream<UploadEvent>(response);
+    const events = [];
+
+    for await (const event of stream) events.push(event);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("application/x-ndjson");
+    expect(events).toEqual([
+      {
+        phase: "accepted",
+        title: "Quarterly import",
+        bytes: 4,
+      },
+      {
+        phase: "complete",
+        tags: ["reports", "finance"],
+      },
+    ]);
+  });
+});

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -19,6 +19,12 @@ import {
   FARM_CACHE_INVALIDATION_HEADER,
 } from "../cache-invalidation";
 import type { DefinedCacheKey, InferCacheKeyData, RouteDataCacheKey } from "../cache";
+import {
+  isFarmAPIStream,
+  isJSONStreamResponse,
+  readJSONStream,
+  type FarmAPIStream,
+} from "./transport";
 
 export const FARM_API_ROUTE_REF_SYMBOL: unique symbol = Symbol.for("farm.api.route-ref") as any;
 
@@ -275,13 +281,26 @@ type QueryInputProp<TValue> =
 type HasRequiredKeys<T> = RequiredKeys<T> extends never ? false : true;
 
 // Type utilities to extract endpoint input/output types from TypedEndpoint
+type InferEndpointBody<T> = T extends {
+  __types: {
+    inputBody: infer TInputBody;
+  };
+}
+  ? TInputBody
+  : T extends {
+        __types: {
+          body: infer TBody;
+        };
+      }
+    ? TBody
+    : never;
+
 type InferEndpointInput<T> = T extends {
   __types: {
-    body: infer TBody;
     query: infer TQuery;
   };
 }
-  ? Simplify<BodyInputProp<TBody> & QueryInputProp<TQuery>>
+  ? Simplify<BodyInputProp<InferEndpointBody<T>> & QueryInputProp<TQuery>>
   : {};
 
 type InferEndpointOutput<T> = T extends {
@@ -289,7 +308,9 @@ type InferEndpointOutput<T> = T extends {
     response: infer R;
   };
 }
-  ? R
+  ? R extends { readonly __farmStreamItem: infer TItem }
+    ? FarmAPIStream<TItem>
+    : R
   : any;
 
 type InferEndpointError<T> = T extends {
@@ -432,18 +453,24 @@ export function createAPIClient<
     }
 
     // Prepare fetch options
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      ...options.headers,
+      ...requestOptions.headers,
+    };
     const fetchOptions: RequestInit = {
       method: requestOptions.method || "GET",
-      headers: {
-        "Content-Type": "application/json",
-        ...options.headers,
-        ...requestOptions.headers,
-      },
+      headers,
     };
 
     // Handle body
-    if (requestOptions.body) {
-      fetchOptions.body = JSON.stringify(requestOptions.body);
+    if (requestOptions.body !== undefined) {
+      if (isFormData(requestOptions.body)) {
+        deleteHeader(headers, "content-type");
+        fetchOptions.body = requestOptions.body;
+      } else {
+        fetchOptions.body = JSON.stringify(requestOptions.body);
+      }
     }
 
     const response = await fetch(url.toString(), fetchOptions);
@@ -452,7 +479,7 @@ export function createAPIClient<
     );
     let data: any = undefined;
     if (response.status !== 204 && response.status !== 205) {
-      data = await response.json();
+      data = isJSONStreamResponse(response) ? readJSONStream(response) : await response.json();
     }
 
     return { response, data };
@@ -657,7 +684,7 @@ export function createAPIClient<
       try {
         const result = await promise;
 
-        if (!result.error && isCacheEnabled) {
+        if (!result.error && isCacheEnabled && !isFarmAPIStream(result.data)) {
           const updatedAt = Date.now();
           cacheState.set(cacheKey, {
             data: result.data,
@@ -1022,6 +1049,23 @@ function normalizeError(error: unknown): Error {
   });
   (normalized as Error & { cause?: unknown }).cause = error;
   return normalized;
+}
+
+function isFormData(value: unknown): value is FormData {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    ((typeof FormData !== "undefined" && value instanceof FormData) ||
+      (Object.prototype.toString.call(value) === "[object FormData]" &&
+        typeof (value as { entries?: unknown }).entries === "function"))
+  );
+}
+
+function deleteHeader(headers: Record<string, string>, name: string): void {
+  const normalized = name.toLowerCase();
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === normalized) delete headers[key];
+  }
 }
 
 function createResponseError(response: Response, data: any): Error {

--- a/packages/farm/src/api/endpoint.ts
+++ b/packages/farm/src/api/endpoint.ts
@@ -5,6 +5,7 @@ import {
   revalidatePath,
   type RouteDataCacheKey,
 } from "../cache";
+import { isMultipartSchema, type MultipartSchema, type TypedFormData } from "./transport";
 
 // Generic schema type that works with both Zod v3 and v4
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -24,6 +25,9 @@ type InferOutput<T> = T extends { _output: infer O }
   : T extends { parse: (data: unknown) => infer R }
     ? R
     : unknown;
+
+type InferBodyInput<T> =
+  T extends MultipartSchema<AnySchema> ? TypedFormData<InferOutput<T>> : InferOutput<T>;
 
 type InferHeadersOutput<T> = [T] extends [never]
   ? Record<string, string>
@@ -236,9 +240,11 @@ export type TypedEndpoint<
   TResponse = any,
   THeaders = Record<string, string>,
   TErrors = never,
+  TBodyInput = TBody,
 > = {
   __types: {
     body: TBody;
+    inputBody: TBodyInput;
     query: TQuery;
     headers: THeaders;
     response: TResponse;
@@ -259,7 +265,8 @@ type CreatedEndpoint<
   InferOutput<TQuery>,
   Awaited<TResponse>,
   InferHeadersOutput<THeaders>,
-  EndpointErrorContracts<TErrors>
+  EndpointErrorContracts<TErrors>,
+  InferBodyInput<TBody>
 >;
 
 type AnyEndpointOptions = EndpointOptions<
@@ -439,6 +446,7 @@ export function createEndpoint(
   // Store type information for inference
   endpoint.__types = {
     body: options.body,
+    inputBody: isMultipartSchema(options.body) ? "form-data" : options.body,
     query: options.query,
     headers: options.headers,
     response: null as any,

--- a/packages/farm/src/api/index.ts
+++ b/packages/farm/src/api/index.ts
@@ -1,4 +1,5 @@
 export * from "./endpoint";
 export * from "./route-manager";
 export * from "./client";
+export * from "./transport";
 export * from "./vite-plugin";

--- a/packages/farm/src/api/runtime.ts
+++ b/packages/farm/src/api/runtime.ts
@@ -73,7 +73,7 @@ async function invokeAPIRouteEndpointInContext(
 
   let body: any = undefined;
   if (request.method.toUpperCase() !== "GET" && request.method.toUpperCase() !== "HEAD") {
-    body = await readJSONBody(request);
+    body = await readRequestBody(request);
   }
 
   const headers = Object.fromEntries(request.headers.entries());
@@ -205,17 +205,58 @@ function isFarmContextHandler(endpoint: unknown): boolean {
   return firstParameter === "ctx" || firstParameter === "context" || firstParameter.startsWith("{");
 }
 
-async function readJSONBody(request: Request): Promise<unknown> {
+async function readRequestBody(request: Request): Promise<unknown> {
+  const contentType = request.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
+
   try {
+    if (contentType === "multipart/form-data") {
+      return formDataToObject(await request.clone().formData());
+    }
+
     const text = await request.clone().text();
-    if (text) {
+    if (!text) return undefined;
+    if (contentType === "application/x-www-form-urlencoded") {
+      return searchParamsToObject(new URLSearchParams(text));
+    }
+    if (contentType === "application/json" || contentType?.endsWith("+json")) {
       return JSON.parse(text);
     }
+
+    // Preserve permissive JSON parsing for callers that omit content-type.
+    return JSON.parse(text);
   } catch {
-    // Body might not be JSON.
+    // Validation below returns the route's typed 400 response when applicable.
   }
 
   return undefined;
+}
+
+function formDataToObject(
+  formData: FormData,
+): Record<string, FormDataEntryValue | FormDataEntryValue[]> {
+  return entriesToObject(formData.entries());
+}
+
+function searchParamsToObject(searchParams: URLSearchParams): Record<string, string | string[]> {
+  return entriesToObject(searchParams.entries());
+}
+
+function entriesToObject<TValue>(
+  entries: IterableIterator<[string, TValue]>,
+): Record<string, TValue | TValue[]> {
+  const output: Record<string, TValue | TValue[]> = Object.create(null);
+  for (const [key, value] of entries) {
+    if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
+    const current = output[key];
+    if (current === undefined) {
+      output[key] = value;
+    } else if (Array.isArray(current)) {
+      current.push(value);
+    } else {
+      output[key] = [current, value];
+    }
+  }
+  return output;
 }
 
 function validateInput(schema: any, value: unknown, error: string): unknown | Response {

--- a/packages/farm/src/api/transport.ts
+++ b/packages/farm/src/api/transport.ts
@@ -1,0 +1,245 @@
+export type MultipartField = string | number | boolean | bigint | Blob | Date | null | undefined;
+
+export type MultipartValues = Record<string, MultipartField | readonly MultipartField[]>;
+
+/**
+ * A real FormData value that retains the submitted value shape for generated
+ * API-client inference.
+ */
+export type TypedFormData<TValues> = FormData & {
+  readonly __farmMultipartInput: TValues;
+};
+
+export type MultipartSchema<TSchema> = TSchema & {
+  readonly __farmMultipartSchema: true;
+};
+
+export type FarmStreamResponse<TItem> = Response & {
+  readonly __farmStreamItem: TItem;
+};
+
+export interface FarmAPIStream<TItem> extends AsyncIterable<TItem> {
+  readonly response: Response;
+  cancel(reason?: unknown): Promise<void>;
+}
+
+type SchemaLike = {
+  parse(data: unknown): unknown;
+};
+
+/**
+ * Mark a body schema as multipart. The handler still receives the schema's
+ * parsed object; generated clients require `toFormData(...)` for the request.
+ */
+export function multipart<TSchema extends SchemaLike>(schema: TSchema): MultipartSchema<TSchema> {
+  if (!Object.isExtensible(schema) && !isMultipartSchema(schema)) {
+    throw new TypeError("multipart() requires an extensible schema object");
+  }
+
+  if (!isMultipartSchema(schema)) {
+    Object.defineProperty(schema, "__farmMultipartSchema", {
+      value: true,
+      configurable: false,
+      enumerable: false,
+      writable: false,
+    });
+  }
+
+  return schema as MultipartSchema<TSchema>;
+}
+
+export function isMultipartSchema(value: unknown): value is MultipartSchema<SchemaLike> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { __farmMultipartSchema?: unknown }).__farmMultipartSchema === true &&
+    typeof (value as SchemaLike).parse === "function"
+  );
+}
+
+/**
+ * Encode a typed object as multipart FormData without converting File or Blob
+ * values to JSON or base64.
+ */
+export function toFormData<TValues extends MultipartValues>(
+  values: TValues,
+): TypedFormData<TValues> {
+  const formData = new FormData();
+
+  for (const [key, value] of Object.entries(values)) {
+    if (isUnsafeFormKey(key)) continue;
+    if (Array.isArray(value)) {
+      for (const entry of value) appendFormValue(formData, key, entry);
+      continue;
+    }
+    appendFormValue(formData, key, value as MultipartField);
+  }
+
+  return formData as TypedFormData<TValues>;
+}
+
+/**
+ * Stream JSON values as newline-delimited JSON. Each source value becomes one
+ * independently decodable item instead of buffering the whole response.
+ */
+export function jsonStream<TItem>(
+  source: AsyncIterable<TItem> | Iterable<TItem>,
+  init: ResponseInit = {},
+): FarmStreamResponse<TItem> {
+  const iterator = toAsyncIterator(source);
+  const encoder = new TextEncoder();
+  let finished = false;
+
+  const body = new ReadableStream<Uint8Array>(
+    {
+      async pull(controller) {
+        if (finished) return;
+
+        try {
+          const next = await iterator.next();
+          if (next.done) {
+            finished = true;
+            controller.close();
+            return;
+          }
+          controller.enqueue(encoder.encode(`${JSON.stringify(next.value)}\n`));
+        } catch (error) {
+          finished = true;
+          controller.error(error);
+        }
+      },
+      async cancel(reason) {
+        finished = true;
+        await iterator.return?.(reason);
+      },
+    },
+    {
+      // Do not read the next application event until the response consumer
+      // requests another chunk.
+      highWaterMark: 0,
+    },
+  );
+  const headers = new Headers(init.headers);
+  if (!headers.has("content-type")) {
+    headers.set("content-type", "application/x-ndjson; charset=utf-8");
+  }
+  headers.set("cache-control", headers.get("cache-control") ?? "no-store");
+
+  return new Response(body, {
+    ...init,
+    headers,
+  }) as FarmStreamResponse<TItem>;
+}
+
+export function isJSONStreamResponse(response: { headers?: Pick<Headers, "get"> | null }): boolean {
+  const contentType = response.headers?.get?.("content-type")?.toLowerCase() ?? "";
+  return contentType.includes("application/x-ndjson") || contentType.includes("application/ndjson");
+}
+
+/**
+ * Decode a Farm JSON stream lazily. The response body is read only as the
+ * consumer advances the async iterator, preserving fetch backpressure.
+ */
+export function readJSONStream<TItem>(response: Response): FarmAPIStream<TItem> {
+  if (!response.body) {
+    throw new TypeError("Cannot read a JSON stream response without a body");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let completed = false;
+  let claimed = false;
+
+  const iterator: AsyncIterator<TItem> = {
+    async next() {
+      while (true) {
+        const lineEnd = buffer.indexOf("\n");
+        if (lineEnd >= 0) {
+          const line = buffer.slice(0, lineEnd).trim();
+          buffer = buffer.slice(lineEnd + 1);
+          if (!line) continue;
+          return { done: false, value: JSON.parse(line) as TItem };
+        }
+
+        if (completed) {
+          const line = buffer.trim();
+          buffer = "";
+          if (!line) return { done: true, value: undefined };
+          return { done: false, value: JSON.parse(line) as TItem };
+        }
+
+        const chunk = await reader.read();
+        completed = chunk.done;
+        buffer += decoder.decode(chunk.value, { stream: !chunk.done });
+      }
+    },
+    async return() {
+      completed = true;
+      buffer = "";
+      await reader.cancel();
+      return { done: true, value: undefined };
+    },
+  };
+
+  return {
+    response,
+    async cancel(reason) {
+      completed = true;
+      buffer = "";
+      await reader.cancel(reason);
+    },
+    [Symbol.asyncIterator]() {
+      if (claimed) {
+        throw new TypeError("Farm API streams can only be consumed once");
+      }
+      claimed = true;
+      return iterator;
+    },
+  };
+}
+
+export function isFarmAPIStream(value: unknown): value is FarmAPIStream<unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "response" in value &&
+    typeof (value as FarmAPIStream<unknown>).cancel === "function" &&
+    typeof (value as FarmAPIStream<unknown>)[Symbol.asyncIterator] === "function"
+  );
+}
+
+function appendFormValue(formData: FormData, key: string, value: MultipartField): void {
+  if (value === undefined) return;
+  if (value === null) {
+    formData.append(key, "");
+    return;
+  }
+  if (value instanceof Blob) {
+    formData.append(key, value);
+    return;
+  }
+  if (value instanceof Date) {
+    formData.append(key, value.toISOString());
+    return;
+  }
+  formData.append(key, String(value));
+}
+
+function isUnsafeFormKey(key: string): boolean {
+  return key === "__proto__" || key === "constructor" || key === "prototype";
+}
+
+function toAsyncIterator<TItem>(
+  source: AsyncIterable<TItem> | Iterable<TItem>,
+): AsyncIterator<TItem> {
+  if (Symbol.asyncIterator in Object(source)) {
+    return (source as AsyncIterable<TItem>)[Symbol.asyncIterator]();
+  }
+
+  const iterator = (source as Iterable<TItem>)[Symbol.iterator]();
+  return {
+    next: async () => iterator.next(),
+    return: iterator.return ? async (value?: unknown) => iterator.return!(value) : undefined,
+  };
+}

--- a/packages/farm/src/client.ts
+++ b/packages/farm/src/client.ts
@@ -9,6 +9,7 @@ export type {
   ServerAPIClientOptions,
   ServerAPIClientWithoutIntegrationsOptions,
 } from "./api/client";
+export type { FarmAPIStream } from "./api/transport";
 export { useMutation } from "./mutation-client";
 export type {
   InferMutationData,

--- a/packages/farm/src/client/index.ts
+++ b/packages/farm/src/client/index.ts
@@ -45,6 +45,7 @@ export type {
   ServerAPIClientOptions,
   ServerAPIClientWithoutIntegrationsOptions,
 } from "../api/client";
+export type { FarmAPIStream } from "../api/transport";
 export { useMutation } from "../mutation-client";
 export type {
   InferMutationData,

--- a/packages/farm/types/api.d.ts
+++ b/packages/farm/types/api.d.ts
@@ -12,6 +12,50 @@ declare module "@farm.js/core/api" {
    */
   export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS";
 
+  export type MultipartField = string | number | boolean | bigint | Blob | Date | null | undefined;
+
+  export type MultipartValues = Record<string, MultipartField | readonly MultipartField[]>;
+
+  export type TypedFormData<TValues> = FormData & {
+    readonly __farmMultipartInput: TValues;
+  };
+
+  export type MultipartSchema<TSchema> = TSchema & {
+    readonly __farmMultipartSchema: true;
+  };
+
+  export type FarmStreamResponse<TItem> = Response & {
+    readonly __farmStreamItem: TItem;
+  };
+
+  export interface FarmAPIStream<TItem> extends AsyncIterable<TItem> {
+    readonly response: Response;
+    cancel(reason?: unknown): Promise<void>;
+  }
+
+  export function multipart<TSchema extends { parse(data: unknown): unknown }>(
+    schema: TSchema,
+  ): MultipartSchema<TSchema>;
+
+  export function isMultipartSchema(
+    value: unknown,
+  ): value is MultipartSchema<{ parse(data: unknown): unknown }>;
+
+  export function toFormData<TValues extends MultipartValues>(
+    values: TValues,
+  ): TypedFormData<TValues>;
+
+  export function jsonStream<TItem>(
+    source: AsyncIterable<TItem> | Iterable<TItem>,
+    init?: ResponseInit,
+  ): FarmStreamResponse<TItem>;
+
+  export function isJSONStreamResponse(response: {
+    headers?: Pick<Headers, "get"> | null;
+  }): boolean;
+  export function readJSONStream<TItem>(response: Response): FarmAPIStream<TItem>;
+  export function isFarmAPIStream(value: unknown): value is FarmAPIStream<unknown>;
+
   /**
    * API endpoint context
    */

--- a/packages/farm/types/client.d.ts
+++ b/packages/farm/types/client.d.ts
@@ -379,6 +379,11 @@ declare module "@farm.js/core/client" {
     key: CacheKey<TData>;
   };
 
+  export interface FarmAPIStream<TItem> extends AsyncIterable<TItem> {
+    readonly response: Response;
+    cancel(reason?: unknown): Promise<void>;
+  }
+
   export class APIClientError<
     TCode extends string = string,
     TData = unknown,
@@ -542,6 +547,7 @@ declare module "@farm.js/core/client" {
   type TypedEndpointLike = {
     __types: {
       body: any;
+      inputBody?: any;
       query: any;
       response: any;
       errors?: any;
@@ -583,13 +589,26 @@ declare module "@farm.js/core/client" {
   type HasRequiredKeys<T> = RequiredKeys<T> extends never ? false : true;
 
   // Type utilities to extract endpoint input/output types
+  type InferEndpointBody<T> = T extends {
+    __types: {
+      inputBody: infer TInputBody;
+    };
+  }
+    ? TInputBody
+    : T extends {
+          __types: {
+            body: infer TBody;
+          };
+        }
+      ? TBody
+      : never;
+
   type InferEndpointInput<T> = T extends {
     __types: {
-      body: infer TBody;
       query: infer TQuery;
     };
   }
-    ? SimplifyEndpointInput<BodyInputProp<TBody> & QueryInputProp<TQuery>>
+    ? SimplifyEndpointInput<BodyInputProp<InferEndpointBody<T>> & QueryInputProp<TQuery>>
     : {};
 
   type InferEndpointOutput<T> = T extends {
@@ -597,7 +616,9 @@ declare module "@farm.js/core/client" {
       response: infer R;
     };
   }
-    ? R
+    ? R extends { readonly __farmStreamItem: infer TItem }
+      ? FarmAPIStream<TItem>
+      : R
     : any;
 
   type InferEndpointError<T> = T extends {

--- a/tests/e2e/framework-features.spec.ts
+++ b/tests/e2e/framework-features.spec.ts
@@ -150,6 +150,39 @@ test.describe("Framework feature integration", () => {
     await expect(page.getByTestId("client-runtime-boundary")).toHaveText("runtime:client");
   });
 
+  test("validates multipart uploads and streams typed progress events", async ({ request }) => {
+    const response = await request.post("/api/transport-lab", {
+      multipart: {
+        title: "Framework report",
+        file: {
+          name: "report.txt",
+          mimeType: "text/plain",
+          buffer: Buffer.from("farm"),
+        },
+        tags: "framework",
+      },
+    });
+
+    expect(response.ok()).toBeTruthy();
+    expect(response.headers()["content-type"]).toContain("application/x-ndjson");
+    expect(
+      (await response.text())
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line)),
+    ).toEqual([
+      {
+        phase: "accepted",
+        title: "Framework report",
+        bytes: 4,
+      },
+      {
+        phase: "complete",
+        tags: ["framework"],
+      },
+    ]);
+  });
+
   test("hydrates and navigates optional catch-all routes", async ({ page }) => {
     await page.goto("/optional-catchall/one/two");
     await expect(page.getByTestId("optional-catchall-slug")).toHaveText("one/two");


### PR DESCRIPTION
## Summary

- add typed multipart bodies with `multipart()` and `toFormData()`
- validate uploaded files and repeated form fields through the normal endpoint schema pipeline
- add `jsonStream()` and typed single-consumer `FarmAPIStream` decoding for incremental NDJSON results
- preserve response backpressure, iterator cancellation, and no-store defaults
- add framework example, docs, unit coverage, type assertions, and an E2E upload/stream flow

## Verification

- `pnpm --filter @farm.js/core build`
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter farm-example-basic type-check`
- focused Vitest suite: 5 files, 21 tests
- targeted Playwright multipart/stream flow: 1 test
- targeted Oxlint: 0 warnings, 0 errors
- `git diff --check`

## Notes

- files remain native `Blob`/`File` values instead of JSON or base64
- generated clients infer both the required typed `FormData` input and streamed event union
- this PR is independent of the fetcher/form lifecycle PR


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add typed multipart uploads and NDJSON streaming to Farm. Endpoints can validate file uploads, and clients get typed, single-consumer async iterables for progress/events.

- **New Features**
  - `multipart(schema)` marks upload bodies; files stay as real `Blob`/`File` and repeated fields are preserved.
  - `toFormData(values)` builds typed `FormData` without JSON/base64 conversion.
  - `jsonStream(source)` sends newline-delimited JSON with backpressure, cancellation, and `no-store` by default.
  - `readJSONStream(response)` returns a typed `FarmAPIStream<T>`; client output types infer streams automatically.
  - API client auto-detects `FormData`, removes `content-type`, and disables caching for stream results.
  - Runtime parses `multipart/form-data`, `application/x-www-form-urlencoded`, and JSON, then validates through the normal schema pipeline.
  - Docs, example route, unit tests, and an E2E upload/stream flow added under `@farm.js/core/api`.

- **Migration**
  - For uploads: wrap the body schema with `multipart(...)`, and call `toFormData(...)` in the client. Do not set `Content-Type` manually.
  - For streamed results: return `jsonStream(...)` from the route, and iterate `result.data` in the client. Call `result.data.cancel()` if you stop listening.

<sup>Written for commit e761c1dccf58cf0e5e2abf1b483e13112fc5917d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

