### PR TITLE
feat: showcase billing and email APIs

### DIFF
--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -350,12 +350,11 @@ const integrationCodeTabs = [
     id: "integrations",
     label: "farm.config.ts",
     language: "ts",
-    highlightLines: [5, 7, 8, 9, 10, 11],
+    highlightLines: [5, 6, 7, 8, 9, 10],
     code: `import { defineConfig } from "@farm.js/core";
 import { resend, stripe } from "@farm.js/integrations";
 import { emailTemplates } from "./email";
 export default defineConfig({
-    auth: true,
     integrations: {
         billing: stripe({ secretKey: process.env.STRIPE_SECRET_KEY }),
         email: resend({
@@ -366,15 +365,23 @@ export default defineConfig({
 });`,
   },
   {
-    id: "config",
-    label: "Server and client APIs",
+    id: "apis",
+    label: "Billing and email APIs",
     language: "ts",
-    highlightLines: [2, 5],
-    code: `import { auth } from "@farm.js/auth/server";
-const user = await auth.user({ required: true });
+    highlightLines: [3, 7, 9],
+    code: `import { api, apiClient } from "@/lib/api";
 
-import { useAuth } from "@farm.js/auth/client";
-const { user, signIn, signOut } = useAuth();`,
+const checkout = await apiClient.billing.checkout.post({
+    body: { productId: "pro" },
+});
+
+await api.email.send.post({
+    body: {
+        template: "welcome",
+        to: "ada@example.com",
+        data: { name: "Ada" },
+    },
+});`,
   },
 ] as const satisfies readonly [HighlightedCodeTab, ...HighlightedCodeTab[]];
 
@@ -1120,11 +1127,11 @@ function DeveloperExperienceGrid() {
         <TypedApiVisual />
       </FeatureCell>
       <FeatureCell
-        body="Enable Farm Auth with one config key, then add billing, email, jobs, storage, docs, and agent runtimes through integrations."
+        body="Configure billing and email once, then use their typed APIs from client and server code."
         className="border-t border-white/12"
         icon={Plug}
         index="01.3"
-        label="Auth + integrations"
+        label="Billing + email"
         title="Start built in. Extend when needed."
       >
         <IntegrationVisual />


### PR DESCRIPTION
## Summary

- replace the landing-page auth API example with typed billing checkout and email send calls
- remove `auth: true` from the integration configuration sample
- align the feature label and description with the billing and email examples

## Why

The “Start built in. Extend when needed.” card configured billing and email but switched to Auth-specific client and server APIs in its second tab. This keeps the card focused on one clear integration story.

## Validation

- `pnpm exec oxfmt --check docs/src/app/page.tsx`
- `pnpm --dir docs build`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the landing-page Auth example with typed billing checkout and email send APIs to keep the integration story focused. Updated config and UI copy to match billing/email usage.

- **New Features**
  - Swapped the “Server and client APIs” tab for “Billing and email APIs” using `api`/`apiClient` with `billing.checkout.post` and `email.send.post`.
  - Removed `auth: true` from the `farm.config.ts` example; kept `stripe` and `resend` integrations.
  - Updated the feature label to “Billing + email” and simplified the description to emphasize typed APIs from client and server.

<sup>Written for commit 3d5498d1edf352c79b97395a4180f3c9d95c7c45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

