### PR TITLE
fix(build): content-hash the client stylesheet href

### DIFF
--- a/packages/farm/src/__tests__/client-css-href.test.ts
+++ b/packages/farm/src/__tests__/client-css-href.test.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  FARM_CLIENT_CSS_HREF_PLACEHOLDER,
+  resolveHashedClientCssHref,
+} from "../nitro/client-css-href";
+
+const tempDirs: string[] = [];
+
+async function makeClientOutputDir(css?: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "farm-client-css-"));
+  tempDirs.push(dir);
+  if (css !== undefined) {
+    await fs.writeFile(path.join(dir, "farm-client.css"), css);
+  }
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("resolveHashedClientCssHref", () => {
+  it("copies the stylesheet to a fingerprinted assets path and returns its href", async () => {
+    const dir = await makeClientOutputDir("body { color: red; }");
+
+    const href = await resolveHashedClientCssHref(dir);
+
+    expect(href).toMatch(/^\/assets\/farm-client-h[0-9a-f]{8}\.css$/);
+    const copied = await fs.readFile(path.join(dir, href.slice(1)), "utf8");
+    expect(copied).toBe("body { color: red; }");
+    // The stable file stays for anything that hardcoded its path.
+    await expect(fs.readFile(path.join(dir, "farm-client.css"), "utf8")).resolves.toBe(
+      "body { color: red; }",
+    );
+  });
+
+  it("changes the href when the stylesheet bytes change", async () => {
+    const first = await resolveHashedClientCssHref(await makeClientOutputDir("a{}"));
+    const second = await resolveHashedClientCssHref(await makeClientOutputDir("b{}"));
+    const firstAgain = await resolveHashedClientCssHref(await makeClientOutputDir("a{}"));
+
+    expect(first).not.toBe(second);
+    expect(first).toBe(firstAgain);
+  });
+
+  it("falls back to the stable name for empty or missing stylesheets", async () => {
+    await expect(resolveHashedClientCssHref(await makeClientOutputDir(""))).resolves.toBe(
+      "/farm-client.css",
+    );
+    await expect(resolveHashedClientCssHref(await makeClientOutputDir())).resolves.toBe(
+      "/farm-client.css",
+    );
+  });
+
+  it("produces hrefs the placeholder can never collide with", () => {
+    // Substitution is a plain string replace over generated code, so the
+    // placeholder must not be a substring any real href could contain.
+    expect(FARM_CLIENT_CSS_HREF_PLACEHOLDER).toMatch(/^\/__[a-z_]+__$/);
+  });
+});

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -378,9 +378,12 @@ export default function RootLayout({ children }) {
           expect(html).toContain('data-farm-layout-client="true"');
           expect(html).toContain('id="__farm_route_slots_data__"');
           expect(html.match(/src="\/farm-client\.js"/g)).toHaveLength(1);
-          expect(html.match(/href="\/farm-client\.css"/g)).toHaveLength(1);
-          const clientStylesheetIndex = html.indexOf(
-            '<link rel="stylesheet" href="/farm-client.css">',
+          // The stylesheet href carries a content fingerprint so browsers
+          // cannot serve stale CSS against fresh HTML.
+          const stylesheetPattern = /href="\/assets\/farm-client-h[0-9a-f]{8}\.css"/g;
+          expect(html.match(stylesheetPattern)).toHaveLength(1);
+          const clientStylesheetIndex = html.search(
+            /<link rel="stylesheet" href="\/assets\/farm-client-h[0-9a-f]{8}\.css">/,
           );
           expect(clientStylesheetIndex).toBeGreaterThan(-1);
           expect(clientStylesheetIndex).toBeLessThan(html.indexOf("</head>"));

--- a/packages/farm/src/__tests__/vercel-assets.test.ts
+++ b/packages/farm/src/__tests__/vercel-assets.test.ts
@@ -20,6 +20,9 @@ describe("Vercel immutable Farm assets", () => {
   it("does not give immutable caching to stable or unhashed URLs", () => {
     expect(isFarmVercelImmutableAssetPath("/farm-client.js")).toBe(false);
     expect(isFarmVercelImmutableAssetPath("/farm-client.css")).toBe(false);
+    // The content-hashed stylesheet copy lives under assets/ precisely so the
+    // existing -h fingerprint rule grants it immutable caching.
+    expect(isFarmVercelImmutableAssetPath("/assets/farm-client-h1a2b3c4d.css")).toBe(true);
     expect(isFarmVercelImmutableAssetPath("/assets/logo.svg")).toBe(false);
     expect(isFarmVercelImmutableAssetPath("/assets/icon-v2.svg")).toBe(false);
     expect(isFarmVercelImmutableAssetPath("/assets/readme-how-to-build.js")).toBe(false);

--- a/packages/farm/src/nitro/client-css-href.ts
+++ b/packages/farm/src/nitro/client-css-href.ts
@@ -1,0 +1,40 @@
+import path from "path";
+
+/**
+ * Stands in for the client stylesheet href inside generated server code.
+ * The client and SSR graphs build in parallel, so the final stylesheet bytes
+ * (fonts are merged in after Vite emits them) do not exist yet when server
+ * code is generated. buildNitroUniversal substitutes the real, content-hashed
+ * href when it writes the SSR bundle to disk.
+ */
+export const FARM_CLIENT_CSS_HREF_PLACEHOLDER = "/__farm_client_css_href__";
+
+/**
+ * Content-hash the final client stylesheet and return the href generated
+ * server code should reference.
+ *
+ * The hash is taken after font CSS has been merged in, so any change to the
+ * bytes a browser would receive changes the URL. The hashed copy lives under
+ * assets/, where the -h fingerprint already qualifies for immutable caching;
+ * the stable farm-client.css stays in place for anything that hardcoded it.
+ * A missing or empty stylesheet falls back to the stable name, matching the
+ * empty file written for intentionally style-free applications.
+ */
+export async function resolveHashedClientCssHref(clientOutputDir: string): Promise<string> {
+  const fs = await import("fs/promises");
+  try {
+    const css = await fs.readFile(path.join(clientOutputDir, "farm-client.css"));
+    if (css.length > 0) {
+      const { createHash } = await import("node:crypto");
+      const hash = createHash("sha256").update(css).digest("hex").slice(0, 8);
+      const hashedName = `farm-client-h${hash}.css`;
+      const assetsDir = path.join(clientOutputDir, "assets");
+      await fs.mkdir(assetsDir, { recursive: true });
+      await fs.writeFile(path.join(assetsDir, hashedName), css);
+      return `/assets/${hashedName}`;
+    }
+  } catch {
+    // Fall through to the stable name.
+  }
+  return "/farm-client.css";
+}

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -6760,7 +6760,9 @@ async function buildNitroUniversal(
   const clientCssHref = await resolveHashedClientCssHref(clientOutputDir);
   for (const output of Object.values(ssrBundle)) {
     if (output.type === "chunk" && output.code.includes(FARM_CLIENT_CSS_HREF_PLACEHOLDER)) {
-      output.code = output.code.replaceAll(FARM_CLIENT_CSS_HREF_PLACEHOLDER, clientCssHref);
+      // split/join rather than replaceAll: the package's lib target predates
+      // ES2021, and a fixed token needs no regex escaping either way.
+      output.code = output.code.split(FARM_CLIENT_CSS_HREF_PLACEHOLDER).join(clientCssHref);
     }
   }
 

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1,9 +1,6 @@
 import type { RedirectConfig, ResolvedFarmConfig, RewriteConfig } from "../config";
 import { hasCustomFarmRouteContext, resolveDeployOutputPath } from "../config";
-import {
-  FARM_CLIENT_CSS_HREF_PLACEHOLDER,
-  resolveHashedClientCssHref,
-} from "./client-css-href";
+import { FARM_CLIENT_CSS_HREF_PLACEHOLDER, resolveHashedClientCssHref } from "./client-css-href";
 import type { RouteManager } from "../routing/route-manager";
 import type { APIRouteManager } from "../api/route-manager";
 import type { ServerRenderer } from "../server/renderer";

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1,5 +1,9 @@
 import type { RedirectConfig, ResolvedFarmConfig, RewriteConfig } from "../config";
 import { hasCustomFarmRouteContext, resolveDeployOutputPath } from "../config";
+import {
+  FARM_CLIENT_CSS_HREF_PLACEHOLDER,
+  resolveHashedClientCssHref,
+} from "./client-css-href";
 import type { RouteManager } from "../routing/route-manager";
 import type { APIRouteManager } from "../api/route-manager";
 import type { ServerRenderer } from "../server/renderer";
@@ -3937,7 +3941,7 @@ const farmDocsHandler = ${
 }, {
   rootDir: farmDocsRuntimeRoot,
   clientEntry: "/farm-client.js",
-  stylesheets: ["/farm-fonts.css", "/farm-client.css"],
+  stylesheets: ["/farm-fonts.css", "/__farm_client_css_href__"],
   resolveLayoutFonts: (pathname) =>
     resolveFarmLayoutFonts(
       getApplicableLayouts(getFarmRoutePathname(pathname)).map((layout) => layout.module),
@@ -4300,7 +4304,7 @@ function createFarmErrorDocument(html, title) {
       '  <meta name="viewport" content="width=device-width, initial-scale=1">\\n' +
       '  <link rel="icon" href="data:,">\\n' +
       '  <title>' + escapedTitle + '</title>\\n' +
-      '  <link rel="stylesheet" href="/farm-client.css">\\n' +
+      '  <link rel="stylesheet" href="/__farm_client_css_href__">\\n' +
       renderFarmRendererHydrationScript() + '\\n' +
       '</head>\\n<body>\\n' +
       '  <div id="root">' + html + '</div>\\n' +
@@ -4316,7 +4320,7 @@ function createFarmErrorDocument(html, title) {
       .replace(/<\\/body>/i, '</div></body>');
   }
   fullHtml = fullHtml
-    .replace(/<head([^>]*)>/i, '<head$1>\\n  <link rel="stylesheet" href="/farm-client.css">')
+    .replace(/<head([^>]*)>/i, '<head$1>\\n  <link rel="stylesheet" href="/__farm_client_css_href__">')
     .replace(/<\\/head>/i, renderFarmRendererHydrationScript() + '\\n</head>')
     .replace(/<head([^>]*)>([\\s\\S]*?)<\\/head>/i, function(match, attrs, headContent) {
       return headContent.includes("<title")
@@ -5068,8 +5072,8 @@ ${
     bodyMatch[0],
     "<body" + bodyMatch[1] + ">" + rootMarkup + "</body>",
   );
-  if (!html.includes('href="/farm-client.css"')) {
-    const clientStylesheet = '  <link rel="stylesheet" href="/farm-client.css">\\n';
+  if (!html.includes('href="/__farm_client_css_href__"')) {
+    const clientStylesheet = '  <link rel="stylesheet" href="/__farm_client_css_href__">\\n';
     const firstStyleIndex = html.search(/<style(?:\\s|>)/i);
     html =
       firstStyleIndex >= 0
@@ -5854,7 +5858,7 @@ async function handleFarmRequestInContext(
             '  <meta name="viewport" content="width=device-width, initial-scale=1">\\n' +
             (hasFavicon ? '' : '  <link rel="icon" href="data:,">\\n') +
             '  <title>' + title + '</title>' + metaTags + '\\n' +
-            '  <link rel="stylesheet" href="/farm-client.css">\\n' +
+            '  <link rel="stylesheet" href="/__farm_client_css_href__">\\n' +
             '  <link rel="modulepreload" href="/farm-client.js">\\n' +
             renderFarmRendererHydrationScript() + '\\n' +
             '</head>\\n<body>\\n  <div id="root">';
@@ -5909,7 +5913,7 @@ async function handleFarmRequestInContext(
           // Layout provides full HTML structure - inject CSS and client script
           fullHtml = html
             // Inject CSS link after opening head tag or first meta tag
-            .replace(/<head([^>]*)>/i, '<head$1>\\n  <link rel="stylesheet" href="/farm-client.css">')
+            .replace(/<head([^>]*)>/i, '<head$1>\\n  <link rel="stylesheet" href="/__farm_client_css_href__">')
             .replace(/<\\/head>/i, renderFarmRendererHydrationScript() + '\\n</head>')
             // Inject title if not present and we have one
             .replace(/<head([^>]*)>([\\s\\S]*?)<\\/head>/i, (match, attrs, headContent) => {
@@ -5946,7 +5950,7 @@ async function handleFarmRequestInContext(
   <meta name="viewport" content="width=device-width, initial-scale=1">
   \${hasFavicon ? "" : '<link rel="icon" href="data:,">'}
   <title>\${title}</title>\${metaTags}
-  <link rel="stylesheet" href="/farm-client.css">
+  <link rel="stylesheet" href="/__farm_client_css_href__">
   \${renderFarmRendererHydrationScript()}
 </head>
 <body>
@@ -6215,7 +6219,7 @@ async function handleFarmRequestInContext(
     let fullHtml;
     if (hasFullDocument) {
       fullHtml = html
-        .replace(/<head([^>]*)>/i, '<head$1>\\n  <link rel="stylesheet" href="/farm-client.css">')
+        .replace(/<head([^>]*)>/i, '<head$1>\\n  <link rel="stylesheet" href="/__farm_client_css_href__">')
         .replace(/<\\/head>/i, renderFarmRendererHydrationScript() + '\\n</head>')
         .replace(
           /<\\/body>/i,
@@ -6232,7 +6236,7 @@ async function handleFarmRequestInContext(
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" href="data:,">
-  <link rel="stylesheet" href="/farm-client.css">
+  <link rel="stylesheet" href="/__farm_client_css_href__">
   <title>404 - Page Not Found</title>
   \${renderFarmRendererHydrationScript()}
 </head>
@@ -6750,6 +6754,18 @@ async function buildNitroUniversal(
 
   const scheduledTasks = mergeScheduledTasks(farmWorkflows.scheduledTasks, farmCron.scheduledTasks);
   const cloudflareCronConfig = createFarmCronCloudflareConfig(farmCron.jobs);
+
+  // The client build has fully settled by now (fonts merged, output
+  // validated), so the stylesheet href baked into server code can carry the
+  // content hash of the bytes browsers will actually receive. Substituting in
+  // memory, before any consumer, covers the disk write below as well as the
+  // prebuilt-SSR copies and prerendering that reuse this bundle directly.
+  const clientCssHref = await resolveHashedClientCssHref(clientOutputDir);
+  for (const output of Object.values(ssrBundle)) {
+    if (output.type === "chunk" && output.code.includes(FARM_CLIENT_CSS_HREF_PLACEHOLDER)) {
+      output.code = output.code.replaceAll(FARM_CLIENT_CSS_HREF_PLACEHOLDER, clientCssHref);
+    }
+  }
 
   // Write SSR bundle to disk
   await fs.mkdir(ssrOutputDir, { recursive: true });


### PR DESCRIPTION
Diagnosed in a production app: after a redeploy, browsers kept serving **stale CSS against fresh HTML**. Every JS chunk carries an `-h` content fingerprint, but `farm-client.css` has a stable name, generated HTML hardcodes it, and it's served with only `etag`/`last-modified` — so heuristic freshness applies and a warm cache doesn't revalidate. The framework already knows this file can't be cached aggressively: `isFarmVercelImmutableAssetPath('/farm-client.css')` is deliberately `false`.

**Why it can't be hashed at the Rollup level.** Two ordering constraints:
1. Font CSS is **merged into** `farm-client.css` after Vite emits it (`mergeBuiltFontCss`), so a Rollup `[hash]` would describe pre-merge bytes and go stale when only fonts change.
2. The client and SSR graphs build **in parallel**, and the SSR graph's generated code embeds the href — before the final bytes exist.

**Design.** Generated server code embeds a placeholder (`FARM_CLIENT_CSS_HREF_PLACEHOLDER`). `buildNitroUniversal` — which runs strictly after both graphs settle — hashes the final bytes, writes the copy to `assets/farm-client-h<8hex>.css`, and substitutes the href **in the in-memory SSR bundle before any consumer**: the disk write, both `copyPrebuiltSSRBundle` calls, prerendering, and Nitro. Placing the copy under `assets/` means the existing `-h` fingerprint rule grants it **immutable caching on Vercel with no regex change**. The stable `farm-client.css` remains for anything that hardcoded it, and empty/missing stylesheets fall back to the stable name (style-free apps keep their intentional empty file).

**Verified on `examples/basic`** (node-server preset):
- served HTML references `/assets/farm-client-hf42bfe47.css`; the asset serves 200 (54 KB); `/farm-client.css` still 200 for compat
- zero placeholder occurrences anywhere in the output
- **editing `globals.css` changes the href** (`hf42bfe47` → `hd98ee927`) — the actual cache-bust, proven
- `production-prebuilt-ssr` full suite 20/20 (one assertion updated: it pinned the un-hashed href contract), `client-css-href` 4 new unit tests, `vercel-assets` asserts the hashed path is immutable-eligible

Two review notes worth having in the open:
- My first cut substituted only in the disk-write loop; verification caught the placeholder leaking through `copyPrebuiltSSRBundle`, which copies from the **in-memory** bundle — hence the substitute-before-any-consumer design.
- `farm-client.js` has the same theoretical staleness (stable entry name → can reference deleted hashed chunks after a deploy). Left for a follow-up to keep this reviewable; happy to file it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Content-hashes the client stylesheet href so browsers don’t serve stale CSS after deploys. Previously HTML hardcoded /farm-client.css and relied on heuristic caching; now generated HTML references a content-hashed copy under /assets/, with /farm-client.css kept for compatibility and empty/missing stylesheets falling back to the stable name.

- Embeds a placeholder (/__farm_client_css_href__) in generated SSR code; after both graphs settle, `buildNitroUniversal` hashes the final merged stylesheet (post-font merge), writes /assets/farm-client-h<8hex>.css, and returns its href (or /farm-client.css if empty/missing).
- Substitutes the href across the in-memory SSR bundle before any consumer (disk write, prebuilt SSR copies, prerendering, Nitro), using split/join instead of replaceAll to support the pre-ES2021 lib target.
- Updates HTML injection sites (docs handler, error document, layout/404) to use the placeholder; adds `client-css-href` tests and updates `production-prebuilt-ssr` and `vercel-assets` to assert the hashed path is immutable-eligible.
- No migrations or config changes. Note: `farm-client.js` still has a stable name; follow-up planned.

<sup>Written for commit af027f4222e77ed262461cc41753583d48a5141d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

