### PR TITLE
feat: add configurable API base URL

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -19,6 +19,25 @@ import type { APIRouter } from "./api.generated";
 export const api = createAPIClient<APIRouter>();
 ```
 
+The client uses the current origin and `/api` by default. To point every default client at another
+API, configure it once in `farm.config.ts`:
+
+```ts
+import { defineConfig } from "@farm.js/core";
+
+export default defineConfig({
+  api: {
+    baseURL: () => process.env.API_ORIGIN,
+    basePath: "/api",
+  },
+});
+```
+
+`https://api.example.com` becomes `https://api.example.com/api`. A URL that already has a path,
+such as `https://api.example.com/v1`, uses that path directly. `baseURL` and `basePath` may be sync
+or async resolver functions; Farm evaluates them during config resolution and embeds only the
+resulting public URL.
+
 ## Call a route
 
 **Browser usage**

--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -232,6 +232,7 @@ mount, and shortcut together.
 | extends       | Composing local or package Farm layers with project-first overrides.              |
 | srcDir        | Changing the app source folder from the default src.                              |
 | renderer      | Selecting React (default) or an adapter such as Preact, Svelte, Vue, or Solid.    |
+| api           | Configuring the public root used by Farm's typed browser API client.              |
 | integrations  | Registering built-in or custom integrations.                                      |
 | auth          | Enabling Farm's built-in email/password auth, sessions, helpers, and hooks.       |
 | theme         | Enabling light, dark, and system modes with client and server APIs.               |
@@ -250,6 +251,32 @@ mount, and shortcut together.
 | images        | Configuring responsive widths, remote allowlists, formats, and optimizer limits.  |
 | performance   | Budgeting image and font preload hints without changing the rendered resources.   |
 | openapi       | Publishing API reference docs.                                                    |
