### PR TITLE
feat(farm): add deferred route island hydration

### DIFF
--- a/docs/src/app/docs/server-rendering/page.md
+++ b/docs/src/app/docs/server-rendering/page.md
@@ -146,6 +146,10 @@ Farm propagates the strategy to the route hydration boundary, emits it in the ro
 splits production route modules behind dynamic imports. Deferred routes therefore avoid evaluating
 their route chunk until its trigger while preserving the initial SSR output.
 
+These strategies control hydration of the initial server-rendered document. During client-side
+navigation, the navigation itself signals user intent, so Farm loads and renders the destination
+route immediately instead of leaving the previous route visible while waiting for another trigger.
+
 | Strategy      | Hydration trigger                                                     |
 | ------------- | --------------------------------------------------------------------- |
 | `load`        | Immediately. This is the default and compatibility-first behavior.    |

--- a/docs/src/app/docs/server-rendering/page.md
+++ b/docs/src/app/docs/server-rendering/page.md
@@ -127,6 +127,39 @@ export default function DashboardPage() {
 }
 ```
 
+## Deferred route islands
+
+Client routes and server routes that import a client boundary can defer their JavaScript while Farm
+keeps the server-rendered HTML visible. Add an optional static `island` export to the client module:
+
+```tsx
+"use client";
+
+export const island = "interaction";
+
+export function CopyButton({ value }: { value: string }) {
+  return <button onClick={() => navigator.clipboard.writeText(value)}>Copy</button>;
+}
+```
+
+Farm propagates the strategy to the route hydration boundary, emits it in the route manifest, and
+splits production route modules behind dynamic imports. Deferred routes therefore avoid evaluating
+their route chunk until its trigger while preserving the initial SSR output.
+
+| Strategy      | Hydration trigger                                                     |
+| ------------- | --------------------------------------------------------------------- |
+| `load`        | Immediately. This is the default and compatibility-first behavior.    |
+| `interaction` | The first button-like click; Farm replays that click after hydration. |
+| `visible`     | When the route boundary approaches the viewport.                      |
+| `idle`        | During browser idle time, with a timeout fallback.                    |
+
+The export must be one of these static string literals so Farm can analyze it without executing
+application code. Without an explicit route-level `island` export, a route that imports client
+boundaries with different strategies safely falls back to `load` because its current route-level
+React root cannot schedule those children independently. Keep interactive leaves small today; a
+future compiler boundary can reuse the same export for independently hydrated nested component
+islands.
+
 ## Automatic optimized boundaries
 
 Farm can experimentally render large, non-interactive Server Component regions through the native

--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   getClientModuleMetadata,
+  getIslandStrategyExport,
   hasHydrateExport,
   hasUseClientDirective,
   isClientComponentModule,
@@ -102,6 +103,7 @@ describe("client component path resolution", () => {
     expect(getClientModuleMetadata(sourceFile, root)).toEqual({
       isClientComponent: false,
       shouldHydrate: true,
+      islandStrategy: "load",
     });
     expect(isClientComponentModule(sourceFile, root)).toBe(false);
     expect(shouldHydrateModule(sourceFile, root)).toBe(true);
@@ -123,9 +125,66 @@ describe("client component path resolution", () => {
     expect(getClientModuleMetadata(pageFile, root)).toEqual({
       isClientComponent: false,
       shouldHydrate: true,
+      islandStrategy: "load",
     });
     expect(isClientComponentModule(pageFile, root)).toBe(false);
     expect(shouldHydrateModule(pageFile, root)).toBe(true);
+  });
+
+  it("reads a static island strategy from client modules", () => {
+    expect(
+      getIslandStrategyExport(
+        '"use client";\nexport const island = "interaction";\nexport function Copy() {}',
+      ),
+    ).toBe("interaction");
+    expect(() => getIslandStrategyExport("export const island = getStrategy();")).toThrow(
+      /must be a static/,
+    );
+  });
+
+  it("propagates an imported client boundary island strategy to its route", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-client-island-"));
+    tempDirs.push(root);
+
+    const pageFile = path.join(root, "src", "app", "demo", "page.tsx");
+    const clientFile = path.join(root, "src", "app", "demo", "copy-button.tsx");
+    fs.mkdirSync(path.dirname(pageFile), { recursive: true });
+    fs.writeFileSync(
+      clientFile,
+      '"use client";\nexport const island = "interaction";\nexport function CopyButton() { return null; }\n',
+    );
+    fs.writeFileSync(
+      pageFile,
+      'import { CopyButton } from "./copy-button";\nexport default function Page() { return <CopyButton />; }\n',
+    );
+
+    expect(getClientModuleMetadata(pageFile, root)).toEqual({
+      isClientComponent: false,
+      shouldHydrate: true,
+      islandStrategy: "interaction",
+    });
+  });
+
+  it("falls back to eager hydration when imported island strategies disagree", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-client-islands-mixed-"));
+    tempDirs.push(root);
+
+    const pageFile = path.join(root, "src", "app", "demo", "page.tsx");
+    fs.mkdirSync(path.dirname(pageFile), { recursive: true });
+    fs.writeFileSync(
+      path.join(path.dirname(pageFile), "copy.tsx"),
+      '"use client";\nexport const island = "interaction";\nexport function Copy() { return null; }\n',
+    );
+    fs.writeFileSync(
+      path.join(path.dirname(pageFile), "chart.tsx"),
+      '"use client";\nexport const island = "visible";\nexport function Chart() { return null; }\n',
+    );
+    fs.writeFileSync(
+      pageFile,
+      'import { Copy } from "./copy";\nimport { Chart } from "./chart";\nexport default function Page() { return <><Copy /><Chart /></>; }\n',
+    );
+
+    expect(getClientModuleMetadata(pageFile, root).islandStrategy).toBe("load");
   });
 
   it("preserves request-scoped server props when building ordinary hydration props", () => {
@@ -175,6 +234,9 @@ describe("client component path resolution", () => {
     expect(source).toContain("currentPath: window.location.pathname + window.location.search");
     expect(source).toContain('if (action !== "pop" && to === this.currentPath)');
     expect(source).toContain("this.currentPath = to;");
+    expect(source).toContain("scheduleFarmIslandHydration");
+    expect(source).toContain("load: () => import(");
+    expect(source).not.toContain("imports.push(`import Page${index}");
   });
 
   it("uses a document swap when dev navigation enters the docs runtime", () => {

--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -137,9 +137,39 @@ describe("client component path resolution", () => {
         '"use client";\nexport const island = "interaction";\nexport function Copy() {}',
       ),
     ).toBe("interaction");
+    expect(
+      getIslandStrategyExport(`
+// export const island = chooseStrategy();
+const example = 'export const island = "idle"';
+export const island = "visible" as const // hydrate near the viewport
+export function Chart() {}
+`),
+    ).toBe("visible");
     expect(() => getIslandStrategyExport("export const island = getStrategy();")).toThrow(
       /must be a static/,
     );
+  });
+
+  it("ignores unrelated island exports in imported server modules", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-client-shared-island-"));
+    tempDirs.push(root);
+
+    const pageFile = path.join(root, "src", "app", "demo", "page.tsx");
+    fs.mkdirSync(path.dirname(pageFile), { recursive: true });
+    fs.writeFileSync(
+      path.join(path.dirname(pageFile), "shared.ts"),
+      "export const island = getDomainIsland();\nexport const value = 1;\n",
+    );
+    fs.writeFileSync(
+      path.join(path.dirname(pageFile), "button.tsx"),
+      '"use client";\nexport const island = "interaction";\nexport function Button() {}\n',
+    );
+    fs.writeFileSync(
+      pageFile,
+      'import { value } from "./shared";\nimport { Button } from "./button";\nexport default function Page() { return <Button data-value={value} />; }\n',
+    );
+
+    expect(getClientModuleMetadata(pageFile, root).islandStrategy).toBe("interaction");
   });
 
   it("propagates an imported client boundary island strategy to its route", () => {
@@ -235,6 +265,10 @@ describe("client component path resolution", () => {
     expect(source).toContain('if (action !== "pop" && to === this.currentPath)');
     expect(source).toContain("this.currentPath = to;");
     expect(source).toContain("scheduleFarmIslandHydration");
+    expect(source).toContain("pendingPageHydrationController?.abort()");
+    expect(source).toContain("reactRootContainer !== container");
+    expect(source).toContain('document.getElementById("__farm_page__") || currentRoot');
+    expect(source).toContain("Navigation itself signals intent");
     expect(source).toContain("load: () => import(");
     expect(source).not.toContain("imports.push(`import Page${index}");
   });
@@ -257,6 +291,8 @@ describe("client component path resolution", () => {
     expect(source).toContain(
       "async handlePopState(event) {\n    if (document.documentElement.dataset.farmDocsRuntime === 'true') return;",
     );
+    expect(source).toContain("The scheduler owns queue draining and exactly-once click replay");
+    expect(source).toContain("pendingPageHydrationController?.abort()");
     expect(routerSource).toContain(
       'if (document.documentElement.dataset.farmDocsRuntime === "true") return;',
     );

--- a/packages/farm/src/__tests__/island-runtime.test.ts
+++ b/packages/farm/src/__tests__/island-runtime.test.ts
@@ -93,14 +93,77 @@ describe("scheduleFarmIslandHydration", () => {
       hydrate: () => button.addEventListener("click", () => handledClicks++),
     });
 
-    document.dispatchEvent(
-      new CustomEvent("farm:island-interaction", { detail: { target: button } }),
-    );
     await scheduled;
 
     expect(queue).toHaveLength(0);
     await vi.runAllTimersAsync();
     expect(handledClicks).toBe(1);
+  });
+
+  it("hydrates and replays non-HTML ARIA button interactions", async () => {
+    vi.useFakeTimers();
+    document.body.innerHTML =
+      '<div id="island"><svg role="button" tabindex="0"><circle /></svg></div>';
+    const container = document.getElementById("island")!;
+    const button = container.querySelector("svg")!;
+    let handledClicks = 0;
+    const scheduled = scheduleFarmIslandHydration({
+      container,
+      strategy: "interaction",
+      hydrate: () => button.addEventListener("click", () => handledClicks++),
+    });
+
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await scheduled;
+    await vi.runAllTimersAsync();
+
+    expect(handledClicks).toBe(1);
+  });
+
+  it("cancels a deferred boundary without hydrating it", async () => {
+    const controller = new AbortController();
+    const hydrate = vi.fn();
+    const container = document.getElementById("island")!;
+    const scheduled = scheduleFarmIslandHydration({
+      container,
+      strategy: "interaction",
+      signal: controller.signal,
+      hydrate,
+    });
+
+    controller.abort();
+
+    await expect(scheduled).resolves.toBeUndefined();
+    container.querySelector("button")!.click();
+    expect(hydrate).not.toHaveBeenCalled();
+  });
+
+  it("does not finish or replay an in-flight hydration after cancellation", async () => {
+    const controller = new AbortController();
+    const container = document.getElementById("island")!;
+    const button = container.querySelector("button")!;
+    let finishHydrate!: () => void;
+    const hydrate = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishHydrate = resolve;
+        }),
+    );
+    const scheduled = scheduleFarmIslandHydration({
+      container,
+      strategy: "interaction",
+      signal: controller.signal,
+      hydrate,
+    });
+
+    button.click();
+    await vi.waitFor(() => expect(hydrate).toHaveBeenCalledOnce());
+    controller.abort();
+    await expect(scheduled).resolves.toBeUndefined();
+    finishHydrate();
+    await Promise.resolve();
+
+    expect(container.hasAttribute("data-farm-island-hydrated")).toBe(false);
   });
 
   it("uses idle scheduling with a timeout", async () => {

--- a/packages/farm/src/__tests__/island-runtime.test.ts
+++ b/packages/farm/src/__tests__/island-runtime.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { scheduleFarmIslandHydration } from "../client/island-runtime";
+
+describe("scheduleFarmIslandHydration", () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="island"><button type="button">Copy</button></div>';
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    delete (window as typeof window & { __FARM_PREHYDRATION_CLICK_QUEUE__?: unknown })
+      .__FARM_PREHYDRATION_CLICK_QUEUE__;
+    document.body.innerHTML = "";
+  });
+
+  it("hydrates load boundaries immediately", async () => {
+    const hydrate = vi.fn(() => "hydrated");
+    const container = document.getElementById("island")!;
+
+    await expect(scheduleFarmIslandHydration({ container, strategy: null, hydrate })).resolves.toBe(
+      "hydrated",
+    );
+    expect(hydrate).toHaveBeenCalledOnce();
+  });
+
+  it("waits for visibility before hydrating visible boundaries", async () => {
+    let notifyVisibility: IntersectionObserverCallback | undefined;
+    const disconnect = vi.fn();
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        constructor(callback: IntersectionObserverCallback) {
+          notifyVisibility = callback;
+        }
+        observe() {}
+        disconnect() {
+          disconnect();
+        }
+      },
+    );
+    const hydrate = vi.fn(() => "visible");
+    const container = document.getElementById("island")!;
+    const scheduled = scheduleFarmIslandHydration({
+      container,
+      strategy: "visible",
+      hydrate,
+    });
+
+    expect(hydrate).not.toHaveBeenCalled();
+    notifyVisibility?.(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+
+    await expect(scheduled).resolves.toBe("visible");
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+
+  it("hydrates interaction boundaries and replays their first button click", async () => {
+    vi.useFakeTimers();
+    const container = document.getElementById("island")!;
+    const button = container.querySelector("button")!;
+    let handledClicks = 0;
+    const hydrate = vi.fn(() => {
+      button.addEventListener("click", () => handledClicks++);
+    });
+    const scheduled = scheduleFarmIslandHydration({
+      container,
+      strategy: "interaction",
+      hydrate,
+    });
+
+    button.click();
+    await scheduled;
+    expect(hydrate).toHaveBeenCalledOnce();
+    expect(handledClicks).toBe(0);
+
+    await vi.runAllTimersAsync();
+    expect(handledClicks).toBe(1);
+  });
+
+  it("claims and replays clicks captured by the inline pre-hydration queue", async () => {
+    vi.useFakeTimers();
+    const container = document.getElementById("island")!;
+    const button = container.querySelector("button")!;
+    const queue = [{ target: button }];
+    Object.assign(window, { __FARM_PREHYDRATION_CLICK_QUEUE__: queue });
+    let handledClicks = 0;
+    const scheduled = scheduleFarmIslandHydration({
+      container,
+      strategy: "interaction",
+      hydrate: () => button.addEventListener("click", () => handledClicks++),
+    });
+
+    document.dispatchEvent(
+      new CustomEvent("farm:island-interaction", { detail: { target: button } }),
+    );
+    await scheduled;
+
+    expect(queue).toHaveLength(0);
+    await vi.runAllTimersAsync();
+    expect(handledClicks).toBe(1);
+  });
+
+  it("uses idle scheduling with a timeout", async () => {
+    let idleCallback: (() => void) | undefined;
+    const cancelIdleCallback = vi.fn();
+    vi.stubGlobal(
+      "requestIdleCallback",
+      vi.fn((callback: () => void) => {
+        idleCallback = callback;
+        return 7;
+      }),
+    );
+    vi.stubGlobal("cancelIdleCallback", cancelIdleCallback);
+    const hydrate = vi.fn(() => "idle");
+    const container = document.getElementById("island")!;
+    const scheduled = scheduleFarmIslandHydration({ container, strategy: "idle", hydrate });
+
+    expect(hydrate).not.toHaveBeenCalled();
+    idleCallback?.();
+
+    await expect(scheduled).resolves.toBe("idle");
+    expect(cancelIdleCallback).toHaveBeenCalledWith(7);
+  });
+});

