### PR TITLE
feat: add OpenTelemetry tracing

### DIFF
--- a/docs/src/app/docs/observability/page.md
+++ b/docs/src/app/docs/observability/page.md
@@ -1,12 +1,112 @@
 ---
-title: "Observability"
-description: "Listen to Farm runtime events for server lifecycle, route matching, rendering, API routes, integrations, integration databases, cache, PPR, builds, plugins, and errors."
+title: "Observability and tracing"
+description: "Export OpenTelemetry traces and listen to correlated Farm runtime events in development and production."
 section: "Runtime"
 ---
 
-# Observability
+# Observability and tracing
 
-Listen to Farm runtime events for server lifecycle, route matching, rendering, API routes, integrations, integration databases, cache, PPR, builds, plugins, and errors.
+Farm has two complementary observability layers:
+
+- OpenTelemetry traces show the request timeline and export to any OTLP-compatible backend.
+- Farm events expose detailed framework lifecycle data for logs, alerts, and custom integrations.
+
+The same lifecycle events are attached to the active OpenTelemetry span, and delivered events include `traceId`, `spanId`, and `traceSampled` for correlation.
+
+## OpenTelemetry quick start
+
+Install Farm's optional Node SDK setup package:
+
+```bash
+pnpm add @farm.js/otel
+```
+
+Create one instrumentation file at `src/instrumentation.ts` or `instrumentation.ts`:
+
+```ts
+import type { FarmInstrumentationContext } from "@farm.js/core/instrumentation";
+
+export async function register(context: FarmInstrumentationContext) {
+  if (context.runtime !== "nodejs") return;
+
+  const { registerOTel } = await import("@farm.js/otel");
+  return registerOTel({
+    serviceName: "storefront",
+    serviceVersion: process.env.APP_VERSION,
+  });
+}
+```
+
+Enable Farm spans in `farm.config.ts`:
+
+```ts
+import { defineConfig } from "@farm.js/core";
+
+export default defineConfig({
+  observability: {
+    tracing: {
+      attributes: {
+        "deployment.environment": process.env.NODE_ENV ?? "development",
+      },
+    },
+  },
+});
+```
+
+`@farm.js/otel` uses the OTLP HTTP trace exporter by default. Configure the destination with standard OpenTelemetry environment variables:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otel-collector.example.com
+OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer%20TOKEN"
+```
+
+Use `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` when traces need a different endpoint. You can also pass a custom `traceExporter`, `spanProcessors`, sampler, resource, or instrumentation list to `registerOTel`.
+
+Both pieces are intentional: `instrumentation.ts` starts an SDK/exporter, while `observability.tracing` tells Farm to create framework spans. Without an SDK, the OpenTelemetry API remains a no-op.
+
+## What Farm traces
+
+| Span                                      | Meaning                                                                       |
+| ----------------------------------------- | ----------------------------------------------------------------------------- |
+| `GET /products/:id`                       | Server request span with method, route, path, status, and propagated context. |
+| `farm.render /products/:id`               | Completed page render.                                                        |
+| `farm.middleware auth`                    | Completed middleware execution.                                               |
+| `farm.api POST /api/products`             | Completed API route execution.                                                |
+| `farm.integration stripe.checkout.create` | Completed integration operation when that event is emitted.                   |
+| `farm.storage query`                      | Completed integration database operation when that event is emitted.          |
+| `farm.ppr.refresh /dashboard`             | Completed PPR refresh.                                                        |
+| `farm.plugin plugin.hook`                 | Completed plugin hook when that event is emitted.                             |
+
+Incoming W3C `traceparent` headers are extracted automatically. A matched Farm route renames the request span from the raw pathname to the route pattern and sets `http.route`. Status codes of 500 or higher and thrown errors mark spans as errors.
+
+To wrap application work in a typed Farm-aware child span:
+
+```ts
+import { runWithFarmSpan } from "@farm.js/core/observability";
+
+const result = await runWithFarmSpan(
+  "catalog.recommendations",
+  () => loadRecommendations(productId),
+  {
+    kind: "integration",
+    attributes: { "product.id": productId },
+  },
+);
+```
+
+Use `getFarmTraceContext()` when a log or provider call needs the current trace and span IDs.
+
+## Instrumentation lifecycle
+
+Farm calls `register(context)` once before the development server or production request runtime starts. The context contains:
+
+- `mode`: `development`, `production`, or `test`
+- `runtime`: `nodejs`, `edge`, or `bun`
+- `root`: the runtime working directory
+
+`register` may return a cleanup function or an object with `shutdown()`. An exported `shutdown()` function is also supported. Farm runs cleanup during development server close and production graceful shutdown, after active requests drain, so batched spans are flushed before the process exits.
+
+Keep Node-only SDK imports inside the `runtime === "nodejs"` branch. Edge and Bun deployments can initialize a runtime-compatible OpenTelemetry SDK in their own branch without changing Farm's tracing API.
 
 ## Subscribe to events
 
@@ -26,6 +126,7 @@ onFarmEvent((event) => {
 
 | Family               | Examples                                                                         |
 | -------------------- | -------------------------------------------------------------------------------- |
+| Request              | request.start, request.complete, request.error                                   |
 | Server               | server.start, server.ready, server.shutdown                                      |
 | Routing              | route.discovered, route.matched, route.notFound, route.redirect                  |
 | Rendering            | render.start, render.complete, render.stream.shellReady, render.error            |
@@ -48,6 +149,7 @@ import { defineConfig } from "@farm.js/core";
 export default defineConfig({
   observability: {
     logs: true,
+    tracing: true,
     events: ["cache.hit", "cache.miss", "ppr.shell.cached"],
     onEvent(event) {
       if (event.type === "cache.miss") {
@@ -58,7 +160,7 @@ export default defineConfig({
 });
 ```
 
-`events` is optional. Leave it out to receive every emitted event.
+`events` is optional. Leave it out to receive every emitted event. Filtering event delivery does not disable span creation or the events recorded on active spans.
 
 ## Runtime subscription
 
@@ -116,7 +218,10 @@ export default defineConfig({
 
 ## Production notes
 
+- Keep `@farm.js/otel` in `dependencies`, not `devDependencies`, so it is available in the deployed server bundle.
+- Set `OTEL_SERVICE_NAME` or pass `serviceName` explicitly; use deployment/version resource attributes for release comparisons.
+- Farm's production lifecycle waits for active requests and then shuts down instrumentation, allowing the batch processor to flush.
 - Filter high-volume events before shipping them to a log drain.
-- Attach request IDs in middleware so event streams can be correlated.
+- Use the emitted trace and span IDs to correlate Farm events with application logs.
 - Treat event payloads as operational metadata; do not put secrets in event fields.
 - Watch `api.validation.failed`, `integration.webhook.failed`, `cache.error`, and `ppr.refresh.error` in production.

--- a/docs/src/app/docs/page.md
+++ b/docs/src/app/docs/page.md
@@ -59,7 +59,7 @@ Cache, PPR, observability, instant preview, and deployment output.
 
 - [Post-response Work](/docs/after): Schedule short server work with after() without delaying the response.
 - [Cache and PPR](/docs/cache-ppr): Use shared runtime cache helpers, tag/path invalidation, ISR-style revalidation, and static shell caching for PPR pages.
-- [Observability](/docs/observability): Listen to Farm runtime events for server lifecycle, route matching, rendering, API routes, integrations, integration databases, cache, PPR, builds, plugins, and errors.
+- [Observability](/docs/observability): Export OpenTelemetry traces and consume correlated Farm runtime events in development and production.
 - [DevTools and Doctor](/docs/devtools): Inspect the resolved app runtime in the browser and run the same diagnostics from the terminal or CI.
 - [Cron](/docs/cron): Map portable UTC schedules to ordinary API routes, run them locally, and compile them to deployment-native triggers.
 - [Instant Preview](/docs/preview): Expose the current local app through a public URL for sharing, webhooks, OAuth callbacks, and external testing.

--- a/docs/src/app/docs/reference/page.md
+++ b/docs/src/app/docs/reference/page.md
@@ -10,21 +10,24 @@ A compact map of the main package exports and where to learn more.
 
 ## Core exports
 
-| Export area                 | What it covers                                                                       |
-| --------------------------- | ------------------------------------------------------------------------------------ |
-| @farm.js/core               | Config, app types, plugins, integrations, routing, OpenAPI, docs, cache.             |
-| @farm.js/core/client        | Link, router helpers, callable route actions, API client, integration client.        |
-| @farm.js/core/plugin/client | Advanced browser lifecycle manager and client plugin event types.                    |
-| @farm.js/core/navigation    | Next-compatible redirect, notFound, and client navigation hooks.                     |
-| @farm.js/core/headers       | Next-compatible request headers and cookies helpers.                                 |
-| @farm.js/core/router        | Lightweight route matching, href building, and active-route checks.                  |
-| @farm.js/core/query         | Query and route param types.                                                         |
-| @farm.js/core/storage       | Key/value clients, drivers, mounts, and `getStorage()`.                              |
-| @farm.js/core/cache         | Data cache, revalidation, cache keys.                                                |
-| @farm.js/cache-redis        | Distributed Redis cache, tag versions, and regeneration leases.                      |
-| @farm.js/core/after         | Post-response server work with `after()`.                                            |
-| @farm.js/core/cron          | Cron route authorization, schedule types, manifests, and deployment adapter helpers. |
-| @farm.js/integrations       | Auth, billing, email, jobs, AI, API keys, provider clients.                          |
+| Export area                   | What it covers                                                                       |
+| ----------------------------- | ------------------------------------------------------------------------------------ |
+| @farm.js/core                 | Config, app types, plugins, integrations, routing, OpenAPI, docs, cache.             |
+| @farm.js/core/client          | Link, router helpers, callable route actions, API client, integration client.        |
+| @farm.js/core/plugin/client   | Advanced browser lifecycle manager and client plugin event types.                    |
+| @farm.js/core/navigation      | Next-compatible redirect, notFound, and client navigation hooks.                     |
+| @farm.js/core/headers         | Next-compatible request headers and cookies helpers.                                 |
+| @farm.js/core/router          | Lightweight route matching, href building, and active-route checks.                  |
+| @farm.js/core/query           | Query and route param types.                                                         |
+| @farm.js/core/storage         | Key/value clients, drivers, mounts, and `getStorage()`.                              |
+| @farm.js/core/cache           | Data cache, revalidation, cache keys.                                                |
+| @farm.js/cache-redis          | Distributed Redis cache, tag versions, and regeneration leases.                      |
+| @farm.js/core/after           | Post-response server work with `after()`.                                            |
+| @farm.js/core/cron            | Cron route authorization, schedule types, manifests, and deployment adapter helpers. |
+| @farm.js/core/observability   | Farm events, request tracing, custom spans, and active trace context.                |
+| @farm.js/core/instrumentation | Startup and shutdown convention types for development and production runtimes.       |
+| @farm.js/otel                 | Optional Node OpenTelemetry SDK, OTLP exporter, and auto-instrumentation setup.      |
+| @farm.js/integrations         | Auth, billing, email, jobs, AI, API keys, provider clients.                          |
 
 ## Recommended reading path
 

--- a/packages/farm-otel/package.json
+++ b/packages/farm-otel/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@farm.js/otel",
+  "version": "0.1.0-beta.25",
+  "description": "OpenTelemetry SDK setup for Farm.js applications",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/farming-labs/farm.js",
+    "directory": "packages/farm-otel"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && tsc",
+    "dev": "tsc --watch",
+    "type-check": "tsc --noEmit",
+    "test": "pnpm run build && node --test test/*.test.mjs"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "1.9.1",
+    "@opentelemetry/auto-instrumentations-node": "0.79.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.221.0",
+    "@opentelemetry/instrumentation": "0.221.0",
+    "@opentelemetry/resources": "2.10.0",
+    "@opentelemetry/sdk-node": "0.221.0",
+    "@opentelemetry/sdk-trace-base": "2.10.0",
+    "@opentelemetry/semantic-conventions": "1.43.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.5",
+    "typescript": "^5.3.3"
+  },
+  "engines": {
+    "node": ">=20.6.0"
+  }
+}

