### PR TITLE
fix(starter): show the resolved compiler mode

### DIFF
--- a/packages/create-farm-app/templates/react-compiler/README.md
+++ b/packages/create-farm-app/templates/react-compiler/README.md
@@ -37,6 +37,8 @@ FARM_REACT_COMPILER=true pnpm build
 FARM_REACT_COMPILER=false pnpm build
 ```
 
+The status shown on the starter page reflects the resolved value used for that build.
+
 Components are considered automatically. Add `"use no compiler"` to a component when you need an
 explicit React-only path.
 

--- a/packages/create-farm-app/templates/react-compiler/farm.config.ts
+++ b/packages/create-farm-app/templates/react-compiler/farm.config.ts
@@ -4,6 +4,11 @@ import { react } from "@farm.js/react";
 const compilerEnabled = process.env.FARM_REACT_COMPILER !== "false";
 
 export default defineConfig({
+  vite: {
+    define: {
+      __FARM_REACT_COMPILER_ENABLED__: JSON.stringify(compilerEnabled),
+    },
+  },
   renderer: react({
     experimental: {
       compiler: compilerEnabled,

--- a/packages/create-farm-app/templates/react-compiler/farm.config.ts
+++ b/packages/create-farm-app/templates/react-compiler/farm.config.ts
@@ -4,9 +4,9 @@ import { react } from "@farm.js/react";
 const compilerEnabled = process.env.FARM_REACT_COMPILER !== "false";
 
 export default defineConfig({
-  vite: {
-    define: {
-      __FARM_REACT_COMPILER_ENABLED__: JSON.stringify(compilerEnabled),
+  env: {
+    public: {
+      FARM_REACT_COMPILER_ENABLED: () => compilerEnabled,
     },
   },
   renderer: react({

--- a/packages/create-farm-app/templates/react-compiler/scripts/verify-experiment.mjs
+++ b/packages/create-farm-app/templates/react-compiler/scripts/verify-experiment.mjs
@@ -65,6 +65,10 @@ try {
 
   await page.goto(origin, { waitUntil: "networkidle" });
   await page.getByRole("heading", { name: /compiler handles the rest/i }).waitFor();
+  assert.equal(
+    (await page.locator("[data-compiler-status]").textContent())?.trim(),
+    "experimental.compiler: true",
+  );
 
   const executions = {};
   for (const pathName of ["compiled", "react"]) {

--- a/packages/create-farm-app/templates/react-compiler/scripts/verify-experiment.mjs
+++ b/packages/create-farm-app/templates/react-compiler/scripts/verify-experiment.mjs
@@ -6,6 +6,7 @@ import { chromium } from "@playwright/test";
 
 const port = Number(process.env.FARM_EXPERIMENT_PORT || 4327);
 const origin = `http://127.0.0.1:${port}`;
+const compilerEnabled = process.env.FARM_REACT_COMPILER !== "false";
 const serverEntry = path.resolve(".farm/.output/server/index.mjs");
 const screenshotPath =
   process.env.FARM_EXPERIMENT_SCREENSHOT || "/tmp/farm-react-compiler-starter.png";
