### PR TITLE
feat: polish rendering features and font loading

### DIFF
--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -8,9 +8,12 @@ import {
   BookOpenText,
   Bot,
   Braces,
+  Check,
   CloudCog,
+  Cpu,
   Database,
   ExternalLink,
+  FileOutput,
   FileText,
   FolderTree,
   GitFork,
@@ -1070,7 +1073,7 @@ function FeatureCell({
   icon: LucideIcon;
   label: string;
   title: string;
-  body: string;
+  body: ReactNode;
   className?: string;
   children: ReactNode;
 }) {
@@ -1363,6 +1366,209 @@ function AdvancedRoutesVisual() {
   );
 }
 
+const optimizedBoundaryChecks = [
+  ["Host-only tree", "pass"],
+  ["Client code", "none"],
+  ["Events or refs", "none"],
+  ["Size gate", "pass"],
+] as const;
+
+function FeatureDiagramFrame({
+  ariaLabel,
+  href,
+  icon: Icon,
+  label,
+  status,
+  footerLabel,
+  footerValue,
+  children,
+}: {
+  ariaLabel: string;
+  href: string;
+  icon: LucideIcon;
+  label: string;
+  status: string;
+  footerLabel: string;
+  footerValue: string;
+  children: ReactNode;
+}) {
+  return (
+    <FoundationCanvas interactive>
+      <a
+        aria-label={ariaLabel}
+        className="group/diagram absolute inset-0 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-white"
+        href={href}
+      >
+        <figure className="farm-illustration-surface absolute -bottom-px -right-px top-4 flex w-[calc(100%-1.5rem)] flex-col overflow-hidden border border-white/10 transition-colors duration-150 group-hover/diagram:border-white/18 sm:w-[calc(100%-2.5rem)]">
+          <figcaption className="flex h-10 shrink-0 items-center justify-between border-b border-white/8 px-4 font-mono text-[9px] font-normal uppercase tracking-normal">
+            <span className="flex items-center gap-1.5 text-white/54">
+              <Icon aria-hidden className="size-3" strokeWidth={1.5} />
+              {label}
+            </span>
+            <span className="border border-white/12 bg-white/[0.035] px-2 py-1 text-white/44">
+              {status}
+            </span>
+          </figcaption>
+
+          <div className="relative min-h-0 flex-1">
+            <span
+              aria-hidden
+              className="pointer-events-none absolute inset-0 bg-[linear-gradient(rgb(255_255_255/0.018)_1px,transparent_1px),linear-gradient(90deg,rgb(255_255_255/0.018)_1px,transparent_1px)] bg-[size:24px_24px] opacity-55"
+            />
+            <div className="relative z-10 h-full">{children}</div>
+          </div>
+
+          <div className="flex h-12 shrink-0 items-center justify-between border-t border-white/10 bg-white/[0.025] px-4 font-mono text-[9px] font-normal uppercase tracking-normal sm:px-5">
+            <span className="text-white/32">{footerLabel}</span>
+            <span className="flex items-center gap-2 text-white/86">
+              {footerValue}
+              <ArrowRight
+                aria-hidden
+                className="size-3 transition-transform duration-150 group-hover/diagram:translate-x-0.5"
+                strokeWidth={1.5}
+              />
+            </span>
+          </div>
+        </figure>
+      </a>
+    </FoundationCanvas>
+  );
+}
+
+function DiagramConnector() {
+  return (
+    <div aria-hidden className="flex min-w-0 items-center">
+      <span className="h-px min-w-0 flex-1 bg-white/12" />
+      <span className="grid size-6 shrink-0 place-items-center border border-white/12 bg-black text-white/46">
+        <ArrowRight className="size-2.5" strokeWidth={1.5} />
+      </span>
+      <span className="h-px min-w-0 flex-1 bg-white/12" />
+    </div>
+  );
+}
+
+function OptimizedBoundaryVisual() {
+  return (
+    <FeatureDiagramFrame
+      ariaLabel="Read about automatic optimized boundaries"
+      footerLabel="Selected renderer"
+      footerValue="Strata / Rust"
+      href="/docs/server-rendering#automatic-optimized-boundaries"
+      icon={Cpu}
+      label="Boundary analysis"
+      status="Experimental"
+    >
+      <div className="grid h-full grid-cols-[minmax(0,0.88fr)_2.25rem_minmax(0,1.12fr)] items-center px-4 sm:grid-cols-[minmax(0,0.82fr)_3rem_minmax(0,1.18fr)] sm:px-5">
+        <div className="flex h-[152px] min-w-0 flex-col border border-white/12 bg-black/88">
+          <div className="flex h-8 shrink-0 items-center justify-between border-b border-white/8 px-3 font-mono text-[8px] font-normal uppercase tracking-normal">
+            <span className="text-white/34">Candidate</span>
+            <span className="text-white/58">RSC</span>
+          </div>
+          <div className="flex min-h-0 flex-1 flex-col items-center justify-center px-2 text-center font-mono tracking-normal">
+            <span className="border border-white/10 bg-white/[0.035] px-2 py-1 text-[7px] uppercase text-white/38 sm:text-[8px]">
+              Server component
+            </span>
+            <span className="mt-3 text-[11px] text-white/86 sm:text-xs">&lt;article&gt;</span>
+            <span className="mt-1 text-[8px] text-white/32 sm:text-[9px]">host-only region</span>
+          </div>
+        </div>
+
+        <DiagramConnector />
+
+        <div className="flex h-[152px] min-w-0 flex-col border border-white/12 bg-black/88">
+          <div className="flex h-8 shrink-0 items-center justify-between border-b border-white/8 px-3 font-mono text-[8px] font-normal uppercase tracking-normal">
+            <span className="text-white/34">Runtime scan</span>
+            <span className="flex items-center gap-1 text-white/68">
+              <Check aria-hidden className="size-2.5" strokeWidth={1.8} /> Eligible
+            </span>
+          </div>
+          <div className="min-h-0 flex-1 px-3">
+            {optimizedBoundaryChecks.map(([label, value]) => (
+              <div
+                key={label}
+                className="flex h-[30px] items-center justify-between border-b border-white/8 font-mono text-[8px] tracking-normal last:border-b-0 sm:text-[9px]"
+              >
+                <span className="truncate text-white/38">{label}</span>
+                <span className="ml-2 flex shrink-0 items-center gap-1 text-white/68">
+                  <Check aria-hidden className="size-2.5" strokeWidth={1.8} />
+                  {value}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </FeatureDiagramFrame>
+  );
+}
+
+function MarkdownMirrorsVisual() {
+  return (
+    <FeatureDiagramFrame
+      ariaLabel="Read about automatic Markdown mirrors"
+      footerLabel="Content negotiation"
+      footerValue="text/markdown"
+      href="/docs/markdown"
+      icon={FileOutput}
+      label="Representation map"
+      status="Automatic"
+    >
+      <div className="grid h-full grid-cols-[minmax(0,0.88fr)_2.25rem_minmax(0,1.12fr)] items-center px-4 sm:grid-cols-[minmax(0,0.82fr)_3rem_minmax(0,1.18fr)] sm:px-5">
+        <div className="flex h-[152px] min-w-0 flex-col border border-white/12 bg-black/88">
+          <div className="flex h-8 shrink-0 items-center justify-between border-b border-white/8 px-3 font-mono text-[8px] font-normal uppercase tracking-normal">
+            <span className="text-white/34">Source</span>
+            <span className="text-white/58">Page</span>
+          </div>
+          <div className="flex min-h-0 flex-1 flex-col items-center justify-center px-2 text-center font-mono tracking-normal">
+            <span className="border border-white/10 bg-white/[0.035] px-2 py-1 text-[7px] uppercase text-white/38 sm:text-[8px]">
+              App route
+            </span>
+            <span className="mt-3 text-[11px] text-white/86 sm:text-xs">/pricing</span>
+            <span className="mt-1 text-[8px] text-white/32 sm:text-[9px]">one source</span>
+          </div>
+        </div>
+
+        <DiagramConnector />
+
+        <div className="flex h-[152px] min-w-0 flex-col border border-white/12 bg-black/88">
+          <div className="flex h-8 shrink-0 items-center justify-between border-b border-white/8 px-3 font-mono text-[8px] font-normal uppercase tracking-normal">
+            <span className="text-white/34">Representations</span>
+            <span className="text-white/58">2 outputs</span>
+          </div>
+          <div className="grid min-h-0 flex-1 grid-rows-2">
+            <div className="flex min-w-0 items-center justify-between border-b border-white/8 px-3 font-mono tracking-normal">
+              <div className="min-w-0">
+                <span className="block text-[7px] uppercase text-white/28 sm:text-[8px]">
+                  Browser
+                </span>
+                <span className="mt-1 block truncate text-[9px] text-white/74 sm:text-[10px]">
+                  /pricing
+                </span>
+              </div>
+              <span className="ml-2 border border-white/10 bg-white/[0.025] px-2 py-1 text-[7px] uppercase text-white/48 sm:text-[8px]">
+                HTML
+              </span>
+            </div>
+            <div className="flex min-w-0 items-center justify-between px-3 font-mono tracking-normal">
+              <div className="min-w-0">
+                <span className="block text-[7px] uppercase text-white/28 sm:text-[8px]">
+                  Agent
+                </span>
+                <span className="mt-1 block truncate text-[9px] text-white/86 sm:text-[10px]">
+                  /pricing.md
+                </span>
+              </div>
+              <span className="ml-2 border border-white/14 bg-white/[0.045] px-2 py-1 text-[7px] uppercase text-white/78 sm:text-[8px]">
+                Markdown
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </FeatureDiagramFrame>
+  );
+}
+
 function AgentRuntimeVisual() {
   return (
     <FoundationCodeTabsVisual
@@ -1408,7 +1614,7 @@ function FoundationGrid() {
         <DeploymentVisual />
       </FeatureCell>
       <FeatureCell
-        body="Enable docs in your app config, then serve pages, Markdown, search, and agent-ready endpoints from the same source."
+        body="Enable a complete docs surface with MDX, navigation, search, MCP, and agent-ready endpoints from the same source."
         className="border-t border-white/12"
         icon={BookOpenText}
         index="02.3"
@@ -1446,6 +1652,40 @@ function FoundationGrid() {
         title="Configure the whole route in one place"
       >
         <AdvancedRoutesVisual />
+      </FeatureCell>
+      <FeatureCell
+        body={
+          <>
+            Farm detects large, host-only Server Component regions and renders eligible trees
+            through{" "}
+            <a
+              className="font-medium text-white underline decoration-white/45 underline-offset-4 transition-[text-decoration-color] duration-150 hover:decoration-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+              href="https://github.com/farming-labs/strata"
+              rel="noreferrer"
+              target="_blank"
+            >
+              Strata
+            </a>
+            {"'s Rust-native renderer. Everything else stays on React."}
+          </>
+        }
+        className="border-t border-white/12"
+        icon={Cpu}
+        index="02.7"
+        label="Experimental rendering"
+        title="Native rendering for static regions"
+      >
+        <OptimizedBoundaryVisual />
+      </FeatureCell>
+      <FeatureCell
+        body="Every app page receives a Markdown representation at a .md URL or through content negotiation. Keep the generated output or override it with page.md."
+        className="border-t border-white/12 lg:border-l"
+        icon={FileOutput}
+        index="02.8"
+        label="Markdown mirrors"
+        title="Every page, readable by agents"
+      >
+        <MarkdownMirrorsVisual />
       </FeatureCell>
     </section>
   );

--- a/packages/farm/src/__tests__/font-vite.test.ts
+++ b/packages/farm/src/__tests__/font-vite.test.ts
@@ -69,9 +69,10 @@ export const demo = localFont({ src: "./demo.woff2", family: "Dev Demo" });`,
       expect(transformed?.code).not.toContain("font-runtime-stub");
       expect(transformed?.code).not.toContain("@farm.js/core/font");
       expect(transformed?.code).toContain("font-css");
-      expect(renderFarmFontDevHead(root)).toContain('<link rel="preload"');
-      expect(renderFarmFontDevHead(root)).toContain('href="/docs/@farm/font/');
-      expect(renderFarmFontDevHead(root)).not.toContain('rel="stylesheet"');
+      const head = renderFarmFontDevHead(root);
+      expect(head).toContain('<link rel="preload"');
+      expect(head).toContain('href="/docs/@farm/font/');
+      expect(head).toContain('<link rel="stylesheet" href="/@farm/fonts.css">');
 
       await new Promise<void>((resolve) => http.listen(0, "127.0.0.1", resolve));
       const address = http.address();

--- a/packages/farm/src/font-vite.ts
+++ b/packages/farm/src/font-vite.ts
@@ -248,7 +248,7 @@ export async function transformFarmFontCalls(
 export function renderFarmFontDevHead(root: string): string {
   const registry = registries.get(normalizeRoot(root));
   if (!registry || registry.production || registry.size === 0) return "";
-  return registry.renderPreloadTags(false);
+  return `${registry.renderPreloadTags(false)}\n  <link rel="stylesheet" href="/@farm/fonts.css">`;
 }
 
 class FarmFontRegistry {


### PR DESCRIPTION
## Summary

- add polished homepage feature cards for automatic optimized boundaries and Markdown representations
- introduce a shared diagram frame so both graphics use consistent structure, spacing, states, and responsive behavior
- link the Strata renderer directly from the optimized-boundary description
- include generated development font CSS in the initial document head alongside font preloads

## Why

The homepage needed a clearer explanation of Farm's experimental rendering boundary and automatic Markdown representation features.

Development font files were preloaded, but their generated @font-face declarations and CSS variables arrived later through a client-side virtual CSS import. This allowed the fallback mono face to paint briefly before Geist replaced it.

The new render-blocking development font stylesheet makes Geist available during the initial document render while preserving the existing font preloads and HMR imports.

## Validation

- pnpm --filter @farm.js/core test -- src/__tests__/font-vite.test.ts
- pnpm --filter @farm.js/core type-check
- pnpm exec oxlint docs/src/app/page.tsx packages/farm/src/font-vite.ts packages/farm/src/__tests__/font-vite.test.ts
- pnpm --dir docs run build
- verified the homepage in narrow and wide layouts
- verified Geist Mono and Geist Pixel are loaded after a cold refresh with no browser-console errors


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the homepage rendering section with clear, consistent diagrams for optimized boundaries and Markdown mirrors, and fixes dev font loading so Geist renders on first paint.

- **New Features**
  - Adds a shared diagram frame and two homepage visuals: automatic optimized boundaries (with Strata/Rust renderer) and automatic Markdown representations via content negotiation or .md routes.
  - Links the Strata renderer directly from the optimized boundary feature.

- **Bug Fixes**
  - Injects the generated dev font CSS (`/@farm/fonts.css`) into the initial document head alongside preloads to prevent a brief mono fallback before Geist loads.
  - Updates tests in `@farm.js/core` to assert both preload and stylesheet tags.

<sup>Written for commit 650ee9e8551e72989d543088bd2e1e37fe50c7db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

