### PR TITLE
docs: add renderer guides

### DIFF
--- a/docs/src/app/docs/renderers/page.md
+++ b/docs/src/app/docs/renderers/page.md
@@ -1,0 +1,85 @@
+---
+title: "Renderers"
+description: "Choose React, Solid, or Vue for application UI while keeping FARMJS routing, server APIs, middleware, observability, and deployment."
+section: "Core"
+---
+
+# Renderers
+
+Choose React, Solid, or Vue for application UI while keeping FARMJS routing, server APIs,
+middleware, observability, and deployment. React remains the default; Solid and Vue are beta
+renderer adapters.
+
+## Choose a renderer
+
+| Renderer                       | Select it with      | Route components | Best fit                                                 |
+| ------------------------------ | ------------------- | ---------------- | -------------------------------------------------------- |
+| [React](/docs/renderers/react) | Omit `renderer`     | `.tsx`, `.jsx`   | Complete FARMJS client API and integration UI support.   |
+| [Solid](/docs/renderers/solid) | `renderer: solid()` | `.tsx`, `.jsx`   | Fine-grained interactive UI with FARMJS server features. |
+| [Vue](/docs/renderers/vue)     | `renderer: vue()`   | `.vue`           | Vue SFCs, SSR, hydration, and FARMJS server features.    |
+
+The renderer controls component compilation, element creation, server rendering, and browser
+hydration. FARMJS continues to control route discovery, layouts, API routes, middleware, cache and
+storage, integrations, observability, and deployment output.
+
+## Feature support
+
+| Capability                                       | React                    | Solid                | Vue                  |
+| ------------------------------------------------ | ------------------------ | -------------------- | -------------------- |
+| File pages and nested layouts                    | Available                | Available            | Available            |
+| Server rendering and browser hydration           | Available                | Available            | Available            |
+| Loading, error, not-found, and slot files        | Available                | Available            | Available            |
+| Static metadata and favicon configuration        | Available                | Available            | Available            |
+| API routes and generated typed API clients       | Available                | Available            | Available            |
+| Server functions, middleware, cache, and storage | Available                | Available            | Available            |
+| Observability and production Node output         | Available                | Available            | Available            |
+| Basic create-app starter                         | Available                | Available            | Available            |
+| `Link`, router hooks, actions, fetchers, queries | Available                | React API only       | React API only       |
+| Client theme and i18n hooks                      | Available                | React API only       | React API only       |
+| Programmatic UI routes                           | Available                | React-oriented today | React-oriented today |
+| Markdown/MDX visual routes and docs adapter      | Available                | React-oriented today | React-oriented today |
+| Generated JSX metadata images                    | Available                | React-oriented today | React-oriented today |
+| React Server Components and optimized boundaries | Available experimentally | Not applicable       | Not applicable       |
+| Integration UI providers and provider starters   | Available                | React-oriented today | React-oriented today |
+
+“React API only” means the server feature remains usable, but its current convenience hook or
+component imports React. Solid and Vue applications should call validated endpoints through the
+generated API client and use their renderer's native state primitives.
+
+## Renderer-neutral server code
+
+Keep product and server behavior outside the component runtime whenever possible:
+
+```ts
+import { createEndpoint } from "@farm.js/core";
+import { createServerFn } from "@farm.js/core/server-fn";
+import { z } from "zod";
+
+const input = z.object({ name: z.string().min(1) });
+
+const greet = createServerFn({
+  input,
+  async handler({ input }) {
+    return { message: `Hello, ${input.name}` };
+  },
+});
+
+export const POST = createEndpoint(
+  "/api/greeting",
+  { method: "POST", body: input },
+  async ({ body }) => greet(body),
+);
+```
+
+React, Solid, and Vue components can call this endpoint through the same generated client. Database
+access, secrets, validation, cache invalidation, middleware, and the server-function handler remain
+on the server.
+
+## Switch renderers deliberately
+
+The renderer option is application-wide. Do not mix React, Solid, and Vue route components in the
+same route tree. Share server modules, schemas, API clients, CSS, and plain TypeScript across
+renderers; rewrite component and client-state code using the selected renderer's native primitives.
+
+Integration starter templates currently target React. Use the Basic starter for Solid or Vue, then
+add renderer-neutral integrations without their React UI scaffold.

