### PR TITLE
fix: layout client boundary hydration

### DIFF
--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -131,6 +131,43 @@ describe("client component path resolution", () => {
     expect(shouldHydrateModule(pageFile, root)).toBe(true);
   });
 
+  it("detects client boundaries exposed by package export maps", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-client-package-import-"));
+    tempDirs.push(root);
+
+    const pageFile = path.join(root, "src", "app", "layout.tsx");
+    const packageRoot = path.join(root, "node_modules", "@acme", "analytics");
+    fs.mkdirSync(path.join(packageRoot, "dist", "react"), { recursive: true });
+    fs.mkdirSync(path.dirname(pageFile), { recursive: true });
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({
+        name: "@acme/analytics",
+        type: "module",
+        exports: {
+          "./react": {
+            types: "./dist/react/index.d.ts",
+            import: "./dist/react/index.mjs",
+          },
+        },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(packageRoot, "dist", "react", "index.mjs"),
+      `'use client';\nexport function Analytics() { return null; }\n`,
+    );
+    fs.writeFileSync(
+      pageFile,
+      `import { Analytics } from "@acme/analytics/react";\nexport default function Layout({ children }) { return <><Analytics />{children}</>; }\n`,
+    );
+
+    expect(getClientModuleMetadata(pageFile, root)).toEqual({
+      isClientComponent: false,
+      shouldHydrate: true,
+      islandStrategy: "load",
+    });
+  });
+
   it("reads a static island strategy from client modules", () => {
     expect(
       getIslandStrategyExport(
@@ -269,7 +306,9 @@ export function Chart() {}
     expect(source).toContain("reactRootContainer !== container");
     expect(source).toContain('document.getElementById("__farm_page__") || currentRoot');
     expect(source).toContain("Navigation itself signals intent");
-    expect(source).toContain("load: () => import(");
+    expect(source).toContain("pageShouldHydrate:");
+    expect(source).toContain("page.pageShouldHydrate");
+    expect(source).toContain("load: ${load}");
     expect(source).not.toContain("imports.push(`import Page${index}");
   });
 

--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -168,6 +168,97 @@ describe("client component path resolution", () => {
     });
   });
 
