### PR TITLE
fix: restore llms.txt docs header link

### DIFF
--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -1197,8 +1197,8 @@ html[data-farm-docs-runtime="true"] .fd-page-action-menu-item:last-child {
   background: color-mix(in srgb, var(--color-fd-foreground) 6%, transparent) !important;
 }
 
-/* Keep agent discovery routes available without advertising them as reader UI. */
-html[data-farm-docs-runtime="true"] .fd-agent-llms-directive[data-visible-in-header],
+/* Keep the secondary agent links out of the page footer while preserving the
+   primary llms.txt action in the header beside search. */
 html[data-farm-docs-runtime="true"] .fd-llms-txt-links {
   display: none !important;
 }


### PR DESCRIPTION
## Summary

- restore the `LLMS.TXT` action in the docs header beside search
- keep the secondary `llms.txt` and `llms-full.txt` footer links hidden
- preserve the existing shared-theme desktop and mobile header styling

## Root cause

A docs-specific CSS selector grouped the visible header directive with the secondary footer links and applied `display: none !important` to both. The docs configuration and generated `/llms.txt` route were still enabled, but the primary reader-facing header action was hidden.

## Developer impact

The agent-readable docs entry point is visible and directly accessible from the docs header again without adding duplicate links to every page footer.

## Validation

- confirmed `/docs` renders `.fd-agent-llms-directive[data-visible-in-header="true"]`
- confirmed `/llms.txt` responds with `200` and `text/plain`
- confirmed generated production CSS displays the header action and keeps footer links hidden
- formatting check passed
- full Vercel production docs build passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the `LLMS.TXT` docs header action and keeps the secondary `llms.txt`/`llms-full.txt` footer links hidden. Previously the header action was hidden by an over-broad docs CSS selector; now only the footer links are hidden, making the agent entry point visible again without changing header layout.

**Review notes**
- CSS now targets only `.fd-llms-txt-links` for `display: none !important`; it no longer includes `.fd-agent-llms-directive[data-visible-in-header]`.
- No config or routing changes; `/llms.txt` remains enabled and returns 200 text/plain.

<sup>Written for commit 36cd62bf825497702505443244a6073ebb3378af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

