### PR TITLE
feat(react): compile conditional DOM blocks

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -331,10 +331,11 @@ satisfy all of these rules:
 | Body                | Top-level `useState` declarations, optional compiler-safe derived values and synchronous named handlers, then one unconditional JSX return. |
 | State               | `const [value, setValue] = useState(initial)`, including lazy initializers, multiple cells, and queued functional updates.                  |
 | Root                | Exactly one lowercase host JSX element such as `button`, `section`, `input`, or `div`.                                                      |
-| Tree                | A static tree containing host elements only. Nested host elements are supported when their placement cannot change.                         |
+| Tree                | A statically known host tree. Eligible logical and ternary blocks may change one compiler-isolated child location.                          |
 | Text bindings       | State-driven text in a leaf host element.                                                                                                   |
 | Attribute bindings  | Basic attributes, controlled form properties, and individual properties in one inline `style` object.                                       |
 | Events              | Inline handlers and synchronous `const` or function-declaration handlers, used directly or called inside an inline JSX handler.             |
+| Conditional blocks  | `condition && <host />` or `condition ? <host /> : <host />`; `null` and `false` are supported empty ternary branches.                      |
 
 This component is eligible:
 
@@ -398,12 +399,61 @@ state-dependent camelCase property or CSS custom property, so changing `opacity`
 an unrelated `width`. Style spreads, methods, computed names, and conditional whole objects remain
 on React because their final property set or precedence can change.
 
+### Conditional DOM blocks
+
+The compiler can isolate two common child structures when their position is known at build time:
+
+```tsx
+export function StatusPanel() {
+  const [loading, setLoading] = useState(false);
+  const [enabled, setEnabled] = useState(true);
+
+  return (
+    <section>
+      <button onClick={() => setLoading(!loading)}>Toggle loading</button>
+      {loading && <p>Loading…</p>}
+
+      <button onClick={() => setEnabled(!enabled)}>Toggle status</button>
+      {enabled ? <strong>Enabled</strong> : <span>Disabled</span>}
+    </section>
+  );
+}
+```
+
+At build time, Farm records the state cells used by each condition and replaces that child
+expression with a small internal block boundary. When one of those cells changes, the outer user
+component does not execute again. Only the matching boundary asks React to mount, replace, remove,
+or update its selected host branch. Other compiler bindings continue to patch their prepared DOM
+targets directly.
+
+This is intentionally block-local React reconciliation, not manual DOM insertion. Keeping React at
+the boundary preserves delegated events, host property behavior, unmounting, error boundaries,
+Strict Mode, SSR, and hydration. The inactive branch is described by generated code but is not
+pre-mounted or cached in the DOM.
+
+The initial safety limits are:
+
+- Every non-empty branch has exactly one lowercase host root such as `p`, `strong`, `span`, or
+  `div`.
+- Descendants keep a static host-only tree. Stateful text, attributes, inline style properties, and
+  event handlers inside that tree are allowed and update when the block refreshes.
+- A ternary may use `null` or `false` for an empty branch.
+- The conditional must be a JSX child at one statically known location, and its test must use the
+  same deterministic expression subset as other compiler bindings.
+- Custom components, hooks, fragments, nested conditional blocks, lists, refs,
+  `dangerouslySetInnerHTML`, and attribute spreads inside a branch fall back to the original React
+  component.
+
+The optimization boundary matters: the surrounding compiled component and its unrelated siblings
+do not rerender, but React still renders and commits the small conditional boundary. A branch with
+substantial work therefore still pays for that branch work.
+
 ### What falls back to React
 
 | Unsupported shape                                                      | Why React keeps ownership                                                           |
 | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | Keyed lists, `.map()`, element arrays, or helper-rendered children     | Inserts, removals, moves, and identity changes require reconciliation.              |
-| Conditional JSX children or fragments                                  | The prepared DOM path can change when structure appears or disappears.              |
+| Fragments or unsupported/nested conditional JSX                        | Their structure is outside the current single-location host-block contract.         |
 | Custom child components                                                | A child component has its own props, hooks, lifecycle, and reconciliation boundary. |
 | Effects or hooks other than the supported `useState` shape             | Their lifecycle and ordering must remain under React's hook dispatcher.             |
 | `ref` or `dangerouslySetInnerHTML`                                     | They directly participate in DOM ownership.                                         |
@@ -462,6 +512,7 @@ follows:
 | JSX event registration and dispatch            | Comparing flushed values with `Object.is`                       |
 | Parent-driven prop updates                     | Selecting bindings whose state dependencies changed             |
 | Unsupported trees, hooks, refs, and lifecycles | Patching precomputed text/attribute targets after local updates |
+| Host creation/removal inside an eligible block | Refreshing only the matching internal conditional boundary      |
 | Unmounting and the surrounding component tree  | Reapplying bindings after a parent-driven React update          |
 
 Queued functional setters preserve the event's state snapshot. Two calls such as

--- a/examples/react-compiler/README.md
+++ b/examples/react-compiler/README.md
@@ -4,8 +4,8 @@ This production-browser experiment answers two questions:
 
 1. Why build this compiler? Eligible local `useState` updates can patch precomputed DOM targets
    without rerunning the component body or asking React to reconcile the same static tree again.
-2. Where must it stop? Keyed lists, effects, refs, custom components, and other dynamic structures
-   stay on React whenever the compiler cannot prove that a direct binding preserves behavior.
+2. Where must it stop? Eligible host-only conditionals use a small React-owned block boundary.
+   Keyed lists, effects, refs, custom components, and other unproven structures stay on React.
 
 The default `compiler: true` configuration automatically considers components. No annotation is
 needed. A component can explicitly opt out with `"use no compiler"`.
@@ -22,8 +22,9 @@ pnpm --filter farm-react-compiler-example experiment
 
 The Playwright install is needed once per machine (or whenever its browser cache is cleared).
 
-The command creates a production build, starts it on a local port, runs Chromium assertions, checks
-for console/runtime errors, saves `/tmp/farm-react-aot-edge-lab.png`, and prints a JSON report.
+The command creates a production build, starts it on a local port, runs desktop and mobile Chromium
+assertions, checks for console/runtime errors and horizontal overflow, saves screenshots under
+`/tmp/farm-react-aot-edge-lab*`, and prints a JSON report.
 
 ## Expected report
 
@@ -34,6 +35,8 @@ for console/runtime errors, saves `/tmp/farm-react-aot-edge-lab.png`, and prints
 | Two state cells            | text/class/data/input all update, update executions `0` | —                                              | AOT dependency lists update only bindings affected by each state cell. |
 | Calculated style bindings  | value `6`, progress `50%`, update executions `0`        | —                                              | Safe calls and individual CSS properties use prepared dependencies.    |
 | Controlled form bindings  | textarea/select/checkbox update, executions `0`         | —                                              | Form properties and textarea selection stay coherent.                  |
+| Logical conditional block | branch mounts, updates, and unmounts; executions `0`     | —                                              | Only the isolated React block refreshes.                                |
+| Ternary conditional block | `strong` and `span` replace each other; executions `0`   | —                                              | React preserves branch and event semantics without the outer rerender. |
 | Keyed list                 | intentionally not compiled                              | 3 correct keyed rows, update executions `2`    | Dynamic child structure safely falls back to React reconciliation.     |
 
 The package runtime test also measures one equivalent update under a React `Profiler`:
@@ -56,6 +59,17 @@ reconciliation unnecessary.
 Calling a Hook directly inside `items.map(...)` is invalid React because the number or order of Hook
 calls can change. Put the Hook inside a separate `Row` component and key that component. The compiler
 has a regression test confirming that the invalid inline shape is rejected rather than transformed.
+
+## Conditional block boundary
+
+The `07A` and `07B` cards exercise `condition && <host />` and
+`condition ? <host /> : <host />` in the production browser build. The compiler records each
+condition's state dependencies and lowers the child to a private React boundary. A matching state
+update refreshes that boundary while the user component's execution counter stays unchanged.
+
+This does not pre-mount both branches or bypass React's event system. React still creates, replaces,
+and removes the selected host branch. Custom components, hooks, fragments, nested conditionals,
+lists, refs, spreads, and dangerous HTML inside a branch intentionally fall back.
 
 ## Heavy compiler-on/off benchmark
 

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -10,6 +10,7 @@ const serverEntry = path.resolve(".farm/.output/server/index.mjs");
 const compilerReportPath = path.resolve(".farm/react-compiler.json");
 const screenshotPath =
   process.env.FARM_EXPERIMENT_SCREENSHOT || "/tmp/farm-react-aot-edge-lab.png";
+const mobileScreenshotPath = screenshotPath.replace(/(\.[^.]+)?$/, "-mobile$1");
 
 await access(serverEntry);
 const compilerReport = JSON.parse(await readFile(compilerReportPath, "utf8"));
