### PR TITLE
feat: add polished default error pages

### DIFF
--- a/packages/farm/src/__tests__/error-page.test.ts
+++ b/packages/farm/src/__tests__/error-page.test.ts
@@ -1,0 +1,185 @@
+// @vitest-environment node
+
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Script } from "node:vm";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createDefaultErrorMarkup,
+  DEFAULT_ERROR_STYLES,
+  getDefaultErrorStatusText,
+  resolveDefaultErrorStatus,
+  type DefaultErrorSourceFrame,
+} from "../components/error-page";
+import { createDefaultErrorDiagnostics } from "../server/error-diagnostics";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("default error page", () => {
+  it("renders the approved diagnostic layout in development", () => {
+    const sourceFrame: DefaultErrorSourceFrame = {
+      file: "src/app/[owner]/page.tsx",
+      line: 13,
+      column: 16,
+      lines: [
+        { number: 12, content: "" },
+        {
+          number: 13,
+          content: 'const data = await api<ProfileData>("/users/demo");',
+          highlight: true,
+        },
+        { number: 14, content: "return <Profile data={data} />;" },
+      ],
+    };
+    const html = createDefaultErrorMarkup({
+      statusCode: 500,
+      requestPath: "/query-demo",
+      method: "GET",
+      message: 'Request failed: <script>alert("x")</script>',
+      errorName: "Error",
+      stack: "Error: Request failed\n    at <project>/src/app/[owner]/page.tsx:13:16",
+      sourceFrame,
+      development: true,
+      farmVersion: "0.1.0-beta.31",
+      nodeVersion: "v22.0.0",
+      mode: "development",
+    });
+
+    expect(html).toContain('role="alert"');
+    expect(html).toContain(">500</p>");
+    expect(html).toContain("Runtime error");
+    expect(html).toContain("Application failed during server rendering");
+    expect(html).toContain("GET /query-demo");
+    expect(html).toContain("500 Internal Server Error");
+    expect(html).toContain(">Details</h2>");
+    expect(html).toContain("COPY DEBUG REPORT");
+    expect(html).toContain("src/app/[owner]/page.tsx:13:16");
+    expect(html).toContain("farm-default-error__source-line--active");
+    expect(html).toContain("# Farm.js debug report");
+    expect(html).toContain("TRY AGAIN");
+    expect(html).toContain("RETURN HOME");
+    expect(html).not.toContain('<script>alert("x")</script>');
+    expect(html).toContain("&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;");
+
+    const reportMatch = html.match(
+      /<script id="farm-default-error-report" type="application\/json">([\s\S]*?)<\/script>/,
+    );
+    expect(reportMatch).not.toBeNull();
+    const report = JSON.parse(reportMatch![1]);
+    expect(report).toContain("# Farm.js debug report");
+    expect(report).toContain("## Source");
+    expect(report).toContain("## Filtered stack");
+
+    const executableScripts = Array.from(html.matchAll(/<script>([\s\S]*?)<\/script>/g));
+    expect(executableScripts).toHaveLength(2);
+    for (const script of executableScripts) {
+      expect(() => new Script(script[1])).not.toThrow();
+    }
+  });
+
+  it("supports status-bearing failures with matching copy and HTTP labels", () => {
+    expect(resolveDefaultErrorStatus(Object.assign(new Error("busy"), { status: 503 }))).toBe(503);
+    expect(resolveDefaultErrorStatus({ statusCode: "429" })).toBe(429);
+    expect(resolveDefaultErrorStatus({ status: 302 })).toBe(500);
+    expect(resolveDefaultErrorStatus(new Error("boom"))).toBe(500);
+    expect(getDefaultErrorStatusText(429)).toBe("Too Many Requests");
+    expect(getDefaultErrorStatusText(599)).toBe("Server Error");
+
+    const html = createDefaultErrorMarkup({
+      statusCode: 503,
+      requestPath: "/dashboard",
+      development: false,
+    });
+    expect(html).toContain(">503</p>");
+    expect(html).toContain("503 Service Unavailable");
+    expect(html).toContain("The service is temporarily unavailable");
+  });
+
+  it("keeps production output private while preserving recovery actions", () => {
+    const html = createDefaultErrorMarkup({
+      statusCode: 500,
+      requestPath: "/account",
+      message: "database password=super-secret",
+      stack: "/Users/example/private/app.ts:10:2",
+      sourceFrame: {
+        file: "src/app/account/page.tsx",
+        line: 10,
+        column: 2,
+        lines: [{ number: 10, content: "throw new Error(secret);", highlight: true }],
+      },
+      development: false,
+    });
+
+    expect(html).toContain("An unexpected error prevented this page from rendering.");
+    expect(html).toContain("TRY AGAIN");
+    expect(html).toContain("RETURN HOME");
+    expect(html).not.toContain("COPY DEBUG REPORT");
+    expect(html).not.toContain("src/app/account/page.tsx");
+    expect(html).not.toContain("super-secret");
+    expect(html).not.toContain("/Users/example");
+  });
+
+  it("supports adaptive themes, responsive reflow, and reduced motion", () => {
+    expect(DEFAULT_ERROR_STYLES).toContain("@media (prefers-color-scheme: dark)");
+    expect(DEFAULT_ERROR_STYLES).toContain(".dark .farm-default-error");
+    expect(DEFAULT_ERROR_STYLES).toContain('[data-theme="dark"]');
+    expect(DEFAULT_ERROR_STYLES).toContain('[data-theme="light"]');
+    expect(DEFAULT_ERROR_STYLES).toContain("@media (max-width: 620px)");
+    expect(DEFAULT_ERROR_STYLES).toContain("@media (prefers-reduced-motion: reduce)");
+    expect(DEFAULT_ERROR_STYLES).toContain("border: 1px solid var(--farm-error-line)");
+    expect(DEFAULT_ERROR_STYLES).toContain("font-size: clamp(76px, 13vw, 112px)");
+  });
+});
+
+describe("default error diagnostics", () => {
+  it("finds the failing project line and redacts common secrets", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "farm-error-page-"));
+    temporaryDirectories.push(root);
+    const sourcePath = path.join(root, "src", "app", "profile", "page.tsx");
+    await mkdir(path.dirname(sourcePath), { recursive: true });
+    await writeFile(
+      sourcePath,
+      [
+        "export async function ProfilePage() {",
+        '  const owner = "demo";',
+        "  const data = await loadProfile(owner);",
+        "  return data;",
+        "}",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const error = new Error("Profile failed token=private-value");
+    error.stack = [
+      "Error: Profile failed token=private-value",
+      `    at ProfilePage (${sourcePath}:3:16)`,
+      "    at processTicksAndRejections (node:internal/process/task_queues:105:5)",
+    ].join("\n");
+
+    const diagnostics = createDefaultErrorDiagnostics(error, root);
+
+    expect(diagnostics.message).toBe("Profile failed token=[REDACTED]");
+    expect(diagnostics.stack).toContain("<project>/src/app/profile/page.tsx:3:16");
+    expect(diagnostics.stack).not.toContain("private-value");
+    expect(diagnostics.stack).not.toContain("node:internal");
+    expect(diagnostics.sourceFrame).toMatchObject({
+      file: "src/app/profile/page.tsx",
+      line: 3,
+      column: 16,
+    });
+    expect(diagnostics.sourceFrame?.lines.find((line) => line.highlight)).toEqual({
+      number: 3,
+      content: "  const data = await loadProfile(owner);",
+      highlight: true,
+    });
+  });
+});

