### PR TITLE
feat: add first-class font loading

### DIFF
--- a/docs/src/app/docs/fonts/page.md
+++ b/docs/src/app/docs/fonts/page.md
@@ -1,0 +1,103 @@
+---
+title: "Fonts"
+description: "Load local and remote fonts as self-hosted, hashed Farm assets without runtime loader code."
+---
+
+# Fonts
+
+Farm compiles font declarations into ordinary CSS and content-hashed assets. The loader call is removed from the application bundle, so it adds no browser runtime and does not require inline styles or `dangerouslySetInnerHTML`.
+
+## Local fonts
+
+Call `localFont` at module scope in a layout or page. The source can be relative to that module or a package font specifier.
+
+```tsx title="src/app/layout.tsx"
+import { localFont } from "@farm.js/core/font";
+
+const geist = localFont({
+  src: "geist/dist/fonts/geist-sans/Geist-Variable.woff2",
+  family: "Geist Sans",
+  weight: "100 900",
+  variable: "--font-geist-sans",
+  fallback: ["system-ui", "sans-serif"],
+});
+
+export default function RootLayout({ children }) {
+  return <main className={`${geist.variable} ${geist.className}`}>{children}</main>;
+}
+```
+
+Farm emits the font with a content hash, generates its `@font-face`, and adds a preload hint by default. `display` defaults to `"swap"`.
+
+### Fonts in `public`
+
+An absolute URL beginning with `/` resolves from Farm's configured `publicDir`:
+
+```tsx title="src/app/layout.tsx"
+const geist = localFont({
+  src: "/fonts/Geist-Variable.woff2",
+  family: "Geist Sans",
+  weight: "100 900",
+  variable: "--font-geist-sans",
+});
+```
+
+For example, the source above reads `public/fonts/Geist-Variable.woff2`. Farm generates the CSS and preload hint but keeps the public URL, so it does not emit a duplicate font asset. Use a relative or package source when you want Farm to create a content-hashed filename.
+
+## Multiple weights and styles
+
+Use explicit sources when one family has more than one file.
+
+```ts
+const editorial = localFont({
+  family: "Editorial",
+  src: [
+    { path: "./Editorial-Regular.woff2", weight: 400 },
+    { path: "./Editorial-Bold.woff2", weight: 700 },
+    { path: "./Editorial-Italic.woff2", weight: 400, style: "italic" },
+  ],
+  variable: "--font-editorial",
+});
+```
+
+Set `preload: false` for sources that are not needed above the fold or are only used on a narrow route.
+
+## Remote fonts
+
+`remoteFont` downloads the file during the build and serves it from the application by default. The browser does not contact the original font host.
+
+```ts
+import { remoteFont } from "@farm.js/core/font";
+
+const brand = remoteFont({
+  src: "https://fonts.example.com/brand.woff2",
+  family: "Brand Sans",
+  weight: "100 900",
+  variable: "--font-brand",
+  integrity: "sha384-BASE64_DIGEST",
+});
+```
+
+Remote sources must use HTTPS. Add `integrity` when the host publishes a stable file so Farm can reject unexpected bytes. Builds fail clearly when a self-hosted remote font cannot be downloaded or does not match its integrity value.
+
+Pass a direct `.woff2`, `.woff`, `.ttf`, or `.otf` URL, not a provider stylesheet URL. For Geist, installing the `geist` package and using `localFont` keeps the font version in the lockfile. For Google Fonts, download the licensed font files into the project or use their direct font-file URLs with `remoteFont`.
+
+If a license or hosting policy requires the browser to retain the original URL, opt into external loading:
+
+```ts
+const partner = remoteFont({
+  src: "https://cdn.example.com/partner.woff2",
+  family: "Partner Sans",
+  strategy: "external",
+});
+```
+
+## Returned values
+
+Every loader returns:
+
+- `className`, which applies the generated font stack
+- `variable`, which defines the configured CSS custom property, or an empty string when none was configured
+- `style`, an inline-style compatible object containing `fontFamily` and any fixed style or weight
+
+The options must be static and the call must initialize a module-scope variable. This lets Farm resolve files, validate remote URLs, deduplicate identical declarations, generate CSS, and assign assets to the build before application code runs.

--- a/docs/src/app/docs/page.md
+++ b/docs/src/app/docs/page.md
@@ -20,6 +20,7 @@ Create an app and learn the files that matter.
 Routes, rendering, layouts, and request flow.
 
 - [Routing](/docs/routing): Farm uses an app directory routing model with static routes, dynamic segments, catch-all routes, and typed navigation.
+- [Fonts](/docs/fonts): Compile local or remote fonts into self-hosted, hashed assets with generated CSS and no loader runtime.
 - [Layouts and Route Boundaries](/docs/layouts): Wrap routes with root and nested layouts, then use loading, error, and not-found files for route-level UX.
 - [Rendering Model](/docs/server-rendering): Choose dynamic rendering, static rendering, ISR, or PPR with route-level exports and config.
 - [Built-in Authentication](/docs/auth): Enable email/password auth, sessions, server helpers, and React APIs with the top-level `auth` framework config.

--- a/docs/src/app/docs/reference/page.md
+++ b/docs/src/app/docs/reference/page.md
@@ -44,6 +44,7 @@ A compact map of the main package exports and where to learn more.
 | `@farm.js/core/client`           | `createIntegrations`, `createIntegrationClient`, `createIntegrationServerClient`, `endpoint`.              |
 | `@farm.js/core/plugin/client`    | `createClientPluginManager` and browser lifecycle types for advanced tooling.                              |
 | `@farm.js/core/navigation`       | `redirect`, `permanentRedirect`, `notFound`, `useRouter`, `usePathname`, `useSearchParams`.                |
+| `@farm.js/core/font`             | Build-time `localFont` and `remoteFont` loaders with generated CSS, hashed assets, and preload hints.      |
 | `@farm.js/core/headers`          | `headers`, `cookies`.                                                                                      |
 | `@farm.js/core/router`           | `createFarmRouter`, `matchFarmRoute`, `buildFarmRoutePath`, `isFarmRouteActive`.                           |
 | `@farm.js/core/storage`          | `sqliteStorage`, `postgresStorage`, `redisStorage`, `createStorageClient`, `defineStorageClient`.          |

