### PR TITLE
fix(docs): preserve page dates and hide agent links

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
     "@databuddy/sdk": "2.6.0",
     "@farm.js/core": "workspace:*",
     "@farming-labs/docs": "0.2.99",
-    "@farming-labs/farmjs": "0.2.102",
+    "@farming-labs/farmjs": "https://pkg.pr.new/farming-labs/docs/@farming-labs/farmjs@458",
     "@farming-labs/theme": "0.2.99",
     "@prisma/client": "6.7.0",
     "better-call": "^1.0.19",

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
     "@databuddy/sdk": "2.6.0",
     "@farm.js/core": "workspace:*",
     "@farming-labs/docs": "0.2.99",
-    "@farming-labs/farmjs": "https://pkg.pr.new/farming-labs/docs/@farming-labs/farmjs@458",
+    "@farming-labs/farmjs": "0.2.103",
     "@farming-labs/theme": "0.2.99",
     "@prisma/client": "6.7.0",
     "better-call": "^1.0.19",

--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -1197,6 +1197,12 @@ html[data-farm-docs-runtime="true"] .fd-page-action-menu-item:last-child {
   background: color-mix(in srgb, var(--color-fd-foreground) 6%, transparent) !important;
 }
 
+/* Keep agent discovery routes available without advertising them as reader UI. */
+html[data-farm-docs-runtime="true"] .fd-agent-llms-directive[data-visible-in-header],
+html[data-farm-docs-runtime="true"] .fd-llms-txt-links {
+  display: none !important;
+}
+
 #nd-docs-layout[data-fd-framework] .fd-llms-txt-link,
 #nd-docs-layout[data-fd-framework] .fd-last-updated-footer {
   border-radius: 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: 0.2.99
         version: 0.2.99(react@19.2.8)(supports-color@10.2.2)
       '@farming-labs/farmjs':
