### PR TITLE
feat: add client runtime error overlay

### DIFF
--- a/examples/basic/src/app/runtime-error-demo/page.tsx
+++ b/examples/basic/src/app/runtime-error-demo/page.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import React from "react";
+import { Link } from "@farm.js/core/client";
+
+interface DemoApiResponse {
+  user: {
+    profile: {
+      displayName: string;
+    };
+  };
+}
+
+export default function RuntimeErrorDemoPage() {
+  const triggerRuntimeError = () => {
+    const response = { user: undefined } as unknown as DemoApiResponse;
+
+    window.setTimeout(() => {
+      // This deliberately mirrors an API response shape mismatch after hydration.
+      document.title = response.user.profile.displayName;
+    }, 0);
+  };
+
+  const triggerUnhandledRejection = () => {
+    void Promise.reject(
+      new Error("Intentional rejected promise from the runtime error demo"),
+    );
+  };
+
+  return (
+    <section className="mx-auto max-w-3xl py-8 sm:py-14">
+      <div className="mb-8 flex items-center gap-3 text-sm font-medium text-gray-500">
+        <span className="h-px w-8 bg-gray-300" aria-hidden="true" />
+        Development diagnostic
+      </div>
+
+      <h1 className="max-w-2xl text-4xl font-bold tracking-tight text-gray-950 sm:text-5xl">
+        Test the browser runtime error overlay
+      </h1>
+      <p className="mt-5 max-w-2xl text-lg leading-8 text-gray-600">
+        These controls intentionally reproduce failures that can happen after a page hydrates.
+        Farm.js should catch them and show a useful source location, debug report, and recovery
+        actions.
+      </p>
+
+      <div className="mt-10 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div className="border-b border-gray-200 bg-gray-50 px-6 py-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-gray-500">
+            Real failure scenarios
+          </p>
+        </div>
+
+        <div className="divide-y divide-gray-200">
+          <div className="grid gap-5 p-6 sm:grid-cols-[1fr_auto] sm:items-center">
+            <div>
+              <h2 className="font-semibold text-gray-950">Unexpected API response</h2>
+              <p className="mt-1 text-sm leading-6 text-gray-600">
+                Reads a nested profile field from missing user data and causes a genuine
+                JavaScript TypeError.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={triggerRuntimeError}
+              className="inline-flex min-h-11 items-center justify-center rounded-md bg-red-600 px-5 text-sm font-semibold text-white transition-colors hover:bg-red-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600"
+            >
+              Trigger runtime error
+            </button>
+          </div>
+
+          <div className="grid gap-5 p-6 sm:grid-cols-[1fr_auto] sm:items-center">
+            <div>
+              <h2 className="font-semibold text-gray-950">Unhandled async failure</h2>
+              <p className="mt-1 text-sm leading-6 text-gray-600">
+                Rejects a promise without a catch handler, like a failed background task.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={triggerUnhandledRejection}
+              className="inline-flex min-h-11 items-center justify-center rounded-md border border-gray-300 bg-white px-5 text-sm font-semibold text-gray-800 transition-colors hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500"
+            >
+              Trigger rejected promise
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <p className="mt-6 text-sm leading-6 text-gray-500">
+        The overlay is development-only. Production builds keep the browser's normal error
+        behavior. <Link href="/" className="font-medium text-blue-700 hover:underline">Return home</Link>
+      </p>
+    </section>
+  );
+}

