### PR TITLE
fix: unblock beta publishing

### DIFF
--- a/examples/auth0-integration/package.json
+++ b/examples/auth0-integration/package.json
@@ -9,13 +9,13 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/auth0": "0.1.0-beta.2",
-    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/auth0": "workspace:*",
+    "@farm.js/core": "workspace:*",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",

--- a/examples/authjs-integration/package.json
+++ b/examples/authjs-integration/package.json
@@ -9,13 +9,13 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/authjs": "0.1.0-beta.2",
-    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/authjs": "workspace:*",
+    "@farm.js/core": "workspace:*",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",

--- a/examples/autumn-integration/package.json
+++ b/examples/autumn-integration/package.json
@@ -10,16 +10,16 @@
     "generate": "farm generate"
   },
   "dependencies": {
-    "@farm.js/autumn": "0.1.0-beta.2",
-    "@farm.js/better-auth": "0.1.0-beta.2",
-    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/autumn": "workspace:*",
+    "@farm.js/better-auth": "workspace:*",
+    "@farm.js/core": "workspace:*",
     "better-auth": "^1.5.5",
     "better-sqlite3": "^12.8.0",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -15,14 +15,14 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/core": "workspace:*",
     "better-call": "^1.0.19",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "zod": "^4.1.12"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "tailwindcss": "^4.0.0",

--- a/examples/cf-agent/package.json
+++ b/examples/cf-agent/package.json
@@ -15,15 +15,15 @@
     "verify:worker": "wrangler deploy --dry-run --config .farm-cf-agent.wrangler.jsonc --outdir .farm/cf-agent/wrangler"
   },
   "dependencies": {
-    "@farm.js/cf-agent": "0.1.0-beta.2",
-    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/cf-agent": "workspace:*",
+    "@farm.js/core": "workspace:*",
     "agents": "0.17.4",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^5.20260710.1",
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/node": "^20.10.5",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/examples/clerk-integration/package.json
+++ b/examples/clerk-integration/package.json
@@ -11,13 +11,13 @@
   "dependencies": {
     "@clerk/backend": "^3.2.0",
     "@clerk/react": "^6.1.0",
-    "@farm.js/clerk": "0.1.0-beta.2",
-    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/clerk": "workspace:*",
+    "@farm.js/core": "workspace:*",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",

--- a/examples/deployment-presets/package.json
+++ b/examples/deployment-presets/package.json
@@ -18,12 +18,12 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/core": "workspace:*",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "typescript": "^5.3.3",

--- a/examples/docs-integration/package.json
+++ b/examples/docs-integration/package.json
@@ -9,12 +9,12 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/core": "workspace:*",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "typescript": "^5.5.3",

--- a/examples/email-integrations/resend-example/package.json
+++ b/examples/email-integrations/resend-example/package.json
@@ -9,14 +9,14 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "0.1.0-beta.2",
-    "@farm.js/email": "0.1.0-beta.2",
+    "@farm.js/core": "workspace:*",
+    "@farm.js/email": "workspace:*",
     "@react-email/components": "^1.0.12",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",

--- a/examples/eve-agent/package.json
+++ b/examples/eve-agent/package.json
@@ -13,15 +13,15 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "0.1.0-beta.2",
-    "@farm.js/eve": "0.1.0-beta.2",
+    "@farm.js/core": "workspace:*",
+    "@farm.js/eve": "workspace:*",
     "ai": "^7.0.26",
     "eve": "0.24.6",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "typescript": "^5.3.3",

--- a/examples/i18n/package.json
+++ b/examples/i18n/package.json
@@ -10,12 +10,12 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/core": "workspace:*",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "typescript": "^5.3.3",

--- a/examples/jobs-inngest/package.json
+++ b/examples/jobs-inngest/package.json
@@ -9,13 +9,13 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "0.1.0-beta.2",
-    "@farm.js/jobs": "0.1.0-beta.2",
+    "@farm.js/core": "workspace:*",
+    "@farm.js/jobs": "workspace:*",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",

--- a/examples/jobs-integration/package.json
+++ b/examples/jobs-integration/package.json
@@ -9,13 +9,13 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "0.1.0-beta.2",
-    "@farm.js/jobs": "0.1.0-beta.2",
+    "@farm.js/core": "workspace:*",
+    "@farm.js/jobs": "workspace:*",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",

--- a/examples/jobs-trigger/package.json
+++ b/examples/jobs-trigger/package.json
@@ -9,13 +9,13 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "0.1.0-beta.2",
-    "@farm.js/jobs": "0.1.0-beta.2",
+    "@farm.js/core": "workspace:*",
+    "@farm.js/jobs": "workspace:*",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",

--- a/examples/polar-integration/package.json
+++ b/examples/polar-integration/package.json
@@ -10,16 +10,16 @@
     "generate": "farm generate"
   },
   "dependencies": {
-    "@farm.js/better-auth": "0.1.0-beta.2",
-    "@farm.js/core": "0.1.0-beta.2",
-    "@farm.js/polar": "0.1.0-beta.2",
+    "@farm.js/better-auth": "workspace:*",
+    "@farm.js/core": "workspace:*",
+    "@farm.js/polar": "workspace:*",
     "better-auth": "^1.5.5",
     "better-sqlite3": "^12.8.0",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",

--- a/examples/preview-gateway/package.json
+++ b/examples/preview-gateway/package.json
@@ -9,7 +9,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/preview-gateway": "0.1.0-beta.2",
+    "@farm.js/preview-gateway": "workspace:*",
     "@farm.js/preview-tunnel": "0.1.0-beta.19",
     "@vercel/blob": "^2.6.1",
     "ioredis": "^5.9.3"

--- a/examples/rsc-demo/package.json
+++ b/examples/rsc-demo/package.json
@@ -17,7 +17,7 @@
     "deploy:cloudflare": "pnpm run build:cloudflare && npx wrangler pages deploy .output/public --project-name=farm-rsc-demo"
   },
   "dependencies": {
-    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/core": "workspace:*",
     "picocolors": "^1.0.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",
@@ -25,7 +25,7 @@
     "zod": "^4.1.0"
   },
   "devDependencies": {
-    "@farm.js/plugin": "0.1.0-beta.2",
+    "@farm.js/plugin": "workspace:*",
     "@rollup/plugin-terser": "^0.4.4",
     "@tailwindcss/vite": "^4.1.0",
     "@types/react": "^19.0.0",

--- a/examples/simple-demo/package.json
+++ b/examples/simple-demo/package.json
@@ -7,7 +7,7 @@
     "dev": "node server.js"
   },
   "dependencies": {
-    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/core": "workspace:*",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },

--- a/examples/ssr-ssg-demo/package.json
+++ b/examples/ssr-ssg-demo/package.json
@@ -14,14 +14,14 @@
     "deploy:netlify": "farm deploy --netlify"
   },
   "dependencies": {
-    "@farm.js/core": "0.1.0-beta.2",
+    "@farm.js/core": "workspace:*",
     "better-call": "^1.0.19",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "tailwindcss": "^4.0.0",

--- a/examples/stripe-integration/package.json
+++ b/examples/stripe-integration/package.json
@@ -9,14 +9,14 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "0.1.0-beta.2",
-    "@farm.js/stripe": "0.1.0-beta.2",
+    "@farm.js/core": "workspace:*",
+    "@farm.js/stripe": "workspace:*",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "stripe": "^20.4.1"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",

--- a/examples/stripe-integrations/drizzle/package.json
+++ b/examples/stripe-integrations/drizzle/package.json
@@ -11,9 +11,9 @@
   },
   "dependencies": {
     "@better-auth/passkey": "^1.3.1",
-    "@farm.js/better-auth": "0.1.0-beta.2",
-    "@farm.js/core": "0.1.0-beta.2",
-    "@farm.js/stripe": "0.1.0-beta.2",
+    "@farm.js/better-auth": "workspace:*",
+    "@farm.js/core": "workspace:*",
+    "@farm.js/stripe": "workspace:*",
     "better-auth": "^1.3.1",
     "better-sqlite3": "^12.6.2",
     "drizzle-orm": "^0.44.6",
@@ -22,7 +22,7 @@
     "stripe": "^20.4.1"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",

--- a/examples/stripe-integrations/prisma-org/package.json
+++ b/examples/stripe-integrations/prisma-org/package.json
@@ -11,9 +11,9 @@
   },
   "dependencies": {
     "@better-auth/passkey": "^1.3.1",
-    "@farm.js/better-auth": "0.1.0-beta.2",
-    "@farm.js/core": "0.1.0-beta.2",
-    "@farm.js/stripe": "0.1.0-beta.2",
+    "@farm.js/better-auth": "workspace:*",
+    "@farm.js/core": "workspace:*",
+    "@farm.js/stripe": "workspace:*",
     "@prisma/client": "^6.7.0",
     "better-auth": "^1.3.1",
     "better-sqlite3": "^12.6.2",
@@ -22,7 +22,7 @@
     "stripe": "^20.4.1"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",

--- a/examples/stripe-integrations/prisma/package.json
+++ b/examples/stripe-integrations/prisma/package.json
@@ -11,9 +11,9 @@
   },
   "dependencies": {
     "@better-auth/passkey": "^1.3.1",
-    "@farm.js/better-auth": "0.1.0-beta.2",
-    "@farm.js/core": "0.1.0-beta.2",
-    "@farm.js/stripe": "0.1.0-beta.2",
+    "@farm.js/better-auth": "workspace:*",
+    "@farm.js/core": "workspace:*",
+    "@farm.js/stripe": "workspace:*",
     "@prisma/client": "^6.7.0",
     "better-auth": "^1.3.1",
     "better-sqlite3": "^12.6.2",
@@ -22,7 +22,7 @@
     "stripe": "^20.4.1"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",

--- a/examples/stripe-integrations/sqlite/package.json
+++ b/examples/stripe-integrations/sqlite/package.json
@@ -11,9 +11,9 @@
   },
   "dependencies": {
     "@better-auth/passkey": "^1.3.1",
-    "@farm.js/better-auth": "0.1.0-beta.2",
-    "@farm.js/core": "0.1.0-beta.2",
-    "@farm.js/stripe": "0.1.0-beta.2",
+    "@farm.js/better-auth": "workspace:*",
+    "@farm.js/core": "workspace:*",
+    "@farm.js/stripe": "workspace:*",
     "better-auth": "^1.3.1",
     "better-sqlite3": "^12.6.2",
     "react": "19.2.8",
@@ -21,7 +21,7 @@
     "stripe": "^20.4.1"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",

--- a/examples/supabase-integration/package.json
+++ b/examples/supabase-integration/package.json
@@ -9,13 +9,13 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "0.1.0-beta.2",
-    "@farm.js/supabase": "0.1.0-beta.2",
+    "@farm.js/core": "workspace:*",
+    "@farm.js/supabase": "workspace:*",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",

--- a/examples/workos-integration/package.json
+++ b/examples/workos-integration/package.json
@@ -9,13 +9,13 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "0.1.0-beta.2",
-    "@farm.js/workos": "0.1.0-beta.2",
+    "@farm.js/core": "workspace:*",
+    "@farm.js/workos": "workspace:*",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.2",
+    "@farm.js/cli": "workspace:*",
     "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",

--- a/packages/create-farm-app/package.json
+++ b/packages/create-farm-app/package.json
@@ -43,7 +43,6 @@
     "prompts": "^2.4.2"
   },
   "devDependencies": {
-    "@farm.js/cli": "workspace:*",
     "@types/node": "^20.10.5",
     "@types/prompts": "^2.4.9",
     "tsdown": "^0.15.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,10 +119,10 @@ importers:
   examples/auth0-integration:
     dependencies:
       '@farm.js/auth0':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-auth0
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm
       react:
         specifier: 19.2.8
@@ -132,7 +132,7 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-cli
       '@types/node':
         specifier: ^20.10.5
@@ -153,10 +153,10 @@ importers:
   examples/authjs-integration:
     dependencies:
       '@farm.js/authjs':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-authjs
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm
       react:
         specifier: 19.2.8
@@ -166,7 +166,7 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-cli
       '@types/node':
         specifier: ^20.10.5
@@ -187,13 +187,13 @@ importers:
   examples/autumn-integration:
     dependencies:
       '@farm.js/autumn':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-autumn
       '@farm.js/better-auth':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-better-auth
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm
       better-auth:
         specifier: ^1.5.5
@@ -209,7 +209,7 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-cli
       '@types/better-sqlite3':
         specifier: ^7.6.13
@@ -233,7 +233,7 @@ importers:
   examples/basic:
     dependencies:
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm
       better-call:
         specifier: ^1.0.19
@@ -249,7 +249,7 @@ importers:
         version: 4.1.12
     devDependencies:
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-cli
       '@types/react':
         specifier: ^19.0.0
@@ -304,10 +304,10 @@ importers:
   examples/cf-agent:
     dependencies:
       '@farm.js/cf-agent':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-cf-agent
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm
       agents:
         specifier: 0.17.4
@@ -323,7 +323,7 @@ importers:
         specifier: ^5.20260710.1
         version: 5.20260716.1
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-cli
       '@types/node':
         specifier: ^20.10.5
@@ -353,10 +353,10 @@ importers:
         specifier: ^6.1.0
         version: 6.1.0(react-dom@19.2.8)(react@19.2.8)
       '@farm.js/clerk':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-clerk
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm
       react:
         specifier: 19.2.8
@@ -366,7 +366,7 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-cli
       '@types/node':
         specifier: ^20.10.5
@@ -387,7 +387,7 @@ importers:
   examples/deployment-presets:
     dependencies:
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm
       react:
         specifier: 19.2.8
@@ -397,7 +397,7 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-cli
       '@types/react':
         specifier: ^18.2.45
@@ -415,7 +415,7 @@ importers:
   examples/docs-integration:
     dependencies:
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm
       react:
         specifier: 19.2.8
@@ -425,7 +425,7 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-cli
       '@types/react':
         specifier: ^18.2.45
@@ -443,10 +443,10 @@ importers:
   examples/email-integrations/resend-example:
     dependencies:
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../../packages/farm
       '@farm.js/email':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../../packages/farm-email
       '@react-email/components':
         specifier: ^1.0.12
@@ -459,7 +459,7 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../../packages/farm-cli
       '@types/node':
         specifier: ^20.10.5
@@ -480,10 +480,10 @@ importers:
   examples/eve-agent:
     dependencies:
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm
       '@farm.js/eve':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-eve
       ai:
         specifier: ^7.0.26
@@ -499,7 +499,7 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-cli
       '@types/react':
         specifier: ^19.0.0
@@ -517,7 +517,7 @@ importers:
   examples/i18n:
     dependencies:
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm
       react:
         specifier: 19.2.8
@@ -527,7 +527,7 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-cli
       '@types/react':
         specifier: ^19.0.0
@@ -545,10 +545,10 @@ importers:
   examples/jobs-inngest:
     dependencies:
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm
       '@farm.js/jobs':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-jobs
       react:
         specifier: 19.2.8
@@ -558,7 +558,7 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-cli
       '@types/node':
         specifier: ^20.10.5
@@ -579,10 +579,10 @@ importers:
   examples/jobs-integration:
     dependencies:
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm
       '@farm.js/jobs':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-jobs
       react:
         specifier: 19.2.8
@@ -592,7 +592,7 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-cli
       '@types/node':
         specifier: ^20.10.5
@@ -613,10 +613,10 @@ importers:
   examples/jobs-trigger:
     dependencies:
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm
       '@farm.js/jobs':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-jobs
       react:
         specifier: 19.2.8
@@ -626,7 +626,7 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-cli
       '@types/node':
         specifier: ^20.10.5
@@ -647,13 +647,13 @@ importers:
   examples/polar-integration:
     dependencies:
       '@farm.js/better-auth':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-better-auth
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm
       '@farm.js/polar':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-polar
       better-auth:
         specifier: ^1.5.5
@@ -669,7 +669,7 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-cli
       '@types/better-sqlite3':
         specifier: ^7.6.13
@@ -693,7 +693,7 @@ importers:
   examples/preview-gateway:
     dependencies:
       '@farm.js/preview-gateway':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-preview-gateway
       '@farm.js/preview-tunnel':
         specifier: 0.1.0-beta.19
@@ -715,7 +715,7 @@ importers:
   examples/rsc-demo:
     dependencies:
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm
       picocolors:
         specifier: ^1.0.0
@@ -734,7 +734,7 @@ importers:
         version: 4.1.12
     devDependencies:
       '@farm.js/plugin':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farmjs-plugin
       '@rollup/plugin-terser':
         specifier: ^0.4.4
@@ -770,7 +770,7 @@ importers:
   examples/simple-demo:
     dependencies:
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm
       react:
         specifier: 18.3.1
@@ -786,7 +786,7 @@ importers:
   examples/ssr-ssg-demo:
     dependencies:
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm
       better-call:
         specifier: ^1.0.19
@@ -802,7 +802,7 @@ importers:
         version: 3.24.1
     devDependencies:
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-cli
       '@types/react':
         specifier: ^18.2.45
@@ -823,10 +823,10 @@ importers:
   examples/stripe-integration:
     dependencies:
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm
       '@farm.js/stripe':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-stripe
       react:
         specifier: 19.2.8
@@ -839,7 +839,7 @@ importers:
         version: 20.4.1(@types/node@20.19.21)
     devDependencies:
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-cli
       '@types/node':
         specifier: ^20.10.5
@@ -863,13 +863,13 @@ importers:
         specifier: ^1.3.1
         version: 1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5)(better-call@1.3.2)(nanostores@1.2.0)
       '@farm.js/better-auth':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../../packages/farm-better-auth
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../../packages/farm
       '@farm.js/stripe':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../../packages/farm-stripe
       better-auth:
         specifier: ^1.3.1
@@ -891,7 +891,7 @@ importers:
         version: 20.4.1(@types/node@20.19.21)
     devDependencies:
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../../packages/farm-cli
       '@types/better-sqlite3':
         specifier: ^7.6.13
@@ -921,13 +921,13 @@ importers:
         specifier: ^1.3.1
         version: 1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5)(better-call@1.3.2)(nanostores@1.2.0)
       '@farm.js/better-auth':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../../packages/farm-better-auth
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../../packages/farm
       '@farm.js/stripe':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../../packages/farm-stripe
       '@prisma/client':
         specifier: ^6.7.0
