### PR TITLE
feat: use native preview tunnel

### DIFF
--- a/benchmarks/preview-tunnel/README.md
+++ b/benchmarks/preview-tunnel/README.md
@@ -1,0 +1,37 @@
+# Preview tunnel benchmark
+
+Compares the direct local target, the TypeScript persistent preview agent, and the Rust N-API persistent preview agent over the same WebSocket relay and protocol.
+
+## Prerequisites
+
+Build the independent Rust package first:
+
+```bash
+cd ../farm-preview-agent-rs
+npm install
+npm run build
+```
+
+Then run the benchmark from the Farm.js repository:
+
+```bash
+pnpm benchmark:preview
+```
+
+Override the Rust package path when it is not a sibling of `farm.js`:
+
+```bash
+FARM_PREVIEW_RUST_PACKAGE=/absolute/path/to/farm-preview-agent-rs pnpm benchmark:preview
+```
+
+The benchmark validates POST bodies, query strings, response status and headers, and automatic route invalidation before recording latency and throughput. Both agents use the same relay, target server, 4 KiB payload, warmup, and concurrency settings.
+
+Environment variables can override the workload:
+
+- `FARM_PREVIEW_BENCH_WARMUP`
+- `FARM_PREVIEW_BENCH_SEQUENTIAL`
+- `FARM_PREVIEW_BENCH_CONCURRENT`
+- `FARM_PREVIEW_BENCH_CONCURRENCY`
+- `FARM_PREVIEW_BENCH_PAYLOAD`
+
+See [results-2026-08-05.md](./results-2026-08-05.md) for the first verified comparison.

--- a/benchmarks/preview-tunnel/README.md
+++ b/benchmarks/preview-tunnel/README.md
@@ -7,7 +7,7 @@ Compares the direct local target, the TypeScript persistent preview agent, and t
 Build the independent Rust package first:
 
 ```bash
-cd ../farm-preview-agent-rs
+cd ../tunnel
 npm install
 npm run build
 ```
@@ -21,7 +21,7 @@ pnpm benchmark:preview
 Override the Rust package path when it is not a sibling of `farm.js`:
 
 ```bash
-FARM_PREVIEW_RUST_PACKAGE=/absolute/path/to/farm-preview-agent-rs pnpm benchmark:preview
+FARM_PREVIEW_RUST_PACKAGE=/absolute/path/to/tunnel pnpm benchmark:preview
 ```
 
 The benchmark validates POST bodies, query strings, response status and headers, and automatic route invalidation before recording latency and throughput. Both agents use the same relay, target server, 4 KiB payload, warmup, and concurrency settings.

--- a/benchmarks/preview-tunnel/README.md
+++ b/benchmarks/preview-tunnel/README.md
@@ -4,15 +4,17 @@ Compares the direct local target, the TypeScript persistent preview agent, and t
 
 ## Prerequisites
 
-Build the independent Rust package first:
+From the Farm.js repository root, build the independent Rust package in the sibling
+`tunnel` repository first:
 
 ```bash
 cd ../tunnel
 npm install
 npm run build
+cd ../farm.js
 ```
 
