### PR TITLE
feat: require integration context for bound plugins

### DIFF
--- a/docs/src/app/docs/integrations/custom/page.md
+++ b/docs/src/app/docs/integrations/custom/page.md
@@ -363,10 +363,6 @@ export function betterAuthSessionPlugin() {
     name: "better-auth:session",
     runtime: {
       async context({ request, integration }) {
-        if (!integration) {
-          throw new Error("better-auth:session must be registered by an integration");
-        }
-
         return {
           session: await integration.instance.api.getSession({
             headers: request.headers,
@@ -386,15 +382,20 @@ export const auth = defineIntegration({
 ```
 
 `integration` contains the registration `key`, `category`, `type`, shared `instance`, and
-`serverRuntime` ownership. It is available to `setup` and every server hook on plugins contributed
-through `integration.plugins`. Because a normal application plugin has no owner, the field is
-optional and remains `undefined` for global plugins.
+`serverRuntime` ownership. It is required in `setup` and every server hook created through
+`definePlugin.forIntegration<T>()`, so bound plugins do not need a runtime guard. A normal
+application plugin has no owner; its `integration` field remains optional and `undefined` when the
+plugin is registered globally.
 
 `forIntegration<T>()` is a type-only binding: it does not wrap the plugin or add runtime data. It gives
 every server hook the exact instance type and makes `defineIntegration` reject a plugin whose
 expected instance does not match the configured `instance`. If the configured value is
 `{ auth: betterAuth() }`, bind `{ auth: BetterAuthInstance }` and
 `integration.instance.auth.api` is fully checked and autocompleted.
+
+A bound plugin cannot be registered directly in the global `plugins` array. TypeScript rejects that
+configuration because Farm cannot provide an owning integration there. Contribute it through the
+matching integration's `plugins` array instead.
 
 Prefer the return type inferred by `defineIntegration`. If a package must publish an explicit
 integration type, preserve the instance as the third `FarmIntegration` type argument so its plugin

--- a/examples/basic/src/lib/integration-lab.ts
+++ b/examples/basic/src/lib/integration-lab.ts
@@ -52,9 +52,6 @@ function integrationLabResponsePlugin() {
     name: 'integration-lab:response',
     runtime: {
       after({ kind, route, response, integration }) {
-        if (!integration) {
-          throw new Error('integration-lab:response must be registered by an integration');
-        }
         if (kind !== 'integration' || route?.pattern !== '/api/route-lab/message') {
           return;
         }

--- a/packages/farm/src/__tests__/integrations.test.ts
+++ b/packages/farm/src/__tests__/integrations.test.ts
@@ -114,7 +114,7 @@ describe("integrations runtime", () => {
           context({ integration }) {
             requestIntegration = integration;
             return {
-              billingLabel: integration?.instance.label,
+              billingLabel: integration.instance.label,
             };
           },
         },

--- a/packages/farm/src/__tests__/plugin-lifecycle.types.ts
+++ b/packages/farm/src/__tests__/plugin-lifecycle.types.ts
@@ -1,10 +1,19 @@
 import { expectTypeOf } from "vitest";
+import { defineConfig } from "../config";
 import { defineIntegration, type FarmIntegration } from "../integrations";
-import { definePlugin, type FarmPlugin, type FarmPluginRuntimeSession } from "../plugin";
+import {
+  definePlugin,
+  type FarmPlugin,
+  type FarmPluginIntegrationContext,
+  type FarmPluginRuntimeSession,
+} from "../plugin";
 
 const inferredPlugin = definePlugin({
   name: "typed-runtime",
-  setup() {
+  setup({ integration }) {
+    expectTypeOf(integration).toEqualTypeOf<
+      Readonly<FarmPluginIntegrationContext<unknown>> | undefined
+    >();
     return {
       tracer: {
         start(pathname: string) {
@@ -34,6 +43,8 @@ expectTypeOf(inferredPlugin).toMatchTypeOf<
   FarmPlugin<{ tracer: { start(pathname: string): { id: string } } }, { trace: { id: string } }>
 >();
 
+defineConfig({ plugins: [inferredPlugin] });
+
 expectTypeOf<FarmPluginRuntimeSession["response"]>().toEqualTypeOf<Response | undefined>();
 
 interface AuthIntegrationInstance {
@@ -44,12 +55,23 @@ interface AuthIntegrationInstance {
   };
 }
 
+const authInstance: AuthIntegrationInstance = {
+  auth: {
+    api: {
+      async getSession() {
+        return { userId: "user-1" };
+      },
+    },
+  },
+};
+
 const authPlugin = definePlugin.forIntegration<AuthIntegrationInstance>()({
   name: "typed-auth",
   runtime: {
     async context({ request, integration }) {
-      if (!integration) return {};
-
+      expectTypeOf(integration).toEqualTypeOf<
+        Readonly<FarmPluginIntegrationContext<AuthIntegrationInstance>>
+      >();
       expectTypeOf(integration.instance.auth.api.getSession).toBeFunction();
       // @ts-expect-error unknown instance methods must fail type checking
       integration.instance.auth.api.missingMethod();
@@ -61,18 +83,17 @@ const authPlugin = definePlugin.forIntegration<AuthIntegrationInstance>()({
   },
 });
 
+defineConfig({
+  plugins: [
+    // @ts-expect-error integration-bound plugins must be contributed by an integration
+    authPlugin,
+  ],
+});
+
 const authIntegration = defineIntegration({
   category: "auth",
   type: "typed-auth",
-  instance: {
-    auth: {
-      api: {
-        async getSession() {
-          return { userId: "user-1" };
-        },
-      },
-    },
-  },
+  instance: authInstance,
   plugins: [authPlugin],
 });
 

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -261,7 +261,8 @@ export interface ResolvedFarmDeployConfig extends Omit<FarmDeployConfig, "output
 export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite" | "docs" | "env" | "layers"> {
   /** Reusable Farm directories or installed packages, applied from left to right. */
   extends?: readonly FarmLayerEntry[];
-  plugins?: FarmPlugin[];
+  /** Global plugins. Integration-bound plugins must be contributed through an integration. */
+  plugins?: FarmPlugin<any, any, any, any, unknown, false>[];
   integrations?: FarmIntegrationsUserConfig;
   /**
    * Farm-native authentication. `true` enables email/password auth with

--- a/packages/farm/src/integrations.ts
+++ b/packages/farm/src/integrations.ts
@@ -460,6 +460,11 @@ export interface FarmIntegrationPluginOwner {
   serverRuntime: boolean;
 }
 
+/** A normal plugin or an integration-bound plugin compatible with the shared instance. */
+export type FarmIntegrationContributedPlugin<TInstance = unknown> =
+  | FarmPlugin<any, any, any, any, unknown, false>
+  | FarmPlugin<any, any, any, any, TInstance, true>;
+
 export interface FarmIntegration<
   TSchema extends FarmIntegrationSchema | undefined = FarmIntegrationSchema | undefined,
   TConfig = unknown,
@@ -487,7 +492,7 @@ export interface FarmIntegration<
   providers?: readonly FarmIntegrationProvider[];
   documentNavigations?: readonly FarmIntegrationDocumentNavigation[];
   /** Additional Farm plugins owned and configured by this integration. */
-  plugins?: readonly FarmPlugin<any, any, any, any, NoInfer<TInstance>>[];
+  plugins?: readonly FarmIntegrationContributedPlugin<NoInfer<TInstance>>[];
 }
 
 export type FarmIntegrationsUserConfig = Record<string, FarmIntegration<any, any, any> | undefined>;
@@ -855,7 +860,7 @@ type FarmIntegrationInput<
   config?: FarmIntegrationConfigInput<TConfig, TSchema>;
   routes?: FarmIntegrationRoutesInput<TSchema>;
   endpoints?: FarmIntegrationEndpointsInput<TSchema>;
-  plugins?: readonly FarmPlugin<any, any, any, any, NoInfer<TInstance>>[];
+  plugins?: readonly FarmIntegrationContributedPlugin<NoInfer<TInstance>>[];
 } & (
     | {
         category: FarmIntegrationCategory;
@@ -1172,7 +1177,7 @@ function createIntegrationPluginContext(
 }
 
 function withIntegrationPluginOwner(
-  plugin: FarmPlugin,
+  plugin: FarmPlugin<any, any, any, any, any, boolean>,
   owner: Readonly<FarmIntegrationPluginOwner>,
   integration?: Readonly<FarmPluginIntegrationContext>,
 ): FarmPlugin {

--- a/packages/farm/src/plugin.ts
+++ b/packages/farm/src/plugin.ts
@@ -14,6 +14,7 @@ import { getFarmPluginIntegrationContext } from "./plugin-integration-context";
 
 type MaybePromise<T> = T | Promise<T>;
 declare const FARM_PLUGIN_INTEGRATION_INSTANCE: unique symbol;
+declare const FARM_PLUGIN_INTEGRATION_BOUND: unique symbol;
 
 export interface FarmPluginIntegrationContext<TInstance = unknown> {
   /** Key used to register the integration in farm.config.ts. */
@@ -69,6 +70,17 @@ export interface FarmPluginContext<TIntegrationInstance = unknown> {
   /** @deprecated Use `ctx.req` inside request hooks. */
   requestContext: PluginRequestContext;
 }
+
+type FarmPluginHookContext<
+  TContext,
+  TIntegrationInstance,
+  TIntegrationBound extends boolean,
+> = TIntegrationBound extends true
+  ? Omit<TContext, "integration"> & {
+      /** The owning integration bound by `definePlugin.forIntegration<T>()`. */
+      readonly integration: Readonly<FarmPluginIntegrationContext<TIntegrationInstance>>;
+    }
+  : TContext;
 
 export interface FarmPluginLifecycle {
   /**
@@ -250,25 +262,97 @@ export type FarmPluginRuntimeStartEvent<
 export interface FarmPluginRuntimeCloseEvent<TState = unknown, TIntegrationInstance = unknown>
   extends FarmPluginStateContext<TState, TIntegrationInstance>, ShutdownPayload {}
 
+type FarmPluginContextFor<
+  TIntegrationInstance,
+  TIntegrationBound extends boolean,
+> = FarmPluginHookContext<
+  FarmPluginContext<TIntegrationInstance>,
+  TIntegrationInstance,
+  TIntegrationBound
+>;
+
+type FarmRequestPluginContextFor<
+  TIntegrationInstance,
+  TIntegrationBound extends boolean,
+> = FarmPluginHookContext<
+  FarmRequestPluginContext<TIntegrationInstance>,
+  TIntegrationInstance,
+  TIntegrationBound
+>;
+
+type FarmPluginSetupContextFor<
+  TIntegrationInstance,
+  TIntegrationBound extends boolean,
+> = FarmPluginHookContext<
+  FarmPluginSetupContext<TIntegrationInstance>,
+  TIntegrationInstance,
+  TIntegrationBound
+>;
+
+type FarmPluginStateContextFor<
+  TState,
+  TIntegrationInstance,
+  TIntegrationBound extends boolean,
+> = FarmPluginHookContext<
+  FarmPluginStateContext<TState, TIntegrationInstance>,
+  TIntegrationInstance,
+  TIntegrationBound
+>;
+
+type FarmPluginRuntimeEventFor<
+  TEvent,
+  TIntegrationInstance,
+  TIntegrationBound extends boolean,
+> = FarmPluginHookContext<TEvent, TIntegrationInstance, TIntegrationBound>;
+
 export interface FarmPluginRuntimeHooks<
   TState = unknown,
   TRequestContext extends object = Record<string, unknown>,
   TIntegrationInstance = unknown,
+  TIntegrationBound extends boolean = false,
 > {
-  start?(event: FarmPluginRuntimeStartEvent<TState, TIntegrationInstance>): MaybePromise<void>;
+  start?(
+    event: FarmPluginRuntimeEventFor<
+      FarmPluginRuntimeStartEvent<TState, TIntegrationInstance>,
+      TIntegrationInstance,
+      TIntegrationBound
+    >,
+  ): MaybePromise<void>;
   context?(
-    event: FarmPluginRuntimeContextEvent<TState, TIntegrationInstance>,
+    event: FarmPluginRuntimeEventFor<
+      FarmPluginRuntimeContextEvent<TState, TIntegrationInstance>,
+      TIntegrationInstance,
+      TIntegrationBound
+    >,
   ): MaybePromise<TRequestContext>;
   before?(
-    event: FarmPluginRuntimeBeforeEvent<TState, TRequestContext, TIntegrationInstance>,
+    event: FarmPluginRuntimeEventFor<
+      FarmPluginRuntimeBeforeEvent<TState, TRequestContext, TIntegrationInstance>,
+      TIntegrationInstance,
+      TIntegrationBound
+    >,
   ): MaybePromise<Request | Response | void>;
   after?(
-    event: FarmPluginRuntimeAfterEvent<TState, TRequestContext, TIntegrationInstance>,
+    event: FarmPluginRuntimeEventFor<
+      FarmPluginRuntimeAfterEvent<TState, TRequestContext, TIntegrationInstance>,
+      TIntegrationInstance,
+      TIntegrationBound
+    >,
   ): MaybePromise<Response | void>;
   error?(
-    event: FarmPluginRuntimeErrorEvent<TState, TRequestContext, TIntegrationInstance>,
+    event: FarmPluginRuntimeEventFor<
+      FarmPluginRuntimeErrorEvent<TState, TRequestContext, TIntegrationInstance>,
+      TIntegrationInstance,
+      TIntegrationBound
+    >,
   ): MaybePromise<void>;
-  close?(event: FarmPluginRuntimeCloseEvent<TState, TIntegrationInstance>): MaybePromise<void>;
+  close?(
+    event: FarmPluginRuntimeEventFor<
+      FarmPluginRuntimeCloseEvent<TState, TIntegrationInstance>,
+      TIntegrationInstance,
+      TIntegrationBound
+    >,
+  ): MaybePromise<void>;
 }
 
 export interface FarmPluginRuntimeRequestOptions {
@@ -293,60 +377,76 @@ export type FarmPluginDiscoveredRoute =
   | ({ kind: "middleware" } & MiddlewareDiscoveredPayload)
   | ({ kind: "api" } & APIRouteDiscoveredPayload);
 
-export interface FarmPluginRouterHooks<TState = unknown, TIntegrationInstance = unknown> {
+export interface FarmPluginRouterHooks<
+  TState = unknown,
+  TIntegrationInstance = unknown,
+  TIntegrationBound extends boolean = false,
+> {
   discovered?(
     route: FarmPluginDiscoveredRoute,
-    context: FarmPluginStateContext<TState, TIntegrationInstance>,
+    context: FarmPluginStateContextFor<TState, TIntegrationInstance, TIntegrationBound>,
   ): MaybePromise<void>;
   generated?(
     routes: RoutesGeneratedPayload,
-    context: FarmPluginStateContext<TState, TIntegrationInstance>,
+    context: FarmPluginStateContextFor<TState, TIntegrationInstance, TIntegrationBound>,
   ): MaybePromise<void>;
   before?(
     route: RouteMatchPayload,
-    context: FarmPluginStateContext<TState, TIntegrationInstance>,
+    context: FarmPluginStateContextFor<TState, TIntegrationInstance, TIntegrationBound>,
   ): MaybePromise<void>;
   after?(
     result: RouteMatchResultPayload,
-    context: FarmPluginStateContext<TState, TIntegrationInstance>,
+    context: FarmPluginStateContextFor<TState, TIntegrationInstance, TIntegrationBound>,
   ): MaybePromise<void>;
 }
 
-export interface FarmPluginRenderHooks<TState = unknown, TIntegrationInstance = unknown> {
+export interface FarmPluginRenderHooks<
+  TState = unknown,
+  TIntegrationInstance = unknown,
+  TIntegrationBound extends boolean = false,
+> {
   before?(
     render: RenderLifecyclePayload,
-    context: FarmPluginStateContext<TState, TIntegrationInstance>,
+    context: FarmPluginStateContextFor<TState, TIntegrationInstance, TIntegrationBound>,
   ): MaybePromise<void>;
   html?(
     html: string,
     render: RenderLifecyclePayload,
-    context: FarmPluginStateContext<TState, TIntegrationInstance>,
+    context: FarmPluginStateContextFor<TState, TIntegrationInstance, TIntegrationBound>,
   ): MaybePromise<string | void>;
 }
 
-export interface FarmPluginBuildHooks<TState = unknown, TIntegrationInstance = unknown> {
+export interface FarmPluginBuildHooks<
+  TState = unknown,
+  TIntegrationInstance = unknown,
+  TIntegrationBound extends boolean = false,
+> {
   before?(
     bundle: BundleLifecyclePayload,
-    context: FarmPluginStateContext<TState, TIntegrationInstance>,
+    context: FarmPluginStateContextFor<TState, TIntegrationInstance, TIntegrationBound>,
   ): MaybePromise<void>;
   configure?(
     buildConfig: any,
-    context: FarmPluginStateContext<TState, TIntegrationInstance>,
+    context: FarmPluginStateContextFor<TState, TIntegrationInstance, TIntegrationBound>,
   ): MaybePromise<any>;
   after?(
     result: BundleResultPayload,
-    context: FarmPluginStateContext<TState, TIntegrationInstance>,
+    context: FarmPluginStateContextFor<TState, TIntegrationInstance, TIntegrationBound>,
   ): MaybePromise<void>;
 }
 
-export interface FarmPluginDevHooks<TState = unknown, TIntegrationInstance = unknown> {
+export interface FarmPluginDevHooks<
+  TState = unknown,
+  TIntegrationInstance = unknown,
+  TIntegrationBound extends boolean = false,
+> {
   server?(
     viteServer: ViteDevServer,
-    context: FarmPluginStateContext<TState, TIntegrationInstance>,
+    context: FarmPluginStateContextFor<TState, TIntegrationInstance, TIntegrationBound>,
   ): MaybePromise<void>;
   update?(
     update: HMRUpdatePayload,
-    context: FarmPluginStateContext<TState, TIntegrationInstance>,
+    context: FarmPluginStateContextFor<TState, TIntegrationInstance, TIntegrationBound>,
   ): MaybePromise<void>;
 }
 
@@ -364,6 +464,7 @@ export interface FarmPlugin<
   TClientState = any,
   TClientPublic = any,
   TIntegrationInstance = unknown,
+  TIntegrationBound extends boolean = false,
 > {
   name: string;
   version?: string;
@@ -372,156 +473,173 @@ export interface FarmPlugin<
   /** Transform Farm config before it is resolved. */
   configure?: (
     config: FarmConfig,
-    context: FarmPluginContext<TIntegrationInstance>,
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => MaybePromise<FarmConfig | void>;
   /** Initialize private plugin state once for this plugin manager. */
-  setup?: (context: FarmPluginSetupContext<TIntegrationInstance>) => MaybePromise<TState>;
+  setup?: (
+    context: FarmPluginSetupContextFor<TIntegrationInstance, TIntegrationBound>,
+  ) => MaybePromise<TState>;
 
-  runtime?: FarmPluginRuntimeHooks<TState, TRequestContext, TIntegrationInstance>;
-  router?: FarmPluginRouterHooks<TState, TIntegrationInstance>;
-  render?: FarmPluginRenderHooks<TState, TIntegrationInstance>;
-  build?: FarmPluginBuildHooks<TState, TIntegrationInstance>;
-  dev?: FarmPluginDevHooks<TState, TIntegrationInstance>;
+  runtime?: FarmPluginRuntimeHooks<
+    TState,
+    TRequestContext,
+    TIntegrationInstance,
+    TIntegrationBound
+  >;
+  router?: FarmPluginRouterHooks<TState, TIntegrationInstance, TIntegrationBound>;
+  render?: FarmPluginRenderHooks<TState, TIntegrationInstance, TIntegrationBound>;
+  build?: FarmPluginBuildHooks<TState, TIntegrationInstance, TIntegrationBound>;
+  dev?: FarmPluginDevHooks<TState, TIntegrationInstance, TIntegrationBound>;
   /** Optional browser lifecycle for this logical plugin. */
   client?: FarmPluginClientConfig<TClientState, TClientPublic>;
 
   /** @internal Carries the expected integration instance type without runtime data. */
   readonly [FARM_PLUGIN_INTEGRATION_INSTANCE]?: (instance: TIntegrationInstance) => void;
+  /** @internal Prevents integration-bound plugins from being registered globally. */
+  readonly [FARM_PLUGIN_INTEGRATION_BOUND]?: TIntegrationBound;
 
   /** @deprecated Use `setup` instead. */
-  init?: (context: FarmPluginContext<TIntegrationInstance>) => void | Promise<void>;
+  init?: (
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
+  ) => void | Promise<void>;
   /** @deprecated Use `runtime.start` instead. */
-  ready?: (context: FarmPluginContext<TIntegrationInstance>) => void | Promise<void>;
+  ready?: (
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
+  ) => void | Promise<void>;
   /** @deprecated Use `dev.server` instead. */
   devServerCreated?: (
     viteServer: ViteDevServer,
-    context: FarmPluginContext<TIntegrationInstance>,
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => void | Promise<void>;
 
   /** @deprecated Use `configure` instead. */
   config?: (
     config: FarmConfig,
-    context: FarmPluginContext<TIntegrationInstance>,
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => FarmConfig | Promise<FarmConfig>;
   configResolved?: (
     config: FarmConfig,
-    context: FarmPluginContext<TIntegrationInstance>,
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => void | Promise<void>;
   /** @deprecated Use `build.before` instead. */
-  buildStart?: (context: FarmPluginContext<TIntegrationInstance>) => void | Promise<void>;
+  buildStart?: (
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
+  ) => void | Promise<void>;
   /** @deprecated Use `build.after` instead. */
-  buildEnd?: (context: FarmPluginContext<TIntegrationInstance>) => void | Promise<void>;
+  buildEnd?: (
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
+  ) => void | Promise<void>;
 
   /** @deprecated Use `router.discovered` instead. */
   routeDiscovered?: (
     route: RouteDiscoveredPayload,
-    context: FarmPluginContext<TIntegrationInstance>,
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => void | Promise<void>;
   /** @deprecated Use `router.generated` instead. */
   routesGenerated?: (
     routes: RoutesGeneratedPayload,
-    context: FarmPluginContext<TIntegrationInstance>,
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => void | Promise<void>;
   /** @deprecated Use `router.discovered` instead. */
   middlewareDiscovered?: (
     middleware: MiddlewareDiscoveredPayload,
-    context: FarmPluginContext<TIntegrationInstance>,
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => void | Promise<void>;
   /** @deprecated Use `router.discovered` instead. */
   apiRouteDiscovered?: (
     route: APIRouteDiscoveredPayload,
-    context: FarmPluginContext<TIntegrationInstance>,
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => void | Promise<void>;
   /** @deprecated Use `router.before` instead. */
   beforeRouteMatch?: (
     route: RouteMatchPayload,
-    context: FarmPluginContext<TIntegrationInstance>,
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => void | Promise<void>;
   /** @deprecated Use `router.after` instead. */
   afterRouteMatch?: (
     result: RouteMatchResultPayload,
-    context: FarmPluginContext<TIntegrationInstance>,
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => void | Promise<void>;
   /** @deprecated Use `render.before` instead. */
   beforeRender?: (
     render: RenderLifecyclePayload,
-    context: FarmPluginContext<TIntegrationInstance>,
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => void | Promise<void>;
   /** @deprecated Use `render.html` instead. */
   afterRender?: (
     html: string,
     render: RenderLifecyclePayload,
-    context: FarmPluginContext<TIntegrationInstance>,
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => string | Promise<string> | void | Promise<void>;
   /** @deprecated Use `runtime.before` instead. */
   beforeApiHandler?: (
     request: Request,
     api: APIHandlerLifecyclePayload,
-    context: FarmRequestPluginContext<TIntegrationInstance>,
+    context: FarmRequestPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => Request | Promise<Request> | void | Promise<void>;
   /** @deprecated Use `runtime.after` instead. */
   afterApiHandler?: (
     response: Response,
     api: APIHandlerLifecyclePayload,
-    context: FarmPluginContext<TIntegrationInstance>,
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => Response | Promise<Response> | void | Promise<void>;
   onError?: (
     error: ErrorLifecyclePayload,
-    context: FarmPluginContext<TIntegrationInstance>,
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => void | Promise<void>;
   /** @deprecated Use `dev.update` instead. */
   hmrUpdate?: (
     update: HMRUpdatePayload,
-    context: FarmPluginContext<TIntegrationInstance>,
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => void | Promise<void>;
   /** @deprecated Use `build.before` instead. */
   beforeBundle?: (
     bundle: BundleLifecyclePayload,
-    context: FarmPluginContext<TIntegrationInstance>,
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => void | Promise<void>;
   /** @deprecated Use `build.after` instead. */
   afterBundle?: (
     result: BundleResultPayload,
-    context: FarmPluginContext<TIntegrationInstance>,
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => void | Promise<void>;
   /** @deprecated Use `build.configure` instead. */
   beforeNitroBuild?: (
     nitroConfig: any,
-    context: FarmPluginContext<TIntegrationInstance>,
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => any | Promise<any>;
   afterNitroBuild?: (
     payload: NitroBuildLifecyclePayload,
-    context: FarmPluginContext<TIntegrationInstance>,
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => void | Promise<void>;
   /** @deprecated Use `runtime.close` instead. */
   shutdown?: (
     payload: ShutdownPayload,
-    context: FarmPluginContext<TIntegrationInstance>,
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => void | Promise<void>;
 
   /** @deprecated Use the Web Request based `runtime.before` hook instead. */
   beforeRequest?: (
     req: FarmRequest,
     res: FarmResponse,
-    context: FarmRequestPluginContext<TIntegrationInstance>,
+    context: FarmRequestPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => void | Promise<void>;
   /** @deprecated Use the Web Response based `runtime.after` hook instead. */
   afterResponse?: (
     req: FarmRequest,
     res: FarmResponse,
-    context: FarmRequestPluginContext<TIntegrationInstance>,
+    context: FarmRequestPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => void | Promise<void>;
 
   // Transform hooks
   /** @deprecated Use `render.html` instead. */
   transformHTML?: (
     html: string,
-    context: FarmPluginContext<TIntegrationInstance>,
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => string | Promise<string>;
   /** @deprecated Use `render.before` or `render.html` instead. */
   transformPage?: (
     component: any,
-    context: FarmPluginContext<TIntegrationInstance>,
+    context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
   ) => any | Promise<any>;
 }
 
@@ -1304,8 +1422,15 @@ export function definePlugin<
   TClientPublic = undefined,
   TIntegrationInstance = unknown,
 >(
-  plugin: FarmPlugin<TState, TRequestContext, TClientState, TClientPublic, TIntegrationInstance>,
-): FarmPlugin<TState, TRequestContext, TClientState, TClientPublic, TIntegrationInstance> {
+  plugin: FarmPlugin<
+    TState,
+    TRequestContext,
+    TClientState,
+    TClientPublic,
+    TIntegrationInstance,
+    false
+  >,
+): FarmPlugin<TState, TRequestContext, TClientState, TClientPublic, TIntegrationInstance, false> {
   return plugin;
 }
 
@@ -1323,9 +1448,17 @@ export namespace definePlugin {
         TRequestContext,
         TClientState,
         TClientPublic,
-        TIntegrationInstance
+        TIntegrationInstance,
+        true
       >,
-    ): FarmPlugin<TState, TRequestContext, TClientState, TClientPublic, TIntegrationInstance> {
+    ): FarmPlugin<
+      TState,
+      TRequestContext,
+      TClientState,
+      TClientPublic,
+      TIntegrationInstance,
+      true
+    > {
       return plugin;
     };
   }


### PR DESCRIPTION
## Summary

- make `integration` required and fully typed in every server hook created with `definePlugin.forIntegration<T>()`
- reject integration-bound plugins in the global `farm.config.ts` `plugins` array while preserving normal global plugins
- keep both normal and correctly bound plugins composable through `defineIntegration`, with mismatched instance types rejected
- update the integration example, compile-time coverage, runtime tests, and documentation

## Why

Farm already supplies the owning integration at runtime for plugins contributed by an integration, but the shared hook context type still exposed it as optional. That forced redundant guards and allowed bound plugins to be registered globally, where the ownership guarantee cannot be fulfilled.

## Validation

- `pnpm build`
- `pnpm type-check` (67 tasks)
- `pnpm lint`
- `pnpm docs:check-navigation`
- focused core plugin and integration tests (46 tests)
- framework integration Playwright test in Chromium


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require integration context for plugins bound via `definePlugin.forIntegration<T>()`, and block their registration in global `plugins` to improve type safety and prevent misconfiguration.

- **New Features**
  - `integration` is required in `setup` and all server hooks for plugins created with `definePlugin.forIntegration<T>()`.
  - Global `farm.config.ts` `plugins` only accept normal plugins; integration-bound plugins must be contributed via `defineIntegration` `plugins`.
  - Enforce instance type matching in `defineIntegration`, with full autocomplete on `integration.instance.*`.
  - Added `FarmIntegrationContributedPlugin<TInstance>` so integrations can include both normal and correctly bound plugins.

- **Migration**
  - Create bound plugins with `definePlugin.forIntegration<T>()` and contribute them through `defineIntegration({ plugins: [...] })`.
  - Do not register bound plugins in global `plugins`.
  - Remove runtime guards like `if (!integration) ...` in bound plugin hooks.
  - Ensure the bound plugin’s expected instance type matches the integration’s configured instance.

<sup>Written for commit 44dfaab3190b486de540048e78f75e21cc211ff5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