-        specifier: https://pkg.pr.new/farming-labs/docs/@farming-labs/farmjs@458
-        version: '@pkg.pr.new/farming-labs/docs/@farming-labs/farmjs@458(@farm.js/core@packages+farm)(@farming-labs/docs@0.2.99)(@farming-labs/theme@0.2.99)(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(rollup@4.52.4)(supports-color@10.2.2)'
+        specifier: 0.2.103
+        version: 0.2.103(@farm.js/core@packages+farm)(@farming-labs/docs@0.2.99)(@farming-labs/theme@0.2.99)(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(rollup@4.52.4)(supports-color@10.2.2)
       '@farming-labs/theme':
         specifier: 0.2.99
         version: 0.2.99(@farming-labs/docs@0.2.99)(@types/react-dom@18.3.7)(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(tailwindcss@3.4.18)
@@ -4134,6 +4134,48 @@ packages:
       - bare-abort-controller
       - react-native-b4a
       - supports-color
+    dev: false
+
+  /@farming-labs/farmjs@0.2.103(@farm.js/core@packages+farm)(@farming-labs/docs@0.2.99)(@farming-labs/theme@0.2.99)(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(rollup@4.52.4)(supports-color@10.2.2):
+    resolution: {integrity: sha512-HJ87wvyq8naz8Sa/AkmWsLmvzmUQ/vcoujHfT2MnGnpnq5YKdaCHfB3vXdj1go6z6xHFmU5+/VxlfhuC/Jmopg==}
+    peerDependencies:
+      '@farm.js/core': ^0.1.0-beta.19
+      '@farming-labs/docs': '*'
+      '@farming-labs/theme': '*'
+      react: ^18.2.0 || ^19.0.0
+      react-dom: ^18.2.0 || ^19.0.0
+    dependencies:
+      '@farm.js/core': link:packages/farm
+      '@farming-labs/docs': 0.2.99(react@19.2.8)(supports-color@10.2.2)
+      '@farming-labs/theme': 0.2.99(@farming-labs/docs@0.2.99)(@types/react-dom@18.3.7)(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(tailwindcss@3.4.18)
+      '@mdx-js/rollup': 3.1.1(rollup@4.52.4)(supports-color@10.2.2)
+      '@scalar/core': 0.4.6
+      fumadocs-core: 16.7.16(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(zod@4.3.6)
+      gray-matter: 4.0.3
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      remark-frontmatter: 5.0.0(supports-color@10.2.2)
+      remark-gfm: 4.0.1(supports-color@10.2.2)
+      remark-mdx-frontmatter: 5.2.0
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@mdx-js/mdx'
+      - '@mixedbread/sdk'
+      - '@orama/core'
+      - '@oramacloud/client'
+      - '@tanstack/react-router'
+      - '@types/estree-jsx'
+      - '@types/hast'
+      - '@types/mdast'
+      - '@types/react'
+      - algoliasearch
+      - flexsearch
+      - lucide-react
+      - next
+      - react-router
+      - rollup
+      - supports-color
+      - waku
     dev: false
 
   /@farming-labs/farmjs@0.2.99(@farm.js/core@packages+farm)(@farming-labs/docs@0.2.99)(@farming-labs/theme@0.2.99)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)(rollup@4.52.4)(supports-color@10.2.2):
@@ -17716,49 +17758,4 @@ packages:
 
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
-    dev: false
-
-  '@pkg.pr.new/farming-labs/docs/@farming-labs/farmjs@458(@farm.js/core@packages+farm)(@farming-labs/docs@0.2.99)(@farming-labs/theme@0.2.99)(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(rollup@4.52.4)(supports-color@10.2.2)':
-    resolution: {tarball: https://pkg.pr.new/farming-labs/docs/@farming-labs/farmjs@458}
-    id: '@pkg.pr.new/farming-labs/docs/@farming-labs/farmjs@458'
-    name: '@farming-labs/farmjs'
-    version: 0.2.102
-    peerDependencies:
-      '@farm.js/core': ^0.1.0-beta.19
-      '@farming-labs/docs': '*'
-      '@farming-labs/theme': '*'
-      react: ^18.2.0 || ^19.0.0
-      react-dom: ^18.2.0 || ^19.0.0
-    dependencies:
-      '@farm.js/core': link:packages/farm
-      '@farming-labs/docs': 0.2.99(react@19.2.8)(supports-color@10.2.2)
-      '@farming-labs/theme': 0.2.99(@farming-labs/docs@0.2.99)(@types/react-dom@18.3.7)(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(tailwindcss@3.4.18)
-      '@mdx-js/rollup': 3.1.1(rollup@4.52.4)(supports-color@10.2.2)
-      '@scalar/core': 0.4.6
-      fumadocs-core: 16.7.16(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(zod@4.3.6)
-      gray-matter: 4.0.3
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      remark-frontmatter: 5.0.0(supports-color@10.2.2)
-      remark-gfm: 4.0.1(supports-color@10.2.2)
-      remark-mdx-frontmatter: 5.2.0
-      zod: 4.3.6
-    transitivePeerDependencies:
-      - '@mdx-js/mdx'
-      - '@mixedbread/sdk'
-      - '@orama/core'
-      - '@oramacloud/client'
-      - '@tanstack/react-router'
-      - '@types/estree-jsx'
-      - '@types/hast'
-      - '@types/mdast'
-      - '@types/react'
-      - algoliasearch
-      - flexsearch
-      - lucide-react
-      - next
-      - react-router
-      - rollup
-      - supports-color
-      - waku
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: 0.2.99
         version: 0.2.99(react@19.2.8)(supports-color@10.2.2)
       '@farming-labs/farmjs':
-        specifier: 0.2.102
-        version: 0.2.102(@farm.js/core@packages+farm)(@farming-labs/docs@0.2.99)(@farming-labs/theme@0.2.99)(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(rollup@4.52.4)(supports-color@10.2.2)
+        specifier: https://pkg.pr.new/farming-labs/docs/@farming-labs/farmjs@458
+        version: '@pkg.pr.new/farming-labs/docs/@farming-labs/farmjs@458(@farm.js/core@packages+farm)(@farming-labs/docs@0.2.99)(@farming-labs/theme@0.2.99)(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(rollup@4.52.4)(supports-color@10.2.2)'
       '@farming-labs/theme':
         specifier: 0.2.99
         version: 0.2.99(@farming-labs/docs@0.2.99)(@types/react-dom@18.3.7)(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(tailwindcss@3.4.18)
@@ -4134,48 +4134,6 @@ packages:
       - bare-abort-controller
       - react-native-b4a
       - supports-color
-    dev: false
-
-  /@farming-labs/farmjs@0.2.102(@farm.js/core@packages+farm)(@farming-labs/docs@0.2.99)(@farming-labs/theme@0.2.99)(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(rollup@4.52.4)(supports-color@10.2.2):
-    resolution: {integrity: sha512-wXoVYjYbv9z+aaQqnQBj6sDjCspV1icWrLmZ6UbrLFcVw8TotgEe67ez2kHCw5iTTgRyP8uDkOHroRl85FOlpw==}
-    peerDependencies:
-      '@farm.js/core': ^0.1.0-beta.19
-      '@farming-labs/docs': '*'
-      '@farming-labs/theme': '*'
-      react: ^18.2.0 || ^19.0.0
-      react-dom: ^18.2.0 || ^19.0.0
-    dependencies:
-      '@farm.js/core': link:packages/farm
-      '@farming-labs/docs': 0.2.99(react@19.2.8)(supports-color@10.2.2)
-      '@farming-labs/theme': 0.2.99(@farming-labs/docs@0.2.99)(@types/react-dom@18.3.7)(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(tailwindcss@3.4.18)
-      '@mdx-js/rollup': 3.1.1(rollup@4.52.4)(supports-color@10.2.2)
-      '@scalar/core': 0.4.6
-      fumadocs-core: 16.7.16(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(zod@4.3.6)
-      gray-matter: 4.0.3
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      remark-frontmatter: 5.0.0(supports-color@10.2.2)
-      remark-gfm: 4.0.1(supports-color@10.2.2)
-      remark-mdx-frontmatter: 5.2.0
-      zod: 4.3.6
-    transitivePeerDependencies:
-      - '@mdx-js/mdx'
-      - '@mixedbread/sdk'
-      - '@orama/core'
-      - '@oramacloud/client'
-      - '@tanstack/react-router'
-      - '@types/estree-jsx'
-      - '@types/hast'
-      - '@types/mdast'
-      - '@types/react'
-      - algoliasearch
-      - flexsearch
-      - lucide-react
-      - next
-      - react-router
-      - rollup
-      - supports-color
-      - waku
     dev: false
 
   /@farming-labs/farmjs@0.2.99(@farm.js/core@packages+farm)(@farming-labs/docs@0.2.99)(@farming-labs/theme@0.2.99)(@types/react@18.3.26)(react-dom@19.2.8)(react@19.2.8)(rollup@4.52.4)(supports-color@10.2.2):
@@ -17758,4 +17716,49 @@ packages:
 
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+    dev: false
+
+  '@pkg.pr.new/farming-labs/docs/@farming-labs/farmjs@458(@farm.js/core@packages+farm)(@farming-labs/docs@0.2.99)(@farming-labs/theme@0.2.99)(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(rollup@4.52.4)(supports-color@10.2.2)':
+    resolution: {tarball: https://pkg.pr.new/farming-labs/docs/@farming-labs/farmjs@458}
+    id: '@pkg.pr.new/farming-labs/docs/@farming-labs/farmjs@458'
+    name: '@farming-labs/farmjs'
+    version: 0.2.102
+    peerDependencies:
+      '@farm.js/core': ^0.1.0-beta.19
+      '@farming-labs/docs': '*'
+      '@farming-labs/theme': '*'
+      react: ^18.2.0 || ^19.0.0
+      react-dom: ^18.2.0 || ^19.0.0
+    dependencies:
+      '@farm.js/core': link:packages/farm
+      '@farming-labs/docs': 0.2.99(react@19.2.8)(supports-color@10.2.2)
+      '@farming-labs/theme': 0.2.99(@farming-labs/docs@0.2.99)(@types/react-dom@18.3.7)(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(tailwindcss@3.4.18)
+      '@mdx-js/rollup': 3.1.1(rollup@4.52.4)(supports-color@10.2.2)
+      '@scalar/core': 0.4.6
+      fumadocs-core: 16.7.16(@types/react@18.3.26)(lucide-react@1.23.0)(next@16.2.4)(react-dom@19.2.8)(react@19.2.8)(supports-color@10.2.2)(zod@4.3.6)
+      gray-matter: 4.0.3
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      remark-frontmatter: 5.0.0(supports-color@10.2.2)
+      remark-gfm: 4.0.1(supports-color@10.2.2)
+      remark-mdx-frontmatter: 5.2.0
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@mdx-js/mdx'
+      - '@mixedbread/sdk'
+      - '@orama/core'
+      - '@oramacloud/client'
+      - '@tanstack/react-router'
+      - '@types/estree-jsx'
+      - '@types/hast'
+      - '@types/mdast'
+      - '@types/react'
+      - algoliasearch
+      - flexsearch
+      - lucide-react
+      - next
+      - react-router
+      - rollup
+      - supports-color
+      - waku
     dev: false


### PR DESCRIPTION
## What changed

- update `@farming-labs/farmjs` to the official `0.2.103` registry release
- hide the reader-facing `LLMS.TXT`, `llms.txt`, and `llms-full.txt` controls in Farm-owned `globals.css`
- keep `/llms.txt` and `/llms-full.txt` available for agents
- keep `@farming-labs/docs` and `@farming-labs/theme` pinned at `0.2.99` so the Farm presentation remains isolated

## Why

Vercel stamps copied content files with an old mtime. The Farm adapter previously read that copied-file timestamp and rendered `Last updated at October 20, 2018`. `@farming-labs/farmjs@0.2.103` consumes Farm’s bundled `.farm-docs-last-modified.json` manifest instead.

## Validation

- `pnpm --filter farmjs-docs build`
- exact Vercel deployment `dpl_FboeGCASdvUNpa47sBCyUFyW6A8e` is Ready
- deployed `/docs/getting-started` reports `Last updated at August 10, 2026`, not the copied-file 2018 timestamp
- deployed sitemap reports `<lastmod>2026-08-10</lastmod>`
- `/llms.txt` and `/llms-full.txt` both return 200 and remain non-empty
- browser: visible LLM links are hidden, Edit on GitHub remains visible, and the 286/754/240 sidebar/article/TOC layout is unchanged