### PR TITLE
feat: add opt-in anonymous telemetry

### DIFF
--- a/docs/.env.example
+++ b/docs/.env.example
@@ -1,1 +1,4 @@
 DATABASE_URL="postgresql://user:password@localhost:5432/farmjs"
+FARM_TELEMETRY_IDENTITY_SALT="replace-with-a-long-random-server-only-value"
+FARM_TELEMETRY_DASHBOARD_TOKEN="replace-with-a-long-random-dashboard-token"
+FARM_TELEMETRY_RETENTION_DAYS="90"

--- a/docs/docs.config.ts
+++ b/docs/docs.config.ts
@@ -325,6 +325,7 @@ const sidebar = [
     children: [
       { label: "Testing", slug: "testing", icon: "terminal" },
       { label: "CLI", slug: "cli", icon: "terminal" },
+      { label: "Telemetry", slug: "telemetry", icon: "activity" },
       { label: "Examples", slug: "examples", icon: "box" },
       { label: "Reference", slug: "reference", icon: "book" },
     ],

--- a/docs/prisma/schema.prisma
+++ b/docs/prisma/schema.prisma
@@ -15,3 +15,30 @@ model WaitlistEntry {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 }
+
+model FarmTelemetryEvent {
+  id                    String   @id @default(cuid())
+  eventId               String   @unique
+  schemaVersion         Int
+  eventType             String
+  identityHash          String
+  source                String
+  packageName           String
+  packageVersion        String
+  command               String?
+  packageManager        String?
+  renderer              String?
+  template              String?
+  deployTarget          String?
+  typescript            Boolean?
+  installedDependencies Boolean?
+  nodeMajor             Int
+  platform              String
+  architecture          String
+  createdAt             DateTime @default(now())
+
+  @@index([createdAt])
+  @@index([eventType, createdAt])
+  @@index([identityHash, createdAt])
+  @@index([packageVersion, createdAt])
+}

--- a/docs/src/app/api/telemetry/dashboard/session/route.ts
+++ b/docs/src/app/api/telemetry/dashboard/session/route.ts
@@ -1,0 +1,73 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const MAX_FORM_BYTES = 4 * 1024;
+const SESSION_MAX_AGE_SECONDS = 12 * 60 * 60;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_ATTEMPTS = 20;
+
+let attempts = 0;
+let attemptsStartedAt = 0;
+
+function isRateLimited(now = Date.now()): boolean {
+  if (now - attemptsStartedAt >= RATE_LIMIT_WINDOW_MS) {
+    attemptsStartedAt = now;
+    attempts = 0;
+  }
+  attempts += 1;
+  return attempts > RATE_LIMIT_ATTEMPTS;
+}
+
+function safeEqual(received: string | undefined, expected: string): boolean {
+  if (!received) return false;
+  const receivedBytes = Buffer.from(received);
+  const expectedBytes = Buffer.from(expected);
+  return (
+    receivedBytes.length === expectedBytes.length && timingSafeEqual(receivedBytes, expectedBytes)
+  );
+}
+
+function sessionValue(token: string): string {
+  return createHmac("sha256", token).update("farm.telemetry.dashboard.v1").digest("hex");
+}
+
+function sessionCookie(value: string, maxAge: number): string {
+  const secure = process.env.NODE_ENV === "production" ? "; Secure" : "";
+  return `farm_telemetry_dashboard=${value}; Path=/telemetry; HttpOnly; SameSite=Strict; Max-Age=${maxAge}${secure}`;
+}
+
+function redirect(location: string, cookie?: string): Response {
+  const headers = new Headers({
+    location,
+    "cache-control": "no-store",
+    "x-content-type-options": "nosniff",
+  });
+  if (cookie) headers.set("set-cookie", cookie);
+  return new Response(null, { status: 303, headers });
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const contentType = request.headers.get("content-type")?.toLowerCase() || "";
+  if (!contentType.startsWith("application/x-www-form-urlencoded")) {
+    return new Response("Unsupported content type", { status: 415 });
+  }
+  const contentLength = Number.parseInt(request.headers.get("content-length") || "0", 10);
+  if (Number.isFinite(contentLength) && contentLength > MAX_FORM_BYTES) {
+    return new Response("Payload too large", { status: 413 });
+  }
+
+  const body = await request.text();
+  if (new TextEncoder().encode(body).byteLength > MAX_FORM_BYTES) {
+    return new Response("Payload too large", { status: 413 });
+  }
+  const fields = new URLSearchParams(body);
+  if (fields.get("action") === "logout") {
+    return redirect("/telemetry", sessionCookie("", 0));
+  }
+  if (isRateLimited()) return redirect("/telemetry?error=rate-limited");
+
+  const expected = process.env.FARM_TELEMETRY_DASHBOARD_TOKEN?.trim();
+  if (!expected || !safeEqual(fields.get("token")?.trim(), expected)) {
+    return redirect("/telemetry?error=invalid");
+  }
+  return redirect("/telemetry", sessionCookie(sessionValue(expected), SESSION_MAX_AGE_SECONDS));
+}

--- a/docs/src/app/api/telemetry/v1/events/route.ts
+++ b/docs/src/app/api/telemetry/v1/events/route.ts
@@ -1,0 +1,226 @@
+import { createHmac } from "node:crypto";
+import { getPrisma } from "../../../../../lib/prisma";
+import { z } from "zod";
+
+const MAX_BODY_BYTES = 8 * 1024;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const GLOBAL_RATE_LIMIT = 2_000;
+const IDENTITY_RATE_LIMIT = 120;
+const MAX_RATE_LIMIT_ENTRIES = 4_096;
+const PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1_000;
+const DEFAULT_RETENTION_DAYS = 90;
+
+const commands = [
+  "dev",
+  "build",
+  "auth:migrate",
+  "upgrade",
+  "generate",
+  "doctor",
+  "explain",
+  "preview",
+  "migrate",
+  "cron:list",
+  "cron:run",
+  "add:integration",
+  "deploy",
+] as const;
+
+const templates = [
+  "basic",
+  "react-compiler",
+  "auth",
+  "better-auth",
+  "ai",
+  "auth0",
+  "authjs",
+  "autumn",
+  "clerk",
+  "jobs-inngest",
+  "jobs-trigger",
+  "polar",
+  "resend",
+  "stripe",
+  "supabase",
+  "unkey",
+  "workos",
+] as const;
+
+const runtimeFields = {
+  schemaVersion: z.literal(1),
+  eventId: z.string().uuid(),
+  anonymousId: z.string().uuid(),
+  packageVersion: z
+    .string()
+    .min(1)
+    .max(64)
+    .regex(/^[0-9A-Za-z.+_-]+$/),
+  nodeMajor: z.number().int().min(16).max(99),
+  platform: z.enum(["darwin", "linux", "windows", "other"]),
+  architecture: z.enum(["arm64", "x64", "other"]),
+};
+
+const commandEventSchema = z
+  .object({
+    ...runtimeFields,
+    eventType: z.literal("command_invoked"),
+    source: z.literal("cli"),
+    packageName: z.literal("@farm.js/cli"),
+    command: z.enum(commands),
+    deployTarget: z.enum(["vercel", "cloudflare", "netlify", "node", "custom"]).optional(),
+  })
+  .strict();
+
+const projectCreatedEventSchema = z
+  .object({
+    ...runtimeFields,
+    eventType: z.literal("project_created"),
+    source: z.literal("create-app"),
+    packageName: z.literal("@farm.js/create-app"),
+    template: z.enum(templates).optional(),
+    renderer: z.enum(["react", "preact", "solid", "vue", "svelte"]).optional(),
+    packageManager: z.enum(["npm", "pnpm", "yarn", "bun"]).optional(),
+    typescript: z.boolean().optional(),
+    installedDependencies: z.boolean().optional(),
+  })
+  .strict();
+
+const telemetryEventSchema = z.discriminatedUnion("eventType", [
+  commandEventSchema,
+  projectCreatedEventSchema,
+]);
+
+type TelemetryEvent = z.infer<typeof telemetryEventSchema>;
+type RateLimitBucket = { count: number; startedAt: number };
+
+const rateLimitBuckets = new Map<string, RateLimitBucket>();
+let lastPruneAt = 0;
+
+function json(body: Record<string, unknown>, status: number): Response {
+  return Response.json(body, {
+    status,
+    headers: {
+      "cache-control": "no-store",
+      "x-content-type-options": "nosniff",
+    },
+  });
+}
+
+function takeRateLimit(key: string, limit: number, now = Date.now()): boolean {
+  const current = rateLimitBuckets.get(key);
+  if (!current || now - current.startedAt >= RATE_LIMIT_WINDOW_MS) {
+    rateLimitBuckets.set(key, { count: 1, startedAt: now });
+    if (rateLimitBuckets.size > MAX_RATE_LIMIT_ENTRIES) {
+      for (const [bucketKey, bucket] of rateLimitBuckets) {
+        if (now - bucket.startedAt >= RATE_LIMIT_WINDOW_MS) rateLimitBuckets.delete(bucketKey);
+      }
+    }
+    return true;
+  }
+  if (current.count >= limit) return false;
+  current.count += 1;
+  return true;
+}
+
+function identityHash(anonymousId: string, salt: string): string {
+  return createHmac("sha256", salt).update(anonymousId).digest("hex");
+}
+
+function retentionDays(): number {
+  const configured = Number.parseInt(process.env.FARM_TELEMETRY_RETENTION_DAYS || "", 10);
+  return Number.isFinite(configured) && configured >= 1 && configured <= 3_650
+    ? configured
+    : DEFAULT_RETENTION_DAYS;
+}
+
+async function pruneExpiredEvents(prisma: Awaited<ReturnType<typeof getPrisma>>): Promise<void> {
+  const now = Date.now();
+  if (now - lastPruneAt < PRUNE_INTERVAL_MS) return;
+  lastPruneAt = now;
+  const cutoff = new Date(now - retentionDays() * 24 * 60 * 60 * 1_000);
+  try {
+    await prisma.farmTelemetryEvent.deleteMany({ where: { createdAt: { lt: cutoff } } });
+  } catch (error) {
+    console.error("[farmjs.telemetry.prune]", error);
+  }
+}
+
+function databaseRecord(event: TelemetryEvent, hash: string) {
+  return {
+    eventId: event.eventId,
+    schemaVersion: event.schemaVersion,
+    eventType: event.eventType,
+    identityHash: hash,
+    source: event.source,
+    packageName: event.packageName,
+    packageVersion: event.packageVersion,
+    command: event.eventType === "command_invoked" ? event.command : null,
+    deployTarget: event.eventType === "command_invoked" ? event.deployTarget : null,
+    template: event.eventType === "project_created" ? event.template : null,
+    renderer: event.eventType === "project_created" ? event.renderer : null,
+    packageManager: event.eventType === "project_created" ? event.packageManager : null,
+    typescript: event.eventType === "project_created" ? event.typescript : null,
+    installedDependencies:
+      event.eventType === "project_created" ? event.installedDependencies : null,
+    nodeMajor: event.nodeMajor,
+    platform: event.platform,
+    architecture: event.architecture,
+  };
+}
+
+export async function POST(request: Request): Promise<Response> {
+  if (!takeRateLimit("global", GLOBAL_RATE_LIMIT)) {
+    return json({ ok: false, error: "rate_limited" }, 429);
+  }
+  const contentType = request.headers.get("content-type")?.toLowerCase() || "";
+  if (!contentType.startsWith("application/json")) {
+    return json({ ok: false, error: "content_type" }, 415);
+  }
+  const contentLength = Number.parseInt(request.headers.get("content-length") || "0", 10);
+  if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+    return json({ ok: false, error: "payload_too_large" }, 413);
+  }
+
+  let body: unknown;
+  try {
+    const text = await request.text();
+    if (new TextEncoder().encode(text).byteLength > MAX_BODY_BYTES) {
+      return json({ ok: false, error: "payload_too_large" }, 413);
+    }
+    body = JSON.parse(text);
+  } catch {
+    return json({ ok: false, error: "invalid_json" }, 400);
+  }
+
+  const parsed = telemetryEventSchema.safeParse(body);
+  if (!parsed.success) {
+    return json({ ok: false, error: "invalid_event" }, 400);
+  }
+
+  const salt = process.env.FARM_TELEMETRY_IDENTITY_SALT;
+  if (!salt) {
+    return json({ ok: true, stored: false, warning: "telemetry_not_configured" }, 202);
+  }
+  const hash = identityHash(parsed.data.anonymousId, salt);
+  if (!takeRateLimit(`identity:${hash}`, IDENTITY_RATE_LIMIT)) {
+    return json({ ok: false, error: "rate_limited" }, 429);
+  }
+  if (!process.env.DATABASE_URL) {
+    return json({ ok: true, stored: false, warning: "database_not_configured" }, 202);
+  }
+
+  try {
+    const prisma = await getPrisma();
+    const record = databaseRecord(parsed.data, hash);
+    await prisma.farmTelemetryEvent.upsert({
+      where: { eventId: parsed.data.eventId },
+      update: {},
+      create: record,
+    });
+    await pruneExpiredEvents(prisma);
+    return json({ ok: true, stored: true }, 202);
+  } catch (error) {
+    console.error("[farmjs.telemetry.ingest]", error);
+    return json({ ok: true, stored: false, warning: "database_unavailable" }, 202);
+  }
+}

