### PR TITLE
fix(ssr): stop $-sequences in dynamic content corrupting generated documents

### DIFF
--- a/packages/farm/src/__tests__/document-injection.test.ts
+++ b/packages/farm/src/__tests__/document-injection.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment node
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const universalBuildSource = fs.readFileSync(
+  path.join(process.cwd(), "src", "nitro", "universal-build.ts"),
+  "utf-8",
+);
+
+// The production handler is emitted from a template literal, so the snippet is
+// extracted from the source and un-escaped (\\ -> \, \` -> `, \$ -> $) before
+// being executed the way the emitted bundle runs it.
+function extractEmittedFullDocumentInjection(): string {
+  const start = universalBuildSource.indexOf(
+    "fullHtml = html\n            // Inject CSS link",
+  );
+  const end = universalBuildSource.indexOf("// Add DOCTYPE if not present", start);
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  const emitted = universalBuildSource
+    .slice(start, end)
+    .replace(/\\([\\`$])/g, "$1");
+  return emitted.slice(0, emitted.lastIndexOf(";") + 1);
+}
+
+function serializeFarmInlineValue(value: unknown): string {
+  return JSON.stringify(value).replace(/</g, "\\u003c");
+}
+
+function renderFarmClientBootstrapScript(
+  _canonicalPath?: string,
+  selectedRouteSlots?: unknown[],
+  pageProps?: Record<string, unknown>,
+): string {
+  return (
+    '<script id="__farm_route_slots_data__" type="application/json">' +
+    serializeFarmInlineValue(selectedRouteSlots || []) +
+    "</script><script>window.__FARM_PROPS__=" +
+    serializeFarmInlineValue(pageProps || {}) +
+    ";</script>"
+  );
+}
+
+describe("generated full-document injection", () => {
+  it("keeps $-sequences in page props literal when injecting the bootstrap script", () => {
+    const inject = new Function(
+      "html",
+      "title",
+      "metaTags",
+      "pageProps",
+      "routeSlotPayload",
+      "clientPageProps",
+      "renderFarmClientBootstrapScript",
+      "renderFarmRendererHydrationScript",
+      "let fullHtml;\n" +
+        extractEmittedFullDocumentInjection() +
+        "\nreturn fullHtml;",
+    );
+
+    const clientPageProps = { note: "totals: $$ then $& then $' then $`" };
+    const fullHtml = inject(
+      "<html><head><title>App</title></head><body><main>page</main></body></html>",
+      "Farm.js App",
+      "",
+      { __farmCanonicalPath: "/notes" },
+      [],
+      clientPageProps,
+      renderFarmClientBootstrapScript,
+      () => "",
+    ) as string;
+
+    // A string replacement would expand $& into </body> and $' into the rest of
+    // the document, corrupting window.__FARM_PROPS__ and duplicating markup.
+    expect(fullHtml).toContain(serializeFarmInlineValue(clientPageProps));
+    expect(fullHtml.match(/<\/body>/gi)).toHaveLength(1);
+    expect(fullHtml.match(/<\/html>/gi)).toHaveLength(1);
+  });
+
+  it("never passes dynamic markup as a string replacement in the generated document pipeline", () => {
+    // String replacements interpret $&, $', $` and $$ in the replacement text,
+    // so every dynamically built replacement must go through a function.
+    const stringReplacementWithDynamicMarkup =
+      /\.replace\(\s*\/[^\n]*\/i,\s*(?:'[^']*'\s*\+\s*)?(?:renderFarmClientBootstrapScript|renderFarmRendererHydrationScript)\(/g;
+    expect(
+      universalBuildSource.match(stringReplacementWithDynamicMarkup),
+    ).toBeNull();
+    expect(universalBuildSource).not.toContain("'<head$1>' + runtimeMarkup");
+    expect(universalBuildSource).not.toContain(
+      `"<body" + bodyMatch[1] + ">" + rootMarkup + "</body>",`,
+    );
+  });
+});

--- a/packages/farm/src/__tests__/document-injection.test.ts
+++ b/packages/farm/src/__tests__/document-injection.test.ts
@@ -13,15 +13,11 @@ const universalBuildSource = fs.readFileSync(
 // extracted from the source and un-escaped (\\ -> \, \` -> `, \$ -> $) before
 // being executed the way the emitted bundle runs it.
 function extractEmittedFullDocumentInjection(): string {
-  const start = universalBuildSource.indexOf(
-    "fullHtml = html\n            // Inject CSS link",
-  );
+  const start = universalBuildSource.indexOf("fullHtml = html\n            // Inject CSS link");
   const end = universalBuildSource.indexOf("// Add DOCTYPE if not present", start);
   expect(start).toBeGreaterThan(-1);
   expect(end).toBeGreaterThan(start);
-  const emitted = universalBuildSource
-    .slice(start, end)
-    .replace(/\\([\\`$])/g, "$1");
+  const emitted = universalBuildSource.slice(start, end).replace(/\\([\\`$])/g, "$1");
   return emitted.slice(0, emitted.lastIndexOf(";") + 1);
 }
 
@@ -54,9 +50,7 @@ describe("generated full-document injection", () => {
       "clientPageProps",
       "renderFarmClientBootstrapScript",
       "renderFarmRendererHydrationScript",
-      "let fullHtml;\n" +
-        extractEmittedFullDocumentInjection() +
-        "\nreturn fullHtml;",
+      "let fullHtml;\n" + extractEmittedFullDocumentInjection() + "\nreturn fullHtml;",
     );
 
     const clientPageProps = { note: "totals: $$ then $& then $' then $`" };
@@ -83,12 +77,13 @@ describe("generated full-document injection", () => {
     // so every dynamically built replacement must go through a function.
     const stringReplacementWithDynamicMarkup =
       /\.replace\(\s*\/[^\n]*\/i,\s*(?:'[^']*'\s*\+\s*)?(?:renderFarmClientBootstrapScript|renderFarmRendererHydrationScript)\(/g;
-    expect(
-      universalBuildSource.match(stringReplacementWithDynamicMarkup),
-    ).toBeNull();
+    expect(universalBuildSource.match(stringReplacementWithDynamicMarkup)).toBeNull();
     expect(universalBuildSource).not.toContain("'<head$1>' + runtimeMarkup");
     expect(universalBuildSource).not.toContain(
       `"<body" + bodyMatch[1] + ">" + rootMarkup + "</body>",`,
+    );
+    expect(universalBuildSource).toContain(
+      `() => '<html lang="en"' + farmThemeDocument.attributes + '>'`,
     );
   });
 });

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -4361,7 +4361,9 @@ function createFarmErrorDocument(html, title) {
   }
   fullHtml = fullHtml
     .replace(/<head([^>]*)>/i, '<head$1>\\n  <link rel="stylesheet" href="/__farm_client_css_href__">')
-    .replace(/<\\/head>/i, renderFarmRendererHydrationScript() + '\\n</head>')
+    // Function replacements: dynamic markup may contain $-sequences ($&, $', $$)
+    // that a string replacement would expand, corrupting the document.
+    .replace(/<\\/head>/i, function() { return renderFarmRendererHydrationScript() + '\\n</head>'; })
     .replace(/<head([^>]*)>([\\s\\S]*?)<\\/head>/i, function(match, attrs, headContent) {
       return headContent.includes("<title")
         ? match
@@ -4369,8 +4371,10 @@ function createFarmErrorDocument(html, title) {
     })
     .replace(
       /<\\/body>/i,
-      '  ' + renderFarmClientBootstrapScript() + '\\n' +
-        '  <script type="module" src="/__farm_client_js_src__"></script>\\n</body>',
+      function() {
+        return '  ' + renderFarmClientBootstrapScript() + '\\n' +
+          '  <script type="module" src="/__farm_client_js_src__"></script>\\n</body>';
+      },
     );
   return fullHtml.trim().startsWith("<!DOCTYPE")
     ? fullHtml
@@ -4410,7 +4414,10 @@ function applyFarmI18nDocument(html, requestPath, snapshot) {
   const runtimeMarkup =
     renderFarmI18nAlternateLinks(requestPath, snapshot) +
     '<script>window.__FARM_I18N__ = ' + serializeFarmInlineValue(snapshot) + ';</script>';
-  nextHtml = nextHtml.replace(/<head([^>]*)>/i, '<head$1>' + runtimeMarkup);
+  nextHtml = nextHtml.replace(/<head([^>]*)>/i, function(_match, attributes) {
+    // Function replacement: runtimeMarkup may contain $-sequences ($&, $', $$).
+    return '<head' + attributes + '>' + runtimeMarkup;
+  });
   return nextHtml;
 }
 
@@ -5199,7 +5206,8 @@ ${
   );
   let html = source.replace(
     bodyMatch[0],
-    "<body" + bodyMatch[1] + ">" + rootMarkup + "</body>",
+    // Function replacement: rendered markup may contain $-sequences ($&, $', $$).
+    function() { return "<body" + bodyMatch[1] + ">" + rootMarkup + "</body>"; },
   );
   if (!html.includes('href="/__farm_client_css_href__"')) {
     const clientStylesheet = '  <link rel="stylesheet" href="/__farm_client_css_href__">\\n';
@@ -5210,7 +5218,7 @@ ${
         : html.replace(/<[/]head>/i, clientStylesheet + "</head>");
   }
   if (!html.includes('id="__farm_route_slots_data__"')) {
-    html = html.replace(/<[/]body>/i, renderFarmClientBootstrapScript() + "\\n</body>");
+    html = html.replace(/<[/]body>/i, function() { return renderFarmClientBootstrapScript() + "\\n</body>"; });
   }
   if (!html.includes('src="/__farm_client_js_src__"')) {
     html = html.replace(
@@ -5219,7 +5227,7 @@ ${
     );
   }
   if (!html.includes('window._$HY')) {
-    html = html.replace(/<[/]head>/i, renderFarmRendererHydrationScript() + "\\n</head>");
+    html = html.replace(/<[/]head>/i, function() { return renderFarmRendererHydrationScript() + "\\n</head>"; });
   }
   const headers = new Headers(response.headers);
   headers.delete("content-length");
@@ -6067,7 +6075,7 @@ async function handleFarmRequestInContext(
           fullHtml = html
             // Inject CSS link after opening head tag or first meta tag
             .replace(/<head([^>]*)>/i, '<head$1>\\n  <link rel="stylesheet" href="/__farm_client_css_href__">')
-            .replace(/<\\/head>/i, renderFarmRendererHydrationScript() + '\\n</head>')
+            .replace(/<\\/head>/i, () => renderFarmRendererHydrationScript() + '\\n</head>')
             // Inject title if not present and we have one
             .replace(/<head([^>]*)>([\\s\\S]*?)<\\/head>/i, (match, attrs, headContent) => {
               let nextHeadContent = headContent;
@@ -6079,10 +6087,13 @@ async function handleFarmRequestInContext(
                 ? match
                 : "<head" + attrs + ">" + nextHeadContent + "\\n</head>";
             })
-            // Inject client script before closing body tag
+            // Inject client script before closing body tag. Function replacement:
+            // serialized page props may contain $-sequences ($&, $', $$) that a
+            // string replacement would expand into surrounding document markup,
+            // corrupting the inline bootstrap script.
             .replace(
               /<\\/body>/i,
-              '  ' + renderFarmClientBootstrapScript(
+              () => '  ' + renderFarmClientBootstrapScript(
                 pageProps.__farmCanonicalPath,
                 routeSlotPayload,
                 clientPageProps
@@ -6373,10 +6384,10 @@ async function handleFarmRequestInContext(
     if (hasFullDocument) {
       fullHtml = html
         .replace(/<head([^>]*)>/i, '<head$1>\\n  <link rel="stylesheet" href="/__farm_client_css_href__">')
-        .replace(/<\\/head>/i, renderFarmRendererHydrationScript() + '\\n</head>')
+        .replace(/<\\/head>/i, () => renderFarmRendererHydrationScript() + '\\n</head>')
         .replace(
           /<\\/body>/i,
-          '  ' + renderFarmClientBootstrapScript() + '\\n' +
+          () => '  ' + renderFarmClientBootstrapScript() + '\\n' +
             '  <script type="module" src="/__farm_client_js_src__"></script>\\n</body>',
         );
       if (!fullHtml.trim().startsWith('<!DOCTYPE')) {

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -6033,7 +6033,7 @@ async function handleFarmRequestInContext(
             '</body>\\n</html>';
           const themedStreamPrefix = streamPrefix.replace(
             '<html lang="en">',
-            '<html lang="en"' + farmThemeDocument.attributes + '>'
+            () => '<html lang="en"' + farmThemeDocument.attributes + '>'
           );
           const streamedDocument = createFarmDocumentStream(
             renderedPage.stream,


### PR DESCRIPTION
## Problem

The generated production handler in `packages/farm/src/nitro/universal-build.ts` injects dynamic markup into rendered documents with `String.prototype.replace` using **string** replacement arguments. JS interprets `$`-sequences in string replacements: `$&` becomes the matched text, `$'` everything after the match, `` $` `` everything before it, and `$$` a literal `$`.

In the `hasFullDocument` branch (custom root layout returning a full `<html>` document), the client bootstrap — which embeds `window.__FARM_PROPS__` serialized from loader/page data, params, and search values — is injected via:

```js
html.replace(/<\/body>/i, '  ' + renderFarmClientBootstrapScript(...) + ...)
```

Any `$`-sequence in user or attacker-influenced data is expanded into surrounding document markup:

- A prop containing `$&`/`$'` splices `</body>` or the entire document tail into the inline props script, making it invalid JS — hydration never runs and the page is left non-interactive.
- **XSS angle:** with `$'`/`` $` ``, attacker-influenced values re-splice raw preceding/following document markup *inside a `<script>` context*. Content that was safely HTML-escaped for its original context is duplicated into a script context where the escaping rules differ, and the duplicated markup itself re-enters the DOM — a markup-splicing primitive that can escalate beyond the guaranteed hydration DoS.
- Even a benign Yelp-style `"$$"` price string silently corrupts the payload (`$$` → `$`).

The same hazard exists at seven sibling sites in the file's generated code: the `</head>` hydration-script injections, the error-document and 404-document chains, the i18n `<head>` injection (whose markup embeds request-path-derived alternate links), and the docs layout body swap (whose replacement embeds rendered user markup).

## Fix

Convert every dynamically built replacement argument in the generated document pipeline to a function replacement — a replacer function's return value is used literally, with no `$`-sequence processing:

- full-document branch: bootstrap (`</body>`) and hydration (`</head>`) injections
- 404 branch: same two injections
- `createFarmErrorDocument`: same two injections
- `applyFarmI18nDocument`: `<head>` runtime-markup injection
- `wrapFarmDocsResponseWithLayouts`: body swap with rendered markup, bootstrap and hydration injections

Static replacements that intentionally use `$1` backreferences are unchanged.

## Tests

`src/__tests__/document-injection.test.ts`:

1. **Behavioral:** extracts the emitted full-document injection snippet from the source template, un-escapes it, and executes it with page props containing `$$`, `$&`, `$'`, and `` $` ``. Asserts the serialized props survive byte-for-byte and the document has exactly one `</body>`/`</html>`. On the previous code this fails with the document tail spliced into `window.__FARM_PROPS__`.
2. **Static:** scans the source for any `.replace(` call passing `renderFarmClientBootstrapScript`/`renderFarmRendererHydrationScript` output (or the i18n/docs markup concatenations) as a string replacement. Previously matched 8 sites; now matches none.

Both tests fail on the previous code and pass with this change (verified with the package's vitest).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch dynamic HTML injections in the generated SSR handler from string to function replacements to prevent `$`-sequence expansion. Previously, `$&`, `$'`, ``$` ``, and `$$` in page data expanded during replace, corrupting `window.__FARM_PROPS__` and breaking hydration; now injected content is inserted literally.

- Updates `packages/farm/src/nitro/universal-build.ts` to use function replacers at all dynamic injection sites: hydration into `</head>` and bootstrap into `</body>` for full-document, 404, and error documents; i18n `<head>` insertion; docs/streaming body swap and streaming shell; and streamed theme document `<html>` attribute injection. Static replacements that rely on backreferences remain unchanged.
- Adds `packages/farm/src/__tests__/document-injection.test.ts` with a behavioral test validating `$`-sequence round-trips and a static scan that forbids string replacements for dynamic markup, including the streamed theme document replacement.
- No migration required; this restores correct hydration and eliminates markup splicing risks for pages with `$` in data.

<sup>Written for commit 341bcd6386244a31090a9a5c80ecbda25f2c4060. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

