### PR TITLE
fix(create-app): resolve the newest beta with pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ No install needed: [open the playground on StackBlitz](https://stackblitz.com/gi
 ### Create a New App
 
 ```bash
-pnpm create @farm.js/app@beta my-app --template basic --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-app --template basic --typescript
 cd my-app
 pnpm dev
 ```

--- a/docs/src/app/docs/cli/page.md
+++ b/docs/src/app/docs/cli/page.md
@@ -11,13 +11,13 @@ Use the Farm CLI to run, build, generate types, migrate apps, deploy output, and
 ## Create an app
 
 ```bash
-pnpm create @farm.js/app@beta my-app --template basic --typescript
-pnpm create @farm.js/app@beta my-preact-app --template basic --renderer preact --typescript
-pnpm create @farm.js/app@beta my-solid-app --template basic --renderer solid --typescript
-pnpm create @farm.js/app@beta my-vue-app --template basic --renderer vue --typescript
-pnpm create @farm.js/app@beta my-svelte-app --template basic --renderer svelte --typescript
-pnpm create @farm.js/app@beta stripe-app --template stripe --typescript
-pnpm create @farm.js/app@beta --list-templates
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-app --template basic --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-preact-app --template basic --renderer preact --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-solid-app --template basic --renderer solid --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-vue-app --template basic --renderer vue --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-svelte-app --template basic --renderer svelte --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta stripe-app --template stripe --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta --list-templates
 ```
 
 The create-app CLI includes Basic, Farm.js Auth, Better Auth, and one ready-to-configure starter

--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -90,7 +90,7 @@ aliases, server rendering and streaming, and browser hydration. See the
 Create a ready-to-run Preact application from the CLI:
 
 ```bash
-pnpm create @farm.js/app@beta my-preact-app --template basic --renderer preact --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-preact-app --template basic --renderer preact --typescript
 ```
 
 ### Svelte
@@ -124,7 +124,7 @@ typed server calls, and current compatibility boundaries.
 Create a ready-to-run Svelte application from the CLI:
 
 ```bash
-pnpm create @farm.js/app@beta my-svelte-app --template basic --renderer svelte --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-svelte-app --template basic --renderer svelte --typescript
 ```
 
 ### Vue
@@ -163,7 +163,7 @@ current compatibility boundaries.
 Create a ready-to-run Vue application from the CLI:
 
 ```bash
-pnpm create @farm.js/app@beta my-vue-app --template basic --renderer vue --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-vue-app --template basic --renderer vue --typescript
 ```
 
 ### Solid
@@ -194,7 +194,7 @@ calls, and current compatibility boundaries.
 Create a ready-to-run Solid application directly from the CLI:
 
 ```bash
-pnpm create @farm.js/app@beta my-solid-app --template basic --renderer solid --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-solid-app --template basic --renderer solid --typescript
 ```
 
 Omitting `renderer` selects React. The renderer option is currently available for the Basic starter;

--- a/docs/src/app/docs/getting-started/page.md
+++ b/docs/src/app/docs/getting-started/page.md
@@ -31,10 +31,10 @@ files.
 React is the default renderer. The Basic starter can instead use Preact, Solid, Vue, or Svelte:
 
 ```bash
-pnpm create @farm.js/app@beta my-preact-app --template basic --renderer preact --typescript
-pnpm create @farm.js/app@beta my-solid-app --template basic --renderer solid --typescript
-pnpm create @farm.js/app@beta my-vue-app --template basic --renderer vue --typescript
-pnpm create @farm.js/app@beta my-svelte-app --template basic --renderer svelte --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-preact-app --template basic --renderer preact --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-solid-app --template basic --renderer solid --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-vue-app --template basic --renderer vue --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-svelte-app --template basic --renderer svelte --typescript
 ```
 
 See [Renderers](/docs/renderers) before choosing an adapter. Integration starters currently use
@@ -68,7 +68,7 @@ integration wiring, an app-owned UI feature, `.env.example`, and a minimal dark 
 For example:
 
 ```bash
-pnpm create @farm.js/app@beta stripe-app --template stripe --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta stripe-app --template stripe --typescript
 ```
 
 The generated README lists the required environment values and links to the provider guide.
@@ -76,7 +76,7 @@ The generated README lists the required environment values and links to the prov
 To explore Farm's experimental React AOT compiler with the shared dark starter UI:
 
 ```bash
-pnpm create @farm.js/app@beta compiler-app --template react-compiler --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta compiler-app --template react-compiler --typescript
 ```
 
 The same project is available as the standalone

--- a/docs/src/app/docs/getting-started/page.md
+++ b/docs/src/app/docs/getting-started/page.md
@@ -15,12 +15,14 @@ Farm keeps the first project small: an app directory, a config file, package met
 **Terminal**
 
 ```bash
-pnpm create @farm.js/app@beta my-app --template basic --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-app --template basic --typescript
 cd my-app
 pnpm dev
 ```
 
 This command follows the current `beta` dist-tag and explicitly selects the minimal Basic starter.
+The scoped `minimumReleaseAge=0` setting lets pnpm 11 use a beta published within the last 24 hours
+without changing your global supply-chain policy.
 Use `pnpm create`, not `pnpm add`: pnpm resolves the `@farm.js/app` initializer name to the
 published `@farm.js/create-app` package. The scaffolder installs React and all other starter
 dependencies automatically. Use `--skip-install` if you only want it to generate the project

--- a/docs/src/app/docs/renderers/page.md
+++ b/docs/src/app/docs/renderers/page.md
@@ -149,7 +149,7 @@ renderers; rewrite component and client-state code using the selected renderer's
 The Basic and Better Auth templates support every renderer directly:
 
 ```bash
-pnpm create @farm.js/app@beta my-auth-app --template better-auth --renderer vue --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-auth-app --template better-auth --renderer vue --typescript
 ```
 
 Other integration starter templates currently target React. Add their renderer-neutral server

--- a/docs/src/app/docs/renderers/preact/page.md
+++ b/docs/src/app/docs/renderers/preact/page.md
@@ -13,7 +13,7 @@ application selects Preact.
 ## Create an app
 
 ```bash
-pnpm create @farm.js/app@beta my-preact-app --template basic --renderer preact --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-preact-app --template basic --renderer preact --typescript
 ```
 
 For an existing Basic app, install the adapter and Preact:
@@ -110,7 +110,7 @@ compatibility surfaces until their Preact paths are covered by dedicated tests.
 The Better Auth starter includes native Preact routes and forms:
 
 ```bash
-pnpm create @farm.js/app@beta my-auth-app --template better-auth --renderer preact --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-auth-app --template better-auth --renderer preact --typescript
 ```
 
 Other integration starter templates currently target React, so add their renderer-neutral provider

--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -12,7 +12,7 @@ do not need a renderer option or an additional adapter package.
 ## Create an app
 
 ```bash
-pnpm create @farm.js/app@beta my-app --template basic --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-app --template basic --typescript
 ```
 
 Omitting `renderer` keeps React active:
@@ -97,7 +97,7 @@ Start from the focused experimental starter when you want the compiler flag, sha
 UI, a live AOT-versus-React comparison, and a reproducible browser check already wired together:
 
 ```bash
-pnpm create @farm.js/app@beta compiler-app --template react-compiler --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta compiler-app --template react-compiler --typescript
 ```
 
 You can also clone the standalone

--- a/docs/src/app/docs/renderers/solid/page.md
+++ b/docs/src/app/docs/renderers/solid/page.md
@@ -12,7 +12,7 @@ the FARMJS renderer contract. React remains the default unless the application s
 ## Create an app
 
 ```bash
-pnpm create @farm.js/app@beta my-solid-app --template basic --renderer solid --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-solid-app --template basic --renderer solid --typescript
 ```
 
 For an existing Basic app, install the adapter and Solid runtime:
@@ -110,7 +110,7 @@ adapter, and generated JSX metadata images remain React-oriented today.
 The Better Auth starter includes native Solid routes, signals, and forms:
 
 ```bash
-pnpm create @farm.js/app@beta my-auth-app --template better-auth --renderer solid --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-auth-app --template better-auth --renderer solid --typescript
 ```
 
 Other integration starter templates currently target React, so add their renderer-neutral provider

--- a/docs/src/app/docs/renderers/svelte/page.md
+++ b/docs/src/app/docs/renderers/svelte/page.md
@@ -12,7 +12,7 @@ the FARMJS renderer contract. React remains the default unless the application s
 ## Create an app
 
 ```bash
-pnpm create @farm.js/app@beta my-svelte-app --template basic --renderer svelte --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-svelte-app --template basic --renderer svelte --typescript
 ```
 
 For an existing Basic app, install the adapter and Svelte 5:
@@ -130,7 +130,7 @@ the docs adapter, and generated JSX metadata images remain React-oriented today.
 The Better Auth starter includes native Svelte routes, runes, and forms:
 
 ```bash
-pnpm create @farm.js/app@beta my-auth-app --template better-auth --renderer svelte --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-auth-app --template better-auth --renderer svelte --typescript
 ```
 
 Other integration starter templates currently target React, so add their renderer-neutral provider

--- a/docs/src/app/docs/renderers/vue/page.md
+++ b/docs/src/app/docs/renderers/vue/page.md
@@ -13,7 +13,7 @@ Vue.
 ## Create an app
 
 ```bash
-pnpm create @farm.js/app@beta my-vue-app --template basic --renderer vue --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-vue-app --template basic --renderer vue --typescript
 ```
 
 For an existing Basic app, install the adapter and Vue runtime:
@@ -140,7 +140,7 @@ adapter, and generated JSX metadata images remain React-oriented today.
 The Better Auth starter includes native Vue SFC routes, composables, and forms:
 
 ```bash
-pnpm create @farm.js/app@beta my-auth-app --template better-auth --renderer vue --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-auth-app --template better-auth --renderer vue --typescript
 ```
 
 Other integration starter templates currently target React, so add their renderer-neutral provider

--- a/docs/src/components/home/install-command.tsx
+++ b/docs/src/components/home/install-command.tsx
@@ -61,7 +61,7 @@ const commands: readonly CommandOption[] = [
   },
   {
     label: "pnpm",
-    command: "pnpm create @farm.js/app@beta my-app",
+    command: "pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-app",
     brand: pnpmIconUrl,
     kind: "install",
   },

--- a/packages/create-farm-app/README.md
+++ b/packages/create-farm-app/README.md
@@ -5,7 +5,7 @@ Create a new FARMJS application
 FARMJS is currently in beta.
 
 ```bash
-pnpm create @farm.js/app@beta my-app --template basic --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-app --template basic --typescript
 cd my-app
 pnpm dev
 ```
@@ -13,7 +13,8 @@ pnpm dev
 The scaffolder installs FARMJS, React by default, TypeScript, and the other starter dependencies
 automatically. The command explicitly selects the minimal Basic starter. Use `pnpm create`, not
 `pnpm add`; pnpm resolves this initializer command to the published `@farm.js/create-app` package.
-Pass `--skip-install` when you only want to generate the project files.
+The command scopes `minimumReleaseAge=0` to the initializer so pnpm 11 can resolve a beta published
+within the last 24 hours. Pass `--skip-install` when you only want to generate the project files.
 
 Choose React, Preact, Solid, Vue, or Svelte for the Basic and Better Auth starters:
 

--- a/packages/create-farm-app/README.md
+++ b/packages/create-farm-app/README.md
@@ -19,7 +19,7 @@ within the last 24 hours. Pass `--skip-install` when you only want to generate t
 Choose React, Preact, Solid, Vue, or Svelte for the Basic and Better Auth starters:
 
 ```bash
-pnpm create @farm.js/app@beta my-app --template better-auth --renderer solid --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-app --template better-auth --renderer solid --typescript
 ```
 
 React remains the default when `--renderer` is omitted. The interactive Basic and Better Auth
@@ -28,7 +28,7 @@ flows also offer a renderer chooser.
 List every starter:
 
 ```bash
-pnpm create @farm.js/app@beta --list-templates
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta --list-templates
 ```
 
 Available templates:
@@ -43,7 +43,7 @@ home page, and setup documentation. Better Auth has renderer-native UI for all f
 other integration templates currently use React. For example:
 
 ```bash
-pnpm create @farm.js/app@beta stripe-app --template stripe --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta stripe-app --template stripe --typescript
 ```
 
 See the [FARMJS repository](https://github.com/farming-labs/farm.js) for documentation, examples, and support.

--- a/packages/create-farm-app/templates/auth/README.md
+++ b/packages/create-farm-app/templates/auth/README.md
@@ -20,7 +20,7 @@ This project was generated from the FARMJS Auth template included with `@farm.js
 ## Quick start
 
 ```bash
-pnpm create @farm.js/app@beta my-app --template auth --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-app --template auth --typescript
 cd my-app
 pnpm dev
 ```

--- a/packages/create-farm-app/templates/better-auth/README.md
+++ b/packages/create-farm-app/templates/better-auth/README.md
@@ -19,7 +19,7 @@ This project was generated from the Better Auth template included with `@farm.js
 ## Quick start
 
 ```bash
-pnpm create @farm.js/app@beta my-app --template better-auth --renderer solid --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-app --template better-auth --renderer solid --typescript
 cd my-app
 cp .env.example .env.local
 ```

--- a/packages/create-farm-app/templates/react-compiler/README.md
+++ b/packages/create-farm-app/templates/react-compiler/README.md
@@ -10,7 +10,7 @@ update beside ordinary React reconciliation.
 ## Create this starter
 
 ```bash
-pnpm create @farm.js/app@beta my-compiler-app --template react-compiler --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-compiler-app --template react-compiler --typescript
 cd my-compiler-app
 pnpm dev
 ```

--- a/packages/farm-preact/README.md
+++ b/packages/farm-preact/README.md
@@ -19,5 +19,5 @@ export default defineConfig({
 Create a complete starter from the FARMJS CLI:
 
 ```bash
-pnpm create @farm.js/app@beta my-preact-app --template basic --renderer preact --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-preact-app --template basic --renderer preact --typescript
 ```

--- a/packages/farm-svelte/README.md
+++ b/packages/farm-svelte/README.md
@@ -19,7 +19,7 @@ export default defineConfig({
 Create a complete starter:
 
 ```bash
-pnpm create @farm.js/app@beta my-svelte-app --template basic --renderer svelte --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-svelte-app --template basic --renderer svelte --typescript
 ```
 
 See the [Svelte renderer guide](https://farm.js.dev/docs/renderers/svelte) and the

--- a/playground/src/app/blog/[slug]/page.tsx
+++ b/playground/src/app/blog/[slug]/page.tsx
@@ -58,7 +58,7 @@ export default function BlogPostPage({ params, searchParams }: PageProps) {
         <p>Ready to build your first Farm.js application? Let's get started!</p>
         
         <h2>Installation</h2>
-        <pre><code>pnpm create @farm.js/app@beta my-app
+        <pre><code>pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-app
 cd my-app
 pnpm dev</code></pre>
         

--- a/scripts/generate-docs-og.mjs
+++ b/scripts/generate-docs-og.mjs
@@ -413,7 +413,7 @@ try {
             </div>
 
             <footer class="footer">
-              <div class="command"><span class="prompt">$</span><strong>pnpm create @farm.js/app@beta</strong> my-app</div>
+              <div class="command"><span class="prompt">$</span><strong>pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta</strong> my-app</div>
               <div class="url">farmjs.dev</div>
             </footer>
           </section>

--- a/skills/farmjs/SKILL.md
+++ b/skills/farmjs/SKILL.md
@@ -58,9 +58,9 @@ Use `"use client"` when a component uses React hooks, browser APIs, or client-on
 Follow the current beta channel for beta apps and use `pnpm create`, not `pnpm add`:
 
 ```bash
-pnpm create @farm.js/app@beta my-app --template basic --typescript
-pnpm create @farm.js/app@beta my-app --template basic --renderer vue --typescript
-pnpm create @farm.js/app@beta --list-templates
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-app --template basic --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-app --template basic --renderer vue --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta --list-templates
 ```
 
 React is the default renderer. The Basic and Better Auth starters support `react`, `preact`,


### PR DESCRIPTION
## What changed

- update every user-facing pnpm scaffolding example to scope `minimumReleaseAge=0` to the create command
- explain the pnpm 11 behavior on the getting-started and package pages
- keep npm, Yarn, and Bun commands unchanged

## Why

pnpm 11 protects users by ignoring package versions published within the last 24 hours when resolving a dist-tag. As a result, `pnpm create @farm.js/app@beta` can select an older `@farm.js/create-app` beta even though npm's `beta` tag points to the newest release. The resolver makes this choice before the FARMJS initializer runs, so it cannot be corrected inside the scaffolder.

The scoped config override preserves the simple `@beta` workflow while applying only to this invocation; it does not change the user's global pnpm policy.

## Impact

New users copying a pnpm command from the README, docs homepage, getting-started guide, playground, package README, or auth starter READMEs receive the newest published FARMJS beta immediately.

## Verification

- reproduced pnpm 11.18.0 selecting beta.20 from a fresh store while npm's `beta` tag pointed to beta.22
- confirmed `pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta ...` generated beta.22 with both pnpm 11.18.0 and pnpm 8.12.1
- `corepack pnpm exec oxfmt --check ...`
- `node --test packages/create-farm-app/test/create-app.test.mjs`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pnpm beta scaffolding: `pnpm create @farm.js/app@beta` could select an older beta under pnpm 11, while the updated command resolves the newest beta by scoping `--config.minimumReleaseAge=0` to that invocation. Updated all pnpm scaffolding examples and guidance; npm, Yarn, and Bun commands remain unchanged.

- The override bypasses pnpm 11’s 24-hour hold only for scaffolding and leaves the global policy unchanged.

<sup>Written for commit ba05279bb87a7b58c50b6adbf976e46658082410. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

