### PR TITLE
feat: add convention-based dynamic OG images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build packages
         run: pnpm build
         env:
-          NODE_OPTIONS: --max-old-space-size=4096
+          NODE_OPTIONS: --max-old-space-size=8192
 
       - name: Run tests
         run: pnpm test -- ${{ matrix.test_args }}
@@ -118,7 +118,7 @@ jobs:
       - name: Build packages
         run: pnpm build
         env:
-          NODE_OPTIONS: --max-old-space-size=4096
+          NODE_OPTIONS: --max-old-space-size=8192
 
       - name: Build examples
         run: pnpm build:examples -- ${{ matrix.build_args }}
@@ -149,7 +149,7 @@ jobs:
       - name: Verify framework features
         run: pnpm test:e2e:framework
         env:
-          NODE_OPTIONS: --max-old-space-size=4096
+          NODE_OPTIONS: --max-old-space-size=8192
 
       - name: Upload Playwright failure artifacts
         if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Type check
         run: pnpm type-check
         env:
-          NODE_OPTIONS: --max-old-space-size=4096
+          NODE_OPTIONS: --max-old-space-size=8192
 
   lint:
     name: Lint

--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -594,7 +594,7 @@ Static images inside a dynamic segment are shared by every concrete route. Use a
 
 ### Generated metadata images
 
-Place `opengraph-image.tsx` or `twitter-image.tsx` next to a route segment when the image needs data or route params. Farm automatically adds the nearest matching image to the page head when `openGraph.images` or `twitter.images` is not already set.
+Place `opengraph-image.tsx` or `twitter-image.tsx` next to a route segment when the image needs data or route params. Return ordinary stateless JSX: Farm owns the image endpoint and PNG renderer, so the component does not import `ImageResponse` or declare an API URL. Farm also adds the nearest matching image to the page head when `openGraph.images` or `twitter.images` is not already set.
 
 **src/app/products/[id]/opengraph-image.tsx**
 
@@ -603,23 +603,49 @@ import type { PageProps } from "@farm.js/core";
 
 export const size = { width: 1200, height: 630 };
 export const alt = "Product preview";
-export const contentType = "image/svg+xml";
+export const revalidate = 300;
 
-export default function ProductOpenGraphImage({ params }: PageProps) {
+function ProductCard({ name, id }: { name: string; id: string }) {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
-      <rect width="1200" height="630" fill="#111827" />
-      <text x="80" y="340" fill="white" fontSize="72">
-        Product {params.id}
-      </text>
-    </svg>
+    <div className="flex h-full w-full flex-col justify-between bg-[#09090b] p-20 text-white">
+      <span className="text-3xl font-medium text-emerald-400">Acme</span>
+      <div className="flex flex-col">
+        <span className="text-2xl text-zinc-400">Product {id}</span>
+        <span className="mt-3 text-8xl font-bold tracking-tight">{name}</span>
+      </div>
+    </div>
   );
+}
+
+export default async function ProductOpenGraphImage({ params }: PageProps) {
+  const product = await getProduct(params.id);
+  return <ProductCard id={params.id} name={product.name} />;
 }
 ```
 
-For `/products/42`, this file is served at `/products/42/opengraph-image` and Farm emits `og:image`, `og:image:width`, `og:image:height`, and `og:image:alt` tags. The default return value can be a React SVG element, a string, bytes, or a `Response`.
+For `/products/42`, Farm calls the component with `params.id === "42"`, serves the generated PNG at `/products/42/opengraph-image`, and emits `og:image`, `og:image:width`, `og:image:height`, and `og:image:alt` tags. A nested page such as `/products/42/reviews` inherits this image until a nearer route segment defines its own. The component and its data-loading code remain on the server.
 
-Keep only one implementation for each image kind in a segment. For example, defining both `opengraph-image.png` and `opengraph-image.tsx` produces a build error. For broad social-platform compatibility, prefer a 1200 by 630 PNG or JPEG unless the image must be generated dynamically.
+`className` supports the image renderer's Tailwind utility set, including arbitrary values. Inline `style` can be used with it and wins when both set the same property. This is not a browser screenshot: image JSX supports flex layout, typography, borders, gradients, absolute positioning, and embedded images, but not CSS Grid, animations, media queries, pseudo-elements, hooks, or stateful and class components. The application stylesheet and custom Tailwind plugins are not executed. Use an absolute URL for an `<img>` source.
+
+Farm uses 1200 by 630 when `size` is omitted and includes Geist as the default font. Export `fonts` to embed a custom brand font:
+
+```tsx
+const brandFont = fetch("https://cdn.example.com/fonts/Brand-Bold.ttf").then((response) =>
+  response.arrayBuffer(),
+);
+
+export const fonts = [
+  { name: "Brand", data: brandFont, weight: 700 as const, style: "normal" as const },
+];
+```
+
+Satori-compatible TTF, OTF, and WOFF files are supported; WOFF2 is not. Set `fontFamily: "Brand"` on the element that uses the font.
+
+Generated images revalidate on every request by default. Export `revalidate = 300` to let a CDN cache the route for five minutes, or `revalidate = false` only when the output is permanently immutable. Farm emits an `ETag`, supports conditional requests and `HEAD`, and performs JSX-to-image rendering internally.
+
+For advanced renderers, the default export may still return a `Response`, string, or bytes. To preserve the earlier React-to-SVG behavior, export `contentType = "image/svg+xml"` and return an SVG React element. A returned `Response` keeps its own status, headers, and body.
+
+Keep only one implementation for each image kind in a segment. For example, defining both `opengraph-image.png` and `opengraph-image.tsx` produces a build error. For broad social-platform compatibility, use 1200 by 630; generated JSX routes emit PNG automatically.
 
 ## File Route States
 

--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -533,6 +533,40 @@ export default function ProductPage() {
 }
 ```
 
