### PR TITLE
fix: align production sites e2e output paths

### DIFF
--- a/playwright.production-sites.config.ts
+++ b/playwright.production-sites.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   },
   webServer: [
     {
-      command: `NODE_ENV=production HOST=127.0.0.1 PORT=${docsPort} node docs/.farm/.output/server/index.mjs`,
+      command: `NODE_ENV=production HOST=127.0.0.1 PORT=${docsPort} node docs/.vercel/output/server/index.mjs`,
       url: docsBaseURL,
       reuseExistingServer: false,
       timeout: 30_000,

--- a/tests/e2e-production-sites/docs.production.spec.ts
+++ b/tests/e2e-production-sites/docs.production.spec.ts
@@ -3,8 +3,8 @@ import { expect, test } from "@playwright/test";
 
 test.beforeAll(async () => {
   await Promise.all([
-    access("docs/.farm/.output/server/index.mjs"),
-    access("docs/.farm/.output/public/farm-client.js"),
+    access("docs/.vercel/output/server/index.mjs"),
+    access("docs/.vercel/output/public/farm-client.js"),
   ]);
 });
 
@@ -20,7 +20,7 @@ test("boots the emitted docs site and navigates into the guide", async ({ page }
   expect(response?.ok()).toBe(true);
   expect(response?.headers()["x-frame-options"]).toBe("DENY");
   await expect(page).toHaveTitle(/Farm\.js/);
-  await expect(page.getByRole("heading", { level: 1 })).toContainText("A Framework for");
+  await expect(page.getByRole("heading", { level: 1 })).toContainText(/a framework for/i);
   await expect(page.getByRole("navigation", { name: "Primary navigation" })).toBeVisible();
 
   const getStarted = page.getByRole("link", { name: "Get Started", exact: true }).first();


### PR DESCRIPTION
## Summary

- start the production docs server from the Vercel output directory emitted by its deployment configuration
- update the docs production E2E preflight checks to validate the same output directory
- make the hero-copy assertion case-insensitive so it matches the current rendered copy

## Root cause

The docs production build completed successfully at `docs/.vercel/output`, but the Playwright server command and preflight assertions still referenced `docs/.farm/.output`. Once the server path was corrected, the suite also exposed an outdated capitalization-sensitive hero assertion.

## Impact

The Framework E2E job can start the emitted docs server and exercise the production docs flow instead of failing before Playwright begins.

## Validation

- built the docs and SSR/SSG demo production outputs
- `pnpm exec playwright test --config playwright.production-sites.config.ts` (4 passed)
- `oxfmt --check playwright.production-sites.config.ts tests/e2e-production-sites/docs.production.spec.ts`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned the production docs E2E to use the Vercel output by starting the server from `docs/.vercel/output` and updating preflight checks; also made the hero H1 assertion case-insensitive to match current copy. This unblocks the Framework E2E job so it boots the emitted docs site and runs the production flow instead of failing in preflight.

<sup>Written for commit 9bf1e1a82a87292cfa207c2e563c950546c5c6d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

