### PR TITLE
docs: refine React compiler showcase

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1,6 +1,6 @@
 ---
 title: "React Renderer"
-description: "Use FARMJS with the default React renderer, including client hooks, integrations, streaming SSR, and experimental Server Components."
+description: "Use FARMJS with the default React renderer, including client hooks, streaming SSR, and the experimental AOT compiler."
 section: "Core"
 ---
 
@@ -62,8 +62,36 @@ export function Counter() {
 
 ## Experimental AOT compiler
 
-Install `@farm.js/react` to keep React as the renderer while opting into Farm's experimental
-ahead-of-time state compiler:
+Farm's experimental React compiler moves a narrow class of local state-update work from React's
+runtime render-and-reconcile path into build-time binding metadata. It is disabled by default and
+only affects the React renderer that enables it. Preact, Solid, Vue, Svelte, and custom renderers do
+not receive this transform.
+
+The compiler is intentionally conservative. It only transforms a component when it can prove that
+the component has one stable host-element tree and that each supported state value maps to known
+text or attribute targets. If that proof fails, the original component stays on React.
+
+### Why this compiler exists
+
+An ordinary local `useState` update asks React to run the component again, produce another element
+tree, reconcile it with the previous tree, and commit the changed DOM. That general model is needed
+for dynamic React applications, but it repeats work when a component's structure is fixed and only
+a few text or attribute values can change.
+
+For that safe subset, Farm prepares three things ahead of time:
+
+1. local state cells and their setters;
+2. the DOM path of every state-driven text or attribute binding; and
+3. the state-cell dependencies for each binding.
+
+After mount, an eligible local update flushes the changed cells and patches only the affected
+bindings. It does not schedule another React render or reconciliation pass for that update. React
+still owns initial rendering, component placement, parent-driven prop updates, events, SSR,
+hydration, and unmounting.
+
+### Enable the compiler
+
+Install `@farm.js/react` to select the React renderer with compiler options:
 
 ```bash
 pnpm add @farm.js/react
@@ -82,12 +110,66 @@ export default defineConfig({
 });
 ```
 
-`compiler: true` automatically considers application TSX and JSX. Eligible components keep React
-for placement, props, events, server rendering, and hydration, but local `useState` updates patch
-precomputed text and attribute bindings without rerunning the component or reconciling its tree.
-Unsupported components safely remain ordinary React components.
+`compiler: true` is the recommended starting point for the experiment. It means automatic
+inference with safe React fallback:
 
-Use annotation mode for selective adoption:
+```ts
+compiler: {
+  mode: "infer",
+  onUnsupported: "fallback",
+}
+```
+
+Omitting `experimental.compiler` or setting it to `false` disables the transform.
+
+### Configuration API
+
+```ts
+type ReactCompilerMode = "infer" | "annotation";
+type UnsupportedCompilerBehavior = "fallback" | "warn" | "error";
+
+interface ReactCompilerOptions {
+  mode?: ReactCompilerMode;
+  directive?: string;
+  onUnsupported?: UnsupportedCompilerBehavior;
+}
+```
+
+| Option          | Values                                | Default          | Purpose                                                                  |
+| --------------- | ------------------------------------- | ---------------- | ------------------------------------------------------------------------ |
+| `compiler`      | `false`, `true`, or an options object | `false`          | Disables, enables with defaults, or configures the React-only transform. |
+| `mode`          | `"infer"`, `"annotation"`             | `"infer"`        | Selects components automatically or only through an explicit directive.  |
+| `directive`     | non-empty string                      | `"use compiler"` | Names the module/function directive used by annotation mode.             |
+| `onUnsupported` | `"fallback"`, `"warn"`, `"error"`     | `"fallback"`     | Controls what happens outside the current supported subset.              |
+
+`directive` is valid only when `mode` is `"annotation"`. Invalid modes, invalid unsupported
+behaviors, and directives configured in inference mode throw a configuration error instead of
+silently changing behavior.
+
+### Component selection
+
+#### Automatic inference
+
+`compiler: true` and `mode: "infer"` inspect top-level, capitalized function components in
+application `.tsx` and `.jsx` modules under the project root. Dependencies in `node_modules` are not
+transformed. Every eligible component is compiled; every unsupported component remains unchanged.
+
+Use the built-in function directive to keep a specific component entirely on React:
+
+```tsx
+export function ReactOwnedEditor() {
+  "use no compiler";
+
+  // React always owns this component.
+}
+```
+
+The opt-out is intentionally local. It documents a known ownership boundary without disabling the
+compiler for the rest of the module.
+
+#### Annotation mode
+
+Annotation mode is useful for a staged rollout or a strict, reviewed set of components:
 
 ```ts
 renderer: react({
@@ -101,17 +183,229 @@ renderer: react({
 }),
 ```
 
-Place the directive inside a component or at the top of its module. The directive can be renamed in
-configuration and only applies in annotation mode.
+Place the configured directive inside one component to select only that component:
 
-The initial compiler group supports a single static host-element tree, top-level `useState`, basic
-events, and state-driven text or attributes. Keyed lists, conditional child structure, effects,
-refs, and custom child components fall back to React and are planned as later compiler groups.
+```tsx
+export function Counter() {
+  "use compiler";
+
+  const [count, setCount] = useState(0);
+  return <button onClick={() => setCount((value) => value + 1)}>{count}</button>;
+}
+```
+
+Or place it at the top of a module to select every eligible component in that module:
+
+```tsx
+"use compiler";
+
+import { useState } from "react";
+
+export function Counter() {
+  const [count, setCount] = useState(0);
+  return <button onClick={() => setCount(count + 1)}>{count}</button>;
+}
+```
+
+The directive name is configurable:
+
+```ts
+compiler: {
+  mode: "annotation",
+  directive: "use optimize",
+}
+```
+
+An explicitly selected component that cannot be compiled produces a warning even when
+`onUnsupported` is `"fallback"`. Explicit selection should not fail silently.
+
+### Unsupported-component behavior
+
+| Value        | Behavior                                                                                 | Good fit                                       |
+| ------------ | ---------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `"fallback"` | Keep the original React component. Inferred unsupported candidates are quiet.            | Broad automatic experimentation.               |
+| `"warn"`     | Keep the React component and emit a diagnostic containing the component name and reason. | Finding missed optimization opportunities.     |
+| `"error"`    | Stop the transform/build when a considered component cannot be compiled.                 | Enforcing a reviewed annotation-mode contract. |
+
+For example, an unsupported keyed list can report:
+
+```text
+[react-compiler] KeyedList: dynamic child structures require React reconciliation; using React.
+```
+
+Use `"warn"` while exploring the compiler. Use annotation mode with `"error"` when CI should prove
+that every explicitly selected component still satisfies the supported contract.
+
+### Current supported contract
+
+The current compiler deliberately supports a smaller subset than general React. A component must
+satisfy all of these rules:
+
+| Area                | Current supported shape                                                                                                                             |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Component discovery | A top-level, capitalized function declaration, function expression, or arrow component in application `.tsx` or `.jsx`.                             |
+| Function shape      | Synchronous, non-generator, non-generic block body with zero parameters or one identifier such as `props`.                                          |
+| Body                | One or more top-level `useState` declarations followed by one unconditional JSX return.                                                             |
+| State               | `const [value, setValue] = useState(initial)`, including lazy initializers, multiple cells, and queued functional updates.                          |
+| Root                | Exactly one lowercase host JSX element such as `button`, `section`, `input`, or `div`.                                                              |
+| Tree                | A static tree containing host elements only. Nested host elements are supported when their placement cannot change.                                 |
+| Text bindings       | State-driven text in a leaf host element.                                                                                                           |
+| Attribute bindings  | State-driven basic attributes and properties, including `className`, `htmlFor`, `data-*`, `aria-*`, `value`, `checked`, `selected`, and `disabled`. |
+| Events              | React-owned JSX event handlers. A compiled state setter must be called from a JSX event handler.                                                    |
+
+This component is eligible:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+
+export function StatusButton(props: { initial: number }) {
+  const [count, setCount] = useState(props.initial);
+  const [active, setActive] = useState(false);
+
+  return (
+    <button
+      aria-pressed={active}
+      className={active ? "active" : "idle"}
+      data-count={count}
+      onClick={() => {
+        setCount((value) => value + 1);
+        setActive((value) => !value);
+      }}
+    >
+      Count: {count}
+    </button>
+  );
+}
+```
+
+The compiler records separate dependencies for `count` and `active`. Changing `count` does not
+reevaluate bindings that depend only on `active`, and vice versa.
+
+### What falls back to React
+
+| Unsupported shape                                                  | Why React keeps ownership                                                           |
+| ------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| Keyed lists, `.map()`, element arrays, or helper-rendered children | Inserts, removals, moves, and identity changes require reconciliation.              |
+| Conditional JSX children or fragments                              | The prepared DOM path can change when structure appears or disappears.              |
+| Custom child components                                            | A child component has its own props, hooks, lifecycle, and reconciliation boundary. |
+| Effects or hooks other than the supported `useState` shape         | Their lifecycle and ordering must remain under React's hook dispatcher.             |
+| `ref` or `dangerouslySetInnerHTML`                                 | They directly participate in DOM ownership.                                         |
+| Stateful `style`, `children`, or `key` bindings                    | These need specialized property, structure, or identity semantics.                  |
+| JSX attribute spreads or namespaced attributes                     | The compiler cannot currently enumerate a stable binding contract.                  |
+| Multiple/conditional returns or non-state statements               | The compiler does not yet prove control flow or derived local values.               |
+| Destructured props, async/generator, or generic components         | These function shapes are outside the current lowering.                             |
+| Setters called outside JSX event handlers                          | The compiler only controls and batches event-driven local updates.                  |
+
+Keys do not make list reconciliation unnecessary. A key tells React which child identity survives
+an insert, removal, or move; React still needs to compare the dynamic children. Calling a Hook
+directly inside a list iteration is also invalid React because the number or order of calls can
+change. Put the Hook inside a keyed child component and leave that structure on React.
+
+### Build-time transformation
+
+The React renderer installs `farm:react-aot-compiler` as a pre-transform. The current implementation
+is a Babel AST transform, not a Rust compiler pass. It parses application TSX/JSX before ordinary
+JSX lowering, discovers candidate components, validates the full supported contract, and emits
+source maps with the transformed module.
+
+For each eligible component, the transform conceptually emits a definition like this:
+
+```ts
+createCompiledComponent({
+  initialize: (props) => [props.initial],
+  render: (props, state) => <button>Count: {state[0].get()}</button>,
+  bindings: [
+    {
+      kind: "text",
+      path: [],
+      dependencies: [0],
+      read: (_props, state) => ["Count: ", state[0].get()],
+    },
+  ],
+});
+```
+
+The actual output imports `createCompiledComponent` from `@farm.js/react/compiler-runtime` only in
+modules where at least one component compiled. Unsupported modules keep their original source and
+do not receive the runtime import.
+
+### Runtime behavior
+
+The generated runtime wrapper is still a React component. Its responsibilities are split as
+follows:
+
+| React owns                                     | Compiler runtime owns                                           |
+| ---------------------------------------------- | --------------------------------------------------------------- |
+| Initial element creation and placement         | Local compiler-cell values                                      |
+| SSR markup and hydration                       | Queuing local setter calls into one microtask                   |
+| JSX event registration and dispatch            | Comparing flushed values with `Object.is`                       |
+| Parent-driven prop updates                     | Selecting bindings whose state dependencies changed             |
+| Unsupported trees, hooks, refs, and lifecycles | Patching precomputed text/attribute targets after local updates |
+| Unmounting and the surrounding component tree  | Reapplying bindings after a parent-driven React update          |
+
+Queued functional setters preserve the event's state snapshot. Two calls such as
+`setCount(value => value + 1)` are applied in order during the same microtask flush, while reads
+inside the event still see the previous snapshot. If the final value is `Object.is`-equal to the
+previous value, no binding is patched.
+
+Attribute updates preserve important DOM behavior:
+
+- `className` and `htmlFor` map to `class` and `for`;
+- input `value` and `checked`, option `selected`, and element `disabled` use DOM properties;
+- `data-*` and `aria-*` booleans are stringified; and
+- nullish values and ordinary false boolean attributes are removed.
+
+The server output is ordinary React HTML and contains no compiler marker. React hydrates that
+markup normally; direct binding updates begin after the component mounts.
+
+### Safety reasoning
+
+The compiler uses fallback as a semantic boundary, not as an error-recovery trick. A precomputed
+path is only correct while the host tree has the same shape. Dynamic children, custom components,
+refs, and effects can change ownership or lifecycle in ways the current compiler does not yet
+model. Letting React handle them is the optimization's correctness mechanism.
+
+Parent-driven prop updates also remain React updates. After React reconciles the new props, the
+runtime reapplies compiler-owned bindings from the current local cells so prop changes and local
+state remain coherent.
+
+### Verification and benchmark scope
+
+The package and example test suites verify more than generated code:
+
+- compiled local updates change the same text and attributes as base React;
+- one eligible update adds no React render or commit, while the equivalent base component adds one;
+- server-rendered markup hydrates and remains interactive;
+- lazy initialization, event snapshots, and batched functional setters are preserved;
+- multiple state cells update only their dependent bindings;
+- boolean `data-*` and `aria-*` attributes keep React-compatible string values; and
+- keyed lists, effects, refs, and custom child components remain on React without corrupting output.
+
+The heavy example uses a fixed 768-host-node tree with three state cells and sparse bindings. Its
+compiler-off → compiler-on crossover run measures a deliberately favorable supported workload. The
+reference run reported 88.2% lower median update latency, 86% lower p95 latency, and zero added
+component executions on the compiled path. These numbers describe that warm update path, not page
+load, build time, browser layout/paint, network work, effects, child-component updates, or general
+React performance.
+
+Run the benchmark on target devices before using its timing as a product estimate. The structural
+result—no extra component execution or React commit for an eligible local update—is the more stable
+property.
+
+### Recommended rollout
+
+1. Start with `compiler: true` and confirm the application behaves normally.
+2. Change `onUnsupported` to `"warn"` to see why candidates remain on React.
+3. Add `"use no compiler"` to known React-owned boundaries when the reason is intentional.
+4. Use annotation mode for components whose compiler ownership should be explicit.
+5. Use annotation mode with `onUnsupported: "error"` when CI must enforce that selected components
+   remain eligible.
 
 The [`examples/react-compiler`](https://github.com/farming-labs/farm.js/tree/main/examples/react-compiler)
-app runs an eligible compiled counter beside an equivalent component marked `"use no compiler"`.
-Both update the same text and class bindings, while the live component-execution values expose the
-render work skipped by the compiled path.
+app includes batching, multiple bindings, keyed fallback, compiler-on/off production builds, and
+the reproducible heavy-interaction benchmark.
 
 ## React-specific FARMJS APIs
 

--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -455,6 +455,10 @@
     min-height: 1rem;
   }
 
+  .farm-highlighted-code--value-cycle-compact .sh__line {
+    min-height: 1.125rem;
+  }
+
   .farm-highlighted-code .sh__token--keyword {
     font-weight: 650;
   }
@@ -467,8 +471,15 @@
     animation: farm-code-cycle-panel-in 260ms cubic-bezier(0.22, 1, 0.36, 1);
   }
 
-  .farm-code-value-cycle {
-    animation: farm-code-value-cycle-in 260ms cubic-bezier(0.22, 1, 0.36, 1);
+  .farm-code-typewriter .sh__line:last-child::after {
+    display: inline-block;
+    width: 0.45em;
+    height: 1.05em;
+    margin-left: 0.18em;
+    background: rgb(255 255 255 / 0.72);
+    vertical-align: -0.12em;
+    animation: farm-terminal-cursor-blink 0.8s steps(1, end) infinite;
+    content: "";
   }
 
   @media (min-width: 768px) {
@@ -675,18 +686,6 @@
   from {
     opacity: 0;
     transform: translate3d(0, 4px, 0);
-  }
-
-  to {
-    opacity: 1;
-    transform: translate3d(0, 0, 0);
-  }
-}
-
-@keyframes farm-code-value-cycle-in {
-  from {
-    opacity: 0;
-    transform: translate3d(0, 3px, 0);
   }
 
   to {
@@ -1085,7 +1084,8 @@
     animation: none;
   }
 
-  .farm-code-value-cycle {
+  .farm-code-typewriter .sh__line:last-child::after {
+    display: none;
     animation: none;
   }
 

--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -388,22 +388,11 @@
 
   .farm-renderer-value {
     display: inline-block;
-    width: 9ch;
+    width: 10ch;
     height: 1.5rem;
     overflow: hidden;
+    white-space: nowrap;
     vertical-align: bottom;
-  }
-
-  .farm-renderer-value-track {
-    display: flex;
-    flex-direction: column;
-    animation: farm-renderer-value-cycle 10s cubic-bezier(0.65, 0, 0.35, 1) infinite;
-    will-change: transform;
-  }
-
-  .farm-renderer-value-item {
-    height: 1.5rem;
-    flex: 0 0 1.5rem;
   }
 
   .farm-highlighted-code {
@@ -471,7 +460,8 @@
     animation: farm-code-cycle-panel-in 260ms cubic-bezier(0.22, 1, 0.36, 1);
   }
 
-  .farm-code-typewriter .sh__line:last-child::after {
+  .farm-code-typewriter .sh__line:last-child::after,
+  .farm-inline-typewriter::after {
     display: inline-block;
     width: 0.45em;
     height: 1.05em;
@@ -653,32 +643,6 @@
   100% {
     clip-path: inset(0 0 100% 0);
     opacity: 1;
-  }
-}
-
-@keyframes farm-renderer-value-cycle {
-  0%,
-  18% {
-    transform: translate3d(0, 0, 0);
-  }
-
-  25%,
-  43% {
-    transform: translate3d(0, -1.5rem, 0);
-  }
-
-  50%,
-  68% {
-    transform: translate3d(0, -3rem, 0);
-  }
-
-  75%,
-  93% {
-    transform: translate3d(0, -4.5rem, 0);
-  }
-
-  100% {
-    transform: translate3d(0, -6rem, 0);
   }
 }
 
@@ -1075,16 +1039,12 @@
     animation: none;
   }
 
-  .farm-renderer-value-track {
-    animation: none;
-    transform: none;
-  }
-
   .farm-code-cycle-panel {
     animation: none;
   }
 
-  .farm-code-typewriter .sh__line:last-child::after {
+  .farm-code-typewriter .sh__line:last-child::after,
+  .farm-inline-typewriter::after {
     display: none;
     animation: none;
   }

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -488,25 +488,39 @@ const reactCompilerConfigPrefix = `import { defineConfig } from "@farm.js/core";
 import { react } from "@farm.js/react";
 
 export default defineConfig({
-    renderer: react({
-        experimental: {`;
+  renderer: react({ experimental: {`;
 const reactCompilerConfigVariants = [
   {
     id: "automatic",
-    code: `            compiler: true,`,
+    code: `    compiler: true,`,
   },
   {
     id: "annotations",
-    code: `            compiler: {
-                mode: "annotation",
-                directive: "use compiler",
-                onUnsupported: "warn",
-            },`,
+    code: `    compiler: {
+      mode: "annotation",
+      directive: "use compiler",
+    },`,
   },
 ] as const satisfies readonly [HighlightedCodeValueVariant, ...HighlightedCodeValueVariant[]];
-const reactCompilerConfigSuffix = `        },
-    }),
+const reactCompilerConfigSuffix = `  } }),
 });`;
+const reactCompilerMetrics = [
+  {
+    description: "The compiler reduced the median latency of the benchmarked update path by 88.2%.",
+    label: "Median update latency",
+    value: "88.2% lower",
+  },
+  {
+    description: "The same state update was 8.5 times faster with the compiler on.",
+    label: "State update speed",
+    value: "8.5× faster",
+  },
+  {
+    description: "The compiled update caused no extra component renders.",
+    label: "Extra renders",
+    value: "0",
+  },
+] as const;
 
 const layersConfigTabs = [
   {
@@ -1267,10 +1281,11 @@ function RendererVisual() {
 function ReactCompilerVisual() {
   return (
     <div className="farm-feature-spotlight relative flex h-[340px] min-w-0 items-end overflow-hidden px-6 sm:px-10">
-      <div className="relative z-10 flex w-full min-w-0 flex-col">
+      <div className="relative z-10 flex h-[290px] w-full min-w-0 flex-col">
         <HighlightedCodeValueCycle
           autoRotateMs={4200}
-          className="flex h-[290px] min-w-0 flex-col"
+          className="flex h-[248px] min-w-0 flex-col border-b-0"
+          compact
           copyable
           id="react-compiler-config"
           label="farm.config.ts"
@@ -1279,17 +1294,38 @@ function ReactCompilerVisual() {
           suffixCode={reactCompilerConfigSuffix}
           variants={reactCompilerConfigVariants}
         />
-        <a
-          className="group flex h-12 shrink-0 items-center justify-between border-x border-white/10 bg-black px-4 font-mono text-[9px] uppercase tracking-normal text-white/54 transition-colors duration-150 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-white sm:px-5"
-          href="/docs/renderers/react#experimental-aot-compiler"
+        <div
+          aria-label="React compiler benchmark results"
+          className="grid h-[42px] shrink-0 grid-cols-[repeat(3,minmax(0,1fr))_2.625rem] border-x border-white/10 bg-black"
+          role="group"
         >
-          Read how it works
-          <ArrowRight
-            aria-hidden
-            className="size-3 transition-transform duration-150 group-hover:translate-x-0.5"
-            strokeWidth={1.5}
-          />
-        </a>
+          {reactCompilerMetrics.map((metric) => (
+            <div
+              key={metric.label}
+              className="flex min-w-0 flex-col justify-center border-r border-white/8 px-2 sm:px-3"
+              title={metric.description}
+            >
+              <span className="truncate font-mono text-[8.5px] font-bold tabular-nums tracking-normal text-white sm:text-[10px]">
+                {metric.value}
+              </span>
+              <span className="truncate font-mono text-[6.5px] uppercase tracking-normal text-white/38 sm:text-[7.5px]">
+                {metric.label}
+              </span>
+            </div>
+          ))}
+          <a
+            aria-label="See how the React compiler works"
+            className="group grid place-items-center text-white/48 transition-[background-color,color] duration-150 hover:bg-white/[0.04] hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-white"
+            href="/docs/renderers/react#experimental-aot-compiler"
+            title="How it works"
+          >
+            <ArrowUpRight
+              aria-hidden
+              className="size-3.5 transition-transform duration-150 group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
+              strokeWidth={1.5}
+            />
+          </a>
+        </div>
       </div>
     </div>
   );
@@ -1385,17 +1421,16 @@ function DeveloperExperienceGrid() {
       <FeatureCell
         body={
           <>
-            Turn on the compiler and Farm prepares safe state updates during the build. In our test,
-            those updates were <span className="font-mono text-white/86">8.5× faster</span> and did
-            not run the component again. React still handles anything the compiler cannot safely
-            optimize.
+            Farm prepares safe state updates at build time. In our test, they were{" "}
+            <span className="font-mono font-bold text-white">8.5× faster</span> with no extra
+            component renders. React handles anything the compiler cannot safely optimize.
           </>
         }
         className="border-t border-white/12 lg:border-l"
         icon={Cpu}
         index="01.6"
         label="React compiler"
-        title="Faster React updates with AOT compilation"
+        title="React updates optimized ahead of time"
       >
         <ReactCompilerVisual />
       </FeatureCell>

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -66,6 +66,7 @@ import {
   HighlightedCode,
   HighlightedCodeTabs,
   HighlightedCodeValueCycle,
+  TypewriterValueCycle,
 } from "../components/home/highlighted-code";
 import type {
   HighlightedCodeTab,
@@ -483,7 +484,12 @@ export default defineConfig({
 
 const typedApiHighlightLines = [1, 7, 8] as const;
 const docsHighlightLines = [3, 4] as const;
-const rendererOptions = ["preact()", "solid()", "vue()", "svelte()"] as const;
+const rendererValueVariants = [
+  { id: "preact", code: "preact()," },
+  { id: "solid", code: "solid()," },
+  { id: "vue", code: "vue()," },
+  { id: "svelte", code: "svelte()," },
+] as const satisfies readonly [HighlightedCodeValueVariant, ...HighlightedCodeValueVariant[]];
 const reactCompilerConfigPrefix = `import { defineConfig } from "@farm.js/core";
 import { react } from "@farm.js/react";
 
@@ -1232,18 +1238,13 @@ function RendererVisual() {
               {"  "}
               <span className="text-white/78">renderer</span>
               <span className="text-white/42">: </span>
-              <span className="farm-renderer-value" data-renderer-count={rendererOptions.length}>
-                <span className="farm-renderer-value-track">
-                  {[...rendererOptions, rendererOptions[0]].map((renderer, index) => (
-                    <span
-                      key={`${renderer}-${index}`}
-                      className="farm-renderer-value-item text-white/94"
-                    >
-                      {renderer}
-                      <span className="text-white/42">,</span>
-                    </span>
-                  ))}
-                </span>
+              <span className="farm-renderer-value">
+                <TypewriterValueCycle
+                  className="text-white/94"
+                  holdMs={1800}
+                  mutedTrailingText=","
+                  variants={rendererValueVariants}
+                />
               </span>
             </span>
             <span className="sh__line">

--- a/docs/src/components/home/highlighted-code.tsx
+++ b/docs/src/components/home/highlighted-code.tsx
@@ -51,6 +51,13 @@ interface HighlightedCodeValueCycleProps {
   variants: readonly [HighlightedCodeValueVariant, ...HighlightedCodeValueVariant[]];
 }
 
+interface TypewriterValueCycleProps {
+  className?: string;
+  holdMs: number;
+  mutedTrailingText?: string;
+  variants: readonly [HighlightedCodeValueVariant, ...HighlightedCodeValueVariant[]];
+}
+
 type TypewriterPhase = "holding" | "deleting" | "typing";
 
 interface TypewriterState {
@@ -272,6 +279,32 @@ function useTypewriterVariant(
   }, [holdMs, prefersReducedMotion, state, variants]);
 
   return state;
+}
+
+export function TypewriterValueCycle({
+  className,
+  holdMs,
+  mutedTrailingText,
+  variants,
+}: TypewriterValueCycleProps) {
+  const typewriter = useTypewriterVariant(holdMs, variants);
+  const trailingText = mutedTrailingText ?? "";
+  const hasMutedTrailingText = Boolean(
+    trailingText && typewriter.displayedCode.endsWith(trailingText),
+  );
+  const primaryText = hasMutedTrailingText
+    ? typewriter.displayedCode.slice(0, -trailingText.length)
+    : typewriter.displayedCode;
+
+  return (
+    <span
+      className={["farm-inline-typewriter", className].filter(Boolean).join(" ")}
+      data-typewriter-phase={typewriter.phase}
+    >
+      {primaryText || (hasMutedTrailingText ? null : "\u200b")}
+      {hasMutedTrailingText ? <span className="text-white/42">{trailingText}</span> : null}
+    </span>
+  );
 }
 
 function HighlightedCodeBody({

--- a/docs/src/components/home/highlighted-code.tsx
+++ b/docs/src/components/home/highlighted-code.tsx
@@ -41,6 +41,7 @@ interface HighlightedCodeTabsProps {
 interface HighlightedCodeValueCycleProps {
   autoRotateMs: number;
   className?: string;
+  compact?: boolean;
   copyable?: boolean;
   id: string;
   label: string;
@@ -49,6 +50,19 @@ interface HighlightedCodeValueCycleProps {
   suffixCode: string;
   variants: readonly [HighlightedCodeValueVariant, ...HighlightedCodeValueVariant[]];
 }
+
+type TypewriterPhase = "holding" | "deleting" | "typing";
+
+interface TypewriterState {
+  activeIndex: number;
+  displayedCode: string;
+  phase: TypewriterPhase;
+  targetIndex: number;
+}
+
+const TYPEWRITER_DELETE_DELAY_MS = 14;
+const TYPEWRITER_START_DELAY_MS = 180;
+const TYPEWRITER_TYPE_DELAY_MS = 22;
 
 function figureClassName(className?: string) {
   return [
@@ -154,6 +168,112 @@ function useAutoRotatingIndex(autoRotateMs: number | undefined, itemCount: numbe
   return [activeIndex, setActiveIndex] as const;
 }
 
+function commonPrefixLength(first: string, second: string) {
+  const comparableLength = Math.min(first.length, second.length);
+  let index = 0;
+
+  while (index < comparableLength && first[index] === second[index]) index += 1;
+
+  return index;
+}
+
+function useTypewriterVariant(
+  holdMs: number,
+  variants: readonly [HighlightedCodeValueVariant, ...HighlightedCodeValueVariant[]],
+) {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const [state, setState] = useState<TypewriterState>(() => ({
+    activeIndex: 0,
+    displayedCode: variants[0].code,
+    phase: "holding",
+    targetIndex: 0,
+  }));
+
+  useEffect(() => {
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const updatePreference = () => setPrefersReducedMotion(reducedMotion.matches);
+
+    updatePreference();
+    reducedMotion.addEventListener("change", updatePreference);
+
+    return () => reducedMotion.removeEventListener("change", updatePreference);
+  }, []);
+
+  useEffect(() => {
+    if (prefersReducedMotion || variants.length < 2) {
+      setState((current) => {
+        const firstVariant = variants[0];
+
+        if (
+          current.activeIndex === 0 &&
+          current.displayedCode === firstVariant.code &&
+          current.phase === "holding" &&
+          current.targetIndex === 0
+        ) {
+          return current;
+        }
+
+        return {
+          activeIndex: 0,
+          displayedCode: firstVariant.code,
+          phase: "holding",
+          targetIndex: 0,
+        };
+      });
+      return;
+    }
+
+    let delay = 0;
+    let updateState: (current: TypewriterState) => TypewriterState;
+
+    if (state.phase === "holding") {
+      delay = holdMs;
+      updateState = (current) => ({
+        ...current,
+        phase: "deleting",
+        targetIndex: (current.activeIndex + 1) % variants.length,
+      });
+    } else if (state.phase === "deleting") {
+      const currentCode = variants[state.activeIndex]?.code ?? variants[0].code;
+      const targetCode = variants[state.targetIndex]?.code ?? variants[0].code;
+      const retainedLength = commonPrefixLength(currentCode, targetCode);
+
+      if (state.displayedCode.length > retainedLength) {
+        delay = TYPEWRITER_DELETE_DELAY_MS;
+        updateState = (current) => ({
+          ...current,
+          displayedCode: current.displayedCode.slice(0, -1),
+        });
+      } else {
+        delay = TYPEWRITER_START_DELAY_MS;
+        updateState = (current) => ({
+          ...current,
+          activeIndex: current.targetIndex,
+          phase: "typing",
+        });
+      }
+    } else {
+      const targetCode = variants[state.activeIndex]?.code ?? variants[0].code;
+
+      if (state.displayedCode.length < targetCode.length) {
+        delay = TYPEWRITER_TYPE_DELAY_MS;
+        updateState = (current) => ({
+          ...current,
+          displayedCode: targetCode.slice(0, current.displayedCode.length + 1),
+        });
+      } else {
+        updateState = (current) => ({ ...current, phase: "holding" });
+      }
+    }
+
+    const timer = window.setTimeout(() => setState(updateState), delay);
+
+    return () => window.clearTimeout(timer);
+  }, [holdMs, prefersReducedMotion, state, variants]);
+
+  return state;
+}
+
 function HighlightedCodeBody({
   ariaLabel,
   ariaLabelledBy,
@@ -237,6 +357,7 @@ export function HighlightedCode({
 export function HighlightedCodeValueCycle({
   autoRotateMs,
   className,
+  compact = false,
   copyable = false,
   id,
   label,
@@ -245,12 +366,13 @@ export function HighlightedCodeValueCycle({
   suffixCode,
   variants,
 }: HighlightedCodeValueCycleProps) {
-  const [activeIndex] = useAutoRotatingIndex(autoRotateMs, variants.length);
-  const activeVariant = variants[activeIndex] ?? variants[0];
+  const typewriter = useTypewriterVariant(autoRotateMs, variants);
+  const activeVariant = variants[typewriter.activeIndex] ?? variants[0];
   const completeCode = `${prefixCode}\n${activeVariant.code}\n${suffixCode}`;
-  const valueLineCount = activeVariant.code.split("\n").length;
+  const visibleValue = typewriter.displayedCode || " ";
+  const valueLineCount = visibleValue.split("\n").length;
   const highlightedValue = renderHighlightedCode(
-    activeVariant.code,
+    visibleValue,
     Array.from({ length: valueLineCount }, (_, index) => index + 1),
   );
 
@@ -268,15 +390,26 @@ export function HighlightedCodeValueCycle({
       </figcaption>
       <pre
         aria-label={`${label} code`}
-        className="min-h-0 max-w-full flex-1 overflow-x-auto py-2 font-mono text-[9.5px] leading-4 tracking-normal sm:text-[10px]"
+        className={[
+          "min-h-0 max-w-full flex-1 overflow-x-auto font-mono tracking-normal",
+          compact
+            ? "py-1 text-[10.5px] leading-[18px] sm:text-[11px]"
+            : "py-2 text-[9.5px] leading-4 sm:text-[10px]",
+        ].join(" ")}
         id={id}
         tabIndex={0}
       >
-        <code className="farm-highlighted-code farm-highlighted-code--value-cycle block min-w-full">
+        <code
+          className={[
+            "farm-highlighted-code farm-highlighted-code--value-cycle block min-w-full",
+            compact && "farm-highlighted-code--value-cycle-compact",
+          ]
+            .filter(Boolean)
+            .join(" ")}
+        >
           <span dangerouslySetInnerHTML={{ __html: renderHighlightedCode(prefixCode) }} />
           <span
-            key={activeVariant.id}
-            className="farm-code-value-cycle block"
+            className="farm-code-typewriter block"
             dangerouslySetInnerHTML={{ __html: highlightedValue }}
           />
           <span dangerouslySetInnerHTML={{ __html: renderHighlightedCode(suffixCode) }} />

--- a/examples/react-compiler/README.md
+++ b/examples/react-compiler/README.md
@@ -47,9 +47,9 @@ speed depends on event work, DOM work, layout, paint, application shape, and dev
 
 ## Keys and Hooks boundary
 
-`items.map(item => <Row key={item} />)` changes tree structure, so Group 1 leaves it to React. Keys
-tell React which row identity survived an insert, delete, or move; they do not make reconciliation
-unnecessary.
+`items.map(item => <Row key={item} />)` changes tree structure, so the current compiler leaves it to
+React. Keys tell React which row identity survived an insert, delete, or move; they do not make
+reconciliation unnecessary.
 
 Calling a Hook directly inside `items.map(...)` is invalid React because the number or order of Hook
 calls can change. Put the Hook inside a separate `Row` component and key that component. The compiler
@@ -58,8 +58,8 @@ has a regression test confirming that the invalid inline shape is rejected rathe
 ## Heavy compiler-on/off benchmark
 
 The page also contains `HeavyInteractionBenchmark`: one component with 768 static host nodes, three
-local state cells, and a small number of dynamic text/attribute targets. It represents the workload
-the first compiler group is designed to optimize—a large stable tree with sparse local updates.
+local state cells, and a small number of dynamic text/attribute targets. It represents a workload
+the current compiler is designed to optimize—a large stable tree with sparse local updates.
 
 Run the full crossover benchmark:
 

--- a/examples/react-compiler/src/components/compiler-edge-lab.tsx
+++ b/examples/react-compiler/src/components/compiler-edge-lab.tsx
@@ -203,7 +203,7 @@ export function CompilerEdgeLab() {
   return (
     <section className="edge-lab" aria-labelledby="edge-lab-title">
       <div className="section-heading">
-        <span>EDGE LAB / GROUP 1</span>
+        <span>EDGE LAB / SUPPORTED SCOPE</span>
         <h2 id="edge-lab-title">Correctness before coverage.</h2>
         <p>
           Eligible local state gets direct bindings. Dynamic tree shapes fall
@@ -225,7 +225,8 @@ export function CompilerEdgeLab() {
         <p>
           Never call a Hook directly inside <code>items.map(...)</code>. Put the
           Hook in a separate keyed row component. This compiler rejects the
-          inline pattern; Group 1 leaves the keyed list itself to React.
+          inline pattern; the current compiler leaves the keyed list itself to
+          React.
         </p>
       </aside>
     </section>

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -1,6 +1,6 @@
 # @farm.js/react
 
-React renderer integration for FARMJS, including the experimental Group 1 AOT compiler.
+React renderer integration for FARMJS, including the experimental AOT compiler.
 
 React remains the default renderer and needs no package or configuration. Install this package only
 when opting into the compiler experiment:
@@ -49,9 +49,9 @@ export function Counter() {
 
 The directive is configurable and only has meaning in annotation mode.
 
-## Group 1 contract
+## Current compiler contract
 
-The first compiler group handles components that the compiler can prove have:
+The current compiler handles components that it can prove have:
 
 - one host-element root and a static host-element tree;
 - top-level `useState` declarations;
@@ -71,5 +71,5 @@ second component render and commit, while the compiled component remains at one 
 commit and updates its two bindings directly. This is a deterministic structural performance
 assertion; it is not presented as a cross-machine timing benchmark.
 
-Keyed list lowering, structural conditionals, effects, and more advanced hook support belong to
-later compiler groups and intentionally stay on React in this release.
+Keyed list lowering, structural conditionals, effects, and more advanced hook support intentionally
+stay on React in this release.

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -409,7 +409,7 @@ function compileCandidate(
       continue;
     }
     if (!t.isVariableDeclaration(statement) || statement.declarations.length !== 1) {
-      return "only top-level useState declarations and one return are supported in Group 1";
+      return "only top-level useState declarations and one return are supported by the current compiler";
     }
     const declaration = statement.declarations[0];
     if (


### PR DESCRIPTION
## Summary

- restore the final compact React compiler landing-page showcase and benchmark stats
- animate the compiler option as a real looping editor sequence: keep `compiler:` fixed, backspace `true`, type the annotation object, then reverse back to `true`
- expand the experimental AOT compiler guide with configuration, supported transformations, safety fallbacks, diagnostics, and current limitations
- align the package README and interactive compiler example with the public terminology

## Benchmark context

The landing-page figures come from the fixed 768-node interactive benchmark: median browser update latency improved by 88.2% (8.5×), with zero extra component renders. These figures describe that benchmark rather than build or page-load performance.

## Verification

- `pnpm --filter @farm.js/react test` — 24 tests passed
- `pnpm --filter @farm.js/react type-check`
- `pnpm docs:check-navigation` — 70 visible pages covered
- `FARM_VITE_BUILDER=rolldown pnpm --dir docs exec farm build --preset node-server`
- targeted `oxlint`, `oxfmt`, and `git diff --check`
- live browser sampling across a complete typewriter loop and desktop visual review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the experimental React AOT compiler and improves the homepage showcase without changing runtime behavior. Replaces the landing-page value-cycling animations with an accessible typewriter sequence and aligns “Group 1” terminology to “current compiler”.

- Docs: expands the AOT compiler guide for `@farm.js/react` (enablement, `compiler` config with `mode`/`directive`/`onUnsupported`, inference vs annotation, supported contract, fallback behavior, build-time transform and runtime roles, safety, verification, and rollout steps).
- Homepage: adds a typewriter code demo for both renderer selection and the React compiler config, with a blinking cursor and a compact metrics bar; respects reduced-motion preferences.
- Components/CSS: introduces `TypewriterValueCycle`, updates `HighlightedCodeValueCycle` to use a typewriter state machine, adds a `compact` option and compact line heights, and removes the old value-cycle keyframes/hooks.
- Terminology: updates `examples/react-compiler` and `packages/farm-react/README.md` from “Group 1” to “current compiler”.
- Compiler: changes one diagnostic string in `packages/farm-react/src/compiler.ts`; no API or behavior change.

**Rollout/Review notes**
- No migration required. Update tests that assert exact diagnostic text to the “current compiler” phrasing.
- Visually validate desktop/mobile with reduced-motion enabled. Confirm the renderer-line and compiler-config typewriter sequences and the metrics bar render without layout regressions.

<sup>Written for commit 29eb859952df4984fde5e33b42cc1b800088f21f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