@@ -949,7 +949,7 @@ importers:
         version: 20.4.1(@types/node@20.19.21)
     devDependencies:
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../../packages/farm-cli
       '@types/better-sqlite3':
         specifier: ^7.6.13
@@ -979,13 +979,13 @@ importers:
         specifier: ^1.3.1
         version: 1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5)(better-call@1.3.2)(nanostores@1.2.0)
       '@farm.js/better-auth':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../../packages/farm-better-auth
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../../packages/farm
       '@farm.js/stripe':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../../packages/farm-stripe
       '@prisma/client':
         specifier: ^6.7.0
@@ -1007,7 +1007,7 @@ importers:
         version: 20.4.1(@types/node@20.19.21)
     devDependencies:
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../../packages/farm-cli
       '@types/better-sqlite3':
         specifier: ^7.6.13
@@ -1037,13 +1037,13 @@ importers:
         specifier: ^1.3.1
         version: 1.5.5(@better-auth/core@1.5.5)(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5)(better-call@1.3.2)(nanostores@1.2.0)
       '@farm.js/better-auth':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../../packages/farm-better-auth
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../../packages/farm
       '@farm.js/stripe':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../../packages/farm-stripe
       better-auth:
         specifier: ^1.3.1
@@ -1062,7 +1062,7 @@ importers:
         version: 20.4.1(@types/node@20.19.21)
     devDependencies:
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../../packages/farm-cli
       '@types/better-sqlite3':
         specifier: ^7.6.13
