### PR TITLE
feat: support injected integration instances

### DIFF
--- a/docs/src/app/docs/integrations/auth/auth0/page.md
+++ b/docs/src/app/docs/integrations/auth/auth0/page.md
@@ -50,6 +50,31 @@ auth0({
 });
 ```
 
+## Choose route ownership
+
+### Let Farm construct the Auth0 flow
+
+The configuration above is the default path. When `instance` is omitted, Farm constructs the OAuth
+flow from the Auth0 domain, client credentials, session secret, callback settings, and scopes. Farm
+then owns the login, signup, callback, logout, profile, and protected-route behavior.
+
+### Provide application-owned middleware
+
+```ts
+auth0({
+  instance: {
+    matcher: ["/auth(.*)", "/dashboard(.*)"],
+    middleware(request) {
+      return myAuth0Middleware(request);
+    },
+  },
+});
+```
+
+This advanced path accepts a compatible middleware adapter rather than the Auth0 SDK itself. The
+supplied instance wins and Farm only mounts its middleware; it does not create the built-in login,
+callback, logout, or profile routes.
+
 ## Environment variables
 
 | Variable              | Required                  | Purpose                                                                   |
@@ -132,6 +157,7 @@ Only root-relative `returnTo` values are accepted. Invalid or external values fa
 
 | Option                    | Default                | Use                                                                          |
 | ------------------------- | ---------------------- | ---------------------------------------------------------------------------- |
+| `instance`                | None                   | Application-owned middleware adapter; disables the built-in flow.            |
 | `domain`                  | `AUTH0_DOMAIN`         | Auth0 tenant domain.                                                         |
 | `clientId`                | `AUTH0_CLIENT_ID`      | OAuth client ID.                                                             |
 | `clientSecret`            | `AUTH0_CLIENT_SECRET`  | OAuth client secret for confidential clients.                                |
@@ -143,8 +169,6 @@ Only root-relative `returnTo` values are accepted. Invalid or external values fa
 | `scopes`                  | `openid profile email` | Requested OAuth scopes.                                                      |
 | `tokenEndpointAuthMethod` | `auto`                 | `client_secret_basic`, `client_secret_post`, `none`, or automatic selection. |
 | `protectedRoutes`         | None                   | One matcher or a list of matchers.                                           |
-
-Advanced adapters can pass `instance: { middleware, matcher }`. In that mode Farm mounts the supplied middleware and does not create the built-in login, callback, logout, or profile routes.
 
 ## Production checklist
 

--- a/docs/src/app/docs/integrations/auth/authjs/page.md
+++ b/docs/src/app/docs/integrations/auth/authjs/page.md
@@ -10,6 +10,16 @@ Use this adapter when Auth.js should own providers, callbacks, cookies, and sess
 
 Farm creates the catch-all route. It does not reimplement Auth.js or generate a separate Farm auth client.
 
+## SDK ownership
+
+Auth.js is application-owned only. Farm cannot safely construct it from a small credential set
+because providers, adapters, callbacks, cookies, events, and session behavior are application
+decisions. Create the Auth.js object in application code and pass it through `instance`; Farm owns
+only catch-all route mounting and integration logging.
+
+There is intentionally no Farm-constructed fallback for this adapter. Applications wanting a
+Farm-owned configuration path can use [Farm Auth](/docs/auth) instead.
+
 ## Add Auth.js
 
 **Terminal**

--- a/docs/src/app/docs/integrations/auth/better-auth/page.md
+++ b/docs/src/app/docs/integrations/auth/better-auth/page.md
@@ -14,6 +14,16 @@ Use either top-level `auth` or `integrations.auth`, not both. They are alternati
 
 For a complete application-owned example, use the [Farm.js Better Auth Starter](https://github.com/farming-labs/farmjs-better-auth-starter). It keeps the Better Auth instance, database adapter, native client, and extension points explicit.
 
+## SDK ownership
+
+Better Auth is application-owned only. Farm cannot construct it from a small credential set because
+the database, adapters, providers, plugins, callbacks, migrations, and cookie behavior are part of
+the application's auth design. Create the Better Auth object in application code and pass it through
+`instance`; Farm owns only catch-all route mounting and integration logging.
+
+For a Farm-constructed alternative, use top-level [Farm Auth](/docs/auth). Do not configure both
+ownership models in the same application.
+
 ## Add Better Auth
 
 **Terminal**

--- a/docs/src/app/docs/integrations/auth/clerk/page.md
+++ b/docs/src/app/docs/integrations/auth/clerk/page.md
@@ -48,11 +48,22 @@ The keys can be omitted from the call when the environment variables are set.
 
 Install `@clerk/react` and `@clerk/backend` in the application. Farm loads the React provider at render time and the backend client inside protected-route middleware.
 
-## Use an existing Clerk instance
+## Choose SDK ownership
+
+### Let Farm construct Clerk
+
+The configuration above is the default path. When `instance` is omitted, Farm lazily creates one
+Clerk backend client from `publishableKey` and `secretKey`. Both values may be passed directly or
+read from the documented environment variables.
+
+### Provide an application-owned instance
 
 Pass a backend client through `instance` to keep Clerk construction and version-specific options in
 application code. The publishable key is still required for `ClerkProvider`; the secret key is not
 required by Farm when the backend instance is supplied.
+
+When both an instance and construction credentials are present, the instance wins. Farm-owned
+options such as `protectedRoutes`, `providerProps`, and sign-in URLs still belong in `clerk(...)`.
 
 ```ts
 import { createClerkClient } from "@clerk/backend";

--- a/docs/src/app/docs/integrations/auth/clerk/page.md
+++ b/docs/src/app/docs/integrations/auth/clerk/page.md
@@ -48,6 +48,28 @@ The keys can be omitted from the call when the environment variables are set.
 
 Install `@clerk/react` and `@clerk/backend` in the application. Farm loads the React provider at render time and the backend client inside protected-route middleware.
 
+## Use an existing Clerk instance
+
+Pass a backend client through `instance` to keep Clerk construction and version-specific options in
+application code. The publishable key is still required for `ClerkProvider`; the secret key is not
+required by Farm when the backend instance is supplied.
+
+```ts
+import { createClerkClient } from "@clerk/backend";
+import { clerk } from "@farm.js/integrations/clerk";
+
+const clerkClient = createClerkClient({
+  secretKey: process.env.CLERK_SECRET_KEY,
+  publishableKey: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+});
+
+export const auth = clerk({
+  instance: clerkClient,
+  publishableKey: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+  protectedRoutes: ["/dashboard(.*)"],
+});
+```
+
 ## Create sign-in and sign-up pages
 
 `signInUrl` and `signUpUrl` tell Farm where your Clerk pages live. They do not create those pages.
