### PR TITLE
feat(react): compile static bindings

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -323,18 +323,18 @@ policy.
 The current compiler deliberately supports a smaller subset than general React. A component must
 satisfy all of these rules:
 
-| Area                | Current supported shape                                                                                                                             |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Component discovery | A top-level, capitalized function declaration, function expression, or arrow component in application `.tsx` or `.jsx`.                             |
-| Function shape      | Synchronous, non-generator, non-generic block body with zero parameters, one props identifier, or flat object props destructuring.                  |
-| Props               | Flat object destructuring supports shorthand names, aliases, and defaults. Nested, computed, and rest patterns fall back.                           |
-| Body                | Top-level `useState` declarations, optional compiler-safe derived values and synchronous named handlers, then one unconditional JSX return.         |
-| State               | `const [value, setValue] = useState(initial)`, including lazy initializers, multiple cells, and queued functional updates.                          |
-| Root                | Exactly one lowercase host JSX element such as `button`, `section`, `input`, or `div`.                                                              |
-| Tree                | A static tree containing host elements only. Nested host elements are supported when their placement cannot change.                                 |
-| Text bindings       | State-driven text in a leaf host element.                                                                                                           |
-| Attribute bindings  | State-driven basic attributes and properties, including `className`, `htmlFor`, `data-*`, `aria-*`, `value`, `checked`, `selected`, and `disabled`. |
-| Events              | React-owned inline handlers or synchronous `const` handlers passed directly to an event, such as `onClick={increment}`.                             |
+| Area                | Current supported shape                                                                                                                     |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Component discovery | A top-level, capitalized function declaration, function expression, or arrow component in application `.tsx` or `.jsx`.                     |
+| Function shape      | Synchronous, non-generator, non-generic block body with zero parameters, one props identifier, or flat object props destructuring.          |
+| Props               | Flat object destructuring supports shorthand names, aliases, and defaults. Nested, computed, and rest patterns fall back.                   |
+| Body                | Top-level `useState` declarations, optional compiler-safe derived values and synchronous named handlers, then one unconditional JSX return. |
+| State               | `const [value, setValue] = useState(initial)`, including lazy initializers, multiple cells, and queued functional updates.                  |
+| Root                | Exactly one lowercase host JSX element such as `button`, `section`, `input`, or `div`.                                                      |
+| Tree                | A static tree containing host elements only. Nested host elements are supported when their placement cannot change.                         |
+| Text bindings       | State-driven text in a leaf host element.                                                                                                   |
+| Attribute bindings  | Basic attributes, controlled form properties, and individual properties in one inline `style` object.                                       |
+| Events              | Inline handlers and synchronous `const` or function-declaration handlers, used directly or called inside an inline JSX handler.             |
 
 This component is eligible:
 