--- a/examples/basic/src/app/runtime-error-demo/page.tsx
+++ b/examples/basic/src/app/runtime-error-demo/page.tsx
@@ -1,23 +1,27 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import { Link } from "@farm.js/core/client";
 
 interface DemoApiResponse {
   user: {
     profile: {
-      displayName: string;
+      formatDisplayName(): string;
     };
   };
 }
 
 export default function RuntimeErrorDemoPage() {
+  const [displayName, setDisplayName] = useState("Waiting for a profile");
+
   const triggerRuntimeError = () => {
-    const response = { user: undefined } as unknown as DemoApiResponse;
+    const response = {
+      user: { profile: { displayName: "Ada Lovelace" } },
+    } as unknown as DemoApiResponse;
 
     window.setTimeout(() => {
-      // This deliberately mirrors an API response shape mismatch after hydration.
-      document.title = response.user.profile.displayName;
+      // The deployed API still returns displayName, but this client expects the newer SDK method.
+      setDisplayName(response.user.profile.formatDisplayName());
     }, 0);
   };
 
@@ -55,9 +59,10 @@ export default function RuntimeErrorDemoPage() {
             <div>
               <h2 className="font-semibold text-gray-950">Unexpected API response</h2>
               <p className="mt-1 text-sm leading-6 text-gray-600">
-                Reads a nested profile field from missing user data and causes a genuine
-                JavaScript TypeError.
+                Calls a profile formatter added by a newer client, while the API still returns
+                the older data shape.
               </p>
+              <p className="mt-2 font-mono text-xs text-gray-500">Preview: {displayName}</p>
             </div>
             <button
               type="button"

--- a/examples/basic/src/farm.d.ts
+++ b/examples/basic/src/farm.d.ts
@@ -43,6 +43,7 @@ export type RoutePath =
   | "/prefetch-e2e"
   | "/query-demo"
   | `/repos/${string}/${string}`
+  | "/runtime-error-demo"
   | "/slot-lab"
   | `/slot-lab/photo/${string}`
   | "/storage-demo"
@@ -79,6 +80,7 @@ export type RoutePattern =
   | "/prefetch-e2e"
   | "/query-demo"
   | "/repos/[owner]/[repo]"
+  | "/runtime-error-demo"
   | "/slot-lab"
   | "/slot-lab/photo/[id]"
   | "/storage-demo"
@@ -115,6 +117,7 @@ export type RouteModulePattern =
   | "/prefetch-e2e"
   | "/query-demo"
   | "/repos/[owner]/[repo]"
+  | "/runtime-error-demo"
   | "/slot-lab"
   | "/slot-lab/photo/[id]"
   | "/storage-demo"

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -583,6 +583,7 @@
     "@farming-labs/orm": "0.0.62",
     "@farming-labs/orm-runtime": "0.0.62",
     "@formatjs/icu-messageformat-parser": "3.5.15",
+    "@jridgewell/trace-mapping": "0.3.31",
     "@mdx-js/mdx": "^3.1.1",
     "@opentelemetry/api": "1.9.1",
     "@scalar/api-reference": "^1.38.1",

--- a/packages/farm/src/__tests__/client-plugin.test.ts
+++ b/packages/farm/src/__tests__/client-plugin.test.ts
@@ -25,7 +25,12 @@ function createManager(registrations: FarmClientPluginRegistration[]) {
 }
 
 describe("client plugin lifecycle", () => {
-  afterEach(() => {
+  afterEach(async () => {
+    window.dispatchEvent(new Event("pagehide"));
+    await Promise.resolve();
+    document.querySelectorAll("[data-farm-runtime-error-overlay]").forEach((element) => {
+      element.remove();
+    });
     vi.restoreAllMocks();
   });
 
@@ -278,5 +283,44 @@ describe("client plugin lifecycle", () => {
     await manager.failNavigation(navigation, failure);
 
     expect(calls).toEqual(["navigation-error", "navigation"]);
+  });
+
+  it("shows unexpected browser failures in development without requiring an error plugin", async () => {
+    const manager = createManager([]);
+    await manager.start();
+
+    const event = new ErrorEvent("error", {
+      error: new Error("Unexpected client render failure"),
+      message: "Unexpected client render failure",
+      filename: "http://localhost/src/app.tsx",
+      lineno: 17,
+      colno: 9,
+    });
+    window.dispatchEvent(event);
+    await Promise.resolve();
+
+    const host = document.querySelector<HTMLElement>("[data-farm-runtime-error-overlay]");
+    expect(host?.hidden).toBe(false);
+    expect(host?.shadowRoot?.querySelector("[data-farm-runtime-error-message]")?.textContent).toBe(
+      "Unexpected client render failure",
+    );
+
+    await manager.close();
+    expect(document.querySelector("[data-farm-runtime-error-overlay]")).toBeNull();
+  });
+
+  it("does not install the runtime error overlay in production", async () => {
+    const manager = createClientPluginManager([], {
+      router: createRouter(),
+      isDev: false,
+      isProd: true,
+      window,
+    });
+    await manager.start();
+
+    await manager.reportError(new Error("Production failure"), "window");
+
+    expect(document.querySelector("[data-farm-runtime-error-overlay]")).toBeNull();
+    await manager.close();
   });
 });

--- a/packages/farm/src/__tests__/runtime-error-overlay.test.ts
+++ b/packages/farm/src/__tests__/runtime-error-overlay.test.ts
@@ -151,6 +151,55 @@ describe("client runtime error overlay", () => {
     overlay.destroy();
   });
 
+  it("leaves recoverable React hydration diagnostics in the console", () => {
+    const message =
+      "Hydration failed because the server rendered text didn't match the client. As a result this tree will be regenerated on the client.";
+    const error = new Error(message);
+    error.stack = [
+      error.toString(),
+      `    at throwOnHydrationMismatch (${window.location.origin}/node_modules/.vite/deps/react-dom_client.js:3920:13)`,
+    ].join("\n");
+    const overlay = createFarmRuntimeErrorOverlay({ window });
+
+    overlay.show(error, {
+      phase: "window",
+      location: createLocation("/feature-lab"),
+    });
+
+    expect(document.querySelector("[data-farm-runtime-error-overlay]")).toBeNull();
+
+    overlay.show(error, {
+      phase: "hydration",
+      location: createLocation("/feature-lab"),
+    });
+
+    const { shadow } = getOverlay();
+    expect(shadow.querySelector("[data-farm-runtime-error-type]")?.textContent).toBe(
+      "Hydration Error",
+    );
+    overlay.destroy();
+  });
+
+  it("formats property paths in messages as safe inline code", () => {
+    const overlay = createFarmRuntimeErrorOverlay({ window });
+    const message =
+      "response.user.profile.formatDisplayName is not a function <img src=x onerror=alert(1)>";
+
+    overlay.show(new TypeError(message), {
+      phase: "window",
+      location: createLocation(),
+    });
+
+    const { shadow } = getOverlay();
+    const messageElement = shadow.querySelector("[data-farm-runtime-error-message]");
+    expect(messageElement?.textContent).toBe(message);
+    expect(messageElement?.querySelector(".farm-runtime-error__inline-code")?.textContent).toBe(
+      "response.user.profile.formatDisplayName",
+    );
+    expect(messageElement?.querySelector("img")).toBeNull();
+    overlay.destroy();
+  });
+
   it("deduplicates repeated failures and does not reopen a dismissed error", () => {
     const overlay = createFarmRuntimeErrorOverlay({ window });
     const error = new Error("Render loop failed");

--- a/packages/farm/src/__tests__/runtime-error-overlay.test.ts
+++ b/packages/farm/src/__tests__/runtime-error-overlay.test.ts
@@ -80,6 +80,73 @@ describe("client runtime error overlay", () => {
     overlay.destroy();
   });
 
+  it("maps transformed module positions back to clean original source", async () => {
+    const originalSource = [
+      "export function render() {",
+      "  const user = undefined;",
+      "",
+      "  user.profile.name;",
+      "}",
+    ].join("\n");
+    const sourceMap = window.btoa(
+      JSON.stringify({
+        version: 3,
+        sources: ["example.tsx"],
+        sourcesContent: [originalSource],
+        names: [],
+        mappings: ";AAGE",
+      }),
+    );
+    const transformedSource = [
+      "const user = void 0;",
+      "user.profile.name;",
+      `//# sourceMappingURL=data:application/json;base64,${sourceMap}`,
+    ].join("\n");
+    const request = vi.fn(async () => new Response(transformedSource, { status: 200 }));
+    const overlay = createFarmRuntimeErrorOverlay({ window, fetch: request });
+    const error = new TypeError("Cannot read properties of undefined (reading 'profile')");
+    error.stack = [
+      error.toString(),
+      `    at render (${window.location.origin}/src/example.tsx?import:2:5)`,
+    ].join("\n");
+
+    overlay.show(error, {
+      phase: "window",
+      location: createLocation(),
+    });
+    await flushAsyncWork();
+
+    const { shadow } = getOverlay();
+    expect(shadow.querySelector(".farm-default-error__source-path")?.textContent).toBe(
+      "/src/example.tsx:4:3",
+    );
+    expect(shadow.querySelector(".farm-default-error__source-path")?.textContent).not.toContain(
+      "?import",
+    );
+    expect(shadow.querySelector(".farm-default-error__source-line--active")?.textContent).toContain(
+      "user.profile.name;",
+    );
+
+    overlay.destroy();
+  });
+
+  it("ignores errors raised by injected browser extensions", () => {
+    const overlay = createFarmRuntimeErrorOverlay({ window });
+    const error = new Error("Extension connection failed");
+    error.stack = [
+      error.toString(),
+      "    at Object.connect (chrome-extension://nkbihfbeogaeaoehlefnkodbefgpgknn/scripts/inpage.js:7:84179)",
+    ].join("\n");
+
+    overlay.show(error, {
+      phase: "window",
+      location: createLocation(),
+    });
+
+    expect(document.querySelector("[data-farm-runtime-error-overlay]")).toBeNull();
+    overlay.destroy();
+  });
+
   it("deduplicates repeated failures and does not reopen a dismissed error", () => {
     const overlay = createFarmRuntimeErrorOverlay({ window });
     const error = new Error("Render loop failed");

--- a/packages/farm/src/__tests__/runtime-error-overlay.test.ts
+++ b/packages/farm/src/__tests__/runtime-error-overlay.test.ts
@@ -1,0 +1,196 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createFarmRuntimeErrorOverlay } from "../client/runtime-error-overlay";
+
+function createLocation(pathname = "/dashboard") {
+  return {
+    href: `http://localhost${pathname}`,
+    pathname,
+    search: "",
+    hash: "",
+  };
+}
+
+function getOverlay() {
+  const host = document.querySelector<HTMLDivElement>("[data-farm-runtime-error-overlay]");
+  const shadow = host?.shadowRoot;
+  if (!host || !shadow) throw new Error("Expected the Farm runtime error overlay");
+  return { host, shadow };
+}
+
+async function flushAsyncWork() {
+  await new Promise((resolve) => window.setTimeout(resolve, 0));
+}
+
+describe("client runtime error overlay", () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute("data-theme");
+    document.documentElement.classList.remove("dark", "light");
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("renders the error and resolves a same-origin source frame", async () => {
+    const source = [
+      "export function mount() {",
+      "  const user = undefined;",
+      "  return user.name;",
+      "}",
+      "mount();",
+    ].join("\n");
+    const request = vi.fn(async () => new Response(source, { status: 200 }));
+    const overlay = createFarmRuntimeErrorOverlay({ window, fetch: request });
+    const error = new TypeError("Cannot read properties of undefined (reading 'name')");
+    error.stack = [
+      error.toString(),
+      `    at mount (${window.location.origin}/src/dashboard.tsx:3:15)`,
+    ].join("\n");
+
+    overlay.show(error, {
+      phase: "unhandled-rejection",
+      location: createLocation(),
+    });
+    await flushAsyncWork();
+
+    const { host, shadow } = getOverlay();
+    expect(host.hidden).toBe(false);
+    expect(shadow.querySelector("[data-farm-runtime-error-message]")?.textContent).toBe(
+      "Cannot read properties of undefined (reading 'name')",
+    );
+    expect(shadow.querySelector("[data-farm-runtime-error-phase]")?.textContent).toBe(
+      "Unhandled Rejection",
+    );
+    expect(shadow.querySelector(".farm-default-error__source-path")?.textContent).toBe(
+      "/src/dashboard.tsx:3:15",
+    );
+    expect(shadow.querySelector(".farm-default-error__source-line--active")?.textContent).toContain(
+      "return user.name;",
+    );
+    const issueBody = new URL(
+      shadow.querySelector<HTMLAnchorElement>("[data-farm-runtime-error-issue]")?.href || "",
+    ).searchParams.get("body");
+    expect(issueBody).toContain("return user.name;");
+    expect(request).toHaveBeenCalledWith(
+      `${window.location.origin}/src/dashboard.tsx`,
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+
+    overlay.destroy();
+  });
+
+  it("deduplicates repeated failures and does not reopen a dismissed error", () => {
+    const overlay = createFarmRuntimeErrorOverlay({ window });
+    const error = new Error("Render loop failed");
+    const context = { phase: "window", location: createLocation("/editor") };
+
+    overlay.show(error, context);
+    overlay.show(error, context);
+
+    let current = getOverlay();
+    expect(current.shadow.querySelector("[data-farm-runtime-error-occurrences]")?.textContent).toBe(
+      "Repeated ×2",
+    );
+    expect(document.querySelectorAll("[data-farm-runtime-error-overlay]")).toHaveLength(1);
+
+    current.shadow.querySelector<HTMLButtonElement>("[data-farm-runtime-error-dismiss]")?.click();
+    expect(current.host.hidden).toBe(true);
+
+    overlay.show(error, context);
+    expect(current.host.hidden).toBe(true);
+
+    overlay.show(new Error("A different failure"), context);
+    current = getOverlay();
+    expect(current.host.hidden).toBe(false);
+    expect(current.shadow.querySelector("[data-farm-runtime-error-message]")?.textContent).toBe(
+      "A different failure",
+    );
+
+    overlay.destroy();
+  });
+
+  it("copies an AI-friendly debug report and exposes issue and recovery actions", async () => {
+    const reload = vi.fn();
+    let copiedReport = "";
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: vi.fn(() => {
+        copiedReport = document.querySelector<HTMLTextAreaElement>("textarea")?.value || "";
+        return true;
+      }),
+    });
+    const overlay = createFarmRuntimeErrorOverlay({
+      window,
+      farmVersion: "test-version",
+      reload,
+    });
+    overlay.show(new Error("Widget crashed"), {
+      phase: "hydration",
+      location: createLocation("/widgets"),
+    });
+
+    const { shadow } = getOverlay();
+    shadow.querySelector<HTMLButtonElement>("[data-farm-runtime-error-copy]")?.click();
+    await flushAsyncWork();
+
+    expect(copiedReport).toContain("# Farm.js client runtime debug report");
+    expect(copiedReport).toContain("- Message: Widget crashed");
+    expect(copiedReport).toContain("- Phase: Hydration");
+    expect(copiedReport).toContain("- Farm.js: test-version");
+    expect(copiedReport).toContain("## Diagnostic request");
+    expect(shadow.querySelector("[data-farm-runtime-error-copy-label]")?.textContent).toBe(
+      "Copied",
+    );
+
+    const issueLink = shadow.querySelector<HTMLAnchorElement>("[data-farm-runtime-error-issue]");
+    const issueUrl = new URL(issueLink?.href || "");
+    expect(issueUrl.origin + issueUrl.pathname).toBe(
+      "https://github.com/farming-labs/farm.js/issues/new",
+    );
+    expect(issueUrl.searchParams.get("title")).toBe("[runtime error] Widget crashed");
+    expect(issueUrl.searchParams.get("body")).toContain("## Runtime error report");
+    expect(issueUrl.searchParams.get("body")).toContain("- Page path: /widgets");
+    expect(issueUrl.searchParams.get("body")).not.toContain("http://localhost/widgets");
+    expect(issueLink?.target).toBe("_blank");
+    expect(issueLink?.rel).toBe("noopener noreferrer");
+
+    shadow.querySelector<HTMLButtonElement>("[data-farm-runtime-error-reload]")?.click();
+    expect(reload).toHaveBeenCalledOnce();
+
+    overlay.destroy();
+    Reflect.deleteProperty(document, "execCommand");
+  });
+
+  it("follows an explicit dark theme and supports keyboard dismissal", async () => {
+    const overlay = createFarmRuntimeErrorOverlay({ window });
+    overlay.show(new Error("Theme test"), {
+      phase: "window",
+      location: createLocation(),
+    });
+    document.documentElement.dataset.theme = "dark";
+    await flushAsyncWork();
+
+    const { host, shadow } = getOverlay();
+    expect(
+      shadow.querySelector<HTMLElement>("[data-farm-runtime-error-viewport]")?.dataset.theme,
+    ).toBe("dark");
+
+    shadow.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    expect(host.hidden).toBe(true);
+
+    overlay.destroy();
+  });
+
+  it("leaves chunk-load failures to the existing recovery system", () => {
+    const overlay = createFarmRuntimeErrorOverlay({ window });
+
+    overlay.show(new TypeError("Failed to fetch dynamically imported module: /chunk.js"), {
+      phase: "unhandled-rejection",
+      location: createLocation(),
+    });
+
+    expect(document.querySelector("[data-farm-runtime-error-overlay]")).toBeNull();
+    overlay.destroy();
+  });
+});

--- a/packages/farm/src/__tests__/runtime-error-overlay.test.ts
+++ b/packages/farm/src/__tests__/runtime-error-overlay.test.ts
@@ -59,9 +59,13 @@ describe("client runtime error overlay", () => {
     expect(shadow.querySelector("[data-farm-runtime-error-message]")?.textContent).toBe(
       "Cannot read properties of undefined (reading 'name')",
     );
-    expect(shadow.querySelector("[data-farm-runtime-error-phase]")?.textContent).toBe(
-      "Unhandled Rejection",
+    expect(shadow.querySelector("[data-farm-runtime-error-type]")?.textContent).toBe(
+      "Runtime TypeError",
     );
+    expect(
+      shadow.querySelector("[data-farm-runtime-error-message]")?.closest(".farm-default-error__row")
+        ?.textContent,
+    ).toContain("Cannot read properties of undefined (reading 'name')");
     expect(shadow.querySelector(".farm-default-error__source-path")?.textContent).toBe(
       "/src/dashboard.tsx:3:15",
     );
@@ -202,6 +206,7 @@ describe("client runtime error overlay", () => {
     await flushAsyncWork();
 
     expect(copiedReport).toContain("# Farm.js client runtime debug report");
+    expect(copiedReport).toContain("- Type: Hydration Error");
     expect(copiedReport).toContain("- Message: Widget crashed");
     expect(copiedReport).toContain("- Phase: Hydration");
     expect(copiedReport).toContain("- Farm.js: test-version");

--- a/packages/farm/src/client/plugin.ts
+++ b/packages/farm/src/client/plugin.ts
@@ -1,5 +1,10 @@
 "use client";
 
+import {
+  createFarmRuntimeErrorOverlay,
+  type FarmRuntimeErrorOverlay,
+} from "./runtime-error-overlay";
+
 type MaybePromise<T> = T | Promise<T>;
 
 export type FarmClientPluginEnforce = "pre" | "post";
@@ -209,14 +214,21 @@ export class FarmClientPluginManager {
   private started = false;
   private closed = false;
   private readonly reportedErrors = new WeakSet<object>();
+  private readonly runtimeErrorOverlay?: FarmRuntimeErrorOverlay;
 
   private readonly handleWindowError = (event: ErrorEvent) => {
     const error = event.error ?? new Error(event.message || "Unknown browser error");
-    void this.reportError(error, "window");
+    void this.reportError(error, "window", undefined, this.getLocation(), event);
   };
 
   private readonly handleUnhandledRejection = (event: PromiseRejectionEvent) => {
-    void this.reportError(event.reason, "unhandled-rejection");
+    void this.reportError(
+      event.reason,
+      "unhandled-rejection",
+      undefined,
+      this.getLocation(),
+      event,
+    );
   };
 
   private readonly handlePageHide = () => {
@@ -234,6 +246,11 @@ export class FarmClientPluginManager {
       isProd: options.isProd ?? !options.isDev,
       window: options.window ?? (typeof window !== "undefined" ? window : undefined),
     };
+    if (this.options.isDev && this.options.window) {
+      this.runtimeErrorOverlay = createFarmRuntimeErrorOverlay({
+        window: this.options.window,
+      });
+    }
   }
 
   start(): Promise<void> {
@@ -392,6 +409,7 @@ export class FarmClientPluginManager {
     phase: FarmClientPluginErrorPhase,
     navigation?: FarmClientNavigationSession,
     location = this.getLocation(),
+    sourceEvent?: Event,
   ): Promise<void> {
     if (this.closed) return;
     if (isObject(error)) {
@@ -400,7 +418,7 @@ export class FarmClientPluginManager {
     }
 
     if (!this.started && !this.starting) await this.start();
-    await this.runErrorHooks({ error, phase, navigation, location });
+    await this.runErrorHooks({ error, phase, navigation, location }, undefined, sourceEvent);
   }
 
   close(reason: FarmClientPluginCloseEvent["reason"] = "manual"): Promise<void> {
@@ -459,7 +477,7 @@ export class FarmClientPluginManager {
     const clientWindow = this.options.window;
     if (!clientWindow) return;
 
-    if (this.instances.some(({ plugin }) => plugin.error)) {
+    if (this.runtimeErrorOverlay || this.instances.some(({ plugin }) => plugin.error)) {
       clientWindow.addEventListener("error", this.handleWindowError);
       clientWindow.addEventListener("unhandledrejection", this.handleUnhandledRejection);
     }
@@ -509,6 +527,7 @@ export class FarmClientPluginManager {
     clientWindow?.removeEventListener("pagehide", this.handlePageHide);
     for (const observer of this.performanceObservers) observer.disconnect();
     this.performanceObservers.length = 0;
+    this.runtimeErrorOverlay?.destroy();
 
     for (const instance of [...this.instances].reverse()) {
       try {
@@ -546,7 +565,13 @@ export class FarmClientPluginManager {
   private async runErrorHooks(
     event: Pick<FarmClientPluginErrorEvent, "error" | "phase" | "location" | "navigation">,
     excluded?: FarmClientPluginInstance,
+    sourceEvent?: Event,
   ): Promise<void> {
+    this.runtimeErrorOverlay?.show(event.error, {
+      phase: event.phase,
+      location: event.location,
+      sourceEvent,
+    });
     for (const instance of this.instances) {
       if (instance === excluded || !instance.plugin.error) continue;
       try {

--- a/packages/farm/src/client/runtime-error-overlay.ts
+++ b/packages/farm/src/client/runtime-error-overlay.ts
@@ -1,5 +1,11 @@
 "use client";
 
+import {
+  originalPositionFor,
+  sourceContentFor,
+  TraceMap,
+  type SourceMapInput,
+} from "@jridgewell/trace-mapping";
 import { DEFAULT_ERROR_STYLES } from "../components/error-styles";
 import { FARM_VERSION } from "../version";
 import { isChunkLoadError } from "./chunk-recovery";
@@ -327,6 +333,8 @@ class DefaultFarmRuntimeErrorOverlay implements FarmRuntimeErrorOverlay {
       context.sourceEvent,
       this.options.window,
     );
+    if (sourceLocation && isBrowserExtensionUrl(sourceLocation.url)) return;
+
     const fingerprint = createErrorFingerprint(error, context, sourceLocation);
     if (this.dismissedFingerprints.has(fingerprint)) return;
 
@@ -610,7 +618,7 @@ function resolveBrowserSourceLocation(
   for (const stackLine of error.stack.split("\n").slice(1)) {
     const match = stackLine
       .trim()
-      .match(/\(?((?:https?|file):\/\/[^)\s]+|\/[^)\s]+):(\d+):(\d+)\)?$/);
+      .match(/\(?((?:[a-z][a-z\d+.-]*):\/\/[^)\s]+|\/[^)\s]+):(\d+):(\d+)\)?$/i);
     if (!match) continue;
     return {
       ...createSourceLocation(match[1], Number(match[2]), Number(match[3]), clientWindow),
@@ -629,10 +637,7 @@ function createSourceLocation(
   let displayPath = url;
   try {
     const parsed = new URL(url, clientWindow.location.href);
-    displayPath =
-      parsed.origin === clientWindow.location.origin
-        ? `${parsed.pathname}${parsed.search}`
-        : parsed.href;
+    displayPath = parsed.origin === clientWindow.location.origin ? parsed.pathname : parsed.href;
   } catch {}
 
   return { url, displayPath, line, column };
@@ -687,27 +692,167 @@ async function loadBrowserSourceFrame(
     const source = await response.text();
     if (source.length > 1_000_000) return undefined;
 
-    const lines = source.split(/\r?\n/);
-    if (location.line < 1 || location.line > lines.length) return undefined;
-    const start = Math.max(1, location.line - 2);
-    const end = Math.min(lines.length, location.line + 2);
-    const frameLines: BrowserSourceLine[] = [];
-    for (let number = start; number <= end; number += 1) {
-      frameLines.push({
-        number,
-        content: lines[number - 1] || " ",
-        highlight: number === location.line,
-      });
-    }
+    const mappedFrame = await createMappedSourceFrame(
+      source,
+      sourceUrl,
+      location,
+      request,
+      options.window,
+    );
+    if (mappedFrame) return mappedFrame;
 
-    return {
-      path: location.displayPath,
-      line: location.line,
-      column: location.column,
-      lines: frameLines,
-    };
+    return createSourceFrame(source, location.displayPath, location.line, location.column);
   } catch {
     return undefined;
+  }
+}
+
+async function createMappedSourceFrame(
+  generatedSource: string,
+  generatedUrl: URL,
+  location: BrowserSourceLocation,
+  request: typeof fetch,
+  clientWindow: Window,
+): Promise<BrowserSourceFrame | undefined> {
+  const traceMap = await loadTraceMap(generatedSource, generatedUrl, request, clientWindow);
+  if (!traceMap) return undefined;
+
+  const original = originalPositionFor(traceMap, {
+    line: location.line,
+    column: Math.max(0, location.column - 1),
+  });
+  if (!original.source || original.line == null) return undefined;
+
+  const originalSource = sourceContentFor(traceMap, original.source);
+  if (originalSource == null) return undefined;
+
+  const originalLines = originalSource.split(/\r?\n/);
+  const generatedLine = generatedSource.split(/\r?\n/)[location.line - 1] || "";
+  const line = refineOriginalLine(generatedLine, originalLines, original.line);
+  const lineContent = originalLines[line - 1] || "";
+  const trimmedGeneratedLine = generatedLine.trim();
+  const column =
+    line !== original.line && trimmedGeneratedLine && lineContent.includes(trimmedGeneratedLine)
+      ? lineContent.indexOf(trimmedGeneratedLine) + 1
+      : (original.column ?? 0) + 1;
+
+  return createSourceFrame(
+    originalSource,
+    formatDisplaySourceUrl(original.source, clientWindow),
+    line,
+    column,
+  );
+}
+
+async function loadTraceMap(
+  generatedSource: string,
+  generatedUrl: URL,
+  request: typeof fetch,
+  clientWindow: Window,
+): Promise<TraceMap | undefined> {
+  const matches = Array.from(generatedSource.matchAll(/\/\/[#@]\s*sourceMappingURL=([^\s]+)/g));
+  const reference = matches[matches.length - 1]?.[1];
+  if (!reference) return undefined;
+
+  let sourceMapJson: string;
+  if (reference.startsWith("data:")) {
+    sourceMapJson = decodeSourceMapDataUrl(reference, clientWindow);
+  } else {
+    const sourceMapUrl = new URL(reference, generatedUrl);
+    if (sourceMapUrl.origin !== clientWindow.location.origin) return undefined;
+    const response = await request(sourceMapUrl.href, {
+      headers: { Accept: "application/json, text/plain" },
+    });
+    if (!response.ok) return undefined;
+    sourceMapJson = await response.text();
+    if (sourceMapJson.length > 2_000_000) return undefined;
+  }
+
+  return new TraceMap(JSON.parse(sourceMapJson) as SourceMapInput, generatedUrl.href);
+}
+
+function decodeSourceMapDataUrl(value: string, clientWindow: Window): string {
+  const separator = value.indexOf(",");
+  if (separator < 0) throw new Error("Invalid inline source map");
+  const metadata = value.slice(0, separator);
+  const payload = value.slice(separator + 1);
+  if (!metadata.includes(";base64")) return decodeURIComponent(payload);
+
+  const binary = clientWindow.atob(payload);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+function refineOriginalLine(
+  generatedLine: string,
+  originalLines: string[],
+  mappedLine: number,
+): number {
+  const normalizedGeneratedLine = normalizeSourceLine(generatedLine);
+  if (normalizedGeneratedLine.length < 8) return mappedLine;
+
+  let bestMatch = mappedLine;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (let index = 0; index < originalLines.length; index += 1) {
+    if (normalizeSourceLine(originalLines[index]) !== normalizedGeneratedLine) continue;
+    const line = index + 1;
+    const distance = Math.abs(line - mappedLine);
+    if (distance < bestDistance) {
+      bestMatch = line;
+      bestDistance = distance;
+    }
+  }
+  return bestMatch;
+}
+
+function normalizeSourceLine(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function createSourceFrame(
+  source: string,
+  path: string,
+  line: number,
+  column: number,
+): BrowserSourceFrame | undefined {
+  const lines = source.split(/\r?\n/);
+  if (line < 1 || line > lines.length) return undefined;
+  const start = Math.max(1, line - 2);
+  const end = Math.min(lines.length, line + 2);
+  const frameLines: BrowserSourceLine[] = [];
+  for (let number = start; number <= end; number += 1) {
+    frameLines.push({
+      number,
+      content: lines[number - 1] || " ",
+      highlight: number === line,
+    });
+  }
+
+  return { path, line, column, lines: frameLines };
+}
+
+function formatDisplaySourceUrl(url: string, clientWindow: Window): string {
+  try {
+    const parsed = new URL(url, clientWindow.location.href);
+    return parsed.origin === clientWindow.location.origin ? parsed.pathname : parsed.href;
+  } catch {
+    return url.replace(/[?#].*$/, "");
+  }
+}
+
+function isBrowserExtensionUrl(url: string): boolean {
+  try {
+    return [
+      "chrome-extension:",
+      "moz-extension:",
+      "safari-web-extension:",
+      "ms-browser-extension:",
+    ].includes(new URL(url).protocol);
+  } catch {
+    return /^(?:chrome|moz|safari-web|ms-browser)-extension:\/\//i.test(url);
   }
 }
 

--- a/packages/farm/src/client/runtime-error-overlay.ts
+++ b/packages/farm/src/client/runtime-error-overlay.ts
@@ -187,11 +187,13 @@ const OVERLAY_STYLES = `
 }
 
 .farm-runtime-error__inline-code {
-  padding: 2px 4px;
-  border: 1px solid var(--farm-error-line);
-  background: var(--farm-error-panel);
+  padding: 2px 5px;
+  border: 1px solid var(--farm-error-line-strong);
+  background: var(--farm-error-source-line);
+  color: var(--farm-error-source-marker);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 0.92em;
+  font-size: 0.94em;
+  font-weight: 600;
   line-height: inherit;
   overflow-wrap: anywhere;
   box-decoration-break: clone;

--- a/packages/farm/src/client/runtime-error-overlay.ts
+++ b/packages/farm/src/client/runtime-error-overlay.ts
@@ -199,7 +199,7 @@ const OVERLAY_STYLES = `
   }
 
   .farm-runtime-error__viewport .farm-default-error__code {
-    font-size: 60px;
+    font-size: 72px;
   }
 
   .farm-runtime-error__viewport .farm-default-error__eyebrow {

--- a/packages/farm/src/client/runtime-error-overlay.ts
+++ b/packages/farm/src/client/runtime-error-overlay.ts
@@ -168,6 +168,18 @@ const OVERLAY_STYLES = `
   min-width: 166px;
 }
 
+.farm-runtime-error__viewport .farm-default-error__panel {
+  border: 0;
+  box-shadow: inset 0 0 0 0.5px var(--farm-error-line-strong);
+}
+
+.farm-runtime-error__github-icon {
+  width: 15px;
+  height: 15px;
+  flex: 0 0 auto;
+  margin-right: 8px;
+}
+
 @media (max-width: 620px) {
   .farm-runtime-error__occurrences {
     margin-right: 0;
@@ -199,7 +211,7 @@ const OVERLAY_STYLES = `
   }
 
   .farm-runtime-error__viewport .farm-default-error__code {
-    font-size: 72px;
+    font-size: 80px;
   }
 
   .farm-runtime-error__viewport .farm-default-error__eyebrow {
@@ -259,7 +271,7 @@ const OVERLAY_MARKUP = `
         </section>
       </section>
       <div class="farm-default-error__actions">
-        <a class="farm-default-error__action farm-default-error__action--primary farm-runtime-error__action" data-farm-runtime-error-issue target="_blank" rel="noopener noreferrer">Open GitHub issue <span aria-hidden="true">↗</span></a>
+        <a class="farm-default-error__action farm-default-error__action--primary farm-runtime-error__action" data-farm-runtime-error-issue target="_blank" rel="noopener noreferrer"><svg class="farm-runtime-error__github-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M12 .7a11.5 11.5 0 0 0-3.64 22.41c.58.1.79-.25.79-.56v-2.23c-3.22.7-3.9-1.37-3.9-1.37-.52-1.34-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.57-.29-5.27-1.29-5.27-5.68 0-1.26.45-2.28 1.18-3.09-.12-.29-.51-1.47.11-3.05 0 0 .96-.31 3.16 1.18A10.95 10.95 0 0 1 12 6.1c.98 0 1.95.13 2.87.39 2.2-1.49 3.16-1.18 3.16-1.18.62 1.58.23 2.76.11 3.05.74.81 1.18 1.83 1.18 3.09 0 4.4-2.71 5.38-5.29 5.67.42.36.79 1.07.79 2.16v3.27c0 .31.21.67.8.56A11.5 11.5 0 0 0 12 .7Z" /></svg><span>Open GitHub issue</span></a>
         <button class="farm-default-error__action farm-runtime-error__action" type="button" data-farm-runtime-error-reload>Reload page</button>
         <button class="farm-default-error__action farm-runtime-error__action" type="button" data-farm-runtime-error-dismiss>Dismiss</button>
       </div>

--- a/packages/farm/src/client/runtime-error-overlay.ts
+++ b/packages/farm/src/client/runtime-error-overlay.ts
@@ -212,8 +212,8 @@ const OVERLAY_STYLES = `
 @media (max-height: 760px) {
   .farm-runtime-error__viewport .farm-default-error {
     place-items: start center;
-    padding-top: 16px;
-    padding-bottom: 16px;
+    padding-top: 12px;
+    padding-bottom: 12px;
   }
 
   .farm-runtime-error__viewport .farm-default-error__code {
@@ -239,7 +239,7 @@ const OVERLAY_STYLES = `
   }
 
   .farm-runtime-error__viewport .farm-default-error__actions {
-    margin-top: 14px;
+    margin-top: 10px;
   }
 }
 `;
@@ -252,16 +252,19 @@ const OVERLAY_MARKUP = `
       <p class="farm-default-error__eyebrow">Client runtime error</p>
       <header class="farm-default-error__summary">
         <h1 id="farm-runtime-error-title" class="farm-default-error__title">Application failed in the browser</h1>
-        <p id="farm-runtime-error-description" class="farm-default-error__message" data-farm-runtime-error-message></p>
       </header>
       <section class="farm-default-error__panel" aria-label="Error information">
         <div class="farm-default-error__row">
-          <span class="farm-default-error__label">Location</span>
-          <span class="farm-default-error__value" data-farm-runtime-error-location></span>
+          <span class="farm-default-error__label">Error type</span>
+          <span class="farm-default-error__value" data-farm-runtime-error-type></span>
         </div>
         <div class="farm-default-error__row">
-          <span class="farm-default-error__label">Phase</span>
-          <span class="farm-default-error__value" data-farm-runtime-error-phase></span>
+          <span class="farm-default-error__label">Error message</span>
+          <span id="farm-runtime-error-description" class="farm-default-error__value" data-farm-runtime-error-message></span>
+        </div>
+        <div class="farm-default-error__row">
+          <span class="farm-default-error__label">Location</span>
+          <span class="farm-default-error__value" data-farm-runtime-error-location></span>
         </div>
         <section class="farm-default-error__details" aria-labelledby="farm-runtime-error-details-title">
           <div class="farm-default-error__details-header">
@@ -438,12 +441,13 @@ class DefaultFarmRuntimeErrorOverlay implements FarmRuntimeErrorOverlay {
   }
 
   private render(record: RuntimeErrorRecord): void {
+    this.getElement("[data-farm-runtime-error-type]").textContent = formatErrorType(
+      record.error,
+      record.context.phase,
+    );
     this.getElement("[data-farm-runtime-error-message]").textContent = record.error.message;
     this.getElement("[data-farm-runtime-error-location]").textContent =
       `${record.context.location.pathname}${record.context.location.search}` || "/";
-    this.getElement("[data-farm-runtime-error-phase]").textContent = formatPhase(
-      record.context.phase,
-    );
     this.getElement("[data-farm-runtime-error-meta]").textContent =
       `Farm.js v${this.options.farmVersion || FARM_VERSION} · development · browser`;
     this.renderIssueLink(record);
@@ -897,6 +901,21 @@ function formatPhase(phase: string): string {
     .replace(/\b\w/g, (character) => character.toUpperCase());
 }
 
+function formatErrorType(error: NormalizedRuntimeError, phase: string): string {
+  const category =
+    phase === "hydration"
+      ? "Hydration"
+      : phase === "navigation"
+        ? "Navigation"
+        : phase === "setup" || phase.startsWith("plugin:")
+          ? "Plugin"
+          : phase === "performance"
+            ? "Performance"
+            : "Runtime";
+  const name = error.name.trim() || "Error";
+  return `${category} ${name}`;
+}
+
 function formatSourcePath(sourceFrame: BrowserSourceFrame): string {
   if (!sourceFrame.line) return sourceFrame.path;
   return `${sourceFrame.path}:${sourceFrame.line}:${sourceFrame.column || 1}${
@@ -935,7 +954,7 @@ function createFarmRuntimeErrorDebugReport(
     "# Farm.js client runtime debug report",
     "",
     "## Error",
-    `- Name: ${record.error.name}`,
+    `- Type: ${formatErrorType(record.error, record.context.phase)}`,
     `- Message: ${record.error.message}`,
     `- Phase: ${formatPhase(record.context.phase)}`,
     `- Page: ${record.context.location.href}`,
@@ -982,7 +1001,7 @@ function createGithubIssueUrl(
       "> This report was prefilled by the Farm.js development error overlay. Review it and remove sensitive information before submitting.",
       "",
       "### Error",
-      `- Name: ${record.error.name}`,
+      `- Type: ${formatErrorType(record.error, record.context.phase)}`,
       `- Message: ${record.error.message}`,
       `- Phase: ${formatPhase(record.context.phase)}`,
       `- Page path: ${record.context.location.pathname}`,

--- a/packages/farm/src/client/runtime-error-overlay.ts
+++ b/packages/farm/src/client/runtime-error-overlay.ts
@@ -262,7 +262,7 @@ const OVERLAY_MARKUP = `
   <main class="farm-default-error" data-farm-runtime-error role="alertdialog" aria-modal="true" aria-labelledby="farm-runtime-error-title" aria-describedby="farm-runtime-error-description">
     <div class="farm-default-error__content">
       <p class="farm-default-error__code" aria-hidden="true">500</p>
-      <p class="farm-default-error__eyebrow">Client runtime error</p>
+      <p class="farm-default-error__eyebrow">Runtime error</p>
       <header class="farm-default-error__summary">
         <h1 id="farm-runtime-error-title" class="farm-default-error__title">Application failed in the browser</h1>
       </header>

--- a/packages/farm/src/client/runtime-error-overlay.ts
+++ b/packages/farm/src/client/runtime-error-overlay.ts
@@ -100,7 +100,7 @@ const OVERLAY_STYLES = `
 }
 
 .farm-runtime-error__viewport .farm-default-error__code {
-  font-size: clamp(64px, 10vw, 92px);
+  font-size: clamp(96px, 10vw, 120px);
   line-height: 0.92;
 }
 
@@ -174,10 +174,12 @@ const OVERLAY_STYLES = `
 }
 
 .farm-runtime-error__github-icon {
-  width: 15px;
-  height: 15px;
+  display: block;
+  width: 18px;
+  height: 18px;
   flex: 0 0 auto;
-  margin-right: 8px;
+  margin-right: 10px;
+  color: currentColor;
 }
 
 @media (max-width: 620px) {
@@ -201,6 +203,10 @@ const OVERLAY_STYLES = `
   .farm-runtime-error__viewport .farm-default-error__action {
     min-width: 0;
   }
+
+  .farm-runtime-error__viewport .farm-default-error__code {
+    font-size: 80px;
+  }
 }
 
 @media (max-height: 760px) {
@@ -211,7 +217,7 @@ const OVERLAY_STYLES = `
   }
 
   .farm-runtime-error__viewport .farm-default-error__code {
-    font-size: 80px;
+    font-size: 88px;
   }
 
   .farm-runtime-error__viewport .farm-default-error__eyebrow {

--- a/packages/farm/src/client/runtime-error-overlay.ts
+++ b/packages/farm/src/client/runtime-error-overlay.ts
@@ -187,17 +187,12 @@ const OVERLAY_STYLES = `
 }
 
 .farm-runtime-error__inline-code {
-  padding: 2px 5px;
-  border: 1px solid var(--farm-error-line-strong);
-  background: var(--farm-error-source-line);
   color: var(--farm-error-source-marker);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 0.94em;
   font-weight: 600;
   line-height: inherit;
   overflow-wrap: anywhere;
-  box-decoration-break: clone;
-  -webkit-box-decoration-break: clone;
 }
 
 @media (max-width: 620px) {

--- a/packages/farm/src/client/runtime-error-overlay.ts
+++ b/packages/farm/src/client/runtime-error-overlay.ts
@@ -182,6 +182,22 @@ const OVERLAY_STYLES = `
   color: currentColor;
 }
 
+.farm-runtime-error__message-value {
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.farm-runtime-error__inline-code {
+  padding: 2px 4px;
+  border: 1px solid var(--farm-error-line);
+  background: var(--farm-error-panel);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.92em;
+  line-height: inherit;
+  overflow-wrap: anywhere;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}
+
 @media (max-width: 620px) {
   .farm-runtime-error__occurrences {
     margin-right: 0;
@@ -260,7 +276,7 @@ const OVERLAY_MARKUP = `
         </div>
         <div class="farm-default-error__row">
           <span class="farm-default-error__label">Error message</span>
-          <span id="farm-runtime-error-description" class="farm-default-error__value" data-farm-runtime-error-message></span>
+          <span id="farm-runtime-error-description" class="farm-default-error__value farm-runtime-error__message-value" data-farm-runtime-error-message></span>
         </div>
         <div class="farm-default-error__row">
           <span class="farm-default-error__label">Location</span>
@@ -355,6 +371,7 @@ class DefaultFarmRuntimeErrorOverlay implements FarmRuntimeErrorOverlay {
       this.options.window,
     );
     if (sourceLocation && isBrowserExtensionUrl(sourceLocation.url)) return;
+    if (isRecoverableReactHydrationError(error, context, sourceLocation)) return;
 
     const fingerprint = createErrorFingerprint(error, context, sourceLocation);
     if (this.dismissedFingerprints.has(fingerprint)) return;
@@ -445,7 +462,11 @@ class DefaultFarmRuntimeErrorOverlay implements FarmRuntimeErrorOverlay {
       record.error,
       record.context.phase,
     );
-    this.getElement("[data-farm-runtime-error-message]").textContent = record.error.message;
+    renderErrorMessage(
+      this.getElement("[data-farm-runtime-error-message]"),
+      record.error.message,
+      this.document,
+    );
     this.getElement("[data-farm-runtime-error-location]").textContent =
       `${record.context.location.pathname}${record.context.location.search}` || "/";
     this.getElement("[data-farm-runtime-error-meta]").textContent =
@@ -876,6 +897,45 @@ function isBrowserExtensionUrl(url: string): boolean {
   } catch {
     return /^(?:chrome|moz|safari-web|ms-browser)-extension:\/\//i.test(url);
   }
+}
+
+function isRecoverableReactHydrationError(
+  error: NormalizedRuntimeError,
+  context: FarmRuntimeErrorOverlayContext,
+  location?: BrowserSourceLocation,
+): boolean {
+  if (context.phase !== "window") return false;
+
+  const isKnownRecoverableMessage = [
+    /^Hydration failed because the server rendered (?:text|HTML) didn't match the client\b/i,
+    /^Text content does not match server-rendered HTML\b/i,
+    /^There was an error while hydrating but React was able to recover\b/i,
+  ].some((pattern) => pattern.test(error.message));
+  if (!isKnownRecoverableMessage) return false;
+
+  return /(?:react-dom(?:_client)?(?:\.development)?\.js|react-dom\/|throwOnHydrationMismatch|onRecoverableError)/i.test(
+    `${location?.url || ""}\n${error.stack || ""}`,
+  );
+}
+
+function renderErrorMessage(container: Element, message: string, document: Document): void {
+  const fragments: Node[] = [];
+  const codePattern = /`([^`\n]+)`|\b[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*){2,}\b/g;
+  let offset = 0;
+
+  for (const match of message.matchAll(codePattern)) {
+    const index = match.index ?? 0;
+    if (index > offset) fragments.push(document.createTextNode(message.slice(offset, index)));
+
+    const code = document.createElement("code");
+    code.className = "farm-runtime-error__inline-code";
+    code.textContent = match[1] || match[0];
+    fragments.push(code);
+    offset = index + match[0].length;
+  }
+
+  if (offset < message.length) fragments.push(document.createTextNode(message.slice(offset)));
+  container.replaceChildren(...fragments);
 }
 
 function createErrorFingerprint(

--- a/packages/farm/src/client/runtime-error-overlay.ts
+++ b/packages/farm/src/client/runtime-error-overlay.ts
@@ -1,0 +1,879 @@
+"use client";
+
+import { DEFAULT_ERROR_STYLES } from "../components/error-styles";
+import { FARM_VERSION } from "../version";
+import { isChunkLoadError } from "./chunk-recovery";
+
+export interface FarmRuntimeErrorLocation {
+  href: string;
+  pathname: string;
+  search: string;
+  hash: string;
+}
+
+export interface FarmRuntimeErrorOverlayContext {
+  phase: string;
+  location: FarmRuntimeErrorLocation;
+  sourceEvent?: Event;
+}
+
+export interface FarmRuntimeErrorOverlayOptions {
+  window: Window;
+  farmVersion?: string;
+  reload?: () => void;
+  fetch?: typeof fetch;
+}
+
+export interface FarmRuntimeErrorOverlay {
+  show(error: unknown, context: FarmRuntimeErrorOverlayContext): void;
+  dismiss(): void;
+  destroy(): void;
+}
+
+interface NormalizedRuntimeError {
+  name: string;
+  message: string;
+  stack?: string;
+}
+
+interface BrowserSourceLocation {
+  url: string;
+  displayPath: string;
+  line: number;
+  column: number;
+  stackLine?: string;
+}
+
+interface BrowserSourceLine {
+  number?: number;
+  content: string;
+  highlight?: boolean;
+}
+
+interface BrowserSourceFrame {
+  path: string;
+  line?: number;
+  column?: number;
+  lines: BrowserSourceLine[];
+  unavailable?: boolean;
+}
+
+interface RuntimeErrorRecord {
+  error: NormalizedRuntimeError;
+  context: FarmRuntimeErrorOverlayContext;
+  fingerprint: string;
+  occurrences: number;
+  sourceLocation?: BrowserSourceLocation;
+  sourceFrame: BrowserSourceFrame;
+}
+
+const OVERLAY_STYLES = `
+:host {
+  position: fixed;
+  inset: 0;
+  z-index: 2147483647;
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+:host([hidden]) {
+  display: none;
+}
+
+.farm-runtime-error__viewport {
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+
+.farm-runtime-error__viewport .farm-default-error {
+  min-height: 100%;
+  padding: clamp(22px, 4vh, 36px) 24px;
+}
+
+.farm-runtime-error__viewport .farm-default-error__code {
+  font-size: clamp(64px, 10vw, 92px);
+  line-height: 0.92;
+}
+
+.farm-runtime-error__viewport .farm-default-error__eyebrow {
+  margin-top: 22px;
+  margin-bottom: 18px;
+}
+
+.farm-runtime-error__viewport .farm-default-error__summary {
+  margin-bottom: 20px;
+}
+
+.farm-runtime-error__viewport .farm-default-error__row {
+  min-height: 48px;
+}
+
+.farm-runtime-error__viewport .farm-default-error__details {
+  padding-top: 16px;
+  padding-bottom: 14px;
+}
+
+.farm-runtime-error__viewport .farm-default-error__details-header {
+  margin-bottom: 8px;
+}
+
+.farm-runtime-error__viewport .farm-default-error__source-path {
+  padding-top: 9px;
+  padding-bottom: 9px;
+}
+
+.farm-runtime-error__viewport .farm-default-error__source-code {
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.farm-runtime-error__viewport .farm-default-error__meta {
+  margin-top: 10px;
+}
+
+.farm-runtime-error__viewport .farm-default-error__actions {
+  margin-top: 20px;
+}
+
+.farm-runtime-error__occurrences {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  margin-right: auto;
+  padding: 0 8px;
+  border: 1px solid var(--farm-error-line);
+  color: var(--farm-error-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.farm-runtime-error__occurrences[hidden],
+.farm-runtime-error__action[hidden] {
+  display: none;
+}
+
+.farm-runtime-error__copy {
+  min-width: 166px;
+}
+
+@media (max-width: 620px) {
+  .farm-runtime-error__occurrences {
+    margin-right: 0;
+  }
+
+  .farm-runtime-error__viewport .farm-default-error__content,
+  .farm-runtime-error__viewport .farm-default-error__panel,
+  .farm-runtime-error__viewport .farm-default-error__details,
+  .farm-runtime-error__viewport .farm-default-error__source,
+  .farm-runtime-error__viewport .farm-default-error__actions {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .farm-runtime-error__viewport .farm-default-error__actions {
+    width: 100%;
+  }
+
+  .farm-runtime-error__viewport .farm-default-error__action {
+    min-width: 0;
+  }
+}
+
+@media (max-height: 760px) {
+  .farm-runtime-error__viewport .farm-default-error {
+    place-items: start center;
+    padding-top: 16px;
+    padding-bottom: 16px;
+  }
+
+  .farm-runtime-error__viewport .farm-default-error__code {
+    font-size: 60px;
+  }
+
+  .farm-runtime-error__viewport .farm-default-error__eyebrow {
+    margin-top: 14px;
+    margin-bottom: 12px;
+  }
+
+  .farm-runtime-error__viewport .farm-default-error__summary {
+    margin-bottom: 14px;
+  }
+
+  .farm-runtime-error__viewport .farm-default-error__row {
+    min-height: 42px;
+  }
+
+  .farm-runtime-error__viewport .farm-default-error__details {
+    padding-top: 12px;
+    padding-bottom: 10px;
+  }
+
+  .farm-runtime-error__viewport .farm-default-error__actions {
+    margin-top: 14px;
+  }
+}
+`;
+
+const OVERLAY_MARKUP = `
+<div class="farm-runtime-error__viewport" data-farm-runtime-error-viewport>
+  <main class="farm-default-error" data-farm-runtime-error role="alertdialog" aria-modal="true" aria-labelledby="farm-runtime-error-title" aria-describedby="farm-runtime-error-description">
+    <div class="farm-default-error__content">
+      <p class="farm-default-error__code" aria-hidden="true">500</p>
+      <p class="farm-default-error__eyebrow">Client runtime error</p>
+      <header class="farm-default-error__summary">
+        <h1 id="farm-runtime-error-title" class="farm-default-error__title">Application failed in the browser</h1>
+        <p id="farm-runtime-error-description" class="farm-default-error__message" data-farm-runtime-error-message></p>
+      </header>
+      <section class="farm-default-error__panel" aria-label="Error information">
+        <div class="farm-default-error__row">
+          <span class="farm-default-error__label">Location</span>
+          <span class="farm-default-error__value" data-farm-runtime-error-location></span>
+        </div>
+        <div class="farm-default-error__row">
+          <span class="farm-default-error__label">Phase</span>
+          <span class="farm-default-error__value" data-farm-runtime-error-phase></span>
+        </div>
+        <section class="farm-default-error__details" aria-labelledby="farm-runtime-error-details-title">
+          <div class="farm-default-error__details-header">
+            <h2 id="farm-runtime-error-details-title" class="farm-default-error__details-title">Details</h2>
+            <span class="farm-runtime-error__occurrences" data-farm-runtime-error-occurrences hidden></span>
+            <button class="farm-default-error__copy farm-runtime-error__copy" type="button" data-farm-runtime-error-copy>
+              <span data-farm-runtime-error-copy-label>Copy debug report</span>
+              <span class="farm-default-error__sr-only" aria-live="polite" data-farm-runtime-error-copy-status></span>
+            </button>
+          </div>
+          <div data-farm-runtime-error-source></div>
+          <p class="farm-default-error__meta" data-farm-runtime-error-meta></p>
+        </section>
+      </section>
+      <div class="farm-default-error__actions">
+        <a class="farm-default-error__action farm-default-error__action--primary farm-runtime-error__action" data-farm-runtime-error-issue target="_blank" rel="noopener noreferrer">Open GitHub issue <span aria-hidden="true">↗</span></a>
+        <button class="farm-default-error__action farm-runtime-error__action" type="button" data-farm-runtime-error-reload>Reload page</button>
+        <button class="farm-default-error__action farm-runtime-error__action" type="button" data-farm-runtime-error-dismiss>Dismiss</button>
+      </div>
+    </div>
+  </main>
+</div>
+`;
+
+class DefaultFarmRuntimeErrorOverlay implements FarmRuntimeErrorOverlay {
+  private readonly options: FarmRuntimeErrorOverlayOptions;
+  private readonly document: Document;
+  private readonly host: HTMLDivElement;
+  private readonly shadow: ShadowRoot;
+  private readonly dismissedFingerprints = new Set<string>();
+  private readonly themeObserver: MutationObserver;
+  private readonly colorSchemeQuery?: MediaQueryList;
+  private current?: RuntimeErrorRecord;
+  private previousFocus?: Element | null;
+  private renderSequence = 0;
+  private copyResetTimer?: number;
+  private destroyed = false;
+
+  constructor(options: FarmRuntimeErrorOverlayOptions) {
+    this.options = options;
+    this.document = options.window.document;
+    this.host = this.document.createElement("div");
+    this.host.dataset.farmRuntimeErrorOverlay = "";
+    this.host.hidden = true;
+    this.shadow = this.host.attachShadow({ mode: "open" });
+    this.shadow.innerHTML = `<style>${DEFAULT_ERROR_STYLES}${OVERLAY_STYLES}</style>${OVERLAY_MARKUP}`;
+
+    this.getElement<HTMLButtonElement>("[data-farm-runtime-error-reload]").addEventListener(
+      "click",
+      this.handleReload,
+    );
+    this.getElement<HTMLButtonElement>("[data-farm-runtime-error-dismiss]").addEventListener(
+      "click",
+      this.handleDismiss,
+    );
+    this.getElement<HTMLButtonElement>("[data-farm-runtime-error-copy]").addEventListener(
+      "click",
+      this.handleCopy,
+    );
+    this.shadow.addEventListener("keydown", this.handleKeyDown);
+
+    this.themeObserver = new MutationObserver(this.updateTheme);
+    this.themeObserver.observe(this.document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class", "data-theme", "data-color-scheme", "style"],
+    });
+    if (this.document.body) {
+      this.themeObserver.observe(this.document.body, {
+        attributes: true,
+        attributeFilter: ["class", "data-theme", "data-color-scheme", "style"],
+      });
+    }
+
+    this.colorSchemeQuery = options.window.matchMedia?.("(prefers-color-scheme: dark)");
+    this.colorSchemeQuery?.addEventListener?.("change", this.updateTheme);
+    this.updateTheme();
+  }
+
+  show(errorLike: unknown, context: FarmRuntimeErrorOverlayContext): void {
+    if (this.destroyed || isChunkLoadError(errorLike) || isChunkLoadError(context.sourceEvent)) {
+      return;
+    }
+
+    const error = normalizeRuntimeError(errorLike);
+    const sourceLocation = resolveBrowserSourceLocation(
+      error,
+      context.sourceEvent,
+      this.options.window,
+    );
+    const fingerprint = createErrorFingerprint(error, context, sourceLocation);
+    if (this.dismissedFingerprints.has(fingerprint)) return;
+
+    if (this.current?.fingerprint === fingerprint) {
+      this.current.occurrences += 1;
+      this.renderOccurrences(this.current.occurrences);
+      return;
+    }
+
+    const record: RuntimeErrorRecord = {
+      error,
+      context,
+      fingerprint,
+      occurrences: 1,
+      sourceLocation,
+      sourceFrame: createFallbackSourceFrame(error, sourceLocation),
+    };
+    this.current = record;
+    const sequence = ++this.renderSequence;
+    this.render(record);
+    this.mount();
+
+    if (sourceLocation) {
+      void loadBrowserSourceFrame(sourceLocation, this.options)
+        .then((sourceFrame) => {
+          if (
+            !sourceFrame ||
+            this.destroyed ||
+            sequence !== this.renderSequence ||
+            this.current !== record
+          ) {
+            return;
+          }
+          record.sourceFrame = sourceFrame;
+          this.renderSourceFrame(sourceFrame);
+          this.renderIssueLink(record);
+        })
+        .catch(() => {});
+    }
+  }
+
+  dismiss(): void {
+    if (this.destroyed || this.host.hidden) return;
+    if (this.current) this.dismissedFingerprints.add(this.current.fingerprint);
+    this.host.hidden = true;
+    this.renderSequence += 1;
+    if (this.previousFocus instanceof HTMLElement && this.previousFocus.isConnected) {
+      this.previousFocus.focus();
+    }
+    this.previousFocus = undefined;
+  }
+
+  destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.renderSequence += 1;
+    this.themeObserver.disconnect();
+    this.colorSchemeQuery?.removeEventListener?.("change", this.updateTheme);
+    this.shadow.removeEventListener("keydown", this.handleKeyDown);
+    if (this.copyResetTimer !== undefined) {
+      this.options.window.clearTimeout(this.copyResetTimer);
+    }
+    this.host.remove();
+    this.current = undefined;
+  }
+
+  private mount(): void {
+    if (!this.host.isConnected) {
+      (this.document.body || this.document.documentElement).appendChild(this.host);
+    }
+    const wasHidden = this.host.hidden;
+    this.host.hidden = false;
+    if (wasHidden) {
+      this.previousFocus = this.document.activeElement;
+      this.options.window.setTimeout(() => {
+        if (!this.host.hidden && !this.destroyed) {
+          this.getElement<HTMLAnchorElement>("[data-farm-runtime-error-issue]").focus({
+            preventScroll: true,
+          });
+        }
+      }, 0);
+    }
+  }
+
+  private render(record: RuntimeErrorRecord): void {
+    this.getElement("[data-farm-runtime-error-message]").textContent = record.error.message;
+    this.getElement("[data-farm-runtime-error-location]").textContent =
+      `${record.context.location.pathname}${record.context.location.search}` || "/";
+    this.getElement("[data-farm-runtime-error-phase]").textContent = formatPhase(
+      record.context.phase,
+    );
+    this.getElement("[data-farm-runtime-error-meta]").textContent =
+      `Farm.js v${this.options.farmVersion || FARM_VERSION} · development · browser`;
+    this.renderIssueLink(record);
+    this.renderOccurrences(record.occurrences);
+    this.renderSourceFrame(record.sourceFrame);
+    this.resetCopyStatus();
+  }
+
+  private renderOccurrences(occurrences: number): void {
+    const badge = this.getElement<HTMLElement>("[data-farm-runtime-error-occurrences]");
+    badge.hidden = occurrences < 2;
+    badge.textContent = occurrences < 2 ? "" : `Repeated ×${occurrences}`;
+  }
+
+  private renderIssueLink(record: RuntimeErrorRecord): void {
+    this.getElement<HTMLAnchorElement>("[data-farm-runtime-error-issue]").href =
+      createGithubIssueUrl(record, this.options.window, this.options.farmVersion || FARM_VERSION);
+  }
+
+  private renderSourceFrame(sourceFrame: BrowserSourceFrame): void {
+    const container = this.getElement<HTMLElement>("[data-farm-runtime-error-source]");
+    container.replaceChildren();
+
+    const source = this.document.createElement("div");
+    source.className = "farm-default-error__source";
+
+    const path = this.document.createElement("p");
+    path.className = "farm-default-error__source-path";
+    path.textContent = formatSourcePath(sourceFrame);
+    source.appendChild(path);
+
+    const pre = this.document.createElement("pre");
+    pre.className = "farm-default-error__source-code";
+    pre.tabIndex = 0;
+    const code = this.document.createElement("code");
+    for (const line of sourceFrame.lines) {
+      const row = this.document.createElement("span");
+      row.className = `farm-default-error__source-line${line.highlight ? " farm-default-error__source-line--active" : ""}`;
+
+      const gutter = this.document.createElement("span");
+      gutter.className = "farm-default-error__source-gutter";
+      gutter.textContent = `${line.highlight ? ">" : " "} ${line.number ?? ""}`;
+
+      const text = this.document.createElement("span");
+      text.className = "farm-default-error__source-text";
+      text.textContent = line.content || " ";
+
+      row.append(gutter, text);
+      code.appendChild(row);
+    }
+    pre.appendChild(code);
+    source.appendChild(pre);
+    container.appendChild(source);
+  }
+
+  private readonly handleReload = () => {
+    (this.options.reload || (() => this.options.window.location.reload()))();
+  };
+
+  private readonly handleDismiss = () => {
+    this.dismiss();
+  };
+
+  private readonly handleCopy = async () => {
+    if (!this.current) return;
+    const report = createFarmRuntimeErrorDebugReport(
+      this.current,
+      this.options.window,
+      this.options.farmVersion || FARM_VERSION,
+    );
+    const label = this.getElement<HTMLElement>("[data-farm-runtime-error-copy-label]");
+    const status = this.getElement<HTMLElement>("[data-farm-runtime-error-copy-status]");
+
+    try {
+      await copyText(report, this.options.window, this.document);
+      label.textContent = "Copied";
+      status.textContent = "Debug report copied";
+      if (this.copyResetTimer !== undefined) {
+        this.options.window.clearTimeout(this.copyResetTimer);
+      }
+      this.copyResetTimer = this.options.window.setTimeout(() => this.resetCopyStatus(), 1800);
+    } catch {
+      status.textContent = "Unable to copy the debug report";
+    }
+  };
+
+  private readonly handleKeyDown = (event: Event) => {
+    const keyboardEvent = event as KeyboardEvent;
+    if (keyboardEvent.key === "Escape") {
+      keyboardEvent.preventDefault();
+      this.dismiss();
+      return;
+    }
+    if (keyboardEvent.key !== "Tab") return;
+
+    const controls = Array.from(
+      this.shadow.querySelectorAll<HTMLElement>("a[href], button:not([hidden]):not([disabled])"),
+    );
+    if (controls.length === 0) return;
+    const first = controls[0];
+    const last = controls[controls.length - 1];
+    const active = this.shadow.activeElement;
+
+    if (keyboardEvent.shiftKey && active === first) {
+      keyboardEvent.preventDefault();
+      last.focus();
+    } else if (!keyboardEvent.shiftKey && active === last) {
+      keyboardEvent.preventDefault();
+      first.focus();
+    }
+  };
+
+  private readonly updateTheme = () => {
+    this.getElement<HTMLElement>("[data-farm-runtime-error-viewport]").dataset.theme =
+      resolveDocumentTheme(this.document, this.options.window);
+  };
+
+  private resetCopyStatus(): void {
+    this.getElement("[data-farm-runtime-error-copy-label]").textContent = "Copy debug report";
+    this.getElement("[data-farm-runtime-error-copy-status]").textContent = "";
+  }
+
+  private getElement<T extends Element = HTMLElement>(selector: string): T {
+    const element = this.shadow.querySelector<T>(selector);
+    if (!element) throw new Error(`Farm runtime error overlay is missing ${selector}`);
+    return element;
+  }
+}
+
+export function createFarmRuntimeErrorOverlay(
+  options: FarmRuntimeErrorOverlayOptions,
+): FarmRuntimeErrorOverlay {
+  return new DefaultFarmRuntimeErrorOverlay(options);
+}
+
+function normalizeRuntimeError(errorLike: unknown): NormalizedRuntimeError {
+  if (errorLike instanceof Error) {
+    return {
+      name: errorLike.name || "Error",
+      message: errorLike.message || "An unknown browser error occurred.",
+      stack: errorLike.stack,
+    };
+  }
+
+  if (errorLike && typeof errorLike === "object") {
+    const error = errorLike as Record<string, unknown>;
+    const name = typeof error.name === "string" && error.name ? error.name : "Error";
+    const message =
+      typeof error.message === "string" && error.message
+        ? error.message
+        : typeof error.reason === "string" && error.reason
+          ? error.reason
+          : stringifyUnknown(errorLike);
+    return {
+      name,
+      message: message || "An unknown browser error occurred.",
+      stack: typeof error.stack === "string" ? error.stack : undefined,
+    };
+  }
+
+  return {
+    name: "Error",
+    message: stringifyUnknown(errorLike) || "An unknown browser error occurred.",
+  };
+}
+
+function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value == null) return "";
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function resolveBrowserSourceLocation(
+  error: NormalizedRuntimeError,
+  sourceEvent: Event | undefined,
+  clientWindow: Window,
+): BrowserSourceLocation | undefined {
+  if (sourceEvent && "filename" in sourceEvent) {
+    const event = sourceEvent as ErrorEvent;
+    if (event.filename && event.lineno) {
+      return createSourceLocation(event.filename, event.lineno, event.colno || 1, clientWindow);
+    }
+  }
+
+  if (!error.stack) return undefined;
+  for (const stackLine of error.stack.split("\n").slice(1)) {
+    const match = stackLine
+      .trim()
+      .match(/\(?((?:https?|file):\/\/[^)\s]+|\/[^)\s]+):(\d+):(\d+)\)?$/);
+    if (!match) continue;
+    return {
+      ...createSourceLocation(match[1], Number(match[2]), Number(match[3]), clientWindow),
+      stackLine: stackLine.trim(),
+    };
+  }
+  return undefined;
+}
+
+function createSourceLocation(
+  url: string,
+  line: number,
+  column: number,
+  clientWindow: Window,
+): BrowserSourceLocation {
+  let displayPath = url;
+  try {
+    const parsed = new URL(url, clientWindow.location.href);
+    displayPath =
+      parsed.origin === clientWindow.location.origin
+        ? `${parsed.pathname}${parsed.search}`
+        : parsed.href;
+  } catch {}
+
+  return { url, displayPath, line, column };
+}
+
+function createFallbackSourceFrame(
+  error: NormalizedRuntimeError,
+  location?: BrowserSourceLocation,
+): BrowserSourceFrame {
+  const firstStackLine =
+    location?.stackLine || error.stack?.split("\n").find((line) => line.trim().startsWith("at "));
+  return {
+    path: location?.displayPath || "Browser stack",
+    line: location?.line,
+    column: location?.column,
+    unavailable: true,
+    lines: [
+      {
+        number: location?.line,
+        content: firstStackLine?.trim() || error.message,
+        highlight: true,
+      },
+    ],
+  };
+}
+
+async function loadBrowserSourceFrame(
+  location: BrowserSourceLocation,
+  options: FarmRuntimeErrorOverlayOptions,
+): Promise<BrowserSourceFrame | undefined> {
+  const request = options.fetch || options.window.fetch?.bind(options.window);
+  if (!request) return undefined;
+
+  let sourceUrl: URL;
+  try {
+    sourceUrl = new URL(location.url, options.window.location.href);
+  } catch {
+    return undefined;
+  }
+  if (
+    sourceUrl.origin !== options.window.location.origin ||
+    (sourceUrl.protocol !== "http:" && sourceUrl.protocol !== "https:")
+  ) {
+    return undefined;
+  }
+
+  try {
+    const response = await request(sourceUrl.href, {
+      headers: { Accept: "text/plain, application/javascript" },
+    });
+    if (!response.ok) return undefined;
+    const source = await response.text();
+    if (source.length > 1_000_000) return undefined;
+
+    const lines = source.split(/\r?\n/);
+    if (location.line < 1 || location.line > lines.length) return undefined;
+    const start = Math.max(1, location.line - 2);
+    const end = Math.min(lines.length, location.line + 2);
+    const frameLines: BrowserSourceLine[] = [];
+    for (let number = start; number <= end; number += 1) {
+      frameLines.push({
+        number,
+        content: lines[number - 1] || " ",
+        highlight: number === location.line,
+      });
+    }
+
+    return {
+      path: location.displayPath,
+      line: location.line,
+      column: location.column,
+      lines: frameLines,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function createErrorFingerprint(
+  error: NormalizedRuntimeError,
+  context: FarmRuntimeErrorOverlayContext,
+  location?: BrowserSourceLocation,
+): string {
+  return [
+    context.phase,
+    context.location.pathname,
+    error.name,
+    error.message,
+    location?.displayPath || "",
+    location?.line || "",
+    error.stack?.split("\n")[1]?.trim() || "",
+  ].join("\u0000");
+}
+
+function formatPhase(phase: string): string {
+  return phase
+    .replace(/^plugin:/, "Plugin · ")
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function formatSourcePath(sourceFrame: BrowserSourceFrame): string {
+  if (!sourceFrame.line) return sourceFrame.path;
+  return `${sourceFrame.path}:${sourceFrame.line}:${sourceFrame.column || 1}${
+    sourceFrame.unavailable ? " · source preview unavailable" : ""
+  }`;
+}
+
+function resolveDocumentTheme(document: Document, clientWindow: Window): "light" | "dark" {
+  for (const element of [document.documentElement, document.body]) {
+    if (!element) continue;
+    const explicit =
+      element.getAttribute("data-theme") || element.getAttribute("data-color-scheme");
+    if (explicit === "dark" || element.classList.contains("dark")) return "dark";
+    if (explicit === "light" || element.classList.contains("light")) return "light";
+  }
+
+  const colorScheme = clientWindow.getComputedStyle?.(document.documentElement).colorScheme;
+  if (colorScheme?.includes("dark") && !colorScheme.includes("light")) return "dark";
+  return clientWindow.matchMedia?.("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function createFarmRuntimeErrorDebugReport(
+  record: RuntimeErrorRecord,
+  clientWindow: Window,
+  farmVersion: string,
+): string {
+  const source = record.sourceFrame.lines
+    .map(
+      (line) =>
+        `${line.highlight ? ">" : " "} ${line.number ? String(line.number).padStart(4, " ") : "    "} | ${line.content}`,
+    )
+    .join("\n");
+  const viewport = `${clientWindow.innerWidth}×${clientWindow.innerHeight}`;
+
+  return [
+    "# Farm.js client runtime debug report",
+    "",
+    "## Error",
+    `- Name: ${record.error.name}`,
+    `- Message: ${record.error.message}`,
+    `- Phase: ${formatPhase(record.context.phase)}`,
+    `- Page: ${record.context.location.href}`,
+    `- Occurrences: ${record.occurrences}`,
+    "",
+    "## Browser runtime",
+    `- Farm.js: ${farmVersion}`,
+    `- User agent: ${clientWindow.navigator.userAgent}`,
+    `- Viewport: ${viewport}`,
+    `- Online: ${clientWindow.navigator.onLine === false ? "no" : "yes"}`,
+    "",
+    "## Source",
+    `\`${formatSourcePath(record.sourceFrame)}\``,
+    "",
+    "```text",
+    source,
+    "```",
+    "",
+    "## Stack trace",
+    "```text",
+    record.error.stack || "Stack trace unavailable.",
+    "```",
+    "",
+    "## Diagnostic request",
+    "Identify the most likely root cause from the message, source frame, and stack trace. Explain the smallest safe fix and how to verify it.",
+  ].join("\n");
+}
+
+function createGithubIssueUrl(
+  record: RuntimeErrorRecord,
+  clientWindow: Window,
+  farmVersion: string,
+): string {
+  const source = record.sourceFrame.lines
+    .map(
+      (line) =>
+        `${line.highlight ? ">" : " "} ${line.number ? String(line.number).padStart(4, " ") : "    "} | ${line.content}`,
+    )
+    .join("\n");
+  const body = truncateText(
+    [
+      "## Runtime error report",
+      "",
+      "> This report was prefilled by the Farm.js development error overlay. Review it and remove sensitive information before submitting.",
+      "",
+      "### Error",
+      `- Name: ${record.error.name}`,
+      `- Message: ${record.error.message}`,
+      `- Phase: ${formatPhase(record.context.phase)}`,
+      `- Page path: ${record.context.location.pathname}`,
+      `- Occurrences: ${record.occurrences}`,
+      `- Farm.js: ${farmVersion}`,
+      `- Browser: ${clientWindow.navigator.userAgent}`,
+      `- Viewport: ${clientWindow.innerWidth}×${clientWindow.innerHeight}`,
+      `- Online: ${clientWindow.navigator.onLine === false ? "no" : "yes"}`,
+      "",
+      "### Source",
+      `\`${formatSourcePath(record.sourceFrame)}\``,
+      "",
+      "```text",
+      source,
+      "```",
+      "",
+      "### Stack trace",
+      "```text",
+      record.error.stack || "Stack trace unavailable.",
+      "```",
+      "",
+      "### Expected behavior",
+      "Describe what you expected to happen and the steps needed to reproduce the failure.",
+      "",
+      "### Diagnostic request",
+      "Identify the most likely root cause from the message, source frame, and stack trace. Explain the smallest safe fix and how to verify it.",
+    ].join("\n"),
+    6_000,
+  );
+  const issueUrl = new URL("https://github.com/farming-labs/farm.js/issues/new");
+  issueUrl.searchParams.set("title", truncateText(`[runtime error] ${record.error.message}`, 120));
+  issueUrl.searchParams.set("body", body);
+  return issueUrl.href;
+}
+
+function truncateText(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength - 24)}\n\n[report truncated]`;
+}
+
+async function copyText(value: string, clientWindow: Window, document: Document): Promise<void> {
+  if (clientWindow.navigator.clipboard && clientWindow.isSecureContext) {
+    await clientWindow.navigator.clipboard.writeText(value);
+    return;
+  }
+
+  const area = document.createElement("textarea");
+  area.value = value;
+  area.readOnly = true;
+  area.style.position = "fixed";
+  area.style.opacity = "0";
+  document.body.appendChild(area);
+  area.select();
+  const copied = document.execCommand("copy");
+  area.remove();
+  if (!copied) throw new Error("Copy command was rejected");
+}

--- a/playwright.production.config.ts
+++ b/playwright.production.config.ts
@@ -8,6 +8,7 @@ process.env.FARM_E2E_MODE = "prod";
 
 export default defineConfig({
   testDir: "./tests/e2e",
+  testIgnore: ["runtime-error-overlay.spec.ts"],
   timeout: 30_000,
   expect: {
     timeout: 5_000,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1332,6 +1332,9 @@ importers:
       '@formatjs/icu-messageformat-parser':
         specifier: 3.5.15
         version: 3.5.15
+      '@jridgewell/trace-mapping':
+        specifier: 0.3.31
+        version: 0.3.31
       '@mdx-js/mdx':
         specifier: ^3.1.1
         version: 3.1.1(supports-color@10.2.2)

--- a/tests/e2e/runtime-error-overlay.spec.ts
+++ b/tests/e2e/runtime-error-overlay.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Development runtime error overlay", () => {
+  test("shows unhandled client failures and provides recovery controls", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 633 });
+    await page.goto("/runtime-error-demo");
+    await page.getByRole("button", { name: "Trigger runtime error" }).click();
+
+    const overlay = page.getByRole("alertdialog", { name: "Application failed in the browser" });
+    await expect(overlay).toBeVisible();
+    await expect(overlay.getByText(/Cannot read properties of undefined/)).toBeVisible();
+    await expect(overlay.getByText("Window", { exact: true })).toBeVisible();
+    await expect(overlay.getByRole("button", { name: "Copy debug report" })).toBeVisible();
+    const issueLink = overlay.getByRole("link", { name: "Open GitHub issue" });
+    await expect(issueLink).toBeVisible();
+    const issueUrl = new URL((await issueLink.getAttribute("href")) || "");
+    expect(issueUrl.origin + issueUrl.pathname).toBe(
+      "https://github.com/farming-labs/farm.js/issues/new",
+    );
+    expect(issueUrl.searchParams.get("title")).toContain("Cannot read properties of undefined");
+    expect(issueUrl.searchParams.get("body")).toContain("- Page path: /runtime-error-demo");
+    await expect(overlay.getByRole("button", { name: "Reload page" })).toBeVisible();
+
+    const statusBox = await overlay.locator(".farm-default-error__code").boundingBox();
+    const actionsBox = await overlay.locator(".farm-default-error__actions").boundingBox();
+    const viewport = page.viewportSize();
+    expect(statusBox?.y).toBeGreaterThanOrEqual(10);
+    expect((actionsBox?.y || 0) + (actionsBox?.height || 0)).toBeLessThanOrEqual(
+      viewport?.height || 0,
+    );
+
+    await overlay.getByRole("button", { name: "Dismiss" }).click();
+    await expect(overlay).toBeHidden();
+    await expect(
+      page.getByRole("heading", { name: "Test the browser runtime error overlay" }),
+    ).toBeVisible();
+  });
+
+  test("follows dark mode for unhandled promise rejections", async ({ page }) => {
+    await page.emulateMedia({ colorScheme: "dark" });
+    await page.goto("/runtime-error-demo");
+    await page.getByRole("button", { name: "Trigger rejected promise" }).click();
+
+    const overlay = page.getByRole("alertdialog", { name: "Application failed in the browser" });
+    await expect(overlay).toBeVisible();
+    await expect(
+      overlay.getByText("Intentional rejected promise from the runtime error demo", {
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect(overlay.getByText("Unhandled Rejection", { exact: true })).toBeVisible();
+    await expect(
+      page.locator("[data-farm-runtime-error-viewport][data-theme='dark']"),
+    ).toBeVisible();
+  });
+
+  test("keeps the overlay inside a mobile viewport", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/runtime-error-demo");
+    await page.getByRole("button", { name: "Trigger runtime error" }).click();
+
+    const viewport = page.locator("[data-farm-runtime-error-viewport]");
+    await expect(
+      page.getByRole("alertdialog", { name: "Application failed in the browser" }),
+    ).toBeVisible();
+    const dimensions = await viewport.evaluate((element) => ({
+      clientWidth: element.clientWidth,
+      scrollWidth: element.scrollWidth,
+    }));
+    expect(dimensions.scrollWidth).toBe(dimensions.clientWidth);
+  });
+});

--- a/tests/e2e/runtime-error-overlay.spec.ts
+++ b/tests/e2e/runtime-error-overlay.spec.ts
@@ -8,13 +8,13 @@ test.describe("Development runtime error overlay", () => {
 
     const overlay = page.getByRole("alertdialog", { name: "Application failed in the browser" });
     await expect(overlay).toBeVisible();
-    await expect(overlay.getByText(/Cannot read properties of undefined/)).toBeVisible();
+    await expect(overlay.getByText(/formatDisplayName is not a function/)).toBeVisible();
     await expect(overlay.getByText("Window", { exact: true })).toBeVisible();
     await expect(
-      overlay.getByText("/src/app/runtime-error-demo/page.tsx:20:7", { exact: true }),
+      overlay.getByText(/\/src\/app\/runtime-error-demo\/page\.tsx:24:\d+/, { exact: true }),
     ).toBeVisible();
     await expect(overlay.locator(".farm-default-error__source-line--active")).toContainText(
-      "document.title = response.user.profile.displayName;",
+      "setDisplayName(response.user.profile.formatDisplayName());",
     );
     await expect(overlay.getByRole("button", { name: "Copy debug report" })).toBeVisible();
     const issueLink = overlay.getByRole("link", { name: "Open GitHub issue" });
@@ -23,10 +23,20 @@ test.describe("Development runtime error overlay", () => {
     expect(issueUrl.origin + issueUrl.pathname).toBe(
       "https://github.com/farming-labs/farm.js/issues/new",
     );
-    expect(issueUrl.searchParams.get("title")).toContain("Cannot read properties of undefined");
+    expect(issueUrl.searchParams.get("title")).toContain("formatDisplayName is not a function");
     expect(issueUrl.searchParams.get("body")).toContain("- Page path: /runtime-error-demo");
     await expect(overlay.getByRole("button", { name: "Reload page" })).toBeVisible();
-    await expect(overlay.locator(".farm-default-error__code")).toHaveCSS("font-size", "72px");
+    await expect(overlay.locator(".farm-default-error__code")).toHaveCSS("font-size", "80px");
+    await expect(overlay.locator(".farm-default-error__panel")).toHaveCSS(
+      "border-top-width",
+      "0px",
+    );
+    await expect(overlay.locator(".farm-default-error__panel")).toHaveCSS(
+      "box-shadow",
+      /0\.5px.*inset/,
+    );
+    await expect(overlay.locator(".farm-runtime-error__github-icon")).toBeVisible();
+    await expect(issueLink).not.toContainText("↗");
 
     const statusBox = await overlay.locator(".farm-default-error__code").boundingBox();
     const actionsBox = await overlay.locator(".farm-default-error__actions").boundingBox();

--- a/tests/e2e/runtime-error-overlay.spec.ts
+++ b/tests/e2e/runtime-error-overlay.spec.ts
@@ -10,6 +10,12 @@ test.describe("Development runtime error overlay", () => {
     await expect(overlay).toBeVisible();
     await expect(overlay.getByText(/Cannot read properties of undefined/)).toBeVisible();
     await expect(overlay.getByText("Window", { exact: true })).toBeVisible();
+    await expect(
+      overlay.getByText("/src/app/runtime-error-demo/page.tsx:20:7", { exact: true }),
+    ).toBeVisible();
+    await expect(overlay.locator(".farm-default-error__source-line--active")).toContainText(
+      "document.title = response.user.profile.displayName;",
+    );
     await expect(overlay.getByRole("button", { name: "Copy debug report" })).toBeVisible();
     const issueLink = overlay.getByRole("link", { name: "Open GitHub issue" });
     await expect(issueLink).toBeVisible();

--- a/tests/e2e/runtime-error-overlay.spec.ts
+++ b/tests/e2e/runtime-error-overlay.spec.ts
@@ -9,7 +9,9 @@ test.describe("Development runtime error overlay", () => {
     const overlay = page.getByRole("alertdialog", { name: "Application failed in the browser" });
     await expect(overlay).toBeVisible();
     await expect(overlay.getByText(/formatDisplayName is not a function/)).toBeVisible();
-    await expect(overlay.getByText("Window", { exact: true })).toBeVisible();
+    await expect(overlay.getByText("Runtime TypeError", { exact: true })).toBeVisible();
+    await expect(overlay.getByText("Error message", { exact: true })).toBeVisible();
+    await expect(overlay.getByText("Window", { exact: true })).toHaveCount(0);
     await expect(
       overlay.getByText(/\/src\/app\/runtime-error-demo\/page\.tsx:24:\d+/, { exact: true }),
     ).toBeVisible();
@@ -67,7 +69,7 @@ test.describe("Development runtime error overlay", () => {
         exact: true,
       }),
     ).toBeVisible();
-    await expect(overlay.getByText("Unhandled Rejection", { exact: true })).toBeVisible();
+    await expect(overlay.getByText("Runtime Error", { exact: true })).toBeVisible();
     await expect(
       page.locator("[data-farm-runtime-error-viewport][data-theme='dark']"),
     ).toBeVisible();

--- a/tests/e2e/runtime-error-overlay.spec.ts
+++ b/tests/e2e/runtime-error-overlay.spec.ts
@@ -26,6 +26,7 @@ test.describe("Development runtime error overlay", () => {
     expect(issueUrl.searchParams.get("title")).toContain("Cannot read properties of undefined");
     expect(issueUrl.searchParams.get("body")).toContain("- Page path: /runtime-error-demo");
     await expect(overlay.getByRole("button", { name: "Reload page" })).toBeVisible();
+    await expect(overlay.locator(".farm-default-error__code")).toHaveCSS("font-size", "72px");
 
     const statusBox = await overlay.locator(".farm-default-error__code").boundingBox();
     const actionsBox = await overlay.locator(".farm-default-error__actions").boundingBox();

--- a/tests/e2e/runtime-error-overlay.spec.ts
+++ b/tests/e2e/runtime-error-overlay.spec.ts
@@ -26,7 +26,7 @@ test.describe("Development runtime error overlay", () => {
     expect(issueUrl.searchParams.get("title")).toContain("formatDisplayName is not a function");
     expect(issueUrl.searchParams.get("body")).toContain("- Page path: /runtime-error-demo");
     await expect(overlay.getByRole("button", { name: "Reload page" })).toBeVisible();
-    await expect(overlay.locator(".farm-default-error__code")).toHaveCSS("font-size", "80px");
+    await expect(overlay.locator(".farm-default-error__code")).toHaveCSS("font-size", "88px");
     await expect(overlay.locator(".farm-default-error__panel")).toHaveCSS(
       "border-top-width",
       "0px",
@@ -36,6 +36,7 @@ test.describe("Development runtime error overlay", () => {
       /0\.5px.*inset/,
     );
     await expect(overlay.locator(".farm-runtime-error__github-icon")).toBeVisible();
+    await expect(overlay.locator(".farm-runtime-error__github-icon")).toHaveCSS("width", "18px");
     await expect(issueLink).not.toContainText("↗");
 
     const statusBox = await overlay.locator(".farm-default-error__code").boundingBox();
@@ -54,6 +55,7 @@ test.describe("Development runtime error overlay", () => {
   });
 
   test("follows dark mode for unhandled promise rejections", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
     await page.emulateMedia({ colorScheme: "dark" });
     await page.goto("/runtime-error-demo");
     await page.getByRole("button", { name: "Trigger rejected promise" }).click();
@@ -69,6 +71,7 @@ test.describe("Development runtime error overlay", () => {
     await expect(
       page.locator("[data-farm-runtime-error-viewport][data-theme='dark']"),
     ).toBeVisible();
+    await expect(overlay.locator(".farm-default-error__code")).toHaveCSS("font-size", "120px");
   });
 
   test("keeps the overlay inside a mobile viewport", async ({ page }) => {

--- a/tests/e2e/runtime-error-overlay.spec.ts
+++ b/tests/e2e/runtime-error-overlay.spec.ts
@@ -8,6 +8,7 @@ test.describe("Development runtime error overlay", () => {
 
     const overlay = page.getByRole("alertdialog", { name: "Application failed in the browser" });
     await expect(overlay).toBeVisible();
+    await expect(overlay.locator(".farm-default-error__eyebrow")).toHaveText("Runtime error");
     await expect(overlay.getByText(/formatDisplayName is not a function/)).toBeVisible();
     const inlineCode = overlay.locator(".farm-runtime-error__inline-code");
     await expect(inlineCode).toHaveText("response.user.profile.formatDisplayName");

--- a/tests/e2e/runtime-error-overlay.spec.ts
+++ b/tests/e2e/runtime-error-overlay.spec.ts
@@ -13,7 +13,9 @@ test.describe("Development runtime error overlay", () => {
     await expect(inlineCode).toHaveText("response.user.profile.formatDisplayName");
     await expect(inlineCode).toHaveCSS("font-family", /monospace/);
     await expect(inlineCode).toHaveCSS("font-weight", "600");
-    await expect(inlineCode).toHaveCSS("background-color", "rgba(185, 28, 28, 0.08)");
+    await expect(inlineCode).toHaveCSS("color", "rgb(185, 28, 28)");
+    await expect(inlineCode).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+    await expect(inlineCode).toHaveCSS("border-top-width", "0px");
     await expect(overlay.getByText("Runtime TypeError", { exact: true })).toBeVisible();
     await expect(overlay.getByText("Error message", { exact: true })).toBeVisible();
     await expect(overlay.getByText("Window", { exact: true })).toHaveCount(0);

--- a/tests/e2e/runtime-error-overlay.spec.ts
+++ b/tests/e2e/runtime-error-overlay.spec.ts
@@ -9,9 +9,11 @@ test.describe("Development runtime error overlay", () => {
     const overlay = page.getByRole("alertdialog", { name: "Application failed in the browser" });
     await expect(overlay).toBeVisible();
     await expect(overlay.getByText(/formatDisplayName is not a function/)).toBeVisible();
-    await expect(overlay.locator(".farm-runtime-error__inline-code")).toHaveText(
-      "response.user.profile.formatDisplayName",
-    );
+    const inlineCode = overlay.locator(".farm-runtime-error__inline-code");
+    await expect(inlineCode).toHaveText("response.user.profile.formatDisplayName");
+    await expect(inlineCode).toHaveCSS("font-family", /monospace/);
+    await expect(inlineCode).toHaveCSS("font-weight", "600");
+    await expect(inlineCode).toHaveCSS("background-color", "rgba(185, 28, 28, 0.08)");
     await expect(overlay.getByText("Runtime TypeError", { exact: true })).toBeVisible();
     await expect(overlay.getByText("Error message", { exact: true })).toBeVisible();
     await expect(overlay.getByText("Window", { exact: true })).toHaveCount(0);

--- a/tests/e2e/runtime-error-overlay.spec.ts
+++ b/tests/e2e/runtime-error-overlay.spec.ts
@@ -9,6 +9,9 @@ test.describe("Development runtime error overlay", () => {
     const overlay = page.getByRole("alertdialog", { name: "Application failed in the browser" });
     await expect(overlay).toBeVisible();
     await expect(overlay.getByText(/formatDisplayName is not a function/)).toBeVisible();
+    await expect(overlay.locator(".farm-runtime-error__inline-code")).toHaveText(
+      "response.user.profile.formatDisplayName",
+    );
     await expect(overlay.getByText("Runtime TypeError", { exact: true })).toBeVisible();
     await expect(overlay.getByText("Error message", { exact: true })).toBeVisible();
     await expect(overlay.getByText("Window", { exact: true })).toHaveCount(0);


### PR DESCRIPTION
## What changed

- add a development-only client runtime error overlay for hydration, navigation, plugin, window, and unhandled rejection failures
- reuse the default error-page visual language with light/dark themes, source frames, deduplication, focus management, responsive layouts, reload, dismiss, and an AI-friendly copy report
- map transformed browser positions back to original application source through inline or external source maps
- hide bundler-only query markers such as `?import` and ignore errors owned by injected browser extensions
- replace the generic retry action with a prefilled GitHub issue link that opens for review before submission
- leave chunk-load failures with the existing chunk recovery system and keep the overlay disabled in production
- add a real runtime-error demo route plus browser coverage for a TypeError and an unhandled promise rejection

## Why

Unexpected post-hydration browser failures previously remained in the console unless an application supplied its own error plugin. The first overlay pass could also surface transformed module paths or unrelated errors from injected extensions. This gives developers a consistent, application-focused diagnostic surface while preserving the existing production behavior.

## Developer impact

In development, unexpected client failures now identify the phase and page, highlight the failing line from the original TSX/JS source when a source map is available, and provide a detailed report that can be copied or used to prefill a GitHub issue. Extension-owned failures are left to their extension, and internal module queries are excluded from visible source paths.

## Validation

- `vitest run src/__tests__/runtime-error-overlay.test.ts src/__tests__/client-plugin.test.ts` (15 tests)
- `tsc --noEmit`
- `oxlint` and `oxfmt --check` on the changed files
- `playwright test tests/e2e/runtime-error-overlay.spec.ts --project=chromium` (3 scenarios)
- full package `tsup` build
- live browser verification resolves the demo failure to `/src/app/runtime-error-demo/page.tsx:20:7`, highlights the original TSX statement, and contains no `?import`
- visual checks at 1280×633 in light and dark modes and at 390×844 in dark mode
