### PR TITLE
fix: restrict route explanation to registered manifests

### DIFF
--- a/packages/farm-cli/src/explain.ts
+++ b/packages/farm-cli/src/explain.ts
@@ -258,7 +258,12 @@ function discoverMatchingPages(
     const sourceDirectory = path.join(source.root, source.srcDir);
     if (!existsSync(sourceDirectory)) continue;
     for (const entry of readdirSync(sourceDirectory, { withFileTypes: true })) {
-      if (!entry.isFile() || !isProgrammaticRoutesFileName(entry.name)) continue;
+      if (
+        (!entry.isFile() && !entry.isSymbolicLink()) ||
+        !isProgrammaticRoutesFileName(entry.name)
+      ) {
+        continue;
+      }
       const filePath = path.join(sourceDirectory, entry.name);
       const moduleSource = readFileSync(filePath, "utf8");
       for (const pattern of scanProgrammaticPagePaths(moduleSource)) {

--- a/packages/farm-cli/src/explain.ts
+++ b/packages/farm-cli/src/explain.ts
@@ -2,6 +2,7 @@ import {
   farmRouteRuleMatches,
   getFarmSourceRoots,
   getFarmPresetRuntime,
+  isProgrammaticRoutesFileName,
   loadConfig,
   mergeFarmRouteRuntimeConfigs,
   resolveConfig,
@@ -256,8 +257,9 @@ function discoverMatchingPages(
 
     const sourceDirectory = path.join(source.root, source.srcDir);
     if (!existsSync(sourceDirectory)) continue;
-    for (const filePath of walkFiles(sourceDirectory)) {
-      if (!/\.(?:tsx?|jsx?)$/.test(filePath) || filePath.endsWith(".d.ts")) continue;
+    for (const entry of readdirSync(sourceDirectory, { withFileTypes: true })) {
+      if (!entry.isFile() || !isProgrammaticRoutesFileName(entry.name)) continue;
+      const filePath = path.join(sourceDirectory, entry.name);
       const moduleSource = readFileSync(filePath, "utf8");
       for (const pattern of scanProgrammaticPagePaths(moduleSource)) {
         const match = matchRoutePattern(pattern, pathname);

--- a/packages/farm-cli/test/explain.test.mjs
+++ b/packages/farm-cli/test/explain.test.mjs
@@ -83,7 +83,11 @@ test("discovers pages declared through the programmatic router", async () => {
     );
     await writeFile(
       path.join(root, "src/lib/unregistered.ts"),
-      'page("/not-registered", { component: () => null });\n',
+      [
+        'import { page } from "@farm.js/core";',
+        'page("/not-registered", { component: () => null });',
+        "",
+      ].join("\n"),
     );
 
     const explanation = await explainFarmRoute("/catalog/42", { root });

--- a/packages/farm-cli/test/explain.test.mjs
+++ b/packages/farm-cli/test/explain.test.mjs
@@ -70,7 +70,7 @@ test("discovers pages declared through the programmatic router", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "farm-cli-explain-programmatic-"));
 
   try {
-    await mkdir(path.join(root, "src"), { recursive: true });
+    await mkdir(path.join(root, "src/lib"), { recursive: true });
     await writeFile(path.join(root, "farm.config.mjs"), "export default {};\n");
     await writeFile(
       path.join(root, "src/farm.routes.ts"),
@@ -81,12 +81,20 @@ test("discovers pages declared through the programmatic router", async () => {
         "",
       ].join("\n"),
     );
+    await writeFile(
+      path.join(root, "src/lib/unregistered.ts"),
+      'page("/not-registered", { component: () => null });\n',
+    );
 
     const explanation = await explainFarmRoute("/catalog/42", { root });
 
     assert.equal(explanation.pattern, "/catalog/[id]");
     assert.deepEqual(explanation.params, { id: "42" });
     assert.equal(explanation.filePath, "src/farm.routes.ts");
+    await assert.rejects(
+      () => explainFarmRoute("/not-registered", { root }),
+      /No Farm page route matches/,
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- restrict programmatic route discovery in `farm explain` to root `farm.route*`, `farm.routes*`, and `routes*` manifest files that the runtime actually loads
- add a regression proving unrelated source-level `page(...)` calls cannot create phantom explanations

## Validation

- `pnpm --filter @farm.js/cli build`
- `node --test packages/farm-cli/test/explain.test.mjs`
- `pnpm exec oxfmt --check packages/farm-cli/src/explain.ts packages/farm-cli/test/explain.test.mjs`
- `pnpm exec oxlint packages/farm-cli/src/explain.ts packages/farm-cli/test/explain.test.mjs`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts programmatic route discovery in `farm explain` to root manifests the runtime loads, preventing false matches from unrelated `page()` calls.

- **Bug Fixes**
  - Only scan `src/` for files matching `farm.route*`, `farm.routes*`, and `routes*` via `isProgrammaticRoutesFileName`; recursive scanning of all `*.ts/js` files is removed.
  - Regression test ensures `page()` in `src/lib/unregistered.ts` no longer creates phantom explanations while `src/farm.routes.ts` still resolves.

<sup>Written for commit 896e1f2b5c7d8e92450b7592fe69b0c3ec6be802. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

