### PR TITLE
fix(build): report completion once, naming the preset that ran

### DIFF
--- a/packages/farm-cli/src/build.ts
+++ b/packages/farm-cli/src/build.ts
@@ -53,15 +53,15 @@ export async function buildFarm(options: BuildFarmOptions = {}) {
         config.deploy = deploy;
       }
 
-      // Build
+      // Build. Completion is reported by the build pipeline itself, which
+      // also knows the preset and output directory; a second banner here
+      // would only repeat it.
       await buildRuntimeResult.value.build(config, {
         preset: config.preset,
         root,
         productionVite: productionViteResult.value,
       });
     });
-
-    logger.success("✅ Build completed successfully!");
   } catch (error: any) {
     logger.error(`❌ Build failed: ${error.message}`);
     if (error.stack) {

--- a/packages/farm/src/build/index.ts
+++ b/packages/farm/src/build/index.ts
@@ -102,8 +102,12 @@ async function buildWithProductionNodeEnv(config: ResolvedFarmConfig, options: B
       suppressLintOnLink: config.suppressLintOnLink,
       componentExtensions: config.renderer.componentExtensions,
       i18nConfig: config.i18n,
-    }).catch(() => {
-      // Non-fatal; type generation is for DX only.
+    }).catch((error: unknown) => {
+      // Non-fatal; type generation is for DX only. But say so: a silently
+      // skipped run leaves src/farm.d.ts describing routes that no longer
+      // exist, which reads as the framework having gone stale.
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn(`Route type generation failed (farm.d.ts may be stale): ${message}`);
     });
 
     // Type artifacts and API discovery scan independent inputs, so keep them
@@ -167,7 +171,10 @@ async function buildWithProductionNodeEnv(config: ResolvedFarmConfig, options: B
       success: true,
     });
 
-    logger.success("✅ Build completed successfully!");
+    // The one completion summary for the whole pipeline: inner stages and the
+    // CLI stay quiet so success is reported exactly once, and the line that
+    // names the output directory also names the preset that chose it.
+    logger.success(`✅ Build completed successfully! (preset: ${preset})`);
     logger.info(`📁 Output directory: ${deployOutputDir}`);
   } catch (error) {
     await pluginManager.runHookParallel("onError", {

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -875,9 +875,7 @@ export async function buildUniversal(
       routeRuntimeManifest,
     );
     logger.info(`📋 Route runtime manifest: ${path.relative(root, runtimeManifestPath)}`);
-
-    logger.success("✅ Build completed successfully!");
-    logger.info(`📁 Output directory: ${deployOutputDir}`);
+    // The completion summary is printed once, by the build orchestrator.
   } catch (error) {
     if (lifecyclePluginManager) {
       await lifecyclePluginManager.runHookParallel("onError", {


### PR DESCRIPTION
Found while building an app on beta.29 and reproduced on main with `examples/basic`.

`farm build` printed the success banner **three times** (once each from `buildUniversal`, `buildFarm`, and the CLI) and the output directory **twice**:

```
112:[success] ✅ Build completed successfully!
113:[info] 📁 Output directory: …/.vercel/output
114:[success] ✅ Build completed successfully!
115:[info] 📁 Output directory: …/.vercel/output
116:[success] ✅ Build completed successfully!
```

While debugging a caching problem this repeatedly made me second-guess whether a rebuild had actually run.

- `build/index.ts` (the orchestrator) now owns the single summary; `buildUniversal` and the CLI stay quiet
- The summary **names the preset next to the output directory** — after this change the same build prints `✅ Build completed successfully! (preset: node-server)` above `📁 Output directory: …`, which also makes preset/directory mismatches visible at a glance (a separate bug, PR to follow)
- Route type generation failures during build now `warn` that `farm.d.ts` may be stale instead of being swallowed by an empty `catch`

Verified by rebuilding `examples/basic` with `--preset node-server`: exactly one banner, one output-directory line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report build completion once and name the preset that ran, removing duplicate banners that looked like multiple builds. Previously, `farm build` printed success three times and the output directory twice; now only the orchestrator logs a single summary and directory line.

**Behavior changes**
- Centralizes the summary in `farm/src/build/index.ts`: logs "✅ Build completed successfully! (preset: <name>)" and one "📁 Output directory: …". The CLI and universal build no longer log completion.
- Route type generation failures now warn that `farm.d.ts` may be stale; the build continues.

<sup>Written for commit 1c4e384b5754e5b574eb72bf67d7e045b8e9ca47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

