### PR TITLE
fix(cli): reconcile farm deploy target flag with a mismatched configured preset

### DIFF
--- a/packages/farm-cli/src/build.ts
+++ b/packages/farm-cli/src/build.ts
@@ -12,6 +12,8 @@ export { withProductionNodeEnv };
 export interface BuildFarmOptions {
   root?: string;
   preset?: string;
+  /** Deployment platform the build serves. Wins over the preset-derived target. */
+  target?: string;
 }
 
 /**
@@ -46,9 +48,12 @@ export async function buildFarm(options: BuildFarmOptions = {}) {
 
       const config = await resolveConfig(userConfig, mode);
 
-      // Override preset if provided via CLI
-      if (options.preset) {
-        const deploy = resolveDeployConfig(userConfig, { preset: options.preset as any });
+      // Override preset/target if provided via CLI
+      if (options.preset || options.target) {
+        const deploy = resolveDeployConfig(userConfig, {
+          preset: options.preset as any,
+          target: options.target,
+        });
         config.preset = deploy.preset;
         config.deploy = deploy;
       }

--- a/packages/farm-cli/src/deploy.ts
+++ b/packages/farm-cli/src/deploy.ts
@@ -158,7 +158,11 @@ async function resolveFarmDeployContext(options: DeployFarmOptions) {
   // steps would otherwise resolve different directories.
   const configuredPreset = userConfig?.deploy?.preset || userConfig?.preset;
   const configuredPresetTarget = getDeployTargetForPreset(configuredPreset);
-  const presetMatchesPlatform = Boolean(configuredPreset) && configuredPresetTarget === platform;
+  const configuredTarget = normalizeDeployTarget(userConfig?.deploy?.target);
+  const presetMatchesPlatform =
+    Boolean(configuredPreset) &&
+    (configuredPresetTarget === platform ||
+      (!configuredPresetTarget && configuredTarget === platform));
   if (cliTarget && configuredPreset && !presetMatchesPlatform) {
     logger.warn(
       `Configured preset "${configuredPreset}" targets ${configuredPresetTarget || "an unknown platform"}; using the "${getPresetForDeployTarget(platform)}" preset because --${cliTarget} was passed.`,

--- a/packages/farm-cli/src/deploy.ts
+++ b/packages/farm-cli/src/deploy.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "child_process";
 import { existsSync, readFileSync } from "fs";
 import path from "path";
 import {
+  getDeployTargetForPreset,
   getPresetForDeployTarget,
   getFarmPresetRuntime,
   loadConfig,
@@ -86,7 +87,7 @@ export async function deployFarm(options: DeployFarmOptions = {}) {
   }
 
   logger.info(`🚀 Building with ${plan.preset} preset...`);
-  await buildFarm({ root: plan.root, preset: plan.preset });
+  await buildFarm({ root: plan.root, preset: plan.preset, target: plan.target });
 
   if (!existsSync(plan.outputDir)) {
     throw new FarmDeployError(
@@ -151,10 +152,24 @@ async function resolveFarmDeployContext(options: DeployFarmOptions) {
     );
   }
 
+  // A target flag expresses current intent, so a configured preset that
+  // builds for a different platform must not steer this deploy: buildFarm
+  // derives its output directory from the preset, and the build and deploy
+  // steps would otherwise resolve different directories.
+  const configuredPreset = userConfig?.deploy?.preset || userConfig?.preset;
+  const configuredPresetTarget = getDeployTargetForPreset(configuredPreset);
+  const presetMatchesPlatform = Boolean(configuredPreset) && configuredPresetTarget === platform;
+  if (cliTarget && configuredPreset && !presetMatchesPlatform) {
+    logger.warn(
+      `Configured preset "${configuredPreset}" targets ${configuredPresetTarget || "an unknown platform"}; using the "${getPresetForDeployTarget(platform)}" preset because --${cliTarget} was passed.`,
+    );
+  }
   const deployConfig = resolveDeployConfig(userConfig || {}, {
     target: platform,
     preset: cliTarget
-      ? userConfig?.deploy?.preset || userConfig?.preset || getPresetForDeployTarget(platform)
+      ? presetMatchesPlatform
+        ? configuredPreset
+        : getPresetForDeployTarget(platform)
       : undefined,
   });
   const preset = deployConfig.preset || getPresetForDeployTarget(platform) || "node-server";

--- a/packages/farm-cli/test/deploy.test.mjs
+++ b/packages/farm-cli/test/deploy.test.mjs
@@ -170,3 +170,63 @@ test("binds an untrusted Netlify site value to the intended option", async () =>
     if (root) await rm(root, { recursive: true, force: true });
   }
 });
+
+test("a target flag overrides a configured preset for another platform", async () => {
+  let root;
+
+  try {
+    root = await mkdtemp(path.join(tmpdir(), "farm-cli-deploy-cross-preset-"));
+    await writeFile(
+      path.join(root, "farm.config.mjs"),
+      "export default { deploy: { target: 'cloudflare', preset: 'cloudflare-module' } };\n",
+    );
+
+    const plan = await createFarmDeployPlan({ root, vercel: true });
+
+    assert.equal(plan.target, "vercel");
+    assert.equal(plan.preset, "vercel");
+    assert.equal(plan.outputDir, path.join(root, ".vercel", "output"));
+    assert.equal(plan.build.command, "farm build --preset vercel");
+  } finally {
+    if (root) await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a target flag overrides a mismatched top-level preset", async () => {
+  let root;
+
+  try {
+    root = await mkdtemp(path.join(tmpdir(), "farm-cli-deploy-top-preset-"));
+    await writeFile(path.join(root, "farm.config.mjs"), "export default { preset: 'vercel' };\n");
+
+    const plan = await createFarmDeployPlan({ root, cloudflare: true });
+
+    assert.equal(plan.target, "cloudflare");
+    assert.equal(plan.preset, "cloudflare-pages");
+    assert.equal(plan.outputDir, path.join(root, ".farm", ".output"));
+    assert.equal(plan.build.command, "farm build --preset cloudflare-pages");
+  } finally {
+    if (root) await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("keeps a configured preset that already builds for the flagged platform", async () => {
+  let root;
+
+  try {
+    root = await mkdtemp(path.join(tmpdir(), "farm-cli-deploy-edge-preset-"));
+    await writeFile(
+      path.join(root, "farm.config.mjs"),
+      "export default { deploy: { preset: 'vercel-edge' } };\n",
+    );
+
+    const plan = await createFarmDeployPlan({ root, vercel: true });
+
+    assert.equal(plan.target, "vercel");
+    assert.equal(plan.preset, "vercel-edge");
+    assert.equal(plan.runtime, "edge");
+    assert.equal(plan.outputDir, path.join(root, ".vercel", "output"));
+  } finally {
+    if (root) await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/farm-cli/test/deploy.test.mjs
+++ b/packages/farm-cli/test/deploy.test.mjs
@@ -230,3 +230,24 @@ test("keeps a configured preset that already builds for the flagged platform", a
     if (root) await rm(root, { recursive: true, force: true });
   }
 });
+
+test("keeps a custom preset when its configured target matches the flag", async () => {
+  let root;
+
+  try {
+    root = await mkdtemp(path.join(tmpdir(), "farm-cli-deploy-custom-preset-"));
+    await writeFile(
+      path.join(root, "farm.config.mjs"),
+      "export default { deploy: { target: 'vercel', preset: 'custom-vercel' } };\n",
+    );
+
+    const plan = await createFarmDeployPlan({ root, vercel: true });
+
+    assert.equal(plan.target, "vercel");
+    assert.equal(plan.preset, "custom-vercel");
+    assert.equal(plan.outputDir, path.join(root, ".vercel", "output"));
+    assert.equal(plan.build.command, "farm build --preset custom-vercel");
+  } finally {
+    if (root) await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

`farm deploy --<target>` resolves its deploy plan and the build it triggers with different `resolveDeployConfig` overrides:

- `resolveFarmDeployContext` (deploy.ts) resolves with `{ target: <cli flag>, preset: userConfig.deploy.preset || userConfig.preset || ... }` — a configured preset for a *different* platform survives the CLI flag.
- `buildFarm` (build.ts) re-resolves with `{ preset }` only, so its target — and therefore the default output directory — is derived from the preset, not the flag.

With `defineConfig({ deploy: { target: "cloudflare", preset: "cloudflare-module" } })`, running `farm deploy --vercel` makes the deploy step look for `.vercel/output` while the build writes `.farm/.output`, failing with `INVALID_BUILD_OUTPUT`. The inverse (a `vercel` preset with `farm deploy --cloudflare`) is worse: the build writes `.vercel/output` and `wrangler pages deploy` runs from a stale or empty `.farm/.output`, silently shipping the wrong content.

## Fix

The CLI flag expresses current intent and now wins:

- In `resolveFarmDeployContext`, the configured preset is kept only when `getDeployTargetForPreset(preset)` matches the flagged platform (so `vercel-edge` still works under `--vercel`). Otherwise Farm warns and uses `getPresetForDeployTarget(platform)`.
- `deployFarm` now passes `target: plan.target` to `buildFarm`, and `BuildFarmOptions` gains an optional `target` that is forwarded into `resolveDeployConfig`. Both resolution calls now receive identical overrides, so the plan's `outputDir` and the build's `config.deploy.outputDir` converge by construction — including the no-flag case where a config's `deploy.target` and preset disagree.

`farm build --preset` behavior is unchanged (`target` is unset there).

## Tests

Added to `packages/farm-cli/test/deploy.test.mjs` (existing `node --test` plan suite, no platform CLIs or builds invoked):

- cross-platform configured preset + `--vercel` → preset `vercel`, output `.vercel/output`, build command `farm build --preset vercel` (fails on main: preset stayed `cloudflare-module`)
- top-level `preset: "vercel"` + `--cloudflare` → preset `cloudflare-pages`, output `.farm/.output` (fails on main: preset stayed `vercel`)
- `deploy.preset: "vercel-edge"` + `--vercel` → preset preserved, runtime `edge` (guards against over-eager clobbering)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciles `farm deploy --<target>` with a mismatched configured preset so build and deploy agree on platform and output directory, preventing `INVALID_BUILD_OUTPUT` and stale deployments. Matching presets—including custom ones with a configured target that equals the flag—are preserved.

- In deploy planning, keep the configured preset only when `getDeployTargetForPreset(preset)` (or a configured `deploy.target`) matches the flagged platform; otherwise warn and use `getPresetForDeployTarget(<target>)`.
- `deployFarm` passes `target` to `buildFarm`; `BuildFarmOptions` accepts `target`. Both calls to `resolveDeployConfig` receive the same overrides, ensuring `plan.outputDir` equals `config.deploy.outputDir`.
- Behavior change: a mismatched configured preset no longer overrides the CLI target during build; the CLI target wins. `farm build --preset` is unchanged.
- Tests cover cross-platform preset override, mismatched top-level preset override, preserving `vercel-edge`, and retaining a matching custom preset with a configured target.

<sup>Written for commit 406c358ed17dc22bfbed5ed125f2327cbfc51653. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

