### PR TITLE
feat(react): compile common component syntax

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -326,14 +326,15 @@ satisfy all of these rules:
 | Area                | Current supported shape                                                                                                                             |
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Component discovery | A top-level, capitalized function declaration, function expression, or arrow component in application `.tsx` or `.jsx`.                             |
-| Function shape      | Synchronous, non-generator, non-generic block body with zero parameters or one identifier such as `props`.                                          |
-| Body                | Top-level `useState` declarations, optional compiler-safe derived `const` values in source order, then one unconditional JSX return.                |
+| Function shape      | Synchronous, non-generator, non-generic block body with zero parameters, one props identifier, or flat object props destructuring.                  |
+| Props               | Flat object destructuring supports shorthand names, aliases, and defaults. Nested, computed, and rest patterns fall back.                           |
+| Body                | Top-level `useState` declarations, optional compiler-safe derived values and synchronous named handlers, then one unconditional JSX return.         |
 | State               | `const [value, setValue] = useState(initial)`, including lazy initializers, multiple cells, and queued functional updates.                          |
 | Root                | Exactly one lowercase host JSX element such as `button`, `section`, `input`, or `div`.                                                              |
 | Tree                | A static tree containing host elements only. Nested host elements are supported when their placement cannot change.                                 |
 | Text bindings       | State-driven text in a leaf host element.                                                                                                           |
 | Attribute bindings  | State-driven basic attributes and properties, including `className`, `htmlFor`, `data-*`, `aria-*`, `value`, `checked`, `selected`, and `disabled`. |
-| Events              | React-owned JSX event handlers. A compiled state setter must be called from a JSX event handler.                                                    |
+| Events              | React-owned inline handlers or synchronous `const` handlers passed directly to an event, such as `onClick={increment}`.                             |
 
 This component is eligible:
 
@@ -342,23 +343,24 @@ This component is eligible:
 
 import { useState } from "react";
 
