### PR TITLE
superseded: application metadata routes (see #357)

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -751,6 +751,92 @@ export const metadata: Metadata = {
 
 Root layout metadata applies the favicon to every route. Nested layouts and pages can override individual icon entries through their own metadata. Do not render a `<link rel="icon">` element from the layout component; declaring `metadata.icons` lets Farm place the tags in the document head in both development and production.
 
+### Application metadata routes
+
+Use server-only metadata files when crawlers or browsers need an application-level document rather than an HTML `<meta>` tag. Farm discovers three conventions in `src/app` and route segments:
+
+| File          | Public route            | Default return type      |
+| ------------- | ----------------------- | ------------------------ |
+| `sitemap.ts`  | `/sitemap.xml`          | `MetadataRoute.Sitemap`  |
+| `robots.ts`   | `/robots.txt`           | `MetadataRoute.Robots`   |
+| `manifest.ts` | `/manifest.webmanifest` | `MetadataRoute.Manifest` |
+
+The default export can be a literal value or a sync or async function. Functions receive the matched `params`, the current `Request`, its `URLSearchParams`, and the concrete route-segment `path`.
+
+**src/app/sitemap.ts**
+
+```ts
+import type { MetadataRoute } from "@farm.js/core";
+
+export const revalidate = 3600;
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const products = await listProducts();
+
+  return [
+    {
+      url: "https://acme.test",
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 1,
+    },
+    ...products.map((product) => ({
+      url: `https://acme.test/products/${product.id}`,
+      lastModified: product.updatedAt,
+      priority: 0.8,
+    })),
+  ];
+}
+```
+
+Farm escapes XML values and supports language alternates through `alternates.languages`.
+
+**src/app/robots.ts**
+
+```ts
+import type { MetadataRoute } from "@farm.js/core";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/admin/", "/preview/"],
+    },
+    sitemap: "https://acme.test/sitemap.xml",
+    host: "https://acme.test",
+  };
+}
+```
+
+**src/app/manifest.ts**
+
+```ts
+import type { MetadataRoute } from "@farm.js/core";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "Acme Store",
+    short_name: "Acme",
+    description: "The Acme product catalog",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#ffffff",
+    theme_color: "#16a34a",
+    icons: [
+      { src: "/icon-192.png", sizes: "192x192", type: "image/png" },
+      { src: "/icon-512.png", sizes: "512x512", type: "image/png" },
+    ],
+  };
+}
+```
+
+Farm automatically adds the nearest discovered manifest to rendered page heads unless `metadata.manifest` already supplies an explicit URL. A nested file keeps its route prefix: `src/app/docs/sitemap.ts` is served at `/docs/sitemap.xml`, and a file under `[tenant]` receives the concrete tenant param.
+
+Generated metadata routes accept `GET` and `HEAD` and return `405` for other methods. They revalidate by default. Export `revalidate = 300` for shared CDN caching or `revalidate = false` only for permanently immutable output. A returned `Response` is an escape hatch for custom XML, headers, or status codes.
+
+`feed.ts` is not reserved yet because feeds need an explicit RSS, Atom, or JSON Feed contract. Use an API or programmatic route for feeds until that format is defined.
+
 ### Static metadata images
 
 Place `opengraph-image.png` next to a page or layout segment for a zero-code, route-local social image. Farm supports `.png`, `.jpg`, `.jpeg`, `.gif`, and `.webp` files.

--- a/packages/farm/src/__tests__/fixtures/middleware-production-fixture.ts
+++ b/packages/farm/src/__tests__/fixtures/middleware-production-fixture.ts
@@ -92,6 +92,51 @@ export default {
   );
   await fs.writeFile(path.join(root, "src", "app", "globals.css"), "");
   await fs.writeFile(
+    path.join(root, "src", "app", "sitemap.ts"),
+    `
+export const revalidate = 600;
+
+export default function sitemap({ searchParams }: any) {
+  const campaign = searchParams.get("campaign") || "organic";
+  return [
+    {
+      url: "https://example.test/?campaign=" + campaign,
+      lastModified: new Date("2026-08-16T12:00:00.000Z"),
+      changeFrequency: "daily",
+      priority: 1,
+    },
+  ];
+}
+`.trim(),
+  );
+  await fs.writeFile(
+    path.join(root, "src", "app", "robots.ts"),
+    `
+export default {
+  rules: {
+    userAgent: "*",
+    allow: "/",
+    disallow: "/private/",
+  },
+  sitemap: "https://example.test/sitemap.xml",
+};
+`.trim(),
+  );
+  await fs.writeFile(
+    path.join(root, "src", "app", "manifest.ts"),
+    `
+export default function manifest() {
+  return {
+    name: "Farm production fixture",
+    short_name: "Farm",
+    start_url: "/",
+    display: "standalone",
+    theme_color: "#16a34a",
+  };
+}
+`.trim(),
+  );
+  await fs.writeFile(
     path.join(root, "src", "app", "rewrite-target", "page.tsx"),
     `
 import React from "react";
@@ -386,6 +431,14 @@ export default function UserImage({ params }: { params: { id: string } }) {
     },
     \`User \${params.id}\`,
   );
+}
+`.trim(),
+  );
+  await fs.writeFile(
+    path.join(root, "src", "app", "users", "[id]", "sitemap.ts"),
+    `
+export default function userSitemap({ params, path }: any) {
+  return [{ url: "https://example.test" + path + "/profile", priority: Number(params.id) / 100 }];
 }
 `.trim(),
   );

--- a/packages/farm/src/__tests__/metadata-route.test.ts
+++ b/packages/farm/src/__tests__/metadata-route.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { createFarmMetadataRouteResponse } from "../metadata-route";
+
+describe("application metadata route responses", () => {
+  it("serializes sitemap entries and escapes XML values", async () => {
+    const response = createFarmMetadataRouteResponse(
+      "sitemap",
+      [
+        {
+          url: "https://farm.test/products?a=1&b=2",
+          lastModified: new Date("2026-08-16T12:00:00.000Z"),
+          changeFrequency: "daily",
+          priority: 0.8,
+          alternates: {
+            languages: {
+              en: "https://farm.test/en/products",
+              am: "https://farm.test/am/products",
+            },
+          },
+        },
+      ],
+      { revalidate: 600 },
+    );
+
+    expect(response.headers.get("content-type")).toBe("application/xml; charset=utf-8");
+    expect(response.headers.get("cache-control")).toBe(
+      "public, s-maxage=600, stale-while-revalidate=300",
+    );
+    expect(await response.text()).toBe(`<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://farm.test/products?a=1&amp;b=2</loc>
+    <lastmod>2026-08-16T12:00:00.000Z</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://farm.test/en/products" />
+    <xhtml:link rel="alternate" hreflang="am" href="https://farm.test/am/products" />
+  </url>
+</urlset>
+`);
+  });
+
+  it("serializes robots rules, sitemaps, and host", async () => {
+    const response = createFarmMetadataRouteResponse("robots", {
+      rules: [
+        { userAgent: "*", allow: "/", disallow: ["/admin/", "/preview/"] },
+        { userAgent: ["FarmBot", "SearchBot"], crawlDelay: 2 },
+      ],
+      sitemap: ["https://farm.test/sitemap.xml", "https://farm.test/docs/sitemap.xml"],
+      host: "https://farm.test",
+    });
+
+    expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(await response.text()).toBe(`User-agent: *
+Allow: /
+Disallow: /admin/
+Disallow: /preview/
+
+User-agent: FarmBot
+User-agent: SearchBot
+Crawl-delay: 2
+
+Sitemap: https://farm.test/sitemap.xml
+Sitemap: https://farm.test/docs/sitemap.xml
+Host: https://farm.test
+`);
+  });
+
+  it("serializes manifests and automatically strips the body for HEAD", async () => {
+    const response = createFarmMetadataRouteResponse(
+      "manifest",
+      {
+        name: "Farm Store",
+        short_name: "Store",
+        start_url: "/",
+        display: "standalone",
+      },
+      {},
+      { method: "HEAD" },
+    );
+
+    expect(response.headers.get("content-type")).toBe("application/manifest+json; charset=utf-8");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(await response.text()).toBe("");
+  });
+
+  it("preserves custom Responses and rejects unsupported methods", async () => {
+    const custom = new Response("custom feed", {
+      status: 202,
+      headers: { "x-custom": "yes" },
+    });
+    expect(createFarmMetadataRouteResponse("sitemap", custom)).toBe(custom);
+
+    const response = createFarmMetadataRouteResponse("robots", {}, {}, { method: "POST" });
+    expect(response.status).toBe(405);
+    expect(response.headers.get("allow")).toBe("GET, HEAD");
+  });
+
+  it("reports invalid convention values with focused errors", () => {
+    expect(() => createFarmMetadataRouteResponse("sitemap", {})).toThrow(
+      "sitemap.ts must return an array",
+    );
+    expect(() => createFarmMetadataRouteResponse("robots", { rules: [] })).toThrow(
+      "at least one rule",
+    );
+    expect(() => createFarmMetadataRouteResponse("manifest", [])).toThrow(
+      "manifest.ts must return a manifest object",
+    );
+  });
+});