@@ -67,7 +68,7 @@ try {
   await page.getByRole("heading", { name: /compiler handles the rest/i }).waitFor();
   assert.equal(
     (await page.locator("[data-compiler-status]").textContent())?.trim(),
-    "experimental.compiler: true",
+    `experimental.compiler: ${String(compilerEnabled)}`,
   );
 
   const executions = {};
@@ -86,7 +87,7 @@ try {
     executions[pathName].added = executions[pathName].final - executions[pathName].initial;
   }
 
-  assert.equal(executions.compiled.added, 0);
+  assert.equal(executions.compiled.added, compilerEnabled ? 0 : 2);
   assert.equal(executions.react.added, 2);
   assert.deepEqual(browserErrors, []);
 
@@ -98,6 +99,7 @@ try {
         result: "PASS",
         productionUrl: origin,
         screenshot: screenshotPath,
+        compilerEnabled,
         compiledUpdateExecutions: executions.compiled.added,
         reactUpdateExecutions: executions.react.added,
       },

--- a/packages/create-farm-app/templates/react-compiler/src/app/globals.css
+++ b/packages/create-farm-app/templates/react-compiler/src/app/globals.css
@@ -216,6 +216,11 @@ code {
   box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
+.status-dot[data-enabled="false"] {
+  background: var(--ink-faint);
+  box-shadow: 0 0 0 3px rgb(255 255 255 / 6%);
+}
+
 .compiler-check {
   margin-top: 1.9rem;
   border: 1px solid var(--line);

--- a/packages/create-farm-app/templates/react-compiler/src/app/page.tsx
+++ b/packages/create-farm-app/templates/react-compiler/src/app/page.tsx
@@ -1,7 +1,10 @@
 import { CompilerComparison } from "../components/compiler-comparison";
 import { ResourceLinks } from "../components/resource-links";
+import { reactCompilerEnabled } from "../compiler-mode";
 
 export default function HomePage() {
+  const compilerMode = reactCompilerEnabled ? "true" : "false";
+
   return (
     <main className="landing-main">
       <section className="hero-section">
@@ -29,8 +32,8 @@ export default function HomePage() {
             <div className="command-row">
               <span>02</span>
               <div className="compiler-status">
-                <span className="status-dot" aria-hidden="true" />
-                <code>experimental.compiler: true</code>
+                <span className="status-dot" data-enabled={compilerMode} aria-hidden="true" />
+                <code data-compiler-status>experimental.compiler: {compilerMode}</code>
               </div>
             </div>
           </div>

--- a/packages/create-farm-app/templates/react-compiler/src/app/page.tsx
+++ b/packages/create-farm-app/templates/react-compiler/src/app/page.tsx
@@ -1,9 +1,9 @@
+import { publicEnv } from "@farm.js/core/env";
 import { CompilerComparison } from "../components/compiler-comparison";
 import { ResourceLinks } from "../components/resource-links";
-import { reactCompilerEnabled } from "../compiler-mode";
 
 export default function HomePage() {
-  const compilerMode = reactCompilerEnabled ? "true" : "false";
+  const compilerMode = String(publicEnv.FARM_REACT_COMPILER_ENABLED);
 
   return (
     <main className="landing-main">

--- a/packages/create-farm-app/templates/react-compiler/src/compiler-mode.ts
+++ b/packages/create-farm-app/templates/react-compiler/src/compiler-mode.ts
@@ -1,0 +1,3 @@
+declare const __FARM_REACT_COMPILER_ENABLED__: boolean;
+
+export const reactCompilerEnabled = __FARM_REACT_COMPILER_ENABLED__;

--- a/packages/create-farm-app/templates/react-compiler/src/compiler-mode.ts
+++ b/packages/create-farm-app/templates/react-compiler/src/compiler-mode.ts
@@ -1,3 +1,0 @@
-declare const __FARM_REACT_COMPILER_ENABLED__: boolean;
-
-export const reactCompilerEnabled = __FARM_REACT_COMPILER_ENABLED__;

--- a/packages/create-farm-app/test/create-app.test.mjs
+++ b/packages/create-farm-app/test/create-app.test.mjs
@@ -289,12 +289,15 @@ test("generates the experimental React Compiler starter with the shared dark sta
     const config = await readFile(path.join(generatedDir, "farm.config.ts"), "utf8");
     assert.match(config, /from "@farm\.js\/react"/);
     assert.match(config, /experimental:\s*\{\s*compiler: compilerEnabled/s);
+    assert.match(config, /__FARM_REACT_COMPILER_ENABLED__/);
     assert.match(config, /theme:\s*\{\s*default: "dark"/s);
 
     const page = await readFile(path.join(generatedDir, "src/app/page.tsx"), "utf8");
     assert.match(page, /className="landing-main"/);
     assert.match(page, /FARMJS \/ React Compiler starter/);
     assert.match(page, /The compiler handles the rest\./);
+    assert.match(page, /data-compiler-status/);
+    assert.match(page, /reactCompilerEnabled/);
     assert.match(page, /<CompilerComparison \/>/);
     assert.match(page, /<ResourceLinks className="resource-links" \/>/);
 
@@ -315,6 +318,7 @@ test("generates the experimental React Compiler starter with the shared dark sta
     for (const relativePath of [
       "src/app/globals.css",
       "src/app/page.tsx",
+      "src/compiler-mode.ts",
       "src/components/compiler-comparison.tsx",
       "src/components/resource-links.tsx",
     ]) {

--- a/packages/create-farm-app/test/create-app.test.mjs
+++ b/packages/create-farm-app/test/create-app.test.mjs
@@ -289,7 +289,7 @@ test("generates the experimental React Compiler starter with the shared dark sta
     const config = await readFile(path.join(generatedDir, "farm.config.ts"), "utf8");
     assert.match(config, /from "@farm\.js\/react"/);
     assert.match(config, /experimental:\s*\{\s*compiler: compilerEnabled/s);
-    assert.match(config, /__FARM_REACT_COMPILER_ENABLED__/);
+    assert.match(config, /FARM_REACT_COMPILER_ENABLED/);
     assert.match(config, /theme:\s*\{\s*default: "dark"/s);
 
     const page = await readFile(path.join(generatedDir, "src/app/page.tsx"), "utf8");
@@ -297,7 +297,7 @@ test("generates the experimental React Compiler starter with the shared dark sta
     assert.match(page, /FARMJS \/ React Compiler starter/);
     assert.match(page, /The compiler handles the rest\./);
     assert.match(page, /data-compiler-status/);
-    assert.match(page, /reactCompilerEnabled/);
+    assert.match(page, /publicEnv\.FARM_REACT_COMPILER_ENABLED/);
     assert.match(page, /<CompilerComparison \/>/);
     assert.match(page, /<ResourceLinks className="resource-links" \/>/);
 
@@ -318,7 +318,6 @@ test("generates the experimental React Compiler starter with the shared dark sta
     for (const relativePath of [
       "src/app/globals.css",
       "src/app/page.tsx",
-      "src/compiler-mode.ts",
       "src/components/compiler-comparison.tsx",
       "src/components/resource-links.tsx",
     ]) {

--- a/packages/farm/src/__tests__/type-artifacts.test.ts
+++ b/packages/farm/src/__tests__/type-artifacts.test.ts
@@ -75,6 +75,7 @@ describe("generateFarmTypeArtifacts", () => {
     expect(readFileSync(apiTypesPath, "utf8")).toContain("post: typeof POST_hello;");
     expect(types).toContain('import type FarmConfig from "../farm.config"');
     expect(types).toContain('declare module "@farm.js/core/env"');
+    expect(types).not.toContain("export {};");
     const imageTypes = readFileSync(path.join(process.cwd(), "types", "images.d.ts"), "utf8");
     expect(imageTypes).toContain('declare module "*.png"');
     expect(imageTypes).toContain('import("@farm.js/core/image").StaticImageData');

--- a/packages/farm/src/type-artifacts.ts
+++ b/packages/farm/src/type-artifacts.ts
@@ -208,7 +208,7 @@ export async function generateFarmTypeArtifacts(
 
 import "@farm.js/core/image";
 
-${unifiedSections.map((section) => section.trimEnd()).join("\n\n")}
+${unifiedSections.map(normalizeUnifiedTypeSection).join("\n\n")}
 `,
       options.check,
       result.stalePaths,
@@ -222,6 +222,14 @@ ${unifiedSections.map((section) => section.trimEnd()).join("\n\n")}
   }
 
   return result;
+}
+
+function normalizeUnifiedTypeSection(section: string): string {
+  // The unified artifact already imports @farm.js/core/image, so it is a module.
+  // Individual generators add this marker for standalone declaration files, but
+  // formatters remove the now-redundant export and make `farm generate --check`
+  // report a false stale-file failure.
+  return section.trimEnd().replace(/\n+export \{\};$/, "");
 }
 
 function resolveGeneratedPath(


### PR DESCRIPTION
## What changed

- Expose the resolved compiler flag through Farm public env.
- Render the actual enabled/disabled value in the starter UI.
- Give the disabled state a distinct neutral indicator.
- Make the production experiment aware of both compiler-on and compiler-off builds.
- Document that the visible status follows the build.

## Why

`FARM_REACT_COMPILER=false` disabled compilation but the page still claimed `experimental.compiler: true`. The UI now reads the same resolved value as the renderer configuration through Farm public env, which is available consistently during SSR and hydration.

## Validation

- `pnpm --filter @farm.js/create-app test`
- `pnpm exec oxfmt --check` on the changed template and test files
- The standalone mirror validates full compiler-on and compiler-off production experiments.