### PR TITLE
fix: support src alias across builds

### DIFF
--- a/packages/create-farm-app/templates/basic/tsconfig.json
+++ b/packages/create-farm-app/templates/basic/tsconfig.json
@@ -6,6 +6,10 @@
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/packages/create-farm-app/test/create-app.test.mjs
+++ b/packages/create-farm-app/test/create-app.test.mjs
@@ -96,6 +96,13 @@ test("generates a buildable starter application", async () => {
     );
     assert.doesNotMatch(generatedConfig, /srcDir/);
 
+    const generatedTsconfig = JSON.parse(
+      await readFile(path.join(tempDir, "generated-app/tsconfig.json"), "utf8"),
+    );
+    assert.deepEqual(generatedTsconfig.compilerOptions.paths, {
+      "@/*": ["./src/*"],
+    });
+
     const generatedGitignore = await readFile(
       path.join(tempDir, "generated-app/.gitignore"),
       "utf8",

--- a/packages/farm/src/__tests__/create-server.test.ts
+++ b/packages/farm/src/__tests__/create-server.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   createFarmClientOptimizeDepsConfig,
   createFarmClientOptimizeDepsEntries,
+  createFarmSourceAlias,
   FARM_CLIENT_OPTIMIZE_DEPS_INCLUDE,
   mergeFarmViteConfig,
 } from "../server/vite-config";
@@ -40,6 +41,12 @@ describe("mergeFarmViteConfig", () => {
     expect(createFarmClientOptimizeDepsConfig(entries)?.entries).toEqual(entries);
   });
 
+  it("maps @ to the configured application source directory", () => {
+    expect(createFarmSourceAlias("/workspace/app", "web")).toEqual({
+      "@": "/workspace/app/web",
+    });
+  });
+
   it("preserves Farm plugins and dependency safeguards when user Vite config is merged", () => {
     const farmPlugin = { name: "farm:framework" };
     const userPlugin = { name: "app:plugin" };
@@ -48,7 +55,10 @@ describe("mergeFarmViteConfig", () => {
       {
         plugins: [farmPlugin],
         server: { middlewareMode: false, port: 3000, strictPort: true },
-        resolve: { dedupe: ["react", "react-dom"] },
+        resolve: {
+          alias: { "@": "/workspace/app/src", "farm-runtime": "/farm/runtime" },
+          dedupe: ["react", "react-dom"],
+        },
         optimizeDeps: {
           noDiscovery: true,
           entries: ["src/app/**/page.tsx"],
@@ -60,7 +70,10 @@ describe("mergeFarmViteConfig", () => {
       {
         plugins: [userPlugin],
         server: { port: 4100, strictPort: false },
-        resolve: { dedupe: ["react-dom", "react-is"] },
+        resolve: {
+          alias: { "@": "/workspace/app/custom-src", "app-only": "/app/only" },
+          dedupe: ["react-dom", "react-is"],
+        },
         optimizeDeps: {
           entries: ["src/browser-entry.ts"],
           include: ["react", "react-dom"],
@@ -77,6 +90,11 @@ describe("mergeFarmViteConfig", () => {
       strictPort: false,
     });
     expect(merged.resolve?.dedupe).toEqual(["react", "react-dom", "react-is"]);
+    expect(merged.resolve?.alias).toEqual({
+      "@": "/workspace/app/custom-src",
+      "farm-runtime": "/farm/runtime",
+      "app-only": "/app/only",
+    });
     expect(merged.optimizeDeps).toMatchObject({
       noDiscovery: true,
       entries: ["src/browser-entry.ts"],

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -24,6 +24,7 @@ async function createProductionFixture(): Promise<string> {
   });
   await fs.symlink(packageRoot, path.join(root, "node_modules", "@farm.js", "core"), "dir");
   await fs.mkdir(path.join(root, "src", "app"), { recursive: true });
+  await fs.mkdir(path.join(root, "src", "lib"), { recursive: true });
   await fs.writeFile(
     path.join(root, "package.json"),
     JSON.stringify({ private: true, type: "module" }, null, 2),
@@ -39,12 +40,17 @@ export default function RootLayout({ children }) {
   );
   await fs.writeFile(path.join(root, "src", "app", "prebuilt-ssr-marker.txt"), "copied SSR asset");
   await fs.writeFile(
+    path.join(root, "src", "lib", "alias-marker.ts"),
+    `export const aliasMarker = "src alias resolved";`,
+  );
+  await fs.writeFile(
     path.join(root, "src", "app", "page.tsx"),
     `
 import markerAsset from "./prebuilt-ssr-marker.txt?url";
+import { aliasMarker } from "@/lib/alias-marker";
 
 export default function Page() {
-  return <main data-prebuilt-ssr="ready" data-marker-asset={markerAsset}>prebuilt SSR output</main>;
+  return <main data-prebuilt-ssr="ready" data-marker-asset={markerAsset}>prebuilt SSR output: {aliasMarker}</main>;
 }
 `.trim(),
   );
@@ -366,7 +372,9 @@ export default function DynamicPage({ params }) {
         expect(response.status).toBe(200);
         expect(response.headers.get("x-production-header")).toBe("standalone");
         expect(response.headers.get("cache-control")).toBe("private, no-store");
-        await expect(response.text()).resolves.toContain("prebuilt SSR output");
+        const html = await response.text();
+        expect(html).toContain("prebuilt SSR output");
+        expect(html).toContain("src alias resolved");
 
         const staticUrl = new URL("/static-page", response.url);
         const staticResponse = await fetch(staticUrl);

--- a/packages/farm/src/__tests__/vite-config.test.ts
+++ b/packages/farm/src/__tests__/vite-config.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 
 import { describe, expect, it } from "vitest";
+import path from "node:path";
 import { FARM_CLIENT_OPTIMIZE_DEPS_INCLUDE } from "../server/vite-config";
 import { defineConfig } from "../vite";
 
@@ -16,5 +17,13 @@ describe("Farm Vite dependency optimization", () => {
     expect(config.optimizeDeps.entries).toEqual([
       "src/app/**/{page,layout,loading,error,not-found,default}.{js,jsx,ts,tsx}",
     ]);
+  });
+
+  it("maps @ to srcDir in the development Vite config", async () => {
+    const config = await defineConfig({ srcDir: "web" });
+
+    expect(config.resolve?.alias).toMatchObject({
+      "@": path.resolve(process.cwd(), "web"),
+    });
   });
 });

--- a/packages/farm/src/build/index.ts
+++ b/packages/farm/src/build/index.ts
@@ -12,7 +12,7 @@ import { generateFarmTypeArtifacts } from "../type-artifacts";
 import { PluginManager } from "../plugin";
 import { farmEnvironmentFunctionsPlugin } from "../environment-vite";
 import { farmFontImportsPlugin } from "../font-vite";
-import { mergeFarmViteConfig } from "../server/vite-config";
+import { createFarmSourceAlias, mergeFarmViteConfig } from "../server/vite-config";
 import {
   canUseRolldownForRouteDiscovery,
   loadFarmProductionVite,
@@ -215,6 +215,9 @@ async function createProjectModuleServer(
       server: {
         middlewareMode: true,
         hmr: false,
+      },
+      resolve: {
+        alias: createFarmSourceAlias(root, config.srcDir),
       },
       optimizeDeps: {
         noDiscovery: true,

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -60,6 +60,7 @@ import { loadFarmProductionVite, type FarmProductionViteRuntime } from "../build
 import { adaptTailwindVitePlugin } from "../build/vite-plugin-compat";
 import { mergeFarmFontCss } from "../font-vite";
 import type { FarmIslandStrategy } from "../island";
+import { createFarmSourceAlias } from "../server/vite-config";
 
 // Type alias for OutputBundle
 type OutputBundle = Rollup.OutputBundle;
@@ -2879,9 +2880,7 @@ async function buildSSRInMemory(
           }
         : undefined,
       resolve: {
-        alias: {
-          "@": path.resolve(root, "src"),
-        },
+        alias: createFarmSourceAlias(root, config.srcDir),
         // Programmatic route wrappers are created inside @farm.js/core. Resolve
         // their React imports from the application so React 18/19 elements and
         // the selected server renderer always share the same runtime instance.

--- a/packages/farm/src/server/vite-config.ts
+++ b/packages/farm/src/server/vite-config.ts
@@ -58,7 +58,18 @@ export function createFarmClientOptimizeDepsConfig(
   };
 }
 
+/**
+ * Farm's application-source alias. Keep this shared by development, route
+ * discovery, and production bundling so `@/…` always follows `srcDir`.
+ */
+export function createFarmSourceAlias(projectRoot: string, srcDir = "src"): Record<string, string> {
+  return {
+    "@": path.resolve(projectRoot, srcDir),
+  };
+}
+
 type ViteNoExternal = NonNullable<NonNullable<ViteUserConfig["ssr"]>["noExternal"]>;
+type ViteAlias = NonNullable<NonNullable<ViteUserConfig["resolve"]>["alias"]>;
 
 function mergeNoExternal(
   farmValue: ViteNoExternal | undefined,
@@ -70,6 +81,27 @@ function mergeNoExternal(
     value == null || value === true ? [] : Array.isArray(value) ? value : [value];
 
   return Array.from(new Set([...normalize(farmValue), ...normalize(userValue)]));
+}
+
+function mergeAlias(farmValue: ViteAlias | undefined, userValue: ViteAlias | undefined): ViteAlias {
+  if (!farmValue) return userValue || {};
+  if (!userValue) return farmValue;
+
+  if (!Array.isArray(farmValue) && !Array.isArray(userValue)) {
+    return {
+      ...farmValue,
+      ...userValue,
+    };
+  }
+
+  const normalize = (value: ViteAlias): Exclude<ViteAlias, Record<string, string>> =>
+    Array.isArray(value)
+      ? [...value]
+      : Object.entries(value).map(([find, replacement]) => ({ find, replacement }));
+
+  // Vite uses the first matching array entry. Put application entries first
+  // so an explicit user alias can intentionally override a Farm default.
+  return [...normalize(userValue), ...normalize(farmValue)];
 }
 
 export function mergeFarmViteConfig(
@@ -94,6 +126,7 @@ export function mergeFarmViteConfig(
     resolve: {
       ...farmConfig.resolve,
       ...userConfig.resolve,
+      alias: mergeAlias(farmConfig.resolve?.alias, userConfig.resolve?.alias),
       dedupe: Array.from(
         new Set([...(farmConfig.resolve?.dedupe || []), ...(userConfig.resolve?.dedupe || [])]),
       ),

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -61,6 +61,7 @@ import type { FarmI18nClientSnapshot } from "./i18n/types";
 import {
   createFarmClientOptimizeDepsConfig,
   createFarmClientOptimizeDepsEntries,
+  createFarmSourceAlias,
 } from "./server/vite-config";
 import { resolveFarmDocsFontAssets, toFarmDocsPublicFontAssets } from "./docs/fonts";
 
@@ -4464,7 +4465,7 @@ export async function defineConfig(config: FarmVitePluginOptions = {}): Promise<
       // Stub out problematic server-only modules during dev mode
       alias: {
         ...getFarmLayerAliases(config.layers),
-        "@": path.resolve(appRoot, "src"),
+        ...createFarmSourceAlias(appRoot, config.srcDir),
         // Nitro internals that should not be resolved in browser
         "supports-color":
           "data:text/javascript,export default false; export const supportsColor = false; export const stdout = false; export const stderr = false;",


### PR DESCRIPTION
## What changed

- add a shared Farm source-alias helper that maps `@` to the configured `srcDir`
- apply the alias consistently in development, production route discovery, and universal SSR builds
- preserve Farm defaults when merging application Vite aliases while allowing an explicit user `@` override
- add the `@/*` TypeScript path mapping to newly scaffolded applications
- cover custom `srcDir`, alias merging, scaffold output, and production SSR with regression tests

## Why

Farm's development and bundle configuration exposed `@`, but the production route-discovery module server did not. A route importing `@/…` could therefore work during development and then fail before production bundling. The alias also assumed a literal `src` directory, and a shallow `resolve` merge could discard defaults.

## Validation

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/create-server.test.ts src/__tests__/vite-config.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/create-app build`
- `node --test packages/create-farm-app/test/create-app.test.mjs`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/production-prebuilt-ssr.test.ts -t "boots standalone Node output through the package import mapping"`

All checks pass locally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the `@` src alias reliable across dev, production route discovery, and SSR by resolving it to the configured `srcDir`. Also adds `@/*` TypeScript paths to new apps and allows user-defined `@` aliases to override Farm defaults.

- **Bug Fixes**
  - Introduced `createFarmSourceAlias` and applied it in dev, route discovery, and universal SSR builds.
  - Merged `resolve.alias` properly so user aliases can override Farm defaults while keeping dedupe settings.
  - Added `baseUrl` and `paths: { "@/*": ["./src/*"] }` to scaffolded `tsconfig.json`.
  - Added regression tests for custom `srcDir`, alias merging, scaffold output, and production SSR alias resolution.

<sup>Written for commit b54d56adef1162bcd2b8fe388887bfa2e4ea06cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

