### PR TITLE
test: add shared renderer conformance suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dev": "turbo --filter \"./packages/*\" dev",
     "test": "node scripts/test-packages.js",
     "test:farm": "pnpm --filter @farm.js/core test",
+    "test:renderers": "node scripts/test-renderers.mjs",
     "test:ci": "node scripts/run-tests.js",
     "test:e2e": "playwright test",
     "test:e2e:production": "corepack pnpm --filter @farm.js/core build && corepack pnpm --filter @farm.js/cli build && corepack pnpm test:e2e:production:run",

--- a/packages/farm-preact/package.json
+++ b/packages/farm-preact/package.json
@@ -59,6 +59,7 @@
   },
   "devDependencies": {
     "@farm.js/core": "workspace:*",
+    "@farm.js/renderer-tests": "workspace:*",
     "@types/node": "^20.10.5",
     "jsdom": "^25.0.0",
     "preact": "10.29.8",

--- a/packages/farm-preact/src/__tests__/client.test.ts
+++ b/packages/farm-preact/src/__tests__/client.test.ts
@@ -1,31 +1,11 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it } from "vitest";
-import { createElement, createRoot, hydrateRoot } from "../client";
+import { defineRendererClientConformance } from "@farm.js/renderer-tests";
+import * as clientRuntime from "../client";
+import * as serverRuntime from "../server";
 
