### PR TITLE
feat: expose static pages as markdown

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -91,7 +91,7 @@ mount, and shortcut together.
 | cron          | Mapping portable UTC schedules to ordinary GET API routes.                        |
 | i18n          | Configuring locale routes, detection, message catalogs, typing, and direction.    |
 | docs          | Serving the built-in docs runtime and docs API.                                   |
-| md            | Exposing markdown mirrors like /pricing.md.                                       |
+| md            | Restricting or disabling automatic markdown mirrors like /pricing.md.             |
 | mdx           | Rendering `page.md` and `page.mdx` app routes, plus MDX components.               |
 | deploy        | Selecting a target, preset, and output directory.                                 |
 | deploymentId  | Detecting stale browser requests during rolling deployments.                      |

--- a/docs/src/app/docs/markdown/page.md
+++ b/docs/src/app/docs/markdown/page.md
@@ -8,12 +8,25 @@ section: "Content"
 
 Expose markdown versions of app pages so agents, crawlers, docs tools, and support workflows can read rendered content as text.
 
-Farm supports two markdown flows:
+Every app page receives a markdown representation automatically:
 
-- `page.md` and `page.mdx` are source-authored app pages.
-- `md` mirrors convert rendered `page.tsx` routes back into markdown.
+- `page.tsx` routes are rendered on the server and converted into markdown.
+- `page.md` and `page.mdx` routes return their original source.
+- A `page.md` beside `page.tsx` overrides the generated representation without replacing the
+  React page.
 
-Use source-authored pages for static content such as about pages, policies, changelogs, and content-heavy marketing pages. Use mirrors when the canonical source is a React route.
+No configuration is required. Use source-authored pages for static content such as about pages,
+policies, changelogs, and content-heavy marketing pages. Keep `page.tsx` as the canonical page when
+the visual route needs React, and add a sidecar only when its generated markdown needs a curated
+replacement.
+
+## Representation precedence
+
+| Files in a route folder      | HTML page         | Markdown representation |
+| ---------------------------- | ----------------- | ----------------------- |
+| `page.tsx`                   | Rendered React UI | Generated from HTML     |
+| `page.tsx` and `page.md`     | Rendered React UI | Exact `page.md` source  |
+| `page.md` or `page.mdx` only | Rendered Markdown | Exact source            |
 
 ## Markdown app pages
 
@@ -31,6 +44,36 @@ description: A markdown-first static page.
 ```
 
 This creates `/about` automatically. Because the route is source-authored markdown, Farm also serves the raw source at `/about.md` by default.
+
+## Override a React page
+
+Keep the visual page in React:
+
+**src/app/pricing/page.tsx**
+
+```tsx
+export default function PricingPage() {
+  return <PricingCalculator />;
+}
+```
+
+Then add an optional agent-focused representation beside it:
+
+**src/app/pricing/page.md**
+
+```md
+# Pricing
+
+Farm.js is free and open source.
+
+## Plans
+
+- Community: free
+- Cloud: contact us
+```
+
+The browser still renders `page.tsx` at `/pricing`. Requests to `/pricing.md`, or requests to
+`/pricing` with `Accept: text/markdown`, receive the exact contents of `page.md`.
 
 ## Configure MDX components
 
@@ -57,7 +100,10 @@ export const components = {
 
 Set `mdx.markdownRoutes` to `false` when source-authored pages should render as HTML only.
 
-## Expose pages
+## Restrict exposed pages
+
+Automatic mirrors include all application page routes. Restrict them when an application contains
+authenticated or private pages:
 
 **farm.config.ts**
 
@@ -84,17 +130,16 @@ export default defineConfig({
 - Pricing, docs, changelog, and policy pages become easy to cite.
 - Teams can keep one source of truth: the actual rendered page.
 
-## Expose every route
-
-Use `md: true` when an internal app or documentation site should expose markdown mirrors for every rendered page.
+Disable generated mirrors for every React page with `md: false`:
 
 ```ts
 export default defineConfig({
-  md: true,
+  md: false,
 });
 ```
 
-For public apps, prefer an explicit list so private or account pages are not exposed as markdown.
+Explicit `page.md` and `page.mdx` sources use `mdx.markdownRoutes`; set that option to `false` when
+their raw routes must also be disabled.
 
 ## Per-route options
 
@@ -126,10 +171,20 @@ Markdown mirrors call the rendered page, strip scripts/styles, convert HTML head
 curl http://localhost:3000/pricing.md
 ```
 
