### PR TITLE
fix: polish create-app starter labels and docs links

### DIFF
--- a/packages/create-farm-app/src/index.ts
+++ b/packages/create-farm-app/src/index.ts
@@ -19,22 +19,22 @@ const templateDetails: Record<
   }
 > = {
   basic: {
-    title: "FARMJS Basic",
-    description: "A minimal FARMJS app with built-in Tailwind support",
+    title: "Farm.js Basic",
+    description: "A minimal Farm.js app with built-in Tailwind support",
     instructions: [
       "Tailwind is enabled by default. You only need postcss config for custom plugins.",
     ],
   },
   auth: {
-    title: "FARMJS Auth",
-    description: "FARMJS-native auth with local SQLite, secure sessions, and protected routes",
+    title: "Farm.js Auth",
+    description: "Farm.js-native auth with local SQLite, secure sessions, and protected routes",
     instructions: [
       "FARMJS Auth uses local SQLite automatically; no auth environment variables are needed locally.",
       "For production, set FARM_AUTH_URL, FARM_AUTH_SECRET, and DATABASE_URL, then run the auth:migrate script.",
     ],
   },
   "better-auth": {
-    title: "FARMJS Better Auth",
+    title: "Farm.js Better Auth",
     description: "Better Auth with Postgres, secure sessions, and protected routes",
     instructions: [
       "Before starting, copy .env.example to .env.local and set DATABASE_URL and BETTER_AUTH_SECRET.",

--- a/packages/create-farm-app/templates/auth/src/components/resource-links.tsx
+++ b/packages/create-farm-app/templates/auth/src/components/resource-links.tsx
@@ -61,7 +61,7 @@ export function ResourceLinks({ className, primary }: ResourceLinksProps) {
       ) : null}
       <span className="resource-link-item">
         {primary ? <ResourceSeparator /> : null}
-        <a href="https://farm.js.dev">
+        <a href="https://farmjs.dev">
           <DocsIcon />
           <span>Docs</span>
         </a>

--- a/packages/create-farm-app/templates/auth/src/components/site-header.tsx
+++ b/packages/create-farm-app/templates/auth/src/components/site-header.tsx
@@ -21,7 +21,7 @@ export function SiteHeader({ user }: SiteHeaderProps) {
       </a>
 
       <nav className="header-nav" aria-label="Primary navigation">
-        <a href="https://farm.js.dev">Docs</a>
+        <a href="https://farmjs.dev">Docs</a>
         {user ? (
           <a className="header-account" href="/dashboard">
             <span className="avatar" aria-hidden="true">

--- a/packages/create-farm-app/templates/basic/src/components/resource-links.tsx
+++ b/packages/create-farm-app/templates/basic/src/components/resource-links.tsx
@@ -61,7 +61,7 @@ export function ResourceLinks({ className, primary }: ResourceLinksProps) {
       ) : null}
       <span className="resource-link-item">
         {primary ? <ResourceSeparator /> : null}
-        <a href="https://farm.js.dev">
+        <a href="https://farmjs.dev">
           <DocsIcon />
           <span>Docs</span>
         </a>

--- a/packages/create-farm-app/templates/better-auth/src/components/resource-links.tsx
+++ b/packages/create-farm-app/templates/better-auth/src/components/resource-links.tsx
@@ -61,7 +61,7 @@ export function ResourceLinks({ className, primary }: ResourceLinksProps) {
       ) : null}
       <span className="resource-link-item">
         {primary ? <ResourceSeparator /> : null}
-        <a href="https://farm.js.dev">
+        <a href="https://farmjs.dev">
           <DocsIcon />
           <span>Docs</span>
         </a>

--- a/packages/create-farm-app/templates/better-auth/src/components/site-header.tsx
+++ b/packages/create-farm-app/templates/better-auth/src/components/site-header.tsx
@@ -21,7 +21,7 @@ export function SiteHeader({ user }: SiteHeaderProps) {
       </a>
 
       <nav className="header-nav" aria-label="Primary navigation">
-        <a href="https://farm.js.dev">Docs</a>
+        <a href="https://farmjs.dev">Docs</a>
         {user ? (
           <a className="header-account" href="/dashboard">
             <span className="avatar" aria-hidden="true">

--- a/packages/create-farm-app/test/create-app.test.mjs
+++ b/packages/create-farm-app/test/create-app.test.mjs
@@ -107,6 +107,8 @@ test("generates a buildable starter application", async () => {
     assert.match(generatedResourceLinks, /function ResourceSeparator\(\)/);
     assert.match(generatedResourceLinks, /className="resource-separator"/);
     assert.match(generatedResourceLinks, /aria-hidden="true"/);
+    assert.match(generatedResourceLinks, /href="https:\/\/farmjs\.dev"/);
+    assert.doesNotMatch(generatedResourceLinks, /farm\.js\.dev/);
     assert.doesNotMatch(generatedResourceLinks, /Docs ↗|GitHub ↗/);
 
     const generatedStyles = await readFile(
@@ -273,7 +275,16 @@ for (const template of [
       assert.match(generatedResourceLinks, /function ResourceSeparator\(\)/);
       assert.match(generatedResourceLinks, /className="resource-separator"/);
       assert.match(generatedResourceLinks, /aria-hidden="true"/);
+      assert.match(generatedResourceLinks, /href="https:\/\/farmjs\.dev"/);
+      assert.doesNotMatch(generatedResourceLinks, /farm\.js\.dev/);
       assert.doesNotMatch(generatedResourceLinks, /Docs ↗|GitHub ↗/);
+
+      const generatedSiteHeader = await readFile(
+        path.join(generatedDir, "src/components/site-header.tsx"),
+        "utf8",
+      );
+      assert.match(generatedSiteHeader, /href="https:\/\/farmjs\.dev"/);
+      assert.doesNotMatch(generatedSiteHeader, /farm\.js\.dev/);
 
       const generatedStyles = await readFile(
         path.join(generatedDir, "src/app/globals.css"),

--- a/packages/create-farm-app/test/create-app.test.mjs
+++ b/packages/create-farm-app/test/create-app.test.mjs
@@ -8,6 +8,15 @@ import { fileURLToPath } from "node:url";
 
 const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
+test("uses Farm.js branding for CLI template choices", async () => {
+  const source = await readFile(path.join(packageDir, "src/index.ts"), "utf8");
+
+  assert.match(source, /title: "Farm\.js Basic"/);
+  assert.match(source, /title: "Farm\.js Auth"/);
+  assert.match(source, /title: "Farm\.js Better Auth"/);
+  assert.doesNotMatch(source, /title: "FARMJS/);
+});
+
 test("generates a buildable starter application", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "create-farm-app-"));
 


### PR DESCRIPTION
## What changed

- use `Farm.js` casing in the interactive create-app starter choices
- point Basic, Auth, and Better Auth starter documentation links to the live `https://farmjs.dev` site
- cover the CLI labels and generated documentation links with regression assertions

## Why

The all-caps starter option labels looked inconsistent in the CLI, and the generated starter links used `farm.js.dev`, which does not resolve. The active documentation site is `farmjs.dev`.

## Validation

- `pnpm test` in `packages/create-farm-app` (5 passing)
- `pnpm type-check` in `packages/create-farm-app`
- `oxfmt --check`
- `oxlint`
- live HTTP verification of `https://farmjs.dev`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the `create-farm-app` starters by switching CLI template titles to “Farm.js” and fixing Docs links to use https://farmjs.dev across Basic, Auth, and Better Auth starters.

Added regression tests in `packages/create-farm-app` to verify branding and ensure no `farm.js.dev` links are generated.

<sup>Written for commit fe224f788ccf0d05b3784e738fb616d6ae3e7f58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