-Then run the benchmark from the Farm.js repository:
+Then run the benchmark:
 
 ```bash
 pnpm benchmark:preview

--- a/benchmarks/preview-tunnel/results-2026-08-05.md
+++ b/benchmarks/preview-tunnel/results-2026-08-05.md
@@ -1,0 +1,50 @@
+# Preview tunnel benchmark — 2026-08-05
+
+## Result
+
+The persistent WebSocket architecture removes the dominant Blob-polling delay. With both agents using the same relay and protocol, the Rust N-API agent also outperformed the TypeScript agent.
+
+| Path                        | Workload      | Mean latency |     p50 |      p95 |      p99 |  Throughput |
+| --------------------------- | ------------- | -----------: | ------: | -------: | -------: | ----------: |
+| Direct localhost            | Sequential    |      0.21 ms | 0.19 ms |  0.34 ms |  0.70 ms | 4,674 req/s |
+| TypeScript persistent agent | Sequential    |      0.47 ms | 0.44 ms |  0.60 ms |  1.43 ms | 2,124 req/s |
+| Rust N-API persistent agent | Sequential    |      0.29 ms | 0.28 ms |  0.33 ms |  0.81 ms | 3,427 req/s |
+| Direct localhost            | 25 concurrent |      3.78 ms | 3.16 ms |  8.01 ms | 24.89 ms | 6,466 req/s |
+| TypeScript persistent agent | 25 concurrent |      7.34 ms | 6.73 ms | 10.24 ms | 21.46 ms | 3,367 req/s |
+| Rust N-API persistent agent | 25 concurrent |      4.45 ms | 4.01 ms |  6.70 ms | 12.18 ms | 5,539 req/s |
+
+Against TypeScript, the Rust agent reduced mean latency by 38% sequentially and 39% at concurrency 25. It increased throughput by 61% sequentially and 65% at concurrency 25.
+
+## Current hosted polling baseline
+
+The deployed `preview.farming-labs.dev` Blob-polling gateway was sampled separately with the same 4 KiB response body. Ten sequential requests averaged **1,772 ms**, with a 1,703 ms p50 and 2,457 ms p95. This live result includes internet distance and hosted infrastructure, so it is not a direct language benchmark. It demonstrates that changing the data path is much more important than changing the agent language.
+
+## Correctness checks
+
+Before recording timings, the harness verifies both agents preserve:
+
+- HTTP method and query string.
+- Binary request and response bodies.
+- Response status and headers.
+- Concurrent request correlation by ID.
+- Automatic route invalidation after the agent disconnects or the local target stops.
+
+## Environment
+
+- Apple M1, 16 GB RAM.
+- macOS 26.2.
+- Node.js 23.11.0.
+- Rust 1.92.0.
+- 4 KiB response payload.
+- 25 warmup requests.
+- 150 sequential measured requests.
+- 500 concurrent measured requests with concurrency 25.
+- Optimized and stripped Rust build (3.3 MB native binary).
+
+## Limitations
+
+The persistent-agent comparison runs on loopback to isolate implementation overhead. The prototype buffers bodies and encodes them as base64 JSON; it does not yet stream chunks or proxy WebSocket upgrades. A production benchmark must add TLS, a remote relay region, larger bodies, slow consumers, disconnect recovery, and Vite HMR traffic.
+
+## Recommendation
+
+Keep TypeScript as the portable fallback and protocol reference. Use the Rust N-API agent as the optional native fast path after the persistent relay is deployed. The next protocol revision should replace base64 JSON bodies with binary frames and add streaming, backpressure, authentication, reconnects, and WebSocket upgrade forwarding.

--- a/benchmarks/preview-tunnel/run.mjs
+++ b/benchmarks/preview-tunnel/run.mjs
@@ -12,7 +12,9 @@ import {
 const require = createRequire(import.meta.url);
 const defaultRustPackage = fileURLToPath(new URL("../../../tunnel", import.meta.url));
 const rustPackage = process.env.FARM_PREVIEW_RUST_PACKAGE || defaultRustPackage;
-const { activePreviewAgentCount, startPreviewAgent, stopPreviewAgent } = require(rustPackage);
+const { activePreviewAgentCount, startPreviewAgent, stopPreviewAgent, waitPreviewAgent } = require(
+  rustPackage,
+);
 
 const warmupRequests = readPositiveInteger("FARM_PREVIEW_BENCH_WARMUP", 25);
 const sequentialRequests = readPositiveInteger("FARM_PREVIEW_BENCH_SEQUENTIAL", 150);
@@ -76,7 +78,7 @@ try {
   await close(target);
   targetClosed = true;
   await expectInactive(`${relayAddress.httpUrl}/preview/benchmark-rust`, 4_000);
-  assert.equal(await stopPreviewAgent(rustSession.sessionId), true);
+  assert.equal(await waitPreviewAgent(rustSession.sessionId), true);
   rustSession = undefined;
   assert.equal(activePreviewAgentCount(), 0);
   reportStage("Rust automatic shutdown verified.");

--- a/benchmarks/preview-tunnel/run.mjs
+++ b/benchmarks/preview-tunnel/run.mjs
@@ -1,0 +1,234 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { createServer } from "node:http";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+
+import {
+  createPersistentPreviewRelay,
+  startTypeScriptPreviewAgent,
+} from "../../packages/farm-preview-tunnel/dist/index.js";
+
+const require = createRequire(import.meta.url);
+const defaultRustPackage = fileURLToPath(
+  new URL("../../../farm-preview-agent-rs", import.meta.url),
+);
+const rustPackage = process.env.FARM_PREVIEW_RUST_PACKAGE || defaultRustPackage;
+const { activePreviewAgentCount, startPreviewAgent, stopPreviewAgent } = require(rustPackage);
+
+const warmupRequests = readPositiveInteger("FARM_PREVIEW_BENCH_WARMUP", 25);
+const sequentialRequests = readPositiveInteger("FARM_PREVIEW_BENCH_SEQUENTIAL", 150);
+const concurrentRequests = readPositiveInteger("FARM_PREVIEW_BENCH_CONCURRENT", 500);
+const concurrency = readPositiveInteger("FARM_PREVIEW_BENCH_CONCURRENCY", 25);
+const payload = Buffer.alloc(readPositiveInteger("FARM_PREVIEW_BENCH_PAYLOAD", 4096), "f");
+
+const target = createServer(async (request, response) => {
+  if (request.url?.startsWith("/echo")) {
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    response.statusCode = 202;
+    response.setHeader("content-type", "application/octet-stream");
+    response.setHeader("x-preview-target", "farm-benchmark");
+    response.end(Buffer.concat(chunks));
+    return;
+  }
+
+  response.statusCode = 200;
+  response.setHeader("content-type", "application/octet-stream");
+  response.setHeader("x-preview-target", "farm-benchmark");
+  response.end(payload);
+});
+
+await listen(target);
+const targetAddress = target.address();
+const targetUrl = `http://127.0.0.1:${targetAddress.port}`;
+const relay = createPersistentPreviewRelay({ requestTimeoutMs: 10_000 });
+const relayAddress = await relay.listen();
+
+const results = [];
+let typescriptAgent;
+let rustSession;
+let targetClosed = false;
+
+try {
+  await verifyEndpoint(targetUrl);
+  results.push(await benchmarkEndpoint("Direct localhost", targetUrl));
+
+  typescriptAgent = await startTypeScriptPreviewAgent({
+    relayUrl: relayAddress.websocketUrl,
+    name: "benchmark-typescript",
+    targetUrl,
+  });
+  await verifyEndpoint(typescriptAgent.publicUrl);
+  results.push(await benchmarkEndpoint("TypeScript persistent agent", typescriptAgent.publicUrl));
+  await typescriptAgent.close();
+  typescriptAgent = undefined;
+  await expectInactive(`${relayAddress.httpUrl}/preview/benchmark-typescript`);
+
+  rustSession = await startPreviewAgent(relayAddress.websocketUrl, "benchmark-rust", targetUrl);
+  assert.equal(activePreviewAgentCount(), 1);
+  await verifyEndpoint(rustSession.publicUrl);
+  results.push(await benchmarkEndpoint("Rust N-API persistent agent", rustSession.publicUrl));
+  await close(target);
+  targetClosed = true;
+  await expectInactive(`${relayAddress.httpUrl}/preview/benchmark-rust`, 4_000);
+  assert.equal(await stopPreviewAgent(rustSession.sessionId), true);
+  rustSession = undefined;
+  assert.equal(activePreviewAgentCount(), 0);
+
+  printResults(results);
+} finally {
+  if (typescriptAgent) await typescriptAgent.close();
+  if (rustSession) await stopPreviewAgent(rustSession.sessionId);
+  await relay.close();
+  if (!targetClosed) await close(target);
+}
+
+async function verifyEndpoint(baseUrl) {
+  const body = Buffer.from("farm-preview-correctness");
+  const response = await fetch(`${baseUrl}/echo?mode=verify`, {
+    method: "POST",
+    headers: { "content-type": "application/octet-stream" },
+    body,
+  });
+  assert.equal(response.status, 202);
+  assert.equal(response.headers.get("x-preview-target"), "farm-benchmark");
+  assert.deepEqual(Buffer.from(await response.arrayBuffer()), body);
+}
+
+async function expectInactive(url, timeoutMs = 1_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const response = await fetch(url);
+    if (response.status === 404) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.fail(`Preview route remained active after its agent stopped: ${url}`);
+}
+
+async function benchmarkEndpoint(name, baseUrl) {
+  for (let index = 0; index < warmupRequests; index += 1) {
+    await checkedFetch(`${baseUrl}/payload?warmup=${index}`);
+  }
+
+  const sequential = [];
+  const sequentialStarted = performance.now();
+  for (let index = 0; index < sequentialRequests; index += 1) {
+    const started = performance.now();
+    await checkedFetch(`${baseUrl}/payload?sequential=${index}`);
+    sequential.push(performance.now() - started);
+  }
+  const sequentialElapsed = performance.now() - sequentialStarted;
+
+  const concurrent = [];
+  const concurrentStarted = performance.now();
+  let nextRequest = 0;
+  await Promise.all(
+    Array.from({ length: concurrency }, async () => {
+      while (true) {
+        const index = nextRequest;
+        nextRequest += 1;
+        if (index >= concurrentRequests) return;
+        const started = performance.now();
+        await checkedFetch(`${baseUrl}/payload?concurrent=${index}`);
+        concurrent.push(performance.now() - started);
+      }
+    }),
+  );
+  const concurrentElapsed = performance.now() - concurrentStarted;
+
+  return {
+    name,
+    sequential: summarize(sequential, sequentialElapsed),
+    concurrent: summarize(concurrent, concurrentElapsed),
+  };
+}
+
+async function checkedFetch(url) {
+  const response = await fetch(url);
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("x-preview-target"), "farm-benchmark");
+  const body = Buffer.from(await response.arrayBuffer());
+  assert.equal(body.length, payload.length);
+}
+
+function summarize(samples, elapsedMs) {
+  const sorted = samples.toSorted((left, right) => left - right);
+  return {
+    requests: samples.length,
+    meanMs: average(samples),
+    p50Ms: percentile(sorted, 0.5),
+    p95Ms: percentile(sorted, 0.95),
+    p99Ms: percentile(sorted, 0.99),
+    requestsPerSecond: samples.length / (elapsedMs / 1000),
+  };
+}
+
+function average(values) {
+  return values.reduce((total, value) => total + value, 0) / values.length;
+}
+
+function percentile(sorted, ratio) {
+  return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * ratio) - 1)];
+}
+
+function printResults(values) {
+  const rows = values.flatMap((result) => [
+    toRow(result.name, "sequential", result.sequential),
+    toRow(result.name, `concurrent x${concurrency}`, result.concurrent),
+  ]);
+  console.table(rows);
+  console.log(
+    JSON.stringify(
+      {
+        environment: {
+          node: process.version,
+          platform: `${process.platform}-${process.arch}`,
+          payloadBytes: payload.length,
+          warmupRequests,
+          sequentialRequests,
+          concurrentRequests,
+          concurrency,
+        },
+        results: values,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+function toRow(agent, mode, value) {
+  return {
+    agent,
+    mode,
+    requests: value.requests,
+    "mean ms": value.meanMs.toFixed(2),
+    "p50 ms": value.p50Ms.toFixed(2),
+    "p95 ms": value.p95Ms.toFixed(2),
+    "p99 ms": value.p99Ms.toFixed(2),
+    "req/s": value.requestsPerSecond.toFixed(1),
+  };
+}
+
+function readPositiveInteger(name, fallback) {
+  const value = Number(process.env[name] || fallback);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  return value;
+}
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+}
+
+function close(server) {
+  if (!server.listening) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}

--- a/benchmarks/preview-tunnel/run.mjs
+++ b/benchmarks/preview-tunnel/run.mjs
@@ -29,6 +29,7 @@ const target = createServer(async (request, response) => {
     response.statusCode = 202;
     response.setHeader("content-type", "application/octet-stream");
     response.setHeader("x-preview-target", "farm-benchmark");
+    response.setHeader("x-preview-request-url", request.url);
     response.end(Buffer.concat(chunks));
     return;
   }
@@ -36,6 +37,7 @@ const target = createServer(async (request, response) => {
   response.statusCode = 200;
   response.setHeader("content-type", "application/octet-stream");
   response.setHeader("x-preview-target", "farm-benchmark");
+  response.setHeader("x-preview-request-url", request.url || "/");
   response.end(payload);
 });
 
@@ -100,6 +102,7 @@ async function verifyEndpoint(baseUrl) {
   });
   assert.equal(response.status, 202);
   assert.equal(response.headers.get("x-preview-target"), "farm-benchmark");
+  assert.equal(response.headers.get("x-preview-request-url"), "/echo?mode=verify");
   assert.deepEqual(Buffer.from(await response.arrayBuffer()), body);
 }
 
@@ -107,7 +110,9 @@ async function expectInactive(url, timeoutMs = 1_000) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const response = await fetch(url);
-    if (response.status === 404) return;
+    const status = response.status;
+    await response.arrayBuffer();
+    if (status === 404) return;
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
   assert.fail(`Preview route remained active after its agent stopped: ${url}`);
@@ -155,8 +160,10 @@ async function checkedFetch(url) {
   const response = await fetch(url);
   assert.equal(response.status, 200);
   assert.equal(response.headers.get("x-preview-target"), "farm-benchmark");
+  const requestUrl = new URL(url);
+  assert.equal(response.headers.get("x-preview-request-url"), `/payload${requestUrl.search}`);
   const body = Buffer.from(await response.arrayBuffer());
-  assert.equal(body.length, payload.length);
+  assert.deepEqual(body, payload);
 }
 
 function summarize(samples, elapsedMs) {

--- a/benchmarks/preview-tunnel/run.mjs
+++ b/benchmarks/preview-tunnel/run.mjs
@@ -10,9 +10,7 @@ import {
 } from "../../packages/farm-preview-tunnel/dist/index.js";
 
 const require = createRequire(import.meta.url);
-const defaultRustPackage = fileURLToPath(
-  new URL("../../../farm-preview-agent-rs", import.meta.url),
-);
+const defaultRustPackage = fileURLToPath(new URL("../../../tunnel", import.meta.url));
 const rustPackage = process.env.FARM_PREVIEW_RUST_PACKAGE || defaultRustPackage;
 const { activePreviewAgentCount, startPreviewAgent, stopPreviewAgent } = require(rustPackage);
 
@@ -44,6 +42,7 @@ const targetAddress = target.address();
 const targetUrl = `http://127.0.0.1:${targetAddress.port}`;
 const relay = createPersistentPreviewRelay({ requestTimeoutMs: 10_000 });
 const relayAddress = await relay.listen();
+reportStage(`Target ${targetUrl} and relay ${relayAddress.websocketUrl} are ready.`);
 
 const results = [];
 let typescriptAgent;
@@ -52,6 +51,7 @@ let targetClosed = false;
 
 try {
   await verifyEndpoint(targetUrl);
+  reportStage("Direct target correctness verified.");
   results.push(await benchmarkEndpoint("Direct localhost", targetUrl));
 
   typescriptAgent = await startTypeScriptPreviewAgent({
@@ -59,22 +59,27 @@ try {
     name: "benchmark-typescript",
     targetUrl,
   });
+  reportStage(`TypeScript agent registered at ${typescriptAgent.publicUrl}.`);
   await verifyEndpoint(typescriptAgent.publicUrl);
   results.push(await benchmarkEndpoint("TypeScript persistent agent", typescriptAgent.publicUrl));
   await typescriptAgent.close();
   typescriptAgent = undefined;
   await expectInactive(`${relayAddress.httpUrl}/preview/benchmark-typescript`);
+  reportStage("TypeScript forwarding and shutdown verified.");
 
   rustSession = await startPreviewAgent(relayAddress.websocketUrl, "benchmark-rust", targetUrl);
+  reportStage(`Rust agent registered at ${rustSession.publicUrl}.`);
   assert.equal(activePreviewAgentCount(), 1);
   await verifyEndpoint(rustSession.publicUrl);
   results.push(await benchmarkEndpoint("Rust N-API persistent agent", rustSession.publicUrl));
+  reportStage("Rust forwarding verified; stopping the local target.");
   await close(target);
   targetClosed = true;
   await expectInactive(`${relayAddress.httpUrl}/preview/benchmark-rust`, 4_000);
   assert.equal(await stopPreviewAgent(rustSession.sessionId), true);
   rustSession = undefined;
   assert.equal(activePreviewAgentCount(), 0);
+  reportStage("Rust automatic shutdown verified.");
 
   printResults(results);
 } finally {
@@ -219,6 +224,10 @@ function readPositiveInteger(name, fallback) {
   return value;
 }
 
+function reportStage(message) {
+  console.error(`[preview-benchmark] ${message}`);
+}
+
 function listen(server) {
   return new Promise((resolve, reject) => {
     server.once("error", reject);
@@ -230,5 +239,6 @@ function close(server) {
   if (!server.listening) return Promise.resolve();
   return new Promise((resolve, reject) => {
     server.close((error) => (error ? reject(error) : resolve()));
+    server.closeAllConnections?.();
   });
 }

--- a/docs/src/app/docs/cli/page.md
+++ b/docs/src/app/docs/cli/page.md
@@ -146,7 +146,7 @@ farm preview --dry-run
 
 `farm preview` exposes the app that is already running locally. It does not build or deploy the app. Use it when a teammate, webhook provider, OAuth provider, mobile device, or browser automation tool needs a public URL for the current `farm dev` session.
 
-Farm detects the running app on common local ports, or you can pass `--port` / `--url` when the app is running somewhere specific. By default it connects to the hosted Farm Preview gateway and returns a URL such as `https://stripe-webhook.preview.farming-labs.dev`.
+Farm detects the running app on common local ports, or you can pass `--port` / `--url` when the app is running somewhere specific. By default `@farm.js/tunnel` tries to open one outbound WebSocket to the hosted Farm Preview relay and returns a URL such as `https://stripe-webhook.preview.farming-labs.dev`. During the relay rollout, the CLI falls back to compatibility gateway polling if the native connection is unavailable.
 
 The preview terminal logs forwarded traffic:
 

--- a/docs/src/app/docs/preview/page.md
+++ b/docs/src/app/docs/preview/page.md
@@ -58,6 +58,16 @@ https://checkout-test.preview.farming-labs.dev
 
 Keep both terminals running while you test. Stop the preview with `Ctrl+C`.
 
+## Automatic Shutdown
+
+The preview lifecycle is tied to the local app. When `farm dev` stops or the configured local target becomes unreachable, `farm preview` automatically closes the hosted gateway session and exits:
+
+```txt
+Local preview target http://localhost:4324 is no longer reachable. Closing preview session.
+```
+
+The public URL is invalidated as soon as the session closes, so later requests return `404`. You do not need to run a separate command to stop or clean up the tunnel.
+
 ## Commands
 
 ```bash

--- a/docs/src/app/docs/preview/page.md
+++ b/docs/src/app/docs/preview/page.md
@@ -38,17 +38,19 @@ Open a preview in another terminal:
 farm preview --port 4324 --name checkout-test
 ```
 
-Farm prints the local target, hosted gateway, and public URL:
+Farm prints the local target, persistent relay, and public URL:
 
 ```txt
 Creating public preview for the running app...
 Local:  http://localhost:4324
-Gateway: https://preview.farming-labs.dev
-Opening Farm preview gateway session...
+Relay: wss://preview.farming-labs.dev/agent
+Opening native Farm preview tunnel...
 Preview URL ready.
 Public: https://checkout-test.preview.farming-labs.dev
-Forwarding requests until Ctrl+C. Remote traffic will be logged below.
+Forwarding requests through the native tunnel until Ctrl+C.
 ```
+
+During the relay rollout, the CLI warns and falls back to compatibility gateway polling if the hosted endpoint cannot accept the native WebSocket connection. An explicitly configured `FARM_PREVIEW_RELAY_URL` is tried first as well.
 
 Open the public URL from another browser, device, webhook provider, or test runner:
 
@@ -60,11 +62,7 @@ Keep both terminals running while you test. Stop the preview with `Ctrl+C`.
 
 ## Automatic Shutdown
 
-The preview lifecycle is tied to the local app. When `farm dev` stops or the configured local target becomes unreachable, `farm preview` automatically closes the hosted gateway session and exits:
-
-```txt
-Local preview target http://localhost:4324 is no longer reachable. Closing preview session.
-```
+The preview lifecycle is tied to the local app. When `farm dev` stops or the configured local target becomes unreachable, the native tunnel closes its hosted relay session and `farm preview` exits. The compatibility path closes its gateway session the same way.
 
 The public URL is invalidated as soon as the session closes, so later requests return `404`. You do not need to run a separate command to stop or clean up the tunnel.
 
@@ -204,20 +202,19 @@ The default gateway is operated by Farming Labs:
 https://preview.farming-labs.dev
 ```
 
-Regular Farm apps do not need Vercel, DNS, Redis, ngrok, `cloudflared`, or a local tunnel binary. The CLI opens outbound HTTPS requests to the gateway, polls for queued public requests, forwards them to the local app, and uploads the response.
+Regular Farm apps do not need Vercel, DNS, Redis, ngrok, `cloudflared`, or a separately installed tunnel binary. The CLI loads `@farm.js/tunnel`, tries to open one outbound WebSocket to the gateway, and forwards requests through its native Rust transport. Compatibility gateway polling keeps previews available while the hosted relay is being rolled out.
 
 The hosted gateway owns:
 
 - TLS for `*.preview.farming-labs.dev`.
 - Session creation and expiry.
-- Public request queueing.
-- Response relay.
+- Request and response relay over the persistent WebSocket or compatibility polling path.
 - Stale session cleanup.
 
 The local CLI owns:
 
 - Local target detection.
-- Local reachability checks.
+- Native tunnel lifecycle and local reachability checks.
 - Forwarding requests to `localhost`.
 - Request and response logging.
 - Closing the preview when the local app exits.
@@ -270,6 +267,7 @@ Use this path only when the hosted Farm gateway is not appropriate for your envi
 | Variable                      | Purpose                                                   |
 | ----------------------------- | --------------------------------------------------------- |
 | `FARM_PREVIEW_GATEWAY_URL`    | Override the hosted gateway URL.                          |
+| `FARM_PREVIEW_RELAY_URL`      | Override the persistent WebSocket relay URL.              |
 | `FARM_PREVIEW_DOMAIN`         | Override the preview domain used for generated hostnames. |
 | `FARM_PREVIEW_NAME`           | Provide a default readable preview name.                  |
 | `FARM_PREVIEW_PROVIDER`       | Select `farm` or `local`.                                 |

--- a/docs/src/farm.d.ts
+++ b/docs/src/farm.d.ts
@@ -266,3 +266,5 @@ declare module "@farm.js/core" {
     public: FarmResolvedEnv["public"];
   }
 }
+
+export {};

--- a/examples/preview-gateway/README.md
+++ b/examples/preview-gateway/README.md
@@ -4,14 +4,19 @@ This is the Vercel gateway behind `farm preview`.
 
 This example is for Farming Labs maintainers or teams self-hosting their own gateway. Regular Farm app developers do not need to copy, deploy, or configure this app. The default `farm preview` command is backed by the hosted Farming Labs gateway.
 
-It accepts public requests on `*.preview.farming-labs.dev`, hands them to the local `farm preview` CLI over outbound HTTPS polling, and returns the local app response to the public caller. No `cloudflared`, ngrok, or local tunnel binary is required on the developer machine.
+It accepts public requests on `*.preview.farming-labs.dev`, hands them to the local `farm preview` CLI over its persistent outbound WebSocket, and returns the local app response to the public caller. The existing outbound HTTPS polling gateway remains available as a compatibility fallback.
+
+The hosted relay uses Redis to coordinate WebSocket agents and HTTP requests across Vercel Function instances. Requests that reach the Function holding the agent socket stay on the direct in-memory path; requests that reach another instance cross the shared Redis queue.
 
 ## Deploy
 
 ```bash
-cd examples/preview-gateway
+cd /path/to/farm.js
+vercel link
 vercel --prod
 ```
+
+Configure the Vercel project root directory as `examples/preview-gateway`. Deploy from the monorepo root so Vercel includes the `@farm.js/preview-tunnel` workspace package.
 
 Attach both domains to the Vercel project:
 
@@ -24,7 +29,23 @@ Vercel will show the DNS records it expects. After DNS is verified, Vercel handl
 
 ## Required environment for production
 
-Use a shared store so all Vercel function invocations see the same sessions and queued requests.
+Two shared stores keep the native and compatibility transports reliable across Vercel Function instances.
+
+### Native WebSocket coordination
+
+Create an Upstash for Redis resource in the relay's region and connect it to Production and Preview:
+
+```bash
+vercel integration add upstash/upstash-kv \
+  --plan free \
+  --name preview-relay-coordinator \
+  -m primaryRegion=iad1 \
+  -m autoUpgrade=false
+```
+
+The integration injects `REDIS_URL`. Without it, the WebSocket relay uses only the current Function's memory, which is suitable for local development but not multi-instance Vercel traffic.
+
+### Compatibility polling storage
 
 The hosted Farming Labs gateway uses Vercel Blob. Create and link it once:
 
@@ -34,8 +55,7 @@ vercel blob create-store farm-preview-gateway --access private --region iad1 --y
 
 When the project is linked, Vercel connects the store and injects the Blob env automatically.
 
-If you prefer a Redis-compatible REST store, the reusable gateway package also reads either set of variables:
-
+If you prefer a Redis-compatible REST store for the polling fallback, the reusable gateway package also reads either set of variables:
 
 ```txt
 UPSTASH_REDIS_REST_URL
@@ -56,7 +76,7 @@ FARM_PREVIEW_DOMAIN=preview.farming-labs.dev
 FARM_PREVIEW_GATEWAY_URL=https://preview.farming-labs.dev
 ```
 
-Without Blob or Redis REST env vars, the gateway falls back to in-memory storage. That is useful for local development, but not reliable for production Vercel traffic because requests can be handled by different function instances.
+Without Blob or Redis REST env vars, compatibility polling falls back to in-memory storage. That is useful for local development, but not reliable for production Vercel traffic because requests can be handled by different Function instances.
 
 ## CLI usage
 
@@ -96,4 +116,6 @@ http://localhost:3000/__preview/local-check
 
 ## Limits
 
-This gateway buffers request and response bodies. It is intended for local app sharing, OAuth callbacks, webhooks, API testing, and design review. It is not a streaming WebSocket/SSE tunnel.
+This gateway buffers request and response bodies. It is intended for local app sharing, OAuth callbacks, webhooks, API testing, and design review. The agent transport is a persistent WebSocket, but WebSocket upgrades and SSE streams from the local target are not forwarded yet.
+
+Vercel closes a Function WebSocket at the Function's maximum duration. The deployed gateway uses the current 30-minute maximum; reconnect/resume remains future work for the native agent.

--- a/examples/preview-gateway/api/index.ts
+++ b/examples/preview-gateway/api/index.ts
@@ -5,7 +5,10 @@ import {
   type PreviewGatewaySession,
   type PreviewGatewayStore,
 } from "@farm.js/preview-gateway";
+import { createPersistentPreviewRelay } from "@farm.js/preview-tunnel";
 import { del, get, list, put } from "@vercel/blob";
+
+import { createRedisPreviewRelayCoordinator } from "../lib/redis-coordinator.js";
 
 interface ExpiringValue<T> {
   expiresAt: number;
@@ -201,12 +204,25 @@ function isMissingBlobError(error: unknown) {
 }
 
 export const config = {
-  maxDuration: 60,
+  maxDuration: 1800,
 };
 
-export default createNodePreviewGatewayHandler({
-  domain: process.env.FARM_PREVIEW_DOMAIN || "preview.farming-labs.dev",
+const domain = process.env.FARM_PREVIEW_DOMAIN || "preview.farming-labs.dev";
+const coordinator = createRedisPreviewRelayCoordinator();
+const pollingGateway = createNodePreviewGatewayHandler({
+  domain,
   baseUrl: process.env.FARM_PREVIEW_GATEWAY_URL,
   clientHeartbeatTimeoutMs: 1000 * 60 * 30,
   store: createVercelBlobStore(),
 });
+
+const persistentRelay = createPersistentPreviewRelay({
+  publicBaseUrl: process.env.FARM_PREVIEW_GATEWAY_URL || `https://${domain}`,
+  publicDomain: domain,
+  publicWebSocketUrl: `wss://${domain}/agent`,
+  healthPath: "/api/tunnel/health",
+  fallbackHandler: pollingGateway,
+  coordinator,
+});
+
+export default persistentRelay.server;

--- a/examples/preview-gateway/lib/redis-coordinator.ts
+++ b/examples/preview-gateway/lib/redis-coordinator.ts
@@ -1,0 +1,125 @@
+import {
+  isAgentToRelayMessage,
+  isRelayToAgentMessage,
+  type PersistentPreviewRelayCoordinator,
+  type PersistentPreviewRelayCoordinatorSession,
+  type TunnelRequestMessage,
+  type TunnelResponseMessage,
+} from "@farm.js/preview-tunnel";
+import Redis from "ioredis";
+
+const KEY_PREFIX = "farm-preview:native";
+const QUEUE_TTL_MS = 60_000;
+
+const TOUCH_SESSION_SCRIPT = `
+  if redis.call("GET", KEYS[1]) == ARGV[1] then
+    return redis.call("PEXPIRE", KEYS[1], ARGV[2])
+  end
+  return 0
+`;
+
+const RELEASE_SESSION_SCRIPT = `
+  if redis.call("GET", KEYS[1]) == ARGV[1] then
+    return redis.call("DEL", KEYS[1])
+  end
+  return 0
+`;
+
+export class RedisPreviewRelayCoordinator implements PersistentPreviewRelayCoordinator {
+  private readonly redis: Redis;
+
+  constructor(url: string) {
+    this.redis = new Redis(url, {
+      connectionName: "farm-preview-relay",
+      connectTimeout: 5_000,
+      enableReadyCheck: true,
+      lazyConnect: true,
+      maxRetriesPerRequest: 2,
+    });
+    this.redis.on("error", () => undefined);
+  }
+
+  async claimSession(session: PersistentPreviewRelayCoordinatorSession, ttlMs: number) {
+    const result = await this.redis.set(this.nameKey(session.name), session.id, "PX", ttlMs, "NX");
+    return result === "OK";
+  }
+
+  async findSession(name: string) {
+    const id = await this.redis.get(this.nameKey(name));
+    return id ? { id, name } : undefined;
+  }
+
+  async touchSession(session: PersistentPreviewRelayCoordinatorSession, ttlMs: number) {
+    const result = await this.redis.eval(
+      TOUCH_SESSION_SCRIPT,
+      1,
+      this.nameKey(session.name),
+      session.id,
+      ttlMs,
+    );
+    return Number(result) === 1;
+  }
+
+  async releaseSession(session: PersistentPreviewRelayCoordinatorSession) {
+    await this.redis.eval(RELEASE_SESSION_SCRIPT, 1, this.nameKey(session.name), session.id);
+  }
+
+  async publishRequest(sessionId: string, request: TunnelRequestMessage) {
+    await this.push(this.requestKey(sessionId), request);
+  }
+
+  async takeRequest(sessionId: string, timeoutMs: number) {
+    const value = await this.take(this.requestKey(sessionId), timeoutMs);
+    if (!value) return undefined;
+    const message: unknown = JSON.parse(value);
+    return isRelayToAgentMessage(message) && message.type === "request" ? message : undefined;
+  }
+
+  async publishResponse(sessionId: string, response: TunnelResponseMessage) {
+    await this.push(this.responseKey(sessionId, response.id), response);
+  }
+
+  async takeResponse(sessionId: string, requestId: string, timeoutMs: number) {
+    const value = await this.take(this.responseKey(sessionId, requestId), timeoutMs);
+    if (!value) return undefined;
+    const message: unknown = JSON.parse(value);
+    return isAgentToRelayMessage(message) && message.type === "response" ? message : undefined;
+  }
+
+  private async push(key: string, value: unknown) {
+    await this.redis
+      .multi()
+      .rpush(key, JSON.stringify(value))
+      .pexpire(key, QUEUE_TTL_MS)
+      .exec();
+  }
+
+  private async take(key: string, timeoutMs: number) {
+    const blocker = this.redis.duplicate({ maxRetriesPerRequest: null });
+    blocker.on("error", () => undefined);
+    try {
+      const timeoutSeconds = Math.max(1, Math.ceil(timeoutMs / 1_000));
+      const result = await blocker.blpop(key, timeoutSeconds);
+      return result?.[1];
+    } finally {
+      blocker.disconnect();
+    }
+  }
+
+  private nameKey(name: string) {
+    return `${KEY_PREFIX}:names:${name}`;
+  }
+
+  private requestKey(sessionId: string) {
+    return `${KEY_PREFIX}:requests:${sessionId}`;
+  }
+
+  private responseKey(sessionId: string, requestId: string) {
+    return `${KEY_PREFIX}:responses:${sessionId}:${requestId}`;
+  }
+}
+
+export function createRedisPreviewRelayCoordinator() {
+  const url = process.env.REDIS_URL || process.env.KV_URL || process.env.UPSTASH_REDIS_URL;
+  return url ? new RedisPreviewRelayCoordinator(url) : undefined;
+}

--- a/examples/preview-gateway/package.json
+++ b/examples/preview-gateway/package.json
@@ -10,7 +10,9 @@
   },
   "dependencies": {
     "@farm.js/preview-gateway": "0.1.0-beta.2",
-    "@vercel/blob": "^2.6.1"
+    "@farm.js/preview-tunnel": "0.1.0-beta.19",
+    "@vercel/blob": "^2.6.1",
+    "ioredis": "^5.9.3"
   },
   "devDependencies": {
     "@types/node": "^20.10.5",

--- a/examples/preview-gateway/public/robots.txt
+++ b/examples/preview-gateway/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/examples/preview-gateway/tsconfig.json
+++ b/examples/preview-gateway/tsconfig.json
@@ -16,5 +16,5 @@
     "rootDir": ".",
     "types": ["node"]
   },
-  "include": ["api/**/*.ts"]
+  "include": ["api/**/*.ts", "lib/**/*.ts"]
 }

--- a/examples/preview-gateway/vercel.json
+++ b/examples/preview-gateway/vercel.json
@@ -1,10 +1,11 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "pnpm run build",
+  "installCommand": "pnpm install --filter farm-preview-gateway-vercel... --frozen-lockfile",
+  "outputDirectory": "public",
   "regions": ["iad1"],
   "functions": {
     "api/index.ts": {
-      "maxDuration": 60
+      "maxDuration": 1800
     }
   },
   "routes": [

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "docs:check-navigation": "node scripts/check-docs-navigation.mjs",
     "build:examples": "node scripts/build-examples.js",
     "benchmark:frameworks": "node benchmarks/frameworks/run.mjs",
+    "benchmark:preview": "pnpm --filter @farm.js/preview-tunnel build && node benchmarks/preview-tunnel/run.mjs",
     "lint": "oxlint . && oxfmt --check .",
     "format": "oxlint --fix . && oxfmt .",
     "lint:fix": "oxlint --fix . && oxfmt .",

--- a/packages/farm-cli/package.json
+++ b/packages/farm-cli/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@farm.js/core": "workspace:*",
+    "@farm.js/tunnel": "0.1.0",
     "commander": "^11.1.0",
     "croner": "9.1.0",
     "picocolors": "^1.0.0"

--- a/packages/farm-cli/src/index.ts
+++ b/packages/farm-cli/src/index.ts
@@ -40,6 +40,11 @@ export {
   type PreviewGatewaySession,
 } from "./preview-gateway";
 export {
+  runNativePreviewTunnel,
+  type NativeTunnelRuntime,
+  type RunNativePreviewTunnelOptions,
+} from "./preview-native";
+export {
   FarmGeneratedArtifactsStaleError,
   generateFarmArtifacts,
   type GenerateFarmOptions,

--- a/packages/farm-cli/src/preview-gateway.ts
+++ b/packages/farm-cli/src/preview-gateway.ts
@@ -5,6 +5,7 @@ import type { PreviewFarmOptions, PreviewTarget } from "./preview";
 export interface PreviewGatewayPlan {
   provider: "farm-gateway";
   gatewayUrl: string;
+  relayUrl: string;
   target: PreviewTarget;
   requestedName: string;
   requestedHostname: string;
@@ -71,12 +72,14 @@ export function createPreviewGatewayPlan(
   const gatewayUrl = normalizeGatewayUrl(
     options.gatewayUrl || process.env.FARM_PREVIEW_GATEWAY_URL || DEFAULT_GATEWAY_URL,
   );
+  const relayUrl = normalizeRelayUrl(process.env.FARM_PREVIEW_RELAY_URL || gatewayUrl);
   const domain = normalizePreviewDomain(process.env.FARM_PREVIEW_DOMAIN || DEFAULT_PREVIEW_DOMAIN);
   const requestedHostname = `${requestedName}.${domain}`;
 
   return {
     provider: "farm-gateway",
     gatewayUrl,
+    relayUrl,
     target,
     requestedName,
     requestedHostname,
@@ -353,6 +356,7 @@ async function closeGatewaySession(plan: PreviewGatewayPlan, session: PreviewGat
 export function formatGatewayPlan(plan: PreviewGatewayPlan) {
   return [
     `Gateway: ${plan.gatewayUrl}`,
+    `Relay:   ${plan.relayUrl}`,
     `Local:   ${plan.target.localUrl}`,
     `Public:  ${plan.requestedPublicUrl}`,
   ].join("\n");
@@ -368,6 +372,20 @@ function formatRequestPath(path: string) {
 
 function normalizeGatewayUrl(value: string) {
   return value.replace(/\/+$/, "");
+}
+
+function normalizeRelayUrl(value: string) {
+  const url = new URL(value);
+  if (url.protocol === "http:") url.protocol = "ws:";
+  if (url.protocol === "https:") url.protocol = "wss:";
+  if (url.protocol !== "ws:" && url.protocol !== "wss:") {
+    throw new Error(`Preview relay must use ws or wss, received ${url.protocol}`);
+  }
+  const pathname = url.pathname.replace(/\/+$/, "");
+  url.pathname = pathname.endsWith("/agent") ? pathname : `${pathname}/agent`;
+  url.search = "";
+  url.hash = "";
+  return url.toString();
 }
 
 function normalizePreviewDomain(value: string) {

--- a/packages/farm-cli/src/preview-native.ts
+++ b/packages/farm-cli/src/preview-native.ts
@@ -1,0 +1,66 @@
+import { logger } from "@farm.js/core";
+import type { PreviewAgentSession } from "@farm.js/tunnel";
+import type { PreviewGatewayPlan } from "./preview-gateway";
+
+export interface NativeTunnelRuntime {
+  startPreviewAgent(
+    relayUrl: string,
+    name: string,
+    targetUrl: string,
+  ): Promise<PreviewAgentSession>;
+  stopPreviewAgent(sessionId: string): Promise<boolean>;
+  waitPreviewAgent(sessionId: string): Promise<boolean>;
+}
+
+export interface RunNativePreviewTunnelOptions {
+  runtime?: NativeTunnelRuntime;
+}
+
+export async function runNativePreviewTunnel(
+  plan: PreviewGatewayPlan,
+  options: RunNativePreviewTunnelOptions = {},
+): Promise<PreviewAgentSession> {
+  const runtime = options.runtime || (await loadNativeTunnel());
+  const session = await runtime.startPreviewAgent(
+    plan.relayUrl,
+    plan.requestedName,
+    plan.target.localUrl,
+  );
+  let stopping = false;
+
+  const stop = () => {
+    if (stopping) return;
+    stopping = true;
+    void runtime.stopPreviewAgent(session.sessionId);
+  };
+
+  process.once("SIGINT", stop);
+  process.once("SIGTERM", stop);
+
+  logger.success("Preview URL ready.");
+  logger.info(`Public: ${session.publicUrl}`);
+  logger.info("Forwarding requests through the native tunnel until Ctrl+C.");
+
+  try {
+    const waited = await runtime.waitPreviewAgent(session.sessionId);
+    if (!waited) {
+      throw new Error("The native preview tunnel stopped before its lifecycle could be observed.");
+    }
+    return session;
+  } finally {
+    process.removeListener("SIGINT", stop);
+    process.removeListener("SIGTERM", stop);
+    await runtime.stopPreviewAgent(session.sessionId).catch(() => false);
+  }
+}
+
+async function loadNativeTunnel(): Promise<NativeTunnelRuntime> {
+  try {
+    return await import("@farm.js/tunnel");
+  } catch (error) {
+    const reason = error instanceof Error ? ` ${error.message}` : "";
+    throw new Error(
+      `Could not load @farm.js/tunnel for this platform. Reinstall @farm.js/cli so its native platform package is restored.${reason}`,
+    );
+  }
+}

--- a/packages/farm-cli/src/preview.ts
+++ b/packages/farm-cli/src/preview.ts
@@ -1,6 +1,7 @@
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { setTimeout as delay } from "node:timers/promises";
 import { loadConfig, logger } from "@farm.js/core";
+import type { PreviewAgentSession } from "@farm.js/tunnel";
 import {
   createPreviewGatewayPlan,
   formatGatewayPlan,
@@ -8,6 +9,7 @@ import {
   type PreviewGatewayPlan,
   type PreviewGatewaySession,
 } from "./preview-gateway";
+import { runNativePreviewTunnel } from "./preview-native";
 
 export interface PreviewFarmOptions {
   root?: string;
@@ -43,7 +45,7 @@ export interface PreviewFarmResult {
   target: PreviewTarget;
   plan: PreviewTunnelPlan | PreviewGatewayPlan;
   publicUrl?: string;
-  session?: PreviewGatewaySession;
+  session?: PreviewAgentSession | PreviewGatewaySession;
 }
 
 const DEFAULT_PREVIEW_PORTS = [3000, 4319, 5173, 4173, 8080];
@@ -64,12 +66,20 @@ export async function previewFarm(options: PreviewFarmOptions = {}): Promise<Pre
       return { target, plan };
     }
 
-    logger.info(`Gateway: ${plan.gatewayUrl}`);
-    logger.info("Opening Farm preview gateway session...");
-    const session = await runPreviewGateway(plan, {
-      timeoutMs: options.timeoutMs,
-    });
-    return { target, plan, publicUrl: session.publicUrl, session };
+    logger.info(`Relay: ${plan.relayUrl}`);
+    logger.info("Opening native Farm preview tunnel...");
+    try {
+      const session = await runNativePreviewTunnel(plan);
+      return { target, plan, publicUrl: session.publicUrl, session };
+    } catch (error) {
+      logger.warn(
+        `Native preview relay unavailable; using compatibility gateway polling.${formatPreviewError(error)}`,
+      );
+      const session = await runPreviewGateway(plan, {
+        timeoutMs: options.timeoutMs,
+      });
+      return { target, plan, publicUrl: session.publicUrl, session };
+    }
   }
 
   const plan = createPreviewTunnelPlan(target, options);
@@ -83,6 +93,10 @@ export async function previewFarm(options: PreviewFarmOptions = {}): Promise<Pre
   logger.info("Opening public tunnel...");
   const publicUrl = await runPreviewTunnel(plan, options.timeoutMs ?? 30000);
   return { target, plan, publicUrl };
+}
+
+function formatPreviewError(error: unknown) {
+  return error instanceof Error && error.message ? ` ${error.message}` : "";
 }
 
 function shouldUseManagedGateway(options: PreviewFarmOptions) {

--- a/packages/farm-cli/test/preview.test.mjs
+++ b/packages/farm-cli/test/preview.test.mjs
@@ -13,7 +13,9 @@ const {
   createPreviewTunnelPlan,
   forwardGatewayRequest,
   parsePreviewPublicUrl,
+  previewFarm,
   resolvePreviewTarget,
+  runNativePreviewTunnel,
   runPreviewGateway,
 } = require("../dist/index.js");
 const execFileAsync = promisify(execFile);
@@ -106,11 +108,63 @@ test("creates a managed gateway preview plan by default", () => {
 
     assert.equal(plan.provider, "farm-gateway");
     assert.equal(plan.gatewayUrl, "https://preview.farming-labs.dev");
+    assert.equal(plan.relayUrl, "wss://preview.farming-labs.dev/agent");
     assert.equal(plan.requestedPublicUrl, "https://stripe-webhook.preview.farming-labs.dev");
   } finally {
     restoreEnv("FARM_PREVIEW_GATEWAY_URL", previousGateway);
     restoreEnv("FARM_PREVIEW_DOMAIN", previousDomain);
   }
+});
+
+test("runs the managed preview through the native tunnel lifecycle", async () => {
+  let resolveWait;
+  const wait = new Promise((resolve) => {
+    resolveWait = resolve;
+  });
+  const calls = [];
+  const runtime = {
+    async startPreviewAgent(...args) {
+      calls.push(["start", ...args]);
+      return {
+        sessionId: "native-session",
+        publicUrl: "https://native.preview.farming-labs.dev",
+      };
+    },
+    async stopPreviewAgent(sessionId) {
+      calls.push(["stop", sessionId]);
+      return false;
+    },
+    async waitPreviewAgent(sessionId) {
+      calls.push(["wait", sessionId]);
+      return await wait;
+    },
+  };
+  const plan = {
+    provider: "farm-gateway",
+    gatewayUrl: "https://preview.farming-labs.dev",
+    relayUrl: "wss://preview.farming-labs.dev/agent",
+    target: {
+      localUrl: "http://localhost:3000",
+      host: "localhost",
+      port: 3000,
+      source: "port",
+    },
+    requestedName: "native",
+    requestedHostname: "native.preview.farming-labs.dev",
+    requestedPublicUrl: "https://native.preview.farming-labs.dev",
+  };
+
+  const running = runNativePreviewTunnel(plan, { runtime });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(calls, [
+    ["start", "wss://preview.farming-labs.dev/agent", "native", "http://localhost:3000"],
+    ["wait", "native-session"],
+  ]);
+
+  resolveWait(true);
+  const session = await running;
+  assert.equal(session.sessionId, "native-session");
+  assert.deepEqual(calls.at(-1), ["stop", "native-session"]);
 });
 
 test("forwards a gateway request to the local target", async () => {
@@ -187,6 +241,39 @@ test("closes the gateway session when the local target stops", async () => {
     assert.equal(gateway.deletedSessions.length, 1);
     assert.equal(gateway.deletedSessions[0], "sess_watch");
   } finally {
+    await app.close().catch(() => undefined);
+    await gateway.close();
+  }
+});
+
+test("falls back to gateway polling while the hosted native relay is unavailable", async () => {
+  const app = await createTestServer();
+  const gateway = await createPreviewGatewayTestServer();
+  const previousRelay = process.env.FARM_PREVIEW_RELAY_URL;
+  process.env.FARM_PREVIEW_RELAY_URL = "ws://127.0.0.1:1/agent";
+
+  try {
+    const preview = previewFarm({
+      port: app.port,
+      gatewayUrl: gateway.url,
+      name: "fallback-check",
+      timeoutMs: 1000,
+    });
+
+    await gateway.waitForSession();
+    await app.close();
+
+    const result = await Promise.race([
+      preview,
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("fallback preview did not stop")), 4000),
+      ),
+    ]);
+
+    assert.equal(result.session.id, "sess_watch");
+    assert.equal(gateway.deletedSessions.length, 1);
+  } finally {
+    restoreEnv("FARM_PREVIEW_RELAY_URL", previousRelay);
     await app.close().catch(() => undefined);
     await gateway.close();
   }

--- a/packages/farm-cli/tsdown.config.ts
+++ b/packages/farm-cli/tsdown.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   // This package currently does not publish a `types` entry.
   dts: false,
   clean: true,
-  external: ["@farm.js/core", "commander", "croner"],
+  external: ["@farm.js/core", "@farm.js/tunnel", "commander", "croner"],
   splitting: false,
   sourcemap: true,
 });

--- a/packages/farm-preview-tunnel/README.md
+++ b/packages/farm-preview-tunnel/README.md
@@ -19,6 +19,18 @@ const agent = await startTypeScriptPreviewAgent({
 console.log(agent.publicUrl);
 ```
 
+When the relay binds to all interfaces behind a public reverse proxy, configure the
+externally reachable HTTP and WebSocket URLs independently:
+
+```ts
+const relay = createPersistentPreviewRelay({
+  host: "0.0.0.0",
+  port: 4400,
+  publicBaseUrl: "https://preview.example.com",
+  publicWebSocketUrl: "wss://preview.example.com/agent",
+});
+```
+
 The agent closes automatically when the local target becomes unreachable. The relay then removes its public route.
 
 ## Rust agent

--- a/packages/farm-preview-tunnel/README.md
+++ b/packages/farm-preview-tunnel/README.md
@@ -5,10 +5,7 @@ Experimental persistent preview relay and TypeScript agent for Farm.js.
 Unlike the current hosted preview gateway, this package keeps requests out of remote object storage. The agent opens one outbound WebSocket to the relay, and the relay multiplexes HTTP requests and responses over that connection.
 
 ```ts
-import {
-  createPersistentPreviewRelay,
-  startTypeScriptPreviewAgent,
-} from "@farm.js/preview-tunnel";
+import { createPersistentPreviewRelay, startTypeScriptPreviewAgent } from "@farm.js/preview-tunnel";
 
 const relay = createPersistentPreviewRelay({ port: 4400 });
 const address = await relay.listen();
@@ -26,7 +23,7 @@ The agent closes automatically when the local target becomes unreachable. The re
 
 ## Rust agent
 
-The independent `@farm.js/preview-agent-rs` N-API package implements the same protocol and can replace `startTypeScriptPreviewAgent` as an optional native fast path. The TypeScript agent remains the portable fallback and protocol reference.
+The independent `@farm.js/tunnel` N-API package implements the same protocol and can replace `startTypeScriptPreviewAgent` as an optional native fast path. The TypeScript agent remains the portable fallback and protocol reference.
 
 ## Prototype limitations
 

--- a/packages/farm-preview-tunnel/README.md
+++ b/packages/farm-preview-tunnel/README.md
@@ -23,7 +23,7 @@ The agent closes automatically when the local target becomes unreachable. The re
 
 ## Rust agent
 
-The independent `@farm.js/tunnel` N-API package implements the same protocol and can replace `startTypeScriptPreviewAgent` as an optional native fast path. The TypeScript agent remains the portable fallback and protocol reference.
+The independent `@farm.js/tunnel` N-API package implements the same protocol and is the native agent used by `farm preview`. The TypeScript agent remains the portable protocol reference and fallback.
 
 ## Prototype limitations
 

--- a/packages/farm-preview-tunnel/README.md
+++ b/packages/farm-preview-tunnel/README.md
@@ -1,8 +1,8 @@
 # `@farm.js/preview-tunnel`
 
-Experimental persistent preview relay and TypeScript agent for Farm.js.
+Persistent preview relay protocol and TypeScript reference agent for Farm.js.
 
-Unlike the current hosted preview gateway, this package keeps requests out of remote object storage. The agent opens one outbound WebSocket to the relay, and the relay multiplexes HTTP requests and responses over that connection.
+The agent opens one outbound WebSocket to the relay, and the relay multiplexes HTTP requests and responses over that connection. The hosted gateway uses this transport first and keeps its HTTPS polling gateway as a compatibility fallback.
 
 ```ts
 import { createPersistentPreviewRelay, startTypeScriptPreviewAgent } from "@farm.js/preview-tunnel";
@@ -27,9 +27,12 @@ const relay = createPersistentPreviewRelay({
   host: "0.0.0.0",
   port: 4400,
   publicBaseUrl: "https://preview.example.com",
+  publicDomain: "preview.example.com",
   publicWebSocketUrl: "wss://preview.example.com/agent",
 });
 ```
+
+When the relay can run on multiple server instances, provide a shared `PersistentPreviewRelayCoordinator`. Same-instance requests continue to use the direct in-memory path; the coordinator carries requests and responses only when the HTTP request lands on another instance. The hosted Vercel gateway uses Redis lists and expiring session ownership for this path.
 
 The agent closes automatically when the local target becomes unreachable. The relay then removes its public route.
 
@@ -42,6 +45,6 @@ The independent `@farm.js/tunnel` N-API package implements the same protocol and
 - Request and response bodies are buffered and base64-encoded in JSON.
 - Authentication and reconnect/resume are not implemented yet.
 - WebSocket upgrade forwarding and Vite HMR are not implemented yet.
-- The relay must run on infrastructure that supports long-lived WebSockets.
+- The relay must run on infrastructure that supports long-lived WebSockets. Clients do not reconnect when the infrastructure's maximum connection duration is reached yet.
 
 See `benchmarks/preview-tunnel` for the correctness and performance harness.

--- a/packages/farm-preview-tunnel/README.md
+++ b/packages/farm-preview-tunnel/README.md
@@ -1,0 +1,38 @@
+# `@farm.js/preview-tunnel`
+
+Experimental persistent preview relay and TypeScript agent for Farm.js.
+
+Unlike the current hosted preview gateway, this package keeps requests out of remote object storage. The agent opens one outbound WebSocket to the relay, and the relay multiplexes HTTP requests and responses over that connection.
+
+```ts
+import {
+  createPersistentPreviewRelay,
+  startTypeScriptPreviewAgent,
+} from "@farm.js/preview-tunnel";
+
+const relay = createPersistentPreviewRelay({ port: 4400 });
+const address = await relay.listen();
+
+const agent = await startTypeScriptPreviewAgent({
+  relayUrl: address.websocketUrl,
+  name: "my-preview",
+  targetUrl: "http://127.0.0.1:3000",
+});
+
+console.log(agent.publicUrl);
+```
+
+The agent closes automatically when the local target becomes unreachable. The relay then removes its public route.
+
+## Rust agent
+
+The independent `@farm.js/preview-agent-rs` N-API package implements the same protocol and can replace `startTypeScriptPreviewAgent` as an optional native fast path. The TypeScript agent remains the portable fallback and protocol reference.
+
+## Prototype limitations
+
+- Request and response bodies are buffered and base64-encoded in JSON.
+- Authentication and reconnect/resume are not implemented yet.
+- WebSocket upgrade forwarding and Vite HMR are not implemented yet.
+- The relay must run on infrastructure that supports long-lived WebSockets.
+
+See `benchmarks/preview-tunnel` for the correctness and performance harness.

--- a/packages/farm-preview-tunnel/package.json
+++ b/packages/farm-preview-tunnel/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@farm.js/preview-tunnel",
+  "version": "0.1.0-beta.19",
+  "description": "Persistent preview tunnel protocol, relay, and TypeScript agent for Farm.js",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/farming-labs/farm.js",
+    "directory": "packages/farm-preview-tunnel"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "test": "tsdown && node --test test/*.test.mjs",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "ws": "^8.21.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.5",
+    "@types/ws": "^8.18.1",
+    "tsdown": "^0.15.7",
+    "typescript": "^5.3.3"
+  }
+}

--- a/packages/farm-preview-tunnel/package.json
+++ b/packages/farm-preview-tunnel/package.json
@@ -26,8 +26,8 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsdown",
-    "test": "tsdown && node --test test/*.test.mjs",
+    "build": "tsdown && tsc --noEmit false --emitDeclarationOnly",
+    "test": "pnpm run build && node --test test/*.test.mjs",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/farm-preview-tunnel/src/agent.ts
+++ b/packages/farm-preview-tunnel/src/agent.ts
@@ -1,0 +1,185 @@
+import { WebSocket } from "ws";
+
+import type {
+  ReadyMessage,
+  RelayToAgentMessage,
+  TunnelRequestMessage,
+  TunnelResponseMessage,
+} from "./protocol.js";
+
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "content-length",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+export interface TypeScriptPreviewAgentOptions {
+  relayUrl: string;
+  name: string;
+  targetUrl: string;
+  connectTimeoutMs?: number;
+  localProbeIntervalMs?: number;
+  localProbeTimeoutMs?: number;
+}
+
+export interface TypeScriptPreviewAgent {
+  sessionId: string;
+  publicUrl: string;
+  close(): Promise<void>;
+}
+
+export async function startTypeScriptPreviewAgent(
+  options: TypeScriptPreviewAgentOptions,
+): Promise<TypeScriptPreviewAgent> {
+  const socket = new WebSocket(options.relayUrl);
+  const ready = await waitForReady(socket, options);
+  const stopWatchingTarget = watchLocalTarget(socket, options);
+
+  socket.on("message", (data) => {
+    const message = JSON.parse(data.toString()) as RelayToAgentMessage;
+    if (message.type === "request") {
+      void forwardRequest(socket, options.targetUrl, message);
+    }
+  });
+
+  return {
+    sessionId: ready.sessionId,
+    publicUrl: ready.publicUrl,
+    async close() {
+      stopWatchingTarget();
+      await closeSocket(socket);
+    },
+  };
+}
+
+function watchLocalTarget(socket: WebSocket, options: TypeScriptPreviewAgentOptions) {
+  let stopped = false;
+  let timer: NodeJS.Timeout | undefined;
+  const intervalMs = options.localProbeIntervalMs ?? 2_000;
+  const timeoutMs = options.localProbeTimeoutMs ?? 1_000;
+
+  const stop = () => {
+    stopped = true;
+    if (timer) clearTimeout(timer);
+  };
+  const probe = async () => {
+    if (stopped) return;
+    try {
+      await fetch(options.targetUrl, { signal: AbortSignal.timeout(timeoutMs) });
+      timer = setTimeout(probe, intervalMs);
+    } catch {
+      stop();
+      if (socket.readyState === socket.OPEN) {
+        socket.close(1001, "Local preview target stopped");
+      }
+    }
+  };
+
+  socket.once("close", stop);
+  timer = setTimeout(probe, intervalMs);
+  return stop;
+}
+
+function waitForReady(socket: WebSocket, options: TypeScriptPreviewAgentOptions) {
+  return new Promise<ReadyMessage>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      socket.terminate();
+      reject(new Error("Persistent preview relay did not accept the agent in time."));
+    }, options.connectTimeoutMs ?? 10_000);
+
+    const onOpen = () => {
+      socket.send(JSON.stringify({ type: "register", name: options.name }));
+    };
+    const onMessage = (data: WebSocket.RawData) => {
+      const message = JSON.parse(data.toString()) as RelayToAgentMessage;
+      if (message.type === "ready") {
+        cleanup();
+        resolve(message);
+      } else if (message.type === "error") {
+        cleanup();
+        reject(new Error(message.message));
+      }
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onClose = () => {
+      cleanup();
+      reject(new Error("Persistent preview relay closed before the agent was ready."));
+    };
+    const cleanup = () => {
+      clearTimeout(timeout);
+      socket.off("open", onOpen);
+      socket.off("message", onMessage);
+      socket.off("error", onError);
+      socket.off("close", onClose);
+    };
+
+    socket.on("open", onOpen);
+    socket.on("message", onMessage);
+    socket.on("error", onError);
+    socket.on("close", onClose);
+  });
+}
+
+async function forwardRequest(socket: WebSocket, targetUrl: string, request: TunnelRequestMessage) {
+  let response: TunnelResponseMessage;
+  try {
+    const headers = new Headers();
+    for (const [name, value] of Object.entries(request.headers)) {
+      if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) headers.set(name, value);
+    }
+    const method = request.method.toUpperCase();
+    const result = await fetch(new URL(request.path, ensureTrailingSlash(targetUrl)), {
+      method,
+      headers,
+      body:
+        method === "GET" || method === "HEAD" || !request.body
+          ? undefined
+          : Buffer.from(request.body, "base64"),
+      redirect: "manual",
+    });
+    const responseHeaders: Record<string, string> = {};
+    for (const [name, value] of result.headers) {
+      if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) responseHeaders[name] = value;
+    }
+    response = {
+      type: "response",
+      id: request.id,
+      status: result.status,
+      headers: responseHeaders,
+      body: Buffer.from(await result.arrayBuffer()).toString("base64"),
+    };
+  } catch (error) {
+    response = {
+      type: "response",
+      id: request.id,
+      status: 502,
+      headers: { "content-type": "text/plain; charset=utf-8" },
+      body: Buffer.from(error instanceof Error ? error.message : String(error)).toString("base64"),
+    };
+  }
+
+  if (socket.readyState === socket.OPEN) socket.send(JSON.stringify(response));
+}
+
+function ensureTrailingSlash(value: string) {
+  return value.endsWith("/") ? value : `${value}/`;
+}
+
+function closeSocket(socket: WebSocket) {
+  if (socket.readyState === socket.CLOSED) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    socket.once("close", () => resolve());
+    socket.close(1000, "Preview agent stopped");
+  });
+}

--- a/packages/farm-preview-tunnel/src/agent.ts
+++ b/packages/farm-preview-tunnel/src/agent.ts
@@ -6,6 +6,7 @@ import type {
   TunnelRequestMessage,
   TunnelResponseMessage,
 } from "./protocol.js";
+import { isRelayToAgentMessage } from "./protocol.js";
 
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
@@ -27,6 +28,7 @@ export interface TypeScriptPreviewAgentOptions {
   connectTimeoutMs?: number;
   localProbeIntervalMs?: number;
   localProbeTimeoutMs?: number;
+  requestTimeoutMs?: number;
 }
 
 export interface TypeScriptPreviewAgent {
@@ -39,14 +41,45 @@ export async function startTypeScriptPreviewAgent(
   options: TypeScriptPreviewAgentOptions,
 ): Promise<TypeScriptPreviewAgent> {
   const socket = new WebSocket(options.relayUrl);
-  const ready = await waitForReady(socket, options);
+  const onSocketError = () => {
+    // WebSocket errors are followed by close; keep a listener for the socket's full lifetime.
+  };
+  socket.on("error", onSocketError);
+
+  let ready: ReadyMessage;
+  try {
+    ready = await waitForReady(socket, options);
+  } catch (error) {
+    socket.off("error", onSocketError);
+    throw error;
+  }
+
+  const inFlight = new Map<string, AbortController>();
   const stopWatchingTarget = watchLocalTarget(socket, options);
+  const abortInFlight = () => {
+    for (const controller of inFlight.values()) controller.abort();
+    inFlight.clear();
+  };
 
   socket.on("message", (data) => {
-    const message = JSON.parse(data.toString()) as RelayToAgentMessage;
-    if (message.type === "request") {
-      void forwardRequest(socket, options.targetUrl, message);
+    const message = parseRelayMessage(data);
+    if (!message) {
+      socket.close(1008, "Invalid relay message");
+      return;
     }
+    if (message.type === "request") {
+      const controller = new AbortController();
+      inFlight.get(message.id)?.abort();
+      inFlight.set(message.id, controller);
+      void forwardRequest(socket, options, message, controller).finally(() => {
+        if (inFlight.get(message.id) === controller) inFlight.delete(message.id);
+      });
+    }
+  });
+  socket.once("close", () => {
+    stopWatchingTarget();
+    abortInFlight();
+    socket.off("error", onSocketError);
   });
 
   return {
@@ -54,6 +87,7 @@ export async function startTypeScriptPreviewAgent(
     publicUrl: ready.publicUrl,
     async close() {
       stopWatchingTarget();
+      abortInFlight();
       await closeSocket(socket);
     },
   };
@@ -62,23 +96,33 @@ export async function startTypeScriptPreviewAgent(
 function watchLocalTarget(socket: WebSocket, options: TypeScriptPreviewAgentOptions) {
   let stopped = false;
   let timer: NodeJS.Timeout | undefined;
+  let probeController: AbortController | undefined;
   const intervalMs = options.localProbeIntervalMs ?? 2_000;
   const timeoutMs = options.localProbeTimeoutMs ?? 1_000;
 
   const stop = () => {
     stopped = true;
     if (timer) clearTimeout(timer);
+    probeController?.abort();
   };
   const probe = async () => {
     if (stopped) return;
+    const controller = new AbortController();
+    probeController = controller;
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      await fetch(options.targetUrl, { signal: AbortSignal.timeout(timeoutMs) });
+      const response = await fetch(options.targetUrl, { signal: controller.signal });
+      await response.body?.cancel();
       timer = setTimeout(probe, intervalMs);
     } catch {
+      if (stopped) return;
       stop();
       if (socket.readyState === socket.OPEN) {
         socket.close(1001, "Local preview target stopped");
       }
+    } finally {
+      clearTimeout(timeout);
+      if (probeController === controller) probeController = undefined;
     }
   };
 
@@ -99,7 +143,12 @@ function waitForReady(socket: WebSocket, options: TypeScriptPreviewAgentOptions)
       socket.send(JSON.stringify({ type: "register", name: options.name }));
     };
     const onMessage = (data: WebSocket.RawData) => {
-      const message = JSON.parse(data.toString()) as RelayToAgentMessage;
+      const message = parseRelayMessage(data);
+      if (!message) {
+        cleanup();
+        reject(new Error("Persistent preview relay sent an invalid handshake message."));
+        return;
+      }
       if (message.type === "ready") {
         cleanup();
         resolve(message);
@@ -131,15 +180,26 @@ function waitForReady(socket: WebSocket, options: TypeScriptPreviewAgentOptions)
   });
 }
 
-async function forwardRequest(socket: WebSocket, targetUrl: string, request: TunnelRequestMessage) {
+async function forwardRequest(
+  socket: WebSocket,
+  options: TypeScriptPreviewAgentOptions,
+  request: TunnelRequestMessage,
+  controller: AbortController,
+) {
   let response: TunnelResponseMessage;
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, options.requestTimeoutMs ?? 30_000);
+
   try {
     const headers = new Headers();
     for (const [name, value] of Object.entries(request.headers)) {
       if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) headers.set(name, value);
     }
     const method = request.method.toUpperCase();
-    const result = await fetch(new URL(request.path, ensureTrailingSlash(targetUrl)), {
+    const result = await fetch(resolveTargetUrl(options.targetUrl, request.path), {
       method,
       headers,
       body:
@@ -147,11 +207,21 @@ async function forwardRequest(socket: WebSocket, targetUrl: string, request: Tun
           ? undefined
           : Buffer.from(request.body, "base64"),
       redirect: "manual",
+      signal: controller.signal,
     });
-    const responseHeaders: Record<string, string> = {};
+    const responseHeaders: Record<string, string | string[]> = {};
     for (const [name, value] of result.headers) {
-      if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) responseHeaders[name] = value;
+      const normalizedName = name.toLowerCase();
+      if (
+        normalizedName !== "content-encoding" &&
+        normalizedName !== "set-cookie" &&
+        !HOP_BY_HOP_HEADERS.has(normalizedName)
+      ) {
+        responseHeaders[name] = value;
+      }
     }
+    const setCookies = getSetCookies(result.headers);
+    if (setCookies.length) responseHeaders["set-cookie"] = setCookies;
     response = {
       type: "response",
       id: request.id,
@@ -160,16 +230,47 @@ async function forwardRequest(socket: WebSocket, targetUrl: string, request: Tun
       body: Buffer.from(await result.arrayBuffer()).toString("base64"),
     };
   } catch (error) {
+    const unsafePath = error instanceof UnsafePreviewPathError;
     response = {
       type: "response",
       id: request.id,
-      status: 502,
+      status: timedOut ? 504 : unsafePath ? 400 : 502,
       headers: { "content-type": "text/plain; charset=utf-8" },
       body: Buffer.from(error instanceof Error ? error.message : String(error)).toString("base64"),
     };
+  } finally {
+    clearTimeout(timeout);
   }
 
   if (socket.readyState === socket.OPEN) socket.send(JSON.stringify(response));
+}
+
+function parseRelayMessage(data: WebSocket.RawData): RelayToAgentMessage | undefined {
+  try {
+    const value: unknown = JSON.parse(data.toString());
+    return isRelayToAgentMessage(value) ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveTargetUrl(targetUrl: string, requestPath: string) {
+  if (!requestPath.startsWith("/") || /^[/\\]{2}/.test(requestPath)) {
+    throw new UnsafePreviewPathError();
+  }
+
+  const base = new URL(ensureTrailingSlash(targetUrl));
+  if (base.protocol !== "http:" && base.protocol !== "https:") {
+    throw new UnsafePreviewPathError();
+  }
+  const resolved = new URL(requestPath, base);
+  if (resolved.origin !== base.origin) throw new UnsafePreviewPathError();
+  return resolved;
+}
+
+function getSetCookies(headers: Headers) {
+  const getSetCookie = (headers as Headers & { getSetCookie?: () => string[] }).getSetCookie;
+  return getSetCookie?.call(headers) || [];
 }
 
 function ensureTrailingSlash(value: string) {
@@ -182,4 +283,10 @@ function closeSocket(socket: WebSocket) {
     socket.once("close", () => resolve());
     socket.close(1000, "Preview agent stopped");
   });
+}
+
+class UnsafePreviewPathError extends Error {
+  constructor() {
+    super("Preview request path cannot change the local target authority.");
+  }
 }

--- a/packages/farm-preview-tunnel/src/index.ts
+++ b/packages/farm-preview-tunnel/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./agent.js";
+export * from "./protocol.js";
+export * from "./relay.js";

--- a/packages/farm-preview-tunnel/src/protocol.ts
+++ b/packages/farm-preview-tunnel/src/protocol.ts
@@ -22,7 +22,7 @@ export interface TunnelResponseMessage {
   type: "response";
   id: string;
   status: number;
-  headers: Record<string, string>;
+  headers: Record<string, string | string[]>;
   body?: string;
 }
 
@@ -35,6 +35,25 @@ export interface TunnelErrorMessage {
 export type AgentToRelayMessage = RegisterMessage | TunnelResponseMessage;
 export type RelayToAgentMessage = ReadyMessage | TunnelRequestMessage | TunnelErrorMessage;
 
+export function isAgentToRelayMessage(value: unknown): value is AgentToRelayMessage {
+  if (!isRecord(value)) return false;
+  if (value.type === "register") return typeof value.name === "string";
+  return value.type === "response" && isTunnelResponseMessage(value);
+}
+
+export function isRelayToAgentMessage(value: unknown): value is RelayToAgentMessage {
+  if (!isRecord(value)) return false;
+  if (value.type === "ready") {
+    return typeof value.sessionId === "string" && typeof value.publicUrl === "string";
+  }
+  if (value.type === "error") {
+    return (
+      (value.id === undefined || typeof value.id === "string") && typeof value.message === "string"
+    );
+  }
+  return value.type === "request" && isTunnelRequestMessage(value);
+}
+
 export function normalizePreviewName(value: string) {
   return value
     .toLowerCase()
@@ -42,4 +61,52 @@ export function normalizePreviewName(value: string) {
     .replace(/[^a-z0-9-]+/g, "-")
     .replace(/^-+|-+$/g, "")
     .slice(0, 63);
+}
+
+function isTunnelRequestMessage(value: Record<string, unknown>) {
+  return (
+    typeof value.id === "string" &&
+    typeof value.method === "string" &&
+    typeof value.path === "string" &&
+    isHeaders(value.headers, false) &&
+    (value.body === undefined || typeof value.body === "string")
+  );
+}
+
+function isTunnelResponseMessage(value: Record<string, unknown>) {
+  return (
+    typeof value.id === "string" &&
+    Number.isInteger(value.status) &&
+    (value.status as number) >= 100 &&
+    (value.status as number) <= 599 &&
+    isHeaders(value.headers, true) &&
+    (value.body === undefined || typeof value.body === "string")
+  );
+}
+
+function isHeaders(value: unknown, allowArrays: boolean) {
+  if (!isRecord(value)) return false;
+  return Object.entries(value).every(
+    ([name, header]) =>
+      isHeaderName(name) &&
+      (isHeaderValue(header) ||
+        (allowArrays && Array.isArray(header) && header.every(isHeaderValue))),
+  );
+}
+
+function isHeaderName(value: string) {
+  return /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(value);
+}
+
+function isHeaderValue(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    !value.includes("\0") &&
+    !value.includes("\r") &&
+    !value.includes("\n")
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/farm-preview-tunnel/src/protocol.ts
+++ b/packages/farm-preview-tunnel/src/protocol.ts
@@ -1,0 +1,45 @@
+export interface RegisterMessage {
+  type: "register";
+  name: string;
+}
+
+export interface ReadyMessage {
+  type: "ready";
+  sessionId: string;
+  publicUrl: string;
+}
+
+export interface TunnelRequestMessage {
+  type: "request";
+  id: string;
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  body?: string;
+}
+
+export interface TunnelResponseMessage {
+  type: "response";
+  id: string;
+  status: number;
+  headers: Record<string, string>;
+  body?: string;
+}
+
+export interface TunnelErrorMessage {
+  type: "error";
+  id?: string;
+  message: string;
+}
+
+export type AgentToRelayMessage = RegisterMessage | TunnelResponseMessage;
+export type RelayToAgentMessage = ReadyMessage | TunnelRequestMessage | TunnelErrorMessage;
+
+export function normalizePreviewName(value: string) {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 63);
+}

--- a/packages/farm-preview-tunnel/src/relay.ts
+++ b/packages/farm-preview-tunnel/src/relay.ts
@@ -26,9 +26,39 @@ export interface PersistentPreviewRelayOptions {
   host?: string;
   port?: number;
   publicBaseUrl?: string;
+  publicDomain?: string;
   publicWebSocketUrl?: string;
+  healthPath?: string;
+  fallbackHandler?: PersistentPreviewRelayFallbackHandler;
+  coordinator?: PersistentPreviewRelayCoordinator;
+  coordinatorSessionTtlMs?: number;
   requestTimeoutMs?: number;
   maxBodyBytes?: number;
+}
+
+export type PersistentPreviewRelayFallbackHandler = (
+  request: IncomingMessage,
+  response: ServerResponse,
+) => void | Promise<void>;
+
+export interface PersistentPreviewRelayCoordinatorSession {
+  id: string;
+  name: string;
+}
+
+export interface PersistentPreviewRelayCoordinator {
+  claimSession(session: PersistentPreviewRelayCoordinatorSession, ttlMs: number): Promise<boolean>;
+  findSession(name: string): Promise<PersistentPreviewRelayCoordinatorSession | undefined>;
+  touchSession(session: PersistentPreviewRelayCoordinatorSession, ttlMs: number): Promise<boolean>;
+  releaseSession(session: PersistentPreviewRelayCoordinatorSession): Promise<void>;
+  publishRequest(sessionId: string, request: TunnelRequestMessage): Promise<void>;
+  takeRequest(sessionId: string, timeoutMs: number): Promise<TunnelRequestMessage | undefined>;
+  publishResponse(sessionId: string, response: TunnelResponseMessage): Promise<void>;
+  takeResponse(
+    sessionId: string,
+    requestId: string,
+    timeoutMs: number,
+  ): Promise<TunnelResponseMessage | undefined>;
 }
 
 export interface PersistentPreviewRelayAddress {
@@ -55,69 +85,53 @@ export function createPersistentPreviewRelay(options: PersistentPreviewRelayOpti
   const pending = new Map<string, PendingRequest>();
   const websocketServer = new WebSocketServer({ noServer: true });
   const host = options.host || "127.0.0.1";
+  const publicDomain = normalizeDomain(options.publicDomain);
+  const healthPath = options.healthPath || "/api/health";
+  const coordinatorSessionTtlMs = options.coordinatorSessionTtlMs ?? 60_000;
   const requestTimeoutMs = options.requestTimeoutMs ?? 30_000;
   const maxBodyBytes = options.maxBodyBytes ?? 5 * 1024 * 1024;
   let address: PersistentPreviewRelayAddress | undefined;
 
   const server = createServer(async (request, response) => {
     try {
-      if (request.url === "/api/health") {
-        return sendJson(response, 200, { ok: true, transport: "websocket", agents: agents.size });
+      const url = new URL(request.url || "/", "http://localhost");
+      if (url.pathname === healthPath) {
+        return sendJson(response, 200, {
+          ok: true,
+          transport: "websocket",
+          coordination: options.coordinator ? "shared" : "local",
+          agents: agents.size,
+        });
       }
 
-      const route = resolvePublicRoute(request);
+      const route = resolvePublicRoute(request, publicDomain);
       if (!route) {
-        return sendText(response, 404, "Preview route not found.");
+        return handleFallback(request, response, options.fallbackHandler);
       }
 
-      const session = agents.get(route.name);
-      if (!session || session.socket.readyState !== session.socket.OPEN) {
-        return sendText(
-          response,
-          404,
-          `No active persistent preview is running for "${route.name}".`,
+      const localSession = agents.get(route.name);
+      const activeLocalSession =
+        localSession?.socket.readyState === localSession?.socket.OPEN ? localSession : undefined;
+      const coordinatedSession = activeLocalSession
+        ? undefined
+        : await options.coordinator?.findSession(route.name);
+      if (!activeLocalSession && !coordinatedSession) {
+        return handleFallback(request, response, options.fallbackHandler, () =>
+          sendText(response, 404, `No active persistent preview is running for "${route.name}".`),
         );
       }
 
-      const id = randomUUID();
-      const uploadController = new AbortController();
-      const timeout = setTimeout(() => {
-        uploadController.abort();
-        pending.delete(id);
-        if (!response.headersSent) {
-          sendText(response, 504, "The persistent preview agent did not respond in time.");
-        }
-      }, requestTimeoutMs);
-
-      let body: Buffer;
-      try {
-        body = await readRequestBody(request, maxBodyBytes, uploadController.signal);
-      } catch (error) {
-        if (uploadController.signal.aborted) return;
-        clearTimeout(timeout);
-        throw error;
-      }
-
-      if (uploadController.signal.aborted || response.writableEnded) return;
-      const message: TunnelRequestMessage = {
-        type: "request",
-        id,
-        method: request.method || "GET",
+      await forwardPublicRequest({
+        request,
+        response,
         path: route.path,
-        headers: normalizeIncomingHeaders(request.headers),
-        ...(body.length ? { body: body.toString("base64") } : {}),
-      };
-
-      pending.set(id, { response, sessionId: session.id, timeout });
-      try {
-        session.socket.send(JSON.stringify(message), (error) => {
-          if (error) failPendingRequest(id, session.id, pending);
-        });
-      } catch (error) {
-        pending.delete(id);
-        clearTimeout(timeout);
-        throw error;
-      }
+        localSession: activeLocalSession,
+        coordinatedSession,
+        coordinator: options.coordinator,
+        pending,
+        requestTimeoutMs,
+        maxBodyBytes,
+      });
     } catch (error) {
       const status = error instanceof BodyLimitError ? 413 : 500;
       sendText(response, status, error instanceof Error ? error.message : String(error));
@@ -137,73 +151,102 @@ export function createPersistentPreviewRelay(options: PersistentPreviewRelayOpti
 
   websocketServer.on("connection", (socket) => {
     let session: AgentSession | undefined;
+    let registering = false;
 
     socket.on("message", (data) => {
-      let message: unknown;
-      try {
-        message = JSON.parse(data.toString());
-      } catch {
-        rejectSocketMessage(socket, "Invalid tunnel message.");
-        return;
-      }
-
-      if (!isAgentToRelayMessage(message)) {
-        rejectSocketMessage(socket, "Invalid tunnel message.");
-        return;
-      }
-
-      if (message.type === "register") {
-        if (session) {
-          rejectSocketMessage(socket, "The preview agent is already registered.");
-          return;
-        }
-        const name = normalizePreviewName(message.name);
-        if (!name) {
-          socket.send(
-            JSON.stringify({ type: "error", message: "A valid preview name is required." }),
-          );
-          socket.close(1008, "Invalid preview name");
+      void (async () => {
+        let message: unknown;
+        try {
+          message = JSON.parse(data.toString());
+        } catch {
+          rejectSocketMessage(socket, "Invalid tunnel message.");
           return;
         }
 
-        const existing = agents.get(name);
-        if (existing && existing.socket.readyState === existing.socket.OPEN) {
-          socket.send(
-            JSON.stringify({ type: "error", message: `Preview name "${name}" is already active.` }),
-          );
-          socket.close(1008, "Preview name unavailable");
+        if (!isAgentToRelayMessage(message)) {
+          rejectSocketMessage(socket, "Invalid tunnel message.");
           return;
         }
 
-        session = { id: randomUUID(), name, socket };
-        agents.set(name, session);
-        const baseUrl = trimTrailingSlash(options.publicBaseUrl || address?.httpUrl || "");
-        if (!baseUrl) {
-          socket.close(1011, "Relay is not listening");
-          return;
-        }
-        const ready: ReadyMessage = {
-          type: "ready",
-          sessionId: session.id,
-          publicUrl: `${baseUrl}/preview/${name}`,
-        };
-        socket.send(JSON.stringify(ready));
-        return;
-      }
+        if (message.type === "register") {
+          if (session || registering) {
+            rejectSocketMessage(socket, "The preview agent is already registered.");
+            return;
+          }
+          registering = true;
+          try {
+            const name = normalizePreviewName(message.name);
+            if (!name) {
+              socket.send(
+                JSON.stringify({ type: "error", message: "A valid preview name is required." }),
+              );
+              socket.close(1008, "Invalid preview name");
+              return;
+            }
 
-      if (message.type === "response") {
-        if (!session) {
-          rejectSocketMessage(socket, "Register the preview agent before sending responses.");
+            const existing = agents.get(name);
+            if (existing && existing.socket.readyState === existing.socket.OPEN) {
+              rejectPreviewName(socket, name);
+              return;
+            }
+
+            const nextSession = { id: randomUUID(), name, socket };
+            if (
+              options.coordinator &&
+              !(await options.coordinator.claimSession(nextSession, coordinatorSessionTtlMs))
+            ) {
+              rejectPreviewName(socket, name);
+              return;
+            }
+            if (socket.readyState !== socket.OPEN) {
+              await options.coordinator?.releaseSession(nextSession);
+              return;
+            }
+
+            session = nextSession;
+            agents.set(name, session);
+            const baseUrl = trimTrailingSlash(options.publicBaseUrl || address?.httpUrl || "");
+            if (!baseUrl) {
+              socket.close(1011, "Relay is not listening");
+              return;
+            }
+            const ready: ReadyMessage = {
+              type: "ready",
+              sessionId: session.id,
+              publicUrl: createPublicUrl(baseUrl, publicDomain, name),
+            };
+            socket.send(JSON.stringify(ready));
+            if (options.coordinator) {
+              void pumpCoordinatedRequests(
+                session,
+                agents,
+                options.coordinator,
+                coordinatorSessionTtlMs,
+              );
+            }
+          } finally {
+            registering = false;
+          }
           return;
         }
-        completePendingRequest(message, session.id, pending);
-      }
+
+        if (message.type === "response") {
+          if (!session) {
+            rejectSocketMessage(socket, "Register the preview agent before sending responses.");
+            return;
+          }
+          if (!completePendingRequest(message, session.id, pending)) {
+            await options.coordinator?.publishResponse(session.id, message);
+          }
+        }
+      })().catch(() => socket.close(1011, "Preview relay coordination failed"));
     });
 
     socket.on("close", () => {
       if (session && agents.get(session.name)?.id === session.id) {
         agents.delete(session.name);
         failPendingRequestsForSession(session.id, pending);
+        void options.coordinator?.releaseSession(session).catch(() => undefined);
       }
     });
   });
@@ -243,13 +286,168 @@ export function createPersistentPreviewRelay(options: PersistentPreviewRelayOpti
   };
 }
 
-function resolvePublicRoute(request: IncomingMessage) {
+interface ForwardPublicRequestOptions {
+  request: IncomingMessage;
+  response: ServerResponse;
+  path: string;
+  localSession?: AgentSession;
+  coordinatedSession?: PersistentPreviewRelayCoordinatorSession;
+  coordinator?: PersistentPreviewRelayCoordinator;
+  pending: Map<string, PendingRequest>;
+  requestTimeoutMs: number;
+  maxBodyBytes: number;
+}
+
+async function forwardPublicRequest(options: ForwardPublicRequestOptions) {
+  const id = randomUUID();
+  const uploadController = new AbortController();
+  const deadline = Date.now() + options.requestTimeoutMs;
+  const timeout = setTimeout(() => {
+    uploadController.abort();
+    options.pending.delete(id);
+    if (!options.response.headersSent) {
+      sendText(options.response, 504, "The persistent preview agent did not respond in time.");
+    }
+  }, options.requestTimeoutMs);
+
+  let body: Buffer;
+  try {
+    body = await readRequestBody(options.request, options.maxBodyBytes, uploadController.signal);
+  } catch (error) {
+    if (uploadController.signal.aborted) return;
+    clearTimeout(timeout);
+    throw error;
+  }
+
+  if (uploadController.signal.aborted || options.response.writableEnded) return;
+  const message: TunnelRequestMessage = {
+    type: "request",
+    id,
+    method: options.request.method || "GET",
+    path: options.path,
+    headers: normalizeIncomingHeaders(options.request.headers),
+    ...(body.length ? { body: body.toString("base64") } : {}),
+  };
+
+  const localSession = options.localSession;
+  if (localSession) {
+    options.pending.set(id, {
+      response: options.response,
+      sessionId: localSession.id,
+      timeout,
+    });
+    try {
+      localSession.socket.send(JSON.stringify(message), (error) => {
+        if (error) failPendingRequest(id, localSession.id, options.pending);
+      });
+    } catch (error) {
+      options.pending.delete(id);
+      clearTimeout(timeout);
+      throw error;
+    }
+    return;
+  }
+
+  if (!options.coordinator || !options.coordinatedSession) {
+    clearTimeout(timeout);
+    throw new Error("Persistent preview relay coordination is unavailable.");
+  }
+
+  await options.coordinator.publishRequest(options.coordinatedSession.id, message);
+  const remainingMs = Math.max(1, deadline - Date.now());
+  const coordinatedResponse = await options.coordinator.takeResponse(
+    options.coordinatedSession.id,
+    id,
+    remainingMs,
+  );
+  clearTimeout(timeout);
+  if (options.response.writableEnded) return;
+  if (!coordinatedResponse) {
+    sendText(options.response, 504, "The persistent preview agent did not respond in time.");
+    return;
+  }
+  writeTunnelResponse(options.response, coordinatedResponse);
+}
+
+async function pumpCoordinatedRequests(
+  session: AgentSession,
+  agents: Map<string, AgentSession>,
+  coordinator: PersistentPreviewRelayCoordinator,
+  sessionTtlMs: number,
+) {
+  const waitMs = Math.max(50, Math.min(15_000, Math.floor(sessionTtlMs / 3)));
+  try {
+    while (
+      agents.get(session.name)?.id === session.id &&
+      session.socket.readyState === session.socket.OPEN
+    ) {
+      if (!(await coordinator.touchSession(session, sessionTtlMs))) {
+        session.socket.close(1011, "Preview session ownership was lost");
+        return;
+      }
+      const request = await coordinator.takeRequest(session.id, waitMs);
+      if (!request) continue;
+      if (
+        agents.get(session.name)?.id !== session.id ||
+        session.socket.readyState !== session.socket.OPEN
+      ) {
+        return;
+      }
+      session.socket.send(JSON.stringify(request));
+    }
+  } catch {
+    session.socket.close(1011, "Preview relay coordination failed");
+  }
+}
+
+function resolvePublicRoute(request: IncomingMessage, publicDomain: string | undefined) {
   const url = new URL(request.url || "/", "http://localhost");
   const match = url.pathname.match(/^\/preview\/([^/]+)(\/.*)?$/);
-  if (!match) return undefined;
-  const name = normalizePreviewName(match[1]);
-  const path = `${match[2] || "/"}${url.search}`;
-  return name ? { name, path } : undefined;
+  if (match) {
+    const name = normalizePreviewName(match[1]);
+    const path = `${match[2] || "/"}${url.search}`;
+    return name ? { name, path } : undefined;
+  }
+
+  if (!publicDomain) return undefined;
+  const host = normalizeHost(request.headers.host);
+  const suffix = `.${publicDomain}`;
+  if (!host?.endsWith(suffix)) return undefined;
+
+  const subdomain = host.slice(0, -suffix.length);
+  const name = normalizePreviewName(subdomain);
+  if (!name || name !== subdomain || subdomain.includes(".")) return undefined;
+  return { name, path: `${url.pathname || "/"}${url.search}` };
+}
+
+async function handleFallback(
+  request: IncomingMessage,
+  response: ServerResponse,
+  fallbackHandler: PersistentPreviewRelayFallbackHandler | undefined,
+  onMissing = () => sendText(response, 404, "Preview route not found."),
+) {
+  if (fallbackHandler) return await fallbackHandler(request, response);
+  return onMissing();
+}
+
+function createPublicUrl(baseUrl: string, publicDomain: string | undefined, name: string) {
+  if (!publicDomain) return `${baseUrl}/preview/${name}`;
+  const url = new URL(baseUrl);
+  return `${url.protocol}//${name}.${publicDomain}`;
+}
+
+function normalizeDomain(value: string | undefined) {
+  if (!value) return undefined;
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, "")
+    .replace(/[:/].*$/, "");
+}
+
+function normalizeHost(value: string | string[] | undefined) {
+  const host = Array.isArray(value) ? value[0] : value;
+  return host?.split(":", 1)[0].trim().toLowerCase().replace(/\.$/, "");
 }
 
 function completePendingRequest(
@@ -258,19 +456,24 @@ function completePendingRequest(
   pending: Map<string, PendingRequest>,
 ) {
   const entry = pending.get(message.id);
-  if (!entry || entry.sessionId !== sessionId) return;
+  if (!entry || entry.sessionId !== sessionId) return false;
   pending.delete(message.id);
   clearTimeout(entry.timeout);
 
+  writeTunnelResponse(entry.response, message);
+  return true;
+}
+
+function writeTunnelResponse(response: ServerResponse, message: TunnelResponseMessage) {
   for (const [name, value] of Object.entries(message.headers)) {
     if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) {
-      entry.response.setHeader(name, value);
+      response.setHeader(name, value);
     }
   }
-  entry.response.setHeader("cache-control", "no-store");
-  entry.response.setHeader("x-farm-preview-transport", "websocket");
-  entry.response.statusCode = message.status;
-  entry.response.end(message.body ? Buffer.from(message.body, "base64") : undefined);
+  response.setHeader("cache-control", "no-store");
+  response.setHeader("x-farm-preview-transport", "websocket");
+  response.statusCode = message.status;
+  response.end(message.body ? Buffer.from(message.body, "base64") : undefined);
 }
 
 function failPendingRequestsForSession(sessionId: string, pending: Map<string, PendingRequest>) {
@@ -375,6 +578,14 @@ function rejectSocketMessage(socket: WebSocket, message: string) {
   socket.send(JSON.stringify({ type: "error", message }), () => {
     socket.close(1008, "Invalid tunnel message");
   });
+}
+
+function rejectPreviewName(socket: WebSocket, name: string) {
+  if (socket.readyState !== socket.OPEN) return;
+  socket.send(
+    JSON.stringify({ type: "error", message: `Preview name "${name}" is already active.` }),
+  );
+  socket.close(1008, "Preview name unavailable");
 }
 
 function listen(server: Server, port: number, host: string) {

--- a/packages/farm-preview-tunnel/src/relay.ts
+++ b/packages/farm-preview-tunnel/src/relay.ts
@@ -1,0 +1,298 @@
+import { randomUUID } from "node:crypto";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { WebSocketServer, type WebSocket } from "ws";
+
+import {
+  normalizePreviewName,
+  type AgentToRelayMessage,
+  type ReadyMessage,
+  type TunnelRequestMessage,
+  type TunnelResponseMessage,
+} from "./protocol.js";
+
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "content-length",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+export interface PersistentPreviewRelayOptions {
+  host?: string;
+  port?: number;
+  publicBaseUrl?: string;
+  requestTimeoutMs?: number;
+  maxBodyBytes?: number;
+}
+
+export interface PersistentPreviewRelayAddress {
+  host: string;
+  port: number;
+  httpUrl: string;
+  websocketUrl: string;
+}
+
+interface AgentSession {
+  id: string;
+  name: string;
+  socket: WebSocket;
+}
+
+interface PendingRequest {
+  response: ServerResponse;
+  timeout: NodeJS.Timeout;
+}
+
+export function createPersistentPreviewRelay(options: PersistentPreviewRelayOptions = {}) {
+  const agents = new Map<string, AgentSession>();
+  const pending = new Map<string, PendingRequest>();
+  const websocketServer = new WebSocketServer({ noServer: true });
+  const host = options.host || "127.0.0.1";
+  const requestTimeoutMs = options.requestTimeoutMs ?? 30_000;
+  const maxBodyBytes = options.maxBodyBytes ?? 5 * 1024 * 1024;
+  let address: PersistentPreviewRelayAddress | undefined;
+
+  const server = createServer(async (request, response) => {
+    try {
+      if (request.url === "/api/health") {
+        return sendJson(response, 200, { ok: true, transport: "websocket", agents: agents.size });
+      }
+
+      const route = resolvePublicRoute(request);
+      if (!route) {
+        return sendText(response, 404, "Preview route not found.");
+      }
+
+      const session = agents.get(route.name);
+      if (!session || session.socket.readyState !== session.socket.OPEN) {
+        return sendText(
+          response,
+          404,
+          `No active persistent preview is running for "${route.name}".`,
+        );
+      }
+
+      const body = await readRequestBody(request, maxBodyBytes);
+      const id = randomUUID();
+      const message: TunnelRequestMessage = {
+        type: "request",
+        id,
+        method: request.method || "GET",
+        path: route.path,
+        headers: normalizeIncomingHeaders(request.headers),
+        ...(body.length ? { body: body.toString("base64") } : {}),
+      };
+
+      const timeout = setTimeout(() => {
+        pending.delete(id);
+        if (!response.headersSent) {
+          sendText(response, 504, "The persistent preview agent did not respond in time.");
+        }
+      }, requestTimeoutMs);
+
+      pending.set(id, { response, timeout });
+      session.socket.send(JSON.stringify(message));
+    } catch (error) {
+      const status = error instanceof BodyLimitError ? 413 : 500;
+      sendText(response, status, error instanceof Error ? error.message : String(error));
+    }
+  });
+
+  server.on("upgrade", (request, socket, head) => {
+    const url = new URL(request.url || "/", "http://localhost");
+    if (url.pathname !== "/agent") {
+      socket.destroy();
+      return;
+    }
+    websocketServer.handleUpgrade(request, socket, head, (websocket) => {
+      websocketServer.emit("connection", websocket, request);
+    });
+  });
+
+  websocketServer.on("connection", (socket) => {
+    let session: AgentSession | undefined;
+
+    socket.on("message", (data) => {
+      let message: AgentToRelayMessage;
+      try {
+        message = JSON.parse(data.toString()) as AgentToRelayMessage;
+      } catch {
+        socket.send(JSON.stringify({ type: "error", message: "Invalid tunnel message." }));
+        return;
+      }
+
+      if (message.type === "register") {
+        if (session) return;
+        const name = normalizePreviewName(message.name);
+        if (!name) {
+          socket.send(
+            JSON.stringify({ type: "error", message: "A valid preview name is required." }),
+          );
+          socket.close(1008, "Invalid preview name");
+          return;
+        }
+
+        const existing = agents.get(name);
+        if (existing && existing.socket.readyState === existing.socket.OPEN) {
+          socket.send(
+            JSON.stringify({ type: "error", message: `Preview name "${name}" is already active.` }),
+          );
+          socket.close(1008, "Preview name unavailable");
+          return;
+        }
+
+        session = { id: randomUUID(), name, socket };
+        agents.set(name, session);
+        const baseUrl = options.publicBaseUrl || address?.httpUrl;
+        if (!baseUrl) {
+          socket.close(1011, "Relay is not listening");
+          return;
+        }
+        const ready: ReadyMessage = {
+          type: "ready",
+          sessionId: session.id,
+          publicUrl: `${baseUrl}/preview/${name}`,
+        };
+        socket.send(JSON.stringify(ready));
+        return;
+      }
+
+      if (message.type === "response") {
+        completePendingRequest(message, pending);
+      }
+    });
+
+    socket.on("close", () => {
+      if (session && agents.get(session.name)?.id === session.id) {
+        agents.delete(session.name);
+      }
+    });
+  });
+
+  return {
+    server,
+    async listen(): Promise<PersistentPreviewRelayAddress> {
+      if (address) return address;
+      await listen(server, options.port ?? 0, host);
+      const serverAddress = server.address();
+      if (!serverAddress || typeof serverAddress === "string") {
+        throw new Error("Persistent preview relay did not expose a TCP address.");
+      }
+      const displayHost = host === "0.0.0.0" ? "127.0.0.1" : host;
+      address = {
+        host,
+        port: serverAddress.port,
+        httpUrl: `http://${displayHost}:${serverAddress.port}`,
+        websocketUrl: `ws://${displayHost}:${serverAddress.port}/agent`,
+      };
+      return address;
+    },
+    async close() {
+      for (const session of agents.values()) session.socket.close(1001, "Relay shutting down");
+      for (const { response, timeout } of pending.values()) {
+        clearTimeout(timeout);
+        if (!response.headersSent)
+          sendText(response, 503, "Persistent preview relay is shutting down.");
+      }
+      pending.clear();
+      await closeWebSocketServer(websocketServer);
+      await closeServer(server);
+      address = undefined;
+    },
+  };
+}
+
+function resolvePublicRoute(request: IncomingMessage) {
+  const url = new URL(request.url || "/", "http://localhost");
+  const match = url.pathname.match(/^\/preview\/([^/]+)(\/.*)?$/);
+  if (!match) return undefined;
+  const name = normalizePreviewName(match[1]);
+  const path = `${match[2] || "/"}${url.search}`;
+  return name ? { name, path } : undefined;
+}
+
+function completePendingRequest(
+  message: TunnelResponseMessage,
+  pending: Map<string, PendingRequest>,
+) {
+  const entry = pending.get(message.id);
+  if (!entry) return;
+  pending.delete(message.id);
+  clearTimeout(entry.timeout);
+
+  for (const [name, value] of Object.entries(message.headers)) {
+    if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) {
+      entry.response.setHeader(name, value);
+    }
+  }
+  entry.response.setHeader("cache-control", "no-store");
+  entry.response.setHeader("x-farm-preview-transport", "websocket");
+  entry.response.statusCode = message.status;
+  entry.response.end(message.body ? Buffer.from(message.body, "base64") : undefined);
+}
+
+async function readRequestBody(request: IncomingMessage, maxBodyBytes: number) {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.length;
+    if (size > maxBodyBytes) throw new BodyLimitError(maxBodyBytes);
+    chunks.push(buffer);
+  }
+  return Buffer.concat(chunks);
+}
+
+function normalizeIncomingHeaders(headers: IncomingMessage["headers"]) {
+  const normalized: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    if (value === undefined || HOP_BY_HOP_HEADERS.has(name.toLowerCase())) continue;
+    normalized[name] = Array.isArray(value) ? value.join(", ") : value;
+  }
+  return normalized;
+}
+
+function sendJson(response: ServerResponse, status: number, value: unknown) {
+  response.statusCode = status;
+  response.setHeader("content-type", "application/json; charset=utf-8");
+  response.end(JSON.stringify(value));
+}
+
+function sendText(response: ServerResponse, status: number, value: string) {
+  if (response.writableEnded) return;
+  response.statusCode = status;
+  response.setHeader("content-type", "text/plain; charset=utf-8");
+  response.end(value);
+}
+
+function listen(server: Server, port: number, host: string) {
+  return new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, host, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+function closeServer(server: Server) {
+  if (!server.listening) return Promise.resolve();
+  return new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function closeWebSocketServer(server: WebSocketServer) {
+  return new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+class BodyLimitError extends Error {
+  constructor(maxBodyBytes: number) {
+    super(`Preview request body exceeds ${maxBodyBytes} bytes.`);
+  }
+}

--- a/packages/farm-preview-tunnel/src/relay.ts
+++ b/packages/farm-preview-tunnel/src/relay.ts
@@ -3,8 +3,8 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { WebSocketServer, type WebSocket } from "ws";
 
 import {
+  isAgentToRelayMessage,
   normalizePreviewName,
-  type AgentToRelayMessage,
   type ReadyMessage,
   type TunnelRequestMessage,
   type TunnelResponseMessage,
@@ -26,6 +26,7 @@ export interface PersistentPreviewRelayOptions {
   host?: string;
   port?: number;
   publicBaseUrl?: string;
+  publicWebSocketUrl?: string;
   requestTimeoutMs?: number;
   maxBodyBytes?: number;
 }
@@ -45,6 +46,7 @@ interface AgentSession {
 
 interface PendingRequest {
   response: ServerResponse;
+  sessionId: string;
   timeout: NodeJS.Timeout;
 }
 
@@ -77,8 +79,26 @@ export function createPersistentPreviewRelay(options: PersistentPreviewRelayOpti
         );
       }
 
-      const body = await readRequestBody(request, maxBodyBytes);
       const id = randomUUID();
+      const uploadController = new AbortController();
+      const timeout = setTimeout(() => {
+        uploadController.abort();
+        pending.delete(id);
+        if (!response.headersSent) {
+          sendText(response, 504, "The persistent preview agent did not respond in time.");
+        }
+      }, requestTimeoutMs);
+
+      let body: Buffer;
+      try {
+        body = await readRequestBody(request, maxBodyBytes, uploadController.signal);
+      } catch (error) {
+        if (uploadController.signal.aborted) return;
+        clearTimeout(timeout);
+        throw error;
+      }
+
+      if (uploadController.signal.aborted || response.writableEnded) return;
       const message: TunnelRequestMessage = {
         type: "request",
         id,
@@ -88,15 +108,16 @@ export function createPersistentPreviewRelay(options: PersistentPreviewRelayOpti
         ...(body.length ? { body: body.toString("base64") } : {}),
       };
 
-      const timeout = setTimeout(() => {
+      pending.set(id, { response, sessionId: session.id, timeout });
+      try {
+        session.socket.send(JSON.stringify(message), (error) => {
+          if (error) failPendingRequest(id, session.id, pending);
+        });
+      } catch (error) {
         pending.delete(id);
-        if (!response.headersSent) {
-          sendText(response, 504, "The persistent preview agent did not respond in time.");
-        }
-      }, requestTimeoutMs);
-
-      pending.set(id, { response, timeout });
-      session.socket.send(JSON.stringify(message));
+        clearTimeout(timeout);
+        throw error;
+      }
     } catch (error) {
       const status = error instanceof BodyLimitError ? 413 : 500;
       sendText(response, status, error instanceof Error ? error.message : String(error));
@@ -118,16 +139,24 @@ export function createPersistentPreviewRelay(options: PersistentPreviewRelayOpti
     let session: AgentSession | undefined;
 
     socket.on("message", (data) => {
-      let message: AgentToRelayMessage;
+      let message: unknown;
       try {
-        message = JSON.parse(data.toString()) as AgentToRelayMessage;
+        message = JSON.parse(data.toString());
       } catch {
-        socket.send(JSON.stringify({ type: "error", message: "Invalid tunnel message." }));
+        rejectSocketMessage(socket, "Invalid tunnel message.");
+        return;
+      }
+
+      if (!isAgentToRelayMessage(message)) {
+        rejectSocketMessage(socket, "Invalid tunnel message.");
         return;
       }
 
       if (message.type === "register") {
-        if (session) return;
+        if (session) {
+          rejectSocketMessage(socket, "The preview agent is already registered.");
+          return;
+        }
         const name = normalizePreviewName(message.name);
         if (!name) {
           socket.send(
@@ -148,7 +177,7 @@ export function createPersistentPreviewRelay(options: PersistentPreviewRelayOpti
 
         session = { id: randomUUID(), name, socket };
         agents.set(name, session);
-        const baseUrl = options.publicBaseUrl || address?.httpUrl;
+        const baseUrl = trimTrailingSlash(options.publicBaseUrl || address?.httpUrl || "");
         if (!baseUrl) {
           socket.close(1011, "Relay is not listening");
           return;
@@ -163,13 +192,18 @@ export function createPersistentPreviewRelay(options: PersistentPreviewRelayOpti
       }
 
       if (message.type === "response") {
-        completePendingRequest(message, pending);
+        if (!session) {
+          rejectSocketMessage(socket, "Register the preview agent before sending responses.");
+          return;
+        }
+        completePendingRequest(message, session.id, pending);
       }
     });
 
     socket.on("close", () => {
       if (session && agents.get(session.name)?.id === session.id) {
         agents.delete(session.name);
+        failPendingRequestsForSession(session.id, pending);
       }
     });
   });
@@ -184,11 +218,13 @@ export function createPersistentPreviewRelay(options: PersistentPreviewRelayOpti
         throw new Error("Persistent preview relay did not expose a TCP address.");
       }
       const displayHost = host === "0.0.0.0" ? "127.0.0.1" : host;
+      const localHttpUrl = `http://${displayHost}:${serverAddress.port}`;
       address = {
         host,
         port: serverAddress.port,
-        httpUrl: `http://${displayHost}:${serverAddress.port}`,
-        websocketUrl: `ws://${displayHost}:${serverAddress.port}/agent`,
+        httpUrl: localHttpUrl,
+        websocketUrl:
+          options.publicWebSocketUrl || `ws://${displayHost}:${serverAddress.port}/agent`,
       };
       return address;
     },
@@ -218,10 +254,11 @@ function resolvePublicRoute(request: IncomingMessage) {
 
 function completePendingRequest(
   message: TunnelResponseMessage,
+  sessionId: string,
   pending: Map<string, PendingRequest>,
 ) {
   const entry = pending.get(message.id);
-  if (!entry) return;
+  if (!entry || entry.sessionId !== sessionId) return;
   pending.delete(message.id);
   clearTimeout(entry.timeout);
 
@@ -236,16 +273,71 @@ function completePendingRequest(
   entry.response.end(message.body ? Buffer.from(message.body, "base64") : undefined);
 }
 
-async function readRequestBody(request: IncomingMessage, maxBodyBytes: number) {
-  const chunks: Buffer[] = [];
-  let size = 0;
-  for await (const chunk of request) {
-    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-    size += buffer.length;
-    if (size > maxBodyBytes) throw new BodyLimitError(maxBodyBytes);
-    chunks.push(buffer);
+function failPendingRequestsForSession(sessionId: string, pending: Map<string, PendingRequest>) {
+  for (const [id, entry] of pending) {
+    if (entry.sessionId !== sessionId) continue;
+    pending.delete(id);
+    clearTimeout(entry.timeout);
+    sendText(entry.response, 502, "The persistent preview agent disconnected.");
   }
-  return Buffer.concat(chunks);
+}
+
+function failPendingRequest(id: string, sessionId: string, pending: Map<string, PendingRequest>) {
+  const entry = pending.get(id);
+  if (!entry || entry.sessionId !== sessionId) return;
+  pending.delete(id);
+  clearTimeout(entry.timeout);
+  sendText(entry.response, 502, "The persistent preview agent disconnected.");
+}
+
+function readRequestBody(request: IncomingMessage, maxBodyBytes: number, signal: AbortSignal) {
+  return new Promise<Buffer>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+
+    const cleanup = () => {
+      signal.removeEventListener("abort", onAbort);
+      request.off("data", onData);
+      request.off("end", onEnd);
+      request.off("error", onError);
+      request.off("aborted", onRequestAborted);
+    };
+    const onAbort = () => {
+      cleanup();
+      request.resume();
+      reject(new RequestTimeoutError());
+    };
+    const onData = (chunk: Buffer | string) => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      size += buffer.length;
+      if (size > maxBodyBytes) {
+        cleanup();
+        request.resume();
+        reject(new BodyLimitError(maxBodyBytes));
+        return;
+      }
+      chunks.push(buffer);
+    };
+    const onEnd = () => {
+      cleanup();
+      resolve(Buffer.concat(chunks));
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onRequestAborted = () => {
+      cleanup();
+      reject(new Error("Preview request upload was aborted."));
+    };
+
+    if (signal.aborted) return onAbort();
+    signal.addEventListener("abort", onAbort, { once: true });
+    request.on("data", onData);
+    request.once("end", onEnd);
+    request.once("error", onError);
+    request.once("aborted", onRequestAborted);
+  });
 }
 
 function normalizeIncomingHeaders(headers: IncomingMessage["headers"]) {
@@ -264,10 +356,25 @@ function sendJson(response: ServerResponse, status: number, value: unknown) {
 }
 
 function sendText(response: ServerResponse, status: number, value: string) {
-  if (response.writableEnded) return;
+  if (response.writableEnded || response.destroyed) return;
+  if (response.headersSent) {
+    response.end();
+    return;
+  }
   response.statusCode = status;
   response.setHeader("content-type", "text/plain; charset=utf-8");
   response.end(value);
+}
+
+function trimTrailingSlash(value: string) {
+  return value.replace(/\/+$/, "");
+}
+
+function rejectSocketMessage(socket: WebSocket, message: string) {
+  if (socket.readyState !== socket.OPEN) return;
+  socket.send(JSON.stringify({ type: "error", message }), () => {
+    socket.close(1008, "Invalid tunnel message");
+  });
 }
 
 function listen(server: Server, port: number, host: string) {
@@ -294,5 +401,11 @@ function closeWebSocketServer(server: WebSocketServer) {
 class BodyLimitError extends Error {
   constructor(maxBodyBytes: number) {
     super(`Preview request body exceeds ${maxBodyBytes} bytes.`);
+  }
+}
+
+class RequestTimeoutError extends Error {
+  constructor() {
+    super("Preview request upload timed out.");
   }
 }

--- a/packages/farm-preview-tunnel/test/tunnel.test.mjs
+++ b/packages/farm-preview-tunnel/test/tunnel.test.mjs
@@ -150,6 +150,111 @@ test("advertises explicit public HTTP and WebSocket endpoints", async () => {
   }
 });
 
+test("routes wildcard preview hosts and advertises the matching public URL", async () => {
+  const relay = createPersistentPreviewRelay({
+    publicBaseUrl: "https://preview.example.com",
+    publicDomain: "preview.example.com",
+  });
+  const address = await relay.listen();
+  const target = createServer((request, response) => response.end(request.url));
+  await listen(target);
+  const targetAddress = target.address();
+  const agent = await startTypeScriptPreviewAgent({
+    relayUrl: `ws://127.0.0.1:${address.port}/agent`,
+    name: "wildcard-agent",
+    targetUrl: `http://127.0.0.1:${targetAddress.port}`,
+  });
+
+  try {
+    assert.equal(agent.publicUrl, "https://wildcard-agent.preview.example.com");
+    const response = await requestWithHost(
+      `${address.httpUrl}/nested/path?from=wildcard`,
+      "wildcard-agent.preview.example.com",
+    );
+    assert.equal(response.status, 200);
+    assert.equal(response.body, "/nested/path?from=wildcard");
+  } finally {
+    await agent.close();
+    await relay.close();
+    await close(target);
+  }
+});
+
+test("falls through to an existing HTTP gateway when no native session matches", async () => {
+  const fallbackRequests = [];
+  const relay = createPersistentPreviewRelay({
+    publicDomain: "preview.example.com",
+    healthPath: "/api/tunnel/health",
+    fallbackHandler(request, response) {
+      fallbackRequests.push({ host: request.headers.host, url: request.url });
+      response.statusCode = 202;
+      response.end("polling fallback");
+    },
+  });
+  const address = await relay.listen();
+
+  try {
+    const response = await requestWithHost(
+      `${address.httpUrl}/fallback?transport=polling`,
+      "missing.preview.example.com",
+    );
+    assert.equal(response.status, 202);
+    assert.equal(response.body, "polling fallback");
+    assert.deepEqual(fallbackRequests, [
+      {
+        host: "missing.preview.example.com",
+        url: "/fallback?transport=polling",
+      },
+    ]);
+
+    const health = await fetch(`${address.httpUrl}/api/tunnel/health`);
+    assert.equal(health.status, 200);
+    assert.equal((await health.json()).transport, "websocket");
+  } finally {
+    await relay.close();
+  }
+});
+
+test("coordinates requests across separate relay instances", async () => {
+  const coordinator = new MemoryRelayCoordinator();
+  const relayA = createPersistentPreviewRelay({
+    publicBaseUrl: "https://preview.example.com",
+    publicDomain: "preview.example.com",
+    coordinator,
+    coordinatorSessionTtlMs: 150,
+    requestTimeoutMs: 2_000,
+  });
+  const relayB = createPersistentPreviewRelay({
+    publicBaseUrl: "https://preview.example.com",
+    publicDomain: "preview.example.com",
+    coordinator,
+    coordinatorSessionTtlMs: 150,
+    requestTimeoutMs: 2_000,
+  });
+  const [addressA, addressB] = await Promise.all([relayA.listen(), relayB.listen()]);
+  const target = createServer((request, response) => response.end(`shared:${request.url}`));
+  await listen(target);
+  const targetAddress = target.address();
+  const agent = await startTypeScriptPreviewAgent({
+    relayUrl: addressA.websocketUrl,
+    name: "shared-agent",
+    targetUrl: `http://127.0.0.1:${targetAddress.port}`,
+  });
+
+  try {
+    const response = await requestWithHost(
+      `${addressB.httpUrl}/from/another/instance?coordinated=true`,
+      "shared-agent.preview.example.com",
+    );
+    assert.equal(response.status, 200);
+    assert.equal(response.body, "shared:/from/another/instance?coordinated=true");
+  } finally {
+    await agent.close();
+    await Promise.all([relayA.close(), relayB.close()]);
+    await close(target);
+  }
+});
+
 test("rejects preview paths that could replace the local target authority", async () => {
   let sensitiveRequests = 0;
   const sensitive = createServer((_request, response) => {
@@ -326,6 +431,102 @@ function startStalledUpload(value) {
   });
 }
 
+function requestWithHost(value, host) {
+  const url = new URL(value);
+  return new Promise((resolve, reject) => {
+    const request = createRequest(
+      {
+        host: url.hostname,
+        port: url.port,
+        path: `${url.pathname}${url.search}`,
+        headers: { host },
+      },
+      (response) => {
+        const chunks = [];
+        response.on("data", (chunk) => chunks.push(chunk));
+        response.once("end", () => {
+          resolve({
+            status: response.statusCode,
+            body: Buffer.concat(chunks).toString(),
+          });
+        });
+      },
+    );
+    request.once("error", reject);
+    request.end();
+  });
+}
+
 function closeWebSocketServer(server) {
   return new Promise((resolve) => server.close(() => resolve()));
+}
+
+class MemoryRelayCoordinator {
+  sessions = new Map();
+  requests = new Map();
+  responses = new Map();
+
+  async claimSession(session, ttlMs) {
+    const existing = await this.findSession(session.name);
+    if (existing) return false;
+    this.sessions.set(session.name, { ...session, expiresAt: Date.now() + ttlMs });
+    return true;
+  }
+
+  async findSession(name) {
+    const session = this.sessions.get(name);
+    if (!session) return undefined;
+    if (session.expiresAt <= Date.now()) {
+      this.sessions.delete(name);
+      return undefined;
+    }
+    return { id: session.id, name: session.name };
+  }
+
+  async touchSession(session, ttlMs) {
+    const existing = this.sessions.get(session.name);
+    if (existing?.id !== session.id) return false;
+    existing.expiresAt = Date.now() + ttlMs;
+    return true;
+  }
+
+  async releaseSession(session) {
+    if (this.sessions.get(session.name)?.id === session.id) this.sessions.delete(session.name);
+  }
+
+  async publishRequest(sessionId, request) {
+    pushQueue(this.requests, sessionId, request);
+  }
+
+  async takeRequest(sessionId, timeoutMs) {
+    return await takeQueue(this.requests, sessionId, timeoutMs);
+  }
+
+  async publishResponse(sessionId, response) {
+    pushQueue(this.responses, `${sessionId}:${response.id}`, response);
+  }
+
+  async takeResponse(sessionId, requestId, timeoutMs) {
+    return await takeQueue(this.responses, `${sessionId}:${requestId}`, timeoutMs);
+  }
+}
+
+function pushQueue(queues, key, value) {
+  const queue = queues.get(key) || [];
+  queue.push(value);
+  queues.set(key, queue);
+}
+
+async function takeQueue(queues, key, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    const queue = queues.get(key);
+    const value = queue?.shift();
+    if (value) {
+      if (!queue.length) queues.delete(key);
+      return value;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  } while (Date.now() < deadline);
+  return undefined;
 }

--- a/packages/farm-preview-tunnel/test/tunnel.test.mjs
+++ b/packages/farm-preview-tunnel/test/tunnel.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
-import { createServer } from "node:http";
+import { once } from "node:events";
+import { createServer, request as createRequest } from "node:http";
 import test from "node:test";
+import { gzipSync } from "node:zlib";
+import { WebSocket, WebSocketServer } from "ws";
 
 import { createPersistentPreviewRelay, startTypeScriptPreviewAgent } from "../dist/index.js";
 
@@ -53,6 +56,221 @@ test("forwards requests over one persistent websocket and closes with the agent"
   }
 });
 
+test("preserves repeated cookies and removes encoding after decoding a response", async () => {
+  const target = createServer((_request, response) => {
+    response.statusCode = 200;
+    response.setHeader("content-encoding", "gzip");
+    response.setHeader("content-type", "text/plain");
+    response.setHeader("set-cookie", [
+      "access=one; Path=/; HttpOnly",
+      "refresh=two; Path=/; HttpOnly",
+    ]);
+    response.end(gzipSync(Buffer.from("decoded preview response")));
+  });
+  await listen(target);
+  const targetAddress = target.address();
+  const relay = createPersistentPreviewRelay();
+  const relayAddress = await relay.listen();
+  const agent = await startTypeScriptPreviewAgent({
+    relayUrl: relayAddress.websocketUrl,
+    name: "response-headers",
+    targetUrl: `http://127.0.0.1:${targetAddress.port}`,
+  });
+
+  try {
+    const response = await fetch(agent.publicUrl);
+    assert.equal(await response.text(), "decoded preview response");
+    assert.equal(response.headers.get("content-encoding"), null);
+    assert.deepEqual(getSetCookies(response.headers), [
+      "access=one; Path=/; HttpOnly",
+      "refresh=two; Path=/; HttpOnly",
+    ]);
+  } finally {
+    await agent.close();
+    await relay.close();
+    await close(target);
+  }
+});
+
+test("rejects malformed and unauthenticated agent messages without crashing", async () => {
+  const relay = createPersistentPreviewRelay();
+  const address = await relay.listen();
+
+  try {
+    for (const message of [
+      JSON.stringify({ type: "register" }),
+      JSON.stringify({
+        type: "response",
+        id: "not-owned",
+        status: 200,
+        headers: {},
+      }),
+    ]) {
+      const socket = new WebSocket(address.websocketUrl);
+      await once(socket, "open");
+      const responseMessage = once(socket, "message");
+      const closed = once(socket, "close");
+      socket.send(message);
+      const [data] = await responseMessage;
+      assert.equal(JSON.parse(data.toString()).type, "error");
+      const [code] = await closed;
+      assert.equal(code, 1008);
+    }
+
+    const health = await fetch(`${address.httpUrl}/api/health`);
+    assert.equal(health.status, 200);
+    assert.equal((await health.json()).agents, 0);
+  } finally {
+    await relay.close();
+  }
+});
+
+test("advertises explicit public HTTP and WebSocket endpoints", async () => {
+  const relay = createPersistentPreviewRelay({
+    publicBaseUrl: "https://preview.example.com/",
+    publicWebSocketUrl: "wss://preview.example.com/agent",
+  });
+  const address = await relay.listen();
+  const target = createServer((_request, response) => response.end("ok"));
+  await listen(target);
+  const targetAddress = target.address();
+  const agent = await startTypeScriptPreviewAgent({
+    relayUrl: `ws://127.0.0.1:${address.port}/agent`,
+    name: "public-address",
+    targetUrl: `http://127.0.0.1:${targetAddress.port}`,
+  });
+
+  try {
+    assert.equal(address.websocketUrl, "wss://preview.example.com/agent");
+    assert.equal(agent.publicUrl, "https://preview.example.com/preview/public-address");
+  } finally {
+    await agent.close();
+    await relay.close();
+    await close(target);
+  }
+});
+
+test("rejects preview paths that could replace the local target authority", async () => {
+  let sensitiveRequests = 0;
+  const sensitive = createServer((_request, response) => {
+    sensitiveRequests += 1;
+    response.end("sensitive");
+  });
+  const target = createServer((_request, response) => response.end("target"));
+  await Promise.all([listen(sensitive), listen(target)]);
+  const sensitiveAddress = sensitive.address();
+  const targetAddress = target.address();
+  const relay = createPersistentPreviewRelay();
+  const address = await relay.listen();
+  const agent = await startTypeScriptPreviewAgent({
+    relayUrl: address.websocketUrl,
+    name: "safe-target",
+    targetUrl: `http://127.0.0.1:${targetAddress.port}`,
+  });
+
+  try {
+    const response = await fetch(`${agent.publicUrl}//127.0.0.1:${sensitiveAddress.port}/private`);
+    assert.equal(response.status, 400);
+    assert.match(await response.text(), /cannot change the local target authority/i);
+    assert.equal(sensitiveRequests, 0);
+  } finally {
+    await agent.close();
+    await relay.close();
+    await Promise.all([close(sensitive), close(target)]);
+  }
+});
+
+test("applies the relay deadline while a request body is still uploading", async () => {
+  const target = createServer((_request, response) => response.end("target"));
+  await listen(target);
+  const targetAddress = target.address();
+  const relay = createPersistentPreviewRelay({ requestTimeoutMs: 50 });
+  const address = await relay.listen();
+  const agent = await startTypeScriptPreviewAgent({
+    relayUrl: address.websocketUrl,
+    name: "upload-timeout",
+    targetUrl: `http://127.0.0.1:${targetAddress.port}`,
+  });
+
+  try {
+    const status = await startStalledUpload(`${agent.publicUrl}/upload`);
+    assert.equal(status, 504);
+  } finally {
+    await agent.close();
+    await relay.close();
+    await close(target);
+  }
+});
+
+test("cancels stalled local requests at the agent deadline", async () => {
+  let localRequestClosed;
+  const requestClosed = new Promise((resolve) => {
+    localRequestClosed = resolve;
+  });
+  const target = createServer((request) => {
+    request.once("close", localRequestClosed);
+  });
+  await listen(target);
+  const targetAddress = target.address();
+  const relay = createPersistentPreviewRelay({ requestTimeoutMs: 1_000 });
+  const address = await relay.listen();
+  const agent = await startTypeScriptPreviewAgent({
+    relayUrl: address.websocketUrl,
+    name: "local-timeout",
+    targetUrl: `http://127.0.0.1:${targetAddress.port}`,
+    requestTimeoutMs: 50,
+  });
+
+  try {
+    const response = await fetch(`${agent.publicUrl}/stall`);
+    assert.equal(response.status, 504);
+    await Promise.race([
+      requestClosed,
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("The stalled local request was not cancelled.")), 1_000),
+      ),
+    ]);
+  } finally {
+    await agent.close();
+    await relay.close();
+    await close(target);
+  }
+});
+
+test("survives an abrupt relay connection failure after startup", async () => {
+  const target = createServer((_request, response) => response.end("target"));
+  await listen(target);
+  const targetAddress = target.address();
+  const relayServer = createServer();
+  const websocketServer = new WebSocketServer({ server: relayServer });
+  let peer;
+  websocketServer.on("connection", (socket) => {
+    peer = socket;
+    socket.once("message", () => {
+      socket.send(
+        JSON.stringify({
+          type: "ready",
+          sessionId: "abrupt-session",
+          publicUrl: "https://preview.example.com/preview/abrupt",
+        }),
+      );
+    });
+  });
+  await listen(relayServer);
+  const relayAddress = relayServer.address();
+  const agent = await startTypeScriptPreviewAgent({
+    relayUrl: `ws://127.0.0.1:${relayAddress.port}`,
+    name: "abrupt",
+    targetUrl: `http://127.0.0.1:${targetAddress.port}`,
+  });
+
+  peer.terminate();
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  await agent.close();
+  await closeWebSocketServer(websocketServer);
+  await Promise.all([close(relayServer), close(target)]);
+});
+
 function listen(server) {
   return new Promise((resolve, reject) => {
     server.once("error", reject);
@@ -64,14 +282,50 @@ function close(server) {
   if (!server.listening) return Promise.resolve();
   return new Promise((resolve, reject) => {
     server.close((error) => (error ? reject(error) : resolve()));
+    server.closeAllConnections?.();
   });
 }
 
 async function expectInactive(url) {
   for (let attempt = 0; attempt < 50; attempt += 1) {
     const response = await fetch(url);
-    if (response.status === 404) return;
+    const status = response.status;
+    await response.arrayBuffer();
+    if (status === 404) return;
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
   assert.fail(`Preview route remained active after the local target stopped: ${url}`);
+}
+
+function getSetCookies(headers) {
+  return headers.getSetCookie?.() || [];
+}
+
+function startStalledUpload(value) {
+  const url = new URL(value);
+  return new Promise((resolve, reject) => {
+    const request = createRequest(
+      {
+        host: url.hostname,
+        port: url.port,
+        path: `${url.pathname}${url.search}`,
+        method: "POST",
+        headers: { "content-length": "100" },
+      },
+      (response) => {
+        const status = response.statusCode;
+        response.resume();
+        response.once("end", () => {
+          request.destroy();
+          resolve(status);
+        });
+      },
+    );
+    request.once("error", reject);
+    request.write("partial");
+  });
+}
+
+function closeWebSocketServer(server) {
+  return new Promise((resolve) => server.close(() => resolve()));
 }

--- a/packages/farm-preview-tunnel/test/tunnel.test.mjs
+++ b/packages/farm-preview-tunnel/test/tunnel.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import test from "node:test";
+
+import { createPersistentPreviewRelay, startTypeScriptPreviewAgent } from "../dist/index.js";
+
+test("forwards requests over one persistent websocket and closes with the agent", async () => {
+  const target = createServer(async (request, response) => {
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    response.statusCode = 201;
+    response.setHeader("content-type", "application/json");
+    response.end(
+      JSON.stringify({
+        method: request.method,
+        url: request.url,
+        body: Buffer.concat(chunks).toString(),
+      }),
+    );
+  });
+  await listen(target);
+  const targetAddress = target.address();
+
+  const relay = createPersistentPreviewRelay();
+  const relayAddress = await relay.listen();
+  const agent = await startTypeScriptPreviewAgent({
+    relayUrl: relayAddress.websocketUrl,
+    name: "typed-agent",
+    targetUrl: `http://127.0.0.1:${targetAddress.port}`,
+    localProbeIntervalMs: 10,
+    localProbeTimeoutMs: 50,
+  });
+
+  try {
+    const response = await fetch(`${agent.publicUrl}/hello?from=test`, {
+      method: "POST",
+      body: "farm",
+    });
+    assert.equal(response.status, 201);
+    assert.equal(response.headers.get("x-farm-preview-transport"), "websocket");
+    assert.deepEqual(await response.json(), {
+      method: "POST",
+      url: "/hello?from=test",
+      body: "farm",
+    });
+
+    await close(target);
+    await expectInactive(agent.publicUrl);
+  } finally {
+    await agent.close();
+    await relay.close();
+    await close(target);
+  }
+});
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+}
+
+function close(server) {
+  if (!server.listening) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function expectInactive(url) {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const response = await fetch(url);
+    if (response.status === 404) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.fail(`Preview route remained active after the local target stopped: ${url}`);
+}

--- a/packages/farm-preview-tunnel/tsconfig.json
+++ b/packages/farm-preview-tunnel/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/farm-preview-tunnel/tsdown.config.ts
+++ b/packages/farm-preview-tunnel/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  dts: true,
+  format: ["esm"],
+  clean: true,
+});

--- a/packages/farm-preview-tunnel/tsdown.config.ts
+++ b/packages/farm-preview-tunnel/tsdown.config.ts
@@ -5,4 +5,7 @@ export default defineConfig({
   dts: true,
   format: ["esm"],
   clean: true,
+  splitting: false,
+  sourcemap: true,
+  outDir: "dist",
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -695,9 +695,15 @@ importers:
       '@farm.js/preview-gateway':
         specifier: 0.1.0-beta.2
         version: link:../../packages/farm-preview-gateway
+      '@farm.js/preview-tunnel':
+        specifier: 0.1.0-beta.19
+        version: link:../../packages/farm-preview-tunnel
       '@vercel/blob':
         specifier: ^2.6.1
         version: 2.6.1
+      ioredis:
+        specifier: ^5.9.3
+        version: 5.11.1
     devDependencies:
       '@types/node':
         specifier: ^20.10.5
@@ -17463,4 +17469,49 @@ packages:
 
   /yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
+    dev: false
+
+  /@ioredis/commands@1.10.0:
+    resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
+    dev: false
+
+  /cluster-key-slot@1.1.1:
+    resolution: {integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
+    dev: false
+
+  /ioredis@5.11.1:
+    resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
+    engines: {node: '>=12.22.0'}
+    dependencies:
+      '@ioredis/commands': 1.10.0
+      cluster-key-slot: 1.1.1
+      debug: 4.4.3(supports-color@10.2.2)
+      denque: 2.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+    dependencies:
+      redis-errors: 1.2.0
+    dev: false
+
+  /standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1599,6 +1599,25 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
 
+  packages/farm-preview-tunnel:
+    dependencies:
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.10.5
+        version: 20.19.21
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
+      tsdown:
+        specifier: ^0.15.7
+        version: 0.15.7(supports-color@10.2.2)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+
   packages/farm-stripe:
     dependencies:
       '@farm.js/core':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1448,6 +1448,9 @@ importers:
       '@farm.js/core':
         specifier: workspace:*
         version: link:../farm
+      '@farm.js/tunnel':
+        specifier: 0.1.0
+        version: 0.1.0
       commander:
         specifier: ^11.1.0
         version: 11.1.0
@@ -3976,6 +3979,92 @@ packages:
     os: [win32]
     requiresBuild: true
     optional: true
+
+  /@farm.js/tunnel-darwin-arm64@0.1.0:
+    resolution: {integrity: sha512-QY2GqvBeGhJXnI+0M2E6cQQbTYgxT2t7qYZQZohB5AP1IzKivyl+AM8e3e3DWuevoS6qbehqxnyg+yqCBk94Rw==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@farm.js/tunnel-darwin-x64@0.1.0:
+    resolution: {integrity: sha512-iniAHaEQ0mP5fbBv9UD+uC6ZJKiy33OszOaGzS50fWDxgpUpfkf++TgU2ASW7h2B8G48mpKMSO8t0yxhKcjH8Q==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@farm.js/tunnel-linux-arm64-gnu@0.1.0:
+    resolution: {integrity: sha512-X9jwnZPv6xyY8+uS781qv7gmp7n0tAee/EN67piFSiUv3+BZdC7YXMc3NrT29hUEhIsG5vmYr+TDyr8j1ynqsA==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@farm.js/tunnel-linux-arm64-musl@0.1.0:
+    resolution: {integrity: sha512-oAiHgXXj1GEVIe5YZKY0PBFEdFOssgWEF4gUuDKP8GIFqXEc/Jqe7udYInsVniuBxkMYM5zS5j862KNeUNFACw==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@farm.js/tunnel-linux-x64-gnu@0.1.0:
+    resolution: {integrity: sha512-Btzqj2G7RPmGl7GWH0WXZWdwqovMsqTol0qkbMsqJILLXHi/wRjKbQ8cTL8dV3u1pVWlJGAvQyoB5esCnADnfQ==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@farm.js/tunnel-linux-x64-musl@0.1.0:
+    resolution: {integrity: sha512-HeQJaPaPLXp5OpthCwHb9SvGXJPG01/DWk5Y0zxhxGo7+lxSkXFNyM5HQY2TqavkcbTKoHX7KcKaJqAfU4dh2g==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@farm.js/tunnel-win32-arm64-msvc@0.1.0:
+    resolution: {integrity: sha512-VzIHitxt2oot9Ob3TD/EQxKFZoZnou2QyI5/Y3eOExP4JwrlWhN7dskpKU566IIoB5Yv1ubcXJN+KE255zWAlA==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@farm.js/tunnel-win32-x64-msvc@0.1.0:
+    resolution: {integrity: sha512-pchzMhRSr6XJ6C5Hd5DfdR0dd4NIAy9FMoojrfuMaR+YovXAU/MbwHfleIqnlAU0SrM9XQMzEH0RkR8ZvclD+Q==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@farm.js/tunnel@0.1.0:
+    resolution: {integrity: sha512-03KDpHY71+Z2FM2MVfrricXJP9y0uZfhdcDiT9eBi5v6wMjW2znaOoINoikGi82Gd4vCJMbeib6SD5GhD7rm3Q==}
+    engines: {node: '>=20.0.0'}
+    optionalDependencies:
+      '@farm.js/tunnel-darwin-arm64': 0.1.0
+      '@farm.js/tunnel-darwin-x64': 0.1.0
+      '@farm.js/tunnel-linux-arm64-gnu': 0.1.0
+      '@farm.js/tunnel-linux-arm64-musl': 0.1.0
+      '@farm.js/tunnel-linux-x64-gnu': 0.1.0
+      '@farm.js/tunnel-linux-x64-musl': 0.1.0
+      '@farm.js/tunnel-win32-arm64-msvc': 0.1.0
+      '@farm.js/tunnel-win32-x64-msvc': 0.1.0
+    dev: false
 
   /@farming-labs/docs@0.2.44(react@19.2.8)(supports-color@10.2.2):
     resolution: {integrity: sha512-Y+qC2lC4sG36QeMAUXUQE8hYseNpFhkA2bCWjCxXdGAT4Mhw3pf1WwiT1umZFc2jvluN9ywVW1ShyN/BVMQxVA==}


### PR DESCRIPTION
## Summary

- add a persistent WebSocket preview relay and portable TypeScript agent
- integrate the external Rust N-API implementation from https://github.com/farming-labs/tunnel
- benchmark direct, TypeScript, Rust, and current hosted polling paths
- document automatic tunnel shutdown with the dev server

## Why

The current hosted polling prototype averaged about 1,772 ms per request in the comparison run. A persistent connection avoids object-storage polling and preserves normal HTTP request and response behavior.

In the same local benchmark, the Rust agent averaged 0.29 ms sequential latency and 5,539 requests/second at concurrency 25, versus 0.47 ms and 3,367 requests/second for the TypeScript reference agent.

## Verification

- pnpm --filter @farm.js/preview-tunnel test
- cross-language benchmark correctness checks for request bodies, query strings, statuses, headers, and automatic shutdown
- Rust package: npm test
- Rust package: cargo fmt --check
- Rust package: cargo clippy --all-targets --all-features -- -D warnings
- Rust package: npm pack --dry-run

## Notes

This PR keeps the TypeScript implementation as the protocol reference and portable fallback. The Rust implementation is maintained independently as @farm.js/tunnel. Switching the production farm preview command to the persistent path is intentionally left for a follow-up after the relay deployment and native-package release workflow are ready.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes `farm preview` through a native WebSocket tunnel for faster, lower‑latency previews, with automatic fallback to the existing gateway polling. Deploys the WebSocket relay in the gateway example with Redis coordination for multi‑instance handling.

- **New Features**
  - New `@farm.js/preview-tunnel` with `createPersistentPreviewRelay` and `startTypeScriptPreviewAgent`.
  - `farm preview` first tries `@farm.js/tunnel` at `wss://…/agent`, prints the Relay URL, and falls back to gateway polling if native is unavailable. The session exits when the local app stops and the public route is invalidated immediately. Supports `FARM_PREVIEW_RELAY_URL`; otherwise derives `wss://…/agent` from the gateway URL.
  - Hosted gateway now serves the native relay via `createPersistentPreviewRelay`, coordinates agents and HTTP requests across instances using Redis, and increases function max duration to 30 minutes.
  - Relay multiplexes HTTP over one WebSocket and enforces safety: rejects authority‑changing paths, strips hop‑by‑hop headers, preserves `set-cookie`, decodes compressed responses, times out uploads/stalled requests, and returns 404 after sessions end.
  - Benchmark tool (`benchmark:preview`) compares direct, TypeScript, and Rust agents with correctness checks and publishes initial results.
  - Docs updated to make the native tunnel the default, explain the fallback, and describe automatic shutdown.

- **Dependencies**
  - Added `@farm.js/tunnel` to the CLI and `ws` to `@farm.js/preview-tunnel`.
  - Example gateway adds `ioredis` for relay coordination.

<sup>Written for commit eda6272bd930d9b8fe0295e3c9f6ca2bd077b36c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