+Agents can also request the normal page URL with explicit content negotiation:
+
+```bash
+curl -H "Accept: text/markdown" http://localhost:3000/pricing
+```
+
+Farm returns the same markdown representation with `Content-Type: text/markdown`,
+`Content-Location: /pricing.md`, and `Vary: Accept`. The HTML response also advertises the
+`.md` URL through a `Link` header, while ordinary browser requests continue to receive HTML.
+
 ## Production notes
 
-- Expose only pages that are safe for agents and crawlers.
-- Keep authenticated dashboards out of `md.expose`.
+- Restrict `md.expose` when authenticated or private pages should not have generated mirrors.
 - Use `cache` for stable public pages.
-- Use `page.md` or `page.mdx` when markdown is the source of truth.
+- Add `page.md` beside `page.tsx` when the generated representation needs a precise override.
+- Use `page.md` or `page.mdx` alone when markdown is the page source of truth.
 - Use markdown mirrors for docs, pricing, policies, changelogs, release notes, and help center pages.

--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -491,7 +491,9 @@ Use `page.md` or `page.mdx` for static content routes. They behave like app page
 This page renders at `/about` and exposes source at `/about.md`.
 ```
 
-Do not place `page.tsx` and `page.mdx` in the same folder. Farm treats that as a duplicate route and asks you to choose one page source.
+When `page.tsx` and `page.md` or `page.mdx` share a folder, the React file owns the HTML route and
+the markdown file becomes its exact `.md` representation. Without a sidecar, Farm derives markdown
+from the rendered React page automatically.
 
 ## Metadata And OG Images
 

--- a/packages/farm/src/__tests__/app-markdown.test.ts
+++ b/packages/farm/src/__tests__/app-markdown.test.ts
@@ -74,6 +74,45 @@ describe("app markdown pages", () => {
     await expect(response?.text()).resolves.toBe("# About\n\nRaw source.");
   });
 
+  it("serves raw source through markdown content negotiation", async () => {
+    const response = await createFarmMarkdownSourceResponse({
+      request: new Request("https://farm.test/", {
+        headers: {
+          Accept: "text/html, text/markdown;q=0.9",
+        },
+      }),
+      config: resolveMdxConfig(undefined),
+      resolveSource(pathname) {
+        expect(pathname).toBe("/");
+        return {
+          filePath: "/app/page.md",
+          source: "# Curated home",
+        };
+      },
+    });
+
+    expect(response?.headers.get("content-type")).toContain("text/markdown");
+    expect(response?.headers.get("content-location")).toBe("/index.md");
+    expect(response?.headers.get("vary")).toBe("Accept");
+    await expect(response?.text()).resolves.toBe("# Curated home");
+  });
+
+  it("ignores content negotiation when markdown has zero preference", async () => {
+    const response = await createFarmMarkdownSourceResponse({
+      request: new Request("https://farm.test/about", {
+        headers: {
+          Accept: "text/markdown;q=0",
+        },
+      }),
+      config: resolveMdxConfig(undefined),
+      resolveSource() {
+        throw new Error("resolveSource should not be called");
+      },
+    });
+
+    expect(response).toBeNull();
+  });
+
   it("allows raw markdown routes to be disabled", async () => {
     const response = await createFarmMarkdownSourceResponse({
       request: new Request("https://farm.test/about.md"),

--- a/packages/farm/src/__tests__/markdown.test.ts
+++ b/packages/farm/src/__tests__/markdown.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest";
 import { resolveConfig } from "../config";
 import {
+  applyMarkdownNegotiationHeaders,
   createMarkdownMirrorResponse,
   htmlToMarkdown,
   resolveMarkdownConfig,
@@ -10,12 +11,19 @@ import {
 } from "../markdown";
 
 describe("resolveMarkdownConfig", () => {
-  it("keeps markdown mirrors disabled by default", () => {
+  it("exposes markdown mirrors automatically by default", () => {
     expect(resolveMarkdownConfig(undefined)).toMatchObject({
-      enabled: false,
-      expose: [],
+      enabled: true,
+      expose: true,
       cache: false,
       includeMetadata: true,
+    });
+  });
+
+  it("allows automatic markdown mirrors to be disabled", () => {
+    expect(resolveMarkdownConfig(false)).toMatchObject({
+      enabled: false,
+      expose: [],
     });
   });
 
@@ -38,6 +46,18 @@ describe("resolveMarkdownConfig", () => {
       expose: true,
     });
   });
+
+  it("keeps automatic exposure when only mirror options are configured", () => {
+    expect(
+      resolveMarkdownConfig({
+        cache: 60,
+      }),
+    ).toMatchObject({
+      enabled: true,
+      expose: true,
+      cache: 60,
+    });
+  });
 });
 
 describe("resolveMarkdownMirrorTarget", () => {
@@ -54,6 +74,42 @@ describe("resolveMarkdownMirrorTarget", () => {
       pathname: "/blog/farm",
       route: { route: "/blog/[slug]" },
     });
+  });
+
+  it("maps the root markdown alias to the index page", () => {
+    const config = resolveMarkdownConfig({
+      expose: ["/"],
+    });
+
+    expect(resolveMarkdownMirrorTarget(config, "/index.md")).toMatchObject({
+      pathname: "/",
+      route: { route: "/" },
+    });
+  });
+
+  it("negotiates markdown for an exposed page through the Accept header", () => {
+    const config = resolveMarkdownConfig({
+      expose: ["/pricing"],
+    });
+
+    expect(
+      resolveMarkdownMirrorTarget(config, "/pricing", {
+        accept: "text/markdown",
+      }),
+    ).toMatchObject({
+      pathname: "/pricing",
+      route: { route: "/pricing" },
+    });
+    expect(
+      resolveMarkdownMirrorTarget(config, "/pricing", {
+        accept: "text/markdown; q=0",
+      }),
+    ).toBeNull();
+    expect(
+      resolveMarkdownMirrorTarget(config, "/pricing", {
+        accept: "text/html",
+      }),
+    ).toBeNull();
   });
 
   it("ignores routes that are not exposed", () => {
@@ -111,6 +167,35 @@ describe("createMarkdownMirrorResponse", () => {
     expect(markdown).toContain("**plans**");
   });
 
+  it("returns markdown for content-negotiated page requests", async () => {
+    const config = resolveMarkdownConfig({
+      expose: ["/pricing"],
+    });
+
+    const response = await createMarkdownMirrorResponse({
+      request: new Request("http://farm.test/pricing", {
+        headers: {
+          Accept: "text/html, text/markdown;q=0.9",
+        },
+      }),
+      config,
+      routeExists: (pathname) => pathname === "/pricing",
+      renderPage: (request) => {
+        expect(request.headers.get("accept")).toBe("text/html");
+        return new Response("<html><body><main><h1>Pricing</h1></main></body></html>", {
+          headers: {
+            "content-type": "text/html; charset=utf-8",
+          },
+        });
+      },
+    });
+
+    expect(response?.headers.get("content-type")).toContain("text/markdown");
+    expect(response?.headers.get("content-location")).toBe("/pricing.md");
+    expect(response?.headers.get("vary")).toBe("Accept");
+    await expect(response?.text()).resolves.toContain("# Pricing");
+  });
+
   it("returns null when the target page route does not exist", async () => {
     const config = resolveMarkdownConfig({
       expose: ["/pricing"],
@@ -147,6 +232,59 @@ describe("createMarkdownMirrorResponse", () => {
 
     expect(response?.headers.get("content-type")).toContain("text/markdown");
     await expect(response?.text()).resolves.toBe("");
+  });
+});
+
+describe("applyMarkdownNegotiationHeaders", () => {
+  it("advertises the alternate markdown representation on HTML responses", () => {
+    const response = applyMarkdownNegotiationHeaders(
+      new Response("<html><body>Farm</body></html>", {
+        headers: {
+          "content-type": "text/html",
+          vary: "Cookie",
+        },
+      }),
+      {
+        config: resolveMarkdownConfig({
+          expose: ["/"],
+        }),
+        pathname: "/",
+      },
+    );
+
+    expect(response.headers.get("vary")).toBe("Cookie, Accept");
+    expect(response.headers.get("link")).toContain(
+      '</index.md>; rel="alternate"; type="text/markdown"',
+    );
+  });
+
+  it("does not modify unexposed or non-HTML responses", () => {
+    const config = resolveMarkdownConfig({
+      expose: ["/pricing"],
+    });
+    const unexposed = new Response("<html><body>Private</body></html>", {
+      headers: {
+        "content-type": "text/html",
+      },
+    });
+    const json = new Response("{}", {
+      headers: {
+        "content-type": "application/json",
+      },
+    });
+
+    expect(
+      applyMarkdownNegotiationHeaders(unexposed, {
+        config,
+        pathname: "/account",
+      }),
+    ).toBe(unexposed);
+    expect(
+      applyMarkdownNegotiationHeaders(json, {
+        config,
+        pathname: "/pricing",
+      }),
+    ).toBe(json);
   });
 });
 

--- a/packages/farm/src/__tests__/route-manager.test.ts
+++ b/packages/farm/src/__tests__/route-manager.test.ts
@@ -163,16 +163,47 @@ describe("RouteManager", () => {
       expect(routes.get("/docs")?.modulePath).toBe("/test/src/app/docs/page.mdx");
     });
 
-    it("should reject duplicate page files for one route segment", async () => {
+    it("uses page.md as the markdown representation beside page.tsx", async () => {
       const { globFiles } = await import("../utils");
       vi.mocked(globFiles).mockImplementation(async (pattern: string) => {
         if (pattern.includes("page")) {
-          return ["about/page.tsx", "about/page.mdx"];
+          return ["about/page.tsx", "about/page.md"];
+        }
+        return [];
+      });
+
+      await routeManager.discoverRoutes();
+
+      expect(routeManager.getRoutes().get("/about")).toMatchObject({
+        modulePath: "/test/src/app/about/page.tsx",
+        markdownSourcePath: "/test/src/app/about/page.md",
+      });
+    });
+
+    it("rejects multiple component pages for one route segment", async () => {
+      const { globFiles } = await import("../utils");
+      vi.mocked(globFiles).mockImplementation(async (pattern: string) => {
+        if (pattern.includes("page")) {
+          return ["about/page.tsx", "about/page.jsx"];
         }
         return [];
       });
 
       await expect(routeManager.discoverRoutes()).rejects.toThrow('Duplicate page route "/about"');
+    });
+
+    it("rejects ambiguous markdown representations for one page", async () => {
+      const { globFiles } = await import("../utils");
+      vi.mocked(globFiles).mockImplementation(async (pattern: string) => {
+        if (pattern.includes("page")) {
+          return ["about/page.tsx", "about/page.md", "about/page.mdx"];
+        }
+        return [];
+      });
+
+      await expect(routeManager.discoverRoutes()).rejects.toThrow(
+        'Duplicate markdown representation for page route "/about"',
+      );
     });
 
     it("requires an intercepted URL to have a canonical page", async () => {

--- a/packages/farm/src/app-markdown.ts
+++ b/packages/farm/src/app-markdown.ts
@@ -3,6 +3,7 @@ import { readFile } from "fs/promises";
 import path from "path";
 import { pathToFileURL } from "url";
 import type { Metadata, RouteModule } from "./types";
+import { requestAcceptsMarkdown } from "./markdown";
 
 export type FarmMdxComponent = React.ComponentType<any> | keyof React.JSX.IntrinsicElements;
 export type FarmMdxComponents = Record<string, FarmMdxComponent>;
@@ -232,7 +233,8 @@ export async function createFarmMarkdownSourceResponse(options: {
   }
 
   const url = new URL(options.request.url);
-  if (!url.pathname.endsWith(".md")) {
+  const hasMarkdownExtension = url.pathname.toLowerCase().endsWith(".md");
+  if (!hasMarkdownExtension && !requestAcceptsMarkdown(options.request.headers.get("accept"))) {
     return null;
   }
 
@@ -242,13 +244,19 @@ export async function createFarmMarkdownSourceResponse(options: {
     return null;
   }
 
+  const headers = new Headers({
+    "Content-Type": "text/markdown; charset=utf-8",
+    "Content-Location": targetPathname === "/" ? "/index.md" : `${targetPathname}.md`,
+    "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+    "X-Farm-Markdown-Route": targetPathname,
+    "X-Farm-Markdown-Source": source.filePath,
+  });
+  if (!hasMarkdownExtension) {
+    headers.set("Vary", "Accept");
+  }
+
   return new Response(options.request.method === "HEAD" ? null : source.source, {
     status: 200,
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
-      "X-Farm-Markdown-Route": targetPathname,
-      "X-Farm-Markdown-Source": source.filePath,
-    },
+    headers,
   });
 }

--- a/packages/farm/src/markdown.ts
+++ b/packages/farm/src/markdown.ts
@@ -7,8 +7,16 @@ export type FarmMarkdownRouteInput =
     };
 
 export interface FarmMarkdownUserConfig {
+  /**
+   * Enable generated markdown representations for React pages.
+   * @default true
+   */
   enabled?: boolean;
+  /**
+   * Routes that may expose generated markdown. Every page is exposed by default.
+   */
   expose?: boolean | FarmMarkdownRouteInput[];
+  /** @deprecated Use `expose`. */
   routes?: FarmMarkdownRouteInput[];
   cache?: number | false;
   includeMetadata?: boolean;
@@ -32,6 +40,10 @@ export interface FarmMarkdownMirrorTarget {
   route: FarmMarkdownResolvedRoute | null;
 }
 
+export interface ResolveMarkdownMirrorTargetOptions {
+  accept?: string | null;
+}
+
 export interface CreateMarkdownMirrorResponseOptions {
   request: Request;
   config?: FarmMarkdownResolvedConfig;
@@ -39,10 +51,15 @@ export interface CreateMarkdownMirrorResponseOptions {
   renderPage: (request: Request) => Response | Promise<Response>;
 }
 
+export interface ApplyMarkdownNegotiationHeadersOptions {
+  config?: FarmMarkdownResolvedConfig;
+  pathname: string;
+}
+
 export function resolveMarkdownConfig(
   config: FarmMarkdownUserConfig | boolean | undefined,
 ): FarmMarkdownResolvedConfig {
-  if (config === false || config === undefined) {
+  if (config === false) {
     return {
       enabled: false,
       expose: [],
@@ -51,7 +68,7 @@ export function resolveMarkdownConfig(
     };
   }
 
-  if (config === true) {
+  if (config === true || config === undefined) {
     return {
       enabled: true,
       expose: true,
@@ -60,7 +77,7 @@ export function resolveMarkdownConfig(
     };
   }
 
-  const exposeInput = config.expose ?? config.routes ?? [];
+  const exposeInput = config.expose ?? config.routes ?? true;
   const expose =
     exposeInput === true
       ? true
@@ -79,12 +96,16 @@ export function resolveMarkdownConfig(
 export function resolveMarkdownMirrorTarget(
   config: FarmMarkdownResolvedConfig | undefined,
   pathname: string,
+  options: ResolveMarkdownMirrorTargetOptions = {},
 ): FarmMarkdownMirrorTarget | null {
-  if (!config?.enabled || !pathname.endsWith(".md")) {
+  const hasMarkdownExtension = pathname.toLowerCase().endsWith(".md");
+  if (!config?.enabled || (!hasMarkdownExtension && !requestAcceptsMarkdown(options.accept))) {
     return null;
   }
 
-  const targetPathname = normalizeMarkdownRoute(pathname.slice(0, -".md".length) || "/");
+  const targetPathname = normalizeMarkdownRoute(
+    hasMarkdownExtension ? pathname.slice(0, -".md".length) || "/" : pathname,
+  );
   const route = findExposedMarkdownRoute(config, targetPathname);
   if (!route && config.expose !== true) {
     return null;
@@ -104,7 +125,10 @@ export async function createMarkdownMirrorResponse(
   }
 
   const requestUrl = new URL(options.request.url);
-  const target = resolveMarkdownMirrorTarget(options.config, requestUrl.pathname);
+  const hasMarkdownExtension = requestUrl.pathname.toLowerCase().endsWith(".md");
+  const target = resolveMarkdownMirrorTarget(options.config, requestUrl.pathname, {
+    accept: options.request.headers.get("accept"),
+  });
   if (!target) {
     return null;
   }
@@ -137,14 +161,45 @@ export async function createMarkdownMirrorResponse(
   });
   const headersOut = new Headers({
     "Content-Type": "text/markdown; charset=utf-8",
+    "Content-Location": target.pathname === "/" ? "/index.md" : `${target.pathname}.md`,
     "X-Farm-Markdown-Route": target.pathname,
   });
+  if (!hasMarkdownExtension) {
+    headersOut.set("Vary", "Accept");
+  }
   const cache = target.route?.cache ?? options.config?.cache ?? false;
   headersOut.set("Cache-Control", createMarkdownCacheHeader(cache));
 
   return new Response(options.request.method === "HEAD" ? null : markdown, {
     status: pageResponse.status,
     headers: headersOut,
+  });
+}
+
+export function applyMarkdownNegotiationHeaders(
+  response: Response,
+  options: ApplyMarkdownNegotiationHeadersOptions,
+): Response {
+  if (!isHtmlResponse(response)) {
+    return response;
+  }
+
+  const target = resolveMarkdownMirrorTarget(options.config, options.pathname, {
+    accept: "text/markdown",
+  });
+  if (!target) {
+    return response;
+  }
+
+  const alternatePath = getMarkdownAlternatePath(target.pathname);
+  const headers = new Headers(response.headers);
+  appendHeaderToken(headers, "Vary", "Accept");
+  headers.append("Link", `<${alternatePath}>; rel="alternate"; type="text/markdown"`);
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
   });
 }
 
@@ -228,12 +283,49 @@ function normalizeMarkdownRouteInput(input: FarmMarkdownRouteInput): FarmMarkdow
 }
 
 function normalizeMarkdownRoute(route: string): string {
-  const withoutMarkdownExtension = route.endsWith(".md") ? route.slice(0, -3) : route;
+  const withoutMarkdownExtension = route.toLowerCase().endsWith(".md") ? route.slice(0, -3) : route;
   const withSlash = withoutMarkdownExtension.startsWith("/")
     ? withoutMarkdownExtension
     : `/${withoutMarkdownExtension}`;
   const normalized = withSlash.replace(/\/+/g, "/").replace(/\/$/g, "");
   return normalized === "" || normalized === "/index" ? "/" : normalized;
+}
+
+export function requestAcceptsMarkdown(accept: string | null | undefined): boolean {
+  if (!accept) {
+    return false;
+  }
+
+  return accept.split(",").some((entry) => {
+    const [mediaType, ...parameters] = entry
+      .trim()
+      .toLowerCase()
+      .split(";")
+      .map((part) => part.trim());
+    if (mediaType !== "text/markdown") {
+      return false;
+    }
+
+    const quality = parameters.find((parameter) => parameter.startsWith("q="));
+    return quality === undefined || Number(quality.slice(2)) > 0;
+  });
+}
+
+function getMarkdownAlternatePath(pathname: string): string {
+  return pathname === "/" ? "/index.md" : `${pathname}.md`;
+}
+
+function appendHeaderToken(headers: Headers, name: string, token: string): void {
+  const current = headers.get(name);
+  if (!current) {
+    headers.set(name, token);
+    return;
+  }
+
+  const tokens = current.split(",").map((value) => value.trim().toLowerCase());
+  if (!tokens.includes(token.toLowerCase())) {
+    headers.set(name, `${current}, ${token}`);
+  }
 }
 
 function findExposedMarkdownRoute(

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -65,6 +65,7 @@ type UniversalPageRoute = {
   pattern: string;
   modulePath: string;
   source?: string;
+  markdownSourcePath?: string;
 };
 type UniversalBoundaryRoute = {
   pattern: string;
@@ -620,11 +621,17 @@ export async function buildUniversal(
     // Get page routes first (needed for both client and SSR builds)
     const pageRoutes: UniversalPageRoute[] = [];
     for (const [pattern, entry] of routeManager.getRoutes()) {
+      const markdownSourcePath =
+        entry.markdownSourcePath ||
+        (isFarmMarkdownPageFile(entry.modulePath) ? entry.modulePath : undefined);
       pageRoutes.push({
         pattern,
         modulePath: entry.modulePath,
-        ...(isFarmMarkdownPageFile(entry.modulePath)
-          ? { source: readFileSync(entry.modulePath, "utf8") }
+        ...(markdownSourcePath
+          ? {
+              source: readFileSync(markdownSourcePath, "utf8"),
+              markdownSourcePath,
+            }
           : {}),
       });
     }
@@ -2780,9 +2787,7 @@ function generateVirtualEntryCode(
   // Generate imports for all page routes
   const pageImports: string[] = [];
   const pageRegistrations: string[] = [];
-  const hasMarkdownPages = pageRoutes.some(
-    (route) => route.source !== undefined || isFarmMarkdownPageFile(route.modulePath),
-  );
+  const hasMarkdownPages = pageRoutes.some((route) => route.source !== undefined);
   const orderedPageRoutes = pageRoutes
     .map((route, index) => ({ route, index }))
     .sort(
@@ -2794,7 +2799,7 @@ function generateVirtualEntryCode(
 
   orderedPageRoutes.forEach((route, index) => {
     const varName = `pageRoute${index}`;
-    if (route.source !== undefined || isFarmMarkdownPageFile(route.modulePath)) {
+    if (isFarmMarkdownPageFile(route.modulePath)) {
       pageRegistrations.push(`
   {
     pattern: ${JSON.stringify(route.pattern)},
@@ -2806,7 +2811,7 @@ function generateVirtualEntryCode(
     }),
     markdownSource: {
       source: ${JSON.stringify(route.source ?? "")},
-      filePath: ${JSON.stringify(route.modulePath)},
+      filePath: ${JSON.stringify(route.markdownSourcePath ?? route.modulePath)},
     },
   }`);
       return;
@@ -2819,6 +2824,14 @@ function generateVirtualEntryCode(
     pattern: ${JSON.stringify(route.pattern)},
     module: ${varName},
     shouldHydrate: ${JSON.stringify(shouldHydrate)},
+    ${
+      route.source !== undefined
+        ? `markdownSource: {
+      source: ${JSON.stringify(route.source)},
+      filePath: ${JSON.stringify(route.markdownSourcePath)},
+    },`
+        : ""
+    }
   }`);
   });
 