@@ -24,6 +25,8 @@ for (const component of [
   "ControlledSyntax",
   "CalculatedBindingPanel",
   "FormBindingPanel",
+  "LogicalBlockPanel",
+  "TernaryBlockPanel",
 ]) {
   assert.ok(compiledComponents.has(component), `${component} was not compiled`);
 }
@@ -301,6 +304,73 @@ try {
   const formFinalExecutions = await readNumber(page, `${form} [data-metric="executions"]`);
   assert.equal(formFinalExecutions - formInitialExecutions, 0);
 
+  const logical = '[data-experiment="conditional-logical"]';
+  const logicalInitialExecutions = await readNumber(
+    page,
+    `${logical} [data-metric="executions"]`,
+  );
+  await assertText(page, `${logical} [data-metric="mounted"]`, "no");
+  assert.equal(
+    await page.locator(`${logical} [data-branch="loading"]`).count(),
+    0,
+  );
+  await page.locator(`${logical} [data-action="toggle-logical"]`).click();
+  await assertText(page, `${logical} [data-metric="mounted"]`, "yes");
+  await assertText(
+    page,
+    `${logical} [data-branch="loading"]`,
+    "Loading branch · update 0",
+  );
+  await page.locator(`${logical} [data-action="increment-logical"]`).click();
+  await assertText(page, `${logical} [data-metric="updates"]`, "1");
+  await assertText(
+    page,
+    `${logical} [data-branch="loading"]`,
+    "Loading branch · update 1",
+  );
+  await page.locator(`${logical} [data-action="toggle-logical"]`).click();
+  await assertText(page, `${logical} [data-metric="mounted"]`, "no");
+  assert.equal(
+    await page.locator(`${logical} [data-branch="loading"]`).count(),
+    0,
+  );
+  const logicalFinalExecutions = await readNumber(
+    page,
+    `${logical} [data-metric="executions"]`,
+  );
+  assert.equal(logicalFinalExecutions - logicalInitialExecutions, 0);
+
+  const ternary = '[data-experiment="conditional-ternary"]';
+  const ternaryInitialExecutions = await readNumber(
+    page,
+    `${ternary} [data-metric="executions"]`,
+  );
+  await assertText(page, `${ternary} [data-metric="branch"]`, "on");
+  await assertText(page, `${ternary} [data-branch="enabled"]`, "Enabled");
+  assert.equal(
+    await page
+      .locator(`${ternary} [data-branch="enabled"]`)
+      .evaluate((node) => node.tagName),
+    "STRONG",
+  );
+  await page.locator(`${ternary} [data-action="toggle-ternary"]`).click();
+  await assertText(page, `${ternary} [data-metric="branch"]`, "off");
+  await assertText(page, `${ternary} [data-branch="disabled"]`, "Disabled");
+  assert.equal(
+    await page
+      .locator(`${ternary} [data-branch="disabled"]`)
+      .evaluate((node) => node.tagName),
+    "SPAN",
+  );
+  await page.locator(`${ternary} [data-action="toggle-ternary"]`).click();
+  await assertText(page, `${ternary} [data-metric="branch"]`, "on");
+  await assertText(page, `${ternary} [data-branch="enabled"]`, "Enabled");
+  const ternaryFinalExecutions = await readNumber(
+    page,
+    `${ternary} [data-metric="executions"]`,
+  );
+  assert.equal(ternaryFinalExecutions - ternaryInitialExecutions, 0);
+
   const keyed = '[data-experiment="keyed-fallback"]';
   const keyedInitialExecutions = await readNumber(
     page,
@@ -321,6 +391,32 @@ try {
   ]);
 
   await page.screenshot({ path: screenshotPath, fullPage: true });
+
+  const mobilePage = await browser.newPage({
+    viewport: { width: 390, height: 844 },
+  });
+  mobilePage.on("console", (message) => {
+    if (message.type() === "error") browserErrors.push(`[mobile] ${message.text()}`);
+  });
+  mobilePage.on("pageerror", (error) =>
+    browserErrors.push(`[mobile] ${error.message}`),
+  );
+  await mobilePage.goto(origin, { waitUntil: "networkidle" });
+  assert.equal(
+    await mobilePage.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+    true,
+    "the experiment page overflowed the mobile viewport",
+  );
+  await mobilePage
+    .locator('[data-experiment="conditional-logical"] [data-action="toggle-logical"]')
+    .click();
+  await assertText(
+    mobilePage,
+    '[data-experiment="conditional-logical"] [data-branch="loading"]',
+    "Loading branch · update 0",
+  );
+  await mobilePage.screenshot({ path: mobileScreenshotPath, fullPage: true });
+  await mobilePage.close();
   assert.deepEqual(browserErrors, []);
 
   console.log(
@@ -328,7 +424,10 @@ try {
       {
         result: "PASS",
         productionUrl: origin,
-        screenshot: screenshotPath,
+        screenshots: {
+          desktop: screenshotPath,
+          mobile: mobileScreenshotPath,
+        },
         compilerReport: path.relative(process.cwd(), compilerReportPath),
         compilerSummary: compilerReport.summary,
         experiments: {
@@ -385,6 +484,15 @@ try {
             enabled: false,
             selectionPreserved: true,
             updateExecutions: formFinalExecutions - formInitialExecutions,
+          },
+          conditionalLogicalBlock: {
+            mounted: false,
+            branchValue: 1,
+            updateExecutions: logicalFinalExecutions - logicalInitialExecutions,
+          },
+          conditionalTernaryBlock: {
+            branch: "enabled",
+            updateExecutions: ternaryFinalExecutions - ternaryInitialExecutions,
           },
           keyedFallback: {
             items: 3,

--- a/examples/react-compiler/src/app/globals.css
+++ b/examples/react-compiler/src/app/globals.css
@@ -573,6 +573,57 @@ h1 span {
   white-space: nowrap;
 }
 
+.conditional-stage {
+  display: grid;
+  min-height: 5.5rem;
+  margin-top: 1.7rem;
+  place-items: center;
+  border: 1px solid #33332f;
+  background:
+    linear-gradient(135deg, rgb(184 255 91 / 0.035), transparent 55%),
+    #0d0d0c;
+}
+
+.conditional-stage:empty::before {
+  color: #5f5f59;
+  content: "BLOCK NOT MOUNTED";
+  font:
+    0.6rem "Geist Mono Variable",
+    ui-monospace,
+    monospace;
+  letter-spacing: 0.07em;
+}
+
+.conditional-branch {
+  margin: 0;
+  color: #d8ff9f;
+  font:
+    0.74rem "Geist Mono Variable",
+    ui-monospace,
+    monospace;
+  letter-spacing: 0.035em;
+}
+
+.conditional-branch::before {
+  display: inline-block;
+  width: 0.42rem;
+  height: 0.42rem;
+  margin-right: 0.6rem;
+  border-radius: 50%;
+  background: #b8ff5b;
+  box-shadow: 0 0 0 0.3rem rgb(184 255 91 / 0.09);
+  content: "";
+}
+
+.conditional-branch--paused {
+  color: #999992;
+}
+
+.conditional-branch--paused::before {
+  background: #696963;
+  box-shadow: none;
+}
+
 .edge-card ul {
   display: flex;
   min-height: 2.8rem;

--- a/examples/react-compiler/src/app/page.tsx
+++ b/examples/react-compiler/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { CompilerComparison } from "../components/compiler-comparison";
 import { CompilerEdgeLab } from "../components/compiler-edge-lab";
 import { CommonSyntaxExperiment } from "../components/common-syntax-experiment";
+import { ConditionalBlockExperiment } from "../components/conditional-block-experiment";
 import { HeavyInteractionBenchmark } from "../components/heavy-interaction-benchmark";
 import { StaticBindingExperiment } from "../components/static-binding-experiment";
 
@@ -63,6 +64,8 @@ export default function HomePage() {
       <CommonSyntaxExperiment />
 
       <StaticBindingExperiment />
+
+      <ConditionalBlockExperiment />
 
       <HeavyInteractionBenchmark />
 

--- a/examples/react-compiler/src/components/conditional-block-experiment.tsx
+++ b/examples/react-compiler/src/components/conditional-block-experiment.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState } from "react";
+
+let logicalBlockExecutions = 0;
+let ternaryBlockExecutions = 0;
+
+export function LogicalBlockPanel() {
+  const [loading, setLoading] = useState(false);
+  const [updates, setUpdates] = useState(0);
+
+  return (
+    <article className="edge-card" data-experiment="conditional-logical">
+      <header>
+        <span className="experiment-number">07A</span>
+        <div>
+          <h3>Mount or remove one block</h3>
+          <p>The build isolates an eligible logical branch at one known location.</p>
+        </div>
+      </header>
+      <div className="conditional-stage" aria-live="polite">
+        {loading && (
+          <p className="conditional-branch" data-branch="loading">
+            Loading branch · update {updates}
+          </p>
+        )}
+      </div>
+      <dl className="compact-metrics">
+        <div>
+          <dt>Mounted</dt>
+          <dd data-metric="mounted">{loading ? "yes" : "no"}</dd>
+        </div>
+        <div>
+          <dt>Branch value</dt>
+          <dd data-metric="updates">{updates}</dd>
+        </div>
+        <div>
+          <dt>Executions</dt>
+          <dd data-metric="executions">
+            {typeof window === "undefined" ? 1 : ++logicalBlockExecutions}
+          </dd>
+        </div>
+      </dl>
+      <div className="button-row">
+        <button data-action="toggle-logical" type="button" onClick={() => setLoading(!loading)}>
+          {loading ? "Remove branch" : "Mount branch"}
+        </button>
+        <button
+          data-action="increment-logical"
+          type="button"
+          onClick={() => setUpdates((value) => value + 1)}
+        >
+          Update branch value
+        </button>
+      </div>
+    </article>
+  );
+}
+
+export function TernaryBlockPanel() {
+  const [enabled, setEnabled] = useState(true);
+
+  return (
+    <article className="edge-card" data-experiment="conditional-ternary">
+      <header>
+        <span className="experiment-number">07B</span>
+        <div>
+          <h3>Replace one branch</h3>
+          <p>React swaps the prepared host branch without rerunning this component body.</p>
+        </div>
+      </header>
+      <div className="conditional-stage" aria-live="polite">
+        {enabled ? (
+          <strong className="conditional-branch" data-branch="enabled">
+            Enabled
+          </strong>
+        ) : (
+          <span className="conditional-branch conditional-branch--paused" data-branch="disabled">
+            Disabled
+          </span>
+        )}
+      </div>
+      <dl className="compact-metrics">
+        <div>
+          <dt>Branch</dt>
+          <dd data-metric="branch">{enabled ? "on" : "off"}</dd>
+        </div>
+        <div>
+          <dt>Owner</dt>
+          <dd>React</dd>
+        </div>
+        <div>
+          <dt>Executions</dt>
+          <dd data-metric="executions">
+            {typeof window === "undefined" ? 1 : ++ternaryBlockExecutions}
+          </dd>
+        </div>
+      </dl>
+      <button data-action="toggle-ternary" type="button" onClick={() => setEnabled(!enabled)}>
+        Replace branch
+      </button>
+    </article>
+  );
+}
+
+export function ConditionalBlockExperiment() {
+  "use no compiler";
+
+  return (
+    <section className="edge-lab" aria-labelledby="conditional-blocks-title">
+      <div className="section-heading">
+        <span>CONDITIONAL BLOCKS / PRODUCTION PROOF</span>
+        <h2 id="conditional-blocks-title">Change the branch, not the whole component.</h2>
+        <p>
+          Logical and ternary host branches get a small React-owned boundary. A local condition
+          refreshes that boundary while the surrounding compiled component stays still.
+        </p>
+      </div>
+      <div className="edge-grid edge-grid--paired">
+        <LogicalBlockPanel />
+        <TernaryBlockPanel />
+      </div>
+    </section>
+  );
+}

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -53,19 +53,29 @@ The directive is configurable and only has meaning in annotation mode.
 
 The current compiler handles components that it can prove have:
 
-- one host-element root and a static host-element tree;
+- one host-element root and a statically known host-element tree;
 - an identifier props parameter or flat object destructuring with aliases and defaults;
 - top-level `useState` declarations;
 - optional compiler-safe derived `const` values declared after state and in source order;
 - whitelisted `Boolean`, `Number`, `String`, and deterministic `Math` calculations;
 - optional synchronous `const` or function-declaration handlers used by JSX events;
 - state-driven text, attributes, per-property inline styles, and controlled form properties;
+- host-only `condition && <element>` and `condition ? <element> : <element>` child blocks at
+  statically known locations;
 - React-managed event handlers; and
-- no refs, effects, custom child components, keyed lists, or conditional child structure.
+- no refs, effects, custom child components, or keyed lists.
 
 The generated component preserves React ownership of placement, props, events, SSR, and hydration.
-Local state cells batch updates into a microtask and patch only compiler-known DOM paths. A local
-state update therefore does not schedule a React render or reconciliation pass.
+Local state cells batch updates into a microtask and patch only compiler-known DOM paths. For an
+eligible conditional, the runtime refreshes one small internal React boundary instead of executing
+the user component again. React mounts, replaces, or removes the selected branch, so events,
+unmounting, SSR, hydration, and error boundaries keep React semantics.
+
+Conditional blocks deliberately start with a narrow contract. Each non-empty branch must have one
+lowercase host root and a static host-only subtree. An empty ternary branch may be `null` or `false`.
+Custom components, hooks, fragments, nested conditionals, lists, refs, attribute spreads, and
+`dangerouslySetInnerHTML` inside the block fall back to the normal React component. Both branch
+expressions are isolated at build time, but the inactive branch is not pre-mounted or cached.
 
 Unsupported components fall back to React by default. Use `onUnsupported: "warn"` for diagnostics
 or `onUnsupported: "error"` while tightening an annotated migration.
@@ -90,5 +100,5 @@ commit and updates its two bindings directly. This is a deterministic structural
 assertion; it is not presented as a cross-machine timing benchmark.
 
 Application and prototype calls, dynamic style objects, handlers outside JSX events, nested,
-computed, and rest props patterns, async handlers, keyed list lowering, structural conditionals,
-effects, and more advanced hook support intentionally stay on React in this release.
+computed, and rest props patterns, async handlers, keyed list lowering, unsupported conditional
+shapes, effects, and more advanced hook support intentionally stay on React in this release.

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -161,6 +161,81 @@ const testSource = String.raw`
   assert.equal(staticContainer.querySelector('input[type="checkbox"]').checked, false);
   flushSync(() => staticRoot.unmount());
 
+  let conditionalExecutions = 0;
+  const ConditionalBlocks = createCompiledComponent({
+    displayName: "CompatibilityConditionalBlocks",
+    initialize: () => [false, 0],
+    render(_props, state, blocks) {
+      conditionalExecutions += 1;
+      return React.createElement(
+        "section",
+        null,
+        React.createElement(
+          "button",
+          { onClick: () => state[0].set((value) => !value) },
+          "Toggle branch",
+        ),
+        React.createElement(blocks.Conditional, {
+          id: 0,
+          render: () =>
+            state[0].get()
+              ? React.createElement(
+                  "strong",
+                  { "data-branch": "enabled" },
+                  "Enabled ",
+                  state[1].get(),
+                )
+              : React.createElement(
+                  "span",
+                  { "data-branch": "disabled" },
+                  "Disabled ",
+                  state[1].get(),
+                ),
+        }),
+        React.createElement("output", null, state[1].get()),
+        React.createElement(
+          "button",
+          { onClick: () => state[1].set((value) => Number(value) + 1) },
+          "Increment",
+        ),
+      );
+    },
+    bindings: [
+      { kind: "block", id: 0, dependencies: [0, 1] },
+      {
+        kind: "text",
+        path: [1],
+        dependencies: [1],
+        read: (_props, state) => state[1].get(),
+      },
+    ],
+  });
+
+  const conditionalContainer = document.createElement("div");
+  document.body.append(conditionalContainer);
+  const conditionalRoot = createRoot(conditionalContainer);
+  flushSync(() => conditionalRoot.render(React.createElement(ConditionalBlocks)));
+  const initialConditionalExecutions = conditionalExecutions;
+  conditionalContainer.querySelectorAll("button")[0].click();
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  flushSync(() => {});
+  assert.equal(
+    conditionalContainer.querySelector("[data-branch='enabled']").textContent,
+    "Enabled 0",
+  );
+  conditionalContainer.querySelectorAll("button")[1].click();
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  flushSync(() => {});
+  assert.equal(
+    conditionalContainer.querySelector("[data-branch='enabled']").textContent,
+    "Enabled 1",
+  );
+  assert.equal(conditionalContainer.querySelector("output").textContent, "1");
+  assert.equal(conditionalExecutions, initialConditionalExecutions);
+  flushSync(() => conditionalRoot.unmount());
+
   const hydrationContainer = document.createElement("div");
   hydrationContainer.innerHTML = renderToString(React.createElement(Counter));
   document.body.append(hydrationContainer);

--- a/packages/farm-react/src/__tests__/compiler-conditional-blocks.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-conditional-blocks.test.ts
@@ -1,0 +1,172 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true);
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/Conditional.tsx", infer);
+}
+
+describe("React AOT conditional block compiler", () => {
+  it("lowers logical and ternary host branches into independent block bindings", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function ConditionalPanel() {
+        const [loading, setLoading] = useState(false);
+        const [enabled, setEnabled] = useState(true);
+        return (
+          <main>
+            <button onClick={() => setLoading((value) => !value)}>Loading</button>
+            {loading && <p data-state="loading">Loading…</p>}
+            <button onClick={() => setEnabled((value) => !value)}>Enabled</button>
+            {enabled ? <strong>Enabled</strong> : <span>Disabled</span>}
+          </main>
+        );
+      }
+    `);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.compiled).toEqual(["ConditionalPanel"]);
+    expect(result.code.match(/farmBlocks\.Conditional/g)).toHaveLength(2);
+    expect(result.code).toContain('kind: "block"');
+    expect(result.code).toContain("id: 0");
+    expect(result.code).toContain("id: 1");
+    expect(result.code).toContain("dependencies: [0]");
+    expect(result.code).toContain("dependencies: [1]");
+    await expect(
+      transformWithEsbuild(result.code, "/app/Conditional.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("farmBlocks.Conditional"),
+    });
+  });
+
+  it("keeps branch attributes, text, styles, and handlers under React ownership", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function InteractiveBranch() {
+        const [open, setOpen] = useState(false);
+        const [count, setCount] = useState(0);
+        return (
+          <section>
+            <button onClick={() => setOpen(true)}>Open</button>
+            {open ? (
+              <article
+                className={count > 0 ? "active" : "idle"}
+                style={{ opacity: count > 0 ? 1 : 0.5 }}
+                onClick={() => setCount((value) => value + 1)}
+              >
+                Count: {count}
+              </article>
+            ) : null}
+          </section>
+        );
+      }
+    `);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.compiled).toEqual(["InteractiveBranch"]);
+    expect(result.code).toContain('kind: "block"');
+    expect(result.code).toContain("dependencies: [0, 1]");
+    expect(result.code).toMatch(/farmState\[1\]\.set/);
+    expect(result.code).toMatch(/farmState\[1\]\.get/);
+  });
+
+  it("supports null and false empty branches", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function EmptyBranches() {
+        const [visible, setVisible] = useState(false);
+        return (
+          <div onClick={() => setVisible(!visible)}>
+            {visible ? <p>Visible</p> : null}
+            {visible ? false : <aside>Hidden</aside>}
+          </div>
+        );
+      }
+    `);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.compiled).toEqual(["EmptyBranches"]);
+    expect(result.code.match(/farmBlocks\.Conditional/g)).toHaveLength(2);
+  });
+
+  it.each([
+    {
+      name: "a custom component branch",
+      body: "{visible && <Details />} ",
+      extra: "function Details() { return <p>Details</p>; }",
+      reason: /host elements only/i,
+    },
+    {
+      name: "a fragment branch",
+      body: "{visible && <><p>One</p><p>Two</p></>}",
+      extra: "",
+      reason: /dynamic child structures/i,
+    },
+    {
+      name: "a nested conditional branch",
+      body: "{visible && <div>{enabled && <span>Enabled</span>}</div>}",
+      extra: "",
+      reason: /nested conditional blocks/i,
+    },
+    {
+      name: "a list branch",
+      body: "{visible && <ul>{items.map((item) => <li key={item}>{item}</li>)}</ul>}",
+      extra: "const items = ['a', 'b'];",
+      reason: /static host tree/i,
+    },
+    {
+      name: "a hook call inside a branch",
+      body: "{visible && <p>{useValue()}</p>}",
+      extra: "function useValue() { return 'value'; }",
+      reason: /static host tree/i,
+    },
+    {
+      name: "a ref inside a branch",
+      body: "{visible && <p ref={() => undefined}>Details</p>}",
+      extra: "",
+      reason: /ref requires React ownership/i,
+    },
+    {
+      name: "an attribute spread inside a branch",
+      body: "{visible && <p {...props}>Details</p>}",
+      extra: "const props = {};",
+      reason: /attribute spreads/i,
+    },
+    {
+      name: "dangerous HTML inside a branch",
+      body: "{visible && <p dangerouslySetInnerHTML={{ __html: 'Details' }} />}",
+      extra: "",
+      reason: /dangerouslySetInnerHTML requires React ownership/i,
+    },
+    {
+      name: "an effectful condition",
+      body: "{isVisible(visible) && <p>Details</p>}",
+      extra: "const isVisible = (value: boolean) => value;",
+      reason: /test cannot use function calls/i,
+    },
+  ])("falls back to React for $name", async ({ body, extra, reason }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      ${extra}
+      export function Unsupported() {
+        const [visible, setVisible] = useState(false);
+        const [enabled, setEnabled] = useState(false);
+        return <section onClick={() => setVisible(!visible)}>${body}</section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual([]);
+    expect(
+      result.diagnostics.find((diagnostic) => diagnostic.component === "Unsupported")?.reason,
+    ).toMatch(reason);
+    expect(result.code).not.toContain("compiler-runtime");
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-runtime-conditional-blocks.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-conditional-blocks.test.tsx
@@ -1,0 +1,557 @@
+import React, { StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createCompiledComponent } from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+const roots: Array<{ unmount(): void }> = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+function click(container: Element, selector: string): void {
+  const target = container.querySelector<HTMLElement>(selector);
+  if (!target) throw new Error(`Missing test target: ${selector}`);
+  target.click();
+}
+
+describe("compiled React conditional block runtime", () => {
+  it("mounts, refreshes, and removes an && block without executing the user component", async () => {
+    let executions = 0;
+    const Panel = createCompiledComponent({
+      displayName: "ConditionalPanel",
+      initialize: () => [false, 0],
+      render(_props: Record<string, never>, state, blocks) {
+        executions += 1;
+        const Conditional = blocks.Conditional;
+        return (
+          <main>
+            <button data-action="toggle" onClick={() => state[0].set((value) => !value)}>
+              Toggle
+            </button>
+            <Conditional
+              id={0}
+              render={() =>
+                Boolean(state[0].get()) && (
+                  <p data-branch="details">Branch count: {Number(state[1].get())}</p>
+                )
+              }
+            />
+            <output data-value="count">{Number(state[1].get())}</output>
+            <button
+              data-action="increment"
+              onClick={() => state[1].set((value) => Number(value) + 1)}
+            >
+              Increment
+            </button>
+          </main>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0, 1] },
+        {
+          kind: "text",
+          path: [1],
+          dependencies: [1],
+          read: (_props, state) => state[1].get(),
+        },
+      ],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Panel />));
+
+    expect(executions).toBe(1);
+    expect(container.querySelector("[data-branch='details']")).toBeNull();
+
+    await act(async () => {
+      click(container, "[data-action='toggle']");
+      await Promise.resolve();
+    });
+    expect(container.querySelector("[data-branch='details']")?.textContent).toBe("Branch count: 0");
+    expect(executions).toBe(1);
+
+    await act(async () => {
+      click(container, "[data-action='increment']");
+      await Promise.resolve();
+    });
+    expect(container.querySelector("[data-branch='details']")?.textContent).toBe("Branch count: 1");
+    expect(container.querySelector("[data-value='count']")?.textContent).toBe("1");
+    expect(executions).toBe(1);
+
+    await act(async () => {
+      click(container, "[data-action='toggle']");
+      await Promise.resolve();
+    });
+    expect(container.querySelector("[data-branch='details']")).toBeNull();
+    expect(container.querySelector("[data-value='count']")?.textContent).toBe("1");
+    expect(executions).toBe(1);
+  });
+
+  it("replaces only a ternary branch and preserves React event bubbling", async () => {
+    let executions = 0;
+    const Toggle = createCompiledComponent({
+      displayName: "TernaryToggle",
+      initialize: () => [true, 0],
+      render(_props: Record<string, never>, state, blocks) {
+        executions += 1;
+        const Conditional = blocks.Conditional;
+        return (
+          <section onClick={() => state[1].set((value) => Number(value) + 1)}>
+            <Conditional
+              id={0}
+              render={() =>
+                Boolean(state[0].get()) ? (
+                  <strong data-branch="enabled" onClick={() => state[0].set(false)}>
+                    Enabled
+                  </strong>
+                ) : (
+                  <span data-branch="disabled" onClick={() => state[0].set(true)}>
+                    Disabled
+                  </span>
+                )
+              }
+            />
+            <output>{Number(state[1].get())}</output>
+          </section>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        {
+          kind: "text",
+          path: [0],
+          dependencies: [1],
+          read: (_props, state) => state[1].get(),
+        },
+      ],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Toggle />));
+
+    const enabled = container.querySelector("[data-branch='enabled']");
+    expect(enabled?.tagName).toBe("STRONG");
+    await act(async () => {
+      (enabled as HTMLElement).click();
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector("[data-branch='enabled']")).toBeNull();
+    expect(container.querySelector("[data-branch='disabled']")?.tagName).toBe("SPAN");
+    expect(container.querySelector("output")?.textContent).toBe("1");
+    expect(executions).toBe(1);
+  });
+
+  it("keeps local block state coherent with a parent prop update in the same event", async () => {
+    let executions = 0;
+    const Child = createCompiledComponent({
+      displayName: "PropAndLocalBlock",
+      initialize: () => [0],
+      render(props: { label: string }, state, blocks) {
+        executions += 1;
+        const Conditional = blocks.Conditional;
+        return (
+          <article>
+            <Conditional
+              id={0}
+              render={() =>
+                Number(state[0].get()) > 0 ? (
+                  <p data-result="value">
+                    {props.label}: {Number(state[0].get())}
+                  </p>
+                ) : (
+                  <span data-result="empty">Empty</span>
+                )
+              }
+            />
+            <button onClick={() => state[0].set((value) => Number(value) + 1)}>Local</button>
+          </article>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    function Parent() {
+      const [label, setLabel] = useState("Before");
+      return (
+        <div onClick={() => setLabel("After")}>
+          <Child label={label} />
+        </div>
+      );
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Parent />));
+    const initialExecutions = executions;
+
+    await act(async () => {
+      click(container, "button");
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector("[data-result='value']")?.textContent).toBe("After: 1");
+    expect(executions).toBe(initialExecutions + 1);
+  });
+
+  it("works through StrictMode remounting without re-executing on a local toggle", async () => {
+    let executions = 0;
+    const StrictToggle = createCompiledComponent({
+      displayName: "StrictConditional",
+      initialize: () => [false],
+      render(_props: Record<string, never>, state, blocks) {
+        executions += 1;
+        const Conditional = blocks.Conditional;
+        return (
+          <div>
+            <button onClick={() => state[0].set((value) => !value)}>Toggle</button>
+            <Conditional
+              id={0}
+              render={() => Boolean(state[0].get()) && <p data-strict="ready">Ready</p>}
+            />
+          </div>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <StrictMode>
+          <StrictToggle />
+        </StrictMode>,
+      ),
+    );
+    const initialExecutions = executions;
+
+    await act(async () => {
+      click(container, "button");
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector("[data-strict='ready']")?.textContent).toBe("Ready");
+    expect(executions).toBe(initialExecutions);
+  });
+
+  it("drops a queued conditional refresh after the component unmounts", async () => {
+    const Toggle = createCompiledComponent({
+      displayName: "UnmountedConditional",
+      initialize: () => [false],
+      render(_props: Record<string, never>, state, blocks) {
+        const Conditional = blocks.Conditional;
+        return (
+          <div>
+            <button onClick={() => state[0].set(true)}>Show</button>
+            <Conditional id={0} render={() => Boolean(state[0].get()) && <p>Shown</p>} />
+          </div>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    await act(async () => root.render(<Toggle />));
+
+    await act(async () => {
+      click(container, "button");
+      root.unmount();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toBe("");
+  });
+
+  it("preserves ordinary SSR markup and hydrates a conditional branch", async () => {
+    const Toggle = createCompiledComponent({
+      displayName: "HydratedConditional",
+      initialize: () => [true],
+      render(_props: Record<string, never>, state, blocks) {
+        const Conditional = blocks.Conditional;
+        return (
+          <div>
+            <button onClick={() => state[0].set((value) => !value)}>Toggle</button>
+            <Conditional
+              id={0}
+              render={() =>
+                Boolean(state[0].get()) ? <strong data-server="branch">Enabled</strong> : null
+              }
+            />
+          </div>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const html = renderToString(<Toggle />);
+    expect(html).toContain('<strong data-server="branch">Enabled</strong>');
+    expect(html).not.toContain("farm");
+
+    const container = document.createElement("div");
+    container.innerHTML = html;
+    document.body.append(container);
+    const recoverableErrors: unknown[] = [];
+    let root!: ReturnType<typeof hydrateRoot>;
+    await act(async () => {
+      root = hydrateRoot(container, <Toggle />, {
+        onRecoverableError: (error) => recoverableErrors.push(error),
+      });
+    });
+    roots.push(root);
+
+    await act(async () => {
+      click(container, "button");
+      await Promise.resolve();
+    });
+    expect(container.querySelector("[data-server='branch']")).toBeNull();
+    expect(recoverableErrors).toEqual([]);
+  });
+
+  it("preserves selection when a controlled input updates inside the block", async () => {
+    const FormBlock = createCompiledComponent({
+      displayName: "ConditionalForm",
+      initialize: () => [true, "Farm"],
+      render(_props: Record<string, never>, state, blocks) {
+        const Conditional = blocks.Conditional;
+        return (
+          <section>
+            <Conditional
+              id={0}
+              render={() =>
+                Boolean(state[0].get()) ? (
+                  <label>
+                    Note
+                    <input value={String(state[1].get())} onChange={() => undefined} />
+                  </label>
+                ) : null
+              }
+            />
+            <button onClick={() => state[1].set("Compiler")}>Replace value</button>
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0, 1] }],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<FormBlock />));
+    const input = container.querySelector("input")!;
+    input.focus();
+    input.setSelectionRange(1, 3);
+
+    await act(async () => {
+      click(container, "button");
+      await Promise.resolve();
+    });
+
+    expect(input.value).toBe("Compiler");
+    expect(input.selectionStart).toBe(1);
+    expect(input.selectionEnd).toBe(3);
+  });
+
+  it("handles object, array, and nullish condition transitions", async () => {
+    let observedValue: unknown;
+    let nullEvents = 0;
+    const ValueBlock = createCompiledComponent({
+      displayName: "ConditionalValues",
+      initialize: () => [null],
+      render(_props: Record<string, never>, state, blocks) {
+        const Conditional = blocks.Conditional;
+        return (
+          <section>
+            <button data-value="object" onClick={() => state[0].set({ ready: true })} />
+            <button data-value="array" onClick={() => state[0].set([])} />
+            <button
+              data-value="clear"
+              onClick={() => {
+                nullEvents += 1;
+                state[0].set(null);
+              }}
+            />
+            <Conditional
+              id={0}
+              render={() => {
+                observedValue = state[0].get();
+                return observedValue ? (
+                  <p data-present="value">{Array.isArray(observedValue) ? "array" : "object"}</p>
+                ) : null;
+              }}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<ValueBlock />));
+    expect(container.querySelector("[data-present='value']")).toBeNull();
+
+    for (const [value, expected] of [
+      ["object", "object"],
+      ["array", "array"],
+    ] as const) {
+      await act(async () => {
+        click(container, `[data-value='${value}']`);
+        await Promise.resolve();
+      });
+      expect(container.querySelector("[data-present='value']")?.textContent).toBe(expected);
+    }
+
+    await act(async () => {
+      click(container, "[data-value='clear']");
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(nullEvents).toBe(1);
+    expect(observedValue).toBeNull();
+    expect(container.querySelector("[data-present='value']")).toBeNull();
+  });
+
+  it("routes a block render failure through a React error boundary", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    class Boundary extends React.Component<React.PropsWithChildren, { failed: boolean }> {
+      state = { failed: false };
+      static getDerivedStateFromError() {
+        return { failed: true };
+      }
+      render() {
+        return this.state.failed ? <p data-error="caught">Recovered</p> : this.props.children;
+      }
+    }
+    const BrokenBlock = createCompiledComponent({
+      displayName: "BrokenConditional",
+      initialize: () => [false],
+      render(_props: Record<string, never>, state, blocks) {
+        const Conditional = blocks.Conditional;
+        return (
+          <div>
+            <button onClick={() => state[0].set(true)}>Break</button>
+            <Conditional
+              id={0}
+              render={() => {
+                if (state[0].get()) throw new Error("branch failed");
+                return <p>Safe</p>;
+              }}
+            />
+          </div>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <Boundary>
+          <BrokenBlock />
+        </Boundary>,
+      ),
+    );
+
+    await act(async () => {
+      click(container, "button");
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector("[data-error='caught']")?.textContent).toBe("Recovered");
+  });
+
+  it("matches normal React after one thousand deterministic randomized updates", async () => {
+    let seed = 0x5f3759df;
+    const nextRandom = () => {
+      seed = (seed * 1664525 + 1013904223) >>> 0;
+      return seed / 0x1_0000_0000;
+    };
+    const Compiled = createCompiledComponent({
+      displayName: "RandomConditional",
+      initialize: () => [false, 0],
+      render(_props: Record<string, never>, state, blocks) {
+        const Conditional = blocks.Conditional;
+        return (
+          <div>
+            <button data-random="toggle" onClick={() => state[0].set((value) => !value)} />
+            <button
+              data-random="increment"
+              onClick={() => state[1].set((value) => Number(value) + 1)}
+            />
+            <Conditional
+              id={0}
+              render={() =>
+                Boolean(state[0].get()) ? (
+                  <strong>On {Number(state[1].get())}</strong>
+                ) : (
+                  <span>Off {Number(state[1].get())}</span>
+                )
+              }
+            />
+          </div>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0, 1] }],
+    });
+    function Base() {
+      const [enabled, setEnabled] = useState(false);
+      const [count, setCount] = useState(0);
+      return (
+        <div>
+          <button data-random="toggle" onClick={() => setEnabled((value) => !value)} />
+          <button data-random="increment" onClick={() => setCount((value) => value + 1)} />
+          {enabled ? <strong>On {count}</strong> : <span>Off {count}</span>}
+        </div>
+      );
+    }
+
+    const compiledContainer = document.createElement("div");
+    const baseContainer = document.createElement("div");
+    document.body.append(compiledContainer, baseContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const baseRoot = createRoot(baseContainer);
+    roots.push(compiledRoot, baseRoot);
+    await act(async () => {
+      compiledRoot.render(<Compiled />);
+      baseRoot.render(<Base />);
+    });
+
+    for (let batch = 0; batch < 100; batch += 1) {
+      await act(async () => {
+        for (let update = 0; update < 10; update += 1) {
+          const action = nextRandom() < 0.35 ? "toggle" : "increment";
+          click(compiledContainer, `[data-random='${action}']`);
+          click(baseContainer, `[data-random='${action}']`);
+        }
+        await Promise.resolve();
+      });
+      expect(compiledContainer.innerHTML).toBe(baseContainer.innerHTML);
+    }
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler.test.ts
+++ b/packages/farm-react/src/__tests__/compiler.test.ts
@@ -204,7 +204,7 @@ describe("React AOT compiler", () => {
     expect(result.compiled).toEqual(["Counter"]);
   });
 
-  it("falls back to React for dynamic child structure", async () => {
+  it("compiles a host-only conditional child block", async () => {
     const result = await compileReactModule(
       `
         import { useState } from "react";
@@ -217,8 +217,18 @@ describe("React AOT compiler", () => {
       infer,
     );
 
-    expect(result.compiled).toEqual([]);
-    expect(result.diagnostics[0]?.reason).toMatch(/dynamic child structures/i);
-    expect(result.code).not.toContain("compiler-runtime");
+    expect(result.diagnostics).toEqual([]);
+    expect(result.compiled).toEqual(["MaybeDetails"]);
+    expect(result.code).toContain("farmBlocks.Conditional");
+    expect(result.code).toContain('kind: "block"');
+    expect(result.code).toContain("dependencies: [0]");
+    await expect(
+      transformWithEsbuild(result.code, "/app/MaybeDetails.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("farmBlocks.Conditional"),
+    });
   });
 });

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -43,10 +43,26 @@ export interface CompilerStyleBinding<Props> {
   read(props: Props, state: readonly CompilerCell[]): unknown;
 }
 
+export interface CompilerConditionalBlockBinding {
+  kind: "block";
+  id: number;
+  dependencies: readonly number[];
+}
+
+export interface CompilerConditionalBlockProps {
+  id: number;
+  render(): React.ReactNode;
+}
+
+export interface CompilerBlockRuntime {
+  Conditional: React.ComponentType<CompilerConditionalBlockProps>;
+}
+
 export type CompilerBinding<Props> =
   | CompilerTextBinding<Props>
   | CompilerAttributeBinding<Props>
-  | CompilerStyleBinding<Props>;
+  | CompilerStyleBinding<Props>
+  | CompilerConditionalBlockBinding;
 
 export interface CompiledComponentDefinition<Props> {
   displayName: string;
@@ -55,7 +71,11 @@ export interface CompiledComponentDefinition<Props> {
   /** Changes when the compiler-owned state layout is no longer refresh-compatible. */
   stateSignature?: string;
   initialize(props: Props): readonly unknown[];
-  render(props: Props, state: readonly CompilerCell[]): React.ReactElement;
+  render(
+    props: Props,
+    state: readonly CompilerCell[],
+    blocks: CompilerBlockRuntime,
+  ): React.ReactElement;
   bindings: readonly CompilerBinding<Props>[];
 }
 
@@ -89,10 +109,15 @@ function renderTextValue(value: unknown): string {
   return String(value);
 }
 
-function findBindingTarget(root: Element, path: readonly number[]): Element | null {
+function findBindingTarget(
+  root: Element,
+  path: readonly number[],
+  blockRoots: ReadonlySet<Element>,
+): Element | null {
   let current: Element | null = root;
   for (const index of path) {
-    current = current?.children.item(index) || null;
+    if (!current) return null;
+    current = [...current.children].filter((child) => !blockRoots.has(child))[index] || null;
   }
   return current;
 }
@@ -266,6 +291,78 @@ function updateAttribute(element: Element, name: string, value: unknown): void {
   }
 }
 
+interface ConditionalBlockOwner {
+  setRoot(id: number, root: Element | null): void;
+  subscribe(id: number, refresh: (afterCommit?: () => void) => void): () => void;
+}
+
+function createConditionalBlockComponent(
+  owner: ConditionalBlockOwner,
+): React.ComponentType<CompilerConditionalBlockProps> {
+  class FarmConditionalBlock extends React.Component<CompilerConditionalBlockProps> {
+    static displayName = "FarmCompiledConditionalBlock";
+
+    private unsubscribe: (() => void) | undefined;
+
+    private captureRoot = (root: Element | null) => {
+      owner.setRoot(this.props.id, root);
+    };
+
+    private refresh = (afterCommit?: () => void) => {
+      this.forceUpdate(afterCommit);
+    };
+
+    private subscribe(): void {
+      this.unsubscribe = owner.subscribe(this.props.id, this.refresh);
+    }
+
+    componentDidMount(): void {
+      this.subscribe();
+    }
+
+    componentDidUpdate(previous: CompilerConditionalBlockProps): void {
+      if (previous.id === this.props.id) return;
+      this.unsubscribe?.();
+      owner.setRoot(previous.id, null);
+      this.subscribe();
+    }
+
+    componentWillUnmount(): void {
+      this.unsubscribe?.();
+      owner.setRoot(this.props.id, null);
+    }
+
+    render(): React.ReactNode {
+      const node = this.props.render();
+      if (!React.isValidElement(node)) {
+        if (
+          node === null ||
+          node === undefined ||
+          typeof node === "boolean" ||
+          typeof node === "string" ||
+          typeof node === "number" ||
+          typeof node === "bigint"
+        ) {
+          return node;
+        }
+        throw new TypeError(
+          `Compiled conditional block ${this.props.id} must return one host element or an empty value.`,
+        );
+      }
+      if (typeof node.type !== "string") {
+        throw new TypeError(
+          `Compiled conditional block ${this.props.id} must return one host element.`,
+        );
+      }
+      return React.cloneElement(node, {
+        ref: this.captureRoot,
+      } as React.Attributes);
+    }
+  }
+
+  return FarmConditionalBlock;
+}
+
 /**
  * Runtime target emitted by the AOT transform.
  *
@@ -299,6 +396,10 @@ export function createCompiledComponent<Props>(
     private inputSelection: InputSelectionSnapshot | null = null;
     private readonly dirtyState = new Set<number>();
     private readonly cells: RuntimeCell[];
+    private readonly blockRefreshListeners = new Map<number, (afterCommit?: () => void) => void>();
+    private readonly blockRoots = new Map<number, Element>();
+    private readonly blockRootElements = new Set<Element>();
+    private readonly blockRuntime: CompilerBlockRuntime;
 
     constructor(props: Props) {
       super(props);
@@ -321,6 +422,12 @@ export function createCompiledComponent<Props>(
           },
         };
       });
+      this.blockRuntime = {
+        Conditional: createConditionalBlockComponent({
+          setRoot: (id, root) => this.setBlockRoot(id, root),
+          subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
+        }),
+      };
     }
 
     private captureRoot = (root: Element | null) => {
@@ -360,6 +467,26 @@ export function createCompiledComponent<Props>(
       snapshot.element.setSelectionRange(snapshot.start, snapshot.end, snapshot.direction);
     }
 
+    private setBlockRoot(id: number, root: Element | null): void {
+      const previous = this.blockRoots.get(id);
+      if (previous) this.blockRootElements.delete(previous);
+      if (root) {
+        this.blockRoots.set(id, root);
+        this.blockRootElements.add(root);
+      } else {
+        this.blockRoots.delete(id);
+      }
+    }
+
+    private subscribeToBlock(id: number, refresh: (afterCommit?: () => void) => void): () => void {
+      this.blockRefreshListeners.set(id, refresh);
+      return () => {
+        if (this.blockRefreshListeners.get(id) === refresh) {
+          this.blockRefreshListeners.delete(id);
+        }
+      };
+    }
+
     private scheduleBindingFlush(index: number): void {
       this.dirtyState.add(index);
       this.captureInputSelection();
@@ -377,12 +504,21 @@ export function createCompiledComponent<Props>(
         this.dirtyState.clear();
         if (dirty.size === 0) return;
         try {
+          let blockRefreshScheduled = false;
           for (const binding of definitionReference.current.bindings) {
             if (binding.dependencies.some((dependency) => dirty.has(dependency))) {
-              this.applyBinding(binding);
+              if (binding.kind === "block") {
+                const refresh = this.blockRefreshListeners.get(binding.id);
+                if (refresh) {
+                  blockRefreshScheduled = true;
+                  refresh(() => this.restoreInputSelection(inputSelection));
+                }
+              } else {
+                this.applyBinding(binding);
+              }
             }
           }
-          this.restoreInputSelection(inputSelection);
+          if (!blockRefreshScheduled) this.restoreInputSelection(inputSelection);
         } catch (error) {
           this.bindingError = error;
           this.hasBindingError = true;
@@ -392,8 +528,8 @@ export function createCompiledComponent<Props>(
     }
 
     private applyBinding(binding: CompilerBinding<Props>): void {
-      if (!this.root) return;
-      const target = findBindingTarget(this.root, binding.path);
+      if (!this.root || binding.kind === "block") return;
+      const target = findBindingTarget(this.root, binding.path, this.blockRootElements);
       if (!target) return;
       const value = binding.read(this.props, this.cells);
       if (binding.kind === "text") {
@@ -414,7 +550,9 @@ export function createCompiledComponent<Props>(
       // React has reconciled a parent-driven prop update. Reapply compiled
       // bindings from the current cells so React and the imperative state stay
       // coherent even when both change in the same turn.
-      for (const binding of definitionReference.current.bindings) this.applyBinding(binding);
+      for (const binding of definitionReference.current.bindings) {
+        if (binding.kind !== "block") this.applyBinding(binding);
+      }
     }
 
     componentWillUnmount(): void {
@@ -422,13 +560,16 @@ export function createCompiledComponent<Props>(
       this.root = null;
       this.dirtyState.clear();
       this.inputSelection = null;
+      this.blockRefreshListeners.clear();
+      this.blockRoots.clear();
+      this.blockRootElements.clear();
       refreshListeners.delete(this.refreshDefinition);
     }
 
     render(): React.ReactNode {
       if (this.hasBindingError) throw this.bindingError;
       const currentDefinition = definitionReference.current;
-      const element = currentDefinition.render(this.props, this.cells);
+      const element = currentDefinition.render(this.props, this.cells, this.blockRuntime);
       if (!React.isValidElement(element) || typeof element.type !== "string") {
         throw new TypeError(
           `Compiled component ${currentDefinition.displayName} must return one host element.`,

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -38,12 +38,26 @@ interface PropsPlan {
   destructuredNames: ReadonlySet<string>;
 }
 
-interface PendingBinding {
+interface PendingDomBinding {
   kind: "text" | "attribute" | "style";
   path: number[];
   dependencies: number[];
   name?: string;
   value: t.Expression;
+}
+
+interface PendingConditionalBlockBinding {
+  kind: "block";
+  id: number;
+  dependencies: number[];
+}
+
+type PendingBinding = PendingDomBinding | PendingConditionalBlockBinding;
+
+interface ConditionalBlockPlan {
+  id: number;
+  dependencies: number[];
+  source: t.Expression;
 }
 
 interface Candidate {
@@ -391,10 +405,207 @@ function jsxAttributeName(attribute: t.JSXAttribute): string | undefined {
   return t.isJSXIdentifier(attribute.name) ? attribute.name.name : undefined;
 }
 
+interface ConditionalBlockShape {
+  test: t.Expression;
+  branches: t.JSXElement[];
+}
+
+function isEmptyConditionalBranch(expression: t.Expression): boolean {
+  return t.isNullLiteral(expression) || t.isBooleanLiteral(expression, { value: false });
+}
+
+function conditionalBlockShape(expression: t.Expression): ConditionalBlockShape | null {
+  if (
+    t.isLogicalExpression(expression, { operator: "&&" }) &&
+    t.isExpression(expression.left) &&
+    t.isJSXElement(expression.right)
+  ) {
+    return { test: expression.left, branches: [expression.right] };
+  }
+  if (!t.isConditionalExpression(expression)) return null;
+  const branches = [expression.consequent, expression.alternate];
+  if (
+    !branches.every((branch) => t.isJSXElement(branch) || isEmptyConditionalBranch(branch)) ||
+    !branches.some((branch) => t.isJSXElement(branch))
+  ) {
+    return null;
+  }
+  return {
+    test: expression.test,
+    branches: branches.filter((branch): branch is t.JSXElement => t.isJSXElement(branch)),
+  };
+}
+
+function validateConditionalHostTree(
+  root: t.JSXElement,
+  statesByValue: ReadonlyMap<string, StateBinding>,
+  safeGlobals: ReadonlySet<string>,
+): string | undefined {
+  const visit = (element: t.JSXElement): string | undefined => {
+    const tag = element.openingElement.name;
+    if (!t.isJSXIdentifier(tag) || !/^[a-z]/.test(tag.name)) {
+      return "conditional blocks currently support host elements only";
+    }
+
+    for (const attribute of element.openingElement.attributes) {
+      if (t.isJSXSpreadAttribute(attribute)) {
+        return "conditional blocks do not support JSX attribute spreads";
+      }
+      const name = jsxAttributeName(attribute);
+      if (!name) return "conditional blocks do not support namespaced JSX attributes";
+      if (name === "ref" || name === "dangerouslySetInnerHTML") {
+        return `conditional block ${name} requires React ownership`;
+      }
+      if (
+        !t.isJSXExpressionContainer(attribute.value) ||
+        t.isJSXEmptyExpression(attribute.value.expression) ||
+        /^on[A-Z]/.test(name)
+      ) {
+        continue;
+      }
+
+      const expression = attribute.value.expression;
+      if (name === "style") {
+        if (!t.isObjectExpression(expression)) {
+          return "conditional block styles must use one inline object literal";
+        }
+        for (const property of expression.properties) {
+          if (!t.isObjectProperty(property) || property.computed) {
+            return "conditional block styles do not support spreads, methods, or computed properties";
+          }
+          if (!t.isExpression(property.value)) {
+            return "conditional block style properties must use expression values";
+          }
+          const unsupported = validateDerivedExpression(property.value, safeGlobals);
+          if (unsupported) return `conditional block style cannot use ${unsupported}`;
+        }
+        continue;
+      }
+
+      const unsupported = validateDerivedExpression(expression, safeGlobals);
+      if (unsupported) return `conditional block attribute ${name} cannot use ${unsupported}`;
+    }
+
+    for (const child of element.children) {
+      if (t.isJSXElement(child)) {
+        const reason = visit(child);
+        if (reason) return reason;
+        continue;
+      }
+      if (t.isJSXFragment(child)) {
+        return "conditional blocks do not support fragments yet";
+      }
+      if (!t.isJSXExpressionContainer(child) || t.isJSXEmptyExpression(child.expression)) {
+        continue;
+      }
+      if (conditionalBlockShape(child.expression)) {
+        return "nested conditional blocks are not supported yet";
+      }
+      if (!isTextExpression(child.expression, statesByValue, safeGlobals)) {
+        return "conditional block children must keep one static host tree";
+      }
+    }
+    return undefined;
+  };
+
+  return visit(root);
+}
+
+function analyzeConditionalBlocks(
+  root: t.JSXElement,
+  statesByValue: ReadonlyMap<string, StateBinding>,
+  safeGlobals: ReadonlySet<string>,
+): { blocks?: ConditionalBlockPlan[]; reason?: string } {
+  const blocks: ConditionalBlockPlan[] = [];
+
+  const visit = (element: t.JSXElement): string | undefined => {
+    for (const child of element.children) {
+      if (t.isJSXElement(child)) {
+        const reason = visit(child);
+        if (reason) return reason;
+        continue;
+      }
+      if (!t.isJSXExpressionContainer(child) || t.isJSXEmptyExpression(child.expression)) {
+        continue;
+      }
+      const shape = conditionalBlockShape(child.expression);
+      if (!shape) continue;
+      const unsupported = validateDerivedExpression(shape.test, safeGlobals);
+      if (unsupported) return `conditional block test cannot use ${unsupported}`;
+      for (const branch of shape.branches) {
+        const reason = validateConditionalHostTree(branch, statesByValue, safeGlobals);
+        if (reason) return reason;
+      }
+      blocks.push({
+        id: blocks.length,
+        dependencies: collectStateDependencies(child.expression, statesByValue),
+        source: child.expression,
+      });
+    }
+    return undefined;
+  };
+
+  const reason = visit(root);
+  return reason ? { reason } : { blocks };
+}
+
+function lowerConditionalBlocks(
+  root: t.JSXElement,
+  plans: readonly ConditionalBlockPlan[],
+  blockRuntime: t.Identifier,
+): t.JSXElement {
+  const lowered = t.cloneNode(root, true);
+  let cursor = 0;
+  const visit = (element: t.JSXElement): void => {
+    element.children = element.children.map((child) => {
+      if (t.isJSXElement(child)) {
+        visit(child);
+        return child;
+      }
+      if (
+        !t.isJSXExpressionContainer(child) ||
+        t.isJSXEmptyExpression(child.expression) ||
+        !conditionalBlockShape(child.expression)
+      ) {
+        return child;
+      }
+      const plan = plans[cursor++];
+      const name = t.jsxMemberExpression(
+        t.jsxIdentifier(blockRuntime.name),
+        t.jsxIdentifier("Conditional"),
+      );
+      return t.jsxElement(
+        t.jsxOpeningElement(
+          name,
+          [
+            t.jsxAttribute(
+              t.jsxIdentifier("id"),
+              t.jsxExpressionContainer(t.numericLiteral(plan.id)),
+            ),
+            t.jsxAttribute(
+              t.jsxIdentifier("render"),
+              t.jsxExpressionContainer(
+                t.arrowFunctionExpression([], cloneExpression(child.expression)),
+              ),
+            ),
+          ],
+          true,
+        ),
+        null,
+        [],
+        true,
+      );
+    });
+  };
+  visit(lowered);
+  return lowered;
+}
+
 function analyzeHostTree(
   root: t.JSXElement,
   statesByValue: ReadonlyMap<string, StateBinding>,
   safeGlobals: ReadonlySet<string>,
+  conditionalExpressions: ReadonlySet<t.Expression>,
 ): { bindings?: PendingBinding[]; reason?: string } {
   const bindings: PendingBinding[] = [];
 
@@ -482,12 +693,17 @@ function analyzeHostTree(
     );
     for (const child of expressionChildren) {
       if (t.isJSXEmptyExpression(child.expression)) continue;
+      if (conditionalExpressions.has(child.expression)) continue;
       if (!isTextExpression(child.expression, statesByValue, safeGlobals)) {
         return "dynamic child structures require React reconciliation";
       }
     }
 
-    if (nestedElements.length === 0) {
+    const hasConditionalBlocks = expressionChildren.some(
+      (child) =>
+        !t.isJSXEmptyExpression(child.expression) && conditionalExpressions.has(child.expression),
+    );
+    if (nestedElements.length === 0 && !hasConditionalBlocks) {
       const dependencies = new Set<number>();
       const parts: t.Expression[] = [];
       for (const child of element.children) {
@@ -513,6 +729,7 @@ function analyzeHostTree(
       for (const child of expressionChildren) {
         if (
           !t.isJSXEmptyExpression(child.expression) &&
+          !conditionalExpressions.has(child.expression) &&
           collectStateDependencies(child.expression, statesByValue).length > 0
         ) {
           return "mixed element and stateful text children are not supported yet";
@@ -625,14 +842,22 @@ function bindingObject(
   const properties: t.ObjectProperty[] = [
     t.objectProperty(t.identifier("kind"), t.stringLiteral(binding.kind)),
     t.objectProperty(
-      t.identifier("path"),
-      t.arrayExpression(binding.path.map((part) => t.numericLiteral(part))),
-    ),
-    t.objectProperty(
       t.identifier("dependencies"),
       t.arrayExpression(binding.dependencies.map((part) => t.numericLiteral(part))),
     ),
   ];
+  if (binding.kind === "block") {
+    properties.push(t.objectProperty(t.identifier("id"), t.numericLiteral(binding.id)));
+    return t.objectExpression(properties);
+  }
+  properties.splice(
+    1,
+    0,
+    t.objectProperty(
+      t.identifier("path"),
+      t.arrayExpression(binding.path.map((part) => t.numericLiteral(part))),
+    ),
+  );
   if (binding.name)
     properties.push(t.objectProperty(t.identifier("name"), t.stringLiteral(binding.name)));
   properties.push(
@@ -791,14 +1016,25 @@ function compileCandidate(
   );
   const setterReason = validateSetterUsage(expandedRoot, statesBySetter);
   if (setterReason) return setterReason;
-  const analysis = analyzeHostTree(expandedRoot, statesByValue, safeGlobals);
+  const conditionalAnalysis = analyzeConditionalBlocks(expandedRoot, statesByValue, safeGlobals);
+  if (conditionalAnalysis.reason) return conditionalAnalysis.reason;
+  const conditionalBlocks = conditionalAnalysis.blocks || [];
+  const conditionalExpressions = new Set(conditionalBlocks.map((block) => block.source));
+  const analysis = analyzeHostTree(
+    expandedRoot,
+    statesByValue,
+    safeGlobals,
+    conditionalExpressions,
+  );
   if (analysis.reason) return analysis.reason;
 
   const stateParameter = path.scope.generateUidIdentifier("farmState");
+  const blockParameter = path.scope.generateUidIdentifier("farmBlocks");
   const definitionIdentifier = path.scope.generateUidIdentifier(`${name}Compiled`);
   const propsParameter = propsPlan.definitionParameter;
+  const rootWithBlocks = lowerConditionalBlocks(expandedRoot, conditionalBlocks, blockParameter);
   const rewrittenRoot = rewriteStateAccess(
-    expandedRoot,
+    rootWithBlocks,
     stateParameter,
     statesByValue,
     statesBySetter,
@@ -844,14 +1080,21 @@ function compileCandidate(
       t.objectProperty(
         t.identifier("render"),
         t.arrowFunctionExpression(
-          [t.cloneNode(propsParameter), t.cloneNode(stateParameter)],
+          [t.cloneNode(propsParameter), t.cloneNode(stateParameter), t.cloneNode(blockParameter)],
           rewrittenRoot,
         ),
       ),
       t.objectProperty(
         t.identifier("bindings"),
         t.arrayExpression(
-          (analysis.bindings || []).map((binding) =>
+          [
+            ...(analysis.bindings || []),
+            ...conditionalBlocks.map((block) => ({
+              kind: "block" as const,
+              id: block.id,
+              dependencies: block.dependencies,
+            })),
+          ].map((binding) =>
             bindingObject(binding, propsParameter, stateParameter, statesByValue, statesBySetter),
           ),
         ),


### PR DESCRIPTION
## Summary

Follow-up to #370 that teaches the experimental React AOT compiler to update safe conditional host-element blocks without rerunning the owning component.

- compile logical host branches such as `{loading && <p>Loading…</p>}`
- compile ternary host branches such as `{enabled ? <strong>Enabled</strong> : <span>Disabled</span>}`
- prepare branch factories and a stable DOM anchor at build time
- mount, replace, or remove only the affected block after supported state updates
- preserve React behavior by falling back when a branch is outside the supported boundary
- document the behavior, constraints, and configuration in the React renderer docs and package README
- add an interactive conditional-block experiment to `examples/react-compiler`

## Initial safety boundary

Compilation is intentionally limited to branches that:

- contain host elements, text, and already-supported static bindings
- stay in one compiler-known DOM location
- do not contain hooks or custom components
- can be updated without changing React ownership semantics

Unsupported logical/ternary shapes continue through normal React rendering.

## Verification

- `pnpm --filter @farm.js/react test` — 93 tests passed
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and React 19.2.8 passed
- `pnpm --dir examples/react-compiler type-check`
- production example verification covers logical and ternary transitions with zero extra owning-component executions
- deterministic randomized comparison runs 1,000 updates against normal React
- runtime coverage includes StrictMode, unmount-before-flush, simultaneous parent/local updates, event bubbling, controlled input selection, SSR/hydration, error boundaries, and object/array/nullish transitions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compiles safe conditional DOM blocks in the experimental React AOT compiler so logical/ternary host branches mount/replace/remove without rerunning the owning component; previously all conditionals triggered a render of the component. React still owns the small boundary, preserving events, unmounting, SSR, hydration, and error boundaries.

- Generates `block` bindings with state dependencies and lowers `{cond && <host/>}` and `{cond ? <host/> : <host/>}` to `blocks.Conditional` at a single known child location. Runtime adds a lightweight `FarmCompiledConditionalBlock` and updates only the affected block; non-block bindings now skip block roots when patching.
- Safety limits: each non-empty branch must have exactly one lowercase host root and a static host-only subtree; ternary empty branches may be `null`/`false`. Custom components, hooks, fragments, nested conditionals, lists, refs, spreads, and `dangerouslySetInnerHTML` inside a branch fall back to normal React.
- Docs: expands React renderer guidance and `packages/farm-react/README.md` with behavior, constraints, and configuration.
- Examples: adds interactive conditional-block experiment to `examples/react-compiler` and extends the production verification script with desktop/mobile screenshots and assertions.
- Tests: adds compiler and runtime suites covering StrictMode, parent+local updates in one turn, event bubbling, controlled input selection, SSR/hydration, error boundaries, and randomized equivalence against normal React; updates React version compatibility checks.
- Rollout: no migration required. Supported branches compile automatically; unsupported shapes render via React unchanged. Configuration flags (`compiler: true`, `onUnsupported`) continue to apply.

<sup>Written for commit 03b9941df5c5896dd36f40e2f91ce6fa0df1d574. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

