### PR TITLE
feat: define renderer capability contract

### DIFF
--- a/docs/src/app/docs/renderers/page.md
+++ b/docs/src/app/docs/renderers/page.md
@@ -50,6 +50,34 @@ component imports React. Preact resolves many of those imports through `preact/c
 and Svelte applications should call validated endpoints through the generated API client and use
 their renderer's native state primitives.
 
+## Renderer capability contract
+
+Renderer packages advertise streaming support in their descriptor instead of relying on FARMJS to
+guess from optional runtime exports:
+
+```ts
+import { defineRenderer } from "@farm.js/core";
+
+export const customRenderer = defineRenderer({
+  name: "custom",
+  vite: "@example/renderer/vite",
+  server: "@example/renderer/server",
+  client: "@example/renderer/client",
+  capabilities: {
+    streaming: {
+      node: false,
+      web: true,
+    },
+  },
+});
+```
+
+A renderer advertising `node` streaming must export `renderToPipeableStream()` from its server
+entry. A renderer advertising `web` streaming must export `renderToReadableStream()` returning a
+WHATWG `ReadableStream`. FARMJS validates those declarations when the server renderer starts and
+uses buffered `renderToString()` when neither capability is enabled. Descriptors without a
+`capabilities` field remain buffered for compatibility.
+
 ## Renderer-neutral server code
 
 Keep product and server behavior outside the component runtime whenever possible:

--- a/packages/farm-preact/src/__tests__/renderer.test.ts
+++ b/packages/farm-preact/src/__tests__/renderer.test.ts
@@ -22,6 +22,7 @@ describe("Preact renderer", () => {
       server: "@farm.js/preact/server",
       client: "@farm.js/preact/client",
       jsxImportSource: "preact",
+      capabilities: { streaming: { node: true, web: true } },
     });
     expect(first.dedupe).not.toBe(second.dedupe);
     expect(first.optimizeDeps).not.toBe(second.optimizeDeps);

--- a/packages/farm-preact/src/index.ts
+++ b/packages/farm-preact/src/index.ts
@@ -14,6 +14,9 @@ const PREACT_RENDERER: Readonly<FarmRenderer> = Object.freeze({
     "preact/jsx-runtime",
     "@farm.js/preact/client",
   ],
+  capabilities: {
+    streaming: { node: true, web: true },
+  },
 });
 
 /** Select Preact for JSX compilation, server rendering, streaming, and browser hydration. */
@@ -22,6 +25,9 @@ export function preact(): FarmRenderer {
     ...PREACT_RENDERER,
     dedupe: [...(PREACT_RENDERER.dedupe || [])],
     optimizeDeps: [...(PREACT_RENDERER.optimizeDeps || [])],
+    capabilities: {
+      streaming: { ...PREACT_RENDERER.capabilities?.streaming },
+    },
   };
 }
 

--- a/packages/farm-preact/src/server.ts
+++ b/packages/farm-preact/src/server.ts
@@ -11,6 +11,9 @@ import PreactCompat, {
 } from "./runtime";
 
 export const name = "preact";
+export const capabilities = {
+  streaming: { node: true, web: true },
+} as const;
 export { ErrorBoundary, Fragment, Suspense, createElement, isValidElement };
 
 /** Preact hydration does not require an inline bootstrap before the client entry. */

--- a/packages/farm-solid/src/__tests__/renderer.test.ts
+++ b/packages/farm-solid/src/__tests__/renderer.test.ts
@@ -15,6 +15,7 @@ describe("Solid renderer", () => {
       server: "@farm.js/solid/server",
       client: "@farm.js/solid/client",
       jsxImportSource: "solid-js",
+      capabilities: { streaming: { node: false, web: false } },
     });
     expect(first.dedupe).not.toBe(second.dedupe);
     expect(first.optimizeDeps).not.toBe(second.optimizeDeps);

--- a/packages/farm-solid/src/index.ts
+++ b/packages/farm-solid/src/index.ts
@@ -8,6 +8,9 @@ const SOLID_RENDERER: Readonly<FarmRenderer> = Object.freeze({
   jsxImportSource: "solid-js",
   dedupe: ["solid-js", "solid-js/web", "solid-js/store"],
   optimizeDeps: ["solid-js", "solid-js/web", "solid-js/store", "@farm.js/solid/client"],
+  capabilities: {
+    streaming: { node: false, web: false },
+  },
 });
 
 /** Select Solid for JSX compilation, server rendering, and browser hydration. */
@@ -16,6 +19,9 @@ export function solid(): FarmRenderer {
     ...SOLID_RENDERER,
     dedupe: [...(SOLID_RENDERER.dedupe || [])],
     optimizeDeps: [...(SOLID_RENDERER.optimizeDeps || [])],
+    capabilities: {
+      streaming: { ...SOLID_RENDERER.capabilities?.streaming },
+    },
   };
 }
 

--- a/packages/farm-solid/src/server.ts
+++ b/packages/farm-solid/src/server.ts
@@ -9,6 +9,9 @@ import SolidCompat, {
 } from "./runtime";
 
 export const name = "solid";
+export const capabilities = {
+  streaming: { node: false, web: false },
+} as const;
 export { Fragment, Suspense, ErrorBoundary, createElement, isValidElement };
 export { generateHydrationScript };
 

--- a/packages/farm-svelte/src/__tests__/renderer.test.ts
+++ b/packages/farm-svelte/src/__tests__/renderer.test.ts
@@ -14,6 +14,7 @@ describe("Svelte renderer", () => {
       vite: "@farm.js/svelte/vite",
       server: "@farm.js/svelte/server",
       client: "@farm.js/svelte/client",
+      capabilities: { streaming: { node: false, web: false } },
       componentExtensions: [".svelte"],
     });
     expect(first.componentExtensions).not.toBe(second.componentExtensions);

--- a/packages/farm-svelte/src/index.ts
+++ b/packages/farm-svelte/src/index.ts
@@ -8,6 +8,9 @@ const SVELTE_RENDERER: Readonly<FarmRenderer> = Object.freeze({
   componentExtensions: [".svelte"],
   dedupe: ["svelte"],
   optimizeDeps: ["svelte", "@farm.js/svelte/client"],
+  capabilities: {
+    streaming: { node: false, web: false },
+  },
 });
 
 /** Select Svelte for component compilation, server rendering, and browser hydration. */
@@ -17,6 +20,9 @@ export function svelte(): FarmRenderer {
     componentExtensions: [...(SVELTE_RENDERER.componentExtensions || [])],
     dedupe: [...(SVELTE_RENDERER.dedupe || [])],
     optimizeDeps: [...(SVELTE_RENDERER.optimizeDeps || [])],
+    capabilities: {
+      streaming: { ...SVELTE_RENDERER.capabilities?.streaming },
+    },
   };
 }
 

--- a/packages/farm-svelte/src/server.ts
+++ b/packages/farm-svelte/src/server.ts
@@ -10,6 +10,9 @@ import SvelteCompat, {
 } from "./runtime";
 
 export const name = "svelte";
+export const capabilities = {
+  streaming: { node: false, web: false },
+} as const;
 export { Fragment, Suspense, ErrorBoundary, createElement, isValidElement };
 
 /** Svelte hydration markers are already included in the server-rendered body. */

--- a/packages/farm-vue/src/__tests__/renderer.test.ts
+++ b/packages/farm-vue/src/__tests__/renderer.test.ts
@@ -15,6 +15,7 @@ describe("Vue renderer", () => {
       vite: "@farm.js/vue/vite",
       server: "@farm.js/vue/server",
       client: "@farm.js/vue/client",
+      capabilities: { streaming: { node: false, web: false } },
       componentExtensions: [".vue"],
     });
     expect(first.componentExtensions).not.toBe(second.componentExtensions);

--- a/packages/farm-vue/src/index.ts
+++ b/packages/farm-vue/src/index.ts
@@ -8,6 +8,9 @@ const VUE_RENDERER: Readonly<FarmRenderer> = Object.freeze({
   componentExtensions: [".vue"],
   dedupe: ["vue"],
   optimizeDeps: ["vue", "@farm.js/vue/client"],
+  capabilities: {
+    streaming: { node: false, web: false },
+  },
 });
 
 /** Select Vue for SFC compilation, server rendering, and browser hydration. */
@@ -17,6 +20,9 @@ export function vue(): FarmRenderer {
     componentExtensions: [...(VUE_RENDERER.componentExtensions || [])],
     dedupe: [...(VUE_RENDERER.dedupe || [])],
     optimizeDeps: [...(VUE_RENDERER.optimizeDeps || [])],
+    capabilities: {
+      streaming: { ...VUE_RENDERER.capabilities?.streaming },
+    },
   };
 }
 

--- a/packages/farm-vue/src/server.ts
+++ b/packages/farm-vue/src/server.ts
@@ -10,6 +10,9 @@ import VueCompat, {
 } from "./runtime";
 
 export const name = "vue";
+export const capabilities = {
+  streaming: { node: false, web: false },
+} as const;
 export { Fragment, Suspense, ErrorBoundary, createElement, isValidElement };
 
 /** Vue hydration does not require an inline bootstrap before the client entry. */

--- a/packages/farm/src/__tests__/renderer-capabilities.test.ts
+++ b/packages/farm/src/__tests__/renderer-capabilities.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from "vitest";
+import { ServerRenderer } from "../server/renderer";
+
+function createRendererHarness(options: {
+  capabilities?: { streaming?: { node?: boolean; web?: boolean } };
+  runtime: Record<string, unknown>;
+}) {
+  const renderer = Object.create(ServerRenderer.prototype) as any;
+  renderer.config = {
+    renderer: {
+      name: "test",
+      capabilities: options.capabilities,
+    },
+  };
+  renderer.rendererRuntime = options.runtime;
+  return renderer;
+}
+
+describe("renderer capability dispatch", () => {
+  it("uses an advertised Web stream before the buffered fallback", async () => {
+    const renderToString = vi.fn(() => "buffered");
+    const renderer = createRendererHarness({
+      capabilities: { streaming: { web: true } },
+      runtime: {
+        renderToString,
+        renderToReadableStream() {
+          return new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("<p>web stream</p>"));
+              controller.close();
+            },
+          });
+        },
+      },
+    });
+
+    await expect(renderer.renderElementToCompleteHTML({})).resolves.toBe("<p>web stream</p>");
+    expect(renderToString).not.toHaveBeenCalled();
+  });
+
+  it("keeps buffered SSR for legacy descriptors", async () => {
+    const renderer = createRendererHarness({
+      runtime: {
+        renderToString: () => "<p>buffered</p>",
+      },
+    });
+
+    await expect(renderer.renderElementToCompleteHTML({})).resolves.toBe("<p>buffered</p>");
+  });
+});

--- a/packages/farm/src/__tests__/renderer.test.ts
+++ b/packages/farm/src/__tests__/renderer.test.ts
@@ -2,7 +2,9 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  getFarmRendererCapabilities,
   getFarmRendererComponentExtensions,
+  readFarmRendererWebStream,
   REACT_RENDERER,
   resolveFarmRenderer,
 } from "../renderer";
@@ -16,8 +18,36 @@ describe("renderer configuration", () => {
       server: "@farm.js/core/renderer/react/server",
       client: "@farm.js/core/renderer/react/client",
       jsxImportSource: "react",
+      capabilities: { streaming: { node: true, web: false } },
     });
     expect(renderer).not.toBe(REACT_RENDERER);
+  });
+
+  it("normalizes missing and partial capability declarations", () => {
+    expect(getFarmRendererCapabilities()).toEqual({
+      streaming: { node: false, web: false },
+    });
+    expect(
+      getFarmRendererCapabilities({
+        capabilities: { streaming: { web: true } },
+      }),
+    ).toEqual({
+      streaming: { node: false, web: true },
+    });
+  });
+
+  it("consumes renderer Web streams without assuming one chunk type", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array | string>({
+      start(controller) {
+        controller.enqueue(encoder.encode("<main>"));
+        controller.enqueue("streamed");
+        controller.enqueue(encoder.encode("</main>"));
+        controller.close();
+      },
+    });
+
+    await expect(readFarmRendererWebStream(stream)).resolves.toBe("<main>streamed</main>");
   });
 
   it("accepts a renderer descriptor without sharing mutable arrays", () => {

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -169,7 +169,12 @@ export type {
   ResolvedFarmCspConfig,
   ResolvedFarmSecurityConfig,
 } from "./security";
-export type { FarmRenderer } from "./renderer";
+export type {
+  FarmRenderer,
+  FarmRendererCapabilities,
+  FarmRendererCapabilitiesInput,
+  FarmRendererStreamingCapabilities,
+} from "./renderer";
 export { defineRenderer } from "./renderer";
 
 export interface RedirectConfig {

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -1,6 +1,11 @@
 export * from "./types";
 export { defineRenderer, REACT_RENDERER } from "./renderer";
-export type { FarmRenderer } from "./renderer";
+export type {
+  FarmRenderer,
+  FarmRendererCapabilities,
+  FarmRendererCapabilitiesInput,
+  FarmRendererStreamingCapabilities,
+} from "./renderer";
 export * from "./utils";
 export * from "./storage";
 export * from "./integrations";

--- a/packages/farm/src/renderer.ts
+++ b/packages/farm/src/renderer.ts
@@ -27,6 +27,38 @@ export interface FarmRenderer {
   dedupe?: readonly string[];
   /** Renderer packages seeded into Vite's dependency optimizer. */
   optimizeDeps?: readonly string[];
+  /** Runtime features this renderer intentionally supports. */
+  capabilities?: FarmRendererCapabilitiesInput;
+}
+
+export interface FarmRendererStreamingCapabilities {
+  /** Supports Node.js writable streams through renderToPipeableStream(). */
+  node: boolean;
+  /** Supports WHATWG ReadableStream output through renderToReadableStream(). */
+  web: boolean;
+}
+
+export interface FarmRendererCapabilities {
+  streaming: FarmRendererStreamingCapabilities;
+}
+
+export interface FarmRendererCapabilitiesInput {
+  streaming?: Partial<FarmRendererStreamingCapabilities>;
+}
+
+const DEFAULT_RENDERER_CAPABILITIES: Readonly<FarmRendererCapabilities> = Object.freeze({
+  streaming: Object.freeze({ node: false, web: false }),
+});
+
+export function getFarmRendererCapabilities(
+  renderer?: Pick<FarmRenderer, "capabilities">,
+): FarmRendererCapabilities {
+  return {
+    streaming: {
+      node: renderer?.capabilities?.streaming?.node ?? DEFAULT_RENDERER_CAPABILITIES.streaming.node,
+      web: renderer?.capabilities?.streaming?.web ?? DEFAULT_RENDERER_CAPABILITIES.streaming.web,
+    },
+  };
 }
 
 export const FARM_COMPONENT_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx"] as const;
@@ -61,6 +93,8 @@ export interface FarmServerRendererRuntime {
   createElement(type: unknown, props?: unknown, ...children: unknown[]): unknown;
   isValidElement(value: unknown): boolean;
   renderToString(element: unknown): string | Promise<string>;
+  /** Optional runtime copy of the descriptor capabilities for diagnostics. */
+  readonly capabilities?: FarmRendererCapabilities;
   /** Optional bootstrap required before this renderer hydrates server markup. */
   generateHydrationScript?: () => string;
   /** Optional component used to render route-level failures. */
@@ -74,6 +108,10 @@ export interface FarmServerRendererRuntime {
       onError(error: unknown): void;
     },
   ) => { pipe(destination: NodeJS.WritableStream): void };
+  /** WHATWG streaming primitive used by Web-stream-capable renderers. */
+  renderToReadableStream?: (
+    element: unknown,
+  ) => ReadableStream<Uint8Array | string> | Promise<ReadableStream<Uint8Array | string>>;
 }
 
 export const REACT_RENDERER: Readonly<FarmRenderer> = Object.freeze({
@@ -90,6 +128,9 @@ export const REACT_RENDERER: Readonly<FarmRenderer> = Object.freeze({
     "react/jsx-runtime",
     "react/jsx-dev-runtime",
   ],
+  capabilities: {
+    streaming: { node: true, web: false },
+  },
 });
 
 export function defineRenderer<const TRenderer extends FarmRenderer>(
@@ -113,7 +154,24 @@ export function resolveFarmRenderer(renderer?: FarmRenderer): FarmRenderer {
     componentExtensions: [...(resolved.componentExtensions || [])],
     dedupe: [...(resolved.dedupe || [])],
     optimizeDeps: [...(resolved.optimizeDeps || [])],
+    capabilities: getFarmRendererCapabilities(resolved),
   };
+}
+
+export async function readFarmRendererWebStream(
+  stream: ReadableStream<Uint8Array | string>,
+): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let html = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    html += typeof value === "string" ? value : decoder.decode(value, { stream: true });
+  }
+
+  return html + decoder.decode();
 }
 
 export function isReactRenderer(renderer: Pick<FarmRenderer, "name"> | undefined): boolean {

--- a/packages/farm/src/renderer/react/server.ts
+++ b/packages/farm/src/renderer/react/server.ts
@@ -35,6 +35,9 @@ export class ErrorBoundary extends React.Component<
 }
 
 export const name = "react";
+export const capabilities = {
+  streaming: { node: true, web: false },
+} as const;
 export const Fragment = React.Fragment;
 export const Suspense = React.Suspense;
 export const createElement = React.createElement;

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -53,8 +53,10 @@ import { createFarmThemeDocumentParts } from "../theme/server-runtime";
 import { getTheme as getFarmTheme } from "../theme/server";
 import type { ViteDevServer } from "vite";
 import {
+  getFarmRendererCapabilities,
   getFarmRendererComponentExtensions,
   isReactRenderer,
+  readFarmRendererWebStream,
   resolveFarmRendererModule,
   type FarmServerRendererRuntime,
 } from "../renderer";
@@ -398,6 +400,18 @@ export class ServerRenderer {
       }
     }
 
+    const capabilities = getFarmRendererCapabilities(this.config.renderer);
+    if (capabilities.streaming.node && typeof runtime.renderToPipeableStream !== "function") {
+      throw new Error(
+        `Renderer \`${this.config.renderer.name}\` advertises Node streaming but its server module does not export renderToPipeableStream().`,
+      );
+    }
+    if (capabilities.streaming.web && typeof runtime.renderToReadableStream !== "function") {
+      throw new Error(
+        `Renderer \`${this.config.renderer.name}\` advertises Web streaming but its server module does not export renderToReadableStream().`,
+      );
+    }
+
     this.rendererRuntime = runtime as FarmServerRendererRuntime;
   }
 
