### PR TITLE
feat: add integration starter templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ pnpm dev
 
 Your app will be running at `http://localhost:3000`!
 
+Use `--list-templates` to choose a ready-to-configure Auth0, Auth.js, Autumn, Clerk, Inngest,
+Trigger.dev, Polar, Resend, Stripe, Supabase, Unkey, WorkOS, or AI starter.
+
 ### Manual Installation
 
 ```bash

--- a/docs/src/app/docs/cli/page.md
+++ b/docs/src/app/docs/cli/page.md
@@ -8,6 +8,18 @@ section: "Reference"
 
 Use the Farm CLI to run, build, generate types, migrate apps, deploy output, and add integrations.
 
+## Create an app
+
+```bash
+pnpm create @farm.js/app@beta my-app --template basic --typescript
+pnpm create @farm.js/app@beta stripe-app --template stripe --typescript
+pnpm create @farm.js/app@beta --list-templates
+```
+
+The create-app CLI includes Basic, Farm.js Auth, Better Auth, and one ready-to-configure starter
+for every provider supported by `farm add integration --ui`. See [Getting Started](/docs/getting-started#choose-a-starter)
+for the complete template catalog.
+
 ## Common commands
 
 | Command                          | Purpose                                                              |
@@ -63,7 +75,9 @@ farm add integration better-auth --ui
 farm add integration jobs-trigger
 ```
 
-Without `--ui`, the CLI installs integration wiring. With `--ui`, it also installs app-owned shadcn-style components for the selected provider.
+Without `--ui`, the CLI installs the selected first-party provider package and its integration
+wiring. With `--ui`, it also installs app-owned shadcn-style components for that provider. Farm
+package versions follow the app's installed `@farm.js/core` version, including beta releases.
 
 ## Generate types
 

--- a/docs/src/app/docs/getting-started/page.md
+++ b/docs/src/app/docs/getting-started/page.md
@@ -26,6 +26,38 @@ published `@farm.js/create-app` package. The scaffolder installs React and all o
 dependencies automatically. Use `--skip-install` if you only want it to generate the project
 files.
 
+## Choose a starter
+
+Use `--list-templates` to see the same catalog in the terminal. Provider templates include the
+integration wiring, an app-owned UI feature, `.env.example`, and a minimal dark home page.
+
+| Template       | Included integration      |
+| -------------- | ------------------------- |
+| `basic`        | Minimal Farm.js app       |
+| `auth`         | Farm.js Auth              |
+| `better-auth`  | Better Auth               |
+| `ai`           | AI SDK chat               |
+| `auth0`        | Auth0                     |
+| `authjs`       | Auth.js with GitHub OAuth |
+| `autumn`       | Autumn billing            |
+| `clerk`        | Clerk                     |
+| `jobs-inngest` | Inngest jobs              |
+| `jobs-trigger` | Trigger.dev jobs          |
+| `polar`        | Polar billing             |
+| `resend`       | Resend email              |
+| `stripe`       | Stripe billing            |
+| `supabase`     | Supabase Auth             |
+| `unkey`        | Unkey API keys            |
+| `workos`       | WorkOS AuthKit            |
+
+For example:
+
+```bash
+pnpm create @farm.js/app@beta stripe-app --template stripe --typescript
+```
+
+The generated README lists the required environment values and links to the provider guide.
+
 ## What you get
 
 - File-based routes in src/app.

--- a/docs/src/app/docs/integrations/auth/better-auth/page.md
+++ b/docs/src/app/docs/integrations/auth/better-auth/page.md
@@ -78,7 +78,8 @@ export const appIntegrations = {
 } as const;
 ```
 
-The direct `@farm.js/better-auth` package import remains supported as well. The `@farm.js/integrations/better-auth` path is the compatibility export used by `farm add integration better-auth`.
+The direct `@farm.js/better-auth` package import is what `farm add integration better-auth` writes.
+The `@farm.js/integrations/better-auth` compatibility export remains supported for existing apps.
 
 Farm mounts the instance handler for both methods:
 

--- a/packages/create-farm-app/README.md
+++ b/packages/create-farm-app/README.md
@@ -15,4 +15,24 @@ automatically. The command explicitly selects the minimal Basic starter. Use `pn
 `pnpm add`; pnpm resolves this initializer command to the published `@farm.js/create-app` package.
 Pass `--skip-install` when you only want to generate the project files.
 
