### PR TITLE
fix(nitro): avoid logging production stream control-flow errors

### DIFF
--- a/packages/farm/src/__tests__/universal-build-stream-errors.test.ts
+++ b/packages/farm/src/__tests__/universal-build-stream-errors.test.ts
@@ -3,12 +3,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  isFarmNotFoundError,
-  isFarmRedirectError,
-  notFound,
-  redirect,
-} from "../navigation-errors";
+import { isFarmNotFoundError, isFarmRedirectError, notFound, redirect } from "../navigation-errors";
 
 type RenderedElement = {
   html?: string;
@@ -103,31 +98,25 @@ describe("generated production stream renderer control-flow errors", () => {
     vi.restoreAllMocks();
   });
 
-  it("does not log or buffer redirect() on the readable-stream path", async () => {
+  it("preserves but does not log redirect() on the readable-stream path", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     const { renderFarmElement } = instantiateStreamRenderer();
+    const redirectError = captureThrown(() => redirect("/login"));
 
-    const rendered = await renderFarmElement(
-      readableStreamServer(captureThrown(() => redirect("/login"))),
-      null,
+    await expect(renderFarmElement(readableStreamServer(redirectError), null)).rejects.toBe(
+      redirectError,
     );
-
-    expect(rendered.html).toBe("<div>shell</div><!--deferred-->");
-    expect(rendered.streamErrors).toHaveLength(0);
     expect(consoleError).not.toHaveBeenCalled();
   });
 
-  it("does not log or buffer notFound() on the readable-stream path", async () => {
+  it("preserves but does not log notFound() on the readable-stream path", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     const { renderFarmElement } = instantiateStreamRenderer();
+    const notFoundError = captureThrown(() => notFound());
 
-    const rendered = await renderFarmElement(
-      readableStreamServer(captureThrown(() => notFound())),
-      null,
+    await expect(renderFarmElement(readableStreamServer(notFoundError), null)).rejects.toBe(
+      notFoundError,
     );
-
-    expect(rendered.html).toBe("<div>shell</div><!--deferred-->");
-    expect(rendered.streamErrors).toHaveLength(0);
     expect(consoleError).not.toHaveBeenCalled();
   });
 
@@ -135,37 +124,31 @@ describe("generated production stream renderer control-flow errors", () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     const { renderFarmElement } = instantiateStreamRenderer();
 
-    await expect(
-      renderFarmElement(readableStreamServer(new Error("boom")), null),
-    ).rejects.toThrow("boom");
+    await expect(renderFarmElement(readableStreamServer(new Error("boom")), null)).rejects.toThrow(
+      "boom",
+    );
     expect(consoleError).toHaveBeenCalledWith("[Farm SSR stream]", expect.any(Error));
   });
 
-  it("does not log or buffer redirect() on the pipeable-stream path", async () => {
+  it("preserves but does not log redirect() on the pipeable-stream path", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     const { renderFarmElement } = instantiateStreamRenderer();
+    const redirectError = captureThrown(() => redirect("/login"));
 
-    const rendered = await renderFarmElement(
-      pipeableStreamServer(captureThrown(() => redirect("/login"))),
-      null,
+    await expect(renderFarmElement(pipeableStreamServer(redirectError), null)).rejects.toBe(
+      redirectError,
     );
-
-    expect(rendered.html).toBe("<div>shell</div><!--resolved-->");
-    expect(rendered.streamErrors).toHaveLength(0);
     expect(consoleError).not.toHaveBeenCalled();
   });
 
-  it("does not log or buffer notFound() on the pipeable-stream path", async () => {
+  it("preserves but does not log notFound() on the pipeable-stream path", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     const { renderFarmElement } = instantiateStreamRenderer();
+    const notFoundError = captureThrown(() => notFound());
 
-    const rendered = await renderFarmElement(
-      pipeableStreamServer(captureThrown(() => notFound())),
-      null,
+    await expect(renderFarmElement(pipeableStreamServer(notFoundError), null)).rejects.toBe(
+      notFoundError,
     );
-
-    expect(rendered.html).toBe("<div>shell</div><!--resolved-->");
-    expect(rendered.streamErrors).toHaveLength(0);
     expect(consoleError).not.toHaveBeenCalled();
   });
 
@@ -173,9 +156,9 @@ describe("generated production stream renderer control-flow errors", () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     const { renderFarmElement } = instantiateStreamRenderer();
 
-    await expect(
-      renderFarmElement(pipeableStreamServer(new Error("boom")), null),
-    ).rejects.toThrow("boom");
+    await expect(renderFarmElement(pipeableStreamServer(new Error("boom")), null)).rejects.toThrow(
+      "boom",
+    );
     expect(consoleError).toHaveBeenCalledWith("[Farm SSR stream]", expect.any(Error));
   });
 });

--- a/packages/farm/src/__tests__/universal-build-stream-errors.test.ts
+++ b/packages/farm/src/__tests__/universal-build-stream-errors.test.ts
@@ -1,0 +1,181 @@
+// @vitest-environment node
+
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  isFarmNotFoundError,
+  isFarmRedirectError,
+  notFound,
+  redirect,
+} from "../navigation-errors";
+
+type RenderedElement = {
+  html?: string;
+  shellHtml: string;
+  streamErrors: unknown[];
+  stream?: ReadableStream<Uint8Array>;
+};
+
+type StreamRenderer = {
+  renderFarmElement: (ReactDOMServer: unknown, element: unknown) => Promise<RenderedElement>;
+};
+
+// The production stream renderer only exists inside the generated-entry
+// template, so extract it from the source and instantiate it with the same
+// helpers the generated module imports from the production runtime.
+function instantiateStreamRenderer(): StreamRenderer {
+  const source = fs.readFileSync(
+    path.join(process.cwd(), "src", "nitro", "universal-build.ts"),
+    "utf-8",
+  );
+  const start = source.indexOf("async function renderFarmElement(ReactDOMServer, element)");
+  const end = source.indexOf("function createFarmDocumentStream(");
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  const factory = new Function(
+    "isFarmRedirectError",
+    "isFarmNotFoundError",
+    `${source.slice(start, end)}\nreturn { renderFarmElement, renderFarmElementToString };`,
+  );
+  return factory(isFarmRedirectError, isFarmNotFoundError) as StreamRenderer;
+}
+
+function captureThrown(throwing: () => never): unknown {
+  try {
+    throwing();
+  } catch (error) {
+    return error;
+  }
+}
+
+// Mimics renderToReadableStream for a tree whose shell renders but where a
+// boundary reports an error through onError before the stream completes.
+function readableStreamServer(boundaryError: unknown) {
+  return {
+    renderToReadableStream: async (
+      _element: unknown,
+      options: { onError: (error: unknown) => void },
+    ) => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode("<div>shell</div>"));
+          options.onError(boundaryError);
+          controller.enqueue(encoder.encode("<!--deferred-->"));
+          controller.close();
+        },
+      });
+      return Object.assign(stream, { allReady: Promise.resolve() });
+    },
+  };
+}
+
+// Mimics renderToPipeableStream for the same scenario on the node path.
+function pipeableStreamServer(boundaryError: unknown) {
+  return {
+    renderToPipeableStream: (
+      _element: unknown,
+      options: {
+        onShellReady: () => void;
+        onAllReady: () => void;
+        onError: (error: unknown) => void;
+      },
+    ) => {
+      const pipeable = {
+        pipe(destination: { write: (chunk: unknown) => boolean; end: () => void }) {
+          destination.write("<div>shell</div>");
+          destination.write("<!--resolved-->");
+          destination.end();
+          return destination;
+        },
+      };
+      options.onError(boundaryError);
+      options.onAllReady();
+      queueMicrotask(() => options.onShellReady());
+      return pipeable;
+    },
+  };
+}
+
+describe("generated production stream renderer control-flow errors", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not log or buffer redirect() on the readable-stream path", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { renderFarmElement } = instantiateStreamRenderer();
+
+    const rendered = await renderFarmElement(
+      readableStreamServer(captureThrown(() => redirect("/login"))),
+      null,
+    );
+
+    expect(rendered.html).toBe("<div>shell</div><!--deferred-->");
+    expect(rendered.streamErrors).toHaveLength(0);
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it("does not log or buffer notFound() on the readable-stream path", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { renderFarmElement } = instantiateStreamRenderer();
+
+    const rendered = await renderFarmElement(
+      readableStreamServer(captureThrown(() => notFound())),
+      null,
+    );
+
+    expect(rendered.html).toBe("<div>shell</div><!--deferred-->");
+    expect(rendered.streamErrors).toHaveLength(0);
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it("still logs and rethrows real errors on the readable-stream path", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { renderFarmElement } = instantiateStreamRenderer();
+
+    await expect(
+      renderFarmElement(readableStreamServer(new Error("boom")), null),
+    ).rejects.toThrow("boom");
+    expect(consoleError).toHaveBeenCalledWith("[Farm SSR stream]", expect.any(Error));
+  });
+
+  it("does not log or buffer redirect() on the pipeable-stream path", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { renderFarmElement } = instantiateStreamRenderer();
+
+    const rendered = await renderFarmElement(
+      pipeableStreamServer(captureThrown(() => redirect("/login"))),
+      null,
+    );
+
+    expect(rendered.html).toBe("<div>shell</div><!--resolved-->");
+    expect(rendered.streamErrors).toHaveLength(0);
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it("does not log or buffer notFound() on the pipeable-stream path", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { renderFarmElement } = instantiateStreamRenderer();
+
+    const rendered = await renderFarmElement(
+      pipeableStreamServer(captureThrown(() => notFound())),
+      null,
+    );
+
+    expect(rendered.html).toBe("<div>shell</div><!--resolved-->");
+    expect(rendered.streamErrors).toHaveLength(0);
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it("still logs and rethrows real errors on the pipeable-stream path", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { renderFarmElement } = instantiateStreamRenderer();
+
+    await expect(
+      renderFarmElement(pipeableStreamServer(new Error("boom")), null),
+    ).rejects.toThrow("boom");
+    expect(consoleError).toHaveBeenCalledWith("[Farm SSR stream]", expect.any(Error));
+  });
+});

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -4127,6 +4127,11 @@ async function renderFarmElement(ReactDOMServer, element) {
   if (typeof ReactDOMServer.renderToReadableStream === "function") {
     const stream = await ReactDOMServer.renderToReadableStream(element, {
       onError(error) {
+        // redirect()/notFound() are control flow, not render failures: the
+        // request handler maps them to a response, so skip the error log and
+        // keep them out of streamErrors, where a buffered deferred render
+        // would rethrow them after the shell already succeeded.
+        if (isFarmRedirectError(error) || isFarmNotFoundError(error)) return;
         streamErrors.push(error);
         console.error("[Farm SSR stream]", error);
       },
@@ -4271,6 +4276,8 @@ async function renderFarmElement(ReactDOMServer, element) {
       },
       onShellError: fail,
       onError(error) {
+        // Same control-flow guard as the readable-stream path above.
+        if (isFarmRedirectError(error) || isFarmNotFoundError(error)) return;
         streamErrors.push(error);
         console.error("[Farm SSR stream]", error);
       },

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -4128,11 +4128,10 @@ async function renderFarmElement(ReactDOMServer, element) {
     const stream = await ReactDOMServer.renderToReadableStream(element, {
       onError(error) {
         // redirect()/notFound() are control flow, not render failures: the
-        // request handler maps them to a response, so skip the error log and
-        // keep them out of streamErrors, where a buffered deferred render
-        // would rethrow them after the shell already succeeded.
-        if (isFarmRedirectError(error) || isFarmNotFoundError(error)) return;
+        // request handler must still receive them to map the response status,
+        // but they should not produce a misleading SSR failure log.
         streamErrors.push(error);
+        if (isFarmRedirectError(error) || isFarmNotFoundError(error)) return;
         console.error("[Farm SSR stream]", error);
       },
     });
@@ -4277,8 +4276,8 @@ async function renderFarmElement(ReactDOMServer, element) {
       onShellError: fail,
       onError(error) {
         // Same control-flow guard as the readable-stream path above.
-        if (isFarmRedirectError(error) || isFarmNotFoundError(error)) return;
         streamErrors.push(error);
+        if (isFarmRedirectError(error) || isFarmNotFoundError(error)) return;
         console.error("[Farm SSR stream]", error);
       },
     });


### PR DESCRIPTION
## Problem

Production React stream callbacks logged `redirect()` and `notFound()` as SSR failures. The original patch also removed those errors from `streamErrors`, which could let a buffered render return successful HTML instead of allowing the outer handler to produce the intended redirect or 404 response.

## Fix

Both readable and pipeable stream paths now retain every error in `streamErrors`. Redirect and not-found control flow skips only the misleading `[Farm SSR stream]` console error. Buffered rendering still rethrows the control-flow value so the request handler can map it to the correct response.

## Tests

- redirect control flow is preserved without logging on both stream APIs
- not-found control flow is preserved without logging on both stream APIs
- genuine render failures remain logged and rethrown

`pnpm --filter @farm.js/core exec vitest run src/__tests__/universal-build-stream-errors.test.ts`