### PR TITLE
fix(nitro): detect async pages by constructor instead of source sniffing

### DIFF
--- a/packages/farm/src/__tests__/production-async-page.test.ts
+++ b/packages/farm/src/__tests__/production-async-page.test.ts
@@ -1,0 +1,124 @@
+import fs from "fs";
+import path from "path";
+import React from "react";
+import { describe, expect, it } from "vitest";
+
+// The production renderer is emitted as a template literal, so extract the
+// generated renderPageElement block and execute it against stub components to
+// verify how the shipped handler treats sync vs async pages.
+
+const universalBuildPath = path.join(process.cwd(), "src", "nitro", "universal-build.ts");
+const nitroIndexPath = path.join(process.cwd(), "src", "nitro", "index.ts");
+
+function extractRenderPageElement(source: string): string {
+  const start = source.indexOf("const renderPageElement = async () => {");
+  const endMarker = "return renderFarmElement(ReactDOMServer, wrappedElement);";
+  const endIndex = source.indexOf(endMarker, start);
+  expect(start).toBeGreaterThan(-1);
+  expect(endIndex).toBeGreaterThan(-1);
+  return source.slice(start, source.indexOf("};", endIndex) + 2);
+}
+
+async function runRenderPageElement(
+  PageComponent: unknown,
+  options: { isRedirect?: (error: unknown) => boolean } = {},
+): Promise<{ pageTree: any }> {
+  const source = fs.readFileSync(universalBuildPath, "utf-8");
+  let pageTree: any;
+  const run = new Function(
+    "PageComponent",
+    "pageProps",
+    "React",
+    "isFarmRedirectError",
+    "isFarmNotFoundError",
+    "route",
+    "shouldHydrateLayout",
+    "hydrationIslandStrategy",
+    "applicableLayouts",
+    "renderedRouteSlots",
+    "params",
+    "renderFarmElement",
+    "ReactDOMServer",
+    `${extractRenderPageElement(source)}\nreturn renderPageElement();`,
+  );
+  await run(
+    PageComponent,
+    { params: {} },
+    React,
+    options.isRedirect ?? (() => false),
+    () => false,
+    { shouldHydrate: false },
+    false,
+    "load",
+    [],
+    [],
+    {},
+    (_renderer: unknown, element: unknown) => {
+      pageTree = element;
+      return { html: "" };
+    },
+    {},
+  );
+  return { pageTree };
+}
+
+describe("production async page detection", () => {
+  it('renders sync components through React even when their source contains "async"', async () => {
+    let directCalls = 0;
+    function Page() {
+      directCalls += 1;
+      const submit = async () => {}; // "async" substring in the source
+      return React.createElement("main", { onClick: submit }, "sync page");
+    }
+
+    const { pageTree } = await runRenderPageElement(Page);
+
+    // The component must not be invoked outside React (hooks would throw and
+    // top-level side effects would run twice); it becomes an element type.
+    expect(directCalls).toBe(0);
+    expect(pageTree.props.children.type).toBe(Page);
+  });
+
+  it("still executes genuine async server components to get their element", async () => {
+    let calls = 0;
+    async function Page() {
+      calls += 1;
+      return React.createElement("main", null, "async page");
+    }
+
+    const { pageTree } = await runRenderPageElement(Page);
+
+    expect(calls).toBe(1);
+    expect(pageTree.props.children.type).toBe("main");
+  });
+
+  it("propagates errors thrown by async components instead of silently re-rendering", async () => {
+    async function Page() {
+      throw new Error("boom");
+    }
+
+    await expect(runRenderPageElement(Page)).rejects.toThrow("boom");
+  });
+
+  it("rethrows redirect control-flow errors from async components", async () => {
+    const redirectError = new Error("FARM_REDIRECT");
+    async function Page() {
+      throw redirectError;
+    }
+
+    await expect(
+      runRenderPageElement(Page, { isRedirect: (error) => error === redirectError }),
+    ).rejects.toBe(redirectError);
+  });
+
+  it("never source-sniffs components for the async keyword", () => {
+    const universalBuildSource = fs.readFileSync(universalBuildPath, "utf-8");
+    const nitroIndexSource = fs.readFileSync(nitroIndexPath, "utf-8");
+
+    expect(universalBuildSource).not.toContain('toString().includes("async")');
+    expect(nitroIndexSource).not.toContain('toString().includes("async")');
+    expect(nitroIndexSource).toContain(
+      'typeof PageComponent === "function" && PageComponent.constructor.name === "AsyncFunction"',
+    );
+  });
+});