+Use `generateMetadata` in a layout when the same dynamic metadata flow should apply to every page in a route subtree. Farm passes the matched route params to each layout and merges the result before applying the page metadata. A catch-all docs layout can therefore load the current document for every nested docs URL:
+
+**src/app/docs/[...slug]/layout.tsx**
+
+```tsx
+import type { LayoutProps } from "@farm.js/core";
+
+export async function generateMetadata({ params }: Pick<LayoutProps, "params">) {
+  const slug = params.slug?.split("/") ?? [];
+  const document = await getDocument(slug);
+
+  return {
+    title: document.title,
+    description: document.description,
+    openGraph: {
+      title: document.title,
+      description: document.description,
+      type: "article",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: document.title,
+      description: document.description,
+    },
+  };
+}
+
+export default function DocsLayout({ children }: LayoutProps) {
+  return children;
+}
+```
+
+Pair this layout with `opengraph-image.tsx` in the same `[...slug]` segment to generate a different PNG for each document. `generateMetadata` supplies the title, description, and social fields; the image file renders the PNG described below. Leave `openGraph.images` and `twitter.images` unset when Farm should attach the nearest generated image automatically. An explicit image value still takes precedence.
+
 ### Favicons
 
 Place favicon files in `public/`, then declare them through the root layout metadata. Files in `public/` are served from the application root, so `public/favicon.svg` is available at `/favicon.svg`.

--- a/examples/basic/src/app/feature-lab/metadata/[id]/opengraph-image.tsx
+++ b/examples/basic/src/app/feature-lab/metadata/[id]/opengraph-image.tsx
@@ -2,15 +2,20 @@ import type { PageProps } from '@farm.js/core';
 
 export const size = { width: 1200, height: 630 };
 export const alt = 'Feature metadata preview';
-export const contentType = 'image/svg+xml';
+export const revalidate = 300;
+
+function ProductCard({ id }: { id: string }) {
+  return (
+    <div className="flex h-full w-full flex-col justify-between bg-[#09090b] p-20 text-white">
+      <span className="text-3xl font-medium text-emerald-400">Farm.js</span>
+      <div className="flex flex-col">
+        <span className="text-2xl text-zinc-400">Product</span>
+        <span className="mt-3 text-8xl font-bold tracking-tight">{id}</span>
+      </div>
+    </div>
+  );
+}
 
 export default function FeatureOpenGraphImage({ params }: PageProps) {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
-      <rect width="1200" height="630" fill="#0f172a" />
-      <text x="80" y="340" fill="white" fontSize="72">
-        Feature product {params.id}
-      </text>
-    </svg>
-  );
+  return <ProductCard id={params.id} />;
 }

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -133,6 +133,9 @@
       "internal/production-runtime": [
         "./dist/internal/production-runtime.d.ts"
       ],
+      "internal/metadata-image-runtime": [
+        "./dist/internal/metadata-image-runtime.d.ts"
+      ],
       "internal/client-runtime": [
         "./dist/internal/client-runtime.d.ts"
       ],
@@ -449,6 +452,11 @@
       "import": "./dist/internal/production-runtime.mjs",
       "require": "./dist/internal/production-runtime.cjs"
     },
