### PR TITLE
feat: polish docs code blocks

### DIFF
--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -592,9 +592,11 @@ describe("createFarmDocsHandler", () => {
     expect(html).toContain(
       "#nd-docs-layout figure.shiki.code-block > .code-copy-floating { opacity: 0.72;",
     );
+    expect(html).toContain("color-mix(in srgb, var(--color-fd-foreground, #fff) 4%, transparent)");
     expect(html).toContain("@media (max-width: 640px)");
-    expect(html).toContain(".code-block-header { min-height: 22px;");
-    expect(html).toContain("padding: 10px !important; font-size: 11px;");
+    expect(html).toContain(".code-block-header { min-height: 30px;");
+    expect(html).toContain("padding: 12px !important; font-size: 12px;");
+    expect(html).toContain(".code-block-plain pre { padding: 16px 44px 16px 14px !important;");
     expect(html).toContain("text-transform: lowercase");
     expect(html).toContain('.code-copy[data-copied="true"] .code-copy-check { display: block; }');
     expect(html).not.toContain('<span class="code-block-title">bash</span>');

--- a/packages/farm/src/docs/handler.ts
+++ b/packages/farm/src/docs/handler.ts
@@ -1735,7 +1735,7 @@ function renderFarmDocsBridgeCss(docs: FarmDocsResolvedConfig): string {
     .sh-code { --sh-class: #e5c07b; --sh-identifier: #c8ccd4; --sh-string: #98c379; --sh-keyword: #c678dd; --sh-comment: #5c6370; --sh-property: #e06c75; --sh-sign: #c8ccd4; --sh-space: inherit; }
     .code-block { --fd-code-header-bg: color-mix(in srgb, var(--color-fd-foreground, #fff) 5%, var(--color-fd-background, #000)); --fd-code-body-bg: color-mix(in srgb, var(--color-fd-foreground, #fff) 8%, var(--color-fd-background, #000)); position: relative; width: 100%; min-width: 0; max-width: 100%; margin: 20px 0; overflow: hidden; border: 1px solid var(--color-fd-border, hsl(0 0% 15%)); background: var(--color-fd-background, hsl(0 0% 2%)); box-shadow: 3px 3px 0 0 var(--color-fd-border, hsl(0 0% 15%)); font-family: var(--fd-docs-font-mono); }
     #nd-docs-layout figure.shiki.code-block { box-shadow: 3px 3px 0 0 var(--color-fd-border, hsl(0 0% 15%)) !important; }
-    .code-block-header { display: flex; align-items: center; justify-content: space-between; gap: 10px; min-width: 0; min-height: 30px; border-bottom: 1px solid var(--color-fd-border, hsl(0 0% 15%)); background-color: var(--fd-code-header-bg); background-image: repeating-linear-gradient(-45deg, color-mix(in srgb, var(--color-fd-foreground, #fff) 7%, transparent), color-mix(in srgb, var(--color-fd-foreground, #fff) 7%, transparent) 1px, transparent 1px, transparent 6px); padding: 4px 8px 4px 10px; }
+    .code-block-header { display: flex; align-items: center; justify-content: space-between; gap: 10px; min-width: 0; min-height: 34px; border-bottom: 1px solid var(--color-fd-border, hsl(0 0% 15%)); background-color: var(--fd-code-header-bg); background-image: repeating-linear-gradient(-45deg, color-mix(in srgb, var(--color-fd-foreground, #fff) 4%, transparent), color-mix(in srgb, var(--color-fd-foreground, #fff) 4%, transparent) 1px, transparent 1px, transparent 6px); padding: 4px 8px 4px 10px; }
     .code-block-title { overflow: hidden; color: color-mix(in srgb, var(--color-fd-foreground, #fff) 50%, transparent); font-size: 10px; line-height: 1.2; text-overflow: ellipsis; text-transform: lowercase; white-space: nowrap; }
     .code-copy { display: inline-flex; align-items: center; justify-content: center; width: 22px; height: 22px; flex: 0 0 auto; border: 1px solid var(--color-fd-border, hsl(0 0% 15%)); background: color-mix(in srgb, var(--color-fd-background, #000) 80%, transparent); color: var(--color-fd-muted-foreground, hsl(0 0% 55%)); cursor: pointer; padding: 0; }
     .code-copy-floating { position: absolute; top: 8px; right: 8px; z-index: 2; opacity: 0.72; transition: opacity 150ms ease; }
@@ -1803,7 +1803,7 @@ function renderFarmDocsBridgeCss(docs: FarmDocsResolvedConfig): string {
       .prose h2 { margin-top: 34px; padding-top: 22px; font-size: 23px; }
       .code-block { margin: 16px 0; box-shadow: 2px 2px 0 0 var(--color-fd-border, hsl(0 0% 15%)); }
       #nd-docs-layout figure.shiki.code-block { box-shadow: 2px 2px 0 0 var(--color-fd-border, hsl(0 0% 15%)) !important; }
-      .code-block-header { min-height: 26px; padding: 2px 6px 2px 8px; }
+      .code-block-header { min-height: 32px; padding: 3px 7px 3px 9px; }
       .code-copy-floating { top: 6px; right: 6px; }
       #nd-docs-layout figure.shiki.code-block pre, .code-block pre { padding: 12px 11px !important; font-size: 12px; line-height: 1.5; }
       .sh__line { min-height: 1.5em; }
@@ -1813,13 +1813,11 @@ function renderFarmDocsBridgeCss(docs: FarmDocsResolvedConfig): string {
       .fd-page-footer .fd-last-updated-footer { margin-left: 0; }
     }
     @media (max-width: 640px) {
-      .code-block-header { min-height: 22px; padding: 1px 4px 1px 7px; }
-      .code-block-title { font-size: 9px; }
-      .code-copy { width: 20px; height: 20px; }
-      .code-copy svg { width: 12px; height: 12px; }
-      .code-copy-floating { top: 5px; right: 5px; }
-      #nd-docs-layout figure.shiki.code-block pre, .code-block pre { padding: 10px !important; font-size: 11px; line-height: 1.55; }
-      .sh__line { min-height: 1.55em; }
+      .code-block-header { min-height: 30px; padding: 3px 6px 3px 8px; }
+      .code-copy-floating { top: 7px; right: 7px; }
+      #nd-docs-layout figure.shiki.code-block pre, .code-block pre { padding: 12px !important; font-size: 12px; line-height: 1.6; }
+      #nd-docs-layout figure.shiki.code-block-plain pre, .code-block-plain pre { padding: 16px 44px 16px 14px !important; line-height: 1.65; }
+      .sh__line { min-height: 1.6em; }
     }
 ${farmDocsPixelBorderCss}
   `;

--- a/packages/farm/src/docs/pixel-border-css.ts
+++ b/packages/farm/src/docs/pixel-border-css.ts
@@ -414,8 +414,8 @@ code:not(pre code) {
 }
 
 .code-block-header {
-  min-height: 28px;
-  padding: 3px 7px 3px 9px;
+  min-height: 34px;
+  padding: 4px 8px 4px 10px;
 }
 
 .code-block-title {
@@ -629,8 +629,8 @@ code:not(pre code) {
   }
 
   .code-block-header {
-    min-height: 26px;
-    padding: 2px 6px 2px 8px;
+    min-height: 32px;
+    padding: 3px 7px 3px 9px;
   }
 
   .code-copy-floating {
@@ -670,38 +670,30 @@ code:not(pre code) {
 
 @media (max-width: 640px) {
   .code-block-header {
-    min-height: 22px;
-    padding: 1px 4px 1px 7px;
-  }
-
-  .code-block-title {
-    font-size: 9px;
-  }
-
-  .code-copy {
-    width: 20px;
-    height: 20px;
-  }
-
-  .code-copy svg {
-    width: 12px;
-    height: 12px;
+    min-height: 30px;
+    padding: 3px 6px 3px 8px;
   }
 
   .code-copy-floating {
-    top: 5px;
-    right: 5px;
+    top: 7px;
+    right: 7px;
   }
 
   #nd-docs-layout figure.shiki.code-block pre,
   .code-block pre {
-    padding: 10px !important;
-    font-size: 11px;
-    line-height: 1.55;
+    padding: 12px !important;
+    font-size: 12px;
+    line-height: 1.6;
+  }
+
+  #nd-docs-layout figure.shiki.code-block-plain pre,
+  .code-block-plain pre {
+    padding: 16px 44px 16px 14px !important;
+    line-height: 1.65;
   }
 
   .sh__line {
-    min-height: 1.55em;
+    min-height: 1.6em;
   }
 }
 


### PR DESCRIPTION
## Summary

- soften the diagonal texture in labeled code-block headers
- slightly increase header height across desktop, tablet, and mobile breakpoints
- improve headerless code-block readability and copy-button spacing on mobile
- keep horizontal scrolling and copy behavior unchanged
- update docs renderer assertions for the new responsive styles

## Validation

- `pnpm --filter @farm.js/core test -- docs-handler.test.ts` (18/18)
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/core build`
- browser-verified at 1365px and 390px with no console errors or error overlays
