### PR TITLE
feat: add generated route prop types

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -80,14 +80,30 @@ intercepted slot in the current page.
 ```tsx
 import type { PageProps } from "@farm.js/core";
 
-export default function UserPage({ params }: PageProps) {
-  return <div>User: {params?.id}</div>;
+export default function UserPage({ params }: PageProps<"/users/[id]">) {
+  return <div>User: {params.id}</div>;
 }
+```
+
+The route literal is checked against the generated application routes and narrows `params` to
+`{ id: string }`. The same route-aware generic is available on `LayoutProps`, `LoadingProps`,
+`ErrorProps`, `MetadataProps`, and `LayoutMetadataProps`. Omitting the generic keeps the existing
+`Record<string, string>` behavior for gradual adoption.
+
+Use `GenerateStaticParams` to check build-time paths against the same route:
+
+```tsx
+import type { GenerateStaticParams } from "@farm.js/core";
+
+export const generateStaticParams: GenerateStaticParams<"/users/[id]"> = async () => [
+  { id: "ada" },
+  { id: "grace" },
+];
 ```
 
 ## Typed navigation
 
-Farm writes the route union into the consolidated `src/farm.d.ts` declaration file. Link hrefs accept real routes, query strings, and hash fragments without widening everything to plain string.
+Farm writes the route union into the consolidated `src/farm.d.ts` declaration file. Link hrefs and route component props accept real routes without widening everything to plain string. Link hrefs can also include query strings and hash fragments.
 
 **Client navigation**
 
@@ -502,7 +518,7 @@ Export `metadata` for static head tags or `generateMetadata` when the values dep
 **src/app/products/[id]/page.tsx**
 
 ```tsx
-import type { PageProps } from "@farm.js/core";
+import type { MetadataProps } from "@farm.js/core";
 
 export const metadata = {
   description: "Product details",
@@ -512,7 +528,7 @@ export const metadata = {
   },
 };
 
-export async function generateMetadata({ params }: PageProps) {
+export async function generateMetadata({ params }: MetadataProps<"/products/[id]">) {
   const product = await getProduct(params.id);
 
   return {
@@ -736,8 +752,8 @@ Catch-all routes are useful for docs, CMS content, and nested marketing pages wh
 ```tsx
 import type { PageProps } from "@farm.js/core";
 
