### PR TITLE
docs: clarify KV storage and database usage

### DIFF
--- a/docs/docs.config.ts
+++ b/docs/docs.config.ts
@@ -163,7 +163,7 @@ const sidebar = [
       { label: "Query and Params", slug: "query", icon: "search" },
       { label: "API Routes", slug: "api-routes", icon: "server" },
       { label: "API Client", slug: "api-client", icon: "terminal" },
-      { label: "Storage", slug: "storage", icon: "database" },
+      { label: "KV Storage", slug: "storage", icon: "database" },
     ],
   },
   {
@@ -243,11 +243,11 @@ const sidebar = [
         ],
       },
       {
-        label: "Storage",
+        label: "Database",
         icon: "database",
         children: [
           {
-            label: "ORM Storage",
+            label: "Database & ORM",
             slug: "integrations/orm-storage",
             icon: "database",
           },

--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -322,4 +322,4 @@ caller-specific cache relationships, and handlers can continue calling `invalida
 
 ## When to use integrations instead
 
-Use API routes for app-owned endpoints. Use integrations when a provider or feature needs a package-like surface: config validation, lifecycle hooks, storage schema, middleware, providers, and typed callers bundled together.
+Use API routes for app-owned endpoints. Use integrations when a provider or feature needs a package-like surface: config validation, lifecycle hooks, database schemas, middleware, providers, and typed callers bundled together.

--- a/docs/src/app/docs/cli/page.md
+++ b/docs/src/app/docs/cli/page.md
@@ -69,7 +69,7 @@ farm generate
 
 `farm dev` refreshes generated route/API types automatically when page and API route files change. Use `farm generate` when you want to refresh the same files outside the dev server, such as in CI, before publishing a package, or after moving files while the dev server was stopped.
 
-When integration storage schemas are configured, `farm generate` also writes schema artifacts if Farm can detect the data layer. Pass `--orm` and `--output` when you want explicit schema output for a migration step.
+When integration database schemas are configured, `farm generate` also writes schema artifacts if Farm can detect the data layer. Pass `--orm` and `--output` when you want explicit schema output for a migration step.
 
 ## Framework migrations
 

--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -1,12 +1,12 @@
 ---
 title: "Configuration"
-description: "Use farm.config.ts as the single project control plane for source paths, integrations, docs, storage, deployment, and framework behavior."
+description: "Use farm.config.ts as the single project control plane for source paths, integrations, docs, KV storage, database clients, deployment, and framework behavior."
 section: "Start"
 ---
 
 # Configuration
 
-Use farm.config.ts as the single project control plane for source paths, integrations, docs, storage, deployment, and framework behavior.
+Use farm.config.ts as the single project control plane for source paths, integrations, docs, KV storage, database clients, deployment, and framework behavior.
 
 ## Define config
 
@@ -87,7 +87,7 @@ mount, and shortcut together.
 | srcDir        | Changing the app source folder from the default src.                              |
 | integrations  | Registering built-in or custom integrations.                                      |
 | auth          | Enabling Farm's built-in email/password auth, sessions, helpers, and hooks.       |
-| storage       | Providing storage clients and mounts for framework and integration code.          |
+| storage       | Configuring KV drivers/mounts and, in the current beta, an integration DB client. |
 | migrations    | Running one-shot schema/provider commands with `farm migrate`.                    |
 | cron          | Mapping portable UTC schedules to ordinary GET API routes.                        |
 | i18n          | Configuring locale routes, detection, message catalogs, typing, and direction.    |
@@ -309,7 +309,7 @@ The keys become typed namespaces. `billing` becomes `api.billing`, and `auth` be
 
 ## One-shot migrations
 
-Use `migrations.commands` when the app needs a predictable command before build or deploy. This keeps schema setup close to the storage and integration config without turning the framework into a migration engine.
+Use `migrations.commands` when the app needs a predictable command before build or deploy. This keeps schema setup close to the database and integration config without turning the framework into a migration engine.
 
 ```ts
 import { defineConfig } from "@farm.js/core";
@@ -376,7 +376,8 @@ Prefer a CI release or commit identifier when a deployment runs on multiple serv
 ## Production notes
 
 - Keep secrets in environment variables, not committed config.
-- Use `storage.client` when integrations need schema-backed persistence.
+- Use `storage.driver` and `storage.mounts` for KV data read through `getStorage()`.
+- Use a raw object at `storage.client` only when schema-backed integrations need a database client; see [Database and ORM Clients](/docs/integrations/orm-storage).
 - Use `migrations.commands` for schema setup that should be explicit in CI.
 - Use `docs.entry` when the docs runtime should be mounted automatically.
 - Prefer route-level exports such as `dynamic`, `revalidate`, and `ppr` when behavior belongs to one page.

--- a/docs/src/app/docs/cron/page.md
+++ b/docs/src/app/docs/cron/page.md
@@ -56,7 +56,7 @@ cron: {
 
 ## Implement the Route
 
-The target is a normal route under `src/app/api`. It can use storage, integrations, cache invalidation, and other server APIs just like any other GET handler.
+The target is a normal route under `src/app/api`. It can use KV storage, application databases, integrations, cache invalidation, and other server APIs just like any other GET handler.
 
 ```ts title="src/app/api/maintenance/cleanup/route.ts"
 import { cronRoute } from "@farm.js/core/cron";

--- a/docs/src/app/docs/devtools/page.md
+++ b/docs/src/app/docs/devtools/page.md
@@ -1,6 +1,6 @@
 ---
 title: "DevTools and Doctor"
-description: "Inspect Farm's resolved routes, APIs, integrations, storage, schedules, deployment settings, and diagnostics in the browser or terminal."
+description: "Inspect Farm's resolved routes, APIs, integrations, KV storage, schedules, deployment settings, and diagnostics in the browser or terminal."
 section: "Runtime"
 ---
 
@@ -61,7 +61,7 @@ export default defineConfig({
 | Overview | Route, API, middleware, integration, schedule, and diagnostic totals.                                                        |
 | Routes   | Pages, layouts, loading boundaries, error boundaries, source files, and effective runtime controls.                          |
 | API      | Registered methods, paths, source modules, runtime, regions, and maximum duration.                                           |
-| Systems  | Integration routes and middleware, React providers, schema models, request middleware, and storage mounts.                   |
+| Systems  | Integration routes and middleware, React providers, database models, request middleware, and KV mounts.                      |
 | Runtime  | Deployment target, Nitro preset, output directory, cron routes, workflows, layers, feature flags, and environment key names. |
 
 Use the view navigation to move between surfaces. Routes and API endpoints can be filtered by path, method, or source file. Press `/` while one of those views is active to focus its filter. The **Raw** view contains the complete machine-readable snapshot.
@@ -127,7 +127,7 @@ SUMMARY  2 passed / 1 warning / 0 failed / 1 info
 DEVTOOLS http://localhost:3000/__farm/devtools
 ```
 
-When the dev server is not running, or when DevTools is disabled, Doctor automatically falls back to project inspection. It loads `farm.config.*`, validates the package manifest, checks the app router and root layout, resolves the deployment target, and inspects storage and cron configuration.
+When the dev server is not running, or when DevTools is disabled, Doctor automatically falls back to project inspection. It loads `farm.config.*`, validates the package manifest, checks the app router and root layout, resolves the deployment target, and inspects KV storage and cron configuration.
 
 ## Target another server
 
@@ -161,9 +161,9 @@ Offline mode checks:
 - The app directory or programmatic router contains page routes.
 - A root layout is available from the app or an extended layer.
 - Deployment target, preset, and output directory resolve.
-- Integrations and storage mounts are visible in config.
+- Integrations and KV mounts are visible in config.
 - Configured cron routes have matching app-directory API route files.
-- Serverless targets do not depend on explicitly configured in-memory root storage.
+- Serverless targets do not depend on explicitly configured in-memory root KV storage.
 
 Live mode is more complete because it sees generated and programmatic API routes, inherited runtime settings, loaded middleware, and discovered workflows after Farm initializes the app.
 
@@ -204,7 +204,7 @@ Common diagnostic codes include:
 | `ROOT_LAYOUT_MISSING`          | The app has no shared root layout.                           |
 | `CRON_ROUTE_MISSING`           | A configured schedule targets an API route Farm cannot find. |
 | `CRON_SECRET_NOT_SET`          | Scheduled production requests do not yet have `CRON_SECRET`. |
-| `EPHEMERAL_PRODUCTION_STORAGE` | A serverless deployment uses in-memory root storage.         |
+| `EPHEMERAL_PRODUCTION_STORAGE` | A serverless deployment uses in-memory root KV storage.      |
 | `ROUTE_RUNTIME_UNRESOLVED`     | Farm could not resolve a page's inherited runtime controls.  |
 | `LIVE_RUNTIME_UNREACHABLE`     | An explicitly selected running app did not answer the probe. |
 

--- a/docs/src/app/docs/getting-started/page.md
+++ b/docs/src/app/docs/getting-started/page.md
@@ -137,7 +137,7 @@ farm add integration stripe --ui
 farm add integration unkey
 ```
 
-Integrations can contribute typed callers, routes, providers, middleware, storage schema, CLI registry components, config validation, and lifecycle hooks.
+Integrations can contribute typed callers, routes, providers, middleware, database schemas, CLI registry components, config validation, and lifecycle hooks.
 
 Use `farm add integration better-auth --ui` instead when the application needs to own a Better Auth instance, plugins, adapters, providers, or callbacks. The [Better Auth integration guide](/docs/integrations/auth/better-auth) and [Better Auth starter](https://github.com/farming-labs/farmjs-better-auth-starter) document that explicit path.
 

--- a/docs/src/app/docs/integrations/auth/better-auth/page.md
+++ b/docs/src/app/docs/integrations/auth/better-auth/page.md
@@ -1,6 +1,6 @@
 ---
 title: "Better Auth Integration"
-description: "Mount a Better Auth instance in Farm and use its native client, storage, methods, and plugins."
+description: "Mount a Better Auth instance in Farm and use its native client, database adapter, methods, and plugins."
 section: "Integrations"
 ---
 

--- a/docs/src/app/docs/integrations/auth/page.md
+++ b/docs/src/app/docs/integrations/auth/page.md
@@ -34,14 +34,14 @@ That distinction determines whether you call auth through Farm's generated `api`
 
 ## Choose by ownership
 
-| Provider                                           | Farm owns                                                                                                   | Your app or provider owns                                          |
-| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| [Auth0](/docs/integrations/auth/auth0)             | OAuth routes, PKCE/state validation, local session cookie, profile route, protected-route redirects         | Auth0 tenant, connections, actions, and user records               |
-| [WorkOS](/docs/integrations/auth/workos)           | AuthKit redirects, callback, sealed session cookie, session route, protected-route redirects                | WorkOS organizations, SSO configuration, and user management       |
-| [Supabase](/docs/integrations/auth/supabase)       | Email/password and OAuth routes, SSR cookies, optional auth pages, session route, protected-route redirects | Supabase project, providers, policies, and user data               |
-| [Clerk](/docs/integrations/auth/clerk)             | `ClerkProvider` registration and optional request middleware                                                | Clerk UI, hooks, sessions, organizations, and account flows        |
-| [Auth.js](/docs/integrations/auth/authjs)          | The `/api/auth/[...nextauth]` catch-all route                                                               | Auth.js providers, callbacks, session strategy, and native helpers |
-| [Better Auth](/docs/integrations/auth/better-auth) | The `/api/auth/[...auth]` catch-all route                                                                   | Better Auth storage, plugins, methods, sessions, and native client |
+| Provider                                           | Farm owns                                                                                                   | Your app or provider owns                                                   |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| [Auth0](/docs/integrations/auth/auth0)             | OAuth routes, PKCE/state validation, local session cookie, profile route, protected-route redirects         | Auth0 tenant, connections, actions, and user records                        |
+| [WorkOS](/docs/integrations/auth/workos)           | AuthKit redirects, callback, sealed session cookie, session route, protected-route redirects                | WorkOS organizations, SSO configuration, and user management                |
+| [Supabase](/docs/integrations/auth/supabase)       | Email/password and OAuth routes, SSR cookies, optional auth pages, session route, protected-route redirects | Supabase project, providers, policies, and user data                        |
+| [Clerk](/docs/integrations/auth/clerk)             | `ClerkProvider` registration and optional request middleware                                                | Clerk UI, hooks, sessions, organizations, and account flows                 |
+| [Auth.js](/docs/integrations/auth/authjs)          | The `/api/auth/[...nextauth]` catch-all route                                                               | Auth.js providers, callbacks, session strategy, and native helpers          |
+| [Better Auth](/docs/integrations/auth/better-auth) | The `/api/auth/[...auth]` catch-all route                                                                   | Better Auth database adapter, plugins, methods, sessions, and native client |
 
 ## Register a provider
 

--- a/docs/src/app/docs/integrations/autumn/page.md
+++ b/docs/src/app/docs/integrations/autumn/page.md
@@ -1,6 +1,6 @@
 ---
 title: "Autumn Integration"
-description: "Add subscription and usage billing with Autumn while keeping Farm's integration API and storage layer."
+description: "Add subscription and usage billing with Autumn while keeping Farm's integration and database APIs stable."
 section: "Integrations"
 ---
 
@@ -45,9 +45,9 @@ const checkout = await api.billing.checkout.post({
 });
 ```
 
-## Storage-aware billing
+## Database-backed billing
 
-The integration can persist customer, plan, entitlement, and usage snapshots through ctx.args.db, so the app keeps the same Farm integration surface even when the backing storage client changes.
+The integration can persist customer, plan, entitlement, and usage records through `ctx.args.db`, so the app keeps the same integration surface when the database client changes. This schema-backed path is separate from KV storage.
 
 ## What Autumn adds
 

--- a/docs/src/app/docs/integrations/custom/page.md
+++ b/docs/src/app/docs/integrations/custom/page.md
@@ -1,12 +1,12 @@
 ---
 title: "Custom Integrations"
-description: "Build a first-class Farm integration with typed APIs, route handlers, lifecycle hooks, config validation, middleware, providers, storage schemas, and runtime logs."
+description: "Build a first-class Farm integration with typed APIs, route handlers, lifecycle hooks, config validation, middleware, providers, database schemas, and runtime logs."
 section: "Integrations"
 ---
 
 # Custom Integrations
 
-Use a custom integration when a service is bigger than a helper function. A good integration owns the contract between the app and the service: config, routes, typed callers, storage, lifecycle checks, request behavior, and any UI/provider setup the app needs.
+Use a custom integration when a service is bigger than a helper function. A good integration owns the contract between the app and the service: config, routes, typed callers, database models, lifecycle checks, request behavior, and any UI/provider setup the app needs.
 
 Farm integrations are declared with `defineIntegration`. They are registered in `farm.config.ts`, then Farm turns them into pre-plugins during config resolution.
 
@@ -394,12 +394,12 @@ export const acme = defineIntegration({
 
 Lifecycle hooks receive the same base context plus the parsed `integrationConfig`, a `log` helper, and cleanup support.
 
-| Hook            | When it runs                             | Use it for                                                                            |
-| --------------- | ---------------------------------------- | ------------------------------------------------------------------------------------- |
-| `validate(ctx)` | During integration init                  | Check API keys, required URLs, config combinations, and app prerequisites.            |
-| `setup(ctx)`    | During integration init after validation | Prepare storage, register webhooks, create queues, warm clients, or schedule cleanup. |
-| `ready(ctx)`    | When the app/plugin manager is ready     | Emit ready logs or start background listeners.                                        |
-| `dispose(ctx)`  | During shutdown                          | Close clients, flush buffers, unregister listeners, or stop workers.                  |
+| Hook            | When it runs                             | Use it for                                                                              |
+| --------------- | ---------------------------------------- | --------------------------------------------------------------------------------------- |
+| `validate(ctx)` | During integration init                  | Check API keys, required URLs, config combinations, and app prerequisites.              |
+| `setup(ctx)`    | During integration init after validation | Prepare databases, register webhooks, create queues, warm clients, or schedule cleanup. |
+| `ready(ctx)`    | When the app/plugin manager is ready     | Emit ready logs or start background listeners.                                          |
+| `dispose(ctx)`  | During shutdown                          | Close clients, flush buffers, unregister listeners, or stop workers.                    |
 
 ```ts
 export const acme = defineIntegration({
@@ -649,7 +649,7 @@ Route handlers, route middleware, and route hooks receive `ctx` with these field
 | `input.query`              | Parsed and validated query, if a query schema exists.                           |
 | `args.db`                  | Lazy ORM client for the integration schema.                                     |
 | `args.getDb()`             | Promise-based ORM client resolver.                                              |
-| `args.storage.getClient()` | Raw `storage.client`, if configured.                                            |
+| `args.storage.getClient()` | Raw integration database client from `storage.client`, if configured.           |
 | `data`                     | Small sanitized metadata from `createIntegrations({ data })` and per-call data. |
 | `integration`              | Category, type, slot alias, and original `instance`.                            |
 | `route`                    | Route kind, path, and methods.                                                  |
@@ -660,9 +660,9 @@ Route handlers, route middleware, and route hooks receive `ctx` with these field
 `ctx.req.set(key, value, { exposeToPage: true })` can expose values to page props. Avoid exposing secrets.
 `ctx.requestContext` remains as a deprecated compatibility alias for existing integrations.
 
-## Storage schema
+## Database schema
 
-Declare `schema` when an integration owns data. Farm maps that schema to the integration ORM so route handlers and lifecycle hooks can use `ctx.args.db`.
+Declare `schema` when an integration owns database records. Farm maps that schema to the integration ORM so route handlers and lifecycle hooks can use `ctx.args.db`. This path is separate from KV mounts read with `getStorage()`.
 
 ```ts
 import { defineIntegration, defineIntegrationSchema, integrationRoute } from "@farm.js/core";
@@ -727,11 +727,11 @@ export const billing = defineIntegration({
 });
 ```
 
-If an integration does not define `schema`, `ctx.args.db` throws. Use `ctx.args.storage.getClient()` when you only need the app's raw storage client.
+If an integration does not define `schema`, `ctx.args.db` throws. Use `ctx.args.storage.getClient()` only when the integration needs the raw database or provider client.
 
-## Storage config
+## Database client config
 
-The app supplies the storage client once:
+The app supplies the integration database client once. `storage.client` is the current beta config name; a raw database object here is not returned by `getStorage()` and does not configure a KV mount:
 
 **farm.config.ts**
 
@@ -752,7 +752,7 @@ export default defineConfig({
 });
 ```
 
-The integration code still uses `ctx.args.db`, not SQLite-specific APIs. If the app later switches to another supported client, the integration surface stays the same.
+The integration code still uses `ctx.args.db`, not SQLite-specific APIs. If the app later switches to another supported client, the integration surface stays the same. See [Database and ORM Clients](/docs/integrations/orm-storage) for PostgreSQL, direct application ORM use, and adapter-owned databases.
 
 ## Providers
 
@@ -848,6 +848,6 @@ export const { api, apiClient } = createIntegrations({
 - Define a stable `category` and `type`.
 - Keep app namespace keys predictable in `farm.config.ts`.
 - Add integration tests for valid input, invalid input, middleware short-circuiting, hooks, and client caller inference.
-- Add storage tests with real data when `schema` is present.
+- Add database tests with real data when `schema` is present.
 - Log enough request metadata to debug failures without logging secrets.
-- Document env vars, route paths, API callers, and storage models for app teams.
+- Document env vars, route paths, API callers, and database models for app teams.

--- a/docs/src/app/docs/integrations/orm-storage/page.md
+++ b/docs/src/app/docs/integrations/orm-storage/page.md
@@ -1,29 +1,89 @@
 ---
-title: "ORM Storage for Integrations"
-description: "Pass one storage client through farm.config.ts and let integrations use ctx.args.db through the unified farming-labs/orm-style API."
+title: "Database and ORM Clients"
+description: "Use relational models through @farming-labs/orm, schema-backed Farm integrations, or an integration's own database adapter."
 section: "Integrations"
 ---
 
-# ORM Storage for Integrations
+# Database and ORM Clients
 
-Farm integrations can declare a schema and then use `ctx.args.db` inside route handlers, middleware, and lifecycle hooks. The app decides which storage client backs the data. The integration only depends on the ORM-shaped API.
+Use a database or ORM when data has named fields, relationships, unique constraints, joins, transactions, or queryable filters. This is separate from Farm's [`getStorage()` key/value API](/docs/storage).
 
-This keeps integration code storage agnostic. A Stripe, auth, jobs, email, or custom integration can define models once and work across the supported runtime clients that `@farming-labs/orm` understands.
+Farm supports three database ownership patterns. Choose the owner before choosing the client:
 
-## Pass a client
+| Data owner                                       | Recommended path                                                               |
+| ------------------------------------------------ | ------------------------------------------------------------------------------ |
+| Your application                                 | Create an app-owned ORM client and query it through `db.model`                 |
+| A Farm integration that declares `schema`        | Pass a client through Farm config and query it through `ctx.args.db.model`     |
+| Better Auth, Prisma, Drizzle, or another library | Configure that library's native database adapter and use the library's own API |
+
+KV storage and database clients may use the same infrastructure, but they do not expose the same interface. `postgresStorage(...)` stores key/value records in a PostgreSQL-backed KV table. A raw `pg.Pool` or PostgreSQL ORM client provides relational access.
+
+## Application-owned ORM
+
+Use `@farming-labs/orm` directly when models belong to your application rather than to a Farm integration. Install the packages you import directly instead of relying on Farm's transitive dependencies:
+
+```bash
+pnpm add @farming-labs/orm @farming-labs/orm-sql pg
+```
+
+**src/lib/database.ts**
+
+```ts
+import { Pool } from "pg";
+
+export const database = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+```
+
+**src/lib/db.ts**
+
+```ts
+import { createOrm, defineSchema, id, model, string } from "@farming-labs/orm";
+import { createPgPoolDriver } from "@farming-labs/orm-sql";
+import { database } from "./database";
+
+export const appSchema = defineSchema({
+  project: model({
+    table: "project",
+    fields: {
+      id: id(),
+      name: string(),
+      ownerId: string().map("owner_id"),
+    },
+  }),
+});
+
+export const db = createOrm({
+  schema: appSchema,
+  driver: createPgPoolDriver(database),
+});
+```
+
+Application server code can now import `db` and query its own tables. Farm config is not required for this direct pattern.
+
+## Schema-backed Farm integrations
+
+Use Farm's integration ORM when a reusable integration owns models and should work across supported database clients. The integration declares the schema; the application supplies the runtime client.
+
+### Pass a PostgreSQL client
 
 **farm.config.ts**
 
 ```ts
 import { defineConfig } from "@farm.js/core";
-import { DatabaseSync } from "node:sqlite";
 import { billing } from "./src/integrations/billing";
-
-const sqlite = new DatabaseSync("farm.sqlite");
+import { database } from "./src/lib/database";
 
 export default defineConfig({
   storage: {
-    client: sqlite,
+    client: database,
+    mounts: {
+      cache: {
+        driver: "redis",
+        url: process.env.REDIS_URL!,
+      },
+    },
   },
   integrations: {
     billing,
@@ -31,11 +91,19 @@ export default defineConfig({
 });
 ```
 
-`storage.client` can be a ready runtime client or a lazy factory. Farm storage clients still power Farm's key/value storage. Other objects or functions are treated as runtime clients for schema-backed integration persistence.
+`storage.client` is the current beta config name for the integration runtime client. When its value is a raw `pg.Pool`, Farm detects PostgreSQL and builds the integration ORM from it. The `cache` mount remains a separate KV store and is read with `getStorage("cache")`.
 
-## Declare a schema
+The client can be a ready object or a lazy factory:
 
-**src/integrations/billing.ts**
+```ts
+storage: {
+  client: () => database,
+}
+```
+
+### Declare an integration schema
+
+**src/integrations/billing-schema.ts**
 
 ```ts
 import { defineIntegrationSchema } from "@farm.js/core";
@@ -57,7 +125,6 @@ export const billingSchema = defineIntegrationSchema({
         },
         status: {
           type: "enum",
-          name: "status",
           required: true,
           values: ["free", "active"],
           default: "free",
@@ -86,7 +153,7 @@ export const billingSchema = defineIntegrationSchema({
 });
 ```
 
-## Use db in integration hooks
+### Query through `ctx.args.db`
 
 **src/integrations/billing.ts**
 
@@ -101,7 +168,6 @@ export const billing = defineIntegration({
   schema: billingSchema,
   async setup(ctx) {
     const db = await ctx.args.getDb();
-
     await db.billingAccount.findMany();
   },
   routes: [
@@ -118,76 +184,121 @@ export const billing = defineIntegration({
           },
         });
 
-        return Response.json({
-          account,
-        });
+        return Response.json({ account });
       },
     }),
   ],
 });
 ```
 
-`ctx.args.db` is lazy, so you can access it like a property in handlers. `ctx.args.getDb()` is useful in setup code when you want to await the ORM client directly.
+`ctx.args.db` is lazy in request handlers. Use `await ctx.args.getDb()` when setup or lifecycle code should resolve the client explicitly.
 
-## SQLite shape
-
-For SQLite, create the database client in app code and pass the instance through `storage.client`.
-
-```ts
-import { defineConfig } from "@farm.js/core";
-import { DatabaseSync } from "node:sqlite";
-
-const sqlite = new DatabaseSync("farm.sqlite");
-
-sqlite.exec(`
-  CREATE TABLE IF NOT EXISTS billing_account (
-    id TEXT PRIMARY KEY,
-    owner_id TEXT NOT NULL UNIQUE,
-    status TEXT NOT NULL DEFAULT 'free',
-    seat_quantity INTEGER,
-    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-  );
-`);
-
-export default defineConfig({
-  storage: {
-    client: sqlite,
-  },
-});
-```
-
-Integration code stays the same if the app moves to a different supported client. The schema is the contract; the storage client is an app-level deployment choice.
-
-## What gets typed
-
-The schema controls the type of `ctx.args.db`:
+The integration schema controls the type of `ctx.args.db`:
 
 - Model names become properties such as `ctx.args.db.billingAccount`.
 - Field names become typed input and output fields.
 - Enum values become string unions.
 - Nullable fields include `null`.
 - Datetime fields read as `Date`.
-- Unique constraints can be used in `findUnique` and `where` shapes when the ORM supports them.
+- Unique constraints can be used in unique lookups when the detected driver supports them.
 
-## Raw storage access
+## SQLite runtime client
 
-Use raw storage access when an integration needs the app's client directly:
+The same integration can use a raw SQLite database instead of PostgreSQL:
+
+```ts
+import { defineConfig } from "@farm.js/core";
+import { DatabaseSync } from "node:sqlite";
+
+const database = new DatabaseSync("farm.sqlite");
+
+export default defineConfig({
+  storage: {
+    client: database,
+  },
+});
+```
+
+Create physical tables that match the integration schema before querying them. Switching clients does not migrate or reshape existing data automatically.
+
+## Better Auth and other adapter-owned data
+
+Some integrations own their database configuration. Better Auth is one example:
+
+```ts
+import { betterAuth } from "better-auth";
+import { database } from "./database";
+
+export const auth = betterAuth({
+  database,
+});
+```
+
+Here, Better Auth uses the PostgreSQL pool through its own database adapter and owns the `user`, `session`, `account`, and `verification` tables. Farm's Better Auth integration mounts the HTTP handler; it does not automatically route Better Auth queries through `ctx.args.db`.
+
+The application may reuse the same pool for its own Farming Labs ORM models. Prefer Better Auth's APIs and database hooks for auth-owned writes. Making Better Auth itself query through `@farming-labs/orm` requires a dedicated Better Auth database adapter.
+
+The same ownership rule applies to Prisma, Drizzle, and provider SDKs: configure their native client or adapter directly unless a Farm integration declares a schema for the records.
+
+## Raw runtime client
+
+Use the raw client only for operations that the integration ORM does not represent:
 
 ```ts
 async setup(ctx) {
   const client = await ctx.args.storage.getClient();
 
   if (!client) {
-    ctx.log.warn("No runtime storage client configured.");
+    ctx.log.warn("No integration database client configured.");
+    return;
   }
+
+  // Use a provider-specific operation here.
 }
 ```
 
-Prefer `ctx.args.db` for schema-backed records. Use `ctx.args.storage.getClient()` for provider-specific operations that cannot be represented through the integration schema.
+`ctx.args.storage.getClient()` keeps its current name for compatibility. It returns the raw object from `storage.client`; it does not return a KV mount.
+
+## Schema generation and migrations
+
+Farm can generate artifacts for integration schemas, then run the application's migration command:
+
+```bash
+farm generate
+farm migrate
+```
+
+```ts
+export default defineConfig({
+  storage: {
+    client: database,
+  },
+  migrations: {
+    commands: [
+      {
+        name: "apply database schema",
+        command: "pnpm drizzle-kit migrate",
+      },
+    ],
+  },
+});
+```
+
+`farm migrate` orchestrates the configured command; it does not replace Prisma, Drizzle, SQL, Better Auth, or provider-specific migration tools. Run the migration process owned by each schema owner.
 
 ## Failure modes
 
-- If an integration does not define `schema`, `ctx.args.db` throws with a clear error.
-- If `storage.client` is missing, the ORM layer cannot create a runtime-backed integration DB.
-- If the physical tables do not match the schema, the database client will fail at query time.
-- If a model method does not exist on the underlying ORM client, Farm raises an integration ORM method error.
+- If an integration does not define `schema`, `ctx.args.db` throws. Use the integration's native API or raw runtime client instead.
+- If `storage.client` is missing, Farm cannot construct a runtime-backed integration ORM.
+- If the physical tables do not match the declared schema, the database fails at query time.
+- Passing a raw database client does not configure the KV store used by `getStorage()`.
+- A database-backed KV helper such as `postgresStorage(...)` is not a relational ORM client.
+
+## Production checklist
+
+- Share connection pools instead of creating one pool per request.
+- Keep database credentials in server-only environment variables.
+- Use provider-recommended connection and TLS settings.
+- Run migrations before code that depends on the new schema.
+- Keep each table's ownership clear and avoid bypassing auth or billing invariants with direct writes.
+- Close clients during shutdown when the underlying driver requires it.

--- a/docs/src/app/docs/integrations/page.md
+++ b/docs/src/app/docs/integrations/page.md
@@ -1,12 +1,12 @@
 ---
 title: "Integrations"
-description: "Register services once, get owned routes, typed callers, agent runtimes, providers, middleware, storage access, lifecycle hooks, and validation."
+description: "Register services once, get owned routes, typed callers, agent runtimes, providers, middleware, database models, lifecycle hooks, and validation."
 section: "Integrations"
 ---
 
 # Integrations
 
-Integrations are the Farm layer for connecting product services to your app. A payment provider, auth system, email service, job runner, API-key platform, UI registry, or internal company SDK can register everything it owns in one place: route handlers, typed client/server callers, request middleware, React providers, storage schemas, lifecycle hooks, and runtime logs.
+Integrations are the Farm layer for connecting product services to your app. A payment provider, auth system, email service, job runner, API-key platform, UI registry, or internal company SDK can register everything it owns in one place: route handlers, typed client/server callers, request middleware, React providers, database schemas, lifecycle hooks, and runtime logs.
 
 Farm treats every integration as a small server plugin. That means an integration can participate in framework startup and shutdown, own HTTP routes, and still expose a compact typed API to the rest of the app.
 
@@ -87,10 +87,10 @@ Other integration fields are independent of that HTTP choice:
 | --------------------- | --------------------------------------------------------------------------------------------------- |
 | `middleware`          | Integration-owned request behavior for matchers outside a single endpoint.                          |
 | `providers`           | React provider metadata and optional wrapper components.                                            |
-| `schema`              | Storage models used by `ctx.args.db` through the ORM layer.                                         |
+| `schema`              | Database models used by `ctx.args.db` through the integration ORM.                                  |
 | `config`              | Schema-validated config from defaults, env, input, and resolver output.                             |
 | `validate`            | Early checks before the integration starts.                                                         |
-| `setup`               | Bootstrapping work such as storage checks or webhook registration.                                  |
+| `setup`               | Bootstrapping work such as database checks or webhook registration.                                 |
 | `ready`               | Post-start work once the app is ready.                                                              |
 | `dispose`             | Shutdown cleanup.                                                                                   |
 | `log`                 | Runtime events for registration, request start, request end, request error, and lifecycle messages. |
@@ -101,7 +101,7 @@ Other integration fields are independent of that HTTP choice:
 
 Integration handlers declared through either `routes` or `endpoints` use the same web primitives as
 normal route handlers. The handler receives the `Request` and a context object with params, parsed
-input, request metadata, shared request context, integration metadata, and `args` for storage.
+input, request metadata, shared request context, integration metadata, and `args` for database access.
 
 **src/integrations/local-demo.ts**
 
@@ -265,7 +265,7 @@ The route reads that value from `ctx.data`. Browser-provided data is client cont
 | Agents    | Eve and Cloudflare Agents run beside Farm in development and compose with supported deployment targets.                  |
 | API Keys  | Unkey can create, verify, revoke, update, and delete customer or service keys.                                           |
 | Interface | UI registry entries scaffold shadcn-style integration screens when `--ui` is enabled.                                    |
-| Storage   | ORM storage gives schema-backed integrations a provider-neutral `ctx.args.db`.                                           |
+| Database  | Integration schemas give database-backed integrations a provider-neutral `ctx.args.db`.                                  |
 
 ## When to build your own
 
@@ -274,7 +274,7 @@ Create a custom integration when a service needs one or more of these:
 - Routes or webhooks that should be mounted automatically.
 - Typed client/server functions that should not be hand-written in each app.
 - Config validation that should fail during startup.
-- Storage models shared by routes, hooks, and built-in UI.
+- Database models shared by routes, hooks, and built-in UI.
 - Request middleware that belongs to the service.
 - Setup or teardown work such as webhook registration, queue consumers, or health checks.
 

--- a/docs/src/app/docs/integrations/polar/page.md
+++ b/docs/src/app/docs/integrations/polar/page.md
@@ -45,9 +45,9 @@ const checkout = await api.billing.checkout.post({
 });
 ```
 
-## Storage-aware billing
+## Database-backed billing
 
-Polar callbacks can read and write through ctx.args.db, so webhook snapshots, subscription state, and customer entitlement checks share the same storage-agnostic integration layer.
+Polar callbacks can read and write relational records through `ctx.args.db`, so webhook snapshots, subscription state, and customer entitlement checks share the same database-agnostic integration layer. This path is separate from KV storage.
 
 ## What Polar adds
 

--- a/docs/src/app/docs/integrations/stripe/page.md
+++ b/docs/src/app/docs/integrations/stripe/page.md
@@ -1,12 +1,12 @@
 ---
 title: "Stripe Integration"
-description: "Add checkout, portal sessions, billing status, webhooks, product catalogs, metering, and storage-backed billing snapshots."
+description: "Add checkout, portal sessions, billing status, webhooks, product catalogs, metering, and database-backed billing snapshots."
 section: "Integrations"
 ---
 
 # Stripe Integration
 
-Add checkout, portal sessions, billing status, webhooks, product catalogs, metering, and storage-backed billing snapshots.
+Add checkout, portal sessions, billing status, webhooks, product catalogs, metering, and database-backed billing snapshots.
 
 ## Install from the CLI
 
@@ -56,9 +56,9 @@ if (checkout.data?.redirectTo) {
 }
 ```
 
-## Storage-aware billing
+## Database-backed billing
 
-The Stripe integration can use Farm's integration ORM layer through ctx.args.db, so billing snapshot reads and writes can work across Prisma, Drizzle, SQLite SQL, and other farming-labs/orm compatible clients.
+The Stripe integration can use Farm's integration ORM layer through `ctx.args.db`, so relational billing snapshot reads and writes can work across supported database clients. This is database access, not Farm KV storage.
 
 ## What Stripe adds
 
@@ -70,7 +70,7 @@ The Stripe integration can use Farm's integration ORM layer through ctx.args.db,
 | Billing status  | Subscription, trial, seats, cancellation, and plan state.                                   |
 | Entitlements    | Feature, limit, usage, meter, and billing checks.                                           |
 | Webhooks        | Event verification and snapshot updates for checkout and subscription events.               |
-| Storage         | Schema-backed billing account snapshots through `ctx.args.db`.                              |
+| Database        | Schema-backed billing account snapshots through `ctx.args.db`.                              |
 
 ## Common callers
 

--- a/docs/src/app/docs/observability/page.md
+++ b/docs/src/app/docs/observability/page.md
@@ -1,12 +1,12 @@
 ---
 title: "Observability"
-description: "Listen to Farm runtime events for server lifecycle, route matching, rendering, API routes, integrations, storage, cache, PPR, builds, plugins, and errors."
+description: "Listen to Farm runtime events for server lifecycle, route matching, rendering, API routes, integrations, integration databases, cache, PPR, builds, plugins, and errors."
 section: "Runtime"
 ---
 
 # Observability
 
-Listen to Farm runtime events for server lifecycle, route matching, rendering, API routes, integrations, storage, cache, PPR, builds, plugins, and errors.
+Listen to Farm runtime events for server lifecycle, route matching, rendering, API routes, integrations, integration databases, cache, PPR, builds, plugins, and errors.
 
 ## Subscribe to events
 
@@ -24,17 +24,19 @@ onFarmEvent((event) => {
 
 ## Event families
 
-| Family       | Examples                                                                         |
-| ------------ | -------------------------------------------------------------------------------- |
-| Server       | server.start, server.ready, server.shutdown                                      |
-| Routing      | route.discovered, route.matched, route.notFound, route.redirect                  |
-| Rendering    | render.start, render.complete, render.stream.shellReady, render.error            |
-| Cache        | cache.hit, cache.miss, cache.set, cache.revalidateTag                            |
-| PPR          | ppr.shell.hit, ppr.shell.cached, ppr.shell.invalidated                           |
-| Middleware   | middleware.start, middleware.complete, middleware.shortCircuit, middleware.error |
-| Integrations | integration.ready, integration.api.call.start, integration.webhook.verified      |
-| Storage      | storage.query.start, storage.schema.ready                                        |
-| Build        | build.start, routes.generated, types.generated, manifest.generated               |
+| Family               | Examples                                                                         |
+| -------------------- | -------------------------------------------------------------------------------- |
+| Server               | server.start, server.ready, server.shutdown                                      |
+| Routing              | route.discovered, route.matched, route.notFound, route.redirect                  |
+| Rendering            | render.start, render.complete, render.stream.shellReady, render.error            |
+| Cache                | cache.hit, cache.miss, cache.set, cache.revalidateTag                            |
+| PPR                  | ppr.shell.hit, ppr.shell.cached, ppr.shell.invalidated                           |
+| Middleware           | middleware.start, middleware.complete, middleware.shortCircuit, middleware.error |
+| Integrations         | integration.ready, integration.api.call.start, integration.webhook.verified      |
+| Integration database | storage.query.start, storage.schema.ready                                        |
+| Build                | build.start, routes.generated, types.generated, manifest.generated               |
+
+The `storage.query.*` and `storage.schema.*` event names are compatibility identifiers for integration database activity. They do not describe `getStorage()` KV operations.
 
 ## Configure in farm.config.ts
 
@@ -76,14 +78,14 @@ unsubscribe();
 
 ## Useful event types
 
-| Area         | Events                                                                                                                                                                                                                             |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Cache        | `cache.hit`, `cache.miss`, `cache.set`, `cache.stale`, `cache.bypass`, `cache.invalidated`, `cache.revalidatePath`, `cache.revalidateTag`, `cache.updateTag`, `cache.error`                                                        |
-| PPR          | `ppr.shell.hit`, `ppr.shell.miss`, `ppr.shell.cached`, `ppr.shell.bypass`, `ppr.shell.invalidated`, `ppr.suspense.holeDetected`, `ppr.refresh.start`, `ppr.refresh.complete`, `ppr.refresh.error`                                  |
-| API          | `api.request.start`, `api.request.complete`, `api.validation.failed`, `api.error`                                                                                                                                                  |
-| Integrations | `integration.registered`, `integration.config.validated`, `integration.ready`, `integration.disposed`, `integration.api.call.start`, `integration.api.call.complete`, `integration.webhook.verified`, `integration.webhook.failed` |
-| Middleware   | `middleware.start`, `middleware.complete`, `middleware.shortCircuit`, `middleware.error`                                                                                                                                           |
-| Storage      | `storage.query.start`, `storage.query.complete`, `storage.query.error`, `storage.schema.ready`, `storage.schema.error`                                                                                                             |
+| Area                 | Events                                                                                                                                                                                                                             |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cache                | `cache.hit`, `cache.miss`, `cache.set`, `cache.stale`, `cache.bypass`, `cache.invalidated`, `cache.revalidatePath`, `cache.revalidateTag`, `cache.updateTag`, `cache.error`                                                        |
+| PPR                  | `ppr.shell.hit`, `ppr.shell.miss`, `ppr.shell.cached`, `ppr.shell.bypass`, `ppr.shell.invalidated`, `ppr.suspense.holeDetected`, `ppr.refresh.start`, `ppr.refresh.complete`, `ppr.refresh.error`                                  |
+| API                  | `api.request.start`, `api.request.complete`, `api.validation.failed`, `api.error`                                                                                                                                                  |
+| Integrations         | `integration.registered`, `integration.config.validated`, `integration.ready`, `integration.disposed`, `integration.api.call.start`, `integration.api.call.complete`, `integration.webhook.verified`, `integration.webhook.failed` |
+| Middleware           | `middleware.start`, `middleware.complete`, `middleware.shortCircuit`, `middleware.error`                                                                                                                                           |
+| Integration database | `storage.query.start`, `storage.query.complete`, `storage.query.error`, `storage.schema.ready`, `storage.schema.error`                                                                                                             |
 
 Middleware events include the matched middleware route, request pathname, middleware file/config name, duration for completes, status for short circuits, and the thrown error for failures.
 

--- a/docs/src/app/docs/page.md
+++ b/docs/src/app/docs/page.md
@@ -13,7 +13,7 @@ Create an app and learn the files that matter.
 
 - [Getting Started](/docs/getting-started): Create a Farm.js app, understand the files that matter, and run the development server.
 - [Project Structure](/docs/project-structure): The compact file layout Farm expects, plus the optional files you add only when the app needs them.
-- [Configuration](/docs/configuration): Use farm.config.ts as the single project control plane for source paths, integrations, docs, storage, deployment, and framework behavior.
+- [Configuration](/docs/configuration): Use farm.config.ts as the single project control plane for source paths, integrations, docs, KV storage, database clients, deployment, and framework behavior.
 
 ### Core
 
@@ -29,28 +29,28 @@ Routes, rendering, layouts, and request flow.
 
 ### Data and APIs
 
-Typed params, API routes, API callers, and storage.
+Typed params, API routes, API callers, KV storage, and database access.
 
 - [Query and Params](/docs/query): Parse search params and route params with typed helpers on the server and synchronized state on the client.
 - [API Routes](/docs/api-routes): Expose HTTP handlers from src/app/api and validate input with schemas before handler code runs.
 - [API Client](/docs/api-client): Call app API routes with api.hello.get style inference, cache policies, invalidation, retries, callbacks, and optimistic updates.
 - [Server Queries](/docs/server-queries): Define typed server reads once, deduplicate requests, prefetch browser data, use SWR, and share invalidation keys with routes and APIs.
-- [Storage](/docs/storage): Use Farm storage clients for key-value data and pass storage clients to framework features and integrations.
+- [KV Storage](/docs/storage): Use `getStorage()` for caches, settings, counters, idempotency records, and object-backed values.
 
 ### Integrations
 
 Provider integrations and custom integration contracts.
 
-- [Integrations](/docs/integrations): Register services once, get owned routes, typed callers, providers, middleware, storage access, lifecycle hooks, and validation.
-- [Stripe Integration](/docs/integrations/stripe): Add checkout, portal sessions, billing status, webhooks, product catalogs, metering, and storage-backed billing snapshots.
-- [Autumn Integration](/docs/integrations/autumn): Add subscription, entitlement, and usage billing while keeping Farm's integration API and storage layer.
+- [Integrations](/docs/integrations): Register services once, get owned routes, typed callers, providers, middleware, database models, lifecycle hooks, and validation.
+- [Stripe Integration](/docs/integrations/stripe): Add checkout, portal sessions, billing status, webhooks, product catalogs, metering, and database-backed billing snapshots.
+- [Autumn Integration](/docs/integrations/autumn): Add subscription, entitlement, and usage billing with schema-backed database records through the integration ORM.
 - [Polar Integration](/docs/integrations/polar): Use Polar for products, checkout, customer portals, subscriptions, webhooks, and entitlement-aware app flows.
 - [Auth Integrations](/docs/integrations/auth): Choose built-in Farm Auth or an explicit Better Auth, Auth.js, Clerk, Auth0, WorkOS, or Supabase integration.
 - [Email Integration](/docs/integrations/email): Render React Email templates, send with Resend, schedule messages, preview templates, and receive webhooks.
 - [Jobs Integration](/docs/integrations/jobs): Define typed tasks once and run them through Trigger.dev or Inngest with trigger, schedule, batch, status, and cancel APIs.
 - [Unkey Integration](/docs/integrations/unkey): Create, verify, revoke, update, and delete API keys, plus protect routes with key verification and rate-limit checks.
 - [UI Registry](/docs/integrations/ui-registry): Opt into shadcn-style UI scaffolds for built-in integrations when you want working screens with the integration setup.
-- [ORM Storage for Integrations](/docs/integrations/orm-storage): Pass one storage client through farm.config.ts and let integrations use ctx.args.db through the unified farming-labs/orm-style API.
+- [Database and ORM Clients](/docs/integrations/orm-storage): Use application-owned ORM models, schema-backed integration databases, and adapter-owned data without confusing them with KV storage.
 
 ### Runtime
 
@@ -58,7 +58,7 @@ Cache, PPR, observability, instant preview, and deployment output.
 
 - [Post-response Work](/docs/after): Schedule short server work with after() without delaying the response.
 - [Cache and PPR](/docs/cache-ppr): Use shared runtime cache helpers, tag/path invalidation, ISR-style revalidation, and static shell caching for PPR pages.
-- [Observability](/docs/observability): Listen to Farm runtime events for server lifecycle, route matching, rendering, API routes, integrations, storage, cache, PPR, builds, plugins, and errors.
+- [Observability](/docs/observability): Listen to Farm runtime events for server lifecycle, route matching, rendering, API routes, integrations, integration databases, cache, PPR, builds, plugins, and errors.
 - [DevTools and Doctor](/docs/devtools): Inspect the resolved app runtime in the browser and run the same diagnostics from the terminal or CI.
 - [Cron](/docs/cron): Map portable UTC schedules to ordinary API routes, run them locally, and compile them to deployment-native triggers.
 - [Instant Preview](/docs/preview): Expose the current local app through a public URL for sharing, webhooks, OAuth callbacks, and external testing.

--- a/docs/src/app/docs/project-structure/page.md
+++ b/docs/src/app/docs/project-structure/page.md
@@ -27,14 +27,14 @@ my-app/
 
 ## Common folders
 
-| Path           | Purpose                                                          |
-| -------------- | ---------------------------------------------------------------- |
-| src/app        | Pages, nested layouts, API routes, route boundaries, middleware. |
-| src/lib        | Shared server and client utilities.                              |
-| src/components | Reusable UI and client components.                               |
-| layers         | Optional local Farm layers consumed through `extends`.           |
-| src/farm.d.ts  | Generated project types for routes, env, and i18n.               |
-| farm.config.ts | Framework config, integrations, docs, storage, deployment.       |
+| Path           | Purpose                                                                  |
+| -------------- | ------------------------------------------------------------------------ |
+| src/app        | Pages, nested layouts, API routes, route boundaries, middleware.         |
+| src/lib        | Shared server and client utilities.                                      |
+| src/components | Reusable UI and client components.                                       |
+| layers         | Optional local Farm layers consumed through `extends`.                   |
+| src/farm.d.ts  | Generated project types for routes, env, and i18n.                       |
+| farm.config.ts | Framework config, integrations, docs, KV storage, databases, deployment. |
 
 ## Optional files stay optional
 

--- a/docs/src/app/docs/reference/page.md
+++ b/docs/src/app/docs/reference/page.md
@@ -19,7 +19,7 @@ A compact map of the main package exports and where to learn more.
 | @farm.js/core/headers       | Next-compatible request headers and cookies helpers.                                 |
 | @farm.js/core/router        | Lightweight route matching, href building, and active-route checks.                  |
 | @farm.js/core/query         | Query and route param types.                                                         |
-| @farm.js/core/storage       | Storage clients and mount helpers.                                                   |
+| @farm.js/core/storage       | Key/value clients, drivers, mounts, and `getStorage()`.                              |
 | @farm.js/core/cache         | Data cache, revalidation, cache keys.                                                |
 | @farm.js/cache-redis        | Distributed Redis cache, tag versions, and regeneration leases.                      |
 | @farm.js/core/after         | Post-response server work with `after()`.                                            |
@@ -31,7 +31,7 @@ A compact map of the main package exports and where to learn more.
 1. Start with Getting Started and Project Structure.
 2. Read Routing, Layouts, and Rendering Model.
 3. Add API Routes, API Client, and Query.
-4. Choose integrations and storage once your product needs them.
+4. Choose integrations, KV storage, and database ownership once your product needs them.
 5. Finish with Deployment, Observability, and Reference.
 
 ## Integration exports
@@ -64,5 +64,7 @@ A compact map of the main package exports and where to learn more.
 - API clients are typed callers for app routes.
 - Integrations are provider or feature packages that can own routes, callers, schemas, providers, config, and lifecycle.
 - Plugins are framework-level hooks for server requests, rendering, builds, browser hydration, navigation, and runtime behavior.
-- Storage is the shared place to pass key/value stores and runtime database clients.
+- KV storage uses `getStorage()` for values addressed by string keys.
+- Application models use an application-owned ORM; schema-backed integrations use `ctx.args.db`.
+- The current beta `storage.client` config name also accepts a raw integration database client, but that client is not a KV mount.
 - Cron maps a UTC schedule to an app-owned GET API route; it does not add durable workflow state.

--- a/docs/src/app/docs/storage/page.md
+++ b/docs/src/app/docs/storage/page.md
@@ -1,21 +1,35 @@
 ---
-title: "Storage"
-description: "Use Farm storage clients for key-value data and pass storage clients to framework features and integrations."
+title: "KV Storage"
+description: "Use Farm's key/value API for caches, settings, counters, idempotency records, and object-backed values."
 section: "Data and APIs"
 ---
 
-# Storage
+# KV Storage
 
-Use Farm storage clients for key-value data and pass storage clients to framework features and integrations.
+Farm's `@farm.js/core/storage` module is a **key/value API**. Every value is stored under a string key and read with operations such as `getItem`, `setItem`, `getKeys`, and `removeItem`.
 
-Farm storage has two related configuration paths:
+Use it for caches, feature flags, application settings, rate-limit counters, idempotency records, checkpoints, and object-backed values. Do not use it as a relational ORM for users, accounts, products, or other records that need model fields, relations, joins, or typed filters.
 
-- `storage.mounts` registers named key/value stores that server code reads with `getStorage(name)`.
-- `storage.client` configures the root key/value store when it receives a Farm storage client, or supplies an application-owned database or ORM client to schema-backed integrations when it receives another runtime object.
+## Choose the right data API
 
-Use mounts for values such as settings, feature flags, cache entries, rate-limit counters, idempotency keys, and small JSON records. Use a database or ORM object as `storage.client` when integrations need model-based access through `ctx.args.db`.
+| What you need                                     | Use                                                         |
+| ------------------------------------------------- | ----------------------------------------------------------- |
+| Cache entries, flags, settings, counters, or JSON | Farm KV storage through `getStorage(name)`                  |
+| Rate limiting shared across production instances  | A durable `ratelimit` mount under `storage.mounts`          |
+| Files or values addressed by one key              | An object-backed KV helper such as `s3Storage(...)`         |
+| Application models, relations, joins, and filters | An application-owned `@farming-labs/orm` or another ORM     |
+| Models owned by a schema-backed Farm integration  | Farm's integration ORM through `ctx.args.db`                |
+| Better Auth users, accounts, and sessions         | Better Auth's configured database adapter and instance APIs |
+| Provider-specific SQL or database operations      | The raw integration runtime client through `getClient()`    |
 
-## Create a storage client
+The current beta config groups two different inputs under the `storage` key:
+
+- `storage.driver`, `storage.mounts`, and a Farm storage client configure the KV system used by `getStorage()`.
+- A raw database or ORM object passed to `storage.client` is reserved for schema-backed integrations and is documented under [Database and ORM Clients](/docs/integrations/orm-storage).
+
+These paths do not convert into each other. In particular, a raw PostgreSQL pool supplied as `storage.client` does not become the value returned by `getStorage()`, and it does not make the default in-memory KV store durable.
+
+## Create a KV client
 
 **src/lib/storage.ts**
 
@@ -32,7 +46,7 @@ export const rateLimitStorage = redisStorage({
 });
 ```
 
-Storage helpers return ready-to-use clients, so application code can import and call them directly. Mounting the clients is useful when you want one central configuration and a stable name that any server-side module can retrieve later.
+KV helpers return ready-to-use clients, so application code can import and call them directly. Mounting the clients is useful when you want one central configuration and a stable name that any server-side module can retrieve later.
 
 ## Register named mounts
 
@@ -52,7 +66,7 @@ export default defineConfig({
 });
 ```
 
-Each property under `mounts` is a storage namespace:
+Each property under `mounts` is a KV namespace:
 
 - `app` is an application-defined name. Farm does not attach special behavior to it.
 - `ratelimit` is a Farm convention. The built-in `.rateLimit()` middleware uses this namespace automatically.
@@ -130,9 +144,9 @@ The same mount can be used from other server-only application surfaces:
 
 Do not call `getStorage()` from a client component or browser bundle. Expose the required operation through an API route, server action, or server function instead.
 
-## Storage operations
+## KV operations
 
-Mounted stores expose the standard Farm storage API:
+Mounted stores expose the standard Farm KV API:
 
 ```ts
 const appStore = getStorage("app");
@@ -203,9 +217,9 @@ Mount names describe the responsibility; drivers decide where the values live:
 
 The names are conventions chosen by the application, except for framework-owned names such as `ratelimit`. Two mounts may use the same driver type while remaining isolated, or use different drivers based on durability and latency requirements.
 
-## Supported drivers
+## Supported KV drivers
 
-Farm supports storage at three levels:
+Farm supports KV storage at three levels:
 
 1. Farm convenience helpers for common databases, caches, and object stores.
 2. Direct driver configuration through `driver: "name"`.
@@ -213,7 +227,7 @@ Farm supports storage at three levels:
 
 The root store and every mount can use a different supported driver.
 
-### Farm storage helpers
+### Farm KV helpers
 
 Import these helpers from `@farm.js/core/storage`:
 
@@ -274,7 +288,7 @@ export default defineConfig({
 
 In this example, `getStorage()` uses SQLite, `getStorage("cache")` uses Redis, and `getStorage("uploads")` uses S3.
 
-### Database driver names
+### Database-backed KV drivers
 
 Farm resolves these names through `db0` and exposes the result as key/value storage:
 
@@ -291,7 +305,7 @@ Farm resolves these names through `db0` and exposes the result as key/value stor
 | `libsql-http`                  | libSQL HTTP client      | `url`, optional `authToken`, and optional `tableName`.            |
 | `db0`                          | Existing `db0` database | Pass `{ database, tableName? }` inside `options`.                 |
 
-These drivers create or use a key/value table for Farm storage. They are separate from passing a raw database or ORM object through `storage.client` for integration models.
+These drivers create or use a key/value table for Farm KV storage. They do not expose tables, models, joins, or arbitrary SQL through `getStorage()`. Passing a raw database or ORM object through `storage.client` is a separate integration database path.
 
 ### Complete built-in driver set
 
@@ -329,7 +343,7 @@ Farm also accepts the built-in driver names exported by its installed `unstorage
 | Web Storage             | `localstorage`, `session-storage`, `sessionStorage` | Browser local or session storage.                                                       |
 | Capacitor               | `capacitor-preferences`, `capacitorPreferences`     | Capacitor Preferences-backed mobile storage.                                            |
 
-Farm application storage normally initializes on the server. Browser-only drivers require a compatible custom runtime and should not be used as a reason to call `getStorage()` from client components.
+Farm KV storage normally initializes on the server. Browser-only drivers require a compatible custom runtime and should not be used as a reason to call `getStorage()` from client components.
 
 Most remote and platform drivers load an optional provider SDK. Install the package required by the selected driver, such as `ioredis`, `mongodb`, `@upstash/redis`, `@vercel/kv`, `@vercel/blob`, `@netlify/blobs`, `aws4fetch`, `uploadthing`, the relevant Azure SDK, `@deno/kv`, `idb-keyval`, or `lru-cache`. Database aliases may likewise require `sqlite3`, `better-sqlite3`, `mysql2`, `@electric-sql/pglite`, `@planetscale/database`, or `@libsql/client`; the `sqlite` alias uses Node's built-in `node:sqlite`. Cloudflare binding drivers instead require the corresponding runtime binding.
 
@@ -350,12 +364,12 @@ export const customStorage = driverStorage(() =>
 
 The wrapped driver can be mounted or used as the root Farm storage client just like a built-in helper.
 
-## Runtime clients for integrations
+## Database and ORM clients are separate
 
-`storage.client` has two behaviors based on the configured value:
+The current beta API uses `storage.client` for two distinguishable object shapes:
 
 - A Farm storage client, such as `sqliteStorage(...)`, becomes the root key/value store used by `getStorage()`.
-- Another database, ORM, or provider object becomes the runtime client for schema-backed integrations. That object is not returned by `getStorage(name)`.
+- A raw database, ORM, or provider object becomes the runtime client for schema-backed integrations. That object is not returned by `getStorage(name)`.
 
 ```ts
 import { defineConfig } from "@farm.js/core";
@@ -370,7 +384,9 @@ export default defineConfig({
 });
 ```
 
-When an integration defines a schema, Farm exposes a typed ORM layer at `ctx.args.db`. The integration does not need to know whether the app passed SQLite, Postgres, or another supported runtime client.
+In this example, the raw SQLite database is available only to integrations. Because no KV driver or Farm storage client is configured, `getStorage()` continues to use the default in-memory KV store.
+
+When an integration also defines a schema, Farm exposes a typed ORM layer at `ctx.args.db`. The integration does not need to know whether the app passed SQLite, PostgreSQL, or another supported runtime client.
 
 Use this rule of thumb:
 
@@ -378,37 +394,13 @@ Use this rule of thumb:
 - Use `ctx.args.db` inside an integration that declares models and needs ORM-style queries.
 - Use `ctx.args.storage.getClient()` inside integration server code only when provider-specific operations require the raw configured runtime client.
 
-## Schema migrations
+See [Database and ORM Clients](/docs/integrations/orm-storage) for application-owned ORM usage, integration schemas, PostgreSQL pools, Better Auth ownership, and migrations.
 
-Farm can generate integration schema artifacts with `farm generate`, then run your app-owned migration command with `farm migrate`.
-
-**farm.config.ts**
-
-```ts
-import { defineConfig } from "@farm.js/core";
-
-export default defineConfig({
-  storage: {
-    client: db,
-  },
-  migrations: {
-    commands: [
-      {
-        name: "apply schema",
-        command: "pnpm drizzle-kit migrate",
-      },
-    ],
-  },
-});
-```
-
-`farm migrate` does not hide the database tool. It gives the project one consistent place to run Prisma, Drizzle, SQL files, Better Auth setup, or provider-specific schema commands before `farm build`.
-
-## Storage client or runtime client
+## KV client or database client
 
 | Config                                      | Use it for                                             |
 | ------------------------------------------- | ------------------------------------------------------ |
-| `sqliteStorage(...)`                        | Farm key/value storage with a Farm storage client.     |
+| `sqliteStorage(...)`                        | Farm KV storage with a Farm storage client.            |
 | `redisStorage(...)`                         | Cache, rate-limit, or queue-like key/value data.       |
 | `storage.mounts`                            | Multiple named key/value stores.                       |
 | `storage.client` with a Farm storage client | Reuse a created Farm storage client as the root store. |
@@ -416,8 +408,7 @@ export default defineConfig({
 
 ## Production notes
 
-- Use durable storage for production state.
-- Keep local/memory storage for development and tests.
-- Pass one runtime client through config so integrations do not each invent storage options.
-- Create physical tables/migrations that match integration schemas, then run them with `farm migrate`.
-- Close database clients during app shutdown when the underlying driver requires it.
+- Use a shared durable KV driver for production state that must survive restarts or be visible across instances.
+- Keep memory KV storage for tests and explicitly disposable local state.
+- Do not assume that a PostgreSQL-backed KV helper provides relational database access.
+- Configure KV mounts and database clients independently when an application needs both.

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -1359,7 +1359,7 @@ function StorageVisual() {
     <FoundationCodeTabsVisual
       id="farm-storage-code"
       tabs={storageCodeTabs}
-      tabsLabel="Farm storage examples"
+      tabsLabel="Farm KV storage examples"
     />
   );
 }
@@ -1643,12 +1643,12 @@ function FoundationGrid() {
         <LayersVisual />
       </FeatureCell>
       <FeatureCell
-        body="Mount SQLite, Redis, S3, or any supported driver once, then reuse the storage layer across server code, middleware, rate limits, and integrations."
+        body="Mount SQLite, Redis, S3, or another key/value driver for caches, settings, counters, idempotency records, and object-backed values."
         className="border-t border-white/12"
         icon={Database}
         index="02.5"
-        label="Storage"
-        title="Storage built into the runtime"
+        label="KV Storage"
+        title="Key/value storage for the runtime"
       >
         <StorageVisual />
       </FeatureCell>
@@ -1848,7 +1848,7 @@ function IntegrationsSection() {
             </h2>
             <p className="mt-5 text-sm leading-6 text-white/48 sm:text-base sm:leading-7">
               Start with built-in Farm Auth, keep full control with Better Auth, then add
-              integrations for billing, email, jobs, storage, agents, API keys, and UI—or connect
+              integrations for billing, email, jobs, KV storage, agents, API keys, and UI—or connect
               your own.
             </p>
             <div className="mt-8 flex flex-wrap items-center gap-2">


### PR DESCRIPTION
## What changed

- Rename the user-facing Storage section to KV Storage and explain its key/value scope.
- Add a use-case guide for choosing KV storage, an application ORM, an integration database client, or an adapter-owned database.
- Rewrite the database and ORM guide with PostgreSQL, SQLite, integration schema, migration, and raw-client examples.
- Clarify that Better Auth owns its user and session data through its database adapter.
- Update related integration, configuration, observability, CLI, project structure, and landing-page terminology.

## Why

The existing documentation used “storage” for both Farm’s key/value API and schema-backed integration database clients. This made it unclear whether a PostgreSQL pool configured for an integration also backed `getStorage()`, or whether an ORM could access Better Auth tables automatically.

The revised documentation gives each data owner a distinct name and documents the current beta compatibility behavior of `storage.client`.

## Impact

Users can now select the correct API based on their use case:

- `getStorage()` for key/value data
- an application-owned ORM for relational application models
- `ctx.args.db` for integration-owned schemas
- the provider’s database adapter/API for Better Auth and similar adapters

Existing documentation routes are preserved.

## Validation

- `pnpm --filter farmjs-docs build`
- `git diff --check`
- Desktop and mobile browser verification of the KV Storage and Database/ORM guides
- No horizontal overflow, runtime error overlay, or browser console errors observed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the difference between KV storage and databases/ORMs across the docs so users pick the right API for their data. Renames the Storage docs to KV Storage and adds a focused guide on application ORM, integration schemas, and adapter-owned data.

- **Refactors**
  - Renamed “Storage” to “KV Storage” in navigation and pages, and updated terminology across configuration, CLI, devtools, integrations, and observability.
  - Added “Database and ORM Clients” guide covering app-owned `@farming-labs/orm`, PostgreSQL/SQLite clients, integration schemas via `ctx.args.db`, and Better Auth’s adapter-owned tables.
  - Clarified `storage.mounts` for KV data via `getStorage()` and the current beta `storage.client` behavior (raw integration DB client, not a KV mount).
  - Updated integration docs (Stripe, Polar, Autumn, custom) to say “database-backed” and show `ctx.args.db` usage.
  - Observability events now describe integration database activity; KV operations remain separate.

- **Migration**
  - No runtime changes required. Use `getStorage()` for KV data; use an app-owned ORM for relational app models; pass a raw DB client at `storage.client` only for schema-backed integrations; let Better Auth use its own database adapter.

<sup>Written for commit af18d98fcb5ca1a1ddfa2aedc7028d29d8b8b396. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

