### PR TITLE
feat: add CLI package upgrade channels

### DIFF
--- a/docs/src/app/docs/cli/page.md
+++ b/docs/src/app/docs/cli/page.md
@@ -14,6 +14,8 @@ Use the Farm CLI to run, build, generate types, migrate apps, deploy output, and
 | -------------------------------- | -------------------------------------------------------------------- |
 | farm dev                         | Start the dev server.                                                |
 | farm build                       | Build the app for the configured target.                             |
+| farm upgrade --latest            | Upgrade installed Farm packages to the latest stable release.        |
+| farm upgrade --beta              | Upgrade installed Farm packages to the latest beta release.          |
 | farm doctor                      | Inspect a running app, or fall back to project configuration checks. |
 | farm doctor --offline            | Check project files and config without probing a dev server.         |
 | farm preview                     | Create a public URL for a running local app.                         |
@@ -26,6 +28,23 @@ Use the Farm CLI to run, build, generate types, migrate apps, deploy output, and
 | farm cron list                   | List configured UTC schedules and target routes.                     |
 | farm cron run dailyCleanup       | Invoke one cron route on a running app.                              |
 | farm dev --cron                  | Start the dev server with the opt-in in-memory cron scheduler.       |
+
+## Upgrade Farm packages
+
+```bash
+farm upgrade --latest
+farm upgrade --beta
+farm upgrade --latest --dry-run
+```
+
+`--latest` selects the newest stable release published under npm's `latest` tag. `--beta` selects
+the newest prerelease published under the `beta` tag. Exactly one release channel is required.
+
+Farm reads the app's dependencies and upgrades every published `@farm.js/*` package together. It
+detects npm, pnpm, Yarn, or Bun from `packageManager` and lockfiles, preserves whether each package
+is a regular, development, optional, or peer dependency, and skips local `workspace:`, `file:`,
+`link:`, `portal:`, and `catalog:` references. Use `--dry-run` to inspect the commands without
+changing the project.
 
 ## Provider names
 