+  it("follows package-relative re-exports to a client boundary", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-client-package-reexport-"));
+    tempDirs.push(root);
+
+    const layoutFile = path.join(root, "src", "app", "layout.tsx");
+    const packageRoot = path.join(root, "node_modules", "analytics-react");
+    fs.mkdirSync(path.join(packageRoot, "dist"), { recursive: true });
+    fs.mkdirSync(path.dirname(layoutFile), { recursive: true });
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "analytics-react", exports: "./dist/index.js" }),
+    );
+    fs.writeFileSync(
+      path.join(packageRoot, "dist", "index.js"),
+      'export { Analytics } from "./client.js";\n',
+    );
+    fs.writeFileSync(
+      path.join(packageRoot, "dist", "client.js"),
+      '"use client";\nexport function Analytics() { return null; }\n',
+    );
+    fs.writeFileSync(
+      layoutFile,
+      'import { Analytics } from "analytics-react";\nexport default function Layout() { return <Analytics />; }\n',
+    );
+
+    expect(getClientModuleMetadata(layoutFile, root).shouldHydrate).toBe(true);
+  });
+
+  it("resolves package entries selected by the node export condition", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-client-package-node-"));
+    tempDirs.push(root);
+
+    const pageFile = path.join(root, "src", "app", "page.tsx");
+    const packageRoot = path.join(root, "node_modules", "node-conditioned-client");
+    fs.mkdirSync(path.join(packageRoot, "dist"), { recursive: true });
+    fs.mkdirSync(path.dirname(pageFile), { recursive: true });
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({
+        name: "node-conditioned-client",
+        exports: { node: "./dist/node.js", default: "./dist/default.js" },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(packageRoot, "dist", "node.js"),
+      '"use client";\nexport function NodeClient() { return null; }\n',
+    );
+    fs.writeFileSync(path.join(packageRoot, "dist", "default.js"), "export {};\n");
+    fs.writeFileSync(
+      pageFile,
+      'import { NodeClient } from "node-conditioned-client";\nexport default function Page() { return <NodeClient />; }\n',
+    );
+
+    expect(getClientModuleMetadata(pageFile, root).shouldHydrate).toBe(true);
+  });
+
+  it("ignores type-only and non-code package import examples", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-client-package-types-"));
+    tempDirs.push(root);
+
+    const pageFile = path.join(root, "src", "app", "page.tsx");
+    const packageRoot = path.join(root, "node_modules", "client-types");
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.mkdirSync(path.dirname(pageFile), { recursive: true });
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "client-types", exports: "./index.js" }),
+    );
+    fs.writeFileSync(
+      path.join(packageRoot, "index.js"),
+      '"use client";\nexport function ClientWidget() { return null; }\n',
+    );
+    fs.writeFileSync(
+      pageFile,
+      [
+        'import type { ClientWidget } from "client-types";',
+        'export type { ClientWidget as ExportedWidget } from "client-types";',
+        '// import { ClientWidget } from "client-types";',
+        "const quoted = 'import { ClientWidget } from \"client-types\";';",
+        'const example = `import { ClientWidget } from "client-types";`;',
+        "export default function Page() { return quoted + example; }",
+      ].join("\n"),
+    );
+
+    expect(getClientModuleMetadata(pageFile, root)).toEqual({
+      isClientComponent: false,
+      shouldHydrate: false,
+      islandStrategy: null,
+    });
+  });
+
   it("reads a static island strategy from client modules", () => {
     expect(
       getIslandStrategyExport(
@@ -260,6 +351,17 @@ export function Chart() {}
     expect(source).toMatch(
       /return \{\s+\.\.\.\(existingProps \|\| \{\}\),\s+params: parsedParams,/,
     );
+  });
+
+  it("composes every applicable layout in the development hydration runtime", () => {
+    const source = fs.readFileSync(path.join(process.cwd(), "src", "vite.ts"), "utf-8");
+
+    expect(source).toContain("const layoutComponentCache = new Map();");
+    expect(source).toContain("async function loadLayoutComponents(layouts = [])");
+    expect(source).toContain("for (const layout of layouts)");
+    expect(source).toContain("function wrapWithLoadedLayouts(element, loadedLayouts, params)");
+    expect(source).toContain("for (let index = loadedLayouts.length - 1; index >= 0; index--)");
+    expect(source).not.toContain("layouts.find((layout) => layout.pattern === '/')");
   });
 
   it("uses a document swap when generated SPA navigation leaves the app root", () => {

--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -196,6 +196,34 @@ describe("client component path resolution", () => {
     expect(getClientModuleMetadata(layoutFile, root).shouldHydrate).toBe(true);
   });
 
+  it("follows extensionless package directory re-exports to a client boundary", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-client-package-directory-"));
+    tempDirs.push(root);
+
+    const layoutFile = path.join(root, "src", "app", "layout.tsx");
+    const packageRoot = path.join(root, "node_modules", "directory-client");
+    fs.mkdirSync(path.join(packageRoot, "dist", "client"), { recursive: true });
+    fs.mkdirSync(path.dirname(layoutFile), { recursive: true });
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "directory-client", exports: "./dist/index.js" }),
+    );
+    fs.writeFileSync(
+      path.join(packageRoot, "dist", "index.js"),
+      'export { DirectoryClient } from "./client";\n',
+    );
+    fs.writeFileSync(
+      path.join(packageRoot, "dist", "client", "index.js"),
+      '"use client";\nexport function DirectoryClient() { return null; }\n',
+    );
+    fs.writeFileSync(
+      layoutFile,
+      'import { DirectoryClient } from "directory-client";\nexport default function Layout() { return <DirectoryClient />; }\n',
+    );
+
+    expect(getClientModuleMetadata(layoutFile, root).shouldHydrate).toBe(true);
+  });
+
   it("resolves package entries selected by the node export condition", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-client-package-node-"));
     tempDirs.push(root);
@@ -224,6 +252,37 @@ describe("client component path resolution", () => {
     expect(getClientModuleMetadata(pageFile, root).shouldHydrate).toBe(true);
   });
 
+  it("prefers browser package exports even when node is declared first", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-client-package-browser-"));
+    tempDirs.push(root);
+
+    const layoutFile = path.join(root, "src", "app", "layout.tsx");
+    const packageRoot = path.join(root, "node_modules", "conditional-client");
+    fs.mkdirSync(path.join(packageRoot, "dist"), { recursive: true });
+    fs.mkdirSync(path.dirname(layoutFile), { recursive: true });
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({
+        name: "conditional-client",
+        exports: {
+          node: "./dist/node.js",
+          browser: "./dist/browser.js",
+        },
+      }),
+    );
+    fs.writeFileSync(path.join(packageRoot, "dist", "node.js"), "export {};\n");
+    fs.writeFileSync(
+      path.join(packageRoot, "dist", "browser.js"),
+      '"use client";\nexport function BrowserClient() { return null; }\n',
+    );
+    fs.writeFileSync(
+      layoutFile,
+      'import { BrowserClient } from "conditional-client";\nexport default function Layout() { return <BrowserClient />; }\n',
+    );
+
+    expect(getClientModuleMetadata(layoutFile, root).shouldHydrate).toBe(true);
+  });
+
   it("ignores type-only and non-code package import examples", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-client-package-types-"));
     tempDirs.push(root);
@@ -244,11 +303,14 @@ describe("client component path resolution", () => {
       pageFile,
       [
         'import type { ClientWidget } from "client-types";',
+        'import { type ClientWidget as NamedClientWidget, } from "client-types";',
         'export type { ClientWidget as ExportedWidget } from "client-types";',
         '// import { ClientWidget } from "client-types";',
         "const quoted = 'import { ClientWidget } from \"client-types\";';",
         'const example = `import { ClientWidget } from "client-types";`;',
-        "export default function Page() { return quoted + example; }",
+        'const pattern = /import { ClientWidget } from "client-types"/;',
+        'function Example() { return <p>import { ClientWidget } from "client-types"</p>; }',
+        "export default function Page() { return quoted + example + String(pattern) + String(Example); }",
       ].join("\n"),
     );
 
@@ -361,7 +423,9 @@ export function Chart() {}
     expect(source).toContain("for (const layout of layouts)");
     expect(source).toContain("function wrapWithLoadedLayouts(element, loadedLayouts, params)");
     expect(source).toContain("for (let index = loadedLayouts.length - 1; index >= 0; index--)");
-    expect(source).toContain("const layouts = findLayouts(window.location.pathname);");
+    expect(source).toContain("const layouts = Array.isArray(window.__FARM_LAYOUTS__)");
+    expect(source).toContain("? window.__FARM_LAYOUTS__");
+    expect(source).toContain(": findLayouts(window.location.pathname);");
     expect(source).toMatch(
       /tryHydrateImportedPage\(\s+pageContainer,[\s\S]*?layouts,[\s\S]*?layoutShouldHydrate,/,
     );

--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -361,7 +361,13 @@ export function Chart() {}
     expect(source).toContain("for (const layout of layouts)");
     expect(source).toContain("function wrapWithLoadedLayouts(element, loadedLayouts, params)");
     expect(source).toContain("for (let index = loadedLayouts.length - 1; index >= 0; index--)");
+    expect(source).toContain("const layouts = findLayouts(window.location.pathname);");
+    expect(source).toMatch(
+      /tryHydrateImportedPage\(\s+pageContainer,[\s\S]*?layouts,[\s\S]*?layoutShouldHydrate,/,
+    );
     expect(source).not.toContain("layouts.find((layout) => layout.pattern === '/')");
+    expect(source).not.toContain("'/src/app/layout.tsx'");
+    expect(source).not.toContain("Could not preload layout:");
   });
 
   it("uses a document swap when generated SPA navigation leaves the app root", () => {

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -269,6 +269,111 @@ export default function Page() {
     }
   }, 120_000);
 
+  it("includes package client boundaries imported by a server layout in route hydration", async () => {
+    const root = await createProductionFixture();
+
+    try {
+      const analyticsRoot = path.join(root, "node_modules", "@fixture", "analytics");
+      await fs.mkdir(path.join(analyticsRoot, "dist", "react"), { recursive: true });
+      await fs.writeFile(
+        path.join(analyticsRoot, "package.json"),
+        JSON.stringify(
+          {
+            name: "@fixture/analytics",
+            type: "module",
+            exports: {
+              "./react": {
+                import: "./dist/react/index.mjs",
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      await fs.writeFile(
+        path.join(analyticsRoot, "dist", "react", "index.mjs"),
+        `
+"use client";
+
+import { useEffect } from "react";
+
+export function AnalyticsBoundary() {
+  useEffect(() => {
+    document.documentElement.dataset.layoutEffect = "layout-effect-fired";
+  }, []);
+  return null;
+}
+`.trim(),
+      );
+      await fs.writeFile(
+        path.join(root, "src", "app", "layout.tsx"),
+        `
+import { AnalyticsBoundary } from "@fixture/analytics/react";
+
+export default function RootLayout({ children }) {
+  return <div data-layout="root"><AnalyticsBoundary />{children}</div>;
+}
+`.trim(),
+      );
+      await fs.writeFile(
+        path.join(root, "src", "app", "page.tsx"),
+        `export default function Page() { return <main>layout boundary page</main>; }`,
+      );
+      await fs.mkdir(path.join(root, "src", "app", "docs"), { recursive: true });
+      await fs.writeFile(
+        path.join(root, "src", "app", "docs", "page.md"),
+        `# Layout boundary docs\n\nServer-rendered documentation content.`,
+      );
+
+      const config = await resolveConfig(
+        {
+          root,
+          srcDir: "src",
+          docs: { entry: "/docs" },
+          images: { provider: "none" },
+          generateBuildId: () => "layout-client-boundary-test",
+        },
+        "production",
+      );
+      await build(config, { root, preset: "node-server" });
+
+      const clientBundle = await fs.readFile(
+        path.join(root, ".farm", "client", "farm-client.js"),
+        "utf8",
+      );
+      expect(clientBundle).toContain("layout-effect-fired");
+
+      await runProductionRequest(
+        path.join(root, ".farm", ".output", "server"),
+        async (response) => {
+          expect(response.status).toBe(200);
+          const html = await response.text();
+          expect(html).toContain('data-layout="root"');
+          expect(html).toContain("layout boundary page");
+          expect(html).toContain('id="__farm_page__"');
+          expect(html).toContain('data-farm-client="false"');
+          expect(html).toContain('data-farm-layout-client="true"');
+        },
+      );
+      await runProductionRequest(
+        path.join(root, ".farm", ".output", "server"),
+        async (response) => {
+          expect(response.status).toBe(200);
+          const html = await response.text();
+          expect(html).toContain("Layout boundary docs");
+          expect(html).toContain('id="root"');
+          expect(html).toContain('id="__farm_page__"');
+          expect(html).toContain('data-farm-client="false"');
+          expect(html).toContain('data-farm-layout-client="true"');
+        },
+        "/docs",
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }, 120_000);
+
   it("boots standalone Node output through the package import mapping", async () => {
     const root = await createProductionFixture();
     const isolatedRoot = await fs.mkdtemp(path.join(os.tmpdir(), "farm-standalone-prebuilt-"));

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -293,6 +293,10 @@ export default function Page() {
       );
       await fs.writeFile(
         path.join(analyticsRoot, "dist", "react", "index.mjs"),
+        `export { AnalyticsBoundary } from "./boundary.mjs";`,
+      );
+      await fs.writeFile(
+        path.join(analyticsRoot, "dist", "react", "boundary.mjs"),
         `
 "use client";
 
@@ -330,7 +334,7 @@ export default function RootLayout({ children }) {
         {
           root,
           srcDir: "src",
-          docs: { entry: "/docs" },
+          docs: { entry: "/docs", search: false },
           images: { provider: "none" },
           generateBuildId: () => "layout-client-boundary-test",
         },
@@ -343,6 +347,7 @@ export default function RootLayout({ children }) {
         "utf8",
       );
       expect(clientBundle).toContain("layout-effect-fired");
+      expect(clientBundle).toContain("/docs/[...slug]");
 
       await runProductionRequest(
         path.join(root, ".farm", ".output", "server"),
@@ -366,6 +371,9 @@ export default function RootLayout({ children }) {
           expect(html).toContain('id="__farm_page__"');
           expect(html).toContain('data-farm-client="false"');
           expect(html).toContain('data-farm-layout-client="true"');
+          expect(html).toContain('id="__farm_route_slots_data__"');
+          expect(html.match(/src="\/farm-client\.js"/g)).toHaveLength(1);
+          expect(html.match(/href="\/farm-client\.css"/g)).toHaveLength(1);
         },
         "/docs",
       );

--- a/packages/farm/src/__tests__/server-renderer-route-states.test.tsx
+++ b/packages/farm/src/__tests__/server-renderer-route-states.test.tsx
@@ -424,9 +424,7 @@ function createRenderer(
           modulePath: routeModulePath,
         },
         params: {},
-        layouts: options.layoutMetadata
-          ? [{ pattern: "/", modulePath: layoutModulePath }]
-          : [],
+        layouts: options.layoutMetadata ? [{ pattern: "/", modulePath: layoutModulePath }] : [],
       };
     },
     getMatchingLoading() {

--- a/packages/farm/src/__tests__/server-renderer-route-states.test.tsx
+++ b/packages/farm/src/__tests__/server-renderer-route-states.test.tsx
@@ -17,6 +17,7 @@ type MockResponse = FarmResponse & {
 
 const routeModulePath = "/test/src/app/dashboard/page.tsx";
 const layoutModulePath = "/test/src/app/layout.tsx";
+const dashboardLayoutModulePath = "/test/src/app/dashboard/layout.tsx";
 const loadingModulePath = "/test/src/app/dashboard/loading.tsx";
 const errorModulePath = "/test/src/app/dashboard/error.tsx";
 const ogImageModulePath = "/test/src/app/dashboard/opengraph-image.tsx";
@@ -366,6 +367,42 @@ describe("file route loading.tsx and error.tsx", () => {
     expect(response.body).toContain("window.__FARM_LAYOUT_SHOULD_HYDRATE__ = true");
     expect(response.body).toContain('"shouldHydrate":true');
   });
+
+  it("bootstraps every matched layout when only a nested layout hydrates", async () => {
+    const response = createMockResponse();
+    const renderer = createRenderer(
+      {
+        [routeModulePath]: {
+          default: function DashboardPage() {
+            return React.createElement("main", null, "Nested server dashboard");
+          },
+        },
+        [layoutModulePath]: {
+          default: function RootLayout({ children }: { children: React.ReactNode }) {
+            return React.createElement("section", { "data-layout": "root" }, children);
+          },
+        },
+        [dashboardLayoutModulePath]: {
+          default: function DashboardLayout({ children }: { children: React.ReactNode }) {
+            return React.createElement("article", { "data-layout": "dashboard" }, children);
+          },
+        },
+      },
+      {
+        layoutMetadata: { shouldHydrate: false },
+        dashboardLayoutMetadata: { shouldHydrate: true, islandStrategy: "visible" },
+      },
+    );
+
+    await renderer.renderPage(createMockRequest("/dashboard"), response);
+
+    expect(response.body).toContain('data-layout="root"');
+    expect(response.body).toContain('data-layout="dashboard"');
+    expect(response.body).toContain("window.__FARM_LAYOUT_SHOULD_HYDRATE__ = true");
+    expect(response.body).toContain(
+      'window.__FARM_LAYOUTS__ = [{"pattern":"/","modulePath":"/src/app/layout.tsx","shouldHydrate":false,"islandStrategy":null},{"pattern":"/dashboard","modulePath":"/src/app/dashboard/layout.tsx","shouldHydrate":true,"islandStrategy":"visible"}]',
+    );
+  });
 });
 
 function DeferredReviews({ reviews }: { reviews: Promise<string[]> }) {
@@ -384,6 +421,7 @@ function createRenderer(
     staticImage?: { modulePath: string; staticInfo: any };
     clientMetadata?: { isClientComponent: boolean; shouldHydrate: boolean };
     layoutMetadata?: { shouldHydrate: boolean; islandStrategy?: string };
+    dashboardLayoutMetadata?: { shouldHydrate: boolean; islandStrategy?: string };
     onGenerateClientManifest?: () => void;
   } = {},
 ) {
@@ -418,13 +456,19 @@ function createRenderer(
       };
     },
     matchRoute() {
+      const layouts = [
+        ...(options.layoutMetadata ? [{ pattern: "/", modulePath: layoutModulePath }] : []),
+        ...(options.dashboardLayoutMetadata
+          ? [{ pattern: "/dashboard", modulePath: dashboardLayoutModulePath }]
+          : []),
+      ];
       return {
         route: {
           pattern: "/dashboard",
           modulePath: routeModulePath,
         },
         params: {},
-        layouts: options.layoutMetadata ? [{ pattern: "/", modulePath: layoutModulePath }] : [],
+        layouts,
       };
     },
     getMatchingLoading() {
@@ -470,6 +514,28 @@ function createRenderer(
     },
     generateClientManifest() {
       options.onGenerateClientManifest?.();
+      const layouts = [
+        ...(options.layoutMetadata
+          ? [
+              {
+                pattern: "/",
+                modulePath: layoutModulePath,
+                isClientComponent: false,
+                ...options.layoutMetadata,
+              },
+            ]
+          : []),
+        ...(options.dashboardLayoutMetadata
+          ? [
+              {
+                pattern: "/dashboard",
+                modulePath: dashboardLayoutModulePath,
+                isClientComponent: false,
+                ...options.dashboardLayoutMetadata,
+              },
+            ]
+          : []),
+      ];
       return {
         routes: [
           {
@@ -480,16 +546,7 @@ function createRenderer(
             segments: [{ segment: "dashboard", isDynamic: false }],
           },
         ],
-        layouts: options.layoutMetadata
-          ? [
-              {
-                pattern: "/",
-                modulePath: layoutModulePath,
-                isClientComponent: false,
-                ...options.layoutMetadata,
-              },
-            ]
-          : [],
+        layouts,
       };
     },
   };

--- a/packages/farm/src/__tests__/server-renderer-route-states.test.tsx
+++ b/packages/farm/src/__tests__/server-renderer-route-states.test.tsx
@@ -16,6 +16,7 @@ type MockResponse = FarmResponse & {
 };
 
 const routeModulePath = "/test/src/app/dashboard/page.tsx";
+const layoutModulePath = "/test/src/app/layout.tsx";
 const loadingModulePath = "/test/src/app/dashboard/loading.tsx";
 const errorModulePath = "/test/src/app/dashboard/error.tsx";
 const ogImageModulePath = "/test/src/app/dashboard/opengraph-image.tsx";
@@ -335,6 +336,36 @@ describe("file route loading.tsx and error.tsx", () => {
     expect(response.body).toContain('"isClientComponent":true');
     expect(response.body).toContain('"shouldHydrate":true');
   });
+
+  it("hydrates a client-aware layout without turning its server page into client code", async () => {
+    const response = createMockResponse();
+    const renderer = createRenderer(
+      {
+        [routeModulePath]: {
+          default: function DashboardPage() {
+            return React.createElement("main", null, "Server dashboard");
+          },
+        },
+        [layoutModulePath]: {
+          default: function RootLayout({ children }: { children: React.ReactNode }) {
+            return React.createElement("section", { "data-layout": "root" }, children);
+          },
+        },
+      },
+      {
+        layoutMetadata: { shouldHydrate: true, islandStrategy: "load" },
+      },
+    );
+
+    await renderer.renderPage(createMockRequest("/dashboard"), response);
+
+    expect(response.body).toContain('data-layout="root"');
+    expect(response.body).toContain('data-farm-client="false"');
+    expect(response.body).toContain('data-farm-layout-client="true"');
+    expect(response.body).toContain("window.__FARM_PAGE_SHOULD_HYDRATE__ = false");
+    expect(response.body).toContain("window.__FARM_LAYOUT_SHOULD_HYDRATE__ = true");
+    expect(response.body).toContain('"shouldHydrate":true');
+  });
 });
 
 function DeferredReviews({ reviews }: { reviews: Promise<string[]> }) {
@@ -352,6 +383,7 @@ function createRenderer(
     opengraphImage?: boolean;
     staticImage?: { modulePath: string; staticInfo: any };
     clientMetadata?: { isClientComponent: boolean; shouldHydrate: boolean };
+    layoutMetadata?: { shouldHydrate: boolean; islandStrategy?: string };
     onGenerateClientManifest?: () => void;
   } = {},
 ) {
@@ -392,7 +424,9 @@ function createRenderer(
           modulePath: routeModulePath,
         },
         params: {},
-        layouts: [],
+        layouts: options.layoutMetadata
+          ? [{ pattern: "/", modulePath: layoutModulePath }]
+          : [],
       };
     },
     getMatchingLoading() {
@@ -448,7 +482,16 @@ function createRenderer(
             segments: [{ segment: "dashboard", isDynamic: false }],
           },
         ],
-        layouts: [],
+        layouts: options.layoutMetadata
+          ? [
+              {
+                pattern: "/",
+                modulePath: layoutModulePath,
+                isClientComponent: false,
+                ...options.layoutMetadata,
+              },
+            ]
+          : [],
       };
     },
   };

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1033,8 +1033,7 @@ async function buildClient(
           }
         : getClientModuleMetadata(route.modulePath, root);
       const applicableClientLayouts = clientLayouts.filter(
-        (layout) =>
-          layout.shouldHydrate && layoutAppliesToRoute(layout.pattern, route.pattern),
+        (layout) => layout.shouldHydrate && layoutAppliesToRoute(layout.pattern, route.pattern),
       );
       if (metadata.shouldHydrate || applicableClientLayouts.length > 0) {
         const relativePath = route.modulePath.replace(root, "").replace(/^\//, "");
@@ -1059,6 +1058,38 @@ async function buildClient(
       }
     } catch (error) {
       logger.warn(`⚠️  Could not inspect route file ${route.modulePath}: ${error}`);
+    }
+  }
+
+  if (config.docs?.enabled) {
+    const docsEntry =
+      `/${config.docs.entry || "docs"}`.replace(/\/+/g, "/").replace(/\/$/, "") || "/";
+    const applicableClientLayouts = clientLayouts.filter(
+      (layout) => layout.shouldHydrate && layoutAppliesToRoute(layout.pattern, docsEntry),
+    );
+    if (applicableClientLayouts.length > 0) {
+      const hydrationStrategies = applicableClientLayouts.flatMap((layout) =>
+        layout.islandStrategy ? [layout.islandStrategy] : [],
+      );
+      const islandStrategy = hydrationStrategies.every(
+        (strategy) => strategy === hydrationStrategies[0],
+      )
+        ? (hydrationStrategies[0] ?? "load")
+        : "load";
+      const docsPatterns =
+        docsEntry === "/" ? ["/", "/[...slug]"] : [docsEntry, `${docsEntry}/[...slug]`];
+      const docsClientRoutes = docsPatterns.map((pattern) => ({
+        pattern,
+        modulePath: "",
+        relativePath: "",
+        pageShouldHydrate: false,
+        islandStrategy,
+      }));
+
+      // Docs requests take precedence over app page routes on the server, so
+      // their synthetic layout-only entries must take precedence in the client
+      // route table as well.
+      clientPages.unshift(...docsClientRoutes);
     }
   }
 
@@ -4655,10 +4686,25 @@ ${
     ReactDOMServer,
     React.createElement("div", { id: "root" }, wrappedElement),
   );
-  const html = source.replace(
+  let html = source.replace(
     bodyMatch[0],
     "<body" + bodyMatch[1] + ">" + rootMarkup + "</body>",
   );
+  if (!html.includes('href="/farm-client.css"')) {
+    html = html.replace(
+      /<[/]head>/i,
+      '  <link rel="stylesheet" href="/farm-client.css">\\n</head>',
+    );
+  }
+  if (!html.includes('id="__farm_route_slots_data__"')) {
+    html = html.replace(/<[/]body>/i, renderFarmClientBootstrapScript() + "\\n</body>");
+  }
+  if (!html.includes('src="/farm-client.js"')) {
+    html = html.replace(
+      /<[/]body>/i,
+      '  <script type="module" src="/farm-client.js"></script>\\n</body>',
+    );
+  }
   const headers = new Headers(response.headers);
   headers.delete("content-length");
   headers.delete("etag");

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -996,21 +996,64 @@ async function buildClient(
     pattern: string;
     modulePath: string;
     relativePath: string;
+    pageShouldHydrate: boolean;
     islandStrategy: FarmIslandStrategy;
   }> = [];
 
-  for (const route of pageRoutes) {
-    if (isFarmMarkdownPageFile(route.modulePath)) {
-      continue;
-    }
+  const clientLayouts = layoutRoutes.map((layout) => {
     try {
-      const metadata = getClientModuleMetadata(route.modulePath, root);
-      if (metadata.shouldHydrate) {
+      const metadata = getClientModuleMetadata(layout.modulePath, root);
+      return {
+        ...layout,
+        shouldHydrate: metadata.shouldHydrate,
+        islandStrategy: metadata.islandStrategy,
+      };
+    } catch (error) {
+      logger.warn(`⚠️  Could not inspect layout file ${layout.modulePath}: ${error}`);
+      return {
+        ...layout,
+        shouldHydrate: false,
+        islandStrategy: null,
+      };
+    }
+  });
+
+  const layoutAppliesToRoute = (layoutPattern: string, routePattern: string) =>
+    layoutPattern === "/" ||
+    routePattern === layoutPattern ||
+    routePattern.startsWith(`${layoutPattern}/`);
+
+  for (const route of pageRoutes) {
+    try {
+      const metadata = isFarmMarkdownPageFile(route.modulePath)
+        ? {
+            isClientComponent: false,
+            shouldHydrate: false,
+            islandStrategy: null,
+          }
+        : getClientModuleMetadata(route.modulePath, root);
+      const applicableClientLayouts = clientLayouts.filter(
+        (layout) =>
+          layout.shouldHydrate && layoutAppliesToRoute(layout.pattern, route.pattern),
+      );
+      if (metadata.shouldHydrate || applicableClientLayouts.length > 0) {
         const relativePath = route.modulePath.replace(root, "").replace(/^\//, "");
+        const hydrationStrategies = [
+          ...(metadata.islandStrategy ? [metadata.islandStrategy] : []),
+          ...applicableClientLayouts.flatMap((layout) =>
+            layout.islandStrategy ? [layout.islandStrategy] : [],
+          ),
+        ];
+        const islandStrategy = hydrationStrategies.every(
+          (strategy) => strategy === hydrationStrategies[0],
+        )
+          ? (hydrationStrategies[0] ?? "load")
+          : "load";
         clientPages.push({
           ...route,
           relativePath,
-          islandStrategy: metadata.islandStrategy ?? "load",
+          pageShouldHydrate: metadata.shouldHydrate,
+          islandStrategy,
         });
         logger.info(`📱 Found hydratable route: ${route.pattern} -> ${route.modulePath}`);
       }
@@ -1029,7 +1072,7 @@ async function buildClient(
   });
 
   logger.info(
-    `📱 Total hydratable routes detected: ${clientPages.length} pages and ${clientRouteSlots.length} slots`,
+    `📱 Total hydratable routes detected: ${clientPages.length} pages, ${clientLayouts.filter((layout) => layout.shouldHydrate).length} layouts, and ${clientRouteSlots.length} slots`,
   );
 
   // Generate client hydration entry code
@@ -1041,12 +1084,13 @@ async function buildClient(
   const clientEntryPath = path.join(clientEntryDir, "farm-client-entry.tsx");
   const clientHydrationCode = generateClientHydrationEntry(
     clientPages,
-    layoutRoutes,
+    clientLayouts,
     clientRouteSlots,
     root,
     srcDir,
     isFarmDocsSearchEnabled(config.docs),
     resolveFarmDocsSearchClientModule(root),
+    config.docs?.enabled ? config.docs.entry : undefined,
     config.i18n,
     config.plugins,
   );
@@ -1428,14 +1472,21 @@ function generateClientHydrationEntry(
     pattern: string;
     modulePath: string;
     relativePath: string;
+    pageShouldHydrate: boolean;
     islandStrategy: FarmIslandStrategy;
   }>,
-  layoutRoutes: Array<{ pattern: string; modulePath: string }>,
+  layoutRoutes: Array<{
+    pattern: string;
+    modulePath: string;
+    shouldHydrate: boolean;
+    islandStrategy: FarmIslandStrategy | null;
+  }>,
   clientRouteSlots: UniversalRouteSlot[],
   root: string,
   srcDir: string,
   docsSearchEnabled: boolean,
   docsSearchModuleId: string | undefined,
+  docsEntryPath: string | undefined,
   i18nConfig: ResolvedFarmConfig["i18n"] = {
     enabled: false,
     locales: ["en"],
@@ -1475,7 +1526,7 @@ function generateClientHydrationEntry(
     const relativePath = toImportPath(layout.modulePath);
     layoutImportStatements.push(`import Layout${index} from "${relativePath}";`);
     layoutRegistrations.push(
-      `  { pattern: ${JSON.stringify(layout.pattern)}, Component: Layout${index} }`,
+      `  { pattern: ${JSON.stringify(layout.pattern)}, Component: Layout${index}, shouldHydrate: ${JSON.stringify(layout.shouldHydrate)}, islandStrategy: ${JSON.stringify(layout.islandStrategy)} }`,
     );
   });
 
@@ -1514,6 +1565,19 @@ function isFarmLocaleDocumentChange() {
   return false;
 }
 `;
+  const docsNavigationRuntime = docsEntryPath
+    ? `
+const farmDocsEntryPath = ${JSON.stringify(docsEntryPath)};
+function isFarmDocsPath(pathname) {
+  const normalizedPath = pathname.length > 1 ? pathname.replace(/\\/+$/, "") : pathname;
+  return normalizedPath === farmDocsEntryPath || normalizedPath.startsWith(farmDocsEntryPath + "/");
+}
+`
+    : `
+function isFarmDocsPath() {
+  return false;
+}
+`;
 
   if (clientPages.length === 0 && clientRouteSlots.length === 0) {
     // No client pages - just basic runtime with CSS and SPA navigation
@@ -1524,6 +1588,7 @@ ${layoutImports}
 import { createClientPluginManager, installChunkErrorRecovery } from "@farm.js/core/internal/client-runtime";
 ${clientPluginEntry.imports}
 ${i18nClientRuntime}
+${docsNavigationRuntime}
 ${generateFarmDocsSearchClientRuntime(docsSearchEnabled, docsSearchModuleId)}
 
 installChunkErrorRecovery();
@@ -1539,6 +1604,10 @@ ${generateUniversalRouterStateProperties()}
   navigate: async function(href, options = {}) {
     const url = new URL(href, window.location.origin);
     if (url.origin !== window.location.origin) {
+      window.location.href = href;
+      return;
+    }
+    if (isFarmDocsPath(url.pathname)) {
       window.location.href = href;
       return;
     }
@@ -1616,6 +1685,7 @@ ${generateUniversalRouterStateProperties()}
     const parser = new DOMParser();
     const doc = parser.parseFromString(html, "text/html");
     if (isFarmLocaleDocumentChange(doc)) return false;
+    if (doc.getElementById("nd-docs-layout")) return false;
     
     // Update title
     const newTitle = doc.querySelector("title");
@@ -1771,11 +1841,14 @@ document.addEventListener("click", function(e) {
   const routeSlotEntries: string[] = [];
 
   clientPages.forEach((page) => {
-    const importPath = toImportPath(page.modulePath);
+    const load = page.pageShouldHydrate
+      ? `() => import(${JSON.stringify(toImportPath(page.modulePath))}).then((module) => module.default)`
+      : "null";
     routeEntries.push(`  {
     pattern: ${JSON.stringify(page.pattern)},
+    pageShouldHydrate: ${JSON.stringify(page.pageShouldHydrate)},
     islandStrategy: ${JSON.stringify(page.islandStrategy)},
-    load: () => import(${JSON.stringify(importPath)}).then((module) => module.default),
+    load: ${load},
   }`);
   });
   clientRouteSlots.forEach((slot, index) => {
@@ -1803,6 +1876,7 @@ import { createClientPluginManager, installChunkErrorRecovery, scheduleFarmIslan
 import { matchFarmRoute } from "@farm.js/core/router";
 ${clientPluginEntry.imports}
 ${i18nClientRuntime}
+${docsNavigationRuntime}
 
 ${imports.join("\n")}
 ${generateFarmDocsSearchClientRuntime(docsSearchEnabled, docsSearchModuleId)}
@@ -1846,6 +1920,12 @@ function getApplicableLayouts(pathname) {
   return applicable;
 }
 
+function hasHydratableLayout(pathname) {
+  return getApplicableLayouts(pathname).some(function(layout) {
+    return layout.shouldHydrate === true;
+  });
+}
+
 // Wrap a page element with applicable layouts
 function wrapWithLayouts(pageElement, pathname, params) {
   const layouts = getApplicableLayouts(pathname);
@@ -1862,6 +1942,22 @@ function wrapWithLayouts(pageElement, pathname, params) {
   return wrapped;
 }
 
+function createLayoutPageBoundary(route, pageElement, serverHtml) {
+  const props = {
+    id: "__farm_page__",
+    "data-farm-client": route.pageShouldHydrate ? "true" : "false",
+    "data-farm-layout-client": "true",
+    "data-farm-island": "page",
+    "data-farm-island-strategy": route.islandStrategy || "load",
+  };
+  if (typeof serverHtml === "string") {
+    props.suppressHydrationWarning = true;
+    props.dangerouslySetInnerHTML = { __html: serverHtml };
+    return React.createElement("div", props);
+  }
+  return React.createElement("div", props, pageElement);
+}
+
 // Match pathname to client route
 function matchRoute(pathname) {
   pathname = getFarmRoutePathname(pathname);
@@ -1873,9 +1969,37 @@ function matchRoute(pathname) {
 }
 
 async function loadRouteComponent(route) {
+  if (!route.load) return null;
   if (route.Component) return route.Component;
   route.Component = await route.load();
   return route.Component;
+}
+
+async function createMatchedHydrationElement(matched, pathname, searchParams) {
+  const hydrateLayouts = hasHydratableLayout(pathname);
+  const params = matched.params;
+  let pageElement = null;
+
+  if (matched.route.pageShouldHydrate) {
+    const Component = await loadRouteComponent(matched.route);
+    if (!Component) return null;
+    const props = { params: params, searchParams: Promise.resolve(searchParams) };
+    pageElement = React.createElement(Component, props);
+  } else if (hydrateLayouts) {
+    const serverPage = document.getElementById("__farm_page__");
+    pageElement = createLayoutPageBoundary(
+      matched.route,
+      null,
+      serverPage ? serverPage.innerHTML : "",
+    );
+  }
+
+  if (!pageElement) return null;
+  if (!hydrateLayouts) return pageElement;
+  if (matched.route.pageShouldHydrate) {
+    pageElement = createLayoutPageBoundary(matched.route, pageElement);
+  }
+  return wrapWithLayouts(pageElement, pathname, params);
 }
 
 function matchesRoutePrefix(pathname, pattern) {
@@ -2051,9 +2175,10 @@ async function hydrate() {
     return;
   }
   
-  const container =
-    document.getElementById("__farm_page__") ||
-    document.getElementById("root");
+  const rootContainer = document.getElementById("root");
+  const container = hasHydratableLayout(pathname)
+    ? rootContainer
+    : document.getElementById("__farm_page__") || rootContainer;
   if (!container) {
     console.error("[Farm.js] No root element found");
     return;
@@ -2070,7 +2195,6 @@ async function hydrate() {
       strategy: matched.route.islandStrategy,
       signal: hydrationController.signal,
       hydrate: async function() {
-        const Component = await loadRouteComponent(matched.route);
         if (
           hydrationController.signal.aborted ||
           !container.isConnected ||
@@ -2078,13 +2202,13 @@ async function hydrate() {
         ) {
           return;
         }
-        const params = matched.params;
         const searchParams = Object.fromEntries(new URLSearchParams(window.location.search));
-        const props = { params: params, searchParams: Promise.resolve(searchParams) };
-        const pageElement = React.createElement(Component, props);
-        const wrappedElement = container.id === "__farm_page__"
-          ? pageElement
-          : wrapWithLayouts(pageElement, pathname, params);
+        const wrappedElement = await createMatchedHydrationElement(
+          matched,
+          pathname,
+          searchParams,
+        );
+        if (!wrappedElement) return;
         const shouldHydrate = !isHydrated && Boolean(container.innerHTML.trim());
         const hydrationSession = await farmClientRuntime.beginHydration({
           container,
@@ -2133,6 +2257,10 @@ ${generateUniversalRouterStateProperties()}
   navigate: async function(href, options = {}) {
     const url = new URL(href, window.location.origin);
     if (url.origin !== window.location.origin) {
+      window.location.href = href;
+      return;
+    }
+    if (isFarmDocsPath(url.pathname)) {
       window.location.href = href;
       return;
     }
@@ -2217,14 +2345,17 @@ ${generateUniversalRouterStateProperties()}
         }
       }
 
-      if (matched) {
+      if (matched?.route.pageShouldHydrate) {
         // Navigation itself signals intent, so destination routes load eagerly even
         // when their initial document hydration strategy is deferred.
         const Component = await loadRouteComponent(matched.route);
         const params = matched.params;
         const searchParams = Object.fromEntries(url.searchParams);
         const props = { params: params, searchParams: Promise.resolve(searchParams) };
-        const pageElement = React.createElement(Component, props);
+        let pageElement = React.createElement(Component, props);
+        if (hasHydratableLayout(pathname)) {
+          pageElement = createLayoutPageBoundary(matched.route, pageElement);
+        }
         const wrappedElement = wrapWithLayouts(pageElement, pathname, params);
 
         await farmClientRuntime.markNavigationLoaded(clientNavigation, {
@@ -2318,6 +2449,7 @@ ${generateUniversalRouterStateProperties()}
     const parser = new DOMParser();
     const doc = parser.parseFromString(html, "text/html");
     if (isFarmLocaleDocumentChange(doc)) return false;
+    if (doc.getElementById("nd-docs-layout")) return false;
     const nextRouteSlots = readRouteSlotPayload(doc);
     
     // Update title
@@ -2353,20 +2485,20 @@ ${generateUniversalRouterStateProperties()}
     const newPathname = targetUrl.pathname;
     const matched = matchRoute(newPathname);
     if (matched) {
-      // Re-hydrate the client component
-      const Component = await loadRouteComponent(matched.route);
-      const params = matched.params;
       const searchParams = Object.fromEntries(targetUrl.searchParams);
-      const props = { params: params, searchParams: Promise.resolve(searchParams) };
-      const pageElement = React.createElement(Component, props);
+      const hydrateLayouts = hasHydratableLayout(newPathname);
       const pageContainer =
-        document.getElementById("__farm_page__") || currentRoot;
-      const wrappedElement = pageContainer.id === "__farm_page__"
-        ? pageElement
-        : wrapWithLayouts(pageElement, newPathname, params);
-      reactRoot = hydrateRoot(pageContainer, wrappedElement);
-      reactRootContainer = pageContainer;
-      isHydrated = true;
+        hydrateLayouts ? currentRoot : document.getElementById("__farm_page__") || currentRoot;
+      const wrappedElement = await createMatchedHydrationElement(
+        matched,
+        newPathname,
+        searchParams,
+      );
+      if (wrappedElement) {
+        reactRoot = hydrateRoot(pageContainer, wrappedElement);
+        reactRootContainer = pageContainer;
+        isHydrated = true;
+      }
     }
     return true;
   },
@@ -2499,9 +2631,8 @@ document.addEventListener("click", function(e) {
 // Initial hydration
 if (isFarmDocsSearchPage()) {
   mountFarmDocsSearch();
-} else {
-  void hydrate();
 }
+void hydrate();
 `.trim();
 }
 
@@ -3014,11 +3145,14 @@ function generateVirtualEntryCode(
 
   layoutRoutes.forEach((layout, index) => {
     const varName = `layoutRoute${index}`;
+    const clientMetadata = getClientModuleMetadata(layout.modulePath, config.root);
     layoutImports.push(`import * as ${varName} from "${layout.modulePath}";`);
     layoutRegistrations.push(`
   {
     pattern: ${JSON.stringify(layout.pattern)},
     module: ${varName},
+    shouldHydrate: ${JSON.stringify(clientMetadata.shouldHydrate)},
+    islandStrategy: ${JSON.stringify(clientMetadata.islandStrategy)},
   }`);
   });
 
@@ -4467,6 +4601,76 @@ function getApplicableLayouts(pathname) {
   return applicable;
 }
 
+${
+  config.docs?.enabled
+    ? `async function wrapFarmDocsResponseWithLayouts(request, response) {
+  if (request.method === "HEAD") return response;
+
+  const pathname = getFarmRoutePathname(new URL(request.url).pathname);
+  const applicableLayouts = getApplicableLayouts(pathname);
+  if (!applicableLayouts.some((layout) => layout.shouldHydrate === true)) {
+    return response;
+  }
+
+  const source = await response.text();
+  const bodyMatch = source.match(/<body([^>]*)>([\\s\\S]*?)<\\/body>/i);
+  if (!bodyMatch) {
+    return new Response(source, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  }
+
+  const matchedRoute = matchPageRoute(pathname);
+  const params = matchedRoute?.params || {};
+  const hydrationStrategies = applicableLayouts.flatMap((layout) =>
+    layout.shouldHydrate && layout.islandStrategy ? [layout.islandStrategy] : [],
+  );
+  const islandStrategy = hydrationStrategies.every(
+    (strategy) => strategy === hydrationStrategies[0],
+  )
+    ? (hydrationStrategies[0] || "load")
+    : "load";
+  let wrappedElement = React.createElement("div", {
+    id: "__farm_page__",
+    "data-farm-client": "false",
+    "data-farm-layout-client": "true",
+    "data-farm-island": "page",
+    "data-farm-island-strategy": islandStrategy,
+    dangerouslySetInnerHTML: { __html: bodyMatch[2] },
+  });
+
+  for (let index = applicableLayouts.length - 1; index >= 0; index--) {
+    const LayoutComponent = applicableLayouts[index].module.default;
+    if (LayoutComponent) {
+      wrappedElement = React.createElement(LayoutComponent, {
+        children: wrappedElement,
+        params,
+      });
+    }
+  }
+
+  const rootMarkup = await renderFarmElementToString(
+    ReactDOMServer,
+    React.createElement("div", { id: "root" }, wrappedElement),
+  );
+  const html = source.replace(
+    bodyMatch[0],
+    "<body" + bodyMatch[1] + ">" + rootMarkup + "</body>",
+  );
+  const headers = new Headers(response.headers);
+  headers.delete("content-length");
+  headers.delete("etag");
+  return new Response(html, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}`
+    : ""
+}
+
 const pprShellCache = getFarmDataCache();
 
 function resolvePPRConfig(routeModule) {
@@ -4673,11 +4877,15 @@ async function handleFarmRequestInContext(
       if (!docsResponse.headers.get("content-type")?.toLowerCase().includes("text/html")) {
         return docsResponse;
       }
-      const docsHeaders = new Headers(docsResponse.headers);
+      const wrappedDocsResponse = await wrapFarmDocsResponseWithLayouts(
+        request,
+        docsResponse,
+      );
+      const docsHeaders = new Headers(wrappedDocsResponse.headers);
       docsHeaders.set("x-farm-preload-buffered", "1");
-      return new Response(docsResponse.body, {
-        status: docsResponse.status,
-        statusText: docsResponse.statusText,
+      return new Response(wrappedDocsResponse.body, {
+        status: wrappedDocsResponse.status,
+        statusText: wrappedDocsResponse.statusText,
         headers: docsHeaders,
       });
     }
@@ -4845,6 +5053,20 @@ async function handleFarmRequestInContext(
       
       // Get applicable layouts for this page
       const applicableLayouts = getApplicableLayouts(routePathname);
+      const shouldHydrateLayout = applicableLayouts.some(
+        (layout) => layout.shouldHydrate === true,
+      );
+      const hydrationStrategies = [
+        ...(route.shouldHydrate && route.islandStrategy ? [route.islandStrategy] : []),
+        ...applicableLayouts.flatMap((layout) =>
+          layout.shouldHydrate && layout.islandStrategy ? [layout.islandStrategy] : [],
+        ),
+      ];
+      const hydrationIslandStrategy = hydrationStrategies.every(
+        (strategy) => strategy === hydrationStrategies[0],
+      )
+        ? (hydrationStrategies[0] || "load")
+        : "load";
       const selectedRouteSlots = matchRouteSlots(
         routePathname,
         request.headers.get("x-farm-intercept-from"),
@@ -5057,14 +5279,17 @@ async function handleFarmRequestInContext(
               pageElement = React.createElement(PageComponent, pageProps);
             }
 
-            if (route.shouldHydrate) {
+            if (route.shouldHydrate || shouldHydrateLayout) {
               pageElement = React.createElement(
                 "div",
                 {
                   id: "__farm_page__",
-                  "data-farm-client": "true",
+                  "data-farm-client": route.shouldHydrate ? "true" : "false",
+                  ...(shouldHydrateLayout
+                    ? { "data-farm-layout-client": "true" }
+                    : {}),
                   "data-farm-island": "page",
-                  "data-farm-island-strategy": route.islandStrategy || "load",
+                  "data-farm-island-strategy": hydrationIslandStrategy,
                 },
                 pageElement,
               );

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -936,6 +936,41 @@ export class ServerRenderer {
         }),
       );
       const shouldHydrate = moduleMetadata.shouldHydrate;
+      const layoutHydrationMetadata = layouts.map((layout) => {
+        const manifestEntry = routeManifest.layouts.find(
+          (entry) => entry.pattern === layout.pattern,
+        ) as
+          | {
+              isClientComponent?: boolean;
+              shouldHydrate?: boolean;
+              islandStrategy?: "load" | "interaction" | "visible" | "idle" | null;
+            }
+          | undefined;
+        if (typeof manifestEntry?.shouldHydrate === "boolean") {
+          return {
+            isClientComponent: manifestEntry.isClientComponent === true,
+            shouldHydrate: manifestEntry.shouldHydrate,
+            islandStrategy: manifestEntry.islandStrategy ?? null,
+          };
+        }
+        return getClientModuleMetadata(layout.modulePath, this.config.root);
+      });
+      const shouldHydrateLayout = layoutHydrationMetadata.some(
+        (metadata) => metadata.shouldHydrate,
+      );
+      const hydrationStrategies = [
+        ...(shouldHydrate && moduleMetadata.islandStrategy
+          ? [moduleMetadata.islandStrategy]
+          : []),
+        ...layoutHydrationMetadata.flatMap((metadata) =>
+          metadata.shouldHydrate && metadata.islandStrategy ? [metadata.islandStrategy] : [],
+        ),
+      ];
+      const hydrationIslandStrategy = hydrationStrategies.every(
+        (strategy) => strategy === hydrationStrategies[0],
+      )
+        ? (hydrationStrategies[0] ?? "load")
+        : "load";
       const hasHydratableRouteSlots = renderedRouteSlots.some(
         (slot) => slot.isClientComponent || slot.shouldHydrate,
       );
@@ -943,8 +978,10 @@ export class ServerRenderer {
       (req as any).__FARM_PAGE_PATH__ = route.modulePath;
       (req as any).__FARM_ROUTE__ = pathname;
       (req as any).__FARM_IS_CLIENT_COMPONENT__ = isClientComponent;
-      (req as any).__FARM_SHOULD_HYDRATE__ = shouldHydrate;
-      (req as any).__FARM_ISLAND_STRATEGY__ = moduleMetadata.islandStrategy;
+      (req as any).__FARM_PAGE_SHOULD_HYDRATE__ = shouldHydrate;
+      (req as any).__FARM_LAYOUT_SHOULD_HYDRATE__ = shouldHydrateLayout;
+      (req as any).__FARM_SHOULD_HYDRATE__ = shouldHydrate || shouldHydrateLayout;
+      (req as any).__FARM_ISLAND_STRATEGY__ = hydrationIslandStrategy;
       (req as any).__FARM_HAS_HYDRATABLE_ROUTE_SLOTS__ = hasHydratableRouteSlots;
       (req as any).__FARM_LOADING_MODULE_PATH__ = loadingBoundaryEntry?.modulePath
         ? loadingBoundaryEntry.modulePath.substring(
@@ -1045,14 +1082,18 @@ export class ServerRenderer {
 
             // Wrap hydratable pages in a targeted container so the client can attach
             // without re-hydrating the surrounding layout shell.
-            if (isClientComponent || shouldHydrate) {
+            if (isClientComponent || shouldHydrate || shouldHydrateLayout) {
               pageElement = React.createElement(
                 "div",
                 {
                   id: "__farm_page__",
-                  "data-farm-client": "true",
+                  "data-farm-client":
+                    isClientComponent || shouldHydrate ? "true" : "false",
+                  ...(shouldHydrateLayout
+                    ? { "data-farm-layout-client": "true" }
+                    : {}),
                   "data-farm-island": "page",
-                  "data-farm-island-strategy": moduleMetadata.islandStrategy ?? "load",
+                  "data-farm-island-strategy": hydrationIslandStrategy,
                 },
                 pageElement,
               );
@@ -1605,9 +1646,15 @@ export class ServerRenderer {
 
       // Convert layouts array to object
       for (const layoutEntry of manifest.layouts) {
+        const layoutMetadata =
+          typeof (layoutEntry as any).shouldHydrate === "boolean"
+            ? (layoutEntry as any)
+            : getClientModuleMetadata(layoutEntry.modulePath, this.config.root);
         clientManifest.layouts[layoutEntry.pattern] = {
           modulePath: layoutEntry.modulePath,
           pattern: layoutEntry.pattern,
+          shouldHydrate: layoutMetadata.shouldHydrate,
+          islandStrategy: layoutMetadata.islandStrategy,
           preloads: [layoutEntry.modulePath],
           assets: [],
         };
@@ -1642,6 +1689,12 @@ window.__FARM_ROUTE_SLOTS__ = ${serializeInlineValue((deferredProps.data as any)
 window.__FARM_DEPLOYMENT_ID__ = ${serializeInlineValue(deploymentId)};
 window.__FARM_PATH__ = ${JSON.stringify((req as any).__FARM_ROUTE__ || req.url || "/")};
 window.__FARM_IS_CLIENT__ = ${JSON.stringify(isClientComponent)};
+window.__FARM_PAGE_SHOULD_HYDRATE__ = ${JSON.stringify(
+        (req as any).__FARM_PAGE_SHOULD_HYDRATE__ === true,
+      )};
+window.__FARM_LAYOUT_SHOULD_HYDRATE__ = ${JSON.stringify(
+        (req as any).__FARM_LAYOUT_SHOULD_HYDRATE__ === true,
+      )};
 window.__FARM_SHOULD_HYDRATE__ = ${JSON.stringify((req as any).__FARM_SHOULD_HYDRATE__ === true)};
 window.__FARM_ISLAND_STRATEGY__ = ${JSON.stringify((req as any).__FARM_ISLAND_STRATEGY__ || "load")};
 window.__FARM_PAGE_MODULE__ = ${JSON.stringify(relativePath)};

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -381,7 +381,7 @@ export class ServerRenderer {
         this.ssgManifest = JSON.parse(content);
         logger.info(`Loaded SSG manifest: ${this.ssgManifest.length} pages`);
       }
-    } catch (error) {
+    } catch {
       // No manifest in dev mode or first build
     }
   }
@@ -958,6 +958,14 @@ export class ServerRenderer {
       const shouldHydrateLayout = layoutHydrationMetadata.some(
         (metadata) => metadata.shouldHydrate,
       );
+      const clientLayouts = layouts.map((layout, index) => ({
+        pattern: layout.pattern,
+        modulePath: layout.modulePath.startsWith(this.config.root)
+          ? layout.modulePath.slice(this.config.root.length)
+          : layout.modulePath,
+        shouldHydrate: layoutHydrationMetadata[index]?.shouldHydrate === true,
+        islandStrategy: layoutHydrationMetadata[index]?.islandStrategy ?? null,
+      }));
       const hydrationStrategies = [
         ...(shouldHydrate && moduleMetadata.islandStrategy ? [moduleMetadata.islandStrategy] : []),
         ...layoutHydrationMetadata.flatMap((metadata) =>
@@ -978,6 +986,7 @@ export class ServerRenderer {
       (req as any).__FARM_IS_CLIENT_COMPONENT__ = isClientComponent;
       (req as any).__FARM_PAGE_SHOULD_HYDRATE__ = shouldHydrate;
       (req as any).__FARM_LAYOUT_SHOULD_HYDRATE__ = shouldHydrateLayout;
+      (req as any).__FARM_LAYOUTS__ = clientLayouts;
       (req as any).__FARM_SHOULD_HYDRATE__ = shouldHydrate || shouldHydrateLayout;
       (req as any).__FARM_ISLAND_STRATEGY__ = hydrationIslandStrategy;
       (req as any).__FARM_HAS_HYDRATABLE_ROUTE_SLOTS__ = hasHydratableRouteSlots;
@@ -1690,6 +1699,7 @@ window.__FARM_PAGE_SHOULD_HYDRATE__ = ${JSON.stringify(
 window.__FARM_LAYOUT_SHOULD_HYDRATE__ = ${JSON.stringify(
         (req as any).__FARM_LAYOUT_SHOULD_HYDRATE__ === true,
       )};
+window.__FARM_LAYOUTS__ = ${JSON.stringify((req as any).__FARM_LAYOUTS__ || [])};
 window.__FARM_SHOULD_HYDRATE__ = ${JSON.stringify((req as any).__FARM_SHOULD_HYDRATE__ === true)};
 window.__FARM_ISLAND_STRATEGY__ = ${JSON.stringify((req as any).__FARM_ISLAND_STRATEGY__ || "load")};
 window.__FARM_PAGE_MODULE__ = ${JSON.stringify(relativePath)};
@@ -1720,7 +1730,7 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
 
       // React 19: ensure root is a single DOM node so streaming starts early (avoids Fragment delay)
       const streamRoot = React.createElement("div", { style: { display: "contents" } }, element);
-      const { pipe, abort } = renderToPipeableStream(streamRoot, {
+      const { pipe } = renderToPipeableStream(streamRoot, {
         onShellReady() {
           const shellReadyMs = Date.now() - streamStartTime;
           emitFarmEvent({

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -959,9 +959,7 @@ export class ServerRenderer {
         (metadata) => metadata.shouldHydrate,
       );
       const hydrationStrategies = [
-        ...(shouldHydrate && moduleMetadata.islandStrategy
-          ? [moduleMetadata.islandStrategy]
-          : []),
+        ...(shouldHydrate && moduleMetadata.islandStrategy ? [moduleMetadata.islandStrategy] : []),
         ...layoutHydrationMetadata.flatMap((metadata) =>
           metadata.shouldHydrate && metadata.islandStrategy ? [metadata.islandStrategy] : [],
         ),
@@ -1087,11 +1085,8 @@ export class ServerRenderer {
                 "div",
                 {
                   id: "__farm_page__",
-                  "data-farm-client":
-                    isClientComponent || shouldHydrate ? "true" : "false",
-                  ...(shouldHydrateLayout
-                    ? { "data-farm-layout-client": "true" }
-                    : {}),
+                  "data-farm-client": isClientComponent || shouldHydrate ? "true" : "false",
+                  ...(shouldHydrateLayout ? { "data-farm-layout-client": "true" } : {}),
                   "data-farm-island": "page",
                   "data-farm-island-strategy": hydrationIslandStrategy,
                 },

--- a/packages/farm/src/utils/client-component.ts
+++ b/packages/farm/src/utils/client-component.ts
@@ -316,7 +316,7 @@ function inspectClientModuleMetadata(
     const importedPath = resolveImportedModuleSourcePath(resolvedPath, specifier, root);
     const importedMetadata =
       !specifier.startsWith(".") && !specifier.startsWith("/")
-        ? inspectPackageClientBoundary(importedPath)
+        ? inspectPackageClientBoundary(importedPath, root, visited)
         : inspectClientModuleMetadata(importedPath, root, visited, false);
     if (importedMetadata.isClientComponent || importedMetadata.shouldHydrate) {
       importsClientBoundary = true;
@@ -341,35 +341,120 @@ function inspectClientModuleMetadata(
   };
 }
 
-function inspectPackageClientBoundary(resolvedPath: string | null): ClientModuleMetadata {
-  const parsed = parseClientModuleMetadata(
-    resolvedPath ? readIfExists(resolvedPath) : null,
-    false,
-  );
-  const shouldHydrate = parsed.isClientComponent || parsed.hasHydrateExport;
+function inspectPackageClientBoundary(
+  resolvedPath: string | null,
+  root: string | undefined,
+  visited: Set<string>,
+): ClientModuleMetadata {
+  if (!resolvedPath || visited.has(resolvedPath)) {
+    return {
+      isClientComponent: false,
+      shouldHydrate: false,
+      islandStrategy: null,
+    };
+  }
+
+  visited.add(resolvedPath);
+  const content = readIfExists(resolvedPath);
+  const parsed = parseClientModuleMetadata(content, false);
+  let importsClientBoundary = false;
+  let importedIslandStrategy: FarmIslandStrategy | null = null;
+
+  // Package entry points commonly re-export their React implementation from a
+  // relative file. Follow only files inside that package entry graph: scanning
+  // bare dependencies here would incorrectly turn server package APIs into
+  // client boundaries because of unrelated transitive imports.
+  for (const specifier of getImportSpecifiers(content)) {
+    if (!specifier.startsWith(".") && !specifier.startsWith("/")) continue;
+    const importedPath = resolveImportedModuleSourcePath(resolvedPath, specifier, root);
+    const importedMetadata = inspectPackageClientBoundary(importedPath, root, visited);
+    if (!importedMetadata.shouldHydrate) continue;
+    importsClientBoundary = true;
+    if (importedIslandStrategy === null) {
+      importedIslandStrategy = importedMetadata.islandStrategy;
+    } else if (importedIslandStrategy !== importedMetadata.islandStrategy) {
+      importedIslandStrategy = "load";
+    }
+  }
+
+  const shouldHydrate =
+    parsed.isClientComponent || parsed.hasHydrateExport || importsClientBoundary;
   return {
     isClientComponent: parsed.isClientComponent,
     shouldHydrate,
-    islandStrategy: shouldHydrate ? (parsed.islandStrategy ?? "load") : null,
+    islandStrategy: shouldHydrate
+      ? (parsed.islandStrategy ?? importedIslandStrategy ?? "load")
+      : null,
   };
 }
 
 function getImportSpecifiers(content: string | null): string[] {
-  if (!content) {
-    return [];
-  }
+  if (!content) return [];
 
-  const pattern =
-    /(?:^|\n)\s*(?:import|export)\s+(?:type\s+)?(?:[^"'`]+?\s+from\s+)?["']([^"']+)["']/g;
+  const tokens = tokenizeModuleSource(content);
   const matches = new Set<string>();
-  for (const match of content.matchAll(pattern)) {
-    const specifier = match[1];
+
+  for (let index = 0; index < tokens.length; index++) {
+    const keyword = tokens[index];
+    if (keyword.kind !== "identifier" || !["import", "export"].includes(keyword.value)) {
+      continue;
+    }
+
+    const previous = tokens[index - 1];
+    if (previous?.value === ".") continue;
+
+    const first = tokens[index + 1];
+    if (!first || first.value === "type" || first.value === "(" || first.value === ".") {
+      continue;
+    }
+
+    let specifier: string | undefined;
+    if (keyword.value === "import" && first.kind === "string") {
+      specifier = first.value;
+    } else {
+      if (keyword.value === "export" && first.value !== "{" && first.value !== "*") {
+        continue;
+      }
+
+      let fromIndex = -1;
+      for (let cursor = index + 1; cursor < tokens.length; cursor++) {
+        const token = tokens[cursor];
+        if (token.value === ";") break;
+        if (token.value === "from" && tokens[cursor + 1]?.kind === "string") {
+          fromIndex = cursor;
+          break;
+        }
+      }
+      if (fromIndex === -1 || isTypeOnlyNamedClause(tokens, index + 1, fromIndex)) {
+        continue;
+      }
+      specifier = tokens[fromIndex + 1].value;
+    }
+
     if (!specifier || specifier.startsWith("node:") || specifier.includes("?")) {
       continue;
     }
     matches.add(specifier);
   }
+
   return Array.from(matches);
+}
+
+function isTypeOnlyNamedClause(
+  tokens: ModuleSourceToken[],
+  startIndex: number,
+  endIndex: number,
+): boolean {
+  if (tokens[startIndex]?.value !== "{") return false;
+
+  let entryStartsAt = startIndex + 1;
+  for (let index = entryStartsAt; index <= endIndex; index++) {
+    if (index !== endIndex && tokens[index]?.value !== ",") continue;
+    const entry = tokens.slice(entryStartsAt, index).filter((token) => token.value !== "}");
+    if (entry.length > 0 && entry[0].value !== "type") return false;
+    entryStartsAt = index + 1;
+  }
+  return true;
 }
 
 function resolveImportedModuleSourcePath(
@@ -523,10 +608,17 @@ function resolveConditionalExportTarget(value: unknown): string | null {
   }
   if (!value || typeof value !== "object") return null;
 
-  const conditions = value as Record<string, unknown>;
-  for (const condition of ["browser", "import", "module", "default", "require"]) {
-    if (conditions[condition] === undefined) continue;
-    const resolved = resolveConditionalExportTarget(conditions[condition]);
+  const supportedConditions = new Set([
+    "browser",
+    "node",
+    "import",
+    "module",
+    "default",
+    "require",
+  ]);
+  for (const [condition, target] of Object.entries(value as Record<string, unknown>)) {
+    if (!supportedConditions.has(condition)) continue;
+    const resolved = resolveConditionalExportTarget(target);
     if (resolved) return resolved;
   }
   return null;

--- a/packages/farm/src/utils/client-component.ts
+++ b/packages/farm/src/utils/client-component.ts
@@ -312,9 +312,12 @@ function inspectClientModuleMetadata(
 
   let importsClientBoundary = false;
   let importedIslandStrategy: FarmIslandStrategy | null = null;
-  for (const specifier of getRelativeImportSpecifiers(content)) {
+  for (const specifier of getImportSpecifiers(content)) {
     const importedPath = resolveImportedModuleSourcePath(resolvedPath, specifier, root);
-    const importedMetadata = inspectClientModuleMetadata(importedPath, root, visited, false);
+    const importedMetadata =
+      !specifier.startsWith(".") && !specifier.startsWith("/")
+        ? inspectPackageClientBoundary(importedPath)
+        : inspectClientModuleMetadata(importedPath, root, visited, false);
     if (importedMetadata.isClientComponent || importedMetadata.shouldHydrate) {
       importsClientBoundary = true;
       if (importedIslandStrategy === null) {
@@ -338,7 +341,20 @@ function inspectClientModuleMetadata(
   };
 }
 
-function getRelativeImportSpecifiers(content: string | null): string[] {
+function inspectPackageClientBoundary(resolvedPath: string | null): ClientModuleMetadata {
+  const parsed = parseClientModuleMetadata(
+    resolvedPath ? readIfExists(resolvedPath) : null,
+    false,
+  );
+  const shouldHydrate = parsed.isClientComponent || parsed.hasHydrateExport;
+  return {
+    isClientComponent: parsed.isClientComponent,
+    shouldHydrate,
+    islandStrategy: shouldHydrate ? (parsed.islandStrategy ?? "load") : null,
+  };
+}
+
+function getImportSpecifiers(content: string | null): string[] {
   if (!content) {
     return [];
   }
@@ -348,7 +364,7 @@ function getRelativeImportSpecifiers(content: string | null): string[] {
   const matches = new Set<string>();
   for (const match of content.matchAll(pattern)) {
     const specifier = match[1];
-    if (!specifier || (!specifier.startsWith(".") && !specifier.startsWith("/"))) {
+    if (!specifier || specifier.startsWith("node:") || specifier.includes("?")) {
       continue;
     }
     matches.add(specifier);
@@ -361,6 +377,10 @@ function resolveImportedModuleSourcePath(
   specifier: string,
   root?: string,
 ): string | null {
+  if (!specifier.startsWith(".") && !specifier.startsWith("/")) {
+    return resolvePackageModuleSourcePath(importerPath, specifier, root);
+  }
+
   const candidates = new Set<string>();
   const basePath = specifier.startsWith(".")
     ? path.resolve(path.dirname(importerPath), specifier)
@@ -380,5 +400,151 @@ function resolveImportedModuleSourcePath(
     }
   }
 
+  return null;
+}
+
+function resolvePackageModuleSourcePath(
+  importerPath: string,
+  specifier: string,
+  root?: string,
+): string | null {
+  const packageParts = specifier.split("/");
+  const packageName = specifier.startsWith("@")
+    ? packageParts.slice(0, 2).join("/")
+    : packageParts[0];
+  const packageSubpath = packageParts.slice(packageName.startsWith("@") ? 2 : 1).join("/");
+  const packageDirectory = findPackageDirectory(importerPath, packageName, root);
+  if (!packageDirectory) return null;
+
+  const packageJsonPath = path.join(packageDirectory, "package.json");
+  const packageJson = readPackageJson(packageJsonPath);
+  const exportKey = packageSubpath ? `./${packageSubpath}` : ".";
+  const exportTarget = resolvePackageExport(packageJson?.exports, exportKey);
+  const candidates = new Set<string>();
+
+  if (exportTarget?.startsWith("./")) {
+    candidates.add(path.resolve(packageDirectory, exportTarget));
+  }
+  if (packageSubpath) {
+    candidates.add(path.join(packageDirectory, packageSubpath));
+  } else {
+    for (const entry of [packageJson?.browser, packageJson?.module, packageJson?.main]) {
+      if (typeof entry === "string") candidates.add(path.resolve(packageDirectory, entry));
+    }
+    candidates.add(path.join(packageDirectory, "index"));
+  }
+
+  return resolveSourceCandidate(candidates);
+}
+
+function findPackageDirectory(
+  importerPath: string,
+  packageName: string,
+  root?: string,
+): string | null {
+  const searchRoots = new Set<string>();
+  let current = path.dirname(importerPath);
+  while (true) {
+    searchRoots.add(current);
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  if (root) {
+    current = path.resolve(root);
+    while (true) {
+      searchRoots.add(current);
+      const parent = path.dirname(current);
+      if (parent === current) break;
+      current = parent;
+    }
+  }
+
+  for (const searchRoot of searchRoots) {
+    const packageDirectory = path.join(searchRoot, "node_modules", packageName);
+    if (fs.existsSync(path.join(packageDirectory, "package.json"))) {
+      return packageDirectory;
+    }
+  }
+  return null;
+}
+
+function readPackageJson(packageJsonPath: string): Record<string, any> | null {
+  try {
+    return JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function resolvePackageExport(exportsField: unknown, exportKey: string): string | null {
+  if (typeof exportsField === "string") {
+    return exportKey === "." ? exportsField : null;
+  }
+  if (Array.isArray(exportsField)) {
+    for (const candidate of exportsField) {
+      const resolved = resolvePackageExport(candidate, exportKey);
+      if (resolved) return resolved;
+    }
+    return null;
+  }
+  if (!exportsField || typeof exportsField !== "object") return null;
+
+  const entries = Object.entries(exportsField as Record<string, unknown>);
+  const subpathExports = entries.some(([key]) => key.startsWith("."));
+  if (subpathExports) {
+    const exact = (exportsField as Record<string, unknown>)[exportKey];
+    if (exact !== undefined) return resolveConditionalExportTarget(exact);
+
+    for (const [key, value] of entries) {
+      const wildcardIndex = key.indexOf("*");
+      if (wildcardIndex === -1) continue;
+      const prefix = key.slice(0, wildcardIndex);
+      const suffix = key.slice(wildcardIndex + 1);
+      if (!exportKey.startsWith(prefix) || !exportKey.endsWith(suffix)) continue;
+      const wildcard = exportKey.slice(prefix.length, exportKey.length - suffix.length);
+      const target = resolveConditionalExportTarget(value);
+      return target?.replace("*", wildcard) ?? null;
+    }
+    return null;
+  }
+
+  return exportKey === "." ? resolveConditionalExportTarget(exportsField) : null;
+}
+
+function resolveConditionalExportTarget(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    for (const candidate of value) {
+      const resolved = resolveConditionalExportTarget(candidate);
+      if (resolved) return resolved;
+    }
+    return null;
+  }
+  if (!value || typeof value !== "object") return null;
+
+  const conditions = value as Record<string, unknown>;
+  for (const condition of ["browser", "import", "module", "default", "require"]) {
+    if (conditions[condition] === undefined) continue;
+    const resolved = resolveConditionalExportTarget(conditions[condition]);
+    if (resolved) return resolved;
+  }
+  return null;
+}
+
+function resolveSourceCandidate(candidates: Iterable<string>): string | null {
+  for (const candidate of candidates) {
+    const paths = [candidate];
+    for (const extension of RESOLVABLE_SOURCE_EXTENSIONS) {
+      paths.push(`${candidate}${extension}`, path.join(candidate, `index${extension}`));
+    }
+    for (const sourcePath of paths) {
+      try {
+        if (fs.statSync(sourcePath).isFile()) return sourcePath;
+      } catch {
+        // Continue to the next candidate.
+      }
+    }
+  }
   return null;
 }

--- a/packages/farm/src/utils/client-component.ts
+++ b/packages/farm/src/utils/client-component.ts
@@ -103,6 +103,82 @@ interface ModuleSourceToken {
   line: number;
 }
 
+const REGEXP_PREFIX_PUNCTUATION = new Set([
+  "(",
+  "[",
+  "{",
+  ",",
+  ";",
+  ":",
+  "=",
+  "!",
+  "?",
+  "&",
+  "|",
+  "+",
+  "-",
+  "*",
+  "%",
+  "^",
+  "~",
+  ">",
+]);
+const REGEXP_PREFIX_KEYWORDS = new Set([
+  "await",
+  "case",
+  "delete",
+  "do",
+  "else",
+  "in",
+  "instanceof",
+  "new",
+  "of",
+  "return",
+  "throw",
+  "typeof",
+  "void",
+  "yield",
+]);
+
+function canStartRegularExpression(previous: ModuleSourceToken | undefined): boolean {
+  if (!previous) return true;
+  return previous.kind === "identifier"
+    ? REGEXP_PREFIX_KEYWORDS.has(previous.value)
+    : REGEXP_PREFIX_PUNCTUATION.has(previous.value);
+}
+
+function skipRegularExpression(content: string, startIndex: number): number | null {
+  let index = startIndex + 1;
+  let inCharacterClass = false;
+
+  while (index < content.length) {
+    const character = content[index];
+    if (character === "\n" || character === "\r") return null;
+    if (character === "\\") {
+      index += 2;
+      continue;
+    }
+    if (character === "[") {
+      inCharacterClass = true;
+      index++;
+      continue;
+    }
+    if (character === "]" && inCharacterClass) {
+      inCharacterClass = false;
+      index++;
+      continue;
+    }
+    if (character === "/" && !inCharacterClass) {
+      index++;
+      while (index < content.length && /[A-Za-z]/.test(content[index])) index++;
+      return index;
+    }
+    index++;
+  }
+
+  return null;
+}
+
 function tokenizeModuleSource(content: string): ModuleSourceToken[] {
   const tokens: ModuleSourceToken[] = [];
   let index = 0;
@@ -132,6 +208,14 @@ function tokenizeModuleSource(content: string): ModuleSourceToken[] {
         index++;
       }
       continue;
+    }
+
+    if (character === "/" && canStartRegularExpression(tokens[tokens.length - 1])) {
+      const endIndex = skipRegularExpression(content, index);
+      if (endIndex !== null) {
+        index = endIndex;
+        continue;
+      }
     }
 
     if (character === '"' || character === "'") {
@@ -393,9 +477,19 @@ function getImportSpecifiers(content: string | null): string[] {
 
   const tokens = tokenizeModuleSource(content);
   const matches = new Set<string>();
+  let braceDepth = 0;
 
   for (let index = 0; index < tokens.length; index++) {
     const keyword = tokens[index];
+    if (keyword.value === "{") {
+      braceDepth++;
+      continue;
+    }
+    if (keyword.value === "}") {
+      braceDepth = Math.max(0, braceDepth - 1);
+      continue;
+    }
+    if (braceDepth !== 0) continue;
     if (keyword.kind !== "identifier" || !["import", "export"].includes(keyword.value)) {
       continue;
     }
@@ -447,10 +541,15 @@ function isTypeOnlyNamedClause(
 ): boolean {
   if (tokens[startIndex]?.value !== "{") return false;
 
+  const closingBraceIndex = tokens.findIndex(
+    (token, index) => index > startIndex && index < endIndex && token.value === "}",
+  );
+  if (closingBraceIndex === -1) return false;
+
   let entryStartsAt = startIndex + 1;
-  for (let index = entryStartsAt; index <= endIndex; index++) {
-    if (index !== endIndex && tokens[index]?.value !== ",") continue;
-    const entry = tokens.slice(entryStartsAt, index).filter((token) => token.value !== "}");
+  for (let index = entryStartsAt; index <= closingBraceIndex; index++) {
+    if (index !== closingBraceIndex && tokens[index]?.value !== ",") continue;
+    const entry = tokens.slice(entryStartsAt, index);
     if (entry.length > 0 && entry[0].value !== "type") return false;
     entryStartsAt = index + 1;
   }
@@ -474,18 +573,7 @@ function resolveImportedModuleSourcePath(
       : path.resolve(specifier);
 
   candidates.add(basePath);
-  for (const extension of RESOLVABLE_SOURCE_EXTENSIONS) {
-    candidates.add(`${basePath}${extension}`);
-    candidates.add(path.join(basePath, `index${extension}`));
-  }
-
-  for (const candidate of candidates) {
-    if (fs.existsSync(candidate)) {
-      return candidate;
-    }
-  }
-
-  return null;
+  return resolveSourceCandidate(candidates);
 }
 
 function resolvePackageModuleSourcePath(
@@ -608,17 +696,12 @@ function resolveConditionalExportTarget(value: unknown): string | null {
   }
   if (!value || typeof value !== "object") return null;
 
-  const supportedConditions = new Set([
-    "browser",
-    "node",
-    "import",
-    "module",
-    "default",
-    "require",
-  ]);
-  for (const [condition, target] of Object.entries(value as Record<string, unknown>)) {
-    if (!supportedConditions.has(condition)) continue;
-    const resolved = resolveConditionalExportTarget(target);
+  const conditions = value as Record<string, unknown>;
+  // This metadata controls browser hydration, so prefer client-facing exports
+  // regardless of declaration order while retaining Node-only package support.
+  for (const condition of ["browser", "import", "module", "node", "default", "require"]) {
+    if (conditions[condition] === undefined) continue;
+    const resolved = resolveConditionalExportTarget(conditions[condition]);
     if (resolved) return resolved;
   }
   return null;

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -954,9 +954,7 @@ export function farmPlugin(
           import("react"),
           import("react-dom/server"),
           Promise.all(
-            layoutEntries.map((layout) =>
-              routeManager.loadLayoutModule(layout.modulePath),
-            ),
+            layoutEntries.map((layout) => routeManager.loadLayoutModule(layout.modulePath)),
           ),
         ]);
         const hydrationStrategies = layoutEntries.flatMap((layout) =>
@@ -1034,10 +1032,7 @@ window.__FARM_MANIFEST__ = ${inlineValue({
         const rootMarkup = ReactDOMServer.renderToString(
           React.createElement("div", { id: "root" }, wrappedElement),
         );
-        const html = source.replace(
-          bodyMatch[0],
-          `<body${bodyMatch[1]}>${rootMarkup}</body>`,
-        );
+        const html = source.replace(bodyMatch[0], `<body${bodyMatch[1]}>${rootMarkup}</body>`);
         const headers = new Headers(response.headers);
         headers.delete("content-length");
         headers.delete("etag");
@@ -3539,8 +3534,9 @@ let currentPageComponent = null;
 let currentPageProps = {};
 let appRoot = null;
 
-// Layout component reference (loaded once, reused across navigations)
-let LayoutComponent = null;
+// Layout modules are cached independently so nested client-aware layouts are
+// composed with the same root-to-leaf structure that the server rendered.
+const layoutComponentCache = new Map();
 
 // Track if we've taken over rendering from SSR
 let hasClientTakenOver = false;
@@ -3755,22 +3751,38 @@ async function buildClientHydrationElement(PageComponent, pageProps) {
   return element;
 }
 
-async function ensureLayoutLoaded(layouts = []) {
-  if (LayoutComponent || layouts.length === 0) {
-    return LayoutComponent;
-  }
+async function loadLayoutComponents(layouts = []) {
+  const loadedLayouts = [];
 
-  try {
-    const rootLayout = layouts.find((layout) => layout.pattern === '/');
-    if (rootLayout) {
-      const layoutModule = await import(/* @vite-ignore */ rootLayout.modulePath);
-      LayoutComponent = layoutModule.default;
+  for (const layout of layouts) {
+    if (!layout?.modulePath) continue;
+    try {
+      let LayoutComponent = layoutComponentCache.get(layout.modulePath);
+      if (!LayoutComponent) {
+        const layoutModule = await import(/* @vite-ignore */ layout.modulePath);
+        LayoutComponent = layoutModule.default;
+        if (LayoutComponent) {
+          layoutComponentCache.set(layout.modulePath, LayoutComponent);
+        }
+      }
+      if (LayoutComponent) loadedLayouts.push({ ...layout, Component: LayoutComponent });
+    } catch (error) {
+      console.warn('[Farm.js] Could not load layout:', layout.modulePath, error);
     }
-  } catch (error) {
-    console.warn('[Farm.js] Could not load layout:', error);
   }
 
-  return LayoutComponent;
+  return loadedLayouts;
+}
+
+function wrapWithLoadedLayouts(element, loadedLayouts, params) {
+  let wrapped = element;
+  for (let index = loadedLayouts.length - 1; index >= 0; index--) {
+    wrapped = React.createElement(loadedLayouts[index].Component, {
+      children: wrapped,
+      params,
+    });
+  }
+  return wrapped;
 }
 
 function getCurrentSearchParams() {
@@ -3859,14 +3871,13 @@ async function moduleLooksClient(modulePath) {
 }
 
 async function buildWrappedHydrationElement(PageComponent, pageProps, layouts = []) {
-  await ensureLayoutLoaded(layouts);
+  const loadedLayouts = await loadLayoutComponents(layouts);
   const pageElement = await buildClientHydrationElement(PageComponent, pageProps);
-  const wrappedTree = LayoutComponent
-    ? React.createElement(LayoutComponent, {
-        children: pageElement,
-        params: pageProps?.params || {},
-      })
-    : pageElement;
+  const wrappedTree = wrapWithLoadedLayouts(
+    pageElement,
+    loadedLayouts,
+    pageProps?.params || {},
+  );
   return wrapWithIntegrationProviders(wrappedTree);
 }
 
@@ -3945,13 +3956,11 @@ async function tryHydrateImportedPage(
 
   let wrappedElement;
   if (layoutShouldHydrate) {
-    await ensureLayoutLoaded(layouts);
+    const loadedLayouts = await loadLayoutComponents(layouts);
     if (pageShouldHydrate) {
       pageElement = createLayoutPageBoundary(true, islandStrategy, pageElement);
     }
-    const wrappedTree = LayoutComponent
-      ? React.createElement(LayoutComponent, { children: pageElement, params })
-      : pageElement;
+    const wrappedTree = wrapWithLoadedLayouts(pageElement, loadedLayouts, params);
     wrappedElement = wrapWithIntegrationProviders(wrappedTree);
   } else if (useHydrate && container?.id === '__farm_page__') {
     wrappedElement = wrapWithIntegrationProviders(pageElement);

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -919,6 +919,134 @@ export function farmPlugin(
             fontStylesheetHref: "/@farm/fonts.css",
           })
         : null;
+      const wrapFarmDocsResponseWithLayouts = async (
+        request: Request,
+        response: Response,
+      ): Promise<Response> => {
+        if (
+          request.method === "HEAD" ||
+          !response.headers.get("content-type")?.toLowerCase().includes("text/html")
+        ) {
+          return response;
+        }
+
+        const pathname = new URL(request.url).pathname;
+        const matchedRoute = routeManager.matchRoute(pathname);
+        const layoutEntries = matchedRoute.layouts.map((layout) => ({
+          ...layout,
+          metadata: getClientModuleMetadata(layout.modulePath, farmConfig.root),
+        }));
+        if (!layoutEntries.some((layout) => layout.metadata.shouldHydrate)) {
+          return response;
+        }
+
+        const source = await response.text();
+        const bodyMatch = source.match(/<body([^>]*)>([\s\S]*?)<\/body>/i);
+        if (!bodyMatch) {
+          return new Response(source, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: response.headers,
+          });
+        }
+
+        const [React, ReactDOMServer, layoutModules] = await Promise.all([
+          import("react"),
+          import("react-dom/server"),
+          Promise.all(
+            layoutEntries.map((layout) =>
+              routeManager.loadLayoutModule(layout.modulePath),
+            ),
+          ),
+        ]);
+        const hydrationStrategies = layoutEntries.flatMap((layout) =>
+          layout.metadata.shouldHydrate && layout.metadata.islandStrategy
+            ? [layout.metadata.islandStrategy]
+            : [],
+        );
+        const islandStrategy = hydrationStrategies.every(
+          (strategy) => strategy === hydrationStrategies[0],
+        )
+          ? (hydrationStrategies[0] ?? "load")
+          : "load";
+        const params = matchedRoute.params || {};
+        const toUrlPath = (absolutePath: string) =>
+          absolutePath.startsWith(farmConfig.root)
+            ? absolutePath.slice(farmConfig.root.length)
+            : absolutePath;
+        const clientLayouts = Object.fromEntries(
+          layoutEntries.map((layout) => [
+            layout.pattern,
+            {
+              modulePath: toUrlPath(layout.modulePath),
+              pattern: layout.pattern,
+              shouldHydrate: layout.metadata.shouldHydrate,
+              islandStrategy: layout.metadata.islandStrategy,
+              preloads: [toUrlPath(layout.modulePath)],
+              assets: [],
+            },
+          ]),
+        );
+        const inlineValue = (value: unknown) =>
+          JSON.stringify(value).replace(/</g, "\\u003c").replace(/>/g, "\\u003e");
+        const pageModulePath = matchedRoute.route?.modulePath
+          ? toUrlPath(matchedRoute.route.modulePath)
+          : "";
+        const bootstrapScript = `<script>
+window.__FARM_PROPS__ = ${inlineValue({ params })};
+window.__FARM_ROUTE_SLOTS__ = [];
+window.__FARM_DEPLOYMENT_ID__ = ${inlineValue(farmConfig.deploymentId)};
+window.__FARM_PATH__ = ${inlineValue(pathname)};
+window.__FARM_IS_CLIENT__ = false;
+window.__FARM_PAGE_SHOULD_HYDRATE__ = false;
+window.__FARM_LAYOUT_SHOULD_HYDRATE__ = true;
+window.__FARM_SHOULD_HYDRATE__ = true;
+window.__FARM_ISLAND_STRATEGY__ = ${inlineValue(islandStrategy)};
+window.__FARM_PAGE_MODULE__ = ${inlineValue(pageModulePath)};
+window.__FARM_LOADING_MODULE__ = null;
+window.__FARM_MANIFEST__ = ${inlineValue({
+          routes: {},
+          layouts: clientLayouts,
+          slots: [],
+          clientEntry: "/@farm/client.js",
+          sharedAssets: [],
+        })};
+</script>`;
+
+        let wrappedElement: any = React.createElement("div", {
+          id: "__farm_page__",
+          "data-farm-client": "false",
+          "data-farm-layout-client": "true",
+          "data-farm-island": "page",
+          "data-farm-island-strategy": islandStrategy,
+          dangerouslySetInnerHTML: { __html: bootstrapScript + bodyMatch[2] },
+        });
+        for (let index = layoutModules.length - 1; index >= 0; index--) {
+          const LayoutComponent = layoutModules[index].default;
+          if (LayoutComponent) {
+            wrappedElement = React.createElement(LayoutComponent, {
+              children: wrappedElement,
+              params,
+            });
+          }
+        }
+
+        const rootMarkup = ReactDOMServer.renderToString(
+          React.createElement("div", { id: "root" }, wrappedElement),
+        );
+        const html = source.replace(
+          bodyMatch[0],
+          `<body${bodyMatch[1]}>${rootMarkup}</body>`,
+        );
+        const headers = new Headers(response.headers);
+        headers.delete("content-length");
+        headers.delete("etag");
+        return new Response(html, {
+          status: response.status,
+          statusText: response.statusText,
+          headers,
+        });
+      };
       const farmDocsAPIHandler: FarmDocsAPIHandler | null = farmDocsDevRuntime
         ? farmDocsDevRuntime.createFarmDocsAPIHandler({
             rootDir: farmConfig.root,
@@ -1109,14 +1237,16 @@ export function farmPlugin(
             }
           }
           if (farmDocsHandler) {
-            const docsResponse = await farmDocsHandler(
-              new Request(fullUrl, {
-                method: requestMethod,
-                headers: docsHeaders,
-              }),
-            );
+            const docsRequest = new Request(fullUrl, {
+              method: requestMethod,
+              headers: docsHeaders,
+            });
+            const docsResponse = await farmDocsHandler(docsRequest.clone());
             if (docsResponse) {
-              await sendWebResponse(res, docsResponse);
+              await sendWebResponse(
+                res,
+                await wrapFarmDocsResponseWithLayouts(docsRequest, docsResponse),
+              );
               return;
             }
           }
@@ -1627,6 +1757,27 @@ export function farmPlugin(
                 const layoutModules = await Promise.all(
                   layouts.map((layout) => routeManager.loadLayoutModule(layout.modulePath)),
                 );
+                const layoutHydrationMetadata = layouts.map((layout) =>
+                  getClientModuleMetadata(layout.modulePath, server.config.root),
+                );
+                const shouldHydrateLayout = layoutHydrationMetadata.some(
+                  (metadata) => metadata.shouldHydrate,
+                );
+                const hydrationStrategies = [
+                  ...(shouldHydrate && moduleMetadata.islandStrategy
+                    ? [moduleMetadata.islandStrategy]
+                    : []),
+                  ...layoutHydrationMetadata.flatMap((metadata) =>
+                    metadata.shouldHydrate && metadata.islandStrategy
+                      ? [metadata.islandStrategy]
+                      : [],
+                  ),
+                ];
+                const hydrationIslandStrategy = hydrationStrategies.every(
+                  (strategy) => strategy === hydrationStrategies[0],
+                )
+                  ? (hydrationStrategies[0] ?? "load")
+                  : "load";
 
                 for (const layoutModule of layoutModules) {
                   if ((layoutModule as any).metadata) {
@@ -1750,10 +1901,13 @@ export function farmPlugin(
                   canonicalPath: (routeProps as any).__farmCanonicalPath,
                   modulePath: toUrlPath(route.modulePath),
                   isClientComponent: routeSlots.length > 0 ? false : isClientComponent,
+                  pageShouldHydrate: shouldHydrate,
+                  layoutShouldHydrate: shouldHydrateLayout,
                   shouldHydrate:
                     shouldHydrate ||
+                    shouldHydrateLayout ||
                     routeSlots.some((slot) => slot.isClientComponent || slot.shouldHydrate),
-                  islandStrategy: moduleMetadata.islandStrategy,
+                  islandStrategy: hydrationIslandStrategy,
                   metadata: {
                     title: mergedMetadata.title,
                     description: mergedMetadata.description,
@@ -2241,9 +2395,12 @@ export const getManifest = () => ({
 
         // Convert layouts array to object keyed by pattern
         for (const layout of manifest.layouts) {
+          const layoutMetadata = getClientModuleMetadata(layout.modulePath, server.config.root);
           fullManifest.layouts[layout.pattern] = {
             modulePath: layout.modulePath,
             pattern: layout.pattern,
+            shouldHydrate: layoutMetadata.shouldHydrate,
+            islandStrategy: layoutMetadata.islandStrategy,
             preloads: [layout.modulePath],
             assets: [],
           };
@@ -3705,9 +3862,33 @@ async function buildWrappedHydrationElement(PageComponent, pageProps, layouts = 
   await ensureLayoutLoaded(layouts);
   const pageElement = await buildClientHydrationElement(PageComponent, pageProps);
   const wrappedTree = LayoutComponent
-    ? React.createElement(LayoutComponent, { children: pageElement })
+    ? React.createElement(LayoutComponent, {
+        children: pageElement,
+        params: pageProps?.params || {},
+      })
     : pageElement;
   return wrapWithIntegrationProviders(wrappedTree);
+}
+
+function createLayoutPageBoundary(
+  pageShouldHydrate,
+  islandStrategy,
+  pageElement,
+  serverHtml,
+) {
+  const props = {
+    id: '__farm_page__',
+    'data-farm-client': pageShouldHydrate ? 'true' : 'false',
+    'data-farm-layout-client': 'true',
+    'data-farm-island': 'page',
+    'data-farm-island-strategy': islandStrategy || 'load',
+  };
+  if (typeof serverHtml === 'string') {
+    props.suppressHydrationWarning = true;
+    props.dangerouslySetInnerHTML = { __html: serverHtml };
+    return React.createElement('div', props);
+  }
+  return React.createElement('div', props, pageElement);
 }
 
 async function tryHydrateImportedPage(
@@ -3718,43 +3899,69 @@ async function tryHydrateImportedPage(
   useHydrate = false,
   existingProps = null,
   signal = null,
+  hydrationOptions = {},
 ) {
   const modulePath = route?.modulePath;
   if (!modulePath || signal?.aborted) {
     return false;
   }
 
-  let pageModule = pageModuleCache.get(modulePath);
-  if (!pageModule) {
-    pageModule = await import(/* @vite-ignore */ modulePath);
-    pageModuleCache.set(modulePath, pageModule);
+  const pageShouldHydrate = hydrationOptions.pageShouldHydrate !== false;
+  const layoutShouldHydrate = hydrationOptions.layoutShouldHydrate === true;
+  const islandStrategy = hydrationOptions.islandStrategy || route.islandStrategy || 'load';
+  let pageElement = null;
+
+  if (pageShouldHydrate) {
+    let pageModule = pageModuleCache.get(modulePath);
+    if (!pageModule) {
+      pageModule = await import(/* @vite-ignore */ modulePath);
+      pageModuleCache.set(modulePath, pageModule);
+    }
+    if (signal?.aborted || !container?.isConnected) return false;
+
+    const PageComponent = pageModule?.default;
+    if (!PageComponent) return false;
+
+    currentPageComponent = PageComponent;
+    currentPageProps = await buildRouteComponentProps(
+      pageModule,
+      params,
+      getCurrentSearchParams(),
+      window.location.pathname,
+      existingProps,
+    );
+    pageElement = await buildClientHydrationElement(PageComponent, currentPageProps);
+  } else if (layoutShouldHydrate) {
+    currentPageProps = existingProps || { params };
+    const serverPage = document.getElementById('__farm_page__');
+    pageElement = createLayoutPageBoundary(
+      false,
+      islandStrategy,
+      null,
+      serverPage ? serverPage.innerHTML : '',
+    );
   }
-  if (signal?.aborted || !container?.isConnected) return false;
+  if (signal?.aborted || !container?.isConnected || !pageElement) return false;
 
-  const PageComponent = pageModule?.default;
-  if (!PageComponent) {
-    return false;
+  let wrappedElement;
+  if (layoutShouldHydrate) {
+    await ensureLayoutLoaded(layouts);
+    if (pageShouldHydrate) {
+      pageElement = createLayoutPageBoundary(true, islandStrategy, pageElement);
+    }
+    const wrappedTree = LayoutComponent
+      ? React.createElement(LayoutComponent, { children: pageElement, params })
+      : pageElement;
+    wrappedElement = wrapWithIntegrationProviders(wrappedTree);
+  } else if (useHydrate && container?.id === '__farm_page__') {
+    wrappedElement = wrapWithIntegrationProviders(pageElement);
+  } else {
+    wrappedElement = await buildWrappedHydrationElement(
+      currentPageComponent,
+      currentPageProps,
+      layouts,
+    );
   }
-
-  currentPageComponent = PageComponent;
-  currentPageProps = await buildRouteComponentProps(
-    pageModule,
-    params,
-    getCurrentSearchParams(),
-    window.location.pathname,
-    existingProps,
-  );
-  if (signal?.aborted || !container?.isConnected) return false;
-
-  const wrappedElement = useHydrate && container?.id === '__farm_page__'
-    ? wrapWithIntegrationProviders(
-        await buildClientHydrationElement(PageComponent, currentPageProps),
-      )
-    : await buildWrappedHydrationElement(
-        PageComponent,
-        currentPageProps,
-        layouts,
-      );
   if (signal?.aborted || !container?.isConnected) return false;
 
   if (useHydrate) {
@@ -3802,6 +4009,8 @@ async function renderPage(pageData) {
   const route = {
     modulePath: pageData.modulePath,
     isClientComponent: pageData.isClientComponent === true,
+    pageShouldHydrate: pageData.pageShouldHydrate === true,
+    layoutShouldHydrate: pageData.layoutShouldHydrate === true,
     shouldHydrate: pageData.shouldHydrate === true,
     islandStrategy: pageData.islandStrategy || 'load',
   };
@@ -3843,14 +4052,32 @@ async function renderPage(pageData) {
       const newTitle = doc.querySelector('title');
       if (newTitle) document.title = newTitle.textContent || document.title;
       
-      const shouldHydrate =
-        route.shouldHydrate === true ||
+      const pageShouldHydrate =
+        route.pageShouldHydrate === true ||
         route.isClientComponent ||
         await moduleLooksClient(route.modulePath);
+      const layoutShouldHydrate = route.layoutShouldHydrate === true;
+      const shouldHydrate =
+        route.shouldHydrate === true || pageShouldHydrate || layoutShouldHydrate;
       if (shouldHydrate) {
         try {
-          const hydrationContainer = document.getElementById('__farm_page__') || container;
-          await tryHydrateImportedPage(hydrationContainer, route, params, layouts, true);
+          const hydrationContainer = layoutShouldHydrate
+            ? container
+            : document.getElementById('__farm_page__') || container;
+          await tryHydrateImportedPage(
+            hydrationContainer,
+            route,
+            params,
+            layouts,
+            true,
+            pageData.props,
+            null,
+            {
+              pageShouldHydrate,
+              layoutShouldHydrate,
+              islandStrategy: route.islandStrategy,
+            },
+          );
         } catch (error) {
           // Keep the swapped server HTML when the page can only run on the server.
         }
@@ -3992,7 +4219,6 @@ spaRouter.setNavigationHandler(renderPage);
 async function hydrate() {
   if (isFarmDocsSearchPage()) {
     await mountFarmDocsSearch();
-    return;
   }
 
   const rootContainer = document.getElementById('root')
@@ -4015,10 +4241,15 @@ async function hydrate() {
     let pageProps = normalizeServerProps(window.__FARM_PROPS__);
     applyCanonicalPathFromProps(pageProps);
 
+    const pageShouldHydrate =
+      typeof window.__FARM_PAGE_SHOULD_HYDRATE__ === 'boolean'
+        ? window.__FARM_PAGE_SHOULD_HYDRATE__
+        : isClientComponent || await moduleLooksClient(modulePath);
+    const layoutShouldHydrate = window.__FARM_LAYOUT_SHOULD_HYDRATE__ === true;
     const shouldHydrate =
       window.__FARM_SHOULD_HYDRATE__ === true ||
-      isClientComponent ||
-      await moduleLooksClient(modulePath);
+      pageShouldHydrate ||
+      layoutShouldHydrate;
     const hydratedSlots = await hydrateInitialRouteSlots();
     if (!shouldHydrate) {
       if (hydratedSlots) replayPreHydrationClicks();
@@ -4041,9 +4272,9 @@ async function hydrate() {
     currentPageProps = pageProps;
 
     const layouts = findLayouts(window.location.pathname);
-    const pageContainer = shouldHydrate
-      ? document.getElementById('__farm_page__') || rootContainer
-      : rootContainer;
+    const pageContainer = layoutShouldHydrate
+      ? rootContainer
+      : document.getElementById('__farm_page__') || rootContainer;
 
     if (!pageContainer) {
       console.log('[Farm.js] Server component - SPA router ready')
@@ -4103,6 +4334,11 @@ async function hydrate() {
               shouldHydrate,
               currentPageProps,
               hydrationController.signal,
+              {
+                pageShouldHydrate,
+                layoutShouldHydrate,
+                islandStrategy,
+              },
             );
             if (hydrationController.signal.aborted || !pageContainer.isConnected) {
               await farmClientRuntime.failHydration(

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -4312,15 +4312,6 @@ async function hydrate() {
             return;
           }
 
-          // Layout code is only needed when this route boundary actually hydrates.
-          try {
-            const layoutModule = await import(/* @vite-ignore */ '/src/app/layout.tsx');
-            LayoutComponent = layoutModule.default;
-          } catch (e) {
-            console.warn('[Farm.js] Could not preload layout:', e);
-          }
-          if (hydrationController.signal.aborted || !pageContainer.isConnected) return;
-
           const hydrationSession = await farmClientRuntime.beginHydration({
             container: pageContainer,
             mode: shouldHydrate ? 'hydrate' : 'render',

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -5,7 +5,6 @@ import { logger, toViteModuleId } from "./utils";
 import { defaultGlobalCSS } from "./default-styles";
 import type { FarmPlugin, FarmPluginRuntimeSession, PluginManager } from "./plugin";
 import { generateFarmClientPluginEntryCode } from "./client-plugin-build";
-import { HMRManager } from "./hmr";
 import { APIRouteManager } from "./api/route-manager";
 import type { OpenAPIManager } from "./openapi/manager";
 import { MiddlewareManager } from "./middleware/manager";
@@ -483,13 +482,11 @@ export function farmPlugin(
   });
   let farmApp: FarmApp;
   let server: ViteDevServer;
-  let hmrManager: HMRManager;
   let apiRouteManager: APIRouteManager;
   let openAPIManager: OpenAPIManager | null = null;
   let middlewareManager: MiddlewareManager;
   let refreshRouteDiscovery: ((reason: string) => Promise<void>) | null = null;
   let workflowHandler: ((request: Request) => Promise<Response | null>) | null = null;
-  const pluginManager: PluginManager | undefined = initialPluginManager;
   const logUpdate = (tag: "PAGE" | "API" | "MIDDLEWARE" | "TYPE", message: string) => {
     try {
       const pc = require("picocolors");
@@ -782,9 +779,6 @@ export function farmPlugin(
         });
       });
 
-      // Initialize HMR manager
-      hmrManager = new HMRManager(server);
-
       // Initialize API route manager
       const appDirs = getFarmAppDirectories(farmConfig);
       const routeManager = farmApp.getRouteManager();
@@ -1052,23 +1046,6 @@ window.__FARM_MANIFEST__ = ${inlineValue({
       const farmDocsFontAssets = new Map(
         farmDocsFontAssetList.map(({ url, sourcePath }) => [url, sourcePath]),
       );
-      // Built-in terminal logging (always enabled in development, independent of logger plugin)
-      const logRequest = (method: string, urlPath: string, tag: "API" | "PAGE") => {
-        try {
-          const pc = require("picocolors");
-          const log = [
-            pc.dim("[") + pc.bold(pc.blue("FARM")) + pc.dim("]"),
-            pc.dim("[") + pc.bold(pc.cyan(tag)) + pc.dim("]"),
-            pc.dim("[") + pc.bold(pc.white(method.padEnd(3))) + pc.dim("]"),
-            tag === "API" ? pc.gray("Requesting ") : pc.gray("Loading "),
-            pc.gray(urlPath),
-          ].join(" ");
-          console.log(log);
-        } catch {
-          console.log(`[FARM] [${tag}] [${method}] ${urlPath}`);
-        }
-      };
-
       const logResponse = (
         method: string,
         urlPath: string,
@@ -1500,9 +1477,6 @@ window.__FARM_MANIFEST__ = ${inlineValue({
             const hasExplicitAPIRoute =
               hasMatchedApiRoute || Boolean(apiRouteManager.matchRoute(pathname));
             if (apiHandler && hasExplicitAPIRoute) {
-              // Log API request
-              // logRequest(method, urlPath, "API");
-
               try {
                 // Convert Node.js request to Web Request
                 const url = `http://${req.headers.host || "localhost:3000"}${req.url}`;
@@ -2032,8 +2006,6 @@ window.__FARM_MANIFEST__ = ${inlineValue({
               return;
             }
           }
-
-          // logRequest(method, urlPath, "PAGE");
 
           try {
             if (middlewareManager?.hasMiddleware()) {
@@ -4280,7 +4252,11 @@ async function hydrate() {
     }
     currentPageProps = pageProps;
 
-    const layouts = findLayouts(window.location.pathname);
+    // Prefer the exact root-to-leaf layout chain selected by the server. The
+    // manifest lookup remains a fallback for generated/static responses.
+    const layouts = Array.isArray(window.__FARM_LAYOUTS__)
+      ? window.__FARM_LAYOUTS__
+      : findLayouts(window.location.pathname);
     const pageContainer = layoutShouldHydrate
       ? rootContainer
       : document.getElementById('__farm_page__') || rootContainer;


### PR DESCRIPTION
## Summary

- Resolve bare package client boundaries from package exports and entry points.
- Hydrate client-aware layouts independently while keeping server-only and Markdown pages opaque.
- Apply app layouts and bootstrap state to generated docs in development and production.
- Use full-document navigation when entering the configured docs route to avoid stale module state.

## Root cause

The runtime only treated the page module as the hydration boundary. Client components imported by a layout could be bundled but were never mounted, so effects such as the Databuddy tracker did not run. Generated docs responses also bypassed the app layout path.

## Verification

- pnpm --filter @farm.js/core type-check
- pnpm --filter @farm.js/core build
- 16 client-component tests passed
- 10 renderer route-state tests passed
- Focused production prebuilt SSR regression passed
- 43/44 relevant tests passed; the remaining React 18 compatibility fixture could not run because its local fixture dependencies are absent
- Production docs build completed with 64 hydratable pages and one client-aware layout
- Browser-tested production and development homepage, direct docs load, homepage to docs, and internal docs navigation
- Verified exactly one Databuddy script remains present and the layout boundary hydrates without importing server-only page code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes layout client boundary hydration across pages and docs. Layout-aware components now hydrate reliably for nested layouts, server-only/Markdown pages, and docs routes with a consistent island strategy and stable navigation.

- **Bug Fixes**
  - Treat layouts as independent hydration boundaries; choose the root container when a layout hydrates; expose `__FARM_PAGE_SHOULD_HYDRATE__`, `__FARM_LAYOUT_SHOULD_HYDRATE__`, and `__FARM_LAYOUTS__`; create a layout-only page boundary and load/cache the exact matched layout chain.
  - Detect client modules from bare package imports via `package.json` exports and conditions; support subpaths and wildcards, follow re-exports (including extensionless directories), prefer `browser`/`import` over `node`, handle `node:` specifiers, and ignore type-only and non-code/regex imports to avoid false positives.
  - Apply app layouts and bootstrap state to generated docs in development and production; wrap docs HTML with layouts, inject missing client assets (single `farm-client.js`/CSS), add synthetic layout-only client routes, and force full-document navigation into the configured docs entry.
  - Split page vs layout hydration intent; aggregate island strategy across page and layouts; include per-layout hydration metadata in the manifest and client runtime; only import page modules when `pageShouldHydrate` is true; pick the right hydration container and swap strategy during SPA navigation.

<sup>Written for commit 2cbb4beb6ff733e866ccd3fdd78b61e9ff8ab749. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

