### PR TITLE
fix(nitro): keep repeated query params as arrays in production

### DIFF
--- a/packages/farm/src/__tests__/searchparams.test.ts
+++ b/packages/farm/src/__tests__/searchparams.test.ts
@@ -1,4 +1,8 @@
+import fs from "fs";
+import path from "path";
 import { describe, it, expect } from "vitest";
+
+import { searchParamsToObject } from "../search-params";
 
 describe("SearchParams Parsing", () => {
   it("should parse single query parameter", () => {
@@ -154,5 +158,77 @@ describe("SearchParams in PageProps", () => {
     const tab = search.tab;
 
     expect(tab).toBeUndefined();
+  });
+});
+
+describe("searchParamsToObject", () => {
+  it("keeps single-value parameters as strings", () => {
+    expect(searchParamsToObject(new URLSearchParams("?tab=profile&sort=desc"))).toEqual({
+      tab: "profile",
+      sort: "desc",
+    });
+  });
+
+  it("collects repeated parameters into arrays", () => {
+    expect(searchParamsToObject(new URLSearchParams("?tag=react&tag=typescript&tag=vite"))).toEqual(
+      {
+        tag: ["react", "typescript", "vite"],
+      },
+    );
+  });
+
+  it("mirrors the dev renderer's handling of empty first values", () => {
+    // The dev helper checks truthiness, so an empty-string first value is
+    // replaced instead of collected. Production must agree with dev.
+    expect(searchParamsToObject(new URLSearchParams("?tab=&tab=x"))).toEqual({ tab: "x" });
+    expect(searchParamsToObject(new URLSearchParams(""))).toEqual({});
+  });
+});
+
+describe("SearchParams in the production runtime", () => {
+  const readSource = (...segments: string[]) =>
+    fs.readFileSync(path.join(process.cwd(), "src", ...segments), "utf-8");
+
+  it("builds generated SSR page props with array-aware search params", () => {
+    const source = readSource("nitro", "universal-build.ts");
+
+    expect(source).toContain("  searchParamsToObject,");
+    expect(source).toContain("const searchParamsObj = searchParamsToObject(url.searchParams);");
+    expect(source).not.toContain("Object.fromEntries(url.searchParams.entries())");
+    expect(readSource("nitro", "production-runtime.ts")).toContain(
+      'export { searchParamsToObject } from "../search-params";',
+    );
+  });
+
+  it("hydrates and client-navigates with array-aware search params", () => {
+    const source = readSource("nitro", "universal-build.ts");
+
+    expect(source).toContain(
+      'import { createClientPluginManager, installChunkErrorRecovery, scheduleFarmIslandHydration, searchParamsToObject } from "@farm.js/core/internal/client-runtime";',
+    );
+    expect(source).toContain(
+      "const searchParams = searchParamsToObject(new URLSearchParams(window.location.search));",
+    );
+    expect(source).not.toContain("Object.fromEntries(url.searchParams)");
+    expect(source).not.toContain("Object.fromEntries(targetUrl.searchParams)");
+    expect(source).not.toContain(
+      "Object.fromEntries(new URLSearchParams(window.location.search))",
+    );
+    expect(readSource("client", "production-runtime.ts")).toContain(
+      'export { searchParamsToObject } from "../search-params";',
+    );
+  });
+
+  it("returns array-aware search params from the SPA page-data endpoint", () => {
+    const source = readSource("nitro", "server-entry.ts");
+
+    expect(source).toContain("const searchParams = searchParamsToObject(targetUrl.searchParams);");
+    expect(source).not.toContain("const searchParams: Record<string, string> = {};");
+  });
+
+  it("shares the dev renderer's helper", () => {
+    const source = readSource("server", "renderer.ts");
+
+    expect(source).toContain('import { searchParamsToObject } from "../search-params";');
   });
 });

--- a/packages/farm/src/__tests__/searchparams.test.ts
+++ b/packages/farm/src/__tests__/searchparams.test.ts
@@ -177,10 +177,10 @@ describe("searchParamsToObject", () => {
     );
   });
 
-  it("mirrors the dev renderer's handling of empty first values", () => {
-    // The dev helper checks truthiness, so an empty-string first value is
-    // replaced instead of collected. Production must agree with dev.
-    expect(searchParamsToObject(new URLSearchParams("?tab=&tab=x"))).toEqual({ tab: "x" });
+  it("preserves empty values when a parameter is repeated", () => {
+    expect(searchParamsToObject(new URLSearchParams("?tab=&tab=x&tab="))).toEqual({
+      tab: ["", "x", ""],
+    });
     expect(searchParamsToObject(new URLSearchParams(""))).toEqual({});
   });
 });
@@ -211,9 +211,7 @@ describe("SearchParams in the production runtime", () => {
     );
     expect(source).not.toContain("Object.fromEntries(url.searchParams)");
     expect(source).not.toContain("Object.fromEntries(targetUrl.searchParams)");
-    expect(source).not.toContain(
-      "Object.fromEntries(new URLSearchParams(window.location.search))",
-    );
+    expect(source).not.toContain("Object.fromEntries(new URLSearchParams(window.location.search))");
     expect(readSource("client", "production-runtime.ts")).toContain(
       'export { searchParamsToObject } from "../search-params";',
     );
@@ -230,5 +228,21 @@ describe("SearchParams in the production runtime", () => {
     const source = readSource("server", "renderer.ts");
 
     expect(source).toContain('import { searchParamsToObject } from "../search-params";');
+  });
+
+  it("shares the helper with secondary production, dev navigation, and test runtimes", () => {
+    const nitroSource = readSource("nitro", "index.ts");
+    const viteSource = readSource("vite.ts");
+    const testingSource = readSource("testing.ts");
+
+    expect(nitroSource).toContain(
+      "import { searchParamsToObject } from '@farm.js/core/internal/production-runtime';",
+    );
+    expect(nitroSource).toContain(
+      "const searchParamsObject = searchParamsToObject(url.searchParams);",
+    );
+    expect(viteSource).toContain("const searchParams = searchParamsToObject(url.searchParams);");
+    expect(viteSource).toContain("return searchParamsToObject(url.searchParams);");
+    expect(testingSource).toContain("const search = searchParamsToObject(url.searchParams);");
   });
 });

