### PR TITLE
feat: refine homepage navigation and product copy

### DIFF
--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -19,7 +19,6 @@ import {
   Plug,
   Rocket,
   Route,
-  Settings2,
   Terminal,
   Workflow,
   X,
@@ -88,7 +87,7 @@ export const metadata = {
 
 const navItems = [
   { index: "01", label: "Guide", href: "/docs/getting-started", icon: BookOpen },
-  { index: "02", label: "Config", href: "/docs/configuration", icon: Settings2 },
+  { index: "02", label: "Migrations", href: "/docs/migrations", icon: GitFork },
   { index: "03", label: "Integrations", href: "/docs/integrations", icon: Blocks },
   { index: "04", label: "Resources", href: "/docs", icon: FileText },
 ] as const;
@@ -221,7 +220,7 @@ const ecosystemItems = [
   { label: "React 19", href: withFarmReferral("https://react.dev/"), brand: reactIconUrl },
   { label: "Stripe", href: withFarmReferral("https://stripe.com/"), brand: stripeIconUrl },
   {
-    label: "Cloudflare Agents",
+    label: "Cloudflare",
     href: withFarmReferral("https://developers.cloudflare.com/agents/"),
     brand: cloudflareIconUrl,
   },


### PR DESCRIPTION
## What changed

- replace the homepage navbar's **Config** link with **Migrations**
- point the new navigation item to `/docs/migrations`
- use the existing migration icon
- rename the product-stack tile from **Cloudflare Agents** to **Cloudflare**
- preserve the more specific Cloudflare Agents naming in integration content

## Impact

The homepage now gives migration guides a direct entry point and presents Cloudflare as the broader platform in the product stack. Desktop and mobile navigation share the same updated item.

## Validation

- `oxfmt --check docs/src/app/page.tsx`
- `pnpm --filter farmjs-docs build`
- production SSR verification confirmed two `/docs/migrations` navigation links and the external product-stack label `Cloudflare`
