### PR TITLE
feat: support standardized HTTP QUERY requests

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -54,6 +54,39 @@ if (result.error) {
 }
 ```
 
+## Type-safe QUERY requests
+
+A route that exports `QUERY` becomes a `.query()` caller. Its body and response are inferred from
+the endpoint, just like the existing `.get()` and `.post()` callers:
+
+```ts
+const result = await api.products.search.query(
+  {
+    body: {
+      filters: [{ field: "category", value: "tools" }],
+      limit: 20,
+    },
+  },
+  {
+    cache: {
+      policy: "stale-while-revalidate",
+      staleTime: 30_000,
+    },
+  },
+);
+
+if (!result.error) {
+  // Inferred from the QUERY handler response.
+  console.log(result.data.products, result.data.total);
+}
+```
+
+TypeScript reports an error if `body` is missing or a filter has the wrong shape. Farm sends the
+body as JSON and uses the `QUERY` method on the wire. Opt-in cache keys include the API origin,
+path, URL query parameters, request body, `Content-Type`, and `Content-Encoding`. Multipart QUERY
+requests need an explicit cache key because a generated multipart boundary cannot be represented
+reliably before `fetch` sends the request.
+
 ## Upload files and consume progress streams
 
 `toFormData()` retains the endpoint's body shape while sending files as real multipart fields. When

--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -83,6 +83,48 @@ export const GET = createEndpoint(
 
 Farm parses and validates `body`, `query`, and `headers` before middleware or handler code runs. Header schema keys use the lower-case names exposed by the Fetch `Headers` API. Invalid input returns a `400` response with structured validation issues.
 
+## HTTP QUERY
+
+Use the standardized [`QUERY` HTTP method](https://www.rfc-editor.org/rfc/rfc10008.html) when a
+read operation needs structured request content that is too large or sensitive for a URL. Like
+`GET`, `QUERY` is safe and idempotent; unlike `GET`, its request body has defined semantics.
+
+**src/app/api/products/search/route.ts**
+
+```ts
+import { QUERY as createQueryEndpoint } from "@farm.js/core/api";
+import { z } from "zod";
+
+export const QUERY = createQueryEndpoint(
+  {
+    body: z.object({
+      filters: z.array(z.object({ field: z.string(), value: z.string() })),
+      limit: z.number().int().min(1).max(100).default(20),
+    }),
+  },
+  async ({ body }) => {
+    const products = await searchProducts(body.filters, body.limit);
+    return { products, total: products.length };
+  },
+);
+```
+
+The helper infers the validated `body` inside the handler and exposes the same input and response
+types to the generated client. QUERY requests must include a `Content-Type` header; Farm's generated
+client sets `application/json` automatically. A raw handler is also valid:
+
+```ts
+export async function QUERY(request: Request) {
+  const search = await request.json();
+  return Response.json(await searchProducts(search));
+}
+```
+
+Keep `QUERY` handlers read-only. Use `POST`, `PATCH`, or another unsafe method when the operation
+changes server state. A server can advertise accepted query media types with an `Accept-Query`
+response header. Cross-origin browser requests use a CORS preflight, so include `QUERY` in the
+configured `cors.methods` list when that list is restricted.
+
 ## Uploads and streaming results
 
 Use `multipart()` when an endpoint accepts files. Farm parses the request as `FormData`, preserves

--- a/docs/src/app/docs/openapi/page.md
+++ b/docs/src/app/docs/openapi/page.md
@@ -54,6 +54,12 @@ export const GET = createEndpoint(
 
 The route appears in the generated reference with a typed `limit` query parameter.
 
+`QUERY` routes include their request-body schema too. Farm currently emits OpenAPI 3.0.3, whose
+Path Item Object does not have a native `query` field. To keep the document valid, Farm places each
+`QUERY` Operation Object under the registered `x-oai-additionalOperations.QUERY` extension. This
+maps directly to the native `query` field available in OpenAPI 3.2 without mislabeling the route as
+`GET` or `POST`.
+
 ## Add metadata
 
 ```ts

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -12,6 +12,15 @@ import { PluginManager } from "../plugin";
 import { _runWithCurrentRequest } from "../server/request";
 
 type APIRouter = {
+  search: {
+    query: {
+      __types: {
+        body: { filters: string[] };
+        query: never;
+        response: { results: string[] };
+      };
+    };
+  };
   users: {
     get: {
       __types: {
@@ -60,6 +69,38 @@ beforeEach(() => {
 });
 
 describe("createAPIClient", () => {
+  it("sends typed QUERY bodies and caches each representation separately", async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      return buildResponse({ results: body.filters });
+    });
+    globalThis.fetch = fetchMock as any;
+    const api = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
+    const cache = { policy: "cache-first" as const, staleTime: 10_000 };
+
+    const first = await api.search.query({ body: { filters: ["tools"] } }, { cache });
+    const cached = await api.search.query({ body: { filters: ["tools"] } }, { cache });
+    const differentBody = await api.search.query({ body: { filters: ["seeds"] } }, { cache });
+    const alternateRepresentation = createAPIClient<APIRouter>({
+      baseURL: "http://example.com",
+      headers: { "Content-Type": "application/vnd.farm.search+json" },
+    });
+    await alternateRepresentation.search.query({ body: { filters: ["tools"] } }, { cache });
+
+    expect(first.data).toEqual({ results: ["tools"] });
+    expect(cached.data).toEqual({ results: ["tools"] });
+    expect(differentBody.data).toEqual({ results: ["seeds"] });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "http://example.com/api/search",
+      expect.objectContaining({
+        method: "QUERY",
+        body: JSON.stringify({ filters: ["tools"] }),
+      }),
+    );
+  });
+
   it("uses a baseURL path as the API root", async () => {
     const fetchMock = vi.fn(async () => buildResponse({ users: [], total: 0 }));
     globalThis.fetch = fetchMock as any;

--- a/packages/farm/src/__tests__/api-client.typing.test.ts
+++ b/packages/farm/src/__tests__/api-client.typing.test.ts
@@ -28,6 +28,13 @@ type APIRouter = {
         response: { results: string[] };
       };
     };
+    query: {
+      __types: {
+        body: { filters: Array<{ field: string; value: string }>; limit?: number };
+        query: never;
+        response: { results: Array<{ id: string; title: string }>; total: number };
+      };
+    };
   };
   users: {
     get: {
@@ -82,6 +89,12 @@ describe("createAPIClient typing", () => {
     const helloWithQuery = await api.hello.get({ query: { name: "Farm" } });
     const helloPost = await api.hello.post({ body: { name: "Farm" } });
     const search = await api.search.get({ query: { term: "routes" } });
+    const structuredSearch = await api.search.query({
+      body: {
+        filters: [{ field: "category", value: "tools" }],
+        limit: 20,
+      },
+    });
 
     expectTypeOf<IsAny<typeof helloWithoutQuery.data>>().toEqualTypeOf<false>();
     expectTypeOf(helloWithoutQuery.data).toEqualTypeOf<
@@ -90,6 +103,9 @@ describe("createAPIClient typing", () => {
     expectTypeOf(helloWithQuery.data?.message).toEqualTypeOf<string | undefined>();
     expectTypeOf(helloPost.data?.timestamp).toEqualTypeOf<string | undefined>();
     expectTypeOf(search.data?.results).toEqualTypeOf<string[] | undefined>();
+    expectTypeOf(structuredSearch.data?.results).toEqualTypeOf<
+      Array<{ id: string; title: string }> | undefined
+    >();
 
     // @ts-expect-error body schemas require the body wrapper.
     await api.hello.post();
@@ -99,6 +115,10 @@ describe("createAPIClient typing", () => {
     await api.search.get();
     // @ts-expect-error required body fields stay required.
     await api.users.post({ body: { name: "Ada" } });
+    // @ts-expect-error QUERY preserves its required request body.
+    await api.search.query();
+    // @ts-expect-error QUERY body fields retain their generated types.
+    await api.search.query({ body: { filters: [{ field: "category", value: 1 }] } });
   });
 
   it("infers optimistic updater types from route refs and typed cache keys", async () => {

--- a/packages/farm/src/__tests__/api-route-manager.test.ts
+++ b/packages/farm/src/__tests__/api-route-manager.test.ts
@@ -3,7 +3,7 @@ import os from "os";
 import path from "path";
 import { afterEach, describe, expect, it } from "vitest";
 import { z } from "zod";
-import { createEndpoint } from "../api/endpoint";
+import { createEndpoint, QUERY } from "../api/endpoint";
 import { APIRouteManager } from "../api/route-manager";
 import { defineRoutes } from "../routes";
 
@@ -281,6 +281,55 @@ describe("APIRouteManager", () => {
     await expect(invalidResponse.json()).resolves.toMatchObject({
       error: "Invalid request body",
     });
+  });
+
+  it("discovers QUERY exports, validates their bodies, and advertises the method", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-api-route-"));
+    tempDirs.push(root);
+
+    const routeDir = path.join(root, "api", "search");
+    fs.mkdirSync(routeDir, { recursive: true });
+    const routeFile = path.join(routeDir, "route.js");
+    fs.writeFileSync(routeFile, "export {};\n");
+
+    const manager = new APIRouteManager(root, {
+      ssrLoadModule: async () => ({
+        QUERY: QUERY(
+          {
+            body: z.object({ term: z.string().min(1), limit: z.number().int() }),
+          },
+          ({ body }) => ({ matches: [`${body.term}:${body.limit}`] }),
+        ),
+      }),
+    } as any);
+
+    await manager.discoverRoutes();
+    const handler = manager.getHandler()!;
+    const response = await handler(
+      new Request("http://example.com/api/search", {
+        method: "QUERY",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ term: "tractor", limit: 5 }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ matches: ["tractor:5"] });
+
+    const missingContentType = await handler(
+      new Request("http://example.com/api/search", {
+        method: "QUERY",
+        body: new TextEncoder().encode(JSON.stringify({ term: "tractor", limit: 5 })),
+      }),
+    );
+    expect(missingContentType.status).toBe(400);
+    await expect(missingContentType.json()).resolves.toMatchObject({
+      error: "Invalid QUERY request",
+    });
+
+    const methodNotAllowed = await handler(new Request("http://example.com/api/search"));
+    expect(methodNotAllowed.status).toBe(405);
+    expect(methodNotAllowed.headers.get("Allow")).toBe("QUERY");
   });
 
   it("discovers explicit-path createEndpoint routes from root routes files", async () => {

--- a/packages/farm/src/__tests__/deployment.test.ts
+++ b/packages/farm/src/__tests__/deployment.test.ts
@@ -53,10 +53,15 @@ describe("deployment skew protocol", () => {
     const getRequest = new Request("https://farm.test/page", {
       headers: { Cookie: cookie },
     });
+    const queryRequest = new Request("https://farm.test/search", {
+      method: "QUERY",
+      headers: { Cookie: cookie },
+    });
 
     expect(getFarmRequestDeploymentId(headerRequest)).toBe("release-header");
     expect(getFarmRequestDeploymentId(postRequest)).toBe("release-cookie");
     expect(getFarmRequestDeploymentId(getRequest)).toBeUndefined();
+    expect(getFarmRequestDeploymentId(queryRequest)).toBeUndefined();
   });
 
   it("detects stale clients without rejecting missing or matching IDs", () => {

--- a/packages/farm/src/__tests__/integration-client.test.ts
+++ b/packages/farm/src/__tests__/integration-client.test.ts
@@ -421,6 +421,14 @@ describe("integration client", () => {
             "content-type": "application/json",
           },
         }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, mode: "query" }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        }),
       );
 
     const api = createIntegrationClient({
@@ -434,6 +442,9 @@ describe("integration client", () => {
             endpoint.post<{ message: string }, { ok: boolean; mode: string }>({
               responseFormat: "json",
             }),
+            endpoint.query<{ filters: string[] }, { ok: boolean; mode: string }>({
+              responseFormat: "json",
+            }),
           ),
         },
       },
@@ -445,11 +456,18 @@ describe("integration client", () => {
         message: "hello",
       },
     });
+    const queryResult = await api.localDemo.message.query({
+      body: {
+        filters: ["tools"],
+      },
+    });
 
     expect(getResult.error).toBeNull();
     expect(postResult.error).toBeNull();
     expect(getResult.data?.mode).toBe("get");
     expect(postResult.data?.mode).toBe("post");
+    expect(queryResult.error).toBeNull();
+    expect(queryResult.data?.mode).toBe("query");
     expect(fetchSpy).toHaveBeenNthCalledWith(
       1,
       "http://localhost:3000/api/local-demo/message",
@@ -467,6 +485,18 @@ describe("integration client", () => {
         }),
       }),
     );
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      3,
+      "http://localhost:3000/api/local-demo/message",
+      expect.objectContaining({
+        method: "QUERY",
+        body: JSON.stringify({
+          filters: ["tools"],
+        }),
+      }),
+    );
+    const queryHeaders = new Headers(fetchSpy.mock.calls[2]?.[1]?.headers as HeadersInit);
+    expect(queryHeaders.get("content-type")).toBe("application/json");
   });
 
   it("allows calling single-method namespaces directly while preserving the method accessor", async () => {

--- a/packages/farm/src/__tests__/integrations.test.ts
+++ b/packages/farm/src/__tests__/integrations.test.ts
@@ -882,6 +882,41 @@ describe("integrations runtime", () => {
     });
   });
 
+  it("requires Content-Type for QUERY integration routes", async () => {
+    const handler = vi.fn(() => Response.json({ ok: true }));
+    const manager = createManager();
+    manager.addPlugins(
+      resolveIntegrationPlugins({
+        structuredSearch: defineIntegration({
+          category: "custom",
+          type: "structured-search",
+          instance: {},
+          routes: [
+            integrationRoute.query("/api/structured-search", {
+              handler,
+            }),
+          ],
+        }),
+      }),
+    );
+
+    await manager.runHookParallel("init");
+    const runtime = getRegisteredIntegrationRuntime("structuredSearch");
+    const response = await dispatchIntegrationRequest(
+      runtime!,
+      new Request("http://localhost/api/structured-search", {
+        method: "QUERY",
+      }),
+    );
+
+    expect(response?.status).toBe(400);
+    expect(await response?.json()).toEqual({
+      error: "Invalid QUERY request",
+      message: "QUERY requests must include a Content-Type header.",
+    });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
   it("rejects integration request bodies above the server limit", async () => {
     const handler = vi.fn(() => Response.json({ ok: true }));
     const manager = new PluginManager({

--- a/packages/farm/src/__tests__/openapi-generator.test.ts
+++ b/packages/farm/src/__tests__/openapi-generator.test.ts
@@ -1,0 +1,48 @@
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { OpenAPIGenerator } from "../openapi/generator";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe("OpenAPIGenerator", () => {
+  it("represents QUERY with a request body in a valid OpenAPI 3.0 document", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const root = mkdtempSync(path.join(os.tmpdir(), "farm-openapi-query-"));
+    tempDirs.push(root);
+    const routeFile = path.join(root, "route.mjs");
+    writeFileSync(routeFile, "export const QUERY = async () => Response.json({ ok: true });\n");
+
+    const generator = new OpenAPIGenerator(root, { title: "Search API" });
+    const spec = await generator.generateSpec([
+      {
+        path: "/api/search",
+        methods: ["QUERY"],
+        filePath: realpathSync(routeFile),
+        relativePath: "api/search/route.ts",
+      },
+    ]);
+
+    expect(spec.openapi).toBe("3.0.3");
+    expect(spec.paths["/search"].query).toBeUndefined();
+    expect(spec.paths["/search"]["x-oai-additionalOperations"].QUERY).toMatchObject({
+      operationId: "query_search",
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: { type: "object" },
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -819,9 +819,11 @@ export default defineConfig({
     try {
       const failureApiDir = path.join(root, "src", "app", "api", "failure");
       const afterApiDir = path.join(root, "src", "app", "api", "after-response");
+      const queryApiDir = path.join(root, "src", "app", "api", "structured-search");
       const afterMarkerPath = path.join(root, "after-response.txt");
       await fs.mkdir(failureApiDir, { recursive: true });
       await fs.mkdir(afterApiDir, { recursive: true });
+      await fs.mkdir(queryApiDir, { recursive: true });
       await fs.writeFile(
         path.join(failureApiDir, "route.ts"),
         `
@@ -839,6 +841,17 @@ import { after } from "@farm.js/core";
 export async function GET() {
   after(() => writeFile(${JSON.stringify(afterMarkerPath)}, "finished"));
   return Response.json({ accepted: true }, { status: 202 });
+}
+`.trim(),
+      );
+      await fs.writeFile(
+        path.join(queryApiDir, "route.ts"),
+        `
+export async function QUERY(request: Request) {
+  return Response.json({
+    method: request.method,
+    body: await request.json(),
+  });
 }
 `.trim(),
       );
@@ -880,6 +893,22 @@ export async function GET() {
           expect(marker).toBe("finished");
         },
         "/api/after-response",
+      );
+      await runProductionRequest(
+        path.join(root, ".farm", ".output", "server"),
+        async (response) => {
+          expect(response.status).toBe(200);
+          await expect(response.json()).resolves.toEqual({
+            method: "QUERY",
+            body: { filters: ["tools", "seeds"] },
+          });
+        },
+        "/api/structured-search",
+        {
+          method: "QUERY",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ filters: ["tools", "seeds"] }),
+        },
       );
     } finally {
       await fs.rm(root, { recursive: true, force: true });

--- a/packages/farm/src/__tests__/type-generator.test.ts
+++ b/packages/farm/src/__tests__/type-generator.test.ts
@@ -54,7 +54,7 @@ describe("APITypeGenerator", () => {
     );
     writeFileSync(
       path.join(profileRouteDir, "route.js"),
-      "export function POST() { return Response.json({ ok: true }); }\n",
+      "export function QUERY() { return Response.json({ ok: true }); }\nexport function POST() { return Response.json({ ok: true }); }\n",
     );
 
     const generator = new APITypeGenerator(appDir);
@@ -62,7 +62,9 @@ describe("APITypeGenerator", () => {
 
     expect(content).toContain("import type { GET as GET_status }");
     expect(content).toContain("import type { POST as POST_profile }");
+    expect(content).toContain("import type { QUERY as QUERY_profile }");
     expect(content).toContain("status: {");
     expect(content).toContain("profile: {");
+    expect(content).toContain("query: typeof QUERY_profile;");
   });
 });

--- a/packages/farm/src/agent-runtime.ts
+++ b/packages/farm/src/agent-runtime.ts
@@ -6,7 +6,16 @@ import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { defineIntegration, type FarmIntegration } from "./integrations";
 import type { BundleResultPayload, FarmPlugin } from "./plugin";
 
-const AGENT_RUNTIME_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"] as const;
+const AGENT_RUNTIME_METHODS = [
+  "GET",
+  "HEAD",
+  "QUERY",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "OPTIONS",
+] as const;
 
 const HOP_BY_HOP_HEADERS = [
   "connection",

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -65,7 +65,7 @@ export type StatusPhase = "idle" | "pending" | "success" | "error" | "revalidati
 export type StatusEvent<TData = unknown, TError = unknown> = {
   phase: StatusPhase;
   requestId: string;
-  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS" | "HEAD";
+  method: "GET" | "HEAD" | "QUERY" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS";
   key: string;
   input?: unknown;
   data?: TData;
@@ -163,7 +163,7 @@ export type InvalidateTarget =
     }
   | {
       path: string;
-      method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS" | "HEAD";
+      method?: "GET" | "HEAD" | "QUERY" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS";
       input?: unknown;
     }
   | [CallableRouteRef<any>, unknown?];
@@ -507,7 +507,7 @@ export function createAPIClient<
       : undefined;
     const configuredCacheKey = clientOptions?.key ?? cacheOptions?.key;
     const cacheKey = normalizeFarmClientCacheKey(
-      configuredCacheKey ?? buildCacheKey(methodUpper, path, input, baseURL),
+      configuredCacheKey ?? buildCacheKey(methodUpper, path, input, baseURL, options.headers),
     ) as CacheKey<any>;
     const now = Date.now();
 
@@ -526,7 +526,12 @@ export function createAPIClient<
     const entry = getValidCacheEntry(cacheState, cacheKey, now);
     const policy = cacheOptions?.policy ?? (cacheOptions ? "cache-first" : "network-only");
     const staleTime = cacheOptions?.staleTime ?? 0;
-    const isCacheEnabled = Boolean(cacheOptions) && methodUpper === "GET";
+    const hasReliableDefaultCacheKey =
+      methodUpper !== "QUERY" || !isFormData(input?.body) || configuredCacheKey !== undefined;
+    const isCacheEnabled =
+      Boolean(cacheOptions) &&
+      (methodUpper === "GET" || methodUpper === "QUERY") &&
+      hasReliableDefaultCacheKey;
     const isStale = entry ? isEntryStale(entry, now) : true;
 
     const applyOptimisticUpdates = () => {
@@ -538,7 +543,13 @@ export function createAPIClient<
           update.length === 2
             ? [update[0], undefined, update[1]]
             : [update[0], update[1], update[2]];
-        const targetKey = resolveTargetKey(routeMeta, target, targetInput, baseURL);
+        const targetKey = resolveTargetKey(
+          routeMeta,
+          target,
+          targetInput,
+          baseURL,
+          options.headers,
+        );
         if (!targetKey) continue;
 
         const targetEntry = getValidCacheEntry(cacheState, targetKey, now);
@@ -730,7 +741,7 @@ export function createAPIClient<
           };
 
       for (const target of invalidateOptions.targets) {
-        const targetKey = resolveTargetKey(routeMeta, target, undefined, baseURL);
+        const targetKey = resolveTargetKey(routeMeta, target, undefined, baseURL, options.headers);
         if (!targetKey) continue;
 
         const existing = cacheState.get(targetKey);
@@ -853,7 +864,7 @@ function createNestedProxy(
     apply(_target, _thisArg, args) {
       // Check if the last part is an HTTP method
       const lastPart = path[path.length - 1];
-      const httpMethods = ["get", "post", "put", "delete", "patch", "options", "head"];
+      const httpMethods = ["get", "head", "query", "post", "put", "delete", "patch", "options"];
 
       if (httpMethods.includes(lastPart)) {
         // Method is explicitly called: api.users.get() or api['auth/login'].post()
@@ -989,9 +1000,31 @@ type OptimisticSnapshot = {
   entry?: CacheEntry;
 };
 
-function buildCacheKey(method: string, path: string, input: any, baseURL: string): string {
+function buildCacheKey(
+  method: string,
+  path: string,
+  input: any,
+  baseURL: string,
+  defaultHeaders?: Record<string, string>,
+): string {
   const keyInput =
-    input && typeof input === "object" ? { query: input.query, body: input.body } : input;
+    input && typeof input === "object"
+      ? {
+          query: input.query,
+          body: input.body,
+          ...(method === "QUERY"
+            ? {
+                contentType:
+                  getHeader(input.headers, "content-type") ??
+                  getHeader(defaultHeaders, "content-type") ??
+                  "application/json",
+                contentEncoding:
+                  getHeader(input.headers, "content-encoding") ??
+                  getHeader(defaultHeaders, "content-encoding"),
+              }
+            : {}),
+        }
+      : input;
   const url = resolveFarmAPIRequestURL(path, baseURL);
   return `${method}:${url.origin}${url.pathname}:${stableStringify(keyInput ?? {})}`;
 }
@@ -1012,6 +1045,17 @@ function stableStringify(value: any): string {
   const keys = Object.keys(value).sort();
   const entries = keys.map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`);
   return `{${entries.join(",")}}`;
+}
+
+function getHeader(headers: unknown, name: string): string | undefined {
+  if (!headers || typeof headers !== "object") return undefined;
+
+  if (typeof Headers !== "undefined" && headers instanceof Headers) {
+    return headers.get(name) ?? undefined;
+  }
+
+  const entry = Object.entries(headers).find(([key]) => key.toLowerCase() === name);
+  return entry?.[1] === undefined ? undefined : String(entry[1]);
 }
 
 function getGcAt(now: number, gcTime?: number): number | undefined {
@@ -1046,6 +1090,7 @@ function resolveTargetKey(
   target: InvalidateTarget | AnyRouteRef,
   input?: unknown,
   baseURL = "http://localhost:3000",
+  defaultHeaders?: Record<string, string>,
 ): string | null {
   if (!target) return null;
 
@@ -1056,13 +1101,13 @@ function resolveTargetKey(
     if (!meta) return null;
 
     const { method, routePath } = resolveRouteMeta(meta);
-    return buildCacheKey(method, routePath, input ?? {}, meta.baseURL);
+    return buildCacheKey(method, routePath, input ?? {}, meta.baseURL, defaultHeaders);
   }
 
   if (Array.isArray(target)) {
     const [route, routeInput] = target;
     if (typeof route === "function") {
-      return resolveTargetKey(routeMeta, route, routeInput, baseURL);
+      return resolveTargetKey(routeMeta, route, routeInput, baseURL, defaultHeaders);
     }
     return normalizeFarmClientCacheKey(target);
   }
@@ -1071,14 +1116,14 @@ function resolveTargetKey(
 
   if ("path" in target) {
     const method = target.method ?? "GET";
-    return buildCacheKey(method, target.path, target.input ?? {}, baseURL);
+    return buildCacheKey(method, target.path, target.input ?? {}, baseURL, defaultHeaders);
   }
 
   return null;
 }
 
 function resolveRouteMeta(meta: RouteMeta): { routePath: string; method: string } {
-  const httpMethods = ["get", "post", "put", "delete", "patch", "options", "head"];
+  const httpMethods = ["get", "head", "query", "post", "put", "delete", "patch", "options"];
   const lastPart = meta.path[meta.path.length - 1];
   if (lastPart && httpMethods.includes(lastPart)) {
     return {

--- a/packages/farm/src/api/endpoint.ts
+++ b/packages/farm/src/api/endpoint.ts
@@ -220,7 +220,7 @@ export type EndpointOptions<
   TMiddlewares extends readonly AnyEndpointMiddleware[] = readonly [],
   TErrors extends EndpointErrorDefinitions = {},
 > = {
-  method?: "GET" | "HEAD" | "POST" | "PUT" | "DELETE" | "PATCH" | "OPTIONS";
+  method?: "GET" | "HEAD" | "QUERY" | "POST" | "PUT" | "DELETE" | "PATCH" | "OPTIONS";
   body?: TBody;
   query?: TQuery;
   headers?: THeaders;
@@ -755,6 +755,32 @@ export function HEAD(...args: any[]): any {
     return createEndpoint("", { method: "HEAD" }, args[0]);
   }
   return createEndpoint("", { ...args[0], method: "HEAD" }, args[1]);
+}
+
+/**
+ * Convenience method for safe, idempotent QUERY requests with a request body
+ */
+export function QUERY<T = any>(
+  handler: EndpointHandler<never, never, never, T>,
+): CreatedEndpoint<never, never, never, T>;
+export function QUERY<const TOptions extends MethodlessEndpointOptions, TResponse = any>(
+  options: TOptions,
+  handler: ValidatedEndpointHandlerFromOptions<TOptions, TResponse>,
+): CreatedEndpointFromOptions<TOptions, TResponse>;
+export function QUERY<
+  TBody extends AnySchema = never,
+  TQuery extends AnySchema = never,
+  THeaders extends AnySchema = never,
+  TResponse = any,
+>(
+  options: Omit<EndpointOptions<TBody, TQuery, THeaders, readonly []>, "method">,
+  handler: EndpointHandler<TBody, TQuery, THeaders, TResponse>,
+): CreatedEndpoint<TBody, TQuery, THeaders, TResponse>;
+export function QUERY(...args: any[]): any {
+  if (args.length === 1) {
+    return createEndpoint("", { method: "QUERY" }, args[0]);
+  }
+  return createEndpoint("", { ...args[0], method: "QUERY" }, args[1]);
 }
 
 /**

--- a/packages/farm/src/api/route-manager.ts
+++ b/packages/farm/src/api/route-manager.ts
@@ -29,6 +29,7 @@ export interface APIRouteManagerOptions {
 export const API_ROUTE_METHODS = [
   "GET",
   "HEAD",
+  "QUERY",
   "POST",
   "PUT",
   "DELETE",
@@ -311,7 +312,10 @@ export class APIRouteManager {
       if (!endpoint) {
         return new Response(JSON.stringify({ error: "Method Not Allowed" }), {
           status: 405,
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            Allow: route.methods.join(", "),
+            "Content-Type": "application/json",
+          },
         });
       }
 

--- a/packages/farm/src/api/runtime.ts
+++ b/packages/farm/src/api/runtime.ts
@@ -70,6 +70,11 @@ async function invokeAPIRouteEndpointInContext(
   request: Request,
   params: APIRouteParams,
 ): Promise<Response> {
+  const queryContentTypeError = validateQueryContentType(request);
+  if (queryContentTypeError) {
+    return queryContentTypeError;
+  }
+
   const farmHandler = endpoint.__handler || (isFarmContextHandler(endpoint) ? endpoint : null);
 
   if (!farmHandler) {
@@ -141,6 +146,23 @@ async function invokeAPIRouteEndpointInContext(
 
   const response = normalizeRouteResponse(execution.result);
   return attachEndpointInvalidations(response, execution.invalidations);
+}
+
+function validateQueryContentType(request: Request): Response | null {
+  if (request.method.toUpperCase() !== "QUERY" || request.headers.has("content-type")) {
+    return null;
+  }
+
+  return new Response(
+    JSON.stringify({
+      error: "Invalid QUERY request",
+      message: "QUERY requests must include a Content-Type header.",
+    }),
+    {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
 }
 
 export function normalizeRouteResponse(result: unknown): Response {

--- a/packages/farm/src/api/vite-plugin.ts
+++ b/packages/farm/src/api/vite-plugin.ts
@@ -134,7 +134,10 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
         if (!endpoint) {
           return new Response(JSON.stringify({ error: "Method Not Allowed" }), {
             status: 405,
-            headers: { "Content-Type": "application/json" },
+            headers: {
+              Allow: route.methods.join(", "),
+              "Content-Type": "application/json",
+            },
           });
         }
 

--- a/packages/farm/src/deployment.ts
+++ b/packages/farm/src/deployment.ts
@@ -217,5 +217,5 @@ function readCookie(cookieHeader: string | null, name: string): string | undefin
 }
 
 function isSafeRequestMethod(method: string): boolean {
-  return ["GET", "HEAD", "OPTIONS"].includes(method.toUpperCase());
+  return ["GET", "HEAD", "OPTIONS", "QUERY"].includes(method.toUpperCase());
 }

--- a/packages/farm/src/integration-api.ts
+++ b/packages/farm/src/integration-api.ts
@@ -1,5 +1,6 @@
 export type FarmIntegrationAPIMethod =
   | "GET"
+  | "QUERY"
   | "POST"
   | "PUT"
   | "PATCH"
@@ -348,6 +349,15 @@ export const api = {
   get,
   route,
   fromRoutes,
+  query<TBody = never, TResponse = unknown, TQuery = never, TServer extends boolean = false>(
+    pathOrOptions?: string | IntegrationAPIBuilderOptions<TServer>,
+    maybeOptions: IntegrationAPIBuilderOptions<TServer> = {} as IntegrationAPIBuilderOptions<TServer>,
+  ): FarmIntegrationAPIOperation<TBody, TQuery, TResponse, TServer, "QUERY"> {
+    return operation<TBody, TQuery, TResponse, TServer, "QUERY">("QUERY", pathOrOptions, {
+      bodyFormat: "json",
+      ...(typeof pathOrOptions === "string" ? maybeOptions : pathOrOptions),
+    });
+  },
   post<TBody = never, TResponse = unknown, TQuery = never, TServer extends boolean = false>(
     pathOrOptions?: string | IntegrationAPIBuilderOptions<TServer>,
     maybeOptions: IntegrationAPIBuilderOptions<TServer> = {} as IntegrationAPIBuilderOptions<TServer>,
@@ -405,6 +415,15 @@ export const api = {
     );
   },
   form: {
+    query<TBody = never, TResponse = unknown, TQuery = never, TServer extends boolean = false>(
+      pathOrOptions?: string | IntegrationAPIBuilderOptions<TServer>,
+      maybeOptions: IntegrationAPIBuilderOptions<TServer> = {} as IntegrationAPIBuilderOptions<TServer>,
+    ): FarmIntegrationAPIOperation<TBody, TQuery, TResponse, TServer, "QUERY"> {
+      return operation<TBody, TQuery, TResponse, TServer, "QUERY">("QUERY", pathOrOptions, {
+        bodyFormat: "form",
+        ...(typeof pathOrOptions === "string" ? maybeOptions : pathOrOptions),
+      });
+    },
     post<TBody = never, TResponse = unknown, TQuery = never, TServer extends boolean = false>(
       pathOrOptions?: string | IntegrationAPIBuilderOptions<TServer>,
       maybeOptions: IntegrationAPIBuilderOptions<TServer> = {} as IntegrationAPIBuilderOptions<TServer>,

--- a/packages/farm/src/integration-client.ts
+++ b/packages/farm/src/integration-client.ts
@@ -605,6 +605,25 @@ function createBody(
   return JSON.stringify(body);
 }
 
+function createOperationBody(
+  operation: Pick<FarmIntegrationAPIOperation<any, any, any>, "bodyFormat" | "method">,
+  body: unknown,
+  headers: Headers,
+): BodyInit | undefined {
+  const requestBody = createBody(operation.bodyFormat, body, headers);
+
+  if (operation.method === "QUERY" && requestBody === undefined && !headers.has("content-type")) {
+    headers.set(
+      "content-type",
+      operation.bodyFormat === "form"
+        ? "application/x-www-form-urlencoded;charset=UTF-8"
+        : "application/json",
+    );
+  }
+
+  return requestBody;
+}
+
 async function parseResponseData(response: Response): Promise<unknown> {
   if (response.status === 204 || response.status === 205) {
     return undefined;
@@ -717,10 +736,11 @@ async function executeClientOperation(
       mergeIntegrationClientData(options.data, requestOptions?.data),
     );
 
+    const body = createOperationBody(operation, input.body, headers);
     const response = await fetch(url.toString(), {
       method: operation.method,
       headers,
-      body: createBody(operation.bodyFormat, input.body, headers),
+      body,
       credentials:
         requestOptions?.credentials ?? operation.credentials ?? options.credentials ?? "include",
       signal: requestOptions?.signal,
@@ -827,13 +847,14 @@ async function executeServerOperation(
 
       if (runtime) {
         const dispatchIntegrationRequest = resolveIntegrationRequestDispatcherLocal();
+        const body = createOperationBody(operation, input.body, headers);
         const directResponse = dispatchIntegrationRequest
           ? await dispatchIntegrationRequest(
               runtime,
               new Request(url.toString(), {
                 method: operation.method,
                 headers,
-                body: createBody(operation.bodyFormat, input.body, headers),
+                body,
               }),
               {
                 currentRequest,
@@ -851,10 +872,11 @@ async function executeServerOperation(
 
     appendIntegrationClientDataHeader(headers, data);
 
+    const body = createOperationBody(operation, input.body, headers);
     const response = await fetch(url.toString(), {
       method: operation.method,
       headers,
-      body: createBody(operation.bodyFormat, input.body, headers),
+      body,
       credentials:
         requestOptions?.credentials ?? operation.credentials ?? options.credentials ?? "include",
       signal: requestOptions?.signal,

--- a/packages/farm/src/integrations.ts
+++ b/packages/farm/src/integrations.ts
@@ -596,6 +596,16 @@ export interface FarmIntegrationRouteFactory<
     path: TPath,
     input: IntegrationRouteBuilderOptions<TBody, TQuery, TServer, TSchema>,
   ): FarmTypedIntegrationRoute<TPath, TBody, TQuery, TResponse, TServer, "POST", TSchema>;
+  query<
+    TPath extends string,
+    TBody = never,
+    TResponse = unknown,
+    TQuery = never,
+    TServer extends boolean = false,
+  >(
+    path: TPath,
+    input: IntegrationRouteBuilderOptions<TBody, TQuery, TServer, TSchema>,
+  ): FarmTypedIntegrationRoute<TPath, TBody, TQuery, TResponse, TServer, "QUERY", TSchema>;
   put<
     TPath extends string,
     TBody = never,
@@ -708,6 +718,26 @@ function createIntegrationRouteFactory<
           ...input,
         },
       );
+    },
+    query<
+      TPath extends string,
+      TBody = never,
+      TResponse = unknown,
+      TQuery = never,
+      TServer extends boolean = false,
+    >(path: TPath, input: IntegrationRouteBuilderOptions<TBody, TQuery, TServer, TSchema>) {
+      return defineTypedIntegrationRoute<
+        TPath,
+        TBody,
+        TQuery,
+        TResponse,
+        TServer,
+        "QUERY",
+        TSchema
+      >("QUERY", path, {
+        bodyFormat: "json",
+        ...input,
+      });
     },
     put<
       TPath extends string,
@@ -2209,6 +2239,19 @@ async function validateIntegrationRouteInput(
   request: Request,
   url: URL,
 ): Promise<IntegrationRouteInputValidationResult> {
+  if (request.method.toUpperCase() === "QUERY" && !request.headers.has("content-type")) {
+    return {
+      success: false,
+      response: Response.json(
+        {
+          error: "Invalid QUERY request",
+          message: "QUERY requests must include a Content-Type header.",
+        },
+        { status: 400 },
+      ),
+    };
+  }
+
   const schemas = route.input;
   if (!schemas?.body && !schemas?.query) {
     return {

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1345,7 +1345,7 @@ async function buildClient(
             }
             if (id === "\0empty-api-route") {
               // Stub for API routes - only used in type context, provide empty exports
-              return "export const GET = () => {}; export const POST = () => {}; export const PUT = () => {}; export const DELETE = () => {}; export const PATCH = () => {}; export default {};";
+              return "export const GET = () => {}; export const HEAD = () => {}; export const QUERY = () => {}; export const POST = () => {}; export const PUT = () => {}; export const DELETE = () => {}; export const PATCH = () => {}; export const OPTIONS = () => {}; export default {};";
             }
             if (id === "\0farm-i18n-client-bridge") {
               return 'export { createTranslator, format, getLocale, getLocaleSource, t } from "@farm.js/core/i18n/client";';
@@ -3678,7 +3678,13 @@ async function handleAPIRequest(request) {
   if (!endpoint) {
     const response = new Response(
       JSON.stringify({ error: "Method Not Allowed" }),
-      { status: 405, headers: { "Content-Type": "application/json" } }
+      {
+        status: 405,
+        headers: {
+          "Allow": route.methods.join(", "),
+          "Content-Type": "application/json",
+        },
+      }
     );
     emitFarmEvent({
       type: "api.request.complete",

--- a/packages/farm/src/openapi/generator.ts
+++ b/packages/farm/src/openapi/generator.ts
@@ -290,8 +290,15 @@ export class OpenAPIGenerator {
 
       for (const route of routeList) {
         for (const method of route.methods) {
-          const methodLower = method.toLowerCase();
-          spec.paths[openAPIPath][methodLower] = await this.generateOperation(route, method);
+          const operation = await this.generateOperation(route, method);
+          if (method === "QUERY") {
+            const additionalOperations =
+              spec.paths[openAPIPath]["x-oai-additionalOperations"] ?? {};
+            additionalOperations.QUERY = operation;
+            spec.paths[openAPIPath]["x-oai-additionalOperations"] = additionalOperations;
+          } else {
+            spec.paths[openAPIPath][method.toLowerCase()] = operation;
+          }
         }
       }
     }
@@ -311,7 +318,7 @@ export class OpenAPIGenerator {
    * Extract request body schema from endpoint
    */
   private async getRequestBody(route: APIRouteInfo, method: string): Promise<any> {
-    if (!["POST", "PUT", "PATCH", "DELETE"].includes(method)) {
+    if (!["QUERY", "POST", "PUT", "PATCH", "DELETE"].includes(method)) {
       return undefined;
     }
 
@@ -485,8 +492,8 @@ export class OpenAPIGenerator {
       operation.parameters = parameters;
     }
 
-    // Add request body for POST, PUT, PATCH, DELETE
-    if (["POST", "PUT", "PATCH", "DELETE"].includes(method)) {
+    // QUERY and mutation methods can carry typed request content.
+    if (["QUERY", "POST", "PUT", "PATCH", "DELETE"].includes(method)) {
       operation.requestBody = await this.getRequestBody(route, method);
     }
 
@@ -504,15 +511,17 @@ export class OpenAPIGenerator {
     const action =
       method === "GET"
         ? "Get"
-        : method === "POST"
-          ? "Create"
-          : method === "PUT"
-            ? "Update"
-            : method === "DELETE"
-              ? "Delete"
-              : method === "PATCH"
-                ? "Update"
-                : method;
+        : method === "QUERY"
+          ? "Query"
+          : method === "POST"
+            ? "Create"
+            : method === "PUT"
+              ? "Update"
+              : method === "DELETE"
+                ? "Delete"
+                : method === "PATCH"
+                  ? "Update"
+                  : method;
 
     return `${action} ${lastPart}`;
   }

--- a/packages/farm/src/routes.ts
+++ b/packages/farm/src/routes.ts
@@ -24,6 +24,7 @@ export type ProgrammaticRouteRenderMode = "static" | "dynamic";
 export type ProgrammaticRouteMethod =
   | "GET"
   | "HEAD"
+  | "QUERY"
   | "POST"
   | "PUT"
   | "DELETE"
@@ -1534,6 +1535,7 @@ function isProgrammaticRouteMethod(method: string): method is ProgrammaticRouteM
   return (
     method === "GET" ||
     method === "HEAD" ||
+    method === "QUERY" ||
     method === "POST" ||
     method === "PUT" ||
     method === "DELETE" ||

--- a/packages/farm/src/type-generator.ts
+++ b/packages/farm/src/type-generator.ts
@@ -84,7 +84,7 @@ export class APITypeGenerator {
 
   private extractExportedMethods(content: string): string[] {
     const methods: string[] = [];
-    const httpMethods = ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"];
+    const httpMethods = ["GET", "HEAD", "QUERY", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"];
 
     for (const method of httpMethods) {
       // Look for export const METHOD = or export { METHOD }

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -3182,6 +3182,7 @@ if (!__farmRoute) {
 
 export const GET = __farmRoute.methods.GET;
 export const HEAD = __farmRoute.methods.HEAD;
+export const QUERY = __farmRoute.methods.QUERY;
 export const POST = __farmRoute.methods.POST;
 export const PUT = __farmRoute.methods.PUT;
 export const DELETE = __farmRoute.methods.DELETE;

--- a/packages/farm/types/api.d.ts
+++ b/packages/farm/types/api.d.ts
@@ -10,7 +10,15 @@ declare module "@farm.js/core/api" {
   /**
    * HTTP methods supported by API routes
    */
-  export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS";
+  export type HttpMethod =
+    | "GET"
+    | "HEAD"
+    | "QUERY"
+    | "POST"
+    | "PUT"
+    | "PATCH"
+    | "DELETE"
+    | "OPTIONS";
 
   export type MultipartField = string | number | boolean | bigint | Blob | Date | null | undefined;
 

--- a/packages/farm/types/client.d.ts
+++ b/packages/farm/types/client.d.ts
@@ -475,7 +475,7 @@ declare module "@farm.js/core/client" {
   export type StatusEvent<TData = unknown, TError = unknown> = {
     phase: StatusPhase;
     requestId: string;
-    method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS" | "HEAD";
+    method: "GET" | "HEAD" | "QUERY" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS";
     key: string;
     input?: unknown;
     data?: TData;
@@ -571,7 +571,7 @@ declare module "@farm.js/core/client" {
       }
     | {
         path: string;
-        method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS" | "HEAD";
+        method?: "GET" | "HEAD" | "QUERY" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS";
         input?: unknown;
       }
     | [CallableRouteRef, unknown?];
@@ -975,6 +975,7 @@ declare module "@farm.js/core/client" {
 
   export type FarmIntegrationAPIMethod =
     | "GET"
+    | "QUERY"
     | "POST"
     | "PUT"
     | "PATCH"
@@ -1123,6 +1124,13 @@ declare module "@farm.js/core/client" {
     fromRoutes<TRoutes extends readonly FarmIntegrationRouteOperationCarrier<string, any>[]>(
       routes: TRoutes,
     ): RoutesToAPI<TRoutes>;
+    query<TBody = never, TResponse = unknown, TQuery = never, TServer extends boolean = false>(
+      path: string,
+      options?: IntegrationAPIBuilderOptions<TServer>,
+    ): FarmIntegrationAPIOperation<TBody, TQuery, TResponse, TServer, "QUERY">;
+    query<TBody = never, TResponse = unknown, TQuery = never, TServer extends boolean = false>(
+      options?: IntegrationAPIBuilderOptions<TServer>,
+    ): FarmIntegrationAPIOperation<TBody, TQuery, TResponse, TServer, "QUERY">;
     post<TBody = never, TResponse = unknown, TQuery = never, TServer extends boolean = false>(
       path: string,
       options?: IntegrationAPIBuilderOptions<TServer>,
@@ -1166,6 +1174,13 @@ declare module "@farm.js/core/client" {
       options?: IntegrationAPIBuilderOptions<TServer>,
     ): FarmIntegrationAPIOperation<never, TQuery, TResponse, TServer, "HEAD">;
     form: {
+      query<TBody = never, TResponse = unknown, TQuery = never, TServer extends boolean = false>(
+        path: string,
+        options?: IntegrationAPIBuilderOptions<TServer>,
+      ): FarmIntegrationAPIOperation<TBody, TQuery, TResponse, TServer, "QUERY">;
+      query<TBody = never, TResponse = unknown, TQuery = never, TServer extends boolean = false>(
+        options?: IntegrationAPIBuilderOptions<TServer>,
+      ): FarmIntegrationAPIOperation<TBody, TQuery, TResponse, TServer, "QUERY">;
       post<TBody = never, TResponse = unknown, TQuery = never, TServer extends boolean = false>(
         path: string,
         options?: IntegrationAPIBuilderOptions<TServer>,


### PR DESCRIPTION
## Summary

- add end-to-end support for the standardized HTTP `QUERY` method across file-based and programmatic API routes
- add typed `QUERY` endpoint, integration route, and generated client helpers with body and response inference
- enforce the required `Content-Type` header and include request content metadata in opt-in cache keys
- expose `QUERY` in production routing, deployment handling, agent runtime proxies, and generated route types
- represent QUERY operations in OpenAPI 3.0.3 through `x-oai-additionalOperations.QUERY`
- document API route, client, caching, CORS, and OpenAPI usage

## Why

RFC 10008 standardizes `QUERY` for safe, idempotent requests that need structured request content. Supporting it gives read-only operations a defined alternative to oversized or sensitive URL query strings without incorrectly using `POST`.

## Developer impact

Developers can export a typed `QUERY` route and call the generated `.query()` client with compile-time body and response inference. Farm automatically sends JSON content types, rejects malformed requests missing `Content-Type`, and keeps cache representations separate by request body, `Content-Type`, and `Content-Encoding`.

## Validation

- `pnpm type-check`
- `pnpm build`
- full Farm package suite: 125 test files, 1,014 passed, 1 skipped
- focused QUERY suite: 8 test files, 92 passed
- formatting check passed
- lint completed with 0 errors


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end support for the standardized HTTP QUERY method to API routes, clients, integrations, and OpenAPI so read-only operations can send structured request bodies safely. Previously unsupported; now `QUERY` is typed, validated, cache-aware, and enforced to include `Content-Type` (400 if missing).

- New surface:
  - API routes: `QUERY` endpoint helper in `@farm.js/core/api`; discovery, SSR/prod routing, proxies, and generated types include `QUERY`. 405 now advertises allowed methods via `Allow`.
  - Client: `.query()` caller with body/response inference; caching enabled for `GET` and `QUERY`. Cache keys include origin, path, URL params, request body, `Content-Type`, and `Content-Encoding`.
  - Integrations: `api.query()` and `integrationRoute.query()` (JSON by default, `api.form.query()` supported). Integration client sets a sensible `Content-Type` for `QUERY` when absent.
  - OpenAPI: represents `QUERY` under `x-oai-additionalOperations.QUERY` (valid in OpenAPI 3.0.3) with a request body; maps cleanly to native `query` in OpenAPI 3.2.
- Behavior and constraints:
  - `QUERY` is treated as safe/idempotent; included in deployment “safe method” checks.
  - Runtime enforces `Content-Type` on `QUERY` (API and integrations). Invalid requests return 400 with a structured error.
  - Caching: default keys work for JSON; multipart `QUERY` must provide an explicit `cache.key` due to unpredictable boundaries. Invalidation/optimistic updates consider headers when resolving keys.
- Migration:
  - If you restrict CORS methods, add `QUERY` to your allowed list.
  - Custom callers must send a `Content-Type` header for `QUERY`. The generated clients set JSON (or form) automatically.
  - Regenerate API types and OpenAPI artifacts to include `QUERY`.

<sup>Written for commit 3f37d990018201e62953c989a025b7bbfc166859. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

