### PR TITLE
feat: add typed server function errors

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -459,22 +459,51 @@ When the function is called from the browser, `request` is the underlying Web `R
 
 Farm validates action origin metadata, accepted form/RSC content types, action ID shape, and request size before decoding an action. Browser calls use same-origin credentials and refuse redirects. Unexpected thrown values are logged on the server but become a generic `ServerActionError` in the browser, so secrets and stack traces are not serialized.
 
-Return typed expected failures instead of throwing messages that the UI needs to display:
+### Typed server function errors
+
+Declare expected failures next to the input contract. `error` accepts only declared codes, validates
+the public payload, and preserves the code, status, and data across the RSC action transport:
 
 ```ts
-export const renameProject = createServerFn({
-  input: renameProjectSchema,
-  async handler({ input }) {
-    const session = await requireSession();
-    if (!session.canEdit(input.projectId)) {
-      return { ok: false as const, reason: "forbidden" as const };
+export const updateProduct = createServerFn({
+  input: updateProductSchema,
+
+  errors: {
+    NOT_FOUND: {
+      status: 404,
+      data: z.object({ id: z.string() }),
+    },
+  },
+
+  handler({ input, error }) {
+    const product = findProduct(input.id);
+
+    if (!product) {
+      return error("NOT_FOUND", { id: input.id });
     }
 
-    await updateProject(input);
-    return { ok: true as const };
+    return product;
   },
 });
 ```
+
+`useServerFn`, `useMutation`, and `useFetcher` infer the declared error union. Narrow by `name` and
+`code` to recover the exact payload:
+
+```tsx
+const update = useServerFn(updateProduct);
+
+if (update.error?.name === "ServerFnFailure" && update.error.code === "NOT_FOUND") {
+  // id is inferred as string.
+  showMissingProduct(update.error.data.id);
+}
+```
+
+Add an optional `message` only when it is safe to display publicly. Declared error data schemas must
+support synchronous `parse()` or `safeParse()` because `error()` throws immediately. Hydrated calls
+carry `status` inside the Flight error envelope; progressive form submissions also use it as the HTTP
+status. Unexpected exceptions remain sanitized as a generic `ServerActionError`, without their
+message, stack, or custom properties.
 
 Action references identify which function to execute; they are not authorization tokens. Check authentication, roles, tenant ownership, and resource access inside every action that reads or changes private data.
 

--- a/packages/farm/src/__tests__/mutation-client.test.tsx
+++ b/packages/farm/src/__tests__/mutation-client.test.tsx
@@ -137,6 +137,34 @@ describe("useMutation", () => {
     expect(container.textContent).toBe("success:Farm");
   });
 
+  it("infers declared server function failures", () => {
+    const removeProduct = createServerFn({
+      input: z.object({ id: z.string() }),
+      errors: {
+        NOT_FOUND: {
+          status: 404,
+          data: z.object({ id: z.string() }),
+        },
+      },
+      handler: ({ input, error }) => error("NOT_FOUND", { id: input.id }),
+    });
+
+    function App() {
+      const mutation = useMutation(removeProduct);
+      if (mutation.error?.name === "ServerFnFailure") {
+        expectTypeOf(mutation.error.code).toEqualTypeOf<"NOT_FOUND">();
+        expectTypeOf(mutation.error.data).toEqualTypeOf<{ id: string }>();
+        expectTypeOf(mutation.error.status).toEqualTypeOf<404>();
+      }
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+  });
+
   it("keeps the latest result after an older concurrent request settles", async () => {
     const first = createDeferred<string>();
     const second = createDeferred<string>();

--- a/packages/farm/src/__tests__/server-action-security.test.ts
+++ b/packages/farm/src/__tests__/server-action-security.test.ts
@@ -11,6 +11,11 @@ import {
   sanitizeServerActionError,
   validateServerActionRequest,
 } from "../server-action-security";
+import {
+  createServerFnTransportError,
+  ServerFnFailure,
+  ServerActionError,
+} from "../server-fn-error";
 
 const defaultConfig = resolveServerActionsConfig(undefined);
 
@@ -307,6 +312,47 @@ describe("server action failures and execution context", () => {
       name: "ServerActionError",
       message: "Server function failed",
     });
+  });
+
+  it("serializes only explicitly marked server function failures", () => {
+    const failure = new ServerFnFailure(
+      "NOT_FOUND",
+      { id: "product-1" },
+      {
+        status: 404,
+        message: "Product not found",
+      },
+    );
+    const serialized = sanitizeServerActionError(failure);
+
+    expect(serialized).toEqual({
+      name: "ServerFnFailure",
+      message: "Product not found",
+      code: "NOT_FOUND",
+      status: 404,
+      data: { id: "product-1" },
+    });
+
+    const transported = createServerFnTransportError(serialized);
+    expect(transported).toBeInstanceOf(ServerFnFailure);
+    expect(transported).toMatchObject({
+      code: "NOT_FOUND",
+      status: 404,
+      data: { id: "product-1" },
+    });
+
+    const spoofed = sanitizeServerActionError({
+      name: "ServerFnFailure",
+      message: "leak",
+      code: "LEAK",
+      status: 400,
+      data: { secret: "must-not-cross" },
+    });
+    expect(spoofed).toEqual({
+      name: "ServerActionError",
+      message: "Server function failed",
+    });
+    expect(createServerFnTransportError(spoofed)).toBeInstanceOf(ServerActionError);
   });
 
   it("makes the request and its cancellation signal available during execution", async () => {

--- a/packages/farm/src/__tests__/server-fn-client.test.tsx
+++ b/packages/farm/src/__tests__/server-fn-client.test.tsx
@@ -5,7 +5,12 @@ import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import { z } from "zod";
-import { createServerFn } from "../server-fn";
+import {
+  createServerFn,
+  type InferServerFnError,
+  type ServerActionError,
+  type ServerFnFailure,
+} from "../server-fn";
 import { useServerFn, type UseServerFnReturn } from "../server-fn-client";
 
 describe("useServerFn", () => {
@@ -358,5 +363,51 @@ describe("useServerFn", () => {
     act(() => {
       root?.render(createElement(App));
     });
+  });
+
+  it("infers declared failures in client action state", async () => {
+    const updateProduct = createServerFn({
+      input: z.object({ id: z.string() }),
+      errors: {
+        NOT_FOUND: {
+          status: 404,
+          data: z.object({ id: z.string() }),
+        },
+      },
+      handler({ input, error }) {
+        if (input.id === "missing") return error("NOT_FOUND", { id: input.id });
+        return { id: input.id, updated: true as const };
+      },
+    });
+    type UpdateError = InferServerFnError<typeof updateProduct>;
+    let action!: UseServerFnReturn<{ id: string }, { id: string; updated: true }, UpdateError>;
+
+    function App() {
+      action = useServerFn(updateProduct);
+      expectTypeOf(action.error).toEqualTypeOf<
+        ServerActionError | ServerFnFailure<"NOT_FOUND", { id: string }, 404> | null
+      >();
+      if (action.error?.name === "ServerFnFailure") {
+        expectTypeOf(action.error.code).toEqualTypeOf<"NOT_FOUND">();
+        expectTypeOf(action.error.data).toEqualTypeOf<{ id: string }>();
+      }
+      return createElement("output", null, action.error?.name ?? action.status);
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    await act(async () => {
+      await expect(action.submit({ id: "missing" })).rejects.toMatchObject({
+        name: "ServerFnFailure",
+        code: "NOT_FOUND",
+        status: 404,
+        data: { id: "missing" },
+      });
+    });
+
+    expect(container.textContent).toBe("ServerFnFailure");
   });
 });

--- a/packages/farm/src/__tests__/server-fn.test.ts
+++ b/packages/farm/src/__tests__/server-fn.test.ts
@@ -2,7 +2,13 @@
 
 import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import { z } from "zod";
-import { createServerFn, createServerMiddleware, FARM_SERVER_FN_SYMBOL } from "../server-fn";
+import {
+  createServerFn,
+  createServerMiddleware,
+  FARM_SERVER_FN_SYMBOL,
+  ServerFnFailure,
+  type InferServerFnError,
+} from "../server-fn";
 import {
   getServerActionInvalidations,
   runWithServerActionRequest,
@@ -149,6 +155,66 @@ describe("createServerFn", () => {
 
     expectTypeOf(signup).parameter(0).toEqualTypeOf<{ email: string } | FormData>();
     expectTypeOf(await signup({ email: "ada@example.com" })).toEqualTypeOf<{ ok: true }>();
+  });
+
+  it("returns declared, validated failures through a typed error helper", async () => {
+    const updateProduct = createServerFn({
+      input: z.object({ id: z.string() }),
+      errors: {
+        NOT_FOUND: {
+          status: 404,
+          message: "Product not found",
+          data: z.object({ id: z.string() }),
+        },
+        FORBIDDEN: {
+          status: 403,
+          data: z.object({ permission: z.string() }),
+        },
+      },
+      handler({ input, error }) {
+        if (input.id === "__typecheck__") {
+          // @ts-expect-error only declared server function error codes are accepted.
+          error("MISSING", {});
+          // @ts-expect-error NOT_FOUND requires a string id.
+          error("NOT_FOUND", { id: 123 });
+        }
+
+        return error("NOT_FOUND", { id: input.id });
+      },
+    });
+
+    type UpdateProductError = InferServerFnError<typeof updateProduct>;
+    type NotFoundError = Extract<UpdateProductError, { code: "NOT_FOUND" }>;
+    expectTypeOf<NotFoundError["data"]>().toEqualTypeOf<{ id: string }>();
+    expectTypeOf<NotFoundError["status"]>().toEqualTypeOf<404>();
+
+    await expect(updateProduct({ id: "product-1" })).rejects.toMatchObject({
+      name: "ServerFnFailure",
+      message: "Product not found",
+      code: "NOT_FOUND",
+      status: 404,
+      data: { id: "product-1" },
+    });
+
+    try {
+      await updateProduct({ id: "product-1" });
+    } catch (error) {
+      expect(error).toBeInstanceOf(ServerFnFailure);
+    }
+  });
+
+  it("validates declared server function error definitions", () => {
+    expect(() =>
+      createServerFn({
+        errors: {
+          INVALID: {
+            status: 200,
+            data: z.object({}),
+          },
+        },
+        handler: () => true,
+      }),
+    ).toThrow('Server function error "INVALID" status must be an integer between 400 and 599');
   });
 
   it("validates and filters handler results with an output schema", async () => {

--- a/packages/farm/src/mutation-client.ts
+++ b/packages/farm/src/mutation-client.ts
@@ -16,11 +16,13 @@ export type InferMutationData<TTarget extends AnyMutationTarget> = TTarget exten
   ? TData
   : Awaited<ReturnType<TTarget>>;
 
-export type InferMutationError<TTarget extends AnyMutationTarget> = TTarget extends (
-  ...args: any[]
-) => Promise<APIResult<any, infer TError>>
+export type InferMutationError<TTarget extends AnyMutationTarget> = TTarget extends {
+  readonly __farmServerFnError: infer TError;
+}
   ? TError
-  : Error;
+  : TTarget extends (...args: any[]) => Promise<APIResult<any, infer TError>>
+    ? TError
+    : Error;
 
 export type MutationOptimisticContext<TVariables, TData> = {
   variables: TVariables | undefined;

--- a/packages/farm/src/server-action-security.ts
+++ b/packages/farm/src/server-action-security.ts
@@ -1,5 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { subscribeFarmCacheInvalidation, subscribeFarmCacheTask } from "./cache-invalidation";
+import { serializeServerFnFailure, type SerializedServerFnFailure } from "./server-fn-error";
 
 export const DEFAULT_SERVER_ACTION_BODY_SIZE_LIMIT = 1_000_000;
 
@@ -22,10 +23,12 @@ export interface PreparedServerActionRequest {
   contentType: string;
 }
 
-export type SanitizedServerActionError = {
-  name: "ServerActionError";
-  message: "Server function failed";
-};
+export type SanitizedServerActionError =
+  | {
+      name: "ServerActionError";
+      message: "Server function failed";
+    }
+  | SerializedServerFnFailure;
 
 type ServerActionRequestErrorCode =
   | "BODY_TOO_LARGE"
@@ -186,7 +189,10 @@ export function createServerActionRequestErrorResponse(error: unknown): Response
   });
 }
 
-export function sanitizeServerActionError(_error: unknown): SanitizedServerActionError {
+export function sanitizeServerActionError(error: unknown): SanitizedServerActionError {
+  const declaredFailure = serializeServerFnFailure(error);
+  if (declaredFailure) return declaredFailure;
+
   return {
     name: "ServerActionError",
     message: "Server function failed",

--- a/packages/farm/src/server-fn-client.ts
+++ b/packages/farm/src/server-fn-client.ts
@@ -49,7 +49,7 @@ type ServerFnActionCallbacks<TResult, TError extends Error> = Pick<
 >;
 
 export function useServerFn<TInput, TResult, TError extends Error = Error>(
-  serverFn: ServerFn<TInput, TResult>,
+  serverFn: ServerFn<TInput, TResult, TError>,
   options: UseServerFnOptions<TResult, TError, TInput> = {},
 ): UseServerFnReturn<TInput, TResult, TError> {
   const { initialResult = null, resetOnSubmit = true } = options;

--- a/packages/farm/src/server-fn-error.ts
+++ b/packages/farm/src/server-fn-error.ts
@@ -1,0 +1,105 @@
+export const FARM_SERVER_FN_FAILURE_SYMBOL = Symbol.for("farm.server-fn.failure");
+
+export type SerializedServerFnFailure = {
+  name: "ServerFnFailure";
+  message: string;
+  code: string;
+  status: number;
+  data: unknown;
+};
+
+export class ServerFnFailure<
+  TCode extends string = string,
+  TData = unknown,
+  TStatus extends number = number,
+> extends Error {
+  readonly name = "ServerFnFailure" as const;
+  readonly code: TCode;
+  readonly data: TData;
+  readonly status: TStatus;
+
+  constructor(
+    code: TCode,
+    data: TData,
+    options: {
+      status: TStatus;
+      message: string;
+    },
+  ) {
+    super(options.message);
+    this.code = code;
+    this.data = data;
+    this.status = options.status;
+
+    Object.defineProperty(this, FARM_SERVER_FN_FAILURE_SYMBOL, {
+      value: true,
+      enumerable: false,
+    });
+  }
+}
+
+export class ServerActionError extends Error {
+  readonly name = "ServerActionError" as const;
+
+  constructor(message = "Server function failed") {
+    super(message);
+  }
+}
+
+export function isServerFnFailure(value: unknown): value is ServerFnFailure {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Partial<ServerFnFailure> & {
+    [FARM_SERVER_FN_FAILURE_SYMBOL]?: unknown;
+  };
+  return (
+    candidate[FARM_SERVER_FN_FAILURE_SYMBOL] === true &&
+    candidate.name === "ServerFnFailure" &&
+    typeof candidate.code === "string" &&
+    Number.isInteger(candidate.status) &&
+    (candidate.status ?? 0) >= 400 &&
+    (candidate.status ?? 0) <= 599
+  );
+}
+
+export function serializeServerFnFailure(value: unknown): SerializedServerFnFailure | null {
+  if (!isServerFnFailure(value)) return null;
+
+  return {
+    name: "ServerFnFailure",
+    message: value.message,
+    code: value.code,
+    status: value.status,
+    data: value.data,
+  };
+}
+
+export function createServerFnTransportError(value: unknown): ServerFnFailure | ServerActionError {
+  if (isSerializedServerFnFailure(value)) {
+    return new ServerFnFailure(value.code, value.data, {
+      status: value.status,
+      message: value.message,
+    });
+  }
+
+  const message =
+    value && typeof value === "object" && "message" in value && typeof value.message === "string"
+      ? value.message
+      : "Server function failed";
+  return new ServerActionError(message);
+}
+
+function isSerializedServerFnFailure(value: unknown): value is SerializedServerFnFailure {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Partial<SerializedServerFnFailure>;
+  return (
+    candidate.name === "ServerFnFailure" &&
+    typeof candidate.message === "string" &&
+    typeof candidate.code === "string" &&
+    Number.isInteger(candidate.status) &&
+    (candidate.status ?? 0) >= 400 &&
+    (candidate.status ?? 0) <= 599 &&
+    "data" in candidate
+  );
+}

--- a/packages/farm/src/server-fn.ts
+++ b/packages/farm/src/server-fn.ts
@@ -1,6 +1,16 @@
 import { getServerActionExecutionContext, getServerActionSignal } from "./server-action-security";
 import { _resolveCurrentRequest } from "./server/request-bridge";
 import { applyFarmCacheInvalidationTargets, type FarmCacheInvalidationTarget } from "./cache";
+import { ServerActionError, ServerFnFailure } from "./server-fn-error";
+
+export {
+  FARM_SERVER_FN_FAILURE_SYMBOL,
+  ServerActionError,
+  ServerFnFailure,
+  createServerFnTransportError,
+  isServerFnFailure,
+} from "./server-fn-error";
+export type { SerializedServerFnFailure } from "./server-fn-error";
 
 type MaybePromise<T> = T | Promise<T>;
 
@@ -21,6 +31,44 @@ export type InferServerFnSchemaOutput<T> = T extends { _output: infer O }
   : T extends { parse: (data: unknown) => infer R }
     ? R
     : unknown;
+
+export type ServerFnErrorSchema = ServerFnSchema &
+  ({ parse: (data: unknown) => unknown } | { safeParse: (data: unknown) => unknown });
+
+export type ServerFnErrorDefinition<
+  TSchema extends ServerFnErrorSchema = ServerFnErrorSchema,
+  TStatus extends number = number,
+> = {
+  status: TStatus;
+  /** Schema for the public error payload exposed to callers. */
+  data: TSchema;
+  /** Public message safe to expose to callers. */
+  message?: string;
+};
+
+export type ServerFnErrorDefinitions = Record<
+  string,
+  ServerFnErrorDefinition<ServerFnErrorSchema, number>
+>;
+
+export type ServerFnDeclaredError<TErrors extends ServerFnErrorDefinitions> = {
+  [TCode in keyof TErrors]: ServerFnFailure<
+    TCode & string,
+    InferServerFnSchemaOutput<TErrors[TCode]["data"]>,
+    TErrors[TCode]["status"]
+  >;
+}[keyof TErrors];
+
+export type ServerFnError<TErrors extends ServerFnErrorDefinitions> = keyof TErrors extends never
+  ? Error
+  : ServerActionError | ServerFnDeclaredError<TErrors>;
+
+export type ServerFnErrorHandler<TErrors extends ServerFnErrorDefinitions> = <
+  TCode extends keyof TErrors & string,
+>(
+  code: TCode,
+  data: InferServerFnSchemaInput<TErrors[TCode]["data"]>,
+) => never;
 
 export type ServerFnFormInput = FormData;
 
@@ -66,9 +114,21 @@ export type ServerFnContext<TInput, TContext extends object = {}> = {
   context: Readonly<TContext>;
 };
 
-export type ServerFnHandler<TInput, TResult, TContext extends object = {}> = (
-  ctx: ServerFnContext<TInput, TContext>,
-) => MaybePromise<TResult>;
+export type ServerFnHandlerContext<
+  TInput,
+  TContext extends object = {},
+  TErrors extends ServerFnErrorDefinitions = {},
+> = ServerFnContext<TInput, TContext> & {
+  /** Return a declared, validated error from this server function. */
+  error: ServerFnErrorHandler<TErrors>;
+};
+
+export type ServerFnHandler<
+  TInput,
+  TResult,
+  TContext extends object = {},
+  TErrors extends ServerFnErrorDefinitions = {},
+> = (ctx: ServerFnHandlerContext<TInput, TContext, TErrors>) => MaybePromise<TResult>;
 
 export type ServerFnInvalidationContext<
   TInput,
@@ -120,10 +180,12 @@ export type ServerFnOptions<
   TSchema extends ServerFnSchema | undefined,
   TResult,
   TMiddlewares extends readonly AnyServerFnMiddleware[] = readonly [],
+  TErrors extends ServerFnErrorDefinitions = {},
 > = {
   input?: TSchema;
   output?: undefined;
   middleware?: TMiddlewares;
+  errors?: TErrors;
   invalidates?: ServerFnInvalidations<
     TSchema extends ServerFnSchema ? InferServerFnSchemaOutput<TSchema> : unknown,
     Awaited<TResult>,
@@ -132,7 +194,8 @@ export type ServerFnOptions<
   handler: ServerFnHandler<
     TSchema extends ServerFnSchema ? InferServerFnSchemaOutput<TSchema> : unknown,
     TResult,
-    ServerFnMiddlewareContext<TMiddlewares>
+    ServerFnMiddlewareContext<TMiddlewares>,
+    TErrors
   >;
 };
 
@@ -140,10 +203,12 @@ export type ServerFnOutputOptions<
   TInputSchema extends ServerFnSchema | undefined,
   TOutputSchema extends ServerFnSchema,
   TMiddlewares extends readonly AnyServerFnMiddleware[] = readonly [],
+  TErrors extends ServerFnErrorDefinitions = {},
 > = {
   input?: TInputSchema;
   output: TOutputSchema;
   middleware?: TMiddlewares;
+  errors?: TErrors;
   invalidates?: ServerFnInvalidations<
     TInputSchema extends ServerFnSchema ? InferServerFnSchemaOutput<TInputSchema> : unknown,
     Awaited<InferServerFnSchemaOutput<TOutputSchema>>,
@@ -152,17 +217,22 @@ export type ServerFnOutputOptions<
   handler: ServerFnHandler<
     TInputSchema extends ServerFnSchema ? InferServerFnSchemaOutput<TInputSchema> : unknown,
     unknown,
-    ServerFnMiddlewareContext<TMiddlewares>
+    ServerFnMiddlewareContext<TMiddlewares>,
+    TErrors
   >;
 };
 
-export type ServerFn<TInput, TResult> = ([unknown] extends [TInput]
+export type ServerFn<TInput, TResult, TError extends Error = Error> = ([unknown] extends [TInput]
   ? (input?: TInput | FormData) => Promise<TResult>
   : (input: TInput | FormData) => Promise<TResult>) & {
   readonly __farmServerFn: true;
   readonly __farmServerFnInput?: unknown;
   readonly __farmServerFnOutput?: unknown;
+  readonly __farmServerFnError: TError;
 };
+
+export type InferServerFnError<TServerFn> =
+  TServerFn extends ServerFn<any, any, infer TError> ? TError : Error;
 
 export const FARM_SERVER_FN_SYMBOL = Symbol.for("farm.server-fn");
 
@@ -198,42 +268,52 @@ export function createServerFn<
   TInputSchema extends ServerFnSchema,
   TOutputSchema extends ServerFnSchema,
   const TMiddlewares extends readonly AnyServerFnMiddleware[] = readonly [],
+  const TErrors extends ServerFnErrorDefinitions = {},
 >(
-  options: ServerFnOutputOptions<TInputSchema, TOutputSchema, TMiddlewares>,
+  options: ServerFnOutputOptions<TInputSchema, TOutputSchema, TMiddlewares, TErrors>,
 ): ServerFn<
   InferServerFnSchemaInput<TInputSchema>,
-  Awaited<InferServerFnSchemaOutput<TOutputSchema>>
+  Awaited<InferServerFnSchemaOutput<TOutputSchema>>,
+  ServerFnError<TErrors>
 >;
 export function createServerFn<
   TOutputSchema extends ServerFnSchema,
   const TMiddlewares extends readonly AnyServerFnMiddleware[] = readonly [],
+  const TErrors extends ServerFnErrorDefinitions = {},
 >(
-  options: ServerFnOutputOptions<undefined, TOutputSchema, TMiddlewares>,
-): ServerFn<unknown, Awaited<InferServerFnSchemaOutput<TOutputSchema>>>;
+  options: ServerFnOutputOptions<undefined, TOutputSchema, TMiddlewares, TErrors>,
+): ServerFn<unknown, Awaited<InferServerFnSchemaOutput<TOutputSchema>>, ServerFnError<TErrors>>;
 export function createServerFn<
   TSchema extends ServerFnSchema,
   TResult,
   const TMiddlewares extends readonly AnyServerFnMiddleware[] = readonly [],
+  const TErrors extends ServerFnErrorDefinitions = {},
 >(
-  options: ServerFnOptions<TSchema, TResult, TMiddlewares>,
-): ServerFn<InferServerFnSchemaInput<TSchema>, Awaited<TResult>>;
+  options: ServerFnOptions<TSchema, TResult, TMiddlewares, TErrors>,
+): ServerFn<InferServerFnSchemaInput<TSchema>, Awaited<TResult>, ServerFnError<TErrors>>;
 export function createServerFn<
   TResult,
   const TMiddlewares extends readonly AnyServerFnMiddleware[] = readonly [],
->(options: ServerFnOptions<undefined, TResult, TMiddlewares>): ServerFn<unknown, Awaited<TResult>>;
+  const TErrors extends ServerFnErrorDefinitions = {},
+>(
+  options: ServerFnOptions<undefined, TResult, TMiddlewares, TErrors>,
+): ServerFn<unknown, Awaited<TResult>, ServerFnError<TErrors>>;
 export function createServerFn(options: {
   input?: ServerFnSchema;
   output?: ServerFnSchema;
   middleware?: readonly AnyServerFnMiddleware[];
+  errors?: ServerFnErrorDefinitions;
   invalidates?: ServerFnInvalidations<any, any, any>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  handler: ServerFnHandler<any, any, any>;
+  handler: ServerFnHandler<any, any, any, any>;
 }) {
   if (!options || typeof options.handler !== "function") {
     throw new TypeError("createServerFn requires a handler function");
   }
 
   const middleware = resolveServerFnMiddleware(options.middleware);
+  const errors = normalizeServerFnErrors(options.errors);
+  const error = createServerFnErrorHandler(errors);
   const serverFn = async (value: unknown) => {
     const formData = isFormData(value) ? value : undefined;
     const rawInput = formData ? formDataToObject(formData) : value;
@@ -251,7 +331,7 @@ export function createServerFn(options: {
     let resolvedContext: Readonly<object> = Object.freeze(Object.create(null));
     const result = await runServerFnMiddleware(middleware, handlerContext, async (context) => {
       resolvedContext = context.context;
-      return options.handler(context);
+      return options.handler({ ...context, error });
     });
     const parsedResult = await _parseServerFnSchema(options.output, result, "output");
 
@@ -287,6 +367,10 @@ export function createServerFn(options: {
       value: options.output,
       enumerable: false,
     },
+    __farmServerFnError: {
+      value: undefined,
+      enumerable: false,
+    },
     __farmServerFnMiddleware: {
       value: middleware,
       enumerable: false,
@@ -297,7 +381,7 @@ export function createServerFn(options: {
     },
   });
 
-  return serverFn as ServerFn<unknown, unknown>;
+  return serverFn as ServerFn<unknown, unknown, Error>;
 }
 
 type ServerFnBaseContext = Omit<ServerFnContext<unknown, {}>, "context">;
@@ -305,7 +389,7 @@ type ServerFnBaseContext = Omit<ServerFnContext<unknown, {}>, "context">;
 async function runServerFnMiddleware(
   middleware: readonly AnyServerFnMiddleware[],
   handlerContext: ServerFnBaseContext,
-  handler: ServerFnHandler<any, any, any>,
+  handler: (context: ServerFnContext<any, any>) => MaybePromise<unknown>,
 ) {
   const dispatch = async (index: number, context: Readonly<object>): Promise<unknown> => {
     const current = middleware[index];
@@ -337,6 +421,98 @@ async function runServerFnMiddleware(
   };
 
   return dispatch(0, Object.freeze(Object.create(null)));
+}
+
+function normalizeServerFnErrors(
+  definitions: ServerFnErrorDefinitions | undefined,
+): Readonly<ServerFnErrorDefinitions> {
+  if (definitions === undefined) return Object.freeze({});
+  if (!isPlainServerFnObject(definitions)) {
+    throw new TypeError("createServerFn errors must be an object");
+  }
+
+  const normalized: ServerFnErrorDefinitions = Object.create(null);
+  for (const [code, definition] of Object.entries(definitions)) {
+    if (!code.trim()) {
+      throw new TypeError("Server function error codes cannot be empty");
+    }
+    if (!definition || typeof definition !== "object") {
+      throw new TypeError(`Server function error "${code}" must be an object`);
+    }
+    if (
+      !Number.isInteger(definition.status) ||
+      definition.status < 400 ||
+      definition.status > 599
+    ) {
+      throw new TypeError(
+        `Server function error "${code}" status must be an integer between 400 and 599`,
+      );
+    }
+    if (
+      !definition.data ||
+      (typeof definition.data.parse !== "function" &&
+        typeof definition.data.safeParse !== "function")
+    ) {
+      throw new TypeError(
+        `Server function error "${code}" data must provide synchronous parse() or safeParse()`,
+      );
+    }
+    if (definition.message !== undefined && typeof definition.message !== "string") {
+      throw new TypeError(`Server function error "${code}" message must be a string`);
+    }
+
+    normalized[code] = Object.freeze({ ...definition });
+  }
+
+  return Object.freeze(normalized);
+}
+
+function createServerFnErrorHandler(
+  definitions: Readonly<ServerFnErrorDefinitions>,
+): ServerFnErrorHandler<ServerFnErrorDefinitions> {
+  return ((code: string, data: unknown): never => {
+    const definition = definitions[code];
+    if (!definition) {
+      throw new TypeError(`Server function error "${code}" is not declared`);
+    }
+
+    const parsed = parseServerFnFailureData(code, definition.data, data);
+    throw new ServerFnFailure(code, parsed, {
+      status: definition.status,
+      message: definition.message ?? "Server function failed",
+    });
+  }) as ServerFnErrorHandler<ServerFnErrorDefinitions>;
+}
+
+function parseServerFnFailureData(code: string, schema: ServerFnSchema, value: unknown) {
+  if (typeof schema.safeParse === "function") {
+    const result = schema.safeParse(value);
+    if (isPromiseLike(result)) {
+      throw new TypeError(`Server function error "${code}" data schema must parse synchronously`);
+    }
+    return unwrapSafeParseResult(result);
+  }
+
+  const result = schema.parse!(value);
+  if (isPromiseLike(result)) {
+    throw new TypeError(`Server function error "${code}" data schema must parse synchronously`);
+  }
+  return result;
+}
+
+function isPlainServerFnObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return Boolean(
+    value &&
+    (typeof value === "object" || typeof value === "function") &&
+    "then" in value &&
+    typeof (value as PromiseLike<unknown>).then === "function",
+  );
 }
 
 function resolveServerFnMiddleware(

--- a/packages/farm/src/server-query.ts
+++ b/packages/farm/src/server-query.ts
@@ -14,6 +14,7 @@ import {
   type ServerFn,
   type ServerFnContext,
   type ServerFnHandler,
+  type ServerFnHandlerContext,
   type ServerFnMiddlewareContext,
   type ServerFnSchema,
   _parseServerFnSchema,
@@ -135,7 +136,7 @@ export function createServerQuery(options: AnyServerQueryOptions): ServerQuery<u
   )({
     input: options.input,
     middleware: options.middleware,
-    handler: async (context: ServerFnContext<any, any>) => {
+    handler: async (context: ServerFnHandlerContext<any, any>) => {
       const routeKey = await options.key(context);
       assertServerQueryKey(routeKey);
 

--- a/packages/farmjs-plugin/src/rsc/entries/client.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/client.ts
@@ -1,5 +1,36 @@
 import type { EntryContext } from "../types.js";
 
+export const serverFnTransportErrorClientRuntime = `function createFarmServerFnTransportError(value) {
+  const message = value && typeof value === 'object' && typeof value.message === 'string'
+    ? value.message
+    : 'Server function failed';
+  const error = new Error(message);
+
+  if (
+    value &&
+    typeof value === 'object' &&
+    value.name === 'ServerFnFailure' &&
+    typeof value.code === 'string' &&
+    Number.isInteger(value.status) &&
+    value.status >= 400 &&
+    value.status <= 599 &&
+    Object.prototype.hasOwnProperty.call(value, 'data')
+  ) {
+    error.name = 'ServerFnFailure';
+    error.code = value.code;
+    error.status = value.status;
+    error.data = value.data;
+    Object.defineProperty(error, Symbol.for('farm.server-fn.failure'), {
+      value: true,
+      enumerable: false,
+    });
+    return error;
+  }
+
+  error.name = 'ServerActionError';
+  return error;
+}`;
+
 /**
  * Generates the browser entry file.
  *
@@ -49,6 +80,8 @@ import {
   let actionSetup = "";
   if (ctx.actionsEnabled) {
     actionSetup = `
+${serverFnTransportErrorClientRuntime}
+
 // Ref for payload setter (used by server action callback and refetch)
 const setPayloadRef = { current: null };
 
@@ -100,9 +133,7 @@ setServerCallback(async (id, args) => {
   applyFarmCacheInvalidations(p.returnValue?.invalidations);
   if (!p.returnValue || !p.returnValue.ok) {
     debug('Server action failed:', id);
-    const error = new Error(p.returnValue?.data?.message || 'Server function failed');
-    error.name = 'ServerActionError';
-    throw error;
+    throw createFarmServerFnTransportError(p.returnValue?.data);
   }
   return completeFarmServerQueryAction(serverQueryInvocation, p.returnValue.data);
 });

--- a/packages/farmjs-plugin/src/rsc/entries/rsc.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/rsc.ts
@@ -663,8 +663,11 @@ async function handleFarmRequest(request) {
         if (request.signal.aborted) {
           return new Response(null, { status: 499, headers: { 'Cache-Control': 'no-store' } });
         }
-        console.error('[Farm.js] Server action failed:', e);
-        returnValue = { ok: false, data: sanitizeServerActionError(e) };
+        const actionError = sanitizeServerActionError(e);
+        if (actionError.name === 'ServerActionError') {
+          console.error('[Farm.js] Server action failed:', e);
+        }
+        returnValue = { ok: false, data: actionError };
         debug('Server action failed:', actionId, e);
       }
     } else {
@@ -695,10 +698,13 @@ async function handleFarmRequest(request) {
         if (request.signal.aborted) {
           return new Response(null, { status: 499, headers: { 'Cache-Control': 'no-store' } });
         }
-        console.error('[Farm.js] Form action failed:', e);
-        debug('Form action failed:', e);
-        return new Response('Server function failed', {
-          status: 500,
+        const actionError = sanitizeServerActionError(e);
+        if (actionError.name === 'ServerActionError') {
+          console.error('[Farm.js] Form action failed:', e);
+        }
+        debug('Form action failed:', actionError);
+        return new Response(actionError.message, {
+          status: actionError.name === 'ServerFnFailure' ? actionError.status : 500,
           headers: {
             'Cache-Control': 'no-store',
             'Content-Type': 'text/plain; charset=utf-8',

--- a/packages/farmjs-plugin/src/rsc/entries/security.test.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/security.test.ts
@@ -71,7 +71,9 @@ describe("generated server action security", () => {
     expect(entry).toContain("credentials: 'same-origin'");
     expect(entry).toContain("redirect: 'error'");
     expect(entry).toContain("cache: 'no-store'");
-    expect(entry).toContain("error.name = 'ServerActionError'");
+    expect(entry).toContain("function createFarmServerFnTransportError(value)");
+    expect(entry).toContain("Symbol.for('farm.server-fn.failure')");
+    expect(entry).toContain("throw createFarmServerFnTransportError(p.returnValue?.data)");
     expect(entry).not.toContain("throw p.returnValue?.data");
   });
 

--- a/packages/farmjs-plugin/src/rsc/index.ts
+++ b/packages/farmjs-plugin/src/rsc/index.ts
@@ -30,7 +30,7 @@ import type { FarmLayerEntry, ResolvedFarmLayer } from "@farm.js/core/server";
 import { farmEnvironmentFunctionsPlugin } from "@farm.js/core/environment/vite";
 import { generateRscEntry } from "./entries/rsc.js";
 import { generateSsrEntry } from "./entries/ssr.js";
-import { generateClientEntry } from "./entries/client.js";
+import { generateClientEntry, serverFnTransportErrorClientRuntime } from "./entries/client.js";
 import { transformFarmServerFns } from "./server-fn-transform.js";
 import { transformAutomaticOptimizedBoundaries } from "./automatic-optimized-boundary.js";
 import { resolveRscBuildOutputPath } from "./build-paths.js";
@@ -1040,6 +1040,7 @@ import {
   createFarmDeploymentRequestHeaders,
   isFarmDeploymentMismatchResponse,
 } from '@farm.js/core/deployment';
+${serverFnTransportErrorClientRuntime}
 const farmDeploymentId = ${JSON.stringify(entryContext.deploymentId)};
 setServerCallback(async (id, args) => {
   const refs = createTemporaryReferenceSet();
@@ -1066,9 +1067,7 @@ setServerCallback(async (id, args) => {
   if (!res.ok) throw new Error('Server action failed: ' + res.status);
   const p = await createFromReadableStream(res.body, { temporaryReferences: refs });
   if (p?.returnValue?.ok) return p.returnValue.data;
-  const error = new Error(p?.returnValue?.data?.message || 'Server function failed');
-  error.name = 'ServerActionError';
-  throw error;
+  throw createFarmServerFnTransportError(p?.returnValue?.data);
 });
 `
             : "";


### PR DESCRIPTION
## Summary

- add declared, schema-validated server-function errors with a typed error(code, data) handler helper
- preserve safe error code, status, message, and payload data across RSC and progressive form transports
- infer declared failures in useServerFn, useMutation, and useFetcher while sanitizing unexpected exceptions
- document the API and cover direct, client, security, and generated transport behavior

## Why

Expected application failures should be type-safe and usable by the UI without exposing arbitrary thrown server errors. This gives server functions a first-class error contract independent of experimental React Server Actions.

## Validation

- pnpm --filter @farm.js/core type-check
- 63 focused @farm.js/core tests
- all 37 @farm.js/plugin RSC tests, including production build boot tests
- oxfmt and git diff checks