### PR TITLE
feat(react): compile safe derived local values

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -327,7 +327,7 @@ satisfy all of these rules:
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Component discovery | A top-level, capitalized function declaration, function expression, or arrow component in application `.tsx` or `.jsx`.                             |
 | Function shape      | Synchronous, non-generator, non-generic block body with zero parameters or one identifier such as `props`.                                          |
-| Body                | One or more top-level `useState` declarations followed by one unconditional JSX return.                                                             |
+| Body                | Top-level `useState` declarations, optional compiler-safe derived `const` values in source order, then one unconditional JSX return.                |
 | State               | `const [value, setValue] = useState(initial)`, including lazy initializers, multiple cells, and queued functional updates.                          |
 | Root                | Exactly one lowercase host JSX element such as `button`, `section`, `input`, or `div`.                                                              |
 | Tree                | A static tree containing host elements only. Nested host elements are supported when their placement cannot change.                                 |
@@ -345,18 +345,20 @@ import { useState } from "react";
 export function StatusButton(props: { initial: number }) {
   const [count, setCount] = useState(props.initial);
   const [active, setActive] = useState(false);
+  const statusClass = active ? "active" : "idle";
+  const label = `Count: ${count}`;
 
   return (
     <button
       aria-pressed={active}
-      className={active ? "active" : "idle"}
+      className={statusClass}
       data-count={count}
       onClick={() => {
         setCount((value) => value + 1);
         setActive((value) => !value);
       }}
     >
-      Count: {count}
+      {label}
     </button>
   );
 }
