### PR TITLE
feat: add CLI diagnostics and planning checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,10 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=8192
 
+      - name: Check committed generated types
+        if: matrix.node-version == 20
+        run: pnpm --dir docs exec farm generate --check
+
       - name: Run tests
         run: pnpm test -- ${{ matrix.test_args }}
 
@@ -82,6 +86,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Check docs navigation coverage
+        run: pnpm docs:check-navigation
 
       - name: Lint and Format Check
         run: |

--- a/docs/docs.config.ts
+++ b/docs/docs.config.ts
@@ -153,6 +153,7 @@ const sidebar = [
       { label: "Rendering Model", slug: "server-rendering", icon: "monitor" },
       { label: "Built-in Authentication", slug: "auth", icon: "lock" },
       { label: "Images", slug: "images", icon: "image" },
+      { label: "Fonts", slug: "fonts", icon: "file" },
       { label: "Environment Functions", slug: "environment-functions", icon: "code" },
       { label: "Middleware", slug: "middleware", icon: "shield" },
     ],
@@ -164,6 +165,7 @@ const sidebar = [
       { label: "Query and Params", slug: "query", icon: "search" },
       { label: "API Routes", slug: "api-routes", icon: "server" },
       { label: "API Client", slug: "api-client", icon: "terminal" },
+      { label: "Server Queries", slug: "server-queries", icon: "database" },
       { label: "KV Storage", slug: "storage", icon: "database" },
     ],
   },
