### PR TITLE
feat: add production lifecycle management

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -224,6 +224,14 @@ export default defineConfig({
   server: {
     bodySizeLimit: "10mb",
     trustProxy: false,
+    headersTimeout: "60s",
+    requestTimeout: "5m",
+    keepAliveTimeout: "5s",
+    gracefulShutdownTimeout: "30s",
+    health: {
+      livenessPath: "/_farm/health/live",
+      readinessPath: "/_farm/health/ready",
+    },
   },
 });
 ```
@@ -233,6 +241,17 @@ Farm checks `Content-Length` when present and also counts the received bytes, so
 `trustProxy` defaults to `false`. Enable it only when the app is behind a trusted reverse proxy that removes client-supplied forwarding headers and writes its own `X-Forwarded-For` value. A directly exposed Farm server must leave it disabled so a client cannot spoof the address used by rate limits, logs, or access policy.
 
 Workflow runner secrets are accepted only through `Authorization: Bearer <secret>` or `X-Farm-Workflow-Secret`. Farm does not accept secrets in query strings because URLs are commonly retained in logs, browser history, and referrer data.
+
+The long-running Node adapter applies `headersTimeout`, `requestTimeout`, and `keepAliveTimeout` to its HTTP server. `headersTimeout` limits how long a client can occupy a connection while sending headers, and `requestTimeout` limits receipt of the complete request. These are transport timeouts, not limits on route-handler or database execution. Durations accept milliseconds or strings such as `"15s"`, `"2m"`, and `"1h"`.
+
+On `SIGTERM` or `SIGINT`, Node output immediately fails readiness, stops accepting connections, drains active responses and streams through Nitro, and then runs Farm integration and plugin cleanup. `gracefulShutdownTimeout` is the maximum drain period before remaining connections are forced closed. The process starts plugin and integration runtime state before it begins listening, so a successful readiness response means startup completed.
+
+Farm exposes two non-cacheable production health handlers by default:
+
+- `GET /_farm/health/live` reports whether the process is alive. It stays successful while the process drains.
+- `GET /_farm/health/ready` reports whether the instance should receive traffic. It returns `503` before startup completes and after shutdown begins.
+
+Customize both paths through `server.health`, or set `health: false` when an adapter supplies its own probes. Long-running Node output guarantees the shutdown sequence. Request-driven serverless and edge environments may not expose a reliable process shutdown event, so cleanup there remains platform-specific and must not be required for data correctness.
 
 ## Server action security
 

--- a/docs/src/app/docs/plugins/create-plugin/page.md
+++ b/docs/src/app/docs/plugins/create-plugin/page.md
@@ -356,7 +356,7 @@ Development hooks are not bundled into the production request lifecycle.
 
 ## Start and close resources
 
-Use `runtime.start` for runtime-only startup and `runtime.close` for best-effort cleanup.
+Use `runtime.start` for runtime-only startup and `runtime.close` for plugin cleanup. Long-running Node output completes startup before listening and invokes close after active requests and streams drain.
 
 ```ts
 export const queuePlugin = definePlugin({
@@ -379,7 +379,23 @@ export const queuePlugin = definePlugin({
 });
 ```
 
-Farm starts the runtime lazily in production. Some serverless hosts do not expose a shutdown event, so correctness must not depend solely on `runtime.close`.
+Use `context.lifecycle.onShutdown()` when setup creates a resource that should be disposed independently of the plugin's structured runtime hooks:
+
+```ts
+export const redisPlugin = definePlugin({
+  name: "acme:redis",
+
+  setup({ lifecycle }) {
+    const redis = createRedisClient();
+    lifecycle.onShutdown(() => redis.quit());
+    return { redis };
+  },
+});
+```
+
+Farm runs registered disposers once, in reverse registration order, after attempting every plugin shutdown hook. One failing hook does not prevent later hooks or resource disposers from running.
+
+Request-driven serverless and edge hosts may initialize lazily and may not expose a reliable shutdown event. Correctness must not depend solely on cleanup hooks there; use transactions, leases, and idempotent queue handling for externally visible work.
 
 ## Context rules
 

--- a/docs/src/app/docs/plugins/page.md
+++ b/docs/src/app/docs/plugins/page.md
@@ -153,14 +153,14 @@ Both hooks receive Farm's plugin context. `setup` additionally receives the reso
 
 ### Runtime hooks
 
-| Hook              | Runs                                                         | May return                                                       |
-| ----------------- | ------------------------------------------------------------ | ---------------------------------------------------------------- |
-| `runtime.start`   | Once when the runtime manager starts.                        | Nothing.                                                         |
-| `runtime.context` | At the start of every request.                               | A plain object merged into typed request `ctx`.                  |
-| `runtime.before`  | Before Farm invokes the matched handler.                     | A replacement `Request`, a short-circuit `Response`, or nothing. |
-| `runtime.after`   | After a handler or short circuit produces a response.        | A replacement `Response` or nothing.                             |
-| `runtime.error`   | When runtime context, before, handler, or after work throws. | Nothing.                                                         |
-| `runtime.close`   | During best-effort runtime shutdown.                         | Nothing.                                                         |
+| Hook              | Runs                                                             | May return                                                       |
+| ----------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `runtime.start`   | Once when the runtime manager starts.                            | Nothing.                                                         |
+| `runtime.context` | At the start of every request.                                   | A plain object merged into typed request `ctx`.                  |
+| `runtime.before`  | Before Farm invokes the matched handler.                         | A replacement `Request`, a short-circuit `Response`, or nothing. |
+| `runtime.after`   | After a handler or short circuit produces a response.            | A replacement `Response` or nothing.                             |
+| `runtime.error`   | When runtime context, before, handler, or after work throws.     | Nothing.                                                         |
+| `runtime.close`   | During graceful shutdown in long-running Node output.             | Nothing.                                                         |
 
 Runtime hooks apply to page, API, server-action, integration, docs, asset, and general requests. Use the event's `kind` and `route` values when behavior should apply only to part of the application.
 
@@ -342,7 +342,7 @@ The Node-specific `beforeRequest` and `afterResponse` hooks remain available as 
 - Never place credentials or secrets in page-exposed request data.
 - Use `waitUntil()` only for work that may safely outlive the response.
 - Make `runtime.error` resilient; an error reporter must not hide the original failure.
-- Release timers, sockets, and watchers in `runtime.close` when the host exposes shutdown.
+- Release timers, sockets, and watchers in `runtime.close`. Long-running Node output invokes it for handled shutdown signals; serverless and edge hosts remain platform-specific.
 - Test server and client hook ordering, short circuits, transformed bodies and headers, context collisions, hydration, SPA navigation, and production output.
 
 Continue with [Create a Plugin](/docs/plugins/create-plugin) for complete examples.

--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -314,6 +314,15 @@ describe("resolveConfig", () => {
     expect(defaults.server).toEqual({
       bodySizeLimit: 10_000_000,
       trustProxy: false,
+      headersTimeout: 60_000,
+      requestTimeout: 300_000,
+      keepAliveTimeout: 5_000,
+      gracefulShutdownTimeout: 30_000,
+      health: {
+        enabled: true,
+        livenessPath: "/_farm/health/live",
+        readinessPath: "/_farm/health/ready",
+      },
     });
     expect(defaults.serverActions).toEqual({
       allowedOrigins: [],
@@ -340,6 +349,9 @@ describe("resolveConfig", () => {
         server: {
           bodySizeLimit: "25mb",
           trustProxy: true,
+          headersTimeout: "10s",
+          requestTimeout: "1m",
+          gracefulShutdownTimeout: "20s",
         },
       },
       "production",
@@ -347,6 +359,15 @@ describe("resolveConfig", () => {
     expect(server.server).toEqual({
       bodySizeLimit: 25_000_000,
       trustProxy: true,
+      headersTimeout: 10_000,
+      requestTimeout: 60_000,
+      keepAliveTimeout: 5_000,
+      gracefulShutdownTimeout: 20_000,
+      health: {
+        enabled: true,
+        livenessPath: "/_farm/health/live",
+        readinessPath: "/_farm/health/ready",
+      },
     });
   });
 

--- a/packages/farm/src/__tests__/node-server-entry.test.ts
+++ b/packages/farm/src/__tests__/node-server-entry.test.ts
@@ -23,7 +23,10 @@ describe("Farm production Node entry", () => {
     expect(source).toContain("server.headersTimeout = farmServerConfig.headersTimeout");
     expect(source).toContain("server.requestTimeout = farmServerConfig.requestTimeout");
     expect(source).toContain("server.keepAliveTimeout = farmServerConfig.keepAliveTimeout");
-    expect(source).toContain("await farmProductionLifecycle.start()");
+    expect(source).toContain("startupSignalPromise");
+    expect(source).toContain("await Promise.race([");
+    expect(source).toContain("() => farmProductionLifecycle.start()");
+    expect(source).toContain("Runtime shutdown during startup timed out");
     expect(source).toContain("farmProductionLifecycle.beginDrain(signal)");
     expect(source).toContain('nitroApp.hooks.hook("close"');
     expect(source).toContain("process.env.NITRO_SHUTDOWN_TIMEOUT = String");

--- a/packages/farm/src/__tests__/node-server-entry.test.ts
+++ b/packages/farm/src/__tests__/node-server-entry.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment node
+
+import { transform } from "esbuild";
+import { describe, expect, it } from "vitest";
+import { createFarmNodeServerEntry } from "../nitro/node-server-entry";
+import { resolveFarmServerConfig } from "../server-http";
+
+describe("Farm production Node entry", () => {
+  it("configures timeouts, eager startup, draining, and shutdown disposal", async () => {
+    const source = createFarmNodeServerEntry({
+      nitroEntryFile: "nitro-entry.mjs",
+      nodeHandlerModule: "srvx/node",
+      server: resolveFarmServerConfig({
+        headersTimeout: "12s",
+        requestTimeout: "2m",
+        keepAliveTimeout: "8s",
+        gracefulShutdownTimeout: "40s",
+      }),
+      websocketAdapterModule: "crossws/adapters/node",
+    });
+
+    await expect(transform(source, { loader: "js", format: "esm" })).resolves.toBeDefined();
+    expect(source).toContain("server.headersTimeout = farmServerConfig.headersTimeout");
+    expect(source).toContain("server.requestTimeout = farmServerConfig.requestTimeout");
+    expect(source).toContain("server.keepAliveTimeout = farmServerConfig.keepAliveTimeout");
+    expect(source).toContain("await farmProductionLifecycle.start()");
+    expect(source).toContain("farmProductionLifecycle.beginDrain(signal)");
+    expect(source).toContain('nitroApp.hooks.hook("close"');
+    expect(source).toContain("process.env.NITRO_SHUTDOWN_TIMEOUT = String");
+    expect(source).toContain('from "./nitro-entry.mjs"');
+  });
+});

--- a/packages/farm/src/__tests__/plugin-lifecycle.test.ts
+++ b/packages/farm/src/__tests__/plugin-lifecycle.test.ts
@@ -13,6 +13,49 @@ function createManager() {
 }
 
 describe("plugin lifecycle hooks", () => {
+  it("runs every shutdown hook and registered disposer exactly once", async () => {
+    const manager = createManager();
+    const calls: string[] = [];
+
+    manager.addPlugin(
+      definePlugin({
+        name: "first-resource",
+        setup(context) {
+          context.lifecycle.onShutdown(() => {
+            calls.push("dispose:first");
+          });
+        },
+        shutdown() {
+          calls.push("shutdown:first");
+          throw new Error("first shutdown failed");
+        },
+      }),
+    );
+    manager.addPlugin(
+      definePlugin({
+        name: "second-resource",
+        setup(context) {
+          context.lifecycle.onShutdown(() => {
+            calls.push("dispose:second");
+          });
+        },
+        shutdown() {
+          calls.push("shutdown:second");
+        },
+      }),
+    );
+
+    await manager.startRuntime();
+    await expect(manager.closeRuntime("SIGTERM")).rejects.toMatchObject({
+      name: "FarmRuntimeShutdownError",
+    });
+    await expect(manager.closeRuntime("SIGINT")).rejects.toMatchObject({
+      name: "FarmRuntimeShutdownError",
+    });
+
+    expect(calls).toEqual(["shutdown:first", "shutdown:second", "dispose:second", "dispose:first"]);
+  });
+
   it("indexes request capabilities and invalidates them when plugins are added", () => {
     const manager = createManager();
 

--- a/packages/farm/src/__tests__/plugin-lifecycle.test.ts
+++ b/packages/farm/src/__tests__/plugin-lifecycle.test.ts
@@ -56,6 +56,36 @@ describe("plugin lifecycle hooks", () => {
     expect(calls).toEqual(["shutdown:first", "shutdown:second", "dispose:second", "dispose:first"]);
   });
 
+  it("routes direct shutdown hook calls through runtime cleanup", async () => {
+    const manager = createManager();
+    const calls: string[] = [];
+
+    manager.addPlugin(
+      definePlugin({
+        name: "direct-shutdown-resource",
+        setup({ lifecycle }) {
+          lifecycle.onShutdown(() => {
+            calls.push("dispose");
+          });
+        },
+        shutdown() {
+          calls.push("shutdown");
+          throw new Error("direct shutdown failed");
+        },
+      }),
+    );
+
+    await manager.startRuntime();
+    await expect(manager.runHookParallel("shutdown", { reason: "direct" })).rejects.toMatchObject({
+      name: "FarmRuntimeShutdownError",
+    });
+    await expect(manager.closeRuntime("second-close")).rejects.toMatchObject({
+      name: "FarmRuntimeShutdownError",
+    });
+
+    expect(calls).toEqual(["shutdown", "dispose"]);
+  });
+
   it("indexes request capabilities and invalidates them when plugins are added", () => {
     const manager = createManager();
 

--- a/packages/farm/src/__tests__/production-lifecycle.test.ts
+++ b/packages/farm/src/__tests__/production-lifecycle.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from "vitest";
+import { createFarmProductionLifecycle } from "../production-lifecycle";
+import { resolveFarmServerConfig } from "../server-http";
+
+describe("Farm production lifecycle", () => {
+  it("starts once and exposes separate liveness and readiness responses", async () => {
+    const start = vi.fn(async () => {});
+    const lifecycle = createFarmProductionLifecycle({
+      server: resolveFarmServerConfig(undefined),
+      start,
+    });
+
+    const liveness = await lifecycle.handleHealthRequest(
+      new Request("https://example.com/_farm/health/live"),
+    );
+    expect(liveness?.status).toBe(200);
+    expect(start).not.toHaveBeenCalled();
+
+    const readiness = await lifecycle.handleHealthRequest(
+      new Request("https://example.com/_farm/health/ready"),
+    );
+    expect(readiness?.status).toBe(200);
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(lifecycle.state).toBe("ready");
+
+    await lifecycle.start();
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails readiness and rejects new work while draining", async () => {
+    const handler = vi.fn(async () => new Response("should not run"));
+    const lifecycle = createFarmProductionLifecycle({
+      server: resolveFarmServerConfig(undefined),
+    });
+    lifecycle.beginDrain("SIGTERM");
+
+    const readiness = await lifecycle.handleHealthRequest(
+      new Request("https://example.com/_farm/health/ready"),
+    );
+    const liveness = await lifecycle.handleHealthRequest(
+      new Request("https://example.com/_farm/health/live"),
+    );
+    const response = await lifecycle.runRequest(handler);
+
+    expect(readiness?.status).toBe(503);
+    expect(readiness?.headers.get("retry-after")).toBe("1");
+    expect(liveness?.status).toBe(200);
+    expect(response.status).toBe(503);
+    expect(response.headers.get("connection")).toBe("close");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("tracks a streaming response until it closes", async () => {
+    const lifecycle = createFarmProductionLifecycle({
+      server: resolveFarmServerConfig(undefined),
+    });
+    const response = await lifecycle.runRequest(
+      () =>
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("hello"));
+              controller.close();
+            },
+          }),
+        ),
+    );
+
+    expect(lifecycle.activeRequests).toBe(1);
+    await expect(response.text()).resolves.toBe("hello");
+    expect(lifecycle.activeRequests).toBe(0);
+    await expect(lifecycle.waitForIdle(10)).resolves.toBe(true);
+  });
+
+  it("uses adapter completion notifications without consuming the response body", async () => {
+    const lifecycle = createFarmProductionLifecycle({
+      server: resolveFarmServerConfig(undefined),
+    });
+    let finishResponse: (() => void) | undefined;
+    const response = await lifecycle.runRequest(() => new Response("hello"), {
+      onResponseFinished(callback) {
+        finishResponse = callback;
+      },
+    });
+
+    expect(lifecycle.activeRequests).toBe(1);
+    await expect(response.text()).resolves.toBe("hello");
+    expect(lifecycle.activeRequests).toBe(1);
+    finishResponse?.();
+    expect(lifecycle.activeRequests).toBe(0);
+  });
+
+  it("closes the underlying runtime exactly once", async () => {
+    const close = vi.fn(async () => {});
+    const lifecycle = createFarmProductionLifecycle({
+      server: resolveFarmServerConfig(undefined),
+      close,
+    });
+    await lifecycle.start();
+
+    await Promise.all([lifecycle.close("SIGTERM"), lifecycle.close("SIGINT")]);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledWith("SIGTERM");
+    expect(lifecycle.state).toBe("closed");
+  });
+});

--- a/packages/farm/src/__tests__/production-lifecycle.test.ts
+++ b/packages/farm/src/__tests__/production-lifecycle.test.ts
@@ -29,6 +29,27 @@ describe("Farm production lifecycle", () => {
     expect(start).toHaveBeenCalledTimes(1);
   });
 
+  it("records synchronous startup failures and does not retry them", async () => {
+    const startError = new Error("synchronous startup failed");
+    const start = vi.fn(() => {
+      throw startError;
+    });
+    const lifecycle = createFarmProductionLifecycle({
+      server: resolveFarmServerConfig(undefined),
+      start,
+    });
+
+    await expect(lifecycle.start()).rejects.toBe(startError);
+    await expect(lifecycle.start()).rejects.toBe(startError);
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(lifecycle.state).toBe("failed");
+
+    const liveness = await lifecycle.handleHealthRequest(
+      new Request("https://example.com/_farm/health/live"),
+    );
+    expect(liveness?.status).toBe(503);
+  });
+
   it("fails readiness and rejects new work while draining", async () => {
     const handler = vi.fn(async () => new Response("should not run"));
     const lifecycle = createFarmProductionLifecycle({
@@ -92,6 +113,23 @@ describe("Farm production lifecycle", () => {
     expect(lifecycle.activeRequests).toBe(0);
   });
 
+  it("finishes tracking when a returned response body is already consumed or locked", async () => {
+    const lifecycle = createFarmProductionLifecycle({
+      server: resolveFarmServerConfig(undefined),
+    });
+    const consumedResponse = new Response("consumed");
+    await consumedResponse.text();
+
+    await expect(lifecycle.runRequest(() => consumedResponse)).resolves.toBe(consumedResponse);
+    expect(lifecycle.activeRequests).toBe(0);
+
+    const lockedResponse = new Response("locked");
+    const reader = lockedResponse.body!.getReader();
+    await expect(lifecycle.runRequest(() => lockedResponse)).resolves.toBe(lockedResponse);
+    expect(lifecycle.activeRequests).toBe(0);
+    reader.releaseLock();
+  });
+
   it("closes the underlying runtime exactly once", async () => {
     const close = vi.fn(async () => {});
     const lifecycle = createFarmProductionLifecycle({
@@ -101,6 +139,24 @@ describe("Farm production lifecycle", () => {
     await lifecycle.start();
 
     await Promise.all([lifecycle.close("SIGTERM"), lifecycle.close("SIGINT")]);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledWith("SIGTERM");
+    expect(lifecycle.state).toBe("closed");
+  });
+
+  it("memoizes synchronous close failures and still reaches closed", async () => {
+    const closeError = new Error("synchronous close failed");
+    const close = vi.fn(() => {
+      throw closeError;
+    });
+    const lifecycle = createFarmProductionLifecycle({
+      server: resolveFarmServerConfig(undefined),
+      close,
+    });
+    await lifecycle.start();
+
+    await expect(lifecycle.close("SIGTERM")).rejects.toBe(closeError);
+    await expect(lifecycle.close("SIGINT")).rejects.toBe(closeError);
     expect(close).toHaveBeenCalledTimes(1);
     expect(close).toHaveBeenCalledWith("SIGTERM");
     expect(lifecycle.state).toBe("closed");

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -341,6 +341,9 @@ export default function DynamicPage({ params }) {
       const nodeEnvBeforeBuild = process.env.NODE_ENV;
       await build(config, { root, preset: "node-server" });
       expect(process.env.NODE_ENV).toBe(nodeEnvBeforeBuild);
+      await expect(
+        fs.readFile(path.join(root, ".farm", "ssr", "nitro-entry.mjs"), "utf8"),
+      ).resolves.toContain("farmNitroApp.hooks.hook('close'");
 
       const clientBundle = await fs.readFile(
         path.join(root, ".farm", "client", "farm-client.js"),
@@ -567,6 +570,115 @@ export default defineConfig({
           "request:start",
           "request:finish",
           "runtime:closed:production-server-closed",
+          "resource:closed",
+        ]);
+      } finally {
+        if (productionServer.exitCode === null) productionServer.kill("SIGKILL");
+      }
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }, 120_000);
+
+  it("shuts down when SIGTERM interrupts runtime startup", async () => {
+    const root = await createProductionFixture();
+    const markerPath = path.join(root, "production-startup-signal.log");
+    const serverConfig = { gracefulShutdownTimeout: "500ms" as const };
+
+    try {
+      await fs.writeFile(
+        path.join(root, "farm.config.ts"),
+        `
+import { appendFile } from "node:fs/promises";
+import { defineConfig, definePlugin } from "@farm.js/core";
+
+const lifecyclePlugin = definePlugin({
+  name: "test:startup-signal",
+  setup({ lifecycle }) {
+    lifecycle.onShutdown(async () => {
+      await appendFile(${JSON.stringify(markerPath)}, "resource:closed\\n");
+    });
+  },
+  runtime: {
+    async start() {
+      await appendFile(${JSON.stringify(markerPath)}, "runtime:starting\\n");
+      await new Promise(() => setInterval(() => {}, 1_000));
+    },
+    async close({ reason }) {
+      await appendFile(${JSON.stringify(markerPath)}, \`runtime:closed:\${reason}\\n\`);
+    },
+  },
+});
+
+export default defineConfig({
+  images: { provider: "none" },
+  server: ${JSON.stringify(serverConfig)},
+  plugins: [lifecyclePlugin],
+});
+`.trim(),
+      );
+
+      const config = await resolveConfig(
+        {
+          root,
+          srcDir: "src",
+          images: { provider: "none" },
+          server: serverConfig,
+          plugins: [
+            definePlugin({
+              name: "test:startup-signal-build-marker",
+              runtime: {
+                start() {},
+                close() {},
+              },
+            }),
+          ],
+        },
+        "production",
+      );
+      await build(config, { root, preset: "node-server" });
+
+      const serverDir = path.join(root, ".farm", ".output", "server");
+      const output: string[] = [];
+      const productionServer = spawn(process.execPath, [path.join(serverDir, "index.mjs")], {
+        cwd: serverDir,
+        env: { ...process.env, HOST: "127.0.0.1", PORT: String(await getAvailablePort()) },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      productionServer.stdout.on("data", (chunk) => output.push(String(chunk)));
+      productionServer.stderr.on("data", (chunk) => output.push(String(chunk)));
+
+      try {
+        for (let attempt = 0; attempt < 100; attempt++) {
+          const marker = await fs.readFile(markerPath, "utf8").catch(() => "");
+          if (marker.includes("runtime:starting")) break;
+          if (productionServer.exitCode !== null) {
+            throw new Error(`Production server exited during startup:\n${output.join("")}`);
+          }
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        }
+        expect(await fs.readFile(markerPath, "utf8")).toContain("runtime:starting");
+
+        const exitPromise = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+          (resolve) => {
+            productionServer.once("exit", (code, signal) => resolve({ code, signal }));
+          },
+        );
+        productionServer.kill("SIGTERM");
+        const exit = await Promise.race([
+          exitPromise,
+          new Promise<never>((_resolve, reject) =>
+            setTimeout(
+              () => reject(new Error(`Production startup did not stop:\n${output.join("")}`)),
+              2_000,
+            ),
+          ),
+        ]);
+
+        expect(exit).toEqual({ code: 0, signal: null });
+        expect((await fs.readFile(markerPath, "utf8")).trim().split("\n")).toEqual([
+          "runtime:starting",
+          "runtime:closed:SIGTERM",
           "resource:closed",
         ]);
       } finally {

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -433,6 +433,150 @@ export default function DynamicPage({ params }) {
     }
   }, 120_000);
 
+  it("drains in-flight requests and closes production resources on SIGTERM", async () => {
+    const root = await createProductionFixture();
+    const markerPath = path.join(root, "production-lifecycle.log");
+    const apiDir = path.join(root, "src", "app", "api", "slow");
+    const serverConfig = {
+      gracefulShutdownTimeout: "3s" as const,
+      health: {
+        livenessPath: "/health/live",
+        readinessPath: "/health/ready",
+      },
+    };
+
+    try {
+      await fs.mkdir(apiDir, { recursive: true });
+      await fs.writeFile(
+        path.join(apiDir, "route.ts"),
+        `
+import { appendFile } from "node:fs/promises";
+import { setTimeout as delay } from "node:timers/promises";
+
+export async function GET() {
+  await appendFile(${JSON.stringify(markerPath)}, "request:start\\n");
+  await delay(300);
+  await appendFile(${JSON.stringify(markerPath)}, "request:finish\\n");
+  return new Response("drained response");
+}
+`.trim(),
+      );
+      await fs.writeFile(
+        path.join(root, "farm.config.ts"),
+        `
+import { appendFile } from "node:fs/promises";
+import { defineConfig, definePlugin } from "@farm.js/core";
+
+const lifecyclePlugin = definePlugin({
+  name: "test:production-lifecycle",
+  setup(context) {
+    context.lifecycle.onShutdown(async () => {
+      await appendFile(${JSON.stringify(markerPath)}, "resource:closed\\n");
+    });
+  },
+  runtime: {
+    async start() {
+      await appendFile(${JSON.stringify(markerPath)}, "runtime:ready\\n");
+    },
+    async close({ reason }) {
+      await appendFile(${JSON.stringify(markerPath)}, \`runtime:closed:\${reason}\\n\`);
+    },
+  },
+});
+
+export default defineConfig({
+  images: { provider: "none" },
+  server: ${JSON.stringify(serverConfig)},
+  plugins: [lifecyclePlugin],
+});
+`.trim(),
+      );
+
+      const config = await resolveConfig(
+        {
+          root,
+          srcDir: "src",
+          images: { provider: "none" },
+          server: serverConfig,
+          plugins: [
+            definePlugin({
+              name: "test:production-lifecycle-build-marker",
+              runtime: {
+                start() {},
+                close() {},
+              },
+            }),
+          ],
+        },
+        "production",
+      );
+      await build(config, { root, preset: "node-server" });
+
+      const serverDir = path.join(root, ".farm", ".output", "server");
+      const port = await getAvailablePort();
+      const output: string[] = [];
+      const productionServer = spawn(process.execPath, [path.join(serverDir, "index.mjs")], {
+        cwd: serverDir,
+        env: {
+          ...process.env,
+          HOST: "127.0.0.1",
+          PORT: String(port),
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      productionServer.stdout.on("data", (chunk) => output.push(String(chunk)));
+      productionServer.stderr.on("data", (chunk) => output.push(String(chunk)));
+
+      try {
+        const healthResponse = await waitForServer(
+          `http://127.0.0.1:${port}/health/ready`,
+          () => output.join(""),
+          () => productionServer.exitCode !== null,
+        );
+        expect(healthResponse.status).toBe(200);
+        await expect(healthResponse.json()).resolves.toMatchObject({ status: "ok" });
+
+        const request = fetch(`http://127.0.0.1:${port}/api/slow`);
+        for (let attempt = 0; attempt < 100; attempt++) {
+          const marker = await fs.readFile(markerPath, "utf8").catch(() => "");
+          if (marker.includes("request:start")) break;
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        }
+        expect(await fs.readFile(markerPath, "utf8")).toContain("request:start");
+
+        productionServer.kill("SIGTERM");
+        const response = await request;
+        expect(response.status).toBe(200);
+        await expect(response.text()).resolves.toBe("drained response");
+
+        const exit = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+          (resolve, reject) => {
+            const timeout = setTimeout(() => {
+              productionServer.kill("SIGKILL");
+              reject(new Error(`Production server did not shut down:\n${output.join("")}`));
+            }, 5_000);
+            productionServer.once("exit", (code, signal) => {
+              clearTimeout(timeout);
+              resolve({ code, signal });
+            });
+          },
+        );
+        expect(exit).toEqual({ code: 0, signal: null });
+        expect((await fs.readFile(markerPath, "utf8")).trim().split("\n")).toEqual([
+          "runtime:ready",
+          "request:start",
+          "request:finish",
+          "runtime:closed:production-server-closed",
+          "resource:closed",
+        ]);
+      } finally {
+        if (productionServer.exitCode === null) productionServer.kill("SIGKILL");
+      }
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }, 120_000);
+
   it("keeps standalone production API failures generic", async () => {
     const root = await createProductionFixture();
 

--- a/packages/farm/src/__tests__/server-http.test.ts
+++ b/packages/farm/src/__tests__/server-http.test.ts
@@ -14,11 +14,57 @@ describe("Farm server HTTP policy", () => {
     expect(resolveFarmServerConfig(undefined)).toEqual({
       bodySizeLimit: 10_000_000,
       trustProxy: false,
+      headersTimeout: 60_000,
+      requestTimeout: 300_000,
+      keepAliveTimeout: 5_000,
+      gracefulShutdownTimeout: 30_000,
+      health: {
+        enabled: true,
+        livenessPath: "/_farm/health/live",
+        readinessPath: "/_farm/health/ready",
+      },
     });
-    expect(resolveFarmServerConfig({ bodySizeLimit: "2 MiB", trustProxy: true })).toEqual({
+    expect(
+      resolveFarmServerConfig({
+        bodySizeLimit: "2 MiB",
+        trustProxy: true,
+        headersTimeout: "15s",
+        requestTimeout: "2m",
+        keepAliveTimeout: "10s",
+        gracefulShutdownTimeout: "45s",
+        health: {
+          livenessPath: "/health/live/",
+          readinessPath: "/health/ready/",
+        },
+      }),
+    ).toEqual({
       bodySizeLimit: 2_097_152,
       trustProxy: true,
+      headersTimeout: 15_000,
+      requestTimeout: 120_000,
+      keepAliveTimeout: 10_000,
+      gracefulShutdownTimeout: 45_000,
+      health: {
+        enabled: true,
+        livenessPath: "/health/live",
+        readinessPath: "/health/ready",
+      },
     });
+  });
+
+  it("rejects unsafe timeout and health configurations", () => {
+    expect(() => resolveFarmServerConfig({ headersTimeout: "2m", requestTimeout: "30s" })).toThrow(
+      "headersTimeout must not exceed",
+    );
+    expect(() => resolveFarmServerConfig({ requestTimeout: 0 })).toThrow(
+      "server.requestTimeout must be a positive safe integer",
+    );
+    expect(() =>
+      resolveFarmServerConfig({
+        health: { livenessPath: "/health", readinessPath: "/health" },
+      }),
+    ).toThrow("must be different");
+    expect(resolveFarmServerConfig({ health: false }).health.enabled).toBe(false);
   });
 
   it("rejects streamed Web request bodies above the limit", async () => {

--- a/packages/farm/src/__tests__/server-http.test.ts
+++ b/packages/farm/src/__tests__/server-http.test.ts
@@ -59,11 +59,26 @@ describe("Farm server HTTP policy", () => {
     expect(() => resolveFarmServerConfig({ requestTimeout: 0 })).toThrow(
       "server.requestTimeout must be a positive safe integer",
     );
+    expect(() => resolveFarmServerConfig({ gracefulShutdownTimeout: 2_147_483_648 })).toThrow(
+      "server.gracefulShutdownTimeout must not exceed 2147483647 milliseconds",
+    );
+    expect(() => resolveFarmServerConfig({ gracefulShutdownTimeout: "597h" })).toThrow(
+      "server.gracefulShutdownTimeout must not exceed 2147483647 milliseconds",
+    );
     expect(() =>
       resolveFarmServerConfig({
         health: { livenessPath: "/health", readinessPath: "/health" },
       }),
     ).toThrow("must be different");
+    expect(
+      resolveFarmServerConfig({
+        health: { livenessPath: "///", readinessPath: "/health/ready" },
+      }).health,
+    ).toEqual({
+      enabled: true,
+      livenessPath: "/",
+      readinessPath: "/health/ready",
+    });
     expect(resolveFarmServerConfig({ health: false }).health.enabled).toBe(false);
   });
 

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -112,7 +112,13 @@ export type {
   FarmServerActionsConfig,
   ResolvedFarmServerActionsConfig,
 } from "./server-action-security";
-export type { FarmServerConfig, ResolvedFarmServerConfig } from "./server-http";
+export type {
+  FarmServerConfig,
+  FarmServerDuration,
+  FarmServerHealthConfig,
+  ResolvedFarmServerConfig,
+  ResolvedFarmServerHealthConfig,
+} from "./server-http";
 export type { FarmLayerEntry, ResolvedFarmLayer } from "./layers";
 export type {
   FarmDevtoolsConfig,

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -7,7 +7,7 @@ export * from "./integration-api";
 export { createFarmApp } from "./app";
 export { FarmProvider } from "./provider";
 export { getCurrentRequest } from "./server/request";
-export { definePlugin, PluginManager } from "./plugin";
+export { definePlugin, FarmRuntimeShutdownError, PluginManager } from "./plugin";
 export {
   defineConfig,
   defineFarmConfig,
@@ -170,6 +170,7 @@ export type {
   PluginRequestContext,
   FarmPlugin,
   FarmPluginContext,
+  FarmPluginLifecycle,
   FarmRequestPluginContext,
   FarmRequestStore,
   FarmPluginRuntimeKind,
@@ -225,6 +226,11 @@ export type {
   ResolvedFarmI18nConfig,
   FarmServerActionsConfig,
   ResolvedFarmServerActionsConfig,
+  FarmServerConfig,
+  FarmServerDuration,
+  FarmServerHealthConfig,
+  ResolvedFarmServerConfig,
+  ResolvedFarmServerHealthConfig,
   OpenAPIConfig,
   MiddlewareConfig,
   FarmDeployConfig,

--- a/packages/farm/src/nitro/node-server-entry.ts
+++ b/packages/farm/src/nitro/node-server-entry.ts
@@ -1,0 +1,137 @@
+import type { ResolvedFarmServerConfig } from "../server-http";
+
+export interface FarmNodeServerEntryOptions {
+  nitroEntryFile: string;
+  nodeHandlerModule: string;
+  server: ResolvedFarmServerConfig;
+  websocketAdapterModule: string;
+}
+
+/** Generate the long-running Node adapter entry while retaining Nitro's routing runtime. */
+export function createFarmNodeServerEntry(options: FarmNodeServerEntryOptions): string {
+  const serverConfig = JSON.stringify(options.server);
+  const nitroEntryImport = `./${options.nitroEntryFile.replace(/^\.\//, "")}`;
+
+  return `
+import "#nitro-internal-pollyfills";
+import { Server as HttpServer } from "node:http";
+import { Server as HttpsServer } from "node:https";
+import wsAdapter from ${JSON.stringify(options.websocketAdapterModule)};
+import { toNodeHandler } from ${JSON.stringify(options.nodeHandlerModule)};
+import { useNitroApp, useRuntimeConfig } from "nitro/runtime";
+import {
+  getGracefulShutdownConfig,
+  setupGracefulShutdown,
+  startScheduleRunner,
+  trapUnhandledNodeErrors,
+} from "nitro/runtime/internal";
+import { farmProductionLifecycle } from ${JSON.stringify(nitroEntryImport)};
+
+const farmServerConfig = ${serverConfig};
+if (!process.env.NITRO_SHUTDOWN_TIMEOUT) {
+  process.env.NITRO_SHUTDOWN_TIMEOUT = String(farmServerConfig.gracefulShutdownTimeout);
+}
+const shutdownConfig = getGracefulShutdownConfig();
+
+const nitroApp = useNitroApp();
+nitroApp.hooks.hook("close", async () => {
+  try {
+    await farmProductionLifecycle.close("production-server-closed");
+  } catch (error) {
+    process.exitCode = 1;
+    throw error;
+  }
+});
+
+let startupSignal;
+const startupSignalListeners = new Map();
+if (!shutdownConfig.disabled) {
+  for (const signal of shutdownConfig.signals) {
+    const listener = (receivedSignal) => {
+      startupSignal ||= receivedSignal;
+      farmProductionLifecycle.beginDrain(receivedSignal);
+    };
+    startupSignalListeners.set(signal, listener);
+    process.once(signal, listener);
+  }
+}
+
+try {
+  await farmProductionLifecycle.start();
+} catch (error) {
+  await farmProductionLifecycle.close("production-start-failed").catch((closeError) => {
+    console.error("[Farm] Runtime cleanup after startup failure failed:", closeError);
+  });
+  throw error;
+} finally {
+  for (const [signal, listener] of startupSignalListeners) {
+    process.removeListener(signal, listener);
+  }
+}
+
+if (startupSignal) {
+  try {
+    await farmProductionLifecycle.close(startupSignal);
+  } catch (error) {
+    console.error("[Farm] Runtime shutdown during startup failed:", error);
+    process.exitCode = 1;
+  }
+  process.exit(process.exitCode || 0);
+}
+
+const cert = process.env.NITRO_SSL_CERT;
+const key = process.env.NITRO_SSL_KEY;
+const server = cert && key
+  ? new HttpsServer({ key, cert }, toNodeHandler(nitroApp.fetch))
+  : new HttpServer(toNodeHandler(nitroApp.fetch));
+
+server.headersTimeout = farmServerConfig.headersTimeout;
+server.requestTimeout = farmServerConfig.requestTimeout;
+server.keepAliveTimeout = farmServerConfig.keepAliveTimeout;
+
+if (!shutdownConfig.disabled) {
+  for (const signal of shutdownConfig.signals) {
+    process.once(signal, () => farmProductionLifecycle.beginDrain(signal));
+  }
+}
+
+const configuredPort = Number(process.env.NITRO_PORT || process.env.PORT);
+const port = Number.isFinite(configuredPort) && configuredPort > 0 ? configuredPort : 3000;
+const host = process.env.NITRO_HOST || process.env.HOST;
+const socketPath = process.env.NITRO_UNIX_SOCKET;
+const listener = server.listen(socketPath ? { path: socketPath } : { port, host }, () => {
+  const protocol = cert && key ? "https" : "http";
+  const addressInfo = listener.address();
+  if (typeof addressInfo === "string") {
+    console.log(\`Listening on unix socket \${addressInfo}\`);
+    return;
+  }
+  if (!addressInfo) return;
+  const configuredBaseURL = useRuntimeConfig().app.baseURL || "";
+  const baseURL = configuredBaseURL.endsWith("/") ? configuredBaseURL.slice(0, -1) : configuredBaseURL;
+  const address = addressInfo.family === "IPv6" ? \`[\${addressInfo.address}]\` : addressInfo.address;
+  console.log(\`Listening on \${protocol}://\${address}:\${addressInfo.port}\${baseURL}\`);
+});
+
+server.once("error", async (error) => {
+  console.error(error);
+  process.exitCode = 1;
+  await farmProductionLifecycle.close("production-listen-error").catch((closeError) => {
+    console.error("[Farm] Runtime cleanup after listen failure failed:", closeError);
+  });
+});
+
+trapUnhandledNodeErrors();
+setupGracefulShutdown(listener, nitroApp);
+
+if (import.meta._websocket) {
+  const { handleUpgrade } = wsAdapter(nitroApp.h3App.websocket);
+  server.on("upgrade", handleUpgrade);
+}
+if (import.meta._tasks) {
+  startScheduleRunner();
+}
+
+export default {};
+  `.trim();
+}

--- a/packages/farm/src/nitro/node-server-entry.ts
+++ b/packages/farm/src/nitro/node-server-entry.ts
@@ -44,11 +44,18 @@ nitroApp.hooks.hook("close", async () => {
 });
 
 let startupSignal;
+let resolveStartupSignal;
+const startupSignalPromise = new Promise((resolve) => {
+  resolveStartupSignal = resolve;
+});
 const startupSignalListeners = new Map();
 if (!shutdownConfig.disabled) {
   for (const signal of shutdownConfig.signals) {
     const listener = (receivedSignal) => {
-      startupSignal ||= receivedSignal;
+      if (!startupSignal) {
+        startupSignal = receivedSignal;
+        resolveStartupSignal(receivedSignal);
+      }
       farmProductionLifecycle.beginDrain(receivedSignal);
     };
     startupSignalListeners.set(signal, listener);
@@ -57,7 +64,10 @@ if (!shutdownConfig.disabled) {
 }
 
 try {
-  await farmProductionLifecycle.start();
+  await Promise.race([
+    Promise.resolve().then(() => farmProductionLifecycle.start()),
+    startupSignalPromise,
+  ]);
 } catch (error) {
   await farmProductionLifecycle.close("production-start-failed").catch((closeError) => {
     console.error("[Farm] Runtime cleanup after startup failure failed:", closeError);
@@ -70,10 +80,25 @@ try {
 }
 
 if (startupSignal) {
-  try {
-    await farmProductionLifecycle.close(startupSignal);
-  } catch (error) {
-    console.error("[Farm] Runtime shutdown during startup failed:", error);
+  let startupCloseTimer;
+  const startupCloseCompleted = await Promise.race([
+    Promise.resolve()
+      .then(() => farmProductionLifecycle.close(startupSignal))
+      .then(
+        () => true,
+        (error) => {
+          console.error("[Farm] Runtime shutdown during startup failed:", error);
+          process.exitCode = 1;
+          return true;
+        },
+      ),
+    new Promise((resolve) => {
+      startupCloseTimer = setTimeout(() => resolve(false), farmServerConfig.gracefulShutdownTimeout);
+    }),
+  ]);
+  clearTimeout(startupCloseTimer);
+  if (!startupCloseCompleted) {
+    console.error("[Farm] Runtime shutdown during startup timed out");
     process.exitCode = 1;
   }
   process.exit(process.exitCode || 0);

--- a/packages/farm/src/nitro/production-runtime.ts
+++ b/packages/farm/src/nitro/production-runtime.ts
@@ -4,6 +4,7 @@ export {
   createFarmRequestBodyErrorResponse,
   resolveFarmServerConfig,
 } from "../server-http";
+export { createFarmProductionLifecycle } from "../production-lifecycle";
 export { _runWithCurrentRequest, getCurrentRequest } from "../server/request";
 export {
   configureFarmCache,

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -52,6 +52,7 @@ import {
 import type { FarmRouteRuntimeManifest, FarmRouteRuntimeManifestEntry } from "../route-runtime";
 import { createFarmVercelRouteRuntimeFunctions } from "./vercel-route-runtime";
 import { createFarmVercelImmutableAssetRoute } from "./vercel-assets";
+import { createFarmNodeServerEntry } from "./node-server-entry";
 import { readFarmI18nCatalogs } from "../i18n/catalog";
 import type { FarmI18nCatalogs } from "../i18n/types";
 import { getFarmIntegrationPluginServerRuntime } from "../integrations";
@@ -147,6 +148,18 @@ const NITRO_EXTERNAL_MODULES = new Set([
 const FARM_SSR_PACKAGE_IMPORT = "#farm-ssr-entry";
 const FARM_SSR_OUTPUT_DIR = "farm-ssr";
 const FARM_CLIENT_BUILD_TARGET = ["es2020", "edge88", "firefox78", "chrome87", "safari14"];
+
+function resolveNitroRuntimeDependency(root: string, specifier: string): string {
+  const projectRequire = createRequire(path.join(root, "package.json"));
+  let runtimeRequire = projectRequire;
+  try {
+    runtimeRequire = createRequire(projectRequire.resolve("@farm.js/core"));
+  } catch {
+    // Source-only framework builds can resolve Nitro directly from the project.
+  }
+  const nitroEntry = runtimeRequire.resolve("nitro");
+  return createRequire(nitroEntry).resolve(specifier).split(path.sep).join("/");
+}
 
 function cloneConfigValue<T>(value: T, seen = new WeakMap<object, unknown>()): T {
   if (value === null || typeof value !== "object") return value;
@@ -3107,6 +3120,7 @@ function generateVirtualEntryCode(
   configureFarmObservability,
   createFarmCacheKey,
   createFarmLocaleCookie,
+  createFarmProductionLifecycle,
   createProductionMiddlewareRunner,
   emitFarmEvent,
   getFarmDataCache,
@@ -3368,6 +3382,11 @@ configureFarmObservability(farmObservabilityConfig);
 configureFarmCache(farmResolvedRuntimeConfig.cache);
 const farmI18nConfig = ${JSON.stringify(config.i18n)};
 const farmServerConfig = ${JSON.stringify(config.server)};
+export const farmProductionLifecycle = createFarmProductionLifecycle({
+  server: farmServerConfig,
+  start: () => farmPluginRuntime?.startRuntime(),
+  close: (reason) => farmPluginRuntime?.closeRuntime(reason),
+});
 const farmI18nRuntime = ${
     config.i18n.enabled
       ? `createFarmI18nRuntime(farmI18nConfig, ${JSON.stringify(i18nCatalogs)})`
@@ -5724,30 +5743,39 @@ async function applyFarmPreloadBudget(response, pathname) {
 
 // Export as Web Standard fetch API
 export async function fetch(request, context) {
-  const runtimeOptions = farmPluginRuntime ? getFarmPluginRequestOptions(request) : null;
-  const runRequest = () => farmPluginRuntime
-    ? farmPluginRuntime.runRuntimeRequest(
-      request,
-        (runtimeRequest) =>
-          _runWithCurrentRequest(runtimeRequest, () =>
-            handleFarmPluginRequest(runtimeRequest, runtimeOptions)
-          ),
-        {
-          ...runtimeOptions,
-          waitUntil: typeof context?.waitUntil === "function"
-            ? context.waitUntil.bind(context)
-            : undefined,
-        },
-      )
-    : handleFarmRequest(request);
+  const healthResponse = await farmProductionLifecycle.handleHealthRequest(request);
+  if (healthResponse) return healthResponse;
 
-  const response = await _runWithCurrentRequest(request, () =>
-    _runWithAfterRequest(request, runRequest, context),
-  );
-  const pathname = new URL(request.url).pathname;
-  return applyFarmPreloadBudget(applyConfiguredResponseHeaders(response, pathname), pathname);
+  return farmProductionLifecycle.runRequest(async () => {
+    const runtimeOptions = farmPluginRuntime ? getFarmPluginRequestOptions(request) : null;
+    const runRequest = () => farmPluginRuntime
+      ? farmPluginRuntime.runRuntimeRequest(
+        request,
+          (runtimeRequest) =>
+            _runWithCurrentRequest(runtimeRequest, () =>
+              handleFarmPluginRequest(runtimeRequest, runtimeOptions)
+            ),
+          {
+            ...runtimeOptions,
+            waitUntil: typeof context?.waitUntil === "function"
+              ? context.waitUntil.bind(context)
+              : undefined,
+          },
+        )
+      : handleFarmRequest(request);
+
+    const response = await _runWithCurrentRequest(request, () =>
+      _runWithAfterRequest(request, runRequest, context),
+    );
+    const pathname = new URL(request.url).pathname;
+    return applyFarmPreloadBudget(applyConfiguredResponseHeaders(response, pathname), pathname);
+  }, {
+    onResponseFinished: typeof context?.onResponseFinished === "function"
+      ? context.onResponseFinished
+      : undefined,
+  });
 }
-export default { fetch };
+export default { fetch, lifecycle: farmProductionLifecycle };
   `.trim();
 }
 
@@ -6088,7 +6116,9 @@ async function buildNitroUniversal(
 // Farm.js Nitro Entry
 // This file adapts Farm's Web fetch handler to Nitro's event handler contract.
 
-import handler from './${ssrEntryFile}'
+import handler, { farmProductionLifecycle } from './${ssrEntryFile}'
+
+export { farmProductionLifecycle }
 
 function mergeVaryHeaders(target, source) {
   const values = new Set(
@@ -6141,6 +6171,19 @@ export default async function farmNitroEventHandler(event) {
   `.trim();
 
   await fs.writeFile(nitroEntryPath, nitroEntryCode);
+  const farmNodeServerEntryPath =
+    preset === "node-server" ? path.join(ssrOutputDir, "farm-node-server-entry.mjs") : null;
+  if (farmNodeServerEntryPath) {
+    await fs.writeFile(
+      farmNodeServerEntryPath,
+      createFarmNodeServerEntry({
+        nitroEntryFile: path.basename(nitroEntryPath),
+        nodeHandlerModule: resolveNitroRuntimeDependency(root, "srvx/node"),
+        server: config.server,
+        websocketAdapterModule: resolveNitroRuntimeDependency(root, "crossws/adapters/node"),
+      }),
+    );
+  }
   const prebuiltSSRPlugin = createExternalSSRBundlePlugin(
     nitroEntryPath,
     ssrOutputDir,
@@ -6166,6 +6209,7 @@ export default async function farmNitroEventHandler(event) {
 
   let nitroConfig: NitroConfig = {
     preset,
+    ...(farmNodeServerEntryPath ? { entry: farmNodeServerEntryPath } : {}),
     rootDir: root,
     srcDir: root,
     buildDir: path.join(root, distDir, ".nitro"),
@@ -6352,6 +6396,14 @@ export default async function farmNitroEventHandler(event) {
 
   // Build with Nitro
   const nitroInstance = await nitro.createNitro(nitroConfig);
+  if (farmNodeServerEntryPath) {
+    // The custom entry is only for the final long-running Node server. Nitro
+    // derives its prerenderer config from this config, so remove the override
+    // and let the nitro-prerender preset provide appFetch/closePrerenderer.
+    nitroInstance.hooks.hook("prerender:config", (prerendererConfig) => {
+      delete prerendererConfig.entry;
+    });
+  }
   await nitro.prepare(nitroInstance);
   await nitro.copyPublicAssets(nitroInstance);
   if (prerenderRoutes.length > 0 && canReusePrebuiltSSR) {

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -6116,9 +6116,15 @@ async function buildNitroUniversal(
 // Farm.js Nitro Entry
 // This file adapts Farm's Web fetch handler to Nitro's event handler contract.
 
+import { useNitroApp } from 'nitro/runtime'
 import handler, { farmProductionLifecycle } from './${ssrEntryFile}'
 
 export { farmProductionLifecycle }
+
+const farmNitroApp = useNitroApp()
+farmNitroApp.hooks.hook('close', () =>
+  farmProductionLifecycle.close('production-server-closed')
+)
 
 function mergeVaryHeaders(target, source) {
   const values = new Set(

--- a/packages/farm/src/plugin.ts
+++ b/packages/farm/src/plugin.ts
@@ -13,6 +13,16 @@ import {
 
 type MaybePromise<T> = T | Promise<T>;
 
+export class FarmRuntimeShutdownError extends Error {
+  readonly errors: readonly unknown[];
+
+  constructor(message: string, errors: readonly unknown[]) {
+    super(message);
+    this.name = "FarmRuntimeShutdownError";
+    this.errors = errors;
+  }
+}
+
 export interface PluginRequestContext {
   set: (
     target: FarmRequest | Request,
@@ -41,8 +51,18 @@ export interface FarmPluginContext {
   viteServer?: ViteDevServer;
   isDev: boolean;
   isProd: boolean;
+  /** Register resource cleanup that must run when the application runtime closes. */
+  lifecycle: FarmPluginLifecycle;
   /** @deprecated Use `ctx.req` inside request hooks. */
   requestContext: PluginRequestContext;
+}
+
+export interface FarmPluginLifecycle {
+  /**
+   * Register a database, storage, queue, or other resource disposer.
+   * Disposers run once in reverse registration order after plugin shutdown hooks.
+   */
+  onShutdown(dispose: () => void | Promise<void>): () => void;
 }
 
 export interface FarmRequestPluginContext extends FarmPluginContext {
@@ -430,12 +450,32 @@ export class PluginManager {
   private runtimeClosed = false;
   private runtimeStartPromise?: Promise<void>;
   private runtimeClosePromise?: Promise<void>;
+  private runtimeDisposers: Array<() => void | Promise<void>> = [];
   private runtimeRequestContexts = new WeakMap<Request, Readonly<Record<string, unknown>>>();
   private failedRuntimeSessions = new WeakSet<FarmPluginRuntimeSession>();
 
-  constructor(context: Omit<FarmPluginContext, "requestContext">) {
+  constructor(context: Omit<FarmPluginContext, "requestContext" | "lifecycle">) {
     this.context = {
       ...context,
+      lifecycle: {
+        onShutdown: (dispose) => {
+          if (typeof dispose !== "function") {
+            throw new TypeError("Farm lifecycle.onShutdown requires a cleanup function");
+          }
+          if (this.runtimeClosePromise || this.runtimeClosed) {
+            throw new Error("Farm runtime cleanup cannot be registered after shutdown begins");
+          }
+
+          this.runtimeDisposers.push(dispose);
+          let registered = true;
+          return () => {
+            if (!registered) return;
+            registered = false;
+            const index = this.runtimeDisposers.indexOf(dispose);
+            if (index >= 0) this.runtimeDisposers.splice(index, 1);
+          };
+        },
+      },
       requestContext: {
         set(target, key, value, options) {
           setRequestContext(target as object, key, value, options);
@@ -850,18 +890,33 @@ export class PluginManager {
   }
 
   async closeRuntime(reason = "runtime-closed"): Promise<void> {
-    if (this.runtimeClosed) return;
     if (this.runtimeClosePromise) return this.runtimeClosePromise;
+    if (this.runtimeClosed) return;
 
-    this.runtimeClosePromise = this.runHookParallel("shutdown", {
-      reason,
-    }).then(() => undefined);
-    try {
-      await this.runtimeClosePromise;
-    } catch (error) {
-      this.runtimeClosePromise = undefined;
-      throw error;
-    }
+    this.runtimeClosePromise = (async () => {
+      const errors: unknown[] = [];
+      try {
+        await this.runHookParallel("shutdown", { reason });
+      } catch (error) {
+        if (error instanceof FarmRuntimeShutdownError) errors.push(...error.errors);
+        else errors.push(error);
+      }
+
+      const disposers = this.runtimeDisposers.splice(0).reverse();
+      for (const dispose of disposers) {
+        try {
+          await dispose();
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+
+      this.runtimeClosed = true;
+      if (errors.length > 0) {
+        throw new FarmRuntimeShutdownError("Farm runtime shutdown failed", errors);
+      }
+    })();
+    return this.runtimeClosePromise;
   }
 
   async beginRuntimeRequest(
@@ -1064,6 +1119,7 @@ export class PluginManager {
     ]);
 
     if (sequentialHooks.has(hookName)) {
+      const shutdownErrors: unknown[] = [];
       for (const plugin of plugins) {
         for (const hook of this.getPluginHooks(plugin, hookName)) {
           // Check if response is already sent (only for beforeRequest)
@@ -1075,7 +1131,12 @@ export class PluginManager {
           }
 
           const hookContext = this.getHookContext(hookName, args);
-          await (hook as any).apply(plugin, [...args, hookContext]);
+          try {
+            await (hook as any).apply(plugin, [...args, hookContext]);
+          } catch (error) {
+            if (hookName !== "shutdown") throw error;
+            shutdownErrors.push(error);
+          }
 
           // Check again after plugin execution (only for beforeRequest)
           if (hookName === "beforeRequest") {
@@ -1085,6 +1146,10 @@ export class PluginManager {
             }
           }
         }
+      }
+      if (hookName === "shutdown" && shutdownErrors.length > 0) {
+        this.runtimeClosed = true;
+        throw new FarmRuntimeShutdownError("Farm plugin shutdown hooks failed", shutdownErrors);
       }
     } else {
       // Run other hooks in parallel

--- a/packages/farm/src/plugin.ts
+++ b/packages/farm/src/plugin.ts
@@ -450,6 +450,7 @@ export class PluginManager {
   private runtimeClosed = false;
   private runtimeStartPromise?: Promise<void>;
   private runtimeClosePromise?: Promise<void>;
+  private runtimeShutdownHooksRunning = false;
   private runtimeDisposers: Array<() => void | Promise<void>> = [];
   private runtimeRequestContexts = new WeakMap<Request, Readonly<Record<string, unknown>>>();
   private failedRuntimeSessions = new WeakSet<FarmPluginRuntimeSession>();
@@ -895,11 +896,14 @@ export class PluginManager {
 
     this.runtimeClosePromise = (async () => {
       const errors: unknown[] = [];
+      this.runtimeShutdownHooksRunning = true;
       try {
         await this.runHookParallel("shutdown", { reason });
       } catch (error) {
         if (error instanceof FarmRuntimeShutdownError) errors.push(...error.errors);
         else errors.push(error);
+      } finally {
+        this.runtimeShutdownHooksRunning = false;
       }
 
       const disposers = this.runtimeDisposers.splice(0).reverse();
@@ -1102,6 +1106,11 @@ export class PluginManager {
   }
 
   async runHookParallel<K extends keyof FarmPlugin>(hookName: K, ...args: any[]): Promise<boolean> {
+    if (hookName === "shutdown" && !this.runtimeShutdownHooksRunning) {
+      await this.closeRuntime(args[0]?.reason);
+      return false;
+    }
+
     const plugins = this.getSortedPlugins();
 
     // Run selected hooks sequentially for deterministic execution and short-circuiting.
@@ -1148,7 +1157,6 @@ export class PluginManager {
         }
       }
       if (hookName === "shutdown" && shutdownErrors.length > 0) {
-        this.runtimeClosed = true;
         throw new FarmRuntimeShutdownError("Farm plugin shutdown hooks failed", shutdownErrors);
       }
     } else {
@@ -1165,7 +1173,6 @@ export class PluginManager {
 
     if (hookName === "init") this.initialized = true;
     if (hookName === "ready") this.runtimeReady = true;
-    if (hookName === "shutdown") this.runtimeClosed = true;
 
     return false;
   }

--- a/packages/farm/src/production-lifecycle.ts
+++ b/packages/farm/src/production-lifecycle.ts
@@ -1,0 +1,255 @@
+import type { ResolvedFarmServerConfig } from "./server-http";
+
+export type FarmProductionLifecycleState = "starting" | "ready" | "draining" | "failed" | "closed";
+
+export interface FarmProductionLifecycleOptions {
+  server: ResolvedFarmServerConfig;
+  start?: () => void | Promise<void>;
+  close?: (reason: string) => void | Promise<void>;
+}
+
+export interface FarmResponseCompletionContext {
+  onResponseFinished?: (callback: () => void) => void;
+}
+
+export interface FarmProductionLifecycle {
+  readonly state: FarmProductionLifecycleState;
+  readonly activeRequests: number;
+  start(): Promise<void>;
+  beginDrain(reason?: string): void;
+  waitForIdle(timeoutMs?: number): Promise<boolean>;
+  close(reason?: string): Promise<void>;
+  handleHealthRequest(request: Request): Promise<Response | null>;
+  runRequest(
+    handler: () => Response | Promise<Response>,
+    context?: FarmResponseCompletionContext,
+  ): Promise<Response>;
+}
+
+export function createFarmProductionLifecycle(
+  options: FarmProductionLifecycleOptions,
+): FarmProductionLifecycle {
+  let state: FarmProductionLifecycleState = "starting";
+  let activeRequests = 0;
+  let startPromise: Promise<void> | undefined;
+  let closePromise: Promise<void> | undefined;
+  const idleWaiters = new Set<() => void>();
+
+  const notifyIdle = () => {
+    if (activeRequests !== 0) return;
+    for (const resolve of idleWaiters) resolve();
+    idleWaiters.clear();
+  };
+
+  const start = async () => {
+    if (state === "ready") return;
+    if (startPromise) return startPromise;
+    if (state === "draining" || state === "closed") {
+      throw new Error("Farm production runtime is shutting down");
+    }
+    if (state === "failed") {
+      throw new Error("Farm production runtime failed to start");
+    }
+
+    startPromise = Promise.resolve(options.start?.()).then(
+      () => {
+        if (state === "starting") state = "ready";
+      },
+      (error) => {
+        state = "failed";
+        throw error;
+      },
+    );
+    return startPromise;
+  };
+
+  const beginDrain = (_reason = "production-server-draining") => {
+    if (state === "closed" || state === "failed") return;
+    state = "draining";
+  };
+
+  const waitForIdle = async (
+    timeoutMs = options.server.gracefulShutdownTimeout,
+  ): Promise<boolean> => {
+    if (activeRequests === 0) return true;
+
+    return await new Promise<boolean>((resolve) => {
+      let settled = false;
+      const finish = (drained: boolean) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        idleWaiters.delete(onIdle);
+        resolve(drained);
+      };
+      const onIdle = () => finish(true);
+      const timeout = setTimeout(() => finish(false), timeoutMs);
+      timeout.unref?.();
+      idleWaiters.add(onIdle);
+    });
+  };
+
+  const close = async (reason = "production-server-closed") => {
+    if (closePromise) return closePromise;
+    beginDrain(reason);
+    closePromise = Promise.resolve(options.close?.(reason)).then(
+      () => {
+        state = "closed";
+      },
+      (error) => {
+        state = "closed";
+        throw error;
+      },
+    );
+    return closePromise;
+  };
+
+  const handleHealthRequest = async (request: Request): Promise<Response | null> => {
+    const health = options.server.health;
+    if (!health.enabled) return null;
+
+    const pathname = new URL(request.url).pathname.replace(/\/+$/, "") || "/";
+    const isLiveness = pathname === health.livenessPath;
+    const isReadiness = pathname === health.readinessPath;
+    if (!isLiveness && !isReadiness) return null;
+
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return new Response(null, {
+        status: 405,
+        headers: createHealthHeaders({ allow: "GET, HEAD" }),
+      });
+    }
+
+    if (isReadiness && state === "starting") {
+      try {
+        await start();
+      } catch {
+        // The readiness response below intentionally does not expose startup details.
+      }
+    }
+
+    const healthy = isLiveness ? state !== "failed" && state !== "closed" : state === "ready";
+    const body =
+      request.method === "HEAD" ? null : JSON.stringify({ status: healthy ? "ok" : "unavailable" });
+    return new Response(body, {
+      status: healthy ? 200 : 503,
+      headers: createHealthHeaders(healthy ? undefined : { retryAfter: "1" }),
+    });
+  };
+
+  const runRequest = async (
+    handler: () => Response | Promise<Response>,
+    context: FarmResponseCompletionContext = {},
+  ): Promise<Response> => {
+    if (state === "draining" || state === "closed") return createDrainingResponse();
+    await start();
+    if (state !== "ready") return createDrainingResponse();
+
+    activeRequests++;
+    let finished = false;
+    const finish = () => {
+      if (finished) return;
+      finished = true;
+      activeRequests--;
+      notifyIdle();
+    };
+
+    try {
+      const response = await handler();
+      return trackResponseCompletion(response, finish, context.onResponseFinished);
+    } catch (error) {
+      finish();
+      throw error;
+    }
+  };
+
+  return {
+    get state() {
+      return state;
+    },
+    get activeRequests() {
+      return activeRequests;
+    },
+    start,
+    beginDrain,
+    waitForIdle,
+    close,
+    handleHealthRequest,
+    runRequest,
+  };
+}
+
+function createHealthHeaders(options: { allow?: string; retryAfter?: string } = {}): Headers {
+  const headers = new Headers({
+    "cache-control": "no-store",
+    "content-type": "application/json; charset=utf-8",
+    "x-content-type-options": "nosniff",
+  });
+  if (options.allow) headers.set("allow", options.allow);
+  if (options.retryAfter) headers.set("retry-after", options.retryAfter);
+  return headers;
+}
+
+function createDrainingResponse(): Response {
+  return new Response("Service Unavailable", {
+    status: 503,
+    headers: {
+      "cache-control": "no-store",
+      connection: "close",
+      "content-type": "text/plain; charset=utf-8",
+      "retry-after": "1",
+      "x-content-type-options": "nosniff",
+    },
+  });
+}
+
+function trackResponseCompletion(
+  response: Response,
+  finish: () => void,
+  onResponseFinished?: (callback: () => void) => void,
+): Response {
+  if (onResponseFinished) {
+    try {
+      onResponseFinished(finish);
+      return response;
+    } catch {
+      // Fall through to Web Stream tracking when an adapter rejects registration.
+    }
+  }
+
+  if (!response.body) {
+    finish();
+    return response;
+  }
+
+  const reader = response.body.getReader();
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const result = await reader.read();
+        if (result.done) {
+          finish();
+          controller.close();
+          return;
+        }
+        controller.enqueue(result.value);
+      } catch (error) {
+        finish();
+        controller.error(error);
+      }
+    },
+    async cancel(reason) {
+      try {
+        await reader.cancel(reason);
+      } finally {
+        finish();
+      }
+    },
+  });
+
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}

--- a/packages/farm/src/production-lifecycle.ts
+++ b/packages/farm/src/production-lifecycle.ts
@@ -51,15 +51,17 @@ export function createFarmProductionLifecycle(
       throw new Error("Farm production runtime failed to start");
     }
 
-    startPromise = Promise.resolve(options.start?.()).then(
-      () => {
-        if (state === "starting") state = "ready";
-      },
-      (error) => {
-        state = "failed";
-        throw error;
-      },
-    );
+    startPromise = Promise.resolve()
+      .then(() => options.start?.())
+      .then(
+        () => {
+          if (state === "starting") state = "ready";
+        },
+        (error) => {
+          state = "failed";
+          throw error;
+        },
+      );
     return startPromise;
   };
 
@@ -92,15 +94,17 @@ export function createFarmProductionLifecycle(
   const close = async (reason = "production-server-closed") => {
     if (closePromise) return closePromise;
     beginDrain(reason);
-    closePromise = Promise.resolve(options.close?.(reason)).then(
-      () => {
-        state = "closed";
-      },
-      (error) => {
-        state = "closed";
-        throw error;
-      },
-    );
+    closePromise = Promise.resolve()
+      .then(() => options.close?.(reason))
+      .then(
+        () => {
+          state = "closed";
+        },
+        (error) => {
+          state = "closed";
+          throw error;
+        },
+      );
     return closePromise;
   };
 
@@ -217,7 +221,7 @@ function trackResponseCompletion(
     }
   }
 
-  if (!response.body) {
+  if (!response.body || response.bodyUsed || response.body.locked) {
     finish();
     return response;
   }

--- a/packages/farm/src/server-http.ts
+++ b/packages/farm/src/server-http.ts
@@ -3,6 +3,7 @@ export const DEFAULT_FARM_SERVER_HEADERS_TIMEOUT = 60_000;
 export const DEFAULT_FARM_SERVER_REQUEST_TIMEOUT = 300_000;
 export const DEFAULT_FARM_SERVER_KEEP_ALIVE_TIMEOUT = 5_000;
 export const DEFAULT_FARM_SERVER_GRACEFUL_SHUTDOWN_TIMEOUT = 30_000;
+const MAX_FARM_SERVER_TIMEOUT = 2_147_483_647;
 
 export type FarmServerDuration = number | `${number}${"ms" | "s" | "m" | "h"}`;
 
@@ -103,6 +104,9 @@ export function parseFarmServerDuration(
     if (!Number.isSafeInteger(value) || value <= 0) {
       throw new TypeError(`${optionName} must be a positive safe integer`);
     }
+    if (value > MAX_FARM_SERVER_TIMEOUT) {
+      throw new TypeError(`${optionName} must not exceed ${MAX_FARM_SERVER_TIMEOUT} milliseconds`);
+    }
     return value;
   }
 
@@ -120,6 +124,9 @@ export function parseFarmServerDuration(
   const milliseconds = Math.floor(amount * multiplier);
   if (!Number.isSafeInteger(milliseconds) || milliseconds <= 0) {
     throw new TypeError(`${optionName} must resolve to a positive safe integer`);
+  }
+  if (milliseconds > MAX_FARM_SERVER_TIMEOUT) {
+    throw new TypeError(`${optionName} must not exceed ${MAX_FARM_SERVER_TIMEOUT} milliseconds`);
   }
   return milliseconds;
 }
@@ -155,7 +162,7 @@ function normalizeHealthPath(value: string, optionName: string): string {
   if (!path.startsWith("/") || path.includes("?") || path.includes("#") || path.includes("*")) {
     throw new TypeError(`${optionName} must be an absolute pathname without a query or wildcard`);
   }
-  return path.length > 1 ? path.replace(/\/+$/, "") : path;
+  return path.length > 1 ? path.replace(/\/+$/, "") || "/" : path;
 }
 
 export function parseBodySizeLimit(value: number | string, optionName = "bodySizeLimit"): number {

--- a/packages/farm/src/server-http.ts
+++ b/packages/farm/src/server-http.ts
@@ -1,15 +1,49 @@
 export const DEFAULT_FARM_SERVER_BODY_SIZE_LIMIT = 10_000_000;
+export const DEFAULT_FARM_SERVER_HEADERS_TIMEOUT = 60_000;
+export const DEFAULT_FARM_SERVER_REQUEST_TIMEOUT = 300_000;
+export const DEFAULT_FARM_SERVER_KEEP_ALIVE_TIMEOUT = 5_000;
+export const DEFAULT_FARM_SERVER_GRACEFUL_SHUTDOWN_TIMEOUT = 30_000;
+
+export type FarmServerDuration = number | `${number}${"ms" | "s" | "m" | "h"}`;
+
+export interface FarmServerHealthConfig {
+  /** Liveness endpoint. It remains healthy while a production process drains. */
+  livenessPath?: string;
+  /** Readiness endpoint. It returns 503 until startup completes and while draining. */
+  readinessPath?: string;
+}
+
+export interface ResolvedFarmServerHealthConfig {
+  enabled: boolean;
+  livenessPath: string;
+  readinessPath: string;
+}
 
 export interface FarmServerConfig {
   /** Maximum request body size for API routes, integrations, workflows, and uploads. */
   bodySizeLimit?: number | string;
   /** Trust proxy-provided client IP headers. Enable only behind a trusted proxy. */
   trustProxy?: boolean;
+  /** Maximum time for a Node client to send complete request headers. */
+  headersTimeout?: FarmServerDuration;
+  /** Maximum time for a Node client to send the complete request. */
+  requestTimeout?: FarmServerDuration;
+  /** How long an idle Node keep-alive connection remains open after a response. */
+  keepAliveTimeout?: FarmServerDuration;
+  /** Maximum time the Node adapter drains traffic before forcing shutdown. */
+  gracefulShutdownTimeout?: FarmServerDuration;
+  /** Production liveness and readiness endpoints. Set to false to disable them. */
+  health?: false | FarmServerHealthConfig;
 }
 
 export interface ResolvedFarmServerConfig {
   bodySizeLimit: number;
   trustProxy: boolean;
+  headersTimeout: number;
+  requestTimeout: number;
+  keepAliveTimeout: number;
+  gracefulShutdownTimeout: number;
+  health: ResolvedFarmServerHealthConfig;
 }
 
 export type FarmRequestBodyErrorCode = "BODY_TOO_LARGE" | "INVALID_CONTENT_LENGTH";
@@ -29,13 +63,99 @@ export class FarmRequestBodyError extends Error {
 export function resolveFarmServerConfig(
   config: FarmServerConfig | ResolvedFarmServerConfig | undefined,
 ): ResolvedFarmServerConfig {
+  const headersTimeout = parseFarmServerDuration(
+    config?.headersTimeout ?? DEFAULT_FARM_SERVER_HEADERS_TIMEOUT,
+    "server.headersTimeout",
+  );
+  const requestTimeout = parseFarmServerDuration(
+    config?.requestTimeout ?? DEFAULT_FARM_SERVER_REQUEST_TIMEOUT,
+    "server.requestTimeout",
+  );
+  if (headersTimeout > requestTimeout) {
+    throw new TypeError("server.headersTimeout must not exceed server.requestTimeout");
+  }
+
   return Object.freeze({
     bodySizeLimit: parseBodySizeLimit(
       config?.bodySizeLimit ?? DEFAULT_FARM_SERVER_BODY_SIZE_LIMIT,
       "server.bodySizeLimit",
     ),
     trustProxy: config?.trustProxy === true,
+    headersTimeout,
+    requestTimeout,
+    keepAliveTimeout: parseFarmServerDuration(
+      config?.keepAliveTimeout ?? DEFAULT_FARM_SERVER_KEEP_ALIVE_TIMEOUT,
+      "server.keepAliveTimeout",
+    ),
+    gracefulShutdownTimeout: parseFarmServerDuration(
+      config?.gracefulShutdownTimeout ?? DEFAULT_FARM_SERVER_GRACEFUL_SHUTDOWN_TIMEOUT,
+      "server.gracefulShutdownTimeout",
+    ),
+    health: resolveFarmServerHealthConfig(config?.health),
   });
+}
+
+export function parseFarmServerDuration(
+  value: FarmServerDuration,
+  optionName = "duration",
+): number {
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+      throw new TypeError(`${optionName} must be a positive safe integer`);
+    }
+    return value;
+  }
+
+  const match = value
+    .trim()
+    .toLowerCase()
+    .match(/^(\d+(?:\.\d+)?)\s*(ms|s|m|h)$/);
+  if (!match) {
+    throw new TypeError(`${optionName} must be milliseconds or a duration such as "30s" or "2m"`);
+  }
+
+  const amount = Number(match[1]);
+  const unit = match[2];
+  const multiplier = unit === "ms" ? 1 : unit === "s" ? 1_000 : unit === "m" ? 60_000 : 3_600_000;
+  const milliseconds = Math.floor(amount * multiplier);
+  if (!Number.isSafeInteger(milliseconds) || milliseconds <= 0) {
+    throw new TypeError(`${optionName} must resolve to a positive safe integer`);
+  }
+  return milliseconds;
+}
+
+function resolveFarmServerHealthConfig(
+  config: false | FarmServerHealthConfig | ResolvedFarmServerHealthConfig | undefined,
+): ResolvedFarmServerHealthConfig {
+  if (config === false || (config && "enabled" in config && config.enabled === false)) {
+    return Object.freeze({
+      enabled: false,
+      livenessPath: "/_farm/health/live",
+      readinessPath: "/_farm/health/ready",
+    });
+  }
+
+  const livenessPath = normalizeHealthPath(
+    config?.livenessPath ?? "/_farm/health/live",
+    "server.health.livenessPath",
+  );
+  const readinessPath = normalizeHealthPath(
+    config?.readinessPath ?? "/_farm/health/ready",
+    "server.health.readinessPath",
+  );
+  if (livenessPath === readinessPath) {
+    throw new TypeError("server.health livenessPath and readinessPath must be different");
+  }
+
+  return Object.freeze({ enabled: true, livenessPath, readinessPath });
+}
+
+function normalizeHealthPath(value: string, optionName: string): string {
+  const path = value.trim();
+  if (!path.startsWith("/") || path.includes("?") || path.includes("#") || path.includes("*")) {
+    throw new TypeError(`${optionName} must be an absolute pathname without a query or wildcard`);
+  }
+  return path.length > 1 ? path.replace(/\/+$/, "") : path;
 }
 
 export function parseBodySizeLimit(value: number | string, optionName = "bodySizeLimit"): number {

--- a/packages/farm/src/server-plugins.ts
+++ b/packages/farm/src/server-plugins.ts
@@ -11,6 +11,7 @@ export {
 export type {
   FarmPlugin,
   FarmPluginContext,
+  FarmPluginLifecycle,
   FarmRequestPluginContext,
   FarmRequestStore,
 } from "./plugin";


### PR DESCRIPTION
## Summary

- add a production lifecycle state machine with startup, readiness, draining, request/stream tracking, and exactly-once shutdown
- add a Node server entry that applies HTTP timeouts, stops accepting traffic on handled shutdown signals, drains in-flight work through Nitro, and closes Farm integrations/plugins
- add `context.lifecycle.onShutdown()` for database, Redis, queue, and other resource cleanup
- add configurable liveness/readiness routes and graceful-shutdown timeout settings
- document production lifecycle guarantees and serverless/edge limitations

## Why

Farm previously connected plugin shutdown clearly in development, but long-running production output did not explicitly connect Farm runtime startup and cleanup across the Node adapter lifecycle. This makes readiness meaningful and gives resources a deterministic graceful-shutdown path.

## Validation

- `pnpm exec tsc --noEmit -p packages/farm/tsconfig.json`
- focused lifecycle/config suite: 56 tests passed
- standalone Node production boot test
- end-to-end SIGTERM test proving an in-flight request finishes before plugin close and resource disposal
- production adapter regression subset: 6 tests passed
- oxlint: 0 warnings and 0 errors

The broader production SSR file passed 17 of 18 tests locally; the remaining React 18 compatibility case could not run because its fixture dependencies were unavailable in the worktree. The package JavaScript build completed, while the tsup declaration worker later exhausted its heap; the standalone TypeScript check passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a production lifecycle for long‑running Node output with liveness/readiness probes, request/stream tracking, graceful draining on shutdown, and configurable HTTP timeouts. Startup is now explicit and signal‑aware, and plugins/resources have a safe, exactly‑once cleanup path.

- **New Features**
  - Production state machine with startup, readiness, draining, and exactly‑once close. New work is rejected with 503 while draining; liveness stays OK while draining, readiness returns 503 before startup and during drain.
  - Node server entry eagerly starts runtime before listening, applies `headersTimeout`, `requestTimeout`, and `keepAliveTimeout`, sets `NITRO_SHUTDOWN_TIMEOUT`, handles SIGTERM/SIGINT (including during startup), drains in‑flight work through Nitro, then closes integrations/plugins.
  - Default, non‑cacheable health routes: `GET /_farm/health/live` and `GET /_farm/health/ready` (customize via `server.health`, or disable with `health: false`).
  - New `context.lifecycle.onShutdown()` for resource cleanup; disposers run once in reverse order after plugin shutdown hooks. Aggregated failures surface as `FarmRuntimeShutdownError`.
  - New config with validation and duration parsing: `server.headersTimeout`, `server.requestTimeout`, `server.keepAliveTimeout`, `server.gracefulShutdownTimeout` (e.g., `"15s"`, `"2m"`). Ensures `headersTimeout` ≤ `requestTimeout`, enforces safe integer limits, and validates distinct, normalized health paths.

- **Migration**
  - For `node-server` deployments, point probes to the new readiness/liveness endpoints or set `server.health: false` to use platform probes.
  - Move DB/Redis/queue cleanup to `context.lifecycle.onShutdown()`. Do not rely on shutdown events in serverless/edge.
  - Tune timeouts as needed; defaults are 60s headers, 5m request, 5s keep‑alive, and 30s graceful shutdown.
  - If you catch shutdown errors, handle `FarmRuntimeShutdownError` (contains aggregated causes).

<sup>Written for commit a46ae6eee244f6d791f77cba3ed78b3d1586815b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