@@ -2951,7 +2964,7 @@ import { dirname as farmDocsDirname, join as farmDocsJoin } from "node:path";
 import { fileURLToPath as farmDocsFileURLToPath } from "node:url";`
     : "";
   const markdownHandlerImport = config.md?.enabled
-    ? `import { createMarkdownMirrorResponse } from "@farm.js/core/markdown";`
+    ? `import { applyMarkdownNegotiationHeaders, createMarkdownMirrorResponse } from "@farm.js/core/markdown";`
     : "";
   const appMarkdownImport = hasMarkdownPages
     ? `import { createFarmMarkdownRouteModule, createFarmMarkdownSourceResponse } from "@farm.js/core/app-markdown";`
@@ -4350,9 +4363,9 @@ async function getCachedPPRShell(cacheKey) {
  * Main request handler - created at runtime with bundled routes
  */
 async function handleFarmRequest(request) {
-  ${
+  const response = await ${
     config.i18n.enabled
-      ? `return _runWithFarmI18nRequest(
+      ? `_runWithFarmI18nRequest(
     farmI18nRuntime,
     request,
     async function(farmLocaleResolution) {
@@ -4371,9 +4384,21 @@ async function handleFarmRequest(request) {
       const response = await handleFarmRequestInContext(request, farmLocaleResolution);
       return applyFarmI18nResponse(response, farmLocaleResolution);
     }
-  );`
-      : "return handleFarmRequestInContext(request, null);"
+  )`
+      : "handleFarmRequestInContext(request, null)"
+  };
+  ${
+    config.md?.enabled
+      ? `const pathname = getFarmRoutePathname(new URL(request.url).pathname);
+  if (matchPageRoute(pathname)) {
+    return applyMarkdownNegotiationHeaders(response, {
+      config: farmMarkdownConfig,
+      pathname,
+    });
+  }`
+      : ""
   }
+  return response;
 }
 
 async function handleFarmRequestInContext(

--- a/packages/farm/src/routing/route-manager.ts
+++ b/packages/farm/src/routing/route-manager.ts
@@ -64,6 +64,7 @@ import { createRouteSlotContainerId, parseRouteSlotFile } from "./route-slots";
 interface RouteEntry {
   route: ParsedRoute;
   modulePath: string;
+  markdownSourcePath?: string;
   pattern: string;
   source?: "file" | "programmatic";
   sourceRoot: string;
@@ -586,8 +587,72 @@ export class RouteManager {
       appDir,
     );
 
+    const canonicalPageGroups = new Map<
+      string,
+      {
+        route: ParsedRoute;
+        files: string[];
+      }
+    >();
+    for (const file of pageFiles.filter((candidate) => parseRouteSlotFile(candidate) === null)) {
+      const route = parseRoutePath(file);
+      const pattern = this.createRoutePattern(route);
+      const group = canonicalPageGroups.get(pattern);
+      if (group) {
+        group.files.push(file);
+      } else {
+        canonicalPageGroups.set(pattern, {
+          route,
+          files: [file],
+        });
+      }
+    }
+
+    for (const [pattern, group] of canonicalPageGroups) {
+      const componentFiles = group.files.filter((file) => !isFarmMarkdownPageFile(file));
+      const markdownFiles = group.files.filter(isFarmMarkdownPageFile);
+      if (componentFiles.length > 1) {
+        throw new Error(
+          `Duplicate page route "${pattern}". Found ${componentFiles
+            .map((file) => path.join(appDir, file))
+            .join(" and ")}.`,
+        );
+      }
+      if (markdownFiles.length > 1) {
+        throw new Error(
+          `Duplicate markdown representation for page route "${pattern}". Found ${markdownFiles
+            .map((file) => path.join(appDir, file))
+            .join(" and ")}.`,
+        );
+      }
+
+      const componentFile = componentFiles[0];
+      const markdownFile = markdownFiles[0];
+      const primaryFile = componentFile || markdownFile;
+      if (!primaryFile) continue;
+
+      const modulePath = path.join(appDir, primaryFile);
+      const existing = this.routes.get(pattern);
+      if (existing?.sourceRoot === source.root) {
+        throw new Error(
+          `Duplicate page route "${pattern}". Found both ${existing.modulePath} and ${modulePath}.`,
+        );
+      }
+      this.routes.set(pattern, {
+        route: group.route,
+        modulePath,
+        ...(markdownFile
+          ? {
+              markdownSourcePath: path.join(appDir, markdownFile),
+            }
+          : {}),
+        pattern,
+        source: "file",
+        sourceRoot: source.root,
+      });
+    }
+
     for (const [kind, files, target] of [
-      ["page", pageFiles.filter((file) => parseRouteSlotFile(file) === null), this.routes],
       ["layout", layoutFiles, this.layouts],
       ["loading", loadingFiles, this.loadings],
       ["error", errorFiles, this.errors],

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -16,7 +16,7 @@ import {
   scanProgrammaticPagePaths,
 } from "./routes";
 import type { FarmDocsAPIHandler } from "./docs";
-import { createMarkdownMirrorResponse } from "./markdown";
+import { createMarkdownMirrorResponse, resolveMarkdownMirrorTarget } from "./markdown";
 import { createFarmMarkdownSourceResponse, isFarmMarkdownPageFile } from "./app-markdown";
 import { sendWebResponse } from "./server/response";
 import {
@@ -1094,12 +1094,17 @@ export function farmPlugin(
             config: farmApp.getConfig().mdx,
             resolveSource: async (pathname) => {
               const match = farmApp.getRouteManager().matchRoute(pathname);
-              if (!match.route || !isFarmMarkdownPageFile(match.route.modulePath)) {
+              const sourcePath =
+                match.route?.markdownSourcePath ||
+                (match.route && isFarmMarkdownPageFile(match.route.modulePath)
+                  ? match.route.modulePath
+                  : null);
+              if (!sourcePath) {
                 return null;
               }
               return {
-                source: await fs.promises.readFile(match.route.modulePath, "utf8"),
-                filePath: match.route.modulePath,
+                source: await fs.promises.readFile(sourcePath, "utf8"),
+                filePath: sourcePath,
               };
             },
           });
@@ -1121,6 +1126,37 @@ export function farmPlugin(
           if (markdownResponse) {
             await sendWebResponse(res, markdownResponse);
             return;
+          }
+
+          const markdownPageTarget = resolveMarkdownMirrorTarget(
+            farmApp.getConfig().md,
+            requestPathname,
+            {
+              accept: "text/markdown",
+            },
+          );
+          if (
+            markdownPageTarget &&
+            farmApp.getRouteManager().matchRoute(markdownPageTarget.pathname).route
+          ) {
+            const vary = res.getHeader("Vary");
+            const varyValues = String(vary || "")
+              .split(",")
+              .map((value) => value.trim())
+              .filter(Boolean);
+            if (!varyValues.some((value) => value.toLowerCase() === "accept")) {
+              res.setHeader("Vary", [...varyValues, "Accept"].join(", "));
+            }
+            const alternatePath =
+              markdownPageTarget.pathname === "/"
+                ? "/index.md"
+                : `${markdownPageTarget.pathname}.md`;
+            const alternateLink = `<${alternatePath}>; rel="alternate"; type="text/markdown"`;
+            const currentLink = res.getHeader("Link");
+            res.setHeader(
+              "Link",
+              currentLink ? `${String(currentLink)}, ${alternateLink}` : alternateLink,
+            );
           }
 
           if (


### PR DESCRIPTION
## What changed

- expose a Markdown representation for every app page automatically
- serve `/route.md` and support `Accept: text/markdown`
- map the root route to `/index.md`
- let a colocated `page.md` or `page.mdx` override the generated representation while `page.tsx` continues to own the HTML route
- preserve source Markdown for Markdown-first routes
- advertise Markdown alternatives from HTML responses with `Vary: Accept` and `Link` headers
- allow generated mirrors to be restricted or disabled through `md`
- document the routing precedence, configuration, and private-route considerations

## Why

Agents, crawlers, documentation tools, and support workflows should be able to request a compact text representation of normal application pages without developers maintaining a second routing system. Colocated Markdown remains available when an authored representation is more accurate than HTML-to-Markdown conversion.

## Behavior

| Route files | HTML response | Markdown response |
| --- | --- | --- |
| `page.tsx` | rendered React page | generated from rendered HTML |
| `page.tsx` + `page.md`/`page.mdx` | rendered React page | exact colocated source |
| `page.md`/`page.mdx` only | rendered Markdown page | exact source |

Normal HTML rendering, hydration, client state, and interactions are unchanged.

## Validation

- 54 focused Markdown and route-discovery tests pass
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter farmjs-docs build`
- production runtime checks for `/index.md`, `Accept: text/markdown`, authored sidecar precedence, HTML isolation, alternate headers, and existing docs source routes
- broader core run reached 743 passing tests; remaining failures in the isolated worktree require unrelated unpublished integration aliases and the optional React 18 compatibility fixture