-export default function DocsPage({ params }: PageProps) {
-  const slug = params.slug?.split("/") ?? [];
+export default function DocsPage({ params }: PageProps<"/docs/[...slug]">) {
+  const slug = params.slug.split("/");
   return <main>Docs path: {slug.join(" / ")}</main>;
 }
 ```

--- a/docs/src/farm.d.ts
+++ b/docs/src/farm.d.ts
@@ -7,7 +7,8 @@ import "@farm.js/core/image";
 
 /**
  * Auto-generated route types from src/app.
- * Link href is typed automatically via module augmentation. Regenerated on dev start and when routes change.
+ * Link href and route component props are typed automatically from generated declarations.
+ * Regenerated on dev start and when routes change.
  * Set suppressLintOnLink: true in farm.config.ts to accept any string on Link href.
  */
 export type RoutePath =
@@ -27,6 +28,7 @@ export type RoutePath =
   | "/docs/docs-engine"
   | "/docs/environment-functions"
   | "/docs/examples"
+  | "/docs/fonts"
   | "/docs/getting-started"
   | "/docs/images"
   | "/docs/integrations"
@@ -92,6 +94,73 @@ export type RoutePattern =
   | "/docs/docs-engine"
   | "/docs/environment-functions"
   | "/docs/examples"
+  | "/docs/fonts"
+  | "/docs/getting-started"
+  | "/docs/images"
+  | "/docs/integrations"
+  | "/docs/integrations/auth"
+  | "/docs/integrations/auth/auth0"
+  | "/docs/integrations/auth/authjs"
+  | "/docs/integrations/auth/better-auth"
+  | "/docs/integrations/auth/clerk"
+  | "/docs/integrations/auth/supabase"
+  | "/docs/integrations/auth/workos"
+  | "/docs/integrations/autumn"
+  | "/docs/integrations/cf-agent"
+  | "/docs/integrations/custom"
+  | "/docs/integrations/email"
+  | "/docs/integrations/eve"
+  | "/docs/integrations/inngest"
+  | "/docs/integrations/jobs"
+  | "/docs/integrations/orm-storage"
+  | "/docs/integrations/polar"
+  | "/docs/integrations/stripe"
+  | "/docs/integrations/trigger"
+  | "/docs/integrations/ui-registry"
+  | "/docs/integrations/unkey"
+  | "/docs/internationalization"
+  | "/docs/layers"
+  | "/docs/layouts"
+  | "/docs/markdown"
+  | "/docs/middleware"
+  | "/docs/migrations"
+  | "/docs/migrations/nextjs"
+  | "/docs/migrations/nuxt"
+  | "/docs/migrations/sveltekit"
+  | "/docs/migrations/tanstack"
+  | "/docs/observability"
+  | "/docs/openapi"
+  | "/docs/plugins"
+  | "/docs/plugins/client"
+  | "/docs/plugins/create-plugin"
+  | "/docs/preview"
+  | "/docs/project-structure"
+  | "/docs/query"
+  | "/docs/reference"
+  | "/docs/route-runtime"
+  | "/docs/routing"
+  | "/docs/server-queries"
+  | "/docs/server-rendering"
+  | "/docs/storage"
+  | "/docs/testing";
+export type RouteModulePattern =
+  | "/"
+  | "/docs"
+  | "/docs/[...docs]"
+  | "/docs/after"
+  | "/docs/api-client"
+  | "/docs/api-routes"
+  | "/docs/auth"
+  | "/docs/cache-ppr"
+  | "/docs/cli"
+  | "/docs/configuration"
+  | "/docs/cron"
+  | "/docs/deployment"
+  | "/docs/devtools"
+  | "/docs/docs-engine"
+  | "/docs/environment-functions"
+  | "/docs/examples"
+  | "/docs/fonts"
   | "/docs/getting-started"
   | "/docs/images"
   | "/docs/integrations"
@@ -164,6 +233,14 @@ declare module "@farm.js/core/dist/client.js" {
   }
 }
 
+declare global {
+  namespace FarmJS {
+    interface RouteRegistry {
+      pattern: import("./farm").RouteModulePattern;
+    }
+  }
+}
+
 /**
  * Auto-generated env types from farm.config.
  * Regenerated on dev start, build, and farm generate.
@@ -189,3 +266,5 @@ declare module "@farm.js/core" {
     public: FarmResolvedEnv["public"];
   }
 }
+
+export {};

--- a/packages/farm/src/__tests__/generate-route-types.test.ts
+++ b/packages/farm/src/__tests__/generate-route-types.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
+import ts from "typescript";
 import { generateRouteTypes } from "../routing/generate-route-types";
 
 describe("generateRouteTypes", () => {
@@ -41,6 +42,7 @@ describe("generateRouteTypes", () => {
     const content = fs.readFileSync(outPath, "utf8");
     expect(content).toContain("export type RoutePath =");
     expect(content).toContain("export type RoutePattern =");
+    expect(content).toContain("export type RouteModulePattern =");
     expect(content).toContain('"/"');
     expect(content).toContain('"/about"');
     expect(content).toContain('"/content"');
@@ -50,6 +52,8 @@ describe("generateRouteTypes", () => {
     expect(content).toContain('declare module "@farm.js/core/dist/client.js"');
     expect(content).toContain('_: import("./farm-routes").RoutePath');
     expect(content).toContain('pattern: import("./farm-routes").RoutePattern');
+    expect(content).toContain("namespace FarmJS");
+    expect(content).toContain("interface RouteRegistry");
   });
 
   it("types route-slot targets without exposing slot directory syntax", async () => {
@@ -87,7 +91,7 @@ describe("generateRouteTypes", () => {
     expect(content).not.toContain("(.)photo");
   });
 
-  it("when suppressLintOnLink is true, does not augment LinkDefaultRoute and route types are string", async () => {
+  it("when suppressLintOnLink is true, disables Link linting but keeps route module props typed", async () => {
     const outPath = await generateRouteTypes({
       root: tmpDir,
       srcDir: "src",
@@ -96,7 +100,8 @@ describe("generateRouteTypes", () => {
     const content = fs.readFileSync(outPath, "utf8");
     expect(content).toContain("export type RoutePath = string");
     expect(content).toContain("export type RoutePattern = string");
-    expect(content).not.toContain("declare module");
+    expect(content).toContain('export type RouteModulePattern = "/" | "/about"');
+    expect(content).toContain("interface RouteRegistry");
     expect(content).not.toContain("LinkDefaultRoute");
   });
 
@@ -196,6 +201,138 @@ export const ProductRoute = createRoute("/products/[id]", {
     expect(content).toContain('"/products/[id]"');
   });
 
+  it("types page, layout, metadata, state, and static params from generated routes", async () => {
+    const docsDir = path.join(tmpDir, "src", "app", "docs", "[[...slug]]");
+    const dashboardDir = path.join(tmpDir, "src", "app", "dashboard");
+    await fs.promises.mkdir(docsDir, { recursive: true });
+    await fs.promises.mkdir(dashboardDir, { recursive: true });
+    await fs.promises.writeFile(
+      path.join(docsDir, "page.tsx"),
+      "export default function Docs() { return null; }",
+    );
+    await fs.promises.writeFile(
+      path.join(dashboardDir, "layout.tsx"),
+      "export default function DashboardLayout({ children }) { return children; }",
+    );
+    const reportsRoutePath = path.join(tmpDir, "src", "features", "reports.tsx");
+    await fs.promises.mkdir(path.dirname(reportsRoutePath), { recursive: true });
+    await fs.promises.writeFile(
+      reportsRoutePath,
+      `
+import { createRoute } from "@farm.js/core/routes";
+export const ReportsRoute = createRoute("/reports/[year]", {
+  component: () => null,
+});
+`,
+    );
+
+    const generatedTypesPath = await generateRouteTypes({ root: tmpDir, srcDir: "src" });
+    const typeTestPath = path.join(tmpDir, "route-props.type-test.ts");
+    await fs.promises.writeFile(
+      typeTestPath,
+      `
+import type {
+  AppRoutePattern,
+  ErrorProps,
+  GenerateStaticParams,
+  LayoutMetadataProps,
+  LayoutProps,
+  LoadingProps,
+  MetadataProps,
+  PageProps,
+} from "@farm.js/core";
+import type { PageProps as ClientPageProps } from "@farm.js/core/client";
+
+const route: AppRoutePattern = "/users/[id]";
+void route;
+// @ts-expect-error only generated route patterns are accepted
+const missingRoute: AppRoutePattern = "/missing";
+void missingRoute;
+
+declare const page: PageProps<"/users/[id]">;
+const pageId: string = page.params.id;
+void pageId;
+// @ts-expect-error only parameters declared by this route exist
+page.params.slug;
+
+declare const programmaticPage: PageProps<"/reports/[year]">;
+declare const clientPage: ClientPageProps<"/users/[id]">;
+const generatedIds: string[] = [programmaticPage.params.year, clientPage.params.id];
+void generatedIds;
+
+declare const layout: LayoutProps<"/users/[id]">;
+declare const layoutOnlyRoute: LayoutProps<"/dashboard">;
+declare const layoutMetadata: LayoutMetadataProps<"/users/[id]">;
+declare const metadata: MetadataProps<"/users/[id]">;
+declare const loading: LoadingProps<"/users/[id]">;
+declare const error: ErrorProps<"/users/[id]">;
+const typedIds: string[] = [
+  layout.params.id,
+  layoutMetadata.params.id,
+  metadata.params.id,
+  loading.params.id,
+  error.params.id,
+];
+void typedIds;
+void layoutOnlyRoute;
+
+declare const docs: PageProps<"/docs/[[...slug]]">;
+const docsSlug: string | undefined = docs.params.slug;
+void docsSlug;
+
+declare const legacyPage: PageProps;
+const unknownParam: string = legacyPage.params.anything;
+void unknownParam;
+
+const generateUsers: GenerateStaticParams<"/users/[id]"> = async () => [{ id: 1 }];
+const generateDocs: GenerateStaticParams<"/docs/[[...slug]]"> = () => [
+  {},
+  { slug: ["guides", "routing"] },
+];
+void generateUsers;
+void generateDocs;
+
+// @ts-expect-error dynamic static params require id
+const missingUserId: GenerateStaticParams<"/users/[id]"> = () => [{}];
+void missingUserId;
+// @ts-expect-error catch-all static params use path segment arrays
+const invalidDocsSlug: GenerateStaticParams<"/docs/[[...slug]]"> = () => [{ slug: "guides" }];
+void invalidDocsSlug;
+// @ts-expect-error route literals are checked against generated patterns
+type MissingPage = PageProps<"/missing">;
+declare const missingPage: MissingPage;
+void missingPage;
+`,
+    );
+
+    const program = ts.createProgram({
+      rootNames: [generatedTypesPath, typeTestPath],
+      options: {
+        strict: true,
+        noEmit: true,
+        skipLibCheck: true,
+        target: ts.ScriptTarget.ES2020,
+        module: ts.ModuleKind.ESNext,
+        moduleResolution: ts.ModuleResolutionKind.Bundler,
+        jsx: ts.JsxEmit.ReactJSX,
+        baseUrl: process.cwd(),
+        paths: {
+          "@farm.js/core": ["./src/types.ts"],
+          "@farm.js/core/client": ["./types/client.d.ts"],
+          "@farm.js/core/routes": ["./src/routes.ts"],
+        },
+      },
+    });
+    const diagnostics = ts.getPreEmitDiagnostics(program);
+    const formattedDiagnostics = ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+      getCanonicalFileName: (fileName) => fileName,
+      getCurrentDirectory: () => process.cwd(),
+      getNewLine: () => "\n",
+    });
+
+    expect(formattedDiagnostics).toBe("");
+  }, 30_000);
+
   it("writes a valid empty route union when no pages exist", async () => {
     const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "farm-empty-route-types-"));
     try {
@@ -208,6 +345,7 @@ export const ProductRoute = createRoute("/products/[id]", {
 
       expect(content).toContain("export type RoutePath = never;");
       expect(content).toContain("export type RoutePattern = never;");
+      expect(content).toContain("export type RouteModulePattern = never;");
     } finally {
       await fs.promises.rm(root, { recursive: true, force: true });
     }

--- a/packages/farm/src/client/index.ts
+++ b/packages/farm/src/client/index.ts
@@ -115,4 +115,16 @@ export type {
   FarmNavigationState,
   FarmViewTransitionMode,
 } from "./spa-router";
-export type { PageProps, LayoutProps, Metadata } from "../types";
+export type {
+  AppRoutePattern,
+  ErrorProps,
+  GenerateStaticParams,
+  LayoutMetadataProps,
+  LayoutProps,
+  LoadingProps,
+  Metadata,
+  MetadataProps,
+  PageProps,
+  PageRouteParams,
+  StaticRouteParams,
+} from "../types";

--- a/packages/farm/src/routing/generate-route-types.ts
+++ b/packages/farm/src/routing/generate-route-types.ts
@@ -66,8 +66,8 @@ export interface GenerateRouteTypesOptions {
 const DEFAULT_OUT_FILE = "farm-routes.d.ts";
 
 /**
- * Scan app directory for page files, generate RoutePath union type,
- * and write a .d.ts file for typed Link href.
+ * Scan application route modules, generate page and module route unions,
+ * and write a .d.ts file for typed Link hrefs and route component props.
  */
 export async function generateRouteTypes(options: GenerateRouteTypesOptions): Promise<string> {
   const root = path.resolve(options.root);
@@ -90,21 +90,26 @@ export async function createRouteTypeDeclarations(
   const sourceRoots = options.sourceRoots ?? [{ name: "project", root, srcDir, layer: false }];
 
   const patterns = new Set<string>();
+  const routeModulePatterns = new Set<string>();
 
   const glob = await import("fast-glob");
   for (const source of sourceRoots) {
     const appDir = path.join(source.root, source.srcDir, "app");
     if (fs.existsSync(appDir)) {
-      const pageFiles = await glob.default("**/page.{ts,tsx,js,jsx,md,mdx}", {
-        cwd: appDir,
-        absolute: false,
-      });
+      const routeModuleFiles = await glob.default(
+        "**/{page,layout,loading,error}.{ts,tsx,js,jsx,md,mdx}",
+        {
+          cwd: appDir,
+          absolute: false,
+        },
+      );
 
-      for (const file of pageFiles) {
+      for (const file of routeModuleFiles) {
         if (parseRouteSlotFile(file)) continue;
         const route = parseRoutePath(file);
+        const pattern = createRoutePattern(route);
+        routeModulePatterns.add(pattern);
         if (route.type === "page") {
-          const pattern = createRoutePattern(route);
           patterns.add(pattern);
         }
       }
@@ -112,18 +117,23 @@ export async function createRouteTypeDeclarations(
 
     for (const route of await discoverProgrammaticRoutePaths(source.root, source.srcDir)) {
       patterns.add(route);
+      routeModulePatterns.add(route);
     }
   }
 
   for (const route of extraRoutes) {
     if (route.startsWith("/")) {
       patterns.add(route);
+      routeModulePatterns.add(route);
     }
   }
 
   const sortedPatterns = Array.from(patterns).sort();
   const typeLiterals = Array.from(new Set(sortedPatterns.flatMap(routePatternToTsTypeLiterals)));
   const patternLiterals = sortedPatterns.map(routePatternToRouteLiteral);
+  const routeModulePatternLiterals = Array.from(routeModulePatterns)
+    .sort()
+    .map(routePatternToRouteLiteral);
 
   const routePathType = suppressLintOnLink
     ? "string"
@@ -135,8 +145,11 @@ export async function createRouteTypeDeclarations(
     : patternLiterals.length
       ? patternLiterals.join(" | ")
       : "never";
+  const routeModulePatternType = routeModulePatternLiterals.length
+    ? routeModulePatternLiterals.join(" | ")
+    : "never";
   const routeTypesImportPath = `./${path.basename(outPath).replace(/\.d\.ts$/, "")}`;
-  const augmentationBlock = suppressLintOnLink
+  const linkAugmentationBlock = suppressLintOnLink
     ? ""
     : `
 declare module "@farm.js/core/client" {
@@ -164,13 +177,25 @@ declare module "@farm.js/core/dist/client.js" {
 }
 `;
 
+  const routeModuleAugmentationBlock = `
+declare global {
+  namespace FarmJS {
+    interface RouteRegistry {
+      pattern: import(${JSON.stringify(routeTypesImportPath)}).RouteModulePattern;
+    }
+  }
+}
+`;
+
   const content = `/**
  * Auto-generated route types from src/app.
- * Link href is typed automatically via module augmentation. Regenerated on dev start and when routes change.
+ * Link href and route component props are typed automatically from generated declarations.
+ * Regenerated on dev start and when routes change.
  * Set suppressLintOnLink: true in farm.config.ts to accept any string on Link href.
  */
 export type RoutePath = ${routePathType};
-export type RoutePattern = ${routePatternType};${augmentationBlock}
+export type RoutePattern = ${routePatternType};
+export type RouteModulePattern = ${routeModulePatternType};${linkAugmentationBlock}${routeModuleAugmentationBlock}
 `;
 
   return content;

--- a/packages/farm/src/types.ts
+++ b/packages/farm/src/types.ts
@@ -23,6 +23,58 @@ import type { FarmAuthUserConfig, ResolvedFarmAuthConfig } from "./auth-config";
 import type { FarmPerformanceConfig } from "./preload";
 import type { FarmLayoutFonts } from "./font";
 
+declare global {
+  namespace FarmJS {
+    /** @internal Application route patterns registered by generated types. */
+    interface RouteRegistry {}
+  }
+}
+
+/** All generated route module patterns for the current application. */
+export type AppRoutePattern = FarmJS.RouteRegistry extends {
+  pattern: infer TPattern extends string;
+}
+  ? TPattern
+  : string;
+
+type FarmRoutePropsDefault = never;
+
+type FarmRoutePropsTarget = AppRoutePattern;
+
+type StripPageRouteSuffix<TRoute extends string> = TRoute extends `${infer TPath}?${string}`
+  ? StripPageRouteSuffix<TPath>
+  : TRoute extends `${infer TPath}#${string}`
+    ? StripPageRouteSuffix<TPath>
+    : TRoute;
+
+type SimplifyPageRouteParams<TValue> = { [TKey in keyof TValue]: TValue[TKey] } & {};
+
+type PageRouteSegmentParams<TSegment extends string> = TSegment extends `[[...${infer TParam}]]`
+  ? { [TKey in TParam]?: string }
+  : TSegment extends `[...${infer TParam}]`
+    ? { [TKey in TParam]: string }
+    : TSegment extends `[${infer TParam}]`
+      ? { [TKey in TParam]: string }
+      : {};
+
+type ExtractPageRouteParams<TRoute extends string> =
+  TRoute extends `${infer TSegment}/${infer TRest}`
+    ? PageRouteSegmentParams<TSegment> & ExtractPageRouteParams<TRest>
+    : PageRouteSegmentParams<TRoute>;
+
+/** Infer the decoded params received by a page from a route pattern. */
+export type PageRouteParams<TRoute extends string> = string extends TRoute
+  ? Record<string, string>
+  : TRoute extends string
+    ? SimplifyPageRouteParams<ExtractPageRouteParams<StripPageRouteSuffix<TRoute>>>
+    : never;
+
+type ResolvePageRouteParams<TRoute extends FarmRoutePropsTarget> = [TRoute] extends [never]
+  ? Record<string, string>
+  : TRoute extends string
+    ? PageRouteParams<TRoute>
+    : Record<string, string>;
+
 export type NitroPreset =
   | "node-server"
   | "vercel"
@@ -196,8 +248,8 @@ export interface PluginContextProps {
  * @param middleware - Data set by middleware.ts (optional, available if middleware exists)
  * @param context - Data explicitly exposed by plugins for this request (optional)
  */
-export interface PageProps {
-  params: Record<string, string>;
+export interface PageProps<TRoute extends FarmRoutePropsTarget = FarmRoutePropsDefault> {
+  params: ResolvePageRouteParams<TRoute>;
   searchParams: Promise<Record<string, string | string[] | undefined>>;
   path: string;
   /**
@@ -222,8 +274,8 @@ export interface PageProps {
   context?: PluginContextProps;
 }
 
-export interface LoadingProps {
-  params: Record<string, string>;
+export interface LoadingProps<TRoute extends FarmRoutePropsTarget = FarmRoutePropsDefault> {
+  params: ResolvePageRouteParams<TRoute>;
   searchParams: Promise<Record<string, string | string[] | undefined>>;
   search?: Record<string, string | string[] | undefined>;
   path: string;
@@ -231,7 +283,9 @@ export interface LoadingProps {
   context?: PluginContextProps;
 }
 
-export interface ErrorProps extends LoadingProps {
+export interface ErrorProps<
+  TRoute extends FarmRoutePropsTarget = FarmRoutePropsDefault,
+> extends LoadingProps<TRoute> {
   error: unknown;
   reset: () => void;
 }
@@ -256,21 +310,40 @@ export interface ErrorProps extends LoadingProps {
  * }
  * ```
  */
-export type PagePropsWithMiddleware<T extends Record<string, any>> = PageProps & {
+export type PagePropsWithMiddleware<
+  T extends Record<string, any>,
+  TRoute extends FarmRoutePropsTarget = FarmRoutePropsDefault,
+> = PageProps<TRoute> & {
   middleware: {
     data: Map<keyof T, T[keyof T]>;
   };
 };
 
-export interface LayoutProps {
+export interface LayoutProps<TRoute extends FarmRoutePropsTarget = FarmRoutePropsDefault> {
   children: ReactNode;
-  params: Record<string, string>;
+  params: ResolvePageRouteParams<TRoute>;
 }
 
-export type Page = ComponentType<PageProps>;
-export type Layout = ComponentType<LayoutProps>;
-export type Loading = ComponentType<LoadingProps>;
-export type ErrorBoundary = ComponentType<ErrorProps>;
+/** Props passed to a route's `generateMetadata` function. */
+export type MetadataProps<TRoute extends FarmRoutePropsTarget = FarmRoutePropsDefault> =
+  PageProps<TRoute>;
+
+/** Props passed to a layout's `generateMetadata` function. */
+export interface LayoutMetadataProps<TRoute extends FarmRoutePropsTarget = FarmRoutePropsDefault> {
+  params: ResolvePageRouteParams<TRoute>;
+}
+
+export type Page<TRoute extends FarmRoutePropsTarget = FarmRoutePropsDefault> = ComponentType<
+  PageProps<TRoute>
+>;
+export type Layout<TRoute extends FarmRoutePropsTarget = FarmRoutePropsDefault> = ComponentType<
+  LayoutProps<TRoute>
+>;
+export type Loading<TRoute extends FarmRoutePropsTarget = FarmRoutePropsDefault> = ComponentType<
+  LoadingProps<TRoute>
+>;
+export type ErrorBoundary<TRoute extends FarmRoutePropsTarget = FarmRoutePropsDefault> =
+  ComponentType<ErrorProps<TRoute>>;
 /**
  * Route module exports for pages
  *
@@ -340,8 +413,8 @@ export type ErrorBoundary = ComponentType<ErrorProps>;
  * }
  * ```
  */
-export interface RouteModule {
-  default?: Page;
+export interface RouteModule<TRoute extends FarmRoutePropsTarget = FarmRoutePropsDefault> {
+  default?: Page<TRoute>;
   /** Execution runtime for this route. Layout values are inherited unless overridden. */
   runtime?: FarmRouteRuntime;
   /** Provider-specific execution regions, or "auto" to clear an inherited value. */
@@ -374,13 +447,13 @@ export interface RouteModule {
    * Return all paths to pre-render for dynamic SSG routes
    * Required for dynamic routes (e.g., [slug]) when ssg = true
    */
-  getStaticPaths?: () => Promise<StaticPathParams[]> | StaticPathParams[];
+  getStaticPaths?: GenerateStaticParams<TRoute>;
   /**
    * @deprecated Use getStaticPaths instead
    */
-  generateStaticParams?: () => Promise<StaticPathParams[]> | StaticPathParams[];
+  generateStaticParams?: GenerateStaticParams<TRoute>;
   metadata?: Metadata & Record<string, any>;
-  generateMetadata?: (props: PageProps) => Promise<Metadata> | Metadata;
+  generateMetadata?: (props: MetadataProps<TRoute>) => Promise<Metadata> | Metadata;
 }
 
 /** A value accepted for one static route parameter. */
@@ -392,15 +465,45 @@ export type StaticPathPrimitive = string | number | boolean;
  */
 export type StaticPathParams = Record<string, StaticPathPrimitive | readonly StaticPathPrimitive[]>;
 
-export interface LayoutModule {
-  default: Layout;
+type StaticRouteSegmentParams<TSegment extends string> = TSegment extends `[[...${infer TParam}]]`
+  ? { [TKey in TParam]?: readonly StaticPathPrimitive[] }
+  : TSegment extends `[...${infer TParam}]`
+    ? { [TKey in TParam]: readonly StaticPathPrimitive[] }
+    : TSegment extends `[${infer TParam}]`
+      ? { [TKey in TParam]: StaticPathPrimitive }
+      : {};
+
+type ExtractStaticRouteParams<TRoute extends string> =
+  TRoute extends `${infer TSegment}/${infer TRest}`
+    ? StaticRouteSegmentParams<TSegment> & ExtractStaticRouteParams<TRest>
+    : StaticRouteSegmentParams<TRoute>;
+
+/** Infer the values accepted from `getStaticPaths` for a route pattern. */
+export type StaticRouteParams<TRoute extends string> = string extends TRoute
+  ? StaticPathParams
+  : TRoute extends string
+    ? SimplifyPageRouteParams<ExtractStaticRouteParams<StripPageRouteSuffix<TRoute>>>
+    : never;
+
+type ResolveStaticRouteParams<TRoute extends FarmRoutePropsTarget> = [TRoute] extends [never]
+  ? StaticPathParams
+  : TRoute extends string
+    ? StaticRouteParams<TRoute>
+    : StaticPathParams;
+
+/** A route-aware `getStaticPaths` or `generateStaticParams` function. */
+export type GenerateStaticParams<TRoute extends FarmRoutePropsTarget = FarmRoutePropsDefault> =
+  () => Array<ResolveStaticRouteParams<TRoute>> | Promise<Array<ResolveStaticRouteParams<TRoute>>>;
+
+export interface LayoutModule<TRoute extends FarmRoutePropsTarget = FarmRoutePropsDefault> {
+  default: Layout<TRoute>;
   /** Semantic fonts inherited by framework-owned surfaces for this route. */
   fonts?: FarmLayoutFonts;
   runtime?: FarmRouteRuntime;
   regions?: FarmRouteRegions;
   maxDuration?: FarmRouteMaxDuration;
   metadata?: Metadata & Record<string, any>;
-  generateMetadata?: (props: { params: Record<string, string> }) => Promise<Metadata> | Metadata;
+  generateMetadata?: (props: LayoutMetadataProps<TRoute>) => Promise<Metadata> | Metadata;
 }
 
 export interface Metadata {

--- a/packages/farm/types/client.d.ts
+++ b/packages/farm/types/client.d.ts
@@ -18,6 +18,13 @@ import type {
 } from "react";
 import type { DefinedCacheKey, InferCacheKeyData, RouteDataCacheKey } from "@farm.js/core/cache";
 
+declare global {
+  namespace FarmJS {
+    /** @internal Application route patterns registered by generated types. */
+    interface RouteRegistry {}
+  }
+}
+
 declare module "@farm.js/core/client" {
   export interface MiddlewareProps {
     data: Map<string, any>;
@@ -27,18 +34,122 @@ declare module "@farm.js/core/client" {
     data: Map<string, any>;
   }
 
-  export interface PageProps {
-    params: Record<string, string>;
+  export type AppRoutePattern = FarmJS.RouteRegistry extends {
+    pattern: infer TPattern extends string;
+  }
+    ? TPattern
+    : string;
+
+  type FarmRoutePropsDefault = never;
+
+  type FarmRoutePropsTarget = AppRoutePattern;
+
+  type StripPageRouteSuffix<TRoute extends string> = TRoute extends `${infer TPath}?${string}`
+    ? StripPageRouteSuffix<TPath>
+    : TRoute extends `${infer TPath}#${string}`
+      ? StripPageRouteSuffix<TPath>
+      : TRoute;
+
+  type SimplifyPageRouteParams<TValue> = { [TKey in keyof TValue]: TValue[TKey] } & {};
+
+  type PageRouteSegmentParams<TSegment extends string> = TSegment extends `[[...${infer TParam}]]`
+    ? { [TKey in TParam]?: string }
+    : TSegment extends `[...${infer TParam}]`
+      ? { [TKey in TParam]: string }
+      : TSegment extends `[${infer TParam}]`
+        ? { [TKey in TParam]: string }
+        : {};
+
+  type ExtractPageRouteParams<TRoute extends string> =
+    TRoute extends `${infer TSegment}/${infer TRest}`
+      ? PageRouteSegmentParams<TSegment> & ExtractPageRouteParams<TRest>
+      : PageRouteSegmentParams<TRoute>;
+
+  export type PageRouteParams<TRoute extends string> = string extends TRoute
+    ? Record<string, string>
+    : TRoute extends string
+      ? SimplifyPageRouteParams<ExtractPageRouteParams<StripPageRouteSuffix<TRoute>>>
+      : never;
+
+  type ResolvePageRouteParams<TRoute extends FarmRoutePropsTarget> = [TRoute] extends [never]
+    ? Record<string, string>
+    : TRoute extends string
+      ? PageRouteParams<TRoute>
+      : Record<string, string>;
+
+  export interface PageProps<TRoute extends FarmRoutePropsTarget = FarmRoutePropsDefault> {
+    params: ResolvePageRouteParams<TRoute>;
     searchParams: Promise<Record<string, string | string[] | undefined>>;
     path: string;
     middleware?: MiddlewareProps;
     context?: PluginContextProps;
   }
 
-  export interface LayoutProps {
-    children: ReactNode;
-    params: Record<string, string>;
+  export interface LoadingProps<TRoute extends FarmRoutePropsTarget = FarmRoutePropsDefault> {
+    params: ResolvePageRouteParams<TRoute>;
+    searchParams: Promise<Record<string, string | string[] | undefined>>;
+    search?: Record<string, string | string[] | undefined>;
+    path: string;
+    middleware?: MiddlewareProps;
+    context?: PluginContextProps;
   }
+
+  export interface ErrorProps<
+    TRoute extends FarmRoutePropsTarget = FarmRoutePropsDefault,
+  > extends LoadingProps<TRoute> {
+    error: unknown;
+    reset: () => void;
+  }
+
+  export interface LayoutProps<TRoute extends FarmRoutePropsTarget = FarmRoutePropsDefault> {
+    children: ReactNode;
+    params: ResolvePageRouteParams<TRoute>;
+  }
+
+  export type MetadataProps<TRoute extends FarmRoutePropsTarget = FarmRoutePropsDefault> =
+    PageProps<TRoute>;
+
+  export interface LayoutMetadataProps<
+    TRoute extends FarmRoutePropsTarget = FarmRoutePropsDefault,
+  > {
+    params: ResolvePageRouteParams<TRoute>;
+  }
+
+  export type StaticPathPrimitive = string | number | boolean;
+  export type StaticPathParams = Record<
+    string,
+    StaticPathPrimitive | readonly StaticPathPrimitive[]
+  >;
+
+  type StaticRouteSegmentParams<TSegment extends string> = TSegment extends `[[...${infer TParam}]]`
+    ? { [TKey in TParam]?: readonly StaticPathPrimitive[] }
+    : TSegment extends `[...${infer TParam}]`
+      ? { [TKey in TParam]: readonly StaticPathPrimitive[] }
+      : TSegment extends `[${infer TParam}]`
+        ? { [TKey in TParam]: StaticPathPrimitive }
+        : {};
+
+  type ExtractStaticRouteParams<TRoute extends string> =
+    TRoute extends `${infer TSegment}/${infer TRest}`
+      ? StaticRouteSegmentParams<TSegment> & ExtractStaticRouteParams<TRest>
+      : StaticRouteSegmentParams<TRoute>;
+
+  export type StaticRouteParams<TRoute extends string> = string extends TRoute
+    ? StaticPathParams
+    : TRoute extends string
+      ? SimplifyPageRouteParams<ExtractStaticRouteParams<StripPageRouteSuffix<TRoute>>>
+      : never;
+
+  type ResolveStaticRouteParams<TRoute extends FarmRoutePropsTarget> = [TRoute] extends [never]
+    ? StaticPathParams
+    : TRoute extends string
+      ? StaticRouteParams<TRoute>
+      : StaticPathParams;
+
+  export type GenerateStaticParams<TRoute extends FarmRoutePropsTarget = FarmRoutePropsDefault> =
+    () =>
+      | Array<ResolveStaticRouteParams<TRoute>>
+      | Promise<Array<ResolveStaticRouteParams<TRoute>>>;
 
   export interface Metadata {
     title?: string | { default?: string; template?: string };


### PR DESCRIPTION
## What changed

- generate an application route-module registry alongside typed `Link` routes
- infer `params` for page, layout, loading, error, and metadata props from route literals
- add route-aware `GenerateStaticParams` typing while preserving the existing untyped APIs for gradual adoption
- cover file routes, programmatic routes, layout-only routes, and catch-all routes with compiler-backed tests
- document typed route props and static params

## Why

Route components previously received `Record<string, string>`, so parameter names and static paths could drift from the route without a type error. Generated route declarations now connect the route graph to component props and static path generation, giving applications precise types without requiring another schema or changing runtime behavior.

## Validation

- `pnpm --filter @farm.js/core exec vitest run --silent --reporter=dot`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint` on changed TypeScript files
- `pnpm exec oxfmt --check` on all changed files
- `pnpm --dir docs exec farm generate`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add route-aware prop types so `params` and static paths are inferred from route literals across pages, layouts, loading, error, and metadata. Improves type-safety without changing runtime and keeps untyped APIs for gradual adoption.

- **New Features**
  - Generate `RouteModulePattern` and register routes via `FarmJS.RouteRegistry`.
  - Generic `PageProps`, `LayoutProps`, `LoadingProps`, `ErrorProps`, `MetadataProps`, `LayoutMetadataProps` infer `params` from literals like `"/users/[id]"`.
  - Typed SSG with `GenerateStaticParams<T>` and `StaticRouteParams<T>`.
  - Supports file, programmatic, layout-only, and catch-all routes; `suppressLintOnLink` only disables `Link` href linting, not route prop typing.
  - Export new types from `@farm.js/core` and `@farm.js/core/client`.

- **Migration**
  - No breaking changes; omit the generic to keep `params: Record<string, string>`.
  - Opt in per route: `export default function Page({ params }: PageProps<"/users/[id]">) {}`.
  - For SSG: `export const generateStaticParams: GenerateStaticParams<"/users/[id]"> = () => [...]`.
  - Regenerate declarations by running `farm generate` or during dev/build to refresh `src/farm.d.ts`.

<sup>Written for commit d2b5817d6bbb517bb378c25fc92b10fedb694c50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