+    "./internal/metadata-image-runtime": {
+      "types": "./dist/internal/metadata-image-runtime.d.ts",
+      "import": "./dist/internal/metadata-image-runtime.mjs",
+      "require": "./dist/internal/metadata-image-runtime.cjs"
+    },
     "./internal/client-runtime": {
       "types": "./dist/internal/client-runtime.d.ts",
       "import": "./dist/internal/client-runtime.mjs",
@@ -494,6 +502,7 @@
     "@scalar/api-reference": "^1.38.1",
     "@scalar/openapi-parser": "^0.22.3",
     "@tailwindcss/vite": "4.1.18",
+    "@vercel/og": "0.11.1",
     "@vitejs/plugin-react": "^4.2.1",
     "better-call": "^1.0.19",
     "db0": "^0.3.4",

--- a/packages/farm/src/__tests__/fixtures/middleware-production-fixture.ts
+++ b/packages/farm/src/__tests__/fixtures/middleware-production-fixture.ts
@@ -375,13 +375,16 @@ import React from "react";
 
 export const size = { width: 1200, height: 630 };
 export const alt = "User preview";
-export const contentType = "image/svg+xml";
+export const revalidate = 120;
 
 export default function UserImage({ params }: { params: { id: string } }) {
   return React.createElement(
-    "svg",
-    { xmlns: "http://www.w3.org/2000/svg", viewBox: "0 0 1200 630" },
-    React.createElement("text", null, \`User \${params.id}\`),
+    "div",
+    {
+      className:
+        "flex h-full w-full items-center justify-center bg-[#09090b] text-8xl font-bold text-white",
+    },
+    \`User \${params.id}\`,
   );
 }
 `.trim(),

--- a/packages/farm/src/__tests__/metadata-image.test.tsx
+++ b/packages/farm/src/__tests__/metadata-image.test.tsx
@@ -58,6 +58,14 @@ describe("generated metadata images", () => {
     );
     expect(notModified.status).toBe(304);
     expect((await notModified.arrayBuffer()).byteLength).toBe(0);
+
+    const wildcardNotModified = await createFarmMetadataImageResponse(
+      <div className="flex h-full w-full bg-black text-white">Farm.js</div>,
+      { size: { width: 120, height: 63 } },
+      { ifNoneMatch: "*" },
+    );
+    expect(wildcardNotModified.status).toBe(304);
+    expect((await wildcardNotModified.arrayBuffer()).byteLength).toBe(0);
   });
 
   it("keeps explicit SVG and Response handlers as escape hatches", async () => {

--- a/packages/farm/src/__tests__/metadata-image.test.tsx
+++ b/packages/farm/src/__tests__/metadata-image.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment node
+
+import React from "react";
+import { imageSize } from "image-size";
+import { describe, expect, it } from "vitest";
+import { createFarmMetadataImageResponse } from "../metadata-image";
+
+function ProductCard({ id }: { id: string }) {
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center bg-black text-white">
+      <span className="text-2xl text-emerald-400">Farm.js</span>
+      <span className="mt-4 text-6xl font-bold">Product {id}</span>
+    </div>
+  );
+}
+
+describe("generated metadata images", () => {
+  it("renders stateless JSX with className utilities to a PNG", async () => {
+    const response = await createFarmMetadataImageResponse(<ProductCard id="42" />, {
+      size: { width: 600, height: 315 },
+      revalidate: 60,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/png");
+    expect(response.headers.get("cache-control")).toBe(
+      "public, s-maxage=60, stale-while-revalidate=300",
+    );
+    expect(response.headers.get("etag")).toMatch(/^"[a-f0-9]{32}"$/);
+
+    const bytes = Buffer.from(await response.arrayBuffer());
+    expect(bytes.subarray(0, 8)).toEqual(
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    );
+    expect(imageSize(bytes)).toMatchObject({ width: 600, height: 315, type: "png" });
+  });
+
+  it("supports HEAD and conditional requests without returning an image body", async () => {
+    const first = await createFarmMetadataImageResponse(
+      <div className="flex h-full w-full bg-black text-white">Farm.js</div>,
+      { size: { width: 120, height: 63 } },
+    );
+    const etag = first.headers.get("etag");
+
+    const head = await createFarmMetadataImageResponse(
+      <div className="flex h-full w-full bg-black text-white">Farm.js</div>,
+      { size: { width: 120, height: 63 } },
+      { method: "HEAD" },
+    );
+    expect(head.status).toBe(200);
+    expect(head.headers.get("content-length")).toBe(first.headers.get("content-length"));
+    expect((await head.arrayBuffer()).byteLength).toBe(0);
+
+    const notModified = await createFarmMetadataImageResponse(
+      <div className="flex h-full w-full bg-black text-white">Farm.js</div>,
+      { size: { width: 120, height: 63 } },
+      { ifNoneMatch: etag },
+    );
+    expect(notModified.status).toBe(304);
+    expect((await notModified.arrayBuffer()).byteLength).toBe(0);
+  });
+
+  it("keeps explicit SVG and Response handlers as escape hatches", async () => {
+    const svg = await createFarmMetadataImageResponse(
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+        <text>Farm</text>
+      </svg>,
+      { contentType: "image/svg+xml" },
+    );
+    expect(svg.headers.get("content-type")).toBe("image/svg+xml");
+    expect(await svg.text()).toContain("<svg");
+
+    const custom = new Response("custom", {
+      status: 202,
+      headers: { "Content-Type": "image/custom" },
+    });
+    const response = await createFarmMetadataImageResponse(custom, {});
+    expect(response.status).toBe(202);
+    expect(response.headers.get("content-type")).toBe("image/custom");
+    expect(await response.text()).toBe("custom");
+  });
+});

--- a/packages/farm/src/__tests__/production-middleware.test.ts
+++ b/packages/farm/src/__tests__/production-middleware.test.ts
@@ -70,6 +70,22 @@ describe("production middleware runtime", () => {
           ),
         ),
       ).resolves.toBeUndefined();
+      await expect(
+        fs.access(
+          path.join(
+            root,
+            ".vercel",
+            "output",
+            "functions",
+            "__nitro.func",
+            "node_modules",
+            "@vercel",
+            "og",
+            "dist",
+            "Geist-Regular.ttf",
+          ),
+        ),
+      ).resolves.toBeUndefined();
       const nitroBundle = await readJavaScriptOutput(
         path.join(root, ".vercel", "output", "functions", "__nitro.func"),
       );
@@ -240,8 +256,16 @@ describe("production middleware runtime", () => {
         new Request("https://example.test/users/42/opengraph-image"),
       );
       expect(dynamicImageResponse.status).toBe(200);
-      expect(dynamicImageResponse.headers.get("content-type")).toBe("image/svg+xml");
-      await expect(dynamicImageResponse.text()).resolves.toContain("User 42");
+      expect(dynamicImageResponse.headers.get("content-type")).toBe("image/png");
+      expect(dynamicImageResponse.headers.get("cache-control")).toBe(
+        "public, s-maxage=120, stale-while-revalidate=300",
+      );
+      const dynamicImageBytes = Buffer.from(await dynamicImageResponse.arrayBuffer());
+      expect(dynamicImageBytes.subarray(0, 8)).toEqual(
+        Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      );
+      expect(dynamicImageBytes.readUInt32BE(16)).toBe(1200);
+      expect(dynamicImageBytes.readUInt32BE(20)).toBe(630);
 
       const programmaticResponse = await serverModule.default.fetch(
         new Request("https://example.test/programmatic/42"),

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -1332,4 +1332,52 @@ export default defineConfig({
       await fs.rm(root, { recursive: true, force: true });
     }
   }, 120_000);
+
+  it("bundles generated metadata images for the Cloudflare worker runtime", async () => {
+    const root = await createProductionFixture();
+
+    try {
+      await fs.writeFile(
+        path.join(root, "src", "app", "opengraph-image.tsx"),
+        `
+export const alt = "Cloudflare metadata image";
+
+function Label({ children }) {
+  return <span className="text-4xl text-white">{children}</span>;
+}
+
+export default function OpenGraphImage() {
+  return (
+    <div className="flex h-full w-full items-center justify-center bg-[#09090b]">
+      <Label>Farm.js on Cloudflare</Label>
+    </div>
+  );
+}
+`.trim(),
+      );
+      const config = await resolveConfig(
+        {
+          root,
+          srcDir: "src",
+          images: { provider: "none" },
+          generateBuildId: () => "metadata-image-cloudflare-test",
+          deploy: {
+            target: "cloudflare",
+            preset: "cloudflare-module",
+          },
+        },
+        "production",
+      );
+
+      await build(config, { root, preset: "cloudflare-module" });
+
+      const serverOutput = await readJavaScriptOutput(
+        path.join(root, config.deploy.outputDir, "server"),
+      );
+      expect(serverOutput).not.toContain(".wasm?module");
+      expect(serverOutput).toContain("Cloudflare metadata image");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }, 120_000);
 });

--- a/packages/farm/src/metadata-image.ts
+++ b/packages/farm/src/metadata-image.ts
@@ -154,9 +154,11 @@ async function finalizeMetadataImageResponse(
   responseHeaders.set("Content-Length", String(body.byteLength));
   responseHeaders.set("X-Content-Type-Options", "nosniff");
 
-  const matchesEntityTag = options.ifNoneMatch
-    ?.split(",")
-    .some((candidate) => candidate.trim().replace(/^W\//, "") === etag);
+  const matchesEntityTag =
+    options.ifNoneMatch?.trim() === "*" ||
+    options.ifNoneMatch
+      ?.split(",")
+      .some((candidate) => candidate.trim().replace(/^W\//, "") === etag);
   if (matchesEntityTag) {
     return new Response(null, { status: 304, headers: responseHeaders });
   }

--- a/packages/farm/src/metadata-image.ts
+++ b/packages/farm/src/metadata-image.ts
@@ -1,0 +1,225 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { ImageResponseOptions } from "@vercel/og";
+
+const REACT_FORWARD_REF_TYPE = Symbol.for("react.forward_ref");
+const REACT_MEMO_TYPE = Symbol.for("react.memo");
+const REACT_LAZY_TYPE = Symbol.for("react.lazy");
+
+type MetadataImageSize = {
+  width?: number;
+  height?: number;
+};
+
+type MetadataImageFont = Omit<NonNullable<ImageResponseOptions["fonts"]>[number], "data"> & {
+  data: ArrayBuffer | ArrayBufferView | Promise<ArrayBuffer | ArrayBufferView>;
+};
+
+export type FarmMetadataImageModule = {
+  size?: MetadataImageSize;
+  contentType?: string;
+  revalidate?: number | false;
+  fonts?: MetadataImageFont[];
+  emoji?: ImageResponseOptions["emoji"];
+  debug?: boolean;
+};
+
+export type FarmMetadataImageResponseOptions = {
+  method?: string;
+  ifNoneMatch?: string | null;
+};
+
+function isResponse(value: unknown): value is Response {
+  return (
+    typeof Response !== "undefined" &&
+    (value instanceof Response ||
+      Boolean(
+        value &&
+        typeof value === "object" &&
+        typeof (value as Response).arrayBuffer === "function" &&
+        (value as Response).headers,
+      ))
+  );
+}
+
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return Boolean(
+    value &&
+    (typeof value === "object" || typeof value === "function") &&
+    typeof (value as PromiseLike<unknown>).then === "function",
+  );
+}
+
+async function prepareMetadataImageNode(node: unknown): Promise<unknown> {
+  if (isThenable(node)) {
+    return prepareMetadataImageNode(await node);
+  }
+
+  if (Array.isArray(node)) {
+    return Promise.all(node.map((child) => prepareMetadataImageNode(child)));
+  }
+
+  if (!React.isValidElement(node)) {
+    return node;
+  }
+
+  const element = node as React.ReactElement<Record<string, unknown>>;
+  const type = element.type as any;
+  const props = element.props || {};
+
+  if (typeof type === "function") {
+    if (type.prototype?.isReactComponent) {
+      throw new Error(
+        "Metadata image components must be stateless function components; React class components are not supported.",
+      );
+    }
+    return prepareMetadataImageNode(await type(props));
+  }
+
+  if (type && typeof type === "object") {
+    if (type.$$typeof === REACT_MEMO_TYPE) {
+      return prepareMetadataImageNode(React.createElement(type.type, props));
+    }
+    if (type.$$typeof === REACT_FORWARD_REF_TYPE) {
+      return prepareMetadataImageNode(await type.render(props, null));
+    }
+    if (type.$$typeof === REACT_LAZY_TYPE) {
+      return prepareMetadataImageNode(React.createElement(type._init(type._payload), props));
+    }
+  }
+
+  const preparedChildren = await prepareMetadataImageNode(props.children);
+  const preparedProps: Record<string, unknown> = { ...props };
+
+  if (typeof preparedProps.className === "string") {
+    preparedProps.tw = [preparedProps.tw, preparedProps.className].filter(Boolean).join(" ");
+    delete preparedProps.className;
+  }
+  delete preparedProps.children;
+
+  return React.createElement(type, {
+    ...preparedProps,
+    key: element.key,
+    children: preparedChildren,
+  });
+}
+
+async function normalizeFonts(
+  fonts: MetadataImageFont[] | undefined,
+): Promise<ImageResponseOptions["fonts"] | undefined> {
+  if (!fonts?.length) return undefined;
+
+  return Promise.all(
+    fonts.map(async (font) => {
+      const data = await font.data;
+      const arrayBuffer = ArrayBuffer.isView(data) ? toArrayBuffer(data) : data;
+      return { ...font, data: arrayBuffer } as NonNullable<ImageResponseOptions["fonts"]>[number];
+    }),
+  );
+}
+
+function resolveCacheControl(revalidate: number | false | undefined): string {
+  if (revalidate === false) {
+    return "public, max-age=31536000, immutable";
+  }
+  if (typeof revalidate === "number" && Number.isFinite(revalidate) && revalidate > 0) {
+    return `public, s-maxage=${Math.floor(revalidate)}, stale-while-revalidate=300`;
+  }
+  return "public, max-age=0, must-revalidate";
+}
+
+function toArrayBuffer(value: ArrayBuffer | ArrayBufferView): ArrayBuffer {
+  if (value instanceof ArrayBuffer) return value;
+  const bytes = new Uint8Array(value.byteLength);
+  bytes.set(new Uint8Array(value.buffer, value.byteOffset, value.byteLength));
+  return bytes.buffer;
+}
+
+async function createEntityTag(body: ArrayBuffer): Promise<string> {
+  const digest = await globalThis.crypto.subtle.digest("SHA-256", body);
+  const hash = Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, 32);
+  return `"${hash}"`;
+}
+
+async function finalizeMetadataImageResponse(
+  body: ArrayBuffer,
+  headers: HeadersInit,
+  options: FarmMetadataImageResponseOptions,
+): Promise<Response> {
+  const responseHeaders = new Headers(headers);
+  const etag = await createEntityTag(body);
+  responseHeaders.set("ETag", etag);
+  responseHeaders.set("Content-Length", String(body.byteLength));
+  responseHeaders.set("X-Content-Type-Options", "nosniff");
+
+  const matchesEntityTag = options.ifNoneMatch
+    ?.split(",")
+    .some((candidate) => candidate.trim().replace(/^W\//, "") === etag);
+  if (matchesEntityTag) {
+    return new Response(null, { status: 304, headers: responseHeaders });
+  }
+
+  return new Response(options.method?.toUpperCase() === "HEAD" ? null : body, {
+    status: 200,
+    headers: responseHeaders,
+  });
+}
+
+/** @internal */
+export async function createFarmMetadataImageResponse(
+  value: unknown,
+  imageModule: FarmMetadataImageModule,
+  options: FarmMetadataImageResponseOptions = {},
+): Promise<Response> {
+  const method = (options.method || "GET").toUpperCase();
+  if (method !== "GET" && method !== "HEAD") {
+    return new Response(null, { status: 405, headers: { Allow: "GET, HEAD" } });
+  }
+
+  if (isResponse(value)) {
+    return method === "HEAD"
+      ? new Response(null, { status: value.status, headers: value.headers })
+      : value;
+  }
+
+  const cacheControl = resolveCacheControl(imageModule.revalidate);
+  const explicitContentType = imageModule.contentType?.split(";", 1)[0]?.trim().toLowerCase();
+
+  if (React.isValidElement(value) && explicitContentType !== "image/svg+xml") {
+    const { ImageResponse } = await import("@vercel/og");
+    const element = (await prepareMetadataImageNode(value)) as React.ReactElement;
+    const response = new ImageResponse(element, {
+      width: imageModule.size?.width || 1200,
+      height: imageModule.size?.height || 630,
+      fonts: await normalizeFonts(imageModule.fonts),
+      emoji: imageModule.emoji,
+      debug: imageModule.debug,
+      headers: { "cache-control": cacheControl },
+    });
+    const headers = new Headers(response.headers);
+    headers.set("Cache-Control", cacheControl);
+    return finalizeMetadataImageResponse(await response.arrayBuffer(), headers, options);
+  }
+
+  let body: ArrayBuffer;
+  if (typeof value === "string") {
+    body = toArrayBuffer(new TextEncoder().encode(value));
+  } else if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
+    body = toArrayBuffer(value);
+  } else if (React.isValidElement(value)) {
+    body = toArrayBuffer(new TextEncoder().encode(renderToStaticMarkup(value)));
+  } else {
+    throw new Error("Metadata image must return a Response, string, bytes, or React element");
+  }
+
+  return finalizeMetadataImageResponse(
+    body,
+    {
+      "Content-Type": imageModule.contentType || "image/svg+xml; charset=utf-8",
+      "Cache-Control": cacheControl,
+    },
+    options,
+  );
+}

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -213,6 +213,13 @@ function isCloudflareImagePreset(preset: string): boolean {
   return preset === "cloudflare" || preset === "cloudflare-pages" || preset === "cloudflare-module";
 }
 
+function shouldUseExternalMetadataImageRuntime(
+  preset: string,
+  hasGeneratedMetadataImages: boolean,
+): boolean {
+  return hasGeneratedMetadataImages && preset !== "vercel-edge" && !isCloudflareImagePreset(preset);
+}
+
 function resolveImageRuntime(
   config: ResolvedFarmConfig,
   preset: string,
@@ -241,6 +248,38 @@ function isNitroRollupExternal(id: string): boolean {
     normalizedId.includes("/node_modules/@prisma/client/") ||
     normalizedId.includes("/node_modules/.prisma/client/")
   );
+}
+
+const FARM_METADATA_IMAGE_WASM_PREFIX = "\0farm-metadata-image-wasm:";
+
+function createMetadataImageWasmPlugin(): Rollup.Plugin {
+  return {
+    name: "farm-metadata-image-wasm",
+    resolveId(source, importer) {
+      if (
+        !source.endsWith(".wasm?module") ||
+        !importer?.replace(/\\/g, "/").includes("/@vercel/og/")
+      ) {
+        return null;
+      }
+
+      const requestPath = source.slice(0, -"?module".length);
+      const resolvedPath = path.isAbsolute(requestPath)
+        ? requestPath
+        : path.resolve(path.dirname(importer.split("?", 1)[0]), requestPath);
+      return `${FARM_METADATA_IMAGE_WASM_PREFIX}${resolvedPath}`;
+    },
+    load(id) {
+      if (!id.startsWith(FARM_METADATA_IMAGE_WASM_PREFIX)) return null;
+      const wasmPath = id.slice(FARM_METADATA_IMAGE_WASM_PREFIX.length);
+      const encoded = readFileSync(wasmPath).toString("base64");
+      return `
+const encoded = ${JSON.stringify(encoded)};
+const bytes = Uint8Array.from(atob(encoded), (character) => character.charCodeAt(0));
+export default new WebAssembly.Module(bytes);
+`;
+    },
+  };
 }
 
 function collectSSRExternalPackages(ssrBundle: OutputBundle): Set<string> {
@@ -2679,6 +2718,10 @@ async function buildSSRInMemory(
   // Find a temporary file path for the virtual entry
   // We'll use a plugin to intercept this
   const virtualEntryId = "\0virtual:farm-ssr-entry";
+  const useExternalMetadataImageRuntime = shouldUseExternalMetadataImageRuntime(
+    preset,
+    metadataImageRoutes.some((image) => image.sourceType === "module"),
+  );
 
   try {
     await viteBuild({
@@ -2697,6 +2740,7 @@ async function buildSSRInMemory(
           external: [
             "fsevents",
             "sharp",
+            ...(useExternalMetadataImageRuntime ? ["@vercel/og"] : []),
             "@prisma/client",
             "@prisma/client/default",
             "@prisma/client/default.js",
@@ -2725,6 +2769,7 @@ async function buildSSRInMemory(
         external: [
           "fsevents",
           "sharp",
+          ...(useExternalMetadataImageRuntime ? ["@vercel/og"] : []),
           "esbuild",
           "lightningcss",
           "rollup",
@@ -2753,7 +2798,14 @@ async function buildSSRInMemory(
         // Native and build-only packages above remain explicitly external.
         noExternal:
           preset === "cloudflare-module"
-            ? ["@farm.js/core", "@farm.js/core/image", "better-call"]
+            ? [
+                "@farm.js/core",
+                "@farm.js/core/image",
+                "better-call",
+                ...(metadataImageRoutes.some((image) => image.sourceType === "module")
+                  ? ["@vercel/og"]
+                  : []),
+              ]
             : true,
       },
       define: {
@@ -2762,6 +2814,10 @@ async function buildSSRInMemory(
       },
       plugins: [
         ...(tailwindVitePlugin ? [tailwindVitePlugin] : []),
+        ...(!useExternalMetadataImageRuntime &&
+        metadataImageRoutes.some((image) => image.sourceType === "module")
+          ? [createMetadataImageWasmPlugin()]
+          : []),
         {
           name: "farm-react-production-mode",
           enforce: "pre",
@@ -2874,6 +2930,9 @@ function generateVirtualEntryCode(
   i18nCatalogs: FarmI18nCatalogs,
 ): string {
   const hasPluginRuntime = hasRuntimeIntegrationConfig || hasConfiguredRuntimePlugins;
+  const hasGeneratedMetadataImages = metadataImageRoutes.some(
+    (image) => image.sourceType === "module",
+  );
   const hasMiddlewareRuntime =
     middlewareRoutes.length > 0 || hasFarmMiddlewareConfig(config.middleware);
   const farmDocsBaseConfig = config.docs?.enabled
@@ -3068,6 +3127,9 @@ function generateVirtualEntryCode(
   stripFarmLocaleFromPathname,
   withFarmRouteContext,
 } from "@farm.js/core/internal/production-runtime";`;
+  const metadataImageRuntimeImport = hasGeneratedMetadataImages
+    ? `import { createFarmMetadataImageResponse } from "@farm.js/core/internal/metadata-image-runtime";`
+    : "";
   const pluginRuntimeImport = hasPluginRuntime
     ? `import { PluginManager } from "@farm.js/core/plugin";`
     : "";
@@ -3203,6 +3265,7 @@ ${middlewareImports.join("\n")}
 ${notFoundImport}
 ${apiRouteHelpersImport}
 ${productionRuntimeImport}
+${metadataImageRuntimeImport}
 ${pluginRuntimeImport}
 ${i18nServerImport}
 ${docsHandlerImport}
@@ -4024,30 +4087,14 @@ async function handleMetadataImageRequest(request, routePathname) {
       ? await imageModule.default(props)
       : imageModule.default;
 
-    if (value instanceof Response) {
-      return method === "HEAD"
-        ? new Response(null, { status: value.status, headers: value.headers })
-        : value;
+    ${
+      hasGeneratedMetadataImages
+        ? `return createFarmMetadataImageResponse(value, imageModule, {
+      method,
+      ifNoneMatch: request.headers.get("if-none-match"),
+    });`
+        : 'throw new Error("Generated metadata image runtime is unavailable");'
     }
-
-    let body;
-    if (typeof value === "string" || value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
-      body = value;
-    } else {
-      if (!React.isValidElement(value)) {
-        throw new Error("Metadata image must return a Response, string, bytes, or React element");
-      }
-      body = ReactDOMServer.renderToStaticMarkup(value);
-    }
-
-    return new Response(method === "HEAD" ? null : body, {
-      status: 200,
-      headers: {
-        "Content-Type": imageModule.contentType || "image/svg+xml; charset=utf-8",
-        "Cache-Control": "public, max-age=0, must-revalidate",
-        "X-Content-Type-Options": "nosniff",
-      },
-    });
   } catch (error) {
     console.error("Metadata image render failed:", error);
     return new Response("Internal Server Error", {
@@ -5933,8 +5980,20 @@ async function buildNitroUniversal(
   const outputDir = resolveDeployOutputPath(root, config.deploy.outputDir);
   const ssrOutputDir = path.join(root, distDir, "ssr");
   const imageRuntime = resolveImageRuntime(config, preset);
+  const hasGeneratedMetadataImages = Array.from(routeManager.getMetadataImages().values()).some(
+    (image) => image.sourceType === "module",
+  );
+  const useExternalMetadataImageRuntime = shouldUseExternalMetadataImageRuntime(
+    preset,
+    hasGeneratedMetadataImages,
+  );
+  const nitroRollupExternal = (id: string) =>
+    (useExternalMetadataImageRuntime && id === "@vercel/og") || isNitroRollupExternal(id);
   const ssrExternalPackages = collectSSRExternalPackages(ssrBundle);
-  const copiedRuntimePackages = new Set(imageRuntime === "node" ? ["sharp"] : []);
+  const copiedRuntimePackages = new Set([
+    ...(imageRuntime === "node" ? ["sharp"] : []),
+    ...(useExternalMetadataImageRuntime ? ["@vercel/og"] : []),
+  ]);
   // Nitro normally rebundles the Vite SSR graph so its bare dependencies are
   // deployable. Skip that duplicate pass only when Farm already knows how to
   // package every remaining external; otherwise retain Nitro's proven path.
@@ -6182,10 +6241,15 @@ export default async function farmNitroEventHandler(event) {
         ".prisma/client/default",
         "better-sqlite3",
         "sharp",
+        ...(useExternalMetadataImageRuntime ? ["@vercel/og"] : []),
       ],
     },
     rollupConfig: {
-      external: isNitroRollupExternal,
+      external: nitroRollupExternal,
+      plugins:
+        hasGeneratedMetadataImages && !useExternalMetadataImageRuntime
+          ? [createMetadataImageWasmPlugin()]
+          : [],
     },
     // Keep the public Nitro boolean intact for build hooks. It is translated to
     // Nitro's existing esbuild pass after hooks run, avoiding a second Terser pass.
@@ -6228,7 +6292,7 @@ export default async function farmNitroEventHandler(event) {
     !hasUnsupportedEsbuildOverrides &&
     !hasLateBuildMutationConfig &&
     !hasUnsupportedSSRRebundleOverrides &&
-    nitroConfig.rollupConfig?.external === isNitroRollupExternal &&
+    nitroConfig.rollupConfig?.external === nitroRollupExternal &&
     !hasRollupPlugins(nitroConfig.rollupConfig?.plugins) &&
     customRollupKeys.length === 0 &&
     path.resolve(nitroConfig.output?.serverDir || "") === path.resolve(expectedServerDir) &&
@@ -6359,6 +6423,9 @@ export default async function farmNitroEventHandler(event) {
       : Promise.resolve(),
     imageRuntime === "node"
       ? copySharpRuntime(config, root, path.join(outputDir, "server"), fs)
+      : Promise.resolve(),
+    useExternalMetadataImageRuntime
+      ? copyMetadataImageRuntime(root, path.join(outputDir, "server"), fs)
       : Promise.resolve(),
   ]);
   const failedCopy = copyResults.find(
@@ -6666,6 +6733,51 @@ async function copySharpRuntime(
   };
   await fs.writeFile(functionPackagePath, JSON.stringify(functionPackage, null, 2));
   logger.info(`🖼️  Bundled Sharp image runtime (${copiedPackages.size} packages)`);
+}
+
+async function copyMetadataImageRuntime(
+  root: string,
+  nitroFuncDir: string,
+  fs: typeof import("fs/promises"),
+): Promise<void> {
+  const projectRequire = createRequire(path.join(root, "package.json"));
+  let runtimeRequire = projectRequire;
+  let packageJsonPath = resolvePackageJson(runtimeRequire, "@vercel/og");
+
+  if (!packageJsonPath) {
+    try {
+      runtimeRequire = createRequire(projectRequire.resolve("@farm.js/core"));
+      packageJsonPath = resolvePackageJson(runtimeRequire, "@vercel/og");
+    } catch {
+      // The missing-runtime diagnostic below remains authoritative.
+    }
+  }
+
+  if (!packageJsonPath) {
+    throw new Error(
+      "Generated metadata images require @vercel/og. Reinstall @farm.js/core with production dependencies.",
+    );
+  }
+
+  const packageJson = JSON.parse(await fs.readFile(packageJsonPath, "utf8"));
+  const packageDir = path.dirname(packageJsonPath);
+  const targetDir = path.join(nitroFuncDir, "node_modules", "@vercel", "og");
+  await fs.mkdir(path.dirname(targetDir), { recursive: true });
+  await fs.cp(packageDir, targetDir, {
+    recursive: true,
+    force: true,
+    dereference: true,
+    mode: fsConstants.COPYFILE_FICLONE,
+  });
+
+  const functionPackagePath = path.join(nitroFuncDir, "package.json");
+  const functionPackage = JSON.parse(await fs.readFile(functionPackagePath, "utf8"));
+  functionPackage.dependencies = {
+    ...functionPackage.dependencies,
+    "@vercel/og": String(packageJson.version || "0.11.1"),
+  };
+  await fs.writeFile(functionPackagePath, JSON.stringify(functionPackage, null, 2));
+  logger.info("🖼️  Bundled generated metadata image runtime");
 }
 
 function resolvePackageJson(parentRequire: NodeJS.Require, packageName: string): string | null {

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import { renderToPipeableStream, renderToStaticMarkup } from "react-dom/server";
+import { renderToPipeableStream } from "react-dom/server";
 import * as fs from "fs";
 import * as path from "path";
 import type {
@@ -49,6 +49,7 @@ import { createFarmLocaleCookie, getFarmLocaleVaryHeaders } from "../i18n/resolv
 import { localizeFarmHref, localizeFarmPathname } from "../i18n/routing";
 import { sendWebResponse } from "./response";
 import { renderFarmFontDevHead } from "../font-vite";
+import { createFarmMetadataImageResponse } from "../metadata-image";
 
 let cachedClerkProvider: {
   ClerkProvider: React.ComponentType<{ children?: React.ReactNode } & Record<string, unknown>>;
@@ -1361,6 +1362,14 @@ export class ServerRenderer {
       };
     },
   ): Promise<void> {
+    const method = (req.method || "GET").toUpperCase();
+    if (method !== "GET" && method !== "HEAD") {
+      res.statusCode = 405;
+      res.setHeader("Allow", "GET, HEAD");
+      res.end();
+      return;
+    }
+
     if (options.image.sourceType === "static") {
       if (!options.image.staticInfo) {
         throw new Error(`Static metadata image ${options.image.modulePath} is missing file info`);
@@ -1398,47 +1407,12 @@ export class ServerRenderer {
     value: unknown,
     imageModule: RouteModule,
   ): Promise<void> {
-    if (isWebResponse(value)) {
-      res.statusCode = value.status;
-      value.headers.forEach((headerValue, key) => {
-        res.setHeader(key, headerValue);
-      });
-
-      if (req.method === "HEAD") {
-        res.end();
-        return;
-      }
-
-      const body = Buffer.from(await value.arrayBuffer());
-      res.write(body);
-      res.end();
-      return;
-    }
-
-    const contentType = (imageModule as any).contentType || "image/svg+xml; charset=utf-8";
-    let body: string | Buffer;
-
-    if (typeof value === "string") {
-      body = value;
-    } else if (value instanceof ArrayBuffer) {
-      body = Buffer.from(value);
-    } else if (ArrayBuffer.isView(value)) {
-      body = Buffer.from(value.buffer, value.byteOffset, value.byteLength);
-    } else if (React.isValidElement(value)) {
-      body = renderToStaticMarkup(value);
-    } else {
-      throw new Error("Metadata image must return a Response, string, bytes, or React element");
-    }
-
-    res.statusCode = res.statusCode || 200;
-    res.setHeader("Content-Type", contentType);
-    res.setHeader("Cache-Control", "public, max-age=0, must-revalidate");
-    if (req.method === "HEAD") {
-      res.end();
-      return;
-    }
-    res.write(body);
-    res.end();
+    const ifNoneMatch = req.headers["if-none-match"];
+    const response = await createFarmMetadataImageResponse(value, imageModule, {
+      method: req.method,
+      ifNoneMatch: Array.isArray(ifNoneMatch) ? ifNoneMatch[0] : ifNoneMatch,
+    });
+    await sendWebResponse(res as any, response);
   }
 
   private async writeStaticMetadataImageResponse(

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -55,6 +55,7 @@ export const farmPackageBuildOptions = {
     "i18n/client": "src/i18n/client.tsx",
     "internal/client-runtime": "src/client/production-runtime.ts",
     "internal/production-runtime": "src/nitro/production-runtime.ts",
+    "internal/metadata-image-runtime": "src/metadata-image.ts",
     "internal/build-runtime": "src/nitro/build-runtime.ts",
     "internal/config-runtime": "src/config-runtime.ts",
     "internal/production-node-env": "src/build/production-node-env.ts",
@@ -66,6 +67,7 @@ export const farmPackageBuildOptions = {
   external: [
     "react",
     "react-dom",
+    "@vercel/og",
     "rolldown",
     "sharp",
     "vite",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1196,6 +1196,9 @@ importers:
       '@tailwindcss/vite':
         specifier: 4.1.18
         version: 4.1.18(vite@5.4.20)
+      '@vercel/og':
+        specifier: 0.11.1
+        version: 0.11.1
       '@vitejs/plugin-react':
         specifier: ^4.2.1
         version: 4.7.0(supports-color@10.2.2)(vite@5.4.20)
@@ -17209,4 +17212,147 @@ packages:
 
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+    dev: false
+
+  /@emnapi/runtime@1.11.3:
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
+    requiresBuild: true
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+    optional: true
+
+  /@resvg/resvg-wasm@2.4.0:
+    resolution: {integrity: sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==}
+    engines: {node: '>= 10'}
+    dev: false
+
+  /@shuding/opentype.js@1.4.0-beta.0:
+    resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
+    engines: {node: '>= 8.0.0'}
+    hasBin: true
+    dependencies:
+      fflate: 0.7.5
+      string.prototype.codepointat: 0.2.1
+    dev: false
+
+  /@vercel/og@0.11.1:
+    resolution: {integrity: sha512-02rXXRABFq1B03w3aNhcVfxkY+8Ba5QFi4ax0zS0oOiD/LL9WUd/LA7BjVPakrQmVhIBjuo2oBM5U25R9IuXMg==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@resvg/resvg-wasm': 2.4.0
+      satori: 0.25.0
+    optionalDependencies:
+      sharp: 0.34.5
+    dev: false
+
+  /base64-js@0.0.8:
+    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
+    engines: {node: '>= 0.4'}
+    dev: false
+
+  /camelize@1.0.1:
+    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
+    dev: false
+
+  /css-background-parser@0.1.0:
+    resolution: {integrity: sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==}
+    dev: false
+
+  /css-box-shadow@1.0.0-3:
+    resolution: {integrity: sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==}
+    dev: false
+
+  /css-color-keywords@1.0.0:
+    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /css-gradient-parser@0.0.17:
+    resolution: {integrity: sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==}
+    engines: {node: '>=16'}
+    dev: false
+
+  /css-to-react-native@3.2.0:
+    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
+    dependencies:
+      camelize: 1.0.1
+      css-color-keywords: 1.0.0
+      postcss-value-parser: 4.2.0
+    dev: false
+
+  /emoji-regex-xs@2.0.1:
+    resolution: {integrity: sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==}
+    engines: {node: '>=10.0.0'}
+    dev: false
+
+  /fflate@0.7.5:
+    resolution: {integrity: sha512-QieYf//cis6ywHNi5qW1+PXPQ4bC+XVJAtS4AXIML8P76GroEiOxm/oQtn1f02UkJY1+KsXMJcC+R2v/Eg4G3g==}
+    dev: false
+
+  /hex-rgb@4.3.0:
+    resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /linebreak@1.1.0:
+    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
+    dev: false
+
+  /pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+    dev: false
+
+  /parse-css-color@0.2.1:
+    resolution: {integrity: sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==}
+    dependencies:
+      color-name: 1.1.4
+      hex-rgb: 4.3.0
+    dev: false
+
+  /satori@0.25.0:
+    resolution: {integrity: sha512-utINfLxrYrmSnLvxFT4ZwgwWa8KOjrz7ans32V5wItgHVmzESl/9i33nE38uG0miycab8hUqQtDlOpqrIpB/iw==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@shuding/opentype.js': 1.4.0-beta.0
+      css-background-parser: 0.1.0
+      css-box-shadow: 1.0.0-3
+      css-gradient-parser: 0.0.17
+      css-to-react-native: 3.2.0
+      emoji-regex-xs: 2.0.1
+      escape-html: 1.0.3
+      linebreak: 1.1.0
+      parse-css-color: 0.2.1
+      postcss-value-parser: 4.2.0
+      yoga-layout: 3.2.1
+    dev: false
+
+  /semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /string.prototype.codepointat@0.2.1:
+    resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
+    dev: false
+
+  /tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+    dev: false
+
+  /unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
+    dev: false
+
+  /yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
     dev: false

--- a/tests/e2e/framework-features.spec.ts
+++ b/tests/e2e/framework-features.spec.ts
@@ -375,8 +375,22 @@ test.describe("Framework feature integration", () => {
 
     const image = await request.get("/feature-lab/metadata/7/opengraph-image");
     expect(image.status()).toBe(200);
-    expect(image.headers()["content-type"]).toContain("image/svg+xml");
-    expect(await image.text()).toContain("Feature product 7");
+    expect(image.headers()["content-type"]).toBe("image/png");
+    expect(image.headers()["cache-control"]).toBe(
+      "public, s-maxage=300, stale-while-revalidate=300",
+    );
+    expect(image.headers()["etag"]).toMatch(/^"[a-f0-9]{32}"$/);
+    const imageBytes = await image.body();
+    expect(imageBytes.subarray(0, 8)).toEqual(
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    );
+    expect(imageBytes.readUInt32BE(16)).toBe(1200);
+    expect(imageBytes.readUInt32BE(20)).toBe(630);
+
+    const imageHead = await request.head("/feature-lab/metadata/7/opengraph-image");
+    expect(imageHead.status()).toBe(200);
+    expect(imageHead.headers()["content-type"]).toBe("image/png");
+    expect(await imageHead.body()).toHaveLength(0);
 
     const run = await request.get("/api/maintenance/cleanup", {
       headers: {


### PR DESCRIPTION
## What changed

- render ordinary stateless JSX from `opengraph-image.tsx` and `twitter-image.tsx` as PNG without requiring `ImageResponse` or an API route
- support route params, nested reusable components, `className` utilities, inline styles, custom fonts, dimensions, and image-specific cache settings
- add ETag, conditional GET, and HEAD support while retaining Response, bytes, string, and explicit SVG escape hatches
- package the optional renderer correctly for Node and Vercel and bundle its WASM modules for Cloudflare workers
- keep the renderer out of production graphs when an application has no generated metadata image routes
- document the complete convention, styling limitations, font support, caching behavior, and inheritance model
- update the framework example and E2E coverage to exercise a real 1200×630 PNG

## Why

Generated social images previously required returning SVG or managing a renderer and endpoint manually. This gives Farm.js a convention-based dynamic OG image workflow while preserving advanced escape hatches and avoiding runtime cost for applications that do not use it.

## Validation

- `pnpm --filter @farm.js/core type-check`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`
- 30 focused unit and production tests across development, Node/Vercel, and Cloudflare
- Chromium framework E2E for metadata-image discovery, PNG dimensions, caching, ETag, and HEAD behavior
- frozen lockfile, formatting, lint, and diff-integrity checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds convention-based dynamic OG/Twitter images that render stateless JSX to PNG without custom API routes. Improves caching with `revalidate`, ETag (including wildcard), and `HEAD`, and packages the renderer for Node/Vercel and Cloudflare while staying out of production when unused.

- **New Features**
  - Place `opengraph-image.tsx` or `twitter-image.tsx` next to a route; Farm serves a PNG and injects `og:image` tags.
  - Supports route params, nested components, `className` utilities, inline styles, custom `fonts`, emoji, and `size` (defaults to 1200×630 with Geist).
  - Caching via `revalidate`, ETag, conditional `GET`/`HEAD`; escape hatches with `contentType = "image/svg+xml"` or returning a `Response`. Renderer powered by `@vercel/og` with a runtime entry `@farm.js/core/internal/metadata-image-runtime` and WASM bundling where needed.
  - Docs: show using layout `generateMetadata` to supply dynamic metadata across a subtree and auto-attach the nearest generated image.

- **Bug Fixes**
  - Handle wildcard ETags for metadata images (`If-None-Match: *` returns 304 without a body).
  - Increased CI heap (`NODE_OPTIONS=--max-old-space-size=8192`) for builds, tests, type-check, and E2E to prevent OOM.

<sup>Written for commit 2ff24c4d154166fd995778a403aa7481c3a78299. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

