### PR TITLE
feat(react): harden experimental compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,35 @@ jobs:
           pnpm lint
           pnpm format:check
 
+  react-compiler-compat:
+    name: React Compiler (React ${{ matrix.react-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        react-version: [18.3.1, 19.2.8]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build React renderer
+        run: pnpm --filter @farm.js/react build
+
+      - name: Verify packaged renderer
+        run: node packages/farm-react/scripts/test-react-version.mjs ${{ matrix.react-version }}
+
   build-examples:
     name: Build Examples
     runs-on: ubuntu-latest

--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -132,15 +132,19 @@ interface ReactCompilerOptions {
   mode?: ReactCompilerMode;
   directive?: string;
   onUnsupported?: UnsupportedCompilerBehavior;
+  report?: boolean;
+  reportFile?: string;
 }
 ```
 
-| Option          | Values                                | Default          | Purpose                                                                  |
-| --------------- | ------------------------------------- | ---------------- | ------------------------------------------------------------------------ |
-| `compiler`      | `false`, `true`, or an options object | `false`          | Disables, enables with defaults, or configures the React-only transform. |
-| `mode`          | `"infer"`, `"annotation"`             | `"infer"`        | Selects components automatically or only through an explicit directive.  |
-| `directive`     | non-empty string                      | `"use compiler"` | Names the module/function directive used by annotation mode.             |
-| `onUnsupported` | `"fallback"`, `"warn"`, `"error"`     | `"fallback"`     | Controls what happens outside the current supported subset.              |
+| Option          | Values                                | Default                     | Purpose                                                                  |
+| --------------- | ------------------------------------- | --------------------------- | ------------------------------------------------------------------------ |
+| `compiler`      | `false`, `true`, or an options object | `false`                     | Disables, enables with defaults, or configures the React-only transform. |
+| `mode`          | `"infer"`, `"annotation"`             | `"infer"`                   | Selects components automatically or only through an explicit directive.  |
+| `directive`     | non-empty string                      | `"use compiler"`            | Names the module/function directive used by annotation mode.             |
+| `onUnsupported` | `"fallback"`, `"warn"`, `"error"`     | `"fallback"`                | Controls what happens outside the current supported subset.              |
+| `report`        | boolean                               | `false`                     | Writes a compiler coverage report after a successful production build.   |
+| `reportFile`    | project-relative path                 | `.farm/react-compiler.json` | Changes the report path and enables reporting when provided.             |
 
 `directive` is valid only when `mode` is `"annotation"`. Invalid modes, invalid unsupported
 behaviors, and directives configured in inference mode throw a configuration error instead of
@@ -235,6 +239,74 @@ For example, an unsupported keyed list can report:
 
 Use `"warn"` while exploring the compiler. Use annotation mode with `"error"` when CI should prove
 that every explicitly selected component still satisfies the supported contract.
+
+### Compiler coverage report
+
+Console warnings are useful while editing, but a report makes compiler coverage visible across the
+production browser graph where compiled DOM updates run. Enable it without changing selection or
+fallback behavior:
+
+```ts
+renderer: react({
+  experimental: {
+    compiler: {
+      report: true,
+    },
+  },
+}),
+```
+
+After a successful build, Farm writes `.farm/react-compiler.json`:
+
+```json
+{
+  "version": 1,
+  "summary": {
+    "modules": 2,
+    "componentsConsidered": 4,
+    "compiled": 2,
+    "fallback": 2
+  },
+  "fallbackReasons": [
+    {
+      "count": 2,
+      "reason": "dynamic child structures require React reconciliation"
+    }
+  ],
+  "modules": [
+    {
+      "id": "src/Products.tsx",
+      "compiled": ["ProductRow"],
+      "fallbacks": [
+        {
+          "module": "src/Products.tsx",
+          "component": "ProductList",
+          "reason": "dynamic child structures require React reconciliation",
+          "selected": false
+        }
+      ]
+    }
+  ]
+}
+```
+
+`componentsConsidered` counts candidates selected by the active mode. `compiled` counts components
+using the AOT runtime, and `fallback` counts candidates left on React. `selected` is `true` when an
+annotation explicitly requested compilation. Module paths are relative to the project root, and
+the output is sorted and contains no timestamp, so CI can compare reports without machine-specific
+noise.
+
+Use a different project-relative output path when CI collects artifacts elsewhere:
+
+```ts
+compiler: {
+  reportFile: "artifacts/react-compiler.json",
+}
+```
+
+Report paths cannot be absolute or escape the project root. Reporting is observability only: it
+does not make unsupported components fail. Use `onUnsupported: "error"` when failure is the desired
+policy.
 
 ### Current supported contract
 
@@ -360,6 +432,15 @@ Attribute updates preserve important DOM behavior:
 The server output is ordinary React HTML and contains no compiler marker. React hydrates that
 markup normally; direct binding updates begin after the component mounts.
 
+During development, compiled components receive a module-and-component identity plus a state-layout
+signature. A compatible Fast Refresh replaces the compiled definition while retaining the React
+component type and its local cells. If the compiler-owned state layout changes, the identity is not
+reused and React remounts it instead of preserving incompatible state.
+
+If a direct binding evaluation throws, the runtime schedules a React update and rethrows from the
+component render. This lets the nearest React error boundary handle the failure through React's
+normal recovery path.
+
 ### Safety reasoning
 
 The compiler uses fallback as a semantic boundary, not as an error-recovery trick. A precomputed
@@ -380,6 +461,14 @@ The package and example test suites verify more than generated code:
 - server-rendered markup hydrates and remains interactive;
 - lazy initialization, event snapshots, and batched functional setters are preserved;
 - multiple state cells update only their dependent bindings;
+- Strict Mode mounting, queued-unmount cleanup, bubbled events, controlled input selection, and
+  composition events preserve their React behavior;
+- simultaneous parent-prop and compiled-local updates remain coherent;
+- compatible Fast Refresh preserves state, while binding errors reach React error boundaries;
+- hydration mismatches follow React's recoverable-error path and remain interactive;
+- object, array, and nullish state transitions match normal React across 3,000 deterministic
+  randomized updates;
+- the packaged runtime is exercised separately with React 18.3 and React 19;
 - boolean `data-*` and `aria-*` attributes keep React-compatible string values; and
 - keyed lists, effects, refs, and custom child components remain on React without corrupting output.
 
@@ -397,10 +486,11 @@ property.
 ### Recommended rollout
 
 1. Start with `compiler: true` and confirm the application behaves normally.
-2. Change `onUnsupported` to `"warn"` to see why candidates remain on React.
-3. Add `"use no compiler"` to known React-owned boundaries when the reason is intentional.
-4. Use annotation mode for components whose compiler ownership should be explicit.
-5. Use annotation mode with `onUnsupported: "error"` when CI must enforce that selected components
+2. Enable `report` to record coverage across the complete production build.
+3. Change `onUnsupported` to `"warn"` to see fallback reasons while editing.
+4. Add `"use no compiler"` to known React-owned boundaries when the reason is intentional.
+5. Use annotation mode for components whose compiler ownership should be explicit.
+6. Use annotation mode with `onUnsupported: "error"` when CI must enforce that selected components
    remain eligible.
 
 The [`examples/react-compiler`](https://github.com/farming-labs/farm.js/tree/main/examples/react-compiler)

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -66,6 +66,20 @@ state update therefore does not schedule a React render or reconciliation pass.
 Unsupported components fall back to React by default. Use `onUnsupported: "warn"` for diagnostics
 or `onUnsupported: "error"` while tightening an annotated migration.
 
+Enable a deterministic production-build coverage report to see which components compiled and why
+the rest stayed on React:
+
+```ts
+compiler: {
+  report: true,
+  // reportFile: "artifacts/react-compiler.json",
+}
+```
+
+The default path is `.farm/react-compiler.json`. The report covers the production browser graph and
+contains project-relative module paths, compiled component names, fallback details, and fallback
+reasons aggregated by count. A custom project-relative `reportFile` also enables reporting.
+
 The runtime test compares the same counter interaction on both paths: ordinary React performs a
 second component render and commit, while the compiled component remains at one render and one
 commit and updates its two bindings directly. This is a deterministic structural performance

--- a/packages/farm-react/package.json
+++ b/packages/farm-react/package.json
@@ -56,6 +56,7 @@
     "dev": "tsup --watch",
     "type-check": "tsc --noEmit",
     "test": "vitest run",
+    "test:compat": "pnpm build && node scripts/test-react-version.mjs 18.3.1 && node scripts/test-react-version.mjs 19.2.8",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -1,0 +1,135 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const reactVersion = process.argv[2];
+if (!reactVersion || !/^\d+\.\d+\.\d+/.test(reactVersion)) {
+  throw new TypeError("Usage: node scripts/test-react-version.mjs <react-version>");
+}
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const temporaryRoot = mkdtempSync(join(tmpdir(), `farm-react-${reactVersion}-`));
+
+const testSource = String.raw`
+  import assert from "node:assert/strict";
+  import { JSDOM } from "jsdom";
+
+  const dom = new JSDOM("<!doctype html><html><body></body></html>", { url: "http://localhost" });
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: dom.window.navigator,
+  });
+  globalThis.Element = dom.window.Element;
+  globalThis.HTMLElement = dom.window.HTMLElement;
+  globalThis.HTMLInputElement = dom.window.HTMLInputElement;
+  globalThis.HTMLOptionElement = dom.window.HTMLOptionElement;
+  globalThis.HTMLButtonElement = dom.window.HTMLButtonElement;
+  globalThis.Node = dom.window.Node;
+  globalThis.Event = dom.window.Event;
+  globalThis.MouseEvent = dom.window.MouseEvent;
+
+  const React = (await import("react")).default;
+  const { flushSync } = await import("react-dom");
+  const { createRoot, hydrateRoot } = await import("react-dom/client");
+  const { renderToString } = await import("react-dom/server");
+  const { createCompiledComponent } = await import("@farm.js/react/compiler-runtime");
+
+  const Counter = createCompiledComponent({
+    displayName: "CompatibilityCounter",
+    initialize: () => [0],
+    render(_props, state) {
+      return React.createElement(
+        "button",
+        { onClick: () => state[0].set((value) => Number(value) + 1) },
+        "Count: ",
+        Number(state[0].get()),
+      );
+    },
+    bindings: [
+      {
+        kind: "text",
+        path: [],
+        dependencies: [0],
+        read: (_props, state) => ["Count: ", state[0].get()],
+      },
+    ],
+  });
+
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  flushSync(() => root.render(React.createElement(Counter)));
+  container.querySelector("button").click();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(container.textContent, "Count: 1");
+  flushSync(() => root.unmount());
+
+  const hydrationContainer = document.createElement("div");
+  hydrationContainer.innerHTML = renderToString(React.createElement(Counter));
+  document.body.append(hydrationContainer);
+  const hydrationRoot = hydrateRoot(hydrationContainer, React.createElement(Counter));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  hydrationContainer.querySelector("button").click();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(hydrationContainer.textContent, "Count: 1");
+  flushSync(() => hydrationRoot.unmount());
+
+  assert.equal(React.version.startsWith(${JSON.stringify(reactVersion.split(".", 1)[0])}), true);
+  console.log("@farm.js/react compatibility passed with React " + React.version);
+`;
+
+try {
+  execFileSync("pnpm", ["pack", "--pack-destination", temporaryRoot], {
+    cwd: packageRoot,
+    stdio: "inherit",
+  });
+  const packageArchive = readdirSync(temporaryRoot).find((file) => file.endsWith(".tgz"));
+  if (!packageArchive) throw new Error("pnpm pack did not produce an archive");
+
+  writeFileSync(
+    join(temporaryRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "farm-react-compatibility-test",
+        private: true,
+        type: "module",
+        packageManager: "pnpm@8.12.1",
+        dependencies: {
+          "@farm.js/react": `file:${join(temporaryRoot, packageArchive)}`,
+          jsdom: "25.0.1",
+          react: reactVersion,
+          "react-dom": reactVersion,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeFileSync(join(temporaryRoot, "compatibility.mjs"), testSource);
+  execFileSync(
+    "pnpm",
+    [
+      "install",
+      "--ignore-workspace",
+      "--no-frozen-lockfile",
+      "--ignore-scripts",
+      "--config.auto-install-peers=false",
+    ],
+    {
+      cwd: temporaryRoot,
+      stdio: "inherit",
+    },
+  );
+  execFileSync(process.execPath, ["compatibility.mjs"], {
+    cwd: temporaryRoot,
+    stdio: "inherit",
+  });
+} finally {
+  rmSync(temporaryRoot, { force: true, recursive: true });
+}

--- a/packages/farm-react/src/__tests__/compiler-edge-cases.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-edge-cases.test.ts
@@ -55,6 +55,54 @@ describe("React AOT compiler safety boundaries", () => {
     expect(result.code).not.toContain("compiler-runtime");
   });
 
+  it("keeps a keyed parent on React while compiling its stable row component", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function List(props) {
+        const [items, setItems] = useState(props.items);
+        return <ul onClick={() => setItems([...items])}>{items.map((item) => <Row key={item.id} item={item} />)}</ul>;
+      }
+      export function Row(props) {
+        const [selected, setSelected] = useState(false);
+        return <li onClick={() => setSelected(!selected)}>{props.item.name}: {selected ? "yes" : "no"}</li>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Row"]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        component: "List",
+        reason: expect.stringMatching(/dynamic child structures/i),
+      }),
+    ]);
+    expect(result.code).toContain("createCompiledComponent");
+  });
+
+  it("compiles object, array, and nullish state transitions", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function StructuredState() {
+        const [record, setRecord] = useState({ count: 0 });
+        const [items, setItems] = useState([1]);
+        const [value, setValue] = useState(null);
+        return (
+          <section>
+            <button onClick={() => setRecord((current) => ({ count: current.count + 1 }))}>Object</button>
+            <button onClick={() => setItems((current) => [...current, 2])}>Array</button>
+            <button onClick={() => setValue(value === null ? "ready" : null)}>Null</button>
+            <output data-count={record.count} data-first={items[0]}>{value ?? "empty"}</output>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.compiled).toEqual(["StructuredState"]);
+    expect(result.code).toContain("dependencies: [0]");
+    expect(result.code).toContain("dependencies: [1]");
+    expect(result.code).toContain("dependencies: [2]");
+  });
+
   it("falls back when a stateful helper call could return a dynamic child tree", async () => {
     const result = await compile(`
       import { useState } from "react";

--- a/packages/farm-react/src/__tests__/compiler-report.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-report.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment node
+
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createReactCompilerReport,
+  writeReactCompilerReport,
+  type ReactCompilerModuleObservation,
+} from "../compiler-report";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true })),
+  );
+});
+
+function observations(projectRoot: string): ReactCompilerModuleObservation[] {
+  return [
+    {
+      id: join(projectRoot, "src", "Counter.tsx"),
+      result: {
+        compiled: ["Counter"],
+        diagnostics: [],
+      },
+    },
+    {
+      id: join(projectRoot, "src", "Lists.tsx"),
+      result: {
+        compiled: ["Row"],
+        diagnostics: [
+          {
+            component: "List",
+            reason: "dynamic child structures require React reconciliation",
+            selected: false,
+          },
+          {
+            component: "Grid",
+            reason: "dynamic child structures require React reconciliation",
+            selected: true,
+          },
+        ],
+      },
+    },
+  ];
+}
+
+describe("React compiler coverage report", () => {
+  it("summarizes compiled components and fallback reasons deterministically", () => {
+    const projectRoot = "/workspace/app";
+    const report = createReactCompilerReport(projectRoot, observations(projectRoot));
+
+    expect(report.summary).toEqual({
+      modules: 2,
+      componentsConsidered: 4,
+      compiled: 2,
+      fallback: 2,
+    });
+    expect(report.fallbackReasons).toEqual([
+      {
+        count: 2,
+        reason: "dynamic child structures require React reconciliation",
+      },
+    ]);
+    expect(report.modules.map((module) => module.id)).toEqual(["src/Counter.tsx", "src/Lists.tsx"]);
+    expect(report.modules[1]?.fallbacks[1]).toEqual({
+      module: "src/Lists.tsx",
+      component: "Grid",
+      reason: "dynamic child structures require React reconciliation",
+      selected: true,
+    });
+  });
+
+  it("writes formatted JSON to the configured project-relative file", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "farm-react-report-"));
+    temporaryDirectories.push(projectRoot);
+    const outputPath = await writeReactCompilerReport(
+      projectRoot,
+      ".farm/react-compiler.json",
+      observations(projectRoot),
+    );
+    const report = JSON.parse(await readFile(outputPath, "utf8"));
+
+    expect(outputPath).toBe(join(projectRoot, ".farm", "react-compiler.json"));
+    expect(report.version).toBe(1);
+    expect(report.summary.compiled).toBe(2);
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-runtime-hardening.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-hardening.test.tsx
@@ -1,0 +1,612 @@
+import React, { StrictMode, useState, type ReactNode } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createCompiledComponent, type CompiledComponentDefinition } from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+const roots = new Set<Root>();
+
+function trackRoot(root: Root): Root {
+  roots.add(root);
+  return root;
+}
+
+async function flushCompilerUpdates() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots) root.unmount();
+  });
+  roots.clear();
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+function counterDefinition(
+  displayName: string,
+  prefix = "Count: ",
+): CompiledComponentDefinition<Record<string, never>> {
+  return {
+    displayName,
+    initialize: () => [0],
+    render(_props, state) {
+      return (
+        <button onClick={() => state[0].set((value) => Number(value) + 1)}>
+          {prefix}
+          {Number(state[0].get())}
+        </button>
+      );
+    },
+    bindings: [
+      {
+        kind: "text",
+        path: [],
+        dependencies: [0],
+        read: (_props, state) => [prefix, state[0].get()],
+      },
+    ],
+  };
+}
+
+describe("compiled React runtime hardening", () => {
+  it("survives the StrictMode development mount cycle without rerendering on a local update", async () => {
+    let renders = 0;
+    const definition = counterDefinition("StrictCounter");
+    const Counter = createCompiledComponent({
+      ...definition,
+      render(props, state) {
+        renders += 1;
+        return definition.render(props, state);
+      },
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = trackRoot(createRoot(container));
+
+    await act(async () => {
+      root.render(
+        <StrictMode>
+          <Counter />
+        </StrictMode>,
+      );
+    });
+    const initialRenders = renders;
+
+    await act(async () => {
+      container.querySelector("button")!.click();
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("Count: 1");
+    expect(renders).toBe(initialRenders);
+  });
+
+  it("drops a queued binding flush when the component unmounts first", async () => {
+    let bindingReads = 0;
+    const definition = counterDefinition("UnmountedCounter");
+    const Counter = createCompiledComponent({
+      ...definition,
+      bindings: definition.bindings.map((binding) => ({
+        ...binding,
+        read(props, state) {
+          bindingReads += 1;
+          return binding.read(props, state);
+        },
+      })),
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = trackRoot(createRoot(container));
+    await act(async () => root.render(<Counter />));
+
+    await act(async () => {
+      container.querySelector("button")!.click();
+      root.unmount();
+      roots.delete(root);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("");
+    expect(bindingReads).toBe(0);
+  });
+
+  it("keeps parent props and compiler-local state coherent when both update in one event", async () => {
+    interface Props {
+      label: string;
+      updateParent(): void;
+    }
+
+    const Counter = createCompiledComponent<Props>({
+      displayName: "ParentAndLocalCounter",
+      initialize: () => [0],
+      render(props, state) {
+        return (
+          <button
+            onClick={() => {
+              state[0].set((value) => Number(value) + 1);
+              props.updateParent();
+            }}
+          >
+            {props.label}:{Number(state[0].get())}
+          </button>
+        );
+      },
+      bindings: [
+        {
+          kind: "text",
+          path: [],
+          dependencies: [0],
+          read: (props, state) => [props.label, ":", state[0].get()],
+        },
+      ],
+    });
+
+    function Parent() {
+      const [label, setLabel] = useState("before");
+      return <Counter label={label} updateParent={() => setLabel("after")} />;
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = trackRoot(createRoot(container));
+    await act(async () => root.render(<Parent />));
+
+    await act(async () => {
+      container.querySelector("button")!.click();
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("after:1");
+  });
+
+  it("batches setter calls from nested and bubbled event handlers", async () => {
+    const BubblingCounter = createCompiledComponent({
+      displayName: "BubblingCounter",
+      initialize: () => [0],
+      render(_props: Record<string, never>, state) {
+        return (
+          <section onClick={() => state[0].set((value) => Number(value) + 1)}>
+            <button onClick={() => state[0].set((value) => Number(value) + 1)}>Update</button>
+            <output>{Number(state[0].get())}</output>
+          </section>
+        );
+      },
+      bindings: [
+        {
+          kind: "text",
+          path: [1],
+          dependencies: [0],
+          read: (_props, state) => state[0].get(),
+        },
+      ],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = trackRoot(createRoot(container));
+    await act(async () => root.render(<BubblingCounter />));
+
+    await act(async () => {
+      container.querySelector("button")!.click();
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector("output")?.textContent).toBe("2");
+  });
+
+  it("preserves compiled row state when a React-owned keyed list reorders", async () => {
+    interface Item {
+      id: string;
+      name: string;
+    }
+
+    const Row = createCompiledComponent<{ item: Item }>({
+      displayName: "CompiledKeyedRow",
+      initialize: () => [0],
+      render(props, state) {
+        return (
+          <li>
+            <button onClick={() => state[0].set((value) => Number(value) + 1)}>
+              {props.item.name}:{Number(state[0].get())}
+            </button>
+          </li>
+        );
+      },
+      bindings: [
+        {
+          kind: "text",
+          path: [0],
+          dependencies: [0],
+          read: (props, state) => [props.item.name, ":", state[0].get()],
+        },
+      ],
+    });
+
+    function List() {
+      const [items, setItems] = useState<Item[]>([
+        { id: "a", name: "A" },
+        { id: "b", name: "B" },
+      ]);
+      return (
+        <section>
+          <button onClick={() => setItems((current) => [...current].reverse())}>Reverse</button>
+          <ul>
+            {items.map((item) => (
+              <Row key={item.id} item={item} />
+            ))}
+          </ul>
+        </section>
+      );
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = trackRoot(createRoot(container));
+    await act(async () => root.render(<List />));
+    const buttons = () => [...container.querySelectorAll("li button")];
+
+    await act(async () => {
+      buttons()[0].click();
+      await flushCompilerUpdates();
+    });
+    expect(buttons().map((button) => button.textContent)).toEqual(["A:1", "B:0"]);
+
+    await act(async () => container.querySelector("section > button")!.click());
+    expect(buttons().map((button) => button.textContent)).toEqual(["B:0", "A:1"]);
+  });
+
+  it("preserves controlled input selection and composition-driven values", async () => {
+    const ControlledInput = createCompiledComponent({
+      displayName: "ControlledInput",
+      initialize: () => ["", false],
+      render(_props: Record<string, never>, state) {
+        return (
+          <input
+            data-composing={Boolean(state[1].get())}
+            onCompositionEnd={() => state[1].set(false)}
+            onCompositionStart={() => state[1].set(true)}
+            onInput={(event) => state[0].set(event.currentTarget.value)}
+            value={String(state[0].get())}
+          />
+        );
+      },
+      bindings: [
+        {
+          kind: "attribute",
+          path: [],
+          dependencies: [0],
+          name: "value",
+          read: (_props, state) => state[0].get(),
+        },
+        {
+          kind: "attribute",
+          path: [],
+          dependencies: [1],
+          name: "data-composing",
+          read: (_props, state) => Boolean(state[1].get()),
+        },
+      ],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = trackRoot(createRoot(container));
+    await act(async () => root.render(<ControlledInput />));
+    const input = container.querySelector("input")!;
+
+    await act(async () => {
+      input.dispatchEvent(new Event("compositionstart", { bubbles: true }));
+      input.value = "farm";
+      input.setSelectionRange(4, 4);
+      input.dispatchEvent(new InputEvent("input", { bubbles: true, data: "farm" }));
+      await flushCompilerUpdates();
+    });
+
+    expect(input.value).toBe("farm");
+    expect(input.selectionStart).toBe(4);
+    expect(input.getAttribute("data-composing")).toBe("true");
+
+    await act(async () => {
+      input.dispatchEvent(new Event("compositionend", { bubbles: true }));
+      await flushCompilerUpdates();
+    });
+    expect(input.getAttribute("data-composing")).toBe("false");
+  });
+
+  it("preserves state across a compatible Fast Refresh definition update", async () => {
+    const hmrId = `hardening-refresh-${Math.random()}`;
+    const InitialCounter = createCompiledComponent({
+      ...counterDefinition("RefreshCounter", "Before: "),
+      hmrId,
+      stateSignature: "1",
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = trackRoot(createRoot(container));
+    await act(async () => root.render(<InitialCounter />));
+    await act(async () => {
+      container.querySelector("button")!.click();
+      await flushCompilerUpdates();
+    });
+
+    let UpdatedCounter!: typeof InitialCounter;
+    await act(async () => {
+      UpdatedCounter = createCompiledComponent({
+        ...counterDefinition("RefreshCounter", "After: "),
+        hmrId,
+        stateSignature: "1",
+      });
+    });
+    expect(UpdatedCounter).toBe(InitialCounter);
+    expect(container.textContent).toBe("After: 1");
+
+    await act(async () => {
+      container.querySelector("button")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("After: 2");
+  });
+
+  it("recovers from hydration mismatches and remains interactive", async () => {
+    const Counter = createCompiledComponent(counterDefinition("HydrationMismatchCounter"));
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(<Counter />).replace("Count: ", "Wrong: ");
+    document.body.append(container);
+    const recoverableErrors: unknown[] = [];
+    let root!: Root;
+
+    await act(async () => {
+      root = hydrateRoot(container, <Counter />, {
+        onRecoverableError(error) {
+          recoverableErrors.push(error);
+        },
+      });
+      await flushCompilerUpdates();
+    });
+    trackRoot(root);
+
+    expect(recoverableErrors.length).toBeGreaterThan(0);
+    expect(container.textContent).toBe("Count: 0");
+    await act(async () => {
+      container.querySelector("button")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("Count: 1");
+  });
+
+  it("routes binding failures through the nearest React error boundary", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    class Boundary extends React.Component<{ children: ReactNode }, { failed: boolean }> {
+      state = { failed: false };
+
+      static getDerivedStateFromError() {
+        return { failed: true };
+      }
+
+      render() {
+        return this.state.failed ? <p>Recovered by boundary</p> : this.props.children;
+      }
+    }
+
+    const ThrowingBinding = createCompiledComponent({
+      displayName: "ThrowingBinding",
+      initialize: () => [false],
+      render(_props: Record<string, never>, state) {
+        return <button onClick={() => state[0].set(true)}>Safe</button>;
+      },
+      bindings: [
+        {
+          kind: "text",
+          path: [],
+          dependencies: [0],
+          read: () => {
+            throw new Error("binding failed");
+          },
+        },
+      ],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = trackRoot(createRoot(container));
+    await act(async () =>
+      root.render(
+        <Boundary>
+          <ThrowingBinding />
+        </Boundary>,
+      ),
+    );
+
+    await act(async () => {
+      container.querySelector("button")!.click();
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("Recovered by boundary");
+  });
+
+  it("updates object, array, and nullish state cells", async () => {
+    const StructuredState = createCompiledComponent({
+      displayName: "StructuredState",
+      initialize: () => [{ count: 0 }, [1], null],
+      render(_props: Record<string, never>, state) {
+        const object = state[0].get() as { count: number };
+        const array = state[1].get() as number[];
+        const nullable = state[2].get() as string | null;
+        return (
+          <section>
+            <button onClick={() => state[0].set({ count: object.count + 1 })}>Object</button>
+            <button onClick={() => state[1].set((value) => [...(value as number[]), 2])}>
+              Array
+            </button>
+            <button onClick={() => state[2].set(nullable === null ? "ready" : null)}>Null</button>
+            <output>
+              {object.count}|{array.join(",")}|{nullable ?? "null"}
+            </output>
+          </section>
+        );
+      },
+      bindings: [
+        {
+          kind: "text",
+          path: [3],
+          dependencies: [0, 1, 2],
+          read: (_props, state) => {
+            const object = state[0].get() as { count: number };
+            const array = state[1].get() as number[];
+            const nullable = state[2].get() as string | null;
+            return [object.count, "|", array.join(","), "|", nullable ?? "null"];
+          },
+        },
+      ],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = trackRoot(createRoot(container));
+    await act(async () => root.render(<StructuredState />));
+
+    await act(async () => {
+      for (const button of container.querySelectorAll("button")) button.click();
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector("output")?.textContent).toBe("1|1,2|ready");
+  });
+});
+
+type RandomValue = number | null | { count: number } | number[];
+
+interface RandomOperation {
+  amount: number;
+  kind: "array" | "increment" | "null" | "object";
+}
+
+function applyRandomOperation(value: RandomValue, operation: RandomOperation): RandomValue {
+  if (operation.kind === "null") return null;
+  if (operation.kind === "array") {
+    const array = Array.isArray(value) ? value : [];
+    return [...array.slice(-4), operation.amount];
+  }
+  const numericValue =
+    typeof value === "number"
+      ? value
+      : value && !Array.isArray(value)
+        ? value.count
+        : Array.isArray(value)
+          ? (value.at(-1) ?? 0)
+          : 0;
+  if (operation.kind === "object") return { count: numericValue + operation.amount };
+  return numericValue + operation.amount;
+}
+
+function serializeRandomValue(value: RandomValue): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return `array:${value.join(",")}`;
+  if (typeof value === "object") return `object:${value.count}`;
+  return `number:${value}`;
+}
+
+function createRandomOperations(count: number): RandomOperation[] {
+  let seed = 0x1a2b3c4d;
+  const operations: RandomOperation[] = [];
+  const kinds: RandomOperation["kind"][] = ["increment", "object", "array", "null"];
+  for (let index = 0; index < count; index += 1) {
+    seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0;
+    operations.push({
+      amount: (seed % 7) - 3,
+      kind: kinds[(seed >>> 8) % kinds.length],
+    });
+  }
+  return operations;
+}
+
+describe("compiled-vs-React differential behavior", () => {
+  it("matches React across 3,000 deterministic randomized state transitions", async () => {
+    const operations = createRandomOperations(3000);
+    const compiledOperations = [...operations];
+    const reactOperations = [...operations];
+    let compiledRenders = 0;
+    let reactRenders = 0;
+
+    const CompiledRandomState = createCompiledComponent({
+      displayName: "CompiledRandomState",
+      initialize: () => [0],
+      render(_props: Record<string, never>, state) {
+        compiledRenders += 1;
+        return (
+          <button
+            onClick={() => {
+              const operation = compiledOperations.shift();
+              if (operation) {
+                state[0].set((value) => applyRandomOperation(value as RandomValue, operation));
+              }
+            }}
+          >
+            {serializeRandomValue(state[0].get() as RandomValue)}
+          </button>
+        );
+      },
+      bindings: [
+        {
+          kind: "text",
+          path: [],
+          dependencies: [0],
+          read: (_props, state) => serializeRandomValue(state[0].get() as RandomValue),
+        },
+      ],
+    });
+
+    function ReactRandomState() {
+      reactRenders += 1;
+      const [value, setValue] = useState<RandomValue>(0);
+      return (
+        <button
+          onClick={() => {
+            const operation = reactOperations.shift();
+            if (operation) setValue((current) => applyRandomOperation(current, operation));
+          }}
+        >
+          {serializeRandomValue(value)}
+        </button>
+      );
+    }
+
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = trackRoot(createRoot(compiledContainer));
+    const reactRoot = trackRoot(createRoot(reactContainer));
+    await act(async () => {
+      compiledRoot.render(<CompiledRandomState />);
+      reactRoot.render(<ReactRandomState />);
+    });
+    const compiledButton = compiledContainer.querySelector("button")!;
+    const reactButton = reactContainer.querySelector("button")!;
+
+    for (let batch = 0; batch < 60; batch += 1) {
+      await act(async () => {
+        for (let update = 0; update < 50; update += 1) {
+          compiledButton.click();
+          reactButton.click();
+        }
+        await flushCompilerUpdates();
+      });
+      expect(compiledButton.textContent).toBe(reactButton.textContent);
+    }
+
+    expect(compiledOperations).toHaveLength(0);
+    expect(reactOperations).toHaveLength(0);
+    expect(compiledRenders).toBe(1);
+    expect(reactRenders).toBeGreaterThan(1);
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler.test.ts
+++ b/packages/farm-react/src/__tests__/compiler.test.ts
@@ -32,6 +32,9 @@ describe("React AOT compiler", () => {
     expect(result.code).toContain("createCompiledComponent");
     expect(result.code).toContain('kind: "text"');
     expect(result.code).toContain('kind: "attribute"');
+    expect(result.code).toContain("import.meta.hot");
+    expect(result.code).toContain("/app/Counter.tsx#Counter");
+    expect(result.code).toContain('stateSignature: "1"');
     expect(result.code).toMatch(/farmState\[0\]\.set/);
     expect(result.code).toMatch(/farmState\[0\]\.get/);
     await expect(

--- a/packages/farm-react/src/__tests__/renderer.test.ts
+++ b/packages/farm-react/src/__tests__/renderer.test.ts
@@ -1,7 +1,12 @@
 // @vitest-environment node
 
 import { describe, expect, it } from "vitest";
-import { DEFAULT_COMPILER_DIRECTIVE, normalizeReactCompilerOptions, react } from "../index";
+import {
+  DEFAULT_COMPILER_DIRECTIVE,
+  DEFAULT_COMPILER_REPORT_FILE,
+  normalizeReactCompilerOptions,
+  react,
+} from "../index";
 
 describe("React renderer compiler options", () => {
   it("keeps the compiler disabled unless the experimental option is enabled", () => {
@@ -15,6 +20,8 @@ describe("React renderer compiler options", () => {
           mode: "infer",
           directive: DEFAULT_COMPILER_DIRECTIVE,
           onUnsupported: "fallback",
+          report: false,
+          reportFile: DEFAULT_COMPILER_REPORT_FILE,
         },
       },
     });
@@ -33,6 +40,8 @@ describe("React renderer compiler options", () => {
           mode: "annotation",
           directive: "use fast component",
           onUnsupported: "fallback",
+          report: false,
+          reportFile: DEFAULT_COMPILER_REPORT_FILE,
         },
       },
     });
@@ -45,5 +54,32 @@ describe("React renderer compiler options", () => {
         directive: "use compiler",
       }),
     ).toThrow(/annotation mode/i);
+  });
+
+  it("normalizes compiler coverage reporting", () => {
+    expect(
+      normalizeReactCompilerOptions({
+        report: true,
+        reportFile: "reports/react-compiler.json",
+      }),
+    ).toEqual({
+      mode: "infer",
+      directive: DEFAULT_COMPILER_DIRECTIVE,
+      onUnsupported: "fallback",
+      report: true,
+      reportFile: "reports/react-compiler.json",
+    });
+    expect(normalizeReactCompilerOptions({ reportFile: "coverage/compiler.json" }).report).toBe(
+      true,
+    );
+  });
+
+  it("keeps compiler reports inside the project root", () => {
+    expect(() =>
+      normalizeReactCompilerOptions({ report: true, reportFile: "../outside.json" }),
+    ).toThrow(/project root/i);
+    expect(() =>
+      normalizeReactCompilerOptions({ report: false, reportFile: "compiler.json" }),
+    ).toThrow(/reporting is false/i);
   });
 });

--- a/packages/farm-react/src/__tests__/vite.test.ts
+++ b/packages/farm-react/src/__tests__/vite.test.ts
@@ -1,8 +1,22 @@
 // @vitest-environment node
 
-import { describe, expect, it } from "vitest";
+import { mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { build } from "vite";
+import { afterEach, describe, expect, it } from "vitest";
 import { react } from "../index";
 import { createFarmRendererPlugin } from "../vite";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true })),
+  );
+});
 
 describe("React renderer Vite integration", () => {
   it("does not install a transform when the compiler is disabled", () => {
@@ -17,5 +31,95 @@ describe("React renderer Vite integration", () => {
     expect(plugins).toHaveLength(1);
     expect(plugins[0]?.name).toBe("farm:react-aot-compiler");
     expect(plugins[0]?.enforce).toBe("pre");
+  });
+
+  it("writes a compiler coverage report after a production build", async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), "farm-react-vite-report-"));
+    temporaryDirectories.push(temporaryRoot);
+    const root = await realpath(temporaryRoot);
+    const entry = join(root, "App.tsx");
+    await writeFile(
+      entry,
+      `
+        import { useState } from "react";
+        export function Counter() {
+          const [count, setCount] = useState(0);
+          return <button onClick={() => setCount(count + 1)}>{count}</button>;
+        }
+        export function List() {
+          const [items, setItems] = useState(["A"]);
+          return <ul onClick={() => setItems([...items, "B"])}>{items.map((item) => <li key={item}>{item}</li>)}</ul>;
+        }
+      `,
+      "utf8",
+    );
+
+    await build({
+      root,
+      logLevel: "silent",
+      plugins: createFarmRendererPlugin({
+        rendererOptions: react({
+          experimental: {
+            compiler: { report: true },
+          },
+        }).options,
+      }),
+      build: {
+        write: false,
+        lib: {
+          entry,
+          formats: ["es"],
+        },
+        rollupOptions: {
+          external: ["react", "@farm.js/react/compiler-runtime"],
+        },
+      },
+    });
+
+    const report = JSON.parse(await readFile(join(root, ".farm", "react-compiler.json"), "utf8"));
+    expect(report.summary).toEqual({
+      modules: 1,
+      componentsConsidered: 2,
+      compiled: 1,
+      fallback: 1,
+    });
+    expect(report.modules[0].compiled).toEqual(["Counter"]);
+    expect(report.modules[0].fallbacks[0].component).toBe("List");
+
+    await writeFile(
+      entry,
+      `
+        import { useState } from "react";
+        export function ServerOnlyCounter() {
+          const [count, setCount] = useState(0);
+          return <button onClick={() => setCount(count + 1)}>{count}</button>;
+        }
+      `,
+      "utf8",
+    );
+    await build({
+      root,
+      logLevel: "silent",
+      plugins: createFarmRendererPlugin({
+        ssr: true,
+        rendererOptions: react({
+          experimental: {
+            compiler: { report: true },
+          },
+        }).options,
+      }),
+      build: {
+        write: false,
+        ssr: entry,
+        rollupOptions: {
+          external: ["react", "@farm.js/react/compiler-runtime"],
+        },
+      },
+    });
+
+    const reportAfterSsr = JSON.parse(
+      await readFile(join(root, ".farm", "react-compiler.json"), "utf8"),
+    );
+    expect(reportAfterSsr).toEqual(report);
   });
 });

--- a/packages/farm-react/src/compiler-report.ts
+++ b/packages/farm-react/src/compiler-report.ts
@@ -1,0 +1,91 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, relative, resolve } from "node:path";
+import type { CompileReactModuleResult, CompilerDiagnostic } from "./compiler";
+
+export interface ReactCompilerModuleObservation {
+  id: string;
+  result: Pick<CompileReactModuleResult, "compiled" | "diagnostics">;
+}
+
+export interface ReactCompilerReportFallback extends CompilerDiagnostic {
+  module: string;
+}
+
+export interface ReactCompilerReport {
+  version: 1;
+  summary: {
+    modules: number;
+    componentsConsidered: number;
+    compiled: number;
+    fallback: number;
+  };
+  fallbackReasons: Array<{
+    count: number;
+    reason: string;
+  }>;
+  modules: Array<{
+    id: string;
+    compiled: readonly string[];
+    fallbacks: ReactCompilerReportFallback[];
+  }>;
+}
+
+function projectRelativeId(projectRoot: string, id: string): string {
+  return relative(projectRoot, id).replace(/\\/g, "/");
+}
+
+export function createReactCompilerReport(
+  projectRoot: string,
+  observations: Iterable<ReactCompilerModuleObservation>,
+): ReactCompilerReport {
+  const reasonCounts = new Map<string, number>();
+  let componentsConsidered = 0;
+  let compiled = 0;
+  let fallback = 0;
+
+  const modules = [...observations]
+    .map(({ id, result }) => {
+      componentsConsidered += result.compiled.length + result.diagnostics.length;
+      compiled += result.compiled.length;
+      fallback += result.diagnostics.length;
+      const moduleId = projectRelativeId(projectRoot, id);
+      const fallbacks = result.diagnostics.map((diagnostic) => {
+        reasonCounts.set(diagnostic.reason, (reasonCounts.get(diagnostic.reason) || 0) + 1);
+        return { module: moduleId, ...diagnostic };
+      });
+      return {
+        id: moduleId,
+        compiled: [...result.compiled].sort(),
+        fallbacks,
+      };
+    })
+    .sort((left, right) => left.id.localeCompare(right.id));
+
+  const fallbackReasons = [...reasonCounts]
+    .map(([reason, count]) => ({ count, reason }))
+    .sort((left, right) => right.count - left.count || left.reason.localeCompare(right.reason));
+
+  return {
+    version: 1,
+    summary: {
+      modules: modules.length,
+      componentsConsidered,
+      compiled,
+      fallback,
+    },
+    fallbackReasons,
+    modules,
+  };
+}
+
+export async function writeReactCompilerReport(
+  projectRoot: string,
+  reportFile: string,
+  observations: Iterable<ReactCompilerModuleObservation>,
+): Promise<string> {
+  const outputPath = resolve(projectRoot, reportFile);
+  const report = createReactCompilerReport(projectRoot, observations);
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  return outputPath;
+}

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -30,9 +30,37 @@ export type CompilerBinding<Props> = CompilerTextBinding<Props> | CompilerAttrib
 
 export interface CompiledComponentDefinition<Props> {
   displayName: string;
+  /** Stable development-only identity used to preserve state across compatible refreshes. */
+  hmrId?: string;
+  /** Changes when the compiler-owned state layout is no longer refresh-compatible. */
+  stateSignature?: string;
   initialize(props: Props): readonly unknown[];
   render(props: Props, state: readonly CompilerCell[]): React.ReactElement;
   bindings: readonly CompilerBinding<Props>[];
+}
+
+interface CompiledDefinitionReference<Props> {
+  current: CompiledComponentDefinition<Props>;
+}
+
+interface CompilerHmrRegistryEntry {
+  component: React.ComponentType<unknown>;
+  definition: CompiledDefinitionReference<unknown>;
+  refreshListeners: Set<() => void>;
+  stateSignature: string;
+}
+
+type CompilerHmrRegistry = Map<string, CompilerHmrRegistryEntry>;
+
+const COMPILER_HMR_REGISTRY = Symbol.for("@farm.js/react/compiler-hmr-registry");
+
+function getCompilerHmrRegistry(): CompilerHmrRegistry {
+  const globalTarget = globalThis as typeof globalThis & Record<symbol, unknown>;
+  const existing = globalTarget[COMPILER_HMR_REGISTRY];
+  if (existing instanceof Map) return existing as CompilerHmrRegistry;
+  const registry: CompilerHmrRegistry = new Map();
+  globalTarget[COMPILER_HMR_REGISTRY] = registry;
+  return registry;
 }
 
 function renderTextValue(value: unknown): string {
@@ -91,16 +119,33 @@ function updateAttribute(element: Element, name: string, value: unknown): void {
 export function createCompiledComponent<Props>(
   definition: CompiledComponentDefinition<Props>,
 ): React.ComponentType<Props> {
+  const stateSignature = definition.stateSignature || String(definition.initialize.length);
+  if (definition.hmrId) {
+    const registry = getCompilerHmrRegistry();
+    const existing = registry.get(definition.hmrId);
+    if (existing?.stateSignature === stateSignature) {
+      existing.definition.current = definition as CompiledComponentDefinition<unknown>;
+      existing.component.displayName = `FarmCompiled(${definition.displayName})`;
+      for (const refresh of existing.refreshListeners) refresh();
+      return existing.component as React.ComponentType<Props>;
+    }
+  }
+
+  const definitionReference: CompiledDefinitionReference<Props> = { current: definition };
+  const refreshListeners = new Set<() => void>();
+
   class FarmCompiledComponent extends React.Component<Props> {
     private root: Element | null = null;
     private mounted = false;
     private flushQueued = false;
+    private bindingError: unknown;
+    private hasBindingError = false;
     private readonly dirtyState = new Set<number>();
     private readonly cells: RuntimeCell[];
 
     constructor(props: Props) {
       super(props);
-      this.cells = definition.initialize(props).map((initialValue, index) => {
+      this.cells = definitionReference.current.initialize(props).map((initialValue, index) => {
         let value = initialValue;
         const pending: CompilerStateUpdater[] = [];
         return {
@@ -125,6 +170,10 @@ export function createCompiledComponent<Props>(
       this.root = root;
     };
 
+    private refreshDefinition = () => {
+      if (this.mounted) this.forceUpdate();
+    };
+
     private scheduleBindingFlush(index: number): void {
       this.dirtyState.add(index);
       if (!this.mounted || this.flushQueued) return;
@@ -138,10 +187,16 @@ export function createCompiledComponent<Props>(
         }
         this.dirtyState.clear();
         if (dirty.size === 0) return;
-        for (const binding of definition.bindings) {
-          if (binding.dependencies.some((dependency) => dirty.has(dependency))) {
-            this.applyBinding(binding);
+        try {
+          for (const binding of definitionReference.current.bindings) {
+            if (binding.dependencies.some((dependency) => dirty.has(dependency))) {
+              this.applyBinding(binding);
+            }
           }
+        } catch (error) {
+          this.bindingError = error;
+          this.hasBindingError = true;
+          this.forceUpdate();
         }
       });
     }
@@ -160,26 +215,30 @@ export function createCompiledComponent<Props>(
 
     componentDidMount(): void {
       this.mounted = true;
+      refreshListeners.add(this.refreshDefinition);
     }
 
     componentDidUpdate(): void {
       // React has reconciled a parent-driven prop update. Reapply compiled
       // bindings from the current cells so React and the imperative state stay
       // coherent even when both change in the same turn.
-      for (const binding of definition.bindings) this.applyBinding(binding);
+      for (const binding of definitionReference.current.bindings) this.applyBinding(binding);
     }
 
     componentWillUnmount(): void {
       this.mounted = false;
       this.root = null;
       this.dirtyState.clear();
+      refreshListeners.delete(this.refreshDefinition);
     }
 
     render(): React.ReactNode {
-      const element = definition.render(this.props, this.cells);
+      if (this.hasBindingError) throw this.bindingError;
+      const currentDefinition = definitionReference.current;
+      const element = currentDefinition.render(this.props, this.cells);
       if (!React.isValidElement(element) || typeof element.type !== "string") {
         throw new TypeError(
-          `Compiled component ${definition.displayName} must return one host element.`,
+          `Compiled component ${currentDefinition.displayName} must return one host element.`,
         );
       }
       return React.cloneElement(element, {
@@ -190,5 +249,16 @@ export function createCompiledComponent<Props>(
 
   (FarmCompiledComponent as React.ComponentType<Props>).displayName =
     `FarmCompiled(${definition.displayName})`;
-  return FarmCompiledComponent;
+  const component = FarmCompiledComponent as React.ComponentType<Props>;
+
+  if (definition.hmrId) {
+    getCompilerHmrRegistry().set(definition.hmrId, {
+      component: component as React.ComponentType<unknown>,
+      definition: definitionReference as CompiledDefinitionReference<unknown>,
+      refreshListeners,
+      stateSignature,
+    });
+  }
+
+  return component;
 }

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -387,6 +387,7 @@ function compileCandidate(
   createComponentIdentifier: t.Identifier,
   useStateNames: ReadonlySet<string>,
   reactNames: ReadonlySet<string>,
+  moduleId: string,
 ): string | undefined {
   const { path, name, statementPath } = candidate;
   if (path.node.async || path.node.generator)
@@ -467,6 +468,22 @@ function compileCandidate(
   const definition = t.callExpression(t.cloneNode(createComponentIdentifier), [
     t.objectExpression([
       t.objectProperty(t.identifier("displayName"), t.stringLiteral(name)),
+      t.spreadElement(
+        t.conditionalExpression(
+          t.memberExpression(
+            t.metaProperty(t.identifier("import"), t.identifier("meta")),
+            t.identifier("hot"),
+          ),
+          t.objectExpression([
+            t.objectProperty(t.identifier("hmrId"), t.stringLiteral(`${moduleId}#${name}`)),
+            t.objectProperty(
+              t.identifier("stateSignature"),
+              t.stringLiteral(String(states.length)),
+            ),
+          ]),
+          t.objectExpression([]),
+        ),
+      ),
       t.objectProperty(
         t.identifier("initialize"),
         t.arrowFunctionExpression(
@@ -604,6 +621,7 @@ export async function compileReactModule(
             createComponentIdentifier,
             useStateNames,
             reactNames,
+            id,
           );
           if (reason) {
             diagnostics.push({

--- a/packages/farm-react/src/index.ts
+++ b/packages/farm-react/src/index.ts
@@ -10,6 +10,10 @@ export interface ReactCompilerOptions {
   directive?: string;
   /** What to do when a selected component is outside the safe subset. */
   onUnsupported?: UnsupportedCompilerBehavior;
+  /** Write a machine-readable compiler coverage report after a production build. */
+  report?: boolean;
+  /** Project-relative report location. Providing it also enables reporting. */
+  reportFile?: string;
 }
 
 export interface ReactRendererOptions {
@@ -23,9 +27,28 @@ export interface NormalizedReactCompilerOptions {
   mode: ReactCompilerMode;
   directive: string;
   onUnsupported: UnsupportedCompilerBehavior;
+  report: boolean;
+  reportFile: string;
 }
 
 export const DEFAULT_COMPILER_DIRECTIVE = "use compiler";
+export const DEFAULT_COMPILER_REPORT_FILE = ".farm/react-compiler.json";
+
+function normalizeCompilerReportFile(value: unknown): string {
+  if (value === undefined) return DEFAULT_COMPILER_REPORT_FILE;
+  if (typeof value !== "string" || !value.trim()) {
+    throw new TypeError("The React compiler report file must be a non-empty relative path.");
+  }
+  const normalized = value.trim().replace(/\\/g, "/");
+  if (
+    normalized.startsWith("/") ||
+    /^[A-Za-z]:\//.test(normalized) ||
+    normalized.split("/").includes("..")
+  ) {
+    throw new TypeError("The React compiler report file must stay inside the project root.");
+  }
+  return normalized;
+}
 
 export function normalizeReactCompilerOptions(
   value: true | ReactCompilerOptions,
@@ -47,7 +70,18 @@ export function normalizeReactCompilerOptions(
     throw new TypeError(`Unknown unsupported-component behavior: ${String(onUnsupported)}`);
   }
 
-  return { mode, directive, onUnsupported };
+  if (options.report !== undefined && typeof options.report !== "boolean") {
+    throw new TypeError("The React compiler report option must be a boolean.");
+  }
+  if (options.report === false && options.reportFile !== undefined) {
+    throw new TypeError(
+      "A React compiler report file cannot be configured when reporting is false.",
+    );
+  }
+  const reportFile = normalizeCompilerReportFile(options.reportFile);
+  const report = options.report === true || options.reportFile !== undefined;
+
+  return { mode, directive, onUnsupported, report, reportFile };
 }
 
 const REACT_RENDERER: Readonly<FarmRenderer> = Object.freeze({

--- a/packages/farm-react/src/vite.ts
+++ b/packages/farm-react/src/vite.ts
@@ -1,5 +1,6 @@
 import { normalizePath, type Plugin } from "vite";
 import { compileReactModule } from "./compiler";
+import { writeReactCompilerReport, type ReactCompilerModuleObservation } from "./compiler-report";
 import { normalizeReactCompilerOptions, type NormalizedReactCompilerOptions } from "./index";
 
 interface RendererPluginOptions {
@@ -38,6 +39,8 @@ export function createFarmRendererPlugin(options: RendererPluginOptions = {}): P
   if (!compilerOptions) return [];
 
   let projectRoot = "";
+  const reportEnabled = compilerOptions.report && options.ssr !== true;
+  const reportObservations = new Map<string, ReactCompilerModuleObservation>();
 
   return [
     {
@@ -45,6 +48,9 @@ export function createFarmRendererPlugin(options: RendererPluginOptions = {}): P
       enforce: "pre",
       configResolved(config) {
         projectRoot = normalizePath(config.root).replace(/\/$/, "");
+      },
+      buildStart() {
+        reportObservations.clear();
       },
       async transform(code, id) {
         const cleanId = normalizePath(id.split("?", 1)[0]);
@@ -56,6 +62,13 @@ export function createFarmRendererPlugin(options: RendererPluginOptions = {}): P
           return null;
 
         const result = await compileReactModule(code, cleanId, compilerOptions);
+        if (reportEnabled) {
+          if (result.compiled.length > 0 || result.diagnostics.length > 0) {
+            reportObservations.set(cleanId, { id: cleanId, result });
+          } else {
+            reportObservations.delete(cleanId);
+          }
+        }
         for (const diagnostic of result.diagnostics) {
           const message = `[react-compiler] ${diagnostic.component}: ${diagnostic.reason}; using React.`;
           if (compilerOptions.onUnsupported === "error") this.error(message);
@@ -63,6 +76,14 @@ export function createFarmRendererPlugin(options: RendererPluginOptions = {}): P
         }
         if (result.compiled.length === 0) return null;
         return { code: result.code, map: result.map as any };
+      },
+      async buildEnd(error) {
+        if (error || !reportEnabled || !projectRoot) return;
+        await writeReactCompilerReport(
+          projectRoot,
+          compilerOptions.reportFile,
+          reportObservations.values(),
+        );
       },
     },
   ];


### PR DESCRIPTION
## What changed

- harden the compiled runtime across Strict Mode, unmounts, concurrent parent/local updates, bubbled setters, controlled input composition, hydration recovery, error boundaries, and structured state values
- preserve compiled component state across compatible Fast Refresh updates
- add deterministic randomized differential coverage with 3,000 updates against normal React
- verify the packaged runtime on React 18.3.1 and React 19.2.8 in CI
- add opt-in compiler observability through `report` and `reportFile`, with deterministic browser-graph coverage and aggregated fallback reasons
- document the report API, runtime guarantees, compatibility checks, and rollout guidance

## Why

The initial compiler established the supported AOT path. This follow-up focuses on proving that the optimized path preserves React behavior at lifecycle and integration boundaries, while making compiler coverage and fallback reasons visible in production builds.

## Validation

- `pnpm --filter @farm.js/react test` (42 tests)
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:compat`
- `FARM_REACT_COMPILER=true pnpm --filter farm-react-compiler-example build`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm docs:build`
- touched-file `oxfmt --check`, `oxlint`, and `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the experimental React AOT compiler runtime and adds opt-in production coverage reporting, improving safety, debuggability, and verified compatibility with React 18.3 and 19.2. Old: no coverage report, no Fast Refresh state preservation, limited boundary hardening. New: deterministic report output, refresh-compatible state retention, coherent parent/local updates, error-boundary routing, and broader lifecycle coverage without changing default behavior.

- Compiled components now preserve state across compatible Fast Refresh updates via `hmrId` and `stateSignature`; incompatible updates remount.
- Binding evaluation failures schedule a React update and rethrow during render so the nearest error boundary handles them.
- Runtime preserves behavior across Strict Mode mounts, queued unmounts, bubbled setters, controlled input composition/selection, hydration recovery, keyed-list parents with compiled rows, and structured state transitions.
- Adds deterministic differential tests (3,000 updates) and CI that verifies the packaged `@farm.js/react` runtime against React 18.3.1 and 19.2.8.
- The Vite plugin writes a coverage report for client builds to `.farm/react-compiler.json` (or a custom path) summarizing compiled components and aggregated fallback reasons; SSR builds do not emit the report.
- Docs describe the report format, compatibility checks, runtime guarantees, and rollout guidance.

**Rollout**
- No migration required; the compiler remains disabled by default.
- To record coverage: set `experimental.compiler: { report: true }` or provide `reportFile`. The path must be project-relative and inside the repo; do not set `reportFile` when `report: false`.
- Keep unsupported components on React by default; use `onUnsupported: "warn"` for diagnostics or `"error"` to enforce annotated selections in CI.

<sup>Written for commit 8f944bc406f83056a8c55fed5a8f0eb71406b628. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

