### PR TITLE
feat: redesign the default 404 page

### DIFF
--- a/packages/farm/src/__tests__/not-found.test.tsx
+++ b/packages/farm/src/__tests__/not-found.test.tsx
@@ -4,14 +4,17 @@ import { describe, expect, it } from "vitest";
 import { DEFAULT_NOT_FOUND_STYLES, DefaultNotFoundPage } from "../components/not-found";
 
 describe("DefaultNotFoundPage", () => {
-  it("renders only the error code and home recovery action", () => {
+  it("renders the error code, description, and home recovery action", () => {
     const html = renderToStaticMarkup(
       <DefaultNotFoundPage pathname={'/missing/<script>alert("x")</script>'} />,
     );
 
     expect(html).toContain('aria-labelledby="farm-default-not-found-title"');
+    expect(html).toContain('aria-describedby="farm-default-not-found-description"');
     expect(html).toContain('id="farm-default-not-found-title"');
+    expect(html).toContain('id="farm-default-not-found-description"');
     expect(html).toContain(">404</h1>");
+    expect(html).toContain("Not found");
     expect(html).toContain('href="/"');
     expect(html).toContain("Go home");
     expect(html).not.toContain("Requested route");
@@ -27,6 +30,7 @@ describe("DefaultNotFoundPage", () => {
     expect(DEFAULT_NOT_FOUND_STYLES).toContain('[data-theme="dark"]');
     expect(DEFAULT_NOT_FOUND_STYLES).toContain('[data-theme="light"]');
     expect(DEFAULT_NOT_FOUND_STYLES).toContain("@media (prefers-reduced-motion: reduce)");
+    expect(DEFAULT_NOT_FOUND_STYLES).toContain("border-radius: 0");
   });
 
   it("keeps the minimal markup when no pathname is available", () => {
@@ -34,6 +38,7 @@ describe("DefaultNotFoundPage", () => {
 
     expect(html).not.toContain("Requested route");
     expect(html).toContain(">404</h1>");
+    expect(html).toContain("Not found");
     expect(html).toContain("Go home");
   });
 });

--- a/packages/farm/src/__tests__/not-found.test.tsx
+++ b/packages/farm/src/__tests__/not-found.test.tsx
@@ -4,18 +4,19 @@ import { describe, expect, it } from "vitest";
 import { DEFAULT_NOT_FOUND_STYLES, DefaultNotFoundPage } from "../components/not-found";
 
 describe("DefaultNotFoundPage", () => {
-  it("renders an accessible recovery path and safely includes the requested route", () => {
+  it("renders only the error code and home recovery action", () => {
     const html = renderToStaticMarkup(
       <DefaultNotFoundPage pathname={'/missing/<script>alert("x")</script>'} />,
     );
 
     expect(html).toContain('aria-labelledby="farm-default-not-found-title"');
     expect(html).toContain('id="farm-default-not-found-title"');
-    expect(html).toContain("Page not found");
-    expect(html).toContain("Requested route");
-    expect(html).toContain("/missing/&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;");
+    expect(html).toContain(">404</h1>");
     expect(html).toContain('href="/"');
-    expect(html).toContain("Return home");
+    expect(html).toContain("Go home");
+    expect(html).not.toContain("Requested route");
+    expect(html).not.toContain("Page not found");
+    expect(html).not.toContain("/missing/");
     expect(html).not.toContain("#22c55e");
     expect(html).not.toContain("onmouseover");
   });
@@ -28,10 +29,11 @@ describe("DefaultNotFoundPage", () => {
     expect(DEFAULT_NOT_FOUND_STYLES).toContain("@media (prefers-reduced-motion: reduce)");
   });
 
-  it("omits the route row when no pathname is available", () => {
+  it("keeps the minimal markup when no pathname is available", () => {
     const html = renderToStaticMarkup(<DefaultNotFoundPage />);
 
     expect(html).not.toContain("Requested route");
-    expect(html).toContain("Page not found");
+    expect(html).toContain(">404</h1>");
+    expect(html).toContain("Go home");
   });
 });

--- a/packages/farm/src/__tests__/not-found.test.tsx
+++ b/packages/farm/src/__tests__/not-found.test.tsx
@@ -32,7 +32,7 @@ describe("DefaultNotFoundPage", () => {
     expect(DEFAULT_NOT_FOUND_STYLES).toContain("@media (prefers-reduced-motion: reduce)");
     expect(DEFAULT_NOT_FOUND_STYLES).toContain("border-radius: 0");
     expect(DEFAULT_NOT_FOUND_STYLES).toContain("-webkit-text-stroke: 2px");
-    expect(DEFAULT_NOT_FOUND_STYLES).toContain("box-shadow: 4px 4px 0");
+    expect(DEFAULT_NOT_FOUND_STYLES).not.toContain("box-shadow");
   });
 
   it("keeps the minimal markup when no pathname is available", () => {

--- a/packages/farm/src/__tests__/not-found.test.tsx
+++ b/packages/farm/src/__tests__/not-found.test.tsx
@@ -16,7 +16,7 @@ describe("DefaultNotFoundPage", () => {
     expect(html).toContain(">404</h1>");
     expect(html).toContain("Not found");
     expect(html).toContain('href="/"');
-    expect(html).toContain("Go home");
+    expect(html).toContain("GO HOME");
     expect(html).not.toContain("Requested route");
     expect(html).not.toContain("Page not found");
     expect(html).not.toContain("/missing/");
@@ -41,6 +41,6 @@ describe("DefaultNotFoundPage", () => {
     expect(html).not.toContain("Requested route");
     expect(html).toContain(">404</h1>");
     expect(html).toContain("Not found");
-    expect(html).toContain("Go home");
+    expect(html).toContain("GO HOME");
   });
 });

--- a/packages/farm/src/__tests__/not-found.test.tsx
+++ b/packages/farm/src/__tests__/not-found.test.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_NOT_FOUND_STYLES, DefaultNotFoundPage } from "../components/not-found";
+
+describe("DefaultNotFoundPage", () => {
+  it("renders an accessible recovery path and safely includes the requested route", () => {
+    const html = renderToStaticMarkup(
+      <DefaultNotFoundPage pathname={'/missing/<script>alert("x")</script>'} />,
+    );
+
+    expect(html).toContain('aria-labelledby="farm-default-not-found-title"');
+    expect(html).toContain('id="farm-default-not-found-title"');
+    expect(html).toContain("Page not found");
+    expect(html).toContain("Requested route");
+    expect(html).toContain("/missing/&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;");
+    expect(html).toContain('href="/"');
+    expect(html).toContain("Return home");
+    expect(html).not.toContain("#22c55e");
+    expect(html).not.toContain("onmouseover");
+  });
+
+  it("supports system, class, and data-attribute theme preferences", () => {
+    expect(DEFAULT_NOT_FOUND_STYLES).toContain("@media (prefers-color-scheme: dark)");
+    expect(DEFAULT_NOT_FOUND_STYLES).toContain(".dark .farm-default-not-found");
+    expect(DEFAULT_NOT_FOUND_STYLES).toContain('[data-theme="dark"]');
+    expect(DEFAULT_NOT_FOUND_STYLES).toContain('[data-theme="light"]');
+    expect(DEFAULT_NOT_FOUND_STYLES).toContain("@media (prefers-reduced-motion: reduce)");
+  });
+
+  it("omits the route row when no pathname is available", () => {
+    const html = renderToStaticMarkup(<DefaultNotFoundPage />);
+
+    expect(html).not.toContain("Requested route");
+    expect(html).toContain("Page not found");
+  });
+});

--- a/packages/farm/src/__tests__/not-found.test.tsx
+++ b/packages/farm/src/__tests__/not-found.test.tsx
@@ -31,6 +31,8 @@ describe("DefaultNotFoundPage", () => {
     expect(DEFAULT_NOT_FOUND_STYLES).toContain('[data-theme="light"]');
     expect(DEFAULT_NOT_FOUND_STYLES).toContain("@media (prefers-reduced-motion: reduce)");
     expect(DEFAULT_NOT_FOUND_STYLES).toContain("border-radius: 0");
+    expect(DEFAULT_NOT_FOUND_STYLES).toContain("-webkit-text-stroke: 2px");
+    expect(DEFAULT_NOT_FOUND_STYLES).toContain("box-shadow: 4px 4px 0");
   });
 
   it("keeps the minimal markup when no pathname is available", () => {

--- a/packages/farm/src/components/not-found.tsx
+++ b/packages/farm/src/components/not-found.tsx
@@ -14,6 +14,8 @@ body {
   --farm-not-found-bg: #fafafa;
   --farm-not-found-fg: #171717;
   --farm-not-found-muted: #737373;
+  --farm-not-found-line: rgba(0, 0, 0, 0.16);
+  --farm-not-found-shadow: #a3a3a3;
   --farm-not-found-button-fg: #ffffff;
   min-height: 100vh;
   min-height: 100svh;
@@ -32,6 +34,7 @@ body {
 }
 
 .farm-default-not-found__content {
+  width: min(100%, 280px);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -39,20 +42,48 @@ body {
 
 .farm-default-not-found__code {
   margin: 0;
-  font-size: clamp(72px, 18vw, 112px);
-  font-weight: 600;
-  line-height: 0.8;
-  letter-spacing: -0.08em;
+  color: var(--farm-not-found-fg);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: clamp(88px, 20vw, 140px);
+  font-weight: 800;
+  line-height: 0.75;
+  letter-spacing: -0.1em;
+  transform: translateX(-3px);
+}
+
+@supports (-webkit-text-stroke: 1px currentColor) {
+  .farm-default-not-found__code {
+    color: var(--farm-not-found-bg);
+    -webkit-text-stroke: 2px var(--farm-not-found-fg);
+    text-shadow: 5px 5px 0 var(--farm-not-found-fg);
+  }
 }
 
 .farm-default-not-found__description {
-  margin: 22px 0 30px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 34px 0 30px;
   color: var(--farm-not-found-muted);
-  font-size: 15px;
-  line-height: 1.5;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 10px;
+  line-height: 1;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.farm-default-not-found__description::before,
+.farm-default-not-found__description::after {
+  content: "";
+  height: 1px;
+  flex: 1 1 auto;
+  background: var(--farm-not-found-line);
 }
 
 .farm-default-not-found__home {
+  min-width: 132px;
   min-height: 44px;
   display: inline-flex;
   align-items: center;
@@ -66,17 +97,20 @@ body {
   font-weight: 500;
   line-height: 1;
   text-decoration: none;
-  transition: opacity 150ms ease-out, transform 100ms ease-out;
+  box-shadow: 4px 4px 0 var(--farm-not-found-shadow);
+  transition: opacity 150ms ease-out, transform 120ms ease-out, box-shadow 120ms ease-out;
 }
 
 @media (hover: hover) and (pointer: fine) {
   .farm-default-not-found__home:hover {
-    opacity: 0.78;
+    transform: translate(-2px, -2px);
+    box-shadow: 6px 6px 0 var(--farm-not-found-shadow);
   }
 }
 
 .farm-default-not-found__home:active {
-  transform: translateY(1px);
+  transform: translate(3px, 3px);
+  box-shadow: 1px 1px 0 var(--farm-not-found-shadow);
 }
 
 .farm-default-not-found__home:focus-visible {
@@ -89,6 +123,8 @@ body {
     --farm-not-found-bg: #0a0a0a;
     --farm-not-found-fg: #ededed;
     --farm-not-found-muted: #a1a1a1;
+    --farm-not-found-line: rgba(255, 255, 255, 0.2);
+    --farm-not-found-shadow: #525252;
     --farm-not-found-button-fg: #0a0a0a;
     color-scheme: dark;
   }
@@ -100,6 +136,8 @@ body {
   --farm-not-found-bg: #0a0a0a;
   --farm-not-found-fg: #ededed;
   --farm-not-found-muted: #a1a1a1;
+  --farm-not-found-line: rgba(255, 255, 255, 0.2);
+  --farm-not-found-shadow: #525252;
   --farm-not-found-button-fg: #0a0a0a;
   color-scheme: dark;
 }
@@ -110,6 +148,8 @@ body {
   --farm-not-found-bg: #fafafa;
   --farm-not-found-fg: #171717;
   --farm-not-found-muted: #737373;
+  --farm-not-found-line: rgba(0, 0, 0, 0.16);
+  --farm-not-found-shadow: #a3a3a3;
   --farm-not-found-button-fg: #ffffff;
   color-scheme: light;
 }

--- a/packages/farm/src/components/not-found.tsx
+++ b/packages/farm/src/components/not-found.tsx
@@ -12,15 +12,8 @@ body {
 
 .farm-default-not-found {
   --farm-not-found-bg: #fafafa;
-  --farm-not-found-surface: #ffffff;
   --farm-not-found-fg: #171717;
-  --farm-not-found-muted: #737373;
-  --farm-not-found-subtle: #a3a3a3;
-  --farm-not-found-border: rgba(0, 0, 0, 0.12);
-  --farm-not-found-border-strong: rgba(0, 0, 0, 0.2);
-  --farm-not-found-hover: #f2f2f2;
   --farm-not-found-button-fg: #ffffff;
-  --farm-not-found-shadow: 0 20px 60px rgba(0, 0, 0, 0.06);
   min-height: 100vh;
   min-height: 100svh;
   display: grid;
@@ -37,195 +30,58 @@ body {
   box-sizing: border-box;
 }
 
-.farm-default-not-found__shell {
-  width: min(100%, 620px);
-}
-
-.farm-default-not-found__panel {
-  overflow: hidden;
-  border: 1px solid var(--farm-not-found-border);
-  border-radius: 16px;
-  background: var(--farm-not-found-surface);
-  box-shadow: var(--farm-not-found-shadow);
-}
-
-.farm-default-not-found__status {
-  min-height: 42px;
+.farm-default-not-found__content {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 8px;
-  padding: 0 16px;
-  border-bottom: 1px solid var(--farm-not-found-border);
-  color: var(--farm-not-found-muted);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 11px;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.farm-default-not-found__status-dot {
-  width: 6px;
-  height: 6px;
-  flex: 0 0 auto;
-  border-radius: 999px;
-  background: currentColor;
-  opacity: 0.7;
-}
-
-.farm-default-not-found__hero {
-  display: grid;
-  grid-template-columns: auto 1px minmax(0, 1fr);
-  align-items: center;
-  gap: 28px;
-  padding: 38px 40px;
+  gap: 32px;
 }
 
 .farm-default-not-found__code {
   margin: 0;
-  font-size: clamp(52px, 9vw, 76px);
+  font-size: clamp(72px, 18vw, 112px);
   font-weight: 600;
-  line-height: 0.9;
-  letter-spacing: -0.07em;
-}
-
-.farm-default-not-found__divider {
-  width: 1px;
-  height: 72px;
-  background: var(--farm-not-found-border-strong);
-}
-
-.farm-default-not-found__message {
-  min-width: 0;
-}
-
-.farm-default-not-found__title {
-  margin: 0;
-  font-size: 20px;
-  font-weight: 600;
-  line-height: 1.3;
-  letter-spacing: -0.025em;
-}
-
-.farm-default-not-found__description {
-  max-width: 340px;
-  margin: 8px 0 0;
-  color: var(--farm-not-found-muted);
-  font-size: 14px;
-  line-height: 1.6;
-}
-
-.farm-default-not-found__route {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  align-items: center;
-  gap: 16px;
-  min-height: 48px;
-  padding: 10px 16px;
-  border-top: 1px solid var(--farm-not-found-border);
-  background: var(--farm-not-found-bg);
-}
-
-.farm-default-not-found__route-label {
-  color: var(--farm-not-found-subtle);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 10px;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.farm-default-not-found__route-path {
-  min-width: 0;
-  overflow: hidden;
-  color: var(--farm-not-found-muted);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 12px;
-  text-align: right;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.farm-default-not-found__actions {
-  display: flex;
-  padding: 16px;
-  border-top: 1px solid var(--farm-not-found-border);
+  line-height: 0.8;
+  letter-spacing: -0.08em;
 }
 
 .farm-default-not-found__home {
-  min-height: 40px;
+  min-height: 44px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 24px;
-  padding: 0 16px;
+  padding: 0 20px;
   border: 1px solid var(--farm-not-found-fg);
-  border-radius: 8px;
+  border-radius: 7px;
   color: var(--farm-not-found-button-fg);
   background: var(--farm-not-found-fg);
-  font-size: 13px;
-  font-weight: 550;
+  font-size: 14px;
+  font-weight: 500;
   line-height: 1;
   text-decoration: none;
   transition: opacity 150ms ease-out, transform 100ms ease-out;
 }
 
-.farm-default-not-found__home:hover {
-  opacity: 0.82;
+@media (hover: hover) and (pointer: fine) {
+  .farm-default-not-found__home:hover {
+    opacity: 0.78;
+  }
 }
 
 .farm-default-not-found__home:active {
   transform: translateY(1px);
 }
 
-.farm-default-not-found__home:focus-visible,
-.farm-default-not-found__brand:focus-visible {
+.farm-default-not-found__home:focus-visible {
   outline: 2px solid var(--farm-not-found-fg);
   outline-offset: 3px;
-}
-
-.farm-default-not-found__home-arrow {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  transition: transform 150ms ease-out;
-}
-
-.farm-default-not-found__home:hover .farm-default-not-found__home-arrow {
-  transform: translateX(2px);
-}
-
-.farm-default-not-found__footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 14px 4px 0;
-  color: var(--farm-not-found-subtle);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 10px;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.farm-default-not-found__brand {
-  color: var(--farm-not-found-muted);
-  text-decoration: none;
-  transition: color 150ms ease-out;
-}
-
-.farm-default-not-found__brand:hover {
-  color: var(--farm-not-found-fg);
 }
 
 @media (prefers-color-scheme: dark) {
   .farm-default-not-found {
     --farm-not-found-bg: #0a0a0a;
-    --farm-not-found-surface: #111111;
     --farm-not-found-fg: #ededed;
-    --farm-not-found-muted: #a1a1a1;
-    --farm-not-found-subtle: #666666;
-    --farm-not-found-border: rgba(255, 255, 255, 0.12);
-    --farm-not-found-border-strong: rgba(255, 255, 255, 0.22);
-    --farm-not-found-hover: #191919;
     --farm-not-found-button-fg: #0a0a0a;
-    --farm-not-found-shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
     color-scheme: dark;
   }
 }
@@ -234,15 +90,8 @@ body {
 [data-theme="dark"] .farm-default-not-found,
 [data-color-scheme="dark"] .farm-default-not-found {
   --farm-not-found-bg: #0a0a0a;
-  --farm-not-found-surface: #111111;
   --farm-not-found-fg: #ededed;
-  --farm-not-found-muted: #a1a1a1;
-  --farm-not-found-subtle: #666666;
-  --farm-not-found-border: rgba(255, 255, 255, 0.12);
-  --farm-not-found-border-strong: rgba(255, 255, 255, 0.22);
-  --farm-not-found-hover: #191919;
   --farm-not-found-button-fg: #0a0a0a;
-  --farm-not-found-shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
   color-scheme: dark;
 }
 
@@ -250,61 +99,18 @@ body {
 [data-theme="light"] .farm-default-not-found,
 [data-color-scheme="light"] .farm-default-not-found {
   --farm-not-found-bg: #fafafa;
-  --farm-not-found-surface: #ffffff;
   --farm-not-found-fg: #171717;
-  --farm-not-found-muted: #737373;
-  --farm-not-found-subtle: #a3a3a3;
-  --farm-not-found-border: rgba(0, 0, 0, 0.12);
-  --farm-not-found-border-strong: rgba(0, 0, 0, 0.2);
-  --farm-not-found-hover: #f2f2f2;
   --farm-not-found-button-fg: #ffffff;
-  --farm-not-found-shadow: 0 20px 60px rgba(0, 0, 0, 0.06);
   color-scheme: light;
 }
 
-@media (max-width: 560px) {
-  .farm-default-not-found {
-    padding: 16px;
-  }
-
-  .farm-default-not-found__panel {
-    border-radius: 12px;
-  }
-
-  .farm-default-not-found__hero {
-    grid-template-columns: minmax(0, 1fr);
-    gap: 22px;
-    padding: 30px 24px;
-  }
-
-  .farm-default-not-found__code {
-    font-size: 56px;
-  }
-
-  .farm-default-not-found__divider {
-    width: 100%;
-    height: 1px;
-  }
-
-  .farm-default-not-found__route {
-    grid-template-columns: minmax(0, 1fr);
-    gap: 4px;
-  }
-
-  .farm-default-not-found__route-path {
-    text-align: left;
-  }
-
-  .farm-default-not-found__home {
-    width: 100%;
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
-  .farm-default-not-found__home,
-  .farm-default-not-found__home-arrow,
-  .farm-default-not-found__brand {
+  .farm-default-not-found__home {
     transition: none;
+  }
+
+  .farm-default-not-found__home:active {
+    transform: none;
   }
 }
 `;
@@ -313,58 +119,18 @@ body {
  * Default 404 Not Found page component.
  * Users can override this with their own component via the notFound config option.
  */
-export function DefaultNotFoundPage({ pathname }: NotFoundPageProps) {
+export function DefaultNotFoundPage(_props: NotFoundPageProps) {
   return (
     <>
       <style>{DEFAULT_NOT_FOUND_STYLES}</style>
       <main className="farm-default-not-found" aria-labelledby="farm-default-not-found-title">
-        <div className="farm-default-not-found__shell">
-          <section className="farm-default-not-found__panel">
-            <div className="farm-default-not-found__status">
-              <span aria-hidden="true" className="farm-default-not-found__status-dot" />
-              <span>404 / Route not found</span>
-            </div>
-
-            <div className="farm-default-not-found__hero">
-              <p aria-hidden="true" className="farm-default-not-found__code">
-                404
-              </p>
-              <span aria-hidden="true" className="farm-default-not-found__divider" />
-              <div className="farm-default-not-found__message">
-                <h1 id="farm-default-not-found-title" className="farm-default-not-found__title">
-                  Page not found
-                </h1>
-                <p className="farm-default-not-found__description">
-                  The page you&apos;re looking for doesn&apos;t exist or may have moved.
-                </p>
-              </div>
-            </div>
-
-            {pathname ? (
-              <div className="farm-default-not-found__route">
-                <span className="farm-default-not-found__route-label">Requested route</span>
-                <code className="farm-default-not-found__route-path" title={pathname}>
-                  {pathname}
-                </code>
-              </div>
-            ) : null}
-
-            <div className="farm-default-not-found__actions">
-              <a className="farm-default-not-found__home" href="/">
-                <span>Return home</span>
-                <span aria-hidden="true" className="farm-default-not-found__home-arrow">
-                  →
-                </span>
-              </a>
-            </div>
-          </section>
-
-          <footer className="farm-default-not-found__footer">
-            <a className="farm-default-not-found__brand" href="https://farmjs.dev">
-              Farm.js
-            </a>
-            <span>Route boundary</span>
-          </footer>
+        <div className="farm-default-not-found__content">
+          <h1 id="farm-default-not-found-title" className="farm-default-not-found__code">
+            404
+          </h1>
+          <a className="farm-default-not-found__home" href="/">
+            Go home
+          </a>
         </div>
       </main>
     </>

--- a/packages/farm/src/components/not-found.tsx
+++ b/packages/farm/src/components/not-found.tsx
@@ -15,7 +15,6 @@ body {
   --farm-not-found-fg: #171717;
   --farm-not-found-muted: #737373;
   --farm-not-found-line: rgba(0, 0, 0, 0.16);
-  --farm-not-found-shadow: #a3a3a3;
   --farm-not-found-button-fg: #ffffff;
   min-height: 100vh;
   min-height: 100svh;
@@ -97,20 +96,17 @@ body {
   font-weight: 500;
   line-height: 1;
   text-decoration: none;
-  box-shadow: 4px 4px 0 var(--farm-not-found-shadow);
-  transition: opacity 150ms ease-out, transform 120ms ease-out, box-shadow 120ms ease-out;
+  transition: opacity 150ms ease-out, transform 100ms ease-out;
 }
 
 @media (hover: hover) and (pointer: fine) {
   .farm-default-not-found__home:hover {
-    transform: translate(-2px, -2px);
-    box-shadow: 6px 6px 0 var(--farm-not-found-shadow);
+    opacity: 0.78;
   }
 }
 
 .farm-default-not-found__home:active {
-  transform: translate(3px, 3px);
-  box-shadow: 1px 1px 0 var(--farm-not-found-shadow);
+  transform: translateY(1px);
 }
 
 .farm-default-not-found__home:focus-visible {
@@ -124,7 +120,6 @@ body {
     --farm-not-found-fg: #ededed;
     --farm-not-found-muted: #a1a1a1;
     --farm-not-found-line: rgba(255, 255, 255, 0.2);
-    --farm-not-found-shadow: #525252;
     --farm-not-found-button-fg: #0a0a0a;
     color-scheme: dark;
   }
@@ -137,7 +132,6 @@ body {
   --farm-not-found-fg: #ededed;
   --farm-not-found-muted: #a1a1a1;
   --farm-not-found-line: rgba(255, 255, 255, 0.2);
-  --farm-not-found-shadow: #525252;
   --farm-not-found-button-fg: #0a0a0a;
   color-scheme: dark;
 }
@@ -149,7 +143,6 @@ body {
   --farm-not-found-fg: #171717;
   --farm-not-found-muted: #737373;
   --farm-not-found-line: rgba(0, 0, 0, 0.16);
-  --farm-not-found-shadow: #a3a3a3;
   --farm-not-found-button-fg: #ffffff;
   color-scheme: light;
 }

--- a/packages/farm/src/components/not-found.tsx
+++ b/packages/farm/src/components/not-found.tsx
@@ -5,106 +5,369 @@ export interface NotFoundPageProps {
   pathname?: string;
 }
 
+export const DEFAULT_NOT_FOUND_STYLES = `
+body {
+  margin: 0;
+}
+
+.farm-default-not-found {
+  --farm-not-found-bg: #fafafa;
+  --farm-not-found-surface: #ffffff;
+  --farm-not-found-fg: #171717;
+  --farm-not-found-muted: #737373;
+  --farm-not-found-subtle: #a3a3a3;
+  --farm-not-found-border: rgba(0, 0, 0, 0.12);
+  --farm-not-found-border-strong: rgba(0, 0, 0, 0.2);
+  --farm-not-found-hover: #f2f2f2;
+  --farm-not-found-button-fg: #ffffff;
+  --farm-not-found-shadow: 0 20px 60px rgba(0, 0, 0, 0.06);
+  min-height: 100vh;
+  min-height: 100svh;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  color: var(--farm-not-found-fg);
+  background: var(--farm-not-found-bg);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color-scheme: light;
+}
+
+.farm-default-not-found,
+.farm-default-not-found * {
+  box-sizing: border-box;
+}
+
+.farm-default-not-found__shell {
+  width: min(100%, 620px);
+}
+
+.farm-default-not-found__panel {
+  overflow: hidden;
+  border: 1px solid var(--farm-not-found-border);
+  border-radius: 16px;
+  background: var(--farm-not-found-surface);
+  box-shadow: var(--farm-not-found-shadow);
+}
+
+.farm-default-not-found__status {
+  min-height: 42px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--farm-not-found-border);
+  color: var(--farm-not-found-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.farm-default-not-found__status-dot {
+  width: 6px;
+  height: 6px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0.7;
+}
+
+.farm-default-not-found__hero {
+  display: grid;
+  grid-template-columns: auto 1px minmax(0, 1fr);
+  align-items: center;
+  gap: 28px;
+  padding: 38px 40px;
+}
+
+.farm-default-not-found__code {
+  margin: 0;
+  font-size: clamp(52px, 9vw, 76px);
+  font-weight: 600;
+  line-height: 0.9;
+  letter-spacing: -0.07em;
+}
+
+.farm-default-not-found__divider {
+  width: 1px;
+  height: 72px;
+  background: var(--farm-not-found-border-strong);
+}
+
+.farm-default-not-found__message {
+  min-width: 0;
+}
+
+.farm-default-not-found__title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: -0.025em;
+}
+
+.farm-default-not-found__description {
+  max-width: 340px;
+  margin: 8px 0 0;
+  color: var(--farm-not-found-muted);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.farm-default-not-found__route {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 16px;
+  min-height: 48px;
+  padding: 10px 16px;
+  border-top: 1px solid var(--farm-not-found-border);
+  background: var(--farm-not-found-bg);
+}
+
+.farm-default-not-found__route-label {
+  color: var(--farm-not-found-subtle);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.farm-default-not-found__route-path {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--farm-not-found-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.farm-default-not-found__actions {
+  display: flex;
+  padding: 16px;
+  border-top: 1px solid var(--farm-not-found-border);
+}
+
+.farm-default-not-found__home {
+  min-height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  padding: 0 16px;
+  border: 1px solid var(--farm-not-found-fg);
+  border-radius: 8px;
+  color: var(--farm-not-found-button-fg);
+  background: var(--farm-not-found-fg);
+  font-size: 13px;
+  font-weight: 550;
+  line-height: 1;
+  text-decoration: none;
+  transition: opacity 150ms ease-out, transform 100ms ease-out;
+}
+
+.farm-default-not-found__home:hover {
+  opacity: 0.82;
+}
+
+.farm-default-not-found__home:active {
+  transform: translateY(1px);
+}
+
+.farm-default-not-found__home:focus-visible,
+.farm-default-not-found__brand:focus-visible {
+  outline: 2px solid var(--farm-not-found-fg);
+  outline-offset: 3px;
+}
+
+.farm-default-not-found__home-arrow {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  transition: transform 150ms ease-out;
+}
+
+.farm-default-not-found__home:hover .farm-default-not-found__home-arrow {
+  transform: translateX(2px);
+}
+
+.farm-default-not-found__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 4px 0;
+  color: var(--farm-not-found-subtle);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.farm-default-not-found__brand {
+  color: var(--farm-not-found-muted);
+  text-decoration: none;
+  transition: color 150ms ease-out;
+}
+
+.farm-default-not-found__brand:hover {
+  color: var(--farm-not-found-fg);
+}
+
+@media (prefers-color-scheme: dark) {
+  .farm-default-not-found {
+    --farm-not-found-bg: #0a0a0a;
+    --farm-not-found-surface: #111111;
+    --farm-not-found-fg: #ededed;
+    --farm-not-found-muted: #a1a1a1;
+    --farm-not-found-subtle: #666666;
+    --farm-not-found-border: rgba(255, 255, 255, 0.12);
+    --farm-not-found-border-strong: rgba(255, 255, 255, 0.22);
+    --farm-not-found-hover: #191919;
+    --farm-not-found-button-fg: #0a0a0a;
+    --farm-not-found-shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
+    color-scheme: dark;
+  }
+}
+
+.dark .farm-default-not-found,
+[data-theme="dark"] .farm-default-not-found,
+[data-color-scheme="dark"] .farm-default-not-found {
+  --farm-not-found-bg: #0a0a0a;
+  --farm-not-found-surface: #111111;
+  --farm-not-found-fg: #ededed;
+  --farm-not-found-muted: #a1a1a1;
+  --farm-not-found-subtle: #666666;
+  --farm-not-found-border: rgba(255, 255, 255, 0.12);
+  --farm-not-found-border-strong: rgba(255, 255, 255, 0.22);
+  --farm-not-found-hover: #191919;
+  --farm-not-found-button-fg: #0a0a0a;
+  --farm-not-found-shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
+  color-scheme: dark;
+}
+
+.light .farm-default-not-found,
+[data-theme="light"] .farm-default-not-found,
+[data-color-scheme="light"] .farm-default-not-found {
+  --farm-not-found-bg: #fafafa;
+  --farm-not-found-surface: #ffffff;
+  --farm-not-found-fg: #171717;
+  --farm-not-found-muted: #737373;
+  --farm-not-found-subtle: #a3a3a3;
+  --farm-not-found-border: rgba(0, 0, 0, 0.12);
+  --farm-not-found-border-strong: rgba(0, 0, 0, 0.2);
+  --farm-not-found-hover: #f2f2f2;
+  --farm-not-found-button-fg: #ffffff;
+  --farm-not-found-shadow: 0 20px 60px rgba(0, 0, 0, 0.06);
+  color-scheme: light;
+}
+
+@media (max-width: 560px) {
+  .farm-default-not-found {
+    padding: 16px;
+  }
+
+  .farm-default-not-found__panel {
+    border-radius: 12px;
+  }
+
+  .farm-default-not-found__hero {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 22px;
+    padding: 30px 24px;
+  }
+
+  .farm-default-not-found__code {
+    font-size: 56px;
+  }
+
+  .farm-default-not-found__divider {
+    width: 100%;
+    height: 1px;
+  }
+
+  .farm-default-not-found__route {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 4px;
+  }
+
+  .farm-default-not-found__route-path {
+    text-align: left;
+  }
+
+  .farm-default-not-found__home {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .farm-default-not-found__home,
+  .farm-default-not-found__home-arrow,
+  .farm-default-not-found__brand {
+    transition: none;
+  }
+}
+`;
+
 /**
- * Default 404 Not Found page component
- * Users can override this with their own component via the notFound config option
+ * Default 404 Not Found page component.
+ * Users can override this with their own component via the notFound config option.
  */
 export function DefaultNotFoundPage({ pathname }: NotFoundPageProps) {
   return (
-    <div
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        minHeight: "100vh",
-        fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
-        backgroundColor: "#f9fafb",
-        padding: "20px",
-        textAlign: "center",
-      }}
-    >
-      <div
-        style={{
-          backgroundColor: "white",
-          borderRadius: "12px",
-          padding: "48px",
-          boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)",
-          maxWidth: "500px",
-          width: "100%",
-        }}
-      >
-        <h1
-          style={{
-            fontSize: "96px",
-            fontWeight: "bold",
-            color: "#22c55e",
-            margin: "0 0 16px 0",
-            lineHeight: "1",
-          }}
-        >
-          404
-        </h1>
-        <h2
-          style={{
-            fontSize: "24px",
-            fontWeight: "600",
-            color: "#1f2937",
-            margin: "0 0 16px 0",
-          }}
-        >
-          Page Not Found
-        </h2>
-        <p
-          style={{
-            fontSize: "16px",
-            color: "#6b7280",
-            margin: "0 0 24px 0",
-          }}
-        >
-          {pathname ? (
-            <>
-              The page{" "}
-              <code style={{ backgroundColor: "#f3f4f6", padding: "2px 6px", borderRadius: "4px" }}>
-                {pathname}
-              </code>{" "}
-              doesn't exist.
-            </>
-          ) : (
-            "The page you're looking for doesn't exist or has been moved."
-          )}
-        </p>
-        <a
-          href="/"
-          style={{
-            display: "inline-block",
-            backgroundColor: "#22c55e",
-            color: "white",
-            padding: "12px 24px",
-            borderRadius: "8px",
-            textDecoration: "none",
-            fontWeight: "500",
-            transition: "background-color 0.2s",
-          }}
-          onMouseOver={(e) => (e.currentTarget.style.backgroundColor = "#16a34a")}
-          onMouseOut={(e) => (e.currentTarget.style.backgroundColor = "#22c55e")}
-        >
-          Go Home
-        </a>
-      </div>
-      <p
-        style={{
-          marginTop: "24px",
-          fontSize: "14px",
-          color: "#9ca3af",
-        }}
-      >
-        Powered by{" "}
-        <a href="https://farmjs.dev" style={{ color: "#22c55e", textDecoration: "none" }}>
-          Farm.js
-        </a>
-      </p>
-    </div>
+    <>
+      <style>{DEFAULT_NOT_FOUND_STYLES}</style>
+      <main className="farm-default-not-found" aria-labelledby="farm-default-not-found-title">
+        <div className="farm-default-not-found__shell">
+          <section className="farm-default-not-found__panel">
+            <div className="farm-default-not-found__status">
+              <span aria-hidden="true" className="farm-default-not-found__status-dot" />
+              <span>404 / Route not found</span>
+            </div>
+
+            <div className="farm-default-not-found__hero">
+              <p aria-hidden="true" className="farm-default-not-found__code">
+                404
+              </p>
+              <span aria-hidden="true" className="farm-default-not-found__divider" />
+              <div className="farm-default-not-found__message">
+                <h1 id="farm-default-not-found-title" className="farm-default-not-found__title">
+                  Page not found
+                </h1>
+                <p className="farm-default-not-found__description">
+                  The page you&apos;re looking for doesn&apos;t exist or may have moved.
+                </p>
+              </div>
+            </div>
+
+            {pathname ? (
+              <div className="farm-default-not-found__route">
+                <span className="farm-default-not-found__route-label">Requested route</span>
+                <code className="farm-default-not-found__route-path" title={pathname}>
+                  {pathname}
+                </code>
+              </div>
+            ) : null}
+
+            <div className="farm-default-not-found__actions">
+              <a className="farm-default-not-found__home" href="/">
+                <span>Return home</span>
+                <span aria-hidden="true" className="farm-default-not-found__home-arrow">
+                  →
+                </span>
+              </a>
+            </div>
+          </section>
+
+          <footer className="farm-default-not-found__footer">
+            <a className="farm-default-not-found__brand" href="https://farmjs.dev">
+              Farm.js
+            </a>
+            <span>Route boundary</span>
+          </footer>
+        </div>
+      </main>
+    </>
   );
 }
 

--- a/packages/farm/src/components/not-found.tsx
+++ b/packages/farm/src/components/not-found.tsx
@@ -13,6 +13,7 @@ body {
 .farm-default-not-found {
   --farm-not-found-bg: #fafafa;
   --farm-not-found-fg: #171717;
+  --farm-not-found-muted: #737373;
   --farm-not-found-button-fg: #ffffff;
   min-height: 100vh;
   min-height: 100svh;
@@ -34,7 +35,6 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 32px;
 }
 
 .farm-default-not-found__code {
@@ -45,6 +45,13 @@ body {
   letter-spacing: -0.08em;
 }
 
+.farm-default-not-found__description {
+  margin: 22px 0 30px;
+  color: var(--farm-not-found-muted);
+  font-size: 15px;
+  line-height: 1.5;
+}
+
 .farm-default-not-found__home {
   min-height: 44px;
   display: inline-flex;
@@ -52,7 +59,7 @@ body {
   justify-content: center;
   padding: 0 20px;
   border: 1px solid var(--farm-not-found-fg);
-  border-radius: 7px;
+  border-radius: 0;
   color: var(--farm-not-found-button-fg);
   background: var(--farm-not-found-fg);
   font-size: 14px;
@@ -81,6 +88,7 @@ body {
   .farm-default-not-found {
     --farm-not-found-bg: #0a0a0a;
     --farm-not-found-fg: #ededed;
+    --farm-not-found-muted: #a1a1a1;
     --farm-not-found-button-fg: #0a0a0a;
     color-scheme: dark;
   }
@@ -91,6 +99,7 @@ body {
 [data-color-scheme="dark"] .farm-default-not-found {
   --farm-not-found-bg: #0a0a0a;
   --farm-not-found-fg: #ededed;
+  --farm-not-found-muted: #a1a1a1;
   --farm-not-found-button-fg: #0a0a0a;
   color-scheme: dark;
 }
@@ -100,6 +109,7 @@ body {
 [data-color-scheme="light"] .farm-default-not-found {
   --farm-not-found-bg: #fafafa;
   --farm-not-found-fg: #171717;
+  --farm-not-found-muted: #737373;
   --farm-not-found-button-fg: #ffffff;
   color-scheme: light;
 }
@@ -123,11 +133,21 @@ export function DefaultNotFoundPage(_props: NotFoundPageProps) {
   return (
     <>
       <style>{DEFAULT_NOT_FOUND_STYLES}</style>
-      <main className="farm-default-not-found" aria-labelledby="farm-default-not-found-title">
+      <main
+        className="farm-default-not-found"
+        aria-labelledby="farm-default-not-found-title"
+        aria-describedby="farm-default-not-found-description"
+      >
         <div className="farm-default-not-found__content">
           <h1 id="farm-default-not-found-title" className="farm-default-not-found__code">
             404
           </h1>
+          <p
+            id="farm-default-not-found-description"
+            className="farm-default-not-found__description"
+          >
+            Not found
+          </p>
           <a className="farm-default-not-found__home" href="/">
             Go home
           </a>

--- a/packages/farm/src/components/not-found.tsx
+++ b/packages/farm/src/components/not-found.tsx
@@ -182,7 +182,7 @@ export function DefaultNotFoundPage(_props: NotFoundPageProps) {
             Not found
           </p>
           <a className="farm-default-not-found__home" href="/">
-            Go home
+            GO HOME
           </a>
         </div>
       </main>

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -5464,65 +5464,15 @@ async function handleFarmRequestInContext(
           className: "farm-default-not-found",
           "aria-labelledby": "farm-default-not-found-title",
         },
-          React.createElement("div", { className: "farm-default-not-found__shell" },
-            React.createElement("section", { className: "farm-default-not-found__panel" },
-              React.createElement("div", { className: "farm-default-not-found__status" },
-                React.createElement("span", {
-                  "aria-hidden": "true",
-                  className: "farm-default-not-found__status-dot",
-                }),
-                React.createElement("span", null, "404 / Route not found")
-              ),
-              React.createElement("div", { className: "farm-default-not-found__hero" },
-                React.createElement("p", {
-                  "aria-hidden": "true",
-                  className: "farm-default-not-found__code",
-                }, "404"),
-                React.createElement("span", {
-                  "aria-hidden": "true",
-                  className: "farm-default-not-found__divider",
-                }),
-                React.createElement("div", { className: "farm-default-not-found__message" },
-                  React.createElement("h1", {
-                    id: "farm-default-not-found-title",
-                    className: "farm-default-not-found__title",
-                  }, "Page not found"),
-                  React.createElement("p", {
-                    className: "farm-default-not-found__description",
-                  }, "The page you're looking for doesn't exist or may have moved.")
-                )
-              ),
-              pathname ? React.createElement("div", {
-                className: "farm-default-not-found__route",
-              },
-                React.createElement("span", {
-                  className: "farm-default-not-found__route-label",
-                }, "Requested route"),
-                React.createElement("code", {
-                  className: "farm-default-not-found__route-path",
-                  title: pathname,
-                }, pathname)
-              ) : null,
-              React.createElement("div", { className: "farm-default-not-found__actions" },
-                React.createElement("a", {
-                  className: "farm-default-not-found__home",
-                  href: "/",
-                },
-                  React.createElement("span", null, "Return home"),
-                  React.createElement("span", {
-                    "aria-hidden": "true",
-                    className: "farm-default-not-found__home-arrow",
-                  }, "→")
-                )
-              )
-            ),
-            React.createElement("footer", { className: "farm-default-not-found__footer" },
-              React.createElement("a", {
-                className: "farm-default-not-found__brand",
-                href: "https://farmjs.dev",
-              }, "Farm.js"),
-              React.createElement("span", null, "Route boundary")
-            )
+          React.createElement("div", { className: "farm-default-not-found__content" },
+            React.createElement("h1", {
+              id: "farm-default-not-found-title",
+              className: "farm-default-not-found__code",
+            }, "404"),
+            React.createElement("a", {
+              className: "farm-default-not-found__home",
+              href: "/",
+            }, "Go home")
           )
         )
       );

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -61,6 +61,7 @@ import { adaptTailwindVitePlugin } from "../build/vite-plugin-compat";
 import { mergeFarmFontCss } from "../font-vite";
 import type { FarmIslandStrategy } from "../island";
 import { createFarmSourceAlias } from "../server/vite-config";
+import { DEFAULT_NOT_FOUND_STYLES } from "../components/not-found";
 
 // Type alias for OutputBundle
 type OutputBundle = Rollup.OutputBundle;
@@ -5457,75 +5458,73 @@ async function handleFarmRequestInContext(
   try {
     // Default 404 page component
     function Default404Page() {
-      return React.createElement("div", {
-        style: {
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          justifyContent: "center",
-          minHeight: "100vh",
-          fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
-          backgroundColor: "#f9fafb",
-          padding: "20px",
-          textAlign: "center",
-        }
-      },
-        React.createElement("div", {
-          style: {
-            backgroundColor: "white",
-            borderRadius: "12px",
-            padding: "48px",
-            boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)",
-            maxWidth: "500px",
-            width: "100%",
-          }
+      return React.createElement(React.Fragment, null,
+        React.createElement("style", null, ${JSON.stringify(DEFAULT_NOT_FOUND_STYLES)}),
+        React.createElement("main", {
+          className: "farm-default-not-found",
+          "aria-labelledby": "farm-default-not-found-title",
         },
-          React.createElement("h1", {
-            style: {
-              fontSize: "96px",
-              fontWeight: "bold",
-              color: "#22c55e",
-              margin: "0 0 16px 0",
-              lineHeight: "1",
-            }
-          }, "404"),
-          React.createElement("h2", {
-            style: {
-              fontSize: "24px",
-              fontWeight: "600",
-              color: "#1f2937",
-              margin: "0 0 16px 0",
-            }
-          }, "Page Not Found"),
-          React.createElement("p", {
-            style: {
-              fontSize: "16px",
-              color: "#6b7280",
-              margin: "0 0 24px 0",
-            }
-          }, "The page ", React.createElement("code", {
-            style: { backgroundColor: "#f3f4f6", padding: "2px 6px", borderRadius: "4px" }
-          }, pathname), " doesn't exist."),
-          React.createElement("a", {
-            href: "/",
-            style: {
-              display: "inline-block",
-              backgroundColor: "#22c55e",
-              color: "white",
-              padding: "12px 24px",
-              borderRadius: "8px",
-              textDecoration: "none",
-              fontWeight: "500",
-            }
-          }, "Go Home")
-        ),
-        React.createElement("p", {
-          style: {
-            marginTop: "24px",
-            fontSize: "14px",
-            color: "#9ca3af",
-          }
-        }, "Powered by Farm.js")
+          React.createElement("div", { className: "farm-default-not-found__shell" },
+            React.createElement("section", { className: "farm-default-not-found__panel" },
+              React.createElement("div", { className: "farm-default-not-found__status" },
+                React.createElement("span", {
+                  "aria-hidden": "true",
+                  className: "farm-default-not-found__status-dot",
+                }),
+                React.createElement("span", null, "404 / Route not found")
+              ),
+              React.createElement("div", { className: "farm-default-not-found__hero" },
+                React.createElement("p", {
+                  "aria-hidden": "true",
+                  className: "farm-default-not-found__code",
+                }, "404"),
+                React.createElement("span", {
+                  "aria-hidden": "true",
+                  className: "farm-default-not-found__divider",
+                }),
+                React.createElement("div", { className: "farm-default-not-found__message" },
+                  React.createElement("h1", {
+                    id: "farm-default-not-found-title",
+                    className: "farm-default-not-found__title",
+                  }, "Page not found"),
+                  React.createElement("p", {
+                    className: "farm-default-not-found__description",
+                  }, "The page you're looking for doesn't exist or may have moved.")
+                )
+              ),
+              pathname ? React.createElement("div", {
+                className: "farm-default-not-found__route",
+              },
+                React.createElement("span", {
+                  className: "farm-default-not-found__route-label",
+                }, "Requested route"),
+                React.createElement("code", {
+                  className: "farm-default-not-found__route-path",
+                  title: pathname,
+                }, pathname)
+              ) : null,
+              React.createElement("div", { className: "farm-default-not-found__actions" },
+                React.createElement("a", {
+                  className: "farm-default-not-found__home",
+                  href: "/",
+                },
+                  React.createElement("span", null, "Return home"),
+                  React.createElement("span", {
+                    "aria-hidden": "true",
+                    className: "farm-default-not-found__home-arrow",
+                  }, "→")
+                )
+              )
+            ),
+            React.createElement("footer", { className: "farm-default-not-found__footer" },
+              React.createElement("a", {
+                className: "farm-default-not-found__brand",
+                href: "https://farmjs.dev",
+              }, "Farm.js"),
+              React.createElement("span", null, "Route boundary")
+            )
+          )
+        )
       );
     }
     

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -5477,7 +5477,7 @@ async function handleFarmRequestInContext(
             React.createElement("a", {
               className: "farm-default-not-found__home",
               href: "/",
-            }, "Go home")
+            }, "GO HOME")
           )
         )
       );

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -5463,12 +5463,17 @@ async function handleFarmRequestInContext(
         React.createElement("main", {
           className: "farm-default-not-found",
           "aria-labelledby": "farm-default-not-found-title",
+          "aria-describedby": "farm-default-not-found-description",
         },
           React.createElement("div", { className: "farm-default-not-found__content" },
             React.createElement("h1", {
               id: "farm-default-not-found-title",
               className: "farm-default-not-found__code",
             }, "404"),
+            React.createElement("p", {
+              id: "farm-default-not-found-description",
+              className: "farm-default-not-found__description",
+            }, "Not found"),
             React.createElement("a", {
               className: "farm-default-not-found__home",
               href: "/",

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -50,6 +50,7 @@ import { localizeFarmHref, localizeFarmPathname } from "../i18n/routing";
 import { sendWebResponse } from "./response";
 import { renderFarmFontDevHead } from "../font-vite";
 import { createFarmMetadataImageResponse } from "../metadata-image";
+import { DefaultNotFoundPage } from "../components/not-found";
 
 let cachedClerkProvider: {
   ClerkProvider: React.ComponentType<{ children?: React.ReactNode } & Record<string, unknown>>;
@@ -1884,20 +1885,11 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
       logger.warn(`Failed to render custom 404 page: ${error}`);
     }
 
-    // Fallback to default styled 404 page
-    const defaultContent = `
-      <div style="display:flex;flex-direction:column;align-items:center;justify-content:center;min-height:100vh;font-family:system-ui,-apple-system,sans-serif;background:#f9fafb;padding:20px;text-align:center;">
-        <div style="background:white;border-radius:12px;padding:48px;box-shadow:0 4px 6px rgba(0,0,0,0.1);max-width:500px;width:100%;">
-          <h1 style="font-size:96px;font-weight:bold;color:#22c55e;margin:0 0 16px;line-height:1;">404</h1>
-          <h2 style="font-size:24px;font-weight:600;color:#1f2937;margin:0 0 16px;">Page Not Found</h2>
-          <p style="font-size:16px;color:#6b7280;margin:0 0 24px;">
-            The page <code style="background:#f3f4f6;padding:2px 6px;border-radius:4px;">${pathname}</code> doesn't exist.
-          </p>
-          <a href="/" style="display:inline-block;background:#22c55e;color:white;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:500;">Go Home</a>
-        </div>
-        <p style="margin-top:24px;font-size:14px;color:#9ca3af;">Powered by Farm.js</p>
-      </div>
-    `;
+    // Render the shared adaptive fallback when the app does not provide its own page.
+    const ReactDOMServer = await import("react-dom/server");
+    const defaultContent = ReactDOMServer.renderToString(
+      React.createElement(DefaultNotFoundPage, { pathname }),
+    );
 
     const html = this.createFullHTML(defaultContent, false, pathname);
     res.setHeader("Content-Type", "text/html; charset=utf-8");


### PR DESCRIPTION
## What

- replace the green inline fallback with a centered `404`, a compact `Not found` description, and one flat square `Go home` action
- give the number a neutral outlined, hard-offset treatment and frame the description with subtle technical divider lines
- share the same fallback between the reusable component, dev renderer, and generated production server
- support system dark mode plus common class and data-attribute theme overrides
- retain visible keyboard focus, touch-safe sizing, restrained hover/press feedback, and reduced-motion support

## Why

The existing default 404 uses fixed green and light-only styles. The replacement stays neutral enough for any Farm application while adding more technical character than a plain centered error page.

## Impact

Applications without a custom not-found component receive an adaptive, compact recovery page with a distinctive but unbranded visual treatment. Custom 404 components are unchanged.

## Validation

- `pnpm --dir packages/farm exec vitest run src/__tests__/not-found.test.tsx` (3 tests passed)
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --dir packages/farm exec tsc --noEmit` (passed)
- `pnpm exec oxfmt --check ...` (passed)
- `pnpm exec oxlint ...` (0 errors and 0 warnings in the changed files)
- browser-checked light, dark, and 390×844 mobile layouts with no overflow, error overlay, or console errors
- verified the square button has no box shadow, theme colors adapt correctly, and the home action navigates to `/`
- ESM and CJS package bundles build successfully; the declaration worker later reaches its heap limit under Node 23, while the standalone TypeScript check passes
