### PR TITLE
feat: simplify Farm config defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,14 @@ Create a `farm.config.ts`:
 import { defineConfig } from "@farm.js/core";
 
 export default defineConfig({
-  srcDir: "src",
   deploy: {
     target: "vercel",
   },
 });
 ```
+
+Farm uses `src` as the source directory by default. Add `srcDir` only when your app uses a
+different directory.
 
 `defineFarmConfig` remains available as a deprecated exact alias of `defineConfig`.
 

--- a/docs/farm.config.ts
+++ b/docs/farm.config.ts
@@ -143,7 +143,6 @@ function createDocsContextDemoPlugin(
 }
 
 export default {
-  srcDir: "src",
   preset: "vercel",
   docs: {
     entry: "/docs",

--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -16,7 +16,6 @@ Use farm.config.ts as the single project control plane for source paths, integra
 import { defineConfig } from "@farm.js/core";
 
 export default defineConfig({
-  srcDir: "src",
   deploy: {
     target: "vercel",
   },
@@ -32,6 +31,8 @@ export default defineConfig({
   },
 });
 ```
+
+`srcDir` defaults to `"src"`. Set it only when the application source lives somewhere else.
 
 `defineConfig` is the canonical Farm helper. `defineFarmConfig` remains available as a deprecated exact alias for existing applications.
 

--- a/examples/auth0-integration/farm.config.ts
+++ b/examples/auth0-integration/farm.config.ts
@@ -5,11 +5,5 @@ export default defineConfig({
   experimental: {
     serverComponents: true,
   },
-  vite: {
-    server: {
-      port: 3000,
-      strictPort: true,
-    },
-  },
   integrations: appIntegrations,
 });

--- a/examples/autumn-integration/farm.config.ts
+++ b/examples/autumn-integration/farm.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
   vite: {
     server: {
       port: 3004,
-      strictPort: true,
     },
   },
   integrations: appIntegrations,

