### PR TITLE
fix(routing): strip route group segments from file-route URLs

### DIFF
--- a/packages/farm/src/__tests__/generate-route-types.test.ts
+++ b/packages/farm/src/__tests__/generate-route-types.test.ts
@@ -128,6 +128,29 @@ describe("generateRouteTypes", () => {
     expect(content).not.toContain("(.)photo");
   });
 
+  it("types grouped routes at their group-free URLs", async () => {
+    const marketingDir = path.join(tmpDir, "src", "app", "(marketing)", "pricing");
+    const appGroupDir = path.join(tmpDir, "src", "app", "(app)", "dashboard");
+    await fs.promises.mkdir(marketingDir, { recursive: true });
+    await fs.promises.mkdir(appGroupDir, { recursive: true });
+    await fs.promises.writeFile(
+      path.join(marketingDir, "page.tsx"),
+      "export default function Pricing() { return null; }",
+    );
+    await fs.promises.writeFile(
+      path.join(appGroupDir, "page.tsx"),
+      "export default function Dashboard() { return null; }",
+    );
+
+    const outPath = await generateRouteTypes({ root: tmpDir, srcDir: "src" });
+    const content = fs.readFileSync(outPath, "utf8");
+
+    expect(readTypeAlias(content, "RoutePath")).toContain('"/pricing"');
+    expect(readTypeAlias(content, "RoutePath")).toContain('"/dashboard"');
+    expect(content).not.toContain("(marketing)");
+    expect(content).not.toContain("(app)");
+  });
+
   it("when suppressLintOnLink is true, disables Link linting but keeps route module props typed", async () => {
     const outPath = await generateRouteTypes({
       root: tmpDir,

--- a/packages/farm/src/__tests__/route-manager.test.ts
+++ b/packages/farm/src/__tests__/route-manager.test.ts
@@ -272,6 +272,57 @@ describe("RouteManager", () => {
     });
   });
 
+  describe("route groups", () => {
+    it("registers grouped pages at their group-free URLs", async () => {
+      const { globFiles } = await import("../utils");
+      vi.mocked(globFiles).mockImplementation(async (pattern: string) => {
+        if (pattern.includes("page")) {
+          return [
+            "(marketing)/page.tsx",
+            "(marketing)/pricing/page.tsx",
+            "(app)/dashboard/page.tsx",
+          ];
+        }
+        if (pattern.includes("layout")) {
+          return ["layout.tsx", "(app)/dashboard/layout.tsx"];
+        }
+        if (pattern.includes("loading")) {
+          return ["(marketing)/pricing/loading.tsx"];
+        }
+        return [];
+      });
+
+      await routeManager.discoverRoutes();
+
+      expect(new Set(routeManager.getRoutes().keys())).toEqual(
+        new Set(["/", "/pricing", "/dashboard"]),
+      );
+      expect(routeManager.matchRoute("/").route?.modulePath).toBe(
+        "/test/src/app/(marketing)/page.tsx",
+      );
+      expect(routeManager.matchRoute("/pricing").route?.pattern).toBe("/pricing");
+      expect(routeManager.matchRoute("/dashboard").route?.pattern).toBe("/dashboard");
+
+      const dashboard = routeManager.matchRoute("/dashboard");
+      expect(dashboard.layouts.map((layout) => layout.pattern)).toEqual(["/", "/dashboard"]);
+      expect(routeManager.getMatchingLoading("/pricing")?.route.filePath).toBe(
+        "(marketing)/pricing/loading.tsx",
+      );
+    });
+
+    it("rejects pages from different groups that collapse to one URL", async () => {
+      const { globFiles } = await import("../utils");
+      vi.mocked(globFiles).mockImplementation(async (pattern: string) => {
+        if (pattern.includes("page")) {
+          return ["(a)/x/page.tsx", "(b)/x/page.tsx"];
+        }
+        return [];
+      });
+
+      await expect(routeManager.discoverRoutes()).rejects.toThrow('Duplicate page route "/x"');
+    });
+  });
+
   describe("named route slots", () => {
     beforeEach(async () => {
       const { globFiles } = await import("../utils");

--- a/packages/farm/src/__tests__/utils.test.ts
+++ b/packages/farm/src/__tests__/utils.test.ts
@@ -70,6 +70,24 @@ describe("parseRoutePath", () => {
     const result = parseRoutePath("about/layout.tsx");
     expect(result.type).toBe("layout");
   });
+
+  it("should strip route group segments from the URL", () => {
+    expect(parseRoutePath("(marketing)/page.tsx").segments).toEqual([]);
+    expect(parseRoutePath("(marketing)/pricing/page.tsx").segments).toEqual([
+      { segment: "pricing", isDynamic: false, isOptional: false, isCatchAll: false },
+    ]);
+    expect(parseRoutePath("(shop)/products/[id]/page.tsx").segments).toEqual([
+      { segment: "products", isDynamic: false, isOptional: false, isCatchAll: false },
+      { segment: "id", isDynamic: true, isOptional: false, isCatchAll: false },
+    ]);
+  });
+
+  it("should keep interception marker segments intact", () => {
+    expect(parseRoutePath("feed/(.)photo/page.tsx").segments).toEqual([
+      { segment: "feed", isDynamic: false, isOptional: false, isCatchAll: false },
+      { segment: "(.)photo", isDynamic: false, isOptional: false, isCatchAll: false },
+    ]);
+  });
 });
 
 describe("matchRoute", () => {

--- a/packages/farm/src/utils.ts
+++ b/packages/farm/src/utils.ts
@@ -10,6 +10,9 @@ export function parseRoutePath(filePath: string): ParsedRoute {
   const fileType = getRouteType(fileName);
 
   for (const part of pathParts) {
+    // Route groups like `(marketing)` organize files without adding URL
+    // segments. Mirrors isRouteGroup in router.ts for programmatic routes.
+    if (part.startsWith("(") && part.endsWith(")")) continue;
     if (part.startsWith("[") && part.endsWith("]")) {
       let segment = part.slice(1, -1);
       const isDynamic = true;


### PR DESCRIPTION
## Problem

`parseRoutePath()` only special-cases `[param]` segments; a `(group)` folder falls into the static branch and is kept as a literal URL segment. With the documented layout

```
src/app/
  (marketing)/page.tsx
  (marketing)/pricing/page.tsx
  (app)/dashboard/page.tsx
```

the RouteManager registers `/(marketing)`, `/(marketing)/pricing`, and `/(app)/dashboard`, so the documented URLs `/`, `/pricing`, and `/dashboard` all 404 (docs/src/app/docs/routing/page.md: "The URLs are still `/`, `/pricing`, and `/dashboard`"). The programmatic router already strips groups via `isRouteGroup` (router.ts), so file and programmatic routes disagreed. `generate-route-types.ts` derives from the same parse, so `farm-routes.d.ts` typed `<Link href="/(marketing)/pricing">` (which 404s) and rejected `<Link href="/pricing">` at compile time.

## Fix

Skip route-group segments in `parseRoutePath`'s segment loop, using the exact same rule as the programmatic router's `isRouteGroup` (`startsWith("(") && endsWith(")")`). The rule is inlined rather than shared because `router.ts` is client-shipped and `utils.ts` imports `node:path`.

Everything downstream derives from `parseRoutePath`, so this one change fixes pattern registration, URL matching, `farm-routes.d.ts`, and layout/loading/error boundary resolution together: a `layout.tsx`/`loading.tsx`/`error.tsx` inside a group now registers at its group-free pattern and applies to the group's pages at their real URLs. Interception markers such as `(.)photo` and `(..)photo` are prefixes that do not end with `)` and are unaffected.

Pages from different groups that collapse to the same URL (`(a)/x/page.tsx` + `(b)/x/page.tsx`) now fail fast through the existing `Duplicate page route "/x"` discovery error, which lists both files — same behavior as Next.js for conflicting group paths.

## Tests

- `utils.test.ts`: group segments stripped for root, static, and dynamic grouped routes; interception marker segments kept intact.
- `route-manager.test.ts`: grouped pages register and match at `/`, `/pricing`, `/dashboard`; layouts nest (`/` then `/dashboard`) and loading boundaries resolve for grouped routes; cross-group URL collision throws the duplicate-route error.
- `generate-route-types.test.ts`: real-filesystem run generating `farm-routes.d.ts` with `(marketing)`/`(app)` directories; `RoutePath` contains `"/pricing"` and `"/dashboard"` and no paren segments.

All new tests fail on main and pass with the fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strips `(group)` segments from file-derived route URLs so grouped pages resolve at group-free paths and match the programmatic router. Previously `parseRoutePath` kept `(group)` as a literal segment, registering `/(marketing)/pricing`, typing paren paths in `farm-routes.d.ts`, and causing `/`, `/pricing`, and `/dashboard` to 404.

- Review notes: `parseRoutePath` now skips parts that start with "(" and end with ")`, mirroring the programmatic router’s `isRouteGroup`; the rule is inlined to avoid bundling issues. Tests cover root/static/dynamic grouped routes, registration and matching at `/`, `/pricing`, `/dashboard`, layout/loading resolution, interception markers like `(.)photo` remaining literal, and a fast-fail duplicate-page error when groups collapse to the same URL.
- Migration: Update any links, tests, or type assertions that reference `/(group)` paths to use group-free URLs (for example, `/pricing`, `/dashboard`). If two groups define the same URL, resolve the conflict or expect a discovery error.

<sup>Written for commit 9405f5b325038f446c5f27df512c8911b7d62938. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

