### PR TITLE
fix: remove framework positioning

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@ This document provides an overview of the Farm.js framework architecture and des
 
 ## 🏗️ High-Level Architecture
 
-Farm.js is built as a monorepo containing multiple packages that work together to provide a complete React meta-framework experience.
+Farm.js is built as a monorepo containing multiple packages that work together to provide a complete full-stack framework experience.
 
 ```
 ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
@@ -247,4 +247,4 @@ For developers wanting to understand or contribute to Farm.js:
 4. **Run tests** - Understand expected behavior
 5. **Check documentation** - Comprehensive guides and API reference
 
-This architecture provides a solid foundation for a modern React meta-framework while maintaining simplicity and extensibility.
+This architecture provides a solid foundation for a modern full-stack framework while maintaining simplicity and extensibility.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <strong>A modern React framework for building fast, full-stack, product-integrated applications.</strong>
+  <strong>A framework for building fast, full-stack, product-integrated applications.</strong>
 </p>
 
 <p align="center">
@@ -26,7 +26,7 @@
   <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-Ready-blue.svg" alt="TypeScript ready" /></a>
 </p>
 
-## ✨ Built for Modern React
+## ✨ Built for Full-Stack Products
 
 | Feature                            | What it gives you                                                                                                                                                                               |
 | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -4,9 +4,9 @@ import { Databuddy } from "@databuddy/sdk/react";
 import "./globals.css";
 
 export const metadata = {
-  title: "farmjs.dev - React framework for integrated apps",
+  title: "farmjs.dev - Framework for integrated apps",
   description:
-    "Farm.js is an easy and fast React framework that blends app foundations and external services into one flow so teams can ship products faster.",
+    "Farm.js is an easy and fast full-stack framework that blends app foundations and external services into one flow so teams can ship products faster.",
   icons: {
     icon: [{ url: "/favicon.svg", type: "image/svg+xml", sizes: "any" }],
   },

--- a/examples/basic/src/app/about/page.tsx
+++ b/examples/basic/src/app/about/page.tsx
@@ -8,7 +8,7 @@ import { Link } from "@farm.js/core/client"
 
 export const metadata: Metadata = {
   title: "About | Farm.js",
-  description: "Learn about Farm.js - a modern React meta-framework built on Vite",
+  description: "Learn about Farm.js - a full-stack framework built on Vite",
 };
 
 export default function AboutPage({ params, searchParams }: PageProps) {
@@ -94,4 +94,3 @@ function Feature({ title, description }: { title: string; description: string })
     </div>
   )
 }
-

--- a/examples/basic/src/app/page.tsx
+++ b/examples/basic/src/app/page.tsx
@@ -10,7 +10,7 @@ import { FARM_VERSION } from '@farm.js/core/version'
 
 export const metadata: Metadata = {
   title: "Home | Farm.js",
-  description: "A modern React meta-framework built on Vite with Next.js-like semantics",
+  description: "A full-stack framework built on Vite with app-directory semantics",
   keywords: ["react", "vite", "meta-framework", "ssr", "farm.js"],
 };
 
@@ -23,7 +23,7 @@ export default function HomePage({ params, searchParams }: PageProps) {
         </h1>
         
         <p className="text-xl text-gray-600 max-w-2xl mx-auto">
-          A modern React meta-framework built on Vite with Next.js-like semantics
+          A full-stack framework built on Vite with app-directory semantics
         </p>
       </div>
 

--- a/examples/simple-demo/src/app/page.jsx
+++ b/examples/simple-demo/src/app/page.jsx
@@ -4,7 +4,7 @@ export default function HomePage() {
   return React.createElement('div', { className: 'container' },
     React.createElement('div', { className: 'emoji' }, '🚜'),
     React.createElement('h1', null, 'Farm.js is Live!'),
-    React.createElement('p', null, 'Your Vite-powered React framework is running successfully.'),
+    React.createElement('p', null, 'Your Vite-powered full-stack app is running successfully.'),
     React.createElement('div', { className: 'features' },
       React.createElement('h3', null, '✨ What\'s Working:'),
       React.createElement('ul', null,

--- a/examples/ssr-ssg-demo/src/app/blog/[slug]/page.tsx
+++ b/examples/ssr-ssg-demo/src/app/blog/[slug]/page.tsx
@@ -33,7 +33,7 @@ const blogPosts: Record<string, { title: string; content: string; date: string; 
   "hello-world": {
     title: "Hello World - Getting Started with Farm.js",
     content: `
-      Welcome to Farm.js! This is your first step into a powerful React meta-framework.
+      Welcome to Farm.js! This is your first step into a powerful full-stack framework.
       
       Farm.js provides:
       - File-based routing

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "farm.js",
   "private": true,