@@ -143,8 +165,9 @@ clerk({
 
 | Option              | Default                   | Use                                               |
 | ------------------- | ------------------------- | ------------------------------------------------- |
+| `instance`          | None                      | Existing Clerk backend client.                    |
 | `publishableKey`    | Clerk publishable key env | Client-safe Clerk key.                            |
-| `secretKey`         | `CLERK_SECRET_KEY`        | Server Clerk key.                                 |
+| `secretKey`         | `CLERK_SECRET_KEY`        | Server Clerk key when no instance is supplied.    |
 | `signInUrl`         | `/sign-in`                | App-owned Clerk sign-in page.                     |
 | `signUpUrl`         | `/sign-up`                | App-owned Clerk sign-up page.                     |
 | `protectedRoutes`   | None                      | One matcher or a list of matchers.                |

--- a/docs/src/app/docs/integrations/auth/page.md
+++ b/docs/src/app/docs/integrations/auth/page.md
@@ -32,6 +32,8 @@ Farm supports two auth integration styles:
 
 That distinction determines whether you call auth through Farm's generated `api` clients or through the provider's native SDK.
 
+SDK construction is a separate choice. WorkOS, Supabase, and Clerk can construct their SDK client from integration options or documented environment variables when `instance` is omitted; pass `instance` when the application should construct and own that client instead. An injected instance always wins over constructor options. Auth.js and Better Auth require an application-owned instance because their providers, adapters, callbacks, and plugins are application-specific. Auth0's optional `instance` is a middleware adapter for mounting an existing auth implementation, not an Auth0 SDK client.
+
 ## Choose by ownership
 
 | Provider                                           | Farm owns                                                                                                   | Your app or provider owns                                          |

--- a/docs/src/app/docs/integrations/auth/supabase/page.md
+++ b/docs/src/app/docs/integrations/auth/supabase/page.md
@@ -57,6 +57,34 @@ Farm accepts the standard Supabase URL plus any of these anonymous or publishabl
 
 Keep service-role credentials in separate server code that performs administrative operations. Do not expose them to auth pages or pass them to `supabase(...)`.
 
+## Customize the request-scoped client
+
+Supabase SSR clients contain request cookie handlers, so a single shared client is unsafe. The
+`instance` option is therefore a factory. Farm calls it for every request and supplies its
+cookie-aware `options`; keep those options when adding custom fetch, headers, or other SDK settings.
+
+```ts
+import { supabase } from "@farm.js/integrations/supabase";
+
+export const auth = supabase({
+  instance: ({ createClient, options }) =>
+    createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_ANON_KEY!, {
+      ...options,
+      global: {
+        ...options.global,
+        headers: {
+          ...options.global?.headers,
+          "x-application-name": "farm-dashboard",
+        },
+      },
+    }),
+  protectedRoutes: ["/dashboard(.*)"],
+});
+```
+
+The factory can also use the provided `url` and `anonKey` values when those are configured on the
+integration. Do not create the client outside the factory or cache its return value.
+
 ## Routes and methods
 
 | Method        | Default route    | Purpose                                                           |
@@ -156,6 +184,7 @@ The middleware checks the current Supabase cookie session. Signed-out requests r
 
 | Option            | Default                       | Use                                          |
 | ----------------- | ----------------------------- | -------------------------------------------- |
+| `instance`        | None                          | Request-scoped Supabase client factory.      |
 | `url`             | Supabase URL env              | Project URL.                                 |
 | `anonKey`         | Anonymous/publishable key env | Browser-safe project key.                    |
 | `appBaseUrl`      | `APP_BASE_URL`                | Public app origin.                           |

--- a/docs/src/app/docs/integrations/auth/supabase/page.md
+++ b/docs/src/app/docs/integrations/auth/supabase/page.md
@@ -57,7 +57,15 @@ Farm accepts the standard Supabase URL plus any of these anonymous or publishabl
 
 Keep service-role credentials in separate server code that performs administrative operations. Do not expose them to auth pages or pass them to `supabase(...)`.
 
-## Customize the request-scoped client
+## Choose client ownership
+
+### Let Farm construct Supabase
+
+The configuration above is the default path. When `instance` is omitted, Farm creates a fresh
+Supabase SSR client for every request from `url` and `anonKey`, using its cookie adapter. Both values
+may be supplied directly or through environment variables.
+
+### Provide an application-owned factory
 
 Supabase SSR clients contain request cookie handlers, so a single shared client is unsafe. The
 `instance` option is therefore a factory. Farm calls it for every request and supplies its
@@ -83,7 +91,9 @@ export const auth = supabase({
 ```
 
 The factory can also use the provided `url` and `anonKey` values when those are configured on the
-integration. Do not create the client outside the factory or cache its return value.
+integration. The factory wins when supplied, while routes, pages, OAuth providers, and protection
+remain Farm integration options. Do not create the client outside the factory or cache its return
+value.
 
 ## Routes and methods
 

--- a/docs/src/app/docs/integrations/auth/workos/page.md
+++ b/docs/src/app/docs/integrations/auth/workos/page.md
@@ -51,6 +51,29 @@ Farm builds the absolute redirect URI from the incoming request origin and `call
 
 Development has a local fallback cookie password. Production startup fails without an explicit password.
 
+## Use an existing WorkOS instance
+
+Pass a configured SDK through `instance` when the app needs WorkOS constructor options that Farm
+does not own. Farm uses the instance directly, so `apiKey` is no longer required by the integration.
+The AuthKit client ID can come from the instance, while the cookie password remains required because
+Farm owns the sealed session cookie.
+
+```ts
+import { WorkOS } from "@workos-inc/node";
+import { workos } from "@farm.js/integrations/workos";
+
+const workosClient = new WorkOS({
+  apiKey: process.env.WORKOS_API_KEY,
+  clientId: process.env.WORKOS_CLIENT_ID,
+});
+
+export const auth = workos({
+  instance: workosClient,
+  cookiePassword: process.env.WORKOS_COOKIE_PASSWORD,
+  protectedRoutes: ["/dashboard(.*)"],
+});
+```
+
 ## Routes and methods
 
 | Method | Default route   | Purpose                                                          |
@@ -142,18 +165,19 @@ Signed-out requests receive a `307` redirect to `/login` with the original root-
 
 ## Options
 
-| Option            | Default            | Use                                |
-| ----------------- | ------------------ | ---------------------------------- |
-| `clientId`        | `WORKOS_CLIENT_ID` | AuthKit client ID.                 |
-| `apiKey`          | `WORKOS_API_KEY`   | Server API key.                    |
-| `cookiePassword`  | WorkOS cookie env  | Sealed-session password.           |
-| `cookieName`      | `wos-session`      | Session cookie name.               |
-| `loginPath`       | `/login`           | Sign-in route.                     |
-| `signUpPath`      | `/signup`          | Sign-up route.                     |
-| `callbackPath`    | `/callback`        | AuthKit callback route.            |
-| `logoutPath`      | `/logout`          | Logout route.                      |
-| `sessionPath`     | `/auth/session`    | Session JSON route.                |
-| `protectedRoutes` | None               | One matcher or a list of matchers. |
+| Option            | Default            | Use                                          |
+| ----------------- | ------------------ | -------------------------------------------- |
+| `instance`        | None               | Existing WorkOS SDK instance.                |
+| `clientId`        | `WORKOS_CLIENT_ID` | AuthKit client ID.                           |
+| `apiKey`          | `WORKOS_API_KEY`   | Server API key when no instance is supplied. |
+| `cookiePassword`  | WorkOS cookie env  | Sealed-session password.                     |
+| `cookieName`      | `wos-session`      | Session cookie name.                         |
+| `loginPath`       | `/login`           | Sign-in route.                               |
+| `signUpPath`      | `/signup`          | Sign-up route.                               |
+| `callbackPath`    | `/callback`        | AuthKit callback route.                      |
+| `logoutPath`      | `/logout`          | Logout route.                                |
+| `sessionPath`     | `/auth/session`    | Session JSON route.                          |
+| `protectedRoutes` | None               | One matcher or a list of matchers.           |
 
 ## Production checklist
 

--- a/docs/src/app/docs/integrations/auth/workos/page.md
+++ b/docs/src/app/docs/integrations/auth/workos/page.md
@@ -51,12 +51,22 @@ Farm builds the absolute redirect URI from the incoming request origin and `call
 
 Development has a local fallback cookie password. Production startup fails without an explicit password.
 
-## Use an existing WorkOS instance
+## Choose SDK ownership
+
+### Let Farm construct WorkOS
+
+The configuration above is the default path. When `instance` is omitted, Farm constructs one
+WorkOS client from `clientId` and `apiKey`, supplied directly or through environment variables.
+
+### Provide an application-owned instance
 
 Pass a configured SDK through `instance` when the app needs WorkOS constructor options that Farm
 does not own. Farm uses the instance directly, so `apiKey` is no longer required by the integration.
 The AuthKit client ID can come from the instance, while the cookie password remains required because
 Farm owns the sealed session cookie.
+
+When both are present, the supplied instance wins. Integration-owned route, cookie, and protection
+options still belong in `workos(...)`.
 
 ```ts
 import { WorkOS } from "@workos-inc/node";

--- a/docs/src/app/docs/integrations/autumn/page.md
+++ b/docs/src/app/docs/integrations/autumn/page.md
@@ -36,11 +36,36 @@ export const integrations = {
 };
 ```
 
-Pass `instance: new Autumn(...)` instead of `secretKey` when the application owns the Autumn SDK
-configuration. Farm keeps billing, webhook, route, and storage behavior while using that exact
-client.
-
 `AUTUMN_WEBHOOK_SECRET` is read from the environment when webhook routes are configured.
+
+## Choose SDK ownership
+
+### Let Farm construct Autumn
+
+The config-first example is the default path. When `instance` is omitted, Farm creates the Autumn
+SDK from `secretKey` and optional `serverURL`, supplied directly or through environment variables
+where supported.
+
+### Provide an application-owned instance
+
+```ts
+import { Autumn } from "autumn-js";
+import { autumn } from "@farm.js/integrations/autumn";
+
+const autumnClient = new Autumn({
+  secretKey: process.env.AUTUMN_SECRET_KEY,
+});
+
+export const billing = autumn({
+  instance: autumnClient,
+  billing: {
+    resolveOwner: () => null,
+  },
+});
+```
+
+The instance wins if a secret key is also supplied. Billing, webhook, route, product, meter, and
+storage settings remain integration options in either mode.
 
 ## Usage
 

--- a/docs/src/app/docs/integrations/autumn/page.md
+++ b/docs/src/app/docs/integrations/autumn/page.md
@@ -26,10 +26,21 @@ import { autumn } from "@farm.js/integrations/autumn";
 export const integrations = {
   billing: autumn({
     secretKey: process.env.AUTUMN_SECRET_KEY,
-    webhookSecret: process.env.AUTUMN_WEBHOOK_SECRET,
+    billing: {
+      resolveOwner(ctx) {
+        const userId = ctx.req.get<string>("user.id");
+        return userId ? { id: userId, kind: "user" } : null;
+      },
+    },
   }),
 };
 ```
+
+Pass `instance: new Autumn(...)` instead of `secretKey` when the application owns the Autumn SDK
+configuration. Farm keeps billing, webhook, route, and storage behavior while using that exact
+client.
+
+`AUTUMN_WEBHOOK_SECRET` is read from the environment when webhook routes are configured.
 
 ## Usage
 

--- a/docs/src/app/docs/integrations/cf-agent/page.md
+++ b/docs/src/app/docs/integrations/cf-agent/page.md
@@ -186,6 +186,9 @@ agent: cfAgent({
 
 `CF_AGENT_ORIGIN` is also read automatically. With an external origin, Farm keeps the public route prefix but skips combined Worker generation.
 
+Cloudflare Agents run in a Worker rather than as an in-process SDK, so `origin` is the equivalent
+injection boundary. The application still owns the Agent class, bindings, and Wrangler options.
+
 ## Options
 
 | Option          | Purpose                                                                     |

--- a/docs/src/app/docs/integrations/cf-agent/page.md
+++ b/docs/src/app/docs/integrations/cf-agent/page.md
@@ -108,6 +108,9 @@ export default defineConfig({
 
 The `cloudflare-module` preset is required when Farm and the Agent runtime share one Worker. During `farm dev`, Farm starts Wrangler on an available loopback port and proxies `/agents` with WebSocket upgrades enabled.
 
+This is the Farm-managed path: omit `origin` and pass `config`, `environment`, and `dev` options.
+Farm starts Wrangler and composes the Worker from that configuration.
+
 ## Connect from React
 
 **src/app/page.tsx**
@@ -187,7 +190,8 @@ agent: cfAgent({
 `CF_AGENT_ORIGIN` is also read automatically. With an external origin, Farm keeps the public route prefix but skips combined Worker generation.
 
 Cloudflare Agents run in a Worker rather than as an in-process SDK, so `origin` is the equivalent
-injection boundary. The application still owns the Agent class, bindings, and Wrangler options.
+injection boundary. Supplying it selects the application-owned Worker path and takes precedence over
+managed startup. The application still owns the Agent class and bindings in both modes.
 
 ## Options
 

--- a/docs/src/app/docs/integrations/email/page.md
+++ b/docs/src/app/docs/integrations/email/page.md
@@ -29,9 +29,30 @@ export const email = resend({
 });
 ```
 
-Pass `instance: new Resend(...)` instead of `apiKey` when the application owns Resend client
-construction. Farm keeps templates, defaults, scheduling, previews, routes, and webhooks unchanged
-while using that exact client.
+## Choose SDK ownership
+
+### Let Farm construct Resend
+
+The example above is the default path. When `instance` is omitted, Farm creates the Resend SDK from
+`apiKey`, supplied directly or through `RESEND_API_KEY`.
+
+### Provide an application-owned instance
+
+```tsx
+import { Resend } from "resend";
+import { resend } from "@farm.js/integrations/email";
+
+const resendClient = new Resend(process.env.RESEND_API_KEY);
+
+export const email = resend({
+  instance: resendClient,
+  defaults: { from: "hello@example.com" },
+  templates,
+});
+```
+
+The instance wins if an API key is also supplied. Templates, defaults, scheduling, previews,
+routes, and webhooks remain integration options in either mode.
 
 ## Send mail
 

--- a/docs/src/app/docs/integrations/email/page.md
+++ b/docs/src/app/docs/integrations/email/page.md
@@ -29,6 +29,10 @@ export const email = resend({
 });
 ```
 
+Pass `instance: new Resend(...)` instead of `apiKey` when the application owns Resend client
+construction. Farm keeps templates, defaults, scheduling, previews, routes, and webhooks unchanged
+while using that exact client.
+
 ## Send mail
 
 **Caller**

--- a/docs/src/app/docs/integrations/eve/page.md
+++ b/docs/src/app/docs/integrations/eve/page.md
@@ -120,6 +120,9 @@ agent: eve({
 
 `EVE_BASE_URL` is also read automatically when `origin` is omitted.
 
+Eve runs as a separate service rather than an in-process SDK, so `origin` is the equivalent of an
+`instance` option. The application continues to own Eve's agent and model configuration.
+
 ## Options
 
 | Option                 | Purpose                                                                       |

--- a/docs/src/app/docs/integrations/eve/page.md
+++ b/docs/src/app/docs/integrations/eve/page.md
@@ -40,6 +40,9 @@ export default defineConfig({
 
 The key `agent` is a convention and can be renamed. During `farm dev`, Farm starts Eve on an available loopback port and exposes its `/eve` and `/.well-known/workflow` routes through the Farm origin.
 
+This is the Farm-managed path: omit `origin` and pass runtime options such as `root`, `dev`, and
+`vercel` to the integration. Farm starts or composes the Eve service from that configuration.
+
 ## Define the agent
 
 An instructions file is enough for the first agent. Keep the Eve directory at `agent/` in the Farm project root.
@@ -121,7 +124,9 @@ agent: eve({
 `EVE_BASE_URL` is also read automatically when `origin` is omitted.
 
 Eve runs as a separate service rather than an in-process SDK, so `origin` is the equivalent of an
-`instance` option. The application continues to own Eve's agent and model configuration.
+`instance` option. Supplying it selects the application-owned runtime path and takes precedence over
+managed startup. The application continues to own Eve's agent and model configuration in both
+modes.
 
 ## Options
 

--- a/docs/src/app/docs/integrations/inngest/page.md
+++ b/docs/src/app/docs/integrations/inngest/page.md
@@ -38,6 +38,12 @@ export const appIntegrations = {
 } as const;
 ```
 
+## Runtime ownership
+
+Pass Inngest credentials and endpoint configuration to `inngest(...)`; Farm constructs the HTTP
+runtime adapter and sends events to existing provider functions. Inngest continues to own function
+registration and execution. There is no in-process Inngest SDK instance to inject into Farm.
+
 ## Environment variables
 
 | Variable              | Current use                                                    |

--- a/docs/src/app/docs/integrations/jobs/page.md
+++ b/docs/src/app/docs/integrations/jobs/page.md
@@ -77,6 +77,11 @@ The runtime definition is the jobs integration's injection boundary. Farm does n
 Trigger.dev or Inngest SDK instance in the application process; it calls the configured external
 runtime over HTTP.
 
+This means jobs have one clear ownership split: the application passes provider credentials and
+endpoint options to `trigger(...)` or `inngest(...)`, Farm constructs the HTTP runtime adapter, and
+the provider continues to own deployed tasks or functions. There is no in-process SDK `instance` to
+inject.
+
 ## Create callers
 
 ```ts

--- a/docs/src/app/docs/integrations/jobs/page.md
+++ b/docs/src/app/docs/integrations/jobs/page.md
@@ -73,6 +73,10 @@ export type AppIntegrations = typeof appIntegrations;
 
 Swap `trigger(...)` for `inngest(...)` to keep the same caller namespace with the Inngest runtime. Runtime capabilities are not identical, so check the matrix below before sharing task defaults.
 
+The runtime definition is the jobs integration's injection boundary. Farm does not construct a
+Trigger.dev or Inngest SDK instance in the application process; it calls the configured external
+runtime over HTTP.
+
 ## Create callers
 
 ```ts

--- a/docs/src/app/docs/integrations/page.md
+++ b/docs/src/app/docs/integrations/page.md
@@ -17,7 +17,13 @@ Farm treats every integration as a small server plugin. That means an integratio
 ```ts
 import { defineConfig } from "@farm.js/core";
 import { stripe } from "@farm.js/integrations/stripe";
+import { betterAuth as createBetterAuth } from "better-auth";
 import { betterAuth } from "@farm.js/integrations/better-auth";
+
+const auth = createBetterAuth({
+  baseURL: process.env.BETTER_AUTH_URL,
+  secret: process.env.BETTER_AUTH_SECRET,
+});
 
 export default defineConfig({
   integrations: {
@@ -26,14 +32,49 @@ export default defineConfig({
       webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
     }),
     auth: betterAuth({
-      baseURL: process.env.BETTER_AUTH_URL,
-      secret: process.env.BETTER_AUTH_SECRET,
+      instance: auth,
     }),
   },
 });
 ```
 
 The object key is the application namespace. If you register Stripe as `billing`, the typed caller lives at `api.billing`. If you register it as `stripe`, it lives at `api.stripe`.
+
+## Bring your own provider instance
+
+When an integration uses an in-process vendor SDK, pass a configured client through `instance`.
+Farm uses that exact object and does not create a second client. This lets the application control
+SDK versions, transports, retries, telemetry, test doubles, and provider-specific options without
+waiting for the Farm adapter to expose every constructor option.
+
+```ts
+import Stripe from "stripe";
+import { stripe } from "@farm.js/integrations/stripe";
+
+const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  maxNetworkRetries: 2,
+});
+
+export const billing = stripe({
+  instance: stripeClient,
+  webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
+});
+```
+
+For backward compatibility, integrations that previously accepted credentials still do. When both
+are supplied, `instance` wins and credentials remain available only as configuration metadata.
+Instance injection owns construction, but the object must still implement the SDK methods the Farm
+adapter calls; a vendor breaking those methods can still require an adapter update.
+
+| Integration kind                                                                     | Injection boundary                                                                                                                       |
+| ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Stripe, Autumn, Polar, Resend, Clerk, WorkOS, Auth0, Auth.js, Better Auth, and Unkey | `instance`: an already configured SDK/client or compatible adapter.                                                                      |
+| Supabase SSR                                                                         | `instance`: a request-scoped factory that receives Farm's cookie-aware client options. Never share one SSR auth client between requests. |
+| AI                                                                                   | `model` plus optional AI SDK function overrides. The model is already the injected provider object.                                      |
+| Trigger.dev and Inngest jobs                                                         | `runtime: trigger(...)` or `runtime: inngest(...)`. Farm talks to the selected external runtime and does not construct its SDK.          |
+| Eve and Cloudflare Agents                                                            | `origin` for an external runtime, or Farm's managed development process. Agent SDKs remain application-owned.                            |
+
+Provider pages show the exact constructor and any integration-owned options that are still required.
 
 ## Create callers
 

--- a/docs/src/app/docs/integrations/polar/page.md
+++ b/docs/src/app/docs/integrations/polar/page.md
@@ -26,10 +26,40 @@ import { polar } from "@farm.js/integrations/polar";
 export const integrations = {
   billing: polar({
     accessToken: process.env.POLAR_ACCESS_TOKEN,
-    webhookSecret: process.env.POLAR_WEBHOOK_SECRET,
+    billing: {
+      resolveOwner(ctx) {
+        const userId = ctx.req.get<string>("user.id");
+        return userId ? { id: userId, kind: "user" } : null;
+      },
+    },
   }),
 };
 ```
+
+`POLAR_WEBHOOK_SECRET` is read from the environment when webhook routes are configured.
+
+## Use an existing Polar instance
+
+```ts
+import { Polar } from "@polar-sh/sdk";
+import { polar } from "@farm.js/integrations/polar";
+
+const polarClient = new Polar({
+  accessToken: process.env.POLAR_ACCESS_TOKEN!,
+  server: "sandbox",
+});
+
+export const billing = polar({
+  instance: polarClient,
+  server: "sandbox",
+  billing: {
+    resolveOwner: () => null,
+  },
+});
+```
+
+Farm uses the supplied SDK directly, so the integration does not require `accessToken`. `server`
+still describes the integration environment and defaults from `POLAR_SERVER`.
 
 ## Usage
 

--- a/docs/src/app/docs/integrations/polar/page.md
+++ b/docs/src/app/docs/integrations/polar/page.md
@@ -38,7 +38,17 @@ export const integrations = {
 
 `POLAR_WEBHOOK_SECRET` is read from the environment when webhook routes are configured.
 
-## Use an existing Polar instance
+With no `instance`, Farm constructs the Polar SDK from `accessToken` and `server`. The token can be
+passed directly or read from `POLAR_ACCESS_TOKEN`.
+
+## Choose SDK ownership
+
+### Let Farm construct Polar
+
+Use the config-first example above for the common path. Farm owns SDK construction, while the
+application still supplies billing ownership, products, meters, routes, and webhook behavior.
+
+### Provide an application-owned instance
 
 ```ts
 import { Polar } from "@polar-sh/sdk";
@@ -59,7 +69,8 @@ export const billing = polar({
 ```
 
 Farm uses the supplied SDK directly, so the integration does not require `accessToken`. `server`
-still describes the integration environment and defaults from `POLAR_SERVER`.
+still describes the integration environment and defaults from `POLAR_SERVER`. When both an instance
+and token are supplied, the instance wins.
 
 ## Usage
 

--- a/docs/src/app/docs/integrations/stripe/page.md
+++ b/docs/src/app/docs/integrations/stripe/page.md
@@ -38,9 +38,32 @@ export const integrations = {
 };
 ```
 
-Pass `instance: new Stripe(...)` instead of `secretKey` when the application needs to own Stripe
-SDK construction, retries, telemetry, or API-version settings. Farm uses the supplied instance
-directly; webhook and billing configuration remain integration options.
+## Choose SDK ownership
+
+### Let Farm construct Stripe
+
+The config-first example is the default path. When `instance` is omitted, Farm creates the Stripe
+SDK from `secretKey`, supplied directly or through `STRIPE_SECRET_KEY`.
+
+### Provide an application-owned instance
+
+```ts
+import Stripe from "stripe";
+import { stripe } from "@farm.js/integrations/stripe";
+
+const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  maxNetworkRetries: 2,
+});
+
+export const billing = stripe({
+  instance: stripeClient,
+  webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
+});
+```
+
+Use this path when the application needs to own retries, telemetry, API-version settings, or a
+compatible test adapter. The instance wins if a secret key is also supplied. Webhook, product,
+billing, route, and storage settings remain integration options in either mode.
 
 ## Usage
 

--- a/docs/src/app/docs/integrations/stripe/page.md
+++ b/docs/src/app/docs/integrations/stripe/page.md
@@ -55,10 +55,12 @@ const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   maxNetworkRetries: 2,
 });
 
-export const billing = stripe({
-  instance: stripeClient,
-  webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
-});
+export const integrations = {
+  billing: stripe({
+    instance: stripeClient,
+    webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
+  }),
+};
 ```
 
 Use this path when the application needs to own retries, telemetry, API-version settings, or a

--- a/docs/src/app/docs/integrations/stripe/page.md
+++ b/docs/src/app/docs/integrations/stripe/page.md
@@ -38,6 +38,10 @@ export const integrations = {
 };
 ```
 
+Pass `instance: new Stripe(...)` instead of `secretKey` when the application needs to own Stripe
+SDK construction, retries, telemetry, or API-version settings. Farm uses the supplied instance
+directly; webhook and billing configuration remain integration options.
+
 ## Usage
 
 **Client checkout**

--- a/docs/src/app/docs/integrations/trigger/page.md
+++ b/docs/src/app/docs/integrations/trigger/page.md
@@ -38,6 +38,12 @@ export const appIntegrations = {
 } as const;
 ```
 
+## Runtime ownership
+
+Pass Trigger.dev credentials and endpoint configuration to `trigger(...)`; Farm constructs the HTTP
+runtime adapter and calls the existing provider task. Trigger.dev continues to own task deployment
+and execution. There is no in-process Trigger.dev SDK instance to inject into Farm.
+
 ## Environment variables
 
 | Variable                 | Current use                                                                                  |

--- a/docs/src/app/docs/integrations/unkey/page.md
+++ b/docs/src/app/docs/integrations/unkey/page.md
@@ -26,7 +26,15 @@ export default defineConfig({
 });
 ```
 
-## Use an existing Unkey client
+## Choose client ownership
+
+### Let Farm construct Unkey
+
+The configuration above is the default path. When `instance` is omitted, Farm creates its Unkey
+client from `rootKey`, `apiId`, `baseUrl`, and an optional custom `fetch`, supplied directly or
+through environment variables where supported.
+
+### Provide an application-owned instance
 
 Use `instance` when client construction belongs to application code or a shared dependency
 container. It takes precedence over credentials passed directly to the integration.
@@ -45,7 +53,7 @@ export const keys = unkey({
 ```
 
 The previous `client` option remains supported as a deprecated alias, making this change
-backward-compatible.
+backward-compatible. Routes and protection settings still belong in `unkey(...)` in either mode.
 
 ## Create and verify keys
 

--- a/docs/src/app/docs/integrations/unkey/page.md
+++ b/docs/src/app/docs/integrations/unkey/page.md
@@ -26,6 +26,27 @@ export default defineConfig({
 });
 ```
 
+## Use an existing Unkey client
+
+Use `instance` when client construction belongs to application code or a shared dependency
+container. It takes precedence over credentials passed directly to the integration.
+
+```ts
+import { createUnkeyClient, unkey } from "@farm.js/integrations/unkey";
+
+const unkeyClient = createUnkeyClient({
+  rootKey: process.env.UNKEY_ROOT_KEY,
+  apiId: process.env.UNKEY_API_ID,
+});
+
+export const keys = unkey({
+  instance: unkeyClient,
+});
+```
+
+The previous `client` option remains supported as a deprecated alias, making this change
+backward-compatible.
+
 ## Create and verify keys
 
 **Caller**

--- a/packages/farm-autumn/src/index.ts
+++ b/packages/farm-autumn/src/index.ts
@@ -258,8 +258,10 @@ export interface AutumnBillingOptions {
   hooks?: AutumnBillingHooks;
 }
 
+export type AutumnIntegrationInstance = AutumnSDK;
+
 export interface AutumnIntegrationInput extends AutumnClientPathOptions {
-  instance?: AutumnSDK;
+  instance?: AutumnIntegrationInstance;
   secretKey?: string;
   serverURL?: string;
   appBaseUrl?: string;

--- a/packages/farm-clerk/src/index.ts
+++ b/packages/farm-clerk/src/index.ts
@@ -7,6 +7,8 @@ import {
 } from "@farm.js/integration-utils";
 
 export interface ClerkIntegrationInput {
+  /** Existing Clerk backend client. When provided, Farm does not construct its own client. */
+  instance?: ClerkIntegrationInstance;
   publishableKey?: string;
   secretKey?: string;
   signInUrl?: string;
@@ -17,9 +19,11 @@ export interface ClerkIntegrationInput {
   log?: FarmIntegrationLogger;
 }
 
+export type ClerkIntegrationInstance = ClerkClient;
+
 interface ResolvedClerkConfig {
   publishableKey: string;
-  secretKey: string;
+  secretKey?: string;
 }
 
 function resolveClerkKeys(input: ClerkIntegrationInput): ResolvedClerkConfig {
@@ -30,15 +34,15 @@ function resolveClerkKeys(input: ClerkIntegrationInput): ResolvedClerkConfig {
     "";
   const secretKey = input.secretKey ?? process.env.CLERK_SECRET_KEY ?? "";
 
-  if (!publishableKey || !secretKey) {
+  if (!publishableKey || (!input.instance && !secretKey)) {
     throw new Error(
-      "Clerk integration requires NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY and CLERK_SECRET_KEY.",
+      "Clerk integration requires a publishable key and either a Clerk instance or CLERK_SECRET_KEY.",
     );
   }
 
   return {
     publishableKey,
-    secretKey,
+    secretKey: secretKey || undefined,
   };
 }
 
@@ -50,13 +54,16 @@ export function clerk(input: ClerkIntegrationInput = {}) {
 
   let cachedClient: ClerkClient | null = null;
   const getClient = () => {
+    if (input.instance) {
+      return input.instance;
+    }
     if (cachedClient) {
       return cachedClient;
     }
 
     cachedClient = createClerkClient({
       publishableKey,
-      secretKey,
+      secretKey: secretKey!,
     });
     return cachedClient;
   };
@@ -79,7 +86,7 @@ export function clerk(input: ClerkIntegrationInput = {}) {
         publishableKey,
         secretKey,
       },
-      required: ["publishableKey", "secretKey"],
+      required: input.instance ? ["publishableKey"] : ["publishableKey", "secretKey"],
     }),
     log: input.log,
     providers: [

--- a/packages/farm-email/src/index.ts
+++ b/packages/farm-email/src/index.ts
@@ -61,7 +61,7 @@ export interface ResendIntegrationDefaults {
 
 export interface ResendIntegrationInput<TTemplates extends EmailTemplates = EmailTemplates> {
   apiKey?: string;
-  instance?: ResendSdk;
+  instance?: ResendIntegrationInstance;
   basePath?: string;
   defaults?: ResendIntegrationDefaults;
   templates: TTemplates;

--- a/packages/farm-integrations/src/index.ts
+++ b/packages/farm-integrations/src/index.ts
@@ -30,6 +30,7 @@ export {
   stripeSchema,
 } from "@farm.js/stripe";
 export type {
+  UnkeyIntegrationInstance,
   UnkeyAPIEnvelope,
   UnkeyClient,
   UnkeyClientOptions,
@@ -48,6 +49,19 @@ export type {
   UnkeyVerifyKeyInput,
   UnkeyVerifyKeyResult,
 } from "@farm.js/unkey";
+export type { BetterAuthInstance, BetterAuthIntegrationInput } from "@farm.js/better-auth";
+export type { AuthJsHandlerSet, AuthJsInstance, AuthJsIntegrationInput } from "@farm.js/authjs";
+export type { Auth0Instance, Auth0IntegrationInput } from "@farm.js/auth0";
+export type { ClerkIntegrationInput, ClerkIntegrationInstance } from "@farm.js/clerk";
+export type { WorkOSIntegrationInput, WorkOSIntegrationInstance } from "@farm.js/workos";
+export type {
+  SupabaseIntegrationClient,
+  SupabaseIntegrationClientOptions,
+  SupabaseIntegrationInput,
+  SupabaseIntegrationInstance,
+  SupabaseIntegrationInstanceContext,
+  SupabaseIntegrationPages,
+} from "@farm.js/supabase";
 export type {
   AIChatPrepareContext,
   AIChatRequestBody,
@@ -185,6 +199,7 @@ export type {
   AutumnBillingPlan,
   AutumnBillingProduct,
   AutumnIntegrationInput,
+  AutumnIntegrationInstance,
   AutumnWebhookConfig,
   AutumnWebhookEvent,
 } from "@farm.js/autumn";
@@ -225,6 +240,7 @@ export type {
   PolarBillingPlan,
   PolarBillingProduct,
   PolarIntegrationInput,
+  PolarIntegrationInstance,
   PolarWebhookConfig,
   PolarWebhookEvent,
 } from "@farm.js/polar";

--- a/packages/farm-polar/src/index.ts
+++ b/packages/farm-polar/src/index.ts
@@ -225,6 +225,8 @@ export interface PolarBillingOptions {
 }
 
 export interface PolarIntegrationInput {
+  /** Existing Polar SDK instance. When provided, Farm does not construct its own client. */
+  instance?: PolarIntegrationInstance;
   accessToken?: string;
   server?: "sandbox" | "production";
   appBaseUrl?: string;
@@ -244,8 +246,10 @@ export interface PolarIntegrationInput {
   log?: FarmIntegrationLogger;
 }
 
+export type PolarIntegrationInstance = Polar;
+
 interface ResolvedPolarConfig {
-  accessToken: string;
+  accessToken?: string;
   server: "sandbox" | "production";
   appBaseUrl?: string;
   webhookSecret?: string;
@@ -915,8 +919,8 @@ export function polar<TInput extends PolarIntegrationInput>(
   const appBaseUrl = input.appBaseUrl ?? process.env.APP_BASE_URL ?? undefined;
   const webhookSecret = process.env.POLAR_WEBHOOK_SECRET ?? undefined;
 
-  if (!accessToken) {
-    throw new Error("Polar integration requires POLAR_ACCESS_TOKEN.");
+  if (!input.instance && !accessToken) {
+    throw new Error("Polar integration requires a Polar instance or POLAR_ACCESS_TOKEN.");
   }
 
   const billing = input.billing;
@@ -984,10 +988,12 @@ export function polar<TInput extends PolarIntegrationInput>(
       throw new Error(`Polar billing meter "${key}" requires polar.meterId (or legacy meterId).`);
     }
   }
-  const sdk = new Polar({
-    accessToken,
-    server,
-  });
+  const sdk =
+    input.instance ??
+    new Polar({
+      accessToken,
+      server,
+    });
   const webhookRoutes = webhookDefinitions.map((definition) =>
     integrationRoute.post(definition.path, {
       responseFormat: "json",
@@ -1079,7 +1085,7 @@ export function polar<TInput extends PolarIntegrationInput>(
         appBaseUrl,
         webhookSecret,
       },
-      required: ["accessToken", "server"],
+      required: input.instance ? ["server"] : ["accessToken", "server"],
     }),
     api: createPolarApi({
       productsPath,

--- a/packages/farm-supabase/src/index.ts
+++ b/packages/farm-supabase/src/index.ts
@@ -20,7 +20,6 @@ import {
   withSearchParams,
 } from "@farm.js/integration-utils";
 import {
-  supabaseClient,
   supabaseAuthFormFields,
   type SupabaseCredentials,
   type SupabaseLogoutInput,
@@ -42,7 +41,29 @@ export interface SupabaseIntegrationPages {
   signUp?: string;
 }
 
+export type SupabaseIntegrationClient = ReturnType<typeof createServerClient>;
+export type SupabaseIntegrationClientOptions = Parameters<typeof createServerClient>[2];
+
+export interface SupabaseIntegrationInstanceContext {
+  request: Request;
+  url?: string;
+  anonKey?: string;
+  createClient: typeof createServerClient;
+  options: SupabaseIntegrationClientOptions;
+}
+
+/**
+ * Creates a request-scoped Supabase client using Farm's cookie adapter.
+ *
+ * A factory is used instead of a shared client because Supabase SSR clients
+ * are bound to the cookies of the current request.
+ */
+export type SupabaseIntegrationInstance = (
+  context: SupabaseIntegrationInstanceContext,
+) => SupabaseIntegrationClient;
+
 export interface SupabaseIntegrationInput {
+  instance?: SupabaseIntegrationInstance;
   url?: string;
   anonKey?: string;
   appBaseUrl?: string;
@@ -60,8 +81,8 @@ export interface SupabaseIntegrationInput {
 }
 
 interface ResolvedSupabaseEnv {
-  url: string;
-  anonKey: string;
+  url?: string;
+  anonKey?: string;
   appBaseUrl?: string;
 }
 
@@ -136,9 +157,9 @@ function resolveEnv(input: SupabaseIntegrationInput): ResolvedSupabaseEnv {
     "";
   const appBaseUrl = input.appBaseUrl ?? process.env.APP_BASE_URL ?? undefined;
 
-  if (!url || !anonKey) {
+  if (!input.instance && (!url || !anonKey)) {
     throw new Error(
-      "Supabase integration requires SUPABASE_URL (or NEXT_PUBLIC_SUPABASE_URL) and SUPABASE_ANON_KEY (or a Supabase publishable key env).",
+      "Supabase integration requires an instance factory or SUPABASE_URL (or NEXT_PUBLIC_SUPABASE_URL) and SUPABASE_ANON_KEY (or a Supabase publishable key env).",
     );
   }
 
@@ -737,10 +758,11 @@ function renderCheckEmailPage(
 function createSupabaseHandler(
   context: Pick<FarmIntegrationHandlerContext, "request" | "req">,
   env: ResolvedSupabaseEnv,
+  instance?: SupabaseIntegrationInstance,
 ) {
   const setCookies: string[] = [];
 
-  const supabase = createServerClient(env.url, env.anonKey, {
+  const options: SupabaseIntegrationClientOptions = {
     auth: {
       flowType: "pkce",
       detectSessionInUrl: false,
@@ -756,7 +778,17 @@ function createSupabaseHandler(
         context.req.set("supabase:set-cookies", [...setCookies]);
       },
     },
-  });
+  };
+
+  const supabase = instance
+    ? instance({
+        request: context.request,
+        url: env.url,
+        anonKey: env.anonKey,
+        createClient: createServerClient,
+        options,
+      })
+    : createServerClient(env.url!, env.anonKey!, options);
 
   return {
     supabase,
@@ -852,7 +884,7 @@ export function supabase(input: SupabaseIntegrationInput = {}) {
         appBaseUrl: "APP_BASE_URL",
       },
       input: env,
-      required: ["url", "anonKey"],
+      required: input.instance ? [] : ["url", "anonKey"],
     }),
     api,
     log: input.log,
@@ -909,7 +941,7 @@ export function supabase(input: SupabaseIntegrationInput = {}) {
               });
             }
 
-            const { supabase, setCookies } = createSupabaseHandler(context, env);
+            const { supabase, setCookies } = createSupabaseHandler(context, env, input.instance);
             const { error } = await supabase.auth.signInWithPassword({
               email: parsedRequest.email,
               password: parsedRequest.password,
@@ -991,7 +1023,7 @@ export function supabase(input: SupabaseIntegrationInput = {}) {
             });
           }
 
-          const { supabase, setCookies } = createSupabaseHandler(context, env);
+          const { supabase, setCookies } = createSupabaseHandler(context, env, input.instance);
           const { data, error } = await supabase.auth.signInWithOAuth({
             provider: provider as any,
             options: {
@@ -1089,7 +1121,7 @@ export function supabase(input: SupabaseIntegrationInput = {}) {
             });
           }
 
-          const { supabase, setCookies } = createSupabaseHandler(context, env);
+          const { supabase, setCookies } = createSupabaseHandler(context, env, input.instance);
           const { data, error } = await supabase.auth.signUp({
             email: parsedRequest.email,
             password: parsedRequest.password,
@@ -1199,7 +1231,7 @@ export function supabase(input: SupabaseIntegrationInput = {}) {
             return new Response("Missing Supabase authorization code.", { status: 400 });
           }
 
-          const { supabase, setCookies } = createSupabaseHandler(context, env);
+          const { supabase, setCookies } = createSupabaseHandler(context, env, input.instance);
           const { error } = await supabase.auth.exchangeCodeForSession(code);
           if (error) {
             return new Response(error.message, { status: 500 });
@@ -1235,7 +1267,7 @@ export function supabase(input: SupabaseIntegrationInput = {}) {
             }
           }
 
-          const { supabase, setCookies } = createSupabaseHandler(context, env);
+          const { supabase, setCookies } = createSupabaseHandler(context, env, input.instance);
           const { error } = await supabase.auth.signOut();
           if (error) {
             if (clientRequest) {
@@ -1273,7 +1305,7 @@ export function supabase(input: SupabaseIntegrationInput = {}) {
         path: sessionPath,
         methods: ["GET"],
         async handler(_request: Request, context: FarmIntegrationHandlerContext) {
-          const { supabase, setCookies } = createSupabaseHandler(context, env);
+          const { supabase, setCookies } = createSupabaseHandler(context, env, input.instance);
           const { data, error } = await supabase.auth.getUser();
 
           const headers = new Headers({
@@ -1307,7 +1339,7 @@ export function supabase(input: SupabaseIntegrationInput = {}) {
             {
               matcher: protectedMatchers,
               async handler(_request: Request, context: FarmIntegrationHandlerContext) {
-                const { supabase } = createSupabaseHandler(context, env);
+                const { supabase } = createSupabaseHandler(context, env, input.instance);
                 const {
                   data: { session },
                 } = await supabase.auth.getSession();

--- a/packages/farm-unkey/src/index.ts
+++ b/packages/farm-unkey/src/index.ts
@@ -296,7 +296,12 @@ export interface UnkeyProtectionOptions {
   ) => Promise<Response | void> | Response | void;
 }
 
+export type UnkeyIntegrationInstance = UnkeyClient;
+
 export interface UnkeyIntegrationInput extends UnkeyClientOptions {
+  /** Existing Unkey-compatible client. Preferred over the legacy `client` alias. */
+  instance?: UnkeyIntegrationInstance;
+  /** @deprecated Use `instance` instead. */
   client?: UnkeyClient;
   paths?: UnkeyIntegrationPaths;
   protectedRoutes?: string | string[];
@@ -368,8 +373,8 @@ function createUnkeyApi(paths: ResolvedUnkeyPaths) {
 export function unkey(input: UnkeyIntegrationInput = {}) {
   const config = resolveUnkeyConfig(input);
   const paths = resolveUnkeyPaths(input.paths);
-  const hasInjectedClient = !!input.client;
-  const client = input.client ?? createUnkeyClient(config);
+  const hasInjectedClient = !!(input.instance ?? input.client);
+  const client = input.instance ?? input.client ?? createUnkeyClient(config);
   const protection = input.protection;
   const protectedRoutes = input.protectedRoutes ?? protection?.matcher;
 

--- a/packages/farm-workos/src/index.ts
+++ b/packages/farm-workos/src/index.ts
@@ -66,7 +66,7 @@ function createWorkOSApi(input: {
 }
 
 function resolveEnv(input: WorkOSIntegrationInput): ResolvedWorkOSConfig {
-  const clientId = input.clientId ?? input.instance?.clientId ?? process.env.WORKOS_CLIENT_ID ?? "";
+  const clientId = input.instance?.clientId ?? input.clientId ?? process.env.WORKOS_CLIENT_ID ?? "";
   const apiKey = input.apiKey ?? process.env.WORKOS_API_KEY ?? "";
   const cookiePassword =
     input.cookiePassword ??

--- a/packages/farm-workos/src/index.ts
+++ b/packages/farm-workos/src/index.ts
@@ -14,6 +14,8 @@ import type { WorkOSRedirectQuery, WorkOSRedirectResult, WorkOSSessionResult } f
 import { workosClient } from "./client.js";
 
 export interface WorkOSIntegrationInput {
+  /** Existing WorkOS SDK instance. When provided, Farm does not construct its own client. */
+  instance?: WorkOSIntegrationInstance;
   clientId?: string;
   apiKey?: string;
   cookiePassword?: string;
@@ -27,11 +29,13 @@ export interface WorkOSIntegrationInput {
   log?: FarmIntegrationLogger;
 }
 
+export type WorkOSIntegrationInstance = WorkOS;
+
 const DEV_COOKIE_PASSWORD = "farmjs-workos-cookie-password-development-2026";
 
 interface ResolvedWorkOSConfig {
   clientId: string;
-  apiKey: string;
+  apiKey?: string;
   cookiePassword: string;
 }
 
@@ -62,7 +66,7 @@ function createWorkOSApi(input: {
 }
 
 function resolveEnv(input: WorkOSIntegrationInput): ResolvedWorkOSConfig {
-  const clientId = input.clientId ?? process.env.WORKOS_CLIENT_ID ?? "";
+  const clientId = input.clientId ?? input.instance?.clientId ?? process.env.WORKOS_CLIENT_ID ?? "";
   const apiKey = input.apiKey ?? process.env.WORKOS_API_KEY ?? "";
   const cookiePassword =
     input.cookiePassword ??
@@ -70,8 +74,10 @@ function resolveEnv(input: WorkOSIntegrationInput): ResolvedWorkOSConfig {
     process.env.FARM_WORKOS_COOKIE_PASSWORD ??
     (process.env.NODE_ENV === "production" ? "" : DEV_COOKIE_PASSWORD);
 
-  if (!clientId || !apiKey) {
-    throw new Error("WorkOS integration requires WORKOS_CLIENT_ID and WORKOS_API_KEY.");
+  if (!clientId || (!input.instance && !apiKey)) {
+    throw new Error(
+      "WorkOS integration requires a client ID and either a WorkOS instance or WORKOS_API_KEY.",
+    );
   }
 
   if (!cookiePassword) {
@@ -80,13 +86,13 @@ function resolveEnv(input: WorkOSIntegrationInput): ResolvedWorkOSConfig {
 
   return {
     clientId,
-    apiKey,
+    apiKey: apiKey || undefined,
     cookiePassword,
   };
 }
 
 async function getSession(
-  workos: WorkOS,
+  workos: WorkOSIntegrationInstance,
   request: Request,
   cookieName: string,
   cookiePassword: string,
@@ -122,10 +128,12 @@ export function workos(input: WorkOSIntegrationInput = {}) {
   const logoutPath = input.logoutPath ?? "/logout";
   const sessionPath = input.sessionPath ?? "/auth/session";
 
-  const workos = new WorkOS({
-    apiKey,
-    clientId,
-  });
+  const workos =
+    input.instance ??
+    new WorkOS({
+      apiKey,
+      clientId,
+    });
 
   async function redirectToAuth(request: Request, screenHint: "sign-in" | "sign-up") {
     const requestUrl = new URL(request.url);
@@ -164,7 +172,9 @@ export function workos(input: WorkOSIntegrationInput = {}) {
         apiKey,
         cookiePassword,
       },
-      required: ["clientId", "apiKey", "cookiePassword"],
+      required: input.instance
+        ? ["clientId", "cookiePassword"]
+        : ["clientId", "apiKey", "cookiePassword"],
     }),
     api: createWorkOSApi({
       loginPath,

--- a/packages/farm/src/__tests__/integration-instance-injection.test.ts
+++ b/packages/farm/src/__tests__/integration-instance-injection.test.ts
@@ -84,6 +84,7 @@ describe("integration instance injection", () => {
     } as unknown as WorkOSIntegrationInstance;
     const integration = workos({
       instance,
+      clientId: "client_other",
       cookiePassword: "test-cookie-password-that-is-long-enough",
     });
     const route = integration.routes.find((candidate) => candidate.path === "/login");
@@ -98,6 +99,9 @@ describe("integration instance injection", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ redirectTo: "https://auth.example.com/authorize" });
     expect(getAuthorizationUrl).toHaveBeenCalledOnce();
+    expect(getAuthorizationUrl).toHaveBeenCalledWith(
+      expect.objectContaining({ clientId: "client_test" }),
+    );
   });
 
   it("uses an injected Clerk backend client without requiring a secret key", async () => {

--- a/packages/farm/src/__tests__/integration-instance-injection.test.ts
+++ b/packages/farm/src/__tests__/integration-instance-injection.test.ts
@@ -1,0 +1,201 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from "vitest";
+import { clerk, type ClerkIntegrationInstance } from "../../../farm-clerk/src/index";
+import { polar, type PolarIntegrationInstance } from "../../../farm-polar/src/index";
+import {
+  supabase,
+  type SupabaseIntegrationClient,
+  type SupabaseIntegrationInstanceContext,
+} from "../../../farm-supabase/src/index";
+import { unkey, type UnkeyIntegrationInstance } from "../../../farm-unkey/src/index";
+import { workos, type WorkOSIntegrationInstance } from "../../../farm-workos/src/index";
+import type { FarmIntegrationHandlerContext } from "../integrations";
+
+function createRequestContextStore() {
+  const values = new Map<string, unknown>();
+
+  return {
+    get<T>(key: string) {
+      return values.get(key) as T | undefined;
+    },
+    set(key: string, value: unknown) {
+      values.set(key, value);
+    },
+    has(key: string) {
+      return values.has(key);
+    },
+    delete(key: string) {
+      return values.delete(key);
+    },
+    clear() {
+      values.clear();
+    },
+    snapshot() {
+      return new Map(values);
+    },
+  };
+}
+
+function createContext(
+  request: Request,
+  type: string,
+  path: string,
+): FarmIntegrationHandlerContext {
+  const req = createRequestContextStore();
+
+  return {
+    request,
+    requestId: "req_instance_test",
+    url: new URL(request.url),
+    pathname: new URL(request.url).pathname,
+    method: request.method,
+    params: {},
+    input: {},
+    args: {},
+    data: {},
+    integration: {
+      category: "auth",
+      slot: "auth",
+      type,
+      instance: {},
+    },
+    route: {
+      kind: "route",
+      path,
+      methods: [request.method],
+    },
+    req,
+    requestContext: req,
+    config: {} as FarmIntegrationHandlerContext["config"],
+    isDev: true,
+    isProd: false,
+  };
+}
+
+describe("integration instance injection", () => {
+  it("uses an injected WorkOS SDK without requiring an API key", async () => {
+    const getAuthorizationUrl = vi.fn(() => "https://auth.example.com/authorize");
+    const instance = {
+      clientId: "client_test",
+      userManagement: {
+        getAuthorizationUrl,
+      },
+    } as unknown as WorkOSIntegrationInstance;
+    const integration = workos({
+      instance,
+      cookiePassword: "test-cookie-password-that-is-long-enough",
+    });
+    const route = integration.routes.find((candidate) => candidate.path === "/login");
+    const request = new Request("https://app.example.com/login?returnTo=/dashboard", {
+      headers: {
+        "x-farm-integration-client": "1",
+      },
+    });
+
+    const response = await route!.handler(request, createContext(request, "workos", "/login"));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ redirectTo: "https://auth.example.com/authorize" });
+    expect(getAuthorizationUrl).toHaveBeenCalledOnce();
+  });
+
+  it("uses an injected Clerk backend client without requiring a secret key", async () => {
+    const authenticateRequest = vi.fn(async () => ({
+      isAuthenticated: true,
+      headers: new Headers(),
+      status: "signed-in",
+    }));
+    const instance = {
+      authenticateRequest,
+    } as unknown as ClerkIntegrationInstance;
+    const integration = clerk({
+      instance,
+      publishableKey: "pk_test",
+      protectedRoutes: ["/dashboard(.*)"],
+    });
+    const request = new Request("https://app.example.com/dashboard");
+
+    const response = await integration.middleware![0].handler(
+      request,
+      createContext(request, "clerk", "/dashboard"),
+    );
+
+    expect(response).toBeUndefined();
+    expect(authenticateRequest).toHaveBeenCalledOnce();
+  });
+
+  it("accepts an injected Polar SDK without requiring an access token", () => {
+    const instance = {} as PolarIntegrationInstance;
+
+    expect(() =>
+      polar({
+        instance,
+        billing: {
+          resolveOwner: () => null,
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("creates a fresh injected Supabase client for each request", async () => {
+    const getUser = vi.fn(async () => ({
+      data: { user: { id: "user_test" } },
+      error: null,
+    }));
+    const factory = vi.fn(
+      (_context: SupabaseIntegrationInstanceContext) =>
+        ({ auth: { getUser } }) as unknown as SupabaseIntegrationClient,
+    );
+    const integration = supabase({ instance: factory });
+    const route = integration.routes.find((candidate) => candidate.path === "/auth/session");
+
+    for (const id of ["one", "two"]) {
+      const request = new Request(`https://app.example.com/auth/session?request=${id}`);
+      const response = await route!.handler(
+        request,
+        createContext(request, "supabase", "/auth/session"),
+      );
+
+      expect(response.status).toBe(200);
+    }
+
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(factory.mock.calls[0][0].request).not.toBe(factory.mock.calls[1][0].request);
+    expect(factory.mock.calls[0][0].options.cookies).toMatchObject({
+      getAll: expect.any(Function),
+      setAll: expect.any(Function),
+    });
+  });
+
+  it("prefers the Unkey instance option for protected routes", async () => {
+    const verifyKey = vi.fn(async () => ({
+      valid: true,
+      keyId: "key_test",
+    }));
+    const instance = {
+      verifyKey,
+    } as unknown as UnkeyIntegrationInstance;
+    const integration = unkey({
+      instance,
+      protectedRoutes: ["/api/private(.*)"],
+    });
+    const request = new Request("https://app.example.com/api/private", {
+      headers: {
+        authorization: "Bearer api_test",
+      },
+    });
+
+    const response = await integration.middleware![0].handler(
+      request,
+      createContext(request, "unkey", "/api/private"),
+    );
+
+    expect(response).toBeUndefined();
+    expect(verifyKey).toHaveBeenCalledWith({
+      key: "api_test",
+      permissions: undefined,
+      tags: undefined,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add application-owned `instance` support to WorkOS, Clerk, and Polar
- standardize Unkey on `instance` while preserving `client` as a deprecated alias
- expose consistent instance types for existing Autumn, Resend, auth, billing, and aggregate integration APIs
- add a request-scoped Supabase instance factory that preserves Farm's cookie adapter
- document the equivalent `runtime`, `origin`, and `model` injection boundaries for jobs, agents, and AI

## Why

Applications should be able to own vendor SDK construction, versions, transports, retries, telemetry, and test doubles. Farm should focus on the route and lifecycle contract instead of mirroring every provider constructor option.

Supabase is intentionally different: its SSR client is bound to request cookies, so the integration accepts a per-request factory instead of an unsafe shared singleton.

## Backward compatibility

Credential-based configuration remains supported. When both credentials and `instance` are supplied, the injected instance is used. Existing Unkey `client` configuration continues to work.

## Validation

- type checks passed for core, aggregate integrations, WorkOS, Clerk, Polar, Supabase, Unkey, Autumn, and email
- 5 focused instance-injection tests passed
- formatting and lint checks passed
- full production docs build passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds app-owned SDK instance injection across integrations and clarifies SDK/runtime ownership in docs. Includes a request-scoped `supabase` factory, exported instance types, and fixes WorkOS to honor injected client credentials.

- **New Features**
  - `instance` option for `workos`, `clerk`, `polar`, and `unkey` (keeps `client` as a deprecated alias).
  - `supabase` adds a per-request `instance` factory that preserves Farm’s cookie adapter.
  - Exported instance types via `@farm.js/integrations` for `autumn`, `polar`, `clerk`, `workos`, `unkey`, `supabase`, `resend`, and auth adapters (`better-auth`, `authjs`, `auth0`).
  - Docs add BYO-instance patterns and ownership guidance across auth, jobs, agents, and email.
  - Added focused tests for WorkOS, Clerk, Polar, Supabase (factory), and Unkey.

- **Bug Fixes**
  - WorkOS now reads `clientId` from an injected instance and no longer requires `apiKey` when `instance` is supplied; validation updated accordingly.

<sup>Written for commit 7743a024378077ecbadb13d561916875616bb17a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

