### PR TITLE
fix: harden HTTP request and secret handling

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -213,6 +213,27 @@ You can also pass an already serialized policy as `csp: "default-src 'self'; obj
 
 Farm currently emits small inline hydration and route-state bootstraps, so the compatible example allows inline scripts and styles. A stricter policy must supply correct hashes or renderer-generated nonces for every trusted inline bootstrap. Start with `reportOnly`, inspect violations, and enforce only after the deployed HTML and every third-party integration satisfy the policy.
 
+## Server HTTP policy
+
+Farm applies one request-body limit to API routes, integrations, workflow HTTP triggers, and uploads handled by those surfaces. The default is 10 MB.
+
+```ts
+import { defineConfig } from "@farm.js/core";
+
+export default defineConfig({
+  server: {
+    bodySizeLimit: "10mb",
+    trustProxy: false,
+  },
+});
+```
+
+Farm checks `Content-Length` when present and also counts the received bytes, so chunked requests cannot bypass `bodySizeLimit`. Oversized requests receive `413 Payload Too Large` before the route or integration handler runs. Server Actions keep their separate, tighter `serverActions.bodySizeLimit` setting.
+
+`trustProxy` defaults to `false`. Enable it only when the app is behind a trusted reverse proxy that removes client-supplied forwarding headers and writes its own `X-Forwarded-For` value. A directly exposed Farm server must leave it disabled so a client cannot spoof the address used by rate limits, logs, or access policy.
+
+Workflow runner secrets are accepted only through `Authorization: Bearer <secret>` or `X-Farm-Workflow-Secret`. Farm does not accept secrets in query strings because URLs are commonly retained in logs, browser history, and referrer data.
+
 ## Server action security
 
 Server actions are same-origin application RPC endpoints. Farm rejects cross-origin action requests by default and limits the encoded request body to 1 MB.

--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -311,6 +311,10 @@ describe("resolveConfig", () => {
 
   it("resolves secure server action defaults and overrides", async () => {
     const defaults = await resolveConfig({}, "production");
+    expect(defaults.server).toEqual({
+      bodySizeLimit: 10_000_000,
+      trustProxy: false,
+    });
     expect(defaults.serverActions).toEqual({
       allowedOrigins: [],
       bodySizeLimit: 1_000_000,
@@ -329,6 +333,20 @@ describe("resolveConfig", () => {
     expect(configured.serverActions).toEqual({
       allowedOrigins: ["https://app.example.com", "*.proxy.example.com"],
       bodySizeLimit: 2_000_000,
+    });
+
+    const server = await resolveConfig(
+      {
+        server: {
+          bodySizeLimit: "25mb",
+          trustProxy: true,
+        },
+      },
+      "production",
+    );
+    expect(server.server).toEqual({
+      bodySizeLimit: 25_000_000,
+      trustProxy: true,
     });
   });
 

--- a/packages/farm/src/__tests__/integrations.test.ts
+++ b/packages/farm/src/__tests__/integrations.test.ts
@@ -766,6 +766,42 @@ describe("integrations runtime", () => {
     });
   });
 
+  it("rejects integration request bodies above the server limit", async () => {
+    const handler = vi.fn(() => Response.json({ ok: true }));
+    const manager = new PluginManager({
+      config: { server: { bodySizeLimit: 8 } },
+      isDev: true,
+      isProd: false,
+    });
+    manager.addPlugins(
+      resolveIntegrationPlugins({
+        limited: defineIntegration({
+          category: "custom",
+          type: "limited",
+          instance: {},
+          routes: [
+            integrationRoute.post("/api/limited", {
+              handler,
+            }),
+          ],
+        }),
+      }),
+    );
+    await manager.runHookParallel("init");
+
+    const runtime = getRegisteredIntegrationRuntime("limited");
+    const response = await dispatchIntegrationRequest(
+      runtime!,
+      new Request("http://localhost/api/limited", {
+        method: "POST",
+        body: "request-too-large",
+      }),
+    );
+
+    expect(response?.status).toBe(413);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
   it("runs route-level middleware in order before the route handler", async () => {
     const manager = createManager();
     manager.addPlugins(

--- a/packages/farm/src/__tests__/production-middleware-http.test.ts
+++ b/packages/farm/src/__tests__/production-middleware-http.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import {
+  applyProductionMiddlewareHeaders,
+  createProductionMiddlewareRunner,
+} from "../middleware/production-runtime";
+
+describe("production middleware HTTP behavior", () => {
+  it("keeps multiple middleware cookies as separate Set-Cookie headers", async () => {
+    const runner = createProductionMiddlewareRunner({
+      config: {
+        handler(ctx) {
+          ctx.cookies.set("session", "abc", { httpOnly: true });
+          ctx.cookies.set("theme", "dark", { sameSite: "lax" });
+        },
+      },
+    });
+
+    const result = await runner(new Request("https://example.com/"));
+    expect(result.headers.getSetCookie()).toEqual([
+      "session=abc; Path=/; HttpOnly",
+      "theme=dark; Path=/; SameSite=Lax",
+    ]);
+
+    const response = applyProductionMiddlewareHeaders(
+      new Response("ok", { headers: { "set-cookie": "existing=1; Path=/" } }),
+      result.headers,
+    );
+    expect(response.headers.getSetCookie()).toEqual([
+      "existing=1; Path=/",
+      "session=abc; Path=/; HttpOnly",
+      "theme=dark; Path=/; SameSite=Lax",
+    ]);
+  });
+
+  it("ignores forwarded client addresses unless trustProxy is enabled", async () => {
+    const createRunner = (trustProxy: boolean) =>
+      createProductionMiddlewareRunner({
+        server: { trustProxy },
+        config: {
+          handler(ctx) {
+            ctx.headers.set("x-client-address", ctx.request.socket.remoteAddress || "missing");
+          },
+        },
+      });
+    const request = () =>
+      new Request("https://example.com/", {
+        headers: { "x-forwarded-for": "203.0.113.8, 10.0.0.1" },
+      });
+
+    const direct = await createRunner(false)(request());
+    expect(direct.headers.get("x-client-address")).toBe("127.0.0.1");
+
+    const proxied = await createRunner(true)(request());
+    expect(proxied.headers.get("x-client-address")).toBe("203.0.113.8");
+  });
+});

--- a/packages/farm/src/__tests__/server-http.test.ts
+++ b/packages/farm/src/__tests__/server-http.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment node
+
+import { Readable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { invokeAPIRouteEndpoint } from "../api/runtime";
+import {
+  bufferFarmRequestBody,
+  readNodeRequestBody,
+  resolveFarmServerConfig,
+} from "../server-http";
+
+describe("Farm server HTTP policy", () => {
+  it("resolves safe defaults and size strings", () => {
+    expect(resolveFarmServerConfig(undefined)).toEqual({
+      bodySizeLimit: 10_000_000,
+      trustProxy: false,
+    });
+    expect(resolveFarmServerConfig({ bodySizeLimit: "2 MiB", trustProxy: true })).toEqual({
+      bodySizeLimit: 2_097_152,
+      trustProxy: true,
+    });
+  });
+
+  it("rejects streamed Web request bodies above the limit", async () => {
+    const request = new Request("https://example.com/upload", {
+      method: "POST",
+      body: "123456",
+    });
+
+    await expect(bufferFarmRequestBody(request, 5)).rejects.toMatchObject({
+      code: "BODY_TOO_LARGE",
+      status: 413,
+    });
+  });
+
+  it("rejects Node request bodies above the limit", async () => {
+    const request = Readable.from([Buffer.from("123"), Buffer.from("456")]) as Readable & {
+      headers: Record<string, string>;
+    };
+    request.headers = {};
+
+    await expect(readNodeRequestBody(request as any, 5)).rejects.toMatchObject({
+      code: "BODY_TOO_LARGE",
+      status: 413,
+    });
+  });
+
+  it("returns 413 before invoking an API route or upload handler", async () => {
+    let invoked = false;
+    const response = await invokeAPIRouteEndpoint(
+      async () => {
+        invoked = true;
+        return new Response("ok");
+      },
+      new Request("https://example.com/api/upload", {
+        method: "POST",
+        body: "123456",
+      }),
+      {},
+      5,
+    );
+
+    expect(response.status).toBe(413);
+    expect(invoked).toBe(false);
+  });
+
+  it("returns 400 for an invalid Content-Length before invoking the handler", async () => {
+    let invoked = false;
+    const response = await invokeAPIRouteEndpoint(
+      async () => {
+        invoked = true;
+        return new Response("ok");
+      },
+      new Request("https://example.com/api/upload", {
+        method: "POST",
+        headers: { "content-length": "not-a-number" },
+        body: "x",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(invoked).toBe(false);
+  });
+});

--- a/packages/farm/src/__tests__/workflows.test.ts
+++ b/packages/farm/src/__tests__/workflows.test.ts
@@ -9,6 +9,7 @@ import {
   createFarmWorkflowRequestHandler,
   defineCron,
   discoverFarmWorkflows,
+  prepareFarmWorkflowsForNitro,
   resolveWorkflowsConfig,
 } from "../workflows";
 
@@ -142,8 +143,15 @@ describe("Farm workflows", () => {
     const unauthorizedList = await handler(new Request("https://example.com/api/_farm/workflows"));
     expect(unauthorizedList?.status).toBe(401);
 
-    const list = await handler(
+    const querySecret = await handler(
       new Request("https://example.com/api/_farm/workflows?secret=test-secret"),
+    );
+    expect(querySecret?.status).toBe(401);
+
+    const list = await handler(
+      new Request("https://example.com/api/_farm/workflows", {
+        headers: { "x-farm-workflow-secret": "test-secret" },
+      }),
     );
     await expect(list?.json()).resolves.toEqual({
       workflows: [
@@ -158,9 +166,9 @@ describe("Farm workflows", () => {
     });
 
     const response = await handler(
-      new Request(
-        "https://example.com/api/_farm/workflows/sync-users?secret=test-secret&cursor=abc",
-      ),
+      new Request("https://example.com/api/_farm/workflows/sync-users?cursor=abc", {
+        headers: { authorization: "Bearer test-secret" },
+      }),
     );
 
     expect(response?.status).toBe(200);
@@ -174,6 +182,57 @@ describe("Farm workflows", () => {
       },
     });
     expect(run).toHaveBeenCalledOnce();
+  });
+
+  it("rejects workflow bodies above the server request limit", async () => {
+    const workflow = {
+      id: "sync-users",
+      filePath: "/virtual/sync-users.ts",
+      schedule: [],
+      routePath: "/api/_farm/workflows/sync-users",
+    };
+    const run = vi.fn();
+    const handler = createFarmWorkflowRequestHandler({
+      workflows: [workflow],
+      config: resolveWorkflowsConfig({ secret: "test-secret" }),
+      server: { bodySizeLimit: 8 },
+      loadModule: async () => ({ default: { run } }),
+    });
+
+    const response = await handler(
+      new Request("https://example.com/api/_farm/workflows/sync-users", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-secret",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ cursor: "too-large" }),
+      }),
+    );
+
+    expect(response?.status).toBe(413);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("generates header-only Nitro workflow authentication with the server body limit", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-workflow-nitro-"));
+    await fs.mkdir(path.join(root, "src", "jobs"), { recursive: true });
+    await fs.writeFile(
+      path.join(root, "src", "jobs", "sync.mjs"),
+      "export default { async run() { return { ok: true }; } };",
+    );
+
+    const prepared = await prepareFarmWorkflowsForNitro({
+      root,
+      workflows: { secret: "test-secret" },
+      server: { bodySizeLimit: 1234 },
+    });
+    const handlerSource = await fs.readFile(prepared.handlerPath!, "utf8");
+
+    expect(handlerSource).toContain("const bodySizeLimit = 1234");
+    expect(handlerSource).toContain('getHeader(event, "x-farm-workflow-secret")');
+    expect(handlerSource).toContain("authorization.match(/^Bearer");
+    expect(handlerSource).not.toContain('searchParams.get("secret")');
   });
 
   it("adds scheduled workflows to Vercel crons without duplicating existing entries", () => {

--- a/packages/farm/src/api/route-manager.ts
+++ b/packages/farm/src/api/route-manager.ts
@@ -26,6 +26,7 @@ export interface APIRoute extends FarmRouteRuntimeConfig {
 export interface APIRouteManagerOptions {
   throwOnLoadError?: boolean;
   i18n?: FarmI18nRuntime;
+  bodySizeLimit?: number;
 }
 
 export const API_ROUTE_METHODS = [
@@ -44,6 +45,7 @@ export class APIRouteManager {
   private appDirs: string[];
   private throwOnLoadError: boolean;
   private i18n?: FarmI18nRuntime;
+  private bodySizeLimit?: number;
 
   constructor(
     appDir: string | readonly string[],
@@ -54,6 +56,7 @@ export class APIRouteManager {
     this.viteServer = viteServer;
     this.throwOnLoadError = options.throwOnLoadError === true;
     this.i18n = options.i18n;
+    this.bodySizeLimit = options.bodySizeLimit;
   }
 
   /**
@@ -314,7 +317,7 @@ export class APIRouteManager {
 
       const invoke = async () => {
         try {
-          return await invokeAPIRouteEndpoint(endpoint, request, params);
+          return await invokeAPIRouteEndpoint(endpoint, request, params, this.bodySizeLimit);
         } catch (error: any) {
           console.error(`[API Error] ${pathname}:`, error);
           return new Response(JSON.stringify({ error: "Internal Server Error" }), {

--- a/packages/farm/src/api/runtime.ts
+++ b/packages/farm/src/api/runtime.ts
@@ -5,6 +5,11 @@ import {
   FARM_CACHE_INVALIDATION_HEADER,
 } from "../cache-invalidation";
 import { isEndpointFailure, type EndpointFailure } from "./endpoint";
+import {
+  bufferFarmRequestBody,
+  createFarmRequestBodyErrorResponse,
+  DEFAULT_FARM_SERVER_BODY_SIZE_LIMIT,
+} from "../server-http";
 
 export type APIRouteParamValue = string | string[];
 export type APIRouteParams = Record<string, APIRouteParamValue>;
@@ -45,7 +50,16 @@ export async function invokeAPIRouteEndpoint(
   endpoint: any,
   request: Request,
   params: APIRouteParams = {},
+  bodySizeLimit = DEFAULT_FARM_SERVER_BODY_SIZE_LIMIT,
 ): Promise<Response> {
+  try {
+    request = await bufferFarmRequestBody(request, bodySizeLimit);
+  } catch (error) {
+    const response = createFarmRequestBodyErrorResponse(error);
+    if (response) return response;
+    throw error;
+  }
+
   return _runWithCurrentRequest(request, () =>
     invokeAPIRouteEndpointInContext(endpoint, request, params),
   );

--- a/packages/farm/src/api/vite-plugin.ts
+++ b/packages/farm/src/api/vite-plugin.ts
@@ -22,12 +22,19 @@ import { _withAfterNodeMiddleware } from "../after";
 import { getProgrammaticRouteManifest, isProgrammaticRoutesFileName } from "../routes";
 import { findProgrammaticRouteFilesInDir } from "../routes.server";
 import { toViteModuleId } from "../utils";
+import {
+  createFarmRequestBodyErrorResponse,
+  readNodeRequestBody,
+  resolveFarmServerConfig,
+} from "../server-http";
 
 export interface FarmApiPluginOptions {
   /** Source directory containing the api folder (default: 'src') */
   srcDir?: string;
   /** Enable debug logging */
   debug?: boolean;
+  /** Maximum request body size, for example `"10mb"`. */
+  bodySizeLimit?: number | string;
 }
 
 export interface ApiRoute {
@@ -43,6 +50,9 @@ export interface ApiRoute {
 export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
   const srcDir = options.srcDir ?? "src";
   const debug = options.debug ?? false;
+  const bodySizeLimit = resolveFarmServerConfig({
+    bodySizeLimit: options.bodySizeLimit,
+  }).bodySizeLimit;
 
   // API routes cache
   let apiRoutesCache: Map<string, ApiRoute> = new Map();
@@ -132,7 +142,7 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
         }
 
         try {
-          return await invokeAPIRouteEndpoint(endpoint, request, params);
+          return await invokeAPIRouteEndpoint(endpoint, request, params, bodySizeLimit);
         } catch (error: any) {
           return new Response(JSON.stringify({ error: error.message || "Internal Server Error" }), {
             status: 500,
@@ -351,23 +361,20 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
                 }
               }
 
-              let body: string | undefined;
+              let body: Buffer | undefined;
               if (method !== "GET" && method !== "HEAD") {
-                body = await new Promise<string>((resolve) => {
-                  let data = "";
-                  req.on("data", (chunk: any) => {
-                    data += chunk;
-                  });
-                  req.on("end", () => {
-                    resolve(data);
-                  });
-                });
+                body = await readNodeRequestBody(req as any, bodySizeLimit);
               }
 
               const request = new Request(fullUrl, {
                 method,
                 headers,
-                body: body || undefined,
+                body: body
+                  ? (body.buffer.slice(
+                      body.byteOffset,
+                      body.byteOffset + body.byteLength,
+                    ) as ArrayBuffer)
+                  : undefined,
               });
 
               const response = await apiRouterHandler(request);
@@ -377,6 +384,11 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
 
               await sendWebResponse(res, response);
             } catch (error: any) {
+              const bodyErrorResponse = createFarmRequestBodyErrorResponse(error);
+              if (bodyErrorResponse) {
+                await sendWebResponse(res, bodyErrorResponse);
+                return;
+              }
               const duration = Date.now() - startTime;
               logResponse(method, pathname, 500, duration);
               console.error("[FARM] API error:", error);

--- a/packages/farm/src/app.ts
+++ b/packages/farm/src/app.ts
@@ -11,6 +11,7 @@ import { initStorage } from "./storage";
 import { configureFarmObservability } from "./observability";
 import { normalizeRouteRules } from "./route-rules";
 import { resolveServerActionsConfig } from "./server-action-security";
+import { resolveFarmServerConfig } from "./server-http";
 import { resolveFarmImageConfig, type ResolvedFarmImageConfig } from "./image-config";
 import { getFarmAppDirectories, getFarmSourceRoots } from "./layers";
 import { RouteManager } from "./routing/route-manager";
@@ -141,6 +142,7 @@ export class FarmApp {
       middleware: config.middleware || {},
       routeRules: normalizeRouteRules(config.routeRules),
       context: config.context || (() => undefined),
+      server: resolveFarmServerConfig(config.server),
       serverActions: resolveServerActionsConfig(config.serverActions),
       security: resolveFarmSecurityConfig(config.security),
       images: resolveFarmImageConfig(config.images),

--- a/packages/farm/src/build/index.ts
+++ b/packages/farm/src/build/index.ts
@@ -111,6 +111,7 @@ async function buildWithProductionNodeEnv(config: ResolvedFarmConfig, options: B
       {
         throwOnLoadError: true,
         i18n: farmApp.getI18nRuntime(),
+        bodySizeLimit: config.server.bodySizeLimit,
       },
     );
     const [, apiDiscovery] = await Promise.allSettled([

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -38,6 +38,11 @@ import {
   type ResolvedFarmServerActionsConfig,
 } from "./server-action-security";
 import {
+  resolveFarmServerConfig,
+  type FarmServerConfig,
+  type ResolvedFarmServerConfig,
+} from "./server-http";
+import {
   loadFarmConfigFile,
   resolveFarmLayers,
   type FarmLayerEntry,
@@ -107,6 +112,7 @@ export type {
   FarmServerActionsConfig,
   ResolvedFarmServerActionsConfig,
 } from "./server-action-security";
+export type { FarmServerConfig, ResolvedFarmServerConfig } from "./server-http";
 export type { FarmLayerEntry, ResolvedFarmLayer } from "./layers";
 export type {
   FarmDevtoolsConfig,
@@ -284,6 +290,8 @@ export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite" | "docs" | "
   middleware?: FarmMiddlewareConfig;
   routeRules?: FarmRouteRules;
   context?: BaseFarmConfig["context"];
+  /** Server ingress and trusted-proxy policy. */
+  server?: FarmServerConfig;
   serverActions?: FarmServerActionsConfig;
   /** Build identifier used to detect and recover from deployment version skew. */
   deploymentId?: string;
@@ -329,6 +337,7 @@ export interface ResolvedFarmConfig extends Required<
     | "cron"
     | "workflows"
     | "env"
+    | "server"
     | "serverActions"
     | "devtools"
     | "images"
@@ -352,6 +361,7 @@ export interface ResolvedFarmConfig extends Required<
   cron: FarmCronResolvedConfig;
   workflows: FarmWorkflowsResolvedConfig;
   env: ResolvedFarmEnv;
+  server: ResolvedFarmServerConfig;
   serverActions: ResolvedFarmServerActionsConfig;
   devtools: ResolvedFarmDevtoolsConfig;
   images: ResolvedFarmImageConfig;
@@ -832,6 +842,7 @@ export async function resolveConfig(
     middleware: userConfig.middleware || {},
     notFound: userConfig.notFound || {},
     context: userConfig.context || (() => undefined),
+    server: resolveFarmServerConfig(userConfig.server),
     serverActions: resolveServerActionsConfig(userConfig.serverActions),
     security,
     deploymentId,

--- a/packages/farm/src/integrations.ts
+++ b/packages/farm/src/integrations.ts
@@ -21,6 +21,12 @@ import {
 } from "./request-context";
 import { sendWebResponse } from "./server/response";
 import type { FarmRequest } from "./types";
+import {
+  bufferFarmRequestBody,
+  createFarmRequestBodyErrorResponse,
+  readNodeRequestBody,
+  resolveFarmServerConfig,
+} from "./server-http";
 
 export { api, defineIntegrationAPI, defineIntegrationAPIOperation } from "./integration-api";
 export type {
@@ -1694,15 +1700,25 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
         if (!bodyLoaded) {
           bodyLoaded = true;
           if (req.method && req.method !== "GET" && req.method !== "HEAD") {
-            requestBody = await readRequestBody(req);
+            requestBody = await readNodeRequestBody(
+              req,
+              resolveFarmServerConfig(context.config.server).bodySizeLimit,
+            );
           }
         }
 
         return requestBody;
       };
 
-      const createHandlerRequest = async () => {
-        return createWebRequest(req, fullUrl, await getRequestBody());
+      const createHandlerRequest = async (): Promise<Request | null> => {
+        try {
+          return createWebRequest(req, fullUrl, await getRequestBody());
+        } catch (error) {
+          const response = createFarmRequestBodyErrorResponse(error);
+          if (!response) throw error;
+          await sendWebResponse(res, response);
+          return null;
+        }
       };
 
       for (const entry of middleware) {
@@ -1712,6 +1728,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
         }
 
         const request = await createHandlerRequest();
+        if (!request) return;
         const handlerContext = createIntegrationHandlerContext({
           integration,
           route: {
@@ -1810,6 +1827,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
         }
 
         const request = await createHandlerRequest();
+        if (!request) return;
         const handlerContext = createIntegrationHandlerContext({
           integration,
           route: {
@@ -2506,6 +2524,17 @@ export async function dispatchIntegrationRequest(
     internal?: boolean;
   } = {},
 ): Promise<Response | null> {
+  try {
+    request = await bufferFarmRequestBody(
+      request,
+      resolveFarmServerConfig(runtime.config.server).bodySizeLimit,
+    );
+  } catch (error) {
+    const response = createFarmRequestBodyErrorResponse(error);
+    if (response) return response;
+    throw error;
+  }
+
   const integration = runtime.integration;
   const url = new URL(request.url);
   const pathname = url.pathname;
@@ -3062,19 +3091,6 @@ function getRequestId(req: FarmRequest): string {
     return headerValue[0] || String(Date.now());
   }
   return headerValue || String(Date.now());
-}
-
-async function readRequestBody(req: FarmRequest): Promise<Buffer> {
-  return await new Promise((resolve, reject) => {
-    const chunks: Buffer[] = [];
-    req.on("data", (chunk) => {
-      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-    });
-    req.on("end", () => {
-      resolve(Buffer.concat(chunks));
-    });
-    req.on("error", reject);
-  });
 }
 
 function normalizeMatcher(matcher: string | readonly string[] | undefined): string {

--- a/packages/farm/src/middleware/production-runtime.ts
+++ b/packages/farm/src/middleware/production-runtime.ts
@@ -13,6 +13,7 @@ import { emitFarmEvent } from "../observability";
 import { normalizeMiddlewareModule } from "./module";
 import { stripFarmLocaleFromPathname } from "../i18n/routing";
 import type { ResolvedFarmI18nConfig } from "../i18n/types";
+import type { ResolvedFarmServerConfig } from "../server-http";
 
 export interface ProductionMiddlewareModuleEntry {
   path: string;
@@ -24,6 +25,7 @@ export interface ProductionMiddlewareRunnerOptions {
   config?: FarmMiddlewareConfig | null;
   modules?: ProductionMiddlewareModuleEntry[];
   i18n?: ResolvedFarmI18nConfig;
+  server?: Pick<ResolvedFarmServerConfig, "trustProxy">;
 }
 
 export interface ProductionMiddlewareResult {
@@ -45,8 +47,59 @@ interface ProductionMiddlewareEntry {
 
 interface WebMiddlewareContextState {
   ctx: MiddlewareContext;
+  headers: WebResponseHeaderMap;
   getRequest(): Request;
   getResponse(): Response | null;
+}
+
+const FARM_SET_COOKIE_HEADERS = Symbol("farm.setCookieHeaders");
+
+type InternalMiddlewareParent = MiddlewareContext["parent"] & {
+  [FARM_SET_COOKIE_HEADERS]?: string[];
+};
+
+class WebResponseHeaderMap extends Map<string, string> {
+  private setCookies: string[] = [];
+
+  override set(key: string, value: string): this {
+    if (key.toLowerCase() === "set-cookie") {
+      this.setCookies = [value];
+      super.set("Set-Cookie", value);
+      return this;
+    }
+    return super.set(key, value);
+  }
+
+  override delete(key: string): boolean {
+    if (key.toLowerCase() === "set-cookie") {
+      this.setCookies = [];
+      return super.delete("Set-Cookie") || super.delete("set-cookie");
+    }
+    return super.delete(key);
+  }
+
+  override clear(): void {
+    this.setCookies = [];
+    super.clear();
+  }
+
+  appendSetCookie(value: string): void {
+    this.setCookies.push(value);
+    super.set("Set-Cookie", value);
+  }
+
+  replaceSetCookies(values: readonly string[]): void {
+    this.setCookies = [...values];
+    super.delete("Set-Cookie");
+    super.delete("set-cookie");
+    if (this.setCookies.length > 0) {
+      super.set("Set-Cookie", this.setCookies[this.setCookies.length - 1]);
+    }
+  }
+
+  getSetCookies(): readonly string[] {
+    return this.setCookies;
+  }
 }
 
 function parseCookies(cookieHeader?: string | null): Record<string, string> {
@@ -83,11 +136,10 @@ function serializeCookie(name: string, value: string, options: CookieOptions = {
 
 class WebCookieJar implements CookieJar {
   private cookies: Record<string, string>;
-  private setCookies: string[] = [];
 
   constructor(
     request: Request,
-    private headers: Map<string, string>,
+    private headers: WebResponseHeaderMap,
   ) {
     this.cookies = parseCookies(request.headers.get("cookie"));
   }
@@ -99,8 +151,7 @@ class WebCookieJar implements CookieJar {
   set(name: string, value: string, options: CookieOptions = {}): void {
     this.cookies[name] = value;
     const cookieString = serializeCookie(name, value, options);
-    this.setCookies.push(cookieString);
-    this.headers.set("Set-Cookie", this.setCookies.join(", "));
+    this.headers.appendSetCookie(cookieString);
   }
 
   delete(name: string): void {
@@ -109,8 +160,7 @@ class WebCookieJar implements CookieJar {
       maxAge: 0,
       expires: new Date(0),
     });
-    this.setCookies.push(cookieString);
-    this.headers.set("Set-Cookie", this.setCookies.join(", "));
+    this.headers.appendSetCookie(cookieString);
   }
 
   getAll(): Record<string, string> {
@@ -118,14 +168,14 @@ class WebCookieJar implements CookieJar {
   }
 }
 
-function mapToHeaders(map: Map<string, string>): Headers {
+function mapToHeaders(map: WebResponseHeaderMap): Headers {
   const headers = new Headers();
   for (const [key, value] of map) {
-    if (key.toLowerCase() === "set-cookie") {
-      headers.append(key, value);
-    } else {
-      headers.set(key, value);
-    }
+    if (key.toLowerCase() === "set-cookie") continue;
+    headers.set(key, value);
+  }
+  for (const cookie of map.getSetCookies()) {
+    headers.append("Set-Cookie", cookie);
   }
   return headers;
 }
@@ -138,12 +188,16 @@ function isMiddlewareResponse(value: unknown): value is Response {
   return value instanceof Response;
 }
 
-function createResponseShim(headers: Map<string, string>): Record<string, any> {
+function createResponseShim(headers: WebResponseHeaderMap): Record<string, any> {
   return {
     headersSent: false,
     writableEnded: false,
     setHeader(name: string, value: string | string[]) {
-      headers.set(name, Array.isArray(value) ? value.join(", ") : String(value));
+      if (name.toLowerCase() === "set-cookie") {
+        headers.replaceSetCookies(Array.isArray(value) ? value.map(String) : [String(value)]);
+      } else {
+        headers.set(name, Array.isArray(value) ? value.join(", ") : String(value));
+      }
     },
     getHeader(name: string) {
       return headers.get(name);
@@ -163,13 +217,15 @@ function createResponseShim(headers: Map<string, string>): Record<string, any> {
   };
 }
 
-function withNodeRequestShape(request: Request): Request {
+function withNodeRequestShape(request: Request, trustProxy: boolean): Request {
   const requestWithShape = request as Request & {
     socket?: { remoteAddress?: string };
   };
 
   if (!requestWithShape.socket) {
-    const forwardedFor = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+    const forwardedFor = trustProxy
+      ? request.headers.get("x-forwarded-for")?.split(",")[0]?.trim()
+      : undefined;
     try {
       requestWithShape.socket = {
         remoteAddress: forwardedFor || "127.0.0.1",
@@ -185,15 +241,15 @@ function withNodeRequestShape(request: Request): Request {
 function createHandledResponse(
   body: BodyInit | null,
   init: ResponseInit,
-  headers: Map<string, string>,
+  headers: WebResponseHeaderMap,
 ): Response {
   const responseHeaders = new Headers(init.headers);
   for (const [key, value] of headers) {
-    if (key.toLowerCase() === "set-cookie") {
-      responseHeaders.append(key, value);
-    } else {
-      responseHeaders.set(key, value);
-    }
+    if (key.toLowerCase() === "set-cookie") continue;
+    responseHeaders.set(key, value);
+  }
+  for (const cookie of headers.getSetCookies()) {
+    responseHeaders.append("Set-Cookie", cookie);
   }
   return new Response(body, { ...init, headers: responseHeaders });
 }
@@ -201,19 +257,23 @@ function createHandledResponse(
 function createWebMiddlewareContext(
   request: Request,
   parent?: MiddlewareContext["parent"],
+  trustProxy = false,
 ): WebMiddlewareContextState {
-  let currentRequest = withNodeRequestShape(request);
+  let currentRequest = withNodeRequestShape(request, trustProxy);
   let handledResponse: Response | null = null;
   const url = new URL(currentRequest.url);
   const data = parent?.data ? new Map(parent.data) : new Map<string, any>();
   const locals = parent?.locals ? new Map(parent.locals) : new Map<string, any>();
-  const headers = new Map<string, string>();
+  const headers = new WebResponseHeaderMap();
 
   if (parent?.headers) {
     for (const [key, value] of Object.entries(parent.headers)) {
+      if (key.toLowerCase() === "set-cookie") continue;
       headers.set(key, value);
     }
   }
+  const parentCookies = (parent as InternalMiddlewareParent | undefined)?.[FARM_SET_COOKIE_HEADERS];
+  if (parentCookies) headers.replaceSetCookies(parentCookies);
 
   const ctx = {
     request: currentRequest as any,
@@ -256,7 +316,7 @@ function createWebMiddlewareContext(
     rewrite(rewriteUrl: string): void {
       ctx._rewriteUrl = rewriteUrl;
       const nextUrl = new URL(rewriteUrl, currentRequest.url);
-      currentRequest = withNodeRequestShape(new Request(nextUrl, currentRequest));
+      currentRequest = withNodeRequestShape(new Request(nextUrl, currentRequest), trustProxy);
       ctx.request = currentRequest as any;
       ctx.url = nextUrl;
       ctx.pathname = nextUrl.pathname;
@@ -309,6 +369,7 @@ function createWebMiddlewareContext(
 
   return {
     ctx,
+    headers,
     getRequest: () => currentRequest,
     getResponse: () => handledResponse,
   };
@@ -603,7 +664,11 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
       return emptyResult(request);
     }
 
-    let contextState = createWebMiddlewareContext(request);
+    let contextState = createWebMiddlewareContext(
+      request,
+      undefined,
+      options.server?.trustProxy === true,
+    );
     let ctx = contextState.ctx;
     let currentRequest = contextState.getRequest();
     const initialPathname = options.i18n?.enabled
@@ -637,7 +702,7 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
         response: null,
         data: new Map(ctx.data),
         context: new Map(ctx.locals),
-        headers: mapToHeaders(ctx.headers),
+        headers: mapToHeaders(contextState.headers),
         handled: false,
       };
     }
@@ -652,7 +717,11 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
       }
 
       if (parentData) {
-        contextState = createWebMiddlewareContext(currentRequest, parentData);
+        contextState = createWebMiddlewareContext(
+          currentRequest,
+          parentData,
+          options.server?.trustProxy === true,
+        );
         ctx = contextState.ctx;
       }
 
@@ -678,7 +747,7 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
         if (returnedResponse) {
           const response = applyProductionMiddlewareHeaders(
             returnedResponse,
-            mapToHeaders(ctx.headers),
+            mapToHeaders(contextState.headers),
           );
           emitFarmEvent({
             type: "middleware.shortCircuit",
@@ -690,7 +759,7 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
             response,
             data: new Map(ctx.data),
             context: new Map(ctx.locals),
-            headers: mapToHeaders(ctx.headers),
+            headers: mapToHeaders(contextState.headers),
             handled: true,
           };
         }
@@ -707,7 +776,7 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
             response,
             data: new Map(ctx.data),
             context: new Map(ctx.locals),
-            headers: mapToHeaders(ctx.headers),
+            headers: mapToHeaders(contextState.headers),
             handled: true,
           };
         }
@@ -729,8 +798,9 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
       parentData = {
         data: new Map(ctx.data),
         locals: new Map(ctx.locals),
-        headers: headersToRecord(ctx.headers),
-      };
+        headers: headersToRecord(contextState.headers),
+        [FARM_SET_COOKIE_HEADERS]: [...contextState.headers.getSetCookies()],
+      } as InternalMiddlewareParent;
     }
 
     return {
@@ -738,7 +808,7 @@ export function createProductionMiddlewareRunner(options: ProductionMiddlewareRu
       response: null,
       data: new Map(ctx.data),
       context: new Map(ctx.locals),
-      headers: mapToHeaders(ctx.headers),
+      headers: mapToHeaders(contextState.headers),
       handled: false,
     };
   };
@@ -753,12 +823,19 @@ export function applyProductionMiddlewareHeaders(
   }
 
   const headers = new Headers(response.headers);
+  const getSetCookie = (middlewareHeaders as Headers & { getSetCookie?: () => string[] })
+    .getSetCookie;
+  const setCookies = getSetCookie
+    ? getSetCookie.call(middlewareHeaders)
+    : middlewareHeaders.get("set-cookie")
+      ? [middlewareHeaders.get("set-cookie")!]
+      : [];
   for (const [key, value] of middlewareHeaders) {
-    if (key.toLowerCase() === "set-cookie") {
-      headers.append(key, value);
-    } else {
-      headers.set(key, value);
-    }
+    if (key.toLowerCase() === "set-cookie") continue;
+    headers.set(key, value);
+  }
+  for (const cookie of setCookies) {
+    headers.append("Set-Cookie", cookie);
   }
 
   return new Response(response.body, {

--- a/packages/farm/src/nitro/production-runtime.ts
+++ b/packages/farm/src/nitro/production-runtime.ts
@@ -1,4 +1,9 @@
 export { _runWithAfterRequest } from "../after";
+export {
+  bufferFarmRequestBody,
+  createFarmRequestBodyErrorResponse,
+  resolveFarmServerConfig,
+} from "../server-http";
 export { _runWithCurrentRequest, getCurrentRequest } from "../server/request";
 export {
   configureFarmCache,

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -3230,7 +3230,12 @@ async function handleAPIRequest(request) {
   }
 
   try {
-    return await invokeAPIRouteEndpoint(endpoint, request, params);
+    return await invokeAPIRouteEndpoint(
+      endpoint,
+      request,
+      params,
+      farmServerConfig.bodySizeLimit,
+    );
   } catch (error) {
     console.error(\`[API Error] \${url.pathname}:\`, error);
     return new Response(
@@ -3362,6 +3367,7 @@ const farmObservabilityConfig = farmUserConfig?.observability ?? ${JSON.stringif
 configureFarmObservability(farmObservabilityConfig);
 configureFarmCache(farmResolvedRuntimeConfig.cache);
 const farmI18nConfig = ${JSON.stringify(config.i18n)};
+const farmServerConfig = ${JSON.stringify(config.server)};
 const farmI18nRuntime = ${
     config.i18n.enabled
       ? `createFarmI18nRuntime(farmI18nConfig, ${JSON.stringify(i18nCatalogs)})`
@@ -4201,6 +4207,7 @@ const farmMiddlewareRunner = ${
   config: farmUserConfig?.middleware,
   modules: fileMiddlewareModules,
   i18n: farmI18nConfig,
+  server: farmServerConfig,
 })`
       : "null"
   };

