### PR TITLE
fix(config): let a preset override displace the configured deploy target

### DIFF
--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -714,6 +714,42 @@ describe("resolveDeployConfig", () => {
     });
   });
 
+  it("lets a preset override displace the configured platform target", () => {
+    // The bug this pins: with deploy.target vercel in config,
+    // `farm build --preset node-server` produced a node server inside
+    // .vercel/output — a directory Vercel deploys as Build Output API
+    // content. The explicit preset must replace the deployment plan.
+    const deploy = resolveDeployConfig(
+      { deploy: { target: "vercel" } },
+      { preset: "node-server" },
+    );
+
+    expect(deploy).toMatchObject({
+      target: "node",
+      preset: "node-server",
+      outputDir: ".farm/.output",
+    });
+  });
+
+  it("keeps a preset override with no matching target out of platform directories", () => {
+    const deploy = resolveDeployConfig(
+      { deploy: { target: "vercel" } },
+      { preset: "deno-server" },
+    );
+
+    expect(deploy.preset).toBe("deno-server");
+    expect(deploy.outputDir).toBe(".farm/.output");
+  });
+
+  it("respects an explicitly configured output directory under a preset override", () => {
+    const deploy = resolveDeployConfig(
+      { deploy: { target: "vercel", outputDir: "custom-out" } },
+      { preset: "node-server" },
+    );
+
+    expect(deploy.outputDir).toBe("custom-out");
+  });
+
   it("recognizes the Cloudflare module preset used by agent Workers", () => {
     const deploy = resolveDeployConfig({ preset: "cloudflare-module" });
 

--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -719,10 +719,7 @@ describe("resolveDeployConfig", () => {
     // `farm build --preset node-server` produced a node server inside
     // .vercel/output — a directory Vercel deploys as Build Output API
     // content. The explicit preset must replace the deployment plan.
-    const deploy = resolveDeployConfig(
-      { deploy: { target: "vercel" } },
-      { preset: "node-server" },
-    );
+    const deploy = resolveDeployConfig({ deploy: { target: "vercel" } }, { preset: "node-server" });
 
     expect(deploy).toMatchObject({
       target: "node",
@@ -732,10 +729,7 @@ describe("resolveDeployConfig", () => {
   });
 
   it("keeps a preset override with no matching target out of platform directories", () => {
-    const deploy = resolveDeployConfig(
-      { deploy: { target: "vercel" } },
-      { preset: "deno-server" },
-    );
+    const deploy = resolveDeployConfig({ deploy: { target: "vercel" } }, { preset: "deno-server" });
 
     expect(deploy.preset).toBe("deno-server");
     expect(deploy.outputDir).toBe(".farm/.output");

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -485,7 +485,17 @@ export function resolveDeployConfig(
 ): ResolvedFarmDeployConfig {
   const deploy = config.deploy || {};
   const distDir = config.distDir || ".farm";
-  const target = normalizeDeployTarget(overrides.target || deploy.target);
+  // An explicit preset override replaces the deployment plan, so the
+  // configured platform target must not keep steering the output. Otherwise
+  // `farm build --preset node-server` on an app configured for Vercel writes
+  // a node server into .vercel/output — a directory Vercel will deploy as
+  // Build Output API content.
+  const overrideTarget = normalizeDeployTarget(overrides.target);
+  const target = overrideTarget
+    ? overrideTarget
+    : overrides.preset
+      ? getDeployTargetForPreset(overrides.preset)
+      : normalizeDeployTarget(deploy.target);
   const preset =
     overrides.preset ||
     deploy.preset ||

--- a/playwright.production-sites.config.ts
+++ b/playwright.production-sites.config.ts
@@ -20,13 +20,13 @@ export default defineConfig({
   },
   webServer: [
     {
-      command: `NODE_ENV=production HOST=127.0.0.1 PORT=${docsPort} node docs/.vercel/output/server/index.mjs`,
+      command: `NODE_ENV=production HOST=127.0.0.1 PORT=${docsPort} node docs/.farm/.output/server/index.mjs`,
       url: docsBaseURL,
       reuseExistingServer: false,
       timeout: 30_000,
     },
     {
-      command: `NODE_ENV=production HOST=127.0.0.1 PORT=${demoPort} node examples/ssr-ssg-demo/.vercel/output/server/index.mjs`,
+      command: `NODE_ENV=production HOST=127.0.0.1 PORT=${demoPort} node examples/ssr-ssg-demo/.farm/.output/server/index.mjs`,
       url: demoBaseURL,
       reuseExistingServer: false,
       timeout: 30_000,

--- a/playwright.production.config.ts
+++ b/playwright.production.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     : {
         command: [
           "FARM_VITE_BUILDER=rolldown corepack pnpm --dir examples/basic exec farm build --preset node-server",
-          `NODE_ENV=production CRON_SECRET=farm-production-e2e-secret HOST=127.0.0.1 PORT=${port} node examples/basic/.vercel/output/server/index.mjs`,
+          `NODE_ENV=production CRON_SECRET=farm-production-e2e-secret HOST=127.0.0.1 PORT=${port} node examples/basic/.farm/.output/server/index.mjs`,
         ].join(" && "),
         url: baseURL,
         reuseExistingServer: false,

--- a/tests/e2e-production-sites/docs.production.spec.ts
+++ b/tests/e2e-production-sites/docs.production.spec.ts
@@ -3,8 +3,8 @@ import { expect, test } from "@playwright/test";
 
 test.beforeAll(async () => {
   await Promise.all([
-    access("docs/.vercel/output/server/index.mjs"),
-    access("docs/.vercel/output/public/farm-client.js"),
+    access("docs/.farm/.output/server/index.mjs"),
+    access("docs/.farm/.output/public/farm-client.js"),
   ]);
 });
 

--- a/tests/e2e-production-sites/ssr-ssg.production.spec.ts
+++ b/tests/e2e-production-sites/ssr-ssg.production.spec.ts
@@ -5,8 +5,8 @@ const timestampPattern = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/;
 
 test.beforeAll(async () => {
   await Promise.all([
-    access("examples/ssr-ssg-demo/.vercel/output/server/index.mjs"),
-    access("examples/ssr-ssg-demo/.vercel/output/public/farm-client.js"),
+    access("examples/ssr-ssg-demo/.farm/.output/server/index.mjs"),
+    access("examples/ssr-ssg-demo/.farm/.output/public/farm-client.js"),
   ]);
 });
 


### PR DESCRIPTION
Found while containerising an app that deploys its frontend to Vercel: the Dockerfile ran `farm build --preset node-server`, and the node build landed in **`.vercel/output`** — with `server/index.mjs`, not `functions/` — while `.farm/.output` was never created. Anyone's next `vercel deploy` would push that as Build Output API content, and anyone looking for the node build in the documented location finds nothing.

**Root cause.** `resolveDeployConfig` resolved `target` as `overrides.target || deploy.target`, so a CLI `--preset` override changed nitro's runtime preset but the *configured platform target* kept choosing the output directory. The resolved config ended up as the inconsistent trio `{ preset: 'node-server', target: 'vercel', outputDir: '.vercel/output' }`.

**Fix.** Precedence is now: explicit override target → target derived from an explicit override preset (or none, for presets with no platform mapping, which land in the generic `${distDir}/.output`) → configured target. An explicitly configured `outputDir` is respected in every case, and `farm deploy` is unaffected because it always passes an override target.

**Verified on `examples/basic`** (config target `vercel`):
- `farm build --preset node-server` → `.farm/.output` with `server/index.mjs`, boots and serves 200; `.vercel` not created
- `farm build` (no flag) → `.vercel/output` with `functions/__nitro.func`, unchanged
- 3 new unit tests pin the conflict case, the unmapped-preset case, and explicit-outputDir survival; config/deployment/config-loader suites all green (48 tests)

Sibling of #342 — after both, the build summary names the preset next to the directory it chose, so a mismatch like this would be visible in the log at a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes deploy target resolution so a preset override displaces a configured platform target. Previously, `farm build --preset node-server` on `deploy.target: 'vercel'` wrote a Node server to `.vercel/output`; now preset-derived targets choose `.farm/.output` (or a mapped platform directory) and respect any explicit `outputDir`.

- Precedence: explicit override target > target from an explicit preset (or none) > configured target.
- `resolveDeployConfig` updated in `packages/farm/src/config.ts`.
- Adds 3 unit tests in `packages/farm/src/__tests__/config.test.ts` for conflict resolution, unmapped-preset fallback, and `outputDir` preservation.
- Updates production E2E harnesses to launch from `.farm/.output`: `playwright.production.config.ts`, `playwright.production-sites.config.ts`, and the two specs under `tests/e2e-production-sites/*`.
- `farm deploy` is unaffected; it always passes an override target.
- No migration required; configs without overrides behave as before.

<sup>Written for commit 8fad1a40ee5e2edb1247692c77b57cb3f9cab26e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