--- a/examples/basic/farm.config.ts
+++ b/examples/basic/farm.config.ts
@@ -124,7 +124,6 @@ const runtimeLifecyclePlugin = definePlugin({
 
 export default defineConfig({
   extends: ['./layers/framework-features'],
-  srcDir: 'src',
   outDir: 'dist',
   basePath: '/',
   deploy: {

--- a/examples/better-auth-integration/farm.config.ts
+++ b/examples/better-auth-integration/farm.config.ts
@@ -6,18 +6,17 @@ export default defineConfig({
   experimental: {
     serverComponents: true,
   },
-  vite: {
-    server: {
-      port: 3000,
-      strictPort: true,
-    },
-  },
   integrations: {
     auth: betterAuth({
       instance: auth,
       log(event) {
-        console.log("[better-auth-example]", event.phase, event.route?.path || "none");
+        if (process.env.NODE_ENV !== "production") {
+          console.log("[better-auth]", event.phase, event.route?.path ?? "request");
+        }
       },
     }),
+  },
+  deploy: {
+    target: "vercel",
   },
 });

--- a/examples/clerk-integration/farm.config.ts
+++ b/examples/clerk-integration/farm.config.ts
@@ -5,12 +5,6 @@ export default defineConfig({
   experimental: {
     serverComponents: true,
   },
-  vite: {
-    server: {
-      port: 3000,
-      strictPort: true,
-    },
-  },
   integrations: {
     auth: clerk({
       protectedRoutes: ["/dashboard(.*)"],

--- a/examples/docs-integration/farm.config.ts
+++ b/examples/docs-integration/farm.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from '@farm.js/core';
 
 export default defineConfig({
-  srcDir: 'src',
   deploy: {
     target: 'vercel',
   },

--- a/examples/i18n/farm.config.ts
+++ b/examples/i18n/farm.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from "@farm.js/core";
 
 export default defineConfig({
-  srcDir: "src",
   deploy: {
     target: "node",
   },

--- a/examples/jobs-inngest/farm.config.ts
+++ b/examples/jobs-inngest/farm.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
   vite: {
     server: {
       port: 3001,
-      strictPort: true,
     },
   },
   integrations: appIntegrations,

--- a/examples/jobs-integration/farm.config.ts
+++ b/examples/jobs-integration/farm.config.ts
@@ -5,11 +5,5 @@ export default defineConfig({
   experimental: {
     serverComponents: true,
   },
-  vite: {
-    server: {
-      port: 3000,
-      strictPort: true,
-    },
-  },
   integrations: appIntegrations,
 });

--- a/examples/jobs-trigger/farm.config.ts
+++ b/examples/jobs-trigger/farm.config.ts
@@ -5,11 +5,5 @@ export default defineConfig({
   experimental: {
     serverComponents: true,
   },
-  vite: {
-    server: {
-      port: 3000,
-      strictPort: true,
-    },
-  },
   integrations: appIntegrations,
 });

--- a/examples/polar-integration/farm.config.ts
+++ b/examples/polar-integration/farm.config.ts
@@ -8,9 +8,7 @@ export default defineConfig({
   vite: {
     server: {
       port: 3002,
-      strictPort: true,
     },
   },
   integrations: appIntegrations,
 });
-

--- a/examples/ssr-ssg-demo/farm.config.ts
+++ b/examples/ssr-ssg-demo/farm.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from '@farm.js/core';
 import { createLoggerPlugin } from '@farm.js/core/plugin/server';
 
 export default defineConfig({
-  srcDir: 'src',
   deploy: {
     target: 'vercel',
   },

--- a/examples/stripe-integration/farm.config.ts
+++ b/examples/stripe-integration/farm.config.ts
@@ -5,11 +5,5 @@ export default defineConfig({
   experimental: {
     serverComponents: true,
   },
-  vite: {
-    server: {
-      port: 3000,
-      strictPort: true,
-    },
-  },
   integrations: appIntegrations,
 });

--- a/examples/stripe-integrations/drizzle/farm.config.ts
+++ b/examples/stripe-integrations/drizzle/farm.config.ts
@@ -5,11 +5,5 @@ export default defineConfig({
   experimental: {
     serverComponents: true,
   },
-  vite: {
-    server: {
-      port: 3000,
-      strictPort: true,
-    },
-  },
   integrations: appIntegrations,
 });

--- a/examples/stripe-integrations/prisma-org/farm.config.ts
+++ b/examples/stripe-integrations/prisma-org/farm.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
   vite: {
     server: {
       port: 3001,
-      strictPort: true,
     },
   },
   integrations: appIntegrations,

--- a/examples/stripe-integrations/prisma/farm.config.ts
+++ b/examples/stripe-integrations/prisma/farm.config.ts
@@ -5,11 +5,5 @@ export default defineConfig({
   experimental: {
     serverComponents: true,
   },
-  vite: {
-    server: {
-      port: 3000,
-      strictPort: true,
-    },
-  },
   integrations: appIntegrations,
 });

--- a/examples/stripe-integrations/sqlite/farm.config.ts
+++ b/examples/stripe-integrations/sqlite/farm.config.ts
@@ -5,11 +5,5 @@ export default defineConfig({
   experimental: {
     serverComponents: true,
   },
-  vite: {
-    server: {
-      port: 3000,
-      strictPort: true,
-    },
-  },
   integrations: appIntegrations,
 });

--- a/examples/supabase-integration/farm.config.ts
+++ b/examples/supabase-integration/farm.config.ts
@@ -5,11 +5,5 @@ export default defineConfig({
   experimental: {
     serverComponents: true,
   },
-  vite: {
-    server: {
-      port: 3000,
-      strictPort: true,
-    },
-  },
   integrations: appIntegrations,
 });

--- a/examples/workos-integration/farm.config.ts
+++ b/examples/workos-integration/farm.config.ts
@@ -5,11 +5,5 @@ export default defineConfig({
   experimental: {
     serverComponents: true,
   },
-  vite: {
-    server: {
-      port: 3000,
-      strictPort: true,
-    },
-  },
   integrations: appIntegrations,
 });

--- a/packages/create-farm-app/templates/basic/farm.config.ts
+++ b/packages/create-farm-app/templates/basic/farm.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from "@farm.js/core";
 
 export default defineConfig({
-  srcDir: "src",
   deploy: {
     target: "vercel",
   },

--- a/packages/create-farm-app/test/create-app.test.mjs
+++ b/packages/create-farm-app/test/create-app.test.mjs
@@ -58,6 +58,12 @@ test("generates a buildable starter dependency manifest", async () => {
     assert.match(generatedHomePage, /Welcome to Farm\.js v\{FARM_VERSION\}/);
     assert.doesNotMatch(generatedHomePage, /Welcome to Farm\.js v?\d+\.\d+\.\d+/);
     assert.doesNotMatch(generatedHomePage, /from "farm\//);
+
+    const generatedConfig = await readFile(
+      path.join(tempDir, "generated-app/farm.config.ts"),
+      "utf8",
+    );
+    assert.doesNotMatch(generatedConfig, /srcDir/);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/packages/farm-cli/bin/farm.js
+++ b/packages/farm-cli/bin/farm.js
@@ -33,7 +33,7 @@ function collectOption(value, previous) {
 program
   .command("dev")
   .description("Start development server")
-  .option("-p, --port <port>", "Port to run the server on", "3000")
+  .option("-p, --port <port>", "Override the port to run the server on")
   .option("-r, --root <root>", "Root directory", process.cwd())
   .option("--cron", "Run configured cron routes in-process during development")
   .action(async (options) => {
@@ -43,12 +43,12 @@ program
         {
           root: options.root,
         },
-        parseInt(options.port),
+        options.port === undefined ? undefined : parseInt(options.port, 10),
       );
       if (options.cron) {
         const { startFarmCronScheduler } = require("../dist/index.js");
         const address = server.httpServer?.address();
-        const port = typeof address === "object" && address ? address.port : parseInt(options.port);
+        const port = typeof address === "object" && address ? address.port : 3000;
         const scheduler = await startFarmCronScheduler({
           root: options.root,
           url: `http://localhost:${port}`,

--- a/packages/farm-cli/src/dev.ts
+++ b/packages/farm-cli/src/dev.ts
@@ -1,6 +1,6 @@
 import type { FarmConfig } from "@farm.js/core";
 
-export async function startDevServer(config: FarmConfig = {}, port = 3000) {
+export async function startDevServer(config: FarmConfig = {}, port?: number) {
   const { startDevServer: startFarmDevServer } = await import("@farm.js/core/server");
   return startFarmDevServer(config, port);
 }

--- a/packages/farm-cli/src/migrate.ts
+++ b/packages/farm-cli/src/migrate.ts
@@ -241,7 +241,7 @@ export async function createFrameworkMigrationPlan(
     await planTanStackMigration(root, packageJson, plan, options);
   }
 
-  addSharedFarmFiles(root, packageJson, plan, source, options);
+  addSharedFarmFiles(root, packageJson, plan, options);
   return plan;
 }
 
@@ -393,7 +393,6 @@ function addSharedFarmFiles(
   root: string,
   packageJson: any,
   plan: FrameworkMigrationPlan,
-  source: FarmFrameworkMigrationSource,
   options: { force?: boolean },
 ) {
   const farmConfigPath = ["farm.config.ts", "farm.config.mts", "farm.config.js", "farm.config.mjs"]
@@ -401,19 +400,9 @@ function addSharedFarmFiles(
     .find((file) => existsSync(file));
 
   if (!farmConfigPath) {
-    const output =
-      source === "next"
-        ? `import { defineConfig } from "@farm.js/core";
+    const output = `import { defineConfig } from "@farm.js/core";
 
-export default defineConfig({
-  srcDir: "src",
-});
-`
-        : `import { defineConfig } from "@farm.js/core";
-
-export default defineConfig({
-  srcDir: "src",
-});
+export default defineConfig({});
 `;
 
     plan.operations.push({

--- a/packages/farm-cli/test/migrate.test.mjs
+++ b/packages/farm-cli/test/migrate.test.mjs
@@ -289,6 +289,7 @@ export default function AboutPage() {
     const farmConfig = await readFile(path.join(root, "farm.config.ts"), "utf8");
     assert.match(farmConfig, /defineConfig/);
     assert.doesNotMatch(farmConfig, /defineFarmConfig/);
+    assert.doesNotMatch(farmConfig, /srcDir/);
 
     const packageJson = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
     assert.equal(packageJson.scripts.dev, "farm dev");

--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -177,6 +177,14 @@ describe("loadConfig", () => {
 });
 
 describe("resolveConfig", () => {
+  it('defaults srcDir to "src" and preserves an explicit override', async () => {
+    const defaults = await resolveConfig({}, "development");
+    const configured = await resolveConfig({ srcDir: "app" }, "development");
+
+    expect(defaults.srcDir).toBe("src");
+    expect(configured.srcDir).toBe("app");
+  });
+
   it("keeps optimized boundaries disabled by default and preserves explicit opt-in", async () => {
     const defaults = await resolveConfig({}, "production");
     const configured = await resolveConfig(

--- a/packages/farm/src/__tests__/create-server.test.ts
+++ b/packages/farm/src/__tests__/create-server.test.ts
@@ -9,7 +9,7 @@ describe("mergeFarmViteConfig", () => {
     const merged = mergeFarmViteConfig(
       {
         plugins: [farmPlugin],
-        server: { middlewareMode: false },
+        server: { middlewareMode: false, port: 3000, strictPort: true },
         optimizeDeps: {
           noDiscovery: true,
           include: ["react"],
@@ -19,7 +19,7 @@ describe("mergeFarmViteConfig", () => {
       },
       {
         plugins: [userPlugin],
-        server: { port: 4100 },
+        server: { port: 4100, strictPort: false },
         optimizeDeps: {
           include: ["react", "react-dom"],
           exclude: ["supports-color"],
@@ -29,7 +29,11 @@ describe("mergeFarmViteConfig", () => {
     );
 
     expect(merged.plugins).toEqual([farmPlugin, userPlugin]);
-    expect(merged.server).toMatchObject({ middlewareMode: false, port: 4100 });
+    expect(merged.server).toMatchObject({
+      middlewareMode: false,
+      port: 4100,
+      strictPort: false,
+    });
     expect(merged.optimizeDeps).toMatchObject({
       noDiscovery: true,
       include: ["react", "react-dom"],

--- a/packages/farm/src/__tests__/create-server.test.ts
+++ b/packages/farm/src/__tests__/create-server.test.ts
@@ -10,6 +10,7 @@ describe("mergeFarmViteConfig", () => {
       {
         plugins: [farmPlugin],
         server: { middlewareMode: false, port: 3000, strictPort: true },
+        resolve: { dedupe: ["react", "react-dom"] },
         optimizeDeps: {
           noDiscovery: true,
           include: ["react"],
@@ -20,6 +21,7 @@ describe("mergeFarmViteConfig", () => {
       {
         plugins: [userPlugin],
         server: { port: 4100, strictPort: false },
+        resolve: { dedupe: ["react-dom", "react-is"] },
         optimizeDeps: {
           include: ["react", "react-dom"],
           exclude: ["supports-color"],
@@ -34,6 +36,7 @@ describe("mergeFarmViteConfig", () => {
       port: 4100,
       strictPort: false,
     });
+    expect(merged.resolve?.dedupe).toEqual(["react", "react-dom", "react-is"]);
     expect(merged.optimizeDeps).toMatchObject({
       noDiscovery: true,
       include: ["react", "react-dom"],

--- a/packages/farm/src/server.ts
+++ b/packages/farm/src/server.ts
@@ -8,7 +8,7 @@ export * from "./storage";
 export * from "./cache";
 export * from "./after";
 export * from "./server-query";
-export { createServer, startDevServer } from "./server/create-server";
+export { createServer, DEFAULT_FARM_DEV_SERVER_PORT, startDevServer } from "./server/create-server";
 export { getCurrentRequest } from "./server/request";
 export * from "./server-action-security";
 export * from "./layers";

--- a/packages/farm/src/server/create-server.ts
+++ b/packages/farm/src/server/create-server.ts
@@ -17,6 +17,8 @@ import {
 import { mergeFarmViteConfig } from "./vite-config";
 import { FARM_VERSION } from "../version";
 
+export const DEFAULT_FARM_DEV_SERVER_PORT = 3000;
+
 // Farm.js branding plugin for createServer
 function createBrandingPlugin() {
   let serverStarted = false;
@@ -213,6 +215,8 @@ export async function createServer(config: FarmConfig = {}) {
           ],
           server: {
             middlewareMode: false,
+            port: DEFAULT_FARM_DEV_SERVER_PORT,
+            strictPort: true,
           },
           optimizeDeps: {
             // Avoid Vite scanning server/native-only deps from framework internals.
@@ -294,7 +298,7 @@ export async function createServer(config: FarmConfig = {}) {
 /**
  * Start the development server
  */
-export async function startDevServer(config: FarmConfig = {}, port = 3000) {
+export async function startDevServer(config: FarmConfig = {}, port?: number) {
   const server = await createServer(config);
   await server.listen(port);
   const pluginManager = (server as any).__farmPluginManager as PluginManager | undefined;

--- a/packages/farm/src/server/create-server.ts
+++ b/packages/farm/src/server/create-server.ts
@@ -218,6 +218,10 @@ export async function createServer(config: FarmConfig = {}) {
             port: DEFAULT_FARM_DEV_SERVER_PORT,
             strictPort: true,
           },
+          resolve: {
+            // Keep framework and application modules on one React runtime.
+            dedupe: ["react", "react-dom"],
+          },
           optimizeDeps: {
             // Avoid Vite scanning server/native-only deps from framework internals.
             noDiscovery: true,

--- a/packages/farm/src/server/vite-config.ts
+++ b/packages/farm/src/server/vite-config.ts
@@ -26,6 +26,13 @@ export function mergeFarmViteConfig(
       ...farmConfig.server,
       ...userConfig.server,
     },
+    resolve: {
+      ...farmConfig.resolve,
+      ...userConfig.resolve,
+      dedupe: Array.from(
+        new Set([...(farmConfig.resolve?.dedupe || []), ...(userConfig.resolve?.dedupe || [])]),
+      ),
+    },
     optimizeDeps: {
       ...farmConfig.optimizeDeps,
       ...userConfig.optimizeDeps,

--- a/packages/farm/src/types.ts
+++ b/packages/farm/src/types.ts
@@ -78,6 +78,7 @@ export interface FarmAppContext {}
 
 export interface FarmConfig {
   root?: string;
+  /** App source directory. @default "src" */
   srcDir?: string;
   extends?: readonly FarmLayerEntry[];
   /** Resolved layer graph. Populated by config resolution. */

--- a/skills/farmjs/SKILL.md
+++ b/skills/farmjs/SKILL.md
@@ -63,19 +63,13 @@ export default defineConfig({
   experimental: {
     serverComponents: true,
   },
-  vite: {
-    server: {
-      port: 3000,
-      strictPort: true,
-    },
-  },
   integrations: appIntegrations,
 });
 ```
 
 Common config fields:
 
-- `srcDir`: app source directory, default usually `src`
+- `srcDir`: app source directory; omit it to use the default `src`
 - `experimental.serverComponents`: enables server component behavior
 - `integrations`: provider integrations object
 - `storage.mounts`: named storage instances


### PR DESCRIPTION
## Summary

- make Farm own the default development server port (`3000`) and strict-port behavior
- preserve explicit CLI and Vite server overrides
- keep `srcDir` defaulting to `src` while removing redundant declarations from starters, migrations, docs, and examples
- simplify the Better Auth integration config to contain only application-specific settings

## Why

Farm config should describe application choices rather than repeat framework defaults. This keeps integration setup smaller and gives generated projects a clearer zero-config starting point.

## Validation

- `corepack pnpm --filter @farm.js/core test -- src/__tests__/config.test.ts src/__tests__/create-server.test.ts`
- `corepack pnpm --filter @farm.js/core type-check`
- `corepack pnpm --filter @farm.js/cli type-check`
- `corepack pnpm --filter @farm.js/cli exec node --test test/migrate.test.mjs`
- `corepack pnpm --filter @farm.js/create-app test`
- Better Auth example type-check and formatting checks