--- a/packages/farm/src/server-action-security.ts
+++ b/packages/farm/src/server-action-security.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { subscribeFarmCacheInvalidation, subscribeFarmCacheTask } from "./cache-invalidation";
 import { serializeServerFnFailure, type SerializedServerFnFailure } from "./server-fn-error";
+import { parseBodySizeLimit } from "./server-http";
 
 export const DEFAULT_SERVER_ACTION_BODY_SIZE_LIMIT = 1_000_000;
 
@@ -83,6 +84,7 @@ export function resolveServerActionsConfig(
   const allowedOrigins = (config?.allowedOrigins ?? []).map(normalizeAllowedOriginPattern);
   const bodySizeLimit = parseBodySizeLimit(
     config?.bodySizeLimit ?? DEFAULT_SERVER_ACTION_BODY_SIZE_LIMIT,
+    "serverActions.bodySizeLimit",
   );
 
   return Object.freeze({
@@ -257,44 +259,6 @@ function getFallbackAbortController(): AbortController {
     globalState[FALLBACK_ABORT_CONTROLLER_KEY] = new AbortController();
   }
   return globalState[FALLBACK_ABORT_CONTROLLER_KEY]!;
-}
-
-function parseBodySizeLimit(value: number | string): number {
-  if (typeof value === "number") {
-    if (!Number.isSafeInteger(value) || value <= 0) {
-      throw new TypeError("serverActions.bodySizeLimit must be a positive safe integer");
-    }
-    return value;
-  }
-
-  const match = value
-    .trim()
-    .toLowerCase()
-    .match(/^(\d+(?:\.\d+)?)\s*(b|kb|mb|gb|kib|mib|gib)?$/);
-  if (!match) {
-    throw new TypeError(
-      'serverActions.bodySizeLimit must be bytes or a size string such as "500kb" or "1mb"',
-    );
-  }
-
-  const amount = Number(match[1]);
-  const unit = match[2] ?? "b";
-  const multiplier: Record<string, number> = {
-    b: 1,
-    kb: 1_000,
-    mb: 1_000_000,
-    gb: 1_000_000_000,
-    kib: 1_024,
-    mib: 1_048_576,
-    gib: 1_073_741_824,
-  };
-  const bytes = Math.floor(amount * multiplier[unit]);
-
-  if (!Number.isSafeInteger(bytes) || bytes <= 0) {
-    throw new TypeError("serverActions.bodySizeLimit must resolve to a positive safe integer");
-  }
-
-  return bytes;
 }
 
 function normalizeAllowedOriginPattern(value: string): string {

--- a/packages/farm/src/server-http.ts
+++ b/packages/farm/src/server-http.ts
@@ -1,0 +1,228 @@
+export const DEFAULT_FARM_SERVER_BODY_SIZE_LIMIT = 10_000_000;
+
+export interface FarmServerConfig {
+  /** Maximum request body size for API routes, integrations, workflows, and uploads. */
+  bodySizeLimit?: number | string;
+  /** Trust proxy-provided client IP headers. Enable only behind a trusted proxy. */
+  trustProxy?: boolean;
+}
+
+export interface ResolvedFarmServerConfig {
+  bodySizeLimit: number;
+  trustProxy: boolean;
+}
+
+export type FarmRequestBodyErrorCode = "BODY_TOO_LARGE" | "INVALID_CONTENT_LENGTH";
+
+export class FarmRequestBodyError extends Error {
+  readonly code: FarmRequestBodyErrorCode;
+  readonly status: number;
+
+  constructor(code: FarmRequestBodyErrorCode, status: number, message: string) {
+    super(message);
+    this.name = "FarmRequestBodyError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+export function resolveFarmServerConfig(
+  config: FarmServerConfig | ResolvedFarmServerConfig | undefined,
+): ResolvedFarmServerConfig {
+  return Object.freeze({
+    bodySizeLimit: parseBodySizeLimit(
+      config?.bodySizeLimit ?? DEFAULT_FARM_SERVER_BODY_SIZE_LIMIT,
+      "server.bodySizeLimit",
+    ),
+    trustProxy: config?.trustProxy === true,
+  });
+}
+
+export function parseBodySizeLimit(value: number | string, optionName = "bodySizeLimit"): number {
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+      throw new TypeError(`${optionName} must be a positive safe integer`);
+    }
+    return value;
+  }
+
+  const match = value
+    .trim()
+    .toLowerCase()
+    .match(/^(\d+(?:\.\d+)?)\s*(b|kb|mb|gb|kib|mib|gib)?$/);
+  if (!match) {
+    throw new TypeError(`${optionName} must be bytes or a size string such as "500kb" or "10mb"`);
+  }
+
+  const amount = Number(match[1]);
+  const unit = match[2] ?? "b";
+  const multiplier: Record<string, number> = {
+    b: 1,
+    kb: 1_000,
+    mb: 1_000_000,
+    gb: 1_000_000_000,
+    kib: 1_024,
+    mib: 1_048_576,
+    gib: 1_073_741_824,
+  };
+  const bytes = Math.floor(amount * multiplier[unit]);
+
+  if (!Number.isSafeInteger(bytes) || bytes <= 0) {
+    throw new TypeError(`${optionName} must resolve to a positive safe integer`);
+  }
+
+  return bytes;
+}
+
+export async function bufferFarmRequestBody(request: Request, limit: number): Promise<Request> {
+  if (request.method === "GET" || request.method === "HEAD" || request.body === null) {
+    return request;
+  }
+
+  const bytes = await readFarmRequestBody(request, limit);
+  const body = new Uint8Array(bytes.byteLength);
+  body.set(bytes);
+  return new Request(request, {
+    // oxlint-disable-next-line unicorn/no-invalid-fetch-options -- GET and HEAD return above.
+    body: body.buffer,
+  });
+}
+
+export async function readFarmRequestBody(request: Request, limit: number): Promise<Uint8Array> {
+  try {
+    validateContentLength(request.headers.get("content-length"), limit);
+  } catch (error) {
+    await request.body?.cancel(error).catch(() => {});
+    throw error;
+  }
+  throwIfAborted(request.signal);
+  if (!request.body) return new Uint8Array();
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  const cancelBodyRead = () => {
+    void reader.cancel(request.signal.reason).catch(() => {});
+  };
+  request.signal.addEventListener("abort", cancelBodyRead, { once: true });
+
+  try {
+    while (true) {
+      throwIfAborted(request.signal);
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      total += value.byteLength;
+      if (total > limit) {
+        await reader.cancel("Request body is too large");
+        throw new FarmRequestBodyError("BODY_TOO_LARGE", 413, "Request body is too large");
+      }
+      chunks.push(value);
+    }
+  } catch (error) {
+    if (request.signal.aborted) throwIfAborted(request.signal);
+    throw error;
+  } finally {
+    request.signal.removeEventListener("abort", cancelBodyRead);
+    reader.releaseLock();
+  }
+
+  const body = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body;
+}
+
+export async function readNodeRequestBody(
+  request: {
+    headers: Record<string, string | string[] | undefined>;
+    on(event: "data", listener: (chunk: unknown) => void): unknown;
+    on(event: "end", listener: () => void): unknown;
+    on(event: "error", listener: (error: Error) => void): unknown;
+    removeListener?(event: string, listener: (...args: any[]) => void): unknown;
+    resume?(): unknown;
+  },
+  limit: number,
+): Promise<Buffer> {
+  const rawContentLength = request.headers["content-length"];
+  const contentLength = Array.isArray(rawContentLength) ? rawContentLength[0] : rawContentLength;
+  try {
+    validateContentLength(contentLength, limit);
+  } catch (error) {
+    request.resume?.();
+    throw error;
+  }
+
+  return await new Promise<Buffer>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let settled = false;
+
+    const cleanup = () => {
+      request.removeListener?.("data", onData);
+      request.removeListener?.("end", onEnd);
+      request.removeListener?.("error", onError);
+    };
+    const rejectOnce = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      request.resume?.();
+      reject(error);
+    };
+    const onData = (chunk: unknown) => {
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as any);
+      total += bytes.byteLength;
+      if (total > limit) {
+        rejectOnce(new FarmRequestBodyError("BODY_TOO_LARGE", 413, "Request body is too large"));
+        return;
+      }
+      chunks.push(bytes);
+    };
+    const onEnd = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(Buffer.concat(chunks, total));
+    };
+    const onError = (error: Error) => rejectOnce(error);
+
+    request.on("data", onData);
+    request.on("end", onEnd);
+    request.on("error", onError);
+  });
+}
+
+export function createFarmRequestBodyErrorResponse(error: unknown): Response | null {
+  if (!(error instanceof FarmRequestBodyError)) return null;
+
+  return new Response(error.status === 413 ? "Payload Too Large" : "Bad Request", {
+    status: error.status,
+    headers: {
+      "cache-control": "no-store",
+      "content-type": "text/plain; charset=utf-8",
+      "x-content-type-options": "nosniff",
+    },
+  });
+}
+
+function validateContentLength(value: string | null | undefined, limit: number): void {
+  const contentLength = value?.trim();
+  if (!contentLength) return;
+  if (!/^\d+$/.test(contentLength)) {
+    throw new FarmRequestBodyError("INVALID_CONTENT_LENGTH", 400, "Invalid content-length header");
+  }
+  if (Number(contentLength) > limit) {
+    throw new FarmRequestBodyError("BODY_TOO_LARGE", 413, "Request body is too large");
+  }
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (!signal.aborted) return;
+  if (signal.reason !== undefined) throw signal.reason;
+  throw new DOMException("The operation was aborted", "AbortError");
+}