-export function StatusButton(props: { initial: number }) {
-  const [count, setCount] = useState(props.initial);
+interface StatusButtonProps {
+  initial?: number;
+  label: string;
+}
+
+export function StatusButton({ initial = 0, label: title }: StatusButtonProps) {
+  const [count, setCount] = useState(initial);
   const [active, setActive] = useState(false);
   const statusClass = active ? "active" : "idle";
-  const label = `Count: ${count}`;
+  const visibleLabel = `${title}: ${count}`;
+  const update = () => {
+    setCount((value) => value + 1);
+    setActive((value) => !value);
+  };
 
   return (
-    <button
-      aria-pressed={active}
-      className={statusClass}
-      data-count={count}
-      onClick={() => {
-        setCount((value) => value + 1);
-        setActive((value) => !value);
-      }}
-    >
-      {label}
+    <button aria-pressed={active} className={statusClass} data-count={count} onClick={update}>
+      {visibleLabel}
     </button>
   );
 }
@@ -373,6 +375,13 @@ conditionals, templates, and earlier derived values. State declarations must com
 assignments, object or array literals, functions, JSX, constructors, and other expressions whose
 evaluation or identity cannot be preserved safely still fall back to React.
 
+For destructured props, the original component wrapper still performs JavaScript destructuring on
+every parent render. Defaults therefore apply only to `undefined`, aliases keep their normal local
+names, and the resolved values are passed to the compiled definition. A named handler is expanded
+at build time only when it is synchronous and passed directly to a JSX event. Its state reads and
+setters then use the same compiler cells as an equivalent inline handler. Indirect calls such as
+`onClick={() => increment()}` stay on React until the compiler can prove their closure semantics.
+
 ### What falls back to React
 
 | Unsupported shape                                                      | Why React keeps ownership                                                           |
@@ -386,7 +395,9 @@ evaluation or identity cannot be preserved safely still fall back to React.
 | JSX attribute spreads or namespaced attributes                         | The compiler cannot currently enumerate a stable binding contract.                  |
 | Multiple/conditional returns or impure/control-flow statements         | The compiler only lowers a single, statically analyzable render path.               |
 | Derived calls, assignments, identity-bearing values, functions, or JSX | Their evaluation timing, side effects, or identity cannot yet be preserved safely.  |
-| Destructured props, async/generator, or generic components             | These function shapes are outside the current lowering.                             |
+| Nested, computed, or rest props destructuring                          | These patterns need additional parameter-shape and identity analysis.               |
+| Async/generator handlers or indirect named-handler calls               | Their scheduling and closure semantics are outside the current lowering.            |
+| Async/generator or generic components                                  | These function shapes are outside the current lowering.                             |
 | Setters called outside JSX event handlers                              | The compiler only controls and batches event-driven local updates.                  |
 
 Keys do not make list reconciliation unnecessary. A key tells React which child identity survives

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -16,6 +16,12 @@ const compilerReport = JSON.parse(await readFile(compilerReportPath, "utf8"));
 
 assert.equal(compilerReport.version, 1);
 assert.ok(compilerReport.summary.compiled >= 1);
+const compiledComponents = new Set(
+  compilerReport.modules.flatMap((module) => module.compiled),
+);
+for (const component of ["CommonSyntaxCounter", "ControlledSyntax"]) {
+  assert.ok(compiledComponents.has(component), `${component} was not compiled`);
+}
 
 let serverOutput = "";
 const server = spawn(process.execPath, [serverEntry], {
@@ -149,6 +155,86 @@ try {
       .evaluate((element) => element.classList.contains("edge-card--active")),
   );
 
+  const common = '[data-experiment="common-syntax"]';
+  const commonInitialExecutions = await readNumber(
+    page,
+    `${common} [data-metric="executions"]`,
+  );
+  await assertText(page, `${common} h3`, "Alpha counter");
+  await assertText(page, `${common} [data-metric="count"]`, "2");
+  await assertText(page, `${common} [data-metric="doubled"]`, "4");
+  await assertText(page, '[data-metric="parent-commit"]', "Last parent commit: -1");
+
+  await page.locator(`${common} [data-action="commit"]`).click();
+  await assertText(page, `${common} h3`, "Beta counter");
+  await assertText(page, `${common} [data-metric="count"]`, "3");
+  await assertText(page, `${common} [data-metric="doubled"]`, "6");
+  await assertText(page, '[data-metric="parent-commit"]', "Last parent commit: 4");
+  assert.equal(await page.locator(common).getAttribute("data-count"), "3");
+  assert.equal(await page.locator(common).getAttribute("data-status"), "active");
+  assert.equal(
+    await page.locator(`${common} [data-action="commit"]`).getAttribute("aria-pressed"),
+    "true",
+  );
+
+  await page.locator(`${common} [data-action="commit"]`).click();
+  await assertText(page, `${common} h3`, "Alpha counter");
+  await assertText(page, `${common} [data-metric="count"]`, "4");
+  await assertText(page, `${common} [data-metric="doubled"]`, "8");
+  await assertText(page, '[data-metric="parent-commit"]', "Last parent commit: 6");
+  const commonFinalExecutions = await readNumber(
+    page,
+    `${common} [data-metric="executions"]`,
+  );
+  assert.equal(commonFinalExecutions - commonInitialExecutions, 2);
+
+  const controlled = '[data-experiment="controlled-syntax"]';
+  const controlledInput = page.locator(`${controlled} [data-input="controlled"]`);
+  const controlledInitialExecutions = await readNumber(
+    page,
+    `${controlled} [data-metric="executions"]`,
+  );
+  await assertText(page, `${controlled} label`, "Display name");
+  await assertText(page, `${controlled} [data-metric="value"]`, "empty");
+  await controlledInput.fill("abcd");
+  await assertText(page, `${controlled} [data-metric="value"]`, "abcd");
+  await assertText(page, `${controlled} [data-metric="length"]`, "4");
+
+  await controlledInput.evaluate((input) => {
+    input.focus();
+    input.setSelectionRange(2, 2);
+  });
+  await page.keyboard.insertText("X");
+  await assertText(page, `${controlled} [data-metric="value"]`, "abXcd");
+  assert.deepEqual(
+    await controlledInput.evaluate((input) => [input.selectionStart, input.selectionEnd]),
+    [3, 3],
+  );
+
+  await controlledInput.evaluate((input) => {
+    input.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true }));
+    input.value = "日本";
+    input.dispatchEvent(
+      new InputEvent("input", {
+        bubbles: true,
+        composed: true,
+        data: "日本",
+        inputType: "insertCompositionText",
+        isComposing: true,
+      }),
+    );
+    input.dispatchEvent(
+      new CompositionEvent("compositionend", { bubbles: true, data: "日本" }),
+    );
+  });
+  await assertText(page, `${controlled} [data-metric="value"]`, "日本");
+  await assertText(page, `${controlled} [data-metric="length"]`, "2");
+  const controlledFinalExecutions = await readNumber(
+    page,
+    `${controlled} [data-metric="executions"]`,
+  );
+  assert.equal(controlledFinalExecutions - controlledInitialExecutions, 0);
+
   const keyed = '[data-experiment="keyed-fallback"]';
   const keyedInitialExecutions = await readNumber(
     page,
@@ -205,6 +291,21 @@ try {
             input: "value-1",
             updateExecutions:
               multipleFinalExecutions - multipleInitialExecutions,
+          },
+          commonSyntax: {
+            count: 4,
+            doubled: 8,
+            parentCommit: 6,
+            propDrivenExecutions:
+              commonFinalExecutions - commonInitialExecutions,
+          },
+          controlledInput: {
+            value: "日本",
+            length: 2,
+            updateExecutions:
+              controlledFinalExecutions - controlledInitialExecutions,
+            selectionPreserved: true,
+            compositionObserved: true,
           },
           keyedFallback: {
             items: 3,

--- a/examples/react-compiler/src/app/page.tsx
+++ b/examples/react-compiler/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { CompilerComparison } from "../components/compiler-comparison";
 import { CompilerEdgeLab } from "../components/compiler-edge-lab";
+import { CommonSyntaxExperiment } from "../components/common-syntax-experiment";
 import { HeavyInteractionBenchmark } from "../components/heavy-interaction-benchmark";
 
 export default function HomePage() {
@@ -57,6 +58,8 @@ export default function HomePage() {
       </section>
 
       <CompilerEdgeLab />
+
+      <CommonSyntaxExperiment />
 
       <HeavyInteractionBenchmark />
 

--- a/examples/react-compiler/src/components/common-syntax-experiment.tsx
+++ b/examples/react-compiler/src/components/common-syntax-experiment.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+
+let commonSyntaxExecutions = 0;
+let controlledInputExecutions = 0;
+
+interface CommonSyntaxCounterProps {
+  initial?: number;
+  label: string;
+  onCommit(value: number): void;
+}
+
+export function CommonSyntaxCounter({
+  initial = 2,
+  label: title,
+  onCommit,
+}: CommonSyntaxCounterProps) {
+  const [count, setCount] = useState(initial);
+  const [active, setActive] = useState(false);
+  const doubled = count * 2;
+  const status = active ? "active" : "idle";
+  const commit = () => {
+    onCommit(doubled);
+    setCount((value) => value + 1);
+    setActive((value) => !value);
+  };
+
+  return (
+    <article
+      className={active ? "edge-card edge-card--active" : "edge-card"}
+      data-count={count}
+      data-experiment="common-syntax"
+      data-status={status}
+    >
+      <header>
+        <span className="experiment-number">05A</span>
+        <div>
+          <h3>{title} counter</h3>
+          <p>Default and aliased props with one named event handler.</p>
+        </div>
+      </header>
+      <dl className="compact-metrics" aria-live="polite">
+        <div>
+          <dt>Count</dt>
+          <dd data-metric="count">{count}</dd>
+        </div>
+        <div>
+          <dt>Doubled</dt>
+          <dd data-metric="doubled">{doubled}</dd>
+        </div>
+        <div>
+          <dt>Executions</dt>
+          <dd data-metric="executions">
+            {typeof window === "undefined" ? 1 : ++commonSyntaxExecutions}
+          </dd>
+        </div>
+      </dl>
+      <button
+        aria-pressed={active}
+        data-action="commit"
+        type="button"
+        onClick={commit}
+      >
+        Commit named update
+      </button>
+    </article>
+  );
+}
+
+interface ControlledSyntaxProps {
+  label?: string;
+}
+
+export function ControlledSyntax({
+  label: fieldLabel = "Display name",
+}: ControlledSyntaxProps) {
+  const [value, setValue] = useState("");
+  const length = value.length;
+  const visibleValue = value || "empty";
+  const update = (event: FormEvent<HTMLInputElement>) => {
+    setValue(event.currentTarget.value);
+  };
+
+  return (
+    <article className="edge-card" data-experiment="controlled-syntax">
+      <header>
+        <span className="experiment-number">05B</span>
+        <div>
+          <h3>Controlled named input</h3>
+          <p>A typed handler keeps value, text, and selection coherent.</p>
+        </div>
+      </header>
+      <label className="binding-preview">
+        {fieldLabel}
+        <input data-input="controlled" value={value} onInput={update} />
+      </label>
+      <dl className="compact-metrics" aria-live="polite">
+        <div>
+          <dt>Value</dt>
+          <dd data-metric="value">{visibleValue}</dd>
+        </div>
+        <div>
+          <dt>Length</dt>
+          <dd data-metric="length">{length}</dd>
+        </div>
+        <div>
+          <dt>Executions</dt>
+          <dd data-metric="executions">
+            {typeof window === "undefined" ? 1 : ++controlledInputExecutions}
+          </dd>
+        </div>
+      </dl>
+    </article>
+  );
+}
+
+export function CommonSyntaxExperiment() {
+  "use no compiler";
+
+  const [label, setLabel] = useState("Alpha");
+  const [committed, setCommitted] = useState(-1);
+
+  return (
+    <section className="edge-lab" aria-labelledby="common-syntax-title">
+      <div className="section-heading">
+        <span>COMMON SYNTAX / BROWSER PROOF</span>
+        <h2 id="common-syntax-title">Normal component code, prepared bindings.</h2>
+        <p>
+          These production-hydrated cases exercise prop defaults and aliases,
+          named handlers, parent and local updates in one event, and controlled
+          input behavior.
+        </p>
+      </div>
+      <p data-metric="parent-commit">Last parent commit: {committed}</p>
+      <div className="edge-grid edge-grid--paired">
+        <CommonSyntaxCounter
+          label={label}
+          onCommit={(value) => {
+            setCommitted(value);
+            setLabel((current) => (current === "Alpha" ? "Beta" : "Alpha"));
+          }}
+        />
+        <ControlledSyntax />
+      </div>
+    </section>
+  );
+}

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -54,8 +54,10 @@ The directive is configurable and only has meaning in annotation mode.
 The current compiler handles components that it can prove have:
 
 - one host-element root and a static host-element tree;
+- an identifier props parameter or flat object destructuring with aliases and defaults;
 - top-level `useState` declarations;
 - optional compiler-safe derived `const` values declared after state and in source order;
+- optional synchronous `const` event handlers passed directly to JSX events;
 - state-driven text and basic attribute/property bindings;
 - React-managed event handlers; and
 - no refs, effects, custom child components, keyed lists, or conditional child structure.
@@ -86,5 +88,6 @@ second component render and commit, while the compiled component remains at one 
 commit and updates its two bindings directly. This is a deterministic structural performance
 assertion; it is not presented as a cross-machine timing benchmark.
 
-Keyed list lowering, structural conditionals, effects, and more advanced hook support intentionally
-stay on React in this release.
+Nested, computed, and rest props patterns; indirect or async handlers; keyed list lowering;
+structural conditionals; effects; and more advanced hook support intentionally stay on React in
+this release.

--- a/packages/farm-react/src/__tests__/compiler-edge-cases.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-edge-cases.test.ts
@@ -184,6 +184,105 @@ describe("React AOT compiler safety boundaries", () => {
     expect(result.diagnostics[0]?.reason).toMatch(reason);
   });
 
+  it.each([
+    {
+      name: "nested props",
+      parameter: "{ user: { name } }",
+      reason: /nested component props destructuring/i,
+    },
+    {
+      name: "rest props",
+      parameter: "{ initial, ...rest }",
+      reason: /rest properties in component props destructuring/i,
+    },
+    {
+      name: "computed props",
+      parameter: '{ ["initial"]: initial }',
+      reason: /computed component props destructuring/i,
+    },
+    {
+      name: "a defaulted props object",
+      parameter: "{ initial } = { initial: 0 }",
+      reason: /zero parameters, one props identifier, or flat object props destructuring/i,
+    },
+  ])("falls back for $name", async ({ parameter, reason }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function PropsBoundary(${parameter}) {
+        const [count, setCount] = useState(initial ?? 0);
+        return <button onClick={() => setCount(count + 1)}>{count}</button>;
+      }
+    `);
+
+    expect(result.compiled).toEqual([]);
+    expect(result.diagnostics[0]?.reason).toMatch(reason);
+    expect(result.code).not.toContain("compiler-runtime");
+  });
+
+  it.each([
+    {
+      name: "an async handler",
+      declaration: "const increment = async () => setCount(count + 1);",
+      event: "increment",
+      reason: /event handler increment must be synchronous/i,
+    },
+    {
+      name: "a generator handler",
+      declaration: "const increment = function* () { setCount(count + 1); };",
+      event: "increment",
+      reason: /event handler increment must be synchronous/i,
+    },
+    {
+      name: "an indirectly invoked handler",
+      declaration: "const increment = () => setCount(count + 1);",
+      event: "() => increment()",
+      reason: /must be passed directly to a JSX event/i,
+    },
+    {
+      name: "a handler exposed as a child",
+      declaration: "const increment = () => setCount(count + 1);",
+      event: "increment",
+      child: "{increment}",
+      reason: /must be passed directly to a JSX event/i,
+    },
+    {
+      name: "a handler that reads a later derived value",
+      declaration: "const increment = () => setCount(next); const next = count + 1;",
+      event: "increment",
+      reason: /event handler increment can only reference earlier derived local values/i,
+    },
+  ])("falls back for $name", async ({ declaration, event, child = "{count}", reason }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function HandlerBoundary() {
+        const [count, setCount] = useState(0);
+        ${declaration}
+        return <button onClick={${event}}>${child}</button>;
+      }
+    `);
+
+    expect(result.compiled).toEqual([]);
+    expect(result.diagnostics[0]?.reason).toMatch(reason);
+    expect(result.code).not.toContain("compiler-runtime");
+  });
+
+  it("preserves handler parameter shadowing while rewriting destructured props", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Shadowed({ value: label }) {
+        const [value, setValue] = useState(0);
+        const update = (label) => setValue(label.currentTarget.value.length);
+        return <input aria-label={label} value={value} onInput={update} />;
+      }
+    `);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.compiled).toEqual(["Shadowed"]);
+    expect(result.code).toMatch(/props\.label/);
+    expect(result.code).toContain("label.currentTarget.value.length");
+    expect(result.code).not.toMatch(/props\.label\.currentTarget/);
+  });
+
   it("falls back for hooks placed inside keyed list iteration", async () => {
     const result = await compile(`
       import { useState } from "react";

--- a/packages/farm-react/src/__tests__/compiler-runtime-hardening.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-hardening.test.tsx
@@ -317,6 +317,20 @@ describe("compiled React runtime hardening", () => {
     expect(input.getAttribute("data-composing")).toBe("true");
 
     await act(async () => {
+      input.focus();
+      input.value = "faXrm";
+      input.setSelectionRange(3, 3);
+      input.dispatchEvent(new InputEvent("input", { bubbles: true, data: "X" }));
+      // Model React's controlled-input restoration before the compiler's
+      // queued binding flush. The runtime must restore the event-time caret.
+      input.value = "";
+      await flushCompilerUpdates();
+    });
+    expect(input.value).toBe("faXrm");
+    expect(input.selectionStart).toBe(3);
+    expect(input.selectionEnd).toBe(3);
+
+    await act(async () => {
       input.dispatchEvent(new Event("compositionend", { bubbles: true }));
       await flushCompilerUpdates();
     });

--- a/packages/farm-react/src/__tests__/compiler.test.ts
+++ b/packages/farm-react/src/__tests__/compiler.test.ts
@@ -84,6 +84,83 @@ describe("React AOT compiler", () => {
     });
   });
 
+  it("compiles destructured props and named synchronous event handlers", async () => {
+    const result = await compileReactModule(
+      `
+        import { useState } from "react";
+        interface CounterProps {
+          initial?: number;
+          label: string;
+          onCommit(value: number): void;
+        }
+        export function CommonCounter({
+          initial = 1,
+          label: title,
+          onCommit,
+        }: CounterProps) {
+          const [count, setCount] = useState(initial);
+          const [active, setActive] = useState(false);
+          const doubled = count * 2;
+          const increment = () => {
+            onCommit(doubled);
+            setCount((value) => value + 1);
+            setActive(!active);
+          };
+          return (
+            <button
+              className={active ? "active" : "idle"}
+              data-count={doubled}
+              onClick={increment}
+            >{title}: {doubled}</button>
+          );
+        }
+      `,
+      "/app/CommonCounter.tsx",
+      infer,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.compiled).toEqual(["CommonCounter"]);
+    expect(result.code).toContain("initial = 1");
+    expect(result.code).toContain("label: title");
+    expect(result.code).not.toContain("const increment");
+    expect(result.code).toMatch(/props\.initial/);
+    expect(result.code).toMatch(/props\.title/);
+    expect(result.code).toMatch(/props\.onCommit/);
+    expect(result.code).toMatch(/farmState\[0\]\.set/);
+    expect(result.code).toMatch(/farmState\[1\]\.set/);
+    await expect(
+      transformWithEsbuild(result.code, "/app/CommonCounter.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("createCompiledComponent"),
+    });
+  });
+
+  it("compiles a named function expression used directly as an event", async () => {
+    const result = await compileReactModule(
+      `
+        import { useState } from "react";
+        export const Toggle = ({ initial: start = false }) => {
+          const [active, setActive] = useState(start);
+          const toggle = function toggle() {
+            setActive((value) => !value);
+          };
+          return <button aria-pressed={active} onClick={toggle}>{active ? "on" : "off"}</button>;
+        };
+      `,
+      "/app/Toggle.tsx",
+      infer,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.compiled).toEqual(["Toggle"]);
+    expect(result.code).not.toContain("const toggle");
+    expect(result.code).toMatch(/props\.start/);
+  });
+
   it("only compiles selected components in annotation mode", async () => {
     const result = await compileReactModule(
       `

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -11,6 +11,13 @@ interface RuntimeCell extends CompilerCell {
   flush(): boolean;
 }
 
+interface InputSelectionSnapshot {
+  element: HTMLInputElement;
+  start: number;
+  end: number;
+  direction: "forward" | "backward" | "none";
+}
+
 export interface CompilerTextBinding<Props> {
   kind: "text";
   path: readonly number[];
@@ -82,7 +89,8 @@ function updateAttribute(element: Element, name: string, value: unknown): void {
   const stringifiesBoolean = attributeName.startsWith("data-") || attributeName.startsWith("aria-");
 
   if (name === "value" && element instanceof HTMLInputElement) {
-    element.value = value === null || value === undefined ? "" : String(value);
+    const nextValue = value === null || value === undefined ? "" : String(value);
+    if (element.value !== nextValue) element.value = nextValue;
     return;
   }
 
@@ -140,6 +148,7 @@ export function createCompiledComponent<Props>(
     private flushQueued = false;
     private bindingError: unknown;
     private hasBindingError = false;
+    private inputSelection: InputSelectionSnapshot | null = null;
     private readonly dirtyState = new Set<number>();
     private readonly cells: RuntimeCell[];
 
@@ -174,12 +183,44 @@ export function createCompiledComponent<Props>(
       if (this.mounted) this.forceUpdate();
     };
 
+    private captureInputSelection(): void {
+      const active = this.root?.ownerDocument.activeElement;
+      if (
+        !(active instanceof HTMLInputElement) ||
+        !this.root?.contains(active) ||
+        active.selectionStart === null ||
+        active.selectionEnd === null
+      ) {
+        return;
+      }
+      this.inputSelection = {
+        element: active,
+        start: active.selectionStart,
+        end: active.selectionEnd,
+        direction: active.selectionDirection || "none",
+      };
+    }
+
+    private restoreInputSelection(snapshot: InputSelectionSnapshot | null): void {
+      if (
+        !snapshot ||
+        !snapshot.element.isConnected ||
+        snapshot.element.ownerDocument.activeElement !== snapshot.element
+      ) {
+        return;
+      }
+      snapshot.element.setSelectionRange(snapshot.start, snapshot.end, snapshot.direction);
+    }
+
     private scheduleBindingFlush(index: number): void {
       this.dirtyState.add(index);
+      this.captureInputSelection();
       if (!this.mounted || this.flushQueued) return;
       this.flushQueued = true;
       queueMicrotask(() => {
         this.flushQueued = false;
+        const inputSelection = this.inputSelection;
+        this.inputSelection = null;
         if (!this.mounted) return;
         const dirty = new Set<number>();
         for (const index of this.dirtyState) {
@@ -193,6 +234,7 @@ export function createCompiledComponent<Props>(
               this.applyBinding(binding);
             }
           }
+          this.restoreInputSelection(inputSelection);
         } catch (error) {
           this.bindingError = error;
           this.hasBindingError = true;
@@ -229,6 +271,7 @@ export function createCompiledComponent<Props>(
       this.mounted = false;
       this.root = null;
       this.dirtyState.clear();
+      this.inputSelection = null;
       refreshListeners.delete(this.refreshDefinition);
     }
 

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -21,9 +21,21 @@ interface StateBinding {
   initialValue?: t.Expression;
 }
 
-interface DerivedBinding {
+interface HandlerBinding {
+  name: string;
+  value: t.ArrowFunctionExpression | t.FunctionExpression;
+}
+
+interface LocalBinding {
+  kind: "derived" | "handler";
   name: string;
   value: t.Expression;
+}
+
+interface PropsPlan {
+  definitionParameter: t.Identifier;
+  wrapperProps?: t.Expression;
+  destructuredNames: ReadonlySet<string>;
 }
 
 interface PendingBinding {
@@ -126,6 +138,59 @@ function rewriteDerivedAccess<T extends t.Expression>(
     },
   });
   return (file.program.body[0] as t.ExpressionStatement).expression as T;
+}
+
+function rewriteDestructuredPropAccess<T extends t.Expression>(
+  expression: T,
+  names: ReadonlySet<string>,
+  propsParameter: t.Identifier,
+): T {
+  if (names.size === 0) return cloneExpression(expression);
+  const file = expressionFile(cloneExpression(expression));
+  traverse(file, {
+    ReferencedIdentifier(path) {
+      if (!names.has(path.node.name) || path.scope.hasBinding(path.node.name)) return;
+      path.replaceWith(
+        t.memberExpression(t.cloneNode(propsParameter), t.identifier(path.node.name)),
+      );
+      path.skip();
+    },
+  });
+  return (file.program.body[0] as t.ExpressionStatement).expression as T;
+}
+
+function rewriteHandlerAccess(
+  root: t.JSXElement,
+  handlersByName: ReadonlyMap<string, HandlerBinding>,
+): { root?: t.JSXElement; reason?: string } {
+  if (handlersByName.size === 0) return { root: t.cloneNode(root, true) };
+  const file = expressionFile(t.cloneNode(root, true));
+  let reason: string | undefined;
+  traverse(file, {
+    ReferencedIdentifier(path) {
+      if (reason || path.scope.hasBinding(path.node.name)) return;
+      const handler = handlersByName.get(path.node.name);
+      if (!handler) return;
+      const container = path.parentPath;
+      const attribute = container.parentPath;
+      const eventName = attribute?.isJSXAttribute() && jsxAttributeName(attribute.node);
+      if (
+        !container.isJSXExpressionContainer() ||
+        container.node.expression !== path.node ||
+        !eventName ||
+        !/^on[A-Z]/.test(eventName)
+      ) {
+        reason = `event handler ${handler.name} must be passed directly to a JSX event`;
+        path.stop();
+        return;
+      }
+      path.replaceWith(t.cloneNode(handler.value, true));
+      path.skip();
+    },
+  });
+  return reason
+    ? { reason }
+    : { root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement };
 }
 
 function validateDerivedExpression(expression: t.Expression): string | undefined {
@@ -400,18 +465,65 @@ function lazyInitialValue(expression?: t.Expression): t.Expression {
   );
 }
 
-function clonePropsParameter(
+function analyzePropsParameter(
   path: NodePath<t.FunctionDeclaration | t.FunctionExpression | t.ArrowFunctionExpression>,
-): t.Identifier {
+): PropsPlan | string {
   const parameter = path.node.params[0];
-  return parameter && t.isIdentifier(parameter)
-    ? (t.cloneNode(parameter, true) as t.Identifier)
-    : t.identifier("_props");
+  if (!parameter) {
+    return {
+      definitionParameter: path.scope.generateUidIdentifier("props"),
+      destructuredNames: new Set(),
+    };
+  }
+  if (t.isIdentifier(parameter)) {
+    return {
+      definitionParameter: t.cloneNode(parameter, true) as t.Identifier,
+      wrapperProps: t.cloneNode(parameter, true) as t.Identifier,
+      destructuredNames: new Set(),
+    };
+  }
+  if (!t.isObjectPattern(parameter)) {
+    return "components must use zero parameters, one props identifier, or flat object props destructuring";
+  }
+
+  const localNames = new Set<string>();
+  for (const property of parameter.properties) {
+    if (t.isRestElement(property)) {
+      return "rest properties in component props destructuring are not supported yet";
+    }
+    if (property.computed) {
+      return "computed component props destructuring is not supported yet";
+    }
+    let local: t.Identifier | undefined;
+    if (t.isIdentifier(property.value)) {
+      local = property.value;
+    } else if (t.isAssignmentPattern(property.value) && t.isIdentifier(property.value.left)) {
+      local = property.value.left;
+    }
+    if (!local) {
+      return "nested component props destructuring is not supported yet";
+    }
+    if (localNames.has(local.name)) {
+      return "component props destructuring local names must be unique";
+    }
+    localNames.add(local.name);
+  }
+
+  const definitionParameter = path.scope.generateUidIdentifier("props");
+  return {
+    definitionParameter,
+    wrapperProps: t.objectExpression(
+      [...localNames].map((name) =>
+        t.objectProperty(t.identifier(name), t.identifier(name), false, true),
+      ),
+    ),
+    destructuredNames: localNames,
+  };
 }
 
 function bindingObject(
   binding: PendingBinding,
-  componentPath: Candidate["path"],
+  propsParameter: t.Identifier,
   stateParameter: t.Identifier,
   statesByValue: ReadonlyMap<string, StateBinding>,
   statesBySetter: ReadonlyMap<string, StateBinding>,
@@ -433,7 +545,7 @@ function bindingObject(
     t.objectProperty(
       t.identifier("read"),
       t.arrowFunctionExpression(
-        [clonePropsParameter(componentPath), t.cloneNode(stateParameter)],
+        [t.cloneNode(propsParameter), t.cloneNode(stateParameter)],
         rewriteStateAccess(binding.value, stateParameter, statesByValue, statesBySetter),
       ),
     ),
@@ -441,7 +553,7 @@ function bindingObject(
   return t.objectExpression(properties);
 }
 
-function wrapperElement(definitionIdentifier: t.Identifier, props?: t.Identifier): t.JSXElement {
+function wrapperElement(definitionIdentifier: t.Identifier, props?: t.Expression): t.JSXElement {
   const name = t.jsxIdentifier(definitionIdentifier.name);
   const attributes = props ? [t.jsxSpreadAttribute(t.cloneNode(props))] : [];
   return t.jsxElement(t.jsxOpeningElement(name, attributes, true), null, [], true);
@@ -458,16 +570,13 @@ function compileCandidate(
   if (path.node.async || path.node.generator)
     return "async and generator components are not supported";
   if (path.node.typeParameters) return "generic components are not supported yet";
-  if (
-    path.node.params.length > 1 ||
-    (path.node.params[0] && !t.isIdentifier(path.node.params[0]))
-  ) {
-    return "components must use zero parameters or one props identifier";
-  }
+  if (path.node.params.length > 1) return "components must use at most one props parameter";
+  const propsPlan = analyzePropsParameter(path);
+  if (typeof propsPlan === "string") return propsPlan;
   if (!t.isBlockStatement(path.node.body)) return "components must use a block body";
 
   const states: StateBinding[] = [];
-  const derived: DerivedBinding[] = [];
+  const locals: LocalBinding[] = [];
   let returned: t.ReturnStatement | undefined;
   for (const statement of path.node.body.body) {
     if (t.isReturnStatement(statement)) {
@@ -480,7 +589,7 @@ function compileCandidate(
       statement.kind !== "const" ||
       statement.declarations.length !== 1
     ) {
-      return "only top-level useState declarations, pure derived const values, and one return are supported by the current compiler";
+      return "only top-level useState declarations, pure derived const values, named synchronous handlers, and one return are supported by the current compiler";
     }
     const declaration = statement.declarations[0];
     if (t.isArrayPattern(declaration.id)) {
@@ -494,8 +603,8 @@ function compileCandidate(
       ) {
         return "only const [value, setValue] = useState(initial) state declarations are supported";
       }
-      if (derived.length > 0) {
-        return "useState declarations must appear before derived local values";
+      if (locals.length > 0) {
+        return "useState declarations must appear before derived local values and event handlers";
       }
       states.push({
         valueName: declaration.id.elements[0].name,
@@ -506,9 +615,16 @@ function compileCandidate(
       continue;
     }
     if (!t.isIdentifier(declaration.id) || !t.isExpression(declaration.init)) {
-      return "derived const values must use one identifier and one expression";
+      return "derived const values and event handlers must use one identifier and one expression";
     }
-    derived.push({ name: declaration.id.name, value: declaration.init });
+    if (t.isArrowFunctionExpression(declaration.init) || t.isFunctionExpression(declaration.init)) {
+      if (declaration.init.async || declaration.init.generator) {
+        return `event handler ${declaration.id.name} must be synchronous`;
+      }
+      locals.push({ kind: "handler", name: declaration.id.name, value: declaration.init });
+    } else {
+      locals.push({ kind: "derived", name: declaration.id.name, value: declaration.init });
+    }
   }
 
   if (states.length === 0) return "no local useState binding was found";
@@ -518,13 +634,13 @@ function compileCandidate(
 
   const statesByValue = new Map(states.map((state) => [state.valueName, state]));
   const statesBySetter = new Map(states.map((state) => [state.setterName, state]));
-  const derivedNames = new Set(derived.map((binding) => binding.name));
-  if (derivedNames.size !== derived.length) return "derived local names must be unique";
+  const localNames = new Set(locals.map((binding) => binding.name));
+  if (localNames.size !== locals.length) return "local binding names must be unique";
   for (const state of states) {
     if (
       state.initialValue &&
       (collectStateDependencies(state.initialValue, statesByValue).length > 0 ||
-        collectReferencedLocals(state.initialValue, derivedNames).length > 0 ||
+        collectReferencedLocals(state.initialValue, localNames).length > 0 ||
         [...statesBySetter].some(([setterName]) =>
           referencesIdentifier(state.initialValue!, setterName),
         ))
@@ -533,21 +649,37 @@ function compileCandidate(
     }
   }
   const derivedByName = new Map<string, t.Expression>();
-  for (const binding of derived) {
-    const forwardReferences = collectReferencedLocals(binding.value, derivedNames).filter(
+  const handlersByName = new Map<string, HandlerBinding>();
+  for (const binding of locals) {
+    const forwardReferences = collectReferencedLocals(binding.value, localNames).filter(
       (reference) => !derivedByName.has(reference),
     );
     if (forwardReferences.length > 0) {
-      return `derived local ${binding.name} can only reference earlier derived local values`;
+      return `${binding.kind === "handler" ? "event handler" : "derived local"} ${binding.name} can only reference earlier derived local values`;
     }
     const expanded = rewriteDerivedAccess(binding.value, derivedByName);
+    if (binding.kind === "handler") {
+      handlersByName.set(binding.name, {
+        name: binding.name,
+        value: expanded as t.ArrowFunctionExpression | t.FunctionExpression,
+      });
+      continue;
+    }
     const unsupported = validateDerivedExpression(expanded);
     if (unsupported) {
       return `derived local ${binding.name} cannot use ${unsupported}`;
     }
     derivedByName.set(binding.name, expanded);
   }
-  const expandedRoot = rewriteDerivedAccess(returned.argument, derivedByName) as t.JSXElement;
+  const rootWithDerived = rewriteDerivedAccess(returned.argument, derivedByName) as t.JSXElement;
+  const handlerRewrite = rewriteHandlerAccess(rootWithDerived, handlersByName);
+  if (handlerRewrite.reason) return handlerRewrite.reason;
+  if (!handlerRewrite.root) return "event handlers could not be prepared safely";
+  const expandedRoot = rewriteDestructuredPropAccess(
+    handlerRewrite.root,
+    propsPlan.destructuredNames,
+    propsPlan.definitionParameter,
+  );
   const setterReason = validateSetterUsage(expandedRoot, statesBySetter);
   if (setterReason) return setterReason;
   const analysis = analyzeHostTree(expandedRoot, statesByValue);
@@ -555,7 +687,7 @@ function compileCandidate(
 
   const stateParameter = path.scope.generateUidIdentifier("farmState");
   const definitionIdentifier = path.scope.generateUidIdentifier(`${name}Compiled`);
-  const propsParameter = clonePropsParameter(path);
+  const propsParameter = propsPlan.definitionParameter;
   const rewrittenRoot = rewriteStateAccess(
     expandedRoot,
     stateParameter,
@@ -585,7 +717,19 @@ function compileCandidate(
         t.identifier("initialize"),
         t.arrowFunctionExpression(
           [t.cloneNode(propsParameter)],
-          t.arrayExpression(states.map((state) => lazyInitialValue(state.initialValue))),
+          t.arrayExpression(
+            states.map((state) =>
+              lazyInitialValue(
+                state.initialValue
+                  ? rewriteDestructuredPropAccess(
+                      state.initialValue,
+                      propsPlan.destructuredNames,
+                      propsParameter,
+                    )
+                  : undefined,
+              ),
+            ),
+          ),
         ),
       ),
       t.objectProperty(
@@ -599,24 +743,18 @@ function compileCandidate(
         t.identifier("bindings"),
         t.arrayExpression(
           (analysis.bindings || []).map((binding) =>
-            bindingObject(binding, path, stateParameter, statesByValue, statesBySetter),
+            bindingObject(binding, propsParameter, stateParameter, statesByValue, statesBySetter),
           ),
         ),
       ),
     ]),
   ]);
 
-  const originalProps = path.node.params[0];
   path
     .get("body")
     .replaceWith(
       t.blockStatement([
-        t.returnStatement(
-          wrapperElement(
-            definitionIdentifier,
-            originalProps && t.isIdentifier(originalProps) ? originalProps : undefined,
-          ),
-        ),
+        t.returnStatement(wrapperElement(definitionIdentifier, propsPlan.wrapperProps)),
       ]),
     );
   statementPath.insertAfter(


### PR DESCRIPTION
## Summary

- compile flat destructured React props, including shorthand names, aliases, and default values
- compile synchronous `const` event handlers when they are passed directly to JSX events
- expand earlier compiler-safe derived values inside named handlers while retaining focused fallback diagnostics for unsafe shapes
- preserve controlled input selection across React restoration and the compiler microtask flush
- add a production-hydrated example covering prop defaults, aliases, parent-plus-local updates, multiple setters, controlled input selection, and composition events
- document the new supported contract and remaining React fallback boundaries

## Safety boundaries

Nested, computed, and rest props patterns continue to fall back to React. Async or generator handlers, indirect named-handler calls, impure derived values, dynamic JSX structure, and keyed lists also remain React-owned.

## Verification

- `pnpm --filter @farm.js/react test` — 58 unit/runtime tests passed, including the 3,000-update differential test
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react build`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8 passed
- `pnpm --filter farm-react-compiler-example type-check`
- production example build and `node scripts/verify-experiment.mjs`
- `pnpm --filter farmjs-docs build`
- targeted formatter and linter checks

The browser verifier confirms both new example components appear in the production compiler report, parent and local state remain coherent, controlled updates add zero component executions, selection is preserved, composition input is observed, and no browser errors are emitted.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compiles common React component syntax in `@farm.js/react`: flat props destructuring (shorthand, aliases, defaults) and synchronous named handlers passed directly to JSX events. Previously only identifier props and inline handlers compiled; nested/computed/rest patterns, async/generator or indirect handlers still fall back to React. The runtime now preserves controlled input selection across React’s restoration and the compiler microtask flush.

- Review focus: `packages/farm-react/src/compiler.ts` adds analysis for flat props destructuring and inlines synchronous named handlers when used as `onClick={increment}`; expands earlier derived locals in handlers; tightens fallback diagnostics. Unsupported shapes (nested/computed/rest props, indirect/async handlers) continue to fall back.
- Runtime: `packages/farm-react/src/compiler-runtime.tsx` captures and restores input selection and avoids redundant input value writes to keep caret stable for controlled inputs.
- Docs and examples: docs updated to reflect the new contract and boundaries; production example adds Common Syntax and Controlled Input cases; the verify script asserts both components compile and that count/selection/composition behaviors match expectations.
- Tests and compat: new and expanded tests cover props/handlers boundaries and controlled input hardening; compatibility suite passes on React 18.3.1 and 19.2.8. To opt in, use an identifier or flat destructured props and pass synchronous handlers directly to JSX events; leave nested/computed/rest patterns and indirect/async handlers on React.

<sup>Written for commit 4d01ecd82868a099a0dff067fc3817c0375de581. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

