### PR TITLE
fix(routing): rank optional catch-alls below their exact parent route

### DIFF
--- a/packages/farm/src/__tests__/route-manager.test.ts
+++ b/packages/farm/src/__tests__/route-manager.test.ts
@@ -128,6 +128,70 @@ describe("RouteManager", () => {
       );
       expect(routeManager.matchRoute("/contact").route?.pattern).toBe("/[slug]");
     });
+
+    it("prefers an exact page over an optional catch-all matching its empty case", async () => {
+      const { globFiles } = await import("../utils");
+      vi.mocked(globFiles).mockImplementation(async (pattern: string) => {
+        if (pattern.includes("page")) {
+          return [
+            "page.tsx",
+            "[[...slug]]/page.tsx",
+            "shop/page.tsx",
+            "shop/[id]/page.tsx",
+            "shop/[[...filters]]/page.tsx",
+          ];
+        }
+        return [];
+      });
+      await routeManager.discoverRoutes();
+
+      expect(routeManager.matchRoute("/").route?.pattern).toBe("/");
+      expect(routeManager.matchRoute("/shop").route?.pattern).toBe("/shop");
+      expect(routeManager.matchRoute("/shop").params).toEqual({});
+      expect(routeManager.matchRoute("/shop/42").route?.pattern).toBe("/shop/[id]");
+      expect(routeManager.matchRoute("/shop/sale/red")).toMatchObject({
+        route: { pattern: "/shop/[[...filters]]" },
+        params: { filters: "sale/red" },
+      });
+      expect(routeManager.matchRoute("/blog/a/b")).toMatchObject({
+        route: { pattern: "/[[...slug]]" },
+        params: { slug: "blog/a/b" },
+      });
+    });
+
+    it("prefers an exact dynamic parent over its optional catch-all's empty case", async () => {
+      const { globFiles } = await import("../utils");
+      vi.mocked(globFiles).mockImplementation(async (pattern: string) => {
+        if (pattern.includes("page")) {
+          return ["[category]/page.tsx", "[category]/[[...rest]]/page.tsx"];
+        }
+        return [];
+      });
+      await routeManager.discoverRoutes();
+
+      expect(routeManager.matchRoute("/shoes")).toMatchObject({
+        route: { pattern: "/[category]" },
+        params: { category: "shoes" },
+      });
+      expect(routeManager.matchRoute("/shoes/red")).toMatchObject({
+        route: { pattern: "/[category]/[[...rest]]" },
+        params: { category: "shoes", rest: "red" },
+      });
+    });
+
+    it("ranks required catch-alls above optional catch-alls", async () => {
+      const { globFiles } = await import("../utils");
+      vi.mocked(globFiles).mockImplementation(async (pattern: string) => {
+        if (pattern.includes("page")) {
+          return ["blog/[...slug]/page.tsx", "blog/[[...archive]]/page.tsx"];
+        }
+        return [];
+      });
+      await routeManager.discoverRoutes();
+
+      expect(routeManager.matchRoute("/blog/2024/01").route?.pattern).toBe("/blog/[...slug]");
+      expect(routeManager.matchRoute("/blog").route?.pattern).toBe("/blog/[[...archive]]");
+    });
   });
 
   describe("discoverRoutes", () => {

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -4932,7 +4932,8 @@ function matchesRoutePrefix(pathname, pattern) {
 function routeSlotSpecificity(slot) {
   return slot.pattern.split("/").reduce(function(score, segment) {
     if (!segment) return score;
-    if (segment.startsWith("[[...")) return score + 1;
+    // Optional catch-alls rank below their parent path (mirrors routeSpecificity).
+    if (segment.startsWith("[[...")) return score - 1;
     if (segment.startsWith("[...")) return score + 2;
     if (segment.startsWith("[")) return score + 3;
     return score + 10;

--- a/packages/farm/src/routing/route-manager.ts
+++ b/packages/farm/src/routing/route-manager.ts
@@ -162,7 +162,10 @@ function routeSpecificity(entry: RouteEntry): number {
   return entry.route.segments.reduce((score, segment) => {
     if (!segment.isDynamic) return score + 100;
     if (!segment.isCatchAll) return score + 50;
-    return score + (segment.isOptional ? 5 : 10);
+    // An optional catch-all also matches its parent path (the empty case), so
+    // it must rank just below a page defined at that exact path: -2 nets out
+    // this segment's share of the length seed and one point more.
+    return score + (segment.isOptional ? -2 : 10);
   }, entry.route.segments.length);
 }
 


### PR DESCRIPTION
## Problem

`routeSpecificity` seeds its reduce with `segments.length`, so a route ending in an optional catch-all outscores the exact page for its own parent path:

- `shop/page.tsx` scores `1 + 100 = 101`, but `shop/[[...filters]]/page.tsx` scores `2 + 100 + 5 = 107`
- a root `page.tsx` scores `0`, but `[[...slug]]/page.tsx` scores `6`

Routes are sorted by descending specificity and `matchRoute` returns the first match, so `/shop` resolves to `/shop/[[...filters]]` via its empty case and the dedicated `shop/page.tsx` is unreachable. The same holds for dynamic parents (`/[category]` shadowed by `/[category]/[[...rest]]`).

The sorted order feeds every matcher: dev SSR (`RouteManager.matchRoute`), the client route manifest, and the production bundle's `patternPageRoutes`. The production matcher checks static routes through an exact-path map first, so static parents worked in production but not in dev or on client navigation — a silent dev/prod divergence on top of the shadowing.

## Fix

Score an optional catch-all segment as `-2` instead of `+5`. The `-2` nets out that segment's `+1` share of the length seed and leaves the route exactly one point below its parent path. An exact page at the parent path now always sorts first and wins the empty case, while the optional catch-all keeps winning everything its parent's prefix wins — including non-empty matches and the documented case where a static-prefixed optional catch-all (`/docs/[[...parts]]`) beats a less specific dynamic route (`/[slug]`) even at `/docs`.

The relative order of route kinds is unchanged at every depth: static (`101/seg`) > dynamic (`51`) > required catch-all (`11`) > optional catch-all (now `-1`).

The generated `routeSlotSpecificity` in the production server gets the matching one-line change (`[[...` segments score `-1` instead of `+1`) so route-slot selection stays consistent with dev, which sorts slot candidates with the fixed `routeSpecificity`.

## Tests

Three additions to `route-manager.test.ts` forming a matrix over static, dynamic, required catch-all, and optional catch-all routes:

- exact static page (root and nested) beats the optional catch-all's empty case, while `/shop/[id]` and non-empty catch-all matches keep their winners — fails on main
- exact dynamic parent (`/[category]`) beats its optional catch-all's empty case — fails on main
- required catch-all stays ranked above optional catch-all — regression pin, passes before and after

The existing test "prefers exact and more specific dynamic routes regardless of discovery order" continues to pass, pinning that `/docs` still resolves to `/docs/[[...parts]]` over `/[slug]`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ranks optional catch-all routes below their exact parent route to prevent shadowing. Previously, optional catch-alls could outscore and capture the parent path (e.g., /shop -> /shop/[[...filters]]); now the exact parent page wins the empty case while non-empty paths still hit the catch-all, and dev/client/prod matching stays consistent.

- **Review notes**
  - `routeSpecificity`: optional catch-all segment now scores -2 (was +5); relative order remains static > dynamic > required catch-all > optional catch-all.
  - `routeSlotSpecificity` (generated server) mirrors this for `[[...` segments (-1 vs +1) to keep slot selection consistent.
  - Tests add matrices covering static/dynamic parents and required-vs-optional ranking; they fail on main and pass with this fix.

- **Migration**
  - If you relied on an optional catch-all handling the parent path when a parent page exists, that path will now resolve to the parent page. No other changes required.

<sup>Written for commit b04eda85b3d9ec54f1c7195ff14891225cc67cc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