--- a/packages/farm/src/types.ts
+++ b/packages/farm/src/types.ts
@@ -12,6 +12,7 @@ import type { FarmCronResolvedConfig, FarmCronUserConfig } from "./cron";
 import type { FarmEnvConfig, ResolvedFarmEnv } from "./env";
 import type { FarmRouteRules } from "./route-rules";
 import type { FarmServerActionsConfig } from "./server-action-security";
+import type { FarmServerConfig } from "./server-http";
 import type { FarmLayerEntry, ResolvedFarmLayer } from "./layers";
 import type { FarmRouteMaxDuration, FarmRouteRegions, FarmRouteRuntime } from "./route-runtime";
 import type { FarmDevtoolsUserConfig } from "./devtools-config";
@@ -179,6 +180,8 @@ export interface FarmConfig {
   middleware?: FarmMiddlewareConfig;
   routeRules?: FarmRouteRules;
   context?: FarmContextFactory<any>;
+  /** Server ingress and trusted-proxy policy. */
+  server?: FarmServerConfig;
   serverActions?: FarmServerActionsConfig;
   /** App-wide HTTP security policy. */
   security?: FarmSecurityConfig | ResolvedFarmSecurityConfig;

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -64,6 +64,11 @@ import {
   createFarmSourceAlias,
 } from "./server/vite-config";
 import { resolveFarmDocsFontAssets, toFarmDocsPublicFontAssets } from "./docs/fonts";
+import {
+  createFarmRequestBodyErrorResponse,
+  readNodeRequestBody,
+  resolveFarmServerConfig,
+} from "./server-http";
 
 interface FarmVitePluginOptions extends FarmConfig {
   openapi?: FarmUserConfig["openapi"];
@@ -233,6 +238,13 @@ function createRequestFromNodeRequest(
     method: req.method || "GET",
     headers,
   });
+}
+
+function toRequestBody(body: Buffer | undefined): ArrayBuffer | undefined {
+  if (!body) return undefined;
+  const copy = new Uint8Array(body.byteLength);
+  copy.set(body);
+  return copy.buffer;
 }
 
 function applyWebRequestToNodeRequest(
@@ -564,6 +576,7 @@ export function farmPlugin(
       await farmApp.initialize();
 
       const farmConfig = farmApp.getConfig();
+      const serverConfig = resolveFarmServerConfig(farmConfig.server);
       let imageHandler: FarmImageHandler | null = null;
       if (farmConfig.images.provider !== "none") {
         const { createNodeImageUrlValidator, createSharpImageTransformer } =
@@ -807,6 +820,7 @@ export function farmPlugin(
 
       apiRouteManager = new APIRouteManager(appDirs, server, {
         i18n: farmApp.getI18nRuntime(),
+        bodySizeLimit: serverConfig.bodySizeLimit,
       });
       await apiRouteManager.discoverRoutes();
       let discoveredWorkflows: FarmDiscoveredWorkflow[] = [];
@@ -831,6 +845,7 @@ export function farmPlugin(
             config: workflowConfig,
             loadModule: async (workflow: FarmDiscoveredWorkflow) =>
               server.ssrLoadModule(workflow.filePath) as Promise<Record<string, any>>,
+            server: farmConfig.server,
           });
           logger.success(`✅ Discovered ${discoveredWorkflows.length} Farm workflow task(s)`);
         }
@@ -980,6 +995,7 @@ export function farmPlugin(
           const parsedRequestUrl = new URL(fullUrl);
           const requestPathname = parsedRequestUrl.pathname;
           const currentConfig = farmApp?.getConfig() ?? options;
+          const currentServerConfig = resolveFarmServerConfig(currentConfig.server);
 
           if (imageHandler && requestPathname === farmConfig.images.path) {
             const imageResponse = await imageHandler(
@@ -1183,23 +1199,25 @@ export function farmPlugin(
             (requestPathname === workflowConfig.route ||
               requestPathname.startsWith(`${workflowConfig.route}/`))
           ) {
-            let workflowBody: string | undefined;
-            if (requestMethod !== "GET" && requestMethod !== "HEAD") {
-              workflowBody = await new Promise<string>((resolve) => {
-                let data = "";
-                req.on("data", (chunk) => {
-                  data += chunk;
-                });
-                req.on("end", () => {
-                  resolve(data);
-                });
-              });
+            let workflowBody: Buffer | undefined;
+            try {
+              if (requestMethod !== "GET" && requestMethod !== "HEAD") {
+                workflowBody = await readNodeRequestBody(
+                  req as any,
+                  currentServerConfig.bodySizeLimit,
+                );
+              }
+            } catch (error) {
+              const response = createFarmRequestBodyErrorResponse(error);
+              if (!response) throw error;
+              await sendWebResponse(res, response);
+              return;
             }
             const workflowResponse = await workflowHandler(
               new Request(fullUrl, {
                 method: requestMethod,
                 headers: docsHeaders,
-                body: workflowBody || undefined,
+                body: toRequestBody(workflowBody),
               }),
             );
             if (workflowResponse) {
@@ -1240,23 +1258,15 @@ export function farmPlugin(
                 }
               }
 
-              let body: string | undefined;
+              let body: Buffer | undefined;
               if (req.method !== "GET" && req.method !== "HEAD") {
-                body = await new Promise<string>((resolve) => {
-                  let data = "";
-                  req.on("data", (chunk) => {
-                    data += chunk;
-                  });
-                  req.on("end", () => {
-                    resolve(data);
-                  });
-                });
+                body = await readNodeRequestBody(req as any, currentServerConfig.bodySizeLimit);
               }
 
               const integrationRequest = new Request(fullUrl, {
                 method: req.method,
                 headers,
-                body: body || undefined,
+                body: toRequestBody(body),
               });
 
               const dispatchIntegration = async (request: Request) => {
@@ -1294,6 +1304,11 @@ export function farmPlugin(
               await sendWebResponse(res, response);
               return true;
             } catch (error) {
+              const bodyErrorResponse = createFarmRequestBodyErrorResponse(error);
+              if (bodyErrorResponse) {
+                await sendWebResponse(res, bodyErrorResponse);
+                return true;
+              }
               const duration = Date.now() - startTime;
               logResponse(requestMethod, requestUrl, 500, duration, "API");
               await emitPluginError("integration-handler", error, {
@@ -1374,23 +1389,15 @@ export function farmPlugin(
                 }
 
                 // Get body for POST/PUT/PATCH
-                let body: string | undefined;
+                let body: Buffer | undefined;
                 if (req.method !== "GET" && req.method !== "HEAD") {
-                  body = await new Promise<string>((resolve) => {
-                    let data = "";
-                    req.on("data", (chunk) => {
-                      data += chunk;
-                    });
-                    req.on("end", () => {
-                      resolve(data);
-                    });
-                  });
+                  body = await readNodeRequestBody(req as any, currentServerConfig.bodySizeLimit);
                 }
 
                 const request = new Request(url, {
                   method: req.method,
                   headers,
-                  body: body || undefined,
+                  body: toRequestBody(body),
                 });
 
                 const apiLifecyclePayload = {
@@ -1432,6 +1439,11 @@ export function farmPlugin(
                 await sendWebResponse(res, handledResponse);
                 return;
               } catch (error) {
+                const bodyErrorResponse = createFarmRequestBodyErrorResponse(error);
+                if (bodyErrorResponse) {
+                  await sendWebResponse(res, bodyErrorResponse);
+                  return;
+                }
                 await emitPluginError("api-handler", error, {
                   urlPath,
                   method,
@@ -1454,23 +1466,15 @@ export function farmPlugin(
                   }
                 }
 
-                let body: string | undefined;
+                let body: Buffer | undefined;
                 if (req.method !== "GET" && req.method !== "HEAD") {
-                  body = await new Promise<string>((resolve) => {
-                    let data = "";
-                    req.on("data", (chunk) => {
-                      data += chunk;
-                    });
-                    req.on("end", () => {
-                      resolve(data);
-                    });
-                  });
+                  body = await readNodeRequestBody(req as any, currentServerConfig.bodySizeLimit);
                 }
 
                 const request = new Request(url, {
                   method: req.method,
                   headers,
-                  body: body || undefined,
+                  body: toRequestBody(body),
                 });
 
                 const apiLifecyclePayload = {
@@ -1510,6 +1514,11 @@ export function farmPlugin(
                   return;
                 }
               } catch (error) {
+                const bodyErrorResponse = createFarmRequestBodyErrorResponse(error);
+                if (bodyErrorResponse) {
+                  await sendWebResponse(res, bodyErrorResponse);
+                  return;
+                }
                 await emitPluginError("docs-api-handler", error, {
                   urlPath,
                   method,

--- a/packages/farm/src/workflows.ts
+++ b/packages/farm/src/workflows.ts
@@ -1,3 +1,11 @@
+import {
+  createFarmRequestBodyErrorResponse,
+  readFarmRequestBody,
+  resolveFarmServerConfig,
+  type FarmServerConfig,
+  type ResolvedFarmServerConfig,
+} from "./server-http";
+
 export type FarmWorkflowSchedule = string | string[];
 
 export interface FarmWorkflowsUserConfig {
@@ -78,6 +86,7 @@ export interface FarmWorkflowHTTPHandlerOptions {
   workflows: FarmDiscoveredWorkflow[];
   config: FarmWorkflowsResolvedConfig;
   loadModule: (workflow: FarmDiscoveredWorkflow) => Promise<Record<string, any>>;
+  server?: FarmServerConfig | ResolvedFarmServerConfig;
 }
 
 export const DEFAULT_FARM_WORKFLOW_DIRS = ["src/jobs", "src/workflows", "src/cron"];
@@ -211,7 +220,17 @@ export function createFarmWorkflowRequestHandler(options: FarmWorkflowHTTPHandle
     const secretError = verifyWorkflowSecret(request, options.config);
     if (secretError) return secretError;
 
-    const payload = await readWorkflowPayload(request);
+    let payload: unknown;
+    try {
+      payload = await readWorkflowPayload(
+        request,
+        resolveFarmServerConfig(options.server).bodySizeLimit,
+      );
+    } catch (error) {
+      const response = createFarmRequestBodyErrorResponse(error);
+      if (response) return response;
+      throw error;
+    }
     const module = await options.loadModule(workflow);
     const result = await runFarmWorkflowModule(module, {
       id: workflow.id,
@@ -263,6 +282,7 @@ export async function prepareFarmWorkflowsForNitro(config: {
   root?: string;
   distDir?: string;
   workflows?: FarmWorkflowsResolvedConfig | FarmWorkflowsUserConfig | boolean;
+  server?: FarmServerConfig | ResolvedFarmServerConfig;
 }): Promise<PreparedFarmWorkflows> {
   const workflowConfig = isResolvedWorkflowConfig(config.workflows)
     ? config.workflows
@@ -302,7 +322,11 @@ export async function prepareFarmWorkflowsForNitro(config: {
   const handlerPath = path.join(generatedDir, "http-handler.mjs");
   await fs.writeFile(
     handlerPath,
-    createNitroWorkflowHTTPHandler(workflowConfig, workflows),
+    createNitroWorkflowHTTPHandler(
+      workflowConfig,
+      workflows,
+      resolveFarmServerConfig(config.server),
+    ),
     "utf8",
   );
 
@@ -560,14 +584,20 @@ export default defineTask({
 function createNitroWorkflowHTTPHandler(
   config: FarmWorkflowsResolvedConfig,
   workflows: FarmDiscoveredWorkflow[],
+  server: ResolvedFarmServerConfig,
 ): string {
   return `
 import { H3 } from "h3";
 import { runTask } from "nitro/runtime";
+import {
+  createFarmRequestBodyErrorResponse,
+  readFarmRequestBody
+} from "@farm.js/core/internal/production-runtime";
 
 const route = ${JSON.stringify(config.route)};
 const secretEnv = ${JSON.stringify(config.secretEnv)};
 const inlineSecret = ${JSON.stringify(config.secret || "")};
+const bodySizeLimit = ${JSON.stringify(server.bodySizeLimit)};
 const workflows = ${JSON.stringify(workflows.map(toWorkflowMetadata))};
 const workflowIds = new Set(workflows.map((workflow) => workflow.id));
 
@@ -591,19 +621,19 @@ function verifySecret(event) {
   if (!secret) return null;
   const authorization = getHeader(event, "authorization") || "";
   const headerSecret = getHeader(event, "x-farm-workflow-secret") || "";
-  const querySecret = event.url.searchParams.get("secret") || "";
-  const bearer = authorization.startsWith("Bearer ") ? authorization.slice(7) : "";
-  if (headerSecret === secret || querySecret === secret || bearer === secret) return null;
+  const bearer = authorization.match(/^Bearer\\s+(.+)$/i)?.[1] || "";
+  if (headerSecret === secret || bearer === secret) return null;
   return json({ error: "Unauthorized workflow request." }, 401);
 }
 
 async function readPayload(event) {
   if (event.req.method === "GET" || event.req.method === "HEAD") {
-    const payload = Object.fromEntries(event.url.searchParams.entries());
-    delete payload.secret;
-    return payload;
+    return Object.fromEntries(event.url.searchParams.entries());
   }
-  return await event.req.json().catch(() => ({}));
+  const bytes = await readFarmRequestBody(event.req, bodySizeLimit);
+  const text = new TextDecoder().decode(bytes);
+  if (!text) return {};
+  return JSON.parse(text);
 }
 
 export default new H3()
@@ -621,7 +651,15 @@ export default new H3()
     const unauthorized = verifySecret(event);
     if (unauthorized) return unauthorized;
 
-    const payload = await readPayload(event);
+    let payload;
+    try {
+      payload = await readPayload(event);
+    } catch (error) {
+      const response = createFarmRequestBodyErrorResponse(error);
+      if (response) return response;
+      if (error instanceof SyntaxError) return json({ error: "Invalid workflow request body." }, 400);
+      throw error;
+    }
     const result = await runTask(id, {
       payload,
       context: {
@@ -651,20 +689,24 @@ function toWorkflowMetadata(workflow: FarmDiscoveredWorkflow) {
   };
 }
 
-async function readWorkflowPayload(request: Request): Promise<unknown> {
+async function readWorkflowPayload(request: Request, bodySizeLimit: number): Promise<unknown> {
   const url = new URL(request.url);
   if (request.method === "GET" || request.method === "HEAD") {
-    const payload = Object.fromEntries(url.searchParams.entries());
-    delete payload.secret;
-    return payload;
+    return Object.fromEntries(url.searchParams.entries());
   }
 
+  const bytes = await readFarmRequestBody(request, bodySizeLimit);
+  const text = new TextDecoder().decode(bytes);
+  if (!text) return {};
   const contentType = request.headers.get("content-type") || "";
   if (contentType.includes("application/json")) {
-    return await request.json().catch(() => ({}));
+    try {
+      return JSON.parse(text);
+    } catch {
+      return {};
+    }
   }
 
-  const text = await request.text().catch(() => "");
   return text ? { text } : {};
 }
 
@@ -681,12 +723,10 @@ function verifyWorkflowSecret(
   const secret = config.secret || process.env[config.secretEnv] || "";
   if (!secret) return null;
 
-  const url = new URL(request.url);
   const authorization = request.headers.get("authorization") || "";
-  const bearer = authorization.startsWith("Bearer ") ? authorization.slice(7) : "";
+  const bearer = authorization.match(/^Bearer\s+(.+)$/i)?.[1] || "";
   const headerSecret = request.headers.get("x-farm-workflow-secret") || "";
-  const querySecret = url.searchParams.get("secret") || "";
-  if (bearer === secret || headerSecret === secret || querySecret === secret) return null;
+  if (bearer === secret || headerSecret === secret) return null;
 
   return Response.json({ error: "Unauthorized workflow request." }, { status: 401 });
 }


### PR DESCRIPTION
## Summary

- remove workflow secret authentication from URL query parameters and accept only Bearer authorization or `x-farm-workflow-secret`
- preserve multiple `Set-Cookie` response headers instead of flattening them
- enforce configurable request-body limits across API routes, integrations, workflows, and uploads
- add an explicit `server.trustProxy` policy before honoring forwarded client addresses
- document the server HTTP policy and add regression coverage

## Why

Secrets in URLs can leak through logs, browser history, and referrers. Flattening `Set-Cookie` headers can change cookie semantics. Unbounded request buffering creates a denial-of-service risk, while implicitly trusting `x-forwarded-for` lets directly connected clients spoof their address.

## Configuration

```ts
server: {
  bodySizeLimit: "10mb",
  trustProxy: false,
}
```

The defaults are a 10 MB general request limit and no trusted proxy. Server Actions retain their separate 1 MB default.

## Validation

- Farm core TypeScript check
- 106 core test files passed (872 tests passed, 1 skipped)
- focused HTTP, middleware, integration, configuration, and workflow regression tests


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened HTTP handling across API routes, integrations, and workflows. Enforces request size limits, preserves multiple cookies, and removes insecure workflow secret patterns.

- **Bug Fixes**
  - Reject bodies over the server limit with 413, using Content-Length and streamed byte counting.
  - Preserve multiple Set-Cookie headers instead of flattening them.
  - Stop accepting workflow secrets in query strings; only `Authorization: Bearer <secret>` or `X-Farm-Workflow-Secret`.
  - Add `server.trustProxy`; ignore `X-Forwarded-For` unless enabled.

- **Migration**
  - Update workflow callers to send the secret via headers (Bearer or `X-Farm-Workflow-Secret`).
  - Configure `server` as needed, e.g. `server: { bodySizeLimit: "10mb", trustProxy: false }`. Defaults are 10 MB and not trusting proxies. Server Actions keep their 1 MB limit.

<sup>Written for commit 69f626804da73cb2a0dd7b9c25aae5b5c5e81951. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

