### PR TITLE
fix(fonts): serve self-hosted font URLs root-relative when basePath is set

### DIFF
--- a/packages/farm/src/__tests__/font-vite.test.ts
+++ b/packages/farm/src/__tests__/font-vite.test.ts
@@ -264,9 +264,59 @@ console.log(demo, farmFontPreloadHeader);`,
         .map((output) => String(output.source))
         .join("\n");
 
-      expect(css).toContain('url("/docs/fonts/public.woff2")');
-      expect(entry?.code).toContain("%3C%2Fdocs%2Ffonts%2Fpublic.woff2%3E");
+      expect(css).toContain('url("/fonts/public.woff2")');
+      expect(css).not.toContain("/docs/fonts/");
+      expect(entry?.code).toContain("%3C%2Ffonts%2Fpublic.woff2%3E");
       expect(assets.some((output) => output.fileName.startsWith("assets/fonts/"))).toBe(false);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("mints root-relative production font URLs when basePath is set", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-font-base-path-"));
+    try {
+      await fs.writeFile(path.join(root, "demo.woff2"), Buffer.from("base-path-font"));
+      await fs.writeFile(
+        path.join(root, "entry.ts"),
+        `import { localFont } from "@farm.js/core/font";
+import { farmFontPreloadHeader } from "virtual:farm-font-runtime";
+export const demo = localFont({ src: "./demo.woff2", family: "Base Path Demo" });
+console.log(demo, farmFontPreloadHeader);`,
+      );
+
+      const result = await build({
+        root,
+        configFile: false,
+        logLevel: "silent",
+        plugins: [fontRuntimeStub(), farmPlugin({ root, basePath: "/docs" })],
+        build: {
+          write: false,
+          assetsInlineLimit: 0,
+          rollupOptions: {
+            input: path.join(root, "entry.ts"),
+            output: { entryFileNames: "entry.js" },
+          },
+        },
+      });
+      if (Array.isArray(result)) throw new Error("Expected one Vite build output");
+      const entry = result.output.find(
+        (output): output is Rollup.OutputChunk => output.type === "chunk" && output.isEntry,
+      );
+      const css = result.output
+        .filter((output): output is Rollup.OutputAsset => output.type === "asset")
+        .filter((output) => output.fileName.endsWith(".css"))
+        .map((output) => String(output.source))
+        .join("\n");
+
+      // The hashed asset is emitted at assets/fonts/... in the client output,
+      // which production serves at the root — the CSS src, runtime preload
+      // metadata, and encoded Link header must not carry basePath.
+      expect(css).toMatch(/url\("\/assets\/fonts\/demo-h[a-f0-9]{12}\.woff2"\)/);
+      expect(css).not.toContain("/docs/assets/fonts/");
+      expect(entry?.code).toMatch(/preloads:\s*\[\{\s*href:\s*["']\/assets\/fonts\/demo-/);
+      expect(entry?.code).toContain("%3C%2Fassets%2Ffonts%2Fdemo-");
+      expect(entry?.code).not.toContain("%2Fdocs%2Fassets");
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }

--- a/packages/farm/src/font-vite.ts
+++ b/packages/farm/src/font-vite.ts
@@ -946,14 +946,18 @@ function renderFontDefinitionCss(
 }
 
 function resourceUrl(resource: FontResource, production: boolean, basePath: string): string {
+  // Production font URLs are root-relative: emitted assets land in the client
+  // output, which the server publishes at "/" regardless of basePath — the
+  // same convention as the hashed client JS/CSS hrefs. Only the dev server
+  // mounts under basePath (the Vite base), so only dev URLs carry the prefix.
   if (resource.publicPath) {
-    return production ? joinBasePath(basePath, resource.publicPath) : resource.publicPath;
+    return resource.publicPath;
   }
   if (!resource.bytes) return resource.publicUrl;
   if (!production) {
     return joinBasePath(basePath, `/@farm/font/${resource.hash}${resource.extension}`);
   }
-  return joinBasePath(basePath, `/${resource.outputFileName}`);
+  return `/${resource.outputFileName}`;
 }
 
 async function fetchRemoteFont(url: URL, integrity?: string): Promise<Buffer> {


### PR DESCRIPTION
## Problem

With any non-root `basePath` (e.g. `defineConfig({ basePath: "/app" })`), every self-hosted webfont 404s in production.

The font registry mints all production font URLs through `resourceUrl()` in `packages/farm/src/font-vite.ts`, which prefixes `basePath`:

- `@font-face { src: url(/app/assets/fonts/demo-h<hash>.woff2) }` in the merged `farm-client.css`
- the `Link: </app/assets/fonts/...>; rel=preload` header baked into the server bundle
- the runtime `preloads` metadata on compiled `localFont()` / `remoteFont()` declarations

But the font file is emitted at `assets/fonts/...` inside the client output, which Nitro serves at the root (`publicAssets` with `baseURL: "/"` in `universal-build.ts`; `app.baseURL` is never set from `basePath`). The hashed client JS/CSS hrefs (`/assets/farm-client-h<hash>.css`, `/farm-client-h<hash>.js`) are root-relative for the same reason and load fine — only the font side carried the prefix, so `/app/assets/fonts/...` matches no public asset, falls through to the SSR handler, and 404s. The preload header additionally points browsers at the dead URL on every response.

## Fix

Align font URLs with the framework's existing convention for hashed client assets: production URLs are root-relative, and `basePath` only applies to dev-server URLs (whose Vite base actually mounts there).

`resourceUrl()` now returns:

- `/${outputFileName}` for self-hosted fonts in production (was `joinBasePath(basePath, ...)`)
- `publicPath` unprefixed for publicDir fonts in production (public assets are also served at root)
- dev URLs unchanged (`/@farm/font/...` still under the dev base, matching existing dev tests)

Every mint site (CSS `src:`, the encoded preload Link header, `preloadResources`) funnels through `resourceUrl()`, so this one change fixes all three consistently. A sibling PR aligns the Vercel immutable-cache route in the same direction.

## Tests

- New: `mints root-relative production font URLs when basePath is set` — production build of a self-hosted `localFont()` with `basePath: "/docs"`; asserts the emitted CSS `url()`, the compiled `preloads` metadata, and the encoded preload header are all root-relative. Fails on main (URLs come out `/docs`-prefixed).
- Updated: `uses a font from publicDir without emitting a duplicate asset` previously asserted the broken `/docs/fonts/public.woff2` production URL; it now asserts the root-relative URL that production actually serves.
- Existing dev-mode tests (`serves generated CSS and font bytes during development`, `serves publicDir fonts from their Vite URL in base-path development`) still pass unchanged, pinning that dev behavior is untouched.

```
corepack pnpm --filter @farm.js/core exec vitest run src/__tests__/font-vite.test.ts
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve self-hosted font URLs as root-relative in production when a non-root `basePath` is set. Previously, production minted `/basePath/assets/fonts/...` URLs that 404ed; now URLs are `/assets/fonts/...`, preload headers and runtime preloads match, and dev behavior is unchanged.

- Central change in `resourceUrl(...)` (`packages/farm/src/font-vite.ts`): production returns `/${outputFileName}` for emitted assets and leaves `publicPath` unprefixed; dev still prefixes with `basePath`.
- Tests: added a production test with `basePath` asserting root-relative CSS/preload URLs; updated publicDir test to expect root-relative; existing dev-mode tests pass unchanged.

<sup>Written for commit 10fe2c1020ac2aa148e328e6131dd194158d3117. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

