### PR TITLE
fix: restore docs layout styles after client boundary hydration

### DIFF
--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -46,11 +46,11 @@ export const fonts = defineLayoutFonts({
 export default function RootLayout({ children }: LayoutProps) {
   return (
     <>
-      <main
-        className={`${geistSans.variable} ${geistMono.variable} ${geistPixel.variable} ${geistMono.className} min-h-screen bg-black text-white`}
+      <div
+        className={`${geistSans.variable} ${geistMono.variable} ${geistPixel.variable} ${geistSans.className} min-h-screen bg-black text-white`}
       >
         {children}
-      </main>
+      </div>
       <Databuddy clientId="0af7dbbd-628a-44c9-8814-df4138a061b0" trackWebVitals={true} />
     </>
   );

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -313,12 +313,17 @@ export function AnalyticsBoundary() {
       await fs.writeFile(
         path.join(root, "src", "app", "layout.tsx"),
         `
+import "./globals.css";
 import { AnalyticsBoundary } from "@fixture/analytics/react";
 
 export default function RootLayout({ children }) {
   return <div data-layout="root"><AnalyticsBoundary />{children}</div>;
 }
 `.trim(),
+      );
+      await fs.writeFile(
+        path.join(root, "src", "app", "globals.css"),
+        "h1 { font-family: monospace; font-weight: 400; }",
       );
       await fs.writeFile(
         path.join(root, "src", "app", "page.tsx"),
@@ -374,6 +379,12 @@ export default function RootLayout({ children }) {
           expect(html).toContain('id="__farm_route_slots_data__"');
           expect(html.match(/src="\/farm-client\.js"/g)).toHaveLength(1);
           expect(html.match(/href="\/farm-client\.css"/g)).toHaveLength(1);
+          const clientStylesheetIndex = html.indexOf(
+            '<link rel="stylesheet" href="/farm-client.css">',
+          );
+          const docsThemeIndex = html.indexOf("<style>");
+          expect(clientStylesheetIndex).toBeGreaterThan(-1);
+          expect(docsThemeIndex).toBeGreaterThan(clientStylesheetIndex);
         },
         "/docs",
       );

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -4711,10 +4711,12 @@ ${
     "<body" + bodyMatch[1] + ">" + rootMarkup + "</body>",
   );
   if (!html.includes('href="/farm-client.css"')) {
-    html = html.replace(
-      /<[/]head>/i,
-      '  <link rel="stylesheet" href="/farm-client.css">\\n</head>',
-    );
+    const clientStylesheet = '  <link rel="stylesheet" href="/farm-client.css">\\n';
+    const firstStyleIndex = html.search(/<style(?:\\s|>)/i);
+    html =
+      firstStyleIndex >= 0
+        ? html.slice(0, firstStyleIndex) + clientStylesheet + html.slice(firstStyleIndex)
+        : html.replace(/<[/]head>/i, clientStylesheet + "</head>");
   }
   if (!html.includes('id="__farm_route_slots_data__"')) {
     html = html.replace(/<[/]body>/i, renderFarmClientBootstrapScript() + "\\n</body>");


### PR DESCRIPTION
## Summary

- preserve the hydrated root layout and client boundary behavior while using a neutral docs wrapper
- restore Geist Sans as the docs layout's inherited body font
- emit the layout client stylesheet before the docs inline theme so Tailwind preflight cannot override docs typography and spacing
- add a production regression assertion for the stylesheet cascade order

## Root cause

The layout client-boundary change correctly began wrapping standalone docs responses with the applicable app layout and loading its client stylesheet. The docs root layout had previously been bypassed, so its semantic `<main>` wrapper and monospace class became visible to the docs shell. In production, `/farm-client.css` was also appended after the docs inline theme, allowing global Tailwind reset and body rules to win the cascade.

## Impact

The docs recover their previous fonts, heading weights, widths, and padding without disabling layout hydration. The layout boundary markers, route bootstrap data, client bundle, and Databuddy boundary remain active.

## Validation

- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/production-prebuilt-ssr.test.ts` — 20 tests passed
- `pnpm --dir docs exec farm build --preset node-server`
- compared the local production build against the pre-regression deployment at desktop and 390px mobile widths; computed typography, spacing, and content widths match, with no horizontal overflow


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore docs typography and spacing by fixing stylesheet ordering during layout client-boundary hydration. Keeps hydration behavior while returning Geist Sans and previous layout metrics.

- **Bug Fixes**
  - Insert the layout client stylesheet before the docs inline theme (places `/farm-client.css` before the first `<style>`).
  - Use a neutral wrapper and inherit `geistSans` instead of a monospace default in the docs root layout.
  - Add a production test to assert the stylesheet order.

<sup>Written for commit dbf0defbb16835628311834800aeefe4492ede21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