--- a/docs/src/app/api/waitlist/route.ts
+++ b/docs/src/app/api/waitlist/route.ts
@@ -1,38 +1,6 @@
 import { createEndpoint } from "@farm.js/core/api";
-import type { PrismaClient as PrismaClientType } from "@prisma/client";
 import { z } from "zod";
-
-const globalForPrisma = globalThis as unknown as {
-  prisma?: PrismaClientType;
-};
-
-type PrismaClientConstructor = new (options?: {
-  log?: Array<"query" | "info" | "warn" | "error">;
-}) => PrismaClientType;
-
-type PrismaModule = {
-  PrismaClient: PrismaClientConstructor;
-};
-
-const importRuntimeModule = new Function("specifier", "return import(specifier)") as (
-  specifier: string,
-) => Promise<PrismaModule>;
-
-async function getPrisma() {
-  if (!process.env.DATABASE_URL) {
-    throw new Error("DATABASE_URL is not configured");
-  }
-
-  if (!globalForPrisma.prisma) {
-    const { PrismaClient } = await importRuntimeModule("@prisma/client");
-
-    globalForPrisma.prisma = new PrismaClient({
-      log: process.env.NODE_ENV === "development" ? ["warn", "error"] : ["error"],
-    });
-  }
-
-  return globalForPrisma.prisma;
-}
+import { getPrisma } from "../../../lib/prisma";
 
 const waitlistSchema = z.object({
   email: z.string().trim().email().max(200),

--- a/docs/src/app/docs/cli/page.md
+++ b/docs/src/app/docs/cli/page.md
@@ -52,6 +52,12 @@ React is the default renderer. `--renderer preact`, `--renderer solid`, `--rende
 | farm cron list                   | List configured UTC schedules and target routes.                     |
 | farm cron run dailyCleanup       | Invoke one cron route on a running app.                              |
 | farm dev --cron                  | Start the dev server with the opt-in in-memory cron scheduler.       |
+| farm telemetry status            | Show the anonymous product-telemetry preference.                     |
+| farm telemetry enable            | Opt in to anonymous Farm.js product telemetry.                       |
+| farm telemetry disable           | Opt out and delete the local anonymous installation ID.              |
+
+See [Anonymous telemetry](/docs/telemetry) for the exact event fields, environment overrides, and
+privacy guarantees. Telemetry is off by default during the beta.
 
 ## Upgrade Farm packages
 

--- a/docs/src/app/docs/telemetry/page.md
+++ b/docs/src/app/docs/telemetry/page.md
@@ -1,0 +1,110 @@
+---
+title: "Anonymous telemetry"
+description: "Understand and control Farm.js opt-in product telemetry."
+section: "Reference"
+---
+
+# Anonymous telemetry
+
+Farm.js includes optional anonymous product telemetry in `@farm.js/cli` and
+`@farm.js/create-app`. During the beta, telemetry is **off by default**. It helps the
+maintainers understand which coarse framework paths are useful and where compatibility work should
+be focused.
+
+This is separate from [application observability](/docs/observability). OpenTelemetry describes what
+your application does and is configured by the application owner. Farm.js product telemetry only
+describes use of Farm's own CLI and starter generator, and is sent to Farm's infrastructure after
+you opt in.
+
+## Control telemetry
+
+```bash
+farm telemetry status
+farm telemetry enable
+farm telemetry disable
+```
+
+`farm telemetry enable` creates a random anonymous installation ID in the operating system's local
+configuration directory. `farm telemetry disable` opts out and deletes that ID. Enabling telemetry
+again creates a different ID.
+
+Environment variables can provide an explicit per-process or organization-wide policy:
+
+| Variable                    | Behavior                                                            |
+| --------------------------- | ------------------------------------------------------------------- |
+| `FARM_TELEMETRY=1`          | Enables telemetry, including non-interactive and CI commands.       |
+| `FARM_TELEMETRY=0`          | Disables telemetry for the process.                                 |
+| `FARM_TELEMETRY_DISABLED=1` | Disables telemetry for the process.                                 |
+| `DO_NOT_TRACK=1`            | Disables telemetry and takes precedence over Farm's enable setting. |
+
+Without the explicit `FARM_TELEMETRY=1` override, Farm skips test, CI, and non-interactive
+processes even when the saved local preference is enabled.
+
+The preference file is stored at:
+
+- macOS: `~/Library/Application Support/farmjs/telemetry.json`
+- Linux: `$XDG_CONFIG_HOME/farmjs/telemetry.json`, or `~/.config/farmjs/telemetry.json`
+- Windows: `%APPDATA%\farmjs\telemetry.json`
+
+## Data that is sent
+
+Farm currently sends two versioned event types:
+
+| Event             | Fields                                                                                        |
+| ----------------- | --------------------------------------------------------------------------------------------- |
+| `command_invoked` | Allowlisted command, optional deploy target, Farm package/version, Node major, OS, CPU class. |
+| `project_created` | Allowlisted starter, renderer, package manager, TypeScript/install booleans, runtime fields.  |
+
+Every request also has a random event ID for deduplication and the random local installation ID.
+The server immediately converts the installation ID into an HMAC hash using a server-only salt;
+the raw ID is not stored. Receipt time is assigned by the server instead of trusting a client
+timestamp.
+
+Farm does **not** collect or store:
+
+- project names, filesystem paths, Git remotes, repository names, source code, or route names;
+- usernames, email addresses, account IDs, cookies, application payloads, or application events;
+- environment variable names or values, database URLs, credentials, tokens, or other secrets;
+- IP addresses or user-agent strings.
+
+The client uses a short timeout and ignores network or server failures. Telemetry can never make a
+Farm command fail. There is no persistent retry queue.
+
+## Endpoint, validation, and retention
+
+Events are posted to `https://farmjs.dev/api/telemetry/v1/events`. The endpoint accepts a strict,
+versioned JSON schema, rejects unknown fields and bodies larger than 8 KiB, rate-limits traffic,
+and deduplicates event IDs.
+
+Raw telemetry events are retained for 90 days by default and are pruned by the ingestion service.
+Aggregated package-download counts remain available independently through npm's public download
+statistics. A deployment operator can shorten the event retention window with
+`FARM_TELEMETRY_RETENTION_DAYS`.
+
+For local endpoint development only, `FARM_TELEMETRY_ENDPOINT` can point at an HTTPS URL or an HTTP
+localhost address. Released clients use the Farm-owned endpoint by default.
+
+## Maintainer deployment setup
+
+The Farm-owned docs deployment uses four server-only environment variables:
+
+| Variable                         | Purpose                                                              |
+| -------------------------------- | -------------------------------------------------------------------- |
+| `DATABASE_URL`                   | Pooled Postgres connection used by Prisma.                           |
+| `FARM_TELEMETRY_IDENTITY_SALT`   | Long random secret used to HMAC-hash local anonymous IDs.            |
+| `FARM_TELEMETRY_DASHBOARD_TOKEN` | Long random secret used to open the internal `/telemetry` dashboard. |
+| `FARM_TELEMETRY_RETENTION_DAYS`  | Optional raw-event retention window; defaults to `90`.               |
+
+These values must be encrypted deployment variables and must never use a `PUBLIC_` prefix or be
+committed to the repository. The public CLI does not contain an ingestion secret; the endpoint is
+protected with strict validation, body limits, rate limits, and idempotent event IDs instead.
+
+After connecting Postgres, generate the Prisma client and apply the schema from the repository:
+
+```bash
+pnpm --dir docs prisma:generate
+pnpm --dir docs db:push
+```
+
+`/telemetry` exchanges the dashboard token through a server-side form for a 12-hour HttpOnly,
+SameSite cookie. The token is not placed in the URL, local storage, or client-side JavaScript.

--- a/docs/src/app/telemetry/page.tsx
+++ b/docs/src/app/telemetry/page.tsx
@@ -1,0 +1,561 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import type { Metadata } from "@farm.js/core";
+import { cookies } from "@farm.js/core/headers";
+import {
+  Activity,
+  AlertTriangle,
+  Boxes,
+  Database,
+  Fingerprint,
+  PackageCheck,
+  Terminal,
+} from "lucide-react";
+import { getPrisma } from "../../lib/prisma";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export const metadata = {
+  title: "Farm.js telemetry",
+  description: "Internal anonymous product-health metrics for Farm.js.",
+} satisfies Metadata;
+
+type TelemetryPageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+type GroupCount = {
+  key: string;
+  count: number;
+  lastSeenAt: Date | null;
+};
+
+type RecentEvent = {
+  id: string;
+  eventType: string;
+  source: string;
+  packageVersion: string;
+  command: string | null;
+  packageManager: string | null;
+  renderer: string | null;
+  template: string | null;
+  nodeMajor: number;
+  platform: string;
+  architecture: string;
+  createdAt: Date;
+};
+
+type TelemetryData =
+  | {
+      status: "ready";
+      totalEvents: number;
+      eventsLast24h: number;
+      uniqueInstallations: number;
+      projectsCreated: number;
+      recentEvents: RecentEvent[];
+      eventTypes: GroupCount[];
+      commands: GroupCount[];
+      versions: GroupCount[];
+      templates: GroupCount[];
+      renderers: GroupCount[];
+      packageManagers: GroupCount[];
+      platforms: GroupCount[];
+    }
+  | {
+      status: "not-configured" | "schema-missing" | "unavailable";
+      message: string;
+    };
+
+type GroupRow = {
+  key: string | null;
+  _count: { _all: number };
+  _max: { createdAt: Date | null };
+};
+
+function first(value: string | string[] | undefined): string | undefined {
+  const candidate = Array.isArray(value) ? value[0] : value;
+  return candidate?.trim() || undefined;
+}
+
+function safeTokenEqual(received: string | undefined, expected: string): boolean {
+  if (!received) return false;
+  const receivedBytes = Buffer.from(received);
+  const expectedBytes = Buffer.from(expected);
+  return (
+    receivedBytes.length === expectedBytes.length && timingSafeEqual(receivedBytes, expectedBytes)
+  );
+}
+
+function dashboardSessionValue(token: string): string {
+  return createHmac("sha256", token).update("farm.telemetry.dashboard.v1").digest("hex");
+}
+
+function hasDashboardAccess(): boolean {
+  const expected = process.env.FARM_TELEMETRY_DASHBOARD_TOKEN?.trim();
+  if (!expected) {
+    return process.env.NODE_ENV !== "production";
+  }
+  return safeTokenEqual(
+    cookies().get("farm_telemetry_dashboard")?.value,
+    dashboardSessionValue(expected),
+  );
+}
+
+function readLimit(value: string | string[] | undefined): number {
+  const parsed = Number.parseInt(first(value) || "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.min(parsed, 250) : 100;
+}
+
+function groups(rows: GroupRow[]): GroupCount[] {
+  return rows
+    .map((row) => ({
+      key: row.key || "unknown",
+      count: row._count._all,
+      lastSeenAt: row._max.createdAt,
+    }))
+    .sort((a, b) => b.count - a.count || a.key.localeCompare(b.key));
+}
+
+function errorCode(error: unknown): string | undefined {
+  return typeof error === "object" && error !== null && "code" in error
+    ? String((error as { code?: unknown }).code)
+    : undefined;
+}
+
+function errorName(error: unknown): string | undefined {
+  return error instanceof Error ? error.name : undefined;
+}
+
+async function loadTelemetryData(limit: number): Promise<TelemetryData> {
+  if (!process.env.DATABASE_URL) {
+    return {
+      status: "not-configured",
+      message: "DATABASE_URL is not configured for this deployment.",
+    };
+  }
+
+  try {
+    const prisma = await getPrisma();
+    const last24h = new Date(Date.now() - 24 * 60 * 60 * 1_000);
+    const [
+      totalEvents,
+      eventsLast24h,
+      uniqueInstallations,
+      projectsCreated,
+      recentEvents,
+      eventTypeRows,
+      commandRows,
+      versionRows,
+      templateRows,
+      rendererRows,
+      packageManagerRows,
+      platformRows,
+    ] = await Promise.all([
+      prisma.farmTelemetryEvent.count(),
+      prisma.farmTelemetryEvent.count({ where: { createdAt: { gte: last24h } } }),
+      prisma.farmTelemetryEvent.findMany({
+        distinct: ["identityHash"],
+        select: { identityHash: true },
+      }),
+      prisma.farmTelemetryEvent.count({ where: { eventType: "project_created" } }),
+      prisma.farmTelemetryEvent.findMany({
+        orderBy: { createdAt: "desc" },
+        take: limit,
+        select: {
+          id: true,
+          eventType: true,
+          source: true,
+          packageVersion: true,
+          command: true,
+          packageManager: true,
+          renderer: true,
+          template: true,
+          nodeMajor: true,
+          platform: true,
+          architecture: true,
+          createdAt: true,
+        },
+      }),
+      prisma.farmTelemetryEvent.groupBy({
+        by: ["eventType"],
+        _count: { _all: true },
+        _max: { createdAt: true },
+      }),
+      prisma.farmTelemetryEvent.groupBy({
+        by: ["command"],
+        where: { command: { not: null } },
+        _count: { _all: true },
+        _max: { createdAt: true },
+      }),
+      prisma.farmTelemetryEvent.groupBy({
+        by: ["packageVersion"],
+        _count: { _all: true },
+        _max: { createdAt: true },
+      }),
+      prisma.farmTelemetryEvent.groupBy({
+        by: ["template"],
+        where: { template: { not: null } },
+        _count: { _all: true },
+        _max: { createdAt: true },
+      }),
+      prisma.farmTelemetryEvent.groupBy({
+        by: ["renderer"],
+        where: { renderer: { not: null } },
+        _count: { _all: true },
+        _max: { createdAt: true },
+      }),
+      prisma.farmTelemetryEvent.groupBy({
+        by: ["packageManager"],
+        where: { packageManager: { not: null } },
+        _count: { _all: true },
+        _max: { createdAt: true },
+      }),
+      prisma.farmTelemetryEvent.groupBy({
+        by: ["platform"],
+        _count: { _all: true },
+        _max: { createdAt: true },
+      }),
+    ]);
+
+    return {
+      status: "ready",
+      totalEvents,
+      eventsLast24h,
+      uniqueInstallations: uniqueInstallations.length,
+      projectsCreated,
+      recentEvents,
+      eventTypes: groups(
+        eventTypeRows.map((row) => ({ ...row, key: row.eventType })) as GroupRow[],
+      ),
+      commands: groups(commandRows.map((row) => ({ ...row, key: row.command })) as GroupRow[]),
+      versions: groups(
+        versionRows.map((row) => ({ ...row, key: row.packageVersion })) as GroupRow[],
+      ),
+      templates: groups(templateRows.map((row) => ({ ...row, key: row.template })) as GroupRow[]),
+      renderers: groups(rendererRows.map((row) => ({ ...row, key: row.renderer })) as GroupRow[]),
+      packageManagers: groups(
+        packageManagerRows.map((row) => ({ ...row, key: row.packageManager })) as GroupRow[],
+      ),
+      platforms: groups(platformRows.map((row) => ({ ...row, key: row.platform })) as GroupRow[]),
+    };
+  } catch (error) {
+    const code = errorCode(error);
+    const name = errorName(error);
+    if (code === "P2021" || code === "P2022" || name === "PrismaClientValidationError") {
+      return {
+        status: "schema-missing",
+        message:
+          "The telemetry table is not available yet. Apply the Prisma schema to the database.",
+      };
+    }
+    console.error("[farmjs.telemetry.dashboard]", error);
+    return {
+      status: "unavailable",
+      message: "The telemetry database is currently unreachable.",
+    };
+  }
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+function formatDate(value: Date | null | undefined): string {
+  if (!value) return "-";
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "UTC",
+    timeZoneName: "short",
+  }).format(value);
+}
+
+function PageRails() {
+  return (
+    <div className="pointer-events-none fixed inset-0 hidden lg:block" aria-hidden="true">
+      <div className="absolute inset-y-0 left-0 w-3 border-r border-white/10 bg-[repeating-linear-gradient(-45deg,rgba(255,255,255,0.6),rgba(255,255,255,0.6)_1px,transparent_1px,transparent_5px)] opacity-10" />
+      <div className="absolute inset-y-0 right-0 w-3 border-l border-white/10 bg-[repeating-linear-gradient(-45deg,rgba(255,255,255,0.6),rgba(255,255,255,0.6)_1px,transparent_1px,transparent_5px)] opacity-10" />
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  icon: Icon,
+}: {
+  label: string;
+  value: string;
+  icon: typeof Activity;
+}) {
+  return (
+    <article className="border border-white/10 bg-white/[0.025] p-4">
+      <div className="flex items-center justify-between gap-4">
+        <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-white/45">{label}</p>
+        <Icon className="size-4 text-white/45" strokeWidth={1.7} aria-hidden="true" />
+      </div>
+      <p className="mt-4 text-3xl font-medium tracking-[-0.04em] text-white">{value}</p>
+    </article>
+  );
+}
+
+function GroupTable({ title, rows }: { title: string; rows: GroupCount[] }) {
+  return (
+    <section className="border border-white/10 bg-black">
+      <header className="flex items-center justify-between border-b border-white/10 px-4 py-3">
+        <h2 className="text-sm font-medium text-white">{title}</h2>
+        <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-white/35">
+          {rows.length} values
+        </span>
+      </header>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[420px] table-fixed text-left">
+          <thead className="bg-white/[0.025] font-mono text-[10px] uppercase tracking-[0.14em] text-white/35">
+            <tr>
+              <th className="px-4 py-2 font-normal">Value</th>
+              <th className="w-24 px-4 py-2 text-right font-normal">Events</th>
+              <th className="w-44 px-4 py-2 text-right font-normal">Last seen</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-white/10">
+            {rows.length ? (
+              rows.map((row) => (
+                <tr key={row.key}>
+                  <td className="truncate px-4 py-2.5 font-mono text-xs text-white/75">
+                    {row.key}
+                  </td>
+                  <td className="px-4 py-2.5 text-right font-mono text-xs text-white">
+                    {formatNumber(row.count)}
+                  </td>
+                  <td className="px-4 py-2.5 text-right font-mono text-[11px] text-white/40">
+                    {formatDate(row.lastSeenAt)}
+                  </td>
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td colSpan={3} className="px-4 py-6 text-sm text-white/40">
+                  No events in this group yet.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function StatusPanel({ data }: { data: Exclude<TelemetryData, { status: "ready" }> }) {
+  return (
+    <main className="relative flex min-h-dvh items-center justify-center overflow-hidden bg-black px-5 py-16 text-white">
+      <PageRails />
+      <section className="relative w-full max-w-2xl border border-white/10 bg-white/[0.025] p-6 sm:p-8">
+        <div className="flex items-center gap-3">
+          <AlertTriangle className="size-5 text-white/50" strokeWidth={1.7} aria-hidden="true" />
+          <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-white/45">
+            {data.status.replace("-", " ")}
+          </p>
+        </div>
+        <h1 className="mt-5 text-2xl font-medium tracking-[-0.035em]">Farm.js telemetry</h1>
+        <p className="mt-3 max-w-xl text-sm leading-6 text-white/55">{data.message}</p>
+      </section>
+    </main>
+  );
+}
+
+function AccessPanel({ error }: { error?: string }) {
+  const message =
+    error === "rate-limited"
+      ? "Too many attempts. Wait a minute and try again."
+      : error === "invalid"
+        ? "That dashboard token is not valid."
+        : undefined;
+  return (
+    <main className="relative flex min-h-dvh items-center justify-center overflow-hidden bg-black px-5 py-16 text-white">
+      <PageRails />
+      <section className="relative w-full max-w-md border border-white/10 bg-white/[0.025] p-6 sm:p-8">
+        <div className="flex items-center gap-3">
+          <Fingerprint className="size-5 text-white/50" strokeWidth={1.7} aria-hidden="true" />
+          <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-white/45">
+            Restricted dashboard
+          </p>
+        </div>
+        <h1 className="mt-5 text-2xl font-medium tracking-[-0.035em]">Farm.js telemetry</h1>
+        <p className="mt-3 text-sm leading-6 text-white/55">
+          Enter the server-side dashboard token to open anonymous product-health metrics.
+        </p>
+        <form action="/api/telemetry/dashboard/session" method="post" className="mt-6">
+          <label
+            htmlFor="telemetry-dashboard-token"
+            className="font-mono text-[10px] uppercase tracking-[0.16em] text-white/45"
+          >
+            Dashboard token
+          </label>
+          <input
+            id="telemetry-dashboard-token"
+            name="token"
+            type="password"
+            required
+            autoComplete="current-password"
+            className="mt-2 h-11 w-full border border-white/15 bg-black px-3 font-mono text-sm text-white outline-none transition-colors focus:border-white/45"
+          />
+          {message ? (
+            <p role="alert" className="mt-3 text-xs leading-5 text-red-300/80">
+              {message}
+            </p>
+          ) : null}
+          <button
+            type="submit"
+            className="mt-4 h-10 w-full border border-white bg-white px-4 font-mono text-xs font-medium uppercase tracking-[0.14em] text-black transition-colors hover:bg-white/85 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          >
+            Open dashboard
+          </button>
+        </form>
+        <p className="mt-4 text-xs leading-5 text-white/35">
+          The token is exchanged server-side for a 12-hour HttpOnly cookie and is never stored in
+          the page URL.
+        </p>
+      </section>
+    </main>
+  );
+}
+
+export default async function TelemetryPage({ searchParams }: TelemetryPageProps) {
+  const params = (await searchParams) ?? {};
+  if (!hasDashboardAccess()) return <AccessPanel error={first(params.error)} />;
+  const data = await loadTelemetryData(readLimit(params.limit));
+
+  if (data.status !== "ready") return <StatusPanel data={data} />;
+
+  return (
+    <main className="relative min-h-dvh overflow-hidden bg-black px-3 py-4 text-white sm:px-5 lg:px-8 lg:py-6">
+      <PageRails />
+      <div className="relative mx-auto max-w-[1800px]">
+        <header className="border border-white/10 bg-black p-5 sm:p-7">
+          <div className="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+            <div>
+              <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.18em] text-white/45">
+                <Activity className="size-3.5" strokeWidth={1.7} aria-hidden="true" />
+                Product health / anonymous
+              </div>
+              <h1 className="mt-4 text-3xl font-medium tracking-[-0.045em] sm:text-4xl">
+                Farm.js telemetry
+              </h1>
+              <p className="mt-3 max-w-2xl text-sm leading-6 text-white/50">
+                Coarse, opt-in CLI and project-creation signals. No paths, repositories, source,
+                credentials, user identities, IP addresses, or user-agent strings are stored.
+              </p>
+            </div>
+            <p className="font-mono text-[11px] text-white/40">
+              Refreshed {formatDate(new Date())}
+            </p>
+            {process.env.FARM_TELEMETRY_DASHBOARD_TOKEN ? (
+              <form action="/api/telemetry/dashboard/session" method="post">
+                <input type="hidden" name="action" value="logout" />
+                <button
+                  type="submit"
+                  className="font-mono text-[10px] uppercase tracking-[0.14em] text-white/40 underline decoration-white/20 underline-offset-4 hover:text-white"
+                >
+                  End dashboard session
+                </button>
+              </form>
+            ) : null}
+          </div>
+        </header>
+
+        <section className="mt-3 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <StatCard label="Total events" value={formatNumber(data.totalEvents)} icon={Database} />
+          <StatCard
+            label="Last 24 hours"
+            value={formatNumber(data.eventsLast24h)}
+            icon={Activity}
+          />
+          <StatCard
+            label="Anonymous installations"
+            value={formatNumber(data.uniqueInstallations)}
+            icon={Fingerprint}
+          />
+          <StatCard
+            label="Projects created"
+            value={formatNumber(data.projectsCreated)}
+            icon={PackageCheck}
+          />
+        </section>
+
+        <section className="mt-3 grid gap-3 xl:grid-cols-2 2xl:grid-cols-3">
+          <GroupTable title="Event types" rows={data.eventTypes} />
+          <GroupTable title="CLI commands" rows={data.commands} />
+          <GroupTable title="Farm versions" rows={data.versions} />
+          <GroupTable title="Starter templates" rows={data.templates} />
+          <GroupTable title="Renderers" rows={data.renderers} />
+          <GroupTable title="Package managers" rows={data.packageManagers} />
+          <GroupTable title="Platforms" rows={data.platforms} />
+        </section>
+
+        <section className="mt-3 border border-white/10 bg-black">
+          <header className="flex items-center justify-between border-b border-white/10 px-4 py-3">
+            <div className="flex items-center gap-2">
+              <Terminal className="size-4 text-white/45" strokeWidth={1.7} aria-hidden="true" />
+              <h2 className="text-sm font-medium">Recent events</h2>
+            </div>
+            <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-white/35">
+              newest first
+            </span>
+          </header>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[1100px] text-left">
+              <thead className="bg-white/[0.025] font-mono text-[10px] uppercase tracking-[0.14em] text-white/35">
+                <tr>
+                  <th className="px-4 py-2 font-normal">Received</th>
+                  <th className="px-4 py-2 font-normal">Event</th>
+                  <th className="px-4 py-2 font-normal">Detail</th>
+                  <th className="px-4 py-2 font-normal">Version</th>
+                  <th className="px-4 py-2 font-normal">Source</th>
+                  <th className="px-4 py-2 font-normal">Runtime</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/10">
+                {data.recentEvents.length ? (
+                  data.recentEvents.map((event) => {
+                    const detail = event.command || event.template || event.renderer || "-";
+                    return (
+                      <tr key={event.id}>
+                        <td className="whitespace-nowrap px-4 py-2.5 font-mono text-[11px] text-white/40">
+                          {formatDate(event.createdAt)}
+                        </td>
+                        <td className="px-4 py-2.5 font-mono text-xs text-white">
+                          {event.eventType}
+                        </td>
+                        <td className="px-4 py-2.5 font-mono text-xs text-white/70">{detail}</td>
+                        <td className="px-4 py-2.5 font-mono text-xs text-white/70">
+                          {event.packageVersion}
+                        </td>
+                        <td className="px-4 py-2.5 font-mono text-xs text-white/55">
+                          {event.source}
+                        </td>
+                        <td className="px-4 py-2.5 font-mono text-xs text-white/45">
+                          node {event.nodeMajor} / {event.platform} / {event.architecture}
+                        </td>
+                      </tr>
+                    );
+                  })
+                ) : (
+                  <tr>
+                    <td colSpan={6} className="px-4 py-8 text-center text-sm text-white/40">
+                      <Boxes className="mx-auto mb-3 size-5" strokeWidth={1.6} aria-hidden="true" />
+                      No telemetry events have been received yet.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/docs/src/farm.d.ts
+++ b/docs/src/farm.d.ts
@@ -82,8 +82,10 @@ export type RoutePath =
   | "/docs/server-queries"
   | "/docs/server-rendering"
   | "/docs/storage"
+  | "/docs/telemetry"
   | "/docs/testing"
-  | "/docs/themes";
+  | "/docs/themes"
+  | "/telemetry";
 export type RoutePattern =
   | "/"
   | "/docs"
@@ -155,8 +157,10 @@ export type RoutePattern =
   | "/docs/server-queries"
   | "/docs/server-rendering"
   | "/docs/storage"
+  | "/docs/telemetry"
   | "/docs/testing"
-  | "/docs/themes";
+  | "/docs/themes"
+  | "/telemetry";
 export type RouteModulePattern =
   | "/"
   | "/docs"
@@ -228,8 +232,10 @@ export type RouteModulePattern =
   | "/docs/server-queries"
   | "/docs/server-rendering"
   | "/docs/storage"
+  | "/docs/telemetry"
   | "/docs/testing"
-  | "/docs/themes";
+  | "/docs/themes"
+  | "/telemetry";
 declare module "@farm.js/core/client" {
   interface LinkDefaultRoute {
     _: import("./farm").RoutePath;

--- a/docs/src/lib/api.generated.ts
+++ b/docs/src/lib/api.generated.ts
@@ -6,10 +6,24 @@
  * Runtime imports are used only at the type level.
  */
 
+import type { POST as POST_telemetry_dashboard_session } from "../app/api/telemetry/dashboard/session/route";
+import type { POST as POST_telemetry_v1_events } from "../app/api/telemetry/v1/events/route";
 import type { POST as POST_waitlist } from "../app/api/waitlist/route";
 
 // Type-only representation of your API routes
 export type APIRouter = {
+  telemetry: {
+    dashboard: {
+      session: {
+        post: typeof POST_telemetry_dashboard_session;
+      };
+    };
+    v1: {
+      events: {
+        post: typeof POST_telemetry_v1_events;
+      };
+    };
+  };
   waitlist: {
     post: typeof POST_waitlist;
   };

--- a/docs/src/lib/prisma.ts
+++ b/docs/src/lib/prisma.ts
@@ -1,0 +1,32 @@
+import type { PrismaClient as PrismaClientType } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as {
+  farmDocsPrisma?: PrismaClientType;
+};
+
+type PrismaClientConstructor = new (options?: {
+  log?: Array<"query" | "info" | "warn" | "error">;
+}) => PrismaClientType;
+
+type PrismaModule = {
+  PrismaClient: PrismaClientConstructor;
+};
+
+const importRuntimeModule = new Function("specifier", "return import(specifier)") as (
+  specifier: string,
+) => Promise<PrismaModule>;
+
+export async function getPrisma(): Promise<PrismaClientType> {
+  if (!process.env.DATABASE_URL) {
+    throw new Error("DATABASE_URL is not configured");
+  }
+
+  if (!globalForPrisma.farmDocsPrisma) {
+    const { PrismaClient } = await importRuntimeModule("@prisma/client");
+    globalForPrisma.farmDocsPrisma = new PrismaClient({
+      log: process.env.NODE_ENV === "development" ? ["warn", "error"] : ["error"],
+    });
+  }
+
+  return globalForPrisma.farmDocsPrisma;
+}

--- a/packages/create-farm-app/bin/create-farm-app.js
+++ b/packages/create-farm-app/bin/create-farm-app.js
@@ -19,7 +19,7 @@ program
   .option("--skip-install", "Skip installing dependencies")
   .action(async (projectName, options) => {
     try {
-      await createApp(projectName, options);
+      await createApp(projectName, { ...options, telemetryPackageVersion: version });
     } catch (error) {
       console.error("Failed to create app:", error);
       process.exit(1);

--- a/packages/create-farm-app/src/farm-cli-telemetry.d.ts
+++ b/packages/create-farm-app/src/farm-cli-telemetry.d.ts
@@ -1,0 +1,12 @@
+declare module "@farm.js/cli/telemetry" {
+  export function showFarmTelemetryNotice(): Promise<void>;
+
+  export function trackFarmProjectCreated(input: {
+    packageVersion: string;
+    template?: string;
+    renderer?: string;
+    packageManager?: string;
+    typescript?: boolean;
+    installedDependencies?: boolean;
+  }): Promise<void>;
+}

--- a/packages/create-farm-app/src/index.ts
+++ b/packages/create-farm-app/src/index.ts
@@ -7,6 +7,7 @@ import {
   type AddFarmIntegrationResult,
   type FarmIntegrationProvider,
 } from "@farm.js/cli/add-integration";
+import { showFarmTelemetryNotice, trackFarmProjectCreated } from "@farm.js/cli/telemetry";
 import { logger, showBanner } from "./utils";
 
 interface CreateAppOptions {
@@ -15,6 +16,7 @@ interface CreateAppOptions {
   typescript?: boolean;
   skipInstall?: boolean;
   listTemplates?: boolean;
+  telemetryPackageVersion?: string;
 }
 
 interface TemplateDetails {
@@ -203,6 +205,7 @@ export interface PackageManager {
 
 export async function createApp(projectName?: string, options: CreateAppOptions = {}) {
   showBanner();
+  await showFarmTelemetryNotice();
 
   const templates = await getAvailableTemplates();
   if (templates.length === 0) {
@@ -415,6 +418,15 @@ export async function createApp(projectName?: string, options: CreateAppOptions 
       logger.info(note);
     }
   }
+
+  await trackFarmProjectCreated({
+    packageVersion: options.telemetryPackageVersion ?? "unknown",
+    template,
+    renderer,
+    packageManager: packageManager.name,
+    typescript: useTypeScript,
+    installedDependencies: !options.skipInstall,
+  });
 }
 
 async function copyTemplate(

--- a/packages/create-farm-app/tsdown.config.ts
+++ b/packages/create-farm-app/tsdown.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
       packageDirectory,
       "../farm-cli/src/add-integration.ts",
     ),
+    "@farm.js/cli/telemetry": path.resolve(packageDirectory, "../farm-cli/src/telemetry.ts"),
   },
   noExternal: [/^@farm\.js\/cli(?:\/.*)?$/],
   splitting: false,

--- a/packages/farm-cli/bin/farm.js
+++ b/packages/farm-cli/bin/farm.js
@@ -35,6 +35,44 @@ function collectOption(value, previous) {
   return [...(previous || []), value];
 }
 
+function telemetryCommandPath(command) {
+  const segments = [];
+  let current = command;
+  while (current && current !== program) {
+    segments.unshift(current.name());
+    current = current.parent;
+  }
+  return segments.join(":");
+}
+
+function telemetryDeployTarget(commandPath, options) {
+  if (commandPath !== "deploy") return undefined;
+  if (options.vercel) return "vercel";
+  if (options.cloudflare) return "cloudflare";
+  if (options.netlify) return "netlify";
+  if (options.custom) return "custom";
+  return undefined;
+}
+
+program.hook("preAction", async (_command, actionCommand) => {
+  const commandPath = telemetryCommandPath(actionCommand);
+  if (commandPath.startsWith("telemetry")) return;
+  const {
+    resolveFarmTelemetryCommand,
+    showFarmTelemetryNotice,
+    trackFarmCommand,
+  } = require("../dist/telemetry.js");
+  await showFarmTelemetryNotice();
+  const command = resolveFarmTelemetryCommand(commandPath);
+  if (!command) return;
+  const options = actionCommand.opts();
+  await trackFarmCommand({
+    command,
+    packageVersion: version,
+    deployTarget: telemetryDeployTarget(commandPath, options),
+  });
+});
+
 program
   .command("dev")
   .description("Start development server")
@@ -480,4 +518,49 @@ program
     }
   });
 
-program.parse();
+const telemetryCommand = program
+  .command("telemetry")
+  .description("Control anonymous Farm.js product telemetry");
+
+telemetryCommand
+  .command("status")
+  .description("Show the current telemetry setting")
+  .action(async () => {
+    const { getFarmTelemetryStatus } = require("../dist/telemetry.js");
+    const status = await getFarmTelemetryStatus();
+    console.log(`Anonymous telemetry: ${status.enabled ? "enabled" : "disabled"}`);
+    console.log(`Active for this command: ${status.active ? "yes" : "no"}`);
+    console.log(`Setting source: ${status.source}`);
+    if (status.reason) console.log(`Reason: ${status.reason}`);
+    console.log(`Local anonymous ID: ${status.anonymousId ? "created" : "not created"}`);
+    console.log(`Configuration: ${status.configFile}`);
+    console.log("Privacy details: https://farmjs.dev/docs/telemetry");
+  });
+
+telemetryCommand
+  .command("enable")
+  .description("Opt in to anonymous Farm.js product telemetry")
+  .action(async () => {
+    const { setFarmTelemetryEnabled } = require("../dist/telemetry.js");
+    const status = await setFarmTelemetryEnabled(true);
+    console.log("Anonymous Farm.js telemetry is enabled.");
+    if (!status.active && status.reason)
+      console.log(`It is inactive here because ${status.reason}.`);
+  });
+
+telemetryCommand
+  .command("disable")
+  .description("Opt out and delete the local anonymous installation ID")
+  .action(async () => {
+    const { setFarmTelemetryEnabled } = require("../dist/telemetry.js");
+    const status = await setFarmTelemetryEnabled(false);
+    console.log("Anonymous Farm.js telemetry is disabled and its local ID was deleted.");
+    if (status.enabled) {
+      console.log("An environment variable currently overrides the saved setting.");
+    }
+  });
+
+program.parseAsync().catch((error) => {
+  console.error("Farm CLI failed:", error);
+  process.exitCode = 1;
+});

--- a/packages/farm-cli/src/index.ts
+++ b/packages/farm-cli/src/index.ts
@@ -102,3 +102,20 @@ export {
   type FarmUpgradePlan,
   type FarmUpgradeResult,
 } from "./upgrade";
+export {
+  getFarmTelemetryConfigFile,
+  getFarmTelemetryStatus,
+  resolveFarmTelemetryCommand,
+  setFarmTelemetryEnabled,
+  showFarmTelemetryNotice,
+  trackFarmCommand,
+  trackFarmProjectCreated,
+  type FarmCommandTelemetryInput,
+  type FarmProjectCreatedTelemetryInput,
+  type FarmTelemetryCommand,
+  type FarmTelemetryDeployTarget,
+  type FarmTelemetryPackageManager,
+  type FarmTelemetryRenderer,
+  type FarmTelemetryStatus,
+  type FarmTelemetryTemplate,
+} from "./telemetry";

--- a/packages/farm-cli/src/telemetry.ts
+++ b/packages/farm-cli/src/telemetry.ts
@@ -1,0 +1,412 @@
+import { randomUUID } from "node:crypto";
+import { chmod, mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const TELEMETRY_SCHEMA_VERSION = 1 as const;
+const DEFAULT_TELEMETRY_ENDPOINT = "https://farmjs.dev/api/telemetry/v1/events";
+const TELEMETRY_NOTICE_URL = "https://farmjs.dev/docs/telemetry";
+const REQUEST_TIMEOUT_MS = 750;
+
+const FARM_COMMANDS = [
+  "dev",
+  "build",
+  "auth:migrate",
+  "upgrade",
+  "generate",
+  "doctor",
+  "explain",
+  "preview",
+  "migrate",
+  "cron:list",
+  "cron:run",
+  "add:integration",
+  "deploy",
+] as const;
+
+const FARM_TEMPLATES = [
+  "basic",
+  "react-compiler",
+  "auth",
+  "better-auth",
+  "ai",
+  "auth0",
+  "authjs",
+  "autumn",
+  "clerk",
+  "jobs-inngest",
+  "jobs-trigger",
+  "polar",
+  "resend",
+  "stripe",
+  "supabase",
+  "unkey",
+  "workos",
+] as const;
+
+const RENDERERS = ["react", "preact", "solid", "vue", "svelte"] as const;
+const PACKAGE_MANAGERS = ["npm", "pnpm", "yarn", "bun"] as const;
+const DEPLOY_TARGETS = ["vercel", "cloudflare", "netlify", "node", "custom"] as const;
+
+export type FarmTelemetryCommand = (typeof FARM_COMMANDS)[number];
+export type FarmTelemetryTemplate = (typeof FARM_TEMPLATES)[number];
+export type FarmTelemetryRenderer = (typeof RENDERERS)[number];
+export type FarmTelemetryPackageManager = (typeof PACKAGE_MANAGERS)[number];
+export type FarmTelemetryDeployTarget = (typeof DEPLOY_TARGETS)[number];
+
+interface FarmTelemetryConfig {
+  version: 1;
+  enabled: boolean;
+  noticeShown: boolean;
+  anonymousId?: string;
+}
+
+interface FarmTelemetryEventBase {
+  schemaVersion: typeof TELEMETRY_SCHEMA_VERSION;
+  eventId: string;
+  anonymousId: string;
+  source: "cli" | "create-app";
+  packageName: "@farm.js/cli" | "@farm.js/create-app";
+  packageVersion: string;
+  nodeMajor: number;
+  platform: "darwin" | "linux" | "windows" | "other";
+  architecture: "arm64" | "x64" | "other";
+}
+
+export interface FarmCommandTelemetryInput {
+  command: FarmTelemetryCommand;
+  packageVersion: string;
+  deployTarget?: string;
+}
+
+export interface FarmProjectCreatedTelemetryInput {
+  packageVersion: string;
+  template?: string;
+  renderer?: string;
+  packageManager?: string;
+  typescript?: boolean;
+  installedDependencies?: boolean;
+}
+
+export interface FarmTelemetryStatus {
+  enabled: boolean;
+  active: boolean;
+  source: "configuration" | "environment" | "default";
+  endpoint: string;
+  configFile: string;
+  anonymousId?: string;
+  reason?: string;
+}
+
+type FarmTelemetryEvent =
+  | (FarmTelemetryEventBase & {
+      eventType: "command_invoked";
+      command: FarmTelemetryCommand;
+      deployTarget?: FarmTelemetryDeployTarget;
+    })
+  | (FarmTelemetryEventBase & {
+      eventType: "project_created";
+      template?: FarmTelemetryTemplate;
+      renderer?: FarmTelemetryRenderer;
+      packageManager?: FarmTelemetryPackageManager;
+      typescript?: boolean;
+      installedDependencies?: boolean;
+    });
+
+type FarmTelemetryGeneratedFields = Pick<
+  FarmTelemetryEventBase,
+  "schemaVersion" | "eventId" | "anonymousId" | "nodeMajor" | "platform" | "architecture"
+>;
+type FarmTelemetryEventInput<T = FarmTelemetryEvent> = T extends FarmTelemetryEvent
+  ? Omit<T, keyof FarmTelemetryGeneratedFields>
+  : never;
+
+function defaultConfig(): FarmTelemetryConfig {
+  return {
+    version: TELEMETRY_SCHEMA_VERSION,
+    enabled: false,
+    noticeShown: false,
+  };
+}
+
+function configDirectory(): string {
+  if (process.env.FARM_TELEMETRY_CONFIG_DIR) {
+    return path.resolve(process.env.FARM_TELEMETRY_CONFIG_DIR);
+  }
+  if (process.platform === "win32") {
+    return path.join(
+      process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming"),
+      "farmjs",
+    );
+  }
+  if (process.platform === "darwin") {
+    return path.join(os.homedir(), "Library", "Application Support", "farmjs");
+  }
+  return path.join(process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config"), "farmjs");
+}
+
+export function getFarmTelemetryConfigFile(): string {
+  return path.join(configDirectory(), "telemetry.json");
+}
+
+async function readConfig(): Promise<FarmTelemetryConfig> {
+  try {
+    const parsed = JSON.parse(
+      await readFile(getFarmTelemetryConfigFile(), "utf8"),
+    ) as Partial<FarmTelemetryConfig>;
+    if (parsed.version !== TELEMETRY_SCHEMA_VERSION) return defaultConfig();
+    return {
+      version: TELEMETRY_SCHEMA_VERSION,
+      enabled: parsed.enabled === true,
+      noticeShown: parsed.noticeShown === true,
+      anonymousId: isUuid(parsed.anonymousId) ? parsed.anonymousId : undefined,
+    };
+  } catch {
+    return defaultConfig();
+  }
+}
+
+async function writeConfig(config: FarmTelemetryConfig): Promise<void> {
+  const file = getFarmTelemetryConfigFile();
+  const directory = path.dirname(file);
+  const temporaryFile = `${file}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+    await writeFile(temporaryFile, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
+    await rename(temporaryFile, file);
+    await chmod(file, 0o600).catch(() => undefined);
+  } catch {
+    await unlink(temporaryFile).catch(() => undefined);
+    // Telemetry is best-effort and must never make a Farm command fail.
+  }
+}
+
+function isUuid(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
+  );
+}
+
+function isTrue(value: string | undefined): boolean {
+  return value !== undefined && ["1", "true", "yes", "on"].includes(value.toLowerCase());
+}
+
+function isFalse(value: string | undefined): boolean {
+  return value !== undefined && ["0", "false", "no", "off"].includes(value.toLowerCase());
+}
+
+function environmentDecision(): { enabled?: boolean; reason?: string } {
+  if (process.env.DO_NOT_TRACK !== undefined && !isFalse(process.env.DO_NOT_TRACK)) {
+    return { enabled: false, reason: "DO_NOT_TRACK is set" };
+  }
+  if (isTrue(process.env.FARM_TELEMETRY_DISABLED)) {
+    return { enabled: false, reason: "FARM_TELEMETRY_DISABLED is set" };
+  }
+  if (isTrue(process.env.FARM_TELEMETRY)) return { enabled: true };
+  if (isFalse(process.env.FARM_TELEMETRY)) {
+    return { enabled: false, reason: "FARM_TELEMETRY disables collection" };
+  }
+  return {};
+}
+
+function isContinuousIntegration(): boolean {
+  return (
+    isTrue(process.env.CI) ||
+    isTrue(process.env.GITHUB_ACTIONS) ||
+    isTrue(process.env.BUILDKITE) ||
+    isTrue(process.env.CIRCLECI)
+  );
+}
+
+function isInteractive(): boolean {
+  return process.stdin.isTTY === true && process.stdout.isTTY === true;
+}
+
+function getEndpoint(): string {
+  const candidate = process.env.FARM_TELEMETRY_ENDPOINT || DEFAULT_TELEMETRY_ENDPOINT;
+  try {
+    const url = new URL(candidate);
+    const isLocal = ["localhost", "127.0.0.1", "::1"].includes(url.hostname);
+    if (url.protocol !== "https:" && !(url.protocol === "http:" && isLocal)) {
+      return DEFAULT_TELEMETRY_ENDPOINT;
+    }
+    return url.toString();
+  } catch {
+    return DEFAULT_TELEMETRY_ENDPOINT;
+  }
+}
+
+async function resolveState(): Promise<{
+  config: FarmTelemetryConfig;
+  enabled: boolean;
+  active: boolean;
+  source: FarmTelemetryStatus["source"];
+  reason?: string;
+}> {
+  const config = await readConfig();
+  const environment = environmentDecision();
+  const enabled = environment.enabled ?? config.enabled;
+  const source =
+    environment.enabled !== undefined
+      ? "environment"
+      : config.enabled
+        ? "configuration"
+        : "default";
+
+  if (!enabled) return { config, enabled, active: false, source, reason: environment.reason };
+  if (environment.enabled === true) return { config, enabled, active: true, source };
+  if (process.env.NODE_ENV === "test") {
+    return { config, enabled, active: false, source, reason: "test environments are skipped" };
+  }
+  if (isContinuousIntegration()) {
+    return { config, enabled, active: false, source, reason: "CI environments are skipped" };
+  }
+  if (!isInteractive()) {
+    return {
+      config,
+      enabled,
+      active: false,
+      source,
+      reason: "non-interactive commands are skipped",
+    };
+  }
+  return { config, enabled, active: true, source };
+}
+
+export async function getFarmTelemetryStatus(): Promise<FarmTelemetryStatus> {
+  const state = await resolveState();
+  return {
+    enabled: state.enabled,
+    active: state.active,
+    source: state.source,
+    endpoint: getEndpoint(),
+    configFile: getFarmTelemetryConfigFile(),
+    anonymousId: state.config.anonymousId,
+    reason: state.reason,
+  };
+}
+
+export async function setFarmTelemetryEnabled(enabled: boolean): Promise<FarmTelemetryStatus> {
+  const current = await readConfig();
+  await writeConfig({
+    version: TELEMETRY_SCHEMA_VERSION,
+    enabled,
+    noticeShown: true,
+    anonymousId: enabled ? current.anonymousId || randomUUID() : undefined,
+  });
+  return getFarmTelemetryStatus();
+}
+
+export async function showFarmTelemetryNotice(): Promise<void> {
+  if (!isInteractive() || isContinuousIntegration() || process.env.NODE_ENV === "test") return;
+  if (environmentDecision().enabled !== undefined) return;
+  const config = await readConfig();
+  if (config.noticeShown) return;
+  process.stderr.write(
+    `Farm.js anonymous telemetry is off during beta. Run "farm telemetry enable" to opt in.\nLearn more: ${TELEMETRY_NOTICE_URL}\n`,
+  );
+  await writeConfig({ ...config, noticeShown: true });
+}
+
+export function resolveFarmTelemetryCommand(value: string): FarmTelemetryCommand | undefined {
+  return (FARM_COMMANDS as readonly string[]).includes(value)
+    ? (value as FarmTelemetryCommand)
+    : undefined;
+}
+
+export async function trackFarmCommand(input: FarmCommandTelemetryInput): Promise<void> {
+  const deployTarget = allowlisted(input.deployTarget, DEPLOY_TARGETS);
+  await track({
+    eventType: "command_invoked",
+    source: "cli",
+    packageName: "@farm.js/cli",
+    packageVersion: sanitizeVersion(input.packageVersion),
+    command: input.command,
+    ...(deployTarget ? { deployTarget } : {}),
+  });
+}
+
+export async function trackFarmProjectCreated(
+  input: FarmProjectCreatedTelemetryInput,
+): Promise<void> {
+  const template = allowlisted(input.template, FARM_TEMPLATES);
+  const renderer = allowlisted(input.renderer, RENDERERS);
+  const packageManager = allowlisted(input.packageManager, PACKAGE_MANAGERS);
+  await track({
+    eventType: "project_created",
+    source: "create-app",
+    packageName: "@farm.js/create-app",
+    packageVersion: sanitizeVersion(input.packageVersion),
+    ...(template ? { template } : {}),
+    ...(renderer ? { renderer } : {}),
+    ...(packageManager ? { packageManager } : {}),
+    ...(typeof input.typescript === "boolean" ? { typescript: input.typescript } : {}),
+    ...(typeof input.installedDependencies === "boolean"
+      ? { installedDependencies: input.installedDependencies }
+      : {}),
+  });
+}
+
+async function track(event: FarmTelemetryEventInput): Promise<void> {
+  try {
+    const state = await resolveState();
+    if (!state.active) return;
+    const anonymousId = state.config.anonymousId || randomUUID();
+    if (!state.config.anonymousId) {
+      await writeConfig({ ...state.config, anonymousId });
+    }
+    const payload = {
+      schemaVersion: TELEMETRY_SCHEMA_VERSION,
+      eventId: randomUUID(),
+      anonymousId,
+      nodeMajor: Number.parseInt(process.versions.node.split(".")[0] || "0", 10),
+      platform: normalizePlatform(process.platform),
+      architecture: normalizeArchitecture(process.arch),
+      ...event,
+    } as FarmTelemetryEvent;
+    await send(payload);
+  } catch {
+    // Telemetry is best-effort and must never make a Farm command fail.
+  }
+}
+
+async function send(payload: FarmTelemetryEvent): Promise<void> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  timeout.unref?.();
+  try {
+    await fetch(getEndpoint(), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+      keepalive: true,
+    });
+  } catch {
+    // Network and endpoint failures are intentionally ignored.
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function sanitizeVersion(value: string): string {
+  return /^[0-9A-Za-z.+_-]{1,64}$/.test(value) ? value : "unknown";
+}
+
+function allowlisted<const T extends readonly string[]>(
+  value: string | undefined,
+  values: T,
+): T[number] | undefined {
+  return value && (values as readonly string[]).includes(value) ? (value as T[number]) : undefined;
+}
+
+function normalizePlatform(value: NodeJS.Platform): FarmTelemetryEventBase["platform"] {
+  if (value === "darwin" || value === "linux") return value;
+  if (value === "win32") return "windows";
+  return "other";
+}
+
+function normalizeArchitecture(value: string): FarmTelemetryEventBase["architecture"] {
+  return value === "arm64" || value === "x64" ? value : "other";
+}

--- a/packages/farm-cli/test/telemetry.test.mjs
+++ b/packages/farm-cli/test/telemetry.test.mjs
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  getFarmTelemetryConfigFile,
+  getFarmTelemetryStatus,
+  setFarmTelemetryEnabled,
+  trackFarmCommand,
+  trackFarmProjectCreated,
+} from "../dist/telemetry.mjs";
+
+const TELEMETRY_ENV_KEYS = [
+  "CI",
+  "DO_NOT_TRACK",
+  "FARM_TELEMETRY",
+  "FARM_TELEMETRY_CONFIG_DIR",
+  "FARM_TELEMETRY_DISABLED",
+  "FARM_TELEMETRY_ENDPOINT",
+  "NODE_ENV",
+];
+
+async function withTelemetryEnvironment(run) {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "farm-cli-telemetry-"));
+  const previous = Object.fromEntries(TELEMETRY_ENV_KEYS.map((key) => [key, process.env[key]]));
+  const previousFetch = globalThis.fetch;
+  for (const key of TELEMETRY_ENV_KEYS) delete process.env[key];
+  process.env.FARM_TELEMETRY_CONFIG_DIR = directory;
+  process.env.FARM_TELEMETRY_ENDPOINT = "http://127.0.0.1:43199/events";
+
+  try {
+    await run(directory);
+  } finally {
+    globalThis.fetch = previousFetch;
+    for (const key of TELEMETRY_ENV_KEYS) {
+      if (previous[key] === undefined) delete process.env[key];
+      else process.env[key] = previous[key];
+    }
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+test("telemetry is opt-in and does not create an identity by default", async () => {
+  await withTelemetryEnvironment(async () => {
+    const status = await getFarmTelemetryStatus();
+    assert.equal(status.enabled, false);
+    assert.equal(status.active, false);
+    assert.equal(status.anonymousId, undefined);
+  });
+});
+
+test("enable persists an anonymous ID and disable removes it", async () => {
+  await withTelemetryEnvironment(async () => {
+    await setFarmTelemetryEnabled(true);
+    const firstConfig = JSON.parse(await readFile(getFarmTelemetryConfigFile(), "utf8"));
+    assert.match(firstConfig.anonymousId, /^[0-9a-f-]{36}$/i);
+
+    await setFarmTelemetryEnabled(false);
+    const disabledConfig = JSON.parse(await readFile(getFarmTelemetryConfigFile(), "utf8"));
+    assert.equal(disabledConfig.enabled, false);
+    assert.equal(disabledConfig.anonymousId, undefined);
+
+    await setFarmTelemetryEnabled(true);
+    const secondConfig = JSON.parse(await readFile(getFarmTelemetryConfigFile(), "utf8"));
+    assert.notEqual(secondConfig.anonymousId, firstConfig.anonymousId);
+  });
+});
+
+test("explicit telemetry sends only the strict command payload", async () => {
+  await withTelemetryEnvironment(async () => {
+    process.env.FARM_TELEMETRY = "1";
+    let request;
+    globalThis.fetch = async (url, init) => {
+      request = { url: String(url), init };
+      return { ok: true };
+    };
+
+    await trackFarmCommand({
+      command: "deploy",
+      packageVersion: "0.1.0-beta.36",
+      deployTarget: "vercel",
+    });
+
+    assert.equal(request.url, "http://127.0.0.1:43199/events");
+    const payload = JSON.parse(request.init.body);
+    assert.deepEqual(
+      Object.keys(payload).sort(),
+      [
+        "anonymousId",
+        "architecture",
+        "command",
+        "deployTarget",
+        "eventId",
+        "eventType",
+        "nodeMajor",
+        "packageName",
+        "packageVersion",
+        "platform",
+        "schemaVersion",
+        "source",
+      ].sort(),
+    );
+    assert.equal(payload.eventType, "command_invoked");
+    assert.equal(payload.command, "deploy");
+    assert.equal(JSON.stringify(payload).includes(process.cwd()), false);
+  });
+});
+
+test("project metadata is allowlisted instead of forwarding arbitrary strings", async () => {
+  await withTelemetryEnvironment(async () => {
+    process.env.FARM_TELEMETRY = "1";
+    let payload;
+    globalThis.fetch = async (_url, init) => {
+      payload = JSON.parse(init.body);
+      return { ok: true };
+    };
+
+    await trackFarmProjectCreated({
+      packageVersion: "../../../secret",
+      template: "/private/project",
+      renderer: "react",
+      packageManager: "pnpm",
+      typescript: true,
+      installedDependencies: false,
+    });
+
+    assert.equal(payload.packageVersion, "unknown");
+    assert.equal(payload.template, undefined);
+    assert.equal(payload.renderer, "react");
+    assert.equal(payload.packageManager, "pnpm");
+    assert.equal(payload.typescript, true);
+    assert.equal(payload.installedDependencies, false);
+  });
+});
+
+test("DO_NOT_TRACK wins over an explicit enable flag", async () => {
+  await withTelemetryEnvironment(async () => {
+    process.env.FARM_TELEMETRY = "1";
+    process.env.DO_NOT_TRACK = "1";
+    let called = false;
+    globalThis.fetch = async () => {
+      called = true;
+      return { ok: true };
+    };
+
+    await trackFarmCommand({ command: "build", packageVersion: "0.1.0-beta.36" });
+    const status = await getFarmTelemetryStatus();
+    assert.equal(called, false);
+    assert.equal(status.enabled, false);
+    assert.match(status.reason, /DO_NOT_TRACK/);
+  });
+});
+
+test("transport failures never reject a Farm command", async () => {
+  await withTelemetryEnvironment(async () => {
+    process.env.FARM_TELEMETRY = "1";
+    globalThis.fetch = async () => {
+      throw new Error("offline");
+    };
+    await assert.doesNotReject(
+      trackFarmCommand({ command: "doctor", packageVersion: "0.1.0-beta.36" }),
+    );
+  });
+});

--- a/packages/farm-cli/tsdown.config.ts
+++ b/packages/farm-cli/tsdown.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     dev: "src/dev.ts",
     build: "src/build.ts",
     "add-integration": "src/add-integration.ts",
+    telemetry: "src/telemetry.ts",
   },
   format: ["cjs", "esm"],
   // DTS generation is disabled here due a rolldown dts runtime-symbol failure.


### PR DESCRIPTION
## Summary

- add explicitly opt-in anonymous telemetry to `@farm.js/cli` and `@farm.js/create-app`
- add a strict, rate-limited ingestion endpoint backed by Prisma/Postgres
- add a token-protected internal dashboard at `/telemetry`
- document controls, collected fields, privacy guarantees, retention, and operator setup
- share the docs Prisma client between telemetry and the waitlist endpoint

## Privacy and behavior

- telemetry is off by default during beta
- `farm telemetry enable|disable|status` controls the saved preference
- `DO_NOT_TRACK` and explicit disable variables are honored
- only allowlisted coarse fields are sent; no project paths, repository data, source, env values, IPs, or user-agent fields are persisted
- raw local installation IDs are HMAC-hashed before storage
- delivery is best-effort with a 750 ms timeout and never fails a Farm command
- raw events default to 90-day retention

## Deployment setup

The live `docs` Vercel project now has server-only Production and Development values for the database, identity salt, dashboard token, and retention. Preview intentionally remains unset so pull-request deployments cannot access production telemetry data. The additive Prisma schema was applied to the supplied Neon database.

## Verification

- `pnpm --filter @farm.js/cli test` — 73 passed
- `pnpm --filter @farm.js/create-app test` — 14 passed
- `pnpm --filter @farm.js/create-app type-check`
- `pnpm exec oxfmt --check <changed files>`
- `pnpm exec oxlint <changed files>`
- full docs Vercel production build
- end-to-end opt-in CLI event → local Farm endpoint → Neon storage
- dashboard token exchange → HttpOnly SameSite cookie → authenticated dashboard
- synthetic verification row removed after the check
- staged secret scan confirmed no local or deployment credentials are committed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt‑in anonymous telemetry to `@farm.js/cli` and `@farm.js/create-app`, plus a strict, rate‑limited ingestion service and token‑protected dashboard. Previously we collected no product telemetry; now users can explicitly opt in, the CLI sends allowlisted, coarse events, and no command can fail due to telemetry.

- New behavior: `farm telemetry status|enable|disable` manages a stored preference; `DO_NOT_TRACK`, `FARM_TELEMETRY_DISABLED`, and `FARM_TELEMETRY` override it. The CLI shows a one‑time notice, skips CI/tests/non‑interactive unless `FARM_TELEMETRY=1`, and sends only two event types: `command_invoked` and `project_created`. Best‑effort delivery uses a 750 ms timeout and never affects command outcomes.

**What to review**

- `@farm.js/cli` telemetry module and hook:
  - Pre‑action hook resolves an allowlisted command, derives deploy target flags, and emits `command_invoked`.
  - Config file location by OS, anonymous ID lifecycle, and env‑based precedence (`DO_NOT_TRACK` wins).
  - Strict payload shaping, version sanitization, endpoint selection (`https` only, or `http` for localhost), 750 ms timeout, and tests.
- `docs` ingestion endpoint and storage:
  - Zod‑validated schema for both events with 8 KiB body cap, JSON only, and idempotent `eventId` upsert.
  - Global and per‑identity rate limits; identity HMAC using `FARM_TELEMETRY_IDENTITY_SALT`; no IP or UA persistence.
  - Prisma model `FarmTelemetryEvent` with indices; retention pruning based on `FARM_TELEMETRY_RETENTION_DAYS` (default 90).
- Dashboard at `/telemetry`:
  - Server‑only token exchange to a 12‑hour HttpOnly, SameSite cookie; form input is rate‑limited; no token exposure in URLs.
- `@farm.js/create-app` integration:
  - Notice on start and `project_created` event with allowlisted template/renderer/package manager and booleans; passes `telemetryPackageVersion` from the bin.

**Rollout and migration**

- Users: telemetry remains off by default; run `farm telemetry enable` to opt in. To enforce policy: set `DO_NOT_TRACK=1`, `FARM_TELEMETRY_DISABLED=1`, or `FARM_TELEMETRY=0/1` as needed.
- Docs deployment operators must:
  - Set server‑only `DATABASE_URL`, `FARM_TELEMETRY_IDENTITY_SALT`, `FARM_TELEMETRY_DASHBOARD_TOKEN`, optional `FARM_TELEMETRY_RETENTION_DAYS`.
  - Apply the Prisma schema: `pnpm --dir docs prisma:generate && pnpm --dir docs db:push`.
  - Keep preview deployments unset so PR previews cannot access production data.
- No breaking changes for application projects; no action required from CLI users who do not opt in.

<sup>Written for commit 2de6c203addff79416a8a4343421e847593904d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