@@ -351,15 +351,23 @@ interface StatusButtonProps {
 export function StatusButton({ initial = 0, label: title }: StatusButtonProps) {
   const [count, setCount] = useState(initial);
   const [active, setActive] = useState(false);
+  const visibleCount = Math.max(0, count);
   const statusClass = active ? "active" : "idle";
-  const visibleLabel = `${title}: ${count}`;
-  const update = () => {
+  const visibleLabel = `${title}: ${String(visibleCount)}`;
+
+  function update() {
     setCount((value) => value + 1);
     setActive((value) => !value);
-  };
+  }
 
   return (
-    <button aria-pressed={active} className={statusClass} data-count={count} onClick={update}>
+    <button
+      aria-pressed={active}
+      className={statusClass}
+      data-count={visibleCount}
+      onClick={() => update()}
+      style={{ opacity: active ? 1 : 0.6 }}
+    >
       {visibleLabel}
     </button>
   );
@@ -370,17 +378,25 @@ The compiler records separate dependencies for `count` and `active`. Changing `c
 reevaluate bindings that depend only on `active`, and vice versa.
 
 Derived values are expanded into the generated bindings, so they do not create a runtime scope or
-force a component rerender. They may use literals, props, state, operators, member access,
-conditionals, templates, and earlier derived values. State declarations must come first. Calls,
-assignments, object or array literals, functions, JSX, constructors, and other expressions whose
-evaluation or identity cannot be preserved safely still fall back to React.
+force a component rerender. They may use literals, props, state, operators, optional/member access,
+conditionals, templates, earlier derived values, and a small call whitelist. The whitelist contains
+`Boolean`, `Number`, `String`, and `Math.abs`, `ceil`, `floor`, `max`, `min`, `round`, `sign`, and
+`trunc`. A name is not treated as built-in when the component shadows it. Application helpers,
+prototype methods, `Math.random`, optional calls, assignments, identity-bearing object or array
+literals, functions, JSX, constructors, and other unproven expressions still fall back to React.
 
 For destructured props, the original component wrapper still performs JavaScript destructuring on
 every parent render. Defaults therefore apply only to `undefined`, aliases keep their normal local
-names, and the resolved values are passed to the compiled definition. A named handler is expanded
-at build time only when it is synchronous and passed directly to a JSX event. Its state reads and
-setters then use the same compiler cells as an equivalent inline handler. Indirect calls such as
-`onClick={() => increment()}` stay on React until the compiler can prove their closure semantics.
+names, and the resolved values are passed to the compiled definition. A named handler can be a
+synchronous `const` function or function declaration. It is expanded when passed directly to a JSX
+event or called from that event's inline function, including arguments such as
+`onClick={() => select(productId)}`. Calling it while producing the event prop, exposing it as a
+child, using it outside an event, or making it async/generic still falls back to React.
+
+Stateful styles use one inline object literal. The compiler creates a separate binding for each
+state-dependent camelCase property or CSS custom property, so changing `opacity` does not rewrite
+an unrelated `width`. Style spreads, methods, computed names, and conditional whole objects remain
+on React because their final property set or precedence can change.
 
 ### What falls back to React
 
@@ -391,12 +407,13 @@ setters then use the same compiler cells as an equivalent inline handler. Indire
 | Custom child components                                                | A child component has its own props, hooks, lifecycle, and reconciliation boundary. |
 | Effects or hooks other than the supported `useState` shape             | Their lifecycle and ordering must remain under React's hook dispatcher.             |
 | `ref` or `dangerouslySetInnerHTML`                                     | They directly participate in DOM ownership.                                         |
-| Stateful `style`, `children`, or `key` bindings                        | These need specialized property, structure, or identity semantics.                  |
+| Stateful `children` or `key` bindings                                  | These need structure or identity semantics.                                         |
+| Conditional style objects, style spreads, methods, or computed names   | The final property set or precedence cannot be prepared statically.                 |
 | JSX attribute spreads or namespaced attributes                         | The compiler cannot currently enumerate a stable binding contract.                  |
 | Multiple/conditional returns or impure/control-flow statements         | The compiler only lowers a single, statically analyzable render path.               |
 | Derived calls, assignments, identity-bearing values, functions, or JSX | Their evaluation timing, side effects, or identity cannot yet be preserved safely.  |
 | Nested, computed, or rest props destructuring                          | These patterns need additional parameter-shape and identity analysis.               |
-| Async/generator handlers or indirect named-handler calls               | Their scheduling and closure semantics are outside the current lowering.            |
+| Async/generator/generic handlers or named handlers outside JSX events  | Their scheduling, identity, or closure semantics are outside the current lowering.  |
 | Async/generator or generic components                                  | These function shapes are outside the current lowering.                             |
 | Setters called outside JSX event handlers                              | The compiler only controls and batches event-driven local updates.                  |
 
@@ -455,9 +472,17 @@ previous value, no binding is patched.
 Attribute updates preserve important DOM behavior:
 
 - `className` and `htmlFor` map to `class` and `for`;
-- input `value` and `checked`, option `selected`, and element `disabled` use DOM properties;
+- input and textarea `value`, select values, input `checked`, option `selected`, and element
+  `disabled` use DOM properties;
+- controlled single and multiple selects update their selected options;
+- style bindings patch one property, add `px` where React expects it, preserve unitless numbers and
+  CSS custom properties, and clear nullish values;
 - `data-*` and `aria-*` booleans are stringified; and
 - nullish values and ordinary false boolean attributes are removed.
+
+Focused input and textarea updates capture and restore the current selection around the compiler
+microtask. Composition events remain React-owned, so IME input keeps its normal event ordering while
+the resulting value, selection, and dependent bindings are patched together.
 
 The server output is ordinary React HTML and contains no compiler marker. React hydrates that
 markup normally; direct binding updates begin after the component mounts.
@@ -491,6 +516,8 @@ The package and example test suites verify more than generated code:
 - server-rendered markup hydrates and remains interactive;
 - lazy initialization, event snapshots, and batched functional setters are preserved;
 - multiple state cells update only their dependent bindings;
+- whitelisted calculations, per-property styles, handler wrappers, textarea/select/checkbox
+  properties, and multiple-select values update without rerunning the component;
 - Strict Mode mounting, queued-unmount cleanup, bubbled events, controlled input selection, and
   composition events preserve their React behavior;
 - simultaneous parent-prop and compiled-local updates remain coherent;
@@ -524,8 +551,9 @@ property.
    remain eligible.
 
 The [`examples/react-compiler`](https://github.com/farming-labs/farm.js/tree/main/examples/react-compiler)
-app contains the advanced batching, multiple-binding, keyed-fallback, compiler-on/off, and heavy
-interaction experiments. The standalone starter intentionally keeps the first experience focused.
+app contains batching, multiple-binding, common-syntax, calculated-style, controlled-form,
+keyed-fallback, compiler-on/off, and heavy-interaction experiments. The standalone starter
+intentionally keeps the first experience focused.
 
 ## React-specific FARMJS APIs
 

--- a/examples/react-compiler/README.md
+++ b/examples/react-compiler/README.md
@@ -32,6 +32,8 @@ for console/runtime errors, saves `/tmp/farm-react-aot-edge-lab.png`, and prints
 | Two direct updates         | state `2`, update executions `0`                        | state `2`, update executions `2`               | Eligible updates skip post-mount component executions.                 |
 | Batched functional updates | count `2`, snapshot `0`, update executions `0`          | count `2`, snapshot `0`, update executions `1` | The compiler preserves queued updater and event snapshot behavior.     |
 | Two state cells            | text/class/data/input all update, update executions `0` | —                                              | AOT dependency lists update only bindings affected by each state cell. |
+| Calculated style bindings  | value `6`, progress `50%`, update executions `0`        | —                                              | Safe calls and individual CSS properties use prepared dependencies.    |
+| Controlled form bindings  | textarea/select/checkbox update, executions `0`         | —                                              | Form properties and textarea selection stay coherent.                  |
 | Keyed list                 | intentionally not compiled                              | 3 correct keyed rows, update executions `2`    | Dynamic child structure safely falls back to React reconciliation.     |
 
 The package runtime test also measures one equivalent update under a React `Profiler`:

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -19,7 +19,12 @@ assert.ok(compilerReport.summary.compiled >= 1);
 const compiledComponents = new Set(
   compilerReport.modules.flatMap((module) => module.compiled),
 );
-for (const component of ["CommonSyntaxCounter", "ControlledSyntax"]) {
+for (const component of [
+  "CommonSyntaxCounter",
+  "ControlledSyntax",
+  "CalculatedBindingPanel",
+  "FormBindingPanel",
+]) {
   assert.ok(compiledComponents.has(component), `${component} was not compiled`);
 }
 
@@ -235,6 +240,67 @@ try {
   );
   assert.equal(controlledFinalExecutions - controlledInitialExecutions, 0);
 
+  const calculated = '[data-experiment="calculated-bindings"]';
+  const calculatedInitialExecutions = await readNumber(
+    page,
+    `${calculated} [data-metric="executions"]`,
+  );
+  await assertText(page, `${calculated} [data-metric="value"]`, "2");
+  await assertText(page, `${calculated} [data-metric="percent"]`, "17%");
+  assert.equal(await page.locator(calculated).getAttribute("data-percent"), "17");
+  assert.equal(await page.locator(calculated).evaluate((element) => element.style.opacity), "1");
+  assert.equal(
+    await page.locator(`${calculated} .binding-meter__fill`).evaluate((element) => element.style.width),
+    "17%",
+  );
+
+  await page.locator(`${calculated} [data-action="advance"]`).click();
+  await assertText(page, `${calculated} [data-metric="value"]`, "4");
+  await assertText(page, `${calculated} [data-metric="percent"]`, "33%");
+  assert.equal(await page.locator(calculated).evaluate((element) => element.style.opacity), "0.58");
+  assert.equal(
+    await page.locator(`${calculated} .binding-meter__fill`).evaluate((element) => element.style.width),
+    "33%",
+  );
+
+  await page.locator(`${calculated} [data-action="advance"]`).click();
+  await assertText(page, `${calculated} [data-metric="value"]`, "6");
+  await assertText(page, `${calculated} [data-metric="percent"]`, "50%");
+  assert.equal(await page.locator(calculated).evaluate((element) => element.style.opacity), "1");
+  const calculatedFinalExecutions = await readNumber(
+    page,
+    `${calculated} [data-metric="executions"]`,
+  );
+  assert.equal(calculatedFinalExecutions - calculatedInitialExecutions, 0);
+
+  const form = '[data-experiment="form-bindings"]';
+  const formInitialExecutions = await readNumber(page, `${form} [data-metric="executions"]`);
+  const note = page.locator(`${form} [data-input="note"]`);
+  await assertText(page, `${form} [data-metric="length"]`, "4");
+  await assertText(page, `${form} [data-metric="mode"]`, "balanced");
+  await assertText(page, `${form} [data-metric="summary"]`, "Farm / on");
+
+  await note.fill("Compiler");
+  await note.evaluate((element) => {
+    element.focus();
+    element.setSelectionRange(3, 3);
+  });
+  await page.keyboard.insertText("X");
+  await assertText(page, `${form} [data-metric="length"]`, "9");
+  assert.equal(await note.inputValue(), "ComXpiler");
+  assert.deepEqual(await note.evaluate((element) => [element.selectionStart, element.selectionEnd]), [
+    4,
+    4,
+  ]);
+
+  await page.locator(`${form} [data-input="mode"]`).selectOption("fast");
+  await page.locator(`${form} input[type="checkbox"]`).uncheck();
+  await assertText(page, `${form} [data-metric="mode"]`, "fast");
+  await assertText(page, `${form} [data-metric="summary"]`, "ComXpiler / off");
+  assert.equal(await page.locator(form).getAttribute("data-enabled"), "false");
+  const formFinalExecutions = await readNumber(page, `${form} [data-metric="executions"]`);
+  assert.equal(formFinalExecutions - formInitialExecutions, 0);
+
   const keyed = '[data-experiment="keyed-fallback"]';
   const keyedInitialExecutions = await readNumber(
     page,
@@ -306,6 +372,19 @@ try {
               controlledFinalExecutions - controlledInitialExecutions,
             selectionPreserved: true,
             compositionObserved: true,
+          },
+          calculatedBindings: {
+            value: 6,
+            percent: 50,
+            updateExecutions:
+              calculatedFinalExecutions - calculatedInitialExecutions,
+          },
+          formBindings: {
+            note: "ComXpiler",
+            mode: "fast",
+            enabled: false,
+            selectionPreserved: true,
+            updateExecutions: formFinalExecutions - formInitialExecutions,
           },
           keyedFallback: {
             items: 3,

--- a/examples/react-compiler/src/app/globals.css
+++ b/examples/react-compiler/src/app/globals.css
@@ -495,7 +495,7 @@ h1 span {
   text-transform: uppercase;
 }
 
-.binding-preview input {
+.binding-preview :is(input, textarea, select) {
   width: 100%;
   min-height: 2.8rem;
   border: 1px solid #33332f;
@@ -507,6 +507,70 @@ h1 span {
     0.75rem "Geist Mono Variable",
     ui-monospace,
     monospace;
+}
+
+.binding-preview textarea {
+  min-height: 4.4rem;
+  padding-block: 0.75rem;
+  resize: vertical;
+}
+
+.binding-form {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0 0.8rem;
+  margin-top: 1.25rem;
+}
+
+.binding-check {
+  display: flex;
+  grid-column: 1 / -1;
+  min-height: 2.8rem;
+  align-items: center;
+  gap: 0.65rem;
+  border-block: 1px solid #33332f;
+  color: #999992;
+  font:
+    0.68rem "Geist Mono Variable",
+    ui-monospace,
+    monospace;
+}
+
+.binding-check input {
+  width: 1rem;
+  height: 1rem;
+  accent-color: #b8ff5b;
+}
+
+.binding-meter {
+  height: 0.55rem;
+  overflow: hidden;
+  margin-top: 1.7rem;
+  border: 1px solid #33332f;
+  background: #0d0d0c;
+}
+
+.binding-meter__fill {
+  display: block;
+  height: 100%;
+  background: #b8ff5b;
+  transition: width 160ms ease;
+}
+
+.binding-readout {
+  display: block;
+  overflow: hidden;
+  min-height: 2.8rem;
+  border: 1px solid #33332f;
+  padding: 0.75rem 0.9rem;
+  color: #d8ff9f;
+  background: #0d0d0c;
+  font:
+    0.72rem "Geist Mono Variable",
+    ui-monospace,
+    monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .edge-card ul {
@@ -933,7 +997,8 @@ code {
   }
 
   .compact-metrics,
-  .button-row {
+  .button-row,
+  .binding-form {
     grid-template-columns: 1fr;
   }
 

--- a/examples/react-compiler/src/app/page.tsx
+++ b/examples/react-compiler/src/app/page.tsx
@@ -2,6 +2,7 @@ import { CompilerComparison } from "../components/compiler-comparison";
 import { CompilerEdgeLab } from "../components/compiler-edge-lab";
 import { CommonSyntaxExperiment } from "../components/common-syntax-experiment";
 import { HeavyInteractionBenchmark } from "../components/heavy-interaction-benchmark";
+import { StaticBindingExperiment } from "../components/static-binding-experiment";
 
 export default function HomePage() {
   return (
@@ -60,6 +61,8 @@ export default function HomePage() {
       <CompilerEdgeLab />
 
       <CommonSyntaxExperiment />
+
+      <StaticBindingExperiment />
 
       <HeavyInteractionBenchmark />
 

--- a/examples/react-compiler/src/components/static-binding-experiment.tsx
+++ b/examples/react-compiler/src/components/static-binding-experiment.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useState, type ChangeEvent, type FormEvent } from "react";
+
+let calculatedBindingExecutions = 0;
+let formBindingExecutions = 0;
+
+export function CalculatedBindingPanel({ maximum = 12 }: { maximum?: number }) {
+  const [value, setValue] = useState(2);
+  const [active, setActive] = useState(true);
+  const percent = Math.min(100, Math.round((value / maximum) * 100));
+  const percentLabel = String(percent);
+
+  function advance() {
+    setValue((current) => Math.min(maximum, current + 2));
+    setActive((current) => !current);
+  }
+
+  return (
+    <article
+      className="edge-card"
+      data-experiment="calculated-bindings"
+      data-percent={Number(percentLabel)}
+      style={{ opacity: active ? 1 : 0.58 }}
+    >
+      <header>
+        <span className="experiment-number">06A</span>
+        <div>
+          <h3>Calculated style binding</h3>
+          <p>Safe Math calls feed text, attributes, and individual CSS properties.</p>
+        </div>
+      </header>
+      <div
+        className="binding-meter"
+        aria-label={`${percentLabel}% complete`}
+        role="progressbar"
+        aria-valuemax={100}
+        aria-valuemin={0}
+        aria-valuenow={percent}
+      >
+        <span className="binding-meter__fill" style={{ width: `${percent}%` }} />
+      </div>
+      <dl className="compact-metrics" aria-live="polite">
+        <div>
+          <dt>Value</dt>
+          <dd data-metric="value">{value}</dd>
+        </div>
+        <div>
+          <dt>Progress</dt>
+          <dd data-metric="percent">{percentLabel}%</dd>
+        </div>
+        <div>
+          <dt>Executions</dt>
+          <dd data-metric="executions">
+            {typeof window === "undefined" ? 1 : ++calculatedBindingExecutions}
+          </dd>
+        </div>
+      </dl>
+      <button data-action="advance" type="button" onClick={() => advance()}>
+        Advance by two
+      </button>
+    </article>
+  );
+}
+
+export function FormBindingPanel() {
+  const [note, setNote] = useState("Farm");
+  const [mode, setMode] = useState("balanced");
+  const [enabled, setEnabled] = useState(true);
+  const noteLength = Math.min(99, note.length);
+
+  function updateNote(event: FormEvent<HTMLTextAreaElement>) {
+    setNote(event.currentTarget.value);
+  }
+
+  const updateMode = (event: ChangeEvent<HTMLSelectElement>) => {
+    setMode(event.currentTarget.value);
+  };
+
+  function updateEnabled(event: ChangeEvent<HTMLInputElement>) {
+    setEnabled(event.currentTarget.checked);
+  }
+
+  return (
+    <article
+      className={enabled ? "edge-card edge-card--active" : "edge-card"}
+      data-enabled={enabled}
+      data-experiment="form-bindings"
+    >
+      <header>
+        <span className="experiment-number">06B</span>
+        <div>
+          <h3>Controlled form bindings</h3>
+          <p>Textarea, select, and checkbox properties stay synchronized.</p>
+        </div>
+      </header>
+      <div className="binding-form">
+        <label className="binding-preview">
+          Note
+          <textarea
+            data-input="note"
+            rows={2}
+            value={note}
+            onInput={(event) => updateNote(event)}
+          />
+        </label>
+        <label className="binding-preview">
+          Mode
+          <select data-input="mode" value={mode} onChange={updateMode}>
+            <option value="balanced">Balanced</option>
+            <option value="fast">Fast</option>
+            <option value="precise">Precise</option>
+          </select>
+        </label>
+        <label className="binding-check">
+          <input checked={enabled} type="checkbox" onChange={updateEnabled} />
+          <span>Direct bindings enabled</span>
+        </label>
+      </div>
+      <dl className="compact-metrics" aria-live="polite">
+        <div>
+          <dt>Length</dt>
+          <dd data-metric="length">{noteLength}</dd>
+        </div>
+        <div>
+          <dt>Mode</dt>
+          <dd data-metric="mode">{mode}</dd>
+        </div>
+        <div>
+          <dt>Executions</dt>
+          <dd data-metric="executions">
+            {typeof window === "undefined" ? 1 : ++formBindingExecutions}
+          </dd>
+        </div>
+      </dl>
+      <output className="binding-readout" data-metric="summary">
+        {note || "empty"} / {enabled ? "on" : "off"}
+      </output>
+    </article>
+  );
+}
+
+export function StaticBindingExperiment() {
+  "use no compiler";
+
+  return (
+    <section className="edge-lab" aria-labelledby="static-bindings-title">
+      <div className="section-heading">
+        <span>STATIC BINDINGS / PRODUCTION PROOF</span>
+        <h2 id="static-bindings-title">More everyday values, still one fixed tree.</h2>
+        <p>
+          These cases add safe calculations, per-property styles, handler wrappers, and controlled
+          form properties without adding a React render for local updates.
+        </p>
+      </div>
+      <div className="edge-grid edge-grid--paired">
+        <CalculatedBindingPanel />
+        <FormBindingPanel />
+      </div>
+    </section>
+  );
+}

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -57,8 +57,9 @@ The current compiler handles components that it can prove have:
 - an identifier props parameter or flat object destructuring with aliases and defaults;
 - top-level `useState` declarations;
 - optional compiler-safe derived `const` values declared after state and in source order;
-- optional synchronous `const` event handlers passed directly to JSX events;
-- state-driven text and basic attribute/property bindings;
+- whitelisted `Boolean`, `Number`, `String`, and deterministic `Math` calculations;
+- optional synchronous `const` or function-declaration handlers used by JSX events;
+- state-driven text, attributes, per-property inline styles, and controlled form properties;
 - React-managed event handlers; and
 - no refs, effects, custom child components, keyed lists, or conditional child structure.
 
@@ -88,6 +89,6 @@ second component render and commit, while the compiled component remains at one 
 commit and updates its two bindings directly. This is a deterministic structural performance
 assertion; it is not presented as a cross-machine timing benchmark.
 
-Nested, computed, and rest props patterns; indirect or async handlers; keyed list lowering;
-structural conditionals; effects; and more advanced hook support intentionally stay on React in
-this release.
+Application and prototype calls, dynamic style objects, handlers outside JSX events, nested,
+computed, and rest props patterns, async handlers, keyed list lowering, structural conditionals,
+effects, and more advanced hook support intentionally stay on React in this release.

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -26,8 +26,11 @@ const testSource = String.raw`
   globalThis.Element = dom.window.Element;
   globalThis.HTMLElement = dom.window.HTMLElement;
   globalThis.HTMLInputElement = dom.window.HTMLInputElement;
+  globalThis.HTMLTextAreaElement = dom.window.HTMLTextAreaElement;
+  globalThis.HTMLSelectElement = dom.window.HTMLSelectElement;
   globalThis.HTMLOptionElement = dom.window.HTMLOptionElement;
   globalThis.HTMLButtonElement = dom.window.HTMLButtonElement;
+  globalThis.SVGElement = dom.window.SVGElement;
   globalThis.Node = dom.window.Node;
   globalThis.Event = dom.window.Event;
   globalThis.MouseEvent = dom.window.MouseEvent;
@@ -68,6 +71,95 @@ const testSource = String.raw`
   await Promise.resolve();
   assert.equal(container.textContent, "Count: 1");
   flushSync(() => root.unmount());
+
+  const StaticBindings = createCompiledComponent({
+    displayName: "CompatibilityStaticBindings",
+    initialize: () => [8, "draft", "safe", true],
+    render(_props, state) {
+      return React.createElement(
+        "div",
+        null,
+        React.createElement(
+          "button",
+          {
+            onClick: () => {
+              state[0].set(24);
+              state[1].set("compiled");
+              state[2].set("fast");
+              state[3].set(false);
+            },
+          },
+          "Update bindings",
+        ),
+        React.createElement("div", { "data-bar": true, style: { width: 8 } }),
+        React.createElement("textarea", {
+          "aria-label": "Note",
+          onChange: () => {},
+          value: state[1].get(),
+        }),
+        React.createElement(
+          "select",
+          { "aria-label": "Mode", onChange: () => {}, value: state[2].get() },
+          React.createElement("option", { value: "safe" }, "Safe"),
+          React.createElement("option", { value: "fast" }, "Fast"),
+        ),
+        React.createElement("input", {
+          "aria-label": "Enabled",
+          checked: state[3].get(),
+          readOnly: true,
+          type: "checkbox",
+        }),
+      );
+    },
+    bindings: [
+      {
+        kind: "style",
+        path: [1],
+        dependencies: [0],
+        name: "width",
+        read: (_props, state) => state[0].get(),
+      },
+      {
+        kind: "attribute",
+        path: [2],
+        dependencies: [1],
+        name: "value",
+        read: (_props, state) => state[1].get(),
+      },
+      {
+        kind: "attribute",
+        path: [3],
+        dependencies: [2],
+        name: "value",
+        read: (_props, state) => state[2].get(),
+      },
+      {
+        kind: "attribute",
+        path: [4],
+        dependencies: [3],
+        name: "checked",
+        read: (_props, state) => state[3].get(),
+      },
+    ],
+  });
+
+  const staticContainer = document.createElement("div");
+  document.body.append(staticContainer);
+  const staticRoot = createRoot(staticContainer);
+  flushSync(() => staticRoot.render(React.createElement(StaticBindings)));
+  const textarea = staticContainer.querySelector("textarea");
+  textarea.focus();
+  textarea.setSelectionRange(1, 3);
+  staticContainer.querySelector("button").click();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(staticContainer.querySelector("[data-bar]").style.width, "24px");
+  assert.equal(textarea.value, "compiled");
+  assert.equal(textarea.selectionStart, 1);
+  assert.equal(textarea.selectionEnd, 3);
+  assert.equal(staticContainer.querySelector("select").value, "fast");
+  assert.equal(staticContainer.querySelector('input[type="checkbox"]').checked, false);
+  flushSync(() => staticRoot.unmount());
 
   const hydrationContainer = document.createElement("div");
   hydrationContainer.innerHTML = renderToString(React.createElement(Counter));

--- a/packages/farm-react/src/__tests__/compiler-edge-cases.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-edge-cases.test.ts
@@ -148,7 +148,7 @@ describe("React AOT compiler safety boundaries", () => {
     {
       name: "an impure derived call",
       body: `
-        const label = String(count);
+        const label = formatCount(count);
         return <button onClick={() => setCount(count + 1)}>{label}</button>;
       `,
       reason: /derived local label cannot use function calls/i,
@@ -233,12 +233,6 @@ describe("React AOT compiler safety boundaries", () => {
       reason: /event handler increment must be synchronous/i,
     },
     {
-      name: "an indirectly invoked handler",
-      declaration: "const increment = () => setCount(count + 1);",
-      event: "() => increment()",
-      reason: /must be passed directly to a JSX event/i,
-    },
-    {
       name: "a handler exposed as a child",
       declaration: "const increment = () => setCount(count + 1);",
       event: "increment",
@@ -305,15 +299,15 @@ describe("React AOT compiler safety boundaries", () => {
 
   it.each([
     {
-      name: "stateful style",
+      name: "a stateful style spread",
       source: `
         import { useState } from "react";
-        export function Styled() {
+        export function Styled(props) {
           const [wide, setWide] = useState(false);
-          return <div style={{ width: wide ? 100 : 50 }} onClick={() => setWide(!wide)}>Box</div>;
+          return <div style={{ ...props.style, width: wide ? 100 : 50 }} onClick={() => setWide(!wide)}>Box</div>;
         }
       `,
-      reason: /stateful style/i,
+      reason: /stateful style bindings do not support spreads/i,
     },
     {
       name: "ref ownership",

--- a/packages/farm-react/src/__tests__/compiler-runtime-static-bindings.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-static-bindings.test.tsx
@@ -1,0 +1,253 @@
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createCompiledComponent } from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+const roots = new Set<Root>();
+
+async function flushCompilerUpdates() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots) root.unmount();
+  });
+  roots.clear();
+  document.body.replaceChildren();
+});
+
+describe("compiled static binding runtime", () => {
+  it("patches numeric, unitless, custom, and removed style values without rerendering", async () => {
+    let renders = 0;
+    const StyledPanel = createCompiledComponent({
+      displayName: "StyledPanel",
+      initialize: () => [0],
+      render(_props: Record<string, never>, state) {
+        renders += 1;
+        const phase = Number(state[0].get());
+        return (
+          <button
+            onClick={() => state[0].set((value) => Number(value) + 1)}
+            style={{
+              opacity: phase === 0 ? 1 : 0.55,
+              width: phase === 0 ? 12 : 24,
+              "--progress": phase === 2 ? null : `${phase * 50}%`,
+            }}
+          >
+            Advance
+          </button>
+        );
+      },
+      bindings: [
+        {
+          kind: "style",
+          path: [],
+          dependencies: [0],
+          name: "opacity",
+          read: (_props, state) => (Number(state[0].get()) === 0 ? 1 : 0.55),
+        },
+        {
+          kind: "style",
+          path: [],
+          dependencies: [0],
+          name: "width",
+          read: (_props, state) => (Number(state[0].get()) === 0 ? 12 : 24),
+        },
+        {
+          kind: "style",
+          path: [],
+          dependencies: [0],
+          name: "--progress",
+          read: (_props, state) =>
+            Number(state[0].get()) === 2 ? null : `${Number(state[0].get()) * 50}%`,
+        },
+      ],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.add(root);
+    await act(async () => root.render(<StyledPanel />));
+    const button = container.querySelector("button")!;
+
+    expect(button.style.width).toBe("12px");
+    expect(button.style.opacity).toBe("1");
+    expect(button.style.getPropertyValue("--progress")).toBe("0%");
+    const initialRenders = renders;
+
+    await act(async () => {
+      button.click();
+      await flushCompilerUpdates();
+    });
+    expect(button.style.width).toBe("24px");
+    expect(button.style.opacity).toBe("0.55");
+    expect(button.style.getPropertyValue("--progress")).toBe("50%");
+
+    await act(async () => {
+      button.click();
+      await flushCompilerUpdates();
+    });
+    expect(button.style.getPropertyValue("--progress")).toBe("");
+    expect(renders).toBe(initialRenders);
+  });
+
+  it("keeps textarea, select, checkbox, and text bindings coherent without rerendering", async () => {
+    let renders = 0;
+    const FormBindings = createCompiledComponent({
+      displayName: "FormBindings",
+      initialize: () => ["Farm", "balanced", true],
+      render(_props: Record<string, never>, state) {
+        renders += 1;
+        return (
+          <form>
+            <textarea
+              onInput={(event) => state[0].set(event.currentTarget.value)}
+              value={String(state[0].get())}
+            />
+            <select
+              onChange={(event) => state[1].set(event.currentTarget.value)}
+              value={String(state[1].get())}
+            >
+              <option value="balanced">Balanced</option>
+              <option value="fast">Fast</option>
+            </select>
+            <input
+              checked={Boolean(state[2].get())}
+              onChange={(event) => state[2].set(event.currentTarget.checked)}
+              type="checkbox"
+            />
+            <output>
+              {String(state[0].get())}:{String(state[1].get())}:{state[2].get() ? "on" : "off"}
+            </output>
+          </form>
+        );
+      },
+      bindings: [
+        {
+          kind: "attribute",
+          path: [0],
+          dependencies: [0],
+          name: "value",
+          read: (_props, state) => state[0].get(),
+        },
+        {
+          kind: "attribute",
+          path: [1],
+          dependencies: [1],
+          name: "value",
+          read: (_props, state) => state[1].get(),
+        },
+        {
+          kind: "attribute",
+          path: [2],
+          dependencies: [2],
+          name: "checked",
+          read: (_props, state) => state[2].get(),
+        },
+        {
+          kind: "text",
+          path: [3],
+          dependencies: [0, 1, 2],
+          read: (_props, state) => [
+            state[0].get(),
+            ":",
+            state[1].get(),
+            ":",
+            state[2].get() ? "on" : "off",
+          ],
+        },
+      ],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.add(root);
+    await act(async () => root.render(<FormBindings />));
+    const textarea = container.querySelector("textarea")!;
+    const select = container.querySelector("select")!;
+    const checkbox = container.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+    const initialRenders = renders;
+
+    await act(async () => {
+      textarea.focus();
+      textarea.value = "FaXrm";
+      textarea.setSelectionRange(3, 3);
+      textarea.dispatchEvent(new InputEvent("input", { bubbles: true, data: "X" }));
+      textarea.value = "Farm";
+      await flushCompilerUpdates();
+    });
+    expect(textarea.value).toBe("FaXrm");
+    expect(textarea.selectionStart).toBe(3);
+    expect(textarea.selectionEnd).toBe(3);
+
+    await act(async () => {
+      select.value = "fast";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+      checkbox.click();
+      await flushCompilerUpdates();
+    });
+
+    expect(select.value).toBe("fast");
+    expect(checkbox.checked).toBe(false);
+    expect(container.querySelector("output")?.textContent).toBe("FaXrm:fast:off");
+    expect(renders).toBe(initialRenders);
+  });
+
+  it("updates every selected option for a controlled multiple select", async () => {
+    const MultiSelect = createCompiledComponent({
+      displayName: "MultiSelect",
+      initialize: () => [["one"]],
+      render(_props: Record<string, never>, state) {
+        return (
+          <section>
+            <select multiple value={state[0].get() as string[]} onChange={() => {}}>
+              <option value="one">One</option>
+              <option value="two">Two</option>
+              <option value="three">Three</option>
+            </select>
+            <button onClick={() => state[0].set(["two", "three"])}>Change</button>
+          </section>
+        );
+      },
+      bindings: [
+        {
+          kind: "attribute",
+          path: [0],
+          dependencies: [0],
+          name: "value",
+          read: (_props, state) => state[0].get(),
+        },
+      ],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.add(root);
+    await act(async () => root.render(<MultiSelect />));
+
+    await act(async () => {
+      container.querySelector("button")!.click();
+      await flushCompilerUpdates();
+    });
+
+    expect(
+      [...container.querySelectorAll("option")]
+        .filter((option) => option.selected)
+        .map((option) => option.value),
+    ).toEqual(["two", "three"]);
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-static-bindings.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-static-bindings.test.ts
@@ -1,0 +1,192 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true);
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/StaticBindings.tsx", infer);
+}
+
+describe("React AOT static binding coverage", () => {
+  it("keeps state-independent render instrumentation on React's initial path", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      let executions = 0;
+      export function Instrumented() {
+        const [count, setCount] = useState(0);
+        return (
+          <button onClick={() => setCount(count + 1)}>
+            <span>{count}</span>
+            <span>{typeof window === "undefined" ? 1 : ++executions}</span>
+          </button>
+        );
+      }
+    `);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.compiled).toEqual(["Instrumented"]);
+    expect(result.code).toContain("++executions");
+  });
+
+  it("compiles whitelisted calculations and individual style properties", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Progress({ maximum = 12 }) {
+        const [value, setValue] = useState(2);
+        const [active, setActive] = useState(true);
+        const percent = Math.min(100, Math.round((value / maximum) * 100));
+        const label = String(percent);
+        return (
+          <button
+            data-percent={Number(label)}
+            onClick={() => {
+              setValue((current) => current + 2);
+              setActive((current) => !current);
+            }}
+            style={{
+              opacity: active ? 1 : 0.55,
+              width: label + "%",
+              "--progress": label,
+              color: "lime",
+            }}
+          >
+            {label}%
+          </button>
+        );
+      }
+    `);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.compiled).toEqual(["Progress"]);
+    expect(result.code).toContain('kind: "style"');
+    expect(result.code).toContain('name: "opacity"');
+    expect(result.code).toContain('name: "width"');
+    expect(result.code).toContain('name: "--progress"');
+    expect(result.code).not.toContain('name: "color"');
+    expect(result.code).toContain("Math.min");
+    expect(result.code).toContain("Math.round");
+    expect(result.code).toContain("String");
+    await expect(
+      transformWithEsbuild(result.code, "/app/StaticBindings.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("createCompiledComponent"),
+    });
+  });
+
+  it("compiles function declarations and calls made inside inline JSX handlers", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Stepper() {
+        const [count, setCount] = useState(0);
+        function increment(step: number) {
+          setCount((value) => value + step);
+        }
+        return <button onClick={() => increment(2)}>{Math.max(0, count)}</button>;
+      }
+    `);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.compiled).toEqual(["Stepper"]);
+    expect(result.code).toContain("function increment");
+    expect(result.code).toMatch(/farmState\[0\]\.set/);
+    await expect(
+      transformWithEsbuild(result.code, "/app/StaticBindings.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("function increment"),
+    });
+  });
+
+  it.each([
+    {
+      name: "an application helper",
+      expression: "formatCount(count)",
+    },
+    {
+      name: "a nondeterministic Math call",
+      expression: "Math.random() + count",
+    },
+    {
+      name: "a prototype method call",
+      expression: "String(count).toUpperCase()",
+    },
+  ])("falls back for $name", async ({ expression }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function UnsafeCall() {
+        const [count, setCount] = useState(0);
+        const label = ${expression};
+        return <button onClick={() => setCount(count + 1)}>{label}</button>;
+      }
+    `);
+
+    expect(result.compiled).toEqual([]);
+    expect(result.diagnostics[0]?.reason).toMatch(/cannot use function calls/i);
+  });
+
+  it("does not treat a shadowed global name as a safe call", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Shadowed({ String }) {
+        const [count, setCount] = useState(0);
+        const label = String(count);
+        return <button onClick={() => setCount(count + 1)}>{label}</button>;
+      }
+    `);
+
+    expect(result.compiled).toEqual([]);
+    expect(result.diagnostics[0]?.reason).toMatch(/cannot use function calls/i);
+  });
+
+  it.each([
+    {
+      name: "a conditional style object",
+      style: "active ? { opacity: 1 } : { opacity: 0.5 }",
+      reason: /one inline object literal/i,
+    },
+    {
+      name: "a style spread",
+      style: "{ ...theme, opacity: active ? 1 : 0.5 }",
+      reason: /do not support spreads/i,
+    },
+    {
+      name: "an unsafe style calculation",
+      style: "{ opacity: calculateOpacity(active) }",
+      reason: /property opacity cannot use function calls/i,
+    },
+  ])("falls back for $name", async ({ style, reason }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function UnsafeStyle({ theme }) {
+        const [active, setActive] = useState(false);
+        return <button style={${style}} onClick={() => setActive(!active)}>Toggle</button>;
+      }
+    `);
+
+    expect(result.compiled).toEqual([]);
+    expect(result.diagnostics[0]?.reason).toMatch(reason);
+  });
+
+  it("does not execute a named handler while rendering an event prop", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function RenderCall() {
+        const [count, setCount] = useState(0);
+        const increment = () => setCount(count + 1);
+        return <button onClick={increment()}>{count}</button>;
+      }
+    `);
+
+    expect(result.compiled).toEqual([]);
+    expect(result.diagnostics[0]?.reason).toMatch(/must be passed directly to a JSX event/i);
+  });
+});

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -11,8 +11,10 @@ interface RuntimeCell extends CompilerCell {
   flush(): boolean;
 }
 