@@ -1086,10 +1086,10 @@ importers:
   examples/supabase-integration:
     dependencies:
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm
       '@farm.js/supabase':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-supabase
       react:
         specifier: 19.2.8
@@ -1099,7 +1099,7 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-cli
       '@types/node':
         specifier: ^20.10.5
@@ -1120,10 +1120,10 @@ importers:
   examples/workos-integration:
     dependencies:
       '@farm.js/core':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm
       '@farm.js/workos':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-workos
       react:
         specifier: 19.2.8
@@ -1133,7 +1133,7 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@farm.js/cli':
-        specifier: 0.1.0-beta.2
+        specifier: workspace:*
         version: link:../../packages/farm-cli
       '@types/node':
         specifier: ^20.10.5
@@ -1163,9 +1163,6 @@ importers:
         specifier: ^2.4.2
         version: 2.4.2
     devDependencies:
-      '@farm.js/cli':
-        specifier: workspace:*
-        version: link:../farm-cli
       '@types/node':
         specifier: ^20.10.5
         version: 20.19.21


### PR DESCRIPTION
## Summary

- switch all monorepo-owned Farm.js dependencies in examples from stale `0.1.0-beta.2` pins to `workspace:*`
- remove the unnecessary `@farm.js/cli` workspace dev dependency from `@farm.js/create-app`; its integration scaffold source is already bundled by the build
- update only the corresponding lockfile specifiers

