### PR TITLE
fix(build): emit the configured publicDir into the production client output

### DIFF
--- a/packages/farm/src/__tests__/production-public-dir.test.ts
+++ b/packages/farm/src/__tests__/production-public-dir.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment node
+
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import { createServer as createNetServer } from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { build } from "../build";
+import { loadConfig, resolveConfig } from "../config";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+async function createFixture(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(packageRoot, ".tmp-production-public-dir-"));
+
+  await fs.mkdir(path.join(root, "node_modules", "@farm.js"), { recursive: true });
+  await fs.symlink(packageRoot, path.join(root, "node_modules", "@farm.js", "core"), "dir");
+  await fs.mkdir(path.join(root, "src", "app"), { recursive: true });
+  await fs.mkdir(path.join(root, "static", "nested"), { recursive: true });
+  await fs.writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({ private: true, type: "module" }, null, 2),
+  );
+  await fs.writeFile(path.join(root, "src", "app", "globals.css"), "");
+  await fs.writeFile(
+    path.join(root, "farm.config.ts"),
+    `
+export default {
+  srcDir: "src",
+  images: { provider: "none" },
+  publicDir: "static",
+};
+`.trim(),
+  );
+  await fs.writeFile(
+    path.join(root, "src", "app", "layout.tsx"),
+    `export default function Layout({ children }) { return <html><body>{children}</body></html>; }`,
+  );
+  await fs.writeFile(
+    path.join(root, "src", "app", "page.tsx"),
+    `export default function HomePage() { return <main>custom-public-dir-home</main>; }`,
+  );
+  await fs.writeFile(path.join(root, "static", "hello.txt"), "hello-from-custom-public-dir");
+  await fs.writeFile(path.join(root, "static", "nested", "data.json"), '{"ok":true}');
+
+  return root;
+}
+
+async function loadFixtureConfig(root: string) {
+  const userConfig = await loadConfig(root, undefined, "production");
+  return resolveConfig({ ...userConfig, root }, "production");
+}
+
+async function getAvailablePort(): Promise<number> {
+  const server = createNetServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+  return port;
+}
+
+async function startProductionServer(
+  serverDir: string,
+  readinessPath = "/",
+): Promise<{
+  origin: string;
+  stop: () => Promise<void>;
+}> {
+  const port = await getAvailablePort();
+  const output: string[] = [];
+  const child = spawn(process.execPath, [path.join(serverDir, "index.mjs")], {
+    cwd: serverDir,
+    env: { ...process.env, HOST: "127.0.0.1", PORT: String(port) },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout.on("data", (chunk) => output.push(String(chunk)));
+  child.stderr.on("data", (chunk) => output.push(String(chunk)));
+  const origin = `http://127.0.0.1:${port}`;
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (child.exitCode !== null) {
+      throw new Error(`Production server exited before readiness:\n${output.join("")}`);
+    }
+    try {
+      await fetch(`${origin}${readinessPath}`);
+      return {
+        origin,
+        stop: async () => {
+          if (child.exitCode !== null) return;
+          child.kill("SIGTERM");
+          await new Promise<void>((resolve) => {
+            const timeout = setTimeout(() => {
+              child.kill("SIGKILL");
+              resolve();
+            }, 2_000);
+            child.once("exit", () => {
+              clearTimeout(timeout);
+              resolve();
+            });
+          });
+        },
+      };
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+
+  child.kill("SIGKILL");
+  throw new Error(
+    `Production server did not become ready: ${String(lastError)}\n${output.join("")}`,
+  );
+}
+
+describe("production build with a custom publicDir", () => {
+  it("emits configured publicDir assets into the client output and serves them", async () => {
+    const root = await createFixture();
+    let production: Awaited<ReturnType<typeof startProductionServer>> | undefined;
+
+    try {
+      const config = await loadFixtureConfig(root);
+      expect(config.publicDir).toBe("static");
+      await build(config, { root, preset: "node-server" });
+
+      const publicOutputDir = path.join(root, ".farm", ".output", "public");
+      await expect(fs.readFile(path.join(publicOutputDir, "hello.txt"), "utf8")).resolves.toBe(
+        "hello-from-custom-public-dir",
+      );
+      await expect(
+        fs.readFile(path.join(publicOutputDir, "nested", "data.json"), "utf8"),
+      ).resolves.toBe('{"ok":true}');
+
+      production = await startProductionServer(path.join(root, ".farm", ".output", "server"));
+
+      const assetResponse = await fetch(`${production.origin}/hello.txt`);
+      expect(assetResponse.status).toBe(200);
+      await expect(assetResponse.text()).resolves.toBe("hello-from-custom-public-dir");
+
+      const nestedResponse = await fetch(`${production.origin}/nested/data.json`);
+      expect(nestedResponse.status).toBe(200);
+      await expect(nestedResponse.json()).resolves.toEqual({ ok: true });
+    } finally {
+      await production?.stop();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }, 180_000);
+});

--- a/packages/farm/src/__tests__/vite-config.test.ts
+++ b/packages/farm/src/__tests__/vite-config.test.ts
@@ -3,7 +3,7 @@
 import { describe, expect, it } from "vitest";
 import path from "node:path";
 import { FARM_CLIENT_OPTIMIZE_DEPS_INCLUDE } from "../server/vite-config";
-import { defineConfig } from "../vite";
+import { defineConfig, farmPlugin } from "../vite";
 
 describe("Farm Vite dependency optimization", () => {
   it("pre-bundles framework and route UI entries with React", async () => {
@@ -25,5 +25,27 @@ describe("Farm Vite dependency optimization", () => {
     expect(config.resolve?.alias).toMatchObject({
       "@": path.resolve(process.cwd(), "web"),
     });
+  });
+});
+
+describe("Farm Vite publicDir", () => {
+  it("passes the configured publicDir to Vite through the plugin config hook", () => {
+    const plugin = farmPlugin({ publicDir: "static" });
+
+    const config = (plugin.config as any)?.(
+      {},
+      { command: "serve", mode: "development", isSsrBuild: false },
+    );
+    expect(config.publicDir).toBe("static");
+  });
+
+  it("leaves Vite's default publicDir untouched when none is configured", () => {
+    const plugin = farmPlugin({});
+
+    const config = (plugin.config as any)?.(
+      {},
+      { command: "serve", mode: "development", isSsrBuild: false },
+    );
+    expect("publicDir" in config).toBe(false);
   });
 });

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1238,6 +1238,9 @@ async function buildClient(
   try {
     await viteBuild({
       root,
+      // Vite otherwise falls back to <root>/public, silently dropping every
+      // asset in a custom config.publicDir from the production client output.
+      publicDir: config.publicDir,
       esbuild: {
         jsxDev: false,
       },

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -546,6 +546,9 @@ export function farmPlugin(
       const layerAliases = getFarmLayerAliases(options.layers);
       const layerRoots = (options.layers ?? []).map((layer) => layer.root);
       return {
+        // Honor Farm's publicDir so the dev server serves the same static
+        // directory the production client build emits.
+        ...(options.publicDir ? { publicDir: options.publicDir } : {}),
         define: getEnvDefines(options, configEnv),
         resolve: {
           alias: layerAliases,


### PR DESCRIPTION
## Problem

`publicDir` is a documented top-level Farm option (`config.ts:314`, normalized to `"public"` at `config.ts:901`), but the production client Vite build in `buildClient` (`packages/farm/src/nitro/universal-build.ts`) never passed it through. Vite therefore fell back to its default `<root>/public`, so with e.g. `publicDir: "static"` every file in the configured directory (favicon, images, `robots.txt`, public-path font files) was absent from the deployed output and 404'd in production — on node-server, Vercel, and Cloudflare alike. The option was only ever consumed by the font pipeline (`build/index.ts`, `font-vite.ts`), which resolves font bytes at build time and so masked the breakage for fonts while every other static asset silently disappeared.

Dev had the same gap for plain static files: neither the dev server config nor `farmPlugin` ever set Vite's `publicDir`, so `farm dev` also only served `<root>/public` (the dotted-path check at `vite.ts:1750` reads `server.config.publicDir`).

## Fix

- `buildClient` now passes `publicDir: config.publicDir` to the production client Vite build. Vite copies the directory's contents into the client output dir, which Nitro already serves at `/` via its `publicAssets` entry — no Nitro changes are needed, and Vercel post-processing (`public` → `static` rename) carries the files along automatically.
- `farmPlugin`'s `config` hook forwards `options.publicDir` to Vite (only when set), so the dev server serves the same directory the production build emits.

The default stays byte-identical: the normalized default `"public"` resolves exactly as Vite's own default in both dev and build. The in-memory universal SSR bundle build is unaffected because `build.write: false` skips public-dir copying (verified against the repo's Vite 5.4).

## Tests

- `src/__tests__/production-public-dir.test.ts` (new, mirrors the `production-ssg.test.ts` fixture idiom): builds a fixture with `publicDir: "static"` for node-server, asserts `static/hello.txt` and `static/nested/data.json` land in `.farm/.output/public/` with correct content, then boots the built server and fetches both URLs. Fails on main (files never emitted), passes with the fix.
- `src/__tests__/vite-config.test.ts`: unit tests that `farmPlugin({ publicDir: "static" })`'s config hook returns `publicDir: "static"` (fails on main) and that an unset option leaves Vite's default untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `publicDir` assets are emitted and served by both the production client build and the dev server. Previously, Vite defaulted to `<root>/public`, so assets in a custom `publicDir` were missing in production and not served in dev.

- Build: `buildClient` now forwards `config.publicDir` so the production client output includes those assets; Nitro serving remains unchanged.
- Dev: `farmPlugin` sets `publicDir` only when configured, aligning dev with prod.
- Defaults unchanged: `"public"` resolves identically as before; the in-memory SSR bundle is unaffected (`build.write: false`).
- Tests: new production integration test verifies asset emission and serving; plugin unit test verifies `publicDir` pass-through.
- No migration required; apps with a custom `publicDir` will now see those files in the production output and during `farm dev`.

<sup>Written for commit e6e3ade8a83a75e2d5db584b4ea7fcfe8b961e62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