+type SelectableTextControl = HTMLInputElement | HTMLTextAreaElement;
+
 interface InputSelectionSnapshot {
-  element: HTMLInputElement;
+  element: SelectableTextControl;
   start: number;
   end: number;
   direction: "forward" | "backward" | "none";
@@ -33,7 +35,18 @@ export interface CompilerAttributeBinding<Props> {
   read(props: Props, state: readonly CompilerCell[]): unknown;
 }
 
-export type CompilerBinding<Props> = CompilerTextBinding<Props> | CompilerAttributeBinding<Props>;
+export interface CompilerStyleBinding<Props> {
+  kind: "style";
+  path: readonly number[];
+  dependencies: readonly number[];
+  name: string;
+  read(props: Props, state: readonly CompilerCell[]): unknown;
+}
+
+export type CompilerBinding<Props> =
+  | CompilerTextBinding<Props>
+  | CompilerAttributeBinding<Props>
+  | CompilerStyleBinding<Props>;
 
 export interface CompiledComponentDefinition<Props> {
   displayName: string;
@@ -84,22 +97,157 @@ function findBindingTarget(root: Element, path: readonly number[]): Element | nu
   return current;
 }
 
+const UNITLESS_STYLE_PROPERTIES = new Set([
+  "animationIterationCount",
+  "aspectRatio",
+  "borderImageOutset",
+  "borderImageSlice",
+  "borderImageWidth",
+  "boxFlex",
+  "boxFlexGroup",
+  "boxOrdinalGroup",
+  "columnCount",
+  "columns",
+  "flex",
+  "flexGrow",
+  "flexNegative",
+  "flexOrder",
+  "flexPositive",
+  "flexShrink",
+  "fontWeight",
+  "gridArea",
+  "gridColumn",
+  "gridColumnEnd",
+  "gridColumnSpan",
+  "gridColumnStart",
+  "gridRow",
+  "gridRowEnd",
+  "gridRowSpan",
+  "gridRowStart",
+  "lineClamp",
+  "lineHeight",
+  "opacity",
+  "order",
+  "orphans",
+  "scale",
+  "tabSize",
+  "widows",
+  "zIndex",
+  "zoom",
+  "fillOpacity",
+  "floodOpacity",
+  "stopOpacity",
+  "strokeDasharray",
+  "strokeDashoffset",
+  "strokeMiterlimit",
+  "strokeOpacity",
+  "strokeWidth",
+]);
+
+function unprefixedStyleName(name: string): string {
+  const unprefixed = name.replace(/^(?:Webkit|Moz|ms|O)(?=[A-Z])/, "");
+  return unprefixed ? unprefixed[0].toLowerCase() + unprefixed.slice(1) : name;
+}
+
+function isHtmlOrSvgElement(element: Element): element is HTMLElement | SVGElement {
+  const view = element.ownerDocument.defaultView;
+  return Boolean(
+    view && (element instanceof view.HTMLElement || element instanceof view.SVGElement),
+  );
+}
+
+function isInputElement(element: Element): element is HTMLInputElement {
+  const view = element.ownerDocument.defaultView;
+  return Boolean(view && element instanceof view.HTMLInputElement);
+}
+
+function isTextAreaElement(element: Element): element is HTMLTextAreaElement {
+  const view = element.ownerDocument.defaultView;
+  return Boolean(view && element instanceof view.HTMLTextAreaElement);
+}
+
+function isSelectElement(element: Element): element is HTMLSelectElement {
+  const view = element.ownerDocument.defaultView;
+  return Boolean(view && element instanceof view.HTMLSelectElement);
+}
+
+function isOptionElement(element: Element): element is HTMLOptionElement {
+  const view = element.ownerDocument.defaultView;
+  return Boolean(view && element instanceof view.HTMLOptionElement);
+}
+
+function isSelectableTextControl(
+  element: Element | null | undefined,
+): element is SelectableTextControl {
+  return Boolean(element && (isInputElement(element) || isTextAreaElement(element)));
+}
+
+function updateStyle(element: Element, name: string, value: unknown): void {
+  if (!isHtmlOrSvgElement(element)) return;
+  const customProperty = name.startsWith("--");
+  let nextValue = "";
+  if (value !== null && value !== undefined && typeof value !== "boolean" && value !== "") {
+    nextValue =
+      typeof value === "number" &&
+      value !== 0 &&
+      !customProperty &&
+      !UNITLESS_STYLE_PROPERTIES.has(unprefixedStyleName(name))
+        ? `${value}px`
+        : String(value).trim();
+  }
+
+  if (customProperty || name.includes("-")) {
+    element.style.setProperty(name, nextValue);
+  } else {
+    (element.style as unknown as Record<string, string>)[name] = nextValue;
+  }
+}
+
+function updateSelectValue(element: HTMLSelectElement, value: unknown): void {
+  const options = [...element.options];
+  if (element.multiple) {
+    const selected = new Set(
+      (Array.isArray(value) ? value : value === null || value === undefined ? [] : [value]).map(
+        String,
+      ),
+    );
+    for (const option of options) option.selected = selected.has(option.value);
+    return;
+  }
+
+  const selectedValue = value === null || value === undefined ? "" : String(value);
+  let fallback: HTMLOptionElement | undefined;
+  for (const option of options) {
+    if (!option.disabled && !fallback) fallback = option;
+    if (option.value === selectedValue) {
+      option.selected = true;
+      return;
+    }
+  }
+  if (fallback) fallback.selected = true;
+}
+
 function updateAttribute(element: Element, name: string, value: unknown): void {
   const attributeName = name === "className" ? "class" : name === "htmlFor" ? "for" : name;
   const stringifiesBoolean = attributeName.startsWith("data-") || attributeName.startsWith("aria-");
 
-  if (name === "value" && element instanceof HTMLInputElement) {
+  if (name === "value" && (isInputElement(element) || isTextAreaElement(element))) {
     const nextValue = value === null || value === undefined ? "" : String(value);
     if (element.value !== nextValue) element.value = nextValue;
     return;
   }
 
-  if (name === "checked" && element instanceof HTMLInputElement) {
+  if (name === "value" && isSelectElement(element)) {
+    updateSelectValue(element, value);
+    return;
+  }
+
+  if (name === "checked" && isInputElement(element)) {
     element.checked = Boolean(value);
     return;
   }
 
-  if (name === "selected" && element instanceof HTMLOptionElement) {
+  if (name === "selected" && isOptionElement(element)) {
     element.selected = Boolean(value);
     return;
   }
@@ -186,7 +334,7 @@ export function createCompiledComponent<Props>(
     private captureInputSelection(): void {
       const active = this.root?.ownerDocument.activeElement;
       if (
-        !(active instanceof HTMLInputElement) ||
+        !isSelectableTextControl(active) ||
         !this.root?.contains(active) ||
         active.selectionStart === null ||
         active.selectionEnd === null
@@ -250,6 +398,8 @@ export function createCompiledComponent<Props>(
       const value = binding.read(this.props, this.cells);
       if (binding.kind === "text") {
         target.textContent = renderTextValue(value);
+      } else if (binding.kind === "style") {
+        updateStyle(target, binding.name, value);
       } else {
         updateAttribute(target, binding.name, value);
       }

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -39,7 +39,7 @@ interface PropsPlan {
 }
 
 interface PendingBinding {
-  kind: "text" | "attribute";
+  kind: "text" | "attribute" | "style";
   path: number[];
   dependencies: number[];
   name?: string;
@@ -51,6 +51,9 @@ interface Candidate {
   path: NodePath<t.FunctionDeclaration | t.FunctionExpression | t.ArrowFunctionExpression>;
   statementPath: NodePath;
 }
+
+const SAFE_GLOBAL_CALLS = new Set(["Boolean", "Number", "String"]);
+const SAFE_MATH_CALLS = new Set(["abs", "ceil", "floor", "max", "min", "round", "sign", "trunc"]);
 
 function isComponentName(name: string): boolean {
   return /^[A-Z]/.test(name);
@@ -175,12 +178,29 @@ function rewriteHandlerAccess(
       const attribute = container.parentPath;
       const eventName = attribute?.isJSXAttribute() && jsxAttributeName(attribute.node);
       if (
-        !container.isJSXExpressionContainer() ||
-        container.node.expression !== path.node ||
-        !eventName ||
-        !/^on[A-Z]/.test(eventName)
+        container.isJSXExpressionContainer() &&
+        container.node.expression === path.node &&
+        eventName &&
+        /^on[A-Z]/.test(eventName)
       ) {
-        reason = `event handler ${handler.name} must be passed directly to a JSX event`;
+        path.replaceWith(t.cloneNode(handler.value, true));
+        path.skip();
+        return;
+      }
+
+      const call =
+        container.isCallExpression() && container.node.callee === path.node ? container : null;
+      const event = call && findContainingEvent(call);
+      const eventExpression =
+        event?.node.value &&
+        t.isJSXExpressionContainer(event.node.value) &&
+        event.node.value.expression;
+      const isInsideInlineHandler =
+        eventExpression &&
+        (t.isArrowFunctionExpression(eventExpression) || t.isFunctionExpression(eventExpression)) &&
+        Boolean(call?.findParent((parent) => parent.node === eventExpression));
+      if (!call || !event || !isInsideInlineHandler) {
+        reason = `event handler ${handler.name} must be passed directly to a JSX event or called inside its inline handler`;
         path.stop();
         return;
       }
@@ -193,7 +213,27 @@ function rewriteHandlerAccess(
     : { root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement };
 }
 
-function validateDerivedExpression(expression: t.Expression): string | undefined {
+function isSafeCompilerCall(
+  expression: t.CallExpression,
+  safeGlobals: ReadonlySet<string>,
+): boolean {
+  if (t.isIdentifier(expression.callee)) {
+    return safeGlobals.has(expression.callee.name) && SAFE_GLOBAL_CALLS.has(expression.callee.name);
+  }
+  return (
+    t.isMemberExpression(expression.callee) &&
+    !expression.callee.computed &&
+    t.isIdentifier(expression.callee.object, { name: "Math" }) &&
+    safeGlobals.has("Math") &&
+    t.isIdentifier(expression.callee.property) &&
+    SAFE_MATH_CALLS.has(expression.callee.property.name)
+  );
+}
+
+function validateDerivedExpression(
+  expression: t.Expression,
+  safeGlobals: ReadonlySet<string>,
+): string | undefined {
   let unsupported: string | undefined;
   const reject = (reason: string, path: NodePath) => {
     unsupported = reason;
@@ -204,7 +244,9 @@ function validateDerivedExpression(expression: t.Expression): string | undefined
     ArrayExpression: (path) => reject("array literals", path),
     AssignmentExpression: (path) => reject("assignments", path),
     AwaitExpression: (path) => reject("await expressions", path),
-    CallExpression: (path) => reject("function calls", path),
+    CallExpression(path) {
+      if (!isSafeCompilerCall(path.node, safeGlobals)) reject("function calls", path);
+    },
     ClassExpression: (path) => reject("class expressions", path),
     Function: (path) => reject("function expressions", path),
     JSXElement: (path) => reject("JSX", path),
@@ -304,12 +346,22 @@ function cleanJsxText(value: string): string {
   return result;
 }
 
-function isTextExpression(expression: t.Expression): boolean {
+function isTextExpression(
+  expression: t.Expression,
+  statesByValue: ReadonlyMap<string, StateBinding>,
+  safeGlobals: ReadonlySet<string>,
+): boolean {
+  if (collectStateDependencies(expression, statesByValue).length > 0) {
+    return validateDerivedExpression(expression, safeGlobals) === undefined;
+  }
+
   let supported = true;
   traverse(expressionFile(cloneExpression(expression)), {
     CallExpression(path) {
-      supported = false;
-      path.stop();
+      if (!isSafeCompilerCall(path.node, safeGlobals)) {
+        supported = false;
+        path.stop();
+      }
     },
     OptionalCallExpression(path) {
       supported = false;
@@ -342,8 +394,43 @@ function jsxAttributeName(attribute: t.JSXAttribute): string | undefined {
 function analyzeHostTree(
   root: t.JSXElement,
   statesByValue: ReadonlyMap<string, StateBinding>,
+  safeGlobals: ReadonlySet<string>,
 ): { bindings?: PendingBinding[]; reason?: string } {
   const bindings: PendingBinding[] = [];
+
+  const analyzeStyle = (expression: t.Expression, path: number[]): string | undefined => {
+    if (!t.isObjectExpression(expression)) {
+      return "stateful style bindings must use one inline object literal";
+    }
+    for (const property of expression.properties) {
+      if (!t.isObjectProperty(property) || property.computed) {
+        return "stateful style bindings do not support spreads, methods, or computed properties";
+      }
+      const name = t.isIdentifier(property.key)
+        ? property.key.name
+        : t.isStringLiteral(property.key)
+          ? property.key.value
+          : undefined;
+      if (!name || (name.includes("-") && !name.startsWith("--"))) {
+        return "stateful style property names must use camelCase or a CSS custom property";
+      }
+      if (!t.isExpression(property.value)) {
+        return `stateful style property ${name} must use an expression value`;
+      }
+      const dependencies = collectStateDependencies(property.value, statesByValue);
+      if (dependencies.length === 0) continue;
+      const unsupported = validateDerivedExpression(property.value, safeGlobals);
+      if (unsupported) return `stateful style property ${name} cannot use ${unsupported}`;
+      bindings.push({
+        kind: "style",
+        path: [...path],
+        dependencies,
+        name,
+        value: cloneExpression(property.value),
+      });
+    }
+    return undefined;
+  };
 
   const visit = (element: t.JSXElement, path: number[]): string | undefined => {
     const tag = element.openingElement.name;
@@ -368,9 +455,16 @@ function analyzeHostTree(
       const expression = attribute.value.expression;
       const dependencies = collectStateDependencies(expression, statesByValue);
       if (dependencies.length === 0 || /^on[A-Z]/.test(name)) continue;
-      if (name === "style" || name === "children" || name === "key") {
+      if (name === "style") {
+        const reason = analyzeStyle(expression, path);
+        if (reason) return reason;
+        continue;
+      }
+      if (name === "children" || name === "key") {
         return `stateful ${name} bindings are not supported yet`;
       }
+      const unsupported = validateDerivedExpression(expression, safeGlobals);
+      if (unsupported) return `stateful ${name} binding cannot use ${unsupported}`;
       bindings.push({
         kind: "attribute",
         path: [...path],
@@ -388,7 +482,7 @@ function analyzeHostTree(
     );
     for (const child of expressionChildren) {
       if (t.isJSXEmptyExpression(child.expression)) continue;
-      if (!isTextExpression(child.expression)) {
+      if (!isTextExpression(child.expression, statesByValue, safeGlobals)) {
         return "dynamic child structures require React reconciliation";
       }
     }
@@ -574,6 +668,9 @@ function compileCandidate(
   const propsPlan = analyzePropsParameter(path);
   if (typeof propsPlan === "string") return propsPlan;
   if (!t.isBlockStatement(path.node.body)) return "components must use a block body";
+  const safeGlobals = new Set(
+    [...SAFE_GLOBAL_CALLS, "Math"].filter((name) => !path.scope.getBinding(name)),
+  );
 
   const states: StateBinding[] = [];
   const locals: LocalBinding[] = [];
@@ -582,6 +679,18 @@ function compileCandidate(
     if (t.isReturnStatement(statement)) {
       if (returned) return "components must have one unconditional return";
       returned = statement;
+      continue;
+    }
+    if (t.isFunctionDeclaration(statement)) {
+      if (!statement.id) return "named event handler declarations must have a name";
+      if (statement.async || statement.generator || statement.typeParameters) {
+        return `event handler ${statement.id.name} must be synchronous and non-generic`;
+      }
+      locals.push({
+        kind: "handler",
+        name: statement.id.name,
+        value: t.toExpression(t.cloneNode(statement, true)) as t.FunctionExpression,
+      });
       continue;
     }
     if (
@@ -665,7 +774,7 @@ function compileCandidate(
       });
       continue;
     }
-    const unsupported = validateDerivedExpression(expanded);
+    const unsupported = validateDerivedExpression(expanded, safeGlobals);
     if (unsupported) {
       return `derived local ${binding.name} cannot use ${unsupported}`;
     }
@@ -682,7 +791,7 @@ function compileCandidate(
   );
   const setterReason = validateSetterUsage(expandedRoot, statesBySetter);
   if (setterReason) return setterReason;
-  const analysis = analyzeHostTree(expandedRoot, statesByValue);
+  const analysis = analyzeHostTree(expandedRoot, statesByValue, safeGlobals);
   if (analysis.reason) return analysis.reason;
 
   const stateParameter = path.scope.generateUidIdentifier("farmState");


### PR DESCRIPTION
## Summary

- compile deterministic `Boolean`, `Number`, `String`, and selected `Math` calls while falling back for shadowed, application, prototype, optional, or nondeterministic calls
- compile synchronous function declarations and named handlers called inside inline JSX event handlers
- lower state-driven inline styles into per-property bindings with React-compatible numeric, unitless, custom-property, and removal behavior
- keep textarea, single/multiple select, checkbox, and text bindings coherent without post-mount component executions
- add a polished production experiment and expand the renderer docs with the public contract and safety boundaries

## Safety boundaries

The compiler still falls back to React for dynamic child structure, keyed lists, custom components, refs, unsupported hooks, style spreads or conditional whole objects, computed style names, unsafe calls, and handlers used outside JSX events. Focused input and textarea selection is preserved across the compiler microtask, and DOM checks are owner-window aware for iframe and JSDOM compatibility.

## Verification

- `pnpm --filter @farm.js/react test` — 71 tests passed
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and React 19.2.8
- targeted Oxlint and Oxfmt checks — 0 warnings/errors
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter farmjs-docs build`
- `pnpm --filter farm-react-compiler-example type-check`
- `pnpm --filter farm-react-compiler-example experiment` — production build and browser E2E passed with no console errors

The production experiment reports 8 compiled components and 5 intentional React fallbacks. Calculated text/style updates reached value 6 and 50% progress with 0 added component executions. Controlled textarea/select/checkbox updates preserved selection and also added 0 component executions. The keyed-list case continued to fall back to React.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compiles more React static bindings to skip post-mount rerenders and keep UI coherent. Adds a safe call whitelist, per-property style bindings, and controlled form property updates while preserving React fallbacks for unsafe cases.

- Compiler (`@farm.js/react`): lowers stateful inline `style` objects into per-property bindings; appends px where React expects it, respects unitless properties and CSS custom properties, and clears nullish values. Whitelists calls to `Boolean`, `Number`, `String`, and `Math.abs|ceil|floor|max|min|round|sign|trunc`; rejects shadowed names, prototype/app calls, `Math.random`, optional calls, and computed/conditional style objects or spreads. Expands synchronous named handlers passed directly to JSX events and calls made inside an inline JSX handler; function declarations allowed; handlers used outside events still fall back.
- Runtime: adds `style` binding type with granular patching; patches input/textarea `value`, select (single and multiple) values, checkbox `checked`, and option `selected`; preserves input/textarea selection around the compiler microtask and keeps composition events React-owned; owner-window checks improve JSDOM/iframe safety.
- Docs, examples, tests: updates renderer docs and package README to reflect supported shapes/fallbacks; adds a production example section for calculated bindings and controlled form bindings; extends example CSS and verification script; updates React-version compat harness; adds compiler and runtime tests for static/style/form bindings; adjusts edge-case tests.

<sup>Written for commit 085dff17f6d562fa3fccb9fced74961591c13b15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

