### PR TITLE
fix: make rate limiting atomic

### DIFF
--- a/docs/src/app/docs/storage/page.md
+++ b/docs/src/app/docs/storage/page.md
@@ -8,14 +8,14 @@ section: "Data and APIs"
 
 Farm's `@farm.js/core/storage` module is a **key/value API**. Every value is stored under a string key and read with operations such as `getItem`, `setItem`, `getKeys`, and `removeItem`.
 
-Use it for caches, feature flags, application settings, rate-limit counters, idempotency records, checkpoints, and object-backed values. Do not use it as a relational ORM for users, accounts, products, or other records that need model fields, relations, joins, or typed filters.
+Use it for caches, feature flags, application settings, idempotency records, checkpoints, and object-backed values. Do not use it as a relational ORM for users, accounts, products, or other records that need model fields, relations, joins, or typed filters. Request-rate enforcement uses a separate atomic counter contract described below.
 
 ## Choose the right data API
 
 | What you need                                     | Use                                                         |
 | ------------------------------------------------- | ----------------------------------------------------------- |
 | Cache entries, flags, settings, counters, or JSON | Farm KV storage through `getStorage(name)`                  |
-| Rate limiting shared across production instances  | A durable `ratelimit` mount under `storage.mounts`          |
+| Rate limiting shared across production instances  | An atomic adapter such as `redisRateLimitStorage(...)`      |
 | Files or values addressed by one key              | An object-backed KV helper such as `s3Storage(...)`         |
 | Application models, relations, joins, and filters | An application-owned `@farming-labs/orm` or another ORM     |
 | Models owned by a schema-backed Farm integration  | Farm's integration ORM through `ctx.args.db`                |
@@ -34,15 +34,11 @@ These paths do not convert into each other. In particular, a raw PostgreSQL pool
 **src/lib/storage.ts**
 
 ```ts
-import { redisStorage, sqliteStorage } from "@farm.js/core/storage";
+import { sqliteStorage } from "@farm.js/core/storage";
 
 export const appStorage = sqliteStorage({
   path: "./.farm/storage/app.sqlite",
   tableName: "app_store",
-});
-
-export const rateLimitStorage = redisStorage({
-  url: process.env.REDIS_URL!,
 });
 ```
 
@@ -54,13 +50,12 @@ KV helpers return ready-to-use clients, so application code can import and call 
 
 ```ts
 import { defineConfig } from "@farm.js/core";
-import { appStorage, rateLimitStorage } from "./src/lib/storage";
+import { appStorage } from "./src/lib/storage";
 
 export default defineConfig({
   storage: {
     mounts: {
       app: appStorage,
-      ratelimit: rateLimitStorage,
     },
   },
 });
@@ -69,12 +64,11 @@ export default defineConfig({
 Each property under `mounts` is a KV namespace:
 
 - `app` is an application-defined name. Farm does not attach special behavior to it.
-- `ratelimit` is a Farm convention. The built-in `.rateLimit()` middleware uses this namespace automatically.
 - You can add names such as `cache`, `sessions`, `uploads`, or `webhooks` when the application needs more stores.
 
 A mount name is not a URL, route, database table, or filesystem directory. It is the lookup name that connects configuration to later server-side calls.
 
-`getStorage(name)` always returns a namespaced key/value view. When the name matches a configured mount, operations use that mount's driver. When no matching mount exists, Farm uses the same namespace on the root store instead. The default root store is in memory, so a missing or misspelled production mount does not throw but may store data only for the lifetime of one process.
+`getStorage(name)` always returns a namespaced key/value view. When the name matches a configured mount, operations use that mount's driver. When no matching mount exists, Farm uses the same namespace on the root store instead. The default root store is in memory, so a missing or misspelled production mount does not throw but may store data only for the lifetime of one process. Rate-limit middleware is an exception: enforcement requires its dedicated atomic storage contract and never treats a generic KV mount as atomic.
 
 ## Use a mounted store
 
@@ -165,27 +159,37 @@ await appStore.clear();
 
 Use descriptive keys such as `settings:global`, `tenant:acme:flags`, or `webhook:event_123`. Namespaced keys make inspection and targeted cleanup easier.
 
-## How the rate-limit mount is used
+## Atomic rate-limit storage
 
-The `ratelimit` name is recognized by Farm's built-in rate-limit middleware. Once that mount is configured, middleware can use it without calling `getStorage("ratelimit")` directly:
+The built-in rate limiter uses an atomic `increment(key, windowMs)` contract. Its default adapter is atomic inside one process, which is useful for local development and a single long-running server. Production deployments with multiple processes or regions should pass a shared atomic adapter explicitly:
+
+```bash
+pnpm add @farm.js/cache-redis ioredis
+```
 
 **src/app/api/middleware.ts**
 
 ```ts
+import { redisRateLimitStorage } from "@farm.js/cache-redis";
 import { middleware } from "@farm.js/core/middleware";
+import Redis from "ioredis";
+
+const rateLimits = redisRateLimitStorage({
+  client: () => new Redis(process.env.REDIS_URL!),
+  prefix: "storefront-ratelimit",
+});
 
 export default middleware().rateLimit({
   requests: 100,
   window: "1m",
+  storage: rateLimits,
   keyGenerator: (ctx) => {
     return ctx.request.socket.remoteAddress ?? "unknown";
   },
 });
 ```
 
-For each key, Farm stores a request count and reset time in the `ratelimit` namespace, increments the count, applies the configured TTL, and returns `429` when the limit is reached.
-
-If no `ratelimit` mount is configured, the middleware still uses a `ratelimit` namespace on the root storage. The default root storage is in memory, which is useful for local development but is not shared between production instances and is cleared on restart. Use Redis, Upstash Redis, or another shared store for production rate limits.
+The Redis adapter uses one Lua operation to increment the counter and establish its expiry. A generic `get()` followed by `set()` adapter is rejected because concurrent requests can read the same count and overwrite each other. Limited responses include `Retry-After`; all responses include the [`RateLimit` and `RateLimit-Policy` fields from the current IETF draft](https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/).
 
 Choose a trusted rate-limit identity when possible. An authenticated user or tenant ID is usually more useful than an IP address for application-level limits:
 
@@ -200,22 +204,22 @@ export default middleware().rateLimit({
 });
 ```
 
-You can inspect the namespace manually with `getStorage("ratelimit")`, but normal middleware usage does not require it.
+Adapters may implement `get(key)` so `getRateLimitStatus()` can inspect a counter. Enforcement itself only depends on atomic `increment()`.
 
 ## Choosing mounts and drivers
 
 Mount names describe the responsibility; drivers decide where the values live:
 
-| Use case                                    | Suggested mount             | Typical driver                                        |
-| ------------------------------------------- | --------------------------- | ----------------------------------------------------- |
-| Application settings and durable JSON state | `app` or `settings`         | SQLite, Postgres, MySQL, or libSQL                    |
-| Shared cache entries                        | `cache`                     | Redis, Upstash Redis, or memory for local development |
-| Rate-limit counters                         | `ratelimit`                 | Redis or Upstash Redis                                |
-| Idempotency and webhook deduplication       | `webhooks` or `idempotency` | Redis or a durable SQL store                          |
-| Bucket-backed objects or metadata           | `uploads`                   | S3 or Vercel Blob                                     |
-| Tests and disposable local state            | Any descriptive name        | Memory or local filesystem                            |
+| Use case                                    | Suggested mount              | Typical driver                                        |
+| ------------------------------------------- | ---------------------------- | ----------------------------------------------------- |
+| Application settings and durable JSON state | `app` or `settings`          | SQLite, Postgres, MySQL, or libSQL                    |
+| Shared cache entries                        | `cache`                      | Redis, Upstash Redis, or memory for local development |
+| Rate-limit counters                         | Dedicated rate-limit adapter | `redisRateLimitStorage(...)` or another atomic store  |
+| Idempotency and webhook deduplication       | `webhooks` or `idempotency`  | Redis or a durable SQL store                          |
+| Bucket-backed objects or metadata           | `uploads`                    | S3 or Vercel Blob                                     |
+| Tests and disposable local state            | Any descriptive name         | Memory or local filesystem                            |
 
