### PR TITLE
fix: ignore vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,10 +22,9 @@ out/
 
 # Environment variables
 .env
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env.*
+!.env.example
+!.env.*.example
 
 # Logs
 npm-debug.log*

--- a/examples/basic/.env.example
+++ b/examples/basic/.env.example
@@ -1,0 +1,5 @@
+# Optional: enable the Postgres storage demo with your own connection string.
+DATABASE_URL=
+
+# Tests may use a separate database without overriding DATABASE_URL.
+FARM_TEST_POSTGRES_URL=

--- a/examples/basic/src/app/api/storage-demo/route.ts
+++ b/examples/basic/src/app/api/storage-demo/route.ts
@@ -5,9 +5,7 @@ import { z } from 'zod';
 const backendSchema = z.enum(['local', 'sqlite', 'postgres']);
 type StorageDemoBackend = z.infer<typeof backendSchema>;
 const STORAGE_DEMO_POSTGRES_URL =
-  process.env.DATABASE_URL ??
-  process.env.FARM_TEST_POSTGRES_URL ??
-  'postgresql://neondb_owner:npg_vjgLO9k0ZHIY@ep-wandering-heart-amad1lvi-pooler.c-5.us-east-1.aws.neon.tech/neondb?sslmode=require&channel_binding=require';
+  process.env.DATABASE_URL ?? process.env.FARM_TEST_POSTGRES_URL;
 const postgresTableName = 'interactive_storage_demo_pg';
 
 const STORAGE_DEMO_MOUNTS = {

--- a/examples/basic/src/lib/storage-demo.ts
+++ b/examples/basic/src/lib/storage-demo.ts
@@ -2,9 +2,7 @@ import path from 'node:path';
 import { localStorage, postgresStorage, sqliteStorage } from '@farm.js/core/storage';
 
 export const STORAGE_DEMO_POSTGRES_URL =
-  process.env.DATABASE_URL ??
-  process.env.FARM_TEST_POSTGRES_URL ??
-  'postgresql://neondb_owner:npg_vjgLO9k0ZHIY@ep-wandering-heart-amad1lvi-pooler.c-5.us-east-1.aws.neon.tech/neondb?sslmode=require&channel_binding=require';
+  process.env.DATABASE_URL ?? process.env.FARM_TEST_POSTGRES_URL;
 
 export const STORAGE_DEMO_MOUNTS = {
   local: 'storage-demo-local',


### PR DESCRIPTION
## Summary

- remove the embedded Neon database URL from both storage demo modules
- require `DATABASE_URL` or `FARM_TEST_POSTGRES_URL` to opt into the Postgres demo
- ignore every `.env.*` variant while keeping sanitized `.env.example` templates trackable
- add a safe environment template for the basic storage example

## Root cause

The storage demo included a remote database connection URL as a fallback in committed source. The existing ignore rules covered common local dotenv filenames but did not cover every environment-specific variant.

The exposed Neon credential must still be rotated separately because removing it from the current branch does not remove it from Git history.

## Validation

- basic example TypeScript check passes
- tracked-source Neon hostname and credentialed Neon DSN scan passes
- dotenv policy test confirms environment files are ignored and example templates remain trackable
- `git diff --check` passes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the hardcoded Neon Postgres URL from the storage demos and made Postgres opt-in via environment variables. Tightened `.gitignore` to ignore all `.env.*` files while keeping sanitized examples, and added a safe `.env.example` for the basic example.

- **Bug Fixes**
  - Removed embedded DSN fallback in `examples/basic/src/app/api/storage-demo/route.ts` and `examples/basic/src/lib/storage-demo.ts`; Postgres URL now reads from `DATABASE_URL` or `FARM_TEST_POSTGRES_URL` only.
  - Updated `.gitignore` to ignore `.env.*` while keeping `.env.example` and `.env.*.example` tracked.
  - Added `examples/basic/.env.example` with `DATABASE_URL` and `FARM_TEST_POSTGRES_URL` placeholders.

- **Migration**
  - To use the Postgres demo, set `DATABASE_URL` (or `FARM_TEST_POSTGRES_URL` for tests). Without these, use `local` or `sqlite`.

<sup>Written for commit 86e5767f78368e590295a1d3eff74e18a6d63025. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