@@ -265,6 +267,8 @@ const sidebar = [
     icon: "gauge",
     children: [
       { label: "Cache and PPR", slug: "cache-ppr", icon: "zap" },
+      { label: "Route Runtime", slug: "route-runtime", icon: "server" },
+      { label: "After Responses", slug: "after", icon: "timer" },
       { label: "Observability", slug: "observability", icon: "activity" },
       { label: "DevTools", slug: "devtools", icon: "monitor" },
       { label: "Cron", slug: "cron", icon: "timer" },
@@ -286,6 +290,7 @@ const sidebar = [
     icon: "wrench",
     children: [
       { label: "Plugin Ecosystem", slug: "plugins", icon: "plug" },
+      { label: "Client Plugins", slug: "plugins/client", icon: "monitor" },
       { label: "Create a Plugin", slug: "plugins/create-plugin", icon: "wrench" },
     ],
   },

--- a/docs/src/app/docs/cli/page.md
+++ b/docs/src/app/docs/cli/page.md
@@ -18,8 +18,12 @@ Use the Farm CLI to run, build, generate types, migrate apps, deploy output, and
 | farm upgrade --beta              | Upgrade installed Farm packages to the latest beta release.          |
 | farm doctor                      | Inspect a running app, or fall back to project configuration checks. |
 | farm doctor --offline            | Check project files and config without probing a dev server.         |
+| farm doctor --fix                | Apply safe, additive project corrections.                            |
+| farm explain /products/42        | Explain the files and runtime behavior for one URL.                  |
 | farm preview                     | Create a public URL for a running local app.                         |
 | farm generate                    | Generate route/API types and integration schema artifacts.           |
+| farm generate --check            | Fail when committed generated types are stale.                       |
+| farm deploy --plan               | Resolve the deployment plan without executing it.                    |
 | farm migrate inspect             | Detect supported framework migration sources.                        |
 | farm migrate next --write        | Apply a deterministic Next.js App Router migration.                  |
 | farm migrate tanstack --write    | Apply a deterministic TanStack Router file-route migration.          |
@@ -65,11 +69,20 @@ Without `--ui`, the CLI installs integration wiring. With `--ui`, it also instal
 
 ```bash
 farm generate
+farm generate --check
 ```
 
 `farm dev` refreshes generated route/API types automatically when page and API route files change. Use `farm generate` when you want to refresh the same files outside the dev server, such as in CI, before publishing a package, or after moving files while the dev server was stopped.
 
 When integration database schemas are configured, `farm generate` also writes schema artifacts if Farm can detect the data layer. Pass `--orm` and `--output` when you want explicit schema output for a migration step.
+
+`farm generate --check` computes the route, API, environment, and i18n declarations without writing to disk. It exits non-zero and lists every missing, stale, or obsolete generated file. Use it after a normal generation step when generated types are committed:
+
+```yaml
+- run: farm generate --check
+```
+
+Schema output flags such as `--orm` and `--output` cannot be combined with `--check`; database schema generation can depend on migrations and remains an explicit write operation.
 
 ## Framework migrations
 
@@ -153,6 +166,7 @@ farm doctor
 farm doctor --port 4319
 farm doctor --url http://localhost:4319
 farm doctor --offline
+farm doctor --fix
 farm doctor --json
 ```
 
@@ -162,7 +176,26 @@ Pass `--port` or `--url` when the app runs somewhere else. An explicitly request
 
 The command exits with a non-zero status only when a check fails. Warnings keep a zero exit status, so CI can distinguish broken configuration from production-readiness advice. `--json` prints the complete report without terminal formatting.
 
+`farm doctor --fix` applies only corrections Farm can make without replacing application code. Today that means creating a missing `src/app/layout.tsx`; an existing file is never overwritten. The command reruns diagnostics after each correction and reports exactly which files it created.
+
 See [DevTools and Doctor](/docs/devtools) for the browser dashboard, diagnostics, JSON contract, and CI examples.
+
+## Explain a route
+
+```bash
+farm explain /products/42
+farm explain /products/42 --json
+```
+
+`farm explain` resolves a URL against the app router without starting the app. It reports:
+
+- the matching page file, route pattern, parameters, and source layer;
+- inherited layouts and file- or config-based middleware;
+- route-rule and module runtime controls, rendering mode, PPR, and cache settings;
+- static or generated metadata and the nearest Open Graph and Twitter images;
+- the deployment target, preset, runtime compatibility, and actionable warnings.
+
+Use the text output while debugging and `--json` for tooling. The command is read-only and fails when no page route matches the supplied URL.
 
 ## Build
 
@@ -171,6 +204,15 @@ farm build
 ```
 
 `farm build` respects `deploy.target`, `output`, and provider-specific output options from `farm.config.ts`.
+
+## Plan a deployment
+
+```bash
+farm deploy --plan
+farm deploy --vercel --prod --plan
+```
+
+`farm deploy --plan` resolves the target, Nitro preset, runtime, output directory, and exact build and provider commands. It does not build, inspect build output, check credentials, or call a deployment CLI. This makes it safe to use during review and in CI policy checks.
 
 ## Cron commands
 

--- a/docs/src/app/docs/deployment/page.md
+++ b/docs/src/app/docs/deployment/page.md
@@ -273,8 +273,11 @@ export default defineConfig({
 | `farm deploy --vercel`                 | Uses `vercel deploy --prebuilt`.                        |
 | `farm deploy --cloudflare`             | Deploys the Cloudflare Pages output with Wrangler.      |
 | `farm deploy --netlify`                | Deploys the Netlify output with Netlify CLI.            |
+| `farm deploy --plan`                   | Prints the resolved build and deploy operations only.   |
 
 For other Nitro presets, use the host's documented deploy command or CI workflow after `farm build` writes the Nitro output.
+
+Use `farm deploy --plan` before a release when you want to verify the selected target, preset, runtime, output directory, and provider command. Planning is read-only: it does not run the build, require a provider login, inspect existing output, or deploy anything.
 
 ## Environment variables
 

--- a/docs/src/app/docs/deployment/page.md
+++ b/docs/src/app/docs/deployment/page.md
@@ -277,7 +277,7 @@ export default defineConfig({
 
 For other Nitro presets, use the host's documented deploy command or CI workflow after `farm build` writes the Nitro output.
 
-Use `farm deploy --plan` before a release when you want to verify the selected target, preset, runtime, output directory, and provider command. Planning is read-only: it does not run the build, require a provider login, inspect existing output, or deploy anything.
+Use `farm deploy --plan` before a release when you want to verify the selected target, preset, runtime, output directory, and exact build and provider commands. Planning is read-only: it does not run the build, require a provider login, inspect existing output, or deploy anything.
 
 ## Environment variables
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "docs:dev": "pnpm --filter @farm.js/core build && pnpm --filter farmjs-docs dev",
     "docs:build": "pnpm --filter farmjs-docs build",
     "docs:og": "node scripts/generate-docs-og.mjs",
+    "docs:check-navigation": "node scripts/check-docs-navigation.mjs",
     "build:examples": "node scripts/build-examples.js",
     "benchmark:frameworks": "node benchmarks/frameworks/run.mjs",
     "lint": "oxlint . && oxfmt --check .",

--- a/packages/farm-cli/bin/farm.js
+++ b/packages/farm-cli/bin/farm.js
@@ -144,6 +144,7 @@ program
   )
   .option("--dialect <dialect>", "SQL dialect for Drizzle generation (postgres, mysql, sqlite)")
   .option("-o, --output <output>", "Custom output path")
+  .option("--check", "Fail when committed generated framework types are stale")
   .action(async (options) => {
     try {
       const { generateFarmArtifacts } = require("../dist/index.js");
@@ -153,6 +154,7 @@ program
         orm: options.orm,
         dialect: options.dialect,
         output: options.output,
+        check: options.check,
       });
     } catch (error) {
       console.error("Failed to generate Farm artifacts:", error);
@@ -169,6 +171,7 @@ program
   .option("--host <host>", "Host of a running local app")
   .option("--url <url>", "Base URL of a running Farm app")
   .option("--offline", "Inspect project files without probing a running app")
+  .option("--fix", "Apply safe additive corrections without overwriting application files")
   .option("--timeout <ms>", "Live runtime probe timeout in milliseconds", "1200")
   .option("--json", "Print machine-readable JSON")
   .action(async (options) => {
@@ -185,12 +188,37 @@ program
         host: options.host,
         url: options.url,
         offline: options.offline,
+        fix: options.fix,
         timeoutMs,
       });
       console.log(options.json ? JSON.stringify(report, null, 2) : formatFarmDoctorReport(report));
       if (report.health === "error") process.exitCode = 1;
     } catch (error) {
       console.error("Failed to inspect Farm app:", error);
+      process.exit(1);
+    }
+  });
+
+program
+  .command("explain <path>")
+  .description("Explain how a URL maps to a Farm route and deployment runtime")
+  .option("-r, --root <root>", "Root directory", process.cwd())
+  .option("-c, --config <config>", "Path to farm config file")
+  .option("--json", "Print machine-readable JSON")
+  .action(async (pathname, options) => {
+    try {
+      const { explainFarmRoute, formatFarmRouteExplanation } = require("../dist/index.js");
+      const explanation = await explainFarmRoute(pathname, {
+        root: options.root,
+        configPath: options.config,
+      });
+      console.log(
+        options.json
+          ? JSON.stringify(explanation, null, 2)
+          : formatFarmRouteExplanation(explanation),
+      );
+    } catch (error) {
+      console.error("Failed to explain Farm route:", error);
       process.exit(1);
     }
   });
@@ -433,6 +461,7 @@ program
   .option("--cloudflare", "Deploy to Cloudflare")
   .option("--netlify", "Deploy to Netlify")
   .option("--prod", "Deploy to production (Vercel: uses prebuilt output)")
+  .option("--plan", "Print the resolved deployment plan without building or deploying")
   .option("--custom", "Use your own credentials (not Farm.js managed)")
   .action(async (options) => {
     try {

--- a/packages/farm-cli/src/deploy.ts
+++ b/packages/farm-cli/src/deploy.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from "fs";
 import path from "path";
 import {
   getPresetForDeployTarget,
+  getFarmPresetRuntime,
   loadConfig,
   logger,
   normalizeDeployTarget,
@@ -18,6 +19,20 @@ export interface DeployFarmOptions {
   cloudflare?: boolean;
   netlify?: boolean;
   prod?: boolean;
+  /** Print the resolved build and deployment operations without executing them. */
+  plan?: boolean;
+}
+
+export interface FarmDeployPlan {
+  root: string;
+  target: "vercel" | "cloudflare" | "netlify";
+  preset: string;
+  runtime: "node" | "edge" | "unknown";
+  outputDir: string;
+  production: boolean;
+  build: { command: string; cwd: string };
+  deploy: { command: string; cwd: string };
+  cloudflareAgent?: CloudflareAgentDeployPlan;
 }
 
 export interface CloudflareAgentDeployPlan {
@@ -29,10 +44,55 @@ export interface CloudflareAgentDeployPlan {
  * Deploy Farm.js application
  */
 export async function deployFarm(options: DeployFarmOptions = {}) {
-  const root = options.root || process.cwd();
+  const { plan, deployConfig } = await resolveFarmDeployContext(options);
+
+  if (options.plan) {
+    logger.info(formatFarmDeployPlan(plan));
+    return plan;
+  }
+
+  logger.info(`🚀 Building with ${plan.preset} preset...`);
+  await buildFarm({ root: plan.root, preset: plan.preset });
+
+  if (!existsSync(plan.outputDir)) {
+    throw new Error(`Build output not found at ${plan.outputDir}. Please run 'farm build' first.`);
+  }
+
+  await deployPlatform(plan.target, plan.root, plan.outputDir, deployConfig, options.prod);
+  return plan;
+}
+
+export async function createFarmDeployPlan(
+  options: DeployFarmOptions = {},
+): Promise<FarmDeployPlan> {
+  return (await resolveFarmDeployContext(options)).plan;
+}
+
+export function formatFarmDeployPlan(plan: FarmDeployPlan): string {
+  return [
+    "FARM / DEPLOY PLAN",
+    "",
+    `Target:     ${plan.target}`,
+    `Preset:     ${plan.preset}`,
+    `Runtime:    ${plan.runtime}`,
+    `Output:     ${plan.outputDir}`,
+    `Production: ${plan.production ? "yes" : "no"}`,
+    "",
+    `1. ${plan.build.command}`,
+    `   cwd: ${plan.build.cwd}`,
+    `2. ${plan.deploy.command}`,
+    `   cwd: ${plan.deploy.cwd}`,
+    ...(plan.cloudflareAgent
+      ? ["", `Cloudflare Agent config: ${plan.cloudflareAgent.configPath}`]
+      : []),
+  ].join("\n");
+}
+
+async function resolveFarmDeployContext(options: DeployFarmOptions) {
+  const root = path.resolve(options.root || process.cwd());
   const mode = "production";
   const userConfig = await loadConfig(root, undefined, mode);
-  const config = userConfig ? await resolveConfig(userConfig, mode) : undefined;
+  const config = await resolveConfig({ root, ...userConfig }, mode);
 
   // Determine platform and preset
   const cliTarget = options.vercel
@@ -42,13 +102,12 @@ export async function deployFarm(options: DeployFarmOptions = {}) {
       : options.netlify
         ? "netlify"
         : undefined;
-  const platform = normalizeDeployTarget(cliTarget || config?.deploy.target);
+  const platform = normalizeDeployTarget(cliTarget || config.deploy.target);
 
   if (platform !== "vercel" && platform !== "cloudflare" && platform !== "netlify") {
-    logger.error(
+    throw new Error(
       "Please specify a deployment target with --vercel, --cloudflare, --netlify, or farm.config deploy.target.",
     );
-    process.exit(1);
   }
 
   const deployConfig = resolveDeployConfig(userConfig || {}, {
@@ -58,20 +117,68 @@ export async function deployFarm(options: DeployFarmOptions = {}) {
       : undefined,
   });
   const preset = deployConfig.preset || getPresetForDeployTarget(platform) || "node-server";
-
-  // Build with the correct preset
-  logger.info(`🚀 Building with ${preset} preset...`);
-  await buildFarm({ root, preset });
-
   const nitroOutput = resolveDeployOutputPath(root, deployConfig.outputDir);
+  const cloudflareAgent =
+    platform === "cloudflare" ? resolveCloudflareAgentDeployPlan(root) : undefined;
+  const deploy = createDeployCommand(
+    platform,
+    root,
+    nitroOutput,
+    deployConfig,
+    options.prod,
+    cloudflareAgent,
+  );
+  const plan: FarmDeployPlan = {
+    root: path.resolve(root),
+    target: platform,
+    preset,
+    runtime: getFarmPresetRuntime(preset),
+    outputDir: nitroOutput,
+    production: Boolean(options.prod),
+    build: {
+      command: `farm build --preset ${preset}`,
+      cwd: path.resolve(root),
+    },
+    deploy,
+    ...(cloudflareAgent ? { cloudflareAgent } : {}),
+  };
 
-  if (!existsSync(nitroOutput)) {
-    logger.error(`Build output not found at ${nitroOutput}. Please run 'farm build' first.`);
-    process.exit(1);
+  return { plan, deployConfig };
+}
+
+function createDeployCommand(
+  platform: FarmDeployPlan["target"],
+  root: string,
+  outputDir: string,
+  deployConfig: ReturnType<typeof resolveDeployConfig>,
+  prod: boolean | undefined,
+  cloudflareAgent: CloudflareAgentDeployPlan | undefined,
+): FarmDeployPlan["deploy"] {
+  if (platform === "vercel") {
+    return {
+      command: `vercel deploy --prebuilt --yes${prod ? " --prod" : ""}`,
+      cwd: path.resolve(root),
+    };
   }
-
-  // Deploy using platform CLI (always uses user's credentials)
-  await deployPlatform(platform, root, nitroOutput, deployConfig, options.prod);
+  if (platform === "netlify") {
+    const site = deployConfig.netlify?.site;
+    return {
+      command: `netlify deploy --prod --dir=.${site ? ` --site=${site}` : ""}`,
+      cwd: outputDir,
+    };
+  }
+  if (cloudflareAgent) {
+    return {
+      command: `wrangler deploy --config ${cloudflareAgent.configPath}${cloudflareAgent.environment ? ` --env ${cloudflareAgent.environment}` : ""}`,
+      cwd: path.resolve(root),
+    };
+  }
+  const projectName =
+    deployConfig.cloudflare?.projectName || deployConfig.projectName || "farm-app";
+  return {
+    command: `wrangler pages deploy . --project-name=${projectName}`,
+    cwd: outputDir,
+  };
 }
 
 /**

--- a/packages/farm-cli/src/deploy.ts
+++ b/packages/farm-cli/src/deploy.ts
@@ -38,6 +38,8 @@ export interface FarmDeployPlan {
 export interface CloudflareAgentDeployPlan {
   configPath: string;
   environment?: string;
+  /** The integration will create this config as part of the production build. */
+  generated?: boolean;
 }
 
 /**
@@ -83,7 +85,10 @@ export function formatFarmDeployPlan(plan: FarmDeployPlan): string {
     `2. ${plan.deploy.command}`,
     `   cwd: ${plan.deploy.cwd}`,
     ...(plan.cloudflareAgent
-      ? ["", `Cloudflare Agent config: ${plan.cloudflareAgent.configPath}`]
+      ? [
+          "",
+          `Cloudflare Agent config: ${plan.cloudflareAgent.configPath}${plan.cloudflareAgent.generated ? " (generated during build)" : ""}`,
+        ]
       : []),
   ].join("\n");
 }
@@ -119,7 +124,10 @@ async function resolveFarmDeployContext(options: DeployFarmOptions) {
   const preset = deployConfig.preset || getPresetForDeployTarget(platform) || "node-server";
   const nitroOutput = resolveDeployOutputPath(root, deployConfig.outputDir);
   const cloudflareAgent =
-    platform === "cloudflare" ? resolveCloudflareAgentDeployPlan(root) : undefined;
+    platform === "cloudflare"
+      ? resolveCloudflareAgentDeployPlan(root) ||
+        resolveConfiguredCloudflareAgentDeployPlan(root, config.integrations)
+      : undefined;
   const deploy = createDeployCommand(
     platform,
     root,
@@ -134,7 +142,7 @@ async function resolveFarmDeployContext(options: DeployFarmOptions) {
     preset,
     runtime: getFarmPresetRuntime(preset),
     outputDir: nitroOutput,
-    production: Boolean(options.prod),
+    production: platform === "netlify" || Boolean(options.prod),
     build: {
       command: `farm build --preset ${preset}`,
       cwd: path.resolve(root),
@@ -494,6 +502,48 @@ export function resolveCloudflareAgentDeployPlan(
     configPath,
     ...(typeof environment === "string" ? { environment: environment.trim() } : {}),
   };
+}
+
+function resolveConfiguredCloudflareAgentDeployPlan(
+  root: string,
+  integrations: Record<string, unknown> | undefined,
+): CloudflareAgentDeployPlan | undefined {
+  const integration = Object.values(integrations || {}).find(
+    (value) =>
+      isRecord(value) &&
+      value.category === "agent" &&
+      value.type === "cloudflare" &&
+      value.serverRuntime === false,
+  );
+  if (!isRecord(integration) || !isRecord(integration.instance)) return undefined;
+
+  const configuredPath = integration.instance.config;
+  if (typeof configuredPath !== "string" || !configuredPath.trim()) return undefined;
+
+  const projectRoot = path.resolve(root);
+  const sourceConfigPath = path.resolve(projectRoot, configuredPath);
+  assertPathInsideProject(projectRoot, sourceConfigPath, "Cloudflare Agents source config");
+  const configPath = path.join(path.dirname(sourceConfigPath), ".farm-cf-agent.wrangler.jsonc");
+  const environment = integration.instance.environment;
+
+  return {
+    configPath,
+    ...(typeof environment === "string" && environment.trim()
+      ? { environment: environment.trim() }
+      : {}),
+    generated: true,
+  };
+}
+
+function assertPathInsideProject(projectRoot: string, candidate: string, label: string): void {
+  const relativePath = path.relative(projectRoot, candidate);
+  if (
+    relativePath === ".." ||
+    relativePath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativePath)
+  ) {
+    throw new Error(`${label} must stay inside the Farm project root.`);
+  }
 }
 
 function assertWranglerInstalled(root: string): void {

--- a/packages/farm-cli/src/doctor.ts
+++ b/packages/farm-cli/src/doctor.ts
@@ -5,7 +5,7 @@ import {
   type FarmCronJob,
   type ResolvedFarmConfig,
 } from "@farm.js/core";
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import pc from "picocolors";
 
@@ -45,6 +45,13 @@ export interface FarmDoctorReport {
   };
   summary: Record<FarmDoctorCheckStatus, number>;
   checks: FarmDoctorCheck[];
+  fixes?: FarmDoctorFix[];
+}
+
+export interface FarmDoctorFix {
+  code: string;
+  title: string;
+  filePath: string;
 }
 
 export interface FarmDoctorOptions {
@@ -58,6 +65,8 @@ export interface FarmDoctorOptions {
   fetch?: typeof globalThis.fetch;
   env?: Record<string, string | undefined>;
   now?: () => Date;
+  /** Apply only additive corrections that never overwrite application files. */
+  fix?: boolean;
 }
 
 type LiveSnapshot = {
@@ -107,7 +116,7 @@ export async function runFarmDoctor(options: FarmDoctorOptions = {}): Promise<Fa
   const liveTarget = resolveLiveTarget(options);
   let liveError: string | undefined;
 
-  if (!options.offline) {
+  if (!options.offline && !options.fix) {
     try {
       const snapshot = await fetchLiveSnapshot(liveTarget, options);
       return createLiveReport(snapshot, liveTarget, options.now);
@@ -161,6 +170,13 @@ export function formatFarmDoctorReport(
     `${report.summary.fail} failed`,
     `${report.summary.info} info`,
   ].join(" / ");
+  if (report.fixes?.length) {
+    lines.push("", color.bold("FIXED"));
+    for (const fix of report.fixes) {
+      lines.push(`  ${color.green("✓")} ${fix.title}`);
+      lines.push(`    ${color.dim(fix.filePath)}`);
+    }
+  }
   lines.push("", `${color.bold("SUMMARY")}  ${summary}`);
   if (report.target?.devtoolsUrl) {
     lines.push(`${color.bold("DEVTOOLS")} ${report.target.devtoolsUrl}`);
@@ -316,8 +332,43 @@ async function createProjectReport(
     collectCronChecks(config, options.env || process.env, checks);
   }
 
+  if (config && options.fix) {
+    const fixes = applySafeProjectFixes(root, config, checks);
+    if (fixes.length) {
+      const refreshed = await createProjectReport(root, { ...options, fix: false });
+      refreshed.fixes = fixes;
+      return refreshed;
+    }
+    report.fixes = [];
+  }
+
   finalizeReport(report);
   return report;
+}
+
+function applySafeProjectFixes(
+  root: string,
+  config: ResolvedFarmConfig,
+  checks: readonly FarmDoctorCheck[],
+): FarmDoctorFix[] {
+  const fixes: FarmDoctorFix[] = [];
+  if (checks.some((check) => check.code === "ROOT_LAYOUT_MISSING")) {
+    const layoutPath = path.join(root, config.srcDir, "app", "layout.tsx");
+    if (!existsSync(layoutPath)) {
+      mkdirSync(path.dirname(layoutPath), { recursive: true });
+      writeFileSync(
+        layoutPath,
+        `import type { ReactNode } from "react";\n\nexport default function RootLayout({ children }: { children: ReactNode }) {\n  return (\n    <html lang="en">\n      <body>{children}</body>\n    </html>\n  );\n}\n`,
+        { encoding: "utf8", flag: "wx" },
+      );
+      fixes.push({
+        code: "ROOT_LAYOUT_CREATED",
+        title: "Created the missing root layout",
+        filePath: path.relative(root, layoutPath),
+      });
+    }
+  }
+  return fixes;
 }
 
 function collectNodeCheck(checks: FarmDoctorCheck[]): void {

--- a/packages/farm-cli/src/doctor.ts
+++ b/packages/farm-cli/src/doctor.ts
@@ -305,7 +305,8 @@ async function createProjectReport(
         action: "Add farm.config.ts and export defineConfig({...}).",
       });
     } else {
-      config = await resolveConfig({ root, ...userConfig }, "development");
+      const configRoot = path.resolve(root, userConfig.root || ".");
+      config = await resolveConfig({ ...userConfig, root: configRoot }, "development");
       const configFile = findConfigFile(root, options.configPath);
       checks.push({
         status: "pass",
@@ -353,7 +354,7 @@ function applySafeProjectFixes(
 ): FarmDoctorFix[] {
   const fixes: FarmDoctorFix[] = [];
   if (checks.some((check) => check.code === "ROOT_LAYOUT_MISSING")) {
-    const layoutPath = path.join(root, config.srcDir, "app", "layout.tsx");
+    const layoutPath = path.join(config.root, config.srcDir, "app", "layout.tsx");
     if (!existsSync(layoutPath)) {
       mkdirSync(path.dirname(layoutPath), { recursive: true });
       writeFileSync(

--- a/packages/farm-cli/src/explain.ts
+++ b/packages/farm-cli/src/explain.ts
@@ -1,0 +1,573 @@
+import {
+  farmRouteRuleMatches,
+  getFarmSourceRoots,
+  getFarmPresetRuntime,
+  loadConfig,
+  mergeFarmRouteRuntimeConfigs,
+  resolveConfig,
+  resolveFarmRouteRuleRuntimeConfig,
+  resolveFarmRouteRuntimeConfig,
+  resolveRouteRenderingConfig,
+  type FarmRouteRule,
+  type FarmRouteRuntimeConfig,
+} from "@farm.js/core";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import pc from "picocolors";
+
+const ROUTE_EXTENSIONS = ["tsx", "ts", "jsx", "js", "mdx", "md"] as const;
+const MIDDLEWARE_EXTENSIONS = ["ts", "tsx", "js", "jsx", "mjs", "cjs"] as const;
+const SOCIAL_IMAGE_EXTENSIONS = [
+  "tsx",
+  "ts",
+  "jsx",
+  "js",
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+] as const;
+
+export interface ExplainFarmRouteOptions {
+  root?: string;
+  configPath?: string;
+}
+
+export interface FarmRouteExplanation {
+  pathname: string;
+  pattern: string;
+  params: Record<string, string | string[]>;
+  filePath: string;
+  source: string;
+  layouts: string[];
+  middleware: Array<{ source: "file" | "config"; filePath: string }>;
+  runtime: {
+    runtime: "auto" | "node" | "edge";
+    regions?: string[];
+    maxDuration?: number;
+  };
+  rendering: {
+    mode: "static" | "partial" | "dynamic" | "client";
+    reason: string;
+    ppr: boolean;
+  };
+  cache: {
+    revalidate?: number | false;
+    swr?: number | boolean;
+    isr?: number | boolean;
+    rules: string[];
+  };
+  metadata: {
+    static: string[];
+    dynamic: string[];
+    openGraphImage?: string;
+    twitterImage?: string;
+  };
+  deployment: {
+    target: string;
+    preset: string;
+    runtime: "node" | "edge" | "unknown";
+    compatible: boolean;
+    warnings: string[];
+  };
+}
+
+type PageCandidate = {
+  appDirectory: string;
+  filePath: string;
+  pattern: string;
+  params: Record<string, string | string[]>;
+  source: string;
+  priority: number;
+  score: number;
+};
+
+export async function explainFarmRoute(
+  pathname: string,
+  options: ExplainFarmRouteOptions = {},
+): Promise<FarmRouteExplanation> {
+  const root = path.resolve(options.root || process.cwd());
+  const userConfig = await loadConfig(root, options.configPath, "production");
+  const config = await resolveConfig({ root, ...userConfig }, "production");
+  const normalizedPathname = normalizePathname(pathname, config.basePath || "/");
+  const candidates = discoverMatchingPages(config, normalizedPathname);
+  const page = candidates.sort(
+    (left, right) => right.score - left.score || right.priority - left.priority,
+  )[0];
+
+  if (!page) {
+    throw new Error(`No Farm page route matches ${normalizedPathname}.`);
+  }
+
+  const pageDirectory = path.dirname(page.filePath);
+  const layouts = collectInheritedFiles(
+    page.appDirectory,
+    pageDirectory,
+    "layout",
+    ROUTE_EXTENSIONS,
+  );
+  const middleware = collectMiddleware(
+    root,
+    Boolean(userConfig?.middleware && Object.keys(userConfig.middleware).length),
+    page.appDirectory,
+    pageDirectory,
+  );
+  const pageSource = readFileSync(page.filePath, "utf8");
+  const layoutSources = layouts.map((filePath) => ({
+    filePath,
+    source: readFileSync(filePath, "utf8"),
+  }));
+  const runtime = resolveFarmRouteRuntimeConfig(
+    mergeFarmRouteRuntimeConfigs(
+      resolveFarmRouteRuleRuntimeConfig(normalizedPathname, config.routeRules),
+      ...layoutSources.map(({ source }) => readRuntimeExports(source)),
+      readRuntimeExports(pageSource),
+    ),
+    `Route ${page.pattern}`,
+  );
+  const matchingRules = Object.entries(config.routeRules)
+    .filter(([pattern]) => farmRouteRuleMatches(pattern, normalizedPathname))
+    .sort(([left], [right]) => routeSpecificity(left) - routeSpecificity(right));
+  const rendering = resolveRendering(pageSource, matchingRules);
+  const cache = resolveCaching(pageSource, matchingRules);
+  const metadataSources = [...layoutSources, { filePath: page.filePath, source: pageSource }];
+  const openGraphImage = findNearestSocialImage(
+    page.appDirectory,
+    pageDirectory,
+    "opengraph-image",
+  );
+  const twitterImage = findNearestSocialImage(page.appDirectory, pageDirectory, "twitter-image");
+  const preset = String(config.deploy.preset || config.preset || "node-server");
+  const presetRuntime = getFarmPresetRuntime(preset);
+  const compatible =
+    rendering.mode === "static" ||
+    rendering.mode === "client" ||
+    runtime.runtime === "auto" ||
+    presetRuntime === "unknown" ||
+    runtime.runtime === presetRuntime;
+  const warnings: string[] = [];
+  if (!compatible) {
+    warnings.push(
+      `The route requires ${runtime.runtime}, but the ${preset} preset emits ${presetRuntime} functions.`,
+    );
+  }
+  if (runtime.regions?.length && preset !== "vercel" && preset !== "vercel-edge") {
+    warnings.push(`${preset} does not map Farm per-route region hints.`);
+  }
+  if (runtime.maxDuration && preset !== "vercel") {
+    warnings.push(`${preset} does not map Farm per-route maxDuration.`);
+  }
+
+  return {
+    pathname: normalizedPathname,
+    pattern: page.pattern,
+    params: page.params,
+    filePath: toProjectPath(root, page.filePath),
+    source: page.source,
+    layouts: layouts.map((filePath) => toProjectPath(root, filePath)),
+    middleware,
+    runtime,
+    rendering,
+    cache,
+    metadata: {
+      static: metadataSources
+        .filter(({ source }) => /export\s+const\s+metadata\b/.test(source))
+        .map(({ filePath }) => toProjectPath(root, filePath)),
+      dynamic: metadataSources
+        .filter(({ source }) =>
+          /export\s+(?:async\s+)?function\s+generateMetadata\b|export\s+const\s+generateMetadata\b/.test(
+            source,
+          ),
+        )
+        .map(({ filePath }) => toProjectPath(root, filePath)),
+      ...(openGraphImage ? { openGraphImage: toProjectPath(root, openGraphImage) } : {}),
+      ...(twitterImage ? { twitterImage: toProjectPath(root, twitterImage) } : {}),
+    },
+    deployment: {
+      target: String(config.deploy.target || "node"),
+      preset,
+      runtime: presetRuntime,
+      compatible,
+      warnings,
+    },
+  };
+}
+
+export function formatFarmRouteExplanation(
+  explanation: FarmRouteExplanation,
+  options: { color?: boolean } = {},
+): string {
+  const color = options.color === undefined ? pc : pc.createColors(options.color);
+  const lines = [
+    color.bold("FARM / EXPLAIN"),
+    "",
+    `${color.bold("Path")}       ${explanation.pathname}`,
+    `${color.bold("Pattern")}    ${explanation.pattern}`,
+    `${color.bold("File")}       ${explanation.filePath}`,
+    `${color.bold("Source")}     ${explanation.source}`,
+    `${color.bold("Params")}     ${formatParams(explanation.params)}`,
+    `${color.bold("Layouts")}    ${explanation.layouts.length ? explanation.layouts.join(" -> ") : "none"}`,
+    `${color.bold("Middleware")} ${explanation.middleware.length ? explanation.middleware.map((entry) => entry.filePath).join(", ") : "none"}`,
+    `${color.bold("Runtime")}    ${formatRuntime(explanation.runtime)}`,
+    `${color.bold("Rendering")}  ${explanation.rendering.mode} (${explanation.rendering.reason})${explanation.rendering.ppr ? ", PPR" : ""}`,
+    `${color.bold("Caching")}    ${formatCaching(explanation.cache)}`,
+    `${color.bold("Metadata")}   ${formatMetadata(explanation.metadata)}`,
+    `${color.bold("Deployment")} ${explanation.deployment.target} / ${explanation.deployment.preset} — ${explanation.deployment.compatible ? color.green("compatible") : color.red("incompatible")}`,
+  ];
+  for (const warning of explanation.deployment.warnings)
+    lines.push(`  ${color.yellow("!")} ${warning}`);
+  return lines.join("\n");
+}
+
+function discoverMatchingPages(
+  config: Awaited<ReturnType<typeof resolveConfig>>,
+  pathname: string,
+) {
+  const candidates: PageCandidate[] = [];
+  for (const [priority, source] of getFarmSourceRoots(config).entries()) {
+    const appDirectory = path.join(source.root, source.srcDir, "app");
+    if (!existsSync(appDirectory)) continue;
+    for (const filePath of walkFiles(appDirectory)) {
+      if (!/^page\.(?:tsx?|jsx?|mdx?)$/.test(path.basename(filePath))) continue;
+      const relativeDirectory = path.relative(appDirectory, path.dirname(filePath));
+      if (relativeDirectory.split(path.sep).includes("api")) continue;
+      const pattern = directoryToRoutePattern(relativeDirectory);
+      const match = matchRoutePattern(pattern, pathname);
+      if (!match) continue;
+      candidates.push({
+        appDirectory,
+        filePath,
+        pattern,
+        params: match.params,
+        score: match.score,
+        source: source.name,
+        priority,
+      });
+    }
+  }
+  return candidates;
+}
+
+function walkFiles(directory: string): string[] {
+  const files: string[] = [];
+  const pending = [directory];
+  while (pending.length) {
+    const current = pending.pop()!;
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) pending.push(entryPath);
+      else files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+function directoryToRoutePattern(relativeDirectory: string): string {
+  const segments = relativeDirectory
+    .split(path.sep)
+    .filter(Boolean)
+    .filter((segment) => !/^\(.+\)$/.test(segment) && !segment.startsWith("@"))
+    .map((segment) => segment.replace(/^\(\.{1,3}\)/, ""));
+  return segments.length ? `/${segments.join("/")}` : "/";
+}
+
+function matchRoutePattern(pattern: string, pathname: string) {
+  const patternSegments = splitPath(pattern);
+  const pathSegments = splitPath(pathname);
+  const params: Record<string, string | string[]> = {};
+  let score = 0;
+  let pathIndex = 0;
+
+  for (const segment of patternSegments) {
+    const optionalCatchAll = segment.match(/^\[\[\.\.\.(.+)\]\]$/);
+    if (optionalCatchAll) {
+      params[optionalCatchAll[1]] = pathSegments.slice(pathIndex);
+      pathIndex = pathSegments.length;
+      score += 1;
+      continue;
+    }
+    const catchAll = segment.match(/^\[\.\.\.(.+)\]$/);
+    if (catchAll) {
+      if (pathIndex >= pathSegments.length) return null;
+      params[catchAll[1]] = pathSegments.slice(pathIndex);
+      pathIndex = pathSegments.length;
+      score += 10;
+      continue;
+    }
+    const dynamic = segment.match(/^\[(.+)\]$/);
+    if (dynamic) {
+      if (pathIndex >= pathSegments.length) return null;
+      params[dynamic[1]] = pathSegments[pathIndex++];
+      score += 50;
+      continue;
+    }
+    if (segment !== pathSegments[pathIndex++]) return null;
+    score += 100;
+  }
+
+  return pathIndex === pathSegments.length ? { params, score } : null;
+}
+
+function collectInheritedFiles(
+  appDirectory: string,
+  leafDirectory: string,
+  baseName: string,
+  extensions: readonly string[],
+): string[] {
+  const directories: string[] = [];
+  let current = leafDirectory;
+  while (current === appDirectory || current.startsWith(`${appDirectory}${path.sep}`)) {
+    directories.unshift(current);
+    if (current === appDirectory) break;
+    current = path.dirname(current);
+  }
+  return directories
+    .map((directory) => findFile(directory, baseName, extensions))
+    .filter((filePath): filePath is string => Boolean(filePath));
+}
+
+function collectMiddleware(
+  root: string,
+  hasConfigMiddleware: boolean,
+  appDirectory: string,
+  pageDirectory: string,
+): FarmRouteExplanation["middleware"] {
+  const files = collectInheritedFiles(
+    appDirectory,
+    pageDirectory,
+    "middleware",
+    MIDDLEWARE_EXTENSIONS,
+  );
+  const sourceRoot = path.dirname(appDirectory);
+  const rootMiddleware = findFile(sourceRoot, "middleware", MIDDLEWARE_EXTENSIONS);
+  if (rootMiddleware) files.unshift(rootMiddleware);
+  const uniqueFiles = [...new Set(files)];
+  return [
+    ...(hasConfigMiddleware
+      ? [{ source: "config" as const, filePath: "farm.config (middleware)" }]
+      : []),
+    ...uniqueFiles.map((filePath) => ({
+      source: "file" as const,
+      filePath: toProjectPath(root, filePath),
+    })),
+  ];
+}
+
+function findNearestSocialImage(appDirectory: string, leafDirectory: string, baseName: string) {
+  let current = leafDirectory;
+  while (current === appDirectory || current.startsWith(`${appDirectory}${path.sep}`)) {
+    const filePath = findFile(current, baseName, SOCIAL_IMAGE_EXTENSIONS);
+    if (filePath) return filePath;
+    if (current === appDirectory) break;
+    current = path.dirname(current);
+  }
+  return undefined;
+}
+
+function findFile(directory: string, baseName: string, extensions: readonly string[]) {
+  return extensions
+    .map((extension) => path.join(directory, `${baseName}.${extension}`))
+    .find(existsSync);
+}
+
+function readRuntimeExports(source: string): FarmRouteRuntimeConfig {
+  const runtime = readStringExport(source, "runtime");
+  const maxDuration = readNumberOrAutoExport(source, "maxDuration");
+  const regions = readStringArrayOrAutoExport(source, "regions");
+  return {
+    ...(runtime === "auto" || runtime === "node" || runtime === "edge" ? { runtime } : {}),
+    ...(regions ? { regions } : {}),
+    ...(maxDuration !== undefined ? { maxDuration } : {}),
+  };
+}
+
+function resolveRendering(
+  pageSource: string,
+  matchingRules: Array<[string, FarmRouteRule]>,
+): FarmRouteExplanation["rendering"] {
+  const pageRendering = resolveRouteRenderingConfig(
+    {
+      ...(readBooleanExport(pageSource, "ssg") !== undefined
+        ? { ssg: readBooleanExport(pageSource, "ssg") }
+        : {}),
+      ...(readBooleanExport(pageSource, "ppr") !== undefined
+        ? { ppr: readBooleanExport(pageSource, "ppr") }
+        : {}),
+      ...(readBooleanExport(pageSource, "experimental_ppr") !== undefined
+        ? { experimental_ppr: readBooleanExport(pageSource, "experimental_ppr") }
+        : {}),
+      ...(readNumberOrFalseExport(pageSource, "revalidate") !== undefined
+        ? { revalidate: readNumberOrFalseExport(pageSource, "revalidate") }
+        : {}),
+      ...(readDynamicExport(pageSource) ? { dynamic: readDynamicExport(pageSource) } : {}),
+    },
+    pageSource,
+  );
+  let mode: FarmRouteExplanation["rendering"]["mode"] = pageRendering.ssg
+    ? "static"
+    : pageRendering.ppr
+      ? "partial"
+      : "dynamic";
+  let reason = pageRendering.directive
+    ? `page directive ${JSON.stringify(pageRendering.directive)}`
+    : pageRendering.ssg
+      ? "page static rendering declaration"
+      : pageRendering.ppr
+        ? "page PPR declaration"
+        : "default server rendering";
+  let ppr = pageRendering.ppr;
+
+  for (const [pattern, rule] of matchingRules) {
+    if (rule.prerender === true || rule.render === "static") {
+      mode = "static";
+      reason = `routeRules ${pattern}`;
+      ppr = false;
+    } else if (rule.prerender === false || rule.render === "dynamic" || rule.ssr === true) {
+      mode = "dynamic";
+      reason = `routeRules ${pattern}`;
+      ppr = false;
+    } else if (rule.ssr === false) {
+      mode = "client";
+      reason = `routeRules ${pattern}`;
+      ppr = false;
+    }
+  }
+  return { mode, reason, ppr };
+}
+
+function resolveCaching(
+  pageSource: string,
+  matchingRules: Array<[string, FarmRouteRule]>,
+): FarmRouteExplanation["cache"] {
+  let swr: number | boolean | undefined;
+  let isr: number | boolean | undefined;
+  for (const [, rule] of matchingRules) {
+    if (typeof rule.swr === "number" || typeof rule.swr === "boolean") swr = rule.swr;
+    if (typeof rule.isr === "number" || typeof rule.isr === "boolean") isr = rule.isr;
+  }
+  return {
+    ...(readNumberOrFalseExport(pageSource, "revalidate") !== undefined
+      ? { revalidate: readNumberOrFalseExport(pageSource, "revalidate") }
+      : {}),
+    ...(swr !== undefined ? { swr } : {}),
+    ...(isr !== undefined ? { isr } : {}),
+    rules: matchingRules.map(([pattern]) => pattern),
+  };
+}
+
+function readStringExport(source: string, name: string): string | undefined {
+  return source.match(new RegExp(`export\\s+const\\s+${name}\\s*=\\s*["']([^"']+)["']`))?.[1];
+}
+
+function readDynamicExport(
+  source: string,
+): "auto" | "force-dynamic" | "error" | "force-static" | undefined {
+  const dynamic = readStringExport(source, "dynamic");
+  return dynamic === "auto" ||
+    dynamic === "force-dynamic" ||
+    dynamic === "error" ||
+    dynamic === "force-static"
+    ? dynamic
+    : undefined;
+}
+
+function readBooleanExport(source: string, name: string): boolean | undefined {
+  const value = source.match(new RegExp(`export\\s+const\\s+${name}\\s*=\\s*(true|false)`))?.[1];
+  return value === undefined ? undefined : value === "true";
+}
+
+function readNumberOrAutoExport(source: string, name: string): number | "auto" | undefined {
+  const value = source.match(
+    new RegExp(`export\\s+const\\s+${name}\\s*=\\s*(?:["'](auto)["']|(\\d+))`),
+  );
+  return value?.[1] === "auto" ? "auto" : value?.[2] ? Number(value[2]) : undefined;
+}
+
+function readNumberOrFalseExport(source: string, name: string): number | false | undefined {
+  const value = source.match(new RegExp(`export\\s+const\\s+${name}\\s*=\\s*(false|\\d+)`))?.[1];
+  return value === "false" ? false : value ? Number(value) : undefined;
+}
+
+function readStringArrayOrAutoExport(source: string, name: string): "auto" | string[] | undefined {
+  const auto = source.match(new RegExp(`export\\s+const\\s+${name}\\s*=\\s*["']auto["']`));
+  if (auto) return "auto";
+  const array = source.match(new RegExp(`export\\s+const\\s+${name}\\s*=\\s*\\[([^\\]]*)\\]`))?.[1];
+  if (array === undefined) return undefined;
+  return [...array.matchAll(/["']([^"']+)["']/g)].map((match) => match[1]);
+}
+
+function routeSpecificity(pattern: string): number {
+  return splitPath(pattern).reduce((score, segment) => {
+    if (segment === "**" || segment.startsWith("[[...")) return score + 1;
+    if (segment === "*" || segment.startsWith("[...")) return score + 10;
+    if (segment.startsWith("[") || segment.startsWith(":")) return score + 50;
+    return score + 100;
+  }, 0);
+}
+
+function normalizePathname(value: string, basePath: string): string {
+  let pathname: string;
+  try {
+    pathname = new URL(value, "http://farm.local").pathname;
+  } catch {
+    pathname = value;
+  }
+  pathname = pathname.startsWith("/") ? pathname : `/${pathname}`;
+  const normalizedBase =
+    basePath && basePath !== "/" ? `/${basePath.replace(/^\/+|\/+$/g, "")}` : "";
+  if (
+    normalizedBase &&
+    (pathname === normalizedBase || pathname.startsWith(`${normalizedBase}/`))
+  ) {
+    pathname = pathname.slice(normalizedBase.length) || "/";
+  }
+  return pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
+}
+
+function splitPath(value: string) {
+  return value.split("/").filter(Boolean).map(decodeURIComponent);
+}
+
+function toProjectPath(root: string, filePath: string) {
+  return path.relative(root, filePath).split(path.sep).join("/");
+}
+
+function formatParams(params: FarmRouteExplanation["params"]) {
+  const entries = Object.entries(params);
+  return entries.length
+    ? entries
+        .map(([key, value]) => `${key}=${Array.isArray(value) ? value.join("/") : value}`)
+        .join(", ")
+    : "none";
+}
+
+function formatRuntime(runtime: FarmRouteExplanation["runtime"]) {
+  return [
+    runtime.runtime,
+    runtime.regions?.length ? `regions=${runtime.regions.join(",")}` : "",
+    runtime.maxDuration ? `maxDuration=${runtime.maxDuration}s` : "",
+  ]
+    .filter(Boolean)
+    .join(", ");
+}
+
+function formatCaching(cache: FarmRouteExplanation["cache"]) {
+  const values = [
+    cache.revalidate !== undefined ? `revalidate=${cache.revalidate}` : "",
+    cache.swr !== undefined ? `swr=${cache.swr}` : "",
+    cache.isr !== undefined ? `isr=${cache.isr}` : "",
+    cache.rules.length ? `rules=${cache.rules.join(",")}` : "",
+  ].filter(Boolean);
+  return values.length ? values.join("; ") : "request-time / no declared cache";
+}
+
+function formatMetadata(metadata: FarmRouteExplanation["metadata"]) {
+  const values = [
+    metadata.static.length ? `static=${metadata.static.join(",")}` : "",
+    metadata.dynamic.length ? `dynamic=${metadata.dynamic.join(",")}` : "",
+    metadata.openGraphImage ? `og=${metadata.openGraphImage}` : "",
+    metadata.twitterImage ? `twitter=${metadata.twitterImage}` : "",
+  ].filter(Boolean);
+  return values.length ? values.join("; ") : "none";
+}

--- a/packages/farm-cli/src/explain.ts
+++ b/packages/farm-cli/src/explain.ts
@@ -8,10 +8,11 @@ import {
   resolveFarmRouteRuleRuntimeConfig,
   resolveFarmRouteRuntimeConfig,
   resolveRouteRenderingConfig,
+  scanProgrammaticPagePaths,
   type FarmRouteRule,
   type FarmRouteRuntimeConfig,
 } from "@farm.js/core";
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, realpathSync } from "node:fs";
 import path from "node:path";
 import pc from "picocolors";
 
@@ -74,13 +75,17 @@ export interface FarmRouteExplanation {
 }
 
 type PageCandidate = {
-  appDirectory: string;
   filePath: string;
   pattern: string;
   params: Record<string, string | string[]>;
   source: string;
   priority: number;
   score: number;
+};
+
+type LayeredRouteFile = {
+  filePath: string;
+  pattern: string;
 };
 
 export async function explainFarmRoute(
@@ -100,18 +105,17 @@ export async function explainFarmRoute(
     throw new Error(`No Farm page route matches ${normalizedPathname}.`);
   }
 
-  const pageDirectory = path.dirname(page.filePath);
-  const layouts = collectInheritedFiles(
-    page.appDirectory,
-    pageDirectory,
+  const layouts = collectInheritedRouteFiles(
+    config,
+    normalizedPathname,
     "layout",
     ROUTE_EXTENSIONS,
   );
   const middleware = collectMiddleware(
     root,
     Boolean(userConfig?.middleware && Object.keys(userConfig.middleware).length),
-    page.appDirectory,
-    pageDirectory,
+    config,
+    normalizedPathname,
   );
   const pageSource = readFileSync(page.filePath, "utf8");
   const layoutSources = layouts.map((filePath) => ({
@@ -132,22 +136,21 @@ export async function explainFarmRoute(
   const rendering = resolveRendering(pageSource, matchingRules);
   const cache = resolveCaching(pageSource, matchingRules);
   const metadataSources = [...layoutSources, { filePath: page.filePath, source: pageSource }];
-  const openGraphImage = findNearestSocialImage(
-    page.appDirectory,
-    pageDirectory,
-    "opengraph-image",
-  );
-  const twitterImage = findNearestSocialImage(page.appDirectory, pageDirectory, "twitter-image");
+  const openGraphImage = findNearestSocialImage(config, normalizedPathname, "opengraph-image");
+  const twitterImage = findNearestSocialImage(config, normalizedPathname, "twitter-image");
   const preset = String(config.deploy.preset || config.preset || "node-server");
   const presetRuntime = getFarmPresetRuntime(preset);
   const compatible =
     rendering.mode === "static" ||
     rendering.mode === "client" ||
     runtime.runtime === "auto" ||
-    presetRuntime === "unknown" ||
-    runtime.runtime === presetRuntime;
+    (presetRuntime !== "unknown" && runtime.runtime === presetRuntime);
   const warnings: string[] = [];
-  if (!compatible) {
+  if (presetRuntime === "unknown" && runtime.runtime !== "auto") {
+    warnings.push(
+      `Farm cannot verify the ${runtime.runtime} route requirement because the ${preset} preset runtime is unknown.`,
+    );
+  } else if (!compatible) {
     warnings.push(
       `The route requires ${runtime.runtime}, but the ${preset} preset emits ${presetRuntime} functions.`,
     );
@@ -227,26 +230,54 @@ function discoverMatchingPages(
   const candidates: PageCandidate[] = [];
   for (const [priority, source] of getFarmSourceRoots(config).entries()) {
     const appDirectory = path.join(source.root, source.srcDir, "app");
-    if (!existsSync(appDirectory)) continue;
-    for (const filePath of walkFiles(appDirectory)) {
-      if (!/^page\.(?:tsx?|jsx?|mdx?)$/.test(path.basename(filePath))) continue;
-      const relativeDirectory = path.relative(appDirectory, path.dirname(filePath));
-      if (relativeDirectory.split(path.sep).includes("api")) continue;
-      const pattern = directoryToRoutePattern(relativeDirectory);
-      const match = matchRoutePattern(pattern, pathname);
-      if (!match) continue;
-      candidates.push({
-        appDirectory,
-        filePath,
-        pattern,
-        params: match.params,
-        score: match.score,
-        source: source.name,
-        priority,
-      });
+    if (existsSync(appDirectory)) {
+      for (const filePath of walkFiles(appDirectory)) {
+        if (!/^page\.(?:tsx?|jsx?|mdx?)$/.test(path.basename(filePath))) continue;
+        const relativeDirectory = path.relative(appDirectory, path.dirname(filePath));
+        if (
+          relativeDirectory.split(path.sep).includes("api") ||
+          isRouteSlotDirectory(relativeDirectory)
+        ) {
+          continue;
+        }
+        const pattern = directoryToRoutePattern(relativeDirectory);
+        const match = matchRoutePattern(pattern, pathname);
+        if (!match) continue;
+        candidates.push({
+          filePath,
+          pattern,
+          params: match.params,
+          score: match.score,
+          source: source.name,
+          priority,
+        });
+      }
+    }
+
+    const sourceDirectory = path.join(source.root, source.srcDir);
+    if (!existsSync(sourceDirectory)) continue;
+    for (const filePath of walkFiles(sourceDirectory)) {
+      if (!/\.(?:tsx?|jsx?)$/.test(filePath) || filePath.endsWith(".d.ts")) continue;
+      const moduleSource = readFileSync(filePath, "utf8");
+      for (const pattern of scanProgrammaticPagePaths(moduleSource)) {
+        const match = matchRoutePattern(pattern, pathname);
+        if (!match) continue;
+        candidates.push({
+          filePath,
+          pattern,
+          params: match.params,
+          score: match.score,
+          source: source.name,
+          priority,
+        });
+      }
     }
   }
   return candidates;
+}
+
+function isRouteSlotDirectory(relativeDirectory: string): boolean {
+  return relativeDirectory.split(path.sep).some((segment) => /^@[A-Za-z][\w-]*$/.test(segment));
 }
 
 function walkFiles(directory: string): string[] {
@@ -256,8 +287,12 @@ function walkFiles(directory: string): string[] {
     const current = pending.pop()!;
     for (const entry of readdirSync(current, { withFileTypes: true })) {
       const entryPath = path.join(current, entry.name);
-      if (entry.isDirectory()) pending.push(entryPath);
-      else files.push(entryPath);
+      if (entry.isDirectory()) {
+        if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+        pending.push(entryPath);
+        continue;
+      }
+      files.push(entryPath);
     }
   }
   return files;
@@ -309,66 +344,117 @@ function matchRoutePattern(pattern: string, pathname: string) {
   return pathIndex === pathSegments.length ? { params, score } : null;
 }
 
-function collectInheritedFiles(
-  appDirectory: string,
-  leafDirectory: string,
+function collectInheritedRouteFiles(
+  config: Awaited<ReturnType<typeof resolveConfig>>,
+  pathname: string,
   baseName: string,
   extensions: readonly string[],
 ): string[] {
-  const directories: string[] = [];
-  let current = leafDirectory;
-  while (current === appDirectory || current.startsWith(`${appDirectory}${path.sep}`)) {
-    directories.unshift(current);
-    if (current === appDirectory) break;
-    current = path.dirname(current);
-  }
-  return directories
-    .map((directory) => findFile(directory, baseName, extensions))
-    .filter((filePath): filePath is string => Boolean(filePath));
+  return collectLayeredRouteFiles(config, baseName, extensions)
+    .filter((entry) => matchesRoutePrefix(entry.pattern, pathname))
+    .sort(compareInheritedRouteFiles)
+    .map((entry) => entry.filePath);
 }
 
 function collectMiddleware(
   root: string,
   hasConfigMiddleware: boolean,
-  appDirectory: string,
-  pageDirectory: string,
+  config: Awaited<ReturnType<typeof resolveConfig>>,
+  pathname: string,
 ): FarmRouteExplanation["middleware"] {
-  const files = collectInheritedFiles(
-    appDirectory,
-    pageDirectory,
-    "middleware",
-    MIDDLEWARE_EXTENSIONS,
-  );
-  const sourceRoot = path.dirname(appDirectory);
-  const rootMiddleware = findFile(sourceRoot, "middleware", MIDDLEWARE_EXTENSIONS);
-  if (rootMiddleware) files.unshift(rootMiddleware);
-  const uniqueFiles = [...new Set(files)];
+  const rootMiddleware = new Map<string, LayeredRouteFile>();
+  for (const source of getFarmSourceRoots(config)) {
+    const filePath = findFile(
+      path.join(source.root, source.srcDir),
+      "middleware",
+      MIDDLEWARE_EXTENSIONS,
+    );
+    if (filePath) {
+      rootMiddleware.set("root", {
+        filePath,
+        pattern: "/",
+      });
+    }
+  }
+  const files = [
+    ...rootMiddleware.values(),
+    ...collectLayeredRouteFiles(config, "middleware", MIDDLEWARE_EXTENSIONS).filter((entry) =>
+      matchesRoutePrefix(entry.pattern, pathname),
+    ),
+  ]
+    .sort(compareInheritedRouteFiles)
+    .map((entry) => entry.filePath);
   return [
     ...(hasConfigMiddleware
       ? [{ source: "config" as const, filePath: "farm.config (middleware)" }]
       : []),
-    ...uniqueFiles.map((filePath) => ({
+    ...files.map((filePath) => ({
       source: "file" as const,
       filePath: toProjectPath(root, filePath),
     })),
   ];
 }
 
-function findNearestSocialImage(appDirectory: string, leafDirectory: string, baseName: string) {
-  let current = leafDirectory;
-  while (current === appDirectory || current.startsWith(`${appDirectory}${path.sep}`)) {
-    const filePath = findFile(current, baseName, SOCIAL_IMAGE_EXTENSIONS);
-    if (filePath) return filePath;
-    if (current === appDirectory) break;
-    current = path.dirname(current);
+function collectLayeredRouteFiles(
+  config: Awaited<ReturnType<typeof resolveConfig>>,
+  baseName: string,
+  extensions: readonly string[],
+): LayeredRouteFile[] {
+  const files = new Map<string, LayeredRouteFile>();
+  const filePattern = new RegExp(
+    `^${escapeRegExp(baseName)}\\.(?:${extensions.map(escapeRegExp).join("|")})$`,
+  );
+
+  for (const source of getFarmSourceRoots(config)) {
+    const appDirectory = path.join(source.root, source.srcDir, "app");
+    if (!existsSync(appDirectory)) continue;
+    for (const filePath of walkFiles(appDirectory)) {
+      if (!filePattern.test(path.basename(filePath))) continue;
+      const relativeDirectory = path.relative(appDirectory, path.dirname(filePath));
+      const pattern = directoryToRoutePattern(relativeDirectory);
+      files.set(pattern, {
+        filePath,
+        pattern,
+      });
+    }
   }
-  return undefined;
+
+  return [...files.values()];
+}
+
+function findNearestSocialImage(
+  config: Awaited<ReturnType<typeof resolveConfig>>,
+  pathname: string,
+  baseName: string,
+) {
+  return collectLayeredRouteFiles(config, baseName, SOCIAL_IMAGE_EXTENSIONS)
+    .filter((entry) => matchesRoutePrefix(entry.pattern, pathname))
+    .sort((left, right) => compareInheritedRouteFiles(right, left))[0]?.filePath;
+}
+
+function compareInheritedRouteFiles(left: LayeredRouteFile, right: LayeredRouteFile): number {
+  return splitPath(left.pattern).length - splitPath(right.pattern).length;
+}
+
+function matchesRoutePrefix(pattern: string, pathname: string): boolean {
+  const patternSegments = splitPath(pattern);
+  const pathSegments = splitPath(pathname);
+  if (patternSegments.length > pathSegments.length) return false;
+
+  return patternSegments.every((segment, index) => {
+    if (/^\[{1,2}(?:\.\.\.)?.+\]{1,2}$/.test(segment)) return true;
+    return segment === pathSegments[index];
+  });
 }
 
 function findFile(directory: string, baseName: string, extensions: readonly string[]) {
   return extensions
     .map((extension) => path.join(directory, `${baseName}.${extension}`))
     .find(existsSync);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function readRuntimeExports(source: string): FarmRouteRuntimeConfig {
@@ -530,7 +616,15 @@ function splitPath(value: string) {
 }
 
 function toProjectPath(root: string, filePath: string) {
-  return path.relative(root, filePath).split(path.sep).join("/");
+  let relativePath = path.relative(root, filePath);
+  if (
+    (relativePath === ".." || relativePath.startsWith(`..${path.sep}`)) &&
+    existsSync(root) &&
+    existsSync(filePath)
+  ) {
+    relativePath = path.relative(realpathSync(root), realpathSync(filePath));
+  }
+  return relativePath.split(path.sep).join("/");
 }
 
 function formatParams(params: FarmRouteExplanation["params"]) {

--- a/packages/farm-cli/src/generate.ts
+++ b/packages/farm-cli/src/generate.ts
@@ -29,6 +29,22 @@ export interface GenerateFarmOptions {
   orm?: GenerateFarmSchemaTarget;
   output?: string;
   dialect?: GenerateFarmSqlDialect;
+  /** Verify committed type artifacts without writing files. */
+  check?: boolean;
+}
+
+export class FarmGeneratedArtifactsStaleError extends Error {
+  readonly stalePaths: string[];
+
+  constructor(root: string, stalePaths: readonly string[]) {
+    const normalizedPaths = [...new Set(stalePaths)].sort();
+    const relativePaths = normalizedPaths.map((filePath) => path.relative(root, filePath));
+    super(
+      `Generated types are stale:\n${relativePaths.map((filePath) => `  - ${filePath}`).join("\n")}\nRun farm generate and commit the updated files.`,
+    );
+    this.name = "FarmGeneratedArtifactsStaleError";
+    this.stalePaths = normalizedPaths;
+  }
 }
 
 type PackageManifest = {
@@ -61,6 +77,11 @@ const PRISMA_GENERATED_END = "// Farm.js integrations generated schema: end";
 
 export async function generateFarmArtifacts(options: GenerateFarmOptions = {}) {
   const root = path.resolve(options.root || process.cwd());
+  if (options.check && hasSchemaOptions(options)) {
+    throw new Error(
+      "--check verifies generated framework types and cannot be combined with schema output options.",
+    );
+  }
   const userConfig = await loadConfig(root, options.configPath, "development");
 
   if (!userConfig && hasSchemaOptions(options)) {
@@ -82,7 +103,19 @@ export async function generateFarmArtifacts(options: GenerateFarmOptions = {}) {
     extraRoutes,
     suppressLintOnLink: resolvedConfig.suppressLintOnLink,
     i18nConfig: resolvedConfig.i18n,
+    check: options.check,
   });
+
+  if (options.check) {
+    if (typeArtifacts.stalePaths.length) {
+      throw new FarmGeneratedArtifactsStaleError(root, typeArtifacts.stalePaths);
+    }
+    logger.success(
+      `Generated route, API, env${resolvedConfig.i18n.enabled ? ", and i18n" : ""} types are up to date.`,
+    );
+    return typeArtifacts;
+  }
+
   logger.success(
     `Generated route, API, env${resolvedConfig.i18n.enabled ? ", and i18n" : ""} types (${typeArtifacts.apiRoutes.length} API route${typeArtifacts.apiRoutes.length === 1 ? "" : "s"}).`,
   );
@@ -94,7 +127,7 @@ export async function generateFarmArtifacts(options: GenerateFarmOptions = {}) {
     if (hasSchemaOptions(options)) {
       logger.warn("No integration schemas were found in the current Farm config.");
     }
-    return;
+    return typeArtifacts;
   }
 
   const packageManifest = await readPackageManifest(root);
@@ -109,7 +142,7 @@ export async function generateFarmArtifacts(options: GenerateFarmOptions = {}) {
     logger.warn(
       `Integration schemas were found, but Farm could not choose a schema target automatically: ${(error as Error).message}`,
     );
-    return;
+    return typeArtifacts;
   }
 
   if (!orm) {
@@ -117,7 +150,7 @@ export async function generateFarmArtifacts(options: GenerateFarmOptions = {}) {
       logger.warn(
         "Integration schemas were found, but no data layer was detected. Pass --orm prisma|drizzle|postgres|mysql|sqlite|mongodb to generate schema artifacts.",
       );
-      return;
+      return typeArtifacts;
     }
     throw new Error(
       "Could not auto-detect a schema target. Pass one explicitly with --orm prisma|drizzle|postgres|mysql|sqlite|mongodb.",
@@ -140,7 +173,7 @@ export async function generateFarmArtifacts(options: GenerateFarmOptions = {}) {
 
       await writePrismaSchema(schemaPath, collectedModels);
       logger.success(`Generated Prisma integration schema in ${path.relative(root, schemaPath)}.`);
-      return;
+      return typeArtifacts;
     }
 
     case "drizzle": {
@@ -158,7 +191,7 @@ export async function generateFarmArtifacts(options: GenerateFarmOptions = {}) {
         : path.join(root, "farm-integrations.generated.ts");
       await writeGeneratedFile(outputPath, generateDrizzleSchema(collectedModels, dialect));
       logger.success(`Generated Drizzle integration schema in ${path.relative(root, outputPath)}.`);
-      return;
+      return typeArtifacts;
     }
 
     case "postgres":
@@ -169,7 +202,7 @@ export async function generateFarmArtifacts(options: GenerateFarmOptions = {}) {
         : path.join(root, `farm-integrations.generated.${orm}.sql`);
       await writeGeneratedFile(outputPath, generateSqlSchema(collectedModels, orm));
       logger.success(`Generated ${orm} integration schema in ${path.relative(root, outputPath)}.`);
-      return;
+      return typeArtifacts;
     }
 
     case "mongodb": {
@@ -180,7 +213,7 @@ export async function generateFarmArtifacts(options: GenerateFarmOptions = {}) {
       logger.success(
         `Generated MongoDB integration bootstrap in ${path.relative(root, outputPath)}.`,
       );
-      return;
+      return typeArtifacts;
     }
   }
 }

--- a/packages/farm-cli/src/index.ts
+++ b/packages/farm-cli/src/index.ts
@@ -9,9 +9,12 @@ export {
 } from "./add-integration";
 export { buildFarm } from "./build";
 export {
+  createFarmDeployPlan,
   deployFarm,
+  formatFarmDeployPlan,
   resolveCloudflareAgentDeployPlan,
   type CloudflareAgentDeployPlan,
+  type FarmDeployPlan,
 } from "./deploy";
 export {
   createPreviewTunnelPlan,
@@ -33,15 +36,26 @@ export {
   type PreviewGatewayResponse,
   type PreviewGatewaySession,
 } from "./preview-gateway";
-export { generateFarmArtifacts } from "./generate";
+export {
+  FarmGeneratedArtifactsStaleError,
+  generateFarmArtifacts,
+  type GenerateFarmOptions,
+} from "./generate";
 export {
   formatFarmDoctorReport,
   runFarmDoctor,
   type FarmDoctorCheck,
   type FarmDoctorCheckStatus,
+  type FarmDoctorFix,
   type FarmDoctorOptions,
   type FarmDoctorReport,
 } from "./doctor";
+export {
+  explainFarmRoute,
+  formatFarmRouteExplanation,
+  type ExplainFarmRouteOptions,
+  type FarmRouteExplanation,
+} from "./explain";
 export {
   formatFarmCronJobs,
   listFarmCronJobs,

--- a/packages/farm-cli/test/deploy.test.mjs
+++ b/packages/farm-cli/test/deploy.test.mjs
@@ -13,13 +13,14 @@ const {
 } = require("../dist/index.js");
 
 test("resolves a deployment plan without building or invoking a platform CLI", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "farm-cli-deploy-plan-"));
-  await writeFile(
-    path.join(root, "farm.config.mjs"),
-    "export default { deploy: { target: 'vercel', preset: 'vercel' } };\n",
-  );
+  let root;
 
   try {
+    root = await mkdtemp(path.join(tmpdir(), "farm-cli-deploy-plan-"));
+    await writeFile(
+      path.join(root, "farm.config.mjs"),
+      "export default { deploy: { target: 'vercel', preset: 'vercel' } };\n",
+    );
     const plan = await createFarmDeployPlan({ root, prod: true });
 
     assert.equal(plan.target, "vercel");
@@ -29,44 +30,117 @@ test("resolves a deployment plan without building or invoking a platform CLI", a
     assert.equal(plan.deploy.command, "vercel deploy --prebuilt --yes --prod");
     assert.match(formatFarmDeployPlan(plan), /FARM \/ DEPLOY PLAN/);
   } finally {
-    await rm(root, { recursive: true, force: true });
+    if (root) await rm(root, { recursive: true, force: true });
   }
 });
 
 test("reads a Cloudflare Agents Worker deployment handoff", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "farm-cli-cf-agent-"));
-  await mkdir(path.join(root, ".farm", "cf-agent"), { recursive: true });
-  await writeFile(path.join(root, ".farm-cf-agent.wrangler.jsonc"), "{}\n");
-  await writeFile(
-    path.join(root, ".farm", "cf-agent", "deploy.json"),
-    JSON.stringify({
-      version: 1,
-      provider: "cloudflare-agents",
-      config: ".farm-cf-agent.wrangler.jsonc",
-      environment: "staging",
-    }),
-  );
+  let root;
 
-  assert.deepEqual(resolveCloudflareAgentDeployPlan(root), {
-    configPath: path.join(root, ".farm-cf-agent.wrangler.jsonc"),
-    environment: "staging",
-  });
+  try {
+    root = await mkdtemp(path.join(tmpdir(), "farm-cli-cf-agent-"));
+    await mkdir(path.join(root, ".farm", "cf-agent"), { recursive: true });
+    await writeFile(path.join(root, ".farm-cf-agent.wrangler.jsonc"), "{}\n");
+    await writeFile(
+      path.join(root, ".farm", "cf-agent", "deploy.json"),
+      JSON.stringify({
+        version: 1,
+        provider: "cloudflare-agents",
+        config: ".farm-cf-agent.wrangler.jsonc",
+        environment: "staging",
+      }),
+    );
+
+    assert.deepEqual(resolveCloudflareAgentDeployPlan(root), {
+      configPath: path.join(root, ".farm-cf-agent.wrangler.jsonc"),
+      environment: "staging",
+    });
+  } finally {
+    if (root) await rm(root, { recursive: true, force: true });
+  }
 });
 
 test("keeps generated deployment configs inside the Farm root", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "farm-cli-cf-agent-unsafe-"));
-  await mkdir(path.join(root, ".farm", "cf-agent"), { recursive: true });
-  await writeFile(
-    path.join(root, ".farm", "cf-agent", "deploy.json"),
-    JSON.stringify({
-      version: 1,
-      provider: "cloudflare-agents",
-      config: "../wrangler.jsonc",
-    }),
-  );
+  let root;
 
-  assert.throws(
-    () => resolveCloudflareAgentDeployPlan(root),
-    /must stay inside the Farm project root/,
-  );
+  try {
+    root = await mkdtemp(path.join(tmpdir(), "farm-cli-cf-agent-unsafe-"));
+    await mkdir(path.join(root, ".farm", "cf-agent"), { recursive: true });
+    await writeFile(
+      path.join(root, ".farm", "cf-agent", "deploy.json"),
+      JSON.stringify({
+        version: 1,
+        provider: "cloudflare-agents",
+        config: "../wrangler.jsonc",
+      }),
+    );
+
+    assert.throws(
+      () => resolveCloudflareAgentDeployPlan(root),
+      /must stay inside the Farm project root/,
+    );
+  } finally {
+    if (root) await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("plans the generated Cloudflare Agent config before the first build", async () => {
+  let root;
+
+  try {
+    root = await mkdtemp(path.join(tmpdir(), "farm-cli-cf-agent-first-run-"));
+    await writeFile(
+      path.join(root, "farm.config.mjs"),
+      [
+        "export default {",
+        "  deploy: { target: 'cloudflare', preset: 'cloudflare-module' },",
+        "  integrations: {",
+        "    agent: {",
+        "      kind: 'farm-integration',",
+        "      category: 'agent',",
+        "      type: 'cloudflare',",
+        "      serverRuntime: false,",
+        "      instance: { config: 'cloudflare/wrangler.jsonc', environment: 'staging' },",
+        "    },",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    const plan = await createFarmDeployPlan({ root });
+
+    assert.deepEqual(plan.cloudflareAgent, {
+      configPath: path.join(root, "cloudflare", ".farm-cf-agent.wrangler.jsonc"),
+      environment: "staging",
+      generated: true,
+    });
+    assert.equal(
+      plan.deploy.command,
+      `wrangler deploy --config ${path.join(root, "cloudflare", ".farm-cf-agent.wrangler.jsonc")} --env staging`,
+    );
+    assert.match(formatFarmDeployPlan(plan), /generated during build/);
+  } finally {
+    if (root) await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("reports Netlify deploys as production operations", async () => {
+  let root;
+
+  try {
+    root = await mkdtemp(path.join(tmpdir(), "farm-cli-netlify-plan-"));
+    await writeFile(
+      path.join(root, "farm.config.mjs"),
+      "export default { deploy: { target: 'netlify', preset: 'netlify' } };\n",
+    );
+
+    const plan = await createFarmDeployPlan({ root });
+
+    assert.equal(plan.production, true);
+    assert.equal(plan.deploy.command, "netlify deploy --prod --dir=.");
+    assert.match(formatFarmDeployPlan(plan), /Production: yes/);
+  } finally {
+    if (root) await rm(root, { recursive: true, force: true });
+  }
 });

--- a/packages/farm-cli/test/deploy.test.mjs
+++ b/packages/farm-cli/test/deploy.test.mjs
@@ -1,12 +1,37 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
-const { resolveCloudflareAgentDeployPlan } = require("../dist/index.js");
+const {
+  createFarmDeployPlan,
+  formatFarmDeployPlan,
+  resolveCloudflareAgentDeployPlan,
+} = require("../dist/index.js");
+
+test("resolves a deployment plan without building or invoking a platform CLI", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "farm-cli-deploy-plan-"));
+  await writeFile(
+    path.join(root, "farm.config.mjs"),
+    "export default { deploy: { target: 'vercel', preset: 'vercel' } };\n",
+  );
+
+  try {
+    const plan = await createFarmDeployPlan({ root, prod: true });
+
+    assert.equal(plan.target, "vercel");
+    assert.equal(plan.preset, "vercel");
+    assert.equal(plan.runtime, "node");
+    assert.equal(plan.build.command, "farm build --preset vercel");
+    assert.equal(plan.deploy.command, "vercel deploy --prebuilt --yes --prod");
+    assert.match(formatFarmDeployPlan(plan), /FARM \/ DEPLOY PLAN/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
 
 test("reads a Cloudflare Agents Worker deployment handoff", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "farm-cli-cf-agent-"));

--- a/packages/farm-cli/test/doctor.test.mjs
+++ b/packages/farm-cli/test/doctor.test.mjs
@@ -149,6 +149,38 @@ test("applies only safe additive fixes", async () => {
   }
 });
 
+test("applies safe fixes inside a configured project root", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "farm-cli-doctor-root-"));
+  const projectRoot = path.join(root, "application");
+  const layoutPath = path.join(projectRoot, "src/app/layout.tsx");
+
+  try {
+    await mkdir(path.join(projectRoot, "src/app"), { recursive: true });
+    await writeFile(
+      path.join(root, "farm.config.mjs"),
+      "export default { root: './application' };\n",
+    );
+    await writeFile(
+      path.join(root, "package.json"),
+      JSON.stringify({ name: "doctor-root-fixture" }),
+    );
+    await writeFile(path.join(projectRoot, "src/app/page.tsx"), "export default () => null;\n");
+
+    const report = await runFarmDoctor({ root, offline: true, fix: true });
+
+    assert.deepEqual(report.fixes, [
+      {
+        code: "ROOT_LAYOUT_CREATED",
+        title: "Created the missing root layout",
+        filePath: "application/src/app/layout.tsx",
+      },
+    ]);
+    assert.match(await readFile(layoutPath, "utf8"), /export default function RootLayout/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 async function createTempProject(options = {}) {
   const root = await mkdtemp(path.join(os.tmpdir(), "farm-cli-doctor-"));
   const target = options.target || "node";

--- a/packages/farm-cli/test/doctor.test.mjs
+++ b/packages/farm-cli/test/doctor.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
@@ -123,6 +123,32 @@ test("prints a machine-readable report through the CLI", async () => {
   }
 });
 
+test("applies only safe additive fixes", async () => {
+  const root = await createTempProject({ layout: false });
+  const layoutPath = path.join(root, "src/app/layout.tsx");
+
+  try {
+    const report = await runFarmDoctor({ root, offline: true, fix: true });
+
+    assert.deepEqual(report.fixes, [
+      {
+        code: "ROOT_LAYOUT_CREATED",
+        title: "Created the missing root layout",
+        filePath: "src/app/layout.tsx",
+      },
+    ]);
+    assert.ok(report.checks.some((check) => check.code === "ROOT_LAYOUT_READY"));
+    assert.match(await readFile(layoutPath, "utf8"), /export default function RootLayout/);
+
+    const before = (await stat(layoutPath)).mtimeMs;
+    const repeated = await runFarmDoctor({ root, offline: true, fix: true });
+    assert.deepEqual(repeated.fixes, []);
+    assert.equal((await stat(layoutPath)).mtimeMs, before);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 async function createTempProject(options = {}) {
   const root = await mkdtemp(path.join(os.tmpdir(), "farm-cli-doctor-"));
   const target = options.target || "node";
@@ -153,11 +179,13 @@ async function createTempProject(options = {}) {
     "utf8",
   );
   await writeFile(path.join(root, "src/app/page.tsx"), "export default () => null;\n", "utf8");
-  await writeFile(
-    path.join(root, "src/app/layout.tsx"),
-    "export default ({ children }) => children;\n",
-    "utf8",
-  );
+  if (options.layout !== false) {
+    await writeFile(
+      path.join(root, "src/app/layout.tsx"),
+      "export default ({ children }) => children;\n",
+      "utf8",
+    );
+  }
   await writeFile(
     path.join(root, "src/app/api/maintenance/cleanup/route.ts"),
     "export function GET() { return Response.json({ ok: true }); }\n",

--- a/packages/farm-cli/test/explain.test.mjs
+++ b/packages/farm-cli/test/explain.test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const { explainFarmRoute, formatFarmRouteExplanation } = require("../dist/index.js");
+const execFileAsync = promisify(execFile);
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const cliBin = path.resolve(testDir, "../bin/farm.js");
+
+test("explains a dynamic page and its inherited route behavior", async () => {
+  const root = await createExplainProject();
+
+  try {
+    const explanation = await explainFarmRoute("/products/42?ref=home", { root });
+
+    assert.equal(explanation.pathname, "/products/42");
+    assert.equal(explanation.pattern, "/products/[id]");
+    assert.deepEqual(explanation.params, { id: "42" });
+    assert.equal(explanation.filePath, "src/app/products/[id]/page.tsx");
+    assert.deepEqual(explanation.layouts, ["src/app/layout.tsx", "src/app/products/layout.tsx"]);
+    assert.deepEqual(explanation.middleware, [
+      { source: "file", filePath: "src/middleware.ts" },
+      { source: "file", filePath: "src/app/products/middleware.ts" },
+    ]);
+    assert.equal(explanation.runtime.runtime, "edge");
+    assert.deepEqual(explanation.runtime.regions, ["iad1"]);
+    assert.equal(explanation.rendering.mode, "partial");
+    assert.equal(explanation.rendering.ppr, true);
+    assert.equal(explanation.cache.revalidate, 60);
+    assert.deepEqual(explanation.cache.rules, ["/products/**", "/products/[id]"]);
+    assert.deepEqual(explanation.metadata.dynamic, ["src/app/products/layout.tsx"]);
+    assert.equal(explanation.metadata.openGraphImage, "src/app/products/opengraph-image.tsx");
+    assert.equal(explanation.deployment.target, "vercel");
+    assert.equal(explanation.deployment.compatible, false);
+
+    const formatted = formatFarmRouteExplanation(explanation, { color: false });
+    assert.match(formatted, /FARM \/ EXPLAIN/);
+    assert.match(formatted, /\/products\/\[id\]/);
+    assert.match(formatted, /incompatible/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("prints route explanations as JSON through the CLI", async () => {
+  const root = await createExplainProject();
+
+  try {
+    const result = await execFileAsync(
+      process.execPath,
+      [cliBin, "explain", "/products/42", "--root", root, "--json"],
+      { env: process.env },
+    );
+    const explanation = JSON.parse(result.stdout);
+    assert.equal(explanation.pattern, "/products/[id]");
+    assert.deepEqual(explanation.params, { id: "42" });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+async function createExplainProject() {
+  const root = await mkdtemp(path.join(os.tmpdir(), "farm-cli-explain-"));
+  const productDirectory = path.join(root, "src/app/products/[id]");
+  await mkdir(productDirectory, { recursive: true });
+  await writeFile(
+    path.join(root, "farm.config.mjs"),
+    [
+      "export default {",
+      "  deploy: { target: 'vercel', preset: 'vercel' },",
+      "  routeRules: {",
+      "    '/products/**': { swr: 30, runtime: 'node' },",
+      "    '/products/[id]': { runtime: 'edge', regions: ['iad1'] },",
+      "  },",
+      "};",
+      "",
+    ].join("\n"),
+  );
+  await writeFile(path.join(root, "src/app/layout.tsx"), "export const metadata = {};\n");
+  await writeFile(
+    path.join(root, "src/app/products/layout.tsx"),
+    "export async function generateMetadata() { return {}; }\n",
+  );
+  await writeFile(
+    path.join(root, "src/app/products/[id]/page.tsx"),
+    "export const revalidate = 60;\nexport const ppr = true;\nexport default () => null;\n",
+  );
+  await writeFile(path.join(root, "src/middleware.ts"), "export default () => {};\n");
+  await writeFile(path.join(root, "src/app/products/middleware.ts"), "export default () => {};\n");
+  await writeFile(
+    path.join(root, "src/app/products/opengraph-image.tsx"),
+    "export default () => null;\n",
+  );
+  return root;
+}

--- a/packages/farm-cli/test/explain.test.mjs
+++ b/packages/farm-cli/test/explain.test.mjs
@@ -66,6 +66,92 @@ test("prints route explanations as JSON through the CLI", async () => {
   }
 });
 
+test("discovers pages declared through the programmatic router", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "farm-cli-explain-programmatic-"));
+
+  try {
+    await mkdir(path.join(root, "src"), { recursive: true });
+    await writeFile(path.join(root, "farm.config.mjs"), "export default {};\n");
+    await writeFile(
+      path.join(root, "src/farm.routes.ts"),
+      [
+        'import { defineRoutes, page } from "@farm.js/core";',
+        "const Product = () => null;",
+        'export default defineRoutes([page("/catalog/[id]", { component: Product })]);',
+        "",
+      ].join("\n"),
+    );
+
+    const explanation = await explainFarmRoute("/catalog/42", { root });
+
+    assert.equal(explanation.pattern, "/catalog/[id]");
+    assert.deepEqual(explanation.params, { id: "42" });
+    assert.equal(explanation.filePath, "src/farm.routes.ts");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("uses the virtual route graph when a project overrides layer boundaries", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "farm-cli-explain-layers-"));
+  const layerRoot = path.join(root, "base");
+
+  try {
+    await mkdir(path.join(layerRoot, "src/app/products/[id]"), { recursive: true });
+    await mkdir(path.join(root, "src/app/products"), { recursive: true });
+    await writeFile(
+      path.join(root, "farm.config.mjs"),
+      "export default { extends: ['./base'] };\n",
+    );
+    await writeFile(path.join(layerRoot, "farm.config.mjs"), "export default {};\n");
+    await writeFile(
+      path.join(layerRoot, "src/app/products/[id]/page.tsx"),
+      "export default () => null;\n",
+    );
+    await writeFile(path.join(layerRoot, "src/app/layout.tsx"), "export const runtime = 'node';\n");
+    await writeFile(
+      path.join(layerRoot, "src/app/products/layout.tsx"),
+      "export const metadata = {};\n",
+    );
+    await writeFile(path.join(root, "src/app/layout.tsx"), "export const metadata = {};\n");
+    await writeFile(
+      path.join(root, "src/app/products/layout.tsx"),
+      "export const runtime = 'edge';\nexport async function generateMetadata() { return {}; }\n",
+    );
+
+    const explanation = await explainFarmRoute("/products/42", { root });
+
+    assert.equal(explanation.filePath, "base/src/app/products/[id]/page.tsx");
+    assert.deepEqual(explanation.layouts, ["src/app/layout.tsx", "src/app/products/layout.tsx"]);
+    assert.equal(explanation.runtime.runtime, "edge");
+    assert.deepEqual(explanation.metadata.static, ["src/app/layout.tsx"]);
+    assert.deepEqual(explanation.metadata.dynamic, ["src/app/products/layout.tsx"]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("does not select a route-slot page as the canonical URL", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "farm-cli-explain-slot-"));
+
+  try {
+    await mkdir(path.join(root, "src/app/photo/[id]"), { recursive: true });
+    await mkdir(path.join(root, "src/app/feed/@modal/(.)photo/[id]"), { recursive: true });
+    await writeFile(path.join(root, "farm.config.mjs"), "export default {};\n");
+    await writeFile(path.join(root, "src/app/photo/[id]/page.tsx"), "export default () => null;\n");
+    await writeFile(
+      path.join(root, "src/app/feed/@modal/(.)photo/[id]/page.tsx"),
+      "export default () => null;\n",
+    );
+
+    const explanation = await explainFarmRoute("/photo/42", { root });
+
+    assert.equal(explanation.filePath, "src/app/photo/[id]/page.tsx");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 async function createExplainProject() {
   const root = await mkdtemp(path.join(os.tmpdir(), "farm-cli-explain-"));
   const productDirectory = path.join(root, "src/app/products/[id]");

--- a/packages/farm-cli/test/generate.test.mjs
+++ b/packages/farm-cli/test/generate.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const { FarmGeneratedArtifactsStaleError, generateFarmArtifacts } = require("../dist/index.js");
+
+test("checks committed generated types without rewriting stale output", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "farm-cli-generate-check-"));
+  const apiDirectory = path.join(root, "src/app/api/health");
+  await mkdir(apiDirectory, { recursive: true });
+  await writeFile(path.join(root, "farm.config.mjs"), "export default {};\n");
+  await writeFile(
+    path.join(apiDirectory, "route.ts"),
+    "export const GET = async () => Response.json({ ok: true });\n",
+  );
+
+  try {
+    await generateFarmArtifacts({ root });
+    await generateFarmArtifacts({ root, check: true });
+
+    const apiTypesPath = path.join(root, "src/lib/api.generated.ts");
+    await writeFile(apiTypesPath, "// stale\n");
+
+    await assert.rejects(
+      () => generateFarmArtifacts({ root, check: true }),
+      (error) => {
+        assert.ok(error instanceof FarmGeneratedArtifactsStaleError);
+        assert.deepEqual(error.stalePaths, [apiTypesPath]);
+        assert.match(error.message, /Run farm generate/);
+        return true;
+      },
+    );
+    assert.equal(await readFile(apiTypesPath, "utf8"), "// stale\n");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/farm/src/__tests__/generate-route-types.test.ts
+++ b/packages/farm/src/__tests__/generate-route-types.test.ts
@@ -5,6 +5,10 @@ import * as os from "os";
 import ts from "typescript";
 import { generateRouteTypes } from "../routing/generate-route-types";
 
+function readTypeAlias(content: string, name: string): string {
+  return content.match(new RegExp(`export type ${name} =([\\s\\S]*?);`))?.[1] ?? "";
+}
+
 describe("generateRouteTypes", () => {
   let tmpDir: string;
 
@@ -100,7 +104,9 @@ describe("generateRouteTypes", () => {
     const content = fs.readFileSync(outPath, "utf8");
     expect(content).toContain("export type RoutePath = string");
     expect(content).toContain("export type RoutePattern = string");
-    expect(content).toContain('export type RouteModulePattern = "/" | "/about"');
+    const routeModulePattern = readTypeAlias(content, "RouteModulePattern");
+    expect(routeModulePattern).toContain('"/"');
+    expect(routeModulePattern).toContain('"/about"');
     expect(content).toContain("interface RouteRegistry");
     expect(content).not.toContain("LinkDefaultRoute");
   });
@@ -146,11 +152,13 @@ describe("generateRouteTypes", () => {
 
     const outPath = await generateRouteTypes({ root: tmpDir, srcDir: "src" });
     const content = fs.readFileSync(outPath, "utf8");
-    const routePath = content.match(/export type RoutePath = ([^;]+);/)?.[1];
+    const routePath = readTypeAlias(content, "RoutePath");
+    const routePattern = readTypeAlias(content, "RoutePattern");
 
     expect(routePath).toContain('"/docs"');
     expect(routePath).toContain("`/docs/${string}`");
-    expect(content).toContain('export type RoutePattern = "/" | "/about"');
+    expect(routePattern).toContain('"/"');
+    expect(routePattern).toContain('"/about"');
     expect(content).toContain('"/docs/[[...slug]]"');
   });
 

--- a/packages/farm/src/__tests__/route-runtime-deployment.test.ts
+++ b/packages/farm/src/__tests__/route-runtime-deployment.test.ts
@@ -13,6 +13,7 @@ import {
   createFarmRouteRuntimeManifest,
   validateFarmRouteRuntimeDeployment,
 } from "../route-runtime-manifest";
+import { getFarmPresetRuntime } from "../deployment";
 import type { FarmRouteRuntimeManifest } from "../route-runtime";
 import { RouteManager } from "../routing/route-manager";
 import type { FarmConfig } from "../types";
@@ -118,6 +119,29 @@ describe("route runtime deployment manifest", () => {
         expect.stringContaining("does not map per-route regions"),
         expect.stringContaining("does not map per-route maxDuration"),
       ],
+    });
+  });
+
+  it("classifies self-hosted presets and warns when a custom runtime cannot be inferred", () => {
+    expect(getFarmPresetRuntime("self-host")).toBe("node");
+    expect(getFarmPresetRuntime("farm")).toBe("node");
+    expect(getFarmPresetRuntime("custom")).toBe("unknown");
+
+    const manifest: FarmRouteRuntimeManifest = {
+      version: 1,
+      routes: [
+        {
+          kind: "page",
+          pattern: "/reports",
+          rendering: "dynamic",
+          runtime: "edge",
+        },
+      ],
+    };
+
+    expect(validateFarmRouteRuntimeDeployment(manifest, "custom")).toEqual({
+      runtime: "unknown",
+      warnings: [expect.stringContaining("could not verify")],
     });
   });
 });

--- a/packages/farm/src/__tests__/type-artifacts.test.ts
+++ b/packages/farm/src/__tests__/type-artifacts.test.ts
@@ -240,10 +240,31 @@ describe("generateFarmTypeArtifacts", () => {
     expect(current.stalePaths).toEqual([]);
 
     const staleSource = "// deliberately stale\n";
-    writeFileSync(generated.apiTypesPath!, staleSource);
+    const checkedPaths = Array.from(
+      new Set(
+        [
+          generated.typesPath,
+          generated.routeTypesPath,
+          generated.apiTypesPath,
+          generated.envTypesPath,
+          generated.imageTypesPath,
+          generated.i18nTypesPath,
+        ].filter((filePath): filePath is string => Boolean(filePath)),
+      ),
+    );
+    for (const filePath of checkedPaths) writeFileSync(filePath, staleSource);
+    const preserved = new Map(
+      checkedPaths.map((filePath) => [
+        filePath,
+        { content: readFileSync(filePath, "utf8"), mtimeMs: statSync(filePath).mtimeMs },
+      ]),
+    );
     const stale = await generateFarmTypeArtifacts({ root, check: true });
 
-    expect(stale.stalePaths).toEqual([generated.apiTypesPath]);
-    expect(readFileSync(generated.apiTypesPath!, "utf8")).toBe(staleSource);
+    expect([...stale.stalePaths].sort()).toEqual([...checkedPaths].sort());
+    for (const filePath of checkedPaths) {
+      expect(readFileSync(filePath, "utf8")).toBe(preserved.get(filePath)!.content);
+      expect(statSync(filePath).mtimeMs).toBe(preserved.get(filePath)!.mtimeMs);
+    }
   });
 });

--- a/packages/farm/src/__tests__/type-artifacts.test.ts
+++ b/packages/farm/src/__tests__/type-artifacts.test.ts
@@ -68,6 +68,7 @@ describe("generateFarmTypeArtifacts", () => {
     expect(types).toContain("`/users/${string}`");
     expect(types).toContain('"/users/[id]"');
     expect(types).toContain('"/docs/reference"');
+    expect(types).toContain('export type RoutePath =\n  | "/"');
     expect(types).toContain('_: import("./farm").RoutePath');
     expect(types).toContain('import "@farm.js/core/image"');
     expect(readFileSync(apiTypesPath, "utf8")).toContain("hello: {");
@@ -225,5 +226,24 @@ describe("generateFarmTypeArtifacts", () => {
     for (const filePath of outputPaths.filter((filePath) => filePath !== first.apiTypesPath)) {
       expect(statSync(filePath).mtimeMs).toBe(preservedMtimes.get(filePath));
     }
+  });
+
+  it("checks generated artifacts without changing them", async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "farm-check-type-artifacts-"));
+    const apiRoutePath = path.join(root, "src", "app", "api", "hello", "route.ts");
+    mkdirSync(path.dirname(apiRoutePath), { recursive: true });
+    writeFileSync(apiRoutePath, "export const GET = async () => Response.json({ ok: true });\n");
+
+    const generated = await generateFarmTypeArtifacts({ root });
+    const current = await generateFarmTypeArtifacts({ root, check: true });
+
+    expect(current.stalePaths).toEqual([]);
+
+    const staleSource = "// deliberately stale\n";
+    writeFileSync(generated.apiTypesPath!, staleSource);
+    const stale = await generateFarmTypeArtifacts({ root, check: true });
+
+    expect(stale.stalePaths).toEqual([generated.apiTypesPath]);
+    expect(readFileSync(generated.apiTypesPath!, "utf8")).toBe(staleSource);
   });
 });

--- a/packages/farm/src/deployment.ts
+++ b/packages/farm/src/deployment.ts
@@ -4,6 +4,35 @@ export const FARM_DEPLOYMENT_COOKIE = "__farm_deployment";
 export const FARM_DEPLOYMENT_MISMATCH_CODE = "FARM_DEPLOYMENT_MISMATCH";
 export const FARM_DEPLOYMENT_MISMATCH_STATUS = 409;
 
+export type FarmPresetRuntime = "node" | "edge" | "unknown";
+
+export function getFarmPresetRuntime(preset: string): FarmPresetRuntime {
+  if (
+    preset === "cloudflare" ||
+    preset === "cloudflare-pages" ||
+    preset === "cloudflare-module" ||
+    preset === "netlify-edge" ||
+    preset === "vercel-edge" ||
+    preset === "deno"
+  ) {
+    return "edge";
+  }
+
+  if (
+    preset === "node-server" ||
+    preset === "vercel" ||
+    preset === "netlify" ||
+    preset === "aws-lambda" ||
+    preset === "azure" ||
+    preset === "firebase" ||
+    preset === "bun"
+  ) {
+    return "node";
+  }
+
+  return "unknown";
+}
+
 export interface FarmDeploymentMismatch {
   clientDeploymentId: string;
   serverDeploymentId: string;

--- a/packages/farm/src/deployment.ts
+++ b/packages/farm/src/deployment.ts
@@ -25,7 +25,9 @@ export function getFarmPresetRuntime(preset: string): FarmPresetRuntime {
     preset === "aws-lambda" ||
     preset === "azure" ||
     preset === "firebase" ||
-    preset === "bun"
+    preset === "bun" ||
+    preset === "self-host" ||
+    preset === "farm"
   ) {
     return "node";
   }

--- a/packages/farm/src/route-runtime-manifest.ts
+++ b/packages/farm/src/route-runtime-manifest.ts
@@ -102,6 +102,12 @@ export function validateFarmRouteRuntimeDeployment(
   for (const route of manifest.routes) {
     if (route.rendering === "static") continue;
 
+    if (runtime === "unknown" && route.runtime !== "auto") {
+      warnings.add(
+        `Preset "${preset}" has an unknown runtime, so Farm could not verify routes that explicitly require node or edge.`,
+      );
+    }
+
     if (runtime !== "unknown" && route.runtime !== "auto" && route.runtime !== runtime) {
       throw new Error(
         `Route "${route.pattern}" requires the ${route.runtime} runtime, but preset "${preset}" emits ${runtime} functions. Choose a compatible preset or change the route runtime.`,

--- a/packages/farm/src/route-runtime-manifest.ts
+++ b/packages/farm/src/route-runtime-manifest.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import type { APIRouteManager } from "./api/route-manager";
 import type { ResolvedFarmConfig } from "./config";
+import { getFarmPresetRuntime, type FarmPresetRuntime } from "./deployment";
 import {
   getFarmRouteRuntimeConfig,
   hasFarmRouteRuntimeControls,
@@ -17,7 +18,7 @@ import { resolveRouteRenderingConfigFromFile } from "./ssg";
 export const FARM_ROUTE_RUNTIME_MANIFEST = "route-runtime-manifest.json";
 
 export interface FarmRouteRuntimeDeploymentValidation {
-  runtime: "node" | "edge" | "unknown";
+  runtime: FarmPresetRuntime;
   warnings: string[];
 }
 
@@ -95,7 +96,7 @@ export function validateFarmRouteRuntimeDeployment(
   manifest: FarmRouteRuntimeManifest,
   preset: string,
 ): FarmRouteRuntimeDeploymentValidation {
-  const runtime = getPresetRuntime(preset);
+  const runtime = getFarmPresetRuntime(preset);
   const warnings = new Set<string>();
 
   for (const route of manifest.routes) {
@@ -121,33 +122,6 @@ export function validateFarmRouteRuntimeDeployment(
   }
 
   return { runtime, warnings: Array.from(warnings) };
-}
-
-export function getPresetRuntime(preset: string): FarmRouteRuntimeDeploymentValidation["runtime"] {
-  if (
-    preset === "cloudflare" ||
-    preset === "cloudflare-pages" ||
-    preset === "cloudflare-module" ||
-    preset === "netlify-edge" ||
-    preset === "vercel-edge" ||
-    preset === "deno"
-  ) {
-    return "edge";
-  }
-
-  if (
-    preset === "node-server" ||
-    preset === "vercel" ||
-    preset === "netlify" ||
-    preset === "aws-lambda" ||
-    preset === "azure" ||
-    preset === "firebase" ||
-    preset === "bun"
-  ) {
-    return "node";
-  }
-
-  return "unknown";
 }
 
 function normalizeManifestSource(root: string, modulePath: string): string {

--- a/packages/farm/src/routing/generate-route-types.ts
+++ b/packages/farm/src/routing/generate-route-types.ts
@@ -38,6 +38,14 @@ function routePatternToRouteLiteral(pattern: string): string {
   return JSON.stringify(pattern);
 }
 
+function renderTypeUnion(values: readonly string[]): string {
+  return values.length <= 1 ? values[0] || "never" : `\n  | ${values.join("\n  | ")}`;
+}
+
+function renderTypeAlias(name: string, value: string): string {
+  return `export type ${name} =${value.startsWith("\n") ? "" : " "}${value};`;
+}
+
 function createRoutePattern(route: ParsedRoute): string {
   if (route.segments.length === 0) return "/";
   return (
@@ -135,19 +143,9 @@ export async function createRouteTypeDeclarations(
     .sort()
     .map(routePatternToRouteLiteral);
 
-  const routePathType = suppressLintOnLink
-    ? "string"
-    : typeLiterals.length
-      ? typeLiterals.join(" | ")
-      : "never";
-  const routePatternType = suppressLintOnLink
-    ? "string"
-    : patternLiterals.length
-      ? patternLiterals.join(" | ")
-      : "never";
-  const routeModulePatternType = routeModulePatternLiterals.length
-    ? routeModulePatternLiterals.join(" | ")
-    : "never";
+  const routePathType = suppressLintOnLink ? "string" : renderTypeUnion(typeLiterals);
+  const routePatternType = suppressLintOnLink ? "string" : renderTypeUnion(patternLiterals);
+  const routeModulePatternType = renderTypeUnion(routeModulePatternLiterals);
   const routeTypesImportPath = `./${path.basename(outPath).replace(/\.d\.ts$/, "")}`;
   const linkAugmentationBlock = suppressLintOnLink
     ? ""
@@ -193,9 +191,9 @@ declare global {
  * Regenerated on dev start and when routes change.
  * Set suppressLintOnLink: true in farm.config.ts to accept any string on Link href.
  */
-export type RoutePath = ${routePathType};
-export type RoutePattern = ${routePatternType};
-export type RouteModulePattern = ${routeModulePatternType};${linkAugmentationBlock}${routeModuleAugmentationBlock}
+${renderTypeAlias("RoutePath", routePathType)}
+${renderTypeAlias("RoutePattern", routePatternType)}
+${renderTypeAlias("RouteModulePattern", routeModulePatternType)}${linkAugmentationBlock}${routeModuleAugmentationBlock}
 `;
 
   return content;

--- a/packages/farm/src/type-artifacts.ts
+++ b/packages/farm/src/type-artifacts.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, unlinkSync } from "fs";
-import { dirname, join, resolve } from "path";
+import { dirname, isAbsolute, join, resolve } from "path";
 import { APITypeGenerator, type APIRouteInfo } from "./type-generator";
 import {
   createRouteTypeDeclarations,
@@ -7,7 +7,7 @@ import {
   type GenerateRouteTypesOptions,
 } from "./routing/generate-route-types";
 import { createEnvTypeDeclarations, generateEnvTypes } from "./env-types";
-import { generateFarmImageTypes } from "./image-types";
+import { createFarmImageTypeDeclarations, generateFarmImageTypes } from "./image-types";
 import { generateFarmI18nTypes, renderFarmI18nTypes } from "./i18n/type-generator";
 import { readFarmI18nCatalogs } from "./i18n/catalog";
 import type { ResolvedFarmI18nConfig } from "./i18n/types";
@@ -34,6 +34,8 @@ export interface GenerateFarmTypeArtifactsOptions {
   env?: boolean;
   images?: boolean;
   i18n?: boolean;
+  /** Compare generated content with disk without writing files. */
+  check?: boolean;
 }
 
 export interface GenerateFarmTypeArtifactsResult {
@@ -44,6 +46,8 @@ export interface GenerateFarmTypeArtifactsResult {
   imageTypesPath?: string;
   i18nTypesPath?: string;
   apiRoutes: APIRouteInfo[];
+  /** Generated files whose checked-in content is missing or stale. */
+  stalePaths: string[];
 }
 
 export async function generateFarmTypeArtifacts(
@@ -61,6 +65,7 @@ export async function generateFarmTypeArtifacts(
 
   const result: GenerateFarmTypeArtifactsResult = {
     apiRoutes: [],
+    stalePaths: [],
   };
   const unifiedTypesPath = join(root, srcDir, "farm.d.ts");
   const shouldRefreshUnifiedTypes =
@@ -80,14 +85,22 @@ export async function generateFarmTypeArtifacts(
     unifiedSections.push(await createRouteTypeDeclarations(routeOptions, unifiedTypesPath));
     result.routeTypesPath = unifiedTypesPath;
   } else if (shouldGenerateRoutes) {
-    result.routeTypesPath = await generateRouteTypes({
+    const routeOptions = {
       root,
       srcDir,
       outFile: options.routeTypesOutFile,
       extraRoutes: options.extraRoutes || [],
       suppressLintOnLink: options.suppressLintOnLink,
       sourceRoots,
-    });
+    } satisfies GenerateRouteTypesOptions;
+    if (options.check) {
+      const routeTypesPath = resolveGeneratedPath(root, srcDir, options.routeTypesOutFile!);
+      const content = await createRouteTypeDeclarations(routeOptions, routeTypesPath);
+      checkGeneratedFile(routeTypesPath, content, result.stalePaths);
+      result.routeTypesPath = routeTypesPath;
+    } else {
+      result.routeTypesPath = await generateRouteTypes(routeOptions);
+    }
   }
 
   if (shouldGenerateApi) {
@@ -98,8 +111,7 @@ export async function generateFarmTypeArtifacts(
       : join(root, srcDir, "lib", "api.generated.ts");
     const content = generator.generateAPIRouter(apiRoutes, { outFile: apiTypesPath });
 
-    mkdirSync(dirname(apiTypesPath), { recursive: true });
-    writeFileIfChanged(apiTypesPath, content);
+    writeOrCheckGeneratedFile(apiTypesPath, content, options.check, result.stalePaths);
 
     result.apiTypesPath = apiTypesPath;
     result.apiRoutes = apiRoutes;
@@ -121,7 +133,7 @@ export async function generateFarmTypeArtifacts(
     );
     result.envTypesPath = unifiedTypesPath;
   } else if (shouldGenerateEnv) {
-    result.envTypesPath = await generateEnvTypes({
+    const envOptions = {
       root,
       srcDir,
       outFile: options.envTypesOutFile,
@@ -129,17 +141,34 @@ export async function generateFarmTypeArtifacts(
       layerConfigPaths: (options.layers ?? [])
         .map((layer) => layer.configFile)
         .filter((configFile): configFile is string => Boolean(configFile)),
-    });
+    };
+    if (options.check) {
+      const envTypesPath = resolveGeneratedPath(root, srcDir, options.envTypesOutFile!);
+      checkGeneratedFile(
+        envTypesPath,
+        createEnvTypeDeclarations(envOptions, envTypesPath),
+        result.stalePaths,
+      );
+      result.envTypesPath = envTypesPath;
+    } else {
+      result.envTypesPath = await generateEnvTypes(envOptions);
+    }
   }
 
   // Static image modules are declared by @farm.js/core itself. Keep the
   // explicit output option for callers that need a standalone declaration.
   if (shouldGenerateImages && options.imageTypesOutFile) {
-    result.imageTypesPath = generateFarmImageTypes({
-      root,
-      srcDir,
-      outFile: options.imageTypesOutFile,
-    });
+    const imageTypesPath = resolveGeneratedPath(root, srcDir, options.imageTypesOutFile, false);
+    if (options.check) {
+      checkGeneratedFile(imageTypesPath, createFarmImageTypeDeclarations(), result.stalePaths);
+      result.imageTypesPath = imageTypesPath;
+    } else {
+      result.imageTypesPath = generateFarmImageTypes({
+        root,
+        srcDir,
+        outFile: options.imageTypesOutFile,
+      });
+    }
   }
 
   if (shouldRefreshUnifiedTypes && options.i18nConfig?.enabled && !options.i18nTypesOutFile) {
@@ -147,17 +176,27 @@ export async function generateFarmTypeArtifacts(
     unifiedSections.push(renderFarmI18nTypes(options.i18nConfig.locales, signatures));
     result.i18nTypesPath = unifiedTypesPath;
   } else if (shouldGenerateI18n && options.i18nConfig) {
-    result.i18nTypesPath = await generateFarmI18nTypes({
-      root,
-      srcDir,
-      config: options.i18nConfig,
-      outFile: options.i18nTypesOutFile,
-    });
+    if (options.check) {
+      const i18nTypesPath = resolveGeneratedPath(root, srcDir, options.i18nTypesOutFile!, false);
+      const { signatures } = await readFarmI18nCatalogs(options.i18nConfig);
+      checkGeneratedFile(
+        i18nTypesPath,
+        renderFarmI18nTypes(options.i18nConfig.locales, signatures),
+        result.stalePaths,
+      );
+      result.i18nTypesPath = i18nTypesPath;
+    } else {
+      result.i18nTypesPath = await generateFarmI18nTypes({
+        root,
+        srcDir,
+        config: options.i18nConfig,
+        outFile: options.i18nTypesOutFile,
+      });
+    }
   }
 
   if (shouldRefreshUnifiedTypes) {
-    mkdirSync(dirname(unifiedTypesPath), { recursive: true });
-    writeFileIfChanged(
+    writeOrCheckGeneratedFile(
       unifiedTypesPath,
       `/**
  * Generated by Farm.js. Do not edit.
@@ -166,13 +205,51 @@ export async function generateFarmTypeArtifacts(
 
 import "@farm.js/core/image";
 
-${unifiedSections.join("\n")}`,
+${unifiedSections.map((section) => section.trimEnd()).join("\n\n")}
+`,
+      options.check,
+      result.stalePaths,
     );
     result.typesPath = unifiedTypesPath;
-    removeLegacyTypeArtifacts(root, srcDir);
+    if (options.check) {
+      collectLegacyTypeArtifacts(root, srcDir, result.stalePaths);
+    } else {
+      removeLegacyTypeArtifacts(root, srcDir);
+    }
   }
 
   return result;
+}
+
+function resolveGeneratedPath(
+  root: string,
+  srcDir: string,
+  outFile: string,
+  relativeToSrc = true,
+): string {
+  if (isAbsolute(outFile)) return resolve(outFile);
+  return resolve(root, relativeToSrc ? join(srcDir, outFile) : outFile);
+}
+
+function writeOrCheckGeneratedFile(
+  filePath: string,
+  content: string,
+  check: boolean | undefined,
+  stalePaths: string[],
+): void {
+  if (check) {
+    checkGeneratedFile(filePath, content, stalePaths);
+    return;
+  }
+
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileIfChanged(filePath, content);
+}
+
+function checkGeneratedFile(filePath: string, content: string, stalePaths: string[]): void {
+  if (!existsSync(filePath) || readFileSync(filePath, "utf8") !== content) {
+    stalePaths.push(filePath);
+  }
 }
 
 const LEGACY_TYPE_ARTIFACTS = [
@@ -190,5 +267,13 @@ function removeLegacyTypeArtifacts(root: string, srcDir: string): void {
     if (source.includes(marker)) {
       unlinkSync(filePath);
     }
+  }
+}
+
+function collectLegacyTypeArtifacts(root: string, srcDir: string, stalePaths: string[]): void {
+  for (const [fileName, marker] of LEGACY_TYPE_ARTIFACTS) {
+    const filePath = join(root, srcDir, fileName);
+    if (!existsSync(filePath)) continue;
+    if (readFileSync(filePath, "utf8").includes(marker)) stalePaths.push(filePath);
   }
 }

--- a/scripts/check-docs-navigation.mjs
+++ b/scripts/check-docs-navigation.mjs
@@ -1,0 +1,89 @@
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const docsRoot = path.join(repositoryRoot, "docs", "src", "app", "docs");
+const configPath = path.join(repositoryRoot, "docs", "docs.config.ts");
+
+const pages = collectDocsPages(docsRoot);
+const navigation = readNavigationSlugs(configPath);
+const visiblePages = new Set(pages.filter((page) => !page.hidden).map((page) => page.slug));
+const hiddenPages = new Set(pages.filter((page) => page.hidden).map((page) => page.slug));
+
+const missing = [...visiblePages].filter((slug) => !navigation.has(slug)).sort();
+const unknown = [...navigation]
+  .filter((slug) => !visiblePages.has(slug) && !hiddenPages.has(slug))
+  .sort();
+
+if (missing.length || unknown.length) {
+  const messages = ["Farm docs navigation coverage failed."];
+  if (missing.length) {
+    messages.push(
+      "",
+      "Pages missing from navigation (add them or set hidden: true in frontmatter):",
+      ...missing.map((slug) => `  - /docs/${slug}`.replace(/\/$/, "")),
+    );
+  }
+  if (unknown.length) {
+    messages.push(
+      "",
+      "Navigation entries without a matching docs page:",
+      ...unknown.map((slug) => `  - ${slug || "<docs index>"}`),
+    );
+  }
+  console.error(messages.join("\n"));
+  process.exitCode = 1;
+} else {
+  console.log(
+    `Docs navigation covers ${visiblePages.size} visible pages (${hiddenPages.size} explicitly hidden).`,
+  );
+}
+
+function collectDocsPages(directory) {
+  const pages = [];
+  const pending = [directory];
+
+  while (pending.length) {
+    const current = pending.pop();
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(entryPath);
+        continue;
+      }
+      if (entry.name !== "page.md" && entry.name !== "page.mdx") continue;
+
+      const relativeDirectory = path.relative(directory, path.dirname(entryPath));
+      const slug = relativeDirectory === "" ? "" : relativeDirectory.replaceAll(path.sep, "/");
+      const source = readFileSync(entryPath, "utf8");
+      pages.push({ slug, hidden: readHiddenFrontmatter(source) });
+    }
+  }
+
+  return pages;
+}
+
+function readHiddenFrontmatter(source) {
+  const frontmatter = source.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/)?.[1] || "";
+  return /^\s*hidden:\s*true\s*$/m.test(frontmatter);
+}
+
+function readNavigationSlugs(filePath) {
+  const source = readFileSync(filePath, "utf8");
+  const start = source.indexOf("const sidebar = [");
+  const end = source.indexOf("] satisfies FarmDocsSidebarItem[];", start);
+  if (start === -1 || end === -1) {
+    throw new Error(`Could not locate the static sidebar declaration in ${filePath}.`);
+  }
+
+  const sidebarSource = source.slice(start, end);
+  const slugs = new Set();
+  for (const match of sidebarSource.matchAll(/\bslug\s*:\s*["']([^"']*)["']/g)) {
+    if (slugs.has(match[1])) {
+      throw new Error(`Duplicate docs navigation slug: ${match[1] || "<docs index>"}`);
+    }
+    slugs.add(match[1]);
+  }
+  return slugs;
+}

--- a/scripts/check-docs-navigation.mjs
+++ b/scripts/check-docs-navigation.mjs
@@ -66,18 +66,23 @@ function collectDocsPages(directory) {
 
 function readHiddenFrontmatter(source) {
   const frontmatter = source.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/)?.[1] || "";
-  return /^\s*hidden:\s*true\s*$/m.test(frontmatter);
+  const value = frontmatter.match(
+    /^\s*hidden\s*:\s*(?:"([^"]*)"|'([^']*)'|([^\s#]+))\s*(?:#.*)?$/im,
+  );
+  return (value?.[1] || value?.[2] || value?.[3] || "").toLowerCase() === "true";
 }
 
 function readNavigationSlugs(filePath) {
   const source = readFileSync(filePath, "utf8");
-  const start = source.indexOf("const sidebar = [");
-  const end = source.indexOf("] satisfies FarmDocsSidebarItem[];", start);
-  if (start === -1 || end === -1) {
+  const declaration = /\bconst\s+sidebar\s*=\s*\[/.exec(source);
+  const end = declaration
+    ? /\]\s+satisfies\s+FarmDocsSidebarItem\s*\[\s*\]\s*;?/.exec(source.slice(declaration.index))
+    : null;
+  if (!declaration || !end) {
     throw new Error(`Could not locate the static sidebar declaration in ${filePath}.`);
   }
 
-  const sidebarSource = source.slice(start, end);
+  const sidebarSource = source.slice(declaration.index, declaration.index + end.index);
   const slugs = new Set();
   for (const match of sidebarSource.matchAll(/\bslug\s*:\s*["']([^"']*)["']/g)) {
     if (slugs.has(match[1])) {


### PR DESCRIPTION
## Summary

- add the five missing docs sidebar entries and enforce navigation coverage with explicit hidden-page support in CI
- add read-only generated-type checks, safe doctor corrections, and stable formatter-compatible generated route declarations
- add route explanation and side-effect-free deployment planning with text and JSON-friendly APIs
- document the new CLI workflows and cover their safety and correctness behavior

## Validation

- pnpm --filter @farm.js/core build
- pnpm --filter @farm.js/core type-check
- pnpm --filter @farm.js/cli type-check
- pnpm --filter @farm.js/cli test
- pnpm --filter @farm.js/core exec vitest run src/__tests__/type-artifacts.test.ts src/__tests__/route-runtime-deployment.test.ts
- pnpm docs:check-navigation
- pnpm --dir docs exec farm generate --check
- pnpm docs:build
- pnpm lint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds new CLI safety and planning tools: `generate --check`, `doctor --fix`, `explain`, and `deploy --plan`, plus CI checks for docs navigation and stale generated types. Also adds deployment planning APIs, Cloudflare Agent planning support, and multiline route type unions to prevent formatter diffs.

- **New Features**
  - `farm generate --check` verifies committed route/API/env/i18n types without writing; exits non‑zero on stale and lists paths (`FarmGeneratedArtifactsStaleError`); incompatible with schema flags.
  - `farm doctor --fix` creates a missing `src/app/layout.tsx` safely (no overwrites), respects configured project roots, reruns checks, and reports applied fixes.
  - `farm explain <path> [--json]` resolves a URL to its page, params, layouts, middleware, rendering/cache/runtime, metadata, and deployment compatibility (with preset‑runtime warnings); read‑only text or JSON.
  - `farm deploy --plan` shows target, preset, runtime, output, and exact build/deploy commands without executing; programmatic APIs: `createFarmDeployPlan`, `formatFarmDeployPlan`; includes Cloudflare Agent config (existing or generated) and treats Netlify as production.
  - CI/Docs: adds `pnpm docs:check-navigation` (supports hidden pages) and runs `farm generate --check`; sidebar adds “Fonts”, “Server Queries”, “Route Runtime”, “After Responses”, and “Client Plugins”; CLI docs updated.
  - Route type declarations now emit and accept multiline unions to reduce diff churn.

- **Migration**
  - If you commit generated types, add a CI step: `farm generate --check`.
  - Use `farm deploy --plan` in review or policy checks to validate deployments without credentials; Cloudflare Agent planning is supported.
  - Optional: run `farm doctor --fix` to create a missing root layout safely; no other action required.

<sup>Written for commit 1037a4ebaa2860d5dc369669cacf4808699a8d7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