--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1,0 +1,85 @@
+---
+title: "React Renderer"
+description: "Use FARMJS with the default React renderer, including client hooks, integrations, streaming SSR, and experimental Server Components."
+section: "Core"
+---
+
+# React Renderer
+
+React is the default FARMJS renderer and has the broadest client-feature support. Existing projects
+do not need a renderer option or an additional adapter package.
+
+## Create an app
+
+```bash
+pnpm create @farm.js/app@beta my-app --template basic --typescript
+```
+
+Omitting `renderer` keeps React active:
+
+```ts
+import { defineConfig } from "@farm.js/core";
+
+export default defineConfig({});
+```
+
+## Route components
+
+React routes use `.tsx` or `.jsx` files:
+
+```text
+src/app/layout.tsx
+src/app/page.tsx
+src/app/products/[id]/page.tsx
+```
+
+```tsx
+import type { LayoutProps, Metadata } from "@farm.js/core";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "My FARMJS app",
+};
+
+export default function RootLayout({ children }: LayoutProps) {
+  return <main>{children}</main>;
+}
+```
+
+Add `"use client"` to an interactive component. FARMJS keeps ordinary server-rendered routes out of
+the browser bundle and hydrates the client boundaries imported by the route.
+
+```tsx
+"use client";
+
+import { useState } from "react";
+
+export function Counter() {
+  const [count, setCount] = useState(0);
+  return <button onClick={() => setCount((value) => value + 1)}>Count: {count}</button>;
+}
+```
+
+## React-specific FARMJS APIs
+
+Choose React when the application needs the complete built-in client layer:
+
+- `Link`, `useRouter`, `useNavigation`, and scroll restoration;
+- `useAction`, fetcher forms, mutations, and server-query hooks;
+- `useTheme`, `useLocale`, translations, and the built-in auth hook;
+- integration providers and generated integration UI;
+- Markdown/MDX visual routes and the docs adapter;
+- generated JSX metadata images;
+- experimental React Server Components and optimized Strata boundaries.
+
+Server APIs such as endpoints, server functions, middleware, storage, caching, observability, and
+deployment use the same contracts described in the renderer overview.
+
+## Production rendering
+
+The React adapter supports string rendering and streaming when the active production runtime can
+use `renderToPipeableStream`. Static generation, ISR, PPR, and ordinary dynamic rendering continue
+to follow route configuration rather than the component extension.
+
+See [Rendering Model](/docs/server-rendering) for rendering modes and
+[Renderers](/docs/renderers) for the cross-renderer support matrix.

