### PR TITLE
docs: showcase typed integrations

### DIFF
--- a/docs/src/app/docs/plugins/page.md
+++ b/docs/src/app/docs/plugins/page.md
@@ -153,14 +153,14 @@ Both hooks receive Farm's plugin context. `setup` additionally receives the reso
 
 ### Runtime hooks
 
-| Hook              | Runs                                                             | May return                                                       |
-| ----------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------- |
-| `runtime.start`   | Once when the runtime manager starts.                            | Nothing.                                                         |
-| `runtime.context` | At the start of every request.                                   | A plain object merged into typed request `ctx`.                  |
-| `runtime.before`  | Before Farm invokes the matched handler.                         | A replacement `Request`, a short-circuit `Response`, or nothing. |
-| `runtime.after`   | After a handler or short circuit produces a response.            | A replacement `Response` or nothing.                             |
-| `runtime.error`   | When runtime context, before, handler, or after work throws.     | Nothing.                                                         |
-| `runtime.close`   | During graceful shutdown in long-running Node output.             | Nothing.                                                         |
+| Hook              | Runs                                                         | May return                                                       |
+| ----------------- | ------------------------------------------------------------ | ---------------------------------------------------------------- |
+| `runtime.start`   | Once when the runtime manager starts.                        | Nothing.                                                         |
+| `runtime.context` | At the start of every request.                               | A plain object merged into typed request `ctx`.                  |
+| `runtime.before`  | Before Farm invokes the matched handler.                     | A replacement `Request`, a short-circuit `Response`, or nothing. |
+| `runtime.after`   | After a handler or short circuit produces a response.        | A replacement `Response` or nothing.                             |
+| `runtime.error`   | When runtime context, before, handler, or after work throws. | Nothing.                                                         |
+| `runtime.close`   | During graceful shutdown in long-running Node output.        | Nothing.                                                         |
 
 Runtime hooks apply to page, API, server-action, integration, docs, asset, and general requests. Use the event's `kind` and `route` values when behavior should apply only to part of the application.
 

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -350,18 +350,18 @@ const integrationCodeTabs = [
     id: "integrations",
     label: "integrations.ts",
     language: "ts",
-    highlightLines: [4, 5, 6, 7, 10, 11],
-    code: `import { createUnkeyClient, unkey } from "@farm.js/integrations/unkey";
+    highlightLines: [1, 5, 7],
+    code: `import Stripe from "stripe";
 import { stripe } from "@farm.js/integrations/stripe";
+import { unkey } from "@farm.js/integrations/unkey";
 
-const unkeyClient = createUnkeyClient({
-    rootKey: process.env.UNKEY_ROOT_KEY,
-    apiId: process.env.UNKEY_API_ID,
-});
-
+const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!);
 export const integrations = {
-    keys: unkey({ instance: unkeyClient }),
-    billing: stripe({ secretKey: process.env.STRIPE_SECRET_KEY }),
+    billing: stripe({ instance: stripeClient }),
+    keys: unkey({
+        rootKey: process.env.UNKEY_ROOT_KEY,
+        apiId: process.env.UNKEY_API_ID,
+    }),
 };`,
   },
   {

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -348,39 +348,35 @@ data?.users[0]?.name;
 const integrationCodeTabs = [
   {
     id: "integrations",
-    label: "farm.config.ts",
+    label: "integrations.ts",
     language: "ts",
-    highlightLines: [5, 6, 7, 8, 9, 10],
-    code: `import { defineConfig } from "@farm.js/core";
-import { resend, stripe } from "@farm.js/integrations";
-import { emailTemplates } from "./email";
-export default defineConfig({
-    integrations: {
-        billing: stripe({ secretKey: process.env.STRIPE_SECRET_KEY }),
-        email: resend({
-            apiKey: process.env.RESEND_API_KEY,
-            templates: emailTemplates,
-        }),
-    },
-});`,
+    highlightLines: [4, 5, 6, 7, 10, 11],
+    code: `import { createUnkeyClient, unkey } from "@farm.js/integrations/unkey";
+import { stripe } from "@farm.js/integrations/stripe";
+
+const unkeyClient = createUnkeyClient({
+    rootKey: process.env.UNKEY_ROOT_KEY,
+    apiId: process.env.UNKEY_API_ID,
+});
+
+export const integrations = {
+    keys: unkey({ instance: unkeyClient }),
+    billing: stripe({ secretKey: process.env.STRIPE_SECRET_KEY }),
+};`,
   },
   {
     id: "apis",
-    label: "Billing and email APIs",
+    label: "Typed integration calls",
     language: "ts",
-    highlightLines: [3, 7, 9],
+    highlightLines: [3, 4, 7, 8],
     code: `import { api, apiClient } from "@/lib/api";
+
+const key = await api.keys.create.post({
+    body: { name: "Production key" },
+});
 
 const checkout = await apiClient.billing.checkout.post({
     body: { productId: "pro" },
-});
-
-await api.email.send.post({
-    body: {
-        template: "welcome",
-        to: "ada@example.com",
-        data: { name: "Ada" },
-    },
 });`,
   },
 ] as const satisfies readonly [HighlightedCodeTab, ...HighlightedCodeTab[]];
@@ -1127,12 +1123,12 @@ function DeveloperExperienceGrid() {
         <TypedApiVisual />
       </FeatureCell>
       <FeatureCell
-        body="Configure billing and email once, then use their typed APIs from client and server code."
+        body="Connect billing, API keys, and more in one place. Pass existing provider instances and call every service through typed APIs."
         className="border-t border-white/12"
         icon={Plug}
         index="01.3"
-        label="Billing + email"
-        title="Start built in. Extend when needed."
+        label="Integrations"
+        title="Connect once. Keep full control."
       >
         <IntegrationVisual />
       </FeatureCell>

--- a/docs/src/farm.d.ts
+++ b/docs/src/farm.d.ts
@@ -266,5 +266,3 @@ declare module "@farm.js/core" {
     public: FarmResolvedEnv["public"];
   }
 }
-
-export {};


### PR DESCRIPTION
## Summary

- make the homepage integration showcase provider-agnostic
- replace the Resend/email example with Unkey API keys alongside Stripe billing
- demonstrate application-owned client injection through `instance`
- show typed server and browser integration calls through `api` and `apiClient`

## Why

The previous card focused narrowly on billing and email. The revised example better communicates the broader integration model: applications can inject configured provider clients and still use Farm-generated typed callers.

## Validation

- `pnpm exec oxfmt --check docs/src/app/page.tsx`
- `pnpm exec oxlint docs/src/app/page.tsx`
- `pnpm --dir docs build`
- visually verified both tabs at 1440×900 and 390×844 with no page overflow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the docs homepage integration showcase provider-agnostic and highlight typed integrations with `@farm.js/integrations/unkey` and `@farm.js/integrations/stripe`. Add an `integrations.ts` example that injects a vendor-owned `stripe` client via `instance`, configures Unkey with `rootKey`/`apiId`, updates code tabs and card copy, and shows typed server and browser calls with `api` and `apiClient`.

- Bug Fixes
  - Fix runtime hooks table formatting in plugins docs.
  - Lint/type cleanup; remove stray `export {}` from `docs/src/farm.d.ts`.

<sup>Written for commit 724a4135b145d2f6e5bfae80605d3093160398d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