-The names are conventions chosen by the application, except for framework-owned names such as `ratelimit`. Two mounts may use the same driver type while remaining isolated, or use different drivers based on durability and latency requirements.
+The mount names are conventions chosen by the application. Two mounts may use the same driver type while remaining isolated, or use different drivers based on durability and latency requirements. A mount named `ratelimit` is still generic KV storage and is not accepted as proof of atomic increment support.
 
 ## Supported KV drivers
 
@@ -241,7 +245,7 @@ Import these helpers from `@farm.js/core/storage`:
 | `pgliteStorage(...)`                          | `pglite`                 | Embedded Postgres-compatible storage.                                             |
 | `planetscaleStorage(...)`                     | `planetscale`            | PlanetScale-backed durable storage.                                               |
 | `libsqlStorage(...)`                          | `libsql`                 | Local or remote libSQL/Turso-compatible storage.                                  |
-| `redisStorage(...)`                           | `redis`                  | Shared caches, rate limits, sessions, counters, and short-lived state.            |
+| `redisStorage(...)`                           | `redis`                  | Shared caches, sessions, counters, and short-lived state.                         |
 | `upstashStorage(...)`                         | `upstash`                | HTTP-based Redis storage for serverless and edge-style deployments.               |
 | `mongodbStorage(...)`                         | `mongodb`                | Durable document-backed key/value storage.                                        |
 | `s3Storage(...)`                              | `s3`                     | S3-compatible object-backed values.                                               |