--- a/docs/src/app/docs/renderers/solid/page.md
+++ b/docs/src/app/docs/renderers/solid/page.md
@@ -1,0 +1,103 @@
+---
+title: "Solid Renderer"
+description: "Use Solid components, signals, SSR, and hydration with FARMJS routing and renderer-neutral server primitives."
+section: "Core"
+---
+
+# Solid Renderer
+
+`@farm.js/solid` connects Solid component compilation, server rendering, and browser hydration to
+the FARMJS renderer contract. React remains the default unless the application selects Solid.
+
+## Create an app
+
+```bash
+pnpm create @farm.js/app@beta my-solid-app --template basic --renderer solid --typescript
+```
+
+For an existing Basic app, install the adapter and Solid runtime:
+
+```bash
+pnpm add @farm.js/solid@beta solid-js
+```
+
+```ts
+import { defineConfig } from "@farm.js/core";
+import { solid } from "@farm.js/solid";
+
+export default defineConfig({
+  renderer: solid(),
+});
+```
+
+## Pages and layouts
+
+Solid routes use `.tsx` or `.jsx`. Layout children arrive through the normal `children` property:
+
+```tsx
+import type { LayoutProps, Metadata } from "@farm.js/core";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "FARMJS with Solid",
+};
+
+export default function RootLayout(props: LayoutProps) {
+  return <>{props.children}</>;
+}
+```
+
+Use Solid primitives inside interactive components and mark the component with `"use client"`:
+
+```tsx
+"use client";
+
+import { createSignal } from "solid-js";
+
+export function Counter() {
+  const [count, setCount] = createSignal(0);
+  return <button onClick={() => setCount((value) => value + 1)}>Count: {count()}</button>;
+}
+```
+
+FARMJS server-renders the route and hydrates the Solid boundary in the browser.
+
+## Call FARMJS server code
+
+API routes, endpoint schemas, server functions, middleware, cache, storage, and observability are
+renderer-neutral. Use the generated API client from Solid UI and keep the privileged handler in a
+server module:
+
+```tsx
+"use client";
+
+import { createSignal } from "solid-js";
+import { api } from "../../lib/api.generated";
+
+export function Greeting() {
+  const [message, setMessage] = createSignal("Ready");
+
+  const callServer = async () => {
+    const result = await api.greeting.post({ body: { name: "Solid" } });
+    if (result.data) setMessage(result.data.message);
+  };
+
+  return <button onClick={callServer}>{message()}</button>;
+}
+```
+
+## Current boundaries
+
+React-based client exports such as `Link`, `useAction`, fetchers, query hooks, `useTheme`, and
+integration providers do not become Solid primitives automatically. Use native Solid state and the
+generated API client. Programmatic UI routes, Markdown/MDX visual pages, the docs adapter, and
+generated JSX metadata images remain React-oriented today.
+
+Run the complete example:
+
+```bash
+pnpm --filter farm-solid-renderer-example dev
+```
+
+See the [Solid renderer example](https://github.com/farming-labs/farm.js/tree/main/examples/solid-renderer)
+and the [renderer support matrix](/docs/renderers).

--- a/docs/src/app/docs/renderers/vue/page.md
+++ b/docs/src/app/docs/renderers/vue/page.md
@@ -1,0 +1,138 @@
+---
+title: "Vue Renderer"
+description: "Use Vue Single-File Components, SSR, hydration, and typed FARMJS server calls through the @farm.js/vue adapter."
+section: "Core"
+---
+
+# Vue Renderer
+
+`@farm.js/vue` connects Vue Single-File Component compilation, `createSSRApp` rendering, and browser
+hydration to the FARMJS renderer contract. React remains the default unless the application selects
+Vue.
+
+## Create an app
+
+```bash
+pnpm create @farm.js/app@beta my-vue-app --template basic --renderer vue --typescript
+```
+
+For an existing Basic app, install the adapter and Vue runtime:
+
+```bash
+pnpm add @farm.js/vue@beta vue
+```
+
+```ts
+import { defineConfig } from "@farm.js/core";
+import { vue } from "@farm.js/vue";
+
+export default defineConfig({
+  renderer: vue(),
+});
+```
+
+## Pages and layouts
+
+Vue routes use `.vue` files:
+
+```text
+src/app/layout.vue
+src/app/page.vue
+src/app/products/[id]/page.vue
+```
+
+Use a normal script for FARMJS route exports and `<script setup>` for the Vue component. A layout
+renders its children through the default slot:
+
+```vue
+<script lang="ts">
+import type { Metadata } from "@farm.js/core";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "FARMJS with Vue",
+};
+</script>
+
+<script setup lang="ts">
+defineOptions({ inheritAttrs: false });
+</script>
+
+<template>
+  <slot />
+</template>
+```
+
+`inheritAttrs: false` prevents FARMJS route props such as `path` from falling through to the root
+DOM element. Declare the props with `defineProps` when the page needs them.
+
+## Hydrate interactive routes
+
+Export `hydrate = true` from the route's normal script, then use Vue state and events normally:
+
+```vue
+<script lang="ts">
+export const hydrate = true;
+</script>
+
+<script setup lang="ts">
+import { ref } from "vue";
+
+defineOptions({ inheritAttrs: false });
+
+const count = ref(0);
+</script>
+
+<template>
+  <button type="button" @click="count += 1">Count: {{ count }}</button>
+</template>
+```
+
+FARMJS server-renders the SFC with `createSSRApp` and Vue's `renderToString`, then uses
+`createSSRApp` again to claim the existing browser markup.
+
+## Call FARMJS server code
+
+API routes, endpoint schemas, server functions, middleware, cache, storage, and observability are
+renderer-neutral. Use the generated typed API client from the SFC:
+
+```vue
+<script setup lang="ts">
+import { ref } from "vue";
+import { api } from "../lib/api.generated";
+
+const message = ref("Ready");
+
+async function callServer() {
+  const result = await api.greeting.post({ body: { name: "Vue" } });
+  if (result.data) message.value = result.data.message;
+}
+</script>
+
+<template>
+  <button type="button" @click="callServer">{{ message }}</button>
+</template>
+```
+
+The endpoint can call a validated `createServerFn`; its handler, database access, and secrets remain
+in the server bundle.
+
+## Current boundaries
+
+React-based client exports such as `Link`, `useAction`, fetchers, query hooks, `useTheme`, and
+integration providers do not become Vue composables automatically. Use Vue refs/composables and the
+generated API client. Programmatic UI routes, Markdown/MDX visual pages, the docs adapter, and
+generated JSX metadata images remain React-oriented today.
+
+Integration starter templates currently target React, so select the Basic template for Vue and add
+renderer-neutral provider code afterward.
+
+Run the complete example:
+
+```bash
+pnpm --filter farm-vue-renderer-example dev
+```
+
+See the [Vue renderer example](https://github.com/farming-labs/farm.js/tree/main/examples/vue-renderer),
+the [renderer support matrix](/docs/renderers), and Vue's
+[SSR guide](https://vuejs.org/guide/scaling-up/ssr).


### PR DESCRIPTION
## Summary

- add a renderer overview and cross-renderer feature matrix
- document React, Solid, and Vue setup, route conventions, SSR, hydration, and server calls
- clarify current renderer boundaries and link the complete Solid and Vue examples
- restore the renderer pages already referenced by the beta.27 docs navigation

## Verification

- `pnpm exec oxfmt --check docs/src/app/docs/renderers/page.md docs/src/app/docs/renderers/react/page.md docs/src/app/docs/renderers/solid/page.md docs/src/app/docs/renderers/vue/page.md`
- `pnpm docs:check-navigation`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --dir docs build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds renderer docs: an overview with a cross-renderer feature matrix and new guides for React, Solid, and Vue. Restores the renderer pages referenced by the beta.27 docs navigation.

- New Features
  - Renderer overview explaining responsibilities and a feature support matrix.
  - React guide: default renderer, route files, client boundaries, SSR/streaming, and client APIs.
  - Solid guide: setup with `@farm.js/solid`, config, routes, signals, hydration, and server calls via generated clients.
  - Vue guide: setup with `@farm.js/vue`, SFC routes, metadata exports, `hydrate = true`, SSR/hydration, and typed server calls.
  - Clarifies current boundaries (React-only client helpers for now) and links full Solid/Vue examples.

<sup>Written for commit 21872fc7cf527104ba9e119cd83bb2a90c5db8e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

