### PR TITLE
fix: refine create-app banner

### DIFF
--- a/packages/create-farm-app/src/utils.ts
+++ b/packages/create-farm-app/src/utils.ts
@@ -22,6 +22,9 @@ export function showBanner() {
   for (const line of art) {
     console.log(pc.cyan(line));
   }
-  console.log(pc.bold(pc.green("Create FARMJS App")) + pc.dim("  modern React meta-framework"));
+  console.log("");
+  console.log(
+    pc.bold(pc.green("Create FARMJS App")) + pc.dim("  a framework for product-integrated apps"),
+  );
   console.log("");
 }

--- a/packages/create-farm-app/test/create-app.test.mjs
+++ b/packages/create-farm-app/test/create-app.test.mjs
@@ -8,6 +8,23 @@ import { fileURLToPath } from "node:url";
 
 const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
+test("spaces the CLI banner and matches the website hero copy", async () => {
+  const { showBanner } = await import("../dist/utils.mjs");
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (...values) => lines.push(values.join(" "));
+
+  try {
+    showBanner();
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(lines[8], "");
+  assert.match(lines[9], /Create FARMJS App.*a framework for product-integrated apps/);
+  assert.doesNotMatch(lines.join("\n"), /modern React meta-framework/);
+});
+
 test("uses concise labels for CLI template choices", async () => {
   const source = await readFile(path.join(packageDir, "src/index.ts"), "utf8");
 


### PR DESCRIPTION
## Summary

- add a blank line between the FARMJS ASCII logo and the create-app banner text
- replace `modern React meta-framework` with the website hero copy: `a framework for product-integrated apps`
- add a regression test for both the spacing and wording

## Why

The previous title sat directly against the ASCII artwork and used copy that no longer matched the Farm.js website. This gives the CLI banner clearer visual rhythm and keeps the product language consistent.

## Validation

- `corepack pnpm --filter @farm.js/create-app type-check`
- `corepack pnpm --filter @farm.js/create-app test` — 8 tests passed
- manually previewed the interactive create-app terminal output


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refines the `@farm.js/create-app` CLI banner for clarity and consistency: adds a blank line below the ASCII logo and updates copy to "a framework for product-integrated apps".
Adds a regression test to verify spacing and wording.

<sup>Written for commit 5c89ad4fbc276d786482867b556db943060058b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

