### PR TITLE
style: lowercase the homepage hero

### DIFF
--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -783,8 +783,8 @@ function Hero() {
         </div>
         <HeroTitleFrame>
           <h1 className="max-w-full text-[1.125rem] font-medium leading-[1.02] tracking-normal text-white min-[360px]:text-[1.3125rem] min-[380px]:text-[1.4375rem] min-[400px]:text-[1.5rem] min-[420px]:text-[1.625rem] sm:text-[2.25rem] md:text-[2.625rem] lg:text-[3.25rem]">
-            <span className="block">A Framework for</span>
-            <span className="block whitespace-nowrap">Product integrated Apps</span>
+            <span className="block">a framework for</span>
+            <span className="block whitespace-nowrap">product-integrated apps</span>
           </h1>
         </HeroTitleFrame>
         <p className="mt-5 max-w-[38rem] text-balance text-sm leading-6 text-white/56 sm:text-[15px] sm:leading-6">


### PR DESCRIPTION
## Summary

- render the homepage hero headline in lowercase sentence styling
- hyphenate `product-integrated` for clearer copy
- leave navigation and all other section typography unchanged

## Why

The lowercase treatment gives the primary homepage statement a calmer, more conversational tone without changing the established layout or typography system.

## Validation

- `pnpm exec oxfmt --check docs/src/app/page.tsx`
- `pnpm exec oxlint docs/src/app/page.tsx`
- desktop and mobile browser verification
- no console errors, page errors, or horizontal mobile overflow


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowercased the homepage hero headline and hyphenated "product-integrated" to improve tone and clarity. No changes to navigation or other section typography.

<sup>Written for commit b9de518087ae353afe330ef21c1ea4d87f8207bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