--- a/packages/farm-cli/README.md
+++ b/packages/farm-cli/README.md
@@ -8,4 +8,16 @@ Farm.js is currently in beta.
 npm install @farm.js/cli@beta
 ```
 
+Upgrade every published `@farm.js/*` dependency in an app to one release channel:
+
+```bash
+farm upgrade --latest
+farm upgrade --beta
+farm upgrade --latest --dry-run
+```
+
+`--latest` selects the newest stable release. `--beta` selects the newest beta release. The CLI
+detects npm, pnpm, Yarn, or Bun from the project and leaves `workspace:`, `file:`, and other local
+package references unchanged.
+
 See the [Farm.js repository](https://github.com/farming-labs/farm.js) for documentation, examples, and support.

--- a/packages/farm-cli/bin/farm.js
+++ b/packages/farm-cli/bin/farm.js
@@ -81,6 +81,39 @@ program
   });
 
 program
+  .command("upgrade")
+  .description("Upgrade installed Farm.js packages to a stable or beta release")
+  .option("-r, --root <root>", "Project root", process.cwd())
+  .option("--latest", "Upgrade to the latest stable release")
+  .option("--beta", "Upgrade to the latest beta release")
+  .option("--dry-run", "Print the package-manager commands without installing")
+  .action(async (options) => {
+    try {
+      if (options.latest === options.beta) {
+        throw new Error("Choose exactly one release channel: --latest (stable) or --beta.");
+      }
+
+      const { formatFarmUpgradePlan, upgradeFarm } = require("../dist/index.js");
+      const result = await upgradeFarm({
+        root: options.root,
+        channel: options.beta ? "beta" : "latest",
+        dryRun: options.dryRun,
+      });
+      console.log(formatFarmUpgradePlan(result.plan));
+      console.log(
+        result.executed
+          ? `Upgraded ${result.plan.packages.length} Farm package${
+              result.plan.packages.length === 1 ? "" : "s"
+            } to ${result.plan.channel}.`
+          : "Dry run only. No packages were changed.",
+      );
+    } catch (error) {
+      console.error("Failed to upgrade Farm packages:", error);
+      process.exit(1);
+    }
+  });
+
+program
   .command("generate")
   .description("Generate route/API types and integration schema artifacts")
   .option("-r, --root <root>", "Root directory", process.cwd())

--- a/packages/farm-cli/src/index.ts
+++ b/packages/farm-cli/src/index.ts
@@ -63,3 +63,19 @@ export {
   type FrameworkMigrationOperation,
   type FrameworkMigrationPlan,
 } from "./migrate";
+export {
+  createFarmUpgradePlan,
+  detectFarmPackageManager,
+  formatFarmUpgradePlan,
+  upgradeFarm,
+  type FarmDependencySection,
+  type FarmPackageManager,
+  type FarmSkippedUpgradePackage,
+  type FarmUpgradeChannel,
+  type FarmUpgradeCommand,
+  type FarmUpgradeCommandRunner,
+  type FarmUpgradeOptions,
+  type FarmUpgradePackage,
+  type FarmUpgradePlan,
+  type FarmUpgradeResult,
+} from "./upgrade";

--- a/packages/farm-cli/src/upgrade.ts
+++ b/packages/farm-cli/src/upgrade.ts
@@ -1,0 +1,294 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+export type FarmUpgradeChannel = "latest" | "beta";
+export type FarmPackageManager = "npm" | "pnpm" | "yarn" | "bun";
+export type FarmDependencySection =
+  | "dependencies"
+  | "devDependencies"
+  | "optionalDependencies"
+  | "peerDependencies";
+
+export interface FarmUpgradePackage {
+  name: string;
+  current: string;
+  target: string;
+  section: FarmDependencySection;
+}
+
+export interface FarmSkippedUpgradePackage {
+  name: string;
+  current: string;
+  reason: string;
+  section: FarmDependencySection;
+}
+
+export interface FarmUpgradeCommand {
+  command: FarmPackageManager;
+  args: string[];
+  cwd: string;
+}
+
+export interface FarmUpgradePlan {
+  root: string;
+  packageJsonPath: string;
+  packageManager: FarmPackageManager;
+  channel: FarmUpgradeChannel;
+  packages: FarmUpgradePackage[];
+  skipped: FarmSkippedUpgradePackage[];
+  commands: FarmUpgradeCommand[];
+}
+
+export interface FarmUpgradeOptions {
+  root?: string;
+  channel: FarmUpgradeChannel;
+  dryRun?: boolean;
+  packageManager?: FarmPackageManager;
+  runCommand?: FarmUpgradeCommandRunner;
+}
+
+export interface FarmUpgradeResult {
+  plan: FarmUpgradePlan;
+  executed: boolean;
+}
+
+export type FarmUpgradeCommandRunner = (command: FarmUpgradeCommand) => Promise<void>;
+
+type ProjectPackageJson = {
+  packageManager?: unknown;
+  dependencies?: Record<string, unknown>;
+  devDependencies?: Record<string, unknown>;
+  optionalDependencies?: Record<string, unknown>;
+  peerDependencies?: Record<string, unknown>;
+};
+
+const DEPENDENCY_SECTIONS: readonly FarmDependencySection[] = [
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+  "peerDependencies",
+];
+const LOCAL_SPECIFIER_PREFIXES = ["workspace:", "file:", "link:", "portal:", "catalog:"] as const;
+
+export async function createFarmUpgradePlan(options: FarmUpgradeOptions): Promise<FarmUpgradePlan> {
+  assertUpgradeChannel(options.channel);
+
+  const root = path.resolve(options.root || process.cwd());
+  const packageJsonPath = path.join(root, "package.json");
+  let packageJson: ProjectPackageJson;
+
+  try {
+    packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as ProjectPackageJson;
+  } catch (error) {
+    if (!existsSync(packageJsonPath)) {
+      throw new Error(`No package.json found at ${packageJsonPath}.`);
+    }
+    throw new Error(`Could not read ${packageJsonPath}: ${formatError(error)}`);
+  }
+
+  const packageManager =
+    options.packageManager || detectFarmPackageManager(root, packageJson.packageManager);
+  const packages: FarmUpgradePackage[] = [];
+  const skipped: FarmSkippedUpgradePackage[] = [];
+  const seen = new Set<string>();
+
+  for (const section of DEPENDENCY_SECTIONS) {
+    const dependencies = packageJson[section];
+    if (!dependencies || typeof dependencies !== "object") continue;
+
+    for (const [name, rawSpecifier] of Object.entries(dependencies)) {
+      if (!name.startsWith("@farm.js/") || seen.has(name)) continue;
+      seen.add(name);
+
+      const current = typeof rawSpecifier === "string" ? rawSpecifier : String(rawSpecifier);
+      if (isLocalSpecifier(current)) {
+        skipped.push({
+          name,
+          current,
+          section,
+          reason: "local workspace and file dependencies are not published-package upgrades",
+        });
+        continue;
+      }
+
+      packages.push({
+        name,
+        current,
+        section,
+        target: `${name}@${options.channel}`,
+      });
+    }
+  }
+
+  if (packages.length === 0) {
+    const suffix =
+      skipped.length > 0
+        ? " The Farm packages in this project use local workspace or file references."
+        : "";
+    throw new Error(
+      `No published @farm.js/* dependencies were found in ${packageJsonPath}.${suffix}`,
+    );
+  }
+
+  packages.sort((left, right) => left.name.localeCompare(right.name));
+  skipped.sort((left, right) => left.name.localeCompare(right.name));
+
+  return {
+    root,
+    packageJsonPath,
+    packageManager,
+    channel: options.channel,
+    packages,
+    skipped,
+    commands: createUpgradeCommands(root, packageManager, packages),
+  };
+}
+
+export async function upgradeFarm(options: FarmUpgradeOptions): Promise<FarmUpgradeResult> {
+  const plan = await createFarmUpgradePlan(options);
+  if (options.dryRun) {
+    return { plan, executed: false };
+  }
+
+  const runCommand = options.runCommand || runFarmUpgradeCommand;
+  for (const command of plan.commands) {
+    await runCommand(command);
+  }
+
+  return { plan, executed: true };
+}
+
+export function formatFarmUpgradePlan(plan: FarmUpgradePlan): string {
+  const release = plan.channel === "latest" ? "latest stable" : "latest beta";
+  const lines = [
+    `Farm upgrade: ${release}`,
+    `Project: ${plan.root}`,
+    `Package manager: ${plan.packageManager}`,
+    "Packages:",
+  ];
+
+  for (const entry of plan.packages) {
+    lines.push(`  ${entry.name} (${entry.section}): ${entry.current} -> ${plan.channel}`);
+  }
+
+  if (plan.skipped.length > 0) {
+    lines.push("Skipped local packages:");
+    for (const entry of plan.skipped) {
+      lines.push(`  ${entry.name} (${entry.current})`);
+    }
+  }
+
+  lines.push("Commands:");
+  for (const command of plan.commands) {
+    lines.push(`  ${command.command} ${command.args.join(" ")}`);
+  }
+
+  return lines.join("\n");
+}
+
+export function detectFarmPackageManager(
+  root: string,
+  packageManagerField?: unknown,
+): FarmPackageManager {
+  if (typeof packageManagerField === "string") {
+    const name = packageManagerField.split("@", 1)[0];
+    if (isFarmPackageManager(name)) return name;
+  }
+
+  const lockfileCandidates: Array<[FarmPackageManager, string[]]> = [
+    ["pnpm", ["pnpm-lock.yaml"]],
+    ["yarn", ["yarn.lock"]],
+    ["bun", ["bun.lock", "bun.lockb"]],
+    ["npm", ["package-lock.json", "npm-shrinkwrap.json"]],
+  ];
+
+  for (const [packageManager, lockfiles] of lockfileCandidates) {
+    if (lockfiles.some((lockfile) => existsSync(path.join(root, lockfile)))) {
+      return packageManager;
+    }
+  }
+
+  return "npm";
+}
+
+function createUpgradeCommands(
+  root: string,
+  packageManager: FarmPackageManager,
+  packages: FarmUpgradePackage[],
+): FarmUpgradeCommand[] {
+  const command = packageManager === "npm" ? "install" : "add";
+
+  return DEPENDENCY_SECTIONS.flatMap((section) => {
+    const targets = packages
+      .filter((entry) => entry.section === section)
+      .map((entry) => entry.target);
+    if (targets.length === 0) return [];
+
+    return [
+      {
+        command: packageManager,
+        args: [command, ...getDependencySectionFlags(packageManager, section), ...targets],
+        cwd: root,
+      },
+    ];
+  });
+}
+
+function getDependencySectionFlags(
+  packageManager: FarmPackageManager,
+  section: FarmDependencySection,
+): string[] {
+  if (section === "dependencies") return [];
+
+  if (packageManager === "yarn" || packageManager === "bun") {
+    if (section === "devDependencies") return ["--dev"];
+    if (section === "optionalDependencies") return ["--optional"];
+    return ["--peer"];
+  }
+
+  if (section === "devDependencies") return ["--save-dev"];
+  if (section === "optionalDependencies") return ["--save-optional"];
+  return ["--save-peer"];
+}
+
+function runFarmUpgradeCommand(command: FarmUpgradeCommand): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const executable = process.platform === "win32" ? `${command.command}.cmd` : command.command;
+    const child = spawn(executable, command.args, {
+      cwd: command.cwd,
+      env: process.env,
+      stdio: "inherit",
+    });
+
+    child.on("error", reject);
+    child.on("close", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      const termination = signal ? `signal ${signal}` : `exit code ${code ?? "unknown"}`;
+      reject(new Error(`${command.command} ${command.args.join(" ")} failed with ${termination}.`));
+    });
+  });
+}
+
+function isLocalSpecifier(specifier: string): boolean {
+  return LOCAL_SPECIFIER_PREFIXES.some((prefix) => specifier.startsWith(prefix));
+}
+
+function isFarmPackageManager(value: string): value is FarmPackageManager {
+  return value === "npm" || value === "pnpm" || value === "yarn" || value === "bun";
+}
+
+function assertUpgradeChannel(channel: FarmUpgradeChannel): void {
+  if (channel !== "latest" && channel !== "beta") {
+    throw new Error('Farm upgrade channel must be "latest" or "beta".');
+  }
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/farm-cli/test/upgrade.test.mjs
+++ b/packages/farm-cli/test/upgrade.test.mjs
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+import test from "node:test";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const { createFarmUpgradePlan, upgradeFarm } = require("../dist/index.js");
+const execFileAsync = promisify(execFile);
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const cliBin = path.resolve(testDir, "../bin/farm.js");
+
+test("plans stable upgrades with the detected package manager and dependency sections", async () => {
+  const root = await createTempProject({
+    packageManager: "pnpm@8.12.1",
+    dependencies: {
+      "@farm.js/core": "^0.1.0-beta.3",
+      react: "^19.0.0",
+    },
+    devDependencies: {
+      "@farm.js/cli": "^0.1.0-beta.3",
+    },
+    optionalDependencies: {
+      "@farm.js/plugin": "^0.1.0-beta.3",
+    },
+    peerDependencies: {
+      "@farm.js/integrations": "^0.1.0-beta.3",
+    },
+  });
+
+  try {
+    const plan = await createFarmUpgradePlan({ root, channel: "latest" });
+
+    assert.equal(plan.packageManager, "pnpm");
+    assert.deepEqual(
+      plan.packages.map(({ name, section, target }) => ({ name, section, target })),
+      [
+        {
+          name: "@farm.js/cli",
+          section: "devDependencies",
+          target: "@farm.js/cli@latest",
+        },
+        {
+          name: "@farm.js/core",
+          section: "dependencies",
+          target: "@farm.js/core@latest",
+        },
+        {
+          name: "@farm.js/integrations",
+          section: "peerDependencies",
+          target: "@farm.js/integrations@latest",
+        },
+        {
+          name: "@farm.js/plugin",
+          section: "optionalDependencies",
+          target: "@farm.js/plugin@latest",
+        },
+      ],
+    );
+    assert.deepEqual(
+      plan.commands.map(({ command, args }) => ({ command, args })),
+      [
+        {
+          command: "pnpm",
+          args: ["add", "@farm.js/core@latest"],
+        },
+        {
+          command: "pnpm",
+          args: ["add", "--save-dev", "@farm.js/cli@latest"],
+        },
+        {
+          command: "pnpm",
+          args: ["add", "--save-optional", "@farm.js/plugin@latest"],
+        },
+        {
+          command: "pnpm",
+          args: ["add", "--save-peer", "@farm.js/integrations@latest"],
+        },
+      ],
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("executes beta upgrades and skips local Farm packages", async () => {
+  const root = await createTempProject({
+    dependencies: {
+      "@farm.js/core": "^0.1.0-beta.3",
+      "@farm.js/plugin": "workspace:*",
+    },
+  });
+  const commands = [];
+
+  try {
+    const result = await upgradeFarm({
+      root,
+      channel: "beta",
+      packageManager: "npm",
+      runCommand: async (command) => {
+        commands.push(command);
+      },
+    });
+
+    assert.equal(result.executed, true);
+    assert.equal(result.plan.skipped.length, 1);
+    assert.equal(result.plan.skipped[0].name, "@farm.js/plugin");
+    assert.deepEqual(
+      commands.map(({ command, args }) => ({ command, args })),
+      [
+        {
+          command: "npm",
+          args: ["install", "@farm.js/core@beta"],
+        },
+      ],
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("detects Bun from its lockfile when packageManager is not declared", async () => {
+  const root = await createTempProject({
+    dependencies: {
+      "@farm.js/core": "^0.1.0-beta.3",
+    },
+  });
+
+  try {
+    await writeFile(path.join(root, "bun.lock"), "", "utf8");
+
+    const plan = await createFarmUpgradePlan({ root, channel: "latest" });
+
+    assert.equal(plan.packageManager, "bun");
+    assert.deepEqual(plan.commands[0].args, ["add", "@farm.js/core@latest"]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("prints a dry-run plan through the CLI", async () => {
+  const root = await createTempProject({
+    packageManager: "pnpm@8.12.1",
+    dependencies: {
+      "@farm.js/core": "^0.1.0-beta.3",
+    },
+    devDependencies: {
+      "@farm.js/cli": "^0.1.0-beta.3",
+    },
+  });
+
+  try {
+    const { stdout } = await execFileAsync(process.execPath, [
+      cliBin,
+      "upgrade",
+      "--latest",
+      "--root",
+      root,
+      "--dry-run",
+    ]);
+
+    assert.match(stdout, /Farm upgrade: latest stable/);
+    assert.match(stdout, /pnpm add @farm\.js\/core@latest/);
+    assert.match(stdout, /pnpm add --save-dev @farm\.js\/cli@latest/);
+    assert.match(stdout, /Dry run only\. No packages were changed\./);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("requires an explicit stable or beta channel", async () => {
+  const root = await createTempProject({
+    dependencies: {
+      "@farm.js/core": "^0.1.0-beta.3",
+    },
+  });
+
+  try {
+    await assert.rejects(
+      () => execFileAsync(process.execPath, [cliBin, "upgrade", "--root", root, "--dry-run"]),
+      /Choose exactly one release channel/,
+    );
+    await assert.rejects(
+      () =>
+        execFileAsync(process.execPath, [
+          cliBin,
+          "upgrade",
+          "--latest",
+          "--beta",
+          "--root",
+          root,
+          "--dry-run",
+        ]),
+      /Choose exactly one release channel/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+async function createTempProject(packageJson) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "farm-cli-upgrade-"));
+  await writeFile(
+    path.join(root, "package.json"),
+    `${JSON.stringify({ name: "upgrade-fixture", ...packageJson }, null, 2)}\n`,
+    "utf8",
+  );
+  return root;
+}


### PR DESCRIPTION
## What changed

- add `farm upgrade --latest` for the newest stable Farm.js packages
- add `farm upgrade --beta` for the newest beta packages
- detect npm, pnpm, Yarn, and Bun projects automatically
- preserve dependency sections and skip local/workspace package references
- add `--dry-run` for inspecting commands before execution
- document the command and add CLI test coverage

## Why

Farm.js packages should be upgraded together to avoid version skew. Explicit stable and beta channels also prevent an application from moving onto prerelease packages accidentally.

## Developer impact

Developers can now upgrade every installed published `@farm.js/*` package with one command while keeping their existing package manager and dependency placement.

## Validation

- `pnpm --filter @farm.js/cli type-check`
- `pnpm --filter @farm.js/cli test` (47 tests passed)
- `pnpm lint`
- `git diff --check`