+
+## API client base URL
+
+Farm's typed API client uses the current origin and `/api` by default. Configure `api` when the
+browser should call a different origin or path:
+
+```ts
+import { defineConfig } from "@farm.js/core";
+
+export default defineConfig({
+  api: {
+    baseURL: ({ mode }) =>
+      process.env.GITHUH_API_URL ?? (mode === "development" ? "http://127.0.0.1:8080" : undefined),
+    basePath: "/api",
+  },
+});
+```
+
+An origin-only `baseURL`, such as `https://api.example.com`, is joined with `basePath`. If
+`baseURL` already contains a path, such as `https://api.example.com/v1`, that path is the API root
+and `basePath` is ignored. Both fields accept a string or a sync/async resolver receiving
+`{ root, mode, env }`. Farm resolves the function during configuration and only embeds the resulting
+public URL in the browser bundle.
+
+The option configures `createAPIClient()` automatically. An explicit per-client `baseURL` still
+takes precedence.
 
 ## Images
 

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -60,6 +60,21 @@ beforeEach(() => {
 });
 
 describe("createAPIClient", () => {
+  it("uses a baseURL path as the API root", async () => {
+    const fetchMock = vi.fn(async () => buildResponse({ users: [], total: 0 }));
+    globalThis.fetch = fetchMock as any;
+    const api = createAPIClient<APIRouter>({
+      baseURL: "https://api.example.com/gateway/v1",
+    });
+
+    await api.users.get({ query: { limit: "5" } });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/gateway/v1/users?limit=5",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
   it("applies invalidations declared by the server response", async () => {
     const key = '["products","list"]';
     const cache = getFarmClientDataCache();

--- a/packages/farm/src/__tests__/api-config.test.ts
+++ b/packages/farm/src/__tests__/api-config.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  normalizeFarmAPIConfig,
+  resolveFarmAPIConfig,
+  resolveFarmAPIRequestURL,
+} from "../api/config";
+
+const context = {
+  root: "/workspace/app",
+  mode: "production" as const,
+  env: {
+    server: { API_INTERNAL_HOST: "api.internal" },
+    public: { API_ORIGIN: "https://api.example.com" },
+  },
+};
+
+describe("Farm API config", () => {
+  it("defaults to the same-origin /api root", async () => {
+    await expect(resolveFarmAPIConfig(undefined, context)).resolves.toEqual({
+      baseURL: "/api",
+      basePath: "/api",
+    });
+  });
+
+  it("joins an origin-only baseURL with basePath", async () => {
+    await expect(
+      resolveFarmAPIConfig(
+        {
+          baseURL: "https://api.example.com/",
+          basePath: "v2/api/",
+        },
+        context,
+      ),
+    ).resolves.toEqual({
+      baseURL: "https://api.example.com/v2/api",
+      basePath: "/v2/api",
+    });
+  });
+
+  it("uses a baseURL path instead of appending basePath", async () => {
+    await expect(
+      resolveFarmAPIConfig(
+        {
+          baseURL: "https://api.example.com/gateway/v1/",
+          basePath: "/ignored",
+        },
+        context,
+      ),
+    ).resolves.toEqual({
+      baseURL: "https://api.example.com/gateway/v1",
+      basePath: "/gateway/v1",
+    });
+  });
+
+  it("resolves sync and async config functions with context", async () => {
+    const baseURL = vi.fn(({ env }: typeof context) => env.public.API_ORIGIN as string);
+    const basePath = vi.fn(async ({ mode }: typeof context) =>
+      mode === "production" ? "/v1" : "/api",
+    );
+
+    await expect(resolveFarmAPIConfig({ baseURL, basePath }, context)).resolves.toEqual({
+      baseURL: "https://api.example.com/v1",
+      basePath: "/v1",
+    });
+    expect(baseURL).toHaveBeenCalledWith(context);
+    expect(basePath).toHaveBeenCalledWith(context);
+  });
+
+  it("rejects invalid base URLs and paths", () => {
+    expect(() => normalizeFarmAPIConfig({ baseURL: "api.example.com" })).toThrow(
+      "absolute URL or a root-relative path",
+    );
+    expect(() => normalizeFarmAPIConfig({ basePath: "/api?version=1" })).toThrow(
+      "cannot contain a query string or hash",
+    );
+  });
+
+  it("replaces the canonical /api prefix when the API root has a path", () => {
+    expect(
+      resolveFarmAPIRequestURL("/api/users?limit=5", "https://api.example.com/gateway/v1").href,
+    ).toBe("https://api.example.com/gateway/v1/users?limit=5");
+  });
+
+  it("preserves canonical routes for an origin-only explicit baseURL", () => {
+    expect(resolveFarmAPIRequestURL("/api/users", "https://api.example.com").href).toBe(
+      "https://api.example.com/api/users",
+    );
+  });
+});

--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -501,6 +501,30 @@ describe("resolveConfig", () => {
     expect(getResolvedEnv()).toEqual(config.env);
   });
 
+  it("resolves API URL functions after typed env", async () => {
+    process.env.PUBLIC_API_ORIGIN = "https://api.example.com";
+
+    const config = await resolveConfig(
+      {
+        env: {
+          public: {
+            PUBLIC_API_ORIGIN: (value) => String(value),
+          },
+        },
+        api: {
+          baseURL: ({ env }) => env.public.PUBLIC_API_ORIGIN as string,
+          basePath: async ({ mode }) => (mode === "production" ? "/v2" : "/api"),
+        },
+      },
+      "production",
+    );
+
+    expect(config.api).toEqual({
+      baseURL: "https://api.example.com/v2",
+      basePath: "/v2",
+    });
+  });
+
   it("throws when typed env validation fails", async () => {
     await expect(
       resolveConfig(

--- a/packages/farm/src/__tests__/env.test.ts
+++ b/packages/farm/src/__tests__/env.test.ts
@@ -108,6 +108,7 @@ describe("env", () => {
       { command: "build", mode: "production", isSsrBuild: false },
     );
     expect(browserConfig.define).toEqual({
+      __FARM_API_BASE_URL__: JSON.stringify("/api"),
       __FARM_PUBLIC_ENV__: JSON.stringify({ PUBLIC_APP_URL: "https://farm.test" }),
       __FARM_IMAGE_CONFIG__: publicImageConfig,
     });
@@ -117,6 +118,7 @@ describe("env", () => {
       { command: "build", mode: "production", isSsrBuild: true },
     );
     expect(ssrConfig.define).toEqual({
+      __FARM_API_BASE_URL__: JSON.stringify("/api"),
       __FARM_PUBLIC_ENV__: JSON.stringify({ PUBLIC_APP_URL: "https://farm.test" }),
       __FARM_IMAGE_CONFIG__: publicImageConfig,
       __FARM_ENV__: JSON.stringify({

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -19,6 +19,7 @@ import {
   FARM_CACHE_INVALIDATION_HEADER,
 } from "../cache-invalidation";
 import type { DefinedCacheKey, InferCacheKeyData, RouteDataCacheKey } from "../cache";
+import { getFarmAPIBaseURL, resolveFarmAPIRequestURL } from "./config";
 import {
   isFarmAPIStream,
   isJSONStreamResponse,
@@ -422,10 +423,7 @@ export function createAPIClient<
   options: APIClientOptions | APIClientWithoutIntegrationsOptions = {},
 ): RouteAPIClient<TRouter> | APIClient<TRouter, TIntegrations> {
   options ??= {};
-  // Auto-detect baseURL
-  const baseURL =
-    options.baseURL ||
-    (typeof window !== "undefined" ? window.location.origin : "http://localhost:3000");
+  const baseURL = options.baseURL || getFarmAPIBaseURL();
   const integrationOptions =
     options.integrations === false
       ? false
@@ -449,7 +447,7 @@ export function createAPIClient<
 
   // Create a simple fetch-based client (browser compatible)
   const fetchClient = async (path: string, requestOptions: any = {}) => {
-    const url = new URL(path, baseURL);
+    const url = resolveFarmAPIRequestURL(path, baseURL);
 
     // Handle query parameters
     if (requestOptions.query) {
@@ -787,7 +785,7 @@ export function createAPIClient<
     request,
     routeMeta,
     baseURL,
-    options.baseURL === undefined,
+    isSameOriginAPIBaseURL(baseURL),
     rootAliases,
   ) as APIClient<TRouter, TIntegrations>;
 }
@@ -823,10 +821,11 @@ function createNestedProxy(
       }
       if (prop === FARM_API_ROUTE_META_SYMBOL) {
         const metadata = resolveRouteMeta({ path, baseURL });
+        const requestURL = resolveFarmAPIRequestURL(metadata.routePath, baseURL);
         return Object.freeze({
-          path: metadata.routePath,
+          path: `${requestURL.pathname}${requestURL.search}${requestURL.hash}`,
           method: metadata.method,
-          baseURL,
+          baseURL: requestURL.origin,
           sameOrigin,
         });
       }
@@ -993,8 +992,13 @@ type OptimisticSnapshot = {
 function buildCacheKey(method: string, path: string, input: any, baseURL: string): string {
   const keyInput =
     input && typeof input === "object" ? { query: input.query, body: input.body } : input;
-  const url = new URL(path, baseURL);
+  const url = resolveFarmAPIRequestURL(path, baseURL);
   return `${method}:${url.origin}${url.pathname}:${stableStringify(keyInput ?? {})}`;
+}
+
+function isSameOriginAPIBaseURL(baseURL: string): boolean {
+  if (typeof window === "undefined") return baseURL.startsWith("/");
+  return resolveFarmAPIRequestURL("/api", baseURL).origin === window.location.origin;
 }
 
 function stableStringify(value: any): string {

--- a/packages/farm/src/api/config.ts
+++ b/packages/farm/src/api/config.ts
@@ -1,0 +1,178 @@
+import type { ResolvedFarmEnv } from "../env";
+
+export const DEFAULT_FARM_API_BASE_PATH = "/api";
+
+export interface FarmAPIConfigResolverContext {
+  root: string;
+  mode: "development" | "production";
+  env: ResolvedFarmEnv;
+}
+
+export type FarmAPIConfigValue =
+  | string
+  | undefined
+  | ((context: FarmAPIConfigResolverContext) => string | undefined | Promise<string | undefined>);
+
+export interface FarmAPIConfig {
+  /**
+   * Public API root. An origin-only URL is joined with `basePath`; a URL that
+   * already has a path is used as-is. May be resolved from deployment context.
+   */
+  baseURL?: FarmAPIConfigValue;
+  /** Public API path used when `baseURL` has no path. @default "/api" */
+  basePath?: FarmAPIConfigValue;
+}
+
+export interface ResolvedFarmAPIConfig {
+  /** Fully resolved public API root, either absolute or root-relative. */
+  baseURL: string;
+  /** Effective pathname of `baseURL`. */
+  basePath: string;
+}
+
+declare const __FARM_API_BASE_URL__: string | undefined;
+
+export async function resolveFarmAPIConfig(
+  config: FarmAPIConfig | undefined,
+  context: FarmAPIConfigResolverContext,
+): Promise<ResolvedFarmAPIConfig> {
+  const configuredBasePath = await resolveConfigValue(config?.basePath, context, "api.basePath");
+  const basePath = normalizeFarmAPIBasePath(configuredBasePath ?? DEFAULT_FARM_API_BASE_PATH);
+  const configuredBaseURL = await resolveConfigValue(config?.baseURL, context, "api.baseURL");
+
+  return normalizeFarmAPIConfig({ baseURL: configuredBaseURL, basePath });
+}
+
+/** Normalize already-resolved API strings. */
+export function normalizeFarmAPIConfig(
+  config: { baseURL?: string; basePath?: string } | undefined,
+): ResolvedFarmAPIConfig {
+  const basePath = normalizeFarmAPIBasePath(config?.basePath ?? DEFAULT_FARM_API_BASE_PATH);
+  const baseURL = config?.baseURL?.trim();
+
+  if (!baseURL) {
+    return { baseURL: basePath, basePath };
+  }
+
+  if (baseURL.startsWith("/")) {
+    const url = parseRootRelativeBaseURL(baseURL);
+    if (url.pathname !== "/") {
+      const effectivePath = normalizeFarmAPIBasePath(url.pathname);
+      return { baseURL: effectivePath, basePath: effectivePath };
+    }
+    return { baseURL: basePath, basePath };
+  }
+
+  let url: URL;
+  try {
+    url = new URL(baseURL);
+  } catch {
+    throw new Error(
+      'Farm api.baseURL must be an absolute URL or a root-relative path such as "/api".',
+    );
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("Farm api.baseURL must use http or https.");
+  }
+  if (url.search || url.hash) {
+    throw new Error("Farm api.baseURL cannot contain a query string or hash.");
+  }
+
+  if (url.pathname !== "/") {
+    const effectivePath = normalizeFarmAPIBasePath(url.pathname);
+    return {
+      baseURL: `${url.origin}${effectivePath}`,
+      basePath: effectivePath,
+    };
+  }
+
+  return {
+    baseURL: basePath === "/" ? url.origin : `${url.origin}${basePath}`,
+    basePath,
+  };
+}
+
+export function normalizeFarmAPIBasePath(value: string): string {
+  const path = value.trim();
+  if (!path) {
+    throw new Error("Farm api.basePath cannot be empty.");
+  }
+  if (path.includes("?") || path.includes("#")) {
+    throw new Error("Farm api.basePath cannot contain a query string or hash.");
+  }
+
+  const normalized = `/${path.replace(/^\/+|\/+$/g, "")}`;
+  return normalized === "/" ? "/" : normalized;
+}
+
+/** Read the API root embedded by Farm's Vite build. */
+export function getFarmAPIBaseURL(): string {
+  if (typeof __FARM_API_BASE_URL__ !== "undefined" && __FARM_API_BASE_URL__) {
+    return __FARM_API_BASE_URL__;
+  }
+  return DEFAULT_FARM_API_BASE_PATH;
+}
+
+/** Resolve a canonical Farm route such as `/api/users` against an API root. */
+export function resolveFarmAPIRequestURL(
+  routePath: string,
+  baseURL = getFarmAPIBaseURL(),
+  fallbackOrigin = getDefaultOrigin(),
+): URL {
+  const base = new URL(baseURL, fallbackOrigin);
+  if (base.pathname === "/") {
+    return new URL(routePath, base);
+  }
+
+  const route = new URL(routePath, fallbackOrigin);
+  const suffix = stripCanonicalAPIBasePath(route.pathname);
+  const joinedPath = joinURLPath(base.pathname, suffix);
+  base.pathname = joinedPath;
+  base.search = route.search;
+  base.hash = route.hash;
+  return base;
+}
+
+async function resolveConfigValue(
+  value: FarmAPIConfigValue,
+  context: FarmAPIConfigResolverContext,
+  name: string,
+): Promise<string | undefined> {
+  const resolved = typeof value === "function" ? await value(context) : value;
+  if (resolved === undefined) return undefined;
+  if (typeof resolved !== "string") {
+    throw new Error(`Farm ${name} must resolve to a string or undefined.`);
+  }
+  if (!resolved.trim()) {
+    throw new Error(`Farm ${name} cannot be empty.`);
+  }
+  return resolved;
+}
+
+function parseRootRelativeBaseURL(value: string): URL {
+  const url = new URL(value, "http://farm.local");
+  if (url.search || url.hash) {
+    throw new Error("Farm api.baseURL cannot contain a query string or hash.");
+  }
+  return url;
+}
+
+function stripCanonicalAPIBasePath(pathname: string): string {
+  if (pathname === DEFAULT_FARM_API_BASE_PATH) return "";
+  if (pathname.startsWith(`${DEFAULT_FARM_API_BASE_PATH}/`)) {
+    return pathname.slice(DEFAULT_FARM_API_BASE_PATH.length + 1);
+  }
+  return pathname.replace(/^\/+/, "");
+}
+
+function joinURLPath(basePath: string, suffix: string): string {
+  const normalizedBase = basePath === "/" ? "" : basePath.replace(/\/+$/, "");
+  const normalizedSuffix = suffix.replace(/^\/+/, "");
+  if (!normalizedSuffix) return normalizedBase || "/";
+  return `${normalizedBase}/${normalizedSuffix}`;
+}
+
+function getDefaultOrigin(): string {
+  return typeof window !== "undefined" ? window.location.origin : "http://localhost:3000";
+}

--- a/packages/farm/src/api/index.ts
+++ b/packages/farm/src/api/index.ts
@@ -1,5 +1,6 @@
 export * from "./endpoint";
 export * from "./route-manager";
 export * from "./client";
+export * from "./config";
 export * from "./transport";
 export * from "./vite-plugin";

--- a/packages/farm/src/app.ts
+++ b/packages/farm/src/app.ts
@@ -36,11 +36,13 @@ import { _setDefaultFarmThemeConfig } from "./theme/server";
 import type { ResolvedFarmThemeConfig } from "./theme/types";
 import { getFarmRendererComponentExtensions, resolveFarmRenderer } from "./renderer";
 import type { FarmRenderer } from "./renderer";
+import { normalizeFarmAPIConfig, type ResolvedFarmAPIConfig } from "./api/config";
 
 type NormalizedFarmConfig = Omit<
   Required<FarmConfig>,
-  "devtools" | "images" | "i18n" | "performance" | "security" | "theme"
+  "api" | "devtools" | "images" | "i18n" | "performance" | "security" | "theme"
 > & {
+  api: ResolvedFarmAPIConfig;
   docs: FarmDocsResolvedConfig;
   md: FarmMarkdownResolvedConfig;
   mdx: FarmMdxResolvedConfig;
@@ -158,6 +160,7 @@ export class FarmApp {
       migrations: config.migrations || { commands: [] },
       cron: resolveCronConfig(config.cron),
       workflows: resolveWorkflowsConfig(config.workflows),
+      api: normalizeFarmAppAPIConfig(config.api),
       middleware: config.middleware || {},
       routeRules: normalizeRouteRules(config.routeRules),
       context: config.context || (() => undefined),
@@ -246,6 +249,15 @@ function isResolvedAuthConfig(value: FarmConfig["auth"]): value is ResolvedFarmA
     "emailAndPassword" in value &&
     "database" in value,
   );
+}
+
+function normalizeFarmAppAPIConfig(config: FarmConfig["api"]): ResolvedFarmAPIConfig {
+  if (typeof config?.baseURL === "function" || typeof config?.basePath === "function") {
+    throw new Error(
+      "Farm API config resolver functions must be processed with resolveConfig() before creating a FarmApp.",
+    );
+  }
+  return normalizeFarmAPIConfig(config as { baseURL?: string; basePath?: string } | undefined);
 }
 
 export function createFarmApp(config?: FarmConfig, viteServer?: ViteDevServer): FarmApp {

--- a/packages/farm/src/build/index.ts
+++ b/packages/farm/src/build/index.ts
@@ -329,6 +329,7 @@ async function buildSSR(
       },
     },
     define: {
+      __FARM_API_BASE_URL__: JSON.stringify(config.api.baseURL),
       __FARM_ENV__: JSON.stringify(config.env || { server: {}, public: {} }),
       __FARM_PUBLIC_ENV__: JSON.stringify(config.env?.public || {}),
     },

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -81,6 +81,7 @@ import { resolveFarmThemeConfig } from "./theme/config";
 import type { ResolvedFarmThemeConfig } from "./theme/types";
 import { resolveFarmRenderer } from "./renderer";
 import type { FarmRenderer } from "./renderer";
+import { resolveFarmAPIConfig, type ResolvedFarmAPIConfig } from "./api/config";
 
 const FARM_RESOLVED_CUSTOM_CONTEXT = Symbol.for("farm.resolvedCustomContext");
 
@@ -176,6 +177,12 @@ export type {
   FarmRendererStreamingCapabilities,
 } from "./renderer";
 export { defineRenderer } from "./renderer";
+export type {
+  FarmAPIConfig,
+  FarmAPIConfigResolverContext,
+  FarmAPIConfigValue,
+  ResolvedFarmAPIConfig,
+} from "./api/config";
 
 export interface RedirectConfig {
   source: string;
@@ -354,6 +361,7 @@ export interface ResolvedFarmConfig extends Required<
     | "migrations"
     | "cron"
     | "workflows"
+    | "api"
     | "env"
     | "server"
     | "serverActions"
@@ -380,6 +388,7 @@ export interface ResolvedFarmConfig extends Required<
   migrations: ResolvedFarmMigrationsConfig;
   cron: FarmCronResolvedConfig;
   workflows: FarmWorkflowsResolvedConfig;
+  api: ResolvedFarmAPIConfig;
   env: ResolvedFarmEnv;
   server: ResolvedFarmServerConfig;
   serverActions: ResolvedFarmServerActionsConfig;
@@ -790,6 +799,7 @@ export async function resolveConfig(
   const mdx = resolveMdxConfig(userConfig.mdx);
   const env = resolveEnv(userConfig.env, process.env);
   setEnv(env);
+  const api = await resolveFarmAPIConfig(userConfig.api, { root, mode, env });
   const auth = resolveFarmAuthConfig(userConfig.auth);
   if (auth.enabled && userConfig.integrations?.auth) {
     throw new Error(
@@ -829,6 +839,7 @@ export async function resolveConfig(
     migrations: resolveMigrationsConfig(userConfig.migrations),
     cron: resolveCronConfig(userConfig.cron),
     workflows: resolveWorkflowsConfig(userConfig.workflows),
+    api,
     observability: userConfig.observability ?? false,
     devtools: resolveFarmDevtoolsConfig(userConfig.devtools, mode),
     storage: userConfig.storage || {},

--- a/packages/farm/src/integration-client.ts
+++ b/packages/farm/src/integration-client.ts
@@ -4,6 +4,7 @@ import type {
   FarmIntegrationAPIOperation,
 } from "./integration-api";
 import type { FarmIntegration as FarmIntegrationDefinition } from "./integrations";
+import { resolveFarmAPIRequestURL } from "./api/config";
 
 /**
  * Small per-call integration metadata. When sent from a browser, values are
@@ -697,7 +698,7 @@ async function executeClientOperation(
     const baseURL =
       options.baseURL ||
       (typeof window !== "undefined" ? window.location.origin : "http://localhost:3000");
-    const url = new URL(operation.path, baseURL);
+    const url = resolveFarmAPIRequestURL(operation.path, baseURL);
     appendQuery(url, input.query as Record<string, unknown> | undefined);
 
     const headers = new Headers({

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -3198,6 +3198,7 @@ async function buildSSRInMemory(
             : true,
       },
       define: {
+        __FARM_API_BASE_URL__: JSON.stringify(config.api.baseURL),
         __FARM_ENV__: JSON.stringify(config.env || { server: {}, public: {} }),
         __FARM_PUBLIC_ENV__: JSON.stringify(config.env?.public || {}),
       },

--- a/packages/farm/src/types.ts
+++ b/packages/farm/src/types.ts
@@ -25,6 +25,7 @@ import type { FarmPerformanceConfig } from "./preload";
 import type { FarmLayoutFonts } from "./font";
 import type { FarmSecurityConfig, ResolvedFarmSecurityConfig } from "./security";
 import type { FarmThemeConfig, ResolvedFarmThemeConfig } from "./theme/types";
+import type { FarmAPIConfig } from "./api/config";
 
 declare global {
   namespace FarmJS {
@@ -187,6 +188,8 @@ export interface FarmConfig {
   /** Map portable cron schedules to ordinary GET API routes. */
   cron?: FarmCronUserConfig | FarmCronResolvedConfig | false;
   workflows?: FarmWorkflowsUserConfig | boolean;
+  /** Public base URL and path used by Farm's browser API clients. */
+  api?: FarmAPIConfig;
   env?: FarmEnvConfig<any, any> | ResolvedFarmEnv;
   middleware?: FarmMiddlewareConfig;
   routeRules?: FarmRouteRules;

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -6,6 +6,7 @@ import { defaultGlobalCSS } from "./default-styles";
 import type { FarmPlugin, FarmPluginRuntimeSession, PluginManager } from "./plugin";
 import { generateFarmClientPluginEntryCode } from "./client-plugin-build";
 import { APIRouteManager } from "./api/route-manager";
+import { DEFAULT_FARM_API_BASE_PATH } from "./api/config";
 import type { OpenAPIManager } from "./openapi/manager";
 import { MiddlewareManager } from "./middleware/manager";
 import { generateFarmTypeArtifacts, type GenerateFarmTypeArtifactsOptions } from "./type-artifacts";
@@ -355,6 +356,7 @@ function getEnvDefines(
   configEnv?: ConfigEnv,
 ): Record<string, string> {
   const defines: Record<string, string> = {
+    __FARM_API_BASE_URL__: JSON.stringify(getFarmAPIBaseURLDefine(config)),
     __FARM_PUBLIC_ENV__: JSON.stringify(getPublicEnvDefine(config)),
     __FARM_IMAGE_CONFIG__: JSON.stringify(
       getPublicFarmImageConfig(resolveFarmImageConfig(config.images)),
@@ -366,6 +368,11 @@ function getEnvDefines(
   }
 
   return defines;
+}
+
+function getFarmAPIBaseURLDefine(config: FarmVitePluginOptions): string {
+  const baseURL = config.api?.baseURL;
+  return typeof baseURL === "string" && baseURL ? baseURL : DEFAULT_FARM_API_BASE_PATH;
 }
 
 function isResolvedEnvScope(value: unknown): value is Record<string, unknown> {
@@ -4937,6 +4944,7 @@ export async function defineConfig(config: FarmVitePluginOptions = {}): Promise<
     },
     define: {
       __FARM_DEV__: JSON.stringify(process.env.NODE_ENV === "development"),
+      __FARM_API_BASE_URL__: JSON.stringify(getFarmAPIBaseURLDefine(config)),
       __FARM_PUBLIC_ENV__: JSON.stringify(getPublicEnvDefine(config)),
     },
   };


### PR DESCRIPTION
## Summary

- add a first-class `api.baseURL` and `api.basePath` configuration
- accept strings or sync/async resolver functions with `{ root, mode, env }`
- join an origin-only `baseURL` with `basePath`, while treating an existing URL path as the API root
- inject the resolved public URL into development, SSR, and production client builds
- keep an explicit `createAPIClient({ baseURL })` override as the highest priority
- document the configuration and API-client behavior

## Why

Applications that call a separate API currently need to route a public endpoint through generic runtime configuration. This adds a typed, purpose-built API configuration while retaining `/api` on the current origin as the default.

## Behavior

- no configuration: current origin + `/api`
- `baseURL: "https://api.example.com"` + `basePath: "/v1"`: `https://api.example.com/v1`
- `baseURL: "https://api.example.com/custom"` + `basePath: "/v1"`: `https://api.example.com/custom`
- resolver functions run during config resolution; only the resolved public URL is embedded

## Validation

- focused API/config suites: 82 tests passed
- `corepack pnpm --filter @farm.js/core type-check`
- `NODE_OPTIONS=--max-old-space-size=6144 corepack pnpm --filter @farm.js/core build`
- `oxfmt --check` on all changed files
- `oxlint`: 0 errors (2 pre-existing unused-symbol warnings)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a configurable public API base URL for browser clients. Previously clients assumed the current origin + `/api`; now `api.baseURL`/`api.basePath` can set an absolute or root-relative API root, with the resolved public URL embedded at build time.

- New `api` config in `@farm.js/core`: `baseURL` and `basePath` accept strings or sync/async resolvers with `{ root, mode, env }`. An origin-only `baseURL` joins with `basePath`; a `baseURL` that includes a path is used as the API root. `createAPIClient({ baseURL })` still takes precedence.
- The resolved `api.baseURL` is injected as `__FARM_API_BASE_URL__` for development, SSR, and production; default remains same-origin `/api` when unset.
- Clients now resolve canonical routes (e.g., `/api/...`) against the configured root. This applies to the API client and integration client, cache keys, and route metadata (meta now reports the effective pathname and the origin separately).
- Validation: new focused tests for config and client URL resolution; docs updated with examples.

<sup>Written for commit a4a056fd1a91b548e4b477ce44802a8f660a0ce5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

