### PR TITLE
fix: keep generated types formatter-stable

### DIFF
--- a/packages/farm/src/__tests__/type-artifacts.test.ts
+++ b/packages/farm/src/__tests__/type-artifacts.test.ts
@@ -75,6 +75,7 @@ describe("generateFarmTypeArtifacts", () => {
     expect(readFileSync(apiTypesPath, "utf8")).toContain("post: typeof POST_hello;");
     expect(types).toContain('import type FarmConfig from "../farm.config"');
     expect(types).toContain('declare module "@farm.js/core/env"');
+    expect(types).not.toContain("export {};");
     const imageTypes = readFileSync(path.join(process.cwd(), "types", "images.d.ts"), "utf8");
     expect(imageTypes).toContain('declare module "*.png"');
     expect(imageTypes).toContain('import("@farm.js/core/image").StaticImageData');

--- a/packages/farm/src/type-artifacts.ts
+++ b/packages/farm/src/type-artifacts.ts
@@ -208,7 +208,7 @@ export async function generateFarmTypeArtifacts(
 
 import "@farm.js/core/image";
 
-${unifiedSections.map((section) => section.trimEnd()).join("\n\n")}
+${unifiedSections.map(normalizeUnifiedTypeSection).join("\n\n")}
 `,
       options.check,
       result.stalePaths,
@@ -222,6 +222,14 @@ ${unifiedSections.map((section) => section.trimEnd()).join("\n\n")}
   }
 
   return result;
+}
+
+function normalizeUnifiedTypeSection(section: string): string {
+  // The unified artifact already imports @farm.js/core/image, so it is a module.
+  // Individual generators add this marker for standalone declaration files, but
+  // formatters remove the now-redundant export and make `farm generate --check`
+  // report a false stale-file failure.
+  return section.trimEnd().replace(/\n+export \{\};$/, "");
 }
 
 function resolveGeneratedPath(


### PR DESCRIPTION
## What changed

- Strip redundant standalone `export {};` markers when composing the unified `src/farm.d.ts`.
- Cover the normalized unified artifact in the type-artifact tests.

## Why

`oxfmt` removes the redundant module marker because the unified declaration already contains an import. The generator previously restored it, so formatting and `farm generate --check` disagreed and main CI stayed red.

## Validation

- `pnpm --filter @farm.js/core test -- src/__tests__/type-artifacts.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`
- `pnpm --filter @farm.js/cli build`
- `pnpm --dir docs exec farm generate --check`
- `pnpm exec oxfmt --check packages/farm/src/type-artifacts.ts packages/farm/src/__tests__/type-artifacts.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the unified `src/farm.d.ts` formatter-stable by removing redundant standalone module markers. Previously `oxfmt` stripped `export {};` while the generator restored it, so `farm generate --check` failed and CI stayed red; now sections are normalized and the test covers this.

- Normalizes each unified type section by trimming and stripping a trailing `export {};` so the composed declaration remains a module via `import "@farm.js/core/image"`.
- Extends `type-artifacts.test.ts` to assert the marker is absent.
- No migration required; output types are unchanged, and formatter and `farm generate --check` now agree.

<sup>Written for commit 3d7691bd998f6ca09488eecaf37a1d9ee795b894. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

