### PR TITLE
fix: silence Tailwind dev startup log

### DIFF
--- a/packages/farm/src/server/create-server.ts
+++ b/packages/farm/src/server/create-server.ts
@@ -182,7 +182,6 @@ export async function createServer(config: FarmConfig = {}) {
       try {
         const tailwindcss = (await import("@tailwindcss/vite")).default;
         tailwindVitePlugin = tailwindcss();
-        logger.info("📦 Enabled built-in Tailwind support (@tailwindcss/vite)");
       } catch (error) {
         logger.warn(
           `Tailwind plugin auto-enable failed; continuing without it: ${(error as Error).message}`,


### PR DESCRIPTION
## What changed

- remove the built-in Tailwind success message from `farm dev` startup output
- keep automatic `@tailwindcss/vite` activation unchanged
- keep the warning emitted when Tailwind activation actually fails
- leave production-build Tailwind diagnostics unchanged

## Why

The automatic Tailwind setup is expected framework behavior, so printing an informational line on every development-server start adds noise without requiring user action.

## Validation

- live `farm dev --port 4062` startup: server became ready without the Tailwind success line
- `vitest run src/__tests__/create-server.test.ts` (5 passing)
- `pnpm type-check`
- `oxfmt --check`
- `oxlint`
- `NODE_OPTIONS=--max-old-space-size=6144 pnpm build`

The full core suite completed with 905 passing tests and 1 skipped test. Two `layers.test.ts` cases hit the existing 5-second timeout; this change does not touch the layers implementation or tests.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silenced the Tailwind success message during `farm dev` startup to reduce console noise. Auto-activation via `@tailwindcss/vite`, the failure warning, and production build diagnostics remain unchanged.

<sup>Written for commit d82392a1abbb205b754e2478e286a2069917c60b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

