### PR TITLE
feat: redesign the docs 404 page

### DIFF
--- a/docs/src/app/not-found.tsx
+++ b/docs/src/app/not-found.tsx
@@ -1,40 +1,195 @@
-import { Link } from "@farm.js/core/client";
+import { FARM_VERSION } from "@farm.js/core/version";
+import { ArrowLeft, ArrowRight, BookOpenText, FileQuestion, Route, Terminal } from "lucide-react";
+import { FlickeringGrid } from "../components/ui/flickering-grid";
 
 interface NotFoundProps {
   pathname?: string;
 }
 
-export default function NotFound({ pathname }: NotFoundProps) {
+const recoveryLinks = [
+  { index: "01", label: "Getting started", href: "/docs/getting-started" },
+  { index: "02", label: "Browse integrations", href: "/docs/integrations" },
+  { index: "03", label: "Read the guide", href: "/docs" },
+] as const;
+
+function Wordmark() {
   return (
-    <div className="mx-auto max-w-2xl px-4 py-16 text-center sm:px-6">
-      <span className="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-sm font-medium text-amber-800">
-        404
+    <a
+      aria-label="Farm.js home"
+      className="font-mono text-[11px] font-normal uppercase tracking-normal text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white"
+      href="/"
+    >
+      FARM<span className="text-white/52">.JS</span>
+    </a>
+  );
+}
+
+function IndexedLabel({ index, label }: { index: string; label: string }) {
+  return (
+    <span className="flex min-w-0 items-center gap-1.5 font-mono text-[10px] font-normal uppercase tracking-normal text-current">
+      <span className="text-white/26">{index}</span>
+      <span aria-hidden className="text-white/18">
+        /
       </span>
-      <h1 className="mt-4 text-3xl font-bold text-slate-900">Page not found</h1>
-      <p className="mt-2 text-slate-600">
-        {pathname ? (
-          <>
-            The page{" "}
-            <code className="rounded bg-slate-100 px-1.5 py-0.5 font-mono text-sm">{pathname}</code>{" "}
-            doesn't exist.
-          </>
-        ) : (
-          "The page you're looking for doesn't exist or has been moved."
-        )}
-      </p>
-      <div className="mt-8">
-        <Link
-          href="/"
-          className="inline-flex items-center justify-center rounded-lg bg-emerald-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500"
-        >
-          Go to home
-        </Link>
-        <Link
-          href="/docs"
-          className="ml-4 inline-flex items-center justify-center rounded-lg border border-slate-300 bg-white px-5 py-2.5 text-sm font-semibold text-slate-900 hover:bg-slate-50"
-        >
-          Docs
-        </Link>
+      <span className="truncate">{label}</span>
+    </span>
+  );
+}
+
+export default function NotFound({ pathname }: NotFoundProps) {
+  const requestedPath = pathname || "/unknown-route";
+
+  return (
+    <div className="farm-home min-h-screen overflow-x-hidden bg-black font-sans text-white selection:bg-white selection:text-black">
+      <a
+        aria-label={`Farm.js ${FARM_VERSION} is open source and in beta. View the documentation.`}
+        className="farm-announcement flex h-5 items-center justify-center gap-2 border-b border-white/12 px-4 font-mono text-[10px] font-normal uppercase tracking-normal focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-white"
+        href="/docs"
+      >
+        <span className="text-white/52">Open source</span>
+        <span aria-hidden className="text-white/24">
+          /
+        </span>
+        <span className="text-white/76">Farm.js {FARM_VERSION}</span>
+      </a>
+
+      <div className="farm-page-grid">
+        <div aria-hidden className="farm-page-rail" />
+        <div className="farm-page-content flex min-h-[calc(100svh-1.25rem)] min-w-0 flex-col">
+          <header className="farm-full-rule relative z-40 border-b border-white/12 bg-black/94 backdrop-blur-xl">
+            <div className="flex h-11 items-stretch">
+              <div className="flex shrink-0 items-center px-4 sm:px-7">
+                <Wordmark />
+              </div>
+              <div className="hidden min-w-0 flex-1 items-center border-l border-white/12 px-5 text-white/42 sm:flex">
+                <IndexedLabel index="00" label="Route boundary / not found" />
+              </div>
+              <a
+                className="ml-auto inline-flex h-11 shrink-0 items-center gap-1.5 border-l border-white/12 px-4 font-mono text-[10px] font-normal uppercase tracking-normal text-white/58 transition-[background-color,color] duration-150 hover:bg-white/[0.04] hover:text-white focus-visible:z-10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-white sm:px-5"
+                href="/docs"
+              >
+                <BookOpenText aria-hidden className="size-3.5" strokeWidth={1.5} />
+                Docs
+              </a>
+            </div>
+          </header>
+
+          <main className="relative flex flex-1 flex-col">
+            <section className="farm-full-rule grid flex-1 lg:grid-cols-[minmax(0,1fr)_23rem]">
+              <div className="relative z-10 flex min-w-0 flex-col justify-center px-6 py-14 sm:px-10 sm:py-20 lg:px-14 lg:py-24 xl:px-20">
+                <div className="text-white/46">
+                  <IndexedLabel index="404" label="No matching page route" />
+                </div>
+
+                <div className="mt-8 max-w-[43rem]">
+                  <p className="font-mono text-[10px] uppercase tracking-normal text-white/32">
+                    Error / Not found
+                  </p>
+                  <h1 className="mt-3 text-balance font-geist-pixel text-4xl font-medium leading-[0.98] tracking-normal text-white sm:text-5xl lg:text-[3.5rem]">
+                    This route isn&apos;t in the field.
+                  </h1>
+                  <p className="mt-5 max-w-[38rem] text-sm leading-6 text-white/52 sm:text-[15px]">
+                    Farm.js couldn&apos;t match this request to a page. The route may have moved, or
+                    the address might be incomplete.
+                  </p>
+                </div>
+
+                <div className="mt-8 max-w-[43rem] border border-white/14 bg-black">
+                  <div className="flex h-9 items-center justify-between border-b border-white/10 px-3 font-mono text-[9px] font-normal uppercase tracking-normal text-white/34">
+                    <span className="flex items-center gap-1.5">
+                      <Terminal aria-hidden className="size-3" strokeWidth={1.5} />
+                      Request trace
+                    </span>
+                    <span>text/plain</span>
+                  </div>
+                  <div className="flex min-w-0 items-center gap-3 px-3 py-4 font-mono text-[11px] sm:px-4 sm:text-xs">
+                    <span className="shrink-0 text-white/36">GET</span>
+                    <code className="min-w-0 flex-1 truncate text-white/72" title={requestedPath}>
+                      {requestedPath}
+                    </code>
+                    <span className="shrink-0 border border-white/16 bg-white/[0.055] px-2 py-1 text-[9px] uppercase text-white/68">
+                      404 / no match
+                    </span>
+                  </div>
+                </div>
+
+                <div className="mt-8 flex flex-col gap-3 min-[420px]:flex-row">
+                  <a
+                    className="inline-flex h-11 items-center justify-center gap-2 border border-white bg-white px-5 font-mono text-[10px] font-normal uppercase tracking-normal text-black transition-[background-color,transform] duration-150 hover:bg-white/88 active:translate-y-px focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                    href="/"
+                  >
+                    <ArrowLeft aria-hidden className="size-3.5" strokeWidth={1.5} />
+                    Back to home
+                  </a>
+                  <a
+                    className="inline-flex h-11 items-center justify-center gap-2 border border-white/18 bg-black px-5 font-mono text-[10px] font-normal uppercase tracking-normal text-white transition-[background-color,border-color,transform] duration-150 hover:border-white/42 hover:bg-white/[0.06] active:translate-y-px focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                    href="/docs/getting-started"
+                  >
+                    <BookOpenText aria-hidden className="size-3.5" strokeWidth={1.5} />
+                    Get started
+                    <ArrowRight aria-hidden className="size-3" strokeWidth={1.5} />
+                  </a>
+                </div>
+              </div>
+
+              <aside className="relative min-h-[25rem] overflow-hidden border-t border-white/12 bg-white/[0.018] lg:min-h-0 lg:border-l lg:border-t-0">
+                <div
+                  aria-hidden
+                  className="farm-hero-flicker pointer-events-none absolute inset-0 opacity-75"
+                >
+                  <FlickeringGrid
+                    className="absolute inset-0"
+                    color="rgb(255, 255, 255)"
+                    flickerChance={0.7}
+                    gridGap={8}
+                    maxOpacity={0.28}
+                    squareSize={2}
+                  />
+                </div>
+
+                <div className="relative z-10 flex h-full min-h-[25rem] flex-col p-6 sm:p-8 lg:min-h-0">
+                  <div className="flex items-center justify-between text-white/38">
+                    <IndexedLabel index="SYS" label="Router status" />
+                    <FileQuestion aria-hidden className="size-4" strokeWidth={1.35} />
+                  </div>
+
+                  <div className="my-auto py-10 text-center">
+                    <div className="font-geist-pixel text-[7rem] font-medium leading-none tracking-[-0.08em] text-white sm:text-[8rem] lg:text-[7rem]">
+                      404
+                    </div>
+                    <div className="mx-auto mt-5 flex w-fit items-center gap-2 border border-white/14 bg-black px-3 py-2 font-mono text-[9px] uppercase tracking-normal text-white/46">
+                      <Route aria-hidden className="size-3.5" strokeWidth={1.5} />
+                      Route resolution failed
+                    </div>
+                  </div>
+
+                  <div className="border border-white/12 bg-black/92">
+                    {recoveryLinks.map((item) => (
+                      <a
+                        key={item.href}
+                        className="group flex h-11 items-center justify-between border-b border-white/10 px-3 text-white/48 transition-[background-color,color] duration-150 last:border-b-0 hover:bg-white/[0.045] hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-white"
+                        href={item.href}
+                      >
+                        <IndexedLabel index={item.index} label={item.label} />
+                        <ArrowRight
+                          aria-hidden
+                          className="size-3.5 shrink-0 text-white/26 transition-[color,transform] duration-150 group-hover:translate-x-0.5 group-hover:text-white/72"
+                          strokeWidth={1.5}
+                        />
+                      </a>
+                    ))}
+                  </div>
+                </div>
+              </aside>
+            </section>
+          </main>
+
+          <footer className="farm-top-rule flex flex-col gap-2 px-4 py-3 font-mono text-[9px] font-normal uppercase tracking-normal text-white/34 sm:flex-row sm:items-center sm:justify-between">
+            <span>Request ended with status 404</span>
+            <span className="text-white/22">Farm.js route boundary</span>
+          </footer>
+        </div>
+        <div aria-hidden className="farm-page-rail" />
       </div>
     </div>
   );


### PR DESCRIPTION
## What changed

- Replaced the generic light 404 with a Farm.js-native route boundary
- Reused the docs site's rails, pixel/mono typography, and restrained flickering grid
- Added the requested path trace plus Home, Getting Started, and documentation recovery links
- Added responsive layouts and visible hover/focus states

## Why

The previous page used slate cards, green accents, and rounded buttons that did not match the current Farm.js website.

## Impact

Missing docs and website routes now keep users inside the Farm.js visual system and provide clearer recovery paths.

## Validation

- `pnpm exec oxfmt --check docs/src/app/not-found.tsx`
- `pnpm exec oxlint docs/src/app/not-found.tsx`
- Browser checked at 1440x1000 and 390x844
- Confirmed no console errors, error overlays, or horizontal overflow
- Confirmed missing routes return 404, `/` returns 200, and Back to Home navigates successfully

## Note

The full core declaration build is currently blocked by unrelated `WebResponseHeaderMap` type errors in the existing working tree.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the docs 404 page to match the Farm.js visual system and keep users inside the docs experience. Adds clear recovery paths.

- **New Features**
  - Farm.js-native route boundary with site rails and layout
  - Reused pixel/mono typography and restrained flickering grid
  - Request trace panel with method, path, and 404 status
  - Recovery links: Home, Getting Started, and Docs (plus sidebar quick links)
  - Responsive layout with visible hover/focus states
  - Header announcement uses `@farm.js/core/version` (`FARM_VERSION`); icons via `lucide-react`

<sup>Written for commit 2b45f7da575c91bc13ab4f3b4ac95fa931caa854. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

