### PR TITLE
feat: add Databuddy analytics to docs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -11,6 +11,7 @@
     "db:push": "prisma db push"
   },
   "dependencies": {
+    "@databuddy/sdk": "2.6.0",
     "@farm.js/core": "workspace:*",
     "@farming-labs/docs": "^0.2.44",
     "@farming-labs/theme": "^0.2.44",

--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { LayoutProps } from "@farm.js/core";
+import { Databuddy } from "@databuddy/sdk/react";
 import geistMonoUrl from "../../node_modules/geist/dist/fonts/geist-mono/GeistMono-Variable.woff2?url";
 import geistPixelUrl from "../../node_modules/geist/dist/fonts/geist-pixel/GeistPixel-Square.woff2?url";
 import geistSansUrl from "../../node_modules/geist/dist/fonts/geist-sans/Geist-Variable.woff2?url";
@@ -59,6 +60,7 @@ export default function RootLayout({ children }: LayoutProps) {
       />
       <style dangerouslySetInnerHTML={{ __html: fontFaceCss }} />
       <main className="min-h-screen bg-black font-mono text-white">{children}</main>
+      <Databuddy clientId="0af7dbbd-628a-44c9-8814-df4138a061b0" trackWebVitals={true} />
     </>
   );
 }

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -2636,14 +2636,14 @@ async function buildSSRInMemory(
           ".prisma/client",
           ".prisma/client/default",
         ],
-        // Don't externalize these - bundle them into the SSR output
-        // Keep this list minimal for faster builds
-        noExternal: [
-          "@farm.js/core",
-          "@farm.js/core/image",
-          "better-call",
-          ...(preset === "cloudflare-module" ? [] : ["react", "react-dom", "react-dom/server"]),
-        ],
+        // Node deployments must bundle application dependencies with Farm's
+        // React runtime. Leaving a React component package external can make it
+        // resolve a second React instance at runtime and break hooks during SSR.
+        // Native and build-only packages above remain explicitly external.
+        noExternal:
+          preset === "cloudflare-module"
+            ? ["@farm.js/core", "@farm.js/core/image", "better-call"]
+            : true,
       },
       define: {
         __FARM_ENV__: JSON.stringify(config.env || { server: {}, public: {} }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
 
   docs:
     dependencies:
+      '@databuddy/sdk':
+        specifier: 2.6.0
+        version: 2.6.0(react@19.2.8)
       '@farm.js/core':
         specifier: workspace:*
         version: link:../packages/farm
@@ -2516,6 +2519,20 @@ packages:
       '@clack/core': 0.4.1
       picocolors: 1.1.1
       sisteransi: 1.0.5
+    dev: false
+
+  /@databuddy/sdk@2.6.0(react@19.2.8):
+    resolution: {integrity: sha512-coQVa/AJoesgsFSGWPFtlrl7xZx1nTTvoX3A9YLD+9f3+JDwr3ajVog3WOiLBJSLqk7xC+G+FnR/W/Wda5eWbw==}
+    peerDependencies:
+      react: '>=18'
+      vue: '>=3'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      vue:
+        optional: true
+    dependencies:
+      react: 19.2.8
     dev: false
 
   /@clerk/backend@3.2.0(react-dom@19.2.8)(react@19.2.4):


### PR DESCRIPTION
## What changed

- add `@databuddy/sdk` to the documentation site
- render `Databuddy` directly from the root layout with Web Vitals tracking enabled
- bundle Node SSR application dependencies with Farm's React runtime
- preserve the existing Cloudflare module externalization behavior

## Why

Third-party React component packages could remain external during a Node SSR build and resolve a different React instance from Farm's bundled runtime. Hook-based packages such as Databuddy then failed during SSR with an invalid hook call.

Bundling Node application dependencies through the SSR build keeps React module identity consistent while explicitly externalized native and build-only dependencies remain external.

## Impact

The website can use Databuddy as a normal React layout component without a browser-global guard or an analytics-specific Farm plugin. The SSR fix also applies generally to other hook-based React packages used by Farm applications.

## Validation

- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/core build:runtime`
- `pnpm --dir docs exec farm build`
- verified the generated Vercel handler returns 200 for `/` and `/docs/getting-started`
- verified the homepage loads `https://cdn.databuddy.cc/databuddy.js` with a 200 response and no browser console or page errors

## Known limitation

Farm's server-only Markdown routes do not currently hydrate client components placed in the root layout. Databuddy therefore runs on hydratable React routes such as the homepage, while direct visits to Markdown documentation routes will require generic client-boundary/island support in a follow-up.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `@databuddy/sdk` analytics to the docs and updated SSR bundling to keep a single React instance. This lets Databuddy and other hook-based packages work during SSR, with Web Vitals tracked.

- **New Features**
  - Render `Databuddy` in the docs root layout with Web Vitals tracking.

- **Refactors**
  - Bundle Node app dependencies with Farm’s React runtime (`noExternal: true` for Node presets) to prevent duplicate React instances and invalid hook calls.
  - Preserve Cloudflare module externalization behavior.

<sup>Written for commit e4bd9ff9744f88a481c29929ce223b8ee8ed5010. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