+List every starter:
+
+```bash
+pnpm create @farm.js/app@beta --list-templates
+```
+
+Available templates:
+
+- Core: `basic`, `auth`, `better-auth`
+- Auth: `auth0`, `authjs`, `clerk`, `supabase`, `workos`
+- Billing: `autumn`, `polar`, `stripe`
+- Product integrations: `ai`, `jobs-inngest`, `jobs-trigger`, `resend`, `unkey`
+
+Integration templates include provider wiring, a local UI feature, `.env.example`, a minimal dark
+home page, and setup documentation. For example:
+
+```bash
+pnpm create @farm.js/app@beta stripe-app --template stripe --typescript
+```
+
 See the [FARMJS repository](https://github.com/farming-labs/farm.js) for documentation, examples, and support.

--- a/packages/create-farm-app/bin/create-farm-app.js
+++ b/packages/create-farm-app/bin/create-farm-app.js
@@ -10,6 +10,7 @@ program
   .version(version)
   .argument("[project-name]", "Name of the project")
   .option("-t, --template <template>", "Template to use")
+  .option("--list-templates", "List all available starter templates")
   .option("--typescript", "Use TypeScript template")
   .option("--skip-install", "Skip installing dependencies")
   .action(async (projectName, options) => {

--- a/packages/create-farm-app/package.json
+++ b/packages/create-farm-app/package.json
@@ -43,6 +43,7 @@
     "prompts": "^2.4.2"
   },
   "devDependencies": {
+    "@farm.js/cli": "workspace:*",
     "@types/node": "^20.10.5",
     "@types/prompts": "^2.4.9",
     "tsdown": "^0.15.7",

--- a/packages/create-farm-app/src/farm-cli-add-integration.d.ts
+++ b/packages/create-farm-app/src/farm-cli-add-integration.d.ts
@@ -1,0 +1,28 @@
+declare module "@farm.js/cli/add-integration" {
+  export type FarmIntegrationProvider =
+    | "ai"
+    | "auth0"
+    | "authjs"
+    | "autumn"
+    | "better-auth"
+    | "clerk"
+    | "jobs-inngest"
+    | "jobs-trigger"
+    | "polar"
+    | "resend"
+    | "stripe"
+    | "supabase"
+    | "unkey"
+    | "workos";
+
+  export interface AddFarmIntegrationResult {
+    env: string[];
+    notes: string[];
+  }
+
+  export function addFarmIntegration(options: {
+    root?: string;
+    provider: string;
+    ui?: boolean;
+  }): Promise<AddFarmIntegrationResult>;
+}

--- a/packages/create-farm-app/src/index.ts
+++ b/packages/create-farm-app/src/index.ts
@@ -2,22 +2,33 @@ import prompts from "prompts";
 import path from "path";
 import fs from "fs/promises";
 import { spawn } from "node:child_process";
+import {
+  addFarmIntegration,
+  type AddFarmIntegrationResult,
+  type FarmIntegrationProvider,
+} from "@farm.js/cli/add-integration";
 import { logger, showBanner } from "./utils";
 
 interface CreateAppOptions {
   template?: string;
   typescript?: boolean;
   skipInstall?: boolean;
+  listTemplates?: boolean;
 }
 
-const templateDetails: Record<
-  string,
-  {
-    title: string;
-    description: string;
-    instructions: string[];
-  }
-> = {
+interface TemplateDetails {
+  title: string;
+  description: string;
+  instructions: string[];
+  integration?: {
+    provider: FarmIntegrationProvider;
+    label: string;
+    route: string;
+    docsPath: string;
+  };
+}
+
+const templateDetails: Record<string, TemplateDetails> = {
   basic: {
     title: "Farm.js Basic",
     description: "A minimal Farm.js app with built-in Tailwind support",
@@ -41,7 +52,130 @@ const templateDetails: Record<
       "Better Auth migrations run automatically when the auth instance starts.",
     ],
   },
+  ai: integrationTemplate({
+    title: "Farm.js AI",
+    description: "AI SDK chat route with a ready-to-use chat interface",
+    provider: "ai",
+    label: "AI",
+    route: "/integrations/ai",
+    docsPath: "/docs/integrations",
+  }),
+  auth0: integrationTemplate({
+    title: "Farm.js Auth0",
+    description: "Auth0 login, sessions, protected routes, and account controls",
+    provider: "auth0",
+    label: "Auth0",
+    route: "/integrations/auth0",
+    docsPath: "/docs/integrations/auth/auth0",
+  }),
+  authjs: integrationTemplate({
+    title: "Farm.js Auth.js",
+    description: "Auth.js with GitHub OAuth and Farm-owned route mounting",
+    provider: "authjs",
+    label: "Auth.js",
+    route: "/integrations/authjs",
+    docsPath: "/docs/integrations/auth/authjs",
+  }),
+  autumn: integrationTemplate({
+    title: "Farm.js Autumn",
+    description: "Autumn products, checkout, billing state, and customer portal",
+    provider: "autumn",
+    label: "Autumn",
+    route: "/integrations/autumn",
+    docsPath: "/docs/integrations/autumn",
+  }),
+  clerk: integrationTemplate({
+    title: "Farm.js Clerk",
+    description: "Clerk authentication, account entry points, and protected routes",
+    provider: "clerk",
+    label: "Clerk",
+    route: "/integrations/clerk",
+    docsPath: "/docs/integrations/auth/clerk",
+  }),
+  "jobs-inngest": integrationTemplate({
+    title: "Farm.js Inngest",
+    description: "Typed background jobs backed by Inngest",
+    provider: "jobs-inngest",
+    label: "Inngest",
+    route: "/integrations/jobs-inngest",
+    docsPath: "/docs/integrations/inngest",
+  }),
+  "jobs-trigger": integrationTemplate({
+    title: "Farm.js Trigger.dev",
+    description: "Typed background jobs backed by Trigger.dev",
+    provider: "jobs-trigger",
+    label: "Trigger.dev",
+    route: "/integrations/jobs-trigger",
+    docsPath: "/docs/integrations/trigger",
+  }),
+  polar: integrationTemplate({
+    title: "Farm.js Polar",
+    description: "Polar products, checkout, billing state, and customer portal",
+    provider: "polar",
+    label: "Polar",
+    route: "/integrations/polar",
+    docsPath: "/docs/integrations/polar",
+  }),
+  resend: integrationTemplate({
+    title: "Farm.js Resend",
+    description: "Resend templates, delivery, scheduling, and webhooks",
+    provider: "resend",
+    label: "Resend",
+    route: "/integrations/resend",
+    docsPath: "/docs/integrations/email",
+  }),
+  stripe: integrationTemplate({
+    title: "Farm.js Stripe",
+    description: "Stripe products, checkout, billing portal, and webhooks",
+    provider: "stripe",
+    label: "Stripe",
+    route: "/integrations/stripe",
+    docsPath: "/docs/integrations/stripe",
+  }),
+  supabase: integrationTemplate({
+    title: "Farm.js Supabase",
+    description: "Supabase authentication, sessions, OAuth, and protected routes",
+    provider: "supabase",
+    label: "Supabase",
+    route: "/integrations/supabase",
+    docsPath: "/docs/integrations/auth/supabase",
+  }),
+  unkey: integrationTemplate({
+    title: "Farm.js Unkey",
+    description: "Unkey API key creation, verification, and route protection",
+    provider: "unkey",
+    label: "Unkey",
+    route: "/integrations/unkey",
+    docsPath: "/docs/integrations/unkey",
+  }),
+  workos: integrationTemplate({
+    title: "Farm.js WorkOS",
+    description: "WorkOS AuthKit, organization sessions, and protected routes",
+    provider: "workos",
+    label: "WorkOS",
+    route: "/integrations/workos",
+    docsPath: "/docs/integrations/auth/workos",
+  }),
 };
+
+function integrationTemplate(
+  input: NonNullable<TemplateDetails["integration"]> & {
+    title: string;
+    description: string;
+  },
+): TemplateDetails {
+  return {
+    title: input.title,
+    description: input.description,
+    instructions: [],
+    integration: {
+      provider: input.provider,
+      label: input.label,
+      route: input.route,
+      docsPath: input.docsPath,
+    },
+  };
+}
 
 export type PackageManagerName = "npm" | "pnpm" | "yarn" | "bun";
 
@@ -57,6 +191,15 @@ export async function createApp(projectName?: string, options: CreateAppOptions 
   if (templates.length === 0) {
     logger.error("No templates are available in this package.");
     process.exit(1);
+  }
+
+  if (options.listTemplates) {
+    logger.info("Available templates");
+    for (const template of templates) {
+      const details = templateDetails[template];
+      logger.info(`  ${template.padEnd(14)} ${details?.description ?? ""}`.trimEnd());
+    }
+    return;
   }
 
   // Get project name if not provided
@@ -151,7 +294,7 @@ export async function createApp(projectName?: string, options: CreateAppOptions 
 
   await fs.mkdir(projectPath, { recursive: true });
 
-  await copyTemplate(template!, projectPath, useTypeScript!);
+  const integrationResult = await copyTemplate(template!, projectPath, useTypeScript!);
 
   await updatePackageJson(projectPath, projectName!, packageManager);
 
@@ -174,10 +317,30 @@ export async function createApp(projectName?: string, options: CreateAppOptions 
   for (const instruction of templateDetails[template!]?.instructions ?? []) {
     logger.info(instruction);
   }
+  if (integrationResult) {
+    const details = templateDetails[template!].integration!;
+    logger.info(`Open ${details.route} for the ${details.label} starter.`);
+    if (integrationResult.env.length) {
+      logger.info("Copy .env.example to .env.local and add your provider credentials.");
+    }
+    for (const note of integrationResult.notes) {
+      logger.info(note);
+    }
+  }
 }
 
-async function copyTemplate(template: string, projectPath: string, useTypeScript: boolean) {
-  const templatePath = path.join(__dirname, "..", "templates", template);
+async function copyTemplate(
+  template: string,
+  projectPath: string,
+  useTypeScript: boolean,
+): Promise<AddFarmIntegrationResult | undefined> {
+  const details = templateDetails[template];
+  const templatePath = path.join(
+    __dirname,
+    "..",
+    "templates",
+    details?.integration ? "basic" : template,
+  );
 
   // Copy base template files
   await copyDir(templatePath, projectPath);
@@ -189,6 +352,143 @@ async function copyTemplate(template: string, projectPath: string, useTypeScript
       await copyDir(tsTemplatePath, projectPath);
     }
   }
+
+  if (!details?.integration) {
+    return undefined;
+  }
+
+  const result = await addFarmIntegration({
+    root: projectPath,
+    provider: details.integration.provider,
+    ui: true,
+  });
+  await writeEnvironmentExample(projectPath, result.env);
+  await writeIntegrationHomePage(projectPath, details.integration, result.env.length > 0);
+  await writeIntegrationReadme(projectPath, details.integration, result.env);
+  return result;
+}
+
+async function writeEnvironmentExample(projectPath: string, keys: string[]) {
+  if (keys.length === 0) {
+    return;
+  }
+
+  const envPath = path.join(projectPath, ".env.example");
+  let current = "";
+  try {
+    current = await fs.readFile(envPath, "utf8");
+  } catch {
+    // The provider has no setup-owned environment file yet.
+  }
+
+  const existingKeys = new Set(
+    current
+      .split(/\r?\n/)
+      .map((line) => line.match(/^([A-Z][A-Z0-9_]*)=/)?.[1])
+      .filter((key): key is string => Boolean(key)),
+  );
+  const additions = keys
+    .filter((key) => !existingKeys.has(key))
+    .map((key) => `${key}=${environmentExampleValue(key)}`);
+
+  if (additions.length > 0) {
+    await fs.writeFile(
+      envPath,
+      `${current.trimEnd()}${current.trim() ? "\n" : ""}${additions.join("\n")}\n`,
+      "utf8",
+    );
+  }
+}
+
+function environmentExampleValue(key: string) {
+  if (key === "APP_BASE_URL") {
+    return "http://localhost:3000";
+  }
+  if (key === "AUTH_SECRET") {
+    return "replace-with-at-least-32-random-characters";
+  }
+  if (key === "UNKEY_BASE_URL") {
+    return "https://api.unkey.com";
+  }
+  return "";
+}
+
+async function writeIntegrationHomePage(
+  projectPath: string,
+  integration: NonNullable<TemplateDetails["integration"]>,
+  hasEnvironment: boolean,
+) {
+  const commands = [...(hasEnvironment ? ["cp .env.example .env.local"] : []), "pnpm dev"];
+  const commandRows = commands
+    .map(
+      (command, index) => `            <div className="command-row">
+              <span>${String(index + 1).padStart(2, "0")}</span>
+              <code>${command}</code>
+            </div>`,
+    )
+    .join("\n");
+  const source = `import { ResourceLinks } from "../components/resource-links";
+
+export default function HomePage() {
+  return (
+    <main className="landing-main">
+      <section className="hero-section">
+        <div className="hero-copy">
+          <div className="eyebrow-row">
+            <span>00</span>
+            <span>FARMJS / ${integration.label} starter</span>
+          </div>
+
+          <h1>
+            Start at <code>${integration.route}</code>.
+          </h1>
+
+          <div className="command-list" aria-label="Getting started commands">
+${commandRows}
+          </div>
+
+          <ResourceLinks
+            className="resource-links"
+            primary={{ href: "${integration.route}", label: "Get started" }}
+          />
+        </div>
+      </section>
+    </main>
+  );
+}
+`;
+
+  await fs.writeFile(path.join(projectPath, "src", "app", "page.tsx"), source, "utf8");
+}
+
+async function writeIntegrationReadme(
+  projectPath: string,
+  integration: NonNullable<TemplateDetails["integration"]>,
+  env: string[],
+) {
+  const environmentSetup = env.length
+    ? `cp .env.example .env.local\n# Add values for: ${env.join(", ")}\n`
+    : "";
+  const wiring =
+    integration.provider === "ai"
+      ? "The AI route lives in `src/app/api/chat/route.ts` and its local UI lives under `src/components/farm`."
+      : "The provider wiring lives in `src/lib/integrations` and is registered from `farm.config.ts`.";
+  const source = `# FARMJS ${integration.label} Starter
+
+## Getting started
+
+\`\`\`bash
+pnpm install
+${environmentSetup}pnpm dev
+\`\`\`
+
+Open [${integration.route}](http://localhost:3000${integration.route}) for the integration UI.
+
+${wiring}
+See the [${integration.label} integration guide](https://farm.js.dev${integration.docsPath}) for provider setup and production guidance.
+`;
+
+  await fs.writeFile(path.join(projectPath, "README.md"), source, "utf8");
 }
 
 async function copyDir(src: string, dest: string) {
@@ -272,16 +572,20 @@ async function getAvailableTemplates(): Promise<string[]> {
   const templatesRoot = path.join(__dirname, "..", "templates");
   const entries = await fs.readdir(templatesRoot, { withFileTypes: true });
   const templateOrder = Object.keys(templateDetails);
-  return entries
+  const directoryTemplates = entries
     .filter((entry) => entry.isDirectory() && !entry.name.startsWith("_"))
-    .map((entry) => entry.name)
-    .sort((left, right) => {
-      const leftIndex = templateOrder.indexOf(left);
-      const rightIndex = templateOrder.indexOf(right);
-      const normalizedLeft = leftIndex === -1 ? Number.MAX_SAFE_INTEGER : leftIndex;
-      const normalizedRight = rightIndex === -1 ? Number.MAX_SAFE_INTEGER : rightIndex;
-      return normalizedLeft - normalizedRight || left.localeCompare(right);
-    });
+    .map((entry) => entry.name);
+  const generatedTemplates = Object.entries(templateDetails)
+    .filter(([, details]) => Boolean(details.integration))
+    .map(([name]) => name);
+
+  return [...new Set([...directoryTemplates, ...generatedTemplates])].sort((left, right) => {
+    const leftIndex = templateOrder.indexOf(left);
+    const rightIndex = templateOrder.indexOf(right);
+    const normalizedLeft = leftIndex === -1 ? Number.MAX_SAFE_INTEGER : leftIndex;
+    const normalizedRight = rightIndex === -1 ? Number.MAX_SAFE_INTEGER : rightIndex;
+    return normalizedLeft - normalizedRight || left.localeCompare(right);
+  });
 }
 
 async function updatePackageJson(

--- a/packages/create-farm-app/templates/auth/src/components/resource-links.tsx
+++ b/packages/create-farm-app/templates/auth/src/components/resource-links.tsx
@@ -61,7 +61,7 @@ export function ResourceLinks({ className, primary }: ResourceLinksProps) {
       ) : null}
       <span className="resource-link-item">
         {primary ? <ResourceSeparator /> : null}
-        <a href="https://farmjs.dev">
+        <a href="https://farm.js.dev">
           <DocsIcon />
           <span>Docs</span>
         </a>

--- a/packages/create-farm-app/templates/auth/src/components/site-header.tsx
+++ b/packages/create-farm-app/templates/auth/src/components/site-header.tsx
@@ -21,7 +21,7 @@ export function SiteHeader({ user }: SiteHeaderProps) {
       </a>
 
       <nav className="header-nav" aria-label="Primary navigation">
-        <a href="https://farmjs.dev">Docs</a>
+        <a href="https://farm.js.dev">Docs</a>
         {user ? (
           <a className="header-account" href="/dashboard">
             <span className="avatar" aria-hidden="true">

--- a/packages/create-farm-app/templates/basic/src/components/resource-links.tsx
+++ b/packages/create-farm-app/templates/basic/src/components/resource-links.tsx
@@ -61,7 +61,7 @@ export function ResourceLinks({ className, primary }: ResourceLinksProps) {
       ) : null}
       <span className="resource-link-item">
         {primary ? <ResourceSeparator /> : null}
-        <a href="https://farmjs.dev">
+        <a href="https://farm.js.dev">
           <DocsIcon />
           <span>Docs</span>
         </a>

--- a/packages/create-farm-app/templates/better-auth/src/components/resource-links.tsx
+++ b/packages/create-farm-app/templates/better-auth/src/components/resource-links.tsx
@@ -61,7 +61,7 @@ export function ResourceLinks({ className, primary }: ResourceLinksProps) {
       ) : null}
       <span className="resource-link-item">
         {primary ? <ResourceSeparator /> : null}
-        <a href="https://farmjs.dev">
+        <a href="https://farm.js.dev">
           <DocsIcon />
           <span>Docs</span>
         </a>

--- a/packages/create-farm-app/templates/better-auth/src/components/site-header.tsx
+++ b/packages/create-farm-app/templates/better-auth/src/components/site-header.tsx
@@ -21,7 +21,7 @@ export function SiteHeader({ user }: SiteHeaderProps) {
       </a>
 
       <nav className="header-nav" aria-label="Primary navigation">
-        <a href="https://farmjs.dev">Docs</a>
+        <a href="https://farm.js.dev">Docs</a>
         {user ? (
           <a className="header-account" href="/dashboard">
             <span className="avatar" aria-hidden="true">

--- a/packages/create-farm-app/test/create-app.test.mjs
+++ b/packages/create-farm-app/test/create-app.test.mjs
@@ -14,7 +14,39 @@ test("uses Farm.js branding for CLI template choices", async () => {
   assert.match(source, /title: "Farm\.js Basic"/);
   assert.match(source, /title: "Farm\.js Auth"/);
   assert.match(source, /title: "Farm\.js Better Auth"/);
+  assert.match(source, /title: "Farm\.js Stripe"/);
+  assert.match(source, /title: "Farm\.js Supabase"/);
+  assert.match(source, /title: "Farm\.js Trigger\.dev"/);
   assert.doesNotMatch(source, /title: "FARMJS/);
+});
+
+test("lists every integration starter from the CLI", () => {
+  const output = execFileSync(
+    process.execPath,
+    [path.join(packageDir, "bin/create-farm-app.js"), "--list-templates"],
+    { encoding: "utf8" },
+  );
+
+  for (const template of [
+    "basic",
+    "auth",
+    "better-auth",
+    "ai",
+    "auth0",
+    "authjs",
+    "autumn",
+    "clerk",
+    "jobs-inngest",
+    "jobs-trigger",
+    "polar",
+    "resend",
+    "stripe",
+    "supabase",
+    "unkey",
+    "workos",
+  ]) {
+    assert.match(output, new RegExp(`\\b${template}\\b`));
+  }
 });
 
 test("generates a buildable starter application", async () => {
@@ -107,8 +139,8 @@ test("generates a buildable starter application", async () => {
     assert.match(generatedResourceLinks, /function ResourceSeparator\(\)/);
     assert.match(generatedResourceLinks, /className="resource-separator"/);
     assert.match(generatedResourceLinks, /aria-hidden="true"/);
-    assert.match(generatedResourceLinks, /href="https:\/\/farmjs\.dev"/);
-    assert.doesNotMatch(generatedResourceLinks, /farm\.js\.dev/);
+    assert.match(generatedResourceLinks, /href="https:\/\/farm\.js\.dev"/);
+    assert.doesNotMatch(generatedResourceLinks, /https:\/\/farmjs\.dev/);
     assert.doesNotMatch(generatedResourceLinks, /Docs ↗|GitHub ↗/);
 
     const generatedStyles = await readFile(
@@ -276,16 +308,16 @@ for (const template of [
       assert.match(generatedResourceLinks, /function ResourceSeparator\(\)/);
       assert.match(generatedResourceLinks, /className="resource-separator"/);
       assert.match(generatedResourceLinks, /aria-hidden="true"/);
-      assert.match(generatedResourceLinks, /href="https:\/\/farmjs\.dev"/);
-      assert.doesNotMatch(generatedResourceLinks, /farm\.js\.dev/);
+      assert.match(generatedResourceLinks, /href="https:\/\/farm\.js\.dev"/);
+      assert.doesNotMatch(generatedResourceLinks, /https:\/\/farmjs\.dev/);
       assert.doesNotMatch(generatedResourceLinks, /Docs ↗|GitHub ↗/);
 
       const generatedSiteHeader = await readFile(
         path.join(generatedDir, "src/components/site-header.tsx"),
         "utf8",
       );
-      assert.match(generatedSiteHeader, /href="https:\/\/farmjs\.dev"/);
-      assert.doesNotMatch(generatedSiteHeader, /farm\.js\.dev/);
+      assert.match(generatedSiteHeader, /href="https:\/\/farm\.js\.dev"/);
+      assert.doesNotMatch(generatedSiteHeader, /https:\/\/farmjs\.dev/);
 
       const generatedStyles = await readFile(
         path.join(generatedDir, "src/app/globals.css"),
@@ -349,6 +381,189 @@ for (const template of [
     }
   });
 }
+
+const integrationTemplates = [
+  {
+    name: "ai",
+    label: "AI",
+    route: "ai",
+    packageName: "@farm.js/ai",
+    env: ["AI_GATEWAY_API_KEY"],
+  },
+  {
+    name: "auth0",
+    label: "Auth0",
+    route: "auth0",
+    packageName: "@farm.js/auth0",
+    env: ["AUTH0_DOMAIN", "AUTH0_CLIENT_ID", "AUTH0_CLIENT_SECRET", "AUTH0_SECRET"],
+  },
+  {
+    name: "authjs",
+    label: "Auth.js",
+    route: "authjs",
+    packageName: "@farm.js/authjs",
+    env: ["AUTH_SECRET", "AUTH_GITHUB_ID", "AUTH_GITHUB_SECRET"],
+  },
+  {
+    name: "autumn",
+    label: "Autumn",
+    route: "autumn",
+    packageName: "@farm.js/autumn",
+    env: ["AUTUMN_SECRET_KEY", "AUTUMN_WEBHOOK_SECRET", "APP_BASE_URL"],
+  },
+  {
+    name: "clerk",
+    label: "Clerk",
+    route: "clerk",
+    packageName: "@farm.js/clerk",
+    env: ["NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY", "CLERK_SECRET_KEY"],
+  },
+  {
+    name: "jobs-inngest",
+    label: "Inngest",
+    route: "jobs-inngest",
+    packageName: "@farm.js/jobs",
+    env: ["INNGEST_APP_ID", "INNGEST_EVENT_KEY", "INNGEST_SIGNING_KEY"],
+  },
+  {
+    name: "jobs-trigger",
+    label: "Trigger.dev",
+    route: "jobs-trigger",
+    packageName: "@farm.js/jobs",
+    env: ["TRIGGER_PROJECT_REF", "TRIGGER_SECRET_KEY", "TRIGGER_WEBHOOK_SECRET"],
+  },
+  {
+    name: "polar",
+    label: "Polar",
+    route: "polar",
+    packageName: "@farm.js/polar",
+    env: ["POLAR_ACCESS_TOKEN", "POLAR_WEBHOOK_SECRET", "APP_BASE_URL"],
+  },
+  {
+    name: "resend",
+    label: "Resend",
+    route: "resend",
+    packageName: "@farm.js/email",
+    env: ["RESEND_API_KEY", "RESEND_FROM_EMAIL", "RESEND_WEBHOOK_SECRET"],
+  },
+  {
+    name: "stripe",
+    label: "Stripe",
+    route: "stripe",
+    packageName: "@farm.js/stripe",
+    env: ["STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET"],
+  },
+  {
+    name: "supabase",
+    label: "Supabase",
+    route: "supabase",
+    packageName: "@farm.js/supabase",
+    env: ["SUPABASE_URL", "SUPABASE_ANON_KEY", "APP_BASE_URL"],
+  },
+  {
+    name: "unkey",
+    label: "Unkey",
+    route: "unkey",
+    packageName: "@farm.js/unkey",
+    env: ["UNKEY_ROOT_KEY", "UNKEY_API_ID", "UNKEY_BASE_URL"],
+  },
+  {
+    name: "workos",
+    label: "WorkOS",
+    route: "workos",
+    packageName: "@farm.js/workos",
+    env: ["WORKOS_CLIENT_ID", "WORKOS_API_KEY", "WORKOS_COOKIE_PASSWORD"],
+  },
+];
+
+test("generates every official integration starter", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "create-farm-app-integrations-"));
+
+  try {
+    for (const template of integrationTemplates) {
+      const projectName = `${template.name}-app`;
+      const output = execFileSync(
+        process.execPath,
+        [
+          path.join(packageDir, "bin/create-farm-app.js"),
+          projectName,
+          "--template",
+          template.name,
+          "--typescript",
+          "--skip-install",
+        ],
+        {
+          cwd: tempDir,
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            npm_config_user_agent: "pnpm/11.18.0 npm/? node/v22.0.0",
+          },
+        },
+      );
+      const generatedDir = path.join(tempDir, projectName);
+      const packageJson = JSON.parse(
+        await readFile(path.join(generatedDir, "package.json"), "utf8"),
+      );
+      const homePage = await readFile(path.join(generatedDir, "src/app/page.tsx"), "utf8");
+      const styles = await readFile(path.join(generatedDir, "src/app/globals.css"), "utf8");
+      const environment = await readFile(path.join(generatedDir, ".env.example"), "utf8");
+      const readme = await readFile(path.join(generatedDir, "README.md"), "utf8");
+
+      assert.equal(packageJson.name, projectName);
+      assert.equal(packageJson.packageManager, "pnpm@11.18.0");
+      assert.equal(
+        packageJson.dependencies[template.packageName],
+        packageJson.dependencies["@farm.js/core"],
+      );
+      assert.equal(packageJson.dependencies["@farm.js/integrations"], undefined);
+      assert.equal(packageJson.dependencies["class-variance-authority"], "^0.7.1");
+      assert.match(homePage, new RegExp(`FARMJS / ${escapeRegExp(template.label)} starter`));
+      assert.match(homePage, new RegExp(`href: "/integrations/${template.route}"`));
+      assert.match(homePage, new RegExp(`Start at <code>/integrations/${template.route}</code>`));
+      assert.match(homePage, /label: "Get started"/);
+      assert.match(homePage, /cp \.env\.example \.env\.local/);
+      assert.match(styles, /\[data-theme="dark"\] \{/);
+      assert.doesNotMatch(styles, /^\.dark \{/m);
+      assert.match(readme, new RegExp(`^# FARMJS ${escapeRegExp(template.label)} Starter`, "m"));
+      assert.match(readme, /https:\/\/farm\.js\.dev\/docs\/integrations/);
+      await readFile(
+        path.join(generatedDir, "src/app/integrations", template.route, "page.tsx"),
+        "utf8",
+      );
+
+      for (const key of template.env) {
+        assert.match(environment, new RegExp(`^${key}=`, "m"));
+      }
+
+      if (template.name === "ai") {
+        await readFile(path.join(generatedDir, "src/app/api/chat/route.ts"), "utf8");
+      } else {
+        assert.match(
+          await readFile(path.join(generatedDir, "farm.config.ts"), "utf8"),
+          /integrations: appIntegrations/,
+        );
+        await readFile(path.join(generatedDir, "src/lib/integrations.ts"), "utf8");
+      }
+
+      if (template.name === "authjs") {
+        assert.equal(packageJson.dependencies["@auth/core"], "0.34.3");
+        assert.match(
+          await readFile(path.join(generatedDir, "src/lib/auth.ts"), "utf8"),
+          /GitHub\(\{/,
+        );
+      }
+      if (template.name === "clerk") {
+        assert.equal(packageJson.dependencies["@clerk/react"], "^6.1.0");
+      }
+
+      assert.match(output, new RegExp(`Open /integrations/${template.route}`));
+      assert.match(output, /Copy \.env\.example to \.env\.local/);
+    }
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
 
 test("installs dependencies with the invoking package manager", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "create-farm-app-install-"));
@@ -419,3 +634,7 @@ writeFileSync(process.env.FARM_CREATE_APP_INSTALL_MARKER, JSON.stringify({
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+function escapeRegExp(input) {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/create-farm-app/tsdown.config.ts
+++ b/packages/create-farm-app/tsdown.config.ts
@@ -1,4 +1,8 @@
 import { defineConfig } from "tsdown";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageDirectory = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   entry: {
@@ -10,6 +14,13 @@ export default defineConfig({
   // This package currently does not publish a `types` entry.
   dts: false,
   clean: true,
+  alias: {
+    "@farm.js/cli/add-integration": path.resolve(
+      packageDirectory,
+      "../farm-cli/src/add-integration.ts",
+    ),
+  },
+  noExternal: [/^@farm\.js\/cli(?:\/.*)?$/],
   splitting: false,
   sourcemap: true,
 });

--- a/packages/farm-cli/src/add-integration.ts
+++ b/packages/farm-cli/src/add-integration.ts
@@ -80,6 +80,7 @@ interface IntegrationProviderDefinition {
   provider: FarmIntegrationProvider;
   aliases: readonly string[];
   defaultKey: string;
+  packageName: `@farm.js/${string}`;
   fileName: string;
   exportName: string;
   description: string;
@@ -101,6 +102,7 @@ const PROVIDERS: readonly IntegrationProviderDefinition[] = [
     provider: "ai",
     aliases: ["ai-sdk", "vercel-ai", "vercel-ai-sdk", "chat"],
     defaultKey: "chat",
+    packageName: "@farm.js/ai",
     fileName: "chat",
     exportName: "POST",
     description: "Vercel AI SDK chat route",
@@ -111,7 +113,7 @@ const PROVIDERS: readonly IntegrationProviderDefinition[] = [
       "No farm.config integration wiring is required for this route.",
     ],
     ui: aiChatUIFeature(),
-    template: () => `import { aiChatRoute } from "@farm.js/integrations/ai";
+    template: () => `import { aiChatRoute } from "@farm.js/ai";
 
 export const POST = aiChatRoute({
   model: "openai/gpt-4o-mini",
@@ -123,17 +125,19 @@ export const POST = aiChatRoute({
     provider: "stripe",
     aliases: ["billing-stripe", "payments", "stripe-billing"],
     defaultKey: "billing",
+    packageName: "@farm.js/stripe",
     fileName: "stripe",
     exportName: "stripeIntegration",
     description: "Stripe billing and checkout routes",
     env: ["STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET"],
-    template: () => `import { stripe } from "@farm.js/integrations/stripe";
+    template: () => `import type { FarmIntegrationLogEvent } from "@farm.js/core";
+import { stripe } from "@farm.js/stripe";
 
 export const stripeIntegration = stripe({
   secretKey: process.env.STRIPE_SECRET_KEY,
   webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
   products: [],
-  log(event) {
+  log(event: FarmIntegrationLogEvent) {
     console.log("[stripe]", event.phase, event.route?.path || "none");
   },
 });
@@ -144,12 +148,13 @@ export const stripeIntegration = stripe({
     provider: "supabase",
     aliases: ["auth-supabase", "supabase-auth"],
     defaultKey: "auth",
+    packageName: "@farm.js/supabase",
     fileName: "supabase",
     exportName: "supabaseIntegration",
     description: "Supabase auth routes and middleware",
     env: ["SUPABASE_URL", "SUPABASE_ANON_KEY", "APP_BASE_URL"],
     ui: supabaseAuthUIFeature(),
-    template: () => `import { supabase } from "@farm.js/integrations/supabase";
+    template: () => `import { supabase } from "@farm.js/supabase";
 
 export const supabaseIntegration = supabase({
   callbackUrl: \`\${process.env.APP_BASE_URL || "http://localhost:3000"}/auth/callback\`,
@@ -168,12 +173,13 @@ export const supabaseIntegration = supabase({
     provider: "workos",
     aliases: ["auth-workos", "workos-auth"],
     defaultKey: "auth",
+    packageName: "@farm.js/workos",
     fileName: "workos",
     exportName: "workosIntegration",
     description: "WorkOS auth routes and protected route middleware",
     env: ["WORKOS_CLIENT_ID", "WORKOS_API_KEY", "WORKOS_COOKIE_PASSWORD"],
     ui: workosAuthUIFeature(),
-    template: () => `import { workos } from "@farm.js/integrations/workos";
+    template: () => `import { workos } from "@farm.js/workos";
 
 export const workosIntegration = workos({
   protectedRoutes: ["/dashboard(.*)"],
@@ -187,12 +193,13 @@ export const workosIntegration = workos({
     provider: "auth0",
     aliases: ["auth-auth0", "auth0-auth"],
     defaultKey: "auth",
+    packageName: "@farm.js/auth0",
     fileName: "auth0",
     exportName: "auth0Integration",
     description: "Auth0 login, callback, logout, and profile routes",
     env: ["AUTH0_DOMAIN", "AUTH0_CLIENT_ID", "AUTH0_CLIENT_SECRET", "AUTH0_SECRET"],
     ui: auth0AuthUIFeature(),
-    template: () => `import { auth0 } from "@farm.js/integrations/auth0";
+    template: () => `import { auth0 } from "@farm.js/auth0";
 
 export const auth0Integration = auth0({
   callbackUrl: \`\${process.env.APP_BASE_URL || "http://localhost:3000"}/auth/callback\`,
@@ -207,12 +214,16 @@ export const auth0Integration = auth0({
     provider: "clerk",
     aliases: ["auth-clerk", "clerk-auth"],
     defaultKey: "auth",
+    packageName: "@farm.js/clerk",
     fileName: "clerk",
     exportName: "clerkIntegration",
     description: "Clerk auth provider and protected route middleware",
     env: ["NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY", "CLERK_SECRET_KEY"],
+    dependencies: {
+      "@clerk/react": "^6.1.0",
+    },
     ui: clerkAuthUIFeature(),
-    template: () => `import { clerk } from "@farm.js/integrations/clerk";
+    template: () => `import { clerk } from "@farm.js/clerk";
 
 export const clerkIntegration = clerk({
   signInUrl: "/sign-in",
@@ -228,13 +239,14 @@ export const clerkIntegration = clerk({
     provider: "resend",
     aliases: ["email", "resend-email"],
     defaultKey: "email",
+    packageName: "@farm.js/email",
     fileName: "resend",
     exportName: "resendIntegration",
     description: "Resend email send, preview, schedule, and webhook routes",
     env: ["RESEND_API_KEY", "RESEND_FROM_EMAIL", "RESEND_WEBHOOK_SECRET"],
     ui: resendEmailUIFeature(),
     template: () => `import { createElement } from "react";
-import { resend, template } from "@farm.js/integrations/email";
+import { resend, template } from "@farm.js/email";
 
 function WelcomeEmail(props: { name: string }) {
   return createElement("div", null, \`Welcome \${props.name}\`);
@@ -273,13 +285,14 @@ export const resendIntegration = resend({
     provider: "jobs-inngest",
     aliases: ["inngest", "jobs"],
     defaultKey: "jobs",
+    packageName: "@farm.js/jobs",
     fileName: "jobs-inngest",
     exportName: "jobsIntegration",
     description: "Jobs integration backed by Inngest",
     env: ["INNGEST_APP_ID", "INNGEST_EVENT_KEY", "INNGEST_SIGNING_KEY"],
     notes: ["Add tasks to jobTasks before using the generated jobs API."],
     ui: jobsUIFeature("inngest"),
-    template: () => `import { defineTasks, inngest, jobs } from "@farm.js/integrations/jobs";
+    template: () => `import { defineTasks, inngest, jobs } from "@farm.js/jobs";
 
 export const jobTasks = defineTasks({});
 
@@ -300,13 +313,14 @@ export const jobsIntegration = jobs({
     provider: "jobs-trigger",
     aliases: ["trigger", "trigger-dev", "jobs-triggerdev"],
     defaultKey: "jobs",
+    packageName: "@farm.js/jobs",
     fileName: "jobs-trigger",
     exportName: "jobsIntegration",
     description: "Jobs integration backed by Trigger.dev",
     env: ["TRIGGER_PROJECT_REF", "TRIGGER_SECRET_KEY", "TRIGGER_WEBHOOK_SECRET"],
     notes: ["Add tasks to jobTasks before using the generated jobs API."],
     ui: jobsUIFeature("trigger"),
-    template: () => `import { defineTasks, jobs, trigger } from "@farm.js/integrations/jobs";
+    template: () => `import { defineTasks, jobs, trigger } from "@farm.js/jobs";
 
 export const jobTasks = defineTasks({});
 
@@ -327,6 +341,7 @@ export const jobsIntegration = jobs({
     provider: "polar",
     aliases: ["polar-billing", "billing-polar"],
     defaultKey: "billing",
+    packageName: "@farm.js/polar",
     fileName: "polar",
     exportName: "polarIntegration",
     description: "Polar billing and checkout routes",
@@ -334,9 +349,9 @@ export const jobsIntegration = jobs({
     notes: ["Replace resolveBillingOwner with your app user or organization lookup."],
     ui: polarBillingUIFeature(),
     template: () => `import type { FarmIntegrationHandlerContext } from "@farm.js/core";
-import { polar } from "@farm.js/integrations/polar";
+import { polar } from "@farm.js/polar";
 
-async function resolveBillingOwner(_context: FarmIntegrationHandlerContext) {
+function resolveBillingOwner(_context: FarmIntegrationHandlerContext): never {
   throw new Error("Configure Polar billing owner resolution for your app.");
 }
 
@@ -364,6 +379,7 @@ export const polarIntegration = polar({
     provider: "autumn",
     aliases: ["autumn-billing", "billing-autumn"],
     defaultKey: "billing",
+    packageName: "@farm.js/autumn",
     fileName: "autumn",
     exportName: "autumnIntegration",
     description: "Autumn billing and checkout routes",
@@ -371,9 +387,9 @@ export const polarIntegration = polar({
     notes: ["Replace resolveBillingOwner with your app user or organization lookup."],
     ui: autumnBillingUIFeature(),
     template: () => `import type { FarmIntegrationHandlerContext } from "@farm.js/core";
-import { autumn } from "@farm.js/integrations/autumn";
+import { autumn } from "@farm.js/autumn";
 
-async function resolveBillingOwner(_context: FarmIntegrationHandlerContext) {
+function resolveBillingOwner(_context: FarmIntegrationHandlerContext): never {
   throw new Error("Configure Autumn billing owner resolution for your app.");
 }
 
@@ -400,6 +416,7 @@ export const autumnIntegration = autumn({
     provider: "better-auth",
     aliases: ["betterauth", "auth-better-auth"],
     defaultKey: "auth",
+    packageName: "@farm.js/better-auth",
     fileName: "better-auth",
     exportName: "betterAuthIntegration",
     description: "Better Auth route adapter",
@@ -455,7 +472,7 @@ better-auth.sqlite-wal
       },
     ],
     ui: betterAuthUIFeature(),
-    template: () => `import { betterAuth } from "@farm.js/integrations/better-auth";
+    template: () => `import { betterAuth } from "@farm.js/better-auth";
 import { auth } from "../auth.ts";
 
 export const betterAuthIntegration = betterAuth({
@@ -470,13 +487,47 @@ export const betterAuthIntegration = betterAuth({
     provider: "authjs",
     aliases: ["auth-js", "nextauth", "next-auth"],
     defaultKey: "auth",
+    packageName: "@farm.js/authjs",
     fileName: "authjs",
     exportName: "authjsIntegration",
     description: "Auth.js route adapter",
-    env: [],
-    notes: ["This template expects src/lib/auth.ts to export an Auth.js instance named auth."],
+    env: ["AUTH_SECRET", "AUTH_GITHUB_ID", "AUTH_GITHUB_SECRET"],
+    dependencies: {
+      "@auth/core": "0.34.3",
+    },
+    setupFiles: [
+      {
+        path: "src/lib/auth.ts",
+        source: () => `import { Auth } from "@auth/core";
+import GitHub from "@auth/core/providers/github";
+
+const config = {
+  providers: [
+    GitHub({
+      clientId: process.env.AUTH_GITHUB_ID!,
+      clientSecret: process.env.AUTH_GITHUB_SECRET!,
+    }),
+  ],
+  secret: process.env.AUTH_SECRET,
+  trustHost: true,
+};
+
+const handler = (request: Request) => Auth(request, config);
+
+export const auth = {
+  handlers: {
+    GET: handler,
+    POST: handler,
+  },
+};
+`,
+      },
+    ],
+    notes: [
+      "The generated Auth.js instance uses GitHub OAuth through @auth/core; add or replace providers in src/lib/auth.ts.",
+    ],
     ui: authjsUIFeature(),
-    template: () => `import { authjs } from "@farm.js/integrations/authjs";
+    template: () => `import { authjs } from "@farm.js/authjs";
 import { auth } from "../auth.ts";
 
 export const authjsIntegration = authjs({
@@ -491,12 +542,13 @@ export const authjsIntegration = authjs({
     provider: "unkey",
     aliases: ["api-keys", "apikeys", "keys", "unkey-api-keys"],
     defaultKey: "apiKeys",
+    packageName: "@farm.js/unkey",
     fileName: "unkey",
     exportName: "unkeyIntegration",
     description: "Unkey API key creation, verification, and route protection",
     env: ["UNKEY_ROOT_KEY", "UNKEY_API_ID", "UNKEY_BASE_URL"],
     ui: unkeyApiKeysUIFeature(),
-    template: () => `import { unkey } from "@farm.js/integrations/unkey";
+    template: () => `import { unkey } from "@farm.js/unkey";
 
 export const unkeyIntegration = unkey({
   rootKey: process.env.UNKEY_ROOT_KEY,
@@ -514,6 +566,7 @@ export const unkeyIntegration = unkey({
 export function listFarmIntegrationProviders() {
   return PROVIDERS.map((provider) => ({
     name: provider.provider,
+    packageName: provider.packageName,
     aliases: [...provider.aliases],
     defaultKey: provider.defaultKey,
     description: provider.description,
@@ -883,9 +936,9 @@ async function updatePackageJson(input: {
   const devDependencies = missingDependencies(manifest, input.definition.devDependencies);
   manifest.dependencies = {
     ...manifest.dependencies,
-    ...(hasPackageDependency(manifest, "@farm.js/integrations")
+    ...(hasPackageDependency(manifest, input.definition.packageName)
       ? {}
-      : { "@farm.js/integrations": getFarmIntegrationsVersion(manifest) }),
+      : { [input.definition.packageName]: getFarmIntegrationVersion(manifest) }),
     ...dependencies,
   };
   if (Object.keys(devDependencies).length) {
@@ -1024,14 +1077,18 @@ function hasPackageDependency(manifest: PackageManifest, dependency: string) {
   );
 }
 
-function getFarmIntegrationsVersion(manifest: PackageManifest) {
+function getFarmIntegrationVersion(manifest: PackageManifest) {
   const farmCoreVersion =
     manifest.dependencies?.["@farm.js/core"] ??
     manifest.devDependencies?.["@farm.js/core"] ??
     manifest.peerDependencies?.["@farm.js/core"] ??
     manifest.optionalDependencies?.["@farm.js/core"];
 
-  return farmCoreVersion?.startsWith("workspace:") ? "workspace:*" : "latest";
+  if (!farmCoreVersion) {
+    return "latest";
+  }
+
+  return farmCoreVersion.startsWith("workspace:") ? "workspace:*" : farmCoreVersion;
 }
 
 function toImportPath(relativePath: string) {

--- a/packages/farm-cli/src/ui-feature-registry.ts
+++ b/packages/farm-cli/src/ui-feature-registry.ts
@@ -164,7 +164,7 @@ export function aiChatUIFeature(): UIFeatureDefinition {
     notes: ['Open "/integrations/ai" to try the generated chat UI.'],
     files: () => [
       componentFile("ai-chat.tsx", aiChatTemplate()),
-      integrationPageFile("ai", "AIChat"),
+      integrationPageFile("ai", "AIChat", "ai-chat"),
     ],
   };
 }
@@ -195,41 +195,29 @@ export function workosAuthUIFeature(): UIFeatureDefinition {
           key: input.key,
           provider: "WorkOS",
           componentName: "WorkOSAuthPanel",
-          statusCall: "session.get",
-          logoutCall: "logout.post",
+          statusCall: "session",
+          statusMethod: "get",
+          logoutCall: "logout",
+          logoutMethod: "post",
           loginHref: "/login?returnTo=/dashboard",
           signupHref: "/signup?returnTo=/dashboard",
           statusLabel: "Session",
         }),
       ),
-      integrationPageFile("workos", "WorkOSAuthPanel"),
+      integrationPageFile("workos", "WorkOSAuthPanel", "workos-auth-panel"),
     ],
   };
 }
 
 export function auth0AuthUIFeature(): UIFeatureDefinition {
-  return {
-    name: "auth0-auth",
-    description: "Auth0 auth UI",
-    components: ["badge", "button", "card"],
-    notes: ['Open "/integrations/auth0" to try the generated auth UI.'],
-    files: (input) => [
-      componentFile(
-        "auth0-auth-panel.tsx",
-        hostedAuthTemplate({
-          key: input.key,
-          provider: "Auth0",
-          componentName: "Auth0AuthPanel",
-          statusCall: "profile.get",
-          logoutCall: "logout.get",
-          loginHref: "/auth/login?returnTo=/dashboard",
-          signupHref: "/auth/signup?returnTo=/dashboard",
-          statusLabel: "Profile",
-        }),
-      ),
-      integrationPageFile("auth0", "Auth0AuthPanel"),
-    ],
-  };
+  return authRouteShellUIFeature({
+    provider: "auth0",
+    label: "Auth0",
+    componentName: "Auth0AuthPanel",
+    signInHref: "/auth/login?returnTo=/dashboard",
+    signUpHref: "/auth/signup?returnTo=/dashboard",
+    sessionHref: "/auth/profile",
+  });
 }
 
 export function clerkAuthUIFeature(): UIFeatureDefinition {
@@ -306,12 +294,17 @@ export function jobsUIFeature(provider: "inngest" | "trigger"): UIFeatureDefinit
 export function unkeyApiKeysUIFeature(): UIFeatureDefinition {
   return {
     name: "unkey-api-keys",
-    description: "Unkey API key console UI",
-    components: ["badge", "button", "card", "input", "label"],
-    notes: ['Open "/integrations/unkey" to try the generated API key UI.'],
-    files: (input) => [
-      componentFile("unkey-api-keys-console.tsx", unkeyApiKeysTemplate(input.key)),
+    description: "Unkey protected route UI",
+    components: ["badge", "card"],
+    needsApiClient: false,
+    notes: ['Open "/integrations/unkey" to test the generated protected API route.'],
+    files: () => [
+      componentFile("unkey-api-keys-console.tsx", unkeyApiKeysTemplate()),
       integrationPageFile("unkey", "UnkeyApiKeysConsole"),
+      {
+        path: path.join("src", "app", "api", "protected", "route.ts"),
+        source: unkeyProtectedRouteTemplate(),
+      },
     ],
   };
 }
@@ -343,7 +336,7 @@ function billingUIFeature(input: {
 }
 
 function authRouteShellUIFeature(input: {
-  provider: "authjs" | "better-auth" | "clerk";
+  provider: "auth0" | "authjs" | "better-auth" | "clerk";
   label: string;
   componentName: string;
   signInHref: string;
@@ -354,6 +347,7 @@ function authRouteShellUIFeature(input: {
     name: `${input.provider}-auth`,
     description: `${input.label} auth UI`,
     components: ["badge", "button", "card"],
+    needsApiClient: false,
     notes: [`Open "/integrations/${input.provider}" to try the generated auth UI.`],
     files: () => [
       componentFile(
@@ -366,7 +360,11 @@ function authRouteShellUIFeature(input: {
           sessionHref: input.sessionHref,
         }),
       ),
-      integrationPageFile(input.provider, input.componentName),
+      integrationPageFile(
+        input.provider,
+        input.componentName,
+        input.provider === "authjs" ? "authjs-auth-panel" : undefined,
+      ),
     ],
   };
 }
@@ -378,12 +376,14 @@ function componentFile(fileName: string, source: string): UIFeatureFile {
   };
 }
 
-function integrationPageFile(provider: string, componentName: string): UIFeatureFile {
-  const fileName = kebabCase(componentName);
-
+function integrationPageFile(
+  provider: string,
+  componentName: string,
+  sourceFileName = kebabCase(componentName),
+): UIFeatureFile {
   return {
     path: path.join("src", "app", "integrations", provider, "page.tsx"),
-    source: `import { ${componentName} } from "@/components/farm/${fileName}";
+    source: `import { ${componentName} } from "@/components/farm/${sourceFileName}";
 
 export default function ${componentName}Page() {
   return <${componentName} />;
@@ -622,7 +622,7 @@ const UI_DEPENDENCIES = {
   tailwindcss: "^4.1.18",
 } as const;
 
-const SHADCN_THEME_CSS = `@custom-variant dark (&:is(.dark *));
+const SHADCN_THEME_CSS = `@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
 @theme inline {
   --color-background: var(--background);
@@ -648,7 +648,8 @@ const SHADCN_THEME_CSS = `@custom-variant dark (&:is(.dark *));
   --radius-lg: var(--radius);
 }
 
-:root {
+:root,
+[data-theme="light"] {
   --radius: 0.5rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
@@ -670,7 +671,7 @@ const SHADCN_THEME_CSS = `@custom-variant dark (&:is(.dark *));
   --ring: oklch(0.708 0 0);
 }
 
-.dark {
+[data-theme="dark"] {
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
@@ -1299,12 +1300,17 @@ export function SupabaseAuthPanel() {
   }
 
   async function logout() {
-    const response = await apiClient.${key}.logout.post({ body: { returnTo: "/" } });
-    if (response.data?.redirectTo) {
-      window.location.assign(response.data.redirectTo);
+    const response = await fetch("/auth/logout", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ returnTo: "/" }),
+    });
+    const data = (await response.json()) as { redirectTo?: string; error?: string };
+    if (data.redirectTo) {
+      window.location.assign(data.redirectTo);
       return;
     }
-    setStatus(response.error?.message ?? "Signed out");
+    setStatus(data.error ?? "Signed out");
   }
 
   return (
@@ -1354,7 +1360,9 @@ function hostedAuthTemplate(input: {
   provider: string;
   componentName: string;
   statusCall: string;
+  statusMethod: "get" | "post";
   logoutCall: string;
+  logoutMethod: "get" | "post";
   loginHref: string;
   signupHref: string;
   statusLabel: string;
@@ -1373,7 +1381,7 @@ export function ${input.componentName}() {
 
   async function refreshStatus() {
     setPending(true);
-    const response = await apiClient.${input.key}.${input.statusCall}();
+    const response = await apiClient.${input.key}.${input.statusCall}.${input.statusMethod}();
     if (response.error) {
       setStatus(response.error.message);
     } else {
@@ -1384,7 +1392,7 @@ export function ${input.componentName}() {
 
   async function logout() {
     setPending(true);
-    const response = await apiClient.${input.key}.${input.logoutCall}();
+    const response = await apiClient.${input.key}.${input.logoutCall}.${input.logoutMethod}();
     if (response.data?.redirectTo) {
       window.location.assign(response.data.redirectTo);
       return;
@@ -1657,17 +1665,20 @@ import { apiClient } from "@/lib/api";
 export function ResendEmailConsole() {
   const [to, setTo] = React.useState("");
   const [name, setName] = React.useState("Ada");
-  const [templateId, setTemplateId] = React.useState("welcome");
+  const templateId = "welcome" as const;
   const [status, setStatus] = React.useState("Idle");
   const [previewHtml, setPreviewHtml] = React.useState("");
 
   async function loadTemplates() {
-    const response = await apiClient.${key}.templates.get();
-    setStatus(response.error ? response.error.message : "Templates: " + (response.data ?? []).map((item) => item.id).join(", "));
+    const response = await apiClient.${key}.templates();
+    const templates = Array.isArray(response.data)
+      ? (response.data as Array<{ id: string }>)
+      : [];
+    setStatus(response.error ? response.error.message : "Templates: " + templates.map((item) => item.id).join(", "));
   }
 
   async function preview() {
-    const response = await apiClient.${key}.preview.post({
+    const response = await apiClient.${key}.preview({
       body: {
         templateId,
         data: { name },
@@ -1682,7 +1693,7 @@ export function ResendEmailConsole() {
   }
 
   async function send() {
-    const response = await apiClient.${key}.send.post({
+    const response = await apiClient.${key}.send({
       body: {
         templateId,
         to,
@@ -1705,11 +1716,7 @@ export function ResendEmailConsole() {
             <CardDescription>Template previews and delivery controls.</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div className="grid gap-4 sm:grid-cols-3">
-              <div className="space-y-2">
-                <Label htmlFor="templateId">Template</Label>
-                <Input id="templateId" value={templateId} onChange={(event) => setTemplateId(event.target.value)} />
-              </div>
+            <div className="grid gap-4 sm:grid-cols-2">
               <div className="space-y-2">
                 <Label htmlFor="to">To</Label>
                 <Input id="to" value={to} onChange={(event) => setTo(event.target.value)} />
@@ -1838,47 +1845,11 @@ export function ${componentName}() {
 `;
 }
 
-function unkeyApiKeysTemplate(key: string) {
-  return `"use client";
-
-import * as React from "react";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+function unkeyApiKeysTemplate() {
+  return `import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { apiClient } from "@/lib/api";
 
 export function UnkeyApiKeysConsole() {
-  const [name, setName] = React.useState("Development key");
-  const [prefix, setPrefix] = React.useState("farm");
-  const [apiKey, setApiKey] = React.useState("");
-  const [status, setStatus] = React.useState("Idle");
-
-  async function createKey() {
-    const response = await apiClient.${key}.createKey.post({
-      body: {
-        name,
-        prefix,
-      },
-    });
-    if (response.error) {
-      setStatus(response.error.message);
-      return;
-    }
-    setApiKey(response.data?.key ?? "");
-    setStatus("Created " + (response.data?.keyId ?? "key"));
-  }
-
-  async function verifyKey() {
-    const response = await apiClient.${key}.verifyKey.post({
-      body: {
-        key: apiKey,
-      },
-    });
-    setStatus(response.error ? response.error.message : response.data?.valid ? "Valid key" : "Invalid key");
-  }
-
   return (
     <main className="min-h-screen bg-background px-6 py-12 text-foreground">
       <section className="mx-auto flex w-full max-w-3xl flex-col gap-6">
@@ -1888,34 +1859,31 @@ export function UnkeyApiKeysConsole() {
         </div>
         <Card>
           <CardHeader>
-            <CardTitle className="text-xl">Key console</CardTitle>
-            <CardDescription>API key lifecycle controls.</CardDescription>
+            <CardTitle className="text-xl">Protected API</CardTitle>
+            <CardDescription>Requests are verified by Unkey before the route runs.</CardDescription>
           </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="grid gap-4 sm:grid-cols-2">
-              <div className="space-y-2">
-                <Label htmlFor="name">Name</Label>
-                <Input id="name" value={name} onChange={(event) => setName(event.target.value)} />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="prefix">Prefix</Label>
-                <Input id="prefix" value={prefix} onChange={(event) => setPrefix(event.target.value)} />
-              </div>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="apiKey">API key</Label>
-              <Input id="apiKey" value={apiKey} onChange={(event) => setApiKey(event.target.value)} />
-            </div>
-            <p className="rounded-md border bg-muted/30 px-3 py-2 text-sm">{status}</p>
-            <div className="flex flex-wrap gap-2">
-              <Button type="button" onClick={() => void createKey()}>Create key</Button>
-              <Button type="button" variant="outline" onClick={() => void verifyKey()}>Verify</Button>
-            </div>
+          <CardContent className="space-y-3">
+            <code className="block overflow-x-auto rounded-md border bg-muted/30 p-3 text-xs">
+              curl http://localhost:3000/api/protected -H &quot;Authorization: Bearer YOUR_KEY&quot;
+            </code>
+            <p className="text-sm text-muted-foreground">
+              Create and rotate keys from trusted server code or the Unkey dashboard.
+            </p>
           </CardContent>
         </Card>
       </section>
     </main>
   );
+}
+`;
+}
+
+function unkeyProtectedRouteTemplate() {
+  return `export function GET() {
+  return Response.json({
+    ok: true,
+    message: "Valid Unkey API key.",
+  });
 }
 `;
 }

--- a/packages/farm-cli/test/add-integration.test.mjs
+++ b/packages/farm-cli/test/add-integration.test.mjs
@@ -56,7 +56,7 @@ test("adds a supabase integration to a new app", async () => {
 
     assert.equal(result.provider, "supabase");
     assert.equal(result.key, "auth");
-    assert.equal(packageJson.dependencies["@farm.js/integrations"], "workspace:*");
+    assert.equal(packageJson.dependencies["@farm.js/supabase"], "workspace:*");
     assert.match(registry, /import \{ supabaseIntegration \}/);
     assert.match(registry, /auth: supabaseIntegration/);
     assert.match(component, /supabase\(\{/);
@@ -118,7 +118,7 @@ export default defineConfig({
     const component = await readFile(path.join(root, "src/lib/integrations/stripe.ts"), "utf8");
     const config = await readFile(path.join(root, "farm.config.ts"), "utf8");
 
-    assert.equal(packageJson.dependencies["@farm.js/integrations"], "latest");
+    assert.equal(packageJson.dependencies["@farm.js/stripe"], "^0.1.0");
     assert.match(registry, /existing: existingIntegration/);
     assert.match(registry, /payments: stripeIntegration/);
     assert.match(component, /secretKey: process\.env\.STRIPE_SECRET_KEY/);
@@ -203,7 +203,7 @@ test("adds a stripe integration with the shadcn UI feature pack", async () => {
       components: ["badge", "button", "card"],
       files: result.ui.files,
     });
-    assert.equal(packageJson.dependencies["@farm.js/integrations"], "workspace:*");
+    assert.equal(packageJson.dependencies["@farm.js/stripe"], "workspace:*");
     assert.equal(packageJson.dependencies["class-variance-authority"], "^0.7.1");
     assert.equal(packageJson.dependencies.clsx, "^2.1.1");
     assert.equal(packageJson.dependencies["tailwind-merge"], "^3.3.1");
@@ -213,6 +213,9 @@ test("adds a stripe integration with the shadcn UI feature pack", async () => {
     assert.deepEqual(tsconfig.compilerOptions.paths["@/*"], ["./src/*"]);
     assert.match(globals, /--color-background/);
     assert.match(globals, /^@import "tailwindcss";/);
+    assert.match(globals, /@custom-variant dark \(&:where\(\[data-theme="dark"\]/);
+    assert.match(globals, /\[data-theme="dark"\] \{/);
+    assert.doesNotMatch(globals, /^\.dark \{/m);
     assert.match(globals, /body \{ margin: 0; \}/);
     assert.match(api, /createIntegrations<AppIntegrations>/);
     assert.match(pricing, /apiClient\.billing\.products/);
@@ -278,15 +281,52 @@ test("writes syntactically valid integration and UI files for every provider", a
       const packageJson = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
 
       assert.equal(
-        packageJson.dependencies["@farm.js/integrations"],
+        packageJson.dependencies[provider.packageName],
         "workspace:*",
-        `${provider.name} should install @farm.js/integrations`,
+        `${provider.name} should install ${provider.packageName}`,
       );
+      assert.equal(packageJson.dependencies["@farm.js/integrations"], undefined);
 
       for (const file of result.created.filter((file) => /\.[cm]?[jt]sx?$/.test(file))) {
         const source = await readFile(file, "utf8");
         assertTypeScriptSyntax(source, file);
         assert.doesNotMatch(source, /(["'])@\//, `${file} should use portable relative imports`);
+        if (file.includes(path.join("src", "app", "integrations")) && file.endsWith("page.tsx")) {
+          const importPath = source.match(/from "([^"]+)"/)?.[1];
+          assert.ok(importPath, `${file} should import its feature component`);
+          await readFile(path.resolve(path.dirname(file), `${importPath}.tsx`), "utf8");
+        }
+      }
+
+      if (provider.name === "auth0") {
+        const auth0Panel = await readFile(
+          path.join(root, "src/components/farm/auth0-auth-panel.tsx"),
+          "utf8",
+        );
+        assert.match(auth0Panel, /\/auth\/profile/);
+        assert.doesNotMatch(auth0Panel, /apiClient/);
+      }
+      if (provider.name === "supabase") {
+        assert.match(
+          await readFile(path.join(root, "src/components/farm/supabase-auth-panel.tsx"), "utf8"),
+          /apiClient\.auth\.login\.post/,
+        );
+      }
+      if (provider.name === "workos") {
+        assert.match(
+          await readFile(path.join(root, "src/components/farm/workos-auth-panel.tsx"), "utf8"),
+          /apiClient\.auth\.session\.get\(\)/,
+        );
+      }
+      if (provider.name === "unkey") {
+        assert.doesNotMatch(
+          await readFile(path.join(root, "src/components/farm/unkey-api-keys-console.tsx"), "utf8"),
+          /apiClient/,
+        );
+        assert.match(
+          await readFile(path.join(root, "src/app/api/protected/route.ts"), "utf8"),
+          /Valid Unkey API key/,
+        );
       }
 
       if (result.mode === "integration") {
@@ -361,6 +401,36 @@ test("scaffolds a working Better Auth starter with its UI dependencies", async (
   }
 });
 
+test("scaffolds a complete Auth.js instance with matching dependencies", async () => {
+  const root = await createTempProject({
+    packageJson: {
+      type: "module",
+      dependencies: {
+        "@farm.js/core": "0.1.0-beta.23",
+      },
+    },
+  });
+
+  try {
+    const result = await addFarmIntegration({
+      root,
+      provider: "authjs",
+      ui: true,
+    });
+    const packageJson = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
+    const auth = await readFile(path.join(root, "src/lib/auth.ts"), "utf8");
+
+    assert.equal(packageJson.dependencies["@farm.js/authjs"], "0.1.0-beta.23");
+    assert.equal(packageJson.dependencies["@auth/core"], "0.34.3");
+    assert.match(auth, /import \{ Auth \} from "@auth\/core"/);
+    assert.match(auth, /GitHub\(\{/);
+    assert.match(auth, /handlers:\s*\{\s*GET: handler,\s*POST: handler/s);
+    assert.deepEqual(result.env, ["AUTH_SECRET", "AUTH_GITHUB_ID", "AUTH_GITHUB_SECRET"]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("runs farm add integration stripe --ui through the CLI", async () => {
   const root = await createTempProject({
     packageJson: {
@@ -420,8 +490,8 @@ test("adds a Vercel AI SDK chat route template", async () => {
     assert.equal(result.routeFile, routeFile);
     assert.equal(result.routePath, "/api/chat");
     assert.deepEqual(result.env, ["AI_GATEWAY_API_KEY"]);
-    assert.equal(packageJson.dependencies["@farm.js/integrations"], "workspace:*");
-    assert.match(route, /import \{ aiChatRoute \} from "@farm.js\/integrations\/ai"/);
+    assert.equal(packageJson.dependencies["@farm.js/ai"], "workspace:*");
+    assert.match(route, /import \{ aiChatRoute \} from "@farm.js\/ai"/);
     assert.match(route, /export const POST = aiChatRoute/);
     assert.match(route, /model: "openai\/gpt-4o-mini"/);
     await assert.rejects(() => readFile(path.join(root, "src/lib/integrations.ts"), "utf8"));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1163,6 +1163,9 @@ importers:
         specifier: ^2.4.2
         version: 2.4.2
     devDependencies:
+      '@farm.js/cli':
+        specifier: workspace:*
+        version: link:../farm-cli
       '@types/node':
         specifier: ^20.10.5
         version: 20.19.21


### PR DESCRIPTION
## Summary

- add generated create-app templates for all 13 official integration providers, plus `--list-templates`
- compose each provider starter from the Basic template and `farm add integration --ui`
- install direct first-party provider packages at the app's matching Farm.js version, including beta releases
- give every integration starter the same minimal dark Geist hero used by the Basic/Auth starters
- add environment examples, provider READMEs, corrected `farm.js.dev` links, CLI docs, and starter catalog documentation
- harden generated provider UI/routes and expand generation coverage across every provider

## Why

Developers should be able to scaffold a complete provider starter directly from `pnpm create @farm.js/app@beta` instead of creating a Basic app and wiring the integration separately. Keeping the starters generated from the same integration registry also prevents the CLI and starter catalog from drifting apart.

## Validation

- `corepack pnpm --filter @farm.js/cli test` — 62 tests passed
- `corepack pnpm --filter @farm.js/create-app type-check`
- `corepack pnpm --filter @farm.js/create-app test` — 7 tests passed
- installed, type-checked, and production-built all 13 generated integration starters
- built the documentation site
- visually checked the Stripe starter at desktop and mobile sizes with Geist fonts loaded


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds provider starter templates to `@farm.js/create-app` so you can scaffold a complete integration (Stripe, Supabase, Auth0, etc.) with one command. Also adds `--list-templates` and installs direct provider packages that match your app’s `@farm.js/core` version, including betas.

- **New Features**
  - Generate starters via `--template` for 13 providers: `ai`, `auth0`, `authjs`, `autumn`, `clerk`, `jobs-inngest`, `jobs-trigger`, `polar`, `resend`, `stripe`, `supabase`, `unkey`, `workos` (plus `basic`, `auth`, `better-auth`).
  - `--list-templates` prints the full catalog in the terminal.
  - Each starter composes the Basic app + `farm add integration --ui`, includes shadcn-style UI, `.env.example`, a minimal dark home page, and a README with provider links.
  - Docs updated (Getting Started catalog, CLI examples) and fixed links to `https://farm.js.dev`.

- **Refactors**
  - `farm add integration` now imports from `@farm.js/<provider>` (not `@farm.js/integrations`) and pins that package to your installed `@farm.js/core` version.
  - Auth.js starter scaffolds `src/lib/auth.ts` with GitHub OAuth and adds `@auth/core@0.34.3`.
  - Auth UIs modernized (Auth0/Supabase/WorkOS) and Unkey now includes a protected `/api/protected` route demo.
  - Theme CSS switches to `[data-theme="dark"]`; generator and tests updated accordingly.

<sup>Written for commit 55da6b85c812f5c4b850daffdaa596693370135e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

