### PR TITLE
fix(docs): stabilize Geist font loading

### DIFF
--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -426,8 +426,8 @@ describe("createFarmDocsHandler", () => {
 
     expect(assets).toHaveLength(2);
     expect(assets.map(({ url }) => url)).toEqual([
-      expect.stringMatching(/^\/assets\/Geist-Variable-h[a-f0-9]{12}\.woff2$/),
-      expect.stringMatching(/^\/assets\/GeistMono-Variable-h[a-f0-9]{12}\.woff2$/),
+      expect.stringMatching(/^\/assets\/fonts\/Geist-Variable-h[a-f0-9]{12}\.woff2$/),
+      expect.stringMatching(/^\/assets\/fonts\/GeistMono-Variable-h[a-f0-9]{12}\.woff2$/),
     ]);
     for (const { family, url } of assets) {
       expect(html).toContain(
@@ -438,6 +438,13 @@ describe("createFarmDocsHandler", () => {
     }
     expect(html).toContain('--font-geist-sans: "Geist Sans"');
     expect(html).toContain('--font-geist-mono: "Geist Mono"');
+    expect(html).toContain("font-display: block");
+    expect(html).toContain("font-synthesis: none");
+    expect(response?.headers.get("link")).toBe(
+      assets
+        .map(({ url }) => `<${url}>; rel=preload; as=font; type=font/woff2; crossorigin`)
+        .join(", "),
+    );
     expect(html).not.toContain("/node_modules/geist/");
   });
 

--- a/packages/farm/src/docs/fonts.ts
+++ b/packages/farm/src/docs/fonts.ts
@@ -36,7 +36,7 @@ export function resolveFarmDocsFontAssets(root: string): FarmDocsFontAsset[] {
       {
         family,
         sourcePath,
-        url: `/assets/${baseName}-h${fingerprint}${extension}`,
+        url: `/assets/fonts/${baseName}-h${fingerprint}${extension}`,
       },
     ];
   });

--- a/packages/farm/src/docs/handler.ts
+++ b/packages/farm/src/docs/handler.ts
@@ -1641,7 +1641,7 @@ function renderFarmDocsBridgeCss(
   const fontFaces = fontAssets
     .map(
       ({ family, url }) =>
-        `@font-face { font-family: "${family}"; src: url("${url}") format("woff2"); font-style: normal; font-weight: 100 900; font-display: swap; }`,
+        `@font-face { font-family: "${family}"; src: url("${url}") format("woff2"); font-style: normal; font-weight: 100 900; font-display: block; }`,
     )
     .join("\n");
   const fontVariables = [
@@ -1661,7 +1661,7 @@ function renderFarmDocsBridgeCss(
     * { box-sizing: border-box; }
     html { background: var(--color-fd-background, hsl(0 0% 2%)); scroll-padding-top: calc(var(--fd-nav-height, 44px) + 24px); }
     html[data-farm-docs-sidebar="open"], html[data-farm-docs-sidebar="open"] body { overflow: hidden; }
-    body { margin: 0; min-height: 100vh; background: var(--color-fd-background, hsl(0 0% 2%)); color: var(--color-fd-foreground, oklch(0.985 0.001 106.423)); font-family: var(--fd-docs-font-sans); text-rendering: optimizeLegibility; }
+    body { margin: 0; min-height: 100vh; background: var(--color-fd-background, hsl(0 0% 2%)); color: var(--color-fd-foreground, oklch(0.985 0.001 106.423)); font-family: var(--fd-docs-font-sans); font-synthesis: none; text-rendering: optimizeLegibility; }
     ::selection { background: var(--color-fd-foreground, #fff); color: var(--color-fd-background, #000); }
     a { color: inherit; }
     #nd-docs-layout { --fd-sidebar-col: var(--fd-sidebar-width); display: grid; grid-template: "sidebar header header" var(--fd-nav-height, 44px) "sidebar main toc" 1fr / var(--fd-sidebar-width) minmax(0, 1fr) var(--fd-toc-width) !important; min-height: 100vh; border-top: 1px solid var(--color-fd-border, hsl(0 0% 15%)); background: var(--color-fd-background, hsl(0 0% 2%)); }
@@ -1854,6 +1854,12 @@ function renderFarmDocsFontPreloads(fontAssets: readonly FarmDocsPublicFontAsset
     .join("\n  ");
 }
 
+function renderFarmDocsFontPreloadHeader(fontAssets: readonly FarmDocsPublicFontAsset[]): string {
+  return fontAssets
+    .map(({ url }) => `<${url}>; rel=preload; as=font; type=font/woff2; crossorigin`)
+    .join(", ");
+}
+
 function renderPixelDocsHtml(
   page: LoadedFarmDocsPage,
   pages: FarmDocsPage[],
@@ -1941,6 +1947,7 @@ export function createFarmDocsHandler(
   const faviconHref = resolveFarmDocsFavicon(docs, options);
   const fontAssets =
     options.fontAssets ?? toFarmDocsPublicFontAssets(resolveFarmDocsFontAssets(options.root));
+  const fontPreloadHeader = renderFarmDocsFontPreloadHeader(fontAssets);
 
   return async function handleFarmDocsRequest(request: Request): Promise<Response | null> {
     if (!docs?.enabled || (request.method !== "GET" && request.method !== "HEAD")) return null;
@@ -1987,6 +1994,7 @@ export function createFarmDocsHandler(
         headers: {
           "Content-Type": "text/html; charset=utf-8",
           "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+          ...(fontPreloadHeader ? { Link: fontPreloadHeader } : {}),
         },
       },
     );


### PR DESCRIPTION
## Summary

- serve docs Geist assets from the same canonical `/assets/fonts/` paths as application pages
- send font preloads in the docs HTML response `Link` header
- block fallback painting during the short cold-font load and disable synthetic font rendering
- extend docs-handler coverage for font paths, preload headers, and rendering rules

## Root cause

The homepage and docs used byte-identical Geist files under different URLs. Navigating from the homepage to `/docs` therefore could not reuse the already cached fonts, and docs only advertised its fonts after HTML parsing instead of in the response headers. With `font-display: swap`, the docs shell could paint using the system fallback before the duplicate download completed.

## Impact

The homepage and docs now share one hashed font asset per face. Warm navigation into docs reuses Geist immediately, while direct cold visits begin preloading from the response headers and do not paint a synthetic fallback.

## Validation

- `pnpm exec oxfmt --check packages/farm/src/docs/fonts.ts packages/farm/src/docs/handler.ts packages/farm/src/__tests__/docs-handler.test.ts`
- `pnpm exec oxlint packages/farm/src/docs/fonts.ts packages/farm/src/docs/handler.ts packages/farm/src/__tests__/docs-handler.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/docs-handler.test.ts src/__tests__/font-vite.test.ts src/__tests__/vercel-assets.test.ts` — 36 tests passed
- `pnpm docs:build`
- verified built Vercel responses contain both font preloads plus the Markdown alternate link
- verified the production output contains one canonical Sans, Mono, and Pixel asset
- verified homepage → docs navigation reuses Sans and Mono with `transferSize: 0`
- verified Geist computed styles, no failed requests, no console errors, and no browser error overlay


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Geist font loading in docs so navigation reuses cached fonts and avoids fallback painting. Fonts now preload from response headers and use shared canonical asset paths.

- **Bug Fixes**
  - Use canonical `/assets/fonts/Geist*.woff2` URLs shared with the homepage.
  - Preload fonts via `Link` response header to start downloads immediately.
  - Set `font-display: block` and `font-synthesis: none` to prevent fallback rendering.

<sup>Written for commit e00545e5b1bdcde476e3ee506db12ad67cd97d5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

