### PR TITLE
fix(docs): remove reading time

### DIFF
--- a/docs/docs.config.ts
+++ b/docs/docs.config.ts
@@ -314,10 +314,6 @@ const config = {
   breadcrumb: {
     enabled: true,
   },
-  readingTime: {
-    enabled: true,
-    wordsPerMinute: 220,
-  },
   lastUpdated: {
     enabled: true,
     label: "Last updated at",


### PR DESCRIPTION
## Summary

- remove the Farm.js docs-site `readingTime` configuration
- keep the reusable framework reading-time feature available for other projects

## Why

The Farm.js documentation header showed estimates such as “2 min read,” which added noise without helping navigation. Omitting the optional configuration disables that display for this site.

## Validation

- `pnpm exec oxfmt --check docs/docs.config.ts`
- `pnpm docs:build`
- verified `/docs`, `/docs/routing`, and `/docs/configuration` return 200 without `data-page-reading-time` or minute-read text


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `readingTime` from `docs/docs.config.ts` to hide “min read” labels in the Farm.js docs and reduce noise. This only affects the docs site; the framework’s reading-time feature remains available for other projects.

<sup>Written for commit 4704f195c359572e9bc5fa0157b776873b6f30b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