@@ -365,20 +367,27 @@ export function StatusButton(props: { initial: number }) {
 The compiler records separate dependencies for `count` and `active`. Changing `count` does not
 reevaluate bindings that depend only on `active`, and vice versa.
 
+Derived values are expanded into the generated bindings, so they do not create a runtime scope or
+force a component rerender. They may use literals, props, state, operators, member access,
+conditionals, templates, and earlier derived values. State declarations must come first. Calls,
+assignments, object or array literals, functions, JSX, constructors, and other expressions whose
+evaluation or identity cannot be preserved safely still fall back to React.
+
 ### What falls back to React
 
-| Unsupported shape                                                  | Why React keeps ownership                                                           |
-| ------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
-| Keyed lists, `.map()`, element arrays, or helper-rendered children | Inserts, removals, moves, and identity changes require reconciliation.              |
-| Conditional JSX children or fragments                              | The prepared DOM path can change when structure appears or disappears.              |
-| Custom child components                                            | A child component has its own props, hooks, lifecycle, and reconciliation boundary. |
-| Effects or hooks other than the supported `useState` shape         | Their lifecycle and ordering must remain under React's hook dispatcher.             |
-| `ref` or `dangerouslySetInnerHTML`                                 | They directly participate in DOM ownership.                                         |
-| Stateful `style`, `children`, or `key` bindings                    | These need specialized property, structure, or identity semantics.                  |
-| JSX attribute spreads or namespaced attributes                     | The compiler cannot currently enumerate a stable binding contract.                  |
-| Multiple/conditional returns or non-state statements               | The compiler does not yet prove control flow or derived local values.               |
-| Destructured props, async/generator, or generic components         | These function shapes are outside the current lowering.                             |
-| Setters called outside JSX event handlers                          | The compiler only controls and batches event-driven local updates.                  |
+| Unsupported shape                                                      | Why React keeps ownership                                                           |
+| ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Keyed lists, `.map()`, element arrays, or helper-rendered children     | Inserts, removals, moves, and identity changes require reconciliation.              |
+| Conditional JSX children or fragments                                  | The prepared DOM path can change when structure appears or disappears.              |
+| Custom child components                                                | A child component has its own props, hooks, lifecycle, and reconciliation boundary. |
+| Effects or hooks other than the supported `useState` shape             | Their lifecycle and ordering must remain under React's hook dispatcher.             |
+| `ref` or `dangerouslySetInnerHTML`                                     | They directly participate in DOM ownership.                                         |
+| Stateful `style`, `children`, or `key` bindings                        | These need specialized property, structure, or identity semantics.                  |
+| JSX attribute spreads or namespaced attributes                         | The compiler cannot currently enumerate a stable binding contract.                  |
+| Multiple/conditional returns or impure/control-flow statements         | The compiler only lowers a single, statically analyzable render path.               |
+| Derived calls, assignments, identity-bearing values, functions, or JSX | Their evaluation timing, side effects, or identity cannot yet be preserved safely.  |
+| Destructured props, async/generator, or generic components             | These function shapes are outside the current lowering.                             |
+| Setters called outside JSX event handlers                              | The compiler only controls and batches event-driven local updates.                  |
 
 Keys do not make list reconciliation unnecessary. A key tells React which child identity survives
 an insert, removal, or move; React still needs to compare the dynamic children. Calling a Hook

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -96,6 +96,11 @@ try {
   }
   assert.equal(directExecutions.compiled.added, 0);
   assert.equal(directExecutions.react.added, 2);
+  await assertText(
+    page,
+    '[data-path="compiled"] .update-status',
+    "DOM bindings patched",
+  );
 
   const batchExecutions = {};
 

--- a/examples/react-compiler/src/components/compiler-comparison.tsx
+++ b/examples/react-compiler/src/components/compiler-comparison.tsx
@@ -7,6 +7,10 @@ let reactExecutions = 0;
 
 export function CompiledCounter() {
   const [count, setCount] = useState(0);
+  const statusClass =
+    count > 0 ? "update-status update-status--active" : "update-status";
+  const statusText =
+    count > 0 ? "DOM bindings patched" : "Ready for an update";
 
   return (
     <article
@@ -34,13 +38,7 @@ export function CompiledCounter() {
         </div>
       </div>
 
-      <p
-        className={
-          count > 0 ? "update-status update-status--active" : "update-status"
-        }
-      >
-        {count > 0 ? "DOM bindings patched" : "Ready for an update"}
-      </p>
+      <p className={statusClass}>{statusText}</p>
 
       <button
         type="button"

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -55,6 +55,7 @@ The current compiler handles components that it can prove have:
 
 - one host-element root and a static host-element tree;
 - top-level `useState` declarations;
+- optional compiler-safe derived `const` values declared after state and in source order;
 - state-driven text and basic attribute/property bindings;
 - React-managed event handlers; and
 - no refs, effects, custom child components, keyed lists, or conditional child structure.

--- a/packages/farm-react/src/__tests__/compiler-edge-cases.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-edge-cases.test.ts
@@ -144,6 +144,46 @@ describe("React AOT compiler safety boundaries", () => {
     expect(result.diagnostics[0]?.reason).toMatch(/dynamic child structures/i);
   });
 
+  it.each([
+    {
+      name: "an impure derived call",
+      body: `
+        const label = String(count);
+        return <button onClick={() => setCount(count + 1)}>{label}</button>;
+      `,
+      reason: /derived local label cannot use function calls/i,
+    },
+    {
+      name: "a forward derived reference",
+      body: `
+        const label = next;
+        const next = count + 1;
+        return <button onClick={() => setCount(count + 1)}>{label}</button>;
+      `,
+      reason: /can only reference earlier derived local values/i,
+    },
+    {
+      name: "state declared after a derived value",
+      body: `
+        const seed = 0;
+        const [next, setNext] = useState(seed);
+        return <button onClick={() => setNext(next + 1)}>{count + next}</button>;
+      `,
+      reason: /useState declarations must appear before derived local values/i,
+    },
+  ])("falls back for $name", async ({ body, reason }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function DerivedBoundary() {
+        const [count, setCount] = useState(0);
+        ${body}
+      }
+    `);
+
+    expect(result.compiled).toEqual([]);
+    expect(result.diagnostics[0]?.reason).toMatch(reason);
+  });
+
   it("falls back for hooks placed inside keyed list iteration", async () => {
     const result = await compile(`
       import { useState } from "react";

--- a/packages/farm-react/src/__tests__/compiler.test.ts
+++ b/packages/farm-react/src/__tests__/compiler.test.ts
@@ -47,6 +47,43 @@ describe("React AOT compiler", () => {
     });
   });
 
+  it("compiles state-driven derived local values in source order", async () => {
+    const result = await compileReactModule(
+      `
+        import { useState } from "react";
+        export function DerivedCounter(props: { prefix: string }) {
+          const [count, setCount] = useState(0);
+          const doubled = count * 2;
+          const label = \`\${props.prefix}: \${doubled}\`;
+          const tone = count > 0 ? "active" : "idle";
+          return (
+            <button
+              className={tone}
+              data-count={doubled}
+              onClick={() => setCount(doubled + 1)}
+            >{label}</button>
+          );
+        }
+      `,
+      "/app/DerivedCounter.tsx",
+      infer,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.compiled).toEqual(["DerivedCounter"]);
+    expect(result.code).not.toMatch(/const (doubled|label|tone)/);
+    expect(result.code).toContain("dependencies: [0]");
+    expect(result.code).toMatch(/farmState\[0\]\.get/);
+    await expect(
+      transformWithEsbuild(result.code, "/app/DerivedCounter.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("createCompiledComponent"),
+    });
+  });
+
   it("only compiles selected components in annotation mode", async () => {
     const result = await compileReactModule(
       `

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -21,6 +21,11 @@ interface StateBinding {
   initialValue?: t.Expression;
 }
 
+interface DerivedBinding {
+  name: string;
+  value: t.Expression;
+}
+
 interface PendingBinding {
   kind: "text" | "attribute";
   path: number[];
@@ -92,6 +97,66 @@ function referencesIdentifier(expression: t.Expression, name: string): boolean {
     },
   });
   return referenced;
+}
+
+function collectReferencedLocals(expression: t.Expression, names: ReadonlySet<string>): string[] {
+  const references = new Set<string>();
+  traverse(expressionFile(cloneExpression(expression)), {
+    ReferencedIdentifier(path) {
+      if (names.has(path.node.name) && !path.scope.hasBinding(path.node.name)) {
+        references.add(path.node.name);
+      }
+    },
+  });
+  return [...references];
+}
+
+function rewriteDerivedAccess<T extends t.Expression>(
+  expression: T,
+  derivedByName: ReadonlyMap<string, t.Expression>,
+): T {
+  const file = expressionFile(cloneExpression(expression));
+  traverse(file, {
+    ReferencedIdentifier(path) {
+      if (path.scope.hasBinding(path.node.name)) return;
+      const derived = derivedByName.get(path.node.name);
+      if (!derived) return;
+      path.replaceWith(cloneExpression(derived));
+      path.skip();
+    },
+  });
+  return (file.program.body[0] as t.ExpressionStatement).expression as T;
+}
+
+function validateDerivedExpression(expression: t.Expression): string | undefined {
+  let unsupported: string | undefined;
+  const reject = (reason: string, path: NodePath) => {
+    unsupported = reason;
+    path.stop();
+  };
+
+  traverse(expressionFile(cloneExpression(expression)), {
+    ArrayExpression: (path) => reject("array literals", path),
+    AssignmentExpression: (path) => reject("assignments", path),
+    AwaitExpression: (path) => reject("await expressions", path),
+    CallExpression: (path) => reject("function calls", path),
+    ClassExpression: (path) => reject("class expressions", path),
+    Function: (path) => reject("function expressions", path),
+    JSXElement: (path) => reject("JSX", path),
+    JSXFragment: (path) => reject("JSX", path),
+    NewExpression: (path) => reject("constructor calls", path),
+    ObjectExpression: (path) => reject("object literals", path),
+    OptionalCallExpression: (path) => reject("function calls", path),
+    TaggedTemplateExpression: (path) => reject("tagged templates", path),
+    ThisExpression: (path) => reject("this expressions", path),
+    UnaryExpression(path) {
+      if (path.node.operator === "delete") reject("delete expressions", path);
+    },
+    UpdateExpression: (path) => reject("update expressions", path),
+    YieldExpression: (path) => reject("yield expressions", path),
+  });
+
+  return unsupported;
 }
 
 function findContainingEvent(path: NodePath): NodePath<t.JSXAttribute> | null {
@@ -402,6 +467,7 @@ function compileCandidate(
   if (!t.isBlockStatement(path.node.body)) return "components must use a block body";
 
   const states: StateBinding[] = [];
+  const derived: DerivedBinding[] = [];
   let returned: t.ReturnStatement | undefined;
   for (const statement of path.node.body.body) {
     if (t.isReturnStatement(statement)) {
@@ -409,28 +475,40 @@ function compileCandidate(
       returned = statement;
       continue;
     }
-    if (!t.isVariableDeclaration(statement) || statement.declarations.length !== 1) {
-      return "only top-level useState declarations and one return are supported by the current compiler";
+    if (
+      !t.isVariableDeclaration(statement) ||
+      statement.kind !== "const" ||
+      statement.declarations.length !== 1
+    ) {
+      return "only top-level useState declarations, pure derived const values, and one return are supported by the current compiler";
     }
     const declaration = statement.declarations[0];
-    if (
-      statement.kind !== "const" ||
-      !t.isArrayPattern(declaration.id) ||
-      declaration.id.elements.length !== 2 ||
-      !t.isIdentifier(declaration.id.elements[0]) ||
-      !t.isIdentifier(declaration.id.elements[1]) ||
-      !isUseStateCall(declaration.init, useStateNames, reactNames) ||
-      declaration.init.arguments.length > 1 ||
-      (declaration.init.arguments[0] && !t.isExpression(declaration.init.arguments[0]))
-    ) {
-      return "only const [value, setValue] = useState(initial) declarations are supported";
+    if (t.isArrayPattern(declaration.id)) {
+      if (
+        declaration.id.elements.length !== 2 ||
+        !t.isIdentifier(declaration.id.elements[0]) ||
+        !t.isIdentifier(declaration.id.elements[1]) ||
+        !isUseStateCall(declaration.init, useStateNames, reactNames) ||
+        declaration.init.arguments.length > 1 ||
+        (declaration.init.arguments[0] && !t.isExpression(declaration.init.arguments[0]))
+      ) {
+        return "only const [value, setValue] = useState(initial) state declarations are supported";
+      }
+      if (derived.length > 0) {
+        return "useState declarations must appear before derived local values";
+      }
+      states.push({
+        valueName: declaration.id.elements[0].name,
+        setterName: declaration.id.elements[1].name,
+        index: states.length,
+        initialValue: declaration.init.arguments[0] as t.Expression | undefined,
+      });
+      continue;
     }
-    states.push({
-      valueName: declaration.id.elements[0].name,
-      setterName: declaration.id.elements[1].name,
-      index: states.length,
-      initialValue: declaration.init.arguments[0] as t.Expression | undefined,
-    });
+    if (!t.isIdentifier(declaration.id) || !t.isExpression(declaration.init)) {
+      return "derived const values must use one identifier and one expression";
+    }
+    derived.push({ name: declaration.id.name, value: declaration.init });
   }
 
   if (states.length === 0) return "no local useState binding was found";
@@ -440,27 +518,46 @@ function compileCandidate(
 
   const statesByValue = new Map(states.map((state) => [state.valueName, state]));
   const statesBySetter = new Map(states.map((state) => [state.setterName, state]));
+  const derivedNames = new Set(derived.map((binding) => binding.name));
+  if (derivedNames.size !== derived.length) return "derived local names must be unique";
   for (const state of states) {
     if (
       state.initialValue &&
       (collectStateDependencies(state.initialValue, statesByValue).length > 0 ||
+        collectReferencedLocals(state.initialValue, derivedNames).length > 0 ||
         [...statesBySetter].some(([setterName]) =>
           referencesIdentifier(state.initialValue!, setterName),
         ))
     ) {
-      return "useState initializers cannot reference another local state binding";
+      return "useState initializers cannot reference another local binding";
     }
   }
-  const setterReason = validateSetterUsage(returned.argument, statesBySetter);
+  const derivedByName = new Map<string, t.Expression>();
+  for (const binding of derived) {
+    const forwardReferences = collectReferencedLocals(binding.value, derivedNames).filter(
+      (reference) => !derivedByName.has(reference),
+    );
+    if (forwardReferences.length > 0) {
+      return `derived local ${binding.name} can only reference earlier derived local values`;
+    }
+    const expanded = rewriteDerivedAccess(binding.value, derivedByName);
+    const unsupported = validateDerivedExpression(expanded);
+    if (unsupported) {
+      return `derived local ${binding.name} cannot use ${unsupported}`;
+    }
+    derivedByName.set(binding.name, expanded);
+  }
+  const expandedRoot = rewriteDerivedAccess(returned.argument, derivedByName) as t.JSXElement;
+  const setterReason = validateSetterUsage(expandedRoot, statesBySetter);
   if (setterReason) return setterReason;
-  const analysis = analyzeHostTree(returned.argument, statesByValue);
+  const analysis = analyzeHostTree(expandedRoot, statesByValue);
   if (analysis.reason) return analysis.reason;
 
   const stateParameter = path.scope.generateUidIdentifier("farmState");
   const definitionIdentifier = path.scope.generateUidIdentifier(`${name}Compiled`);
   const propsParameter = clonePropsParameter(path);
   const rewrittenRoot = rewriteStateAccess(
-    returned.argument,
+    expandedRoot,
     stateParameter,
     statesByValue,
     statesBySetter,


### PR DESCRIPTION
## What changed

- accepts compiler-safe derived const values after top-level useState declarations
- expands chained derived values into DOM bindings and event handlers in source order
- falls back with focused diagnostics for forward references and expressions whose evaluation or identity is unsafe to lower
- exercises derived text and class bindings in the maintained production browser experiment
- documents the supported expression boundary

## Why

Common components name state-derived values before returning JSX. Keeping these components on the compiled path removes an artificial source-shape restriction without weakening the existing React fallback boundary.

## Impact and safety

The compiler only accepts statically analyzable expressions. Calls, assignments, functions, JSX, constructors, object and array literals, and similar unsupported expressions remain React-owned. Existing unsupported components continue to fall back rather than being partially compiled.

## Validation

- pnpm --filter @farm.js/react test (46 passed)
- pnpm --filter @farm.js/react type-check
- pnpm --filter @farm.js/react build
- production browser experiment passed with zero compiled update executions and no browser errors
- oxfmt check and git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compiles pure, state‑derived local const values declared after top‑level `useState`, removing an artificial fallback. Previously, any derived locals forced React fallback; now safe derived values inline into DOM bindings and event handlers in source order without creating a runtime scope.

- Compiler: validates and expands derived locals; enforces state‑before‑derived ordering; requires single‑identifier `const` and unique names; allows literals, props, state, operators, member access, conditionals, templates, and earlier derived values; rejects calls, assignments, array/object literals, functions, JSX, constructors, tagged templates, `await`, `this`/`delete`/update/`yield`; forbids forward references; `useState` initializers cannot reference any other local binding; removes derived identifiers from emitted code while preserving dependency tracking.
- Docs/examples/experiment: updates docs and `packages/farm-react/README.md` to include the derived‑locals boundary and examples (`statusClass`/`label`, `statusText`); `examples/react-compiler` now derives these values and the verifier asserts “DOM bindings patched.”
- Tests: adds success coverage for compiled derived locals and failure cases with focused diagnostics (impure calls, forward references, state after derived). No migration required; keep all `useState` declarations before derived locals.

<sup>Written for commit f49a9d682901918a310680c5522f07b86ede35cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

