### PR TITLE
fix: dotted route segments 404 in dev — treated as static assets

### DIFF
--- a/examples/basic/src/app/repos/[owner]/[repo]/page.tsx
+++ b/examples/basic/src/app/repos/[owner]/[repo]/page.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import type { PageProps } from "@farm.js/core";
+
+// Route segments may contain dots (e.g. /repos/kinfish/farm.js). This page
+// exists so e2e coverage can assert dotted segments reach the router instead
+// of being treated as static assets.
+export default function RepoPage({ params = {} }: PageProps) {
+  const { owner = "", repo = "" } = params;
+
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h1 data-testid="repo-title">
+        {owner}/{repo}
+      </h1>
+      <p data-testid="repo-owner">Owner: {owner}</p>
+      <p data-testid="repo-name">Repository: {repo}</p>
+    </div>
+  );
+}

--- a/packages/farm/src/__tests__/dev-static.test.ts
+++ b/packages/farm/src/__tests__/dev-static.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { devServableFileExists } from "../dev-static";
+
+describe("devServableFileExists", () => {
+  let root: string;
+  let publicDir: string;
+
+  beforeAll(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-dev-static-"));
+    publicDir = path.join(root, "public");
+    fs.mkdirSync(path.join(root, "src"), { recursive: true });
+    fs.mkdirSync(publicDir, { recursive: true });
+    fs.writeFileSync(path.join(root, "src", "main.tsx"), "export {};\n");
+    fs.writeFileSync(path.join(publicDir, "favicon.ico"), "icon");
+    fs.writeFileSync(path.join(publicDir, "hello world.txt"), "hi");
+  });
+
+  afterAll(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns true for a real file under the project root", () => {
+    expect(devServableFileExists("/src/main.tsx", [publicDir, root])).toBe(true);
+  });
+
+  it("returns true for a real file under the public dir", () => {
+    expect(devServableFileExists("/favicon.ico", [publicDir, root])).toBe(true);
+  });
+
+  it("decodes URI-encoded pathnames", () => {
+    expect(devServableFileExists("/hello%20world.txt", [publicDir, root])).toBe(true);
+  });
+
+  it("returns false for a dotted route path with no backing file", () => {
+    expect(devServableFileExists("/kinfish/farm.js", [publicDir, root])).toBe(false);
+  });
+
+  it("returns false for directories", () => {
+    expect(devServableFileExists("/src", [publicDir, root])).toBe(false);
+  });
+
+  it("returns false for path traversal attempts", () => {
+    const outside = path.join(root, "outside.txt");
+    fs.writeFileSync(outside, "secret");
+    expect(devServableFileExists("/../outside.txt", [publicDir])).toBe(false);
+    expect(devServableFileExists("/..%2Foutside.txt", [publicDir])).toBe(false);
+  });
+
+  it("returns false for malformed URI encodings", () => {
+    expect(devServableFileExists("/%zz.js", [publicDir, root])).toBe(false);
+  });
+
+  it("ignores non-string base dirs", () => {
+    expect(devServableFileExists("/favicon.ico", [false, undefined, publicDir])).toBe(true);
+    expect(devServableFileExists("/favicon.ico", [false, undefined])).toBe(false);
+  });
+});

--- a/packages/farm/src/__tests__/utils.test.ts
+++ b/packages/farm/src/__tests__/utils.test.ts
@@ -90,6 +90,16 @@ describe("matchRoute", () => {
     expect(result.params).toEqual({ id: "123" });
   });
 
