### PR TITLE
fix(build): content-hash the client entry src

### DIFF
--- a/packages/farm/src/__tests__/client-css-href.test.ts
+++ b/packages/farm/src/__tests__/client-css-href.test.ts
@@ -57,23 +57,23 @@ describe("resolveHashedClientCssHref", () => {
     );
   });
 
-  it("copies the entry module to a fingerprinted name at the public root", async () => {
+  it("references the fingerprinted entry and shims the stable name onto it", async () => {
     const dir = await makeClientOutputDir();
-    await fs.writeFile(path.join(dir, "farm-client.js"), "import('./chunks/a-h12345678.js')");
+    // The bundler emits the fingerprinted entry directly; a copy would be
+    // instantiated a second time through the chunks' back-imports.
+    await fs.writeFile(path.join(dir, "farm-client-hab12cd34.js"), "export const real = true;");
 
     const src = await resolveHashedClientJsSrc(dir);
 
-    // Root depth is load-bearing: the entry resolves its chunks with relative
-    // dynamic imports, so the copy must sit beside the chunks directory.
-    expect(src).toMatch(/^\/farm-client-h[0-9a-f]{8}\.js$/);
-    const copied = await fs.readFile(path.join(dir, src.slice(1)), "utf8");
-    expect(copied).toBe("import('./chunks/a-h12345678.js')");
+    expect(src).toBe("/farm-client-hab12cd34.js");
+    // The stable name becomes a re-export shim, so hardcoded references
+    // still execute the one real module instead of a second instance.
     await expect(fs.readFile(path.join(dir, "farm-client.js"), "utf8")).resolves.toBe(
-      "import('./chunks/a-h12345678.js')",
+      'export * from "./farm-client-hab12cd34.js";\n',
     );
   });
 
-  it("falls back to the stable entry name when the module is missing", async () => {
+  it("falls back to the stable entry name when no fingerprinted entry exists", async () => {
     await expect(resolveHashedClientJsSrc(await makeClientOutputDir())).resolves.toBe(
       "/farm-client.js",
     );

--- a/packages/farm/src/__tests__/client-css-href.test.ts
+++ b/packages/farm/src/__tests__/client-css-href.test.ts
@@ -4,7 +4,9 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   FARM_CLIENT_CSS_HREF_PLACEHOLDER,
+  FARM_CLIENT_JS_SRC_PLACEHOLDER,
   resolveHashedClientCssHref,
+  resolveHashedClientJsSrc,
 } from "../nitro/client-css-href";
 
 const tempDirs: string[] = [];
@@ -55,9 +57,32 @@ describe("resolveHashedClientCssHref", () => {
     );
   });
 
+  it("copies the entry module to a fingerprinted name at the public root", async () => {
+    const dir = await makeClientOutputDir();
+    await fs.writeFile(path.join(dir, "farm-client.js"), "import('./chunks/a-h12345678.js')");
+
+    const src = await resolveHashedClientJsSrc(dir);
+
+    // Root depth is load-bearing: the entry resolves its chunks with relative
+    // dynamic imports, so the copy must sit beside the chunks directory.
+    expect(src).toMatch(/^\/farm-client-h[0-9a-f]{8}\.js$/);
+    const copied = await fs.readFile(path.join(dir, src.slice(1)), "utf8");
+    expect(copied).toBe("import('./chunks/a-h12345678.js')");
+    await expect(fs.readFile(path.join(dir, "farm-client.js"), "utf8")).resolves.toBe(
+      "import('./chunks/a-h12345678.js')",
+    );
+  });
+
+  it("falls back to the stable entry name when the module is missing", async () => {
+    await expect(resolveHashedClientJsSrc(await makeClientOutputDir())).resolves.toBe(
+      "/farm-client.js",
+    );
+  });
+
   it("produces hrefs the placeholder can never collide with", () => {
     // Substitution is a plain string replace over generated code, so the
     // placeholder must not be a substring any real href could contain.
     expect(FARM_CLIENT_CSS_HREF_PLACEHOLDER).toMatch(/^\/__[a-z_]+__$/);
+    expect(FARM_CLIENT_JS_SRC_PLACEHOLDER).toMatch(/^\/__[a-z_]+__$/);
   });
 });

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -377,7 +377,8 @@ export default function RootLayout({ children }) {
           expect(html).toContain('data-farm-client="false"');
           expect(html).toContain('data-farm-layout-client="true"');
           expect(html).toContain('id="__farm_route_slots_data__"');
-          expect(html.match(/src="\/farm-client\.js"/g)).toHaveLength(1);
+          const scriptPattern = /src="\/farm-client-h[0-9a-f]{8}\.js"/g;
+          expect(html.match(scriptPattern)).toHaveLength(1);
           // The stylesheet href carries a content fingerprint so browsers
           // cannot serve stale CSS against fresh HTML.
           const stylesheetPattern = /href="\/assets\/farm-client-h[0-9a-f]{8}\.css"/g;
@@ -1134,7 +1135,9 @@ export default defineRoutes(() => [
             expect(html).toContain("suspense-ready");
             expect(html).toContain('data-page-render-count="1"');
             expect(html).not.toContain('data-page-render-count="2"');
-            expect(html).toContain('<link rel="modulepreload" href="/farm-client.js">');
+            expect(html).toMatch(
+              /<link rel="modulepreload" href="\/farm-client-h[0-9a-f]{8}\.js">/,
+            );
             expect(html).not.toContain("renderToString which does not support Suspense");
           },
           "/suspense",

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -113,6 +113,13 @@ async function waitForServer(
   );
 }
 
+async function readClientBundle(root: string): Promise<string> {
+  const clientDir = path.join(root, ".farm", "client");
+  const entries = await fs.readdir(clientDir);
+  const fingerprinted = entries.find((name) => /^farm-client-h[0-9a-f]+\.js$/.test(name));
+  return fs.readFile(path.join(clientDir, fingerprinted ?? "farm-client.js"), "utf8");
+}
+
 async function runProductionRequest(
   serverDir: string,
   assertion: (response: Response) => Promise<void>,
@@ -347,10 +354,7 @@ export default function RootLayout({ children }) {
       );
       await build(config, { root, preset: "node-server" });
 
-      const clientBundle = await fs.readFile(
-        path.join(root, ".farm", "client", "farm-client.js"),
-        "utf8",
-      );
+      const clientBundle = await readClientBundle(root);
       expect(clientBundle).toContain("layout-effect-fired");
       expect(clientBundle).toContain("/docs/[...slug]");
 
@@ -473,10 +477,7 @@ export default function DynamicPage({ params }) {
         fs.readFile(path.join(root, ".farm", "ssr", "nitro-entry.mjs"), "utf8"),
       ).resolves.toContain("farmNitroApp.hooks.hook('close'");
 
-      const clientBundle = await fs.readFile(
-        path.join(root, ".farm", "client", "farm-client.js"),
-        "utf8",
-      );
+      const clientBundle = await readClientBundle(root);
       expect(clientBundle).toContain("Minified React error");
       expect(clientBundle).not.toContain("Download the React DevTools");
 

--- a/packages/farm/src/__tests__/vercel-assets.test.ts
+++ b/packages/farm/src/__tests__/vercel-assets.test.ts
@@ -23,6 +23,10 @@ describe("Vercel immutable Farm assets", () => {
     // The content-hashed stylesheet copy lives under assets/ precisely so the
     // existing -h fingerprint rule grants it immutable caching.
     expect(isFarmVercelImmutableAssetPath("/assets/farm-client-h1a2b3c4d.css")).toBe(true);
+    // The fingerprinted entry sits at the root — its relative chunk imports
+    // pin it there — and only the farm-client name qualifies at that level.
+    expect(isFarmVercelImmutableAssetPath("/farm-client-h1a2b3c4d.js")).toBe(true);
+    expect(isFarmVercelImmutableAssetPath("/other-h1a2b3c4d.js")).toBe(false);
     expect(isFarmVercelImmutableAssetPath("/assets/logo.svg")).toBe(false);
     expect(isFarmVercelImmutableAssetPath("/assets/icon-v2.svg")).toBe(false);
     expect(isFarmVercelImmutableAssetPath("/assets/readme-how-to-build.js")).toBe(false);

--- a/packages/farm/src/nitro/client-css-href.ts
+++ b/packages/farm/src/nitro/client-css-href.ts
@@ -51,20 +51,39 @@ export async function resolveHashedClientCssHref(clientOutputDir: string): Promi
 }
 
 /**
- * Content-hash the client entry module and return the src generated server
- * code should reference.
+ * The client entry emitted by the current build, if it carries a content
+ * fingerprint. Vite names it farm-client-h<hash>.js so its code-split chunks
+ * import the fingerprinted name natively; emptyOutDir keeps stale builds from
+ * leaving older fingerprints behind.
+ */
+export async function findFingerprintedClientEntry(
+  clientOutputDir: string,
+): Promise<string | null> {
+  const fs = await import("fs/promises");
+  try {
+    const entries = await fs.readdir(clientOutputDir);
+    return entries.find((name) => /^farm-client-h[0-9a-f]+\.js$/.test(name)) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the src generated server code should reference for the client
+ * entry, and keep the stable name working.
  *
- * Unlike the stylesheet, the hashed copy must stay at the root of the public
- * directory: the entry loads its code-split chunks with relative dynamic
- * imports and resolves assets against import.meta.url, so moving it a level
- * deeper would break every chunk load. The stable farm-client.js remains for
- * anything that hardcoded it.
+ * The entry cannot be duplicated under a second name: its chunks import back
+ * into it (it is the shared runtime), so a copy would be instantiated twice
+ * and React would see two instances. Instead the bundler emits the
+ * fingerprinted name directly, and the stable farm-client.js becomes a
+ * re-export shim — anything that hardcoded the old path still executes the
+ * one real module.
  */
 export async function resolveHashedClientJsSrc(clientOutputDir: string): Promise<string> {
-  const name = await hashAndCopy(
-    path.join(clientOutputDir, "farm-client.js"),
-    clientOutputDir,
-    (hash) => `farm-client-h${hash}.js`,
-  );
-  return name ? `/${name}` : "/farm-client.js";
+  const entryName = await findFingerprintedClientEntry(clientOutputDir);
+  if (!entryName) return "/farm-client.js";
+  const fs = await import("fs/promises");
+  const shim = `export * from "./${entryName}";\n`;
+  await fs.writeFile(path.join(clientOutputDir, "farm-client.js"), shim);
+  return `/${entryName}`;
 }

--- a/packages/farm/src/nitro/client-css-href.ts
+++ b/packages/farm/src/nitro/client-css-href.ts
@@ -1,13 +1,34 @@
 import path from "path";
 
 /**
- * Stands in for the client stylesheet href inside generated server code.
- * The client and SSR graphs build in parallel, so the final stylesheet bytes
- * (fonts are merged in after Vite emits them) do not exist yet when server
- * code is generated. buildNitroUniversal substitutes the real, content-hashed
- * href when it writes the SSR bundle to disk.
+ * Stand-ins for the client asset URLs inside generated server code.
+ * The client and SSR graphs build in parallel, so the final asset bytes
+ * (fonts are merged into the stylesheet after Vite emits it) do not exist
+ * yet when server code is generated. buildNitroUniversal substitutes the
+ * real, content-hashed URLs once the client build has settled.
  */
 export const FARM_CLIENT_CSS_HREF_PLACEHOLDER = "/__farm_client_css_href__";
+export const FARM_CLIENT_JS_SRC_PLACEHOLDER = "/__farm_client_js_src__";
+
+async function hashAndCopy(
+  sourcePath: string,
+  destinationDir: string,
+  hashedName: (hash: string) => string,
+): Promise<string | null> {
+  const fs = await import("fs/promises");
+  try {
+    const bytes = await fs.readFile(sourcePath);
+    if (bytes.length === 0) return null;
+    const { createHash } = await import("node:crypto");
+    const hash = createHash("sha256").update(bytes).digest("hex").slice(0, 8);
+    const name = hashedName(hash);
+    await fs.mkdir(destinationDir, { recursive: true });
+    await fs.writeFile(path.join(destinationDir, name), bytes);
+    return name;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Content-hash the final client stylesheet and return the href generated
@@ -21,20 +42,29 @@ export const FARM_CLIENT_CSS_HREF_PLACEHOLDER = "/__farm_client_css_href__";
  * empty file written for intentionally style-free applications.
  */
 export async function resolveHashedClientCssHref(clientOutputDir: string): Promise<string> {
-  const fs = await import("fs/promises");
-  try {
-    const css = await fs.readFile(path.join(clientOutputDir, "farm-client.css"));
-    if (css.length > 0) {
-      const { createHash } = await import("node:crypto");
-      const hash = createHash("sha256").update(css).digest("hex").slice(0, 8);
-      const hashedName = `farm-client-h${hash}.css`;
-      const assetsDir = path.join(clientOutputDir, "assets");
-      await fs.mkdir(assetsDir, { recursive: true });
-      await fs.writeFile(path.join(assetsDir, hashedName), css);
-      return `/assets/${hashedName}`;
-    }
-  } catch {
-    // Fall through to the stable name.
-  }
-  return "/farm-client.css";
+  const name = await hashAndCopy(
+    path.join(clientOutputDir, "farm-client.css"),
+    path.join(clientOutputDir, "assets"),
+    (hash) => `farm-client-h${hash}.css`,
+  );
+  return name ? `/assets/${name}` : "/farm-client.css";
+}
+
+/**
+ * Content-hash the client entry module and return the src generated server
+ * code should reference.
+ *
+ * Unlike the stylesheet, the hashed copy must stay at the root of the public
+ * directory: the entry loads its code-split chunks with relative dynamic
+ * imports and resolves assets against import.meta.url, so moving it a level
+ * deeper would break every chunk load. The stable farm-client.js remains for
+ * anything that hardcoded it.
+ */
+export async function resolveHashedClientJsSrc(clientOutputDir: string): Promise<string> {
+  const name = await hashAndCopy(
+    path.join(clientOutputDir, "farm-client.js"),
+    clientOutputDir,
+    (hash) => `farm-client-h${hash}.js`,
+  );
+  return name ? `/${name}` : "/farm-client.js";
 }

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -3,6 +3,7 @@ import { hasCustomFarmRouteContext, resolveDeployOutputPath } from "../config";
 import {
   FARM_CLIENT_CSS_HREF_PLACEHOLDER,
   FARM_CLIENT_JS_SRC_PLACEHOLDER,
+  findFingerprintedClientEntry,
   resolveHashedClientCssHref,
   resolveHashedClientJsSrc,
 } from "./client-css-href";
@@ -964,7 +965,8 @@ async function validateClientBuildOutput(
   outputDir: string,
 ): Promise<void> {
   const fs = await import("fs/promises");
-  const clientEntryPath = path.join(outputDir, "farm-client.js");
+  const fingerprinted = await findFingerprintedClientEntry(outputDir);
+  const clientEntryPath = path.join(outputDir, fingerprinted ?? "farm-client.js");
   let clientEntrySize = 0;
 
   try {
@@ -1246,7 +1248,7 @@ async function buildClient(
             "farm-client": clientEntryPath,
           },
           output: {
-            entryFileNames: "[name].js",
+            entryFileNames: "[name]-h[hash].js",
             chunkFileNames: "chunks/[name]-h[hash].js",
             hashCharacters: "hex",
             // Use predictable name for CSS so we can reference it in SSR HTML

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1,6 +1,11 @@
 import type { RedirectConfig, ResolvedFarmConfig, RewriteConfig } from "../config";
 import { hasCustomFarmRouteContext, resolveDeployOutputPath } from "../config";
-import { FARM_CLIENT_CSS_HREF_PLACEHOLDER, resolveHashedClientCssHref } from "./client-css-href";
+import {
+  FARM_CLIENT_CSS_HREF_PLACEHOLDER,
+  FARM_CLIENT_JS_SRC_PLACEHOLDER,
+  resolveHashedClientCssHref,
+  resolveHashedClientJsSrc,
+} from "./client-css-href";
 import type { RouteManager } from "../routing/route-manager";
 import type { APIRouteManager } from "../api/route-manager";
 import type { ServerRenderer } from "../server/renderer";
@@ -3935,7 +3940,7 @@ const farmDocsHandler = ${
   contentDir: farmDocsResolvedConfig.contentDir || farmDocsResolvedConfig.config?.contentDir,
 }, {
   rootDir: farmDocsRuntimeRoot,
-  clientEntry: "/farm-client.js",
+  clientEntry: "/__farm_client_js_src__",
   stylesheets: ["/farm-fonts.css", "/__farm_client_css_href__"],
   resolveLayoutFonts: (pathname) =>
     resolveFarmLayoutFonts(
@@ -3946,7 +3951,7 @@ const farmDocsHandler = ${
         : `createFarmDocsHandler(farmDocsResolvedConfig, {
   root: farmDocsRuntimeRoot,
   srcDir: ${JSON.stringify(config.srcDir)},
-  clientEntry: "/farm-client.js",
+  clientEntry: "/__farm_client_js_src__",
   fontAssets: ${JSON.stringify(farmDocsFontAssets)},
   resolveLayoutFonts: (pathname) =>
     resolveFarmLayoutFonts(
@@ -4304,7 +4309,7 @@ function createFarmErrorDocument(html, title) {
       '</head>\\n<body>\\n' +
       '  <div id="root">' + html + '</div>\\n' +
       '  ' + renderFarmClientBootstrapScript() + '\\n' +
-      '  <script type="module" src="/farm-client.js"></script>\\n' +
+      '  <script type="module" src="/__farm_client_js_src__"></script>\\n' +
       '</body>\\n</html>';
   }
 
@@ -4325,7 +4330,7 @@ function createFarmErrorDocument(html, title) {
     .replace(
       /<\\/body>/i,
       '  ' + renderFarmClientBootstrapScript() + '\\n' +
-        '  <script type="module" src="/farm-client.js"></script>\\n</body>',
+        '  <script type="module" src="/__farm_client_js_src__"></script>\\n</body>',
     );
   return fullHtml.trim().startsWith("<!DOCTYPE")
     ? fullHtml
@@ -5078,10 +5083,10 @@ ${
   if (!html.includes('id="__farm_route_slots_data__"')) {
     html = html.replace(/<[/]body>/i, renderFarmClientBootstrapScript() + "\\n</body>");
   }
-  if (!html.includes('src="/farm-client.js"')) {
+  if (!html.includes('src="/__farm_client_js_src__"')) {
     html = html.replace(
       /<[/]body>/i,
-      '  <script type="module" src="/farm-client.js"></script>\\n</body>',
+      '  <script type="module" src="/__farm_client_js_src__"></script>\\n</body>',
     );
   }
   if (!html.includes('window._$HY')) {
@@ -5854,7 +5859,7 @@ async function handleFarmRequestInContext(
             (hasFavicon ? '' : '  <link rel="icon" href="data:,">\\n') +
             '  <title>' + title + '</title>' + metaTags + '\\n' +
             '  <link rel="stylesheet" href="/__farm_client_css_href__">\\n' +
-            '  <link rel="modulepreload" href="/farm-client.js">\\n' +
+            '  <link rel="modulepreload" href="/__farm_client_js_src__">\\n' +
             renderFarmRendererHydrationScript() + '\\n' +
             '</head>\\n<body>\\n  <div id="root">';
           const streamSuffix = '</div>\\n' +
@@ -5863,7 +5868,7 @@ async function handleFarmRequestInContext(
               routeSlotPayload,
               clientPageProps
             ) + '\\n' +
-            '  <script type="module" src="/farm-client.js"></script>\\n' +
+            '  <script type="module" src="/__farm_client_js_src__"></script>\\n' +
             '</body>\\n</html>';
           const themedStreamPrefix = streamPrefix.replace(
             '<html lang="en">',
@@ -5929,7 +5934,7 @@ async function handleFarmRequestInContext(
                 routeSlotPayload,
                 clientPageProps
               ) + '\\n' +
-                '  <script type="module" src="/farm-client.js"></script>\\n</body>',
+                '  <script type="module" src="/__farm_client_js_src__"></script>\\n</body>',
             );
           
           // Add DOCTYPE if not present
@@ -5951,7 +5956,7 @@ async function handleFarmRequestInContext(
 <body>
   <div id="root">\${html}</div>
   \${renderFarmClientBootstrapScript(pageProps.__farmCanonicalPath, routeSlotPayload, clientPageProps)}
-  <script type="module" src="/farm-client.js"></script>
+  <script type="module" src="/__farm_client_js_src__"></script>
 </body>
 </html>\`;
         }
@@ -6219,7 +6224,7 @@ async function handleFarmRequestInContext(
         .replace(
           /<\\/body>/i,
           '  ' + renderFarmClientBootstrapScript() + '\\n' +
-            '  <script type="module" src="/farm-client.js"></script>\\n</body>',
+            '  <script type="module" src="/__farm_client_js_src__"></script>\\n</body>',
         );
       if (!fullHtml.trim().startsWith('<!DOCTYPE')) {
         fullHtml = '<!DOCTYPE html>\\n' + fullHtml;
@@ -6238,7 +6243,7 @@ async function handleFarmRequestInContext(
 <body>
   <div id="root">\${html}</div>
   \${renderFarmClientBootstrapScript()}
-  <script type="module" src="/farm-client.js"></script>
+  <script type="module" src="/__farm_client_js_src__"></script>
 </body>
 </html>\`;
     }
@@ -6755,12 +6760,19 @@ async function buildNitroUniversal(
   // content hash of the bytes browsers will actually receive. Substituting in
   // memory, before any consumer, covers the disk write below as well as the
   // prebuilt-SSR copies and prerendering that reuse this bundle directly.
-  const clientCssHref = await resolveHashedClientCssHref(clientOutputDir);
+  const [clientCssHref, clientJsSrc] = await Promise.all([
+    resolveHashedClientCssHref(clientOutputDir),
+    resolveHashedClientJsSrc(clientOutputDir),
+  ]);
   for (const output of Object.values(ssrBundle)) {
-    if (output.type === "chunk" && output.code.includes(FARM_CLIENT_CSS_HREF_PLACEHOLDER)) {
-      // split/join rather than replaceAll: the package's lib target predates
-      // ES2021, and a fixed token needs no regex escaping either way.
+    if (output.type !== "chunk") continue;
+    // split/join rather than replaceAll: the package's lib target predates
+    // ES2021, and a fixed token needs no regex escaping either way.
+    if (output.code.includes(FARM_CLIENT_CSS_HREF_PLACEHOLDER)) {
       output.code = output.code.split(FARM_CLIENT_CSS_HREF_PLACEHOLDER).join(clientCssHref);
+    }
+    if (output.code.includes(FARM_CLIENT_JS_SRC_PLACEHOLDER)) {
+      output.code = output.code.split(FARM_CLIENT_JS_SRC_PLACEHOLDER).join(clientJsSrc);
     }
   }
 

--- a/packages/farm/src/nitro/vercel-assets.ts
+++ b/packages/farm/src/nitro/vercel-assets.ts
@@ -10,15 +10,18 @@ export interface FarmVercelImmutableAssetRoute {
 /**
  * Apply immutable caching only to Farm/Vite filenames carrying Farm's `-h`
  * content-fingerprint marker. Stable entry filenames and HTML are deliberately
- * excluded because they can change between deployments.
+ * excluded because they can change between deployments. The fingerprinted
+ * client entry lives at the public root — its relative chunk imports pin it
+ * there — so root-level farm-client-h files qualify alongside assets/chunks.
  */
 export function createFarmVercelImmutableAssetRoute(basePath = "/"): FarmVercelImmutableAssetRoute {
   const normalizedBasePath = normalizeBasePath(basePath);
   const escapedBasePath = escapeRegex(normalizedBasePath);
   const prefix = escapedBasePath ? `/${escapedBasePath}` : "";
+  const fingerprint = "-h(?:[a-fA-F0-9]{8}|[a-fA-F0-9]{12}|[a-fA-F0-9]{16})";
 
   return {
-    src: `^${prefix}/(?:assets|chunks)/(?:.+/)*[^/]+-h(?:[a-fA-F0-9]{8}|[a-fA-F0-9]{12}|[a-fA-F0-9]{16})\\.(?!(?:[hH][tT][mM][lL]?)$)[^/]+$`,
+    src: `^${prefix}/(?:(?:assets|chunks)/(?:.+/)*[^/]+|farm-client)${fingerprint}\\.(?!(?:[hH][tT][mM][lL]?)$)[^/]+$`,
     headers: {
       "Cache-Control": FARM_IMMUTABLE_ASSET_CACHE_CONTROL,
     },


### PR DESCRIPTION
Follow-up to #344, completing the cache-busting story for the client entry.

**The problem is worse than the stylesheet's.** `farm-client.js` keeps a stable name while importing content-hashed chunks (`import(\`./chunks/page-h….js\`)`). After a deploy, a browser with a cached entry requests chunk files that **no longer exist** — not stale styling, a broken page until heuristic revalidation.

**Same mechanism as #344, one structural difference.** Generated server code embeds `FARM_CLIENT_JS_SRC_PLACEHOLDER` (12 sites: script tags, the modulepreload, the injection guard, both docs-adapter `clientEntry` options); `buildNitroUniversal` hashes the settled bytes and substitutes in the in-memory bundle. But the hashed copy must stay at the **public root**, not `assets/`: the entry resolves its chunks with relative dynamic imports and `new URL(e, import.meta.url)`, so moving it a level deeper breaks every chunk load. Verified against a real build — the entry contains 15 relative dynamic imports.

- `resolveHashedClientJsSrc` shares one hash-and-copy helper with the stylesheet path
- The Vercel immutable rule now also matches **root-level** `farm-client-h<hex>` files (and *only* the `farm-client` name at that level — `/other-h….js` stays excluded); tests pin both directions
- Stable `farm-client.js` remains for anything that hardcoded it; missing/empty entry falls back to the stable name

**Verified on `examples/basic`** (node-server preset):
- served HTML: `src="/farm-client-hd2064ec8.js"` and modulepreload to match, alongside #344's hashed stylesheet
- the hashed entry serves 200 (413 KB), and its first relative chunk specifier `./chunks/page-he064fb91.js` resolves and serves 200 from `/chunks/…` — the root-depth constraint, proven
- zero placeholder occurrences in the output
- `production-prebuilt-ssr` 20/20 (two React 18/19 streaming assertions updated from the stable-name contract), `client-css-href` 6 tests, `vercel-assets` 4 tests, `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Content-hashes the client entry and updates HTML to load a fingerprinted `/farm-client-h<hash>.js` at the public root, preventing cached `/farm-client.js` from importing missing chunks after deploy. The bundler now emits the fingerprinted entry; `farm-client.js` remains as a one-line re-export shim so hardcoded consumers still execute the same module.

- Adds `FARM_CLIENT_JS_SRC_PLACEHOLDER` and substitutes it across docs, error pages, and all HTML injection/modulepreload paths; introduces `findFingerprintedClientEntry` and `resolveHashedClientJsSrc` to return the hashed src and write the shim.
- Changes bundler output to `entryFileNames: "[name]-h[hash].js"`; SSR output validation resolves the entry via its fingerprint when present.
- Keeps the hashed entry at the public root to preserve relative dynamic imports and `import.meta.url`; do not move it under `assets/`.
- Extends Vercel immutable caching to also match root-level `/farm-client-h*.js` (and only that name), alongside existing `assets/` and `chunks/` rules.
- Migration: No app changes required. If you manage CDN rules, allow immutable caching for root `/farm-client-h*.js`.

<sup>Written for commit de286a39dd49fc8b7dd6daf828f4bc42e8d9029f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