--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -16,8 +16,8 @@
 
   body {
     font-family:
-      var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-      "Liberation Mono", "Courier New", monospace;
+      "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+      "Courier New", monospace;
     margin: 0;
     background: var(--farm-bg);
     font-synthesis: none;

--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -2,37 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
-@font-face {
-  font-family: "Geist Sans";
-  src: url("../../node_modules/geist/dist/fonts/geist-sans/Geist-Variable.woff2") format("woff2");
-  font-display: block;
-  font-style: normal;
-  font-weight: 100 900;
-}
-
-@font-face {
-  font-family: "Geist Mono";
-  src: url("../../node_modules/geist/dist/fonts/geist-mono/GeistMono-Variable.woff2")
-    format("woff2");
-  font-display: block;
-  font-style: normal;
-  font-weight: 100 900;
-}
-
-@font-face {
-  font-family: "Geist Pixel Square";
-  src: url("../../node_modules/geist/dist/fonts/geist-pixel/GeistPixel-Square.woff2")
-    format("woff2");
-  font-display: block;
-  font-style: normal;
-  font-weight: 500;
-}
-
 @layer base {
   :root {
-    --font-geist-sans: "Geist Sans";
-    --font-geist-mono: "Geist Mono";
-    --font-geist-pixel: "Geist Pixel Square";
     --farm-bg: #000;
     --farm-line: rgb(255 255 255 / 0.12);
     --farm-line-soft: rgb(255 255 255 / 0.055);

--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -1,8 +1,6 @@
 import type { LayoutProps } from "@farm.js/core";
+import { localFont } from "@farm.js/core/font";
 import { Databuddy } from "@databuddy/sdk/react";
-import geistMonoUrl from "../../node_modules/geist/dist/fonts/geist-mono/GeistMono-Variable.woff2?url";
-import geistPixelUrl from "../../node_modules/geist/dist/fonts/geist-pixel/GeistPixel-Square.woff2?url";
-import geistSansUrl from "../../node_modules/geist/dist/fonts/geist-sans/Geist-Variable.woff2?url";
 import "./globals.css";
 
 export const metadata = {
@@ -14,52 +12,38 @@ export const metadata = {
   },
 };
 
-const fontFaceCss = `
-@font-face {
-  font-family: "Geist Sans";
-  src: url("${geistSansUrl}") format("woff2");
-  font-display: block;
-  font-style: normal;
-  font-weight: 100 900;
-}
+const geistSans = localFont({
+  src: "../../node_modules/geist/dist/fonts/geist-sans/Geist-Variable.woff2",
+  family: "Geist Sans",
+  weight: "100 900",
+  variable: "--font-geist-sans",
+  fallback: ["ui-sans-serif", "system-ui", "sans-serif"],
+});
 
-@font-face {
-  font-family: "Geist Mono";
-  src: url("${geistMonoUrl}") format("woff2");
-  font-display: block;
-  font-style: normal;
-  font-weight: 100 900;
-}
+const geistMono = localFont({
+  src: "../../node_modules/geist/dist/fonts/geist-mono/GeistMono-Variable.woff2",
+  family: "Geist Mono",
+  weight: "100 900",
+  variable: "--font-geist-mono",
+  fallback: ["ui-monospace", "monospace"],
+});
 
-@font-face {
-  font-family: "Geist Pixel Square";
-  src: url("${geistPixelUrl}") format("woff2");
-  font-display: block;
-  font-style: normal;
-  font-weight: 500;
-}
-
-:root {
-  --font-geist-sans: "Geist Sans";
-  --font-geist-mono: "Geist Mono";
-  --font-geist-pixel: "Geist Pixel Square";
-}
-`;
+const geistPixel = localFont({
+  src: "../../node_modules/geist/dist/fonts/geist-pixel/GeistPixel-Square.woff2",
+  family: "Geist Pixel Square",
+  weight: 500,
+  variable: "--font-geist-pixel",
+  fallback: ["monospace"],
+});
 
 export default function RootLayout({ children }: LayoutProps) {
   return (
     <>
-      <link rel="preload" href={geistSansUrl} as="font" type="font/woff2" crossOrigin="anonymous" />
-      <link rel="preload" href={geistMonoUrl} as="font" type="font/woff2" crossOrigin="anonymous" />
-      <link
-        rel="preload"
-        href={geistPixelUrl}
-        as="font"
-        type="font/woff2"
-        crossOrigin="anonymous"
-      />
-      <style dangerouslySetInnerHTML={{ __html: fontFaceCss }} />
-      <main className="min-h-screen bg-black font-mono text-white">{children}</main>
+      <main
+        className={`${geistSans.variable} ${geistMono.variable} ${geistPixel.variable} ${geistMono.className} min-h-screen bg-black text-white`}
+      >
+        {children}
+      </main>
       <Databuddy clientId="0af7dbbd-628a-44c9-8814-df4138a061b0" trackWebVitals={true} />
     </>
   );

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -102,6 +102,9 @@
       "environment/vite": [
         "./dist/environment/vite.d.ts"
       ],
+      "font": [
+        "./dist/font.d.ts"
+      ],
       "testing": [
         "./dist/testing.d.ts"
       ],
@@ -320,6 +323,11 @@
       "types": "./dist/environment/vite.d.ts",
       "import": "./dist/environment/vite.mjs",
       "require": "./dist/environment/vite.cjs"
+    },
+    "./font": {
+      "types": "./dist/font.d.ts",
+      "import": "./dist/font.mjs",
+      "require": "./dist/font.cjs"
     },
     "./vite": {
       "types": "./dist/vite.d.ts",

--- a/packages/farm/src/__tests__/font-vite.test.ts
+++ b/packages/farm/src/__tests__/font-vite.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { build, createServer, type Plugin, type Rollup } from "vite";
 import { describe, expect, it, vi } from "vitest";
 import { farmFontImportsPlugin, mergeFarmFontCss, renderFarmFontDevHead } from "../font-vite";
+import { appendFarmLinkHeader } from "../nitro/production-runtime";
 import { farmPlugin } from "../vite";
 
 function fontRuntimeStub(): Plugin {
@@ -57,7 +58,7 @@ export const demo = localFont({ src: "./demo.woff2", family: "Dev Demo" });`,
       root,
       configFile: false,
       logLevel: "silent",
-      plugins: [fontRuntimeStub(), farmFontImportsPlugin({ root })],
+      plugins: [fontRuntimeStub(), farmFontImportsPlugin({ root, basePath: "/docs" })],
       server: { middlewareMode: true },
     });
     const http = createHttpServer(vite.middlewares);
@@ -67,8 +68,10 @@ export const demo = localFont({ src: "./demo.woff2", family: "Dev Demo" });`,
       expect(transformed?.code).toContain("farm-font-");
       expect(transformed?.code).not.toContain("font-runtime-stub");
       expect(transformed?.code).not.toContain("@farm.js/core/font");
+      expect(transformed?.code).toContain("font-css");
       expect(renderFarmFontDevHead(root)).toContain('<link rel="preload"');
-      expect(renderFarmFontDevHead(root)).toContain('href="/@farm/fonts.css"');
+      expect(renderFarmFontDevHead(root)).toContain('href="/docs/@farm/font/');
+      expect(renderFarmFontDevHead(root)).not.toContain('rel="stylesheet"');
 
       await new Promise<void>((resolve) => http.listen(0, "127.0.0.1", resolve));
       const address = http.address();
@@ -78,9 +81,58 @@ export const demo = localFont({ src: "./demo.woff2", family: "Dev Demo" });`,
       const fontPath = css.match(/url\("([^"]+)"\)/)?.[1];
 
       expect(css).toContain('font-family: "Dev Demo"');
-      expect(fontPath).toMatch(/^\/@farm\/font\/[a-f0-9]{12}\.woff2$/);
+      expect(fontPath).toMatch(/^\/docs\/@farm\/font\/[a-f0-9]{12}\.woff2$/);
       const bytes = await fetch(`${origin}${fontPath}`).then((response) => response.text());
       expect(bytes).toBe("development-font");
+    } finally {
+      if (http.listening) {
+        await new Promise<void>((resolve, reject) =>
+          http.close((error) => (error ? reject(error) : resolve())),
+        );
+      }
+      await vite.close();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("serves publicDir fonts from their Vite URL in base-path development", async () => {
+    const temporaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "farm-font-public-dev-"));
+    const root = await fs.realpath(temporaryRoot);
+    await fs.mkdir(path.join(root, "public", "fonts"), { recursive: true });
+    await fs.writeFile(
+      path.join(root, "public", "fonts", "public.woff2"),
+      Buffer.from("public-development-font"),
+    );
+    await fs.writeFile(
+      path.join(root, "entry.ts"),
+      `import { localFont } from "@farm.js/core/font";
+export const demo = localFont({ src: "/fonts/public.woff2", family: "Public Dev" });`,
+    );
+    const vite = await createServer({
+      root,
+      configFile: false,
+      logLevel: "silent",
+      plugins: [fontRuntimeStub(), farmFontImportsPlugin({ root, basePath: "/docs" })],
+      server: { middlewareMode: true },
+    });
+    const http = createHttpServer(vite.middlewares);
+
+    try {
+      await vite.transformRequest("/entry.ts");
+      const head = renderFarmFontDevHead(root);
+      expect(head).toContain('href="/fonts/public.woff2"');
+      expect(head).not.toContain('href="/docs/fonts/public.woff2"');
+
+      await new Promise<void>((resolve) => http.listen(0, "127.0.0.1", resolve));
+      const address = http.address();
+      if (!address || typeof address === "string") throw new Error("Missing test server address");
+      const origin = `http://127.0.0.1:${address.port}`;
+      const css = await fetch(`${origin}/@farm/fonts.css`).then((response) => response.text());
+
+      expect(css).toContain('url("/fonts/public.woff2")');
+      await expect(
+        fetch(`${origin}/fonts/public.woff2`).then((response) => response.text()),
+      ).resolves.toBe("public-development-font");
     } finally {
       if (http.listening) {
         await new Promise<void>((resolve, reject) =>
@@ -145,6 +197,25 @@ console.log(demo, farmFontPreloadHeader);`,
       expect(css).toContain("--font-demo:");
       expect(fontAsset?.fileName).toMatch(/^assets\/fonts\/demo-[a-f0-9]{12}\.woff2$/);
       expect(Buffer.from(fontAsset?.source || []).toString()).toBe("test-font-binary");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects loader bindings that would remain after their import is compiled away", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-font-binding-"));
+    try {
+      await fs.writeFile(path.join(root, "demo.woff2"), Buffer.from("binding-font"));
+      await fs.writeFile(
+        path.join(root, "entry.ts"),
+        `import { localFont } from "@farm.js/core/font";
+export const demo = localFont({ src: "./demo.woff2", family: "Binding Demo" });
+console.log(localFont, demo);`,
+      );
+
+      await expect(buildFixture(root)).rejects.toThrow(
+        "localFont can only be referenced by statically compiled font declarations",
+      );
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }
@@ -269,6 +340,103 @@ console.log(demo);`,
       vi.unstubAllGlobals();
       await fs.rm(root, { recursive: true, force: true });
     }
+  });
+
+  it("refetches remote fonts across builds and emits only the current asset", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-font-remote-rebuild-"));
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(Buffer.from("remote-font-v1"), { status: 200 }))
+      .mockResolvedValueOnce(new Response(Buffer.from("remote-font-v2"), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      await fs.writeFile(
+        path.join(root, "entry.ts"),
+        `import { remoteFont } from "@farm.js/core/font";
+export const demo = remoteFont({
+  src: "https://fonts.example.test/rebuild.woff2",
+  family: "Remote Rebuild",
+});
+console.log(demo);`,
+      );
+
+      await buildFixture(root);
+      const secondResult = await buildFixture(root);
+      const fontAssets = secondResult.output.filter(
+        (output): output is Rollup.OutputAsset =>
+          output.type === "asset" && output.fileName.startsWith("assets/fonts/"),
+      );
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fontAssets).toHaveLength(1);
+      expect(Buffer.from(fontAssets[0].source).toString()).toBe("remote-font-v2");
+    } finally {
+      vi.unstubAllGlobals();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("stops reading a remote font as soon as it exceeds 20 MB", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-font-remote-limit-"));
+    const cancel = vi.fn();
+    let pulls = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulls += 1;
+        controller.enqueue(new Uint8Array(1024 * 1024));
+        if (pulls === 25) controller.close();
+      },
+      cancel,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(stream, { status: 200 })),
+    );
+
+    try {
+      await fs.writeFile(
+        path.join(root, "entry.ts"),
+        `import { remoteFont } from "@farm.js/core/font";
+export const demo = remoteFont({
+  src: "https://fonts.example.test/too-large.woff2",
+  family: "Too Large",
+});
+console.log(demo);`,
+      );
+
+      await expect(buildFixture(root)).rejects.toThrow("font exceeds the 20 MB limit");
+      expect(pulls).toBeLessThan(25);
+      expect(cancel).toHaveBeenCalledOnce();
+    } finally {
+      vi.unstubAllGlobals();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("appends configured Link values without replacing generated preloads", () => {
+    const headers = new Headers({
+      Link: "</assets/fonts/demo.woff2>; rel=preload; as=font",
+    });
+
+    appendFarmLinkHeader(headers, "</api>; rel=preconnect");
+    appendFarmLinkHeader(headers, "</api>; rel=preconnect");
+
+    expect(headers.get("Link")).toBe(
+      "</assets/fonts/demo.woff2>; rel=preload; as=font, </api>; rel=preconnect",
+    );
+  });
+
+  it("keeps font preload headers on generated PPR cache-hit responses", async () => {
+    const source = await fs.readFile(
+      path.join(process.cwd(), "src", "nitro", "universal-build.ts"),
+      "utf8",
+    );
+
+    expect(source).toMatch(
+      /farmFontPreloadHeader \? \{ "Link": farmFontPreloadHeader \} : \{\}\),\s+\.\.\.getPPRHeaders\("hit", pprConfig\)/,
+    );
+    expect(source).toContain("appendFarmLinkHeader(headers, header.value);");
   });
 
   it("replaces an earlier generated font section when client and SSR CSS are combined", () => {

--- a/packages/farm/src/__tests__/font-vite.test.ts
+++ b/packages/farm/src/__tests__/font-vite.test.ts
@@ -1,0 +1,288 @@
+// @vitest-environment node
+
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import { createServer as createHttpServer } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { build, createServer, type Plugin, type Rollup } from "vite";
+import { describe, expect, it, vi } from "vitest";
+import { farmFontImportsPlugin, mergeFarmFontCss, renderFarmFontDevHead } from "../font-vite";
+import { farmPlugin } from "../vite";
+
+function fontRuntimeStub(): Plugin {
+  return {
+    name: "font-runtime-stub",
+    enforce: "pre",
+    resolveId(id) {
+      return id === "@farm.js/core/font" ? "\0font-runtime-stub" : null;
+    },
+    load(id) {
+      if (id !== "\0font-runtime-stub") return null;
+      return "export function localFont(){}; export function remoteFont(){};";
+    },
+  };
+}
+
+async function buildFixture(root: string): Promise<Rollup.RollupOutput> {
+  const result = await build({
+    root,
+    configFile: false,
+    logLevel: "silent",
+    plugins: [fontRuntimeStub(), farmPlugin({ root })],
+    build: {
+      write: false,
+      assetsInlineLimit: 0,
+      rollupOptions: {
+        input: path.join(root, "entry.ts"),
+        output: { entryFileNames: "entry.js" },
+      },
+    },
+  });
+  if (Array.isArray(result)) throw new Error("Expected one Vite build output");
+  return result;
+}
+
+describe("Farm font compiler", () => {
+  it("serves generated CSS and font bytes during development", async () => {
+    const temporaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "farm-font-dev-"));
+    const root = await fs.realpath(temporaryRoot);
+    await fs.writeFile(path.join(root, "demo.woff2"), Buffer.from("development-font"));
+    await fs.writeFile(
+      path.join(root, "entry.ts"),
+      `import { localFont } from "@farm.js/core/font";
+export const demo = localFont({ src: "./demo.woff2", family: "Dev Demo" });`,
+    );
+    const vite = await createServer({
+      root,
+      configFile: false,
+      logLevel: "silent",
+      plugins: [fontRuntimeStub(), farmFontImportsPlugin({ root })],
+      server: { middlewareMode: true },
+    });
+    const http = createHttpServer(vite.middlewares);
+
+    try {
+      const transformed = await vite.transformRequest("/entry.ts");
+      expect(transformed?.code).toContain("farm-font-");
+      expect(transformed?.code).not.toContain("font-runtime-stub");
+      expect(transformed?.code).not.toContain("@farm.js/core/font");
+      expect(renderFarmFontDevHead(root)).toContain('<link rel="preload"');
+      expect(renderFarmFontDevHead(root)).toContain('href="/@farm/fonts.css"');
+
+      await new Promise<void>((resolve) => http.listen(0, "127.0.0.1", resolve));
+      const address = http.address();
+      if (!address || typeof address === "string") throw new Error("Missing test server address");
+      const origin = `http://127.0.0.1:${address.port}`;
+      const css = await fetch(`${origin}/@farm/fonts.css`).then((response) => response.text());
+      const fontPath = css.match(/url\("([^"]+)"\)/)?.[1];
+
+      expect(css).toContain('font-family: "Dev Demo"');
+      expect(fontPath).toMatch(/^\/@farm\/font\/[a-f0-9]{12}\.woff2$/);
+      const bytes = await fetch(`${origin}${fontPath}`).then((response) => response.text());
+      expect(bytes).toBe("development-font");
+    } finally {
+      if (http.listening) {
+        await new Promise<void>((resolve, reject) =>
+          http.close((error) => (error ? reject(error) : resolve())),
+        );
+      }
+      await vite.close();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("turns a local font call into static metadata, CSS, and a hashed asset", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-font-vite-"));
+    try {
+      const packageRoot = path.join(root, "node_modules", "demo-font");
+      await fs.mkdir(path.join(packageRoot, "dist"), { recursive: true });
+      await fs.writeFile(
+        path.join(packageRoot, "package.json"),
+        JSON.stringify({ name: "demo-font", exports: { ".": "./index.js" } }),
+      );
+      await fs.writeFile(path.join(packageRoot, "index.js"), "export default {};\n");
+      await fs.writeFile(
+        path.join(packageRoot, "dist", "demo.woff2"),
+        Buffer.from("test-font-binary"),
+      );
+      await fs.writeFile(
+        path.join(root, "entry.ts"),
+        `import { localFont } from "@farm.js/core/font";
+import { farmFontPreloadHeader } from "virtual:farm-font-runtime";
+export const demo = localFont({
+  src: "demo-font/dist/demo.woff2",
+  family: "Demo Sans",
+  weight: "100 900",
+  variable: "--font-demo",
+  fallback: ["system-ui", "sans-serif"],
+});
+console.log(demo, farmFontPreloadHeader);`,
+      );
+
+      const result = await buildFixture(root);
+      const entry = result.output.find(
+        (output): output is Rollup.OutputChunk => output.type === "chunk" && output.isEntry,
+      );
+      const css = result.output
+        .filter((output): output is Rollup.OutputAsset => output.type === "asset")
+        .filter((output) => output.fileName.endsWith(".css"))
+        .map((output) => String(output.source))
+        .join("\n");
+      const fontAsset = result.output.find(
+        (output): output is Rollup.OutputAsset =>
+          output.type === "asset" && output.fileName.startsWith("assets/fonts/"),
+      );
+
+      expect(entry?.code).toMatch(/className:\s*["']farm-font-/);
+      expect(entry?.code).toMatch(/variable:\s*["']farm-font-variable-/);
+      expect(entry?.code).not.toContain("localFont({");
+      expect(entry?.code).not.toContain("__FARM_FONT_PRELOAD_HEADER__");
+      expect(entry?.code).toContain("%3C%2Fassets%2Ffonts%2Fdemo-");
+      expect(css).toContain("@font-face");
+      expect(css).toContain('font-family: "Demo Sans"');
+      expect(css).toContain("font-display: swap");
+      expect(css).toContain("--font-demo:");
+      expect(fontAsset?.fileName).toMatch(/^assets\/fonts\/demo-[a-f0-9]{12}\.woff2$/);
+      expect(Buffer.from(fontAsset?.source || []).toString()).toBe("test-font-binary");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uses a font from publicDir without emitting a duplicate asset", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-font-public-"));
+    try {
+      await fs.mkdir(path.join(root, "static", "fonts"), { recursive: true });
+      await fs.writeFile(
+        path.join(root, "static", "fonts", "public.woff2"),
+        Buffer.from("public-font-binary"),
+      );
+      await fs.writeFile(
+        path.join(root, "entry.ts"),
+        `import { localFont } from "@farm.js/core/font";
+import { farmFontPreloadHeader } from "virtual:farm-font-runtime";
+export const demo = localFont({ src: "/fonts/public.woff2", family: "Public Sans" });
+console.log(demo, farmFontPreloadHeader);`,
+      );
+
+      const result = await build({
+        root,
+        configFile: false,
+        logLevel: "silent",
+        plugins: [fontRuntimeStub(), farmPlugin({ root, basePath: "/docs", publicDir: "static" })],
+        build: {
+          write: false,
+          rollupOptions: {
+            input: path.join(root, "entry.ts"),
+            output: { entryFileNames: "entry.js" },
+          },
+        },
+      });
+      if (Array.isArray(result)) throw new Error("Expected one Vite build output");
+      const entry = result.output.find(
+        (output): output is Rollup.OutputChunk => output.type === "chunk" && output.isEntry,
+      );
+      const assets = result.output.filter(
+        (output): output is Rollup.OutputAsset => output.type === "asset",
+      );
+      const css = assets
+        .filter((output) => output.fileName.endsWith(".css"))
+        .map((output) => String(output.source))
+        .join("\n");
+
+      expect(css).toContain('url("/docs/fonts/public.woff2")');
+      expect(entry?.code).toContain("%3C%2Fdocs%2Ffonts%2Fpublic.woff2%3E");
+      expect(assets.some((output) => output.fileName.startsWith("assets/fonts/"))).toBe(false);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps an explicitly external remote font URL without downloading it", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-font-remote-"));
+    try {
+      await fs.writeFile(
+        path.join(root, "entry.ts"),
+        `import { remoteFont } from "@farm.js/core/font";
+export const demo = remoteFont({
+  src: "https://cdn.example.com/fonts/demo.woff2",
+  family: "Remote Demo",
+  strategy: "external",
+  preload: false,
+});
+console.log(demo);`,
+      );
+
+      const result = await buildFixture(root);
+      const assets = result.output.filter(
+        (output): output is Rollup.OutputAsset => output.type === "asset",
+      );
+      const css = assets
+        .filter((output) => output.fileName.endsWith(".css"))
+        .map((output) => String(output.source))
+        .join("\n");
+
+      expect(css).toContain("https://cdn.example.com/fonts/demo.woff2");
+      expect(assets.some((output) => output.fileName.startsWith("assets/fonts/"))).toBe(false);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("downloads and verifies a remote font for self-hosting", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-font-self-hosted-"));
+    const fontBytes = Buffer.from("self-hosted-font");
+    const integrity = `sha384-${createHash("sha384").update(fontBytes).digest("base64")}`;
+    const fetchMock = vi.fn(async () =>
+      Promise.resolve(
+        new Response(fontBytes, {
+          status: 200,
+          headers: { "Content-Type": "font/woff2" },
+        }),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      await fs.writeFile(
+        path.join(root, "entry.ts"),
+        `import { remoteFont } from "@farm.js/core/font";
+export const demo = remoteFont({
+  src: "https://fonts.example.test/self-hosted.woff2",
+  family: "Self Hosted",
+  integrity: ${JSON.stringify(integrity)},
+});
+console.log(demo);`,
+      );
+
+      const result = await buildFixture(root);
+      const fontAsset = result.output.find(
+        (output): output is Rollup.OutputAsset =>
+          output.type === "asset" && output.fileName.startsWith("assets/fonts/"),
+      );
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+      expect(fontAsset?.fileName).toMatch(/^assets\/fonts\/self-hosted-[a-f0-9]{12}\.woff2$/);
+      expect(Buffer.from(fontAsset?.source || []).toString()).toBe("self-hosted-font");
+    } finally {
+      vi.unstubAllGlobals();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("replaces an earlier generated font section when client and SSR CSS are combined", () => {
+    const clientCss = `.app { color: green; }
+/* farm-fonts:start */
+.old-font {}
+/* farm-fonts:end */`;
+    const serverCss = `/* farm-fonts:start */
+.current-font {}
+/* farm-fonts:end */\n`;
+
+    const merged = mergeFarmFontCss(clientCss, serverCss);
+    expect(merged).toContain(".app { color: green; }");
+    expect(merged).toContain(".current-font {}");
+    expect(merged).not.toContain(".old-font {}");
+  });
+});

--- a/packages/farm/src/build/index.ts
+++ b/packages/farm/src/build/index.ts
@@ -11,6 +11,7 @@ import { getFarmDocsRouteTypeEntries } from "../docs";
 import { generateFarmTypeArtifacts } from "../type-artifacts";
 import { PluginManager } from "../plugin";
 import { farmEnvironmentFunctionsPlugin } from "../environment-vite";
+import { farmFontImportsPlugin } from "../font-vite";
 import { mergeFarmViteConfig } from "../server/vite-config";
 import {
   canUseRolldownForRouteDiscovery,
@@ -203,7 +204,14 @@ async function createProjectModuleServer(
           plugins: [],
         },
       },
-      plugins: [farmEnvironmentFunctionsPlugin()],
+      plugins: [
+        farmFontImportsPlugin({
+          root,
+          basePath: config.basePath,
+          publicDir: config.publicDir,
+        }),
+        farmEnvironmentFunctionsPlugin(),
+      ],
       server: {
         middlewareMode: true,
         hmr: false,

--- a/packages/farm/src/font-vite.ts
+++ b/packages/farm/src/font-vite.ts
@@ -214,6 +214,7 @@ export async function transformFarmFontCalls(
 
   const calls = findFontCalls(ast, bindings);
   if (calls.length === 0) return null;
+  validateFontBindingReferences(ast, calls, cleanId);
 
   const registeredCalls = calls.map((call) => ({
     kind: call.kind,
@@ -247,8 +248,7 @@ export async function transformFarmFontCalls(
 export function renderFarmFontDevHead(root: string): string {
   const registry = registries.get(normalizeRoot(root));
   if (!registry || registry.production || registry.size === 0) return "";
-  const preloads = registry.renderPreloadTags(false);
-  return `${preloads}\n  <link rel="stylesheet" href="/@farm/fonts.css">`;
+  return registry.renderPreloadTags(false);
 }
 
 class FarmFontRegistry {
@@ -319,7 +319,7 @@ class FarmFontRegistry {
   }
 
   getDevResource(pathname: string): FontResource | undefined {
-    for (const resource of this.resources.values()) {
+    for (const resource of this.getActiveResources()) {
       if (resource.bytes && resourceUrl(resource, false, this.basePath) === pathname) {
         return resource;
       }
@@ -328,7 +328,7 @@ class FarmFontRegistry {
   }
 
   emitAssets(context: { emitFile: (file: any) => string }, bundle: OutputBundle): void {
-    for (const resource of this.resources.values()) {
+    for (const resource of this.getActiveResources()) {
       if (!resource.bytes || !resource.outputFileName) continue;
       if (bundle[resource.outputFileName]) continue;
       context.emitFile({
@@ -373,6 +373,14 @@ class FarmFontRegistry {
       for (const definition of definitions) active.set(definition.id, definition);
     }
     return Array.from(active.values()).sort((left, right) => left.id.localeCompare(right.id));
+  }
+
+  private getActiveResources(): FontResource[] {
+    const active = new Set<FontResource>();
+    for (const definition of this.getDefinitions()) {
+      for (const source of definition.sources) active.add(source.resource);
+    }
+    return Array.from(active);
   }
 
   private getPreloadResources(production: boolean) {
@@ -647,6 +655,55 @@ function findFontCalls(ast: AstNode, bindings: ReturnType<typeof findFontBinding
   return calls;
 }
 
+function validateFontBindingReferences(ast: AstNode, calls: FontCall[], id: string): void {
+  const calledBindings = new Set(
+    calls.map((call) => call.binding).filter((binding): binding is string => Boolean(binding)),
+  );
+  const transformedCallees = new Set(
+    calls.flatMap((call) => {
+      const callee = call.node.callee;
+      return call.binding && isAstNode(callee) ? [`${callee.start}:${callee.end}`] : [];
+    }),
+  );
+
+  walkAst(ast, (node, ancestors) => {
+    if (
+      node.type !== "Identifier" ||
+      typeof node.name !== "string" ||
+      !calledBindings.has(node.name)
+    ) {
+      return;
+    }
+    const parent = ancestors.at(-1);
+    if (!parent || isNonReferenceIdentifier(node, parent)) return;
+    if (transformedCallees.has(`${node.start}:${node.end}`)) return;
+    throw fontError(
+      id,
+      `${node.name} can only be referenced by statically compiled font declarations`,
+    );
+  });
+}
+
+function isNonReferenceIdentifier(node: AstNode, parent: AstNode): boolean {
+  if (parent.type === "ImportSpecifier") return true;
+  if (
+    (parent.type === "MemberExpression" || parent.type === "OptionalMemberExpression") &&
+    parent.property === node &&
+    parent.computed !== true
+  ) {
+    return true;
+  }
+  if (
+    (parent.type === "Property" || parent.type === "PropertyDefinition") &&
+    parent.key === node &&
+    parent.computed !== true &&
+    parent.shorthand !== true
+  ) {
+    return true;
+  }
+  return false;
+}
+
 function createFontImportReplacements(
   code: string,
   ast: AstNode,
@@ -880,9 +937,13 @@ function renderFontDefinitionCss(
 }
 
 function resourceUrl(resource: FontResource, production: boolean, basePath: string): string {
-  if (resource.publicPath) return joinBasePath(basePath, resource.publicPath);
+  if (resource.publicPath) {
+    return production ? joinBasePath(basePath, resource.publicPath) : resource.publicPath;
+  }
   if (!resource.bytes) return resource.publicUrl;
-  if (!production) return `/@farm/font/${resource.hash}${resource.extension}`;
+  if (!production) {
+    return joinBasePath(basePath, `/@farm/font/${resource.hash}${resource.extension}`);
+  }
   return joinBasePath(basePath, `/${resource.outputFileName}`);
 }
 
@@ -899,17 +960,39 @@ async function fetchRemoteFont(url: URL, integrity?: string): Promise<Buffer> {
         throw new Error(`request returned ${response.status} ${response.statusText}`);
       const length = Number(response.headers.get("content-length") || 0);
       if (length > MAX_REMOTE_FONT_BYTES) throw new Error("font exceeds the 20 MB limit");
-      const bytes = Buffer.from(await response.arrayBuffer());
-      if (bytes.byteLength > MAX_REMOTE_FONT_BYTES) throw new Error("font exceeds the 20 MB limit");
+      const bytes = await readResponseBodyWithLimit(response, MAX_REMOTE_FONT_BYTES);
       if (integrity) verifyIntegrity(bytes, integrity);
       return bytes;
     })().catch((error) => {
-      remoteBytes.delete(key);
       throw new Error(`[Farm fonts] Failed to download ${url.href}: ${(error as Error).message}`);
     });
     remoteBytes.set(key, pending);
+    const clearPending = () => {
+      if (remoteBytes.get(key) === pending) remoteBytes.delete(key);
+    };
+    void pending.then(clearPending, clearPending);
   }
   return pending;
+}
+
+async function readResponseBodyWithLimit(response: Response, limit: number): Promise<Buffer> {
+  if (!response.body) return Buffer.alloc(0);
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    total += chunk.value.byteLength;
+    if (total > limit) {
+      await reader.cancel("font exceeds the configured byte limit");
+      throw new Error("font exceeds the 20 MB limit");
+    }
+    chunks.push(chunk.value);
+  }
+
+  return Buffer.concat(chunks, total);
 }
 
 function verifyIntegrity(bytes: Buffer, integrity: string): void {

--- a/packages/farm/src/font-vite.ts
+++ b/packages/farm/src/font-vite.ts
@@ -1,0 +1,1204 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
+import type { Plugin, ResolvedConfig, Rollup, ViteDevServer } from "vite";
+import type { FarmFontDisplay, FarmFontSource, RemoteFontSource } from "./font";
+
+const FONT_IMPORTS = new Set(["@farm.js/core", "@farm.js/core/font"]);
+const FONT_FUNCTIONS = new Set<FontLoaderKind>(["localFont", "remoteFont"]);
+const FONT_CSS_PREFIX = "\0farm:font-css:";
+const FONT_RUNTIME_ID = "\0farm:font-runtime";
+const PUBLIC_FONT_RUNTIME_ID = "virtual:farm-font-runtime";
+const PRELOAD_HEADER_MARKER = "__FARM_FONT_PRELOAD_HEADER__";
+const FONT_SECTION_START = "/* farm-fonts:start */";
+const FONT_SECTION_END = "/* farm-fonts:end */";
+const MODULE_EXTENSION_RE = /\.[cm]?[jt]sx?$/;
+const FONT_EXTENSION_RE = /\.(woff2?|ttf|otf)$/i;
+const MAX_REMOTE_FONT_BYTES = 20 * 1024 * 1024;
+const FONT_REGISTRIES_KEY = Symbol.for("farm.fontRegistries");
+const FONT_REMOTE_BYTES_KEY = Symbol.for("farm.fontRemoteBytes");
+
+type FontLoaderKind = "localFont" | "remoteFont";
+type OutputAsset = Rollup.OutputAsset;
+type OutputBundle = Rollup.OutputBundle;
+
+interface AstNode {
+  type: string;
+  start: number;
+  end: number;
+  [key: string]: unknown;
+}
+
+interface FontResource {
+  bytes?: Buffer;
+  extension: string;
+  format: string;
+  hash: string;
+  outputFileName?: string;
+  publicPath?: string;
+  publicUrl: string;
+}
+
+interface NormalizedFontSource {
+  source: string;
+  weight: string;
+  style: string;
+  unicodeRange?: string;
+  resource: FontResource;
+}
+
+interface FontDefinition {
+  id: string;
+  family: string;
+  className: string;
+  variableClassName: string;
+  variable?: string;
+  fallback: string[];
+  display: FarmFontDisplay;
+  preload: boolean;
+  weight?: number | string;
+  style?: string;
+  sources: NormalizedFontSource[];
+}
+
+interface FontCall {
+  kind: FontLoaderKind;
+  binding?: string;
+  node: AstNode;
+  ancestors: readonly AstNode[];
+}
+
+interface Replacement {
+  start: number;
+  end: number;
+  code: string;
+}
+
+export interface TransformFarmFontCallsOptions {
+  code: string;
+  id: string;
+  root: string;
+  production: boolean;
+  parse: (code: string) => AstNode;
+  register: (
+    moduleId: string,
+    calls: Array<{ kind: FontLoaderKind; options: Record<string, unknown> }>,
+  ) => Promise<FontDefinition[]>;
+}
+
+export interface TransformFarmFontCallsResult {
+  code: string;
+  fonts: FontDefinition[];
+}
+
+const registries = getGlobalMap<string, FarmFontRegistry>(FONT_REGISTRIES_KEY);
+const remoteBytes = getGlobalMap<string, Promise<Buffer>>(FONT_REMOTE_BYTES_KEY);
+
+export function farmFontImportsPlugin(
+  options: { root?: string; basePath?: string; publicDir?: string | false } = {},
+): Plugin {
+  let root = normalizeRoot(options.root || process.cwd());
+  let production = process.env.NODE_ENV === "production";
+  let registry = getOrCreateRegistry(root, options.basePath, options.publicDir);
+
+  const updateRoot = (nextRoot: string, basePath?: string, publicDir?: string | false) => {
+    const normalized = normalizeRoot(nextRoot);
+    root = normalized;
+    registry = getOrCreateRegistry(root, basePath, publicDir);
+  };
+
+  return {
+    name: "farm:font-imports",
+    enforce: "post",
+
+    configResolved(config: ResolvedConfig) {
+      production = config.command === "build";
+      updateRoot(
+        config.root,
+        options.basePath || config.base,
+        options.publicDir === undefined ? config.publicDir : options.publicDir,
+      );
+      registry.production = production;
+    },
+
+    configureServer(server: ViteDevServer) {
+      updateRoot(
+        server.config.root,
+        options.basePath || server.config.base,
+        options.publicDir === undefined ? server.config.publicDir : options.publicDir,
+      );
+      registry.production = false;
+      server.middlewares.use(async (req, res, next) => {
+        const pathname = new URL(req.url || "/", "http://farm.local").pathname;
+
+        if (pathname === "/@farm/fonts.css") {
+          res.statusCode = 200;
+          res.setHeader("Content-Type", "text/css; charset=utf-8");
+          res.setHeader("Cache-Control", "no-store");
+          res.end(registry.renderCss(false));
+          return;
+        }
+
+        const resource = registry.getDevResource(pathname);
+        if (!resource?.bytes) {
+          next();
+          return;
+        }
+
+        res.statusCode = 200;
+        res.setHeader("Content-Type", fontContentType(resource.extension));
+        res.setHeader("Cache-Control", "public, max-age=31536000, immutable");
+        res.end(resource.bytes);
+      });
+    },
+
+    resolveId(id) {
+      if (id === PUBLIC_FONT_RUNTIME_ID || id === FONT_RUNTIME_ID) return FONT_RUNTIME_ID;
+      if (id.startsWith("virtual:farm-font-css/")) {
+        return `${FONT_CSS_PREFIX}${id.slice("virtual:farm-font-css/".length)}`;
+      }
+      if (id.startsWith(FONT_CSS_PREFIX)) return id;
+      return null;
+    },
+
+    load(id) {
+      if (id === FONT_RUNTIME_ID) {
+        return `export const farmFontPreloadHeader = decodeURIComponent(${JSON.stringify(PRELOAD_HEADER_MARKER)});`;
+      }
+      if (!id.startsWith(FONT_CSS_PREFIX)) return null;
+      return registry.renderFontCss(
+        id.slice(FONT_CSS_PREFIX.length).replace(/\.css$/, ""),
+        production,
+      );
+    },
+
+    async transform(code, id) {
+      const result = await transformFarmFontCalls({
+        code,
+        id,
+        root,
+        production,
+        parse: (source) => this.parse(source) as unknown as AstNode,
+        register: (moduleId, calls) => registry.register(moduleId, calls, production),
+      });
+
+      if (!result) registry.clearModule(id.split("?", 1)[0]);
+
+      return result ? { code: result.code, map: null } : null;
+    },
+
+    async generateBundle(_options, bundle) {
+      registry.emitAssets(this, bundle);
+    },
+  };
+}
+
+export async function transformFarmFontCalls(
+  options: TransformFarmFontCallsOptions,
+): Promise<TransformFarmFontCallsResult | null> {
+  const cleanId = options.id.split("?", 1)[0];
+  if (
+    !MODULE_EXTENSION_RE.test(cleanId) ||
+    /\.d\.[cm]?ts$/.test(cleanId) ||
+    !containsFontFunction(options.code)
+  ) {
+    return null;
+  }
+
+  const ast = options.parse(options.code);
+  const bindings = findFontBindings(ast);
+  if (bindings.named.size === 0 && bindings.namespaces.size === 0) return null;
+
+  const calls = findFontCalls(ast, bindings);
+  if (calls.length === 0) return null;
+
+  const registeredCalls = calls.map((call) => ({
+    kind: call.kind,
+    options: readFontOptions(options.code, cleanId, call),
+  }));
+  const fonts = await options.register(cleanId, registeredCalls);
+  const replacements: Replacement[] = calls.map((call, index) => ({
+    start: call.node.start,
+    end: call.node.end,
+    code: serializeFontResult(fonts[index]),
+  }));
+  replacements.push(
+    ...createFontImportReplacements(
+      options.code,
+      ast,
+      new Set(calls.map((call) => call.binding).filter((value): value is string => Boolean(value))),
+    ),
+  );
+  const imports = options.production
+    ? ""
+    : Array.from(new Set(fonts.map((font) => font.id)))
+        .map((id) => `import ${JSON.stringify(`virtual:farm-font-css/${id}.css`)};`)
+        .join("\n");
+
+  return {
+    code: `${applyReplacements(options.code, replacements)}\n${imports}\n`,
+    fonts,
+  };
+}
+
+export function renderFarmFontDevHead(root: string): string {
+  const registry = registries.get(normalizeRoot(root));
+  if (!registry || registry.production || registry.size === 0) return "";
+  const preloads = registry.renderPreloadTags(false);
+  return `${preloads}\n  <link rel="stylesheet" href="/@farm/fonts.css">`;
+}
+
+class FarmFontRegistry {
+  root: string;
+  basePath: string;
+  publicDir: string | false;
+  production = false;
+  private modules = new Map<string, FontDefinition[]>();
+  private definitions = new Map<string, FontDefinition>();
+  private resources = new Map<string, FontResource>();
+
+  constructor(root: string, basePath = "/", publicDir?: string | false) {
+    this.root = root;
+    this.basePath = normalizeBasePath(basePath);
+    this.publicDir = normalizePublicDir(root, publicDir);
+  }
+
+  get size(): number {
+    return this.getDefinitions().length;
+  }
+
+  async register(
+    moduleId: string,
+    calls: Array<{ kind: FontLoaderKind; options: Record<string, unknown> }>,
+    production: boolean,
+  ): Promise<FontDefinition[]> {
+    const definitions: FontDefinition[] = [];
+    for (const call of calls) {
+      definitions.push(await this.createDefinition(moduleId, call.kind, call.options, production));
+    }
+    this.modules.set(moduleId, definitions);
+    for (const definition of definitions) this.definitions.set(definition.id, definition);
+    return definitions;
+  }
+
+  clearModule(moduleId: string): void {
+    this.modules.delete(moduleId);
+  }
+
+  renderFontCss(id: string, production: boolean): string {
+    const definition = this.definitions.get(id);
+    return definition ? renderFontDefinitionCss(definition, production, this.basePath) : "";
+  }
+
+  renderCss(production: boolean): string {
+    const css = this.getDefinitions()
+      .map((definition) => renderFontDefinitionCss(definition, production, this.basePath))
+      .join("\n\n");
+    return css ? `${FONT_SECTION_START}\n${css}\n${FONT_SECTION_END}\n` : "";
+  }
+
+  renderPreloadHeader(production: boolean): string {
+    return this.getPreloadResources(production)
+      .map(
+        ({ url, resource }) =>
+          `<${url}>; rel=preload; as=font; type=${fontContentType(resource.extension)}; crossorigin`,
+      )
+      .join(", ");
+  }
+
+  renderPreloadTags(production: boolean): string {
+    return this.getPreloadResources(production)
+      .map(
+        ({ url, resource }) =>
+          `<link rel="preload" href="${escapeHtmlAttribute(url)}" as="font" type="${fontContentType(resource.extension)}" crossorigin>`,
+      )
+      .join("\n  ");
+  }
+
+  getDevResource(pathname: string): FontResource | undefined {
+    for (const resource of this.resources.values()) {
+      if (resource.bytes && resourceUrl(resource, false, this.basePath) === pathname) {
+        return resource;
+      }
+    }
+    return undefined;
+  }
+
+  emitAssets(context: { emitFile: (file: any) => string }, bundle: OutputBundle): void {
+    for (const resource of this.resources.values()) {
+      if (!resource.bytes || !resource.outputFileName) continue;
+      if (bundle[resource.outputFileName]) continue;
+      context.emitFile({
+        type: "asset",
+        fileName: resource.outputFileName,
+        source: resource.bytes,
+      });
+    }
+
+    const css = this.renderCss(true);
+    if (css) {
+      const cssAssets = Object.values(bundle).filter(
+        (entry): entry is OutputAsset => entry.type === "asset" && entry.fileName.endsWith(".css"),
+      );
+      const clientCss =
+        cssAssets.find(
+          (entry): entry is OutputAsset =>
+            entry.type === "asset" && entry.fileName === "farm-client.css",
+        ) ?? (cssAssets.length === 1 ? cssAssets[0] : undefined);
+      if (clientCss) {
+        clientCss.source = replaceFontSection(assetSourceToString(clientCss.source), css);
+      } else if (!bundle["farm-fonts.css"]) {
+        context.emitFile({
+          type: "asset",
+          fileName: "farm-fonts.css",
+          source: css,
+        });
+      }
+    }
+
+    const preloadHeader = encodeURIComponent(this.renderPreloadHeader(true));
+    for (const entry of Object.values(bundle)) {
+      if (entry.type === "chunk" && entry.code.includes(PRELOAD_HEADER_MARKER)) {
+        entry.code = entry.code.split(PRELOAD_HEADER_MARKER).join(preloadHeader);
+      }
+    }
+  }
+
+  private getDefinitions(): FontDefinition[] {
+    const active = new Map<string, FontDefinition>();
+    for (const definitions of this.modules.values()) {
+      for (const definition of definitions) active.set(definition.id, definition);
+    }
+    return Array.from(active.values()).sort((left, right) => left.id.localeCompare(right.id));
+  }
+
+  private getPreloadResources(production: boolean) {
+    const seen = new Set<string>();
+    const resources: Array<{ url: string; resource: FontResource }> = [];
+    for (const definition of this.getDefinitions()) {
+      if (!definition.preload) continue;
+      for (const source of definition.sources) {
+        const url = resourceUrl(source.resource, production, this.basePath);
+        if (seen.has(url)) continue;
+        seen.add(url);
+        resources.push({ url, resource: source.resource });
+      }
+    }
+    return resources;
+  }
+
+  private async createDefinition(
+    moduleId: string,
+    kind: FontLoaderKind,
+    raw: Record<string, unknown>,
+    production: boolean,
+  ): Promise<FontDefinition> {
+    validateOptionKeys(moduleId, kind, raw);
+    const family = requireString(raw.family, moduleId, `${kind}() family`);
+    const display = (raw.display ?? "swap") as FarmFontDisplay;
+    if (!["auto", "block", "swap", "fallback", "optional"].includes(display)) {
+      throw fontError(moduleId, `invalid font-display value ${JSON.stringify(display)}`);
+    }
+    const variable = optionalString(raw.variable, moduleId, `${kind}() variable`);
+    if (variable && !/^--[A-Za-z_][\w-]*$/.test(variable)) {
+      throw fontError(moduleId, `font variable must be a CSS custom property such as --font-sans`);
+    }
+    const fallback = readStringArray(raw.fallback, moduleId, `${kind}() fallback`);
+    const defaultWeight = optionalWeight(raw.weight, moduleId);
+    const defaultStyle = optionalCssDescriptor(raw.style, moduleId, "style") || "normal";
+    const sources = readSources(raw.src, moduleId, kind, defaultWeight, defaultStyle);
+    const strategy = kind === "remoteFont" ? (raw.strategy ?? "self-host") : "self-host";
+    if (strategy !== "self-host" && strategy !== "external") {
+      throw fontError(moduleId, `remoteFont() strategy must be "self-host" or "external"`);
+    }
+    const integrity = optionalString(raw.integrity, moduleId, `${kind}() integrity`);
+
+    const normalizedSources: NormalizedFontSource[] = [];
+    for (const source of sources) {
+      const resource = await this.resolveResource({
+        kind,
+        moduleId,
+        source: source.path,
+        strategy,
+        integrity: source.integrity ?? integrity,
+        production,
+      });
+      normalizedSources.push({
+        source: source.path,
+        weight: String(source.weight ?? defaultWeight ?? "400"),
+        style: source.style || defaultStyle,
+        unicodeRange: source.unicodeRange,
+        resource,
+      });
+    }
+
+    const identity = JSON.stringify({
+      family,
+      display,
+      variable,
+      fallback,
+      preload: raw.preload !== false,
+      sources: normalizedSources.map((source) => ({
+        hash: source.resource.hash,
+        url: source.resource.publicUrl,
+        weight: source.weight,
+        style: source.style,
+        unicodeRange: source.unicodeRange,
+      })),
+    });
+    const id = createHash("sha256").update(identity).digest("hex").slice(0, 10);
+
+    return {
+      id,
+      family,
+      className: `farm-font-${id}`,
+      variableClassName: variable ? `farm-font-variable-${id}` : "",
+      variable,
+      fallback,
+      display,
+      preload: raw.preload !== false,
+      weight: defaultWeight,
+      style: raw.style === undefined ? undefined : defaultStyle,
+      sources: normalizedSources,
+    };
+  }
+
+  private async resolveResource(input: {
+    kind: FontLoaderKind;
+    moduleId: string;
+    source: string;
+    strategy: unknown;
+    integrity?: string;
+    production: boolean;
+  }): Promise<FontResource> {
+    if (input.kind === "remoteFont") {
+      let url: URL;
+      try {
+        url = new URL(input.source);
+      } catch {
+        throw fontError(input.moduleId, `remoteFont() source must be an absolute HTTPS URL`);
+      }
+      if (url.protocol !== "https:") {
+        throw fontError(input.moduleId, `remoteFont() only accepts HTTPS URLs`);
+      }
+      const extension = extensionFromPath(url.pathname);
+      if (input.strategy === "external") {
+        const hash = createHash("sha256").update(url.href).digest("hex").slice(0, 12);
+        const resource = {
+          extension,
+          format: fontFormat(extension),
+          hash,
+          publicUrl: url.href,
+        };
+        this.resources.set(`external:${url.href}`, resource);
+        return resource;
+      }
+
+      const bytes = await fetchRemoteFont(url, input.integrity);
+      return this.createSelfHostedResource(bytes, extension, path.basename(url.pathname));
+    }
+
+    if (input.source.startsWith("/")) {
+      return this.createPublicResource(input.moduleId, input.source);
+    }
+
+    const resolvedPath = resolveLocalFontPath(input.source, input.moduleId, this.root);
+    if (!FONT_EXTENSION_RE.test(resolvedPath)) {
+      throw fontError(
+        input.moduleId,
+        `unsupported local font file ${JSON.stringify(input.source)}`,
+      );
+    }
+    let bytes: Buffer;
+    try {
+      bytes = await readFile(resolvedPath);
+    } catch (error) {
+      throw fontError(
+        input.moduleId,
+        `could not read ${JSON.stringify(input.source)}: ${(error as Error).message}`,
+      );
+    }
+    return this.createSelfHostedResource(
+      bytes,
+      path.extname(resolvedPath),
+      path.basename(resolvedPath),
+    );
+  }
+
+  private async createPublicResource(moduleId: string, source: string): Promise<FontResource> {
+    if (!this.publicDir) {
+      throw fontError(
+        moduleId,
+        `cannot resolve ${JSON.stringify(source)} because publicDir is disabled`,
+      );
+    }
+    const publicPath = normalizePublicFontPath(source, moduleId);
+    const resolvedPath = path.resolve(this.publicDir, `.${publicPath}`);
+    if (!isPathInside(this.publicDir, resolvedPath)) {
+      throw fontError(moduleId, `public font path must stay inside publicDir`);
+    }
+    if (!FONT_EXTENSION_RE.test(resolvedPath)) {
+      throw fontError(moduleId, `unsupported public font file ${JSON.stringify(source)}`);
+    }
+
+    let bytes: Buffer;
+    try {
+      bytes = await readFile(resolvedPath);
+    } catch (error) {
+      throw fontError(
+        moduleId,
+        `could not read ${JSON.stringify(source)} from publicDir: ${(error as Error).message}`,
+      );
+    }
+
+    const extension = path.extname(resolvedPath).toLowerCase();
+    const hash = createHash("sha256").update(bytes).digest("hex").slice(0, 12);
+    const resource: FontResource = {
+      extension,
+      format: fontFormat(extension),
+      hash,
+      publicPath,
+      publicUrl: "",
+    };
+    this.resources.set(`public:${publicPath}`, resource);
+    return resource;
+  }
+
+  private createSelfHostedResource(
+    bytes: Buffer,
+    extension: string,
+    fileName: string,
+  ): FontResource {
+    const normalizedExtension = extension.toLowerCase();
+    const hash = createHash("sha256").update(bytes).digest("hex").slice(0, 12);
+    const baseName = sanitizeFileName(path.basename(fileName, extension)) || "font";
+    const outputFileName = `assets/fonts/${baseName}-${hash}${normalizedExtension}`;
+    const key = `${hash}${normalizedExtension}`;
+    const existing = this.resources.get(key);
+    if (existing) return existing;
+
+    const resource: FontResource = {
+      bytes,
+      extension: normalizedExtension,
+      format: fontFormat(normalizedExtension),
+      hash,
+      outputFileName,
+      publicUrl: "",
+    };
+    this.resources.set(key, resource);
+    return resource;
+  }
+}
+
+function findFontBindings(ast: AstNode) {
+  const named = new Map<string, FontLoaderKind>();
+  const namespaces = new Set<string>();
+  const body = Array.isArray(ast.body) ? ast.body : [];
+
+  for (const statement of body) {
+    if (!isAstNode(statement) || statement.type !== "ImportDeclaration") continue;
+    const source = isAstNode(statement.source) ? statement.source.value : undefined;
+    if (typeof source !== "string" || !FONT_IMPORTS.has(source)) continue;
+
+    const specifiers = Array.isArray(statement.specifiers) ? statement.specifiers : [];
+    for (const specifier of specifiers) {
+      if (!isAstNode(specifier) || !isAstNode(specifier.local)) continue;
+      const localName = specifier.local.name;
+      if (typeof localName !== "string") continue;
+      if (specifier.type === "ImportNamespaceSpecifier") {
+        namespaces.add(localName);
+        continue;
+      }
+      if (specifier.type !== "ImportSpecifier" || !isAstNode(specifier.imported)) continue;
+      const importedName = specifier.imported.name ?? specifier.imported.value;
+      if (isFontLoaderKind(importedName)) named.set(localName, importedName);
+    }
+  }
+  return { named, namespaces };
+}
+
+function findFontCalls(ast: AstNode, bindings: ReturnType<typeof findFontBindings>): FontCall[] {
+  const calls: FontCall[] = [];
+  walkAst(ast, (node, ancestors) => {
+    if (node.type !== "CallExpression" || !isAstNode(node.callee)) return;
+    let kind: FontLoaderKind | undefined;
+    if (node.callee.type === "Identifier" && typeof node.callee.name === "string") {
+      kind = bindings.named.get(node.callee.name);
+      if (kind) calls.push({ kind, binding: node.callee.name, node, ancestors });
+    } else if (
+      node.callee.type === "MemberExpression" &&
+      node.callee.computed !== true &&
+      isAstNode(node.callee.object) &&
+      isAstNode(node.callee.property) &&
+      node.callee.object.type === "Identifier" &&
+      node.callee.property.type === "Identifier" &&
+      typeof node.callee.object.name === "string" &&
+      typeof node.callee.property.name === "string" &&
+      bindings.namespaces.has(node.callee.object.name) &&
+      isFontLoaderKind(node.callee.property.name)
+    ) {
+      kind = node.callee.property.name;
+    }
+    if (kind && node.callee.type !== "Identifier") calls.push({ kind, node, ancestors });
+  });
+  return calls;
+}
+
+function createFontImportReplacements(
+  code: string,
+  ast: AstNode,
+  calledBindings: ReadonlySet<string>,
+): Replacement[] {
+  if (calledBindings.size === 0) return [];
+  const replacements: Replacement[] = [];
+  const body = Array.isArray(ast.body) ? ast.body : [];
+
+  for (const statement of body) {
+    if (!isAstNode(statement) || statement.type !== "ImportDeclaration") continue;
+    const source = isAstNode(statement.source) ? statement.source.value : undefined;
+    if (typeof source !== "string" || !FONT_IMPORTS.has(source)) continue;
+    const specifiers = (Array.isArray(statement.specifiers) ? statement.specifiers : []).filter(
+      isAstNode,
+    );
+    const retained = specifiers.filter((specifier) => {
+      if (specifier.type !== "ImportSpecifier" || !isAstNode(specifier.local)) return true;
+      return typeof specifier.local.name !== "string" || !calledBindings.has(specifier.local.name);
+    });
+    if (retained.length === specifiers.length) continue;
+
+    replacements.push({
+      start: statement.start,
+      end: statement.end,
+      code: renderImportDeclaration(code, source, retained),
+    });
+  }
+
+  return replacements;
+}
+
+function renderImportDeclaration(code: string, source: string, specifiers: AstNode[]): string {
+  if (specifiers.length === 0) return "";
+  const defaultSpecifier = specifiers.find(
+    (specifier) => specifier.type === "ImportDefaultSpecifier",
+  );
+  const namespaceSpecifier = specifiers.find(
+    (specifier) => specifier.type === "ImportNamespaceSpecifier",
+  );
+  const namedSpecifiers = specifiers.filter((specifier) => specifier.type === "ImportSpecifier");
+  const parts: string[] = [];
+
+  if (defaultSpecifier && isAstNode(defaultSpecifier.local)) {
+    parts.push(code.slice(defaultSpecifier.local.start, defaultSpecifier.local.end));
+  }
+  if (namespaceSpecifier && isAstNode(namespaceSpecifier.local)) {
+    parts.push(`* as ${code.slice(namespaceSpecifier.local.start, namespaceSpecifier.local.end)}`);
+  }
+  if (namedSpecifiers.length > 0) {
+    parts.push(
+      `{ ${namedSpecifiers.map((specifier) => code.slice(specifier.start, specifier.end)).join(", ")} }`,
+    );
+  }
+
+  return parts.length > 0 ? `import ${parts.join(", ")} from ${JSON.stringify(source)};` : "";
+}
+
+function readFontOptions(code: string, id: string, call: FontCall): Record<string, unknown> {
+  if (!call.binding) {
+    throw fontError(id, `${call.kind}() must use a named import from @farm.js/core/font`);
+  }
+  const args = Array.isArray(call.node.arguments) ? call.node.arguments : [];
+  if (args.length !== 1 || !isAstNode(args[0]) || args[0].type !== "ObjectExpression") {
+    throw fontError(id, `${call.kind}() requires one inline options object`);
+  }
+  const parent = call.ancestors.at(-1);
+  if (!parent || parent.type !== "VariableDeclarator" || parent.init !== call.node) {
+    throw fontError(id, `${call.kind}() must initialize a module-scope variable`);
+  }
+  const declaration = call.ancestors.at(-2);
+  const statement = call.ancestors.at(-3);
+  const statementParent = call.ancestors.at(-4);
+  const isModuleScope =
+    declaration?.type === "VariableDeclaration" &&
+    (statement?.type === "Program" ||
+      (statement?.type === "ExportNamedDeclaration" && statementParent?.type === "Program"));
+  if (!isModuleScope || call.ancestors.some((ancestor) => isFunctionNode(ancestor))) {
+    throw fontError(id, `${call.kind}() must be declared directly at module scope`);
+  }
+  return evaluateStaticObject(code, id, args[0]);
+}
+
+function evaluateStaticObject(code: string, id: string, node: AstNode): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  const properties = Array.isArray(node.properties) ? node.properties : [];
+  for (const property of properties) {
+    if (!isAstNode(property) || property.type !== "Property" || property.computed === true) {
+      throw fontError(id, "font options do not support spreads or computed properties");
+    }
+    const key = readPropertyName(property.key);
+    if (!key || !isAstNode(property.value)) {
+      throw fontError(id, "font options must use static property names and values");
+    }
+    result[key] = evaluateStaticValue(code, id, property.value);
+  }
+  return result;
+}
+
+function evaluateStaticValue(code: string, id: string, node: AstNode): unknown {
+  if (node.type === "Literal") return node.value;
+  if (node.type === "TemplateLiteral") {
+    const expressions = Array.isArray(node.expressions) ? node.expressions : [];
+    const quasis = Array.isArray(node.quasis) ? node.quasis : [];
+    if (expressions.length === 0 && quasis.length === 1 && isAstNode(quasis[0])) {
+      const templateValue = quasis[0].value;
+      const value =
+        templateValue && typeof templateValue === "object"
+          ? (templateValue as { cooked?: unknown }).cooked
+          : undefined;
+      if (typeof value === "string") return value;
+    }
+  }
+  if (node.type === "ArrayExpression") {
+    const elements = Array.isArray(node.elements) ? node.elements : [];
+    return elements.map((element) => {
+      if (!isAstNode(element) || element.type === "SpreadElement") {
+        throw fontError(id, "font option arrays must contain static values");
+      }
+      return evaluateStaticValue(code, id, element);
+    });
+  }
+  if (node.type === "ObjectExpression") return evaluateStaticObject(code, id, node);
+  if (
+    node.type === "UnaryExpression" &&
+    (node.operator === "+" || node.operator === "-") &&
+    isAstNode(node.argument)
+  ) {
+    const value = evaluateStaticValue(code, id, node.argument);
+    if (typeof value === "number") return node.operator === "-" ? -value : value;
+  }
+  throw fontError(
+    id,
+    `font options must be statically analyzable near ${code.slice(node.start, node.end)}`,
+  );
+}
+
+function readSources(
+  value: unknown,
+  id: string,
+  kind: FontLoaderKind,
+  weight: number | string | undefined,
+  style: string,
+): Array<FarmFontSource & Pick<RemoteFontSource, "integrity">> {
+  if (typeof value === "string") return [{ path: value, weight, style }];
+  if (!Array.isArray(value) || value.length === 0) {
+    throw fontError(id, `${kind}() src must be a string or a non-empty source array`);
+  }
+  return value.map((entry, index) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw fontError(id, `${kind}() src[${index}] must be an object`);
+    }
+    const source = entry as Record<string, unknown>;
+    const unknown = Object.keys(source).filter(
+      (key) =>
+        ![
+          "path",
+          "weight",
+          "style",
+          "unicodeRange",
+          ...(kind === "remoteFont" ? ["integrity"] : []),
+        ].includes(key),
+    );
+    if (unknown.length) throw fontError(id, `unknown src[${index}] option ${unknown[0]}`);
+    return {
+      path: requireString(source.path, id, `${kind}() src[${index}].path`),
+      weight: optionalWeight(source.weight, id) ?? weight,
+      style: optionalCssDescriptor(source.style, id, "style") || style,
+      unicodeRange: optionalUnicodeRange(source.unicodeRange, id),
+      integrity: optionalString(source.integrity, id, `${kind}() src[${index}].integrity`),
+    };
+  });
+}
+
+function validateOptionKeys(id: string, kind: FontLoaderKind, raw: Record<string, unknown>) {
+  const allowed = new Set([
+    "src",
+    "family",
+    "weight",
+    "style",
+    "display",
+    "variable",
+    "fallback",
+    "preload",
+    ...(kind === "remoteFont" ? ["strategy", "integrity"] : []),
+  ]);
+  const unknown = Object.keys(raw).find((key) => !allowed.has(key));
+  if (unknown) throw fontError(id, `unknown ${kind}() option ${JSON.stringify(unknown)}`);
+  if (typeof raw.preload !== "undefined" && typeof raw.preload !== "boolean") {
+    throw fontError(id, `${kind}() preload must be a boolean`);
+  }
+}
+
+function serializeFontResult(font: FontDefinition): string {
+  const stack = renderFamilyStack(font.family, font.fallback);
+  return JSON.stringify({
+    className: font.className,
+    variable: font.variableClassName,
+    style: {
+      fontFamily: stack,
+      ...(font.style ? { fontStyle: font.style } : {}),
+      ...(font.weight !== undefined && !String(font.weight).includes(" ")
+        ? { fontWeight: font.weight }
+        : {}),
+    },
+  });
+}
+
+function renderFontDefinitionCss(
+  font: FontDefinition,
+  production: boolean,
+  basePath: string,
+): string {
+  const faces = font.sources.map((source) => {
+    const descriptors = [
+      `  font-family: ${quoteCssString(font.family)};`,
+      `  src: url(${quoteCssString(resourceUrl(source.resource, production, basePath))}) format(${quoteCssString(source.resource.format)});`,
+      `  font-display: ${font.display};`,
+      `  font-weight: ${source.weight};`,
+      `  font-style: ${source.style};`,
+      ...(source.unicodeRange ? [`  unicode-range: ${source.unicodeRange};`] : []),
+    ];
+    return `@font-face {\n${descriptors.join("\n")}\n}`;
+  });
+  const stack = renderFamilyStack(font.family, font.fallback);
+  faces.push(`.${font.className} {\n  font-family: ${stack};\n}`);
+  if (font.variable && font.variableClassName) {
+    faces.push(`.${font.variableClassName} {\n  ${font.variable}: ${stack};\n}`);
+  }
+  return faces.join("\n\n");
+}
+
+function resourceUrl(resource: FontResource, production: boolean, basePath: string): string {
+  if (resource.publicPath) return joinBasePath(basePath, resource.publicPath);
+  if (!resource.bytes) return resource.publicUrl;
+  if (!production) return `/@farm/font/${resource.hash}${resource.extension}`;
+  return joinBasePath(basePath, `/${resource.outputFileName}`);
+}
+
+async function fetchRemoteFont(url: URL, integrity?: string): Promise<Buffer> {
+  const key = `${url.href}\0${integrity || ""}`;
+  let pending = remoteBytes.get(key);
+  if (!pending) {
+    pending = (async () => {
+      const response = await fetch(url, {
+        headers: { "User-Agent": "Farm.js font compiler" },
+        redirect: "follow",
+      });
+      if (!response.ok)
+        throw new Error(`request returned ${response.status} ${response.statusText}`);
+      const length = Number(response.headers.get("content-length") || 0);
+      if (length > MAX_REMOTE_FONT_BYTES) throw new Error("font exceeds the 20 MB limit");
+      const bytes = Buffer.from(await response.arrayBuffer());
+      if (bytes.byteLength > MAX_REMOTE_FONT_BYTES) throw new Error("font exceeds the 20 MB limit");
+      if (integrity) verifyIntegrity(bytes, integrity);
+      return bytes;
+    })().catch((error) => {
+      remoteBytes.delete(key);
+      throw new Error(`[Farm fonts] Failed to download ${url.href}: ${(error as Error).message}`);
+    });
+    remoteBytes.set(key, pending);
+  }
+  return pending;
+}
+
+function verifyIntegrity(bytes: Buffer, integrity: string): void {
+  const entries = integrity.trim().split(/\s+/);
+  const supported = entries
+    .map((entry) => entry.match(/^(sha(?:256|384|512))-(.+)$/))
+    .filter((entry): entry is RegExpMatchArray => Boolean(entry));
+  if (supported.length === 0) throw new Error("integrity must use sha256, sha384, or sha512");
+  const matches = supported.some((entry) => {
+    const actual = createHash(entry[1]).update(bytes).digest();
+    const expected = Buffer.from(entry[2], "base64");
+    return actual.length === expected.length && timingSafeEqual(actual, expected);
+  });
+  if (!matches) throw new Error("downloaded font did not match its integrity value");
+}
+
+function resolveLocalFontPath(source: string, importer: string, root: string): string {
+  if (source.startsWith(".")) return path.resolve(path.dirname(importer), source);
+  if (path.isAbsolute(source)) {
+    return source;
+  }
+  try {
+    return createRequire(pathToFileURL(importer)).resolve(source);
+  } catch {
+    const segments = source.replace(/\\/g, "/").split("/");
+    if (segments.includes("..")) return path.resolve(root, source);
+
+    let current = path.dirname(importer);
+    const filesystemRoot = path.parse(current).root;
+    while (true) {
+      const candidate = path.join(current, "node_modules", ...segments);
+      if (existsSync(candidate)) return candidate;
+      if (current === filesystemRoot) break;
+      current = path.dirname(current);
+    }
+    return path.resolve(root, "node_modules", ...segments);
+  }
+}
+
+function replaceFontSection(css: string, section: string): string {
+  const start = css.indexOf(FONT_SECTION_START);
+  const end = css.indexOf(FONT_SECTION_END);
+  const withoutExisting =
+    start >= 0 && end >= start
+      ? `${css.slice(0, start)}${css.slice(end + FONT_SECTION_END.length)}`.trimEnd()
+      : css.trimEnd();
+  return `${withoutExisting}${withoutExisting ? "\n\n" : ""}${section}`;
+}
+
+export function mergeFarmFontCss(clientCss: string, fontCss: string): string {
+  return replaceFontSection(clientCss, fontCss);
+}
+
+function getOrCreateRegistry(
+  root: string,
+  basePath = "/",
+  publicDir?: string | false,
+): FarmFontRegistry {
+  const normalized = normalizeRoot(root);
+  const existing = registries.get(normalized);
+  if (existing) {
+    existing.basePath = normalizeBasePath(basePath);
+    existing.publicDir = normalizePublicDir(normalized, publicDir);
+    return existing;
+  }
+  const registry = new FarmFontRegistry(normalized, basePath, publicDir);
+  registries.set(normalized, registry);
+  return registry;
+}
+
+function getGlobalMap<TKey, TValue>(key: symbol): Map<TKey, TValue> {
+  const runtime = globalThis as typeof globalThis & Record<symbol, unknown>;
+  const existing = runtime[key];
+  if (existing instanceof Map) return existing as Map<TKey, TValue>;
+  const created = new Map<TKey, TValue>();
+  runtime[key] = created;
+  return created;
+}
+
+function normalizeRoot(root: string): string {
+  return path.resolve(root).replace(/\\/g, "/");
+}
+
+function normalizePublicDir(root: string, publicDir?: string | false): string | false {
+  if (publicDir === false || publicDir === "") return false;
+  return path.resolve(root, publicDir || "public");
+}
+
+function normalizePublicFontPath(source: string, moduleId: string): string {
+  if (source.includes("?") || source.includes("#")) {
+    throw fontError(moduleId, `public font paths cannot contain a query string or fragment`);
+  }
+  return `/${source.replace(/\\/g, "/").replace(/^\/+/, "")}`;
+}
+
+function isPathInside(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function normalizeBasePath(value: string): string {
+  if (!value || value === "/") return "/";
+  return `/${value.replace(/^\/+|\/+$/g, "")}/`;
+}
+
+function joinBasePath(basePath: string, value: string): string {
+  return basePath === "/" ? value : `${basePath.replace(/\/$/, "")}${value}`;
+}
+
+function extensionFromPath(pathname: string): string {
+  const extension = path.extname(pathname).toLowerCase();
+  if (!FONT_EXTENSION_RE.test(extension)) {
+    throw new Error(`[Farm fonts] Remote font URL must end in .woff2, .woff, .ttf, or .otf`);
+  }
+  return extension;
+}
+
+function fontFormat(extension: string): string {
+  switch (extension.toLowerCase()) {
+    case ".woff2":
+      return "woff2";
+    case ".woff":
+      return "woff";
+    case ".ttf":
+      return "truetype";
+    case ".otf":
+      return "opentype";
+    default:
+      throw new Error(`[Farm fonts] Unsupported font extension ${extension}`);
+  }
+}
+
+function fontContentType(extension: string): string {
+  switch (extension.toLowerCase()) {
+    case ".woff2":
+      return "font/woff2";
+    case ".woff":
+      return "font/woff";
+    case ".ttf":
+      return "font/ttf";
+    case ".otf":
+      return "font/otf";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+function renderFamilyStack(family: string, fallback: string[]): string {
+  return [quoteCssString(family), ...fallback.map(formatFallbackFamily)].join(", ");
+}
+
+function formatFallbackFamily(value: string): string {
+  return /^(?:serif|sans-serif|monospace|cursive|fantasy|system-ui|ui-serif|ui-sans-serif|ui-monospace|emoji|math|fangsong)$/.test(
+    value,
+  )
+    ? value
+    : quoteCssString(value);
+}
+
+function quoteCssString(value: string): string {
+  return JSON.stringify(value.replace(/[\n\r\f]/g, " "));
+}
+
+function sanitizeFileName(value: string): string {
+  return value
+    .replace(/[^A-Za-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}
+
+function assetSourceToString(source: string | Uint8Array): string {
+  return typeof source === "string" ? source : Buffer.from(source).toString("utf8");
+}
+
+function applyReplacements(code: string, replacements: Replacement[]): string {
+  let output = code;
+  for (const replacement of replacements.sort((left, right) => right.start - left.start)) {
+    output = output.slice(0, replacement.start) + replacement.code + output.slice(replacement.end);
+  }
+  return output;
+}
+
+function walkAst(
+  node: AstNode,
+  visit: (node: AstNode, ancestors: readonly AstNode[]) => void,
+  ancestors: readonly AstNode[] = [],
+): void {
+  visit(node, ancestors);
+  const childAncestors = [...ancestors, node];
+  for (const [key, value] of Object.entries(node)) {
+    if (["start", "end", "loc", "range"].includes(key)) continue;
+    if (isAstNode(value)) walkAst(value, visit, childAncestors);
+    else if (Array.isArray(value)) {
+      for (const item of value) if (isAstNode(item)) walkAst(item, visit, childAncestors);
+    }
+  }
+}
+
+function readPropertyName(value: unknown): string | undefined {
+  if (!isAstNode(value)) return undefined;
+  if (value.type === "Identifier" && typeof value.name === "string") return value.name;
+  if (value.type === "Literal" && typeof value.value === "string") return value.value;
+  return undefined;
+}
+
+function isAstNode(value: unknown): value is AstNode {
+  return (
+    Boolean(value) &&
+    typeof value === "object" &&
+    typeof (value as AstNode).type === "string" &&
+    typeof (value as AstNode).start === "number" &&
+    typeof (value as AstNode).end === "number"
+  );
+}
+
+function isFunctionNode(node: AstNode): boolean {
+  return (
+    node.type === "FunctionDeclaration" ||
+    node.type === "FunctionExpression" ||
+    node.type === "ArrowFunctionExpression"
+  );
+}
+
+function isFontLoaderKind(value: unknown): value is FontLoaderKind {
+  return typeof value === "string" && FONT_FUNCTIONS.has(value as FontLoaderKind);
+}
+
+function containsFontFunction(code: string): boolean {
+  return Array.from(FONT_FUNCTIONS).some((name) => code.includes(name));
+}
+
+function requireString(value: unknown, id: string, label: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw fontError(id, `${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown, id: string, label: string): string | undefined {
+  if (value === undefined) return undefined;
+  return requireString(value, id, label);
+}
+
+function readStringArray(value: unknown, id: string, label: string): string[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    throw fontError(id, `${label} must be an array of family names`);
+  }
+  return value as string[];
+}
+
+function optionalWeight(value: unknown, id: string): number | string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 1000) {
+    return value;
+  }
+  if (
+    typeof value === "string" &&
+    /^(?:[1-9]\d{0,2}|1000)(?:\s+(?:[1-9]\d{0,2}|1000))?$/.test(value)
+  ) {
+    const bounds = value.split(/\s+/).map(Number);
+    if (bounds.length === 2 && bounds[0] > bounds[1]) {
+      throw fontError(id, `font weight range must be ordered from lowest to highest`);
+    }
+    return value;
+  }
+  throw fontError(id, `font weight must be a number or range such as "100 900"`);
+}
+
+function optionalCssDescriptor(value: unknown, id: string, label: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !/^[A-Za-z0-9 .-]+$/.test(value)) {
+    throw fontError(id, `font ${label} contains unsupported characters`);
+  }
+  return value;
+}
+
+function optionalUnicodeRange(value: unknown, id: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !/^[Uu+0-9A-Fa-f?*, -]+$/.test(value)) {
+    throw fontError(id, `font unicodeRange contains unsupported characters`);
+  }
+  return value;
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+}
+
+function fontError(id: string, message: string): Error {
+  return new Error(`[Farm fonts] ${message} in ${id.split("?", 1)[0]}`);
+}

--- a/packages/farm/src/font.ts
+++ b/packages/farm/src/font.ts
@@ -1,0 +1,86 @@
+export type FarmFontDisplay = "auto" | "block" | "swap" | "fallback" | "optional";
+
+export interface FarmFontSource {
+  /** Local file path or remote URL, depending on the loader. */
+  path: string;
+  /** A fixed weight (`400`) or variable range (`100 900`). */
+  weight?: number | string;
+  /** Font style for this source. */
+  style?: string;
+  /** Optional CSS unicode-range descriptor. */
+  unicodeRange?: string;
+}
+
+export interface FarmFontOptions {
+  /** CSS font-family name. */
+  family: string;
+  /** A fixed weight (`400`) or variable range (`100 900`). */
+  weight?: number | string;
+  /** Font style. @default "normal" */
+  style?: string;
+  /** Browser loading behavior. @default "swap" */
+  display?: FarmFontDisplay;
+  /** CSS custom property populated by `variable`, for example `--font-sans`. */
+  variable?: `--${string}`;
+  /** Fallback family names appended to the generated stack. */
+  fallback?: string[];
+  /** Emit font preload hints. @default true */
+  preload?: boolean;
+}
+
+export interface LocalFontOptions extends FarmFontOptions {
+  /**
+   * A file relative to this module, a package font specifier, or explicit
+   * sources for a multi-weight family.
+   */
+  src: string | FarmFontSource[];
+}
+
+export interface RemoteFontSource extends FarmFontSource {
+  /** Optional integrity value for this source. Overrides the family-level value. */
+  integrity?: string;
+}
+
+export interface RemoteFontOptions extends FarmFontOptions {
+  /** HTTPS font URL, or explicit remote sources for a multi-weight family. */
+  src: string | RemoteFontSource[];
+  /** Download and fingerprint the font during the build, or retain its URL. */
+  strategy?: "self-host" | "external";
+  /** Optional Subresource Integrity value checked while self-hosting. */
+  integrity?: string;
+}
+
+export interface FarmFont {
+  /** Generated class that applies the font family and fallback stack. */
+  className: string;
+  /** Generated class that defines the configured CSS custom property. */
+  variable: string;
+  /** Inline-style equivalent of the generated family. */
+  style: Readonly<{
+    fontFamily: string;
+    fontStyle?: string;
+    fontWeight?: number | string;
+  }>;
+}
+
+function fontCompilerError(loader: string): never {
+  throw new Error(
+    `[Farm fonts] ${loader}() must be called at module scope with static options and compiled by the Farm Vite plugin.`,
+  );
+}
+
+/**
+ * Compile local font files into hashed application assets and generated CSS.
+ * The call is removed at build time and adds no font-loader runtime code.
+ */
+export function localFont(_options: LocalFontOptions): FarmFont {
+  return fontCompilerError("localFont");
+}
+
+/**
+ * Compile a remote font into a self-hosted application asset by default.
+ * Use `strategy: "external"` only when the browser should retain the remote URL.
+ */
+export function remoteFont(_options: RemoteFontOptions): FarmFont {
+  return fontCompilerError("remoteFont");
+}

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -102,6 +102,7 @@ export * from "./cron";
 export * from "./env";
 export * from "./env-types";
 export * from "./environment";
+export * from "./font";
 export * from "./type-artifacts";
 export { createFarmImageTypeDeclarations, generateFarmImageTypes } from "./image-types";
 export type { GenerateFarmImageTypesOptions } from "./image-types";

--- a/packages/farm/src/nitro/production-runtime.ts
+++ b/packages/farm/src/nitro/production-runtime.ts
@@ -25,3 +25,14 @@ export {
 } from "../navigation-errors";
 export { configureFarmObservability, emitFarmEvent } from "../observability";
 export { resolveFarmRouteContext, withFarmRouteContext } from "../route-context";
+
+export function appendFarmLinkHeader(headers: Headers, value: string): void {
+  const current = headers.get("Link");
+  if (!current) {
+    headers.set("Link", value);
+    return;
+  }
+  if (current !== value && !current.endsWith(`, ${value}`)) {
+    headers.set("Link", `${current}, ${value}`);
+  }
+}

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -2967,6 +2967,7 @@ function generateVirtualEntryCode(
   _runWithMiddlewareContext,
   _runWithMiddlewareData,
   addMetadataImageReference,
+  appendFarmLinkHeader,
   applyProductionMiddlewareHeaders,
   configureFarmCache,
   configureFarmObservability,
@@ -4030,9 +4031,14 @@ function applyConfiguredResponseHeaders(response, pathname) {
   for (const headerRoute of configuredHeaderRoutes) {
     if (!matchRuntimePathPattern(headerRoute.source, pathname)) continue;
     for (const header of headerRoute.headers) {
-      if ((headers || response.headers).get(header.key) === header.value) continue;
+      const currentValue = (headers || response.headers).get(header.key);
+      if (currentValue === header.value) continue;
       if (!headers) headers = new Headers(response.headers);
-      headers.set(header.key, header.value);
+      if (header.key.toLowerCase() === "link") {
+        appendFarmLinkHeader(headers, header.value);
+      } else {
+        headers.set(header.key, header.value);
+      }
     }
   }
 
@@ -4666,6 +4672,7 @@ async function handleFarmRequestInContext(
             status: 200,
             headers: {
               "Content-Type": "text/html; charset=utf-8",
+              ...(farmFontPreloadHeader ? { "Link": farmFontPreloadHeader } : {}),
               ...getPPRHeaders("hit", pprConfig),
             },
           }), middlewareHeaders);

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -56,6 +56,7 @@ import { getFarmIntegrationPluginServerRuntime } from "../integrations";
 import type { TransformOptions } from "esbuild";
 import { loadFarmProductionVite, type FarmProductionViteRuntime } from "../build/production-vite";
 import { adaptTailwindVitePlugin } from "../build/vite-plugin-compat";
+import { mergeFarmFontCss } from "../font-vite";
 
 // Type alias for OutputBundle
 type OutputBundle = Rollup.OutputBundle;
@@ -816,9 +817,45 @@ async function writeSSRAssetsToClient(bundle: OutputBundle, outputDir: string): 
   const fs = await import("fs/promises");
   for (const [fileName, output] of Object.entries(bundle)) {
     if (output.type !== "asset") continue;
+    if (fileName === "farm-fonts.css") {
+      await mergeBuiltFontCss(outputDir, output.source);
+      continue;
+    }
     const filePath = path.join(outputDir, fileName);
     await fs.mkdir(path.dirname(filePath), { recursive: true });
     await fs.writeFile(filePath, output.source);
+  }
+}
+
+async function mergeBuiltFontCss(
+  outputDir: string,
+  fontCssSource?: string | Uint8Array,
+): Promise<void> {
+  const fs = await import("fs/promises");
+  const fontCssPath = path.join(outputDir, "farm-fonts.css");
+  let fontCss = fontCssSource;
+  if (fontCss === undefined) {
+    try {
+      fontCss = await fs.readFile(fontCssPath);
+    } catch {
+      return;
+    }
+  }
+
+  const clientCssPath = path.join(outputDir, "farm-client.css");
+  let clientCss = "";
+  try {
+    clientCss = await fs.readFile(clientCssPath, "utf8");
+  } catch {
+    // A font-only app may not have produced a stylesheet yet.
+  }
+  const normalizedFontCss =
+    typeof fontCss === "string" ? fontCss : Buffer.from(fontCss).toString("utf8");
+  await fs.writeFile(clientCssPath, mergeFarmFontCss(clientCss, normalizedFontCss));
+  try {
+    await fs.rm(fontCssPath, { force: true });
+  } catch {
+    // The CSS may have come from the in-memory SSR bundle only.
   }
 }
 
@@ -1113,6 +1150,7 @@ async function buildClient(
                 'export { useRouter } from "@farm.js/core/client";',
                 'export { usePathname, useSearchParams } from "@farm.js/core/navigation";',
                 'export { createAPIClient } from "@farm.js/core/client";',
+                'export { localFont, remoteFont } from "@farm.js/core/font";',
               ].join("\n");
             }
             return null;
@@ -1141,6 +1179,7 @@ async function buildClient(
         ],
       },
     });
+    await mergeBuiltFontCss(outputDir);
     await validateClientBuildOutput(root, srcDir, outputDir);
   } finally {
     // Clean up temporary entry file
@@ -3091,6 +3130,7 @@ ${mdxComponentsImport}
 ${integrationImports}
 ${imageRuntimeImport}
 ${imageNodeRuntimeImport}
+import { farmFontPreloadHeader } from "virtual:farm-font-runtime";
 import * as React from "react";
 import * as ReactDOMServer from "react-dom/server";
 
@@ -4951,6 +4991,7 @@ async function handleFarmRequestInContext(
           "Cache-Control": renderedPage.stream || hasRequestScopedRender || !sharedCacheControl
             ? "private, no-store"
             : sharedCacheControl,
+          ...(farmFontPreloadHeader ? { "Link": farmFontPreloadHeader } : {}),
           ...(pprConfig.enabled ? getPPRHeaders(pprCanCache ? "miss" : "bypass", pprConfig) : {}),
         };
         const farmI18nSnapshot = getFarmI18nSnapshot();

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -48,6 +48,7 @@ import {
 import { createFarmLocaleCookie, getFarmLocaleVaryHeaders } from "../i18n/resolver";
 import { localizeFarmHref, localizeFarmPathname } from "../i18n/routing";
 import { sendWebResponse } from "./response";
+import { renderFarmFontDevHead } from "../font-vite";
 
 let cachedClerkProvider: {
   ClerkProvider: React.ComponentType<{ children?: React.ReactNode } & Record<string, unknown>>;
@@ -1573,7 +1574,6 @@ export class ServerRenderer {
       for (const [key, value] of Object.entries(options.responseHeaders || {})) {
         res.setHeader(key, value);
       }
-
       const htmlParts: string[] = [];
       const staticShellParts: string[] | undefined = options.captureStaticShell ? [] : undefined;
       let staticShellClosed = false;
@@ -1686,6 +1686,7 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
       const i18nAlternateTags = i18nSnapshot
         ? renderI18nAlternateLinks((req as any).__FARM_ROUTE__ || req.url || "/", i18nSnapshot)
         : "";
+      const fontHead = renderFarmFontDevHead(this.config.root || process.cwd());
 
       // React 19: ensure root is a single DOM node so streaming starts early (avoids Fragment delay)
       const streamRoot = React.createElement("div", { style: { display: "contents" } }, element);
@@ -1710,6 +1711,7 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
   <meta name="farm-deployment-id" content="${escapeHtmlAttribute(deploymentId)}">
   ${hasFavicon ? "" : '<link rel="icon" href="data:,">'}
   <title>${title}</title>${metaTags}${i18nAlternateTags}
+  ${fontHead}
   <link rel="stylesheet" href="/src/app/globals.css" />
   <script type="module" src="/@vite/client"></script>
   ${propsScript}
@@ -1959,6 +1961,7 @@ window.__FARM_INTEGRATION_API_MANIFEST__ = ${JSON.stringify(getRegisteredIntegra
 ${i18nSnapshot ? `window.__FARM_I18N__ = ${serializeInlineValue(i18nSnapshot)};` : ""}
 </script>`;
     const alternateLinks = i18nSnapshot ? renderI18nAlternateLinks(requestPath, i18nSnapshot) : "";
+    const fontHead = renderFarmFontDevHead(this.config.root || process.cwd());
 
     return `<!DOCTYPE html>
 <html lang="${escapeHtmlAttribute(i18nSnapshot?.locale || "en")}"${
@@ -1970,6 +1973,7 @@ ${i18nSnapshot ? `window.__FARM_I18N__ = ${serializeInlineValue(i18nSnapshot)};`
   <meta name="farm-deployment-id" content="${escapeHtmlAttribute(this.getDeploymentId())}">
   <link rel="icon" href="data:,">
   <title>Farm.js App</title>${alternateLinks}
+  ${fontHead}
   <link rel="stylesheet" href="/src/app/globals.css" />
   <script type="module" src="/@vite/client"></script>
   ${integrationManifestScript}

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -52,6 +52,7 @@ import {
 } from "./deployment";
 import { getPublicFarmImageConfig, resolveFarmImageConfig } from "./image-config";
 import { farmImageImportsPlugin } from "./image-vite";
+import { farmFontImportsPlugin } from "./font-vite";
 import { createFarmImageHandler, type FarmImageHandler } from "./image-server";
 import { getFarmI18nClientSnapshot } from "./i18n/server";
 import { localizeFarmPathname } from "./i18n/routing";
@@ -60,6 +61,7 @@ import type { FarmI18nClientSnapshot } from "./i18n/types";
 interface FarmVitePluginOptions extends FarmConfig {
   openapi?: FarmUserConfig["openapi"];
   images?: FarmUserConfig["images"];
+  publicDir?: FarmUserConfig["publicDir"];
 }
 
 type TypeArtifactSelection = Pick<
@@ -455,6 +457,11 @@ export function farmPlugin(
   initialPluginManager?: PluginManager,
 ): Plugin {
   const imageImports = farmImageImportsPlugin();
+  const fontImports = farmFontImportsPlugin({
+    root: options.root,
+    basePath: options.basePath,
+    publicDir: options.publicDir,
+  });
   let farmApp: FarmApp;
   let server: ViteDevServer;
   let hmrManager: HMRManager;
@@ -503,10 +510,16 @@ export function farmPlugin(
     },
 
     async configResolved(config) {
-      // Defer initialization until Vite server is available
+      if (typeof fontImports.configResolved === "function") {
+        await fontImports.configResolved.call(this, config);
+      }
+      // Defer Farm application initialization until Vite server is available.
     },
 
     async configureServer(viteServer) {
+      if (typeof fontImports.configureServer === "function") {
+        await fontImports.configureServer.call(this, viteServer);
+      }
       server = viteServer;
 
       // Store the plugin manager passed during creation
@@ -2077,6 +2090,11 @@ export function farmPlugin(
     },
 
     async resolveId(id, importer, resolveOptions) {
+      if (typeof fontImports.resolveId === "function") {
+        const fontId = await fontImports.resolveId.call(this, id, importer, resolveOptions);
+        if (fontId) return fontId;
+      }
+
       if (typeof imageImports.resolveId === "function") {
         const imageId = await imageImports.resolveId.call(this, id, importer, resolveOptions);
         if (imageId) return imageId;
@@ -2101,6 +2119,11 @@ export function farmPlugin(
     },
 
     async load(id) {
+      if (typeof fontImports.load === "function") {
+        const fontModule = await fontImports.load.call(this, id);
+        if (fontModule) return fontModule;
+      }
+
       if (typeof imageImports.load === "function") {
         const imageModule = await imageImports.load.call(this, id);
         if (imageModule) return imageModule;
@@ -2236,6 +2259,20 @@ export const manifest = getManifest();
       let transformedCode = code;
       let transformed = false;
 
+      if (typeof fontImports.transform === "function") {
+        const fontResult = await fontImports.transform.call(
+          this,
+          transformedCode,
+          id,
+          transformOptions,
+        );
+        const fontCode = typeof fontResult === "string" ? fontResult : fontResult?.code;
+        if (fontCode) {
+          transformedCode = fontCode;
+          transformed = true;
+        }
+      }
+
       if (transformOptions?.ssr && server) {
         const rewrittenImports = rewriteEarlySsrRelativeImports({
           code: transformedCode,
@@ -2300,7 +2337,10 @@ if (import.meta.hot) {
       return transformed ? { code: transformedCode, map: null } : null;
     },
 
-    generateBundle(options, bundle) {
+    async generateBundle(options, bundle) {
+      if (typeof fontImports.generateBundle === "function") {
+        await fontImports.generateBundle.call(this, options, bundle, false);
+      }
       const clientManifest = generateClientManifest(bundle);
       this.emitFile({
         type: "asset",

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -43,6 +43,7 @@ export const farmPackageBuildOptions = {
     env: "src/env.ts",
     "env-types": "src/env-types.ts",
     environment: "src/environment.ts",
+    font: "src/font.ts",
     "environment/vite": "src/environment-vite.ts",
     testing: "src/testing.ts",
     "agent-runtime": "src/agent-runtime.ts",


### PR DESCRIPTION
## Summary

- add statically analyzable `localFont` and `remoteFont` APIs through `@farm.js/core/font`
- compile font declarations into generated CSS, preload hints, and content-hashed self-hosted assets without browser loader code
- support relative files, package font assets, self-hosted HTTPS sources with optional SRI, and explicitly external remote sources
- resolve `/fonts/...` sources from the configured `publicDir`, respect `basePath`, and avoid emitting duplicate assets
- integrate font CSS and preload metadata across development, production, SSR, SSG, and Nitro output
- migrate the Farm documentation site away from manual `?url`, inline `@font-face`, and `dangerouslySetInnerHTML`
- add a dedicated fonts guide

## User impact

Applications can configure local, packaged, public, and remote font files from a layout with static metadata. Farm validates the declarations at build time, supplies deterministic class and variable names, and removes the loader imports from application output.

Relative and package sources are emitted with content-hashed filenames. Public-folder sources retain their existing public URL while still receiving generated CSS and preload hints.

## Validation

- `pnpm --dir packages/farm type-check`
- `pnpm --dir packages/farm exec vitest run src/__tests__/font-vite.test.ts src/__tests__/server-renderer-route-states.test.tsx` (15 tests)
- targeted `oxfmt --check`
- targeted `oxlint`
- `git diff --check`

A full repository/docs production build was not run locally because the machine has critically low free disk space.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add first-class font loading with `localFont` and `remoteFont` that compile declarations into generated CSS, hashed assets, and preload hints with zero runtime loader code. Works across dev, build, SSR/SSG/Nitro, and migrates the docs site to the new API.

- New Features
  - Statically analyzable `@farm.js/core/font` APIs that output deterministic class/variable names and remove loader imports from bundles.
  - Local fonts: relative and package sources are fingerprinted; public `/fonts/...` resolve from `publicDir`, respect `basePath`, and avoid duplicate emits.
  - Remote fonts: HTTPS only; self-host by default with optional `integrity`; 20 MB download cap with clear errors; use `strategy: "external"` to retain the original URL.
  - Preload: dev injects stylesheet and `<link rel="preload">`; SSR sends a `Link` header for fonts and appends to configured `Link` values; headers persist on PPR cache hits; CSS is merged and deduped in production.
  - Development server serves generated font CSS and bytes; production emits content-hashed assets and merges font CSS into the client stylesheet.

- Migration
  - Call `localFont`/`remoteFont` at module scope with static options in layouts/pages.
  - Replace manual `?url` imports, inline `@font-face`, and `dangerouslySetInnerHTML` with the returned `className`/`variable`.
  - Use package or relative sources to get hashed filenames; use `/fonts/...` for assets already in `publicDir`.
  - For remote providers, prefer direct font-file URLs; add `integrity` when available or set `strategy: "external"` if required by licensing/hosting.
  - See the new Fonts guide for examples and details.

<sup>Written for commit ddc8d8ff4c36af3274555a0848bdd3b7cb808a54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