--- a/packages/farm/src/client/island-runtime.ts
+++ b/packages/farm/src/client/island-runtime.ts
@@ -1,0 +1,160 @@
+"use client";
+
+import type { FarmIslandStrategy } from "../island";
+
+export interface ScheduleFarmIslandHydrationOptions<T> {
+  container: Element;
+  strategy?: FarmIslandStrategy | null;
+  hydrate: () => T | Promise<T>;
+}
+
+function runWhenIdle(callback: () => void): () => void {
+  const windowWithIdleCallback = window as typeof window & {
+    requestIdleCallback?: (callback: () => void, options?: { timeout?: number }) => number;
+    cancelIdleCallback?: (handle: number) => void;
+  };
+
+  if (typeof windowWithIdleCallback.requestIdleCallback === "function") {
+    const handle = windowWithIdleCallback.requestIdleCallback(callback, { timeout: 2_000 });
+    return () => windowWithIdleCallback.cancelIdleCallback?.(handle);
+  }
+
+  const handle = window.setTimeout(callback, 1);
+  return () => window.clearTimeout(handle);
+}
+
+function finishIslandHydration(container: Element, activatingTarget?: HTMLElement | null): void {
+  container.setAttribute("data-farm-island-hydrated", "true");
+
+  const windowWithQueue = window as typeof window & {
+    __FARM_PREHYDRATION_CLICK_QUEUE__?: Array<{ target?: EventTarget | null }>;
+  };
+  const queue = windowWithQueue.__FARM_PREHYDRATION_CLICK_QUEUE__;
+  const targets = new Set<HTMLElement>();
+  if (activatingTarget?.isConnected) targets.add(activatingTarget);
+
+  if (Array.isArray(queue)) {
+    for (let index = queue.length - 1; index >= 0; index--) {
+      const target = queue[index]?.target;
+      if (!(target instanceof HTMLElement) || !container.contains(target)) continue;
+      queue.splice(index, 1);
+      if (target.isConnected) targets.add(target);
+    }
+  }
+
+  for (const target of targets) window.setTimeout(() => target.click(), 0);
+}
+
+/**
+ * Defer importing and hydrating a server-rendered client boundary until its
+ * configured trigger. The returned promise resolves with the hydration result.
+ */
+export function scheduleFarmIslandHydration<T>({
+  container,
+  strategy,
+  hydrate,
+}: ScheduleFarmIslandHydrationOptions<T>): Promise<T> {
+  const resolvedStrategy = strategy ?? "load";
+
+  if (resolvedStrategy === "load") {
+    return Promise.resolve()
+      .then(hydrate)
+      .then((value) => {
+        finishIslandHydration(container);
+        return value;
+      });
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    let started = false;
+    let queuedClickTarget: HTMLElement | null = null;
+    const cleanups = new Set<() => void>();
+
+    const cleanup = () => {
+      for (const dispose of cleanups) dispose();
+      cleanups.clear();
+    };
+
+    const start = () => {
+      if (started) return;
+      started = true;
+      cleanup();
+      Promise.resolve()
+        .then(hydrate)
+        .then(
+          (value) => {
+            cleanup();
+            const target = queuedClickTarget;
+            queuedClickTarget = null;
+            finishIslandHydration(container, target);
+            resolve(value);
+          },
+          (error) => {
+            cleanup();
+            reject(error);
+          },
+        );
+    };
+
+    if (resolvedStrategy === "idle") {
+      cleanups.add(runWhenIdle(start));
+      return;
+    }
+
+    if (resolvedStrategy === "visible") {
+      if (typeof IntersectionObserver !== "function") {
+        start();
+        return;
+      }
+
+      const observer = new IntersectionObserver(
+        (entries) => {
+          if (entries.some((entry) => entry.isIntersecting)) start();
+        },
+        { rootMargin: "200px" },
+      );
+      observer.observe(container);
+      cleanups.add(() => observer.disconnect());
+      return;
+    }
+
+    const queueActivatingClick = (event: MouseEvent) => {
+      const target =
+        event.target instanceof Element
+          ? event.target.closest<HTMLElement>(
+              'button,[role="button"],input[type="button"],input[type="submit"],input[type="reset"]',
+            )
+          : null;
+      if (
+        !target ||
+        !container.contains(target) ||
+        target.closest("a[href]") ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.altKey ||
+        event.ctrlKey ||
+        event.shiftKey
+      ) {
+        return;
+      }
+      queuedClickTarget ??= target;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      start();
+    };
+    const activateFromQueuedClick = (event: Event) => {
+      const target = (event as CustomEvent<{ target?: EventTarget | null }>).detail?.target;
+      if (!(target instanceof HTMLElement) || !container.contains(target)) return;
+
+      queuedClickTarget ??= target;
+      start();
+    };
+
+    document.addEventListener("click", queueActivatingClick, true);
+    cleanups.add(() => document.removeEventListener("click", queueActivatingClick, true));
+    document.addEventListener("farm:island-interaction", activateFromQueuedClick);
+    cleanups.add(() =>
+      document.removeEventListener("farm:island-interaction", activateFromQueuedClick),
+    );
+  });
+}

