### PR TITLE
feat: add first-class CSP configuration

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -97,6 +97,7 @@ mount, and shortcut together.
 | deploy        | Selecting a target, preset, and output directory.                                 |
 | deploymentId  | Detecting stale browser requests during rolling deployments.                      |
 | routeRules    | Applying rendering, cache, redirect, CORS, and header behavior to route patterns. |
+| security      | Applying an app-wide CSP with an enforcing or report-only response header.        |
 | serverActions | Restricting trusted action origins and request body size.                         |
 | images        | Configuring responsive widths, remote allowlists, formats, and optimizer limits.  |
 | performance   | Budgeting image and font preload hints without changing the rendered resources.   |
@@ -164,6 +165,53 @@ export default defineConfig({
 ```
 
 A layer may contain an optional plain `farm.config.ts` plus its own `src/app`, components, middleware, APIs, and programmatic routes. It does not use a separate layer registration function. See [Layers](/docs/layers) for package structure, merge rules, aliases, generated types, and override behavior.
+
+## Content Security Policy
+
+Configure an app-wide Content Security Policy under `security.csp`. Farm applies it to pages, API responses, and pre-rendered output through the same response-header pipeline in development and production.
+
+```ts
+import { defineConfig } from "@farm.js/core";
+
+export default defineConfig({
+  security: {
+    csp: {
+      directives: {
+        defaultSrc: ["'self'"],
+        baseUri: ["'self'"],
+        objectSrc: ["'none'"],
+        frameAncestors: ["'none'"],
+        formAction: ["'self'"],
+        scriptSrc: ["'self'", "'unsafe-inline'"],
+        styleSrc: ["'self'", "'unsafe-inline'"],
+        imgSrc: ["'self'", "data:", "blob:"],
+        fontSrc: ["'self'", "data:"],
+        connectSrc: ["'self'", "https:", "wss:"],
+      },
+    },
+  },
+});
+```
+
+Directive names may use camelCase or kebab-case. Farm rejects duplicate normalized names, newlines, and directive values containing semicolons so configuration cannot accidentally create a second policy directive.
+
+Use report-only mode while auditing an existing application:
+
+```ts
+security: {
+  csp: {
+    reportOnly: true,
+    directives: {
+      defaultSrc: ["'self'"],
+      reportTo: ["csp-endpoint"],
+    },
+  },
+}
+```
+
+You can also pass an already serialized policy as `csp: "default-src 'self'; object-src 'none'"`. The longer `contentSecurityPolicy` config name is intentionally unsupported; use `csp`.
+
+Farm currently emits small inline hydration and route-state bootstraps, so the compatible example allows inline scripts and styles. A stricter policy must supply correct hashes or renderer-generated nonces for every trusted inline bootstrap. Start with `reportOnly`, inspect violations, and enforce only after the deployed HTML and every third-party integration satisfy the policy.
 
 ## Server action security
 

--- a/docs/src/app/docs/plugins/page.md
+++ b/docs/src/app/docs/plugins/page.md
@@ -315,7 +315,7 @@ import { routePolicyPlugin } from "./src/plugins/route-policy";
 
 export default defineConfig({
   plugins: [
-    securityPlugin({ contentSecurityPolicy: true }),
+    securityPlugin({ csp: true }),
     tracingPlugin({ service: "storefront" }),
     routePolicyPlugin,
   ],

--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -562,6 +562,38 @@ describe("resolveConfig", () => {
       },
     });
   });
+
+  it("applies security.csp after ordinary and route-rule headers", async () => {
+    const config = await resolveConfig(
+      {
+        root: process.cwd(),
+        headers: [{ source: "/*", headers: [{ key: "X-App", value: "farm" }] }],
+        security: {
+          csp: {
+            directives: {
+              defaultSrc: ["'self'"],
+              objectSrc: ["'none'"],
+            },
+          },
+        },
+      },
+      "production",
+    );
+
+    expect(config.security.csp).toEqual({
+      value: "default-src 'self'; object-src 'none'",
+      reportOnly: false,
+    });
+    expect((await config.headers()).at(-1)).toEqual({
+      source: "/*",
+      headers: [
+        {
+          key: "Content-Security-Policy",
+          value: "default-src 'self'; object-src 'none'",
+        },
+      ],
+    });
+  });
 });
 
 describe("resolveMigrationsConfig", () => {

--- a/packages/farm/src/__tests__/production-ssg.test.ts
+++ b/packages/farm/src/__tests__/production-ssg.test.ts
@@ -11,6 +11,7 @@ import { build } from "../build";
 import { loadConfig, resolveConfig } from "../config";
 
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const testCspPolicy = "default-src 'self'; object-src 'none'";
 
 async function createFixture(externalRewriteOrigin?: string): Promise<string> {
   const root = await fs.mkdtemp(path.join(packageRoot, ".tmp-production-ssg-"));
@@ -43,7 +44,7 @@ export default {
   srcDir: "src",
   images: { provider: "none" },
   security: {
-    csp: "default-src 'self'; object-src 'none'",
+    csp: ${JSON.stringify(testCspPolicy)},
   },
   middleware: [
     {
@@ -428,9 +429,7 @@ describe("production SSG output", () => {
 
       const firstStatic = await fetch(`${production.origin}/static`);
       expect(firstStatic.headers.get("cache-control")).toBe("public, max-age=0, must-revalidate");
-      expect(firstStatic.headers.get("content-security-policy")).toBe(
-        "default-src 'self'; object-src 'none'",
-      );
+      expect(firstStatic.headers.get("content-security-policy")).toBe(testCspPolicy);
       const firstStaticHtml = await firstStatic.text();
       await new Promise((resolve) => setTimeout(resolve, 25));
       const secondStaticHtml = await fetch(`${production.origin}/static`).then((response) =>
@@ -460,9 +459,7 @@ describe("production SSG output", () => {
 
       const firstConfigured = await fetch(`${production.origin}/configured`);
       expect(firstConfigured.headers.get("x-configured-middleware")).toBe("yes");
-      expect(firstConfigured.headers.get("content-security-policy")).toBe(
-        "default-src 'self'; object-src 'none'",
-      );
+      expect(firstConfigured.headers.get("content-security-policy")).toBe(testCspPolicy);
       const firstConfiguredHtml = await firstConfigured.text();
       await new Promise((resolve) => setTimeout(resolve, 25));
       const secondConfiguredHtml = await fetch(`${production.origin}/configured`).then((response) =>
@@ -527,9 +524,7 @@ describe("production SSG output", () => {
 
       const localAPIResponse = await fetch(`${production.origin}/api/local?via=local`);
       expect(localAPIResponse.status).toBe(200);
-      expect(localAPIResponse.headers.get("content-security-policy")).toBe(
-        "default-src 'self'; object-src 'none'",
-      );
+      expect(localAPIResponse.headers.get("content-security-policy")).toBe(testCspPolicy);
       await expect(localAPIResponse.json()).resolves.toEqual({ source: "local-api" });
 
       const localAPIMethodResponse = await fetch(`${production.origin}/api/local`, {

--- a/packages/farm/src/__tests__/production-ssg.test.ts
+++ b/packages/farm/src/__tests__/production-ssg.test.ts
@@ -42,6 +42,9 @@ import { getCurrentRequest } from "@farm.js/core/request";
 export default {
   srcDir: "src",
   images: { provider: "none" },
+  security: {
+    csp: "default-src 'self'; object-src 'none'",
+  },
   middleware: [
     {
       matcher: "/configured",
@@ -425,6 +428,9 @@ describe("production SSG output", () => {
 
       const firstStatic = await fetch(`${production.origin}/static`);
       expect(firstStatic.headers.get("cache-control")).toBe("public, max-age=0, must-revalidate");
+      expect(firstStatic.headers.get("content-security-policy")).toBe(
+        "default-src 'self'; object-src 'none'",
+      );
       const firstStaticHtml = await firstStatic.text();
       await new Promise((resolve) => setTimeout(resolve, 25));
       const secondStaticHtml = await fetch(`${production.origin}/static`).then((response) =>
@@ -454,6 +460,9 @@ describe("production SSG output", () => {
 
       const firstConfigured = await fetch(`${production.origin}/configured`);
       expect(firstConfigured.headers.get("x-configured-middleware")).toBe("yes");
+      expect(firstConfigured.headers.get("content-security-policy")).toBe(
+        "default-src 'self'; object-src 'none'",
+      );
       const firstConfiguredHtml = await firstConfigured.text();
       await new Promise((resolve) => setTimeout(resolve, 25));
       const secondConfiguredHtml = await fetch(`${production.origin}/configured`).then((response) =>
@@ -518,6 +527,9 @@ describe("production SSG output", () => {
 
       const localAPIResponse = await fetch(`${production.origin}/api/local?via=local`);
       expect(localAPIResponse.status).toBe(200);
+      expect(localAPIResponse.headers.get("content-security-policy")).toBe(
+        "default-src 'self'; object-src 'none'",
+      );
       await expect(localAPIResponse.json()).resolves.toEqual({ source: "local-api" });
 
       const localAPIMethodResponse = await fetch(`${production.origin}/api/local`, {

--- a/packages/farm/src/__tests__/security.test.ts
+++ b/packages/farm/src/__tests__/security.test.ts
@@ -44,6 +44,22 @@ describe("security.csp", () => {
     });
   });
 
+  it("revalidates resolved policy values", () => {
+    expect(
+      resolveFarmSecurityConfig({
+        csp: { value: "default-src 'self';", reportOnly: true },
+      }),
+    ).toEqual({
+      csp: { value: "default-src 'self'", reportOnly: true },
+    });
+
+    expect(() =>
+      resolveFarmSecurityConfig({
+        csp: { value: "default-src 'self'\r\nX-Test: yes", reportOnly: false },
+      }),
+    ).toThrow(/single-line/);
+  });
+
   it("rejects the long-form config key with an actionable diagnostic", () => {
     expect(() => resolveFarmSecurityConfig({ contentSecurityPolicy: true } as never)).toThrow(
       /Use security\.csp instead/,
@@ -61,5 +77,22 @@ describe("security.csp", () => {
       /Invalid security\.csp directive value/,
     );
     expect(() => resolveFarmSecurityConfig({ csp: "" })).toThrow(/non-empty/);
+  });
+
+  it("rejects malformed runtime option shapes with actionable errors", () => {
+    expect(() => resolveFarmSecurityConfig({ csp: null } as never)).toThrow(
+      /policy string, false, or an options object/,
+    );
+    expect(() => resolveFarmSecurityConfig({ csp: { policy: 42 } } as never)).toThrow(
+      /non-empty single-line string/,
+    );
+    expect(() => resolveFarmSecurityConfig({ csp: { directives: null } } as never)).toThrow(
+      /directives must be an object/,
+    );
+    expect(() =>
+      resolveFarmSecurityConfig({
+        csp: { policy: "default-src 'self'", reportOnly: "yes" },
+      } as never),
+    ).toThrow(/reportOnly must be a boolean/);
   });
 });

--- a/packages/farm/src/__tests__/security.test.ts
+++ b/packages/farm/src/__tests__/security.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  getFarmSecurityHeader,
+  resolveFarmSecurityConfig,
+  serializeFarmCspDirectives,
+} from "../security";
+
+describe("security.csp", () => {
+  it("serializes camelCase directives without changing source expressions", () => {
+    expect(
+      serializeFarmCspDirectives({
+        defaultSrc: ["'self'"],
+        objectSrc: ["'none'"],
+        upgradeInsecureRequests: true,
+      }),
+    ).toBe("default-src 'self'; object-src 'none'; upgrade-insecure-requests");
+  });
+
+  it("resolves an enforcing policy string", () => {
+    const security = resolveFarmSecurityConfig({
+      csp: "default-src 'self'; object-src 'none';",
+    });
+
+    expect(getFarmSecurityHeader(security)).toEqual({
+      key: "Content-Security-Policy",
+      value: "default-src 'self'; object-src 'none'",
+    });
+  });
+
+  it("supports report-only directives", () => {
+    const security = resolveFarmSecurityConfig({
+      csp: {
+        reportOnly: true,
+        directives: {
+          defaultSrc: ["'self'"],
+          reportTo: ["csp-endpoint"],
+        },
+      },
+    });
+
+    expect(getFarmSecurityHeader(security)).toEqual({
+      key: "Content-Security-Policy-Report-Only",
+      value: "default-src 'self'; report-to csp-endpoint",
+    });
+  });
+
+  it("rejects the long-form config key with an actionable diagnostic", () => {
+    expect(() => resolveFarmSecurityConfig({ contentSecurityPolicy: true } as never)).toThrow(
+      /Use security\.csp instead/,
+    );
+  });
+
+  it("rejects duplicate directives and header injection", () => {
+    expect(() =>
+      serializeFarmCspDirectives({ defaultSrc: ["'self'"], "default-src": ["https:"] }),
+    ).toThrow(/duplicate directive/);
+    expect(() => resolveFarmSecurityConfig({ csp: "default-src 'self'\r\nX-Test: yes" })).toThrow(
+      /single-line/,
+    );
+    expect(() => serializeFarmCspDirectives({ reportUri: ["/csp; object-src *"] })).toThrow(
+      /Invalid security\.csp directive value/,
+    );
+    expect(() => resolveFarmSecurityConfig({ csp: "" })).toThrow(/non-empty/);
+  });
+});

--- a/packages/farm/src/app.ts
+++ b/packages/farm/src/app.ts
@@ -29,11 +29,7 @@ import type { ResolvedFarmI18nConfig } from "./i18n/types";
 import { configureFarmCache } from "./cache";
 import { resolveFarmAuthConfig, type ResolvedFarmAuthConfig } from "./auth-config";
 import { resolveFarmPerformanceConfig, type ResolvedFarmPerformanceConfig } from "./preload";
-import {
-  isResolvedFarmSecurityConfig,
-  resolveFarmSecurityConfig,
-  type ResolvedFarmSecurityConfig,
-} from "./security";
+import { resolveFarmSecurityConfig, type ResolvedFarmSecurityConfig } from "./security";
 
 type NormalizedFarmConfig = Omit<
   Required<FarmConfig>,
@@ -146,9 +142,7 @@ export class FarmApp {
       routeRules: normalizeRouteRules(config.routeRules),
       context: config.context || (() => undefined),
       serverActions: resolveServerActionsConfig(config.serverActions),
-      security: isResolvedFarmSecurityConfig(config.security)
-        ? config.security
-        : resolveFarmSecurityConfig(config.security),
+      security: resolveFarmSecurityConfig(config.security),
       images: resolveFarmImageConfig(config.images),
       performance: resolveFarmPerformanceConfig(config.performance),
       i18n: isResolvedI18nConfig(config.i18n)

--- a/packages/farm/src/app.ts
+++ b/packages/farm/src/app.ts
@@ -29,10 +29,15 @@ import type { ResolvedFarmI18nConfig } from "./i18n/types";
 import { configureFarmCache } from "./cache";
 import { resolveFarmAuthConfig, type ResolvedFarmAuthConfig } from "./auth-config";
 import { resolveFarmPerformanceConfig, type ResolvedFarmPerformanceConfig } from "./preload";
+import {
+  isResolvedFarmSecurityConfig,
+  resolveFarmSecurityConfig,
+  type ResolvedFarmSecurityConfig,
+} from "./security";
 
 type NormalizedFarmConfig = Omit<
   Required<FarmConfig>,
-  "devtools" | "images" | "i18n" | "performance"
+  "devtools" | "images" | "i18n" | "performance" | "security"
 > & {
   docs: FarmDocsResolvedConfig;
   md: FarmMarkdownResolvedConfig;
@@ -44,6 +49,7 @@ type NormalizedFarmConfig = Omit<
   i18n: ResolvedFarmI18nConfig;
   auth: ResolvedFarmAuthConfig;
   performance: ResolvedFarmPerformanceConfig;
+  security: ResolvedFarmSecurityConfig;
 };
 
 const defaultDocsConfig: FarmDocsResolvedConfig = {
@@ -140,6 +146,9 @@ export class FarmApp {
       routeRules: normalizeRouteRules(config.routeRules),
       context: config.context || (() => undefined),
       serverActions: resolveServerActionsConfig(config.serverActions),
+      security: isResolvedFarmSecurityConfig(config.security)
+        ? config.security
+        : resolveFarmSecurityConfig(config.security),
       images: resolveFarmImageConfig(config.images),
       performance: resolveFarmPerformanceConfig(config.performance),
       i18n: isResolvedI18nConfig(config.i18n)

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -63,7 +63,6 @@ import {
 import { resolveFarmPerformanceConfig, type ResolvedFarmPerformanceConfig } from "./preload";
 import {
   getFarmSecurityHeader,
-  isResolvedFarmSecurityConfig,
   resolveFarmSecurityConfig,
   type FarmCspConfig,
   type FarmCspDirectives,
@@ -746,9 +745,7 @@ export async function resolveConfig(
   const routeRules = normalizeRouteRules(userConfig.routeRules);
   const routeRuleRedirects = routeRulesToRedirects(routeRules);
   const routeRuleHeaders = routeRulesToHeaders(routeRules);
-  const security = isResolvedFarmSecurityConfig(userConfig.security)
-    ? userConfig.security
-    : resolveFarmSecurityConfig(userConfig.security);
+  const security = resolveFarmSecurityConfig(userConfig.security);
   const securityHeader = getFarmSecurityHeader(security);
 
   const deploy = resolveDeployConfig(userConfig);

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -61,6 +61,18 @@ import {
   type ResolvedFarmAuthConfig,
 } from "./auth-config";
 import { resolveFarmPerformanceConfig, type ResolvedFarmPerformanceConfig } from "./preload";
+import {
+  getFarmSecurityHeader,
+  isResolvedFarmSecurityConfig,
+  resolveFarmSecurityConfig,
+  type FarmCspConfig,
+  type FarmCspDirectives,
+  type FarmCspDirectiveValue,
+  type FarmCspOptions,
+  type FarmSecurityConfig,
+  type ResolvedFarmCspConfig,
+  type ResolvedFarmSecurityConfig,
+} from "./security";
 
 const FARM_RESOLVED_CUSTOM_CONTEXT = Symbol.for("farm.resolvedCustomContext");
 
@@ -133,6 +145,15 @@ export type {
   FarmAuthUserConfig,
   ResolvedFarmAuthConfig,
 } from "./auth-config";
+export type {
+  FarmCspConfig,
+  FarmCspDirectives,
+  FarmCspDirectiveValue,
+  FarmCspOptions,
+  FarmSecurityConfig,
+  ResolvedFarmCspConfig,
+  ResolvedFarmSecurityConfig,
+} from "./security";
 
 export interface RedirectConfig {
   source: string;
@@ -315,6 +336,7 @@ export interface ResolvedFarmConfig extends Required<
     | "i18n"
     | "auth"
     | "performance"
+    | "security"
   >
 > {
   /** @internal Tracks whether `context` came from user/layer config instead of the default noop. */
@@ -337,6 +359,7 @@ export interface ResolvedFarmConfig extends Required<
   i18n: ResolvedFarmI18nConfig;
   auth: ResolvedFarmAuthConfig;
   performance: ResolvedFarmPerformanceConfig;
+  security: ResolvedFarmSecurityConfig;
   routeRules: FarmRouteRules;
 }
 
@@ -723,6 +746,10 @@ export async function resolveConfig(
   const routeRules = normalizeRouteRules(userConfig.routeRules);
   const routeRuleRedirects = routeRulesToRedirects(routeRules);
   const routeRuleHeaders = routeRulesToHeaders(routeRules);
+  const security = isResolvedFarmSecurityConfig(userConfig.security)
+    ? userConfig.security
+    : resolveFarmSecurityConfig(userConfig.security);
+  const securityHeader = getFarmSecurityHeader(security);
 
   const deploy = resolveDeployConfig(userConfig);
   const root = userConfig.root || process.cwd();
@@ -786,7 +813,11 @@ export async function resolveConfig(
     trailingSlash: userConfig.trailingSlash ?? false,
     redirects: () => [...redirects, ...routeRuleRedirects],
     rewrites: () => rewrites,
-    headers: () => [...headers, ...routeRuleHeaders],
+    headers: () => [
+      ...headers,
+      ...routeRuleHeaders,
+      ...(securityHeader ? [{ source: "/*", headers: [securityHeader] }] : []),
+    ],
     routeRules,
     images: resolveFarmImageConfig(userConfig.images),
     performance: resolveFarmPerformanceConfig(userConfig.performance),
@@ -805,6 +836,7 @@ export async function resolveConfig(
     notFound: userConfig.notFound || {},
     context: userConfig.context || (() => undefined),
     serverActions: resolveServerActionsConfig(userConfig.serverActions),
+    security,
     deploymentId,
     output: userConfig.output || "standalone",
     distDir: userConfig.distDir || ".farm",

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -28,6 +28,15 @@ export type {
   ResolvedFarmPerformanceConfig,
   ResolvedFarmPreloadConfig,
 } from "./preload";
+export type {
+  FarmCspConfig,
+  FarmCspDirectives,
+  FarmCspDirectiveValue,
+  FarmCspOptions,
+  FarmSecurityConfig,
+  ResolvedFarmCspConfig,
+  ResolvedFarmSecurityConfig,
+} from "./security";
 export type { FarmIslandStrategy } from "./island";
 export type { FarmLayerEntry, ResolvedFarmLayer } from "./layers";
 export {

--- a/packages/farm/src/security.ts
+++ b/packages/farm/src/security.ts
@@ -29,40 +29,54 @@ export interface ResolvedFarmSecurityConfig {
   csp: ResolvedFarmCspConfig | false;
 }
 
-export function isResolvedFarmSecurityConfig(
-  input: FarmSecurityConfig | ResolvedFarmSecurityConfig | undefined,
-): input is ResolvedFarmSecurityConfig {
-  return Boolean(
-    input &&
-    (input.csp === false ||
-      (typeof input.csp === "object" &&
-        input.csp !== null &&
-        "value" in input.csp &&
-        "reportOnly" in input.csp)),
-  );
-}
-
 export function resolveFarmSecurityConfig(
-  input: FarmSecurityConfig | undefined,
+  input: FarmSecurityConfig | ResolvedFarmSecurityConfig | undefined,
 ): ResolvedFarmSecurityConfig {
-  if (input && Object.prototype.hasOwnProperty.call(input, "contentSecurityPolicy")) {
+  if (input === undefined) return { csp: false };
+  if (!isPlainRecord(input)) {
+    throw new TypeError("security must be an object containing the csp option.");
+  }
+  if (Object.prototype.hasOwnProperty.call(input, "contentSecurityPolicy")) {
     throw new TypeError(
       "security.contentSecurityPolicy is not supported. Use security.csp instead.",
     );
   }
 
-  if (input?.csp === undefined || input.csp === false) return { csp: false };
+  const csp = input.csp;
+  if (csp === undefined || csp === false) return { csp: false };
 
-  if (typeof input.csp === "string") {
+  if (typeof csp === "string") {
     return {
       csp: {
-        value: validateSerializedCsp(input.csp),
+        value: validateSerializedCsp(csp),
         reportOnly: false,
       },
     };
   }
 
-  const { policy, directives, reportOnly = false } = input.csp;
+  if (!isPlainRecord(csp)) {
+    throw new TypeError("security.csp must be a policy string, false, or an options object.");
+  }
+
+  const reportOnly = validateReportOnly(csp.reportOnly);
+  if (Object.prototype.hasOwnProperty.call(csp, "value")) {
+    if (
+      Object.prototype.hasOwnProperty.call(csp, "policy") ||
+      Object.prototype.hasOwnProperty.call(csp, "directives")
+    ) {
+      throw new TypeError(
+        "Resolved security.csp values cannot include policy or directives options.",
+      );
+    }
+    return {
+      csp: {
+        value: validateSerializedCsp(csp.value),
+        reportOnly,
+      },
+    };
+  }
+
+  const { policy, directives } = csp;
   if (policy !== undefined && directives !== undefined) {
     throw new TypeError("security.csp accepts either policy or directives, not both.");
   }
@@ -75,13 +89,16 @@ export function resolveFarmSecurityConfig(
       value:
         policy !== undefined
           ? validateSerializedCsp(policy)
-          : serializeFarmCspDirectives(directives!),
+          : serializeFarmCspDirectives(directives as FarmCspDirectives),
       reportOnly,
     },
   };
 }
 
 export function serializeFarmCspDirectives(directives: FarmCspDirectives): string {
+  if (!isPlainRecord(directives)) {
+    throw new TypeError("security.csp.directives must be an object.");
+  }
   const serialized: string[] = [];
   const normalizedNames = new Set<string>();
 
@@ -145,10 +162,27 @@ function validateDirectiveValue(value: string): string {
   return normalized;
 }
 
-function validateSerializedCsp(value: string): string {
+function validateSerializedCsp(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new TypeError("security.csp policy must be a non-empty single-line string.");
+  }
   const normalized = value.trim().replace(/;+$/g, "").trim();
   if (!normalized || /[\r\n]/.test(normalized) || normalized.includes("\0")) {
     throw new TypeError("security.csp policy must be a non-empty single-line string.");
   }
   return normalized;
+}
+
+function validateReportOnly(value: unknown): boolean {
+  if (value === undefined) return false;
+  if (typeof value !== "boolean") {
+    throw new TypeError("security.csp.reportOnly must be a boolean.");
+  }
+  return value;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }

--- a/packages/farm/src/security.ts
+++ b/packages/farm/src/security.ts
@@ -1,0 +1,154 @@
+export type FarmCspDirectiveValue = string | readonly string[] | boolean | null | undefined;
+
+export type FarmCspDirectives = Readonly<Record<string, FarmCspDirectiveValue>>;
+
+export interface FarmCspOptions {
+  /** A pre-serialized CSP value. Cannot be combined with directives. */
+  policy?: string;
+  /** CSP directives using camelCase or kebab-case names. */
+  directives?: FarmCspDirectives;
+  /** Emit Content-Security-Policy-Report-Only instead of enforcing the policy. */
+  reportOnly?: boolean;
+}
+
+export type FarmCspConfig = string | FarmCspOptions;
+
+export interface FarmSecurityConfig {
+  /** App-wide Content Security Policy applied to pages, APIs, and static output. */
+  csp?: FarmCspConfig | false;
+  /** @deprecated Use csp. */
+  contentSecurityPolicy?: never;
+}
+
+export interface ResolvedFarmCspConfig {
+  value: string;
+  reportOnly: boolean;
+}
+
+export interface ResolvedFarmSecurityConfig {
+  csp: ResolvedFarmCspConfig | false;
+}
+
+export function isResolvedFarmSecurityConfig(
+  input: FarmSecurityConfig | ResolvedFarmSecurityConfig | undefined,
+): input is ResolvedFarmSecurityConfig {
+  return Boolean(
+    input &&
+    (input.csp === false ||
+      (typeof input.csp === "object" &&
+        input.csp !== null &&
+        "value" in input.csp &&
+        "reportOnly" in input.csp)),
+  );
+}
+
+export function resolveFarmSecurityConfig(
+  input: FarmSecurityConfig | undefined,
+): ResolvedFarmSecurityConfig {
+  if (input && Object.prototype.hasOwnProperty.call(input, "contentSecurityPolicy")) {
+    throw new TypeError(
+      "security.contentSecurityPolicy is not supported. Use security.csp instead.",
+    );
+  }
+
+  if (input?.csp === undefined || input.csp === false) return { csp: false };
+
+  if (typeof input.csp === "string") {
+    return {
+      csp: {
+        value: validateSerializedCsp(input.csp),
+        reportOnly: false,
+      },
+    };
+  }
+
+  const { policy, directives, reportOnly = false } = input.csp;
+  if (policy !== undefined && directives !== undefined) {
+    throw new TypeError("security.csp accepts either policy or directives, not both.");
+  }
+  if (policy === undefined && directives === undefined) {
+    throw new TypeError("security.csp requires a policy string or directives object.");
+  }
+
+  return {
+    csp: {
+      value:
+        policy !== undefined
+          ? validateSerializedCsp(policy)
+          : serializeFarmCspDirectives(directives!),
+      reportOnly,
+    },
+  };
+}
+
+export function serializeFarmCspDirectives(directives: FarmCspDirectives): string {
+  const serialized: string[] = [];
+  const normalizedNames = new Set<string>();
+
+  for (const [configuredName, configuredValue] of Object.entries(directives)) {
+    if (configuredValue === false || configuredValue === null || configuredValue === undefined) {
+      continue;
+    }
+
+    const name = normalizeDirectiveName(configuredName);
+    if (normalizedNames.has(name)) {
+      throw new TypeError(`security.csp contains the duplicate directive ${JSON.stringify(name)}.`);
+    }
+    normalizedNames.add(name);
+
+    const values =
+      configuredValue === true
+        ? []
+        : (Array.isArray(configuredValue) ? configuredValue : [configuredValue]).map(
+            validateDirectiveValue,
+          );
+    serialized.push(values.length > 0 ? `${name} ${values.join(" ")}` : name);
+  }
+
+  if (serialized.length === 0) {
+    throw new TypeError("security.csp.directives must contain at least one enabled directive.");
+  }
+  return serialized.join("; ");
+}
+
+export function getFarmSecurityHeader(
+  security: ResolvedFarmSecurityConfig,
+): { key: string; value: string } | undefined {
+  if (!security.csp) return undefined;
+  return {
+    key: security.csp.reportOnly
+      ? "Content-Security-Policy-Report-Only"
+      : "Content-Security-Policy",
+    value: security.csp.value,
+  };
+}
+
+function normalizeDirectiveName(value: string): string {
+  const name = value
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .toLowerCase();
+  if (!/^[a-z][a-z0-9-]*$/.test(name)) {
+    throw new TypeError(`Invalid security.csp directive name: ${JSON.stringify(value)}.`);
+  }
+  return name;
+}
+
+function validateDirectiveValue(value: string): string {
+  if (typeof value !== "string") {
+    throw new TypeError("security.csp directive values must be strings or booleans.");
+  }
+  const normalized = value.trim();
+  if (!normalized || /[;\r\n]/.test(normalized) || normalized.includes("\0")) {
+    throw new TypeError(`Invalid security.csp directive value: ${JSON.stringify(value)}.`);
+  }
+  return normalized;
+}
+
+function validateSerializedCsp(value: string): string {
+  const normalized = value.trim().replace(/;+$/g, "").trim();
+  if (!normalized || /[\r\n]/.test(normalized) || normalized.includes("\0")) {
+    throw new TypeError("security.csp policy must be a non-empty single-line string.");
+  }
+  return normalized;
+}

--- a/packages/farm/src/types.ts
+++ b/packages/farm/src/types.ts
@@ -22,6 +22,7 @@ import type { FarmCacheUserConfig } from "./cache";
 import type { FarmAuthUserConfig, ResolvedFarmAuthConfig } from "./auth-config";
 import type { FarmPerformanceConfig } from "./preload";
 import type { FarmLayoutFonts } from "./font";
+import type { FarmSecurityConfig, ResolvedFarmSecurityConfig } from "./security";
 
 declare global {
   namespace FarmJS {
@@ -179,6 +180,8 @@ export interface FarmConfig {
   routeRules?: FarmRouteRules;
   context?: FarmContextFactory<any>;
   serverActions?: FarmServerActionsConfig;
+  /** App-wide HTTP security policy. */
+  security?: FarmSecurityConfig | ResolvedFarmSecurityConfig;
   images?: FarmImageConfig;
   /** Browser resource scheduling and preload budgets. */
   performance?: FarmPerformanceConfig;


### PR DESCRIPTION
## Summary

- add typed `security.csp` configuration with directive serialization, raw policies, and report-only mode
- reject the long `contentSecurityPolicy` alias, duplicate directives, and header-injection-shaped values during config resolution
- apply CSP through the existing response-header pipeline across development, dynamic production responses, APIs, and prerendered routes
- document the compatible baseline and the current nonce/hash limitation for Farm inline bootstraps

## Verification

- `pnpm --filter @farm.js/core type-check`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`
- `pnpm --filter @farm.js/core test`
- `pnpm --filter @farm.js/core test -- production-ssg.test.ts`
- focused `oxlint` and `oxfmt --check`

The production test verifies the CSP header on a prerendered page, a dynamically rendered page, and an API response.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class Content Security Policy under `security.csp`, with typed directives, raw policy strings, and report-only mode. The CSP header is strictly validated (single-line, no injection) and applied across pages, APIs, and prerendered output, appended after other headers.

- **New Features**
  - `security.csp` supports `directives` (camel/kebab), a pre-serialized `policy`, and `reportOnly`.
  - Validates all config paths: enforces single-line policies, rejects duplicate directives and header-injection characters, and provides clear errors.
  - Emits `Content-Security-Policy` or `...-Report-Only`, appended via the response-header pipeline after other config and route-rule headers.
  - Tests: directive serialization, report-only, validation and option-shape errors, header order, and production SSG coverage.
  - Docs: new CSP section with examples and a note on current inline bootstrap nonce/hash limitations.

- **Migration**
  - The long-form `contentSecurityPolicy` key is rejected; use `security.csp`.
  - Update plugins to `securityPlugin({ csp: true })`.

<sup>Written for commit 785b1276038649e14fe45cad88d73b119c5a0250. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