@@ -436,36 +450,45 @@ export class ServerRenderer {
   }
 
   private async renderElementToCompleteHTML(element: unknown): Promise<string> {
-    const renderToPipeableStream = this.rendererRuntime.renderToPipeableStream;
-    if (!renderToPipeableStream) {
-      return await this.rendererRuntime.renderToString(element);
+    const capabilities = getFarmRendererCapabilities(this.config.renderer);
+    const renderToPipeableStream = capabilities.streaming.node
+      ? this.rendererRuntime.renderToPipeableStream
+      : undefined;
+
+    if (renderToPipeableStream) {
+      return await new Promise<string>((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        let started = false;
+        const writable = new Writable({
+          write(chunk, _encoding, callback) {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+            callback();
+          },
+        });
+        writable.once("finish", () => resolve(Buffer.concat(chunks).toString("utf8")));
+        writable.once("error", reject);
+
+        const stream = renderToPipeableStream(element, {
+          onShellReady() {
+            started = true;
+            stream.pipe(writable);
+          },
+          onShellError(error) {
+            reject(error);
+          },
+          onError(error) {
+            if (!started) reject(error);
+          },
+        });
+      });
     }
 
-    return await new Promise<string>((resolve, reject) => {
-      const chunks: Buffer[] = [];
-      let started = false;
-      const writable = new Writable({
-        write(chunk, _encoding, callback) {
-          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-          callback();
-        },
-      });
-      writable.once("finish", () => resolve(Buffer.concat(chunks).toString("utf8")));
-      writable.once("error", reject);
+    if (capabilities.streaming.web && this.rendererRuntime.renderToReadableStream) {
+      const stream = await this.rendererRuntime.renderToReadableStream(element);
+      return await readFarmRendererWebStream(stream);
+    }
 
-      const stream = renderToPipeableStream(element, {
-        onShellReady() {
-          started = true;
-          stream.pipe(writable);
-        },
-        onShellError(error) {
-          reject(error);
-        },
-        onError(error) {
-          if (!started) reject(error);
-        },
-      });
-    });
+    return await this.rendererRuntime.renderToString(element);
   }
 
   /**


### PR DESCRIPTION
## What changed

- add an explicit renderer capability contract with separate Node and WHATWG Web streaming flags
- advertise capabilities from every official renderer descriptor and server runtime
- validate advertised runtime exports during server initialization
- dispatch SSR through Node streams, Web streams, or buffered rendering based on the descriptor
- document the custom-renderer contract and export its public TypeScript types

## Why

FARMJS previously inferred streaming by checking for an optional Node-only method. That made renderer behavior implicit and provided no contract for runtimes that expose WHATWG streams.

## Impact

Renderer authors can declare the environment-independent streaming modes they support. Existing descriptors without capabilities continue to use buffered SSR, while invalid advertised capabilities fail early with a targeted diagnostic.

## Validation

- core renderer capability and Web-stream dispatch tests
- React, Preact, Solid, Vue, and Svelte renderer package tests
- core and renderer package type-checks
- core production build
- docs navigation check
- formatter and linter checks on changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines an explicit renderer capability contract and routes SSR via Node streams, Web streams, or a buffered fallback based on advertised support. Replaces implicit Node-only detection with declared `node`/`web` streaming and fails fast when descriptors and runtime exports mismatch.

- Add `capabilities.streaming` (`node`, `web`) to renderer descriptors with safe defaults and normalization.
- Server validates advertised capabilities and uses `renderToPipeableStream`, `renderToReadableStream`, or `renderToString` as appropriate.
- Official renderer descriptors updated: React (Node), Preact (Node + Web), Solid/Vue/Svelte (buffered).
- Docs updated; export types from `@farm.js/core`: `FarmRendererCapabilities`, `FarmRendererStreamingCapabilities`, `FarmRendererCapabilitiesInput`.

- Custom renderers must set `capabilities.streaming` and export the matching methods.
- Descriptors without `capabilities` keep buffered SSR; no changes required.

<sup>Written for commit 893a76def685a487c92bf6d286a82f528ec1993b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