+  it("should match dynamic segments containing dots", () => {
+    const segments = [
+      { segment: "user", isDynamic: true, isOptional: false, isCatchAll: false },
+      { segment: "repo", isDynamic: true, isOptional: false, isCatchAll: false },
+    ];
+    const result = matchRoute("/kinfish/farm.js", segments);
+    expect(result.matches).toBe(true);
+    expect(result.params).toEqual({ user: "kinfish", repo: "farm.js" });
+  });
+
   it("should match catch-all routes", () => {
     const segments = [
       { segment: "blog", isDynamic: false, isOptional: false, isCatchAll: false },

--- a/packages/farm/src/dev-static.ts
+++ b/packages/farm/src/dev-static.ts
@@ -1,0 +1,37 @@
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Route segments may legitimately contain dots (e.g. /kinfish/farm.js), so a
+ * dot alone cannot classify a dev request as a static asset. A dotted path is
+ * only treated as an asset when it maps to a real file under one of the
+ * servable base dirs (project root, public dir), matching the
+ * filesystem-first behavior of production hosting.
+ */
+export function devServableFileExists(
+  pathname: string,
+  baseDirs: Array<string | false | undefined>,
+): boolean {
+  let decodedPathname: string;
+  try {
+    decodedPathname = decodeURIComponent(pathname);
+  } catch {
+    return false;
+  }
+  const relativePathname = decodedPathname.replace(/^\/+/, "");
+  if (!relativePathname) return false;
+  for (const baseDir of baseDirs) {
+    if (typeof baseDir !== "string" || baseDir.length === 0) continue;
+    const resolvedBase = path.resolve(baseDir);
+    const candidate = path.resolve(resolvedBase, relativePathname);
+    if (!candidate.startsWith(resolvedBase + path.sep)) continue;
+    try {
+      if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+        return true;
+      }
+    } catch {
+      // Ignore filesystem errors and keep checking other base dirs.
+    }
+  }
+  return false;
+}

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -45,6 +45,7 @@ import { farmEnvironmentFunctionsPlugin } from "./environment-vite";
 import { FARM_VERSION } from "./version";
 import { createDeferredDataResponse } from "./deferred";
 import { _withAfterNodeMiddleware } from "./after";
+import { devServableFileExists } from "./dev-static";
 import {
   createFarmDeploymentMismatchResponse,
   FARM_DEPLOYMENT_ID_HEADER,
@@ -1642,12 +1643,24 @@ window.__FARM_MANIFEST__ = ${inlineValue({
           }
 
           // Skip internal Vite requests
-          if (
-            req.url?.startsWith("/@") ||
-            req.url?.startsWith("/node_modules") ||
-            (requestPathname.includes(".") && !requestPathname.endsWith(".html"))
-          ) {
+          if (req.url?.startsWith("/@") || req.url?.startsWith("/node_modules")) {
             return next();
+          }
+
+          // Dotted paths are usually static assets (modules, images, source
+          // maps), but dots are also valid inside route segments. Only skip
+          // the router when the request maps to a real file on disk or no app
+          // route matches the pathname.
+          if (requestPathname.includes(".") && !requestPathname.endsWith(".html")) {
+            const matchesAppRoute = Boolean(
+              farmApp?.getRouteManager()?.matchRoute(requestPathname)?.route,
+            );
+            if (
+              !matchesAppRoute ||
+              devServableFileExists(requestPathname, [server.config.publicDir, server.config.root])
+            ) {
+              return next();
+            }
           }
 
           // Handle SPA page-data requests for client-side navigation

--- a/packages/farmjs-plugin/src/dev-static.test.ts
+++ b/packages/farmjs-plugin/src/dev-static.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { devServableFileExists } from "./dev-static.js";
+
+describe("devServableFileExists", () => {
+  let root: string;
+  let publicDir: string;
+
+  beforeAll(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "farmjs-plugin-dev-static-"));
+    publicDir = path.join(root, "public");
+    fs.mkdirSync(path.join(root, "src"), { recursive: true });
+    fs.mkdirSync(publicDir, { recursive: true });
+    fs.writeFileSync(path.join(root, "src", "main.tsx"), "export {};\n");
+    fs.writeFileSync(path.join(publicDir, "favicon.ico"), "icon");
+  });
+
+  afterAll(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns true for real files, false for dotted route paths", () => {
+    expect(devServableFileExists("/src/main.tsx", [publicDir, root])).toBe(true);
+    expect(devServableFileExists("/favicon.ico", [publicDir, root])).toBe(true);
+    expect(devServableFileExists("/kinfish/farm.js", [publicDir, root])).toBe(false);
+  });
+
+  it("returns false for directories and traversal attempts", () => {
+    expect(devServableFileExists("/src", [publicDir, root])).toBe(false);
+    expect(devServableFileExists("/../etc/passwd", [publicDir, root])).toBe(false);
+  });
+});

--- a/packages/farmjs-plugin/src/dev-static.ts
+++ b/packages/farmjs-plugin/src/dev-static.ts
@@ -1,0 +1,36 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/**
+ * Route segments may legitimately contain dots (e.g. /kinfish/farm.js), so a
+ * dot alone cannot classify a dev request as a static asset. A dotted path is
+ * only treated as an asset when it maps to a real file under the project root
+ * or public dir, matching the filesystem-first behavior of production hosting.
+ */
+export function devServableFileExists(
+  pathname: string,
+  baseDirs: Array<string | false | undefined>,
+): boolean {
+  let decodedPathname: string;
+  try {
+    decodedPathname = decodeURIComponent(pathname);
+  } catch {
+    return false;
+  }
+  const relativePathname = decodedPathname.replace(/^\/+/, "");
+  if (!relativePathname) return false;
+  for (const baseDir of baseDirs) {
+    if (typeof baseDir !== "string" || baseDir.length === 0) continue;
+    const resolvedBase = path.resolve(baseDir);
+    const candidate = path.resolve(resolvedBase, relativePathname);
+    if (!candidate.startsWith(resolvedBase + path.sep)) continue;
+    try {
+      if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+        return true;
+      }
+    } catch {
+      // Ignore filesystem errors and keep checking other base dirs.
+    }
+  }
+  return false;
+}

--- a/packages/farmjs-plugin/src/middleware/index.ts
+++ b/packages/farmjs-plugin/src/middleware/index.ts
@@ -18,6 +18,7 @@ import type { Plugin, ViteDevServer } from "vite";
 import type { IncomingMessage, ServerResponse } from "http";
 import { createRequire } from "node:module";
 import { _withAfterNodeMiddleware } from "@farm.js/core/after";
+import { devServableFileExists } from "../dev-static.js";
 
 // Create require for ESM compatibility
 const require_ = createRequire(import.meta.url);
@@ -548,12 +549,16 @@ export default function farmMiddleware(options: FarmMiddlewareOptions = {}): Plu
             const url = req.url || "/";
             const pathname = url.split("?")[0];
 
-            // Skip Vite internal requests
+            // Skip Vite internal requests and real static assets. Dotted
+            // paths that don't map to a file on disk are app routes (route
+            // segments may contain dots) and must still run middleware.
             if (
               pathname.startsWith("/@") ||
               pathname.startsWith("/__") ||
               pathname.startsWith("/node_modules") ||
-              (pathname.includes(".") && !pathname.endsWith("/"))
+              (pathname.includes(".") &&
+                !pathname.endsWith("/") &&
+                devServableFileExists(pathname, [server.config.publicDir, server.config.root]))
             ) {
               return next();
             }

--- a/packages/farmjs-plugin/src/rsc/index.ts
+++ b/packages/farmjs-plugin/src/rsc/index.ts
@@ -37,6 +37,7 @@ import { resolveRscBuildOutputPath } from "./build-paths.js";
 import { assertRscPackageCompatibility } from "./compatibility.js";
 import fs from "fs/promises";
 import path from "path";
+import { devServableFileExists } from "../dev-static.js";
 import { pathToFileURL } from "node:url";
 import { createRequire } from "node:module";
 // Use API and middleware plugins from @farm.js/core (require so CJS build resolves when ESM .mjs is missing)
@@ -1148,13 +1149,17 @@ if (document.readyState === 'loading') {
             const pathname = url.split("?")[0];
             const method = req.method || "GET";
 
+            // Dotted paths only skip RSC rendering when they map to a real
+            // file on disk — route segments may legitimately contain dots.
             if (
               pathname.startsWith("/@") ||
               pathname.startsWith("/__") ||
               pathname.startsWith("/node_modules") ||
               pathname.startsWith("/src/") ||
               pathname.startsWith("/api/") ||
-              (pathname.includes(".") && !pathname.endsWith("/"))
+              (pathname.includes(".") &&
+                !pathname.endsWith("/") &&
+                devServableFileExists(pathname, [server.config.publicDir, server.config.root]))
             ) {
               return next();
             }

--- a/tests/e2e/route-boundaries.spec.ts
+++ b/tests/e2e/route-boundaries.spec.ts
@@ -15,6 +15,27 @@ test.describe("Route-level boundaries", () => {
     await expect(page.getByTestId("route-loading-final")).toBeVisible({ timeout: 15000 });
   });
 
+  test("dynamic route segments containing dots reach the router instead of 404ing as assets", async ({
+    page,
+    request,
+  }) => {
+    const response = await request.get("/repos/kinfish/farm.js");
+    expect(response.status()).toBe(200);
+
+    const html = await response.text();
+    expect(html).toContain("Repository:");
+
+    await page.goto("/repos/kinfish/farm.js");
+    await expect(page.getByTestId("repo-title")).toHaveText("kinfish/farm.js");
+    await expect(page.getByTestId("repo-owner")).toHaveText("Owner: kinfish");
+    await expect(page.getByTestId("repo-name")).toHaveText("Repository: farm.js");
+  });
+
+  test("real static assets are still served when dotted routes exist", async ({ request }) => {
+    const missing = await request.get("/no-such-file.png");
+    expect(missing.status()).toBe(404);
+  });
+
   test("error boundary renders route-scoped fallback for server render failures", async ({
     page,
     request,


### PR DESCRIPTION
## Problem

Any request pathname containing a dot was treated as a static asset by the dev-server middleware, so routes with dotted segments — e.g. `/kinfish/farm.js` matched by `/[user]/[repo]` — never reached the router and returned 404. Since real-world values (repo names, file names, versions like `/v1.2/docs`) frequently contain dots, apps had to work around this by passing them as query params.

The router itself has no dot restriction; the request was dropped before route matching:

- `packages/farm/src/vite.ts` — dev middleware skipped every dotted path via `requestPathname.includes(".")`
- `packages/farmjs-plugin/src/middleware/index.ts` — user middleware never ran for dotted paths
- `packages/farmjs-plugin/src/rsc/index.ts` — RSC dev rendering skipped dotted paths

## Fix

A dotted path is only handed to the asset pipeline when it maps to a **real file** under the project root or public dir (mirroring the filesystem-first behavior of production hosting, where static serving is existence-based), or when **no app route matches** the pathname. Otherwise it proceeds to SSR/route handling as normal.

The existence check lives in a shared `devServableFileExists` helper (added to both packages) with URI decoding and path-traversal containment.

## Behavior after the fix (verified against a live `farm dev` server)

| Request | Before | After |
|---|---|---|
| `/repos/kinfish/farm.js` (dynamic route) | 404 | 200, SSR renders with correct params |
| `/favicon.ico` (real public asset) | 200 | 200 |
| `/src/app/page.tsx` (Vite module) | 200 | 200 |
| `/@vite/client` | 200 | 200 |
| `/no-such-file.png` | 404 | 404 |

## Tests

- Unit tests for `devServableFileExists` (real files, public dir, URI decoding, traversal, directories) in both packages
- `matchRoute` unit test for dotted dynamic segments
- New dotted dynamic route fixture in `examples/basic` (`/repos/[owner]/[repo]`) plus e2e specs asserting the dotted route renders and missing assets still 404
- Full `@farm.js/core` and `@farm.js/plugin` suites: no new failures vs `main` baseline (identical pre-existing failure set); e2e `route-boundaries.spec.ts` 4/4 passing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix dev-server routing so dotted path segments reach the app router in dev instead of 404ing as static assets. Routes like /repos/kinfish/farm.js now work unless the path maps to a real file.

- **Bug Fixes**
  - Added `devServableFileExists` to detect real files under project root/public, with URI decoding and traversal guards.
  - Updated dev middleware in `packages/farm` and `packages/farmjs-plugin` (incl. RSC) to only skip routing when a file exists or no app route matches.
  - Added unit tests and an example dotted route with e2e coverage to verify behavior.

<sup>Written for commit c67d1efede0c1b7f00e1edc63d312f8d9d3402ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