@@ -320,7 +324,7 @@ Farm also accepts the built-in driver names exported by its installed `unstorage
 | Filesystem              | `local`, `fs-lite`, `fsLite`, `fs`                  | Persistent files. `local` is Farm's shorthand for `fs-lite`; `fs` adds watcher support. |
 | Remote HTTP             | `http`                                              | Read and write through an HTTP storage endpoint.                                        |
 | GitHub content          | `github`                                            | Read-only, cached repository content access.                                            |
-| Redis                   | `redis`                                             | Shared cache, counters, sessions, and rate limits.                                      |
+| Redis                   | `redis`                                             | Shared cache, counters, sessions, and short-lived state.                                |
 | Upstash Redis           | `upstash`                                           | REST-based Redis for serverless runtimes.                                               |
 | MongoDB                 | `mongodb`                                           | MongoDB collection-backed values.                                                       |
 | S3-compatible objects   | `s3`                                                | AWS S3, Cloudflare R2's S3 API, and compatible providers.                               |
@@ -401,7 +405,7 @@ See [Database and ORM Clients](/docs/integrations/orm-storage) for application-o
 | Config                                      | Use it for                                             |
 | ------------------------------------------- | ------------------------------------------------------ |
 | `sqliteStorage(...)`                        | Farm KV storage with a Farm storage client.            |
-| `redisStorage(...)`                         | Cache, rate-limit, or queue-like key/value data.       |
+| `redisStorage(...)`                         | Cache or queue-like key/value data.                    |
 | `storage.mounts`                            | Multiple named key/value stores.                       |
 | `storage.client` with a Farm storage client | Reuse a created Farm storage client as the root store. |
 | `storage.client` with a DB/runtime object   | Give integrations a runtime database client.           |

--- a/examples/basic/src/app/storage-demo/page.tsx
+++ b/examples/basic/src/app/storage-demo/page.tsx
@@ -35,7 +35,7 @@ export const mysql = mysqlStorage({
   },
   {
     title: "redisStorage",
-    note: "Redis helper for rate limits, cache, and short-lived state.",
+    note: "Redis helper for cache and short-lived KV state.",
     code: `import { redisStorage } from "@farm.js/core/storage";
 
 export const redis = redisStorage({
@@ -117,7 +117,7 @@ export default defineConfig({
   storage: {
     mounts: {
       app: sqlite,
-      ratelimit: redis,
+      sessions: redis,
     },
   },
 });`}

--- a/packages/farm-cache-redis/README.md
+++ b/packages/farm-cache-redis/README.md
@@ -31,3 +31,26 @@ Application code keeps using the cache APIs from `@farm.js/core/cache`.
 
 Use a distinct namespace for each application or deployment environment. Do not put
 user-specific values in shared keys unless the key includes the user or tenant identity.
+
+## Atomic rate limits
+
+KV `get()` followed by `set()` is not safe for enforcing a request limit across concurrent
+instances. Use the dedicated adapter, which increments and expires the counter in one Redis Lua
+operation:
+
+```ts
+import { redisRateLimitStorage } from "@farm.js/cache-redis";
+import { middleware } from "@farm.js/core/middleware";
+import Redis from "ioredis";
+
+const rateLimits = redisRateLimitStorage({
+  client: () => new Redis(process.env.REDIS_URL!),
+  prefix: "storefront-ratelimit",
+});
+
+export default middleware().rateLimit({
+  requests: 100,
+  window: "1m",
+  storage: rateLimits,
+});
+```

--- a/packages/farm-cache-redis/package.json
+++ b/packages/farm-cache-redis/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@farm.js/cache-redis",
   "version": "0.1.0-beta.3",
-  "description": "Distributed Redis cache adapter for Farm.js",
+  "description": "Distributed Redis cache and atomic rate-limit adapters for Farm.js",
   "keywords": [
     "cache",
     "farm.js",
     "isr",
     "ppr",
+    "rate-limit",
     "redis"
   ],
   "license": "MIT",

--- a/packages/farm-cache-redis/src/index.test.ts
+++ b/packages/farm-cache-redis/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { FarmCacheEntry } from "@farm.js/core/cache";
-import { redisCache, type FarmRedisClient } from "./index";
+import { redisCache, redisRateLimitStorage, type FarmRedisClient } from "./index";
 
 describe("redisCache", () => {
   it("stores entries, increments tag versions, and owns leases", async () => {
@@ -37,35 +37,84 @@ describe("redisCache", () => {
   });
 });
 
+describe("redisRateLimitStorage", () => {
+  it("increments a fixed-window counter atomically and exposes its status", async () => {
+    const client = new FakeRedis();
+    const storage = redisRateLimitStorage({ client, prefix: "limits" });
+
+    const increments = await Promise.all(
+      Array.from({ length: 50 }, () => storage.increment("account:42", 60_000)),
+    );
+
+    expect(increments.map((entry) => entry.count).sort((a, b) => a - b)).toEqual(
+      Array.from({ length: 50 }, (_, index) => index + 1),
+    );
+    await expect(storage.get?.("account:42")).resolves.toMatchObject({ count: 50 });
+  });
+});
+
 class FakeRedis implements FarmRedisClient {
   private values = new Map<string, string>();
+  private expiresAt = new Map<string, number>();
+
+  private read(key: string): string | null {
+    const expiry = this.expiresAt.get(key);
+    if (expiry !== undefined && expiry <= Date.now()) {
+      this.values.delete(key);
+      this.expiresAt.delete(key);
+    }
+    return this.values.get(key) ?? null;
+  }
 
   async get(key: string): Promise<string | null> {
-    return this.values.get(key) ?? null;
+    return this.read(key);
   }
 
   async set(key: string, value: string, ...args: unknown[]): Promise<unknown> {
     if (args.includes("NX") && this.values.has(key)) return null;
     this.values.set(key, value);
+    const pxIndex = args.indexOf("PX");
+    if (pxIndex >= 0 && typeof args[pxIndex + 1] === "number") {
+      this.expiresAt.set(key, Date.now() + Number(args[pxIndex + 1]));
+    }
     return "OK";
   }
 
   async del(key: string): Promise<number> {
+    this.expiresAt.delete(key);
     return this.values.delete(key) ? 1 : 0;
   }
 
   async incr(key: string): Promise<number> {
-    const next = Number(this.values.get(key) ?? 0) + 1;
+    const next = Number(this.read(key) ?? 0) + 1;
     this.values.set(key, String(next));
     return next;
+  }
+
+  async pttl(key: string): Promise<number> {
+    if (this.read(key) === null) return -2;
+    const expiry = this.expiresAt.get(key);
+    return expiry === undefined ? -1 : Math.max(0, expiry - Date.now());
   }
 
   async mget(...keys: string[]): Promise<Array<string | null>> {
     return Promise.all(keys.map((key) => this.get(key)));
   }
 
-  async eval(_script: string, _numberOfKeys: number, key: string, token: string): Promise<unknown> {
-    if ((await this.get(key)) !== token) return 0;
+  async eval(script: string, _numberOfKeys: number, key: string, arg: string): Promise<unknown> {
+    if (script.includes('redis.call("INCR"')) {
+      const count = Number(this.read(key) ?? 0) + 1;
+      this.values.set(key, String(count));
+      const expiry = this.expiresAt.get(key);
+      let ttl = expiry === undefined ? -1 : Math.max(0, expiry - Date.now());
+      if (count === 1 || ttl < 0) {
+        ttl = Number(arg);
+        this.expiresAt.set(key, Date.now() + ttl);
+      }
+      return [count, ttl];
+    }
+
+    if (this.read(key) !== arg) return 0;
     return this.del(key);
   }
 }

--- a/packages/farm-cache-redis/src/index.test.ts
+++ b/packages/farm-cache-redis/src/index.test.ts
@@ -38,22 +38,26 @@ describe("redisCache", () => {
 });
 
 describe("redisRateLimitStorage", () => {
-  it("increments a fixed-window counter atomically and exposes its status", async () => {
+  it("increments and initializes expiry in one Redis script operation", async () => {
     const client = new FakeRedis();
     const storage = redisRateLimitStorage({ client, prefix: "limits" });
 
-    const increments = await Promise.all(
-      Array.from({ length: 50 }, () => storage.increment("account:42", 60_000)),
-    );
+    await expect(storage.increment("account:42", 60_000)).resolves.toMatchObject({ count: 1 });
+    await expect(storage.increment("account:42", 60_000)).resolves.toMatchObject({ count: 2 });
 
-    expect(increments.map((entry) => entry.count).sort((a, b) => a - b)).toEqual(
-      Array.from({ length: 50 }, (_, index) => index + 1),
-    );
-    await expect(storage.get?.("account:42")).resolves.toMatchObject({ count: 50 });
+    expect(client.evalCalls).toHaveLength(2);
+    expect(client.evalCalls[0]).toMatchObject({
+      numberOfKeys: 1,
+      args: ["limits:account:42", "60000"],
+    });
+    expect(client.evalCalls[0].script).toContain('redis.call("INCR", KEYS[1])');
+    expect(client.evalCalls[0].script).toContain("ttl <= 0");
+    await expect(storage.get?.("account:42")).resolves.toMatchObject({ count: 2 });
   });
 });
 
 class FakeRedis implements FarmRedisClient {
+  readonly evalCalls: Array<{ script: string; numberOfKeys: number; args: string[] }> = [];
   private values = new Map<string, string>();
   private expiresAt = new Map<string, number>();
 
@@ -101,13 +105,15 @@ class FakeRedis implements FarmRedisClient {
     return Promise.all(keys.map((key) => this.get(key)));
   }
 
-  async eval(script: string, _numberOfKeys: number, key: string, arg: string): Promise<unknown> {
+  async eval(script: string, numberOfKeys: number, ...args: string[]): Promise<unknown> {
+    this.evalCalls.push({ script, numberOfKeys, args });
+    const [key, arg] = args;
     if (script.includes('redis.call("INCR"')) {
       const count = Number(this.read(key) ?? 0) + 1;
       this.values.set(key, String(count));
       const expiry = this.expiresAt.get(key);
       let ttl = expiry === undefined ? -1 : Math.max(0, expiry - Date.now());
-      if (count === 1 || ttl < 0) {
+      if (count === 1 || ttl <= 0) {
         ttl = Number(arg);
         this.expiresAt.set(key, Date.now() + ttl);
       }

--- a/packages/farm-cache-redis/src/index.ts
+++ b/packages/farm-cache-redis/src/index.ts
@@ -47,7 +47,7 @@ return 0
 const INCREMENT_RATE_LIMIT_SCRIPT = `
 local count = redis.call("INCR", KEYS[1])
 local ttl = redis.call("PTTL", KEYS[1])
-if count == 1 or ttl < 0 then
+if count == 1 or ttl <= 0 then
   redis.call("PEXPIRE", KEYS[1], ARGV[1])
   ttl = tonumber(ARGV[1])
 end

--- a/packages/farm-cache-redis/src/index.ts
+++ b/packages/farm-cache-redis/src/index.ts
@@ -1,4 +1,5 @@
 import type { FarmCacheAdapter, FarmCacheEntry } from "@farm.js/core/cache";
+import type { RateLimitStorage } from "@farm.js/core/middleware";
 
 export interface FarmRedisClient {
   get(key: string): Promise<string | null>;
@@ -16,10 +17,23 @@ export interface FarmRedisClient {
   eval(script: string, numberOfKeys: number, ...args: string[]): Promise<unknown>;
 }
 
+export interface FarmRedisRateLimitClient extends FarmRedisClient {
+  pttl(key: string): Promise<number>;
+}
+
 export interface RedisCacheOptions {
   /** Existing Redis-compatible client or a lazy client factory. */
   client: FarmRedisClient | (() => FarmRedisClient | Promise<FarmRedisClient>);
   /** Prefix isolating Farm cache records from other Redis data. */
+  prefix?: string;
+}
+
+export interface RedisRateLimitOptions {
+  /** Existing Redis-compatible client or a lazy client factory. */
+  client:
+    | FarmRedisRateLimitClient
+    | (() => FarmRedisRateLimitClient | Promise<FarmRedisRateLimitClient>);
+  /** Prefix isolating rate-limit counters from other Redis data. */
   prefix?: string;
 }
 
@@ -28,6 +42,16 @@ if redis.call("get", KEYS[1]) == ARGV[1] then
   return redis.call("del", KEYS[1])
 end
 return 0
+`;
+
+const INCREMENT_RATE_LIMIT_SCRIPT = `
+local count = redis.call("INCR", KEYS[1])
+local ttl = redis.call("PTTL", KEYS[1])
+if count == 1 or ttl < 0 then
+  redis.call("PEXPIRE", KEYS[1], ARGV[1])
+  ttl = tonumber(ARGV[1])
+end
+return { count, ttl }
 `;
 
 /**
@@ -39,7 +63,7 @@ export function redisCache(options: RedisCacheOptions): FarmCacheAdapter {
     throw new TypeError("redisCache requires a Redis-compatible client.");
   }
 
-  const prefix = normalizePrefix(options.prefix || "farm-cache");
+  const prefix = normalizePrefix(options.prefix || "farm-cache", "redisCache");
   let clientPromise: Promise<FarmRedisClient> | undefined;
 
   const getClient = () => {
@@ -105,9 +129,64 @@ export function redisCache(options: RedisCacheOptions): FarmCacheAdapter {
   };
 }
 
-function normalizePrefix(value: string): string {
+/** Create a Redis-backed atomic fixed-window rate-limit store. */
+export function redisRateLimitStorage(options: RedisRateLimitOptions): RateLimitStorage {
+  if (!options?.client) {
+    throw new TypeError("redisRateLimitStorage requires a Redis-compatible client.");
+  }
+
+  const prefix = normalizePrefix(options.prefix || "farm-ratelimit", "redisRateLimitStorage");
+  let clientPromise: Promise<FarmRedisRateLimitClient> | undefined;
+  const getClient = () => {
+    clientPromise ??= Promise.resolve(
+      typeof options.client === "function" ? options.client() : options.client,
+    );
+    return clientPromise;
+  };
+  const key = (value: string) => `${prefix}:${value}`;
+
+  return {
+    async increment(rateLimitKey, windowMs) {
+      if (!Number.isSafeInteger(windowMs) || windowMs <= 0) {
+        throw new TypeError("Rate-limit windowMs must be a positive safe integer.");
+      }
+
+      const result = await (
+        await getClient()
+      ).eval(INCREMENT_RATE_LIMIT_SCRIPT, 1, key(rateLimitKey), String(windowMs));
+      if (!Array.isArray(result) || result.length < 2) {
+        throw new Error("Redis returned an invalid atomic rate-limit result.");
+      }
+
+      const count = Number(result[0]);
+      const ttlMs = Number(result[1]);
+      if (!Number.isSafeInteger(count) || count <= 0 || !Number.isFinite(ttlMs) || ttlMs <= 0) {
+        throw new Error("Redis returned an invalid atomic rate-limit count or expiry.");
+      }
+
+      return { count, resetAt: Date.now() + ttlMs };
+    },
+    async get(rateLimitKey) {
+      const client = await getClient();
+      const redisKey = key(rateLimitKey);
+      const [serializedCount, ttlMs] = await Promise.all([
+        client.get(redisKey),
+        client.pttl(redisKey),
+      ]);
+      if (serializedCount === null || ttlMs <= 0) return null;
+
+      const count = Number(serializedCount);
+      if (!Number.isSafeInteger(count) || count <= 0) {
+        throw new Error(`Redis rate-limit counter ${JSON.stringify(rateLimitKey)} is invalid.`);
+      }
+      return { count, resetAt: Date.now() + ttlMs };
+    },
+  };
+}
+
+function normalizePrefix(value: string, owner: string): string {
   const prefix = value.trim().replace(/:+$/g, "");
-  if (!prefix) throw new TypeError("redisCache prefix cannot be empty.");
+  if (!prefix) throw new TypeError(`${owner} prefix cannot be empty.`);
   return prefix;
 }
 

--- a/packages/farm/scripts/post-build.js
+++ b/packages/farm/scripts/post-build.js
@@ -141,7 +141,7 @@ fixTypeFile(
   /^middleware-.*\.d\.mts$/,
   "middleware.d.mts",
   "MiddlewareContext",
-  "export { middleware, getRateLimitStatus, createContext, MiddlewareManager, getMiddlewareData, getMiddlewareValue, unwrapMiddleware, getFromMiddleware, hasMiddlewareData };\nexport type { MiddlewareContext, MiddlewareFunction, MiddlewareChain, MiddlewareConfig, CookieJar, CookieOptions, RateLimitConfig, RateLimitStorage, RateLimitStatus, NextFunction };",
+  "export { middleware, getRateLimitStatus, memoryRateLimitStorage, UnsupportedRateLimitStorageError, createContext, MiddlewareManager, getMiddlewareData, getMiddlewareValue, unwrapMiddleware, getFromMiddleware, hasMiddlewareData };\nexport type { MiddlewareContext, MiddlewareFunction, MiddlewareChain, MiddlewareConfig, CookieJar, CookieOptions, RateLimitConfig, RateLimitIncrementResult, RateLimitStorage, RateLimitStatus, MemoryRateLimitStorageOptions, NextFunction };",
 );
 fixTypeFile(/^api-.*\.d\.mts$/, "api.d.mts");
 

--- a/packages/farm/src/__tests__/middleware.test.ts
+++ b/packages/farm/src/__tests__/middleware.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, expectTypeOf, vi, beforeEach } from "vitest";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { middleware, getRateLimitStatus } from "../middleware/chain";
+import {
+  middleware,
+  getRateLimitStatus,
+  memoryRateLimitStorage,
+  UnsupportedRateLimitStorageError,
+} from "../middleware/chain";
 import { createContext } from "../middleware/context";
 import { MiddlewareManager } from "../middleware/manager";
 import {
@@ -38,6 +43,28 @@ async function executeChain(handlers: any[], ctx: MiddlewareContext) {
     }
   };
   await executeNext();
+}
+
+function createTestRateLimitStorage(
+  entries: Iterable<[string, { count: number; resetAt: number }]> = [],
+) {
+  const records = new Map(entries);
+  const storage: RateLimitStorage = {
+    increment(key, windowMs) {
+      const now = Date.now();
+      const current = records.get(key);
+      const next =
+        !current || current.resetAt <= now
+          ? { count: 1, resetAt: now + windowMs }
+          : { count: current.count + 1, resetAt: current.resetAt };
+      records.set(key, next);
+      return next;
+    },
+    get(key) {
+      return records.get(key) ?? null;
+    },
+  };
+  return { records, storage };
 }
 
 // Helper to create mock request/response
@@ -403,6 +430,9 @@ describe("Middleware Chain", () => {
 
       await executeNext();
       expect(ctx._handled).toBe(false);
+      expect(ctx.headers.get("RateLimit-Policy")).toBe('"farm";q=2;w=1');
+      expect(ctx.headers.get("RateLimit")).toMatch(/^"farm";r=1;t=\d+$/);
+      expect(ctx.headers.has("Retry-After")).toBe(false);
     }
 
     // Second request - should pass
@@ -446,28 +476,41 @@ describe("Middleware Chain", () => {
           "Content-Type": "application/json",
         }),
       );
+      expect(ctx.headers.get("RateLimit-Policy")).toBe('"farm";q=2;w=1');
+      expect(ctx.headers.get("RateLimit")).toMatch(/^"farm";r=0;t=\d+$/);
+      expect(ctx.headers.get("Retry-After")).toMatch(/^\d+$/);
     }
   });
 
+  it("increments process-local counters atomically across concurrent requests", async () => {
+    const storage = memoryRateLimitStorage();
+
+    const results = await Promise.all(
+      Array.from({ length: 250 }, () => storage.increment("concurrent", 60_000)),
+    );
+
+    expect(results.map((entry) => entry.count).sort((a, b) => a - b)).toEqual(
+      Array.from({ length: 250 }, (_, index) => index + 1),
+    );
+    await expect(Promise.resolve(storage.get?.("concurrent"))).resolves.toMatchObject({
+      count: 250,
+    });
+  });
+
+  it("rejects legacy non-atomic get/set storage", () => {
+    const storage = {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+    } as unknown as RateLimitStorage;
+
+    expect(() => middleware().rateLimit({ requests: 10, window: "1m", storage })).toThrow(
+      UnsupportedRateLimitStorageError,
+    );
+  });
+
   it("should support rate limiting with custom storage (Redis-like)", async () => {
-    const mockRedisStore = new Map<string, string>();
-    const customStorage = {
-      async set(key: string, value: any, ttl?: number) {
-        mockRedisStore.set(key, JSON.stringify(value));
-        if (ttl) {
-          setTimeout(() => {
-            mockRedisStore.delete(key);
-          }, ttl * 1000);
-        }
-      },
-      async get(key: string) {
-        const data = mockRedisStore.get(key);
-        return data ? JSON.parse(data) : null;
-      },
-      async delete(key: string) {
-        mockRedisStore.delete(key);
-      },
-    };
+    const { records: mockRedisStore, storage: customStorage } = createTestRateLimitStorage();
 
     const spyFn = vi.fn();
     const chain = middleware().rateLimit({
@@ -499,7 +542,7 @@ describe("Middleware Chain", () => {
       const ctx = createContext(req, res);
       await executeChain(ctx);
       expect(ctx._handled).toBe(false);
-      const count = JSON.parse(mockRedisStore.get("redis-test-key") || "{}").count;
+      const count = mockRedisStore.get("redis-test-key")?.count;
       expect(count).toBe(1);
     }
 
@@ -509,7 +552,7 @@ describe("Middleware Chain", () => {
       const ctx = createContext(req, res);
       await executeChain(ctx);
       expect(ctx._handled).toBe(false);
-      const count = JSON.parse(mockRedisStore.get("redis-test-key") || "{}").count;
+      const count = mockRedisStore.get("redis-test-key")?.count;
       expect(count).toBe(2);
     }
 
@@ -519,7 +562,7 @@ describe("Middleware Chain", () => {
       const ctx = createContext(req, res);
       await executeChain(ctx);
       expect(ctx._handled).toBe(false);
-      const count = JSON.parse(mockRedisStore.get("redis-test-key") || "{}").count;
+      const count = mockRedisStore.get("redis-test-key")?.count;
       expect(count).toBe(3);
     }
 
@@ -542,18 +585,7 @@ describe("Middleware Chain", () => {
   });
 
   it("should support custom storage with synchronous operations", async () => {
-    const syncStore = new Map<string, any>();
-    const customStorage = {
-      set(key: string, value: any, ttl?: number) {
-        syncStore.set(key, value);
-      },
-      get(key: string) {
-        return syncStore.get(key) || null;
-      },
-      delete(key: string) {
-        syncStore.delete(key);
-      },
-    };
+    const { records: syncStore, storage: customStorage } = createTestRateLimitStorage();
 
     const chain = middleware().rateLimit({
       requests: 2,
@@ -603,19 +635,16 @@ describe("Middleware Chain", () => {
     const storedData = syncStore.get("sync-test-key");
     expect(storedData).toHaveProperty("count");
     expect(storedData).toHaveProperty("resetAt");
-    expect(storedData.count).toBe(2);
+    expect(storedData.count).toBe(3);
   });
 
-  it("should pass TTL to custom storage", async () => {
-    const ttlSpy = vi.fn();
-    const customStorage = {
-      set(key: string, value: any, ttl?: number) {
-        ttlSpy(key, value, ttl);
+  it("should pass the fixed window to custom atomic storage", async () => {
+    const incrementSpy = vi.fn();
+    const customStorage: RateLimitStorage = {
+      increment(key, windowMs) {
+        incrementSpy(key, windowMs);
+        return { count: 1, resetAt: Date.now() + windowMs };
       },
-      get(key: string) {
-        return null;
-      },
-      delete(key: string) {},
     };
 
     const chain = middleware().rateLimit({
@@ -640,39 +669,13 @@ describe("Middleware Chain", () => {
 
     await executeNext();
 
-    expect(ttlSpy).toHaveBeenCalled();
-    const [key, value, ttl] = ttlSpy.mock.calls[0];
-    expect(ttl).toBe(120);
+    expect(incrementSpy).toHaveBeenCalled();
+    const [, windowMs] = incrementSpy.mock.calls[0];
+    expect(windowMs).toBe(120_000);
   });
 
-  it("should support ttl method in custom storage", async () => {
-    const storageWithTTL = new Map<string, { value: any; expiresAt: number }>();
-    const customStorage = {
-      set(key: string, value: any, ttl?: number) {
-        storageWithTTL.set(key, {
-          value,
-          expiresAt: ttl ? Date.now() + ttl * 1000 : Number.POSITIVE_INFINITY,
-        });
-      },
-      get(key: string) {
-        const item = storageWithTTL.get(key);
-        if (!item) return null;
-        if (item.expiresAt < Date.now()) {
-          storageWithTTL.delete(key);
-          return null;
-        }
-        return item.value;
-      },
-      delete(key: string) {
-        storageWithTTL.delete(key);
-      },
-      ttl(key: string) {
-        const item = storageWithTTL.get(key);
-        if (!item) return null;
-        const remainingMs = item.expiresAt - Date.now();
-        return remainingMs > 0 ? Math.ceil(remainingMs / 1000) : null;
-      },
-    };
+  it("should retain the reset time returned by custom storage", async () => {
+    const { records, storage: customStorage } = createTestRateLimitStorage();
 
     const chain = middleware().rateLimit({
       requests: 5,
@@ -702,13 +705,13 @@ describe("Middleware Chain", () => {
       expect(ctx._handled).toBe(false);
     }
 
-    const ttl = customStorage.ttl("ttl-test-key");
-    expect(ttl).not.toBeNull();
-    expect(ttl).toBeGreaterThan(0);
-    expect(ttl).toBeLessThanOrEqual(10);
+    const resetAt = records.get("ttl-test-key")?.resetAt;
+    expect(resetAt).toBeDefined();
+    expect(resetAt! - Date.now()).toBeGreaterThan(0);
+    expect(resetAt! - Date.now()).toBeLessThanOrEqual(10_000);
   });
 
-  it("should support ttl method with default storage", async () => {
+  it("should retain a reset window with default storage", async () => {
     const chain = middleware().rateLimit({
       requests: 3,
       window: "5s",
@@ -745,9 +748,8 @@ describe("Middleware Chain", () => {
 describe("getRateLimitStatus", () => {
   it("should return status with no requests when key does not exist", async () => {
     const storage: RateLimitStorage = {
+      increment: vi.fn(),
       get: vi.fn().mockResolvedValue(null),
-      set: vi.fn(),
-      delete: vi.fn(),
     };
 
     const status = await getRateLimitStatus("test-key", 100, storage);
@@ -768,12 +770,11 @@ describe("getRateLimitStatus", () => {
     const resetAt = now + 60000; // 60 seconds from now
 
     const storage: RateLimitStorage = {
+      increment: vi.fn(),
       get: vi.fn().mockResolvedValue({
         count: 42,
         resetAt,
       }),
-      set: vi.fn(),
-      delete: vi.fn(),
     };
 
     const status = await getRateLimitStatus("user:123", 100, storage);
@@ -791,12 +792,11 @@ describe("getRateLimitStatus", () => {
     const resetAt = now + 120000; // 2 minutes from now
 
     const storage: RateLimitStorage = {
+      increment: vi.fn(),
       get: vi.fn().mockResolvedValue({
         count: 150,
         resetAt,
       }),
-      set: vi.fn(),
-      delete: vi.fn(),
     };
 
     const status = await getRateLimitStatus("ip:192.168.1.1", 100, storage);
@@ -812,12 +812,11 @@ describe("getRateLimitStatus", () => {
     const pastTime = Date.now() - 10000; // 10 seconds ago
 
     const storage: RateLimitStorage = {
+      increment: vi.fn(),
       get: vi.fn().mockResolvedValue({
         count: 50,
         resetAt: pastTime,
       }),
-      set: vi.fn(),
-      delete: vi.fn(),
     };
 
     const status = await getRateLimitStatus("expired-key", 100, storage);
@@ -830,52 +829,21 @@ describe("getRateLimitStatus", () => {
     expect(status.resetAt).toBeNull();
   });
 
-  it("should use storage.ttl() if resetAt is not present", async () => {
+  it("should reject an inspectable storage record without resetAt", async () => {
     const storage: RateLimitStorage = {
+      increment: vi.fn(),
       get: vi.fn().mockResolvedValue({
         count: 30,
-        // No resetAt
-      }),
-      set: vi.fn(),
-      delete: vi.fn(),
-      ttl: vi.fn().mockResolvedValue(90), // 90 seconds remaining
+      } as any),
     };
 
-    const status = await getRateLimitStatus("ttl-key", 100, storage);
-
-    expect(status.requests).toBe(30);
-    expect(status.remaining).toBe(70);
-    expect(status.resetIn).toBe(90);
-    expect(status.resetAt).toBeInstanceOf(Date);
-    expect(storage.ttl).toHaveBeenCalledWith("ttl-key");
+    await expect(getRateLimitStatus("ttl-key", 100, storage)).rejects.toThrow(/resetAt timestamp/);
   });
 
   it("should work with custom storage implementation", async () => {
-    // Create a real custom storage for testing
-    const customStore = new Map<string, any>();
-    const customStorage: RateLimitStorage = {
-      set(key: string, value: any) {
-        customStore.set(key, value);
-      },
-      get(key: string) {
-        return customStore.get(key) || null;
-      },
-      delete(key: string) {
-        customStore.delete(key);
-      },
-      ttl(key: string) {
-        const record = customStore.get(key);
-        if (!record || !record.resetAt) return null;
-        const remainingMs = record.resetAt - Date.now();
-        return remainingMs > 0 ? Math.ceil(remainingMs / 1000) : null;
-      },
-    };
-
-    // Set up initial data
-    customStorage.set("api:user:456", {
-      count: 75,
-      resetAt: Date.now() + 45000, // 45 seconds
-    });
+    const { storage: customStorage } = createTestRateLimitStorage([
+      ["api:user:456", { count: 75, resetAt: Date.now() + 45_000 }],
+    ]);
 
     const status = await getRateLimitStatus("api:user:456", 100, customStorage);
 
@@ -888,25 +856,7 @@ describe("getRateLimitStatus", () => {
   });
 
   it("should integrate with actual rate limiter", async () => {
-    // Create custom storage for testing
-    const testStore = new Map<string, any>();
-    const testStorage: RateLimitStorage = {
-      set(key: string, value: any) {
-        testStore.set(key, value);
-      },
-      get(key: string) {
-        return testStore.get(key) || null;
-      },
-      delete(key: string) {
-        testStore.delete(key);
-      },
-      ttl(key: string) {
-        const record = testStore.get(key);
-        if (!record || !record.resetAt) return null;
-        const remainingMs = record.resetAt - Date.now();
-        return remainingMs > 0 ? Math.ceil(remainingMs / 1000) : null;
-      },
-    };
+    const { storage: testStorage } = createTestRateLimitStorage();
 
     const chain = middleware().rateLimit({
       requests: 5,

--- a/packages/farm/src/__tests__/middleware.test.ts
+++ b/packages/farm/src/__tests__/middleware.test.ts
@@ -482,17 +482,25 @@ describe("Middleware Chain", () => {
     }
   });
 
-  it("increments process-local counters atomically across concurrent requests", async () => {
+  it("enforces the exact process-local limit across a request burst", async () => {
     const storage = memoryRateLimitStorage();
-
-    const results = await Promise.all(
-      Array.from({ length: 250 }, () => storage.increment("concurrent", 60_000)),
+    const { handlers } = middleware()
+      .rateLimit({
+        requests: 100,
+        window: "1m",
+        keyGenerator: () => "burst",
+        storage,
+      })
+      .build();
+    const contexts = Array.from({ length: 250 }, () =>
+      createContext(createMockRequest("/burst"), createMockResponse()),
     );
 
-    expect(results.map((entry) => entry.count).sort((a, b) => a - b)).toEqual(
-      Array.from({ length: 250 }, (_, index) => index + 1),
-    );
-    await expect(Promise.resolve(storage.get?.("concurrent"))).resolves.toMatchObject({
+    await Promise.all(contexts.map((ctx) => executeChain(handlers, ctx)));
+
+    expect(contexts.filter((ctx) => !ctx._handled)).toHaveLength(100);
+    expect(contexts.filter((ctx) => ctx._handled)).toHaveLength(150);
+    await expect(Promise.resolve(storage.get?.("burst"))).resolves.toMatchObject({
       count: 250,
     });
   });

--- a/packages/farm/src/__tests__/storage.test.ts
+++ b/packages/farm/src/__tests__/storage.test.ts
@@ -257,7 +257,7 @@ describe("Storage", () => {
     },
   );
 
-  it("uses the configured ratelimit namespace for default rate limiting", async () => {
+  it("does not use a non-atomic KV mount for rate limiting", async () => {
     const dir = await createTempDir("farm-storage-ratelimit-");
 
     await initStorage({
@@ -284,8 +284,7 @@ describe("Storage", () => {
     await executeChain(handlers, createContext(secondReq, secondRes));
 
     expect(secondRes.writeHead).toHaveBeenCalledWith(429, expect.any(Object));
-    expect(await getStorage("ratelimit").getKeys()).not.toHaveLength(0);
-    expect(await readdir(dir)).not.toHaveLength(0);
+    expect(await getStorage("ratelimit").getKeys()).toHaveLength(0);
   });
 
   it.skipIf(!supportsNodeSqlite)(

--- a/packages/farm/src/middleware/chain.ts
+++ b/packages/farm/src/middleware/chain.ts
@@ -10,44 +10,81 @@ import type {
   RateLimitConfig,
   RateLimitStorage,
   RateLimitStatus,
+  RateLimitIncrementResult,
+  MemoryRateLimitStorageOptions,
   MiddlewareResult,
 } from "./types";
-import { getStorage } from "../storage";
-import type { Storage } from "unstorage";
 
-interface RateLimitRecord {
-  count: number;
-  resetAt: number;
+const DEFAULT_MEMORY_RATE_LIMIT_ENTRIES = 100_000;
+
+export class UnsupportedRateLimitStorageError extends TypeError {
+  constructor() {
+    super(
+      "RateLimitStorage must implement atomic increment(key, windowMs). Legacy get/set adapters can lose increments under concurrency. Use memoryRateLimitStorage() for one process or redisRateLimitStorage() from @farm.js/cache-redis for production.",
+    );
+    this.name = "UnsupportedRateLimitStorageError";
+  }
 }
 
-function getRateLimitStorage(): Storage {
-  return getStorage("ratelimit");
-}
+/** Create an atomic, process-local fixed-window rate-limit store. */
+export function memoryRateLimitStorage(
+  options: MemoryRateLimitStorageOptions = {},
+): RateLimitStorage {
+  const maxEntries = options.maxEntries ?? DEFAULT_MEMORY_RATE_LIMIT_ENTRIES;
+  if (!Number.isSafeInteger(maxEntries) || maxEntries <= 0) {
+    throw new TypeError("memoryRateLimitStorage maxEntries must be a positive safe integer.");
+  }
 
-const defaultRateLimitStorage: RateLimitStorage = {
-  async get(key: string) {
-    const storage = getRateLimitStorage();
-    const value = await storage.getItem<RateLimitRecord>(key);
-    return value ?? null;
-  },
-  async set(key: string, value: any, ttl?: number) {
-    const storage = getRateLimitStorage();
-    await storage.setItem(key, value, ttl ? { ttl } : undefined);
-  },
-  async delete(key: string) {
-    const storage = getRateLimitStorage();
-    await storage.removeItem(key);
-  },
-  async ttl(key: string) {
-    const storage = getRateLimitStorage();
-    const record = await storage.getItem<RateLimitRecord>(key);
-    if (!record || !record.resetAt) {
+  const records = new Map<string, RateLimitIncrementResult>();
+
+  function read(key: string, now: number): RateLimitIncrementResult | null {
+    const record = records.get(key);
+    if (!record) return null;
+    if (record.resetAt <= now) {
+      records.delete(key);
       return null;
     }
-    const remainingMs = record.resetAt - Date.now();
-    return remainingMs > 0 ? Math.ceil(remainingMs / 1000) : null;
-  },
-};
+    return record;
+  }
+
+  function pruneExpired(now: number): void {
+    for (const [key, record] of records) {
+      if (record.resetAt <= now) records.delete(key);
+    }
+  }
+
+  return {
+    increment(key, windowMs) {
+      if (!Number.isSafeInteger(windowMs) || windowMs <= 0) {
+        throw new TypeError("Rate-limit windowMs must be a positive safe integer.");
+      }
+      const now = Date.now();
+      const current = read(key, now);
+      if (current) {
+        const next = { count: current.count + 1, resetAt: current.resetAt };
+        records.set(key, next);
+        return next;
+      }
+
+      if (records.size >= maxEntries) pruneExpired(now);
+      if (records.size >= maxEntries) {
+        throw new Error(
+          `Process-local rate-limit storage reached its ${maxEntries} active-key capacity. Configure a shared production adapter or increase maxEntries.`,
+        );
+      }
+
+      const next = { count: 1, resetAt: now + windowMs };
+      records.set(key, next);
+      return next;
+    },
+    get(key) {
+      const record = read(key, Date.now());
+      return record ? { ...record } : null;
+    },
+  };
+}
+
+const defaultRateLimitStorage = memoryRateLimitStorage();
 
 function parseTimeWindow(window: string): number {
   const match = window.match(/^(\d+)(ms|s|m|h|d)$/);
@@ -64,60 +101,92 @@ function parseTimeWindow(window: string): number {
     d: 24 * 60 * 60 * 1000,
   };
 
-  return value * multipliers[unit];
+  const windowMs = value * multipliers[unit];
+  if (!Number.isSafeInteger(windowMs) || windowMs <= 0) {
+    throw new Error(`Invalid time window: ${window}`);
+  }
+  return windowMs;
 }
 
 function createRateLimitMiddleware(config: RateLimitConfig): MiddlewareFunction {
+  if (!Number.isSafeInteger(config.requests) || config.requests <= 0) {
+    throw new TypeError("Rate limit requests must be a positive safe integer.");
+  }
   const windowMs = parseTimeWindow(config.window);
   const storage = config.storage || defaultRateLimitStorage;
+  assertAtomicRateLimitStorage(storage);
 
   return async (ctx: MiddlewareContext, next) => {
     const key = config.keyGenerator
       ? config.keyGenerator(ctx)
       : `${ctx.request.socket.remoteAddress}:${ctx.pathname}`;
 
+    const current = await storage.increment(key, windowMs);
+    assertRateLimitIncrementResult(current);
     const now = Date.now();
-    const ttlSeconds = Math.ceil(windowMs / 1000);
-    const record = await storage.get(key);
+    const resetIn = Math.max(1, Math.ceil((current.resetAt - now) / 1000));
+    const remaining = Math.max(0, config.requests - current.count);
+    setRateLimitHeaders(ctx, config.requests, remaining, resetIn, Math.ceil(windowMs / 1000));
 
-    if (record && now > record.resetAt) {
-      await storage.delete(key);
-    }
-
-    const current = await storage.get(key);
-
-    if (!current) {
-      await storage.set(
-        key,
-        {
-          count: 1,
-          resetAt: now + windowMs,
-        },
-        ttlSeconds,
-      );
-      return next();
-    }
-
-    if (current.count >= config.requests) {
+    if (current.count > config.requests) {
+      setMiddlewareResponseHeader(ctx, "Retry-After", String(resetIn));
       if (config.onLimit) {
         const result = await config.onLimit(ctx);
-        if (result) return;
+        if (result) return result;
       }
 
       ctx.json(
         {
           error: "Rate limit exceeded",
-          retryAfter: Math.ceil((current.resetAt - now) / 1000),
+          retryAfter: resetIn,
         },
         429,
       );
       return;
     }
 
-    current.count++;
-    await storage.set(key, current, ttlSeconds);
     return next();
   };
+}
+
+function assertAtomicRateLimitStorage(storage: RateLimitStorage): void {
+  if (!storage || typeof storage.increment !== "function") {
+    throw new UnsupportedRateLimitStorageError();
+  }
+}
+
+function assertRateLimitIncrementResult(
+  result: RateLimitIncrementResult,
+): asserts result is RateLimitIncrementResult {
+  if (
+    !result ||
+    !Number.isSafeInteger(result.count) ||
+    result.count <= 0 ||
+    !Number.isFinite(result.resetAt) ||
+    result.resetAt <= 0
+  ) {
+    throw new TypeError(
+      "RateLimitStorage.increment() must return a positive integer count and a resetAt timestamp.",
+    );
+  }
+}
+
+function setRateLimitHeaders(
+  ctx: MiddlewareContext,
+  limit: number,
+  remaining: number,
+  resetIn: number,
+  windowSeconds: number,
+): void {
+  setMiddlewareResponseHeader(ctx, "RateLimit-Policy", `"farm";q=${limit};w=${windowSeconds}`);
+  setMiddlewareResponseHeader(ctx, "RateLimit", `"farm";r=${remaining};t=${resetIn}`);
+}
+
+function setMiddlewareResponseHeader(ctx: MiddlewareContext, name: string, value: string): void {
+  ctx.headers.set(name, value);
+  if (!ctx.response.headersSent && !ctx.response.writableEnded) {
+    ctx.response.setHeader(name, value);
+  }
 }
 
 function matchPattern(pattern: string | RegExp, pathname: string): boolean {
@@ -323,6 +392,15 @@ export async function getRateLimitStatus(
   limit: number,
   storage: RateLimitStorage = defaultRateLimitStorage,
 ): Promise<RateLimitStatus> {
+  if (!Number.isSafeInteger(limit) || limit <= 0) {
+    throw new TypeError("Rate limit must be a positive safe integer.");
+  }
+  assertAtomicRateLimitStorage(storage);
+  if (typeof storage.get !== "function") {
+    throw new TypeError(
+      "getRateLimitStatus() requires a RateLimitStorage adapter that implements get(key).",
+    );
+  }
   const record = await storage.get(key);
 
   if (!record) {
@@ -335,6 +413,7 @@ export async function getRateLimitStatus(
       isLimited: false,
     };
   }
+  assertRateLimitIncrementResult(record);
 
   const now = Date.now();
 
@@ -360,9 +439,6 @@ export async function getRateLimitStatus(
     const remainingMs = record.resetAt - now;
     resetIn = remainingMs > 0 ? Math.ceil(remainingMs / 1000) : null;
     resetAt = new Date(record.resetAt);
-  } else if (storage.ttl) {
-    resetIn = await storage.ttl(key);
-    resetAt = resetIn ? new Date(now + resetIn * 1000) : null;
   }
 
   return {

--- a/packages/farm/src/middleware/index.ts
+++ b/packages/farm/src/middleware/index.ts
@@ -4,7 +4,12 @@
  * Export public API
  */
 
-export { middleware, getRateLimitStatus } from "./chain";
+export {
+  middleware,
+  getRateLimitStatus,
+  memoryRateLimitStorage,
+  UnsupportedRateLimitStorageError,
+} from "./chain";
 export { createContext } from "./context";
 export { MiddlewareManager } from "./manager";
 export {
@@ -33,8 +38,10 @@ export type {
   CookieJar,
   CookieOptions,
   RateLimitConfig,
+  RateLimitIncrementResult,
   RateLimitStorage,
   RateLimitStatus,
+  MemoryRateLimitStorageOptions,
   NextFunction,
   MiddlewareResult,
   FarmMiddlewareConfig,

--- a/packages/farm/src/middleware/types.ts
+++ b/packages/farm/src/middleware/types.ts
@@ -117,11 +117,24 @@ export interface CookieJar {
   getAll(): Record<string, string>;
 }
 
+export interface RateLimitIncrementResult {
+  count: number;
+  resetAt: number;
+}
+
 export interface RateLimitStorage {
-  get(key: string): Promise<any> | any;
-  set(key: string, value: any, ttl?: number): Promise<void> | void;
-  delete(key: string): Promise<void> | void;
-  ttl?(key: string): Promise<number | null> | number | null;
+  /** Atomically increment a key and create or retain its fixed expiry window. */
+  increment(
+    key: string,
+    windowMs: number,
+  ): Promise<RateLimitIncrementResult> | RateLimitIncrementResult;
+  /** Optional inspection support used by getRateLimitStatus(). */
+  get?(key: string): Promise<RateLimitIncrementResult | null> | RateLimitIncrementResult | null;
+}
+
+export interface MemoryRateLimitStorageOptions {
+  /** Maximum number of active keys retained by this process. */
+  maxEntries?: number;
 }
 
 export interface RateLimitConfig {

--- a/packages/farm/src/middleware/types.ts
+++ b/packages/farm/src/middleware/types.ts
@@ -119,6 +119,7 @@ export interface CookieJar {
 
 export interface RateLimitIncrementResult {
   count: number;
+  /** Unix epoch timestamp in milliseconds when the fixed window resets. */
   resetAt: number;
 }
 

--- a/packages/farm/types/middleware.d.ts
+++ b/packages/farm/types/middleware.d.ts
@@ -136,11 +136,13 @@ declare module "@farm.js/core/middleware" {
    */
   export interface RateLimitConfig {
     /** Maximum number of requests */
-    max: number;
-    /** Time window in milliseconds */
-    windowMs: number;
+    requests: number;
+    /** Fixed window such as `500ms`, `10s`, `1m`, or `1h`. */
+    window: string;
     /** Optional custom key generator */
     keyGenerator?: (ctx: MiddlewareContext) => string;
+    /** Optional response customization when the limit is exceeded. */
+    onLimit?: (ctx: MiddlewareContext) => void | Response | Promise<void | Response>;
     /** Optional custom storage */
     storage?: RateLimitStorage;
   }
@@ -148,19 +150,33 @@ declare module "@farm.js/core/middleware" {
   /**
    * Rate limit storage interface
    */
+  export interface RateLimitIncrementResult {
+    count: number;
+    resetAt: number;
+  }
+
   export interface RateLimitStorage {
-    get(key: string): Promise<number | undefined>;
-    set(key: string, value: number, ttlMs: number): Promise<void>;
-    increment(key: string): Promise<number>;
+    increment(
+      key: string,
+      windowMs: number,
+    ): RateLimitIncrementResult | Promise<RateLimitIncrementResult>;
+    get?(key: string): RateLimitIncrementResult | null | Promise<RateLimitIncrementResult | null>;
+  }
+
+  export interface MemoryRateLimitStorageOptions {
+    maxEntries?: number;
   }
 
   /**
    * Rate limit status
    */
   export interface RateLimitStatus {
+    requests: number;
+    limit: number;
     remaining: number;
-    reset: number;
-    total: number;
+    resetIn: number | null;
+    resetAt: Date | null;
+    isLimited: boolean;
   }
 
   /**
@@ -206,12 +222,21 @@ declare module "@farm.js/core/middleware" {
   /**
    * Create a new middleware chain
    */
-  export function middleware(config?: MiddlewareConfig): MiddlewareChain;
+  export function middleware(basePath?: string): MiddlewareChain;
 
   /**
-   * Get rate limit status for current request
+   * Get rate limit status for a key
    */
-  export function getRateLimitStatus(ctx: MiddlewareContext): RateLimitStatus | undefined;
+  export function getRateLimitStatus(
+    key: string,
+    limit: number,
+    storage?: RateLimitStorage,
+  ): Promise<RateLimitStatus>;
+
+  /** Create an atomic, process-local fixed-window rate-limit store. */
+  export function memoryRateLimitStorage(options?: MemoryRateLimitStorageOptions): RateLimitStorage;
+
+  export class UnsupportedRateLimitStorageError extends TypeError {}
 
   /**
    * Create a middleware context from request/response


### PR DESCRIPTION
## Summary

- replace the racy get/set limiter contract with atomic `increment(key, windowMs)`
- provide a bounded, process-local atomic memory adapter and reject legacy non-atomic adapters with a named diagnostic
- add `redisRateLimitStorage()` using one Redis Lua operation for increment plus expiry
- emit current `RateLimit`/`RateLimit-Policy` fields on all limited routes and `Retry-After` on 429 responses
- update storage docs, manual declarations, examples, and Redis package metadata

## Compatibility

Custom rate-limit adapters must implement the new atomic increment contract. Generic `storage.mounts.ratelimit` KV storage is no longer used implicitly because it cannot guarantee an atomic read-modify-write operation.

## Validation

- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`
- `pnpm --filter @farm.js/core test`
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/cache-redis test`
- `pnpm --filter @farm.js/cache-redis type-check`
- focused oxlint and oxfmt checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make rate limiting atomic and consistent under concurrency with a new `increment(key, windowMs)` API, a bounded process-local adapter, and a Redis adapter using a single Lua op. Adds RateLimit headers on all rate‑limited responses, enforces strict validation, and removes KV mounts from enforcement.

- **New Features**
  - Added `memoryRateLimitStorage()` (process‑local, bounded via `maxEntries`) in `@farm.js/core/middleware`; now the default.
  - Added `redisRateLimitStorage()` in `@farm.js/cache-redis` using one Lua op for increment+expiry; includes `get()` for status checks.
  - Emit `RateLimit`/`RateLimit-Policy` on all rate‑limited responses and `Retry-After` on 429s.
  - Stricter validation: positive safe integers for `requests`/window; storage `increment()` must return `{ count > 0, resetAt }`.
  - `UnsupportedRateLimitStorageError` thrown for legacy `get/set` adapters.
  - `getRateLimitStatus()` requires a storage that implements `get()` and includes `resetAt`; docs/examples updated; `redisStorage` is not for rate limits.

- **Migration**
  - Implement atomic `RateLimitStorage.increment(key, windowMs)` and remove `get/set/ttl` usage.
  - Do not rely on `storage.mounts.ratelimit`; pass an adapter to `.rateLimit({ storage })` (e.g., `memoryRateLimitStorage()` or `redisRateLimitStorage()` from `@farm.js/cache-redis`).
  - Update middleware options: `requests` (was `max`) and `window` like `"1m"` (was `windowMs`).
  - Ensure custom adapters return a positive `count` with `resetAt`, and implement `get()` if using `getRateLimitStatus()`.

<sup>Written for commit d21adefc45b072969b6616fe5714c11630740b19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