--- a/packages/farm/src/components/error-page.ts
+++ b/packages/farm/src/components/error-page.ts
@@ -1,0 +1,239 @@
+import { DEFAULT_ERROR_STYLES } from "./error-styles";
+
+export { DEFAULT_ERROR_STYLES } from "./error-styles";
+
+const ERROR_STATUS_TEXT: Record<number, string> = {
+  400: "Bad Request",
+  401: "Unauthorized",
+  402: "Payment Required",
+  403: "Forbidden",
+  404: "Not Found",
+  405: "Method Not Allowed",
+  406: "Not Acceptable",
+  408: "Request Timeout",
+  409: "Conflict",
+  410: "Gone",
+  411: "Length Required",
+  412: "Precondition Failed",
+  413: "Content Too Large",
+  414: "URI Too Long",
+  415: "Unsupported Media Type",
+  416: "Range Not Satisfiable",
+  418: "I'm a Teapot",
+  422: "Unprocessable Content",
+  423: "Locked",
+  424: "Failed Dependency",
+  425: "Too Early",
+  426: "Upgrade Required",
+  428: "Precondition Required",
+  429: "Too Many Requests",
+  431: "Request Header Fields Too Large",
+  451: "Unavailable For Legal Reasons",
+  500: "Internal Server Error",
+  501: "Not Implemented",
+  502: "Bad Gateway",
+  503: "Service Unavailable",
+  504: "Gateway Timeout",
+  505: "HTTP Version Not Supported",
+  506: "Variant Also Negotiates",
+  507: "Insufficient Storage",
+  508: "Loop Detected",
+  510: "Not Extended",
+  511: "Network Authentication Required",
+};
+
+const ERROR_TITLES: Record<number, string> = {
+  400: "The request could not be understood",
+  401: "Authentication is required",
+  403: "You do not have access to this page",
+  404: "The requested page could not be found",
+  405: "This request method is not supported",
+  408: "The request took too long",
+  409: "The request conflicts with the current state",
+  410: "This resource is no longer available",
+  413: "The request is too large",
+  422: "The request could not be processed",
+  429: "Too many requests were sent",
+  500: "Application failed during server rendering",
+  501: "This operation is not implemented",
+  502: "An upstream service returned an invalid response",
+  503: "The service is temporarily unavailable",
+  504: "An upstream service took too long to respond",
+};
+
+const ERROR_PUBLIC_MESSAGES: Record<number, string> = {
+  400: "Check the request and try again.",
+  401: "Sign in and try this request again.",
+  403: "Use an account with the required permissions or return home.",
+  404: "Check the address or return to the home page.",
+  405: "Use a supported request method and try again.",
+  408: "Try the request again in a moment.",
+  409: "Refresh the page, review the latest state, and try again.",
+  410: "Return home to continue browsing.",
+  413: "Reduce the request size and try again.",
+  422: "Review the request data and try again.",
+  429: "Wait a moment before trying again.",
+  500: "An unexpected error prevented this page from rendering.",
+  501: "This operation is not available yet.",
+  502: "Try again after the upstream service recovers.",
+  503: "Try again in a moment.",
+  504: "Try again after the upstream service recovers.",
+};
+
+export interface DefaultErrorSourceLine {
+  number: number;
+  content: string;
+  highlight?: boolean;
+}
+
+export interface DefaultErrorSourceFrame {
+  file: string;
+  line: number;
+  column: number;
+  lines: DefaultErrorSourceLine[];
+}
+
+export interface DefaultErrorPageOptions {
+  statusCode?: number;
+  statusText?: string;
+  requestPath?: string;
+  method?: string;
+  message?: string;
+  errorName?: string;
+  stack?: string;
+  sourceFrame?: DefaultErrorSourceFrame;
+  development?: boolean;
+  farmVersion?: string;
+  nodeVersion?: string;
+  mode?: string;
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function serializeJsonForHtml(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003c")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+function normalizeErrorStatus(status: unknown): number | undefined {
+  const value = typeof status === "string" && status.trim() ? Number(status) : status;
+  return typeof value === "number" && Number.isInteger(value) && value >= 400 && value <= 599
+    ? value
+    : undefined;
+}
+
+export function resolveDefaultErrorStatus(error: unknown): number {
+  if (error && typeof error === "object") {
+    const candidate = error as { status?: unknown; statusCode?: unknown };
+    return (
+      normalizeErrorStatus(candidate.status) ?? normalizeErrorStatus(candidate.statusCode) ?? 500
+    );
+  }
+  return 500;
+}
+
+export function getDefaultErrorStatusText(statusCode: number): string {
+  return ERROR_STATUS_TEXT[statusCode] || (statusCode >= 500 ? "Server Error" : "Request Error");
+}
+
+export function getDefaultErrorTitle(statusCode: number): string {
+  return (
+    ERROR_TITLES[statusCode] ||
+    (statusCode >= 500
+      ? "The server could not complete the request"
+      : "The request could not be completed")
+  );
+}
+
+function getDefaultErrorPublicMessage(statusCode: number): string {
+  return ERROR_PUBLIC_MESSAGES[statusCode] || "Try again or return to the home page.";
+}
+
+function createSourceFrameMarkup(sourceFrame?: DefaultErrorSourceFrame): string {
+  if (!sourceFrame) {
+    return `<p class="farm-default-error__details-empty">Source location is unavailable. Copy the debug report to inspect the filtered stack trace.</p>`;
+  }
+
+  const lines = sourceFrame.lines
+    .map(
+      (line) =>
+        `<span class="farm-default-error__source-line${line.highlight ? " farm-default-error__source-line--active" : ""}"><span class="farm-default-error__source-gutter">${line.highlight ? "&gt;" : "&nbsp;"} ${line.number}</span><span class="farm-default-error__source-text">${escapeHtml(line.content || " ")}</span></span>`,
+    )
+    .join("\n");
+
+  return `<div class="farm-default-error__source"><p class="farm-default-error__source-path">${escapeHtml(sourceFrame.file)}:${sourceFrame.line}:${sourceFrame.column}</p><pre class="farm-default-error__source-code" tabindex="0"><code>${lines}</code></pre></div>`;
+}
+
+function createDebugReport(
+  options: Required<Pick<DefaultErrorPageOptions, "statusCode">> & DefaultErrorPageOptions,
+): string {
+  const statusText = options.statusText || getDefaultErrorStatusText(options.statusCode);
+  const sourceFrame = options.sourceFrame;
+  const source = sourceFrame
+    ? [
+        `\`${sourceFrame.file}:${sourceFrame.line}:${sourceFrame.column}\``,
+        "",
+        "```text",
+        ...sourceFrame.lines.map(
+          (line) =>
+            `${line.highlight ? ">" : " "} ${String(line.number).padStart(4, " ")} | ${line.content}`,
+        ),
+        "```",
+      ].join("\n")
+    : "Source frame unavailable.";
+
+  return [
+    "# Farm.js debug report",
+    "",
+    "## Error",
+    `- Status: ${options.statusCode} ${statusText}`,
+    `- Name: ${options.errorName || "Error"}`,
+    `- Message: ${options.message || getDefaultErrorPublicMessage(options.statusCode)}`,
+    `- Request: ${(options.method || "GET").toUpperCase()} ${options.requestPath || "/"}`,
+    "",
+    "## Runtime",
+    `- Farm.js: ${options.farmVersion || "unknown"}`,
+    `- Node.js: ${options.nodeVersion || "unknown"}`,
+    `- Mode: ${options.mode || "development"}`,
+    "",
+    "## Source",
+    source,
+    "",
+    "## Filtered stack",
+    "```text",
+    options.stack || "Stack trace unavailable.",
+    "```",
+  ].join("\n");
+}
+
+const ERROR_PAGE_SCRIPT = `<script>(function(){var root=document.querySelector("[data-farm-default-error]");if(!root)return;var retry=root.querySelector("[data-farm-error-retry]");if(retry)retry.addEventListener("click",function(){window.location.reload()})})();</script>`;
+const ERROR_COPY_SCRIPT = `<script>(function(){var root=document.querySelector("[data-farm-default-error]");var copy=root&&root.querySelector("[data-farm-error-copy]");var report=document.getElementById("farm-default-error-report");if(!copy||!report)return;copy.addEventListener("click",async function(){var value="";try{value=JSON.parse(report.textContent||'""')}catch(_error){value=report.textContent||""}try{if(navigator.clipboard&&window.isSecureContext){await navigator.clipboard.writeText(value)}else{var area=document.createElement("textarea");area.value=value;area.setAttribute("readonly","");area.style.position="fixed";area.style.opacity="0";document.body.appendChild(area);area.select();document.execCommand("copy");area.remove()}var label=copy.querySelector("[data-farm-error-copy-label]");var status=copy.querySelector("[data-farm-error-copy-status]");if(label)label.textContent="COPIED";if(status)status.textContent="Debug report copied";window.setTimeout(function(){if(label)label.textContent="COPY DEBUG REPORT";if(status)status.textContent=""},1800)}catch(_error){var status=copy.querySelector("[data-farm-error-copy-status]");if(status)status.textContent="Unable to copy the debug report"}})})();</script>`;
+
+export function createDefaultErrorMarkup(options: DefaultErrorPageOptions = {}): string {
+  const statusCode = normalizeErrorStatus(options.statusCode) ?? 500;
+  const statusText = options.statusText || getDefaultErrorStatusText(statusCode);
+  const development = options.development === true;
+  const title = getDefaultErrorTitle(statusCode);
+  const message =
+    development && options.message ? options.message : getDefaultErrorPublicMessage(statusCode);
+  const requestPath = options.requestPath || "/";
+  const method = (options.method || "GET").toUpperCase();
+  const eyebrow = statusCode >= 500 ? "Runtime error" : "Request error";
+  const details = development
+    ? `<section class="farm-default-error__details" aria-labelledby="farm-default-error-details-title"><div class="farm-default-error__details-header"><h2 id="farm-default-error-details-title" class="farm-default-error__details-title">Details</h2><button class="farm-default-error__copy" type="button" data-farm-error-copy><span data-farm-error-copy-label>COPY DEBUG REPORT</span><span class="farm-default-error__sr-only" aria-live="polite" data-farm-error-copy-status></span></button></div>${createSourceFrameMarkup(options.sourceFrame)}<p class="farm-default-error__meta">Farm.js v${escapeHtml(options.farmVersion || "unknown")} · ${escapeHtml(options.mode || "development")} · Node.js ${escapeHtml(options.nodeVersion || "unknown")}</p></section>`
+    : "";
+  const report = development
+    ? `<script id="farm-default-error-report" type="application/json">${serializeJsonForHtml(createDebugReport({ ...options, statusCode, statusText, requestPath, method }))}</script>${ERROR_COPY_SCRIPT}`
+    : "";
+
+  return `<style>${DEFAULT_ERROR_STYLES}</style><main class="farm-default-error" data-farm-default-error role="alert" aria-labelledby="farm-default-error-title" aria-describedby="farm-default-error-description"><div class="farm-default-error__content"><p class="farm-default-error__code" aria-hidden="true">${statusCode}</p><p class="farm-default-error__eyebrow">${escapeHtml(eyebrow)}</p><header class="farm-default-error__summary"><h1 id="farm-default-error-title" class="farm-default-error__title">${escapeHtml(title)}</h1><p id="farm-default-error-description" class="farm-default-error__message">${escapeHtml(message)}</p></header><section class="farm-default-error__panel" aria-label="Error information"><div class="farm-default-error__row"><span class="farm-default-error__label">Request</span><span class="farm-default-error__value">${escapeHtml(method)} ${escapeHtml(requestPath)}</span></div><div class="farm-default-error__row"><span class="farm-default-error__label">Status</span><span class="farm-default-error__value">${statusCode} ${escapeHtml(statusText)}</span></div>${details}</section><div class="farm-default-error__actions"><button class="farm-default-error__action farm-default-error__action--primary" type="button" data-farm-error-retry>TRY AGAIN</button><a class="farm-default-error__action" href="/">RETURN HOME</a></div></div>${report}${ERROR_PAGE_SCRIPT}</main>`;
+}

--- a/packages/farm/src/components/error-styles.ts
+++ b/packages/farm/src/components/error-styles.ts
@@ -1,0 +1,438 @@
+/**
+ * Shared styles for Farm's default HTTP error page.
+ *
+ * Kept framework-agnostic so the same fallback can be used by the development
+ * renderer and generated production runtimes.
+ */
+export const DEFAULT_ERROR_STYLES = `
+body {
+  margin: 0;
+}
+
+.farm-default-error {
+  --farm-error-bg: #fafafa;
+  --farm-error-fg: #171717;
+  --farm-error-muted: #737373;
+  --farm-error-line: rgba(0, 0, 0, 0.16);
+  --farm-error-line-strong: rgba(0, 0, 0, 0.34);
+  --farm-error-panel: rgba(0, 0, 0, 0.018);
+  --farm-error-button-fg: #ffffff;
+  --farm-error-source-line: rgba(185, 28, 28, 0.08);
+  --farm-error-source-marker: #b91c1c;
+  min-height: 100vh;
+  min-height: 100svh;
+  display: grid;
+  place-items: center;
+  padding: clamp(28px, 6vw, 72px) 24px;
+  color: var(--farm-error-fg);
+  background: var(--farm-error-bg);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color-scheme: light;
+}
+
+.farm-default-error,
+.farm-default-error * {
+  box-sizing: border-box;
+}
+
+.farm-default-error__content {
+  width: min(100%, 840px);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.farm-default-error__code {
+  margin: 0;
+  color: var(--farm-error-fg);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: clamp(76px, 13vw, 112px);
+  font-weight: 800;
+  line-height: 0.78;
+  letter-spacing: -0.08em;
+  text-align: center;
+  transform: translateX(-3px);
+}
+
+@supports (-webkit-text-stroke: 1px currentColor) {
+  .farm-default-error__code {
+    color: var(--farm-error-bg);
+    -webkit-text-stroke: 2px var(--farm-error-fg);
+    text-shadow: 4px 4px 0 var(--farm-error-fg);
+  }
+}
+
+.farm-default-error__eyebrow {
+  width: min(100%, 590px);
+  display: flex;
+  align-items: center;
+  align-self: center;
+  gap: 16px;
+  margin: 34px 0 28px;
+  color: var(--farm-error-fg);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.farm-default-error__eyebrow::before,
+.farm-default-error__eyebrow::after {
+  content: "";
+  height: 1px;
+  flex: 1 1 auto;
+  background: var(--farm-error-line-strong);
+}
+
+.farm-default-error__summary {
+  margin-bottom: 28px;
+  text-align: center;
+}
+
+.farm-default-error__title {
+  margin: 0;
+  font-size: clamp(20px, 3vw, 26px);
+  font-weight: 540;
+  line-height: 1.25;
+  letter-spacing: -0.02em;
+}
+
+.farm-default-error__message {
+  max-width: 680px;
+  margin: 8px auto 0;
+  color: var(--farm-error-muted);
+  font-size: 15px;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+}
+
+.farm-default-error__panel {
+  border: 1px solid var(--farm-error-line-strong);
+  background: var(--farm-error-panel);
+}
+
+.farm-default-error__row {
+  min-height: 58px;
+  display: grid;
+  grid-template-columns: minmax(124px, 180px) minmax(0, 1fr);
+  align-items: center;
+  border-bottom: 1px solid var(--farm-error-line);
+}
+
+.farm-default-error__row:last-child {
+  border-bottom: 0;
+}
+
+.farm-default-error__label,
+.farm-default-error__value,
+.farm-default-error__details-title,
+.farm-default-error__copy,
+.farm-default-error__source-path,
+.farm-default-error__meta,
+.farm-default-error__action {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.farm-default-error__label {
+  padding: 0 22px;
+  color: var(--farm-error-muted);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.farm-default-error__value {
+  min-width: 0;
+  padding: 15px 22px;
+  color: var(--farm-error-fg);
+  font-size: 14px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.farm-default-error__details {
+  padding: 20px 22px 18px;
+}
+
+.farm-default-error__details-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 10px;
+}
+
+.farm-default-error__details-title {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.farm-default-error__copy {
+  min-height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 12px;
+  border: 1px solid var(--farm-error-line);
+  border-radius: 0;
+  color: var(--farm-error-fg);
+  background: transparent;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: border-color 150ms ease-out, background 150ms ease-out;
+}
+
+.farm-default-error__source {
+  border: 1px solid var(--farm-error-line);
+  background: var(--farm-error-bg);
+  overflow: hidden;
+}
+
+.farm-default-error__source-path {
+  margin: 0;
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--farm-error-line);
+  color: var(--farm-error-fg);
+  font-size: 12px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.farm-default-error__source-code {
+  margin: 0;
+  padding: 8px 0;
+  overflow-x: auto;
+  color: var(--farm-error-fg);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.75;
+  tab-size: 2;
+}
+
+.farm-default-error__source-line {
+  min-width: max-content;
+  display: grid;
+  grid-template-columns: 68px minmax(0, 1fr);
+  padding: 0 14px 0 0;
+  border-left: 2px solid transparent;
+}
+
+.farm-default-error__source-line--active {
+  border-left-color: var(--farm-error-source-marker);
+  background: var(--farm-error-source-line);
+}
+
+.farm-default-error__source-gutter {
+  padding-right: 14px;
+  color: var(--farm-error-muted);
+  text-align: right;
+  user-select: none;
+}
+
+.farm-default-error__source-line--active .farm-default-error__source-gutter {
+  color: var(--farm-error-source-marker);
+}
+
+.farm-default-error__source-text {
+  white-space: pre;
+}
+
+.farm-default-error__details-empty {
+  margin: 0;
+  padding: 15px;
+  border: 1px solid var(--farm-error-line);
+  color: var(--farm-error-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.farm-default-error__meta {
+  margin: 14px 0 0;
+  color: var(--farm-error-muted);
+  font-size: 10px;
+  line-height: 1.5;
+  letter-spacing: 0.04em;
+  text-align: center;
+}
+
+.farm-default-error__actions {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 28px;
+}
+
+.farm-default-error__action {
+  min-width: 152px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 20px;
+  border: 1px solid var(--farm-error-fg);
+  border-radius: 0;
+  color: var(--farm-error-fg);
+  background: transparent;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: 0.08em;
+  text-decoration: none;
+  cursor: pointer;
+  transition: opacity 150ms ease-out, transform 100ms ease-out;
+}
+
+.farm-default-error__action--primary {
+  color: var(--farm-error-button-fg);
+  background: var(--farm-error-fg);
+}
+
+.farm-default-error__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .farm-default-error__copy:hover {
+    border-color: var(--farm-error-line-strong);
+    background: var(--farm-error-panel);
+  }
+
+  .farm-default-error__action:hover {
+    opacity: 0.76;
+  }
+}
+
+.farm-default-error__copy:active,
+.farm-default-error__action:active {
+  transform: translateY(1px);
+}
+
+.farm-default-error__copy:focus-visible,
+.farm-default-error__action:focus-visible {
+  outline: 2px solid var(--farm-error-fg);
+  outline-offset: 3px;
+}
+
+@media (max-width: 620px) {
+  .farm-default-error {
+    place-items: start center;
+    padding: 48px 16px 32px;
+  }
+
+  .farm-default-error__eyebrow {
+    margin-top: 28px;
+  }
+
+  .farm-default-error__row {
+    grid-template-columns: 1fr;
+    gap: 5px;
+    padding: 14px 16px;
+  }
+
+  .farm-default-error__label,
+  .farm-default-error__value {
+    padding: 0;
+  }
+
+  .farm-default-error__details {
+    padding: 16px;
+  }
+
+  .farm-default-error__details-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .farm-default-error__copy {
+    width: 100%;
+  }
+
+  .farm-default-error__source-line {
+    grid-template-columns: 56px minmax(0, 1fr);
+  }
+
+  .farm-default-error__actions {
+    flex-direction: column;
+  }
+
+  .farm-default-error__action {
+    width: 100%;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .farm-default-error {
+    --farm-error-bg: #0a0a0a;
+    --farm-error-fg: #ededed;
+    --farm-error-muted: #a1a1a1;
+    --farm-error-line: rgba(255, 255, 255, 0.14);
+    --farm-error-line-strong: rgba(255, 255, 255, 0.3);
+    --farm-error-panel: rgba(255, 255, 255, 0.018);
+    --farm-error-button-fg: #0a0a0a;
+    --farm-error-source-line: rgba(248, 113, 113, 0.12);
+    --farm-error-source-marker: #f87171;
+    color-scheme: dark;
+  }
+}
+
+.dark .farm-default-error,
+[data-theme="dark"] .farm-default-error,
+[data-color-scheme="dark"] .farm-default-error {
+  --farm-error-bg: #0a0a0a;
+  --farm-error-fg: #ededed;
+  --farm-error-muted: #a1a1a1;
+  --farm-error-line: rgba(255, 255, 255, 0.14);
+  --farm-error-line-strong: rgba(255, 255, 255, 0.3);
+  --farm-error-panel: rgba(255, 255, 255, 0.018);
+  --farm-error-button-fg: #0a0a0a;
+  --farm-error-source-line: rgba(248, 113, 113, 0.12);
+  --farm-error-source-marker: #f87171;
+  color-scheme: dark;
+}
+
+.light .farm-default-error,
+[data-theme="light"] .farm-default-error,
+[data-color-scheme="light"] .farm-default-error {
+  --farm-error-bg: #fafafa;
+  --farm-error-fg: #171717;
+  --farm-error-muted: #737373;
+  --farm-error-line: rgba(0, 0, 0, 0.16);
+  --farm-error-line-strong: rgba(0, 0, 0, 0.34);
+  --farm-error-panel: rgba(0, 0, 0, 0.018);
+  --farm-error-button-fg: #ffffff;
+  --farm-error-source-line: rgba(185, 28, 28, 0.08);
+  --farm-error-source-marker: #b91c1c;
+  color-scheme: light;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .farm-default-error__copy,
+  .farm-default-error__action {
+    transition: none;
+  }
+
+  .farm-default-error__copy:active,
+  .farm-default-error__action:active {
+    transform: none;
+  }
+}
+`;

--- a/packages/farm/src/nitro/production-runtime.ts
+++ b/packages/farm/src/nitro/production-runtime.ts
@@ -42,6 +42,11 @@ export { resolveFarmRouteContext, withFarmRouteContext } from "../route-context"
 export { _setDefaultFarmThemeConfig, getTheme } from "../theme/server";
 export { applyFarmThemeDocument, createFarmThemeDocumentParts } from "../theme/server-runtime";
 export {
+  createDefaultErrorMarkup,
+  getDefaultErrorStatusText,
+  resolveDefaultErrorStatus,
+} from "../components/error-page";
+export {
   manageFarmDocumentPreloads,
   manageFarmHtmlPreloads,
   manageFarmLinkHeaderPreloads,

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -3509,6 +3509,7 @@ function generateVirtualEntryCode(
   applyProductionMiddlewareHeaders,
   configureFarmCache,
   configureFarmObservability,
+  createDefaultErrorMarkup,
   createFarmInstrumentationLifecycle,
   createFarmCacheKey,
   createFarmThemeDocumentParts,
@@ -3520,6 +3521,7 @@ function generateVirtualEntryCode(
   getFarmDataCache,
   getFarmLocaleVaryHeaders,
   getFarmRedirectError,
+  getDefaultErrorStatusText,
   isFarmNotFoundError,
   isFarmRedirectError,
   localizeFarmHref,
@@ -3531,6 +3533,7 @@ function generateVirtualEntryCode(
   reportFarmPreloadWarnings,
   renderMetadataHead,
   resolveFarmRouteContext,
+  resolveDefaultErrorStatus,
   resolveFarmInstrumentationRuntime,
   runWithFarmRequestSpan,
   stripFarmLocaleFromPathname,
@@ -6023,6 +6026,8 @@ async function handleFarmRequestInContext(
 
       emitFarmEvent({ type: "render.error", route: pathname, error });
       console.error("SSR Error:", error);
+      const errorStatus = resolveDefaultErrorStatus(error);
+      const errorStatusText = getDefaultErrorStatusText(errorStatus);
 
       const errorBoundaryMatch = getMatchingErrorBoundary(routePathname);
       if (errorBoundaryMatch?.route.module?.default) {
@@ -6073,11 +6078,11 @@ async function handleFarmRequestInContext(
             type: "render.complete",
             route: pathname,
             pathname,
-            status: 500,
+            status: errorStatus,
             durationMs: Date.now() - requestStartTime,
           });
           return applyProductionMiddlewareHeaders(new Response(errorDocument, {
-            status: 500,
+            status: errorStatus,
             headers: {
               "Content-Type": "text/html; charset=utf-8",
               "Cache-Control": "private, no-store",
@@ -6089,12 +6094,20 @@ async function handleFarmRequestInContext(
         }
       }
 
-      const errorMessage = "Internal Server Error";
-      const fallbackHtml = '<main><h1>Application Error</h1><p>' +
-        escapeFarmHtmlAttribute(errorMessage) + '</p></main>';
+      const fallbackHtml = createDefaultErrorMarkup({
+        statusCode: errorStatus,
+        statusText: errorStatusText,
+        requestPath: pathname,
+        method: request.method,
+        development: false,
+        mode: "production",
+      });
       const fallbackDocument = applyFarmThemeDocument(
         applyFarmI18nDocument(
-          createFarmErrorDocument(fallbackHtml, "Application Error"),
+          createFarmErrorDocument(
+            fallbackHtml,
+            errorStatus + " - " + errorStatusText
+          ),
           pathname,
           getFarmI18nSnapshot()
         ),
@@ -6105,7 +6118,7 @@ async function handleFarmRequestInContext(
       return applyProductionMiddlewareHeaders(new Response(
         fallbackDocument,
         {
-          status: 500,
+          status: errorStatus,
           headers: {
             "Content-Type": "text/html; charset=utf-8",
             "Cache-Control": "private, no-store",

--- a/packages/farm/src/server/error-diagnostics.ts
+++ b/packages/farm/src/server/error-diagnostics.ts
@@ -1,0 +1,123 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { DefaultErrorSourceFrame } from "../components/error-page";
+
+export interface DefaultErrorDiagnostics {
+  name: string;
+  message: string;
+  stack?: string;
+  sourceFrame?: DefaultErrorSourceFrame;
+}
+
+interface StackLocation {
+  absolutePath: string;
+  displayPath: string;
+  line: number;
+  column: number;
+}
+
+const SECRET_VALUE_PATTERN =
+  /\b(api[_-]?key|access[_-]?token|auth[_-]?token|token|password|secret)\s*[:=]\s*([^\s,;]+)/gi;
+const BEARER_PATTERN = /\b(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi;
+
+function redactErrorText(value: string): string {
+  return value
+    .replace(BEARER_PATTERN, "$1[REDACTED]")
+    .replace(SECRET_VALUE_PATTERN, "$1=[REDACTED]");
+}
+
+function isPathInsideRoot(root: string, filePath: string): boolean {
+  const relative = path.relative(root, filePath);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function normalizeStackPath(value: string): string | undefined {
+  const withoutQuery = value.replace(/[?#].*$/, "");
+  try {
+    return withoutQuery.startsWith("file://") ? fileURLToPath(withoutQuery) : withoutQuery;
+  } catch {
+    return undefined;
+  }
+}
+
+function findStackLocation(stack: string, root: string): StackLocation | undefined {
+  for (const stackLine of stack.split("\n")) {
+    const match = stackLine.match(
+      /(?:\()?((?:file:\/\/\/|\/|[A-Za-z]:[\\/])[^\n()]+):(\d+):(\d+)\)?$/,
+    );
+    if (!match) continue;
+
+    const candidate = normalizeStackPath(match[1]);
+    if (!candidate || candidate.includes(`${path.sep}node_modules${path.sep}`)) continue;
+
+    const absolutePath = path.resolve(candidate);
+    if (!isPathInsideRoot(root, absolutePath) || !fs.existsSync(absolutePath)) continue;
+
+    const relativePath = path.relative(root, absolutePath).split(path.sep).join("/");
+    return {
+      absolutePath,
+      displayPath: relativePath || path.basename(absolutePath),
+      line: Number(match[2]),
+      column: Number(match[3]),
+    };
+  }
+  return undefined;
+}
+
+function createSourceFrame(location: StackLocation): DefaultErrorSourceFrame | undefined {
+  try {
+    const sourceLines = fs.readFileSync(location.absolutePath, "utf8").split(/\r?\n/);
+    if (location.line < 1 || location.line > sourceLines.length) return undefined;
+
+    const start = Math.max(1, location.line - 2);
+    const end = Math.min(sourceLines.length, location.line + 2);
+    const lines = [];
+    for (let line = start; line <= end; line++) {
+      lines.push({
+        number: line,
+        content: sourceLines[line - 1],
+        highlight: line === location.line,
+      });
+    }
+
+    return {
+      file: location.displayPath,
+      line: location.line,
+      column: location.column,
+      lines,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function sanitizeStack(stack: string, root: string): string {
+  const normalizedRoot = path.resolve(root);
+  return redactErrorText(stack)
+    .split(normalizedRoot)
+    .join("<project>")
+    .split("\n")
+    .filter((line, index) => index === 0 || !line.includes("node:internal"))
+    .slice(0, 14)
+    .join("\n");
+}
+
+export function createDefaultErrorDiagnostics(
+  error: unknown,
+  root: string,
+): DefaultErrorDiagnostics {
+  const normalizedError =
+    error instanceof Error
+      ? error
+      : new Error(typeof error === "string" ? error : "Unknown server rendering error");
+  const rawStack = normalizedError.stack || `${normalizedError.name}: ${normalizedError.message}`;
+  const location = findStackLocation(rawStack, path.resolve(root));
+
+  return {
+    name: redactErrorText(normalizedError.name || "Error"),
+    message: redactErrorText(normalizedError.message || "Unknown server rendering error"),
+    stack: sanitizeStack(rawStack, root),
+    sourceFrame: location ? createSourceFrame(location) : undefined,
+  };
+}

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -49,8 +49,14 @@ import { sendWebResponse } from "./response";
 import { renderFarmFontDevHead } from "../font-vite";
 import { createFarmMetadataImageResponse } from "../metadata-image";
 import { DEFAULT_NOT_FOUND_STYLES } from "../components/not-found-styles";
+import {
+  createDefaultErrorMarkup,
+  getDefaultErrorStatusText,
+  resolveDefaultErrorStatus,
+} from "../components/error-page";
 import { createFarmThemeDocumentParts } from "../theme/server-runtime";
 import { getTheme as getFarmTheme } from "../theme/server";
+import { FARM_VERSION } from "../version";
 import type { ViteDevServer } from "vite";
 import {
   getFarmRendererComponentExtensions,
@@ -60,6 +66,7 @@ import {
 } from "../renderer";
 import { pathToFileURL } from "node:url";
 import type { FarmIslandStrategy } from "../island";
+import { createDefaultErrorDiagnostics } from "./error-diagnostics";
 
 let cachedClerkProvider: { ClerkProvider: any } | null = null;
 
@@ -1443,6 +1450,7 @@ export class ServerRenderer {
       }
 
       emitFarmEvent({ type: "render.error", route: pathname, error });
+      const errorStatus = resolveDefaultErrorStatus(error);
       if (pprRefreshRoute) {
         emitFarmEvent({
           type: "ppr.refresh.error",
@@ -1469,6 +1477,7 @@ export class ServerRenderer {
           middlewareContext,
           pluginExposedContext,
           error,
+          statusCode: errorStatus,
           errorModulePath: errorBoundaryEntry.modulePath,
         });
 
@@ -1477,7 +1486,7 @@ export class ServerRenderer {
         }
       }
 
-      await this.render500(req, res, error);
+      await this.renderError(req, res, error, errorStatus);
     }
   }
 
@@ -1714,6 +1723,7 @@ export class ServerRenderer {
       middlewareContext: Map<string, any>;
       pluginExposedContext: Map<string, any>;
       error: unknown;
+      statusCode: number;
       errorModulePath: string;
     },
   ): Promise<boolean> {
@@ -1760,7 +1770,7 @@ export class ServerRenderer {
           this.rendererRuntime.renderToString(wrapped),
         ),
       );
-      res.statusCode = 500;
+      res.statusCode = options.statusCode;
       res.setHeader("Content-Type", "text/html; charset=utf-8");
       res.write(this.createFullHTML(html, false, options.pathname));
       res.end();
@@ -2323,7 +2333,12 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
     res.end();
   }
 
-  private async render500(req: FarmRequest, res: FarmResponse, error: any): Promise<void> {
+  private async renderError(
+    req: FarmRequest,
+    res: FarmResponse,
+    error: unknown,
+    statusCode = 500,
+  ): Promise<void> {
     if (res.headersSent || (res as any).writableEnded) {
       if (!(res as any).writableEnded) {
         res.end();
@@ -2331,26 +2346,48 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
       return;
     }
 
-    res.statusCode = 500;
-
+    res.statusCode = statusCode;
     const isDev = process.env.NODE_ENV === "development";
-    const errorMessage = isDev ? error.stack || error.message : "Internal Server Error";
+    const requestUrl = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
+    const diagnostics = isDev
+      ? createDefaultErrorDiagnostics(error, this.config.root || process.cwd())
+      : undefined;
+    const statusText = getDefaultErrorStatusText(statusCode);
+    const content = createDefaultErrorMarkup({
+      statusCode,
+      statusText,
+      requestPath: requestUrl.pathname,
+      method: req.method || "GET",
+      message: diagnostics?.message,
+      errorName: diagnostics?.name,
+      stack: diagnostics?.stack,
+      sourceFrame: diagnostics?.sourceFrame,
+      development: isDev,
+      farmVersion: FARM_VERSION,
+      nodeVersion: process.version,
+      mode: isDev ? "development" : "production",
+    });
 
     const html = this.createFullHTML(
-      `
-        <h1>500 - Internal Server Error</h1>
-        ${isDev ? `<pre>${errorMessage}</pre>` : ""}
-      `,
+      content,
       false,
-      req.url || "/",
+      requestUrl.pathname,
+      `${statusCode} - ${statusText}`,
     );
 
     res.setHeader("Content-Type", "text/html; charset=utf-8");
+    res.setHeader("Cache-Control", "private, no-store");
+    res.setHeader("X-Content-Type-Options", "nosniff");
     res.write(html);
     res.end();
   }
 
-  private createFullHTML(content: string, isClientComponent = false, requestPath = "/"): string {
+  private createFullHTML(
+    content: string,
+    isClientComponent = false,
+    requestPath = "/",
+    documentTitle = "Farm.js App",
+  ): string {
     const i18nSnapshot = getFarmI18nClientSnapshot();
     const clientScript = isClientComponent
       ? `  <script type="module" src="/@farm/client.js"></script>`
@@ -2379,7 +2416,7 @@ ${i18nSnapshot ? `window.__FARM_I18N__ = ${serializeInlineValue(i18nSnapshot)};`
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="farm-deployment-id" content="${escapeHtmlAttribute(this.getDeploymentId())}">
   <link rel="icon" href="data:,">
-  <title>Farm.js App</title>${alternateLinks}
+  <title>${escapeHtmlAttribute(documentTitle)}</title>${alternateLinks}
   ${fontHead}
   <link rel="stylesheet" href="/src/app/globals.css" />
   <script type="module" src="/@vite/client"></script>


### PR DESCRIPTION
## Summary

- add a polished, responsive default error page that matches the existing 404 design language
- support status-aware fallbacks for HTTP 400–599 errors, including 500, 502, 503, and 504
- show sanitized source frames and an AI-friendly copyable debug report in development
- keep production responses private by omitting messages, stacks, source paths, and diagnostics
- use the shared fallback in both the development renderer and generated production runtime

## Why

The previous fallback rendered a plain 500 heading and raw stack trace. It was difficult to scan, exposed unsanitized development output, and could not represent status-bearing runtime failures accurately.

## Impact

Developers get a focused error message, the failing source line when available, recovery actions, and a structured debug report. End users receive a clean status-specific page without internal implementation details. The existing default 404 page remains unchanged.

## Validation

- `corepack pnpm --filter @farm.js/core test -- src/__tests__/error-page.test.ts src/__tests__/not-found.test.tsx`
- `corepack pnpm --filter @farm.js/core type-check`
- targeted formatting and lint checks


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a polished, status-aware default error page for development and production. Replaces the plain 500 + raw stack with sanitized developer diagnostics in dev and a private, themed fallback in production, returning accurate 4xx/5xx statuses.

- Adds `createDefaultErrorMarkup` and `DEFAULT_ERROR_STYLES` for a responsive page that maps 400–599 to titles and messages; dev shows a highlighted source frame and a copyable debug report, production omits messages, stacks, and source paths.
- Introduces `createDefaultErrorDiagnostics` to find the first project frame, build a 5-line snippet, redact secrets and bearer tokens, and shorten/sanitize stacks with `<project>` path placeholders.
- Updates the dev server renderer to use `renderError` with `resolveDefaultErrorStatus` and `getDefaultErrorStatusText`; sets `Cache-Control: private, no-store` and `X-Content-Type-Options: nosniff`; document title reflects the status.
- Updates the Nitro production runtime and universal build to generate the same fallback and return the detected status; exports `createDefaultErrorMarkup`, `getDefaultErrorStatusText`, and `resolveDefaultErrorStatus` from `@farm.js/core` runtime.
- Adds tests for dev layout, status handling, production privacy, adaptive styles, and diagnostics. Existing 404 remains unchanged.
- Behavior change: errors that set `error.status` or `error.statusCode` in 400–599 now control the HTTP status and page copy; otherwise we return 500. No migration required; custom error boundaries continue to work.

<sup>Written for commit 8c56ad91bc4e202d609f0aed9b1fb244b6726567. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