--- a/packages/farm/src/nitro/index.ts
+++ b/packages/farm/src/nitro/index.ts
@@ -478,7 +478,7 @@ export default defineEventHandler(async (event: H3Event) => {
       // Create page element
       const PageComponent = routeModule.default;
       let pageElement;
-      if (PageComponent.constructor.name === "AsyncFunction" || PageComponent.toString().includes("async")) {
+      if (typeof PageComponent === "function" && PageComponent.constructor.name === "AsyncFunction") {
         pageElement = await PageComponent(pageProps);
       } else {
         pageElement = React.createElement(PageComponent, pageProps);

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -5833,22 +5833,18 @@ async function handleFarmRequestInContext(
             // First, render the page content
             let pageElement;
 
-            // Check if the component is async
-            if (PageComponent.constructor.name === "AsyncFunction" || PageComponent.toString().includes("async")) {
-              // For async components, execute to get the element
-              try {
-                const result = await PageComponent(pageProps);
-                if (React.isValidElement(result)) {
-                  pageElement = result;
-                } else {
-                  pageElement = React.createElement("div", null, String(result));
-                }
-              } catch (asyncError) {
-                if (isFarmRedirectError(asyncError) || isFarmNotFoundError(asyncError)) {
-                  throw asyncError;
-                }
-                // If async rendering fails, try sync rendering as fallback
-                pageElement = React.createElement(PageComponent, pageProps);
+            // Only genuinely async components are executed directly; source
+            // sniffing is unsound because any sync component whose source
+            // contains "async" (e.g. an async event handler) would be called
+            // outside React, breaking hooks and re-running side effects.
+            // Errors, including redirect/notFound controls, propagate to the
+            // outer request handler exactly like sync render errors.
+            if (typeof PageComponent === "function" && PageComponent.constructor.name === "AsyncFunction") {
+              const result = await PageComponent(pageProps);
+              if (React.isValidElement(result)) {
+                pageElement = result;
+              } else {
+                pageElement = React.createElement("div", null, String(result));
               }
             } else {
               // Sync component - create element directly


### PR DESCRIPTION
## Problem

The generated production SSR handler decides whether a page is an async server component with:

```js
if (PageComponent.constructor.name === "AsyncFunction" || PageComponent.toString().includes("async")) {
  const result = await PageComponent(pageProps);
  ...
```

Any **sync** component whose source merely contains the substring `async` — an async event handler (`onClick={async () => save()}`), a `className="async-panel"`, a transpiler helper name — takes the async branch and is invoked directly, outside React:

- If the component uses hooks (any client page), the direct call throws "Invalid hook call". The `catch` below silently swallows it and re-renders via `React.createElement`, so the component's top-level code runs **twice per request** (analytics fire twice, counters double-increment).
- Hookless components that read layout-provided React context render without that context.
- The same silent catch also masks real errors thrown by genuine async pages, re-executing them a second time via `createElement` instead of surfacing the failure.

The secondary generated SSR handler in `src/nitro/index.ts` carries the same heuristic (there a misclassified hook-using page 500s outright).

## Fix

- Classify a component as async only when it genuinely is one: `typeof PageComponent === "function" && PageComponent.constructor.name === "AsyncFunction"` — the exact check the client hydration code (`universal-build.ts`) and dev runtime (`vite.ts`) already use. Everything else goes through `React.createElement`, matching the development renderer (`server/renderer.ts`), which never direct-calls page components.
- Remove the silent catch-and-rerender fallback. Errors thrown by async components now propagate to the outer request handler, which already rethrows/handles `redirect()`/`notFound()` control errors and renders the route error boundary for real failures — the same path sync render errors take.
- Apply the same one-line condition fix to the fallback handler generated by `src/nitro/index.ts`.

## Tests

`src/__tests__/production-async-page.test.ts` extracts the generated `renderPageElement` block from the emitted handler template and executes it against stub components:

- a sync component containing the `async` substring is never invoked outside React and lands in the tree as an element type (fails on main: direct-called once);
- a genuine async component is still executed and its returned element used;
- a plain error thrown by an async component rejects the render (fails on main: silently swallowed and re-rendered);
- redirect control-flow errors still propagate;
- neither generated handler source-sniffs `toString().includes("async")` anymore (fails on main).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects async page components by constructor instead of source sniffing to prevent misclassifying sync pages and double-invoking them. Previously, any component whose source contained "async" was invoked directly outside React; now only functions with constructor name `AsyncFunction` execute directly, and errors propagate instead of being silently re-rendered.

- Update `src/nitro/universal-build.ts` and `src/nitro/index.ts` to use `typeof PageComponent === "function" && PageComponent.constructor.name === "AsyncFunction"` and remove `toString().includes("async")` and the catch-and-rerender fallback.
- Keep redirect/notFound control-flow behavior: those errors bubble to the request handler; sync pages always render via `React.createElement`.
- Add `production-async-page.test.ts` to assert no source sniffing, correct async execution, error propagation, and that sync pages containing the substring "async" are not invoked outside React.

<sup>Written for commit c45cea3ebf8204bc82f0fc68179a15493837ea31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