-  "description": "A modern React meta-framework that human and ai could understand",
+  "description": "A full-stack framework for product-integrated applications",
   "workspaces": [
     "packages/*",
     "examples/*",

--- a/packages/create-farm-app/templates/basic/src/app/layout.tsx
+++ b/packages/create-farm-app/templates/basic/src/app/layout.tsx
@@ -3,7 +3,7 @@ import "./globals.css";
 
 export const metadata: Metadata = {
   title: "FARMJS App",
-  description: "A modern React meta-framework built on Vite",
+  description: "A framework for product-integrated apps",
   icons: {
     icon: [{ url: "/favicon.svg", type: "image/svg+xml", sizes: "any" }],
   },

--- a/packages/create-farm-app/test/create-app.test.mjs
+++ b/packages/create-farm-app/test/create-app.test.mjs
@@ -22,7 +22,7 @@ test("spaces the CLI banner and matches the website hero copy", async () => {
 
   assert.equal(lines[8], "");
   assert.match(lines[9], /Create FARMJS App.*a framework for product-integrated apps/);
-  assert.doesNotMatch(lines.join("\n"), /modern React meta-framework/);
+  assert.doesNotMatch(lines.join("\n"), /React (?:meta-)?framework/i);
 });
 
 test("uses concise labels for CLI template choices", async () => {

--- a/packages/farm-cli/bin/farm.js
+++ b/packages/farm-cli/bin/farm.js
@@ -25,7 +25,10 @@ const banner = `
 ░██        ░██    ░██ ░██     ░██ ░██       ░██ ░██  ░██████     ░██████
 `;
 
-program.name("farm").description("Farm.js CLI - A modern React meta-framework").version(version);
+program
+  .name("farm")
+  .description("Farm.js CLI - A framework for product-integrated apps")
+  .version(version);
 program.addHelpText("beforeAll", `${banner}\n`);
 
 function collectOption(value, previous) {

--- a/playground/src/app/about/page.tsx
+++ b/playground/src/app/about/page.tsx
@@ -15,9 +15,8 @@ export default function AboutPage({ params, searchParams }: PageProps) {
         }}
       >
         <p style={{ lineHeight: "1.6", marginBottom: "1.5rem" }}>
-          Farm.js is a modern React meta-framework that brings together the best of both worlds: the
-          lightning-fast development experience of Vite and the familiar, powerful semantics of
-          Next.js.
+          Farm.js is a full-stack framework that brings together the lightning-fast development
+          experience of Vite and familiar, powerful app-directory semantics.
         </p>
 
         <h2 style={{ marginBottom: "1rem" }}>Key Features</h2>

--- a/playground/src/app/blog/[slug]/page.tsx
+++ b/playground/src/app/blog/[slug]/page.tsx
@@ -9,7 +9,7 @@ export default function BlogPostPage({ params, searchParams }: PageProps) {
     "hello-world": {
       title: "Hello World from Farm.js",
       content: `
-        <p>Welcome to Farm.js, a modern React meta-framework that combines the best of Vite's lightning-fast development experience with Next.js-like semantics!</p>
+        <p>Welcome to Farm.js, a full-stack framework that combines Vite's lightning-fast development experience with familiar app-directory semantics!</p>
         
         <h2>What makes Farm.js special?</h2>
         <ul>
@@ -28,7 +28,7 @@ export default function BlogPostPage({ params, searchParams }: PageProps) {
     "why-farm-js": {
       title: "Why We Built Farm.js",
       content: `
-        <p>The React ecosystem is rich with frameworks, so why did we decide to build another one?</p>
+        <p>The application framework ecosystem is rich with options, so why did we decide to build another one?</p>
         
         <h2>The Problem</h2>
         <p>While working with existing frameworks, we encountered several pain points:</p>

--- a/playground/src/app/blog/page.tsx
+++ b/playground/src/app/blog/page.tsx
@@ -6,14 +6,15 @@ export default function BlogPage({ params, searchParams }: PageProps) {
     {
       slug: "hello-world",
       title: "Hello World from Farm.js",
-      excerpt: "Welcome to our new React meta-framework built on Vite!",
+      excerpt: "Welcome to our new full-stack framework built on Vite!",
       date: "2024-01-15",
       author: "Farm.js Team",
     },
     {
       slug: "why-farm-js",
       title: "Why We Built Farm.js",
-      excerpt: "The story behind creating a new React framework with Vite and Next.js semantics.",
+      excerpt:
+        "The story behind creating a full-stack framework with Vite and app-directory semantics.",
       date: "2024-01-10",
       author: "Farm.js Team",
     },

--- a/skills/farmjs/SKILL.md
+++ b/skills/farmjs/SKILL.md
@@ -7,7 +7,7 @@ metadata:
 
 # Farm.js
 
-Farm.js is a React meta-framework in active development. Prefer local repository sources over memory:
+Farm.js is a full-stack application framework in active development. Prefer local repository sources over memory:
 
 - Docs: `README.md`, `docs/src/app/docs/**`
 - Core package: `packages/farm/src/**`


### PR DESCRIPTION
## Summary

- remove copy that categorizes Farm.js as a React framework or React meta-framework
- position Farm.js as a full-stack framework for product-integrated applications
- align the root README, website metadata, CLI help, architecture guidance, starter metadata, playground, examples, and repository skill copy
- retain technical React references where they describe current APIs such as React Server Components, hooks, or dependencies

## Why

React-specific product positioning unnecessarily narrows the framework's public identity. The updated wording describes what Farm.js enables without coupling the overall product category to one client implementation or disclosing future roadmap details.

## Validation

- repository-wide positioning audit found no remaining React framework/meta-framework categorization
- `corepack pnpm --filter @farm.js/create-app type-check`
- `corepack pnpm --filter @farm.js/create-app test` — 8 tests passed
- verified CLI help renders `Farm.js CLI - A framework for product-integrated apps`
- formatting and `git diff --check` passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repositioned Farm.js as a full-stack framework for product‑integrated apps by removing "React framework/meta‑framework" wording. Copy-only changes across docs, site metadata, CLI, examples, templates, and `package.json`; no behavior changes.

- **Refactors**
  - Replaced React-specific phrasing in README, ARCHITECTURE.md, examples, playground, and `skills/farmjs/SKILL.md`.
  - Updated docs site metadata title and description.
  - Updated CLI help/description to "Farm.js CLI - A framework for product-integrated apps".
  - Updated `package.json` description and `@farm.js/create-app` template metadata and tests.

<sup>Written for commit 3a99df42bacc6e912c3951cbccad6c26c167b1fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