-describe("Preact client renderer", () => {
-  it("mounts, updates, and unmounts a managed root", async () => {
-    const container = document.createElement("div");
-    const root = createRoot(container);
-
-    root.render(createElement("p", null, "First"));
-    expect(container.textContent).toBe("First");
-
-    root.render(createElement("p", null, "Second"));
-    await Promise.resolve();
-    expect(container.textContent).toBe("Second");
-
-    root.unmount();
-    expect(container.childNodes).toHaveLength(0);
-  });
-
-  it("hydrates server-rendered markup and preserves the existing node", () => {
-    const container = document.createElement("div");
-    container.innerHTML = "<button>Continue</button>";
-    const button = container.firstElementChild;
-
-    const root = hydrateRoot(container, createElement("button", null, "Continue"));
-    expect(container.firstElementChild).toBe(button);
-    root.unmount();
-  });
+defineRendererClientConformance({
+  name: "preact",
+  client: clientRuntime,
+  server: serverRuntime,
 });

--- a/packages/farm-preact/src/__tests__/renderer.test.ts
+++ b/packages/farm-preact/src/__tests__/renderer.test.ts
@@ -1,45 +1,34 @@
 // @vitest-environment node
 
 import { Writable } from "node:stream";
+import {
+  defineRendererDescriptorConformance,
+  defineRendererServerConformance,
+} from "@farm.js/renderer-tests";
 import { describe, expect, it } from "vitest";
 import { preact } from "../index";
+import * as serverRuntime from "../server";
 import {
   createElement,
   generateHydrationScript,
   renderToPipeableStream,
   renderToReadableStream,
-  renderToString,
 } from "../server";
 
+defineRendererDescriptorConformance({
+  name: "preact",
+  createDescriptor: preact,
+  expected: {
+    vite: "@farm.js/preact/vite",
+    server: "@farm.js/preact/server",
+    client: "@farm.js/preact/client",
+    jsxImportSource: "preact",
+  },
+});
+
+defineRendererServerConformance(serverRuntime);
+
 describe("Preact renderer", () => {
-  it("returns an isolated renderer descriptor", () => {
-    const first = preact();
-    const second = preact();
-
-    expect(first).toMatchObject({
-      name: "preact",
-      vite: "@farm.js/preact/vite",
-      server: "@farm.js/preact/server",
-      client: "@farm.js/preact/client",
-      jsxImportSource: "preact",
-    });
-    expect(first.dedupe).not.toBe(second.dedupe);
-    expect(first.optimizeDeps).not.toBe(second.optimizeDeps);
-  });
-
-  it("renders FARMJS elements with Preact's server runtime", () => {
-    const html = renderToString(
-      createElement(
-        "main",
-        { className: "preact-app" },
-        createElement("h1", null, "Hello from Preact"),
-      ),
-    );
-
-    expect(html).toContain('<main class="preact-app">');
-    expect(html).toContain("<h1>Hello from Preact</h1>");
-  });
-
   it("streams FARMJS elements through Preact's Node renderer", async () => {
     const html = await new Promise<string>((resolve, reject) => {
       const chunks: Buffer[] = [];

--- a/packages/farm-renderer-tests/package.json
+++ b/packages/farm-renderer-tests/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@farm.js/renderer-tests",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "vitest": "^1.1.0"
+  }
+}

--- a/packages/farm-renderer-tests/src/index.ts
+++ b/packages/farm-renderer-tests/src/index.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+
+export interface RendererDescriptorFixture {
+  name: string;
+  vite: string;
+  server: string;
+  client: string;
+  jsxImportSource?: string;
+  componentExtensions?: readonly string[];
+  dedupe?: readonly string[];
+  optimizeDeps?: readonly string[];
+}
+
+export interface RendererServerFixture {
+  name: string;
+  Fragment: unknown;
+  Suspense: unknown;
+  createElement(type: unknown, props?: unknown, ...children: unknown[]): unknown;
+  isValidElement(value: unknown): boolean;
+  renderToString(element: unknown): string | Promise<string>;
+  generateHydrationScript?: () => string;
+}
+
+export interface RendererRootFixture {
+  render(element: unknown): void;
+  unmount(): void;
+}
+
+export interface RendererClientFixture {
+  createElement(type: unknown, props?: unknown, ...children: unknown[]): unknown;
+  createRoot(container: Element): RendererRootFixture;
+  hydrateRoot(container: Element, element: unknown): RendererRootFixture;
+}
+
+async function settleClientRender(assertion: () => void): Promise<void> {
+  let error: unknown;
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (caught) {
+      error = caught;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  }
+  throw error;
+}
+
+export function defineRendererDescriptorConformance(options: {
+  name: string;
+  createDescriptor(): RendererDescriptorFixture;
+  expected: Partial<RendererDescriptorFixture>;
+}): void {
+  describe(`${options.name} descriptor conformance`, () => {
+    it("returns complete isolated descriptors", () => {
+      const first = options.createDescriptor();
+      const second = options.createDescriptor();
+
+      expect(first).toMatchObject({ name: options.name, ...options.expected });
+      expect(first.vite).toBeTruthy();
+      expect(first.server).toBeTruthy();
+      expect(first.client).toBeTruthy();
+      if (first.componentExtensions) {
+        expect(first.componentExtensions).not.toBe(second.componentExtensions);
+      }
+      if (first.dedupe) expect(first.dedupe).not.toBe(second.dedupe);
+      if (first.optimizeDeps) expect(first.optimizeDeps).not.toBe(second.optimizeDeps);
+    });
+  });
+}
+
+export function defineRendererServerConformance(runtime: RendererServerFixture): void {
+  describe(`${runtime.name} server conformance`, () => {
+    it("exposes FARMJS element primitives", () => {
+      expect(runtime.Fragment).toBeTruthy();
+      expect(runtime.Suspense).toBeTruthy();
+      expect(runtime.isValidElement(runtime.createElement("div", null, "valid"))).toBe(true);
+      expect(runtime.isValidElement(null)).toBe(false);
+    });
+
+    it("renders nested elements, attributes, and escaped text", async () => {
+      const html = await runtime.renderToString(
+        runtime.createElement(
+          "main",
+          { "data-farm-renderer": runtime.name },
+          runtime.createElement("h1", null, `Hello from ${runtime.name}`),
+          runtime.createElement("p", null, "<unsafe>& content"),
+        ),
+      );
+
+      expect(html).toContain(`data-farm-renderer="${runtime.name}"`);
+      expect(html).toContain(`Hello from ${runtime.name}`);
+      expect(html).toContain("&lt;unsafe");
+      expect(html).toContain("&amp; content");
+      expect(html).not.toContain("<unsafe>");
+      expect(html.indexOf("<h1")).toBeLessThan(html.indexOf("<p"));
+    });
+
+    it("returns a deterministic hydration bootstrap", () => {
+      const first = runtime.generateHydrationScript?.() ?? "";
+      const second = runtime.generateHydrationScript?.() ?? "";
+      expect(typeof first).toBe("string");
+      expect(second).toBe(first);
+    });
+  });
+}
+
+export function defineRendererClientConformance(options: {
+  name: string;
+  client: RendererClientFixture;
+  server: Pick<RendererServerFixture, "createElement" | "renderToString">;
+  hydrationHtml?: () => string | Promise<string>;
+  beforeHydrate?: () => void | Promise<void>;
+}): void {
+  describe(`${options.name} client conformance`, () => {
+    it("mounts, updates, wires events, and unmounts a managed root", async () => {
+      const container = document.createElement("div");
+      document.body.append(container);
+      const root = options.client.createRoot(container);
+      let clicks = 0;
+
+      root.render(
+        options.client.createElement("button", { onClick: () => clicks++ }, "First render"),
+      );
+      await settleClientRender(() => expect(container.textContent).toBe("First render"));
+      container.querySelector("button")?.click();
+      expect(clicks).toBe(1);
+
+      root.render(options.client.createElement("p", null, "Second render"));
+      await settleClientRender(() => expect(container.textContent).toBe("Second render"));
+
+      root.unmount();
+      await settleClientRender(() => expect(container.childNodes).toHaveLength(0));
+      container.remove();
+    });
+
+    it("hydrates server markup without replacing its first element", async () => {
+      let clicks = 0;
+      const props = { onClick: () => clicks++ };
+      const element = options.server.createElement("button", props, "Hydrated content");
+      const container = document.createElement("div");
+      container.innerHTML = options.hydrationHtml
+        ? await options.hydrationHtml()
+        : await options.server.renderToString(element);
+      document.body.append(container);
+      const serverNode = container.firstElementChild;
+
+      await options.beforeHydrate?.();
+      const root = options.client.hydrateRoot(
+        container,
+        options.client.createElement("button", props, "Hydrated content"),
+      );
+      await settleClientRender(() => {
+        expect(container.textContent).toContain("Hydrated content");
+        container.querySelector("button")?.click();
+        expect(clicks).toBeGreaterThan(0);
+      });
+      expect(container.firstElementChild).toBe(serverNode);
+
+      root.unmount();
+      await settleClientRender(() => expect(container.childNodes).toHaveLength(0));
+      container.remove();
+    });
+  });
+}

--- a/packages/farm-solid/package.json
+++ b/packages/farm-solid/package.json
@@ -49,7 +49,7 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "type-check": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "vitest run && vitest run --config vitest.client.config.ts",
     "clean": "rm -rf dist"
   },
   "dependencies": {
@@ -57,6 +57,7 @@
   },
   "devDependencies": {
     "@farm.js/core": "workspace:*",
+    "@farm.js/renderer-tests": "workspace:*",
     "@types/node": "^20.10.5",
     "jsdom": "^25.0.0",
     "solid-js": "1.9.14",

--- a/packages/farm-solid/src/__tests__/client.test.ts
+++ b/packages/farm-solid/src/__tests__/client.test.ts
@@ -1,0 +1,34 @@
+import { defineRendererClientConformance } from "@farm.js/renderer-tests";
+import * as clientRuntime from "../client";
+
+interface SolidHydrationBootstrap {
+  events: unknown[];
+  completed: WeakSet<object>;
+  r: Record<string, unknown>;
+  fe(): void;
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var _$HY: SolidHydrationBootstrap | undefined;
+}
+
+defineRendererClientConformance({
+  name: "solid",
+  client: clientRuntime,
+  server: {
+    createElement: clientRuntime.createElement,
+    renderToString: async () => '<button data-hk="00">Hydrated content</button>',
+  },
+  hydrationHtml: async () => '<button data-hk="00">Hydrated content</button>',
+  beforeHydrate() {
+    const bootstrap: SolidHydrationBootstrap = {
+      events: [],
+      completed: new WeakSet(),
+      r: {},
+      fe() {},
+    };
+    globalThis._$HY = bootstrap;
+    Object.assign(window, { _$HY: bootstrap });
+  },
+});

--- a/packages/farm-solid/src/__tests__/renderer.test.ts
+++ b/packages/farm-solid/src/__tests__/renderer.test.ts
@@ -1,39 +1,28 @@
 // @vitest-environment node
 
+import {
+  defineRendererDescriptorConformance,
+  defineRendererServerConformance,
+} from "@farm.js/renderer-tests";
 import { describe, expect, it } from "vitest";
 import { solid } from "../index";
-import { createElement, generateHydrationScript, renderToString } from "../server";
+import * as serverRuntime from "../server";
+import { generateHydrationScript } from "../server";
+
+defineRendererDescriptorConformance({
+  name: "solid",
+  createDescriptor: solid,
+  expected: {
+    vite: "@farm.js/solid/vite",
+    server: "@farm.js/solid/server",
+    client: "@farm.js/solid/client",
+    jsxImportSource: "solid-js",
+  },
+});
+
+defineRendererServerConformance(serverRuntime);
 
 describe("Solid renderer", () => {
-  it("returns an isolated renderer descriptor", () => {
-    const first = solid();
-    const second = solid();
-
-    expect(first).toMatchObject({
-      name: "solid",
-      vite: "@farm.js/solid/vite",
-      server: "@farm.js/solid/server",
-      client: "@farm.js/solid/client",
-      jsxImportSource: "solid-js",
-    });
-    expect(first.dedupe).not.toBe(second.dedupe);
-    expect(first.optimizeDeps).not.toBe(second.optimizeDeps);
-  });
-
-  it("renders FARMJS elements with Solid's server runtime", async () => {
-    const html = await renderToString(
-      createElement(
-        "main",
-        { className: "solid-app" },
-        createElement("h1", null, "Hello from Solid"),
-      ),
-    );
-
-    expect(html).toMatch(/<main[^>]+class="solid-app\s*"/);
-    expect(html).toContain("Hello from Solid");
-    expect(html).toContain("data-hk=");
-  });
-
   it("provides Solid's hydration bootstrap for server documents", () => {
     expect(generateHydrationScript()).toContain("window._$HY");
   });

--- a/packages/farm-solid/src/client.ts
+++ b/packages/farm-solid/src/client.ts
@@ -18,10 +18,11 @@ export interface FarmSolidRoot {
 function inferHydrationRenderId(firstHydratableElement: HTMLElement | null): string | undefined {
   const hydrationKey = firstHydratableElement?.dataset.hk;
 
-  // A resumed component's first hydration key is `${renderId}0`. FARMJS may render
-  // framework-owned page/layout wrappers before entering the selected
-  // renderer, so the Solid subtree can have a non-empty renderId.
-  return hydrationKey?.endsWith("0") ? hydrationKey.slice(0, -1) : undefined;
+  // FARMJS creates host elements through Solid's Dynamic component. Solid
+  // allocates one context id for Dynamic and another for its host element, so
+  // the first key is `${renderId}00`. Recover the owning render id rather than
+  // resuming inside Dynamic's already-serialized component context.
+  return hydrationKey?.endsWith("00") ? hydrationKey.slice(0, -2) : undefined;
 }
 
 function createManagedRoot(

--- a/packages/farm-solid/vitest.client.config.ts
+++ b/packages/farm-solid/vitest.client.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  css: {
+    postcss: {
+      plugins: [],
+    },
+  },
+  resolve: {
+    alias: [
+      { find: /^solid-js\/web$/, replacement: "solid-js/web/dist/web.js" },
+      { find: /^solid-js$/, replacement: "solid-js/dist/solid.js" },
+    ],
+  },
+  ssr: {
+    noExternal: ["solid-js"],
+  },
+  test: {
+    environment: "jsdom",
+    include: ["src/**/client.test.ts"],
+    server: {
+      deps: {
+        inline: ["solid-js"],
+      },
+    },
+  },
+});

--- a/packages/farm-solid/vitest.config.ts
+++ b/packages/farm-solid/vitest.config.ts
@@ -9,5 +9,6 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
+    exclude: ["src/**/client.test.ts"],
   },
 });

--- a/packages/farm-svelte/package.json
+++ b/packages/farm-svelte/package.json
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@farm.js/core": "workspace:*",
+    "@farm.js/renderer-tests": "workspace:*",
     "@types/node": "^20.10.5",
     "jsdom": "^25.0.0",
     "svelte": "5.56.8",

--- a/packages/farm-svelte/src/__tests__/client.test.ts
+++ b/packages/farm-svelte/src/__tests__/client.test.ts
@@ -1,32 +1,11 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it } from "vitest";
-import { createElement, createRoot, hydrateRoot } from "../client";
-import { renderToString } from "../server";
+import { defineRendererClientConformance } from "@farm.js/renderer-tests";
+import * as clientRuntime from "../client";
+import * as serverRuntime from "../server";
 
-describe("Svelte client renderer", () => {
-  it("mounts, updates, and unmounts a managed root", () => {
-    const container = document.createElement("div");
-    const root = createRoot(container);
-
-    root.render(createElement("p", null, "First"));
-    expect(container.textContent).toBe("First");
-
-    root.render(createElement("p", null, "Second"));
-    expect(container.textContent).toBe("Second");
-
-    root.unmount();
-    expect(container.childNodes).toHaveLength(0);
-  });
-
-  it("hydrates server-rendered markup", async () => {
-    const element = createElement("button", null, "Continue");
-    const container = document.createElement("div");
-    container.innerHTML = await renderToString(element);
-    const button = container.querySelector("button");
-
-    const root = hydrateRoot(container, element);
-    expect(container.querySelector("button")).toBe(button);
-    root.unmount();
-  });
+defineRendererClientConformance({
+  name: "svelte",
+  client: clientRuntime,
+  server: serverRuntime,
 });

--- a/packages/farm-svelte/src/__tests__/renderer.test.ts
+++ b/packages/farm-svelte/src/__tests__/renderer.test.ts
@@ -1,26 +1,28 @@
 // @vitest-environment node
 
+import {
+  defineRendererDescriptorConformance,
+  defineRendererServerConformance,
+} from "@farm.js/renderer-tests";
 import { describe, expect, it } from "vitest";
 import { svelte } from "../index";
+import * as serverRuntime from "../server";
 import { createElement, generateHydrationScript, renderToString } from "../server";
 
+defineRendererDescriptorConformance({
+  name: "svelte",
+  createDescriptor: svelte,
+  expected: {
+    vite: "@farm.js/svelte/vite",
+    server: "@farm.js/svelte/server",
+    client: "@farm.js/svelte/client",
+    componentExtensions: [".svelte"],
+  },
+});
+
+defineRendererServerConformance(serverRuntime);
+
 describe("Svelte renderer", () => {
-  it("returns an isolated renderer descriptor", () => {
-    const first = svelte();
-    const second = svelte();
-
-    expect(first).toMatchObject({
-      name: "svelte",
-      vite: "@farm.js/svelte/vite",
-      server: "@farm.js/svelte/server",
-      client: "@farm.js/svelte/client",
-      componentExtensions: [".svelte"],
-    });
-    expect(first.componentExtensions).not.toBe(second.componentExtensions);
-    expect(first.dedupe).not.toBe(second.dedupe);
-    expect(first.optimizeDeps).not.toBe(second.optimizeDeps);
-  });
-
   it("renders FARMJS elements with Svelte's server runtime", async () => {
     const html = await renderToString(
       createElement(

--- a/packages/farm-vue/package.json
+++ b/packages/farm-vue/package.json
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@farm.js/core": "workspace:*",
+    "@farm.js/renderer-tests": "workspace:*",
     "@types/node": "^20.10.5",
     "jsdom": "^25.0.0",
     "tsup": "^8.3.5",

--- a/packages/farm-vue/src/__tests__/client.test.ts
+++ b/packages/farm-vue/src/__tests__/client.test.ts
@@ -1,31 +1,11 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it } from "vitest";
-import { createElement, createRoot, hydrateRoot } from "../client";
+import { defineRendererClientConformance } from "@farm.js/renderer-tests";
+import * as clientRuntime from "../client";
+import * as serverRuntime from "../server";
 
-describe("Vue client renderer", () => {
-  it("mounts, updates, and unmounts a managed root", async () => {
-    const container = document.createElement("div");
-    const root = createRoot(container);
-
-    root.render(createElement("p", null, "First"));
-    expect(container.textContent).toBe("First");
-
-    root.render(createElement("p", null, "Second"));
-    await Promise.resolve();
-    expect(container.textContent).toBe("Second");
-
-    root.unmount();
-    expect(container.childNodes).toHaveLength(0);
-  });
-
-  it("hydrates server-rendered markup", () => {
-    const container = document.createElement("div");
-    container.innerHTML = "<button>Continue</button>";
-    const button = container.firstElementChild;
-
-    const root = hydrateRoot(container, createElement("button", null, "Continue"));
-    expect(container.firstElementChild).toBe(button);
-    root.unmount();
-  });
+defineRendererClientConformance({
+  name: "vue",
+  client: clientRuntime,
+  server: serverRuntime,
 });

--- a/packages/farm-vue/src/__tests__/renderer.test.ts
+++ b/packages/farm-vue/src/__tests__/renderer.test.ts
@@ -1,36 +1,29 @@
 // @vitest-environment node
 
+import {
+  defineRendererDescriptorConformance,
+  defineRendererServerConformance,
+} from "@farm.js/renderer-tests";
 import { defineComponent, h } from "vue";
 import { describe, expect, it } from "vitest";
 import { vue } from "../index";
+import * as serverRuntime from "../server";
 import { createElement, generateHydrationScript, renderToString } from "../server";
 
+defineRendererDescriptorConformance({
+  name: "vue",
+  createDescriptor: vue,
+  expected: {
+    vite: "@farm.js/vue/vite",
+    server: "@farm.js/vue/server",
+    client: "@farm.js/vue/client",
+    componentExtensions: [".vue"],
+  },
+});
+
+defineRendererServerConformance(serverRuntime);
+
 describe("Vue renderer", () => {
-  it("returns an isolated renderer descriptor", () => {
-    const first = vue();
-    const second = vue();
-
-    expect(first).toMatchObject({
-      name: "vue",
-      vite: "@farm.js/vue/vite",
-      server: "@farm.js/vue/server",
-      client: "@farm.js/vue/client",
-      componentExtensions: [".vue"],
-    });
-    expect(first.componentExtensions).not.toBe(second.componentExtensions);
-    expect(first.dedupe).not.toBe(second.dedupe);
-    expect(first.optimizeDeps).not.toBe(second.optimizeDeps);
-  });
-
-  it("renders FARMJS elements with Vue's server runtime", async () => {
-    const html = await renderToString(
-      createElement("main", { className: "vue-app" }, createElement("h1", null, "Hello from Vue")),
-    );
-
-    expect(html).toContain('<main class="vue-app">');
-    expect(html).toContain("<h1>Hello from Vue</h1>");
-  });
-
   it("passes FARMJS children through Vue's default slot", async () => {
     const Layout = defineComponent({
       setup:

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -597,6 +597,7 @@
     "zod": "^4.1.12"
   },
   "devDependencies": {
+    "@farm.js/renderer-tests": "workspace:*",
     "@clerk/react": "^6.1.0",
     "@farm.js/otel": "workspace:*",
     "@opentelemetry/sdk-node": "0.221.0",

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -597,9 +597,9 @@
     "zod": "^4.1.12"
   },
   "devDependencies": {
-    "@farm.js/renderer-tests": "workspace:*",
     "@clerk/react": "^6.1.0",
     "@farm.js/otel": "workspace:*",
+    "@farm.js/renderer-tests": "workspace:*",
     "@opentelemetry/sdk-node": "0.221.0",
     "@opentelemetry/sdk-trace-base": "2.10.0",
     "@types/react": "^18.2.45",

--- a/packages/farm/src/__tests__/renderer-react-client.test.ts
+++ b/packages/farm/src/__tests__/renderer-react-client.test.ts
@@ -1,0 +1,14 @@
+// @vitest-environment jsdom
+
+import { defineRendererClientConformance } from "@farm.js/renderer-tests";
+import * as clientRoots from "../renderer/react/client";
+import * as serverRuntime from "../renderer/react/server";
+
+defineRendererClientConformance({
+  name: "react",
+  client: {
+    ...clientRoots,
+    createElement: serverRuntime.createElement,
+  },
+  server: serverRuntime,
+});

--- a/packages/farm/src/__tests__/renderer.test.ts
+++ b/packages/farm/src/__tests__/renderer.test.ts
@@ -1,11 +1,29 @@
 // @vitest-environment node
 
+import {
+  defineRendererDescriptorConformance,
+  defineRendererServerConformance,
+} from "@farm.js/renderer-tests";
 import { describe, expect, it } from "vitest";
 import {
   getFarmRendererComponentExtensions,
   REACT_RENDERER,
   resolveFarmRenderer,
 } from "../renderer";
+import * as serverRuntime from "../renderer/react/server";
+
+defineRendererDescriptorConformance({
+  name: "react",
+  createDescriptor: () => resolveFarmRenderer(),
+  expected: {
+    vite: "@farm.js/core/renderer/react/vite",
+    server: "@farm.js/core/renderer/react/server",
+    client: "@farm.js/core/renderer/react/client",
+    jsxImportSource: "react",
+  },
+});
+
+defineRendererServerConformance(serverRuntime);
 
 describe("renderer configuration", () => {
   it("keeps React as the default renderer", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1427,6 +1427,9 @@ importers:
       '@farm.js/otel':
         specifier: workspace:*
         version: link:../farm-otel
+      '@farm.js/renderer-tests':
+        specifier: workspace:*
+        version: link:../farm-renderer-tests
       '@opentelemetry/sdk-node':
         specifier: 0.221.0
         version: 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
@@ -1799,6 +1802,9 @@ importers:
       '@farm.js/core':
         specifier: workspace:*
         version: link:../farm
+      '@farm.js/renderer-tests':
+        specifier: workspace:*
+        version: link:../farm-renderer-tests
       '@types/node':
         specifier: ^20.10.5
         version: 20.19.21
@@ -1852,6 +1858,12 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
 
+  packages/farm-renderer-tests:
+    dependencies:
+      vitest:
+        specifier: ^1.1.0
+        version: 1.6.1(@types/node@20.19.21)(jsdom@25.0.1)(supports-color@10.2.2)
+
   packages/farm-solid:
     dependencies:
       vite-plugin-solid:
@@ -1861,6 +1873,9 @@ importers:
       '@farm.js/core':
         specifier: workspace:*
         version: link:../farm
+      '@farm.js/renderer-tests':
+        specifier: workspace:*
+        version: link:../farm-renderer-tests
       '@types/node':
         specifier: ^20.10.5
         version: 20.19.21
@@ -1919,6 +1934,9 @@ importers:
       '@farm.js/core':
         specifier: workspace:*
         version: link:../farm
+      '@farm.js/renderer-tests':
+        specifier: workspace:*
+        version: link:../farm-renderer-tests
       '@types/node':
         specifier: ^20.10.5
         version: 20.19.21
@@ -1962,6 +1980,9 @@ importers:
       '@farm.js/core':
         specifier: workspace:*
         version: link:../farm
+      '@farm.js/renderer-tests':
+        specifier: workspace:*
+        version: link:../farm-renderer-tests
       '@types/node':
         specifier: ^20.10.5
         version: 20.19.21
@@ -2012,7 +2033,7 @@ importers:
         version: 2.0.0
       nitro:
         specifier: 3.0.1-alpha.0
-        version: 3.0.1-alpha.0(rolldown@1.2.3)(vite@6.4.1)
+        version: 3.0.1-alpha.0(rolldown@1.2.4)(vite@6.4.1)
       picocolors:
         specifier: ^1.0.0
         version: 1.1.1
@@ -6871,8 +6892,8 @@ packages:
   /@oxc-project/types@0.140.0:
     resolution: {integrity: sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ==}
 
-  /@oxc-project/types@0.143.0:
-    resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
+  /@oxc-project/types@0.144.0:
+    resolution: {integrity: sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==}
 
   /@oxfmt/darwin-arm64@0.27.0:
     resolution: {integrity: sha512-3vwqyzNlVTVFVzHMlrqxb4tgVgHp6FYS0uIxsIZ/SeEDG0azaqiOw/2t8LlJ9f72PKRLWSey+Ak99tiKgpbsnQ==}
@@ -8298,8 +8319,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-android-arm64@1.2.3:
-    resolution: {integrity: sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==}
+  /@rolldown/binding-android-arm64@1.2.4:
+    resolution: {integrity: sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -8322,8 +8343,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-darwin-arm64@1.2.3:
-    resolution: {integrity: sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==}
+  /@rolldown/binding-darwin-arm64@1.2.4:
+    resolution: {integrity: sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -8346,8 +8367,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-darwin-x64@1.2.3:
-    resolution: {integrity: sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==}
+  /@rolldown/binding-darwin-x64@1.2.4:
+    resolution: {integrity: sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -8370,8 +8391,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-freebsd-x64@1.2.3:
-    resolution: {integrity: sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==}
+  /@rolldown/binding-freebsd-x64@1.2.4:
+    resolution: {integrity: sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -8394,8 +8415,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-linux-arm-gnueabihf@1.2.3:
-    resolution: {integrity: sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==}
+  /@rolldown/binding-linux-arm-gnueabihf@1.2.4:
+    resolution: {integrity: sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -8418,8 +8439,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-linux-arm64-gnu@1.2.3:
-    resolution: {integrity: sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==}
+  /@rolldown/binding-linux-arm64-gnu@1.2.4:
+    resolution: {integrity: sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -8442,8 +8463,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-linux-arm64-musl@1.2.3:
-    resolution: {integrity: sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==}
+  /@rolldown/binding-linux-arm64-musl@1.2.4:
+    resolution: {integrity: sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -8466,8 +8487,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-linux-ppc64-gnu@1.2.3:
-    resolution: {integrity: sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==}
+  /@rolldown/binding-linux-ppc64-gnu@1.2.4:
+    resolution: {integrity: sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -8490,8 +8511,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-linux-s390x-gnu@1.2.3:
-    resolution: {integrity: sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==}
+  /@rolldown/binding-linux-s390x-gnu@1.2.4:
+    resolution: {integrity: sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
@@ -8514,8 +8535,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-linux-x64-gnu@1.2.3:
-    resolution: {integrity: sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==}
+  /@rolldown/binding-linux-x64-gnu@1.2.4:
+    resolution: {integrity: sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -8538,8 +8559,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-linux-x64-musl@1.2.3:
-    resolution: {integrity: sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==}
+  /@rolldown/binding-linux-x64-musl@1.2.4:
+    resolution: {integrity: sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -8562,8 +8583,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-openharmony-arm64@1.2.3:
-    resolution: {integrity: sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==}
+  /@rolldown/binding-openharmony-arm64@1.2.4:
+    resolution: {integrity: sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -8608,8 +8629,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-win32-arm64-msvc@1.2.3:
-    resolution: {integrity: sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==}
+  /@rolldown/binding-win32-arm64-msvc@1.2.4:
+    resolution: {integrity: sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -8632,8 +8653,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rolldown/binding-win32-x64-msvc@1.2.3:
-    resolution: {integrity: sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==}
+  /@rolldown/binding-win32-x64-msvc@1.2.4:
+    resolution: {integrity: sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -15793,7 +15814,7 @@ packages:
       - uploadthing
     dev: false
 
-  /nitro@3.0.1-alpha.0(rolldown@1.2.3)(vite@6.4.1):
+  /nitro@3.0.1-alpha.0(rolldown@1.2.4)(vite@6.4.1):
     resolution: {integrity: sha512-lR3RplfXBOZXNlFQf9AJkqFVFhg5/CNbpBijM0dSYhGymb+FthJSdL6crmXVg518h2NVOd40rehhGZaf9ijW9w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
@@ -15821,7 +15842,7 @@ packages:
       ofetch: 1.5.1
       ohash: 2.0.11
       rendu: 0.0.6
-      rolldown: 1.2.3
+      rolldown: 1.2.4
       rollup: 4.52.4
       srvx: 0.8.16
       undici: 7.16.0
@@ -17192,7 +17213,7 @@ packages:
       glob: 10.5.0
     dev: false
 
-  /rolldown-plugin-dts@0.16.11(rolldown@1.2.3)(supports-color@10.2.2)(typescript@5.9.3):
+  /rolldown-plugin-dts@0.16.11(rolldown@1.2.4)(supports-color@10.2.2)(typescript@5.9.3):
     resolution: {integrity: sha512-9IQDaPvPqTx3RjG2eQCK5GYZITo203BxKunGI80AGYicu1ySFTUyugicAaTZWRzFWh9DSnzkgNeMNbDWBbSs0w==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
@@ -17220,7 +17241,7 @@ packages:
       dts-resolver: 2.1.2
       get-tsconfig: 4.12.0
       magic-string: 0.30.21
-      rolldown: 1.2.3
+      rolldown: 1.2.4
       typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver
@@ -17275,28 +17296,28 @@ packages:
       '@rolldown/binding-win32-arm64-msvc': 1.2.0
       '@rolldown/binding-win32-x64-msvc': 1.2.0
 
-  /rolldown@1.2.3:
-    resolution: {integrity: sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==}
+  /rolldown@1.2.4:
+    resolution: {integrity: sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     dependencies:
-      '@oxc-project/types': 0.143.0
+      '@oxc-project/types': 0.144.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.2.3
-      '@rolldown/binding-darwin-arm64': 1.2.3
-      '@rolldown/binding-darwin-x64': 1.2.3
-      '@rolldown/binding-freebsd-x64': 1.2.3
-      '@rolldown/binding-linux-arm-gnueabihf': 1.2.3
-      '@rolldown/binding-linux-arm64-gnu': 1.2.3
-      '@rolldown/binding-linux-arm64-musl': 1.2.3
-      '@rolldown/binding-linux-ppc64-gnu': 1.2.3
-      '@rolldown/binding-linux-s390x-gnu': 1.2.3
-      '@rolldown/binding-linux-x64-gnu': 1.2.3
-      '@rolldown/binding-linux-x64-musl': 1.2.3
-      '@rolldown/binding-openharmony-arm64': 1.2.3
-      '@rolldown/binding-win32-arm64-msvc': 1.2.3
-      '@rolldown/binding-win32-x64-msvc': 1.2.3
+      '@rolldown/binding-android-arm64': 1.2.4
+      '@rolldown/binding-darwin-arm64': 1.2.4
+      '@rolldown/binding-darwin-x64': 1.2.4
+      '@rolldown/binding-freebsd-x64': 1.2.4
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.4
+      '@rolldown/binding-linux-arm64-gnu': 1.2.4
+      '@rolldown/binding-linux-arm64-musl': 1.2.4
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.4
+      '@rolldown/binding-linux-s390x-gnu': 1.2.4
+      '@rolldown/binding-linux-x64-gnu': 1.2.4
+      '@rolldown/binding-linux-x64-musl': 1.2.4
+      '@rolldown/binding-openharmony-arm64': 1.2.4
+      '@rolldown/binding-win32-arm64-msvc': 1.2.4
+      '@rolldown/binding-win32-x64-msvc': 1.2.4
 
   /rollup@4.52.4:
     resolution: {integrity: sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==}
@@ -18425,8 +18446,8 @@ packages:
       diff: 8.0.2
       empathic: 2.0.0
       hookable: 5.5.3
-      rolldown: 1.2.3
-      rolldown-plugin-dts: 0.16.11(rolldown@1.2.3)(supports-color@10.2.2)(typescript@5.9.3)
+      rolldown: 1.2.4
+      rolldown-plugin-dts: 0.16.11(rolldown@1.2.4)(supports-color@10.2.2)(typescript@5.9.3)
       semver: 7.7.3
       tinyexec: 1.0.1
       tinyglobby: 0.2.15

--- a/scripts/test-renderers.mjs
+++ b/scripts/test-renderers.mjs
@@ -1,0 +1,33 @@
+import { spawnSync } from "node:child_process";
+
+const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+const commands = [
+  [
+    "--filter",
+    "@farm.js/core",
+    "exec",
+    "vitest",
+    "run",
+    "src/__tests__/renderer.test.ts",
+    "src/__tests__/renderer-react-client.test.ts",
+  ],
+  ["--filter", "@farm.js/preact", "test"],
+  ["--filter", "@farm.js/solid", "test"],
+  ["--filter", "@farm.js/vue", "test"],
+  ["--filter", "@farm.js/svelte", "test"],
+  ["--filter", "@farm.js/preact", "type-check"],
+  ["--filter", "@farm.js/solid", "type-check"],
+  ["--filter", "@farm.js/vue", "type-check"],
+  ["--filter", "@farm.js/svelte", "type-check"],
+];
+
+for (const args of commands) {
+  const result = spawnSync(pnpm, args, {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: "inherit",
+  });
+
+  if (result.error) throw result.error;
+  if (result.status !== 0) process.exit(result.status ?? 1);
+}


### PR DESCRIPTION
## What changed

- add a private shared renderer conformance package covering descriptors, server rendering, escaping, client roots, events, hydration, and unmounting
- apply the same contract to React, Preact, Solid, Vue, and Svelte
- add `pnpm test:renderers` as the single renderer matrix command
- run Solid client tests against its browser build and correct the Solid hydration render-id inference

## Why

The renderer packages previously had separate test shapes, so important behavior could be missing without being visible across the matrix. The shared suite found a real Solid hydration bug: FARMJS resumed inside the `Dynamic` component context rather than its owning render context.

## Impact

Every renderer now has the same minimum SSR and browser guarantees. New renderers can adopt one fixture instead of recreating coverage, and Solid preserves and hydrates its server node correctly.

## Validation

- `pnpm test:renderers`
- `pnpm exec oxfmt --check` on changed source and configuration files
- `pnpm exec oxlint` on changed JavaScript and TypeScript files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared renderer conformance suite and fixes Solid hydration key inference, making SSR and client behavior consistent across React, Preact, Solid, Vue, and Svelte. Solid now infers the owning render-id from keys ending in "00" (was "0"), avoiding hydration inside `Dynamic` and preserving server nodes.

- Introduces private `@farm.js/renderer-tests` covering descriptor shape, server rendering/escaping and deterministic hydration bootstrap, client roots/events/hydration, and unmounting; applied to all renderers (includes a new React client test in core).
- Runs Solid client tests against its browser build using a dedicated `vitest.client.config.ts` and aliases.
- Adds `pnpm test:renderers` via `scripts/test-renderers.mjs` to execute the full matrix and type-check renderer packages.

<sup>Written for commit 70d8f1da40221e97eab7813b985aceaa5824e642. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