--- a/packages/farm/src/client/production-runtime.ts
+++ b/packages/farm/src/client/production-runtime.ts
@@ -1,3 +1,4 @@
 export { installChunkErrorRecovery } from "./chunk-recovery";
 export { scheduleFarmIslandHydration } from "./island-runtime";
 export { createClientPluginManager } from "./plugin";
+export { searchParamsToObject } from "../search-params";

--- a/packages/farm/src/nitro/index.ts
+++ b/packages/farm/src/nitro/index.ts
@@ -261,6 +261,7 @@ import type { H3Event } from 'h3';
 import { farmRegistry } from '../farm-registry';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
+import { searchParamsToObject } from '@farm.js/core/internal/production-runtime';
 
 export default defineEventHandler(async (event: H3Event) => {
   try {
@@ -376,19 +377,7 @@ export default defineEventHandler(async (event: H3Event) => {
       }
       
       // Get search params
-      const searchParamsObject: Record<string, string | string[] | undefined> = {};
-      url.searchParams.forEach((value, key) => {
-        const existing = searchParamsObject[key];
-        if (existing) {
-          if (Array.isArray(existing)) {
-            existing.push(value);
-          } else {
-            searchParamsObject[key] = [existing, value];
-          }
-        } else {
-          searchParamsObject[key] = value;
-        }
-      });
+      const searchParamsObject = searchParamsToObject(url.searchParams);
       
       // Load route module - in production, use bundled SSR output
       // Get bundled path from registry or construct it

--- a/packages/farm/src/nitro/production-runtime.ts
+++ b/packages/farm/src/nitro/production-runtime.ts
@@ -53,6 +53,7 @@ export {
   manageFarmLinkHeaderPreloads,
   reportFarmPreloadWarnings,
 } from "../preload";
+export { searchParamsToObject } from "../search-params";
 
 export function appendFarmLinkHeader(headers: Headers, value: string): void {
   const current = headers.get("Link");

--- a/packages/farm/src/nitro/server-entry.ts
+++ b/packages/farm/src/nitro/server-entry.ts
@@ -11,6 +11,7 @@ import type { ServerRenderer } from "../server/renderer";
 import { setEnv } from "../env";
 import { withFarmRouteContext } from "../route-context";
 import { createDeferredDataResponse } from "../deferred";
+import { searchParamsToObject } from "../search-params";
 import {
   createFarmDeploymentMismatchResponse,
   getFarmDeploymentMismatch,
@@ -214,11 +215,8 @@ async function defaultHandler({
         mergedMetadata = { ...mergedMetadata, ...routeModule.metadata };
       }
 
-      // Build search params
-      const searchParams: Record<string, string> = {};
-      targetUrl.searchParams.forEach((value, key) => {
-        searchParams[key] = value;
-      });
+      // Build search params (repeated keys collect into arrays, matching dev)
+      const searchParams = searchParamsToObject(targetUrl.searchParams);
       const routeContext = sr
         ? await sr.resolveRouteContext({
             request,

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -2037,7 +2037,7 @@ document.addEventListener("click", function(e) {
 ${cssImport}
 ${layoutImports}
 ${rendererClientImports}
-import { createClientPluginManager, installChunkErrorRecovery, scheduleFarmIslandHydration } from "@farm.js/core/internal/client-runtime";
+import { createClientPluginManager, installChunkErrorRecovery, scheduleFarmIslandHydration, searchParamsToObject } from "@farm.js/core/internal/client-runtime";
 import { matchFarmRoute } from "@farm.js/core/router";
 ${clientPluginEntry.imports}
 ${i18nClientRuntime}
@@ -2389,7 +2389,7 @@ async function hydrate() {
         ) {
           return;
         }
-        const searchParams = Object.fromEntries(new URLSearchParams(window.location.search));
+        const searchParams = searchParamsToObject(new URLSearchParams(window.location.search));
         const wrappedElement = await createMatchedHydrationElement(
           matched,
           pathname,
@@ -2599,7 +2599,7 @@ ${generateUniversalRouterStateProperties()}
         // when their initial document hydration strategy is deferred.
         const Component = await loadRouteComponent(matched.route);
         const params = matched.params;
-        const searchParams = Object.fromEntries(url.searchParams);
+        const searchParams = searchParamsToObject(url.searchParams);
         const props = { params: params, searchParams: Promise.resolve(searchParams) };
         let pageElement = React.createElement(Component, props);
         if (hasHydratableLayout(pathname)) {
@@ -2732,7 +2732,7 @@ ${generateUniversalRouterStateProperties()}
     // If React already owns the shared layout, update that root. React keeps
     // matching layout component instances and their state mounted.
     if (matched && hydrateLayouts && reactRoot && reactRootContainer === currentRoot) {
-      const searchParams = Object.fromEntries(targetUrl.searchParams);
+      const searchParams = searchParamsToObject(targetUrl.searchParams);
       const wrappedElement = await createMatchedHydrationElement(
         matched,
         newPathname,
@@ -2759,7 +2759,7 @@ ${generateUniversalRouterStateProperties()}
 
     // Check if the new HTML contains an interactive route boundary.
     if (matched) {
-      const searchParams = Object.fromEntries(targetUrl.searchParams);
+      const searchParams = searchParamsToObject(targetUrl.searchParams);
       const pageContainer =
         hydrateLayouts ? currentRoot : document.getElementById("__farm_page__") || currentRoot;
       const wrappedElement = await createMatchedHydrationElement(
@@ -3600,6 +3600,7 @@ function generateVirtualEntryCode(
   resolveDefaultErrorStatus,
   resolveFarmInstrumentationRuntime,
   runWithFarmRequestSpan,
+  searchParamsToObject,
   stripFarmLocaleFromPathname,
   withFarmRouteContext,
 } from "@farm.js/core/internal/production-runtime";`;
@@ -4668,7 +4669,7 @@ async function handleMetadataImageRequest(request, routePathname) {
       throw new Error("Metadata image module does not export a default component or handler");
     }
 
-    const searchParams = Object.fromEntries(url.searchParams.entries());
+    const searchParams = searchParamsToObject(url.searchParams);
     const props = {
       params: match.params,
       searchParams: Promise.resolve(searchParams),
@@ -5650,7 +5651,7 @@ async function handleFarmRequestInContext(
       
       if (PageComponent) {
         // Parse search params - make it a resolved Promise for async components
-        const searchParamsObj = Object.fromEntries(url.searchParams.entries());
+        const searchParamsObj = searchParamsToObject(url.searchParams);
         
         // Render the page component
         const routeContext = hasConfiguredRouteContext
@@ -6220,7 +6221,7 @@ async function handleFarmRequestInContext(
       const errorBoundaryMatch = getMatchingErrorBoundary(routePathname);
       if (errorBoundaryMatch?.route.module?.default) {
         try {
-          const searchParamsObj = Object.fromEntries(url.searchParams.entries());
+          const searchParamsObj = searchParamsToObject(url.searchParams);
           const ErrorComponent = errorBoundaryMatch.route.module.default;
           let errorElement = React.createElement(ErrorComponent, {
             error,

--- a/packages/farm/src/search-params.ts
+++ b/packages/farm/src/search-params.ts
@@ -1,0 +1,27 @@
+/**
+ * Convert URLSearchParams into the object handed to routes as `search` /
+ * `searchParams`: single keys stay strings and repeated keys collect into
+ * arrays, in order. The dev renderer, the production SSR entry, the SPA
+ * page-data endpoint, and the generated client hydration runtime all share
+ * this helper so every environment agrees on one representation.
+ */
+export function searchParamsToObject(
+  searchParams: URLSearchParams,
+): Record<string, string | string[] | undefined> {
+  const output: Record<string, string | string[] | undefined> = {};
+
+  searchParams.forEach((value, key) => {
+    const existing = output[key];
+    if (existing) {
+      if (Array.isArray(existing)) {
+        existing.push(value);
+      } else {
+        output[key] = [existing, value];
+      }
+    } else {
+      output[key] = value;
+    }
+  });
+
+  return output;
+}

--- a/packages/farm/src/search-params.ts
+++ b/packages/farm/src/search-params.ts
@@ -12,7 +12,7 @@ export function searchParamsToObject(
 
   searchParams.forEach((value, key) => {
     const existing = output[key];
-    if (existing) {
+    if (existing !== undefined) {
       if (Array.isArray(existing)) {
         existing.push(value);
       } else {

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -38,6 +38,7 @@ import {
   type MetadataImageKind,
 } from "../metadata";
 import { resolveFarmRouteContext, withFarmRouteContext } from "../route-context";
+import { searchParamsToObject } from "../search-params";
 import { prepareDeferredData, snapshotDeferredData, type DeferredRecord } from "../deferred";
 import { createFarmDeploymentCookie, FARM_DEPLOYMENT_ID_HEADER } from "../deployment";
 import type { StaticMetadataImageInfo } from "../static-metadata-image";
@@ -220,27 +221,6 @@ function createPPRRefreshScript(): string {
 
 function createPreHydrationClickQueueScript(): string {
   return `<script>(function(){if(window.__FARM_PREHYDRATION_CLICK_QUEUE__)return;var queue=[];window.__FARM_PREHYDRATION_CLICK_QUEUE__=queue;window.__FARM_HYDRATED__=false;document.documentElement.dataset.farmHydrated="false";function isModified(event){return !!(event.metaKey||event.altKey||event.ctrlKey||event.shiftKey)}function closestQueuedTarget(target){while(target&&target!==document.documentElement){if(target.matches&&target.matches('button,[role="button"],input[type="button"],input[type="submit"],input[type="reset"]'))return target;target=target.parentElement}return null}document.addEventListener("click",function(event){if(window.__FARM_HYDRATED__)return;if(event.defaultPrevented||event.button!==0||isModified(event))return;var target=closestQueuedTarget(event.target);if(!target||target.closest&&target.closest("a[href]")||target.closest&&target.closest('[data-farm-island-hydrated="true"]'))return;if(queue.some(function(item){return item.target===target}))return;queue.push({target:target,createdAt:Date.now()});document.dispatchEvent(new CustomEvent("farm:island-interaction",{detail:{target:target}}));event.preventDefault();event.stopImmediatePropagation()},true);})();</script>`;
-}
-
-function searchParamsToObject(
-  searchParams: URLSearchParams,
-): Record<string, string | string[] | undefined> {
-  const output: Record<string, string | string[] | undefined> = {};
-
-  searchParams.forEach((value, key) => {
-    const existing = output[key];
-    if (existing) {
-      if (Array.isArray(existing)) {
-        existing.push(value);
-      } else {
-        output[key] = [existing, value];
-      }
-    } else {
-      output[key] = value;
-    }
-  });
-
-  return output;
 }
 
 function createDocumentFooter(options: {

--- a/packages/farm/src/testing.ts
+++ b/packages/farm/src/testing.ts
@@ -18,6 +18,7 @@ import {
 } from "./router";
 import { runWithServerActionRequest } from "./server-action-security";
 import type { ServerFn } from "./server-fn";
+import { searchParamsToObject } from "./search-params";
 import type { FarmContextFactory, MiddlewareProps, PluginContextProps, RouteModule } from "./types";
 
 export type FarmTestQuery = URLSearchParams | Record<string, FarmRouterQueryValue>;
@@ -198,7 +199,7 @@ export function createFarmTestHarness<TContext = unknown>(
       });
       const url = new URL(routeRequest.url);
       const params = resolvePageParams(route.path, url.pathname, routeOptions.params);
-      const search = readSearchParams(url.searchParams);
+      const search = searchParamsToObject(url.searchParams);
       const routeContext = Object.prototype.hasOwnProperty.call(routeOptions, "context")
         ? routeOptions.context
         : await resolveFarmRouteContext(
@@ -435,14 +436,6 @@ function resolvePageParams(
       Array.isArray(value) ? value.map(String).join("/") : String(value),
     ]),
   );
-}
-
-function readSearchParams(searchParams: URLSearchParams): Record<string, string> {
-  const search: Record<string, string> = {};
-  searchParams.forEach((value, key) => {
-    search[key] = value;
-  });
-  return search;
 }
 
 function readCanonicalPath(props: Record<string, unknown>): string | undefined {

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -74,6 +74,7 @@ import {
 } from "./server-http";
 import { createCliColors } from "./cli-colors";
 import { createFarmThemeCssPlugin } from "./theme/vite";
+import { searchParamsToObject } from "./search-params";
 import { emitFarmEvent, runWithFarmRequestSpan } from "./observability";
 import {
   isReactRenderer,
@@ -1878,10 +1879,7 @@ window.__FARM_MANIFEST__ = ${inlineValue({
 
                 // Build search params
                 const targetUrl = new URL(targetPath, "http://localhost");
-                const searchParams: Record<string, string> = {};
-                targetUrl.searchParams.forEach((value, key) => {
-                  searchParams[key] = value;
-                });
+                const searchParams = searchParamsToObject(targetUrl.searchParams);
                 const routeContext = await resolveFarmRouteContext(farmApp.getConfig(), {
                   request,
                   params,
@@ -3322,7 +3320,7 @@ async function hydrateFarmDocsAdapterRuntime() {
 ${rendererClientImports}
 import { installChunkErrorRecovery, SPARouter } from '@farm.js/core/client'
 import { createClientPluginManager } from '@farm.js/core/plugin/client'
-import { scheduleFarmIslandHydration } from '@farm.js/core/internal/client-runtime'
+import { scheduleFarmIslandHydration, searchParamsToObject } from '@farm.js/core/internal/client-runtime'
 import { reviveDeferredData } from '@farm.js/core/deferred'
 import {
   createFarmDeploymentMismatchError,
@@ -3519,10 +3517,7 @@ class LegacyManifestSPARouter {
       const { route, params } = match;
 
       // Parse search params
-      const searchParams = {};
-      url.searchParams.forEach((value, key) => {
-        searchParams[key] = value;
-      });
+      const searchParams = searchParamsToObject(url.searchParams);
 
       // Build page data from manifest (no server request!)
       const pageData = {
@@ -3639,10 +3634,7 @@ class LegacyManifestSPARouter {
 
       const { route, params } = match;
       const url = new URL(window.location.href);
-      const searchParams = {};
-      url.searchParams.forEach((value, key) => {
-        searchParams[key] = value;
-      });
+      const searchParams = searchParamsToObject(url.searchParams);
 
       const pageData = {
         route: route,
@@ -3977,12 +3969,8 @@ function wrapWithLoadedLayouts(element, loadedLayouts, params) {
 }
 
 function getCurrentSearchParams() {
-  const searchParams = {};
   const url = new URL(window.location.href);
-  url.searchParams.forEach((value, key) => {
-    searchParams[key] = value;
-  });
-  return searchParams;
+  return searchParamsToObject(url.searchParams);
 }
 
 function parseClientRouteSchema(schema, value, label) {


### PR DESCRIPTION
## Problem

A request like `GET /search?tag=a&tag=b` behaves differently in dev and production. The dev server builds page props with an array-aware `searchParamsToObject` (`src/server/renderer.ts`), yielding `searchParams = { tag: ["a", "b"] }` — the representation the framework's own tests document. Production instead used `Object.fromEntries(url.searchParams.entries())` (or an overwriting `forEach`), yielding `{ tag: "b" }` and silently dropping every value but the last.

The collapse happened at every production site, so the client agreed with the lossy server value and nothing warned:

- generated SSR entry: page props, error-boundary props, metadata-image props (`src/nitro/universal-build.ts`)
- SPA page-data endpoint (`src/nitro/server-entry.ts`)
- generated client runtime: initial island hydration and all three client-navigation hydration paths (`src/nitro/universal-build.ts`)

A multi-select filter page works under `farm dev` and silently loses state once deployed.

## Fix

- Extract dev's `searchParamsToObject` verbatim into a new shared, dependency-free module `src/search-params.ts`; the dev renderer now imports it, so dev and prod cannot drift again.
- Re-export it from `@farm.js/core/internal/production-runtime` and `@farm.js/core/internal/client-runtime`, the modules the generated server and client bundles already import from.
- Replace every lossy parse in the generated server entry, the generated client runtime, and the SPA page-data endpoint with the shared helper.

`__FARM_PROPS__` and the page-data JSON need no changes: both serialize the now array-aware object with `JSON.stringify`, so server HTML, inline props, page-data responses, and client-side re-parsing all agree.

## Tests

`packages/farm/src/__tests__/searchparams.test.ts` gains:

- unit tests for the shared helper (single values, repeated keys → ordered arrays, empty input, and the dev-mirrored empty-first-value behavior) — fail on main because the module does not exist
- generated-source assertions (the repo's existing `readFileSync`/`toContain` idiom for build templates) proving the server template, client template, page-data endpoint, and dev renderer all use the shared helper and that no `Object.fromEntries(...searchParams...)` parse remains — fail on main

Run: `corepack pnpm --filter @farm.js/core exec vitest run src/__tests__/searchparams.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Production and dev now preserve repeated query params as arrays across all runtimes. Previously production collapsed repeated keys to the last value (?tag=a&tag=b → { tag: "b" }); now SSR, SPA page-data, client hydration/navigation, and dev share one array‑aware parser so server and client agree.

**Review notes**
- Adds shared `searchParamsToObject` (`packages/farm/src/search-params.ts`); re-exported from `@farm.js/core/internal/production-runtime` and `@farm.js/core/internal/client-runtime`; dev renderer now imports it.
- Replaces lossy parsing at all production call sites (SSR page props, metadata-image handler, error-boundary props, SPA page‑data endpoint) and in client hydration/navigation; updates Vite dev SPA/router paths and the test harness to use the same helper.
- Tests cover helper behavior and assert generated templates import/use it; no `Object.fromEntries(...)` remains.
- No wire-format change (`searchParams` stays JSON-serialized). If any code assumed collapsed strings, update it to accept string | string[].

<sup>Written for commit 9a3812f98cacc941f54d632094cc766244750a9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

