### PR TITLE
feat: unify typed endpoint errors

### DIFF
--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -204,7 +204,7 @@ Endpoint middleware is local to one `createEndpoint` declaration and can use its
 ## Typed expected errors
 
 Declare failures that are part of an endpoint's public contract, then return them through the typed
-`fail` function:
+`error` function:
 
 ```ts
 export const POST = createEndpoint(
@@ -217,22 +217,22 @@ export const POST = createEndpoint(
       duplicate: {
         status: 409,
         message: "A product with this name already exists",
-        schema: z.object({
+        data: z.object({
           existingId: z.string(),
         }),
       },
       forbidden: {
         status: 403,
-        schema: z.object({
+        data: z.object({
           permission: z.string(),
         }),
       },
     },
   },
-  async ({ body, fail }) => {
+  async ({ body, error }) => {
     const existing = await findProductByName(body.name);
     if (existing) {
-      return fail("duplicate", {
+      return error("duplicate", {
         existingId: existing.id,
       });
     }
@@ -259,6 +259,10 @@ Farm validates the failure payload before returning a JSON error response. Decla
 payloads are public, so do not include secrets. Undeclared exceptions remain unexpected server
 errors and are not converted into a declared failure. Endpoints without an `errors` declaration
 keep the existing `Error` client type.
+
+The generated client makes this endpoint RPC-like to call, but the transport remains a regular HTTP
+request and JSON error response. Existing endpoint definitions using `schema` and `fail` continue to
+work as deprecated aliases; use `data` and `error` in new code for consistency with server functions.
 
 ## Client inference
 

--- a/packages/farm/src/__tests__/endpoint-errors.test.ts
+++ b/packages/farm/src/__tests__/endpoint-errors.test.ts
@@ -16,28 +16,28 @@ describe("typed endpoint errors", () => {
         duplicate: {
           status: 409,
           message: "A product with this name already exists",
-          schema: z.object({
+          data: z.object({
             existingId: z.string(),
           }),
         },
         forbidden: {
           status: 403,
-          schema: z.object({
+          data: z.object({
             permission: z.string(),
           }),
         },
       },
     },
-    async ({ body, fail }) => {
-      if (false) {
+    async ({ body, error }) => {
+      if (body.name === "__typecheck__") {
         // @ts-expect-error only declared endpoint error codes are accepted.
-        fail("missing", {});
+        error("missing", {});
         // @ts-expect-error duplicate errors require a string existingId.
-        fail("duplicate", { existingId: 123 });
+        error("duplicate", { existingId: 123 });
       }
 
       if (body.name === "Existing") {
-        return fail("duplicate", {
+        return error("duplicate", {
           existingId: "product-1",
         });
       }
@@ -173,7 +173,7 @@ describe("typed endpoint errors", () => {
           errors: {
             invalid: {
               status: 200,
-              schema: z.object({}),
+              data: z.object({}),
             },
           },
         },

--- a/packages/farm/src/api/endpoint.ts
+++ b/packages/farm/src/api/endpoint.ts
@@ -21,6 +21,12 @@ type InferOutput<T> = T extends { _output: infer O }
     ? R
     : unknown;
 
+type InferInput<T> = T extends { _input: infer I }
+  ? I
+  : T extends { parse: (data: infer I) => unknown }
+    ? I
+    : unknown;
+
 type InferBodyInput<T> =
   T extends MultipartSchema<AnySchema> ? TypedFormData<InferOutput<T>> : InferOutput<T>;
 
@@ -30,31 +36,60 @@ type InferHeadersOutput<T> = [T] extends [never]
     ? InferOutput<T>
     : Record<string, string>;
 
-export type EndpointErrorDefinition<
-  TSchema extends AnySchema = AnySchema,
-  TStatus extends number = number,
-> = {
+export type EndpointErrorSchema = AnySchema & { parse: (data: unknown) => unknown };
+
+type EndpointErrorDefinitionBase<TStatus extends number> = {
   status: TStatus;
-  schema: TSchema;
   /** Public message safe to expose to API callers. */
   message?: string;
 };
 
-export type EndpointErrorDefinitions = Record<string, EndpointErrorDefinition<AnySchema, number>>;
+export type EndpointErrorDefinition<
+  TSchema extends EndpointErrorSchema = EndpointErrorSchema,
+  TStatus extends number = number,
+> = EndpointErrorDefinitionBase<TStatus> &
+  (
+    | {
+        /** Schema for the public error payload exposed to API callers. */
+        data: TSchema;
+        schema?: never;
+      }
+    | {
+        data?: never;
+        /** @deprecated Use `data` for consistency with server functions. */
+        schema: TSchema;
+      }
+  );
+
+export type EndpointErrorDefinitions = Record<
+  string,
+  EndpointErrorDefinition<EndpointErrorSchema, number>
+>;
+
+type InferEndpointErrorSchema<TDefinition> = TDefinition extends {
+  data: infer TSchema extends AnySchema;
+}
+  ? TSchema
+  : TDefinition extends { schema: infer TSchema extends AnySchema }
+    ? TSchema
+    : never;
 
 export type EndpointErrorContracts<TErrors extends EndpointErrorDefinitions> = {
   [TCode in keyof TErrors]: {
-    data: InferOutput<TErrors[TCode]["schema"]>;
+    data: InferOutput<InferEndpointErrorSchema<TErrors[TCode]>>;
     status: TErrors[TCode]["status"];
   };
 };
 
-export type EndpointFail<TErrors extends EndpointErrorDefinitions> = <
+export type EndpointErrorHandler<TErrors extends EndpointErrorDefinitions> = <
   TCode extends keyof TErrors & string,
 >(
   code: TCode,
-  data: InferOutput<TErrors[TCode]["schema"]>,
+  data: InferInput<InferEndpointErrorSchema<TErrors[TCode]>>,
 ) => never;
+
+/** @deprecated Use `EndpointErrorHandler`. */
+export type EndpointFail<TErrors extends EndpointErrorDefinitions> = EndpointErrorHandler<TErrors>;
 
 export class EndpointFailure<TCode extends string = string, TData = unknown> extends Error {
   readonly code: TCode;
@@ -219,6 +254,8 @@ export type EndpointHandler<
   request: Request;
   context: Readonly<TContext>;
   params: EndpointParams;
+  error: EndpointErrorHandler<TErrors>;
+  /** @deprecated Use `error`. */
   fail: EndpointFail<TErrors>;
 }) => Promise<TResponse> | TResponse;
 
@@ -393,13 +430,13 @@ export function createEndpoint(
 
   const middleware = normalizeEndpointMiddleware(options.middleware);
   const errors = normalizeEndpointErrors(options.errors);
-  const fail = createEndpointFail(errors);
+  const error = createEndpointErrorHandler(errors);
   const wrappedHandler = (async (ctx: EndpointMiddlewareContext<any, any, any, any>) => {
     const execution = await runEndpointMiddleware(
       middleware,
       ctx,
       handler,
-      fail,
+      error,
       options.invalidates,
     );
     return execution.result;
@@ -426,7 +463,7 @@ export function createEndpoint(
   endpoint.__autoPath = !path; // Flag to indicate path should be auto-inferred
   endpoint.__handler = wrappedHandler; // Used by Farm's route runtime.
   endpoint.__farmInvoke = (ctx: EndpointMiddlewareContext<any, any, any, any>) =>
-    runEndpointMiddleware(middleware, ctx, handler, fail, options.invalidates);
+    runEndpointMiddleware(middleware, ctx, handler, error, options.invalidates);
   endpoint.__middleware = middleware;
   endpoint.__sourceHandler = handler;
   endpoint.__invalidates = options.invalidates;
@@ -474,8 +511,9 @@ function normalizeEndpointErrors(
     ) {
       throw new TypeError(`Endpoint error "${code}" status must be an integer between 400 and 599`);
     }
-    if (!definition.schema || typeof definition.schema.parse !== "function") {
-      throw new TypeError(`Endpoint error "${code}" requires a schema with parse()`);
+    const dataSchema = resolveEndpointErrorSchema(definition);
+    if (!dataSchema || typeof dataSchema.parse !== "function") {
+      throw new TypeError(`Endpoint error "${code}" requires a data schema with parse()`);
     }
     if (definition.message !== undefined && typeof definition.message !== "string") {
       throw new TypeError(`Endpoint error "${code}" message must be a string`);
@@ -487,21 +525,30 @@ function normalizeEndpointErrors(
   return Object.freeze(normalized);
 }
 
-function createEndpointFail(
+function resolveEndpointErrorSchema(
+  definition: EndpointErrorDefinition<EndpointErrorSchema, number>,
+): EndpointErrorSchema | undefined {
+  if (definition.data && definition.schema) {
+    throw new TypeError("Endpoint errors cannot define both data and schema");
+  }
+  return definition.data ?? definition.schema;
+}
+
+function createEndpointErrorHandler(
   definitions: Readonly<EndpointErrorDefinitions>,
-): EndpointFail<EndpointErrorDefinitions> {
+): EndpointErrorHandler<EndpointErrorDefinitions> {
   return ((code: string, data: unknown): never => {
     const definition = definitions[code];
     if (!definition) {
       throw new TypeError(`Endpoint error "${code}" is not declared`);
     }
 
-    const parsed = definition.schema.parse!(data);
+    const parsed = resolveEndpointErrorSchema(definition)!.parse(data);
     throw new EndpointFailure(code, parsed, {
       status: definition.status,
       message: definition.message ?? "Request failed",
     });
-  }) as EndpointFail<EndpointErrorDefinitions>;
+  }) as EndpointErrorHandler<EndpointErrorDefinitions>;
 }
 
 function normalizeEndpointMiddleware(
@@ -526,7 +573,7 @@ async function runEndpointMiddleware(
   middleware: readonly AnyEndpointMiddleware[],
   handlerContext: EndpointMiddlewareContext<any, any, any, any>,
   handler: EndpointHandler<any, any, any, any, any, EndpointErrorDefinitions>,
-  fail: EndpointFail<EndpointErrorDefinitions>,
+  error: EndpointErrorHandler<EndpointErrorDefinitions>,
   invalidations: EndpointInvalidations<any, any, any, any> | undefined,
 ): Promise<{
   result: unknown;
@@ -566,7 +613,7 @@ async function runEndpointMiddleware(
     context = mergeEndpointContext(context, result, index);
   }
 
-  const result = await handler({ ...handlerContext, context, fail });
+  const result = await handler({ ...handlerContext, context, error, fail: error });
   return {
     result,
     context,


### PR DESCRIPTION
## Summary

- make data the canonical schema field for declared endpoint error payloads
- add the typed error(code, data) handler helper
- preserve schema and fail as deprecated aliases for backward compatibility
- retain typed APIClientError reconstruction in the generated RPC-style API client
- document that endpoint calls use ordinary HTTP and JSON transport

## Why

Farm endpoints already exposed typed expected errors through the generated API client, but their schema/fail vocabulary differed from the server-function error API in #283. This aligns the developer experience without changing endpoint transport semantics or breaking existing applications.

## Developer impact

New endpoints can declare errors with data and return them through error(code, data). Existing schema/fail definitions continue to compile and run. HTTP status codes, JSON envelopes, direct endpoint calls, invalidation behavior, and generated client inference remain intact.

## Validation

- pnpm --filter @farm.js/core type-check
- 54 focused endpoint, API client, testing, invalidation, and integration tests
- oxfmt and oxlint
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies typed endpoint errors with server-function errors by making `data` the canonical payload and adding `error(code, data)` in endpoint handlers. Keeps `schema` and `fail` as deprecated aliases; HTTP/JSON transport and generated client behavior stay the same.

- **New Features**
  - Adds `error` to handler context; validates payload with the declared `data` schema and preserves typed client errors.
  - Supports `data` in error definitions and prevents using both `data` and `schema`.

- **Migration**
  - Use `data` and `error` in new endpoints; existing `schema`/`fail` continue to work.
  - No transport or client changes needed; status codes and invalidation are unchanged.

<sup>Written for commit 0f709c127e6e2cdb23a2a62c0b54be8b619f138e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