--- a/packages/farm/src/__tests__/production-middleware.test.ts
+++ b/packages/farm/src/__tests__/production-middleware.test.ts
@@ -42,6 +42,24 @@ describe("production middleware runtime", () => {
       const config = await resolveConfig({ ...userConfig, root }, "production");
       await build(config, { root, preset: "vercel" });
 
+      const routeRuntimeManifest = JSON.parse(
+        await fs.readFile(path.join(root, ".farm", "route-runtime-manifest.json"), "utf8"),
+      );
+      expect(routeRuntimeManifest.routes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: "metadata",
+            pattern: "/sitemap.xml",
+            source: "src/app/sitemap.ts",
+          }),
+          expect.objectContaining({
+            kind: "metadata",
+            pattern: "/users/[id]/sitemap.xml",
+            source: "src/app/users/[id]/sitemap.ts",
+          }),
+        ]),
+      );
+
       const vercelOutputConfig = JSON.parse(
         await fs.readFile(path.join(root, ".vercel", "output", "config.json"), "utf8"),
       );
@@ -125,6 +143,7 @@ describe("production middleware runtime", () => {
         "production middleware: dashboard / settings / dashboard-file / /dashboard/settings",
       );
       expect(html).toContain("server context: dashboard-user / /dashboard/settings");
+      expect(html).toContain('<link rel="manifest" href="/manifest.webmanifest">');
       expect(html).not.toContain("never-serialize-this-session-secret");
       const hydrationProps = readInlineFarmProps(html);
       expect(hydrationProps).toMatchObject({
@@ -203,6 +222,59 @@ describe("production middleware runtime", () => {
       expect(optimizedImageResponse.headers.get("content-type")).toBe("image/webp");
       expect(optimizedImageResponse.headers.get("vary")).toBe("Accept");
       expect((await optimizedImageResponse.arrayBuffer()).byteLength).toBeGreaterThan(0);
+
+      const sitemapResponse = await serverModule.default.fetch(
+        new Request("https://example.test/sitemap.xml?campaign=spring%26summer"),
+      );
+      expect(sitemapResponse.status).toBe(200);
+      expect(sitemapResponse.headers.get("content-type")).toBe("application/xml; charset=utf-8");
+      expect(sitemapResponse.headers.get("cache-control")).toBe(
+        "public, s-maxage=600, stale-while-revalidate=300",
+      );
+      const sitemapXml = await sitemapResponse.text();
+      expect(sitemapXml).toContain("<loc>https://example.test/?campaign=spring&amp;summer</loc>");
+      expect(sitemapXml).toContain("<lastmod>2026-08-16T12:00:00.000Z</lastmod>");
+
+      const userSitemapResponse = await serverModule.default.fetch(
+        new Request("https://example.test/users/42/sitemap.xml"),
+      );
+      expect(userSitemapResponse.status).toBe(200);
+      const userSitemapXml = await userSitemapResponse.text();
+      expect(userSitemapXml).toContain("<loc>https://example.test/users/42/profile</loc>");
+      expect(userSitemapXml).toContain("<priority>0.42</priority>");
+
+      const robotsResponse = await serverModule.default.fetch(
+        new Request("https://example.test/robots.txt"),
+      );
+      expect(robotsResponse.status).toBe(200);
+      expect(robotsResponse.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+      await expect(robotsResponse.text()).resolves.toContain(
+        "Sitemap: https://example.test/sitemap.xml",
+      );
+
+      const manifestResponse = await serverModule.default.fetch(
+        new Request("https://example.test/manifest.webmanifest"),
+      );
+      expect(manifestResponse.status).toBe(200);
+      expect(manifestResponse.headers.get("content-type")).toBe(
+        "application/manifest+json; charset=utf-8",
+      );
+      await expect(manifestResponse.json()).resolves.toMatchObject({
+        name: "Farm production fixture",
+        display: "standalone",
+      });
+
+      const manifestHeadResponse = await serverModule.default.fetch(
+        new Request("https://example.test/manifest.webmanifest", { method: "HEAD" }),
+      );
+      expect(manifestHeadResponse.status).toBe(200);
+      expect(await manifestHeadResponse.text()).toBe("");
+
+      const metadataPostResponse = await serverModule.default.fetch(
+        new Request("https://example.test/robots.txt", { method: "POST" }),
+      );
+      expect(metadataPostResponse.status).toBe(405);
+      expect(metadataPostResponse.headers.get("allow")).toBe("GET, HEAD");
 
       (globalThis as any).__farmMiddlewareEvents = [];
       const configResponse = await serverModule.default.fetch(

--- a/packages/farm/src/__tests__/route-manager.test.ts
+++ b/packages/farm/src/__tests__/route-manager.test.ts
@@ -472,6 +472,60 @@ describe("RouteManager", () => {
       );
     });
   });
+
+  describe("application metadata routes", () => {
+    it("discovers sitemap, robots, and manifest conventions in route segments", async () => {
+      const { globFiles } = await import("../utils");
+      vi.mocked(globFiles).mockImplementation(async (pattern: string) => {
+        if (pattern.includes("page")) return ["page.tsx", "shops/[shop]/page.tsx"];
+        if (pattern.includes("sitemap")) {
+          return ["sitemap.ts", "robots.js", "manifest.ts", "shops/[shop]/sitemap.ts"];
+        }
+        return [];
+      });
+
+      await routeManager.discoverRoutes();
+
+      expect(routeManager.getMetadataRoutes().size).toBe(4);
+      expect(routeManager.matchMetadataRoute("/sitemap.xml")).toMatchObject({
+        metadata: { kind: "sitemap", pattern: "/" },
+        params: {},
+        routePath: "/",
+      });
+      expect(routeManager.matchMetadataRoute("/robots.txt")?.metadata.kind).toBe("robots");
+      expect(routeManager.matchMetadataRoute("/manifest.webmanifest")?.metadata.kind).toBe(
+        "manifest",
+      );
+
+      const shopSitemap = routeManager.matchMetadataRoute("/shops/acme/sitemap.xml");
+      expect(shopSitemap).toMatchObject({
+        metadata: { kind: "sitemap", pattern: "/shops/[shop]" },
+        params: { shop: "acme" },
+        routePath: "/shops/acme",
+      });
+      expect(
+        routeManager.resolveMetadataRoutePath(shopSitemap!.metadata, shopSitemap!.params),
+      ).toBe("/shops/acme/sitemap.xml");
+
+      const manifest = routeManager.getMatchingMetadataRoute("/shops/acme/products", "manifest");
+      expect(manifest?.metadata.pattern).toBe("/");
+      expect(routeManager.resolveMetadataRoutePath(manifest!.metadata, manifest!.params)).toBe(
+        "/manifest.webmanifest",
+      );
+    });
+
+    it("rejects duplicate metadata implementations in one route segment", async () => {
+      const { globFiles } = await import("../utils");
+      vi.mocked(globFiles).mockImplementation(async (pattern: string) => {
+        if (pattern.includes("sitemap")) return ["docs/sitemap.ts", "docs/sitemap.js"];
+        return [];
+      });
+
+      await expect(routeManager.discoverRoutes()).rejects.toThrow(
+        'Duplicate sitemap route "/docs"',
+      );
+    });
+  });
 });
 
 describe("static rendering suggestions with i18n", () => {

--- a/packages/farm/src/__tests__/server-renderer-route-states.test.tsx
+++ b/packages/farm/src/__tests__/server-renderer-route-states.test.tsx
@@ -21,6 +21,8 @@ const dashboardLayoutModulePath = "/test/src/app/dashboard/layout.tsx";
 const loadingModulePath = "/test/src/app/dashboard/loading.tsx";
 const errorModulePath = "/test/src/app/dashboard/error.tsx";
 const ogImageModulePath = "/test/src/app/dashboard/opengraph-image.tsx";
+const sitemapModulePath = "/test/src/app/dashboard/sitemap.ts";
+const manifestModulePath = "/test/src/app/dashboard/manifest.ts";
 const temporaryDirectories: string[] = [];
 
 afterEach(async () => {
@@ -200,6 +202,66 @@ describe("file route loading.tsx and error.tsx", () => {
     expect(response.headers.get("content-type")).toBe("image/svg+xml");
     expect(response.body).toContain("<svg");
     expect(response.body).toContain("OG /dashboard");
+  });
+
+  it("serves sitemap.ts with params, search params, and cache headers", async () => {
+    const response = createMockResponse();
+    const renderer = createRenderer(
+      {
+        [sitemapModulePath]: {
+          revalidate: 120,
+          default({ path: routePath, searchParams }: any) {
+            return [
+              {
+                url: `https://farm.test${routePath}?locale=${searchParams.get("locale")}`,
+                changeFrequency: "daily",
+              },
+            ];
+          },
+        },
+      },
+      {
+        applicationMetadata: {
+          kind: "sitemap",
+          modulePath: sitemapModulePath,
+          outputName: "sitemap.xml",
+        },
+      },
+    );
+
+    await renderer.renderPage(createMockRequest("/dashboard/sitemap.xml?locale=am"), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/xml; charset=utf-8");
+    expect(response.headers.get("cache-control")).toBe(
+      "public, s-maxage=120, stale-while-revalidate=300",
+    );
+    expect(response.body).toContain("<loc>https://farm.test/dashboard?locale=am</loc>");
+  });
+
+  it("automatically links the nearest manifest.ts from rendered pages", async () => {
+    const response = createMockResponse();
+    const renderer = createRenderer(
+      {
+        [routeModulePath]: {
+          default: () => React.createElement("main", null, "Dashboard ready"),
+        },
+        [manifestModulePath]: {
+          default: { name: "Farm dashboard", start_url: "/dashboard" },
+        },
+      },
+      {
+        applicationMetadata: {
+          kind: "manifest",
+          modulePath: manifestModulePath,
+          outputName: "manifest.webmanifest",
+        },
+      },
+    );
+
+    await renderer.renderPage(createMockRequest("/dashboard"), response);
+
+    expect(response.body).toContain('<link rel="manifest" href="/dashboard/manifest.webmanifest">');
   });
 
   it("renders and serves a fingerprinted static metadata image", async () => {
@@ -492,6 +554,11 @@ function createRenderer(
   options: {
     opengraphImage?: boolean;
     staticImage?: { modulePath: string; staticInfo: any };
+    applicationMetadata?: {
+      kind: "sitemap" | "robots" | "manifest";
+      modulePath: string;
+      outputName: "sitemap.xml" | "robots.txt" | "manifest.webmanifest";
+    };
     clientMetadata?: {
       isClientComponent: boolean;
       shouldHydrate: boolean;
@@ -523,7 +590,39 @@ function createRenderer(
       ],
     },
   };
+  const applicationMetadataEntry = options.applicationMetadata
+    ? {
+        pattern: "/dashboard",
+        modulePath: options.applicationMetadata.modulePath,
+        kind: options.applicationMetadata.kind,
+        fileName: options.applicationMetadata.kind,
+        outputName: options.applicationMetadata.outputName,
+        route: {
+          segments: [
+            {
+              segment: "dashboard",
+              isDynamic: false,
+              isCatchAll: false,
+              isOptional: false,
+            },
+          ],
+        },
+      }
+    : null;
   const routeManager = {
+    matchMetadataRoute(pathname: string) {
+      if (
+        !applicationMetadataEntry ||
+        pathname !== `/dashboard/${applicationMetadataEntry.outputName}`
+      ) {
+        return null;
+      }
+      return {
+        metadata: applicationMetadataEntry,
+        params: {},
+        routePath: "/dashboard",
+      };
+    },
     matchMetadataImage(pathname: string) {
       if (!options.opengraphImage || pathname !== "/dashboard/opengraph-image") {
         return null;
@@ -576,6 +675,17 @@ function createRenderer(
         image: metadataImageEntry,
         params: {},
       };
+    },
+    getMatchingMetadataRoute(_pathname: string, kind: string) {
+      if (!applicationMetadataEntry || applicationMetadataEntry.kind !== kind) return null;
+      return {
+        metadata: applicationMetadataEntry,
+        params: {},
+        routePath: "/dashboard",
+      };
+    },
+    resolveMetadataRoutePath() {
+      return applicationMetadataEntry ? `/dashboard/${applicationMetadataEntry.outputName}` : "";
     },
     resolveMetadataImagePath() {
       return options.staticImage

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -62,6 +62,7 @@ export * from "./middleware";
 export * from "./router";
 export * from "./route-rules";
 export * from "./route-runtime";
+export type { MetadataRoute, MetadataRouteContext } from "./metadata-route";
 export {
   createLayoutModuleFromProgrammaticLayout,
   createRoute,

--- a/packages/farm/src/metadata-route.ts
+++ b/packages/farm/src/metadata-route.ts
@@ -1,0 +1,250 @@
+export type ApplicationMetadataRouteKind = "sitemap" | "robots" | "manifest";
+
+export namespace MetadataRoute {
+  export type SitemapChangeFrequency =
+    | "always"
+    | "hourly"
+    | "daily"
+    | "weekly"
+    | "monthly"
+    | "yearly"
+    | "never";
+
+  export interface SitemapEntry {
+    url: string;
+    lastModified?: string | Date;
+    changeFrequency?: SitemapChangeFrequency;
+    priority?: number;
+    alternates?: {
+      languages?: Record<string, string>;
+    };
+  }
+
+  export type Sitemap = SitemapEntry[];
+
+  export interface RobotsRule {
+    userAgent: string | string[];
+    allow?: string | string[];
+    disallow?: string | string[];
+    crawlDelay?: number;
+  }
+
+  export interface Robots {
+    rules: RobotsRule | RobotsRule[];
+    sitemap?: string | string[];
+    host?: string;
+  }
+
+  export interface ManifestIcon {
+    src: string;
+    sizes?: string;
+    type?: string;
+    purpose?: string;
+  }
+
+  export interface Manifest {
+    name?: string;
+    short_name?: string;
+    description?: string;
+    id?: string;
+    start_url?: string;
+    scope?: string;
+    display?: "fullscreen" | "standalone" | "minimal-ui" | "browser" | string;
+    orientation?: string;
+    background_color?: string;
+    theme_color?: string;
+    lang?: string;
+    dir?: "ltr" | "rtl" | "auto";
+    categories?: string[];
+    icons?: ManifestIcon[];
+    [key: string]: unknown;
+  }
+}
+
+export interface MetadataRouteContext {
+  request: Request;
+  params: Record<string, string>;
+  searchParams: URLSearchParams;
+  /** The concrete route-segment path that owns the metadata file. */
+  path: string;
+}
+
+export interface FarmMetadataRouteModule {
+  revalidate?: number | false;
+}
+
+export interface FarmMetadataRouteResponseOptions {
+  method?: string;
+}
+
+function isResponse(value: unknown): value is Response {
+  return (
+    typeof Response !== "undefined" &&
+    (value instanceof Response ||
+      Boolean(
+        value &&
+        typeof value === "object" &&
+        typeof (value as Response).arrayBuffer === "function" &&
+        (value as Response).headers,
+      ))
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function resolveCacheControl(revalidate: number | false | undefined): string {
+  if (revalidate === false) {
+    return "public, max-age=31536000, immutable";
+  }
+  if (typeof revalidate === "number" && Number.isFinite(revalidate) && revalidate > 0) {
+    return `public, s-maxage=${Math.floor(revalidate)}, stale-while-revalidate=300`;
+  }
+  return "public, max-age=0, must-revalidate";
+}
+
+function escapeXml(value: unknown): string {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function serializeSitemap(value: unknown): string {
+  if (!Array.isArray(value)) {
+    throw new TypeError("sitemap.ts must return an array or a Response");
+  }
+
+  const entries = value.map((candidate, index) => {
+    if (!isRecord(candidate) || typeof candidate.url !== "string" || !candidate.url) {
+      throw new TypeError(`sitemap.ts entry ${index} must include a non-empty url`);
+    }
+    return candidate as unknown as MetadataRoute.SitemapEntry;
+  });
+  const hasLanguageAlternates = entries.some(
+    (entry) => entry.alternates?.languages && Object.keys(entry.alternates.languages).length > 0,
+  );
+  const namespace = hasLanguageAlternates ? ' xmlns:xhtml="http://www.w3.org/1999/xhtml"' : "";
+  const lines = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"${namespace}>`,
+  ];
+
+  for (const entry of entries) {
+    lines.push("  <url>", `    <loc>${escapeXml(entry.url)}</loc>`);
+    if (entry.lastModified !== undefined) {
+      const lastModified =
+        entry.lastModified instanceof Date ? entry.lastModified.toISOString() : entry.lastModified;
+      lines.push(`    <lastmod>${escapeXml(lastModified)}</lastmod>`);
+    }
+    if (entry.changeFrequency) {
+      lines.push(`    <changefreq>${escapeXml(entry.changeFrequency)}</changefreq>`);
+    }
+    if (entry.priority !== undefined) {
+      lines.push(`    <priority>${escapeXml(entry.priority)}</priority>`);
+    }
+    for (const [language, href] of Object.entries(entry.alternates?.languages || {})) {
+      lines.push(
+        `    <xhtml:link rel="alternate" hreflang="${escapeXml(language)}" href="${escapeXml(href)}" />`,
+      );
+    }
+    lines.push("  </url>");
+  }
+
+  lines.push("</urlset>");
+  return `${lines.join("\n")}\n`;
+}
+
+function toArray<T>(value: T | T[] | undefined): T[] {
+  return value === undefined ? [] : Array.isArray(value) ? value : [value];
+}
+
+function serializeRobots(value: unknown): string {
+  if (!isRecord(value)) {
+    throw new TypeError("robots.ts must return a robots object or a Response");
+  }
+
+  const robots = value as unknown as MetadataRoute.Robots;
+  const rules = toArray(robots.rules);
+  if (rules.length === 0) {
+    throw new TypeError("robots.ts must return at least one rule");
+  }
+
+  const sections = rules.map((rule, index) => {
+    if (!isRecord(rule)) {
+      throw new TypeError(`robots.ts rule ${index} must be an object`);
+    }
+    const userAgents = toArray(rule.userAgent).filter(
+      (userAgent): userAgent is string => typeof userAgent === "string" && Boolean(userAgent),
+    );
+    if (userAgents.length === 0) {
+      throw new TypeError(`robots.ts rule ${index} must include a userAgent`);
+    }
+
+    const lines = userAgents.map((userAgent) => `User-agent: ${userAgent}`);
+    for (const allow of toArray(rule.allow)) lines.push(`Allow: ${allow}`);
+    for (const disallow of toArray(rule.disallow)) lines.push(`Disallow: ${disallow}`);
+    if (rule.crawlDelay !== undefined) lines.push(`Crawl-delay: ${rule.crawlDelay}`);
+    return lines.join("\n");
+  });
+
+  const globalLines = [
+    ...toArray(robots.sitemap).map((sitemap) => `Sitemap: ${sitemap}`),
+    ...(robots.host ? [`Host: ${robots.host}`] : []),
+  ];
+  return `${[...sections, ...(globalLines.length ? [globalLines.join("\n")] : [])].join("\n\n")}\n`;
+}
+
+function serializeManifest(value: unknown): string {
+  if (!isRecord(value)) {
+    throw new TypeError("manifest.ts must return a manifest object or a Response");
+  }
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+/** @internal */
+export function createFarmMetadataRouteResponse(
+  kind: ApplicationMetadataRouteKind,
+  value: unknown,
+  routeModule: FarmMetadataRouteModule = {},
+  options: FarmMetadataRouteResponseOptions = {},
+): Response {
+  const method = (options.method || "GET").toUpperCase();
+  if (method !== "GET" && method !== "HEAD") {
+    return new Response(null, { status: 405, headers: { Allow: "GET, HEAD" } });
+  }
+
+  if (isResponse(value)) {
+    return method === "HEAD"
+      ? new Response(null, {
+          status: value.status,
+          statusText: value.statusText,
+          headers: value.headers,
+        })
+      : value;
+  }
+
+  const body =
+    kind === "sitemap"
+      ? serializeSitemap(value)
+      : kind === "robots"
+        ? serializeRobots(value)
+        : serializeManifest(value);
+  const contentType =
+    kind === "sitemap"
+      ? "application/xml; charset=utf-8"
+      : kind === "robots"
+        ? "text/plain; charset=utf-8"
+        : "application/manifest+json; charset=utf-8";
+
+  return new Response(method === "HEAD" ? null : body, {
+    headers: {
+      "Content-Type": contentType,
+      "Cache-Control": resolveCacheControl(routeModule.revalidate),
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/packages/farm/src/nitro/production-runtime.ts
+++ b/packages/farm/src/nitro/production-runtime.ts
@@ -19,6 +19,7 @@ export {
   stripFarmLocaleFromPathname,
 } from "../i18n/routing";
 export { addMetadataImageReference, mergeMetadata, renderMetadataHead } from "../metadata";
+export { createFarmMetadataRouteResponse } from "../metadata-route";
 export {
   applyProductionMiddlewareHeaders,
   createProductionMiddlewareRunner,

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -123,6 +123,12 @@ type UniversalMetadataImageRoute = {
   };
   data?: string;
 };
+type UniversalApplicationMetadataRoute = {
+  pattern: string;
+  kind: "sitemap" | "robots" | "manifest";
+  outputName: "sitemap.xml" | "robots.txt" | "manifest.webmanifest";
+  modulePath: string;
+};
 type UniversalMiddlewareRoute = {
   path: string;
   filePath: string;
@@ -2992,6 +2998,16 @@ async function buildSSRInMemory(
     });
   }
 
+  const applicationMetadataRoutes: UniversalApplicationMetadataRoute[] = Array.from(
+    routeManager.getMetadataRoutes().values(),
+    (entry) => ({
+      pattern: entry.pattern,
+      kind: entry.kind,
+      outputName: entry.outputName,
+      modulePath: entry.modulePath,
+    }),
+  );
+
   // Generate API route manifest
   const apiRoutes: Array<{
     path: string;
@@ -3059,7 +3075,7 @@ async function buildSSRInMemory(
   });
 
   logger.info(
-    `📋 Found ${pageRoutes.length} page routes, ${layoutRoutes.length} layouts, ${apiRoutes.length} API routes, and ${middlewareRoutes.length} middleware files`,
+    `📋 Found ${pageRoutes.length} page routes, ${layoutRoutes.length} layouts, ${apiRoutes.length} API routes, ${applicationMetadataRoutes.length} metadata routes, and ${middlewareRoutes.length} middleware files`,
   );
 
   const configuredIntegrationValues = Object.values(config.integrations || {});
@@ -3104,6 +3120,7 @@ async function buildSSRInMemory(
     routeSlots,
     errorRoutes,
     metadataImageRoutes,
+    applicationMetadataRoutes,
     middlewareRoutes,
     redirectRoutes,
     configuredRewrites,
@@ -3335,6 +3352,7 @@ function generateVirtualEntryCode(
   routeSlots: UniversalRouteSlot[],
   errorRoutes: UniversalBoundaryRoute[],
   metadataImageRoutes: UniversalMetadataImageRoute[],
+  applicationMetadataRoutes: UniversalApplicationMetadataRoute[],
   middlewareRoutes: UniversalMiddlewareRoute[],
   redirectRoutes: ProgrammaticRedirectRoute[],
   configuredRewriteRoutes: RewriteConfig[],
@@ -3507,6 +3525,20 @@ function generateVirtualEntryCode(
     metadataImageRegistrations.push(`  ${JSON.stringify(image)}`);
   });
 
+  const applicationMetadataImports: string[] = [];
+  const applicationMetadataRegistrations: string[] = [];
+  applicationMetadataRoutes.forEach((metadata, index) => {
+    const varName = `applicationMetadataRoute${index}`;
+    applicationMetadataImports.push(`import * as ${varName} from "${metadata.modulePath}";`);
+    applicationMetadataRegistrations.push(`
+  {
+    pattern: ${JSON.stringify(metadata.pattern)},
+    kind: ${JSON.stringify(metadata.kind)},
+    outputName: ${JSON.stringify(metadata.outputName)},
+    module: ${varName},
+  }`);
+  });
+
   // Generate imports for all app middleware files
   const middlewareImports: string[] = [];
   const middlewareRegistrations: string[] = [];
@@ -3543,6 +3575,7 @@ function generateVirtualEntryCode(
   createDefaultErrorMarkup,
   createFarmInstrumentationLifecycle,
   createFarmCacheKey,
+  createFarmMetadataRouteResponse,
   createFarmThemeDocumentParts,
   createFarmLocaleCookie,
   createFarmProductionLifecycle,
@@ -3756,6 +3789,7 @@ ${layoutImports.join("\n")}
 ${routeSlotImports.join("\n")}
 ${errorImports.join("\n")}
 ${metadataImageImports.join("\n")}
+${applicationMetadataImports.join("\n")}
 ${middlewareImports.join("\n")}
 ${notFoundImport}
 ${apiRouteHelpersImport}
@@ -4003,6 +4037,10 @@ const errorRoutes = [${errorRegistrations.join(",")}
 
 // Metadata image routes bundled at build time
 const metadataImageRoutes = [${metadataImageRegistrations.join(",")}
+];
+
+// sitemap.ts, robots.ts, and manifest.ts routes bundled at build time
+const applicationMetadataRoutes = [${applicationMetadataRegistrations.join(",")}
 ];
 
 // Redirect routes bundled at build time
@@ -4657,6 +4695,79 @@ async function handleMetadataImageRequest(request, routePathname) {
   }
 }
 
+function matchApplicationMetadataRouteRequest(pathname) {
+  const normalizedPath = normalizeRuntimePath(pathname);
+  for (const metadata of applicationMetadataRoutes) {
+    const suffix = "/" + metadata.outputName;
+    if (normalizedPath !== suffix && !normalizedPath.endsWith(suffix)) continue;
+    const routePath = normalizedPath.slice(0, -suffix.length) || "/";
+    const params = matchRuntimePathPattern(metadata.pattern, routePath);
+    if (params !== null) return { metadata, params, routePath };
+  }
+  return null;
+}
+
+function getMatchingApplicationMetadataRoute(pathname, kind) {
+  const normalizedPath = normalizeRuntimePath(pathname);
+  const pathSegments = splitRuntimePath(normalizedPath);
+  let bestMatch = null;
+
+  for (const metadata of applicationMetadataRoutes) {
+    if (metadata.kind !== kind) continue;
+    const patternDepth = splitRuntimePath(metadata.pattern).length;
+    if (patternDepth > pathSegments.length) continue;
+    const routePath = patternDepth === 0
+      ? "/"
+      : "/" + pathSegments.slice(0, patternDepth).join("/");
+    const params = matchRuntimePathPattern(metadata.pattern, routePath);
+    if (params === null) continue;
+    if (!bestMatch || patternDepth > bestMatch.depth) {
+      bestMatch = { metadata, params, routePath, depth: patternDepth };
+    }
+  }
+
+  return bestMatch;
+}
+
+function createApplicationMetadataHref(match, locale) {
+  const basePath = match.routePath === "/" ? "" : match.routePath;
+  const href = basePath + "/" + match.metadata.outputName;
+  return locale ? localizeFarmHref(href, locale, farmI18nConfig) : href;
+}
+
+async function handleApplicationMetadataRouteRequest(request, routePathname) {
+  const url = new URL(request.url);
+  const match = matchApplicationMetadataRouteRequest(routePathname || url.pathname);
+  if (!match) return null;
+
+  const method = request.method.toUpperCase();
+  if (method !== "GET" && method !== "HEAD") {
+    return new Response(null, { status: 405, headers: { Allow: "GET, HEAD" } });
+  }
+
+  try {
+    const routeModule = match.metadata.module;
+    if (routeModule?.default === undefined) {
+      throw new Error("Metadata route module does not export a default value or handler");
+    }
+    const value = typeof routeModule.default === "function"
+      ? await routeModule.default({
+          request,
+          params: match.params,
+          searchParams: url.searchParams,
+          path: match.routePath,
+        })
+      : routeModule.default;
+    return createFarmMetadataRouteResponse(match.metadata.kind, value, routeModule, { method });
+  } catch (error) {
+    console.error("Metadata route render failed:", error);
+    return new Response("Internal Server Error", {
+      status: 500,
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+  }
+}
+
 function encodeRuntimePathSegment(value) {
   return encodeURIComponent(String(value)).replace(
     /[!'()*]/g,
@@ -4887,7 +4998,11 @@ function hasLocalRequestRoute(request, routePathname) {
   if (matchLocalAPIRequest(request) || matchLocalIntegrationRequest(request)) {
     return true;
   }
-  if (matchPageRoute(routePathname) || matchMetadataImageRequest(routePathname)) {
+  if (
+    matchPageRoute(routePathname) ||
+    matchMetadataImageRequest(routePathname) ||
+    matchApplicationMetadataRouteRequest(routePathname)
+  ) {
     return true;
   }
   if (${imageRuntime === "none" ? "false" : `pathname === ${JSON.stringify(config.images.path)}`}) {
@@ -4961,6 +5076,18 @@ function getFarmPluginRequestOptions(request) {
         ...route,
         pattern: metadataImageMatch.image.pattern,
         params: metadataImageMatch.params,
+      },
+    };
+  }
+
+  const applicationMetadataMatch = matchApplicationMetadataRouteRequest(routePathname);
+  if (applicationMetadataMatch) {
+    return {
+      kind: "asset",
+      route: {
+        ...route,
+        pattern: applicationMetadataMatch.metadata.pattern,
+        params: applicationMetadataMatch.params,
       },
     };
   }
@@ -5419,6 +5546,20 @@ async function handleFarmRequestInContext(
       : ""
   }
 
+  ${
+    applicationMetadataRoutes.length > 0
+      ? `
+  const applicationMetadataResponse = await handleApplicationMetadataRouteRequest(
+    request.clone(),
+    routePathname
+  );
+  if (applicationMetadataResponse) {
+    return applyProductionMiddlewareHeaders(applicationMetadataResponse, middlewareHeaders);
+  }
+  `
+      : ""
+  }
+
   // Preserve the explicit JSON 404 for /api/* misses.
   if (pathname.startsWith("/api/")) {
     if (farmDocsAPIHandler) {
@@ -5794,6 +5935,16 @@ async function handleFarmRequestInContext(
             mergedMetadata,
             await route.module.generateMetadata(pageProps),
           );
+        }
+
+        if (!mergedMetadata.manifest) {
+          const manifestMatch = getMatchingApplicationMetadataRoute(routePathname, "manifest");
+          if (manifestMatch) {
+            mergedMetadata.manifest = createApplicationMetadataHref(
+              manifestMatch,
+              farmLocaleResolution?.locale,
+            );
+          }
         }
 
         for (const kind of ["opengraph", "twitter"]) {

--- a/packages/farm/src/nitro/vercel-route-runtime.ts
+++ b/packages/farm/src/nitro/vercel-route-runtime.ts
@@ -138,7 +138,7 @@ function compareRuntimeRoutes(
   left: FarmRouteRuntimeManifestEntry,
   right: FarmRouteRuntimeManifestEntry,
 ): number {
-  const kindOrder = { page: 0, api: 0, rule: 1 };
+  const kindOrder = { page: 0, api: 0, metadata: 0, rule: 1 };
   const kindDifference = kindOrder[left.kind] - kindOrder[right.kind];
   if (kindDifference !== 0) return kindDifference;
 

--- a/packages/farm/src/route-runtime-manifest.ts
+++ b/packages/farm/src/route-runtime-manifest.ts
@@ -64,6 +64,28 @@ export async function createFarmRouteRuntimeManifest(options: {
     });
   }
 
+  for (const entry of options.routeManager.getMetadataRoutes().values()) {
+    const routeModule = await options.routeManager.loadRouteModule(entry.modulePath);
+    const pattern =
+      entry.pattern === "/" ? `/${entry.outputName}` : `${entry.pattern}/${entry.outputName}`;
+    const inherited = resolveFarmRouteRuleRuntimeConfig(pattern, options.config.routeRules);
+    const own = normalizeFarmRouteRuntimeConfig(
+      getFarmRouteRuntimeConfig(routeModule),
+      `Metadata route "${pattern}"`,
+    );
+
+    routes.push({
+      kind: "metadata",
+      pattern,
+      rendering: "dynamic",
+      source: normalizeManifestSource(root, entry.modulePath),
+      ...resolveFarmRouteRuntimeConfig(
+        mergeFarmRouteRuntimeConfigs(inherited, own),
+        `Metadata route "${pattern}"`,
+      ),
+    });
+  }
+
   for (const [pattern, rule] of Object.entries(options.config.routeRules)) {
     if (!hasFarmRouteRuntimeControls(rule)) continue;
 

--- a/packages/farm/src/route-runtime.ts
+++ b/packages/farm/src/route-runtime.ts
@@ -15,7 +15,7 @@ export interface ResolvedFarmRouteRuntimeConfig {
   maxDuration?: number;
 }
 
-export type FarmRouteRuntimeEntryKind = "page" | "api" | "rule";
+export type FarmRouteRuntimeEntryKind = "page" | "api" | "metadata" | "rule";
 export type FarmRouteRenderingMode = "static" | "dynamic";
 
 export interface FarmRouteRuntimeManifestEntry extends ResolvedFarmRouteRuntimeConfig {

--- a/packages/farm/src/routing/route-manager.ts
+++ b/packages/farm/src/routing/route-manager.ts
@@ -62,6 +62,7 @@ import {
 import type { ResolvedFarmI18nConfig } from "../i18n/types";
 import { createRouteSlotContainerId, parseRouteSlotFile } from "./route-slots";
 import { getFarmRendererComponentExtensions } from "../renderer";
+import type { ApplicationMetadataRouteKind } from "../metadata-route";
 
 interface RouteEntry {
   route: ParsedRoute;
@@ -145,6 +146,12 @@ interface MetadataImageEntry extends RouteEntry {
   staticInfo?: StaticMetadataImageInfo;
 }
 
+export interface ApplicationMetadataRouteEntry extends RouteEntry {
+  kind: ApplicationMetadataRouteKind;
+  fileName: "sitemap" | "robots" | "manifest";
+  outputName: "sitemap.xml" | "robots.txt" | "manifest.webmanifest";
+}
+
 interface RedirectEntry {
   route: ParsedRoute;
   pattern: string;
@@ -170,6 +177,7 @@ export class RouteManager {
   private loadings: Map<string, RouteEntry> = new Map();
   private errors: Map<string, RouteEntry> = new Map();
   private metadataImages: Map<string, MetadataImageEntry> = new Map();
+  private metadataRoutes: Map<string, ApplicationMetadataRouteEntry> = new Map();
   private redirects: Map<string, RedirectEntry> = new Map();
   private programmaticPages: Map<string, ProgrammaticPageRoute> = new Map();
   private programmaticLayouts: Map<string, ProgrammaticLayoutRoute> = new Map();
@@ -200,6 +208,7 @@ export class RouteManager {
     this.loadings.clear();
     this.errors.clear();
     this.metadataImages.clear();
+    this.metadataRoutes.clear();
     this.redirects.clear();
     this.programmaticPages.clear();
     this.programmaticLayouts.clear();
@@ -222,10 +231,17 @@ export class RouteManager {
         ([, left], [, right]) => routeSpecificity(right) - routeSpecificity(left),
       ),
     );
+    this.metadataRoutes = new Map(
+      Array.from(this.metadataRoutes.entries()).sort(
+        ([, left], [, right]) => routeSpecificity(right) - routeSpecificity(left),
+      ),
+    );
 
     // Silent discovery - only log if verbose mode enabled
     if (process.env.FARM_VERBOSE) {
-      logger.info(`Discovered ${this.routes.size} pages and ${this.layouts.size} layouts`);
+      logger.info(
+        `Discovered ${this.routes.size} pages, ${this.layouts.size} layouts, and ${this.metadataRoutes.size} metadata routes`,
+      );
     }
 
     if (process.env.FARM_VERBOSE) {
@@ -344,6 +360,10 @@ export class RouteManager {
     return new Map(this.metadataImages);
   }
 
+  getMetadataRoutes(): Map<string, ApplicationMetadataRouteEntry> {
+    return new Map(this.metadataRoutes);
+  }
+
   getRedirects(): ProgrammaticRedirectRoute[] {
     return Array.from(this.redirects.values()).map((entry) => entry.definition);
   }
@@ -420,6 +440,68 @@ export class RouteManager {
     }
 
     return null;
+  }
+
+  matchMetadataRoute(pathname: string): {
+    metadata: ApplicationMetadataRouteEntry;
+    params: Record<string, string>;
+    routePath: string;
+  } | null {
+    const routePathname = this.toRoutePathname(pathname);
+    const normalizedPath = routePathname === "/" ? "/" : routePathname.replace(/\/$/, "");
+    const suffix = getApplicationMetadataRouteSuffix(normalizedPath);
+    if (!suffix) return null;
+
+    const routePath = normalizedPath.slice(0, -suffix.outputName.length - 1) || "/";
+    for (const metadata of this.metadataRoutes.values()) {
+      if (metadata.kind !== suffix.kind) continue;
+      const match = matchRoute(routePath, metadata.route.segments);
+      if (!match.matches) continue;
+      return { metadata, params: match.params, routePath };
+    }
+
+    return null;
+  }
+
+  getMatchingMetadataRoute(
+    pathname: string,
+    kind: ApplicationMetadataRouteKind,
+  ): {
+    metadata: ApplicationMetadataRouteEntry;
+    params: Record<string, string>;
+    routePath: string;
+  } | null {
+    const routePathname = this.toRoutePathname(pathname);
+    const normalizedPath = routePathname === "/" ? "/" : routePathname.replace(/\/$/, "");
+    const pathSegments = normalizedPath.split("/").filter(Boolean);
+    let bestMatch: {
+      metadata: ApplicationMetadataRouteEntry;
+      params: Record<string, string>;
+      routePath: string;
+    } | null = null;
+
+    for (const metadata of this.metadataRoutes.values()) {
+      if (metadata.kind !== kind || metadata.route.segments.length > pathSegments.length) continue;
+      const routePath =
+        metadata.route.segments.length === 0
+          ? "/"
+          : `/${pathSegments.slice(0, metadata.route.segments.length).join("/")}`;
+      const match = matchRoute(routePath, metadata.route.segments);
+      if (!match.matches) continue;
+      if (!bestMatch || metadata.route.segments.length > bestMatch.metadata.route.segments.length) {
+        bestMatch = { metadata, params: match.params, routePath };
+      }
+    }
+
+    return bestMatch;
+  }
+
+  resolveMetadataRoutePath(
+    metadata: ApplicationMetadataRouteEntry,
+    params: Record<string, string> = {},
+  ): string {
+    const routePath = routeSegmentsToPath(metadata.route.segments, params);
+    return routePath === "/" ? `/${metadata.outputName}` : `${routePath}/${metadata.outputName}`;
   }
 
   getMatchingMetadataImage(
@@ -665,6 +747,7 @@ export class RouteManager {
       `**/{opengraph-image,twitter-image}.{${componentGlob},png,jpg,jpeg,gif,webp}`,
       appDir,
     );
+    const metadataRouteFiles = await safeGlobFiles("**/{sitemap,robots,manifest}.{ts,js}", appDir);
 
     const canonicalPageGroups = new Map<
       string,
@@ -815,6 +898,33 @@ export class RouteManager {
         fileName,
         sourceType,
         staticInfo,
+        source: "file",
+        sourceRoot: source.root,
+      });
+    }
+
+    for (const file of metadataRouteFiles) {
+      const descriptor = getApplicationMetadataRouteDescriptor(
+        path.basename(file, path.extname(file)),
+      );
+      if (!descriptor) continue;
+      const route = parseRoutePath(file);
+      const modulePath = path.join(appDir, file);
+      const pattern = this.createRoutePattern(route);
+      const key = `${descriptor.kind}:${pattern}`;
+      const existing = this.metadataRoutes.get(key);
+
+      if (existing?.sourceRoot === source.root) {
+        throw new Error(
+          `Duplicate ${descriptor.fileName} route "${pattern}". Found both ${existing.modulePath} and ${modulePath}. Keep only one .ts or .js metadata route per segment.`,
+        );
+      }
+
+      this.metadataRoutes.set(key, {
+        route,
+        modulePath,
+        pattern,
+        ...descriptor,
         source: "file",
         sourceRoot: source.root,
       });
@@ -1202,6 +1312,39 @@ function getMetadataImageSuffix(pathname: string): {
     return { kind: "twitter", fileName: "twitter-image" };
   }
 
+  return null;
+}
+
+function getApplicationMetadataRouteDescriptor(fileName: string): {
+  kind: ApplicationMetadataRouteKind;
+  fileName: ApplicationMetadataRouteEntry["fileName"];
+  outputName: ApplicationMetadataRouteEntry["outputName"];
+} | null {
+  if (fileName === "sitemap") {
+    return { kind: "sitemap", fileName: "sitemap", outputName: "sitemap.xml" };
+  }
+  if (fileName === "robots") {
+    return { kind: "robots", fileName: "robots", outputName: "robots.txt" };
+  }
+  if (fileName === "manifest") {
+    return { kind: "manifest", fileName: "manifest", outputName: "manifest.webmanifest" };
+  }
+  return null;
+}
+
+function getApplicationMetadataRouteSuffix(pathname: string): {
+  kind: ApplicationMetadataRouteKind;
+  outputName: ApplicationMetadataRouteEntry["outputName"];
+} | null {
+  for (const fileName of ["sitemap", "robots", "manifest"] as const) {
+    const descriptor = getApplicationMetadataRouteDescriptor(fileName)!;
+    if (
+      pathname === `/${descriptor.outputName}` ||
+      pathname.endsWith(`/${descriptor.outputName}`)
+    ) {
+      return { kind: descriptor.kind, outputName: descriptor.outputName };
+    }
+  }
   return null;
 }
 

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -52,6 +52,7 @@ import { localizeFarmHref, localizeFarmPathname } from "../i18n/routing";
 import { sendWebResponse } from "./response";
 import { renderFarmFontDevHead } from "../font-vite";
 import { createFarmMetadataImageResponse } from "../metadata-image";
+import { createFarmMetadataRouteResponse } from "../metadata-route";
 import { DEFAULT_NOT_FOUND_STYLES } from "../components/not-found-styles";
 import {
   createDefaultErrorMarkup,
@@ -916,6 +917,13 @@ export class ServerRenderer {
       emitFarmEvent({ type: "render.start", route: pathname, pathname });
       searchParamsObject = searchParamsToObject(url.searchParams);
 
+      const metadataRouteMatch = this.routeManager.matchMetadataRoute(pathname);
+      if (metadataRouteMatch) {
+        await this.renderMetadataRoute(req, res, metadataRouteMatch);
+        completeRender(res.statusCode || 200, pathname);
+        return;
+      }
+
       const metadataImageMatch = this.routeManager.matchMetadataImage(pathname);
       if (metadataImageMatch) {
         await this.renderMetadataImage(req, res, {
@@ -1573,6 +1581,23 @@ export class ServerRenderer {
       );
     }
 
+    if (!metadata.manifest) {
+      const manifestMatch = this.routeManager.getMatchingMetadataRoute(
+        options.pathname,
+        "manifest",
+      );
+      if (manifestMatch) {
+        const rawHref = this.routeManager.resolveMetadataRoutePath(
+          manifestMatch.metadata,
+          manifestMatch.params,
+        );
+        const snapshot = getFarmI18nClientSnapshot();
+        metadata.manifest = snapshot
+          ? localizeFarmHref(rawHref, snapshot.locale, snapshot)
+          : rawHref;
+      }
+    }
+
     for (const kind of ["opengraph", "twitter"] as const) {
       const reference = await this.resolveMetadataImageReference(kind, options.pathname);
       if (reference) {
@@ -1626,6 +1651,54 @@ export class ServerRenderer {
     }
 
     return reference;
+  }
+
+  private async renderMetadataRoute(
+    req: FarmRequest,
+    res: FarmResponse,
+    match: NonNullable<ReturnType<RouteManager["matchMetadataRoute"]>>,
+  ): Promise<void> {
+    const method = (req.method || "GET").toUpperCase();
+    if (method !== "GET" && method !== "HEAD") {
+      res.statusCode = 405;
+      res.setHeader("Allow", "GET, HEAD");
+      res.end();
+      return;
+    }
+
+    try {
+      const routeModule = await this.routeManager.loadRouteModule(match.metadata.modulePath);
+      if (routeModule.default === undefined) {
+        throw new Error(
+          `Metadata route module ${match.metadata.modulePath} does not export a default value or handler`,
+        );
+      }
+
+      const request = createWebRequestFromFarmRequest(req);
+      const url = new URL(request.url);
+      const value =
+        typeof routeModule.default === "function"
+          ? await (routeModule.default as any)({
+              request,
+              params: match.params,
+              searchParams: url.searchParams,
+              path: match.routePath,
+            })
+          : routeModule.default;
+      const response = createFarmMetadataRouteResponse(match.metadata.kind, value, routeModule, {
+        method,
+      });
+      await sendWebResponse(res as any, response);
+    } catch (error) {
+      logger.error(`Metadata route render failed for ${match.metadata.modulePath}: ${error}`);
+      await sendWebResponse(
+        res as any,
+        new Response("Internal Server Error", {
+          status: 500,
+          headers: { "Content-Type": "text/plain; charset=utf-8" },
+        }),
+      );
+    }
   }
 
   private async renderMetadataImage(

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -729,7 +729,7 @@ export function farmPlugin(
         const normalized = file.replace(/\\/g, "/");
         return (
           appDirSlugs.some((appDir) => normalized.startsWith(`${appDir}/`)) &&
-          /\/(?:page|default|layout|loading|error|middleware|route)\.(?:ts|tsx|js|jsx|md|mdx)$|\/(?:opengraph-image|twitter-image)(?:\.(?:ts|tsx|js|jsx|png|jpg|jpeg|gif|webp)|\.alt\.txt)$/.test(
+          /\/(?:page|default|layout|loading|error|middleware|route)\.(?:ts|tsx|js|jsx|md|mdx)$|\/(?:sitemap|robots|manifest)\.(?:ts|js)$|\/(?:opengraph-image|twitter-image)(?:\.(?:ts|tsx|js|jsx|png|jpg|jpeg|gif|webp)|\.alt\.txt)$/.test(
             normalized,
           )
         );


### PR DESCRIPTION
## What changed

- Add `sitemap.ts`, `robots.ts`, and `manifest.ts` application metadata route conventions.
- Support literal exports, async resolver functions with route context, and explicit `Response` returns.
- Serialize typed sitemap, robots, and web app manifest values with route-appropriate content types and cache headers.
- Discover and bundle metadata routes in development, Node, and Vercel production runtimes, including nested and dynamic segments.
- Automatically link the nearest `manifest.ts` from rendered page metadata unless an explicit manifest is configured.
- Document the conventions and add unit, renderer, route-manager, runtime-manifest, and production middleware coverage.

## Why

Applications should be able to publish crawler and install metadata alongside their route tree without hand-writing API handlers or maintaining public files separately. The convention keeps these endpoints colocated, typed, and deployable through the same routing pipeline as the rest of the application.

## Behavior and compatibility

- `sitemap.ts` serves `sitemap.xml`, `robots.ts` serves `robots.txt`, and `manifest.ts` serves `manifest.webmanifest` within the same route segment.
- Metadata modules may export a value or a resolver function receiving `request`, `params`, `searchParams`, and `path`.
- `GET` and `HEAD` are supported; other methods return `405` with `Allow: GET, HEAD`.
- A positive `revalidate` export produces shared-cache headers, `false` produces immutable caching, and the default requires revalidation.
- Returning a `Response` is an escape hatch for custom output and headers.
- `feed.ts` is intentionally deferred until Farm defines whether the convention targets RSS, Atom, JSON Feed, or an explicit format selection.

## Validation

- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/core test` (1035 passed, 1 skipped)
- `pnpm lint` (0 errors; existing warnings only)
- `pnpm format:check`
- `pnpm docs:check-navigation`
- Production middleware fixture coverage for Vercel routing, dynamic params, middleware, cache headers, `HEAD`, and `405` behavior


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add sitemap.ts, robots.ts, and manifest.ts application metadata routes that serve /sitemap.xml, /robots.txt, and /manifest.webmanifest without custom handlers. Farm now auto-links the nearest manifest.ts into page heads; previously, pages included a manifest only if `metadata.manifest` was set.

- Routes accept a literal export or a function with `{ request, params, searchParams, path }`; returning a `Response` is supported for full control.
- Correct content types, XML escaping, language alternates (sitemap), and Cache-Control from `revalidate` (number => shared CDN, false => immutable, default => must-revalidate). GET and HEAD only; others return 405 with Allow.
- Discovers and bundles metadata routes across dev, Node, and Vercel, including nested and dynamic segments. Adds “metadata” entries to the route runtime manifest and updates the Vite file watcher.
- Server and production runtimes resolve and serve metadata routes and inject the closest manifest link if `metadata.manifest` is not set; hrefs localize with i18n.
- Exposes `MetadataRoute` and `MetadataRouteContext` from `@farm.js/core`. Includes documentation and test coverage for discovery, rendering, caching, HEAD, 405, and Vercel output.

- Migration: If you do not want an auto-linked manifest, set `metadata.manifest` explicitly or remove the nearest manifest.ts.

<sup>Written for commit fb4d979d42aefd28540a4058c122a703842c99ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

