### PR TITLE
fix(vercel): stop scoping the immutable asset cache route to basePath

### DIFF
--- a/packages/farm/src/__tests__/production-middleware.test.ts
+++ b/packages/farm/src/__tests__/production-middleware.test.ts
@@ -63,9 +63,7 @@ describe("production middleware runtime", () => {
       const vercelOutputConfig = JSON.parse(
         await fs.readFile(path.join(root, ".vercel", "output", "config.json"), "utf8"),
       );
-      expect(vercelOutputConfig.routes[0]).toEqual(
-        createFarmVercelImmutableAssetRoute(config.basePath),
-      );
+      expect(vercelOutputConfig.routes[0]).toEqual(createFarmVercelImmutableAssetRoute());
       expect(vercelOutputConfig.routes[1]).toEqual({ handle: "filesystem" });
 
       const staticAssetsDir = path.join(root, ".vercel", "output", "static", "assets");

--- a/packages/farm/src/__tests__/vercel-assets.test.ts
+++ b/packages/farm/src/__tests__/vercel-assets.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   createFarmVercelImmutableAssetRoute,
   FARM_IMMUTABLE_ASSET_CACHE_CONTROL,
+  type FarmVercelImmutableAssetRoute,
   isFarmVercelImmutableAssetPath,
 } from "../nitro/vercel-assets";
 
@@ -37,9 +38,21 @@ describe("Vercel immutable Farm assets", () => {
     expect(isFarmVercelImmutableAssetPath("/index.html")).toBe(false);
   });
 
-  it("scopes the route to the configured base path", () => {
-    expect(isFarmVercelImmutableAssetPath("/farm/assets/logo-ha1b2c3d4.webp", "/farm")).toBe(true);
-    expect(isFarmVercelImmutableAssetPath("/assets/logo-ha1b2c3d4.webp", "/farm")).toBe(false);
+  it("matches root asset paths even when a base path is configured", () => {
+    // Hashed client assets are emitted and served at the root regardless of
+    // basePath (the client build sets no Vite `base` and Nitro mounts the
+    // client output at "/"), so a basePath-scoped route would never match the
+    // URLs browsers actually request. The cast emulates the old call site
+    // that passed config.basePath.
+    const createRoute = createFarmVercelImmutableAssetRoute as (
+      basePath?: string,
+    ) => FarmVercelImmutableAssetRoute;
+    const matcher = new RegExp(createRoute("/farm").src);
+
+    expect(matcher.test("/assets/logo-ha1b2c3d4.webp")).toBe(true);
+    expect(matcher.test("/farm-client-h1a2b3c4d.js")).toBe(true);
+    expect(matcher.test("/chunks/router-hab12cd90.js")).toBe(true);
+    expect(matcher.test("/farm/assets/logo-ha1b2c3d4.webp")).toBe(false);
   });
 
   it("emits a continuing header route for the Build Output API", () => {

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -7499,7 +7499,9 @@ async function postProcessVercelOutput(
   vercelConfig.routes = [
     // Apply the header before the filesystem handler. `continue` lets Vercel
     // serve the matching file while preserving the immutable cache policy.
-    createFarmVercelImmutableAssetRoute(config.basePath),
+    // Hashed client assets ship at the root regardless of basePath, so the
+    // route is deliberately not basePath-scoped.
+    createFarmVercelImmutableAssetRoute(),
     // Serve static files first
     {
       handle: "filesystem",

--- a/packages/farm/src/nitro/vercel-assets.ts
+++ b/packages/farm/src/nitro/vercel-assets.ts
@@ -13,15 +13,17 @@ export interface FarmVercelImmutableAssetRoute {
  * excluded because they can change between deployments. The fingerprinted
  * client entry lives at the public root — its relative chunk imports pin it
  * there — so root-level farm-client-h files qualify alongside assets/chunks.
+ *
+ * Hashed client assets are emitted and served at the root even when a
+ * basePath is configured — the client build sets no Vite `base` and Nitro
+ * mounts the client output at "/" — so the route matches root paths
+ * unconditionally.
  */
-export function createFarmVercelImmutableAssetRoute(basePath = "/"): FarmVercelImmutableAssetRoute {
-  const normalizedBasePath = normalizeBasePath(basePath);
-  const escapedBasePath = escapeRegex(normalizedBasePath);
-  const prefix = escapedBasePath ? `/${escapedBasePath}` : "";
+export function createFarmVercelImmutableAssetRoute(): FarmVercelImmutableAssetRoute {
   const fingerprint = "-h(?:[a-fA-F0-9]{8}|[a-fA-F0-9]{12}|[a-fA-F0-9]{16})";
 
   return {
-    src: `^${prefix}/(?:(?:assets|chunks)/(?:.+/)*[^/]+|farm-client)${fingerprint}\\.(?!(?:[hH][tT][mM][lL]?)$)[^/]+$`,
+    src: `^/(?:(?:assets|chunks)/(?:.+/)*[^/]+|farm-client)${fingerprint}\\.(?!(?:[hH][tT][mM][lL]?)$)[^/]+$`,
     headers: {
       "Cache-Control": FARM_IMMUTABLE_ASSET_CACHE_CONTROL,
     },
@@ -30,14 +32,6 @@ export function createFarmVercelImmutableAssetRoute(basePath = "/"): FarmVercelI
   };
 }
 
-export function isFarmVercelImmutableAssetPath(pathname: string, basePath = "/"): boolean {
-  return new RegExp(createFarmVercelImmutableAssetRoute(basePath).src).test(pathname);
-}
-
-function normalizeBasePath(basePath: string): string {
-  return basePath.trim().replace(/^\/+|\/+$/g, "");
-}
-
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+export function isFarmVercelImmutableAssetPath(pathname: string): boolean {
+  return new RegExp(createFarmVercelImmutableAssetRoute().src).test(pathname);
 }


### PR DESCRIPTION
## Problem

With a non-root `basePath` (e.g. `defineConfig({ basePath: "/docs", deploy: { target: "vercel" } })`), a Vercel deploy silently loses immutable caching for every content-hashed client asset.

`postProcessVercelOutput` builds the Build-Output-API header route with `createFarmVercelImmutableAssetRoute(config.basePath)` (`packages/farm/src/nitro/universal-build.ts:7502`), which prefixes the regex `src` with the base path (`vercel-assets.ts`), producing `^/docs/(?:(?:assets|chunks)/…|farm-client)-h…`.

But hashed client assets are emitted and served at the root regardless of `basePath`:

- the client Vite build sets no `base` and names outputs `farm-client-h[hash].js`, `chunks/[name]-h[hash].js`, `assets/[name]-h[hash][ext]` (`universal-build.ts:1252-1266`);
- the SSR shell references root-absolute hrefs (`/farm-client-h….js`, `/assets/farm-client-h….css`);
- Nitro `publicAssets` mounts the client output at `baseURL: "/"` (`universal-build.ts:7059-7064`).

So browsers request `/assets/…`, `/chunks/…`, `/farm-client-h….js`, the basePath-prefixed route never matches, and none of the cache-forever assets receive `Cache-Control: public, max-age=31536000, immutable`. Every deploy makes clients re-validate all JS/CSS/font/image chunks. The default `basePath: "/"` only works because the prefix collapses to empty.

## Fix

Hashed client assets ship at the root regardless of `basePath` (a sibling PR moves font URLs the same direction), so the immutable route now matches root asset paths unconditionally:

- `createFarmVercelImmutableAssetRoute()` and `isFarmVercelImmutableAssetPath()` drop their `basePath` parameter; the route `src` is always root-anchored. The now-unused `normalizeBasePath`/`escapeRegex` helpers are removed.
- The call site in `postProcessVercelOutput` no longer passes `config.basePath`, with a comment recording the deliberate decision.
- `production-middleware.test.ts` updated to the new signature (behaviorally identical there — the fixture uses the default basePath).

## Tests

- Replaced the `vercel-assets.test.ts` case that asserted the broken basePath-scoped intent with a regression test that emulates the old `config.basePath` call site (typed cast passing `"/farm"`) and asserts the route still matches `/assets/…`, `/chunks/…`, and `/farm-client-h….js` while rejecting `/farm/assets/…`. It fails on main (the route gets a `^/farm` prefix) and passes with the fix.
- All pre-existing matcher cases (fingerprint shapes, HTML exclusion, stable-name exclusion, case sensitivity) are unchanged and still pass.

Run: `corepack pnpm --filter @farm.js/core exec vitest run src/__tests__/vercel-assets.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop scoping the Vercel immutable asset cache route to basePath so hashed client assets get Cache-Control headers. Previously, a non-root basePath caused the route to miss root-served assets and drop immutable caching; now the route is root-anchored and always matches.

- Dropped the basePath parameter from createFarmVercelImmutableAssetRoute() and isFarmVercelImmutableAssetPath(); removed normalizeBasePath/escapeRegex; updated postProcessVercelOutput to call the zero-arg route before the filesystem handle.
- Updated tests: replaced the basePath-scoped assertion with a regression that proves root matching even when a basePath is passed; other matcher cases remain unchanged.

**Migration**
- If you import createFarmVercelImmutableAssetRoute() or isFarmVercelImmutableAssetPath(), remove the basePath argument.

<sup>Written for commit a216c327ffc5ccb9b170b57a079ccaa9829e5cc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