--- a/packages/farm-otel/src/index.ts
+++ b/packages/farm-otel/src/index.ts
@@ -1,0 +1,118 @@
+import type { Attributes } from "@opentelemetry/api";
+import {
+  getNodeAutoInstrumentations,
+  type InstrumentationConfigMap,
+} from "@opentelemetry/auto-instrumentations-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import type { Instrumentation } from "@opentelemetry/instrumentation";
+import { resourceFromAttributes, type Resource } from "@opentelemetry/resources";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import {
+  BatchSpanProcessor,
+  type Sampler,
+  type SpanExporter,
+  type SpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from "@opentelemetry/semantic-conventions";
+
+export interface FarmOTelOptions {
+  serviceName?: string;
+  serviceVersion?: string;
+  resource?: Resource;
+  resourceAttributes?: Attributes;
+  traceExporter?: SpanExporter;
+  exporter?: ConstructorParameters<typeof OTLPTraceExporter>[0];
+  spanProcessors?: SpanProcessor[];
+  sampler?: Sampler;
+  autoInstrumentations?: boolean;
+  instrumentationConfig?: InstrumentationConfigMap;
+  instrumentations?: Array<Instrumentation | Instrumentation[]>;
+}
+
+export interface FarmOTelController {
+  sdk: NodeSDK;
+  forceFlush(): Promise<void>;
+  shutdown(): Promise<void>;
+}
+
+interface FarmOTelGlobalState {
+  controller?: FarmOTelController;
+  initializing?: Promise<FarmOTelController>;
+}
+
+const FARM_OTEL_STATE = Symbol.for("@farm.js/otel/state");
+
+function getGlobalState(): FarmOTelGlobalState {
+  const target = globalThis as typeof globalThis & {
+    [FARM_OTEL_STATE]?: FarmOTelGlobalState;
+  };
+  return (target[FARM_OTEL_STATE] ??= {});
+}
+
+export async function registerOTel(options: FarmOTelOptions = {}): Promise<FarmOTelController> {
+  const state = getGlobalState();
+  if (state.controller) return state.controller;
+  if (state.initializing) return state.initializing;
+
+  state.initializing = Promise.resolve()
+    .then(() => {
+      const defaultResource = resourceFromAttributes({
+        [ATTR_SERVICE_NAME]: options.serviceName ?? process.env.OTEL_SERVICE_NAME ?? "farm-app",
+        ...(options.serviceVersion ? { [ATTR_SERVICE_VERSION]: options.serviceVersion } : {}),
+        ...options.resourceAttributes,
+      });
+      const resource = options.resource ? defaultResource.merge(options.resource) : defaultResource;
+      const spanProcessors = options.spanProcessors ?? [
+        new BatchSpanProcessor(options.traceExporter ?? new OTLPTraceExporter(options.exporter)),
+      ];
+      const instrumentations =
+        options.instrumentations ??
+        (options.autoInstrumentations === false
+          ? []
+          : [getNodeAutoInstrumentations(options.instrumentationConfig)]);
+      const sdk = new NodeSDK({
+        resource,
+        sampler: options.sampler,
+        spanProcessors,
+        instrumentations,
+      });
+      sdk.start();
+
+      let shutdownPromise: Promise<void> | undefined;
+      const controller: FarmOTelController = {
+        sdk,
+        async forceFlush() {
+          await Promise.all(spanProcessors.map((processor) => processor.forceFlush()));
+        },
+        shutdown() {
+          if (!shutdownPromise) {
+            shutdownPromise = sdk.shutdown().finally(() => {
+              state.controller = undefined;
+              state.initializing = undefined;
+            });
+          }
+          return shutdownPromise;
+        },
+      };
+      state.controller = controller;
+      return controller;
+    })
+    .catch((error) => {
+      state.initializing = undefined;
+      throw error;
+    });
+
+  return state.initializing;
+}
+
+export async function forceFlushOTel(): Promise<void> {
+  const state = getGlobalState();
+  const controller = state.controller ?? (await state.initializing);
+  await controller?.forceFlush();
+}
+
+export async function shutdownOTel(): Promise<void> {
+  const state = getGlobalState();
+  const controller = state.controller ?? (await state.initializing);
+  await controller?.shutdown();
+}

--- a/packages/farm-otel/test/register.test.mjs
+++ b/packages/farm-otel/test/register.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { trace } from "@opentelemetry/api";
+import { registerOTel } from "../dist/index.js";
+
+test("registerOTel starts, exports, flushes, and shuts down a real SDK", async () => {
+  const spans = [];
+  let shutDown = false;
+  const exporter = {
+    export(batch, callback) {
+      spans.push(...batch);
+      callback({ code: 0 });
+    },
+    async shutdown() {
+      shutDown = true;
+    },
+  };
+
+  const controller = await registerOTel({
+    serviceName: "farm-otel-test",
+    autoInstrumentations: false,
+    traceExporter: exporter,
+  });
+  const span = trace.getTracer("farm-otel-test").startSpan("test span");
+  span.end();
+  await controller.forceFlush();
+
+  assert.equal(spans.length, 1);
+  assert.equal(spans[0].name, "test span");
+  assert.equal(spans[0].resource.attributes["service.name"], "farm-otel-test");
+  await controller.shutdown();
+  assert.equal(shutDown, true);
+});

--- a/packages/farm-otel/tsconfig.json
+++ b/packages/farm-otel/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -81,6 +81,9 @@
       "observability": [
         "./dist/observability.d.ts"
       ],
+      "instrumentation": [
+        "./dist/instrumentation.d.ts"
+      ],
       "workflows": [
         "./dist/workflows.d.ts"
       ],
@@ -290,6 +293,11 @@
       "types": "./dist/observability.d.ts",
       "import": "./dist/observability.mjs",
       "require": "./dist/observability.cjs"
+    },
+    "./instrumentation": {
+      "types": "./dist/instrumentation.d.ts",
+      "import": "./dist/instrumentation.mjs",
+      "require": "./dist/instrumentation.cjs"
     },
     "./workflows": {
       "types": "./dist/workflows.d.ts",
@@ -523,6 +531,7 @@
     "@farming-labs/orm-runtime": "0.0.62",
     "@formatjs/icu-messageformat-parser": "3.5.15",
     "@mdx-js/mdx": "^3.1.1",
+    "@opentelemetry/api": "1.9.1",
     "@scalar/api-reference": "^1.38.1",
     "@scalar/openapi-parser": "^0.22.3",
     "@tailwindcss/vite": "4.1.18",
@@ -550,6 +559,9 @@
   },
   "devDependencies": {
     "@clerk/react": "^6.1.0",
+    "@farm.js/otel": "workspace:*",
+    "@opentelemetry/sdk-node": "0.221.0",
+    "@opentelemetry/sdk-trace-base": "2.10.0",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "@vitest/coverage-v8": "^1.1.0",

--- a/packages/farm/src/__tests__/development-observability.test.ts
+++ b/packages/farm/src/__tests__/development-observability.test.ts
@@ -1,0 +1,189 @@
+// @vitest-environment node
+
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import { createServer as createNetServer } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const farmOTelRoot = path.resolve(packageRoot, "../farm-otel");
+
+async function getAvailablePort(): Promise<number> {
+  const server = createNetServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+  return port;
+}
+
+async function waitForServer(url: string, output: () => string): Promise<Response> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 120; attempt++) {
+    try {
+      return await fetch(url);
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+  throw new Error(`Development server did not start: ${String(lastError)}\n${output()}`);
+}
+
+describe("development OpenTelemetry tracing", () => {
+  it("starts instrumentation before traffic and flushes request traces on server close", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-development-otel-"));
+    const traceOutput = path.join(root, "traces.jsonl");
+    let developmentServer: ReturnType<typeof spawn> | undefined;
+
+    try {
+      await fs.mkdir(path.join(root, "node_modules", "@farm.js"), { recursive: true });
+      await fs.symlink(farmOTelRoot, path.join(root, "node_modules", "@farm.js", "otel"), "dir");
+      await fs.symlink(
+        await fs.realpath(path.join(packageRoot, "node_modules", "react")),
+        path.join(root, "node_modules", "react"),
+        "dir",
+      );
+      await fs.symlink(
+        await fs.realpath(path.join(packageRoot, "node_modules", "react-dom")),
+        path.join(root, "node_modules", "react-dom"),
+        "dir",
+      );
+      await fs.mkdir(path.join(root, "src", "app"), { recursive: true });
+      await fs.writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ private: true, type: "module" }, null, 2),
+      );
+      await fs.writeFile(path.join(root, "src", "app", "globals.css"), "");
+      await fs.writeFile(
+        path.join(root, "src", "app", "layout.tsx"),
+        `import React from "react"; export default function Layout({ children }) { return <html><body>{children}</body></html>; }`,
+      );
+      await fs.writeFile(
+        path.join(root, "src", "app", "page.tsx"),
+        `import React from "react"; export default function Page() { return <main data-instrumentation={globalThis.__farmDevelopmentInstrumentation}>development tracing</main>; }`,
+      );
+      await fs.writeFile(
+        path.join(root, "src", "instrumentation.ts"),
+        `
+import { appendFileSync } from "node:fs";
+import { registerOTel } from "@farm.js/otel";
+
+const exporter = {
+  export(spans, callback) {
+    for (const span of spans) {
+      appendFileSync(process.env.FARM_TRACE_OUTPUT, JSON.stringify({
+        name: span.name,
+        attributes: span.attributes,
+        events: span.events.map((event) => event.name),
+      }) + "\\n");
+    }
+    callback({ code: 0 });
+  },
+  async shutdown() {},
+};
+
+export function register(context) {
+  globalThis.__farmDevelopmentInstrumentation = context.mode + ":" + context.runtime;
+  return registerOTel({
+    serviceName: "farm-development-test",
+    autoInstrumentations: false,
+    traceExporter: exporter,
+  });
+}
+`.trim(),
+      );
+
+      const port = await getAvailablePort();
+      const startFile = path.join(root, "start.mjs");
+      await fs.writeFile(
+        startFile,
+        `
+import { createServer } from ${JSON.stringify(
+          pathToFileURL(path.join(packageRoot, "dist", "server.mjs")).href,
+        )};
+
+const server = await createServer({
+  root: process.cwd(),
+  srcDir: "src",
+  images: { provider: "none" },
+  observability: { tracing: true },
+});
+process.once("SIGTERM", async () => {
+  await server.close();
+  process.exit(0);
+});
+await server.listen(Number(process.env.PORT));
+`.trim(),
+      );
+
+      const output: string[] = [];
+      developmentServer = spawn(process.execPath, [startFile], {
+        cwd: root,
+        env: {
+          ...process.env,
+          FARM_TRACE_OUTPUT: traceOutput,
+          PORT: String(port),
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      developmentServer.stdout?.on("data", (chunk) => output.push(String(chunk)));
+      developmentServer.stderr?.on("data", (chunk) => output.push(String(chunk)));
+
+      const response = await waitForServer(`http://localhost:${port}/`, () => output.join(""));
+      const body = await response.text();
+      if (response.status !== 200) {
+        throw new Error(
+          `Development request failed with ${response.status}:\n${body}\n${output.join("")}`,
+        );
+      }
+      expect(body).toContain('data-instrumentation="development:nodejs"');
+
+      developmentServer.kill("SIGTERM");
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(
+          () => reject(new Error(`Development shutdown timed out:\n${output.join("")}`)),
+          8_000,
+        );
+        developmentServer?.once("exit", (code, signal) => {
+          clearTimeout(timeout);
+          if (code && code !== 0) {
+            reject(
+              new Error(`Development server exited with ${code}/${signal}:\n${output.join("")}`),
+            );
+          } else resolve();
+        });
+      });
+      developmentServer = undefined;
+
+      const spans = (await fs.readFile(traceOutput, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      const requestSpan = spans.find((span) => span.name === "GET /");
+      expect(requestSpan).toMatchObject({
+        attributes: {
+          "http.request.method": "GET",
+          "http.response.status_code": 200,
+          "http.route": "/",
+        },
+      });
+      expect(requestSpan.events).toEqual(
+        expect.arrayContaining(["request.start", "route.matched", "request.complete"]),
+      );
+    } finally {
+      if (developmentServer && developmentServer.exitCode === null) {
+        developmentServer.kill("SIGKILL");
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }, 60_000);
+});

--- a/packages/farm/src/__tests__/instrumentation.test.ts
+++ b/packages/farm/src/__tests__/instrumentation.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment node
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createFarmInstrumentationLifecycle,
+  loadFarmInstrumentation,
+  resolveFarmInstrumentationFile,
+  resolveFarmInstrumentationRuntime,
+} from "../instrumentation";
+
+const temporaryRoots: string[] = [];
+
+async function createTemporaryRoot(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-instrumentation-"));
+  temporaryRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("instrumentation convention", () => {
+  it("discovers one source or root instrumentation file and rejects ambiguity", async () => {
+    const root = await createTemporaryRoot();
+    await fs.mkdir(path.join(root, "src"), { recursive: true });
+    const sourceFile = path.join(root, "src", "instrumentation.ts");
+    await fs.writeFile(sourceFile, "export function register() {}\n");
+    expect(resolveFarmInstrumentationFile(root, "src")).toBe(sourceFile);
+
+    await fs.writeFile(path.join(root, "instrumentation.mjs"), "export function register() {}\n");
+    expect(() => resolveFarmInstrumentationFile(root, "src")).toThrow(
+      "multiple instrumentation files",
+    );
+  });
+
+  it("starts and shuts down once in deterministic order", async () => {
+    const calls: string[] = [];
+    const lifecycle = createFarmInstrumentationLifecycle(
+      {
+        async register(context) {
+          calls.push(`register:${context.mode}:${context.runtime}`);
+          return async () => calls.push("registered-cleanup");
+        },
+        async shutdown() {
+          calls.push("module-shutdown");
+        },
+      },
+      { root: "/app", mode: "production", runtime: "nodejs" },
+    );
+
+    await Promise.all([lifecycle.start(), lifecycle.start()]);
+    await Promise.all([lifecycle.shutdown(), lifecycle.shutdown()]);
+    expect(calls).toEqual(["register:production:nodejs", "registered-cleanup", "module-shutdown"]);
+  });
+
+  it("runs exported shutdown even when registered cleanup fails", async () => {
+    const calls: string[] = [];
+    const lifecycle = createFarmInstrumentationLifecycle(
+      {
+        register() {
+          return () => {
+            calls.push("registered-cleanup");
+            throw new Error("cleanup failed");
+          };
+        },
+        shutdown() {
+          calls.push("module-shutdown");
+        },
+      },
+      { root: "/app", mode: "production", runtime: "nodejs" },
+    );
+
+    await lifecycle.start();
+    await expect(lifecycle.shutdown()).rejects.toThrow("cleanup failed");
+    expect(calls).toEqual(["registered-cleanup", "module-shutdown"]);
+  });
+
+  it("loads and executes TypeScript instrumentation with local imports", async () => {
+    const root = await createTemporaryRoot();
+    await fs.mkdir(path.join(root, "src"), { recursive: true });
+    await fs.writeFile(path.join(root, "src", "marker.ts"), `export const marker = "loaded";`);
+    const filePath = path.join(root, "src", "instrumentation.ts");
+    await fs.writeFile(
+      filePath,
+      `
+import { marker } from "./marker";
+export function register(context: { mode: string; runtime: string }) {
+  globalThis.__farmInstrumentationTest = marker + ":" + context.mode + ":" + context.runtime;
+}
+`.trim(),
+    );
+
+    const module = await loadFarmInstrumentation(filePath, root);
+    const lifecycle = createFarmInstrumentationLifecycle(module, {
+      root,
+      mode: "development",
+      runtime: "nodejs",
+    });
+    await lifecycle.start();
+    expect((globalThis as any).__farmInstrumentationTest).toBe("loaded:development:nodejs");
+    delete (globalThis as any).__farmInstrumentationTest;
+  });
+
+  it("maps production presets to instrumentation runtimes", () => {
+    expect(resolveFarmInstrumentationRuntime("node-server")).toBe("nodejs");
+    expect(resolveFarmInstrumentationRuntime("vercel")).toBe("nodejs");
+    expect(resolveFarmInstrumentationRuntime("cloudflare-pages")).toBe("edge");
+    expect(resolveFarmInstrumentationRuntime("bun")).toBe("bun");
+  });
+});

--- a/packages/farm/src/__tests__/observability.test.ts
+++ b/packages/farm/src/__tests__/observability.test.ts
@@ -1,16 +1,35 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+// @vitest-environment node
+
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { SpanStatusCode } from "@opentelemetry/api";
+import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   configureFarmObservability,
   emitFarmEvent,
   onFarmEvent,
   resetFarmObservability,
+  runWithFarmRequestSpan,
   type FarmEvent,
 } from "../observability";
 
+const exporter = new InMemorySpanExporter();
+const processor = new SimpleSpanProcessor(exporter);
+const sdk = new NodeSDK({ spanProcessors: [processor] });
+
 describe("observability", () => {
+  beforeAll(() => {
+    sdk.start();
+  });
+
   afterEach(() => {
     resetFarmObservability();
+    exporter.reset();
     vi.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    await sdk.shutdown();
   });
 
   it("emits events to config and runtime handlers", () => {
@@ -62,5 +81,104 @@ describe("observability", () => {
     expect(log).toHaveBeenCalledWith(
       "[farm:info] render.complete route=/dashboard pathname=/dashboard status=200 durationMs=12",
     );
+  });
+
+  it("creates correlated request and lifecycle spans with propagated trace context", async () => {
+    const events: FarmEvent[] = [];
+    configureFarmObservability({
+      tracing: true,
+      onEvent: (event) => events.push(event),
+    });
+    const traceId = "0af7651916cd43dd8448eb211c80319c";
+    const parentSpanId = "b7ad6b7169203331";
+
+    const response = await runWithFarmRequestSpan(
+      new Request("https://farm.test/products/42", {
+        headers: { traceparent: `00-${traceId}-${parentSpanId}-01` },
+      }),
+      async () => {
+        emitFarmEvent({
+          type: "route.matched",
+          pathname: "/products/42",
+          route: "/products/:id",
+          params: { id: "42" },
+        });
+        emitFarmEvent({
+          type: "middleware.complete",
+          route: "/products/:id",
+          name: "auth",
+          durationMs: 4,
+        });
+        return new Response("ok", { status: 201 });
+      },
+    );
+
+    expect(response.status).toBe(201);
+    await processor.forceFlush();
+    const spans = exporter.getFinishedSpans();
+    const requestSpan = spans.find((span) => span.name === "GET /products/:id");
+    const middlewareSpan = spans.find((span) => span.name === "farm.middleware auth");
+    expect(requestSpan).toBeDefined();
+    expect(requestSpan?.spanContext().traceId).toBe(traceId);
+    expect(requestSpan?.parentSpanContext?.spanId).toBe(parentSpanId);
+    expect(requestSpan?.attributes).toMatchObject({
+      "http.request.method": "GET",
+      "http.response.status_code": 201,
+      "http.route": "/products/:id",
+      "url.path": "/products/42",
+    });
+    expect(requestSpan?.events.map((event) => event.name)).toEqual(
+      expect.arrayContaining([
+        "request.start",
+        "route.matched",
+        "middleware.complete",
+        "request.complete",
+      ]),
+    );
+    expect(middlewareSpan?.parentSpanContext?.spanId).toBe(requestSpan?.spanContext().spanId);
+    expect(events.every((event) => event.traceId === traceId)).toBe(true);
+    expect(events.every((event) => Boolean(event.spanId))).toBe(true);
+  });
+
+  it("marks errors while tracing even when event delivery is filtered", async () => {
+    const delivered: FarmEvent[] = [];
+    configureFarmObservability({
+      tracing: true,
+      events: ["cache.hit"],
+      onEvent: (event) => delivered.push(event),
+    });
+
+    await expect(
+      runWithFarmRequestSpan(new Request("https://farm.test/failure"), async () => {
+        emitFarmEvent({
+          type: "render.error",
+          route: "/failure",
+          error: new Error("render failed"),
+        });
+        throw new Error("request failed");
+      }),
+    ).rejects.toThrow("request failed");
+
+    await processor.forceFlush();
+    const requestSpan = exporter.getFinishedSpans().find((span) => span.name === "GET /failure");
+    expect(delivered).toEqual([]);
+    expect(requestSpan?.status.code).toBe(SpanStatusCode.ERROR);
+    expect(requestSpan?.events.map((event) => event.name)).toContain("render.error");
+  });
+
+  it("creates completed lifecycle spans outside a request context", async () => {
+    configureFarmObservability({ tracing: { spans: ["build"] } });
+
+    const event = emitFarmEvent({
+      type: "build.complete",
+      target: "server",
+      durationMs: 12,
+    });
+
+    await processor.forceFlush();
+    const buildSpan = exporter.getFinishedSpans().find((span) => span.name === "farm.build server");
+    expect(buildSpan).toBeDefined();
+    expect(event.traceId).toBe(buildSpan?.spanContext().traceId);
+    expect(event.spanId).toBe(buildSpan?.spanContext().spanId);
   });
 });

--- a/packages/farm/src/__tests__/production-observability.test.ts
+++ b/packages/farm/src/__tests__/production-observability.test.ts
@@ -1,0 +1,229 @@
+// @vitest-environment node
+
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import { createServer } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { build } from "../build";
+import { resolveConfig } from "../config";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const farmOTelRoot = path.resolve(packageRoot, "../farm-otel");
+
+async function getAvailablePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+  return port;
+}
+
+async function waitForServer(url: string, output: () => string): Promise<Response> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 120; attempt++) {
+    try {
+      return await fetch(url);
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+  throw new Error(`Production server did not start: ${String(lastError)}\n${output()}`);
+}
+
+describe("production OpenTelemetry tracing", () => {
+  it("starts instrumentation before traffic and flushes request traces during graceful shutdown", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-production-otel-"));
+    const traceOutput = path.join(root, "traces.jsonl");
+    let productionServer: ReturnType<typeof spawn> | undefined;
+
+    try {
+      await fs.mkdir(path.join(root, "node_modules", "@farm.js"), { recursive: true });
+      await fs.symlink(packageRoot, path.join(root, "node_modules", "@farm.js", "core"), "dir");
+      await fs.symlink(farmOTelRoot, path.join(root, "node_modules", "@farm.js", "otel"), "dir");
+      await fs.symlink(
+        await fs.realpath(path.join(packageRoot, "node_modules", "react")),
+        path.join(root, "node_modules", "react"),
+        "dir",
+      );
+      await fs.symlink(
+        await fs.realpath(path.join(packageRoot, "node_modules", "react-dom")),
+        path.join(root, "node_modules", "react-dom"),
+        "dir",
+      );
+      await fs.mkdir(path.join(root, "src", "app", "api", "health"), { recursive: true });
+      await fs.writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify(
+          {
+            private: true,
+            type: "module",
+            dependencies: {
+              "@farm.js/core": "workspace:*",
+              "@farm.js/otel": "workspace:*",
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      await fs.writeFile(path.join(root, "src", "app", "globals.css"), "");
+      await fs.writeFile(
+        path.join(root, "src", "app", "layout.tsx"),
+        `export default function Layout({ children }) { return <html><body>{children}</body></html>; }`,
+      );
+      await fs.writeFile(
+        path.join(root, "src", "app", "page.tsx"),
+        `
+export default function Page() {
+  return <main data-instrumentation={globalThis.__farmProductionInstrumentation}>production tracing</main>;
+}
+`.trim(),
+      );
+      await fs.writeFile(
+        path.join(root, "src", "app", "api", "health", "route.ts"),
+        `export async function GET() { return Response.json({ ok: true }); }`,
+      );
+      await fs.writeFile(
+        path.join(root, "src", "instrumentation.ts"),
+        `
+import { appendFileSync } from "node:fs";
+import { registerOTel } from "@farm.js/otel";
+
+const exporter = {
+  export(spans, callback) {
+    for (const span of spans) {
+      appendFileSync(process.env.FARM_TRACE_OUTPUT, JSON.stringify({
+        name: span.name,
+        traceId: span.spanContext().traceId,
+        spanId: span.spanContext().spanId,
+        parentSpanId: span.parentSpanContext?.spanId,
+        attributes: span.attributes,
+        events: span.events.map((event) => event.name),
+      }) + "\\n");
+    }
+    callback({ code: 0 });
+  },
+  async forceFlush() {},
+  async shutdown() {},
+};
+
+export function register(context) {
+  globalThis.__farmProductionInstrumentation = context.mode + ":" + context.runtime;
+  return registerOTel({
+    serviceName: "farm-production-test",
+    autoInstrumentations: false,
+    traceExporter: exporter,
+  });
+}
+`.trim(),
+      );
+
+      const config = await resolveConfig(
+        {
+          root,
+          srcDir: "src",
+          images: { provider: "none" },
+          observability: { tracing: true },
+          generateBuildId: () => "production-otel-test",
+        },
+        "production",
+      );
+      await build(config, { root, preset: "node-server" });
+
+      const serverDirectory = path.join(root, ".farm", ".output", "server");
+      const port = await getAvailablePort();
+      const output: string[] = [];
+      productionServer = spawn(process.execPath, [path.join(serverDirectory, "index.mjs")], {
+        cwd: serverDirectory,
+        env: {
+          ...process.env,
+          FARM_TRACE_OUTPUT: traceOutput,
+          HOST: "127.0.0.1",
+          PORT: String(port),
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      productionServer.stdout?.on("data", (chunk) => output.push(String(chunk)));
+      productionServer.stderr?.on("data", (chunk) => output.push(String(chunk)));
+
+      const response = await waitForServer(`http://127.0.0.1:${port}/`, () => output.join(""));
+      expect(response.status).toBe(200);
+      expect(await response.text()).toContain('data-instrumentation="production:nodejs"');
+
+      const apiResponse = await fetch(`http://127.0.0.1:${port}/api/health`);
+      expect(apiResponse.status).toBe(200);
+      expect(await apiResponse.json()).toEqual({ ok: true });
+
+      productionServer.kill("SIGTERM");
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(
+          () => reject(new Error(`Production shutdown timed out:\n${output.join("")}`)),
+          8_000,
+        );
+        productionServer?.once("exit", (code, signal) => {
+          clearTimeout(timeout);
+          if (code && code !== 0) {
+            reject(
+              new Error(`Production server exited with ${code}/${signal}:\n${output.join("")}`),
+            );
+          } else resolve();
+        });
+      });
+      productionServer = undefined;
+
+      const spans = (await fs.readFile(traceOutput, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      const requestSpan = spans.find((span) => span.name === "GET /");
+      const renderSpan = spans.find((span) => span.name === "farm.render /");
+      const apiRequestSpan = spans.find((span) => span.name === "GET /api/health");
+      const apiSpan = spans.find((span) => span.name === "farm.api GET /api/health");
+      expect(requestSpan).toMatchObject({
+        attributes: {
+          "http.request.method": "GET",
+          "http.response.status_code": 200,
+          "http.route": "/",
+        },
+      });
+      expect(requestSpan.events).toEqual(
+        expect.arrayContaining(["request.start", "route.matched", "request.complete"]),
+      );
+      expect(renderSpan.parentSpanId).toBe(requestSpan.spanId);
+      expect(renderSpan.traceId).toBe(requestSpan.traceId);
+      expect(apiRequestSpan).toMatchObject({
+        attributes: {
+          "http.request.method": "GET",
+          "http.response.status_code": 200,
+          "http.route": "/api/health",
+        },
+      });
+      expect(apiRequestSpan.events).toEqual(
+        expect.arrayContaining([
+          "request.start",
+          "route.matched",
+          "api.request.start",
+          "api.request.complete",
+          "request.complete",
+        ]),
+      );
+      expect(apiSpan.parentSpanId).toBe(apiRequestSpan.spanId);
+      expect(apiSpan.traceId).toBe(apiRequestSpan.traceId);
+    } finally {
+      if (productionServer && productionServer.exitCode === null) {
+        productionServer.kill("SIGKILL");
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }, 120_000);
+});

--- a/packages/farm/src/instrumentation-runtime.ts
+++ b/packages/farm/src/instrumentation-runtime.ts
@@ -1,0 +1,81 @@
+export type FarmInstrumentationRuntime = "nodejs" | "edge" | "bun";
+export type FarmInstrumentationMode = "development" | "production" | "test";
+
+export interface FarmInstrumentationContext {
+  root: string;
+  mode: FarmInstrumentationMode;
+  runtime: FarmInstrumentationRuntime;
+}
+
+export type FarmInstrumentationCleanup =
+  | void
+  | (() => void | Promise<void>)
+  | { shutdown: () => void | Promise<void> };
+
+export interface FarmInstrumentationModule {
+  register?: (
+    context: FarmInstrumentationContext,
+  ) => FarmInstrumentationCleanup | Promise<FarmInstrumentationCleanup>;
+  shutdown?: () => void | Promise<void>;
+}
+
+export interface FarmInstrumentationLifecycle {
+  start(): Promise<void>;
+  shutdown(): Promise<void>;
+}
+
+export function createFarmInstrumentationLifecycle(
+  module: FarmInstrumentationModule | null | undefined,
+  context: FarmInstrumentationContext,
+): FarmInstrumentationLifecycle {
+  let startPromise: Promise<void> | undefined;
+  let shutdownPromise: Promise<void> | undefined;
+  let cleanup: Exclude<FarmInstrumentationCleanup, void> | undefined;
+
+  return {
+    start() {
+      if (!startPromise) {
+        startPromise = Promise.resolve(module?.register?.(context)).then((result) => {
+          cleanup = result || undefined;
+        });
+      }
+      return startPromise;
+    },
+    shutdown() {
+      if (!shutdownPromise) {
+        shutdownPromise = (async () => {
+          try {
+            await startPromise;
+          } catch {
+            // A partially initialized module may still need its exported cleanup.
+          }
+          try {
+            if (typeof cleanup === "function") {
+              await cleanup();
+            } else if (cleanup?.shutdown) {
+              await cleanup.shutdown();
+            }
+          } finally {
+            if (module?.shutdown) {
+              await module.shutdown();
+            }
+          }
+        })();
+      }
+      return shutdownPromise;
+    },
+  };
+}
+
+export function resolveFarmInstrumentationRuntime(preset?: string): FarmInstrumentationRuntime {
+  const normalized = preset?.toLowerCase() ?? "";
+  if (
+    normalized.includes("cloudflare") ||
+    normalized.includes("worker") ||
+    normalized.includes("edge")
+  ) {
+    return "edge";
+  }
+  if (normalized.includes("bun")) return "bun";
+  return "nodejs";
+}

--- a/packages/farm/src/instrumentation.ts
+++ b/packages/farm/src/instrumentation.ts
@@ -1,0 +1,55 @@
+import { build } from "esbuild";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import type { FarmInstrumentationModule } from "./instrumentation-runtime";
+
+export * from "./instrumentation-runtime";
+
+const INSTRUMENTATION_EXTENSIONS = ["ts", "mts", "js", "mjs"] as const;
+
+export function resolveFarmInstrumentationFile(root: string, srcDir = "src"): string | null {
+  const candidates = [
+    ...INSTRUMENTATION_EXTENSIONS.map((extension) =>
+      path.join(root, srcDir, `instrumentation.${extension}`),
+    ),
+    ...INSTRUMENTATION_EXTENSIONS.map((extension) =>
+      path.join(root, `instrumentation.${extension}`),
+    ),
+  ].filter((candidate) => fs.existsSync(candidate));
+
+  if (candidates.length > 1) {
+    throw new Error(
+      `Farm.js found multiple instrumentation files:\n${candidates
+        .map((candidate) => `- ${path.relative(root, candidate)}`)
+        .join("\n")}\nKeep only one instrumentation file in the project root or ${srcDir}/.`,
+    );
+  }
+
+  return candidates[0] ?? null;
+}
+
+export async function loadFarmInstrumentation(
+  filePath: string | null,
+  root: string,
+): Promise<FarmInstrumentationModule | null> {
+  if (!filePath) return null;
+
+  const outputDirectory = path.join(root, ".farm", ".instrumentation-loader");
+  const outputFile = path.join(outputDirectory, "instrumentation.mjs");
+  await fs.promises.mkdir(outputDirectory, { recursive: true });
+  await build({
+    entryPoints: [filePath],
+    outfile: outputFile,
+    bundle: true,
+    format: "esm",
+    platform: "node",
+    target: "node20",
+    packages: "external",
+    sourcemap: "inline",
+  });
+
+  const url = pathToFileURL(outputFile);
+  url.searchParams.set("t", String(Date.now()));
+  return (await import(url.href)) as FarmInstrumentationModule;
+}

--- a/packages/farm/src/nitro/production-runtime.ts
+++ b/packages/farm/src/nitro/production-runtime.ts
@@ -29,7 +29,15 @@ export {
   isFarmNotFoundError,
   isFarmRedirectError,
 } from "../navigation-errors";
-export { configureFarmObservability, emitFarmEvent } from "../observability";
+export {
+  configureFarmObservability,
+  emitFarmEvent,
+  runWithFarmRequestSpan,
+} from "../observability";
+export {
+  createFarmInstrumentationLifecycle,
+  resolveFarmInstrumentationRuntime,
+} from "../instrumentation-runtime";
 export { resolveFarmRouteContext, withFarmRouteContext } from "../route-context";
 export { _setDefaultFarmThemeConfig, getTheme } from "../theme/server";
 export { applyFarmThemeDocument, createFarmThemeDocumentParts } from "../theme/server-runtime";

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -64,6 +64,7 @@ import type { FarmIslandStrategy } from "../island";
 import { createFarmSourceAlias } from "../server/vite-config";
 import { DEFAULT_NOT_FOUND_STYLES } from "../components/not-found";
 import { createFarmThemeCssPlugin } from "../theme/vite";
+import { resolveFarmInstrumentationFile } from "../instrumentation";
 
 // Type alias for OutputBundle
 type OutputBundle = Rollup.OutputBundle;
@@ -2876,6 +2877,7 @@ async function buildSSRInMemory(
 
   const appDirs = getFarmAppDirectories(config);
   const middlewareRoutes = await discoverMiddlewareRoutes(appDirs);
+  const instrumentationPath = resolveFarmInstrumentationFile(root, config.srcDir || "src");
 
   // Check for custom not-found page
   let notFoundPath: string | null = null;
@@ -2952,6 +2954,7 @@ async function buildSSRInMemory(
     configuredRewrites,
     configuredHeaderRoutes,
     notFoundPath,
+    instrumentationPath,
     config,
     configModulePath,
     hasServerRuntimeIntegrations,
@@ -3170,6 +3173,7 @@ function generateVirtualEntryCode(
   configuredRewriteRoutes: RewriteConfig[],
   configuredHeaderRoutes: UniversalConfiguredHeaderRoute[],
   notFoundPath: string | null,
+  instrumentationPath: string | null,
   config: ResolvedFarmConfig,
   configModulePath: string | null,
   hasServerRuntimeIntegrations: boolean,
@@ -3363,6 +3367,7 @@ function generateVirtualEntryCode(
   applyProductionMiddlewareHeaders,
   configureFarmCache,
   configureFarmObservability,
+  createFarmInstrumentationLifecycle,
   createFarmCacheKey,
   createFarmThemeDocumentParts,
   createFarmLocaleCookie,
@@ -3384,6 +3389,8 @@ function generateVirtualEntryCode(
   reportFarmPreloadWarnings,
   renderMetadataHead,
   resolveFarmRouteContext,
+  resolveFarmInstrumentationRuntime,
+  runWithFarmRequestSpan,
   stripFarmLocaleFromPathname,
   withFarmRouteContext,
 } from "@farm.js/core/internal/production-runtime";`;
@@ -3453,6 +3460,9 @@ import { fileURLToPath as farmDocsFileURLToPath } from "node:url";`
   const integrationRuntimeImport = integrationRuntimeExports.length
     ? `import { ${integrationRuntimeExports.join(", ")} } from "@farm.js/core/integrations";`
     : "";
+  const instrumentationImport = instrumentationPath
+    ? `import * as FarmInstrumentationModule from "${instrumentationPath.replace(/\\/g, "/")}";`
+    : "";
   const integrationImports = `
 ${configModulePath ? `import * as FarmUserConfigModule from "${configModulePath}";` : ""}
 ${layerConfigImports}
@@ -3486,22 +3496,56 @@ async function handleAPIRequest(request) {
   }
 
   const { route, params } = match;
+  const startedAt = Date.now();
+  emitFarmEvent({ type: "route.matched", pathname: url.pathname, route: route.path });
+  emitFarmEvent({
+    type: "api.request.start",
+    pathname: url.pathname,
+    route: route.path,
+    method,
+  });
   const endpoint = route.handlers[method];
   if (!endpoint) {
-    return new Response(
+    const response = new Response(
       JSON.stringify({ error: "Method Not Allowed" }),
       { status: 405, headers: { "Content-Type": "application/json" } }
     );
+    emitFarmEvent({
+      type: "api.request.complete",
+      pathname: url.pathname,
+      route: route.path,
+      method,
+      status: response.status,
+      durationMs: Date.now() - startedAt,
+    });
+    return response;
   }
 
   try {
-    return await invokeAPIRouteEndpoint(
+    const response = await invokeAPIRouteEndpoint(
       endpoint,
       request,
       params,
       farmServerConfig.bodySizeLimit,
     );
+    emitFarmEvent({
+      type: "api.request.complete",
+      pathname: url.pathname,
+      route: route.path,
+      method,
+      status: response.status,
+      durationMs: Date.now() - startedAt,
+    });
+    return response;
   } catch (error) {
+    emitFarmEvent({
+      type: "api.error",
+      pathname: url.pathname,
+      route: route.path,
+      method,
+      durationMs: Date.now() - startedAt,
+      error,
+    });
     console.error(\`[API Error] \${url.pathname}:\`, error);
     return new Response(
       JSON.stringify({ error: "Internal Server Error" }),
@@ -3544,6 +3588,7 @@ ${markdownHandlerImport}
 ${appMarkdownImport}
 ${mdxComponentsImport}
 ${integrationImports}
+${instrumentationImport}
 ${imageRuntimeImport}
 ${imageNodeRuntimeImport}
 import { farmFontPreloadHeader } from "virtual:farm-font-runtime";
@@ -3635,10 +3680,33 @@ const farmI18nConfig = ${JSON.stringify(config.i18n)};
 const farmServerConfig = ${JSON.stringify(config.server)};
 const farmThemeConfig = ${JSON.stringify(config.theme)};
 _setDefaultFarmThemeConfig(farmThemeConfig);
+const farmInstrumentationLifecycle = createFarmInstrumentationLifecycle(
+  ${instrumentationPath ? "FarmInstrumentationModule" : "null"},
+  {
+    root:
+      typeof globalThis.process?.cwd === "function" ? globalThis.process.cwd() : ".",
+    mode: "production",
+    runtime: resolveFarmInstrumentationRuntime(${JSON.stringify(preset)}),
+  },
+);
 export const farmProductionLifecycle = createFarmProductionLifecycle({
   server: farmServerConfig,
-  start: () => farmPluginRuntime?.startRuntime(),
-  close: (reason) => farmPluginRuntime?.closeRuntime(reason),
+  start: async () => {
+    await farmInstrumentationLifecycle.start();
+    try {
+      await farmPluginRuntime?.startRuntime();
+    } catch (error) {
+      await farmInstrumentationLifecycle.shutdown();
+      throw error;
+    }
+  },
+  close: async (reason) => {
+    try {
+      await farmPluginRuntime?.closeRuntime(reason);
+    } finally {
+      await farmInstrumentationLifecycle.shutdown();
+    }
+  },
 });
 const farmI18nRuntime = ${
     config.i18n.enabled
@@ -6118,34 +6186,38 @@ export async function fetch(request, context) {
   const healthResponse = await farmProductionLifecycle.handleHealthRequest(request);
   if (healthResponse) return healthResponse;
 
-  return farmProductionLifecycle.runRequest(async () => {
-    const runtimeOptions = farmPluginRuntime ? getFarmPluginRequestOptions(request) : null;
-    const runRequest = () => farmPluginRuntime
-      ? farmPluginRuntime.runRuntimeRequest(
-        request,
-          (runtimeRequest) =>
-            _runWithCurrentRequest(runtimeRequest, () =>
-              handleFarmPluginRequest(runtimeRequest, runtimeOptions)
-            ),
-          {
-            ...runtimeOptions,
-            waitUntil: typeof context?.waitUntil === "function"
-              ? context.waitUntil.bind(context)
-              : undefined,
-          },
-        )
-      : handleFarmRequest(request);
+  return farmProductionLifecycle.runRequest(
+    () =>
+      runWithFarmRequestSpan(request, async () => {
+        const runtimeOptions = farmPluginRuntime ? getFarmPluginRequestOptions(request) : null;
+        const runRequest = () => farmPluginRuntime
+          ? farmPluginRuntime.runRuntimeRequest(
+              request,
+              (runtimeRequest) =>
+                _runWithCurrentRequest(runtimeRequest, () =>
+                  handleFarmPluginRequest(runtimeRequest, runtimeOptions)
+                ),
+              {
+                ...runtimeOptions,
+                waitUntil: typeof context?.waitUntil === "function"
+                  ? context.waitUntil.bind(context)
+                  : undefined,
+              },
+            )
+          : handleFarmRequest(request);
 
-    const response = await _runWithCurrentRequest(request, () =>
-      _runWithAfterRequest(request, runRequest, context),
-    );
-    const pathname = new URL(request.url).pathname;
-    return applyFarmPreloadBudget(applyConfiguredResponseHeaders(response, pathname), pathname);
-  }, {
-    onResponseFinished: typeof context?.onResponseFinished === "function"
-      ? context.onResponseFinished
-      : undefined,
-  });
+        const response = await _runWithCurrentRequest(request, () =>
+          _runWithAfterRequest(request, runRequest, context),
+        );
+        const pathname = new URL(request.url).pathname;
+        return applyFarmPreloadBudget(applyConfiguredResponseHeaders(response, pathname), pathname);
+      }),
+    {
+      onResponseFinished: typeof context?.onResponseFinished === "function"
+        ? context.onResponseFinished
+        : undefined,
+    },
+  );
 }
 export default { fetch, lifecycle: farmProductionLifecycle };
   `.trim();

--- a/packages/farm/src/observability.ts
+++ b/packages/farm/src/observability.ts
@@ -1,3 +1,20 @@
+import {
+  _runWithFarmRequestSpan,
+  configureFarmTracing,
+  getFarmTraceContext,
+  normalizeFarmTracingConfig,
+  recordFarmEventTrace,
+  resetFarmTracing,
+  runWithFarmSpan,
+  type FarmRequestSpanOptions,
+  type FarmResolvedTracingConfig,
+  type FarmSpanOptions,
+  type FarmTraceContext,
+  type FarmTraceSpanKind,
+  type FarmTracingConfig,
+  type FarmTracingUserConfig,
+} from "./tracing";
+
 export type FarmEventLevel = "debug" | "info" | "warn" | "error";
 
 export interface FarmEventBase {
@@ -5,9 +22,29 @@ export interface FarmEventBase {
   timestamp: number;
   level: FarmEventLevel;
   requestId?: string;
+  traceId?: string;
+  spanId?: string;
+  traceSampled?: boolean;
   route?: string;
   pathname?: string;
 }
+
+export type FarmRequestEvent =
+  | (FarmEventBase & { type: "request.start"; method: string; pathname: string })
+  | (FarmEventBase & {
+      type: "request.complete";
+      method: string;
+      pathname: string;
+      status: number;
+      durationMs: number;
+    })
+  | (FarmEventBase & {
+      type: "request.error";
+      method: string;
+      pathname: string;
+      durationMs: number;
+      error: unknown;
+    });
 
 export type FarmServerEvent =
   | (FarmEventBase & {
@@ -130,7 +167,13 @@ export type FarmAPIEvent =
       method: string;
       issues?: unknown;
     })
-  | (FarmEventBase & { type: "api.error"; route: string; method: string; error: unknown });
+  | (FarmEventBase & {
+      type: "api.error";
+      route: string;
+      method: string;
+      durationMs: number;
+      error: unknown;
+    });
 
 export type FarmIntegrationEvent =
   | (FarmEventBase & { type: "integration.registered"; name: string })
@@ -217,6 +260,7 @@ export type FarmErrorEvent = FarmEventBase & {
 };
 
 export type FarmEvent =
+  | FarmRequestEvent
   | FarmServerEvent
   | FarmRouteEvent
   | FarmRenderEvent
@@ -245,33 +289,37 @@ export type FarmObservabilityUserConfig =
       logs?: boolean;
       onEvent?: FarmEventHandler | readonly FarmEventHandler[];
       events?: readonly FarmEventType[];
+      tracing?: FarmTracingUserConfig;
     };
 
 export interface FarmResolvedObservabilityConfig {
   logs: boolean;
   handlers: FarmEventHandler[];
   events?: Set<FarmEventType>;
+  tracing: FarmResolvedTracingConfig;
 }
 
 const runtimeHandlers = new Set<FarmEventHandler>();
 let observabilityState: FarmResolvedObservabilityConfig = {
   logs: false,
   handlers: [],
+  tracing: normalizeFarmTracingConfig(false),
 };
 
 export function configureFarmObservability(config: FarmObservabilityUserConfig | undefined): void {
   observabilityState = normalizeFarmObservabilityConfig(config);
+  configureFarmTracing(observabilityState.tracing);
 }
 
 export function normalizeFarmObservabilityConfig(
   config: FarmObservabilityUserConfig | undefined,
 ): FarmResolvedObservabilityConfig {
   if (config === undefined || config === false) {
-    return { logs: false, handlers: [] };
+    return { logs: false, handlers: [], tracing: normalizeFarmTracingConfig(false) };
   }
 
   if (config === true) {
-    return { logs: true, handlers: [] };
+    return { logs: true, handlers: [], tracing: normalizeFarmTracingConfig(false) };
   }
 
   const handlers = config.onEvent
@@ -284,6 +332,7 @@ export function normalizeFarmObservabilityConfig(
     logs: config.logs ?? false,
     handlers,
     events: config.events ? new Set(config.events) : undefined,
+    tracing: normalizeFarmTracingConfig(config.tracing),
   };
 }
 
@@ -299,7 +348,9 @@ export function resetFarmObservability(): void {
   observabilityState = {
     logs: false,
     handlers: [],
+    tracing: normalizeFarmTracingConfig(false),
   };
+  resetFarmTracing();
 }
 
 export function emitFarmEvent(input: FarmEventInput): FarmEvent {
@@ -308,6 +359,13 @@ export function emitFarmEvent(input: FarmEventInput): FarmEvent {
     level: inferFarmEventLevel(input.type),
     ...input,
   } as FarmEvent;
+
+  const traceContext = recordFarmEventTrace(event);
+  if (traceContext) {
+    event.traceId = traceContext.traceId;
+    event.spanId = traceContext.spanId;
+    event.traceSampled = traceContext.traceSampled;
+  }
 
   if (!shouldEmitFarmEvent(event)) {
     return event;
@@ -329,6 +387,53 @@ export function emitFarmEvent(input: FarmEventInput): FarmEvent {
 
   return event;
 }
+
+export async function runWithFarmRequestSpan<T>(
+  request: Request,
+  handler: () => T | Promise<T>,
+  options: FarmRequestSpanOptions = {},
+): Promise<T> {
+  const url = new URL(request.url);
+  const method = request.method || "GET";
+  return await _runWithFarmRequestSpan(request, handler, {
+    ...options,
+    onStart() {
+      emitFarmEvent({ type: "request.start", method, pathname: url.pathname });
+      options.onStart?.();
+    },
+    onComplete(status, durationMs) {
+      emitFarmEvent({
+        type: "request.complete",
+        method,
+        pathname: url.pathname,
+        status,
+        durationMs,
+      });
+      options.onComplete?.(status, durationMs);
+    },
+    onError(error, durationMs) {
+      emitFarmEvent({
+        type: "request.error",
+        method,
+        pathname: url.pathname,
+        durationMs,
+        error,
+      });
+      options.onError?.(error, durationMs);
+    },
+  });
+}
+
+export { configureFarmTracing, getFarmTraceContext, normalizeFarmTracingConfig, runWithFarmSpan };
+export type {
+  FarmRequestSpanOptions,
+  FarmResolvedTracingConfig,
+  FarmSpanOptions,
+  FarmTraceContext,
+  FarmTraceSpanKind,
+  FarmTracingConfig,
+  FarmTracingUserConfig,
+};
 
 function shouldEmitFarmEvent(event: FarmEvent): boolean {
   if (

--- a/packages/farm/src/server/create-server.ts
+++ b/packages/farm/src/server/create-server.ts
@@ -23,6 +23,12 @@ import { FARM_VERSION } from "../version";
 import { getFarmAppDirectories } from "../layers";
 import { createCliColors } from "../cli-colors";
 import { createFarmThemeCssPlugin } from "../theme/vite";
+import {
+  createFarmInstrumentationLifecycle,
+  loadFarmInstrumentation,
+  resolveFarmInstrumentationFile,
+  type FarmInstrumentationLifecycle,
+} from "../instrumentation";
 
 export const DEFAULT_FARM_DEV_SERVER_PORT = 3000;
 
@@ -116,6 +122,7 @@ function createDevDependencyStubsPlugin() {
  */
 export async function createServer(config: FarmConfig = {}) {
   let pluginManager: PluginManager | null = null;
+  let instrumentation: FarmInstrumentationLifecycle | null = null;
   try {
     const root = config.root || process.cwd();
 
@@ -124,6 +131,22 @@ export async function createServer(config: FarmConfig = {}) {
     const userConfig = await loadConfig(root, undefined, mode);
 
     const resolvedConfig = userConfig ? await resolveConfig(userConfig, mode) : null;
+    const instrumentationConfig = resolvedConfig || config;
+    const instrumentationRoot = instrumentationConfig.root || root;
+    const instrumentationFile = resolveFarmInstrumentationFile(
+      instrumentationRoot,
+      instrumentationConfig.srcDir || "src",
+    );
+    const instrumentationModule = await loadFarmInstrumentation(
+      instrumentationFile,
+      instrumentationRoot,
+    );
+    instrumentation = createFarmInstrumentationLifecycle(instrumentationModule, {
+      root: instrumentationRoot,
+      mode,
+      runtime: "nodejs",
+    });
+    await instrumentation.start();
 
     // Initialize plugin manager
     pluginManager = new PluginManager({
@@ -259,6 +282,20 @@ export async function createServer(config: FarmConfig = {}) {
     );
 
     (server as any).__farmPluginManager = pluginManager;
+    (server as any).__farmInstrumentation = instrumentation;
+    const closeViteServer = server.close.bind(server);
+    server.close = async () => {
+      try {
+        await closeViteServer();
+      } finally {
+        await instrumentation?.shutdown();
+      }
+    };
+    server.httpServer?.once("close", () => {
+      instrumentation?.shutdown().catch((error) => {
+        logger.warn(`Instrumentation shutdown failed: ${error}`);
+      });
+    });
 
     // Update plugin manager with vite server
     pluginManager.updateContext({ config: finalConfig, viteServer: server });
@@ -279,6 +316,7 @@ export async function createServer(config: FarmConfig = {}) {
         error,
       });
     }
+    await instrumentation?.shutdown().catch(() => {});
     logger.error(`Failed to create server: ${error}`);
     throw error;
   }

--- a/packages/farm/src/tracing.ts
+++ b/packages/farm/src/tracing.ts
@@ -1,0 +1,452 @@
+import {
+  context,
+  createContextKey,
+  isSpanContextValid,
+  propagation,
+  SpanKind,
+  SpanStatusCode,
+  trace,
+  type Attributes,
+  type Context,
+  type Span,
+} from "@opentelemetry/api";
+import type { FarmEvent } from "./observability";
+
+export const FARM_TRACER_NAME = "@farm.js/core";
+
+export type FarmTraceSpanKind =
+  | "request"
+  | "render"
+  | "middleware"
+  | "api"
+  | "integration"
+  | "storage"
+  | "ppr"
+  | "build"
+  | "plugin";
+
+export interface FarmTracingConfig {
+  /** Enable Farm's OpenTelemetry spans. */
+  enabled?: boolean;
+  /** Span families to record. All families are enabled by default. */
+  spans?: readonly FarmTraceSpanKind[];
+  /** Add Farm lifecycle events to the active span. Defaults to true. */
+  recordEvents?: boolean;
+  /** Static attributes added to every Farm-created span. */
+  attributes?: Attributes;
+  /** Path prefixes that should not create request spans. */
+  ignorePaths?: readonly string[];
+}
+
+export type FarmTracingUserConfig = boolean | FarmTracingConfig;
+
+export interface FarmResolvedTracingConfig {
+  enabled: boolean;
+  spans: ReadonlySet<FarmTraceSpanKind>;
+  recordEvents: boolean;
+  attributes: Attributes;
+  ignorePaths: readonly string[];
+}
+
+export interface FarmTraceContext {
+  traceId: string;
+  spanId: string;
+  traceSampled: boolean;
+}
+
+export interface FarmRequestSpanOptions {
+  getStatusCode?: () => number | undefined;
+  onStart?: () => void;
+  onComplete?: (status: number, durationMs: number) => void;
+  onError?: (error: unknown, durationMs: number) => void;
+}
+
+export interface FarmSpanOptions {
+  kind?: FarmTraceSpanKind;
+  attributes?: Attributes;
+  spanKind?: SpanKind;
+}
+
+const ALL_SPAN_KINDS: readonly FarmTraceSpanKind[] = [
+  "request",
+  "render",
+  "middleware",
+  "api",
+  "integration",
+  "storage",
+  "ppr",
+  "build",
+  "plugin",
+];
+
+const DEFAULT_IGNORED_PATHS = [
+  "/@vite/",
+  "/@fs/",
+  "/@id/",
+  "/@react-refresh",
+  "/node_modules/",
+  "/__vite",
+  "/.well-known/appspecific/",
+];
+const FARM_REQUEST_METHOD_CONTEXT_KEY = createContextKey("@farm.js/core/request-method");
+
+let tracingState: FarmResolvedTracingConfig = normalizeFarmTracingConfig(false);
+
+export function normalizeFarmTracingConfig(
+  config: FarmTracingUserConfig | undefined,
+): FarmResolvedTracingConfig {
+  if (!config) {
+    return {
+      enabled: false,
+      spans: new Set(ALL_SPAN_KINDS),
+      recordEvents: true,
+      attributes: {},
+      ignorePaths: DEFAULT_IGNORED_PATHS,
+    };
+  }
+
+  if (config === true) {
+    return {
+      enabled: true,
+      spans: new Set(ALL_SPAN_KINDS),
+      recordEvents: true,
+      attributes: {},
+      ignorePaths: DEFAULT_IGNORED_PATHS,
+    };
+  }
+
+  return {
+    enabled: config.enabled ?? true,
+    spans: new Set(config.spans ?? ALL_SPAN_KINDS),
+    recordEvents: config.recordEvents ?? true,
+    attributes: { ...config.attributes },
+    ignorePaths: [...DEFAULT_IGNORED_PATHS, ...(config.ignorePaths ?? [])],
+  };
+}
+
+export function configureFarmTracing(
+  config: FarmTracingUserConfig | FarmResolvedTracingConfig | undefined,
+): void {
+  if (isResolvedFarmTracingConfig(config)) {
+    tracingState = {
+      ...config,
+      spans: new Set(config.spans),
+      attributes: { ...config.attributes },
+      ignorePaths: [...config.ignorePaths],
+    };
+    return;
+  }
+  tracingState = normalizeFarmTracingConfig(config as FarmTracingUserConfig | undefined);
+}
+
+function isResolvedFarmTracingConfig(
+  config: FarmTracingUserConfig | FarmResolvedTracingConfig | undefined,
+): config is FarmResolvedTracingConfig {
+  return (
+    !!config &&
+    typeof config === "object" &&
+    typeof config.enabled === "boolean" &&
+    config.spans instanceof Set &&
+    typeof config.recordEvents === "boolean" &&
+    Array.isArray(config.ignorePaths)
+  );
+}
+
+export function getFarmTracingConfig(): FarmResolvedTracingConfig {
+  return tracingState;
+}
+
+export function resetFarmTracing(): void {
+  tracingState = normalizeFarmTracingConfig(false);
+}
+
+export function getFarmTraceContext(): FarmTraceContext | undefined {
+  return getSpanTraceContext(trace.getSpan(context.active()));
+}
+
+export async function runWithFarmSpan<T>(
+  name: string,
+  handler: () => T | Promise<T>,
+  options: FarmSpanOptions = {},
+): Promise<T> {
+  const spanFamily = options.kind;
+  if (!tracingState.enabled || (spanFamily !== undefined && !tracingState.spans.has(spanFamily))) {
+    return await handler();
+  }
+
+  const tracer = trace.getTracer(FARM_TRACER_NAME);
+  return await tracer.startActiveSpan(
+    name,
+    {
+      kind: options.spanKind ?? SpanKind.INTERNAL,
+      attributes: {
+        ...tracingState.attributes,
+        ...options.attributes,
+      },
+    },
+    async (span) => {
+      try {
+        return await handler();
+      } catch (error) {
+        recordSpanError(span, error);
+        throw error;
+      } finally {
+        span.end();
+      }
+    },
+  );
+}
+
+export async function _runWithFarmRequestSpan<T>(
+  request: Request,
+  handler: () => T | Promise<T>,
+  options: FarmRequestSpanOptions = {},
+): Promise<T> {
+  const startedAt = Date.now();
+  const url = new URL(request.url);
+  const shouldTrace =
+    tracingState.enabled &&
+    tracingState.spans.has("request") &&
+    !tracingState.ignorePaths.some((prefix) => url.pathname.startsWith(prefix));
+
+  if (!shouldTrace) {
+    options.onStart?.();
+    try {
+      const result = await handler();
+      options.onComplete?.(resolveResultStatus(result, options), Date.now() - startedAt);
+      return result;
+    } catch (error) {
+      options.onError?.(error, Date.now() - startedAt);
+      throw error;
+    }
+  }
+
+  const extractedContext = propagation.extract(context.active(), request.headers, {
+    keys(carrier) {
+      return Array.from(carrier.keys());
+    },
+    get(carrier, key) {
+      return carrier.get(key) ?? undefined;
+    },
+  });
+  const requestContext = extractedContext.setValue(FARM_REQUEST_METHOD_CONTEXT_KEY, request.method);
+  const tracer = trace.getTracer(FARM_TRACER_NAME);
+  const attributes: Attributes = {
+    ...tracingState.attributes,
+    "http.request.method": request.method,
+    "url.path": url.pathname,
+    "url.scheme": url.protocol.replace(/:$/, ""),
+    "server.address": url.hostname,
+  };
+  if (url.port) attributes["server.port"] = Number(url.port);
+
+  return await tracer.startActiveSpan(
+    `${request.method} ${url.pathname}`,
+    { kind: SpanKind.SERVER, attributes },
+    requestContext,
+    async (span) => {
+      options.onStart?.();
+      try {
+        const result = await handler();
+        const status = resolveResultStatus(result, options);
+        setResponseStatus(span, status);
+        options.onComplete?.(status, Date.now() - startedAt);
+        return result;
+      } catch (error) {
+        recordSpanError(span, error);
+        options.onError?.(error, Date.now() - startedAt);
+        throw error;
+      } finally {
+        span.end();
+      }
+    },
+  );
+}
+
+export function recordFarmEventTrace(event: FarmEvent): FarmTraceContext | undefined {
+  if (!tracingState.enabled) return undefined;
+
+  const activeContext = context.active();
+  const activeSpan = trace.getSpan(activeContext);
+  const traceContext = getSpanTraceContext(activeSpan);
+  if (activeSpan && traceContext) {
+    if (event.type === "route.matched") {
+      const method =
+        (activeContext.getValue(FARM_REQUEST_METHOD_CONTEXT_KEY) as string | undefined) ?? "HTTP";
+      activeSpan.updateName(`${method} ${event.route}`);
+      activeSpan.setAttribute("http.route", event.route);
+      activeSpan.setAttribute("farm.route", event.route);
+    }
+
+    if (tracingState.recordEvents) {
+      activeSpan.addEvent(event.type, toEventAttributes(event), event.timestamp);
+    }
+
+    const error = event.type === "request.error" ? undefined : getEventError(event);
+    if (error !== undefined) recordSpanError(activeSpan, error);
+  }
+
+  const completedTraceContext = recordCompletedEventSpan(event, activeContext);
+  return traceContext ?? completedTraceContext;
+}
+
+function recordCompletedEventSpan(
+  event: FarmEvent,
+  parentContext: Context,
+): FarmTraceContext | undefined {
+  const descriptor = getCompletedSpanDescriptor(event);
+  if (!descriptor || !tracingState.spans.has(descriptor.kind)) return undefined;
+
+  const tracer = trace.getTracer(FARM_TRACER_NAME);
+  const span = tracer.startSpan(
+    descriptor.name,
+    {
+      kind: SpanKind.INTERNAL,
+      startTime: event.timestamp - descriptor.durationMs,
+      attributes: {
+        ...tracingState.attributes,
+        ...toEventAttributes(event),
+        "farm.event.type": event.type,
+      },
+    },
+    parentContext,
+  );
+
+  const status = "status" in event && typeof event.status === "number" ? event.status : undefined;
+  if (status !== undefined) setResponseStatus(span, status);
+  const error = getEventError(event);
+  if (error !== undefined) recordSpanError(span, error);
+  const traceContext = getSpanTraceContext(span);
+  span.end(event.timestamp);
+  return traceContext;
+}
+
+function getCompletedSpanDescriptor(
+  event: FarmEvent,
+): { kind: FarmTraceSpanKind; name: string; durationMs: number } | undefined {
+  if (!("durationMs" in event) || typeof event.durationMs !== "number") return undefined;
+
+  switch (event.type) {
+    case "render.complete":
+      return { kind: "render", name: `farm.render ${event.route}`, durationMs: event.durationMs };
+    case "render.stream.shellReady":
+      return {
+        kind: "render",
+        name: `farm.render.shell ${event.route}`,
+        durationMs: event.durationMs,
+      };
+    case "render.stream.complete":
+      return {
+        kind: "render",
+        name: `farm.render.stream ${event.route}`,
+        durationMs: event.durationMs,
+      };
+    case "middleware.complete":
+      return {
+        kind: "middleware",
+        name: `farm.middleware ${event.name ?? event.route ?? "anonymous"}`,
+        durationMs: event.durationMs,
+      };
+    case "api.request.complete":
+    case "api.error":
+      return {
+        kind: "api",
+        name: `farm.api ${event.method} ${event.route}`,
+        durationMs: event.durationMs,
+      };
+    case "integration.api.call.complete":
+      return {
+        kind: "integration",
+        name: `farm.integration ${event.integration}.${event.operation}`,
+        durationMs: event.durationMs,
+      };
+    case "storage.query.complete":
+      return {
+        kind: "storage",
+        name: `farm.storage ${event.operation}`,
+        durationMs: event.durationMs,
+      };
+    case "ppr.refresh.complete":
+      return {
+        kind: "ppr",
+        name: `farm.ppr.refresh ${event.route}`,
+        durationMs: event.durationMs,
+      };
+    case "build.complete":
+      return {
+        kind: "build",
+        name: `farm.build${event.target ? ` ${event.target}` : ""}`,
+        durationMs: event.durationMs,
+      };
+    case "plugin.hook.complete":
+      return {
+        kind: "plugin",
+        name: `farm.plugin ${event.plugin}.${event.hook}`,
+        durationMs: event.durationMs,
+      };
+    default:
+      return undefined;
+  }
+}
+
+function toEventAttributes(event: FarmEvent): Attributes {
+  const attributes: Attributes = {};
+  for (const [key, value] of Object.entries(event)) {
+    if (
+      key === "timestamp" ||
+      key === "level" ||
+      key === "error" ||
+      key === "traceId" ||
+      key === "spanId" ||
+      key === "traceSampled" ||
+      value === undefined
+    ) {
+      continue;
+    }
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      attributes[`farm.${key}`] = value;
+    } else if (Array.isArray(value)) {
+      if (value.every((entry) => typeof entry === "string")) {
+        attributes[`farm.${key}`] = value as string[];
+      } else if (value.every((entry) => typeof entry === "number")) {
+        attributes[`farm.${key}`] = value as number[];
+      } else if (value.every((entry) => typeof entry === "boolean")) {
+        attributes[`farm.${key}`] = value as boolean[];
+      }
+    }
+  }
+  return attributes;
+}
+
+function getEventError(event: FarmEvent): unknown {
+  return "error" in event ? event.error : undefined;
+}
+
+function recordSpanError(span: Span, error: unknown): void {
+  const normalized = error instanceof Error ? error : new Error(String(error));
+  span.recordException(normalized);
+  span.setStatus({ code: SpanStatusCode.ERROR, message: normalized.message });
+}
+
+function setResponseStatus(span: Span, status: number): void {
+  span.setAttribute("http.response.status_code", status);
+  if (status >= 500) {
+    span.setStatus({ code: SpanStatusCode.ERROR });
+  }
+}
+
+function resolveResultStatus<T>(result: T, options: FarmRequestSpanOptions): number {
+  if (result instanceof Response) return result.status;
+  return options.getStatusCode?.() ?? 200;
+}
+
+function getSpanTraceContext(span: Span | undefined): FarmTraceContext | undefined {
+  if (!span) return undefined;
+  const spanContext = span.spanContext();
+  if (!isSpanContextValid(spanContext)) return undefined;
+  return {
+    traceId: spanContext.traceId,
+    spanId: spanContext.spanId,
+    traceSampled: (spanContext.traceFlags & 0x01) === 0x01,
+  };
+}

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -1,4 +1,4 @@
-import type { ConfigEnv, Plugin, UserConfig, ViteDevServer, HmrContext } from "vite";
+import type { ConfigEnv, Plugin, UserConfig, ViteDevServer, HmrContext, Connect } from "vite";
 import type { FarmConfig } from "./types";
 import { FarmApp } from "./app";
 import { logger, toViteModuleId } from "./utils";
@@ -73,6 +73,7 @@ import {
 } from "./server-http";
 import { createCliColors } from "./cli-colors";
 import { createFarmThemeCssPlugin } from "./theme/vite";
+import { emitFarmEvent, runWithFarmRequestSpan } from "./observability";
 
 interface FarmVitePluginOptions extends FarmConfig {
   openapi?: FarmUserConfig["openapi"];
@@ -242,6 +243,19 @@ function createRequestFromNodeRequest(
     method: req.method || "GET",
     headers,
   });
+}
+
+function withFarmRequestTracing(
+  handler: Parameters<typeof _withAfterNodeMiddleware>[0],
+): Connect.NextHandleFunction {
+  const middleware = _withAfterNodeMiddleware(handler);
+  return (req, res, next) => {
+    const traceUrl = new URL(`http://${req.headers.host || "localhost:3000"}${req.url || "/"}`);
+    const traceRequest = createRequestFromNodeRequest(req, traceUrl);
+    return runWithFarmRequestSpan(traceRequest, () => middleware(req, res, next), {
+      getStatusCode: () => res.statusCode || 200,
+    });
+  };
 }
 
 function toRequestBody(body: Buffer | undefined): ArrayBuffer | undefined {
@@ -1107,7 +1121,7 @@ window.__FARM_MANIFEST__ = ${inlineValue({
 
       // Register middleware directly (not in return function) to ensure it runs early
       server.middlewares.use(
-        _withAfterNodeMiddleware(async (req, res, next) => {
+        withFarmRequestTracing(async (req, res, next) => {
           const requestUrl = req.url || "/";
           const requestMethod = req.method || "GET";
           const fullUrl = `http://${req.headers.host || "localhost:3000"}${requestUrl}`;
@@ -1504,6 +1518,21 @@ window.__FARM_MANIFEST__ = ${inlineValue({
             const hasExplicitAPIRoute =
               hasMatchedApiRoute || Boolean(apiRouteManager.matchRoute(pathname));
             if (apiHandler && hasExplicitAPIRoute) {
+              const apiRoutePattern =
+                matchedApiRoute?.route.path ||
+                apiRouteManager.matchRoute(pathname)?.route.path ||
+                urlPath;
+              emitFarmEvent({
+                type: "route.matched",
+                pathname,
+                route: apiRoutePattern,
+              });
+              emitFarmEvent({
+                type: "api.request.start",
+                pathname,
+                route: apiRoutePattern,
+                method,
+              });
               try {
                 // Convert Node.js request to Web Request
                 const url = `http://${req.headers.host || "localhost:3000"}${req.url}`;
@@ -1529,10 +1558,7 @@ window.__FARM_MANIFEST__ = ${inlineValue({
                 const apiLifecyclePayload = {
                   pathname: new URL(url).pathname,
                   method,
-                  routePath:
-                    apiRouteManager.matchRoute(new URL(url).pathname)?.route.path ||
-                    matchedApiRoute?.route.path ||
-                    urlPath,
+                  routePath: apiRoutePattern,
                 };
                 const invokeAPIHandler = async (runtimeRequest: Request) => {
                   const handledRequest: Request = pm
@@ -1559,14 +1585,32 @@ window.__FARM_MANIFEST__ = ${inlineValue({
                   : await invokeAPIHandler(request);
 
                 const duration = Date.now() - startTime;
+                emitFarmEvent({
+                  type: "api.request.complete",
+                  pathname,
+                  route: apiRoutePattern,
+                  method,
+                  status: handledResponse.status,
+                  durationMs: duration,
+                });
                 logResponse(method, urlPath, handledResponse.status, duration, "API");
 
                 // Send response
                 await sendWebResponse(res, handledResponse);
                 return;
               } catch (error) {
+                const duration = Date.now() - startTime;
+                emitFarmEvent({
+                  type: "api.error",
+                  pathname,
+                  route: apiRoutePattern,
+                  method,
+                  durationMs: duration,
+                  error,
+                });
                 const bodyErrorResponse = createFarmRequestBodyErrorResponse(error);
                 if (bodyErrorResponse) {
+                  logResponse(method, urlPath, bodyErrorResponse.status, duration, "API");
                   await sendWebResponse(res, bodyErrorResponse);
                   return;
                 }

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -35,6 +35,7 @@ export const farmPackageBuildOptions = {
     markdown: "src/markdown.ts",
     "app-markdown": "src/app-markdown.ts",
     observability: "src/observability.ts",
+    instrumentation: "src/instrumentation.ts",
     workflows: "src/workflows.ts",
     cron: "src/cron.ts",
     "server-fn": "src/server-fn.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1205,6 +1205,9 @@ importers:
       '@mdx-js/mdx':
         specifier: ^3.1.1
         version: 3.1.1(supports-color@10.2.2)
+      '@opentelemetry/api':
+        specifier: 1.9.1
+        version: 1.9.1
       '@scalar/api-reference':
         specifier: ^1.38.1
         version: 1.38.1(supports-color@10.2.2)(tailwindcss@4.1.18)(typescript@5.9.3)
@@ -1291,6 +1294,15 @@ importers:
       '@clerk/react':
         specifier: ^6.1.0
         version: 6.1.0(react-dom@19.2.8)(react@19.2.8)
+      '@farm.js/otel':
+        specifier: workspace:*
+        version: link:../farm-otel
+      '@opentelemetry/sdk-node':
+        specifier: 0.221.0
+        version: 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/sdk-trace-base':
+        specifier: 2.10.0
+        version: 2.10.0(@opentelemetry/api@1.9.1)
       '@types/react':
         specifier: ^18.2.45
         version: 18.3.26
@@ -1595,6 +1607,40 @@ importers:
       '@farm.js/integration-utils':
         specifier: workspace:*
         version: link:../farm-integration-utils
+
+  packages/farm-otel:
+    dependencies:
+      '@opentelemetry/api':
+        specifier: 1.9.1
+        version: 1.9.1
+      '@opentelemetry/auto-instrumentations-node':
+        specifier: 0.79.0
+        version: 0.79.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0)(supports-color@10.2.2)
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: 0.221.0
+        version: 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation':
+        specifier: 0.221.0
+        version: 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/resources':
+        specifier: 2.10.0
+        version: 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node':
+        specifier: 0.221.0
+        version: 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/sdk-trace-base':
+        specifier: 2.10.0
+        version: 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions':
+        specifier: 1.43.0
+        version: 1.43.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.10.5
+        version: 20.19.21
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
 
   packages/farm-polar:
     dependencies:
@@ -4234,7 +4280,7 @@ packages:
     dependencies:
       '@farming-labs/orm': 0.0.62
       '@farming-labs/orm-sql': 0.0.62
-      drizzle-orm: 0.45.2(@prisma/client@6.7.0)(@types/better-sqlite3@7.6.13)(@xata.io/client@0.30.1)(kysely@0.28.17)(pg@8.20.0)
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@6.7.0)(@types/better-sqlite3@7.6.13)(@xata.io/client@0.30.1)(kysely@0.28.17)(pg@8.20.0)
     dev: false
 
   /@farming-labs/orm-dynamodb@0.0.62:
@@ -4690,6 +4736,23 @@ packages:
       tailwindcss: 3.4.18
     dev: false
 
+  /@grpc/grpc-js@1.14.4:
+    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
+    engines: {node: '>=12.10.0'}
+    dependencies:
+      '@grpc/proto-loader': 0.8.1
+      '@js-sdsl/ordered-map': 4.4.2
+
+  /@grpc/proto-loader@0.8.1:
+    resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
+    engines: {node: '>=6'}
+    hasBin: true
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.5
+      yargs: 17.7.3
+
   /@headlessui/tailwindcss@0.2.2(tailwindcss@4.1.18):
     resolution: {integrity: sha512-xNe42KjdyA4kfUKLLPGzME9zkH7Q3rOZ5huFihWNWOQFxnItxPB3/67yBI8/qBfY8nwBRx5GHn4VprsoluVMGw==}
     engines: {node: '>=10'}
@@ -5042,6 +5105,9 @@ packages:
       '@jridgewell/sourcemap-codec': 1.5.5
     dev: true
 
+  /@js-sdsl/ordered-map@4.4.2:
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
   /@levischuck/tiny-cbor@0.2.11:
     resolution: {integrity: sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==}
     dev: false
@@ -5342,6 +5408,1048 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  /@opentelemetry/api-logs@0.221.0:
+    resolution: {integrity: sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  /@opentelemetry/api@1.9.1:
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  /@opentelemetry/auto-instrumentations-node@0.79.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0)(supports-color@10.2.2):
+    resolution: {integrity: sha512-qL53aIjdw56sRDqz6LXD9h15vPTJgPpqv80rbsnRjzhuC9VqZ58fgk/lx0SdECJ2rcu8keeji5ZgjzJwiQZ0fg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.4.1
+      '@opentelemetry/core': ^2.0.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-amqplib': 0.68.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-aws-lambda': 0.73.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-aws-sdk': 0.76.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-bunyan': 0.66.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-cassandra-driver': 0.66.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-connect': 0.64.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-cucumber': 0.37.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-dataloader': 0.38.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-dns': 0.64.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-express': 0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-fs': 0.40.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-generic-pool': 0.64.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-graphql': 0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-grpc': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-hapi': 0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-host-metrics': 0.4.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-http': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-ioredis': 0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-kafkajs': 0.30.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-knex': 0.65.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-koa': 0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-lru-memoizer': 0.65.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-memcached': 0.64.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-mongodb': 0.74.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-mongoose': 0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-mysql': 0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-mysql2': 0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-nestjs-core': 0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-net': 0.65.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-openai': 0.19.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-oracledb': 0.46.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-pg': 0.73.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-pino': 0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-redis': 0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-restify': 0.66.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-router': 0.65.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-runtime-node': 0.34.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-socket.io': 0.68.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-tedious': 0.40.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-undici': 0.31.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/instrumentation-winston': 0.65.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/resource-detector-alibaba-cloud': 0.36.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resource-detector-aws': 2.21.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resource-detector-azure': 0.29.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resource-detector-container': 0.8.12(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resource-detector-gcp': 0.56.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/configuration@0.221.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-uE9y56Zdi9Gt/RdxYnVOo3YmFZkKJJMA0gqtBe8wh8gdtF5Asqe+Oh/TWiDtFb1s+31jNY4CWgnfIB1KOITfFA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      yaml: 2.9.0
+
+  /@opentelemetry/context-async-hooks@2.10.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  /@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  /@opentelemetry/exporter-logs-otlp-grpc@0.221.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-txG1G0IrYSsKKMeiWZfj/i5cQmWB+h+hf3HzPpF3RqZVwp+iQQEIsv8Vtmzy6RWVdHdJZfygmVrBI39YTBvWcw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+
+  /@opentelemetry/exporter-logs-otlp-http@0.221.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-nKXkr4Tomi6fjYVOf+ytcW3dZAVr4v4Bv5gsT6dr2gvpUPJpKgHB4XbMufMsPotRE3g0XH2GwVVCkN2w6SON+Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+
+  /@opentelemetry/exporter-logs-otlp-proto@0.221.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-AH6EY+47gXFaWYgG3hfeOneGiE9xIZGtDBk+9g0sM8NZWzsQhhmqPbQQXJzS7pyCh5jRRr2nYNXVrkCmoojRvQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+
+  /@opentelemetry/exporter-metrics-otlp-grpc@0.221.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-KOgCtO15FC6C1T/xOqBcr7EyUs7B+7yomGNb5Y97d3s38rPbCCk5sewkmE2b0/itOkQ/PptX8CLlD+kn2mEtTg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/exporter-metrics-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+
+  /@opentelemetry/exporter-metrics-otlp-http@0.221.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-sRfCKbOzgy8xZQV2as0RzIZlnCmCseCKZGLfRcrpo2CBngJDr+rPtX0zkG0+oUCV5kfQPUoW3W3C96Ag3Y/Clg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+
+  /@opentelemetry/exporter-metrics-otlp-proto@0.221.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-YMF4LveY2I3yhw61rn6nmC9FE8U24IZHPeKU1Duc5+sbwjMd8FwZAwba318ImdThCg/HuVQvhm2y6bfgNPnfYg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/exporter-metrics-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+
+  /@opentelemetry/exporter-prometheus@0.221.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-kW79a20qWESIuAdDrxzg9WKM98twV/NBWBFRAH57ap/+ssZhiCo0hckzKT0zpuwR/gSHrFAQhJL0bYDrnEM34g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  /@opentelemetry/exporter-trace-otlp-grpc@0.221.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-zXminlZedtq9LvOW64CnNkOqk15zV75k8JgtdTuWFge6+jk2m4GmAUm6L2eIiG1o2a2bZxXw2PDrszm+bps0IA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+
+  /@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-AySXiKoC+meiWm6zdVj5T2LnPDZuatveBby1cMOeQteIWsYXAUxs8Sru13G2pVSPrUXz6vF+og7QVBX6GdC/oQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+
+  /@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-Z9i2T7vgZbWe9rSLYxXVIbeW+XyzUq4rZanW3ZyVNwVDqCsh0EJKUgBWWQ0CZfeuUA+RQPzKgJQHMuWAUnKqXw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+
+  /@opentelemetry/exporter-zipkin@2.10.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-7gsvgf0UDoJ4l9ObrwBmz5G/ZogiPk+lq+g5GpLp24YQF/vPM/BSsnOfcLnfinast5ASUgLo78uSC/ObjlnXgg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  /@opentelemetry/instrumentation-amqplib@0.68.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-U9Fc3C061q+AGxP3xEJTIAJtBduY1GL21J4SjOSxCmmls4UUva16jzQ5ZkunQe0pKalrRjZ/DlZ+wgfgQxqjBw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-aws-lambda@0.73.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-N2BZFlWmVt2zjpiqPnfmIlj7tV/wfKSZCFF/laLAnJSTZjSEdc9JYSXW+KUV0FMUNDfpLCeAcI1xDMdGLdxFJg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/propagator-aws-xray': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+      '@types/aws-lambda': 8.10.162
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-aws-sdk@0.76.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-gg2QaDtWeFezRt2mAl9vBQ38y60tzUShKg1KA9uTgsMJimUHaBnB3X8kEH9Of8jKWT4DDoDcSA37gPcoEc0hiA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-bunyan@0.66.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-IqYQC1dav35NHlD5nYnpBXK8tI6KJ9/MIt8LYKFxwlhMIwfBCfavaklyP8NtVKoJ0WZKzX2v9Sh+xGK1XvSniQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+      '@types/bunyan': 1.8.11
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-cassandra-driver@0.66.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-4ksN7PfXLg7raDyXIjIrtxxzuuDlUx6Fh0s8VXojdl+nn2o0xkYa9jrq1f9Bfqhm+Sce3GOa1RjE3ycvAwk6Xw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-connect@0.64.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-D1Tpom3BpY8g29FFOEQ2FZioVFjyXwXHsh3BOn2BHcg7Taipg+yc+DPGUwvdR4WZrKnNMAG/+FBXNa0S0KhJYA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+      '@types/connect': 3.4.38
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-cucumber@0.37.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-ezhn6D0DSUZkwLBGdfnr+PAENvB92AhbEH/dkcSLYB8dbQiw/NQ8y19jOn3E6MZTt0+FD1YyHtrJS2skDO4nDQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-dataloader@0.38.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-OmOVadK0m7sdlvMwbt1gb2iVUCyvVNDo3x5JLGgnKggLTJBgTcQxgMl3pAhFAMzWGo9URuMxuh3Bphy9Pb9nZw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-dns@0.64.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-La6s9SdKgojZQVFD7AclQBYe3WioVe6zicJswM3QPPPHpCufJYnw8rO/G9o2Yl/OUeS7PYpzwHh4N6lexzbEcA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-express@0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-91pHMujQgDyhEQrdg8RriMBrRZ/qPaJ0Y2dopQ6lHjW5YjoeytWi8ruM//T6f5o0D95hnqRlv79Pel1lGPqaYg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-fs@0.40.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-p39axaaYVKhnl5l4M+1aiXmxrAG2HuTti7DHxs2jDJRst828y5iwqUZLC1UWIKIhW9FfdV5gogXg+nRRhSc0EA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-generic-pool@0.64.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-wM939j8Ox5BBHoA0r/p9etdpyS3GcUf/sfrUx1dtZdqGKU4ZcBxLyPD8QntwFkSI9PHql+rRejTCA6Btktz8Kg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-graphql@0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-vyKzuiBoEulV1FjMSe4iiuwZedt+nNAuaSVOh/3WxjDIuGQ9WsH+0ohd9snhIY6guAjYOGjqvTiYLs6K+OTQQg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-grpc@0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-1U45172SiPWG1MPfrgLItIuXZO/RfJqt5sxsrdlKN1NRV0pUtv7lbpgB1nShwP/SGSKaAFkovbVg3a1hfy3mpQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-hapi@0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-cIXIN4vZXm6aI4yz+4oUIRnkiAxCIpONrMhnGTI+ILKKEsIXP8Uselfr9663+TnisrgRLB7kKp+SoOuGJRHGtw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-host-metrics@0.4.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-jnFyX2sTn2B+9mjsL3qgAHzpxdaia4/FV2GSlf9QrpaiMi6O0M0lA9JZTsf4FTvuOwrIngCk+MeVXjsxgBXXyg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      systeminformation: 5.33.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-http@0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-oIP91CPIANuYr09tGFElPFKAh6JUar+awJf1kBRYlaeo9b0gDwZHEB2zBfFlvdNFHm0wAVutMZODVi5smKT30g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+      forwarded-parse: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-ioredis@0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-I9sZtxXWZ1tRXtRNTEVxpokGtXy6RL1SZhtPVh7zxH78t8ar71V5Dx4bnQiUjKTDzItpC73krD8c0/cEWA9oLg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/redis-common': 0.38.3
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-kafkajs@0.30.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-/p/D4etxJpJGB0VrS+kqF8WfVAMFWf5ybhY0mjzIEd/d/T68+nxTWJaI5MJXFiyOnBUFuMlun12VJt+QJDCSZA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-knex@0.65.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-rJTT12VlDnL6wOWfxnBvkTUIzW2ju+7nqlToMy1tlqL0j6ohlVPxryMCS5h6UqE3CFpq7HtHqVObQHZgrA37KA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-koa@0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-fxuA8jFOdqQzJV9Sitd0dk+zns7RQCFe19ia3LHex5oLiQPaaQovBv37jndX/zAZw6EBORATePHE8OQUwraPCQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-lru-memoizer@0.65.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-s2KisLZ82iDvCF2QbsV1k1wrz3DMSBP9OiMfmNn5oSyaNT7jcNphR4uxr7WjwH+ssucuvhKWqKzJ2vdx7KRMVA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-memcached@0.64.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-ek34tp7Qjci4CLahXybJ3aaixU1d2j28X5JSXSXbp6/rIiFGjMCAXJWw3FeiYmA82D/gV/wzPhL7r7m/p4gUzw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+      '@types/memcached': 2.2.10
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-mongodb@0.74.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-GRnHu69YLQUYgguuYkKi6wpizMY4r7gLC08rSq8cg41p6t7+1YIy5nXoGC61NA7KCZUE9jbcDnzd45i32IblZg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-mongoose@0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-iEBgNrychD36qI16X/V8WZb2JabjQPE+pyrkLU320ApZyhGVsYU9LH3Nqt4Mkg1nFsa9qWhRQrCfhoANCgT6EA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-mysql2@0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-AmviR7l0xMxhC83scY3u+NkkT6blhD/xK9tPi9nYtjNG1gwPtMgZjYOa3f9lGOwpXs/EwN7wiyAgxiO4KTcENA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+      '@opentelemetry/sql-common': 0.42.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-mysql@0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-G4aRrVKcd2Aodqi7WzRZ3LQJNKrM8BpsXEVMHrOb9s8Lg0jZXNvlLY0NWL1yVJrjnqI/unwEsp2aVHkVImPMeA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+      '@types/mysql': 2.15.27
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-nestjs-core@0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-lXb7pjobd2i/9Gmihf9wrOM0MgnDYBxOJq7uWEhZOqULodNFLyPCRUnWxSIbPQdUzlU36QtHjuAeaEBUJnqXkA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-net@0.65.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-W82H8UvaSrWynpI510CNJbq2Aq6L4/zuR/dAvoCZVYeRiChi0LHMI8i3rPe3Tmau2WBwE0jimaWgOs0GCfIHbQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-openai@0.19.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-zHz7m/aUMDyAap7UMzaaxDkbmxEyUOfMBfh+7KICNwTBmIOypMnuUWwXWAfIJLgl+2dnZlNzxZRknULeS4YIhg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-oracledb@0.46.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-nqxQvbp7HvsVPyDdgiZADPQX6B6ZUtLfm+XPuJHtQ3anxIcqU6qhJlrDIEM2LrZMShqf7bs84RHfDt2rgsp7hg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+      '@types/oracledb': 6.5.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-pg@0.73.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-yf3tBVwLHB9cZNNPSToNrthx36ouPe4FctFxy7ya6vSJ6gaiKjNfA/IgFFeuBpZflEQhy6aesPqzZo8ZjFkvNg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+      '@opentelemetry/sql-common': 0.42.0(@opentelemetry/api@1.9.1)
+      '@types/pg': 8.15.6
+      '@types/pg-pool': 2.0.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-pino@0.67.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-Hb6phi2x1bq23OIiesj4imQvXs9Y5MMLtpgXH9hOuMm9LpBYz2cxPNgpgZ/XATuRclP1eRPoSl399o5XKwfoIA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-redis@0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-lyCIEW89cYhMwaUSMBzsKHdwH2wOoqmuwXOARJneo9UL55govLIUCbYYAJ457oM8kdKADymlY4+SUW0DKQeIHw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/redis-common': 0.38.3
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-restify@0.66.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-9zbnL0ML2jFgJmmG1XPQTqwopCogC8eAtUQ0SXvYb+Ux2yuOBOvSg9XvRk/hcQf6WsRMll47cELCMC+IaI9I+g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-router@0.65.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-ti9tDLFLhLoev5U/cGeQpFTlOjFFwrFbieZmwTFql9z8EijXDzFE7a3+3mgnxGl9CZR0luKCwFD/o51NPU+Ngg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-runtime-node@0.34.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-Yb3PcmuK/iIOWY49GSEcSGl7fR4r6UqhZnuy5EWvFaqKqqs9SYnQeyQUEAbnBnSougRpwFBDbdN1SSGcvMhbtQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-socket.io@0.68.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-Bhd0KApVBYV4WQMZZbKRYfvev7SudvCtSn6b36uyUbKowOMEoGpnVoIvm0rlrrBR0KmkcV3Y37SngCGUrTm3lg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-tedious@0.40.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-zTNNxs+KUJf1J+lHzeTDxAIZdVJYvQ8mvGUfyiWcVFgVdl7+4XV+wOBMSd1tZcRRlopfcVODDCOVMx/N7+zvcA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+      '@types/tedious': 4.0.14
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-undici@0.31.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-qunCfgSFV+bjRdAYkWIjVX38jIN/Xj80CiERXXdzYAmdigCFvJPB3AY3j43bjJlkhgbJJSCGdbvQUSut8QIiyQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-winston@0.65.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-hWSPnS530deRa+ttzY+QiGmgsK7aQHpqxbQRm56yO1j4qnIXuYYHaoSJ8/4lLOEcXB+hZs0mAAJ6QiMl1aaiGA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      import-in-the-middle: 3.3.3
+      require-in-the-middle: 8.0.1(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  /@opentelemetry/otlp-exporter-base@0.221.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-UFPIq80OH3Ns/oPFHRj14d4DTOxUo+MUFU8hUiCq5jTqFhdeJnfVSANHT+xp92409cA+oxzvlZCe6NM1wvCuBA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+
+  /@opentelemetry/otlp-grpc-exporter-base@0.221.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-rQDmNgyiGCTrescjnzH2ntVyUKVIq6I2UjuK8+stT/Xg0ZOT71FVJqwjFdspQl6Yol/Yqsut9bDo+ame8oTmDQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+
+  /@opentelemetry/otlp-transformer@0.221.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-lg6lkOU08Az23jVcn/0Els9HP+V8PnR4Km6p0KgpTggS0n/WuhnmY64rSh83Of9iR9nD+dpWr6adlcX8KzAwjg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+
+  /@opentelemetry/propagator-aws-xray@2.2.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-Yjvt2EjL+tfpkVOdKbhTPgpM4SIAez9nG6Q/QjQ3yfcJcjIWp59ph70SLfvmkSL6++3DCnuBG3iWcB18PwWavQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+    dev: false
+
+  /@opentelemetry/propagator-b3@2.10.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-GnA5B24H+1w8BO21J0q+IWNB0z1v+AGbcquTdIt/dufibhnhgxaA8YKvz0I3akRZhB1jHT+/tlzK+qlAjEDybQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+
+  /@opentelemetry/propagator-jaeger@2.10.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-yw/IX8DL470dSMZJoE82ScfYGp7JWZ/G8kFJo35ZILUVTB2jFPTOaioN+8s09pH0RHsWNhweVZb+ZnjJJpCChg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+
+  /@opentelemetry/redis-common@0.38.3:
+    resolution: {integrity: sha512-VCghU1JYs/4gP6Gqf/xro9MEsZ7LrMv2uONVsaESKL38ZOB9BqnI98FfS23wjMnHlpuE+TTaWSoAVNpTwYXzjw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    dev: false
+
+  /@opentelemetry/resource-detector-alibaba-cloud@0.36.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-s75zJV1ShpYL5nk2cODfZY05Haw2hGxcfEFMu3ymvh2QU3HrhXaCW+rmNkhXhRrO8YophMFTyVdb7iCDleC/JQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+    dev: false
+
+  /@opentelemetry/resource-detector-aws@2.21.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-Veavy+khoywR+Hv065SU5jucFTGTiW1KXo39CsJ+8wqdYYz8jiRJPnQ20Kd+X9HbV2+Abb0l5CrJIdxK1ZOqBg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    dev: false
+
+  /@opentelemetry/resource-detector-azure@0.29.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-lWm0vjjlQMoc4Xvvd+dW/OZWT/SI4w+cIN7kbm8KimIZCr1EpAyvyQ7WEOrGoBoXCpQCrsZ18uKTooDgiBCGIw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    dev: false
+
+  /@opentelemetry/resource-detector-container@0.8.12(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-EJRFfIY26whY0w5RDxMRXlfBDgDS001JYMHuOVuDBBsRrV4MBqoVajR9B0L9Vy728+w/HNVnSQkpJFacFr+klg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+    dev: false
+
+  /@opentelemetry/resource-detector-gcp@0.56.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-H8yNeqTsuapbXs6MLZTtelfUCk+5D8jD3+KosCJaXOyx5gl3EWWvs70HbNXTUO4VYLxccySFYJYVCd8YMM0NJw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      gcp-metadata: 8.1.4(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  /@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-FaDcazjyMp7TZZZAsqbo4IkovP0UegoCu0EBkiNt+qCqvUf7FPAsfcrZ3+ZEkKgXZ/jHafop+JoGPDk3A0SmLg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  /@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-t6r1VSvXNtSDnPXU1FbZeetJb7yyovHmgu0wRSoftxtE0g2rSNhQZQUy69sRUCL+iioJpX8SN/S6wq6ZtvLySQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+
+  /@opentelemetry/sdk-node@0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2):
+    resolution: {integrity: sha512-UbYuvtBrQQB5Prsh9KOKy4kxzexFxfMs5MkteHeWMoswsEB7kiNhyUVkAOFW/qsEzNHtrkgyghrD2ilZJa+5YA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/configuration': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/context-async-hooks': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-proto': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-grpc': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-proto': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-prometheus': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-zipkin': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-b3': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-jaeger': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+
+  /@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  /@opentelemetry/sdk-trace-node@2.10.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-GZK/G6oZyBLGlH1pUgeDch7D91KoHd2uotUGIkWCPi9GI5T9X0p4L7nNAMDR1BQjkRYoDqo+ddfVx9t5Uhys+Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+
+  /@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  /@opentelemetry/semantic-conventions@1.43.0:
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
+
+  /@opentelemetry/sql-common@0.42.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-nwUwUU+8O8a4bnLqk6CodWeegGMEANgC94KTAhXcpGWLrW/2/hek/0ajNbjXnSOoNuCX+nteUPs46HFHhou9Xw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+    dev: false
 
   /@orama/orama@3.1.18:
     resolution: {integrity: sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==}
@@ -5756,6 +6864,35 @@ packages:
     resolution: {integrity: sha512-i9IH5lO4fQwnMLvQLYNdgVh9TK3PuWBfQd7QLk/YurnAIg+VeADcZDbmhAi4XBBDD+hDif9hrKyASu0hbjwabw==}
     dependencies:
       '@prisma/debug': 6.7.0
+
+  /@protobufjs/aspromise@1.1.2:
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  /@protobufjs/base64@1.1.2:
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  /@protobufjs/codegen@2.0.5:
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  /@protobufjs/eventemitter@1.1.1:
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  /@protobufjs/fetch@1.1.1:
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  /@protobufjs/float@1.0.2:
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  /@protobufjs/path@1.1.2:
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  /@protobufjs/pool@1.1.0:
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  /@protobufjs/utf8@1.1.2:
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   /@quansync/fs@0.1.5:
     resolution: {integrity: sha512-lNS9hL2aS2NZgNW7BBj+6EBl4rOf8l+tQ0eRY6JWCI8jI2kc53gSoqbjojU0OnAWhzoXiOjFyGsHcDGePB3lhA==}
@@ -8113,6 +9250,10 @@ packages:
       tslib: 2.8.1
     optional: true
 
+  /@types/aws-lambda@8.10.162:
+    resolution: {integrity: sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw==}
+    dev: false
+
   /@types/babel__core@7.20.5:
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
     dependencies:
@@ -8142,6 +9283,18 @@ packages:
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
     dependencies:
       '@types/node': 20.19.21
+
+  /@types/bunyan@1.8.11:
+    resolution: {integrity: sha512-758fRH7umIMk5qt5ELmRMff4mLDlN+xyYzC+dkPTdKwbSkJFvz6xwyScrytPU0QIBbRRwbiE8/BIg8bpajerNQ==}
+    dependencies:
+      '@types/node': 20.19.21
+    dev: false
+
+  /@types/connect@3.4.38:
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+    dependencies:
+      '@types/node': 20.19.21
+    dev: false
 
   /@types/debug@4.1.12:
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -8199,8 +9352,20 @@ packages:
     resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
     dev: false
 
+  /@types/memcached@2.2.10:
+    resolution: {integrity: sha512-AM9smvZN55Gzs2wRrqeMHVP7KE8KWgCJO/XL5yCly2xF6EKa4YlbpK+cLSAH4NG/Ah64HrlegmGqW8kYws7Vxg==}
+    dependencies:
+      '@types/node': 20.19.21
+    dev: false
+
   /@types/ms@2.1.0:
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+    dev: false
+
+  /@types/mysql@2.15.27:
+    resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
+    dependencies:
+      '@types/node': 20.19.21
     dev: false
 
   /@types/node@20.19.21:
@@ -8212,6 +9377,26 @@ packages:
     resolution: {integrity: sha512-anNG/V/Efn/YZY4pRzbACnKxNKoBng2VTFydVu8RRs5hQjikP8CQfaeAV59VFSCzKNp90mXiVXW2QzV56rwMrg==}
     dependencies:
       undici-types: 6.21.0
+    dev: false
+
+  /@types/oracledb@6.5.2:
+    resolution: {integrity: sha512-kK1eBS/Adeyis+3OlBDMeQQuasIDLUYXsi2T15ccNJ0iyUpQ4xDF7svFu3+bGVrI0CMBUclPciz+lsQR3JX3TQ==}
+    dependencies:
+      '@types/node': 20.19.21
+    dev: false
+
+  /@types/pg-pool@2.0.7:
+    resolution: {integrity: sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==}
+    dependencies:
+      '@types/pg': 8.15.6
+    dev: false
+
+  /@types/pg@8.15.6:
+    resolution: {integrity: sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==}
+    dependencies:
+      '@types/node': 20.19.21
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
     dev: false
 
   /@types/phoenix@1.6.7:
@@ -8254,6 +9439,12 @@ packages:
     dependencies:
       csstype: 3.2.3
     dev: true
+
+  /@types/tedious@4.0.14:
+    resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
+    dependencies:
+      '@types/node': 20.19.21
+    dev: false
 
   /@types/unist@2.0.11:
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -9512,6 +10703,10 @@ packages:
       prebuild-install: 7.1.3
     dev: false
 
+  /bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+    dev: false
+
   /binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -9807,6 +11002,9 @@ packages:
     dependencies:
       consola: 3.4.2
 
+  /cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+
   /class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
     dependencies:
@@ -9823,7 +11021,6 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
-    dev: false
 
   /cliui@9.0.1:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
@@ -10059,6 +11256,11 @@ packages:
       typescript: 5.9.3
     dev: false
 
+  /data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+    dev: false
+
   /data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
@@ -10093,7 +11295,7 @@ packages:
       sqlite3:
         optional: true
     dependencies:
-      drizzle-orm: 0.45.2(@prisma/client@6.7.0)(@types/better-sqlite3@7.6.13)(@xata.io/client@0.30.1)(kysely@0.28.17)(pg@8.20.0)
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@6.7.0)(@types/better-sqlite3@7.6.13)(@xata.io/client@0.30.1)(kysely@0.28.17)(pg@8.20.0)
 
   /debug@4.4.3(supports-color@10.2.2):
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -10369,7 +11571,7 @@ packages:
       kysely: 0.28.12
     dev: false
 
-  /drizzle-orm@0.45.2(@prisma/client@6.7.0)(@types/better-sqlite3@7.6.13)(@xata.io/client@0.30.1)(kysely@0.28.17)(pg@8.20.0):
+  /drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@prisma/client@6.7.0)(@types/better-sqlite3@7.6.13)(@xata.io/client@0.30.1)(kysely@0.28.17)(pg@8.20.0):
     resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
@@ -10461,6 +11663,7 @@ packages:
       sqlite3:
         optional: true
     dependencies:
+      '@opentelemetry/api': 1.9.1
       '@prisma/client': 6.7.0(prisma@6.7.0)(typescript@5.9.3)
       '@types/better-sqlite3': 7.6.13
       '@xata.io/client': 0.30.1(typescript@5.9.3)
@@ -10599,7 +11802,6 @@ packages:
 
   /es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
-    dev: true
 
   /es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -11162,6 +12364,14 @@ packages:
     dependencies:
       picomatch: 4.0.5
 
+  /fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+    dev: false
+
   /fetchdts@0.1.7:
     resolution: {integrity: sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA==}
     dev: false
@@ -11243,6 +12453,17 @@ packages:
   /format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
+    dev: false
+
+  /formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+    dependencies:
+      fetch-blob: 3.2.0
+    dev: false
+
+  /forwarded-parse@2.1.2:
+    resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
     dev: false
 
   /forwarded@0.2.0:
@@ -11447,6 +12668,29 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
+  /gaxios@7.1.3(supports-color@10.2.2):
+    resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      node-fetch: 3.3.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /gcp-metadata@8.1.4(supports-color@10.2.2):
+    resolution: {integrity: sha512-iJ9KMsiu+xKtNRX0PmGLSaIU3bUBAyzWTyqKemKPzNPsmmsBCQYmlNg+brEbES7IHSXtdVwzBPzx1vz3FAaipw==}
+    engines: {node: '>=18'}
+    dependencies:
+      gaxios: 7.1.3(supports-color@10.2.2)
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /geist@1.7.0(next@16.2.4):
     resolution: {integrity: sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ==}
     peerDependencies:
@@ -11569,7 +12813,7 @@ packages:
 
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -11578,6 +12822,11 @@ packages:
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: true
+
+  /google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+    dev: false
 
   /gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -12029,6 +13278,14 @@ packages:
     hasBin: true
     dev: false
 
+  /import-in-the-middle@3.3.3:
+    resolution: {integrity: sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==}
+    engines: {node: '>=18'}
+    dependencies:
+      cjs-module-lexer: 2.2.0
+      es-module-lexer: 2.3.1
+      module-details-from-path: 1.0.4
+
   /import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
@@ -12346,6 +13603,12 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  /json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+    dependencies:
+      bignumber.js: 9.3.1
+    dev: false
 
   /json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
@@ -12669,9 +13932,15 @@ packages:
       mlly: 1.8.0
       pkg-types: 1.3.1
 
+  /lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
   /lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
     dev: false
+
+  /long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   /longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -13444,6 +14713,9 @@ packages:
       obliterator: 1.6.1
     dev: false
 
+  /module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
   /moment-timezone@0.5.48:
     resolution: {integrity: sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==}
     dependencies:
@@ -13983,8 +15255,23 @@ packages:
       semver: 7.7.3
     dev: false
 
+  /node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+    dev: false
+
   /node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  /node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+    dev: false
 
   /node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
@@ -14610,6 +15897,23 @@ packages:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
     dev: false
 
+  /protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
+    engines: {node: '>=12.0.0'}
+    requiresBuild: true
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 20.19.21
+      long: 5.3.2
+
   /proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -15101,11 +16405,19 @@ packages:
   /require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  /require-in-the-middle@8.0.1(supports-color@10.2.2):
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   /resend@6.10.0(@react-email/render@2.0.6):
     resolution: {integrity: sha512-i7CwZpYj4Oho1RxsTpLcCUkO08+HiL4NXrm6jLJ2WzJ89UGI8eROSieLONJA3hnUrf1OYnCyfq5F6POnHUMv1Q==}
@@ -15150,6 +16462,13 @@ packages:
   /reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  /rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
+    hasBin: true
+    dependencies:
+      glob: 10.5.0
+    dev: false
 
   /rolldown-plugin-dts@0.16.11(rolldown@1.2.3)(supports-color@10.2.2)(typescript@5.9.3):
     resolution: {integrity: sha512-9IQDaPvPqTx3RjG2eQCK5GYZITo203BxKunGI80AGYicu1ySFTUyugicAaTZWRzFWh9DSnzkgNeMNbDWBbSs0w==}
@@ -15983,6 +17302,13 @@ packages:
 
   /symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  /systeminformation@5.33.1:
+    resolution: {integrity: sha512-DEN6ICHk3Tk0Uf/hrAHh7xlt7iL5CJFBtPZinA0H62DrGG/KPKqq/Nzj6lCXPS4Ay/sf/14zNnk9LpqKzBIc+w==}
+    engines: {node: '>=10.0.0'}
+    os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
+    hasBin: true
+    dev: false
 
   /tabbable@6.2.0:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
@@ -17413,6 +18739,11 @@ packages:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
     dev: false
 
+  /web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+    dev: false
+
   /webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -17675,7 +19006,6 @@ packages:
   /yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
-    dev: false
 
   /yargs-parser@22.0.0:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
@@ -17692,7 +19022,6 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-    dev: false
 
   /yargs@18.0.0:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}


### PR DESCRIPTION
## Summary

- add first-class OpenTelemetry request and lifecycle spans to Farm observability
- correlate Farm events with trace and span IDs while preserving event filtering
- add an `instrumentation.ts` convention with deterministic development and production startup/shutdown
- add the optional `@farm.js/otel` package with OTLP HTTP export, Node auto-instrumentation, flushing, and custom SDK configuration
- document tracing setup, propagation, custom spans, runtime selection, and production guidance

## Why

Farm already exposes detailed observability events, but those events do not provide the distributed request timeline, parent/child relationships, or vendor-neutral export path that OpenTelemetry provides. This integrates both layers so applications can keep using Farm events for logs and alerts while exporting standard traces to any OTLP-compatible backend.

## Developer impact

Tracing remains opt-in through `observability.tracing`. Applications add one `src/instrumentation.ts` or root `instrumentation.ts` file to initialize their SDK. Farm then:

- extracts incoming W3C `traceparent` context
- creates request, render, middleware, API, integration, storage, PPR, build, and plugin spans
- renames request spans to matched route patterns and records semantic HTTP attributes
- exposes `runWithFarmSpan()` and `getFarmTraceContext()`
- starts instrumentation before development or production traffic
- waits for graceful shutdown cleanup so batched spans are flushed

The production request runtime remains free of the build-time instrumentation loader and its Node filesystem/esbuild dependencies.

## Validation

- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/otel type-check`
- `pnpm --filter @farm.js/otel test`
- 26 focused core tests covering tracing, instrumentation, development server shutdown, production builds/requests, APIs, and existing font behavior
- core ESM, CJS, and declaration build
- ESM and CommonJS public export resolution
- lint, formatting, and `git diff --check`
- frozen offline workspace install
- documentation navigation and production build
- package dry-run and production bundle boundary verification


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add first-class OpenTelemetry tracing to Farm. Request and lifecycle spans are exported to any OTLP backend and are correlated with Farm events for a unified view in dev and prod.

- **New Features**
  - Record spans for request, render, middleware, API, integration, storage, PPR, build, and plugins.
  - Farm events now include traceId, spanId, and sampling; request spans are renamed to route patterns with semantic HTTP attributes.
  - New `instrumentation.ts` convention and lifecycle helpers for deterministic start, flush, and shutdown.
  - Optional `@farm.js/otel` package to bootstrap the Node SDK with OTLP HTTP export, auto-instrumentations, custom exporters, and flushing.
  - APIs: `runWithFarmRequestSpan()`, `runWithFarmSpan()`, and `getFarmTraceContext()` with W3C `traceparent` extraction.

- **Migration**
  - Tracing is opt-in: enable via `observability.tracing`.
  - Add `instrumentation.ts` (in `src/` or project root) and call `registerOTel(...)` from `@farm.js/otel`.
  - Configure your OTLP endpoint and auth via env vars or options; the SDK handles graceful shutdown and flush.
  - Optionally create custom spans with `runWithFarmSpan()` and exclude paths using `ignorePaths`.

<sup>Written for commit e36d8440f60edd9aa145ee45c2b9ee78d7a4bef5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