--- a/packages/farm/src/client/island-runtime.ts
+++ b/packages/farm/src/client/island-runtime.ts
@@ -5,7 +5,44 @@ import type { FarmIslandStrategy } from "../island";
 export interface ScheduleFarmIslandHydrationOptions<T> {
   container: Element;
   strategy?: FarmIslandStrategy | null;
+  signal?: AbortSignal;
   hydrate: () => T | Promise<T>;
+}
+
+interface FarmQueuedClick {
+  target?: EventTarget | null;
+}
+
+function getPreHydrationClickQueue(): FarmQueuedClick[] | null {
+  const windowWithQueue = window as typeof window & {
+    __FARM_PREHYDRATION_CLICK_QUEUE__?: FarmQueuedClick[];
+  };
+  return Array.isArray(windowWithQueue.__FARM_PREHYDRATION_CLICK_QUEUE__)
+    ? windowWithQueue.__FARM_PREHYDRATION_CLICK_QUEUE__
+    : null;
+}
+
+function findQueuedTarget(container: Element): Element | null {
+  const queue = getPreHydrationClickQueue();
+  if (!queue) return null;
+  for (const item of queue) {
+    if (item?.target instanceof Element && container.contains(item.target)) return item.target;
+  }
+  return null;
+}
+
+function takeQueuedTargets(container: Element): Element[] {
+  const queue = getPreHydrationClickQueue();
+  if (!queue) return [];
+
+  const targets: Element[] = [];
+  for (let index = queue.length - 1; index >= 0; index--) {
+    const target = queue[index]?.target;
+    if (!(target instanceof Element) || !container.contains(target)) continue;
+    queue.splice(index, 1);
+    targets.unshift(target);
+  }
+  return targets;
 }
 
 function runWhenIdle(callback: () => void): () => void {
@@ -23,26 +60,23 @@ function runWhenIdle(callback: () => void): () => void {
   return () => window.clearTimeout(handle);
 }
 
-function finishIslandHydration(container: Element, activatingTarget?: HTMLElement | null): void {
+function replayClick(target: Element): void {
+  const clickable = target as Element & { click?: () => void };
+  if (typeof clickable.click === "function") {
+    clickable.click();
+    return;
+  }
+  target.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+}
+
+function finishIslandHydration(container: Element, activatingTarget?: Element | null): void {
   container.setAttribute("data-farm-island-hydrated", "true");
 
-  const windowWithQueue = window as typeof window & {
-    __FARM_PREHYDRATION_CLICK_QUEUE__?: Array<{ target?: EventTarget | null }>;
-  };
-  const queue = windowWithQueue.__FARM_PREHYDRATION_CLICK_QUEUE__;
-  const targets = new Set<HTMLElement>();
+  const targets = new Set<Element>();
   if (activatingTarget?.isConnected) targets.add(activatingTarget);
+  for (const target of takeQueuedTargets(container)) if (target.isConnected) targets.add(target);
 
-  if (Array.isArray(queue)) {
-    for (let index = queue.length - 1; index >= 0; index--) {
-      const target = queue[index]?.target;
-      if (!(target instanceof HTMLElement) || !container.contains(target)) continue;
-      queue.splice(index, 1);
-      if (target.isConnected) targets.add(target);
-    }
-  }
-
-  for (const target of targets) window.setTimeout(() => target.click(), 0);
+  for (const target of targets) window.setTimeout(() => replayClick(target), 0);
 }
 
 /**
@@ -52,38 +86,48 @@ function finishIslandHydration(container: Element, activatingTarget?: HTMLElemen
 export function scheduleFarmIslandHydration<T>({
   container,
   strategy,
+  signal,
   hydrate,
-}: ScheduleFarmIslandHydrationOptions<T>): Promise<T> {
+}: ScheduleFarmIslandHydrationOptions<T>): Promise<T | undefined> {
   const resolvedStrategy = strategy ?? "load";
+  if (signal?.aborted) return Promise.resolve(undefined);
 
   if (resolvedStrategy === "load") {
     return Promise.resolve()
-      .then(hydrate)
+      .then(() => (signal?.aborted ? undefined : hydrate()))
       .then((value) => {
-        finishIslandHydration(container);
+        if (!signal?.aborted) finishIslandHydration(container);
         return value;
       });
   }
 
-  return new Promise<T>((resolve, reject) => {
+  return new Promise<T | undefined>((resolve, reject) => {
     let started = false;
-    let queuedClickTarget: HTMLElement | null = null;
-    const cleanups = new Set<() => void>();
+    let cancelled = false;
+    let queuedClickTarget: Element | null = null;
+    const triggerCleanups = new Set<() => void>();
+    let removeAbortListener: (() => void) | null = null;
 
+    const cleanupTriggers = () => {
+      for (const dispose of triggerCleanups) dispose();
+      triggerCleanups.clear();
+    };
     const cleanup = () => {
-      for (const dispose of cleanups) dispose();
-      cleanups.clear();
+      cleanupTriggers();
+      removeAbortListener?.();
+      removeAbortListener = null;
     };
 
     const start = () => {
-      if (started) return;
+      if (started || cancelled) return;
       started = true;
-      cleanup();
+      cleanupTriggers();
       Promise.resolve()
         .then(hydrate)
         .then(
           (value) => {
             cleanup();
+            if (cancelled || signal?.aborted) return;
             const target = queuedClickTarget;
             queuedClickTarget = null;
             finishIslandHydration(container, target);
@@ -96,8 +140,19 @@ export function scheduleFarmIslandHydration<T>({
         );
     };
 
+    if (signal) {
+      const abort = () => {
+        cancelled = true;
+        cleanup();
+        takeQueuedTargets(container);
+        resolve(undefined);
+      };
+      signal.addEventListener("abort", abort, { once: true });
+      removeAbortListener = () => signal.removeEventListener("abort", abort);
+    }
+
     if (resolvedStrategy === "idle") {
-      cleanups.add(runWhenIdle(start));
+      triggerCleanups.add(runWhenIdle(start));
       return;
     }
 
@@ -114,14 +169,14 @@ export function scheduleFarmIslandHydration<T>({
         { rootMargin: "200px" },
       );
       observer.observe(container);
-      cleanups.add(() => observer.disconnect());
+      triggerCleanups.add(() => observer.disconnect());
       return;
     }
 
     const queueActivatingClick = (event: MouseEvent) => {
       const target =
         event.target instanceof Element
-          ? event.target.closest<HTMLElement>(
+          ? event.target.closest(
               'button,[role="button"],input[type="button"],input[type="submit"],input[type="reset"]',
             )
           : null;
@@ -144,17 +199,23 @@ export function scheduleFarmIslandHydration<T>({
     };
     const activateFromQueuedClick = (event: Event) => {
       const target = (event as CustomEvent<{ target?: EventTarget | null }>).detail?.target;
-      if (!(target instanceof HTMLElement) || !container.contains(target)) return;
+      if (!(target instanceof Element) || !container.contains(target)) return;
 
       queuedClickTarget ??= target;
       start();
     };
 
     document.addEventListener("click", queueActivatingClick, true);
-    cleanups.add(() => document.removeEventListener("click", queueActivatingClick, true));
+    triggerCleanups.add(() => document.removeEventListener("click", queueActivatingClick, true));
     document.addEventListener("farm:island-interaction", activateFromQueuedClick);
-    cleanups.add(() =>
+    triggerCleanups.add(() =>
       document.removeEventListener("farm:island-interaction", activateFromQueuedClick),
     );
+
+    const queuedTarget = findQueuedTarget(container);
+    if (queuedTarget) {
+      queuedClickTarget = queuedTarget;
+      start();
+    }
   });
 }

--- a/packages/farm/src/client/production-runtime.ts
+++ b/packages/farm/src/client/production-runtime.ts
@@ -1,2 +1,3 @@
 export { installChunkErrorRecovery } from "./chunk-recovery";
+export { scheduleFarmIslandHydration } from "./island-runtime";
 export { createClientPluginManager } from "./plugin";

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -9,6 +9,7 @@ import {
 import type { FarmClientNavigationSession, FarmClientPluginManager } from "./plugin";
 import { _hydrateFarmI18n, isFarmLocaleChangeHref } from "../i18n/client-runtime";
 import type { FarmI18nClientSnapshot } from "../i18n/types";
+import type { FarmIslandStrategy } from "../island";
 
 /**
  * Farm.js SPA Router
@@ -28,6 +29,7 @@ interface PageData {
   canonicalPath?: string;
   isClientComponent?: boolean;
   shouldHydrate?: boolean;
+  islandStrategy?: FarmIslandStrategy | null;
   metadata?: {
     title?: string;
     description?: string;

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -28,6 +28,7 @@ export type {
   ResolvedFarmPerformanceConfig,
   ResolvedFarmPreloadConfig,
 } from "./preload";
+export type { FarmIslandStrategy } from "./island";
 export type { FarmLayerEntry, ResolvedFarmLayer } from "./layers";
 export {
   getFarmAppDirectories,

--- a/packages/farm/src/island.ts
+++ b/packages/farm/src/island.ts
@@ -1,0 +1,13 @@
+/**
+ * Controls when Farm loads and hydrates a server-rendered client boundary.
+ *
+ * `load` is the compatibility-first default. The deferred strategies keep the
+ * server-rendered HTML visible while postponing the boundary's JavaScript.
+ */
+export type FarmIslandStrategy = "load" | "interaction" | "visible" | "idle";
+
+export const FARM_ISLAND_STRATEGIES = ["load", "interaction", "visible", "idle"] as const;
+
+export function isFarmIslandStrategy(value: unknown): value is FarmIslandStrategy {
+  return FARM_ISLAND_STRATEGIES.includes(value as FarmIslandStrategy);
+}

--- a/packages/farm/src/manifest/generator.ts
+++ b/packages/farm/src/manifest/generator.ts
@@ -159,6 +159,7 @@ export async function generateDevManifest(
       segments: route.segments,
       isClientComponent: metadata.isClientComponent,
       shouldHydrate: metadata.shouldHydrate,
+      islandStrategy: metadata.islandStrategy,
       preloads: [],
       assets: [],
     };
@@ -250,6 +251,7 @@ export async function generateProdManifest(
       segments: route.segments,
       isClientComponent: metadata.isClientComponent,
       shouldHydrate: metadata.shouldHydrate,
+      islandStrategy: metadata.islandStrategy,
       preloads,
       assets,
     };

--- a/packages/farm/src/manifest/types.ts
+++ b/packages/farm/src/manifest/types.ts
@@ -3,6 +3,8 @@
  * Following the TanStack Start pattern: route → chunks/assets
  */
 
+import type { FarmIslandStrategy } from "../island";
+
 /**
  * A tag to be rendered in the HTML (script, link, meta, etc.)
  */
@@ -26,6 +28,8 @@ export interface RouteManifestEntry {
   isClientComponent?: boolean;
   /** Whether this route should hydrate on the client after SSR */
   shouldHydrate?: boolean;
+  /** When Farm should import and hydrate this route boundary */
+  islandStrategy?: FarmIslandStrategy | null;
   /** Route pattern (for client-side matching) */
   pattern: string;
   /** Serializable route search behavior for browser navigation. */
@@ -84,7 +88,13 @@ export interface DehydratedManifest {
     string,
     Pick<
       RouteManifestEntry,
-      "modulePath" | "pattern" | "segments" | "isClientComponent" | "shouldHydrate" | "search"
+      | "modulePath"
+      | "pattern"
+      | "segments"
+      | "isClientComponent"
+      | "shouldHydrate"
+      | "islandStrategy"
+      | "search"
     >
   >;
   /** All layouts (for navigation) */

--- a/packages/farm/src/nitro/server-entry.ts
+++ b/packages/farm/src/nitro/server-entry.ts
@@ -218,6 +218,7 @@ async function defaultHandler({
         modulePath: route.modulePath,
         isClientComponent,
         shouldHydrate,
+        islandStrategy: moduleMetadata.islandStrategy,
         metadata: {
           title: mergedMetadata.title,
           description: mergedMetadata.description,

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -59,6 +59,7 @@ import type { TransformOptions } from "esbuild";
 import { loadFarmProductionVite, type FarmProductionViteRuntime } from "../build/production-vite";
 import { adaptTailwindVitePlugin } from "../build/vite-plugin-compat";
 import { mergeFarmFontCss } from "../font-vite";
+import type { FarmIslandStrategy } from "../island";
 
 // Type alias for OutputBundle
 type OutputBundle = Rollup.OutputBundle;
@@ -955,6 +956,7 @@ async function buildClient(
     pattern: string;
     modulePath: string;
     relativePath: string;
+    islandStrategy: FarmIslandStrategy;
   }> = [];
 
   for (const route of pageRoutes) {
@@ -965,7 +967,11 @@ async function buildClient(
       const metadata = getClientModuleMetadata(route.modulePath, root);
       if (metadata.shouldHydrate) {
         const relativePath = route.modulePath.replace(root, "").replace(/^\//, "");
-        clientPages.push({ ...route, relativePath });
+        clientPages.push({
+          ...route,
+          relativePath,
+          islandStrategy: metadata.islandStrategy ?? "load",
+        });
         logger.info(`📱 Found hydratable route: ${route.pattern} -> ${route.modulePath}`);
       }
     } catch (error) {
@@ -1382,6 +1388,7 @@ function generateClientHydrationEntry(
     pattern: string;
     modulePath: string;
     relativePath: string;
+    islandStrategy: FarmIslandStrategy;
   }>,
   layoutRoutes: Array<{ pattern: string; modulePath: string }>,
   clientRouteSlots: UniversalRouteSlot[],
@@ -1723,10 +1730,13 @@ document.addEventListener("click", function(e) {
   const routeEntries: string[] = [];
   const routeSlotEntries: string[] = [];
 
-  clientPages.forEach((page, index) => {
+  clientPages.forEach((page) => {
     const importPath = toImportPath(page.modulePath);
-    imports.push(`import Page${index} from "${importPath}";`);
-    routeEntries.push(`  { pattern: ${JSON.stringify(page.pattern)}, Component: Page${index} }`);
+    routeEntries.push(`  {
+    pattern: ${JSON.stringify(page.pattern)},
+    islandStrategy: ${JSON.stringify(page.islandStrategy)},
+    load: () => import(${JSON.stringify(importPath)}).then((module) => module.default),
+  }`);
   });
   clientRouteSlots.forEach((slot, index) => {
     const importPath = toImportPath(slot.modulePath);
@@ -1749,7 +1759,7 @@ ${cssImport}
 ${layoutImports}
 import React from "react";
 import { createRoot, hydrateRoot } from "react-dom/client";
-import { createClientPluginManager, installChunkErrorRecovery } from "@farm.js/core/internal/client-runtime";
+import { createClientPluginManager, installChunkErrorRecovery, scheduleFarmIslandHydration } from "@farm.js/core/internal/client-runtime";
 import { matchFarmRoute } from "@farm.js/core/router";
 ${clientPluginEntry.imports}
 ${i18nClientRuntime}
@@ -1820,6 +1830,12 @@ function matchRoute(pathname) {
     if (params !== null) return { route: route, params: params };
   }
   return null;
+}
+
+async function loadRouteComponent(route) {
+  if (route.Component) return route.Component;
+  route.Component = await route.load();
+  return route.Component;
 }
 
 function matchesRoutePrefix(pathname, pattern) {
@@ -1986,50 +2002,51 @@ async function hydrate() {
     return;
   }
   
-  const hasRouteSlots =
-    Array.isArray(window.__FARM_ROUTE_SLOTS__) && window.__FARM_ROUTE_SLOTS__.length > 0;
   const container =
-    (hasRouteSlots ? document.getElementById("__farm_page__") : null) ||
+    document.getElementById("__farm_page__") ||
     document.getElementById("root");
   if (!container) {
     console.error("[Farm.js] No root element found");
     return;
   }
   
-  const Component = matched.route.Component;
-  const params = matched.params;
-  const searchParams = Object.fromEntries(new URLSearchParams(window.location.search));
-  
-  const props = { params: params, searchParams: Promise.resolve(searchParams) };
-  
-  // Create page element and wrap with layouts
-  const pageElement = React.createElement(Component, props);
-  const wrappedElement = hasRouteSlots
-    ? pageElement
-    : wrapWithLayouts(pageElement, pathname, params);
+  container.dataset.farmIsland = "page";
+  container.dataset.farmIslandStrategy = matched.route.islandStrategy || "load";
 
-  const shouldHydrate = !isHydrated && Boolean(container.innerHTML.trim());
-  const hydrationSession = await farmClientRuntime.beginHydration({
+  await scheduleFarmIslandHydration({
     container,
-    mode: shouldHydrate ? "hydrate" : "render",
-  });
+    strategy: matched.route.islandStrategy,
+    hydrate: async function() {
+      const Component = await loadRouteComponent(matched.route);
+      const params = matched.params;
+      const searchParams = Object.fromEntries(new URLSearchParams(window.location.search));
+      const props = { params: params, searchParams: Promise.resolve(searchParams) };
+      const pageElement = React.createElement(Component, props);
+      const wrappedElement = container.id === "__farm_page__"
+        ? pageElement
+        : wrapWithLayouts(pageElement, pathname, params);
+      const shouldHydrate = !isHydrated && Boolean(container.innerHTML.trim());
+      const hydrationSession = await farmClientRuntime.beginHydration({
+        container,
+        mode: shouldHydrate ? "hydrate" : "render",
+      });
 
-  try {
-    if (shouldHydrate) {
-      reactRoot = hydrateRoot(container, wrappedElement);
-      isHydrated = true;
-    } else {
-      if (!reactRoot) {
-        reactRoot = createRoot(container);
+      try {
+        if (shouldHydrate) {
+          reactRoot = hydrateRoot(container, wrappedElement);
+          isHydrated = true;
+        } else {
+          if (!reactRoot) reactRoot = createRoot(container);
+          reactRoot.render(wrappedElement);
+        }
+        currentPathname = pathname;
+        await farmClientRuntime.completeHydration(hydrationSession);
+      } catch (error) {
+        await farmClientRuntime.failHydration(hydrationSession, error);
+        console.error("[Farm.js] Hydration error:", error);
       }
-      reactRoot.render(wrappedElement);
-    }
-    currentPathname = pathname;
-    await farmClientRuntime.completeHydration(hydrationSession);
-  } catch (error) {
-    await farmClientRuntime.failHydration(hydrationSession, error);
-    console.error("[Farm.js] Hydration error:", error);
-  }
+    },
+  });
 }
 
 // SPA Router
@@ -2123,7 +2140,7 @@ ${generateUniversalRouterStateProperties()}
       }
 
       if (matched) {
-        const Component = matched.route.Component;
+        const Component = await loadRouteComponent(matched.route);
         const params = matched.params;
         const searchParams = Object.fromEntries(url.searchParams);
         const props = { params: params, searchParams: Promise.resolve(searchParams) };
@@ -2160,7 +2177,7 @@ ${generateUniversalRouterStateProperties()}
         const html = await this.fetchPage(url.pathname + url.search);
         await farmClientRuntime.markNavigationLoaded(clientNavigation, html);
         await this.runViewTransition(options.viewTransition, async () => {
-          if (!this.swapContent(html, url.pathname + url.search)) {
+          if (!(await this.swapContent(html, url.pathname + url.search))) {
             throw new Error("Farm could not swap the target document");
           }
           const historyState = createHistoryState(
@@ -2215,7 +2232,7 @@ ${generateUniversalRouterStateProperties()}
     return html;
   },
   
-  swapContent: function(html, targetPath) {
+  swapContent: async function(html, targetPath) {
     const parser = new DOMParser();
     const doc = parser.parseFromString(html, "text/html");
     if (isFarmLocaleDocumentChange(doc)) return false;
@@ -2255,7 +2272,7 @@ ${generateUniversalRouterStateProperties()}
     const matched = matchRoute(newPathname);
     if (matched) {
       // Re-hydrate the client component
-      const Component = matched.route.Component;
+      const Component = await loadRouteComponent(matched.route);
       const params = matched.params;
       const searchParams = Object.fromEntries(targetUrl.searchParams);
       const props = { params: params, searchParams: Promise.resolve(searchParams) };
@@ -2873,12 +2890,13 @@ function generateVirtualEntryCode(
     }
 
     pageImports.push(`import * as ${varName} from "${route.modulePath}";`);
-    const shouldHydrate = getClientModuleMetadata(route.modulePath, config.root).shouldHydrate;
+    const clientMetadata = getClientModuleMetadata(route.modulePath, config.root);
     pageRegistrations.push(`
   {
     pattern: ${JSON.stringify(route.pattern)},
     module: ${varName},
-    shouldHydrate: ${JSON.stringify(shouldHydrate)},
+    shouldHydrate: ${JSON.stringify(clientMetadata.shouldHydrate)},
+    islandStrategy: ${JSON.stringify(clientMetadata.islandStrategy)},
     ${
       route.source !== undefined
         ? `markdownSource: {
@@ -4944,10 +4962,15 @@ async function handleFarmRequestInContext(
               pageElement = React.createElement(PageComponent, pageProps);
             }
 
-            if (route.shouldHydrate && renderedRouteSlots.length > 0) {
+            if (route.shouldHydrate) {
               pageElement = React.createElement(
                 "div",
-                { id: "__farm_page__", "data-farm-client": "true" },
+                {
+                  id: "__farm_page__",
+                  "data-farm-client": "true",
+                  "data-farm-island": "page",
+                  "data-farm-island-strategy": route.islandStrategy || "load",
+                },
                 pageElement,
               );
             }

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1980,15 +1980,24 @@ function clearRouteInterception(destination) {
 
 // State
 let reactRoot = null;
+let reactRootContainer = null;
 let currentPathname = null;
 let isHydrated = false;
+let pendingPageHydrationController = null;
 
 ${generateUniversalRouterStateRuntime()}
 
+function cancelPendingPageHydration() {
+  pendingPageHydrationController?.abort();
+  pendingPageHydrationController = null;
+}
+
 function resetReactRoot() {
+  cancelPendingPageHydration();
   if (!reactRoot) return;
   reactRoot.unmount();
   reactRoot = null;
+  reactRootContainer = null;
   isHydrated = false;
 }
 
@@ -2013,40 +2022,67 @@ async function hydrate() {
   container.dataset.farmIsland = "page";
   container.dataset.farmIslandStrategy = matched.route.islandStrategy || "load";
 
-  await scheduleFarmIslandHydration({
-    container,
-    strategy: matched.route.islandStrategy,
-    hydrate: async function() {
-      const Component = await loadRouteComponent(matched.route);
-      const params = matched.params;
-      const searchParams = Object.fromEntries(new URLSearchParams(window.location.search));
-      const props = { params: params, searchParams: Promise.resolve(searchParams) };
-      const pageElement = React.createElement(Component, props);
-      const wrappedElement = container.id === "__farm_page__"
-        ? pageElement
-        : wrapWithLayouts(pageElement, pathname, params);
-      const shouldHydrate = !isHydrated && Boolean(container.innerHTML.trim());
-      const hydrationSession = await farmClientRuntime.beginHydration({
-        container,
-        mode: shouldHydrate ? "hydrate" : "render",
-      });
-
-      try {
-        if (shouldHydrate) {
-          reactRoot = hydrateRoot(container, wrappedElement);
-          isHydrated = true;
-        } else {
-          if (!reactRoot) reactRoot = createRoot(container);
-          reactRoot.render(wrappedElement);
+  const hydrationController = new AbortController();
+  pendingPageHydrationController = hydrationController;
+  try {
+    await scheduleFarmIslandHydration({
+      container,
+      strategy: matched.route.islandStrategy,
+      signal: hydrationController.signal,
+      hydrate: async function() {
+        const Component = await loadRouteComponent(matched.route);
+        if (
+          hydrationController.signal.aborted ||
+          !container.isConnected ||
+          window.location.pathname !== pathname
+        ) {
+          return;
         }
-        currentPathname = pathname;
-        await farmClientRuntime.completeHydration(hydrationSession);
-      } catch (error) {
-        await farmClientRuntime.failHydration(hydrationSession, error);
-        console.error("[Farm.js] Hydration error:", error);
-      }
-    },
-  });
+        const params = matched.params;
+        const searchParams = Object.fromEntries(new URLSearchParams(window.location.search));
+        const props = { params: params, searchParams: Promise.resolve(searchParams) };
+        const pageElement = React.createElement(Component, props);
+        const wrappedElement = container.id === "__farm_page__"
+          ? pageElement
+          : wrapWithLayouts(pageElement, pathname, params);
+        const shouldHydrate = !isHydrated && Boolean(container.innerHTML.trim());
+        const hydrationSession = await farmClientRuntime.beginHydration({
+          container,
+          mode: shouldHydrate ? "hydrate" : "render",
+        });
+
+        try {
+          if (hydrationController.signal.aborted || !container.isConnected) {
+            await farmClientRuntime.failHydration(
+              hydrationSession,
+              new DOMException("Route hydration was cancelled", "AbortError"),
+            );
+            return;
+          }
+          if (shouldHydrate) {
+            reactRoot = hydrateRoot(container, wrappedElement);
+            reactRootContainer = container;
+            isHydrated = true;
+          } else {
+            if (!reactRoot) {
+              reactRoot = createRoot(container);
+              reactRootContainer = container;
+            }
+            reactRoot.render(wrappedElement);
+          }
+          currentPathname = pathname;
+          await farmClientRuntime.completeHydration(hydrationSession);
+        } catch (error) {
+          await farmClientRuntime.failHydration(hydrationSession, error);
+          console.error("[Farm.js] Hydration error:", error);
+        }
+      },
+    });
+  } finally {
+    if (pendingPageHydrationController === hydrationController) {
+      pendingPageHydrationController = null;
+    }
+  }
 }
 
 // SPA Router
@@ -2074,6 +2110,8 @@ ${generateUniversalRouterStateProperties()}
     const from = this.currentPath;
     if (await this.shouldBlockNavigation({ from, to, action })) return;
 
+    // A route transition invalidates any trigger waiting on the previous DOM boundary.
+    cancelPendingPageHydration();
     this.saveScrollPosition(window.location.pathname);
     this.startNavigation(from, url, action);
     let clientNavigation;
@@ -2140,6 +2178,8 @@ ${generateUniversalRouterStateProperties()}
       }
 
       if (matched) {
+        // Navigation itself signals intent, so destination routes load eagerly even
+        // when their initial document hydration strategy is deferred.
         const Component = await loadRouteComponent(matched.route);
         const params = matched.params;
         const searchParams = Object.fromEntries(url.searchParams);
@@ -2166,8 +2206,10 @@ ${generateUniversalRouterStateProperties()}
 
           const container = document.getElementById("root");
           if (container) {
+            if (reactRoot && reactRootContainer !== container) resetReactRoot();
             if (!reactRoot) {
               reactRoot = createRoot(container);
+              reactRootContainer = container;
             }
             reactRoot.render(wrappedElement);
             currentPathname = pathname;
@@ -2277,13 +2319,13 @@ ${generateUniversalRouterStateProperties()}
       const searchParams = Object.fromEntries(targetUrl.searchParams);
       const props = { params: params, searchParams: Promise.resolve(searchParams) };
       const pageElement = React.createElement(Component, props);
-      const hasRouteSlots = nextRouteSlots.length > 0;
       const pageContainer =
-        (hasRouteSlots ? document.getElementById("__farm_page__") : null) || currentRoot;
-      const wrappedElement = hasRouteSlots
+        document.getElementById("__farm_page__") || currentRoot;
+      const wrappedElement = pageContainer.id === "__farm_page__"
         ? pageElement
         : wrapWithLayouts(pageElement, newPathname, params);
       reactRoot = hydrateRoot(pageContainer, wrappedElement);
+      reactRootContainer = pageContainer;
       isHydrated = true;
     }
     return true;

--- a/packages/farm/src/routing/route-manager.ts
+++ b/packages/farm/src/routing/route-manager.ts
@@ -38,6 +38,7 @@ import path from "path";
 import type { ViteDevServer } from "vite";
 import { getClientModuleMetadata } from "../utils/client-component";
 import type { MetadataImageKind } from "../metadata";
+import type { FarmIslandStrategy } from "../island";
 import { getFarmSourceRoots, type FarmSourceRoot } from "../layers";
 import {
   inspectStaticMetadataImage,
@@ -425,6 +426,7 @@ export class RouteManager {
       modulePath: string;
       shouldHydrate: boolean;
       isClientComponent: boolean;
+      islandStrategy: FarmIslandStrategy | null;
       search?: ProgrammaticRouteSearchClientOptions;
       segments: Array<{
         segment: string;
@@ -469,6 +471,7 @@ export class RouteManager {
         modulePath: toUrlPath(entry.modulePath),
         shouldHydrate: metadata.shouldHydrate,
         isClientComponent: metadata.isClientComponent,
+        islandStrategy: metadata.islandStrategy,
         search: getProgrammaticRouteSearchClientOptions(programmaticPage?.search),
         segments: entry.route.segments.map((seg) => ({
           segment: seg.segment,

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -155,7 +155,7 @@ function createPPRRefreshScript(): string {
 }
 
 function createPreHydrationClickQueueScript(): string {
-  return `<script>(function(){if(window.__FARM_PREHYDRATION_CLICK_QUEUE__)return;var queue=[];window.__FARM_PREHYDRATION_CLICK_QUEUE__=queue;window.__FARM_HYDRATED__=false;document.documentElement.dataset.farmHydrated="false";function isModified(event){return !!(event.metaKey||event.altKey||event.ctrlKey||event.shiftKey)}function closestQueuedTarget(target){while(target&&target!==document.documentElement){if(target.matches&&target.matches('button,[role="button"],input[type="button"],input[type="submit"],input[type="reset"]'))return target;target=target.parentElement}return null}document.addEventListener("click",function(event){if(window.__FARM_HYDRATED__)return;if(event.defaultPrevented||event.button!==0||isModified(event))return;var target=closestQueuedTarget(event.target);if(!target||target.closest&&target.closest("a[href]"))return;if(queue.some(function(item){return item.target===target}))return;queue.push({target:target,createdAt:Date.now()});event.preventDefault();event.stopImmediatePropagation()},true);})();</script>`;
+  return `<script>(function(){if(window.__FARM_PREHYDRATION_CLICK_QUEUE__)return;var queue=[];window.__FARM_PREHYDRATION_CLICK_QUEUE__=queue;window.__FARM_HYDRATED__=false;document.documentElement.dataset.farmHydrated="false";function isModified(event){return !!(event.metaKey||event.altKey||event.ctrlKey||event.shiftKey)}function closestQueuedTarget(target){while(target&&target!==document.documentElement){if(target.matches&&target.matches('button,[role="button"],input[type="button"],input[type="submit"],input[type="reset"]'))return target;target=target.parentElement}return null}document.addEventListener("click",function(event){if(window.__FARM_HYDRATED__)return;if(event.defaultPrevented||event.button!==0||isModified(event))return;var target=closestQueuedTarget(event.target);if(!target||target.closest&&target.closest("a[href]")||target.closest&&target.closest('[data-farm-island-hydrated="true"]'))return;if(queue.some(function(item){return item.target===target}))return;queue.push({target:target,createdAt:Date.now()});document.dispatchEvent(new CustomEvent("farm:island-interaction",{detail:{target:target}}));event.preventDefault();event.stopImmediatePropagation()},true);})();</script>`;
 }
 
 function searchParamsToObject(
@@ -943,6 +943,7 @@ export class ServerRenderer {
       (req as any).__FARM_ROUTE__ = pathname;
       (req as any).__FARM_IS_CLIENT_COMPONENT__ = isClientComponent;
       (req as any).__FARM_SHOULD_HYDRATE__ = shouldHydrate;
+      (req as any).__FARM_ISLAND_STRATEGY__ = moduleMetadata.islandStrategy;
       (req as any).__FARM_HAS_HYDRATABLE_ROUTE_SLOTS__ = hasHydratableRouteSlots;
       (req as any).__FARM_LOADING_MODULE_PATH__ = loadingBoundaryEntry?.modulePath
         ? loadingBoundaryEntry.modulePath.substring(
@@ -1046,7 +1047,12 @@ export class ServerRenderer {
             if (isClientComponent || shouldHydrate) {
               pageElement = React.createElement(
                 "div",
-                { id: "__farm_page__", "data-farm-client": "true" },
+                {
+                  id: "__farm_page__",
+                  "data-farm-client": "true",
+                  "data-farm-island": "page",
+                  "data-farm-island-strategy": moduleMetadata.islandStrategy ?? "load",
+                },
                 pageElement,
               );
             }
@@ -1617,6 +1623,7 @@ export class ServerRenderer {
           search: routeEntry.search,
           isClientComponent: routeEntry.isClientComponent,
           shouldHydrate: routeEntry.shouldHydrate,
+          islandStrategy: routeEntry.islandStrategy,
           preloads: [routeEntry.modulePath],
           assets: [],
         };
@@ -1662,6 +1669,7 @@ window.__FARM_DEPLOYMENT_ID__ = ${serializeInlineValue(deploymentId)};
 window.__FARM_PATH__ = ${JSON.stringify((req as any).__FARM_ROUTE__ || req.url || "/")};
 window.__FARM_IS_CLIENT__ = ${JSON.stringify(isClientComponent)};
 window.__FARM_SHOULD_HYDRATE__ = ${JSON.stringify((req as any).__FARM_SHOULD_HYDRATE__ === true)};
+window.__FARM_ISLAND_STRATEGY__ = ${JSON.stringify((req as any).__FARM_ISLAND_STRATEGY__ || "load")};
 window.__FARM_PAGE_MODULE__ = ${JSON.stringify(relativePath)};
 window.__FARM_LOADING_MODULE__ = ${JSON.stringify(
         (req as any).__FARM_LOADING_MODULE_PATH__ || null,

--- a/packages/farm/src/utils/client-component.ts
+++ b/packages/farm/src/utils/client-component.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import { isFarmIslandStrategy, type FarmIslandStrategy } from "../island";
 
 function readIfExists(filePath: string): string | null {
   try {
@@ -58,11 +59,13 @@ export function resolveModuleSourcePath(modulePath: string, root?: string): stri
 export interface ClientModuleMetadata {
   isClientComponent: boolean;
   shouldHydrate: boolean;
+  islandStrategy: FarmIslandStrategy | null;
 }
 
 interface ParsedClientModuleMetadata {
   isClientComponent: boolean;
   hasHydrateExport: boolean;
+  islandStrategy: FarmIslandStrategy | null;
 }
 
 const RESOLVABLE_SOURCE_EXTENSIONS = [
@@ -94,6 +97,22 @@ export function hasHydrateExport(content: string | null): boolean {
   );
 }
 
+export function getIslandStrategyExport(content: string | null): FarmIslandStrategy | null {
+  if (!content) return null;
+
+  const declaration = content.match(/\bexport\s+const\s+island(?:\s*:[^=;]+)?\s*=\s*([^;\r\n]+)/);
+  if (!declaration) return null;
+
+  const literal = declaration[1].trim().match(/^(["'])([^"']+)\1$/);
+  if (!literal || !isFarmIslandStrategy(literal[2])) {
+    throw new Error(
+      'Farm island configuration must be a static "load", "interaction", "visible", or "idle" string literal.',
+    );
+  }
+
+  return literal[2];
+}
+
 export function stripUseClientDirective(content: string): string {
   return content.replace(/^\s*(["'])use client\1\s*;?\s*/, "");
 }
@@ -103,12 +122,14 @@ function parseClientModuleMetadata(content: string | null): ParsedClientModuleMe
     return {
       isClientComponent: false,
       hasHydrateExport: false,
+      islandStrategy: null,
     };
   }
 
   return {
     isClientComponent: hasUseClientDirective(content),
     hasHydrateExport: hasHydrateExport(content),
+    islandStrategy: getIslandStrategyExport(content),
   };
 }
 
@@ -134,6 +155,7 @@ function inspectClientModuleMetadata(
     return {
       isClientComponent: false,
       shouldHydrate: false,
+      islandStrategy: null,
     };
   }
 
@@ -145,22 +167,35 @@ function inspectClientModuleMetadata(
     return {
       isClientComponent: true,
       shouldHydrate: true,
+      islandStrategy: parsed.islandStrategy ?? "load",
     };
   }
 
   let importsClientBoundary = false;
+  let importedIslandStrategy: FarmIslandStrategy | null = null;
   for (const specifier of getRelativeImportSpecifiers(content)) {
     const importedPath = resolveImportedModuleSourcePath(resolvedPath, specifier, root);
     const importedMetadata = inspectClientModuleMetadata(importedPath, root, visited);
     if (importedMetadata.isClientComponent || importedMetadata.shouldHydrate) {
       importsClientBoundary = true;
-      break;
+      if (importedIslandStrategy === null) {
+        importedIslandStrategy = importedMetadata.islandStrategy;
+      } else if (importedIslandStrategy !== importedMetadata.islandStrategy) {
+        // One route-level React root cannot honor multiple schedules safely.
+        // Fall back to eager hydration when its imported boundaries disagree.
+        importedIslandStrategy = "load";
+      }
     }
   }
 
+  const shouldHydrate = parsed.hasHydrateExport || importsClientBoundary;
+
   return {
     isClientComponent: false,
-    shouldHydrate: parsed.hasHydrateExport || importsClientBoundary,
+    shouldHydrate,
+    islandStrategy: shouldHydrate
+      ? (parsed.islandStrategy ?? importedIslandStrategy ?? "load")
+      : null,
   };
 }
 

--- a/packages/farm/src/utils/client-component.ts
+++ b/packages/farm/src/utils/client-component.ts
@@ -97,27 +97,160 @@ export function hasHydrateExport(content: string | null): boolean {
   );
 }
 
+interface ModuleSourceToken {
+  kind: "identifier" | "string" | "punctuation";
+  value: string;
+  line: number;
+}
+
+function tokenizeModuleSource(content: string): ModuleSourceToken[] {
+  const tokens: ModuleSourceToken[] = [];
+  let index = 0;
+  let line = 1;
+
+  while (index < content.length) {
+    const character = content[index];
+    if (/\s/.test(character)) {
+      if (character === "\n") line++;
+      index++;
+      continue;
+    }
+
+    if (character === "/" && content[index + 1] === "/") {
+      index += 2;
+      while (index < content.length && content[index] !== "\n") index++;
+      continue;
+    }
+    if (character === "/" && content[index + 1] === "*") {
+      index += 2;
+      while (index < content.length) {
+        if (content[index] === "\n") line++;
+        if (content[index] === "*" && content[index + 1] === "/") {
+          index += 2;
+          break;
+        }
+        index++;
+      }
+      continue;
+    }
+
+    if (character === '"' || character === "'") {
+      const quote = character;
+      const tokenLine = line;
+      let value = "";
+      index++;
+      while (index < content.length) {
+        const next = content[index];
+        if (next === "\\") {
+          value += next;
+          if (index + 1 < content.length) value += content[index + 1];
+          index += 2;
+          continue;
+        }
+        if (next === quote) {
+          index++;
+          break;
+        }
+        if (next === "\n") line++;
+        value += next;
+        index++;
+      }
+      tokens.push({ kind: "string", value, line: tokenLine });
+      continue;
+    }
+
+    if (character === "`") {
+      index++;
+      while (index < content.length) {
+        const next = content[index];
+        if (next === "\\") {
+          index += 2;
+          continue;
+        }
+        if (next === "`") {
+          index++;
+          break;
+        }
+        if (next === "\n") line++;
+        index++;
+      }
+      continue;
+    }
+
+    if (/[A-Za-z_$]/.test(character)) {
+      const start = index++;
+      while (index < content.length && /[\w$]/.test(content[index])) index++;
+      tokens.push({ kind: "identifier", value: content.slice(start, index), line });
+      continue;
+    }
+
+    tokens.push({ kind: "punctuation", value: character, line });
+    index++;
+  }
+
+  return tokens;
+}
+
+function isIslandExportStart(tokens: ModuleSourceToken[], index: number): boolean {
+  const token = tokens[index];
+  const previous = tokens[index - 1];
+  const startsStatement =
+    !previous ||
+    previous.value === ";" ||
+    previous.value === "{" ||
+    previous.value === "}" ||
+    token.line > previous.line;
+  return (
+    startsStatement &&
+    token.value === "export" &&
+    tokens[index + 1]?.value === "const" &&
+    tokens[index + 2]?.value === "island"
+  );
+}
+
 export function getIslandStrategyExport(content: string | null): FarmIslandStrategy | null {
   if (!content) return null;
 
-  const declaration = content.match(/\bexport\s+const\s+island(?:\s*:[^=;]+)?\s*=\s*([^;\r\n]+)/);
-  if (!declaration) return null;
+  const tokens = tokenizeModuleSource(content);
+  for (let index = 0; index < tokens.length - 2; index++) {
+    if (!isIslandExportStart(tokens, index)) continue;
 
-  const literal = declaration[1].trim().match(/^(["'])([^"']+)\1$/);
-  if (!literal || !isFarmIslandStrategy(literal[2])) {
+    let valueIndex = index + 3;
+    if (tokens[valueIndex]?.value === ":") {
+      while (valueIndex < tokens.length && tokens[valueIndex].value !== "=") valueIndex++;
+    }
+    if (tokens[valueIndex]?.value !== "=") break;
+    valueIndex++;
+
+    const literal = tokens[valueIndex];
+    if (!literal || literal.kind !== "string" || !isFarmIslandStrategy(literal.value)) break;
+
+    let trailingIndex = valueIndex + 1;
+    if (tokens[trailingIndex]?.value === "as" && tokens[trailingIndex + 1]?.value === "const") {
+      trailingIndex += 2;
+    }
+    const trailing = tokens[trailingIndex];
+    if (trailing && trailing.value !== ";" && trailing.line === literal.line) break;
+    return literal.value;
+  }
+
+  if (tokens.some((_token, index) => isIslandExportStart(tokens, index))) {
     throw new Error(
       'Farm island configuration must be a static "load", "interaction", "visible", or "idle" string literal.',
     );
   }
 
-  return literal[2];
+  return null;
 }
 
 export function stripUseClientDirective(content: string): string {
   return content.replace(/^\s*(["'])use client\1\s*;?\s*/, "");
 }
 
-function parseClientModuleMetadata(content: string | null): ParsedClientModuleMetadata {
+function parseClientModuleMetadata(
+  content: string | null,
+  inspectIslandExport: boolean,
+): ParsedClientModuleMetadata {
   if (!content) {
     return {
       isClientComponent: false,
@@ -126,16 +259,21 @@ function parseClientModuleMetadata(content: string | null): ParsedClientModuleMe
     };
   }
 
+  const isClientComponent = hasUseClientDirective(content);
+  const hasHydrate = hasHydrateExport(content);
   return {
-    isClientComponent: hasUseClientDirective(content),
-    hasHydrateExport: hasHydrateExport(content),
-    islandStrategy: getIslandStrategyExport(content),
+    isClientComponent,
+    hasHydrateExport: hasHydrate,
+    islandStrategy:
+      inspectIslandExport || isClientComponent || hasHydrate
+        ? getIslandStrategyExport(content)
+        : null,
   };
 }
 
 export function getClientModuleMetadata(modulePath: string, root?: string): ClientModuleMetadata {
   const resolvedPath = resolveModuleSourcePath(modulePath, root);
-  return inspectClientModuleMetadata(resolvedPath, root, new Set());
+  return inspectClientModuleMetadata(resolvedPath, root, new Set(), true);
 }
 
 export function isClientComponentModule(modulePath: string, root?: string): boolean {
@@ -150,6 +288,7 @@ function inspectClientModuleMetadata(
   resolvedPath: string | null,
   root: string | undefined,
   visited: Set<string>,
+  inspectIslandExport: boolean,
 ): ClientModuleMetadata {
   if (!resolvedPath || visited.has(resolvedPath)) {
     return {
@@ -162,7 +301,7 @@ function inspectClientModuleMetadata(
   visited.add(resolvedPath);
 
   const content = readIfExists(resolvedPath);
-  const parsed = parseClientModuleMetadata(content);
+  const parsed = parseClientModuleMetadata(content, inspectIslandExport);
   if (parsed.isClientComponent) {
     return {
       isClientComponent: true,
@@ -175,7 +314,7 @@ function inspectClientModuleMetadata(
   let importedIslandStrategy: FarmIslandStrategy | null = null;
   for (const specifier of getRelativeImportSpecifiers(content)) {
     const importedPath = resolveImportedModuleSourcePath(resolvedPath, specifier, root);
-    const importedMetadata = inspectClientModuleMetadata(importedPath, root, visited);
+    const importedMetadata = inspectClientModuleMetadata(importedPath, root, visited, false);
     if (importedMetadata.isClientComponent || importedMetadata.shouldHydrate) {
       importsClientBoundary = true;
       if (importedIslandStrategy === null) {

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -1743,6 +1743,7 @@ export function farmPlugin(
                   shouldHydrate:
                     shouldHydrate ||
                     routeSlots.some((slot) => slot.isClientComponent || slot.shouldHydrate),
+                  islandStrategy: moduleMetadata.islandStrategy,
                   metadata: {
                     title: mergedMetadata.title,
                     description: mergedMetadata.description,
@@ -2222,6 +2223,7 @@ export const getManifest = () => ({
             search: route.search,
             isClientComponent: moduleMetadata.isClientComponent,
             shouldHydrate: moduleMetadata.shouldHydrate,
+            islandStrategy: moduleMetadata.islandStrategy,
             preloads: [route.modulePath], // In dev, preload is just the module
             assets: [],
           };
@@ -2980,6 +2982,7 @@ import React from 'react'
 import { hydrateRoot, createRoot } from 'react-dom/client'
 import { installChunkErrorRecovery, SPARouter } from '@farm.js/core/client'
 import { createClientPluginManager } from '@farm.js/core/plugin/client'
+import { scheduleFarmIslandHydration } from '@farm.js/core/internal/client-runtime'
 import { reviveDeferredData } from '@farm.js/core/deferred'
 import {
   createFarmDeploymentMismatchError,
@@ -3232,6 +3235,7 @@ class LegacyManifestSPARouter {
 
     // Only prefetch routes that will hydrate on the client.
     if (!match.route.isClientComponent && !match.route.shouldHydrate) return;
+    if (match.route.islandStrategy && match.route.islandStrategy !== 'load') return;
 
     const modulePath = match.route.modulePath;
     if (this.moduleCache.has(modulePath)) return;
@@ -3444,7 +3448,11 @@ async function hydrateInitialRouteSlots() {
     routeSlotDefinitions.set(getRouteSlotKey(slot), slot);
     if (!slot.isClientComponent && !slot.shouldHydrate) continue;
     try {
-      hydrated = (await renderRouteSlot(slot, 'hydrate')) || hydrated;
+      const slotHydrated = await renderRouteSlot(slot, 'hydrate');
+      hydrated = slotHydrated || hydrated;
+      if (slotHydrated) {
+        replayPreHydrationClicks(document.getElementById(slot.containerId));
+      }
     } catch (error) {
       console.warn('[Farm.js] Could not hydrate route slot:', slot.name, error);
     }
@@ -3515,16 +3523,30 @@ function applyCanonicalPathFromProps(props) {
   window.history.replaceState({ ...(window.history.state || {}), path: canonicalPath }, '', canonicalPath);
 }
 
-function replayPreHydrationClicks() {
-  window.__FARM_HYDRATED__ = true;
-  document.documentElement.dataset.farmHydrated = 'true';
+function replayPreHydrationClicks(container = null) {
+  if (!container) {
+    window.__FARM_HYDRATED__ = true;
+    document.documentElement.dataset.farmHydrated = 'true';
+  } else {
+    container.dataset.farmIslandHydrated = 'true';
+  }
 
   const queue = Array.isArray(window.__FARM_PREHYDRATION_CLICK_QUEUE__)
     ? window.__FARM_PREHYDRATION_CLICK_QUEUE__
     : [];
   if (queue.length === 0) return;
 
-  const queuedClicks = queue.splice(0, queue.length);
+  const queuedClicks = [];
+  const remainingClicks = [];
+  for (const queuedClick of queue) {
+    const target = queuedClick?.target;
+    if (!container || (target instanceof Node && container.contains(target))) {
+      queuedClicks.push(queuedClick);
+    } else {
+      remainingClicks.push(queuedClick);
+    }
+  }
+  queue.splice(0, queue.length, ...remainingClicks);
   for (const queuedClick of queuedClicks) {
     const target = queuedClick?.target;
     if (!target || typeof target.click !== 'function') continue;
@@ -3756,6 +3778,7 @@ async function renderPage(pageData) {
     modulePath: pageData.modulePath,
     isClientComponent: pageData.isClientComponent === true,
     shouldHydrate: pageData.shouldHydrate === true,
+    islandStrategy: pageData.islandStrategy || 'load',
   };
   const params = pageData.props?.params || {};
   const layouts = (pageData.layoutModules || []).map((modulePath, index) => ({
@@ -3955,14 +3978,6 @@ async function hydrate() {
   }
 
   try {
-    // Pre-load layout for SPA navigation
-    try {
-      const layoutModule = await import(/* @vite-ignore */ '/src/app/layout.tsx');
-      LayoutComponent = layoutModule.default;
-    } catch (e) {
-      console.warn('[Farm.js] Could not preload layout:', e);
-    }
-
     // Check if this is a client component (set by SSR)
     const isClientComponent = window.__FARM_IS_CLIENT__ === true;
     const modulePath = window.__FARM_PAGE_MODULE__;
@@ -4010,34 +4025,53 @@ async function hydrate() {
       return
     }
 
-    const hydrationSession = await farmClientRuntime.beginHydration({
+    const currentRoute = findRoute(window.location.pathname)?.route;
+    const islandStrategy = window.__FARM_ISLAND_STRATEGY__ || currentRoute?.islandStrategy || 'load';
+    pageContainer.dataset.farmIsland = 'page';
+    pageContainer.dataset.farmIslandStrategy = islandStrategy;
+
+    await scheduleFarmIslandHydration({
       container: pageContainer,
-      mode: shouldHydrate ? 'hydrate' : 'render',
+      strategy: islandStrategy,
+      hydrate: async () => {
+        // Layout code is only needed when this route boundary actually hydrates.
+        try {
+          const layoutModule = await import(/* @vite-ignore */ '/src/app/layout.tsx');
+          LayoutComponent = layoutModule.default;
+        } catch (e) {
+          console.warn('[Farm.js] Could not preload layout:', e);
+        }
+
+        const hydrationSession = await farmClientRuntime.beginHydration({
+          container: pageContainer,
+          mode: shouldHydrate ? 'hydrate' : 'render',
+        });
+
+        let hydrated = false;
+        try {
+          hydrated = await tryHydrateImportedPage(
+            pageContainer,
+            { modulePath },
+            currentPageProps.params || {},
+            layouts,
+            shouldHydrate,
+            currentPageProps,
+          );
+          await farmClientRuntime.completeHydration(hydrationSession);
+        } catch (error) {
+          await farmClientRuntime.failHydration(hydrationSession, error);
+          throw error;
+        }
+
+        if (hydrated) {
+          replayPreHydrationClicks();
+          console.log('[Farm.js] ✅ Hydrated:', modulePath, '(' + islandStrategy + ')');
+          return;
+        }
+
+        console.log('[Farm.js] Server component - SPA router ready')
+      },
     });
-
-    let hydrated = false;
-    try {
-      hydrated = await tryHydrateImportedPage(
-        pageContainer,
-        { modulePath },
-        currentPageProps.params || {},
-        layouts,
-        shouldHydrate,
-        currentPageProps,
-      );
-      await farmClientRuntime.completeHydration(hydrationSession);
-    } catch (error) {
-      await farmClientRuntime.failHydration(hydrationSession, error);
-      throw error;
-    }
-
-    if (hydrated) {
-      replayPreHydrationClicks();
-      console.log('[Farm.js] ✅ Hydrated:', modulePath);
-      return;
-    }
-
-    console.log('[Farm.js] Server component - SPA router ready')
   } catch (error) {
     console.error('[Farm.js] Hydration error:', error)
   }

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -3380,6 +3380,12 @@ let hasClientTakenOver = false;
 const routeSlotRoots = new Map();
 const routeSlotDefinitions = new Map();
 let activeRouteInterception = null;
+let pendingPageHydrationController = null;
+
+function cancelPendingPageHydration() {
+  pendingPageHydrationController?.abort();
+  pendingPageHydrationController = null;
+}
 
 function normalizeServerProps(rawProps) {
   const props = rawProps && typeof rawProps === 'object' ? { ...rawProps } : {};
@@ -3525,8 +3531,7 @@ function applyCanonicalPathFromProps(props) {
 
 function replayPreHydrationClicks(container = null) {
   if (!container) {
-    window.__FARM_HYDRATED__ = true;
-    document.documentElement.dataset.farmHydrated = 'true';
+    markFarmHydrated();
   } else {
     container.dataset.farmIslandHydrated = 'true';
   }
@@ -3553,6 +3558,11 @@ function replayPreHydrationClicks(container = null) {
     if (target.isConnected === false) continue;
     setTimeout(() => target.click(), 0);
   }
+}
+
+function markFarmHydrated() {
+  window.__FARM_HYDRATED__ = true;
+  document.documentElement.dataset.farmHydrated = 'true';
 }
 
 async function buildClientHydrationElement(PageComponent, pageProps) {
@@ -3697,9 +3707,10 @@ async function tryHydrateImportedPage(
   layouts,
   useHydrate = false,
   existingProps = null,
+  signal = null,
 ) {
   const modulePath = route?.modulePath;
-  if (!modulePath) {
+  if (!modulePath || signal?.aborted) {
     return false;
   }
 
@@ -3708,6 +3719,7 @@ async function tryHydrateImportedPage(
     pageModule = await import(/* @vite-ignore */ modulePath);
     pageModuleCache.set(modulePath, pageModule);
   }
+  if (signal?.aborted || !container?.isConnected) return false;
 
   const PageComponent = pageModule?.default;
   if (!PageComponent) {
@@ -3722,6 +3734,7 @@ async function tryHydrateImportedPage(
     window.location.pathname,
     existingProps,
   );
+  if (signal?.aborted || !container?.isConnected) return false;
 
   const wrappedElement = useHydrate && container?.id === '__farm_page__'
     ? wrapWithIntegrationProviders(
@@ -3732,6 +3745,7 @@ async function tryHydrateImportedPage(
         currentPageProps,
         layouts,
       );
+  if (signal?.aborted || !container?.isConnected) return false;
 
   if (useHydrate) {
     try {
@@ -3762,6 +3776,7 @@ async function tryHydrateImportedPage(
 async function renderPage(pageData) {
   const container = document.getElementById('root');
   if (!container) return;
+  cancelPendingPageHydration();
   const destination = window.location.pathname + window.location.search;
 
   if (pageData.interception) {
@@ -4030,48 +4045,83 @@ async function hydrate() {
     pageContainer.dataset.farmIsland = 'page';
     pageContainer.dataset.farmIslandStrategy = islandStrategy;
 
-    await scheduleFarmIslandHydration({
-      container: pageContainer,
-      strategy: islandStrategy,
-      hydrate: async () => {
-        // Layout code is only needed when this route boundary actually hydrates.
-        try {
-          const layoutModule = await import(/* @vite-ignore */ '/src/app/layout.tsx');
-          LayoutComponent = layoutModule.default;
-        } catch (e) {
-          console.warn('[Farm.js] Could not preload layout:', e);
-        }
+    const hydrationPathname = window.location.pathname;
+    const hydrationController = new AbortController();
+    pendingPageHydrationController = hydrationController;
+    try {
+      await scheduleFarmIslandHydration({
+        container: pageContainer,
+        strategy: islandStrategy,
+        signal: hydrationController.signal,
+        hydrate: async () => {
+          if (
+            hydrationController.signal.aborted ||
+            !pageContainer.isConnected ||
+            window.location.pathname !== hydrationPathname
+          ) {
+            return;
+          }
 
-        const hydrationSession = await farmClientRuntime.beginHydration({
-          container: pageContainer,
-          mode: shouldHydrate ? 'hydrate' : 'render',
-        });
+          // Layout code is only needed when this route boundary actually hydrates.
+          try {
+            const layoutModule = await import(/* @vite-ignore */ '/src/app/layout.tsx');
+            LayoutComponent = layoutModule.default;
+          } catch (e) {
+            console.warn('[Farm.js] Could not preload layout:', e);
+          }
+          if (hydrationController.signal.aborted || !pageContainer.isConnected) return;
 
-        let hydrated = false;
-        try {
-          hydrated = await tryHydrateImportedPage(
-            pageContainer,
-            { modulePath },
-            currentPageProps.params || {},
-            layouts,
-            shouldHydrate,
-            currentPageProps,
-          );
-          await farmClientRuntime.completeHydration(hydrationSession);
-        } catch (error) {
-          await farmClientRuntime.failHydration(hydrationSession, error);
-          throw error;
-        }
+          const hydrationSession = await farmClientRuntime.beginHydration({
+            container: pageContainer,
+            mode: shouldHydrate ? 'hydrate' : 'render',
+          });
 
-        if (hydrated) {
-          replayPreHydrationClicks();
-          console.log('[Farm.js] ✅ Hydrated:', modulePath, '(' + islandStrategy + ')');
-          return;
-        }
+          let hydrated = false;
+          try {
+            if (hydrationController.signal.aborted || !pageContainer.isConnected) {
+              await farmClientRuntime.failHydration(
+                hydrationSession,
+                new DOMException('Route hydration was cancelled', 'AbortError'),
+              );
+              return;
+            }
+            hydrated = await tryHydrateImportedPage(
+              pageContainer,
+              { modulePath },
+              currentPageProps.params || {},
+              layouts,
+              shouldHydrate,
+              currentPageProps,
+              hydrationController.signal,
+            );
+            if (hydrationController.signal.aborted || !pageContainer.isConnected) {
+              await farmClientRuntime.failHydration(
+                hydrationSession,
+                new DOMException('Route hydration was cancelled', 'AbortError'),
+              );
+              return;
+            }
+            await farmClientRuntime.completeHydration(hydrationSession);
+          } catch (error) {
+            await farmClientRuntime.failHydration(hydrationSession, error);
+            throw error;
+          }
 
-        console.log('[Farm.js] Server component - SPA router ready')
-      },
-    });
+          if (hydrated) {
+            // The scheduler owns queue draining and exactly-once click replay.
+            markFarmHydrated();
+            console.log('[Farm.js] ✅ Hydrated:', modulePath, '(' + islandStrategy + ')');
+            return;
+          }
+
+          console.log('[Farm.js] Server component - SPA router ready')
+        },
+      });
+    } finally {
+      if (pendingPageHydrationController === hydrationController) {
+        pendingPageHydrationController = null;
+      }
+    }
   } catch (error) {
     console.error('[Farm.js] Hydration error:', error)
   }


### PR DESCRIPTION
## Summary

- add an optional static `export const island = "load" | "interaction" | "visible" | "idle"` API
- propagate island strategy metadata from client boundaries to their route hydration root
- defer initial page hydration through load, interaction, visibility, or idle scheduling
- split hydratable production pages behind dynamic imports so deferred strategies postpone route-chunk download and evaluation
- hydrate only the targeted `#__farm_page__` boundary on initial load, preserving the server-rendered layout shell
- safely capture and replay the first pre-hydration interaction once
- document the route-level behavior and mixed-strategy eager fallback

## Performance impact

Server-rendered HTML remains visible immediately. For deferred strategies, the browser does not import or evaluate the route page chunk until the selected trigger, reducing initial JavaScript transfer, parsing, and main-thread work. Existing applications keep the compatibility-first `load` default.

This PR intentionally establishes route/page islands using Farm's existing hydration roots. It does not yet create independent React roots for arbitrary nested components; that future compiler boundary can reuse the same static export.

## Validation

- TypeScript: `pnpm exec tsc --noEmit`
- Focused Vitest: 41 tests passed
- Production fixture: client/SSR/Nitro build passed and emitted the page as a separate route chunk
- Formatting: passed
- Lint: 0 errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds deferred route island hydration to Farm so routes can wait to import and hydrate until load, interaction, visibility, or idle. Hardens the scheduler and router to cancel on navigation and safely replay clicks, reducing initial JavaScript work.

- **New Features**
  - Add static `export const island = "load" | "interaction" | "visible" | "idle"` in client modules; defaults to `load`.
  - Propagate the island strategy to the route hydration root; mixed child strategies fall back to `load`.
  - Split production page modules behind dynamic imports so route chunks download only on the chosen trigger.
  - Export `scheduleFarmIslandHydration` from `@farm.js/core/internal/client-runtime`; schedules hydration and replays the first pre-hydration click once.
  - Mark page containers with `data-farm-island="page"` and `data-farm-island-strategy`; pre-hydration queue dispatches `farm:island-interaction`.
  - Add `islandStrategy` to route manifest/types and include it in dev/prod manifests and SPA router.
  - Update docs with usage and strategies; add tests for island runtime and metadata parsing.

- **Bug Fixes**
  - Abortable scheduling and router integration: cancel pending route hydration on navigation and avoid replay after cancellation.
  - Robust interaction handling: capture ARIA “button” clicks, ignore anchors/modified clicks, and scope exactly-once click replay to hydrated containers.
  - Safer triggers: `requestIdleCallback` with timeout and `setTimeout` fallback; visibility via `IntersectionObserver` with margin.
  - Dev/prod runtime updates: load route components via `load()` dynamic imports; initial document respects the island strategy while SPA navigations always load eagerly; dev prefetch skips non-`load` routes.

<sup>Written for commit e7dd1d405eb72dc4fb92503bd19afeeffe732dd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