## Root cause

After the workspace was bumped to beta.24, the exact beta.2 ranges in examples no longer matched the local packages. A normal `pnpm install` therefore queried npm and failed because `@farm.js/auth0@0.1.0-beta.2` was never published. At publish time, create-app also asked pnpm to resolve its new `@farm.js/cli: workspace:*` dev dependency even though that package is not needed in the published manifest.

## Impact

Fresh and frozen workspace installs now resolve every internal Farm.js dependency locally. The recursive beta publish can resume the missing beta.24 packages without republishing versions already present in npm.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter @farm.js/create-app type-check`
- `corepack pnpm --filter @farm.js/create-app test` — 7 tests passed
- create-app publish dry-run completed successfully
- full recursive publish dry-run completed successfully for every unpublished beta.24 package


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks beta publishing by switching examples to `workspace:*` for internal deps and removing an unnecessary dev dependency. Fresh and frozen installs now resolve locally, and recursive beta.24 publishing can proceed.

- **Bug Fixes**
  - Replaced all example `@farm.js/*` deps pinned to `0.1.0-beta.2` with `workspace:*` to stop `pnpm` from querying npm for unpublished packages.
  - Removed `@farm.js/cli` from `@farm.js/create-app` devDependencies; the scaffold is bundled and not needed at publish time.
  - Updated `pnpm-lock.yaml` specifiers only.

<sup>Written for commit 4c3249ed04f73b15b5c818e84344b459587c5537. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

