### PR TITLE
feat(react): add compiled keyed list boundaries

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -331,11 +331,12 @@ satisfy all of these rules:
 | Body                | Top-level `useState` declarations, optional compiler-safe derived values and synchronous named handlers, then one unconditional JSX return. |
 | State               | `const [value, setValue] = useState(initial)`, including lazy initializers, multiple cells, and queued functional updates.                  |
 | Root                | Exactly one lowercase host JSX element such as `button`, `section`, `input`, or `div`.                                                      |
-| Tree                | A statically known host tree. Eligible logical and ternary blocks may change one compiler-isolated child location.                          |
+| Tree                | A statically known host tree. Eligible conditional and keyed-list boundaries may change one compiler-isolated child location.               |
 | Text bindings       | State-driven text in a leaf host element.                                                                                                   |
 | Attribute bindings  | Basic attributes, controlled form properties, and individual properties in one inline `style` object.                                       |
 | Events              | Inline handlers and synchronous `const` or function-declaration handlers, used directly or called inside an inline JSX handler.             |
 | Conditional blocks  | `condition && <host />` or `condition ? <host /> : <host />`; `null` and `false` are supported empty ternary branches.                      |
+| Keyed lists         | A direct keyed `items.map(...)`, or an explicit imported `List`, when it is the only meaningful child of its host container.                |
 
 This component is eligible:
 
@@ -448,29 +449,105 @@ The optimization boundary matters: the surrounding compiled component and its un
 do not rerender, but React still renders and commits the small conditional boundary. A branch with
 substantial work therefore still pays for that branch work.
 
+### Keyed list boundaries
+
+The compiler automatically recognizes a direct keyed map in a safe, statically known container:
+
+```tsx
+export function Inventory() {
+  const [items, setItems] = useState(initialItems);
+
+  return (
+    <ul>
+      {items.map((item) => (
+        <li key={item.id}>{item.label}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+Farm records the list's state dependencies and replaces the map location with a small internal
+React boundary. Updating `items` refreshes that boundary without executing `Inventory` again.
+React still receives the keyed elements and performs the insert, removal, move, render, lifecycle,
+and commit work inside the list. The optimization isolates that work; it does not remove it.
+
+Use the public `List` component when the key should be separate from the row renderer, or when rows
+are custom components:
+
+```tsx
+import { List } from "@farm.js/react/list";
+
+export function Inventory() {
+  const [items, setItems] = useState(initialItems);
+
+  return (
+    <div className="inventory">
+      <List each={items} by={(item) => item.id}>
+        {(item) => <InventoryRow item={item} />}
+      </List>
+    </div>
+  );
+}
+
+function InventoryRow({ item }) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <button onClick={() => setExpanded((value) => !value)}>
+      {item.label}: {expanded ? "open" : "closed"}
+    </button>
+  );
+}
+```
+
+`List` is an ordinary React component, not compiler-only syntax. It accepts an `Iterable`, `null`,
+or `undefined`; calls `by(item, index)` to create each React key; and requires its child function to
+return one React element. It therefore renders correctly when the experimental compiler is off or
+when this particular use cannot be optimized. Hooks belong inside a row component such as
+`InventoryRow`, never directly inside the `List` child function or a `.map()` callback.
+
+The first automatic contract is deliberately narrow:
+
+- The map must be a direct `collection.map(...)` with one synchronous inline callback returning one
+  React element and an explicit item-derived `key`.
+- An array-index key is rejected for compiler isolation because it does not preserve item identity
+  across insertion, removal, or reordering.
+- The optimized `List` shape uses inline `by` and child functions, a compiler-safe `each`
+  expression, and an item-derived key.
+- The map or `List` must be the only meaningful child of its host container. This keeps all
+  compiler-prepared DOM paths outside the boundary stable.
+- Chained expressions such as `items.filter(...).map(...)`, mixed static siblings, spread children,
+  hooks in the callback, and other unproven shapes fall back to normal React.
+
+Stable keys must be unique among siblings and come from the item's identity, such as a database ID.
+Farm does not implement an LIS move algorithm in this release. A compiler-owned LIS can only be
+safe after the compiler owns an entire host-only list island; this boundary intentionally keeps
+React as the sole DOM and Fiber owner.
+
 ### What falls back to React
 
-| Unsupported shape                                                      | Why React keeps ownership                                                           |
-| ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| Keyed lists, `.map()`, element arrays, or helper-rendered children     | Inserts, removals, moves, and identity changes require reconciliation.              |
-| Fragments or unsupported/nested conditional JSX                        | Their structure is outside the current single-location host-block contract.         |
-| Custom child components                                                | A child component has its own props, hooks, lifecycle, and reconciliation boundary. |
-| Effects or hooks other than the supported `useState` shape             | Their lifecycle and ordering must remain under React's hook dispatcher.             |
-| `ref` or `dangerouslySetInnerHTML`                                     | They directly participate in DOM ownership.                                         |
-| Stateful `children` or `key` bindings                                  | These need structure or identity semantics.                                         |
-| Conditional style objects, style spreads, methods, or computed names   | The final property set or precedence cannot be prepared statically.                 |
-| JSX attribute spreads or namespaced attributes                         | The compiler cannot currently enumerate a stable binding contract.                  |
-| Multiple/conditional returns or impure/control-flow statements         | The compiler only lowers a single, statically analyzable render path.               |
-| Derived calls, assignments, identity-bearing values, functions, or JSX | Their evaluation timing, side effects, or identity cannot yet be preserved safely.  |
-| Nested, computed, or rest props destructuring                          | These patterns need additional parameter-shape and identity analysis.               |
-| Async/generator/generic handlers or named handlers outside JSX events  | Their scheduling, identity, or closure semantics are outside the current lowering.  |
-| Async/generator or generic components                                  | These function shapes are outside the current lowering.                             |
-| Setters called outside JSX event handlers                              | The compiler only controls and batches event-driven local updates.                  |
+| Unsupported shape                                                        | Why React keeps ownership                                                           |
+| ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| Unkeyed/index-keyed/chained maps, mixed list siblings, or element arrays | Their structure or item identity is outside the isolated keyed-boundary contract.   |
+| Fragments or unsupported/nested conditional JSX                          | Their structure is outside the current single-location host-block contract.         |
+| Custom child components outside an eligible keyed-list boundary          | A child component has its own props, hooks, lifecycle, and reconciliation boundary. |
+| Effects or hooks other than the supported `useState` shape               | Their lifecycle and ordering must remain under React's hook dispatcher.             |
+| `ref` or `dangerouslySetInnerHTML`                                       | They directly participate in DOM ownership.                                         |
+| Stateful `children` or `key` bindings outside an eligible boundary       | These need structure or identity semantics.                                         |
+| Conditional style objects, style spreads, methods, or computed names     | The final property set or precedence cannot be prepared statically.                 |
+| JSX attribute spreads or namespaced attributes                           | The compiler cannot currently enumerate a stable binding contract.                  |
+| Multiple/conditional returns or impure/control-flow statements           | The compiler only lowers a single, statically analyzable render path.               |
+| Derived calls, assignments, identity-bearing values, functions, or JSX   | Their evaluation timing, side effects, or identity cannot yet be preserved safely.  |
+| Nested, computed, or rest props destructuring                            | These patterns need additional parameter-shape and identity analysis.               |
+| Async/generator/generic handlers or named handlers outside JSX events    | Their scheduling, identity, or closure semantics are outside the current lowering.  |
+| Async/generator or generic components                                    | These function shapes are outside the current lowering.                             |
+| Setters called outside JSX event handlers                                | The compiler only controls and batches event-driven local updates.                  |
 
 Keys do not make list reconciliation unnecessary. A key tells React which child identity survives
-an insert, removal, or move; React still needs to compare the dynamic children. Calling a Hook
-directly inside a list iteration is also invalid React because the number or order of calls can
-change. Put the Hook inside a keyed child component and leave that structure on React.
+an insert, removal, or move; React still compares the dynamic children. The compiler uses that
+identity to decide when a list can have its own refresh boundary, then hands the keyed elements to
+React. Calling a Hook directly inside a list iteration is invalid React because the number or order
+of calls can change. Put the Hook inside a keyed child component instead.
 
 ### Build-time transformation
 
@@ -513,6 +590,7 @@ follows:
 | Parent-driven prop updates                     | Selecting bindings whose state dependencies changed             |
 | Unsupported trees, hooks, refs, and lifecycles | Patching precomputed text/attribute targets after local updates |
 | Host creation/removal inside an eligible block | Refreshing only the matching internal conditional boundary      |
+| Keyed row identity, reconciliation, and DOM    | Refreshing only the matching internal keyed-list boundary       |
 | Unmounting and the surrounding component tree  | Reapplying bindings after a parent-driven React update          |
 
 Queued functional setters preserve the event's state snapshot. Two calls such as
@@ -550,9 +628,11 @@ normal recovery path.
 ### Safety reasoning
 
 The compiler uses fallback as a semantic boundary, not as an error-recovery trick. A precomputed
-path is only correct while the host tree has the same shape. Dynamic children, custom components,
-refs, and effects can change ownership or lifecycle in ways the current compiler does not yet
-model. Letting React handle them is the optimization's correctness mechanism.
+path is only correct while the host tree has the same shape. Conditional and keyed-list boundaries
+isolate the dynamic location and give its structure back to React. Other dynamic children, custom
+components outside those boundaries, refs, and effects can change ownership or lifecycle in ways
+the current compiler does not yet model. Letting React handle them is the optimization's
+correctness mechanism.
 
 Parent-driven prop updates also remain React updates. After React reconciles the new props, the
 runtime reapplies compiler-owned bindings from the current local cells so prop changes and local
@@ -576,9 +656,14 @@ The package and example test suites verify more than generated code:
 - hydration mismatches follow React's recoverable-error path and remain interactive;
 - object, array, and nullish state transitions match normal React across 3,000 deterministic
   randomized updates;
+- automatic keyed maps and explicit `List` boundaries preserve keyed DOM nodes and stateful row
+  identity across inserts, removals, updates, and reorders without rerunning the outer component;
+- 1,000 deterministic randomized list operations produce the same ordered output as normal React;
+- the public `List` renders iterable and nullish collections correctly with the compiler off;
 - the packaged runtime is exercised separately with React 18.3 and React 19;
 - boolean `data-*` and `aria-*` attributes keep React-compatible string values; and
-- keyed lists, effects, refs, and custom child components remain on React without corrupting output.
+- unsupported list shapes, effects, refs, and custom child components outside a keyed boundary
+  remain on React without corrupting output.
 
 The heavy example uses a fixed 768-host-node tree with three state cells and sparse bindings. Its
 compiler-off → compiler-on crossover run measures a deliberately favorable supported workload. The
@@ -603,7 +688,7 @@ property.
 
 The [`examples/react-compiler`](https://github.com/farming-labs/farm.js/tree/main/examples/react-compiler)
 app contains batching, multiple-binding, common-syntax, calculated-style, controlled-form,
-keyed-fallback, compiler-on/off, and heavy-interaction experiments. The standalone starter
+automatic and explicit keyed-list, compiler-on/off, and heavy-interaction experiments. The standalone starter
 intentionally keeps the first experience focused.
 
 ## React-specific FARMJS APIs

--- a/examples/react-compiler/README.md
+++ b/examples/react-compiler/README.md
@@ -4,8 +4,8 @@ This production-browser experiment answers two questions:
 
 1. Why build this compiler? Eligible local `useState` updates can patch precomputed DOM targets
    without rerunning the component body or asking React to reconcile the same static tree again.
-2. Where must it stop? Eligible host-only conditionals use a small React-owned block boundary.
-   Keyed lists, effects, refs, custom components, and other unproven structures stay on React.
+2. Where must it stop? Eligible host-only conditionals and keyed lists use small React-owned
+   boundaries. Effects, refs, unsupported list shapes, and other unproven structures stay on React.
 
 The default `compiler: true` configuration automatically considers components. No annotation is
 needed. A component can explicitly opt out with `"use no compiler"`.
@@ -28,16 +28,17 @@ assertions, checks for console/runtime errors and horizontal overflow, saves scr
 
 ## Expected report
 
-| Experiment                 | Compiled result                                         | Base React / fallback result                   | What it proves                                                         |
-| -------------------------- | ------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------- |
-| Two direct updates         | state `2`, update executions `0`                        | state `2`, update executions `2`               | Eligible updates skip post-mount component executions.                 |
-| Batched functional updates | count `2`, snapshot `0`, update executions `0`          | count `2`, snapshot `0`, update executions `1` | The compiler preserves queued updater and event snapshot behavior.     |
-| Two state cells            | text/class/data/input all update, update executions `0` | —                                              | AOT dependency lists update only bindings affected by each state cell. |
-| Calculated style bindings  | value `6`, progress `50%`, update executions `0`        | —                                              | Safe calls and individual CSS properties use prepared dependencies.    |
-| Controlled form bindings  | textarea/select/checkbox update, executions `0`         | —                                              | Form properties and textarea selection stay coherent.                  |
-| Logical conditional block | branch mounts, updates, and unmounts; executions `0`     | —                                              | Only the isolated React block refreshes.                                |
-| Ternary conditional block | `strong` and `span` replace each other; executions `0`   | —                                              | React preserves branch and event semantics without the outer rerender. |
-| Keyed list                 | intentionally not compiled                              | 3 correct keyed rows, update executions `2`    | Dynamic child structure safely falls back to React reconciliation.     |
+| Experiment                  | Compiled result                                         | Base React / fallback result                   | What it proves                                                         |
+| --------------------------- | ------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------- |
+| Two direct updates          | state `2`, update executions `0`                        | state `2`, update executions `2`               | Eligible updates skip post-mount component executions.                 |
+| Batched functional updates  | count `2`, snapshot `0`, update executions `0`          | count `2`, snapshot `0`, update executions `1` | The compiler preserves queued updater and event snapshot behavior.     |
+| Two state cells             | text/class/data/input all update, update executions `0` | —                                              | AOT dependency lists update only bindings affected by each state cell. |
+| Automatic keyed map         | insert and reverse rows, update executions `0`          | —                                              | A direct item-keyed map gets its own React refresh boundary.           |
+| Explicit `List`             | stateful rows reorder, update executions `0`            | —                                              | React preserves custom-row state by key inside the isolated boundary.  |
+| Calculated style bindings   | value `6`, progress `50%`, update executions `0`        | —                                              | Safe calls and individual CSS properties use prepared dependencies.    |
+| Controlled form bindings   | textarea/select/checkbox update, executions `0`         | —                                              | Form properties and textarea selection stay coherent.                  |
+| Logical conditional block  | branch mounts, updates, and unmounts; executions `0`    | —                                              | Only the isolated React block refreshes.                               |
+| Ternary conditional block  | `strong` and `span` replace each other; executions `0`  | —                                              | React preserves branch and event semantics without the outer rerender. |
 
 The package runtime test also measures one equivalent update under a React `Profiler`:
 
@@ -52,13 +53,33 @@ speed depends on event work, DOM work, layout, paint, application shape, and dev
 
 ## Keys and Hooks boundary
 
-`items.map(item => <Row key={item} />)` changes tree structure, so the current compiler leaves it to
-React. Keys tell React which row identity survived an insert, delete, or move; they do not make
-reconciliation unnecessary.
+For a direct `items.map(item => <Row key={item.id} />)`, the compiler can isolate the list update
+from the outer component. Keys tell React which row identity survived an insert, delete, or move;
+they do not make reconciliation unnecessary. React still compares the rows and owns their DOM,
+events, lifecycle, and state.
 
-Calling a Hook directly inside `items.map(...)` is invalid React because the number or order of Hook
-calls can change. Put the Hook inside a separate `Row` component and key that component. The compiler
-has a regression test confirming that the invalid inline shape is rejected rather than transformed.
+The explicit equivalent separates collection, key, and rendering:
+
+```tsx
+import { List } from "@farm.js/react/list";
+
+<div>
+  <List each={items} by={(item) => item.id}>
+    {(item) => <Row item={item} />}
+  </List>
+</div>;
+```
+
+`List` is useful for custom stateful rows and still works as ordinary React when the compiler is
+off. Automatic maps and optimized `List` boundaries currently need to be the only meaningful child
+of their host container. Index keys, missing keys, chained maps, and mixed sibling structures fall
+back to the complete React component. Farm does not perform compiler-owned LIS moves in this stage;
+React remains the sole owner of row reconciliation.
+
+Calling a Hook directly inside `items.map(...)` or a `List` render callback is invalid React because
+the number or order of Hook calls can change. Put the Hook inside a separate `Row` component and key
+that component. The compiler has a regression test confirming that the invalid inline shape is
+rejected rather than transformed.
 
 ## Conditional block boundary
 
@@ -101,9 +122,9 @@ Repeated reference run on Apple M1, Chromium 145:
 | Production page chunk (gzip) |         3,953 B |     5,221 B |                  **+1,268 B** |
 
 The timing result is intentionally narrow. It does not include browser layout/paint, network work,
-effects, child component updates, or dynamic/keyed structure. Those either add costs outside the
-measured update path or currently fall back to React. Run the command on target devices before using
-the reference number for a product decision.
+effects, child component updates, or keyed-list reconciliation. Those add costs outside the
+measured update path. Unsupported dynamic structures still fall back to React. Run the command on
+target devices before using the reference number for a product decision.
 
 The environment flag controls the two production builds; omission defaults to enabled:
 

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -27,6 +27,9 @@ for (const component of [
   "FormBindingPanel",
   "LogicalBlockPanel",
   "TernaryBlockPanel",
+  "AutomaticKeyedListExperiment",
+  "ExplicitKeyedListExperiment",
+  "StatefulListRow",
 ]) {
   assert.ok(compiledComponents.has(component), `${component} was not compiled`);
 }
@@ -371,24 +374,46 @@ try {
   );
   assert.equal(ternaryFinalExecutions - ternaryInitialExecutions, 0);
 
-  const keyed = '[data-experiment="keyed-fallback"]';
-  const keyedInitialExecutions = await readNumber(
+  const automaticList = '[data-experiment="keyed-automatic"]';
+  const automaticListInitialExecutions = await readNumber(
     page,
-    `${keyed} [data-metric="executions"]`,
+    `${automaticList} [data-metric="executions"]`,
   );
-  await page.locator(`${keyed} [data-action="add-item"]`).click();
-  await page.locator(`${keyed} [data-action="add-item"]`).click();
-  await assertText(page, `${keyed} [data-metric="items"]`, "3");
-  const keyedFinalExecutions = await readNumber(
+  await page.locator(`${automaticList} [data-action="add-item"]`).click();
+  await page.locator(`${automaticList} [data-action="add-item"]`).click();
+  await assertText(page, `${automaticList} [data-metric="items"]`, "4");
+  await page.locator(`${automaticList} [data-action="reverse-items"]`).click();
+  await assertText(page, `${automaticList} [data-metric="first"]`, "Item 4");
+  const automaticListFinalExecutions = await readNumber(
     page,
-    `${keyed} [data-metric="executions"]`,
+    `${automaticList} [data-metric="executions"]`,
   );
-  assert.equal(keyedFinalExecutions - keyedInitialExecutions, 2);
-  assert.deepEqual(await page.locator(`${keyed} li`).allTextContents(), [
-    "item-1",
-    "item-2",
-    "item-3",
+  assert.equal(automaticListFinalExecutions - automaticListInitialExecutions, 0);
+  assert.deepEqual(await page.locator(`${automaticList} li`).allTextContents(), [
+    "Item 4",
+    "Item 3",
+    "Beta",
+    "Alpha",
   ]);
+
+  const explicitList = '[data-experiment="keyed-explicit"]';
+  const explicitListInitialExecutions = await readNumber(
+    page,
+    `${explicitList} [data-metric="executions"]`,
+  );
+  await page.locator(`${explicitList} [data-row="a"]`).click();
+  await assertText(page, `${explicitList} [data-row="a"]`, "Alpha · 1");
+  await page.locator(`${explicitList} [data-action="reverse-items"]`).click();
+  await assertText(page, `${explicitList} [data-metric="first"]`, "Beta");
+  assert.deepEqual(
+    await page.locator(`${explicitList} [data-row]`).allTextContents(),
+    ["Beta · 0", "Alpha · 1"],
+  );
+  const explicitListFinalExecutions = await readNumber(
+    page,
+    `${explicitList} [data-metric="executions"]`,
+  );
+  assert.equal(explicitListFinalExecutions - explicitListInitialExecutions, 0);
 
   await page.screenshot({ path: screenshotPath, fullPage: true });
 
@@ -494,9 +519,18 @@ try {
             branch: "enabled",
             updateExecutions: ternaryFinalExecutions - ternaryInitialExecutions,
           },
-          keyedFallback: {
-            items: 3,
-            updateExecutions: keyedFinalExecutions - keyedInitialExecutions,
+          automaticKeyedList: {
+            items: 4,
+            first: "Item 4",
+            updateExecutions:
+              automaticListFinalExecutions - automaticListInitialExecutions,
+            owner: "React boundary",
+          },
+          explicitKeyedList: {
+            order: ["Beta", "Alpha"],
+            alphaState: 1,
+            updateExecutions:
+              explicitListFinalExecutions - explicitListInitialExecutions,
             owner: "React",
           },
         },

--- a/examples/react-compiler/src/app/globals.css
+++ b/examples/react-compiler/src/app/globals.css
@@ -374,6 +374,10 @@ h1 span {
   border-top: 1px solid #33332f;
 }
 
+.edge-grid--single {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .edge-card {
   min-width: 0;
   padding: clamp(1.25rem, 3vw, 2rem);
@@ -643,6 +647,20 @@ h1 span {
     0.66rem "Geist Mono Variable",
     ui-monospace,
     monospace;
+}
+
+.keyed-row-stage {
+  display: flex;
+  min-height: 2.8rem;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  margin: 0 0 0.8rem;
+}
+
+.keyed-row-stage button {
+  color: #c8c8c1;
+  font-family: "Geist Mono Variable", ui-monospace, monospace;
 }
 
 .hook-warning {

--- a/examples/react-compiler/src/components/compiler-edge-lab.tsx
+++ b/examples/react-compiler/src/components/compiler-edge-lab.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { List } from "@farm.js/react/list";
 import { useState } from "react";
 
 let compiledBatchExecutions = 0;
 let reactBatchExecutions = 0;
 let multipleBindingExecutions = 0;
-let keyedListExecutions = 0;
+let automaticListExecutions = 0;
+let explicitListExecutions = 0;
 
 export function CompiledBatchExperiment() {
   const [count, setCount] = useState(0);
@@ -154,19 +156,24 @@ export function MultipleBindingExperiment() {
   );
 }
 
-export function KeyedListFallbackExperiment() {
-  const [items, setItems] = useState(["item-1"]);
+interface ListItem {
+  id: string;
+  label: string;
+}
+
+export function AutomaticKeyedListExperiment() {
+  const [items, setItems] = useState<ListItem[]>([
+    { id: "a", label: "Alpha" },
+    { id: "b", label: "Beta" },
+  ]);
 
   return (
-    <article
-      className="edge-card edge-card--fallback"
-      data-experiment="keyed-fallback"
-    >
+    <article className="edge-card" data-experiment="keyed-automatic">
       <header>
-        <span className="experiment-number">04</span>
+        <span className="experiment-number">04A</span>
         <div>
-          <h3>Keyed list fallback</h3>
-          <p>Dynamic structure stays under React reconciliation.</p>
+          <h3>Automatic keyed boundary</h3>
+          <p>The build recognizes a direct keyed map and isolates the list.</p>
         </div>
       </header>
       <dl className="compact-metrics" aria-live="polite">
@@ -175,25 +182,99 @@ export function KeyedListFallbackExperiment() {
           <dd data-metric="items">{items.length}</dd>
         </div>
         <div>
+          <dt>First row</dt>
+          <dd data-metric="first">{items[0]?.label}</dd>
+        </div>
+        <div>
           <dt>Executions</dt>
           <dd data-metric="executions">
-            {typeof window === "undefined" ? 1 : ++keyedListExecutions}
+            {typeof window === "undefined" ? 1 : ++automaticListExecutions}
           </dd>
         </div>
       </dl>
       <ul data-list="keyed">
         {items.map((item) => (
-          <li key={item}>{item}</li>
+          <li data-key={item.id} key={item.id}>
+            {item.label}
+          </li>
         ))}
       </ul>
+      <div className="button-row">
+        <button
+          type="button"
+          data-action="add-item"
+          onClick={() =>
+            setItems((value) => [
+              ...value,
+              { id: `item-${value.length + 1}`, label: `Item ${value.length + 1}` },
+            ])
+          }
+        >
+          Add item
+        </button>
+        <button
+          type="button"
+          data-action="reverse-items"
+          onClick={() => setItems((value) => [...value].reverse())}
+        >
+          Reverse rows
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function StatefulListRow({ item }: { item: ListItem }) {
+  const [clicks, setClicks] = useState(0);
+  return (
+    <button data-row={item.id} type="button" onClick={() => setClicks((value) => value + 1)}>
+      {item.label} · {clicks}
+    </button>
+  );
+}
+
+export function ExplicitKeyedListExperiment() {
+  const [items, setItems] = useState<ListItem[]>([
+    { id: "a", label: "Alpha" },
+    { id: "b", label: "Beta" },
+  ]);
+
+  return (
+    <article className="edge-card" data-experiment="keyed-explicit">
+      <header>
+        <span className="experiment-number">04B</span>
+        <div>
+          <h3>Explicit List boundary</h3>
+          <p>A key selector supports custom rows while React preserves their state.</p>
+        </div>
+      </header>
+      <dl className="compact-metrics" aria-live="polite">
+        <div>
+          <dt>Items</dt>
+          <dd data-metric="items">{items.length}</dd>
+        </div>
+        <div>
+          <dt>First row</dt>
+          <dd data-metric="first">{items[0]?.label}</dd>
+        </div>
+        <div>
+          <dt>Executions</dt>
+          <dd data-metric="executions">
+            {typeof window === "undefined" ? 1 : ++explicitListExecutions}
+          </dd>
+        </div>
+      </dl>
+      <div className="keyed-row-stage" data-list="explicit">
+        <List each={items} by={(item) => item.id}>
+          {(item) => <StatefulListRow item={item} />}
+        </List>
+      </div>
       <button
+        data-action="reverse-items"
         type="button"
-        data-action="add-item"
-        onClick={() =>
-          setItems((value) => [...value, `item-${value.length + 1}`])
-        }
+        onClick={() => setItems((value) => [...value].reverse())}
       >
-        Add keyed item
+        Reverse stateful rows
       </button>
     </article>
   );
@@ -215,18 +296,20 @@ export function CompilerEdgeLab() {
         <CompiledBatchExperiment />
         <ReactBatchExperiment />
       </div>
-      <div className="edge-grid">
+      <div className="edge-grid edge-grid--single">
         <MultipleBindingExperiment />
-        <KeyedListFallbackExperiment />
+      </div>
+      <div className="edge-grid">
+        <AutomaticKeyedListExperiment />
+        <ExplicitKeyedListExperiment />
       </div>
 
       <aside className="hook-warning">
         <span>HOOKS + KEYS</span>
         <p>
           Never call a Hook directly inside <code>items.map(...)</code>. Put the
-          Hook in a separate keyed row component. This compiler rejects the
-          inline pattern; the current compiler leaves the keyed list itself to
-          React.
+          Hook in a separate keyed row component. Automatic maps and the explicit
+          <code>List</code> boundary keep row identity and lifecycle under React.
         </p>
       </aside>
     </section>

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -62,14 +62,50 @@ The current compiler handles components that it can prove have:
 - state-driven text, attributes, per-property inline styles, and controlled form properties;
 - host-only `condition && <element>` and `condition ? <element> : <element>` child blocks at
   statically known locations;
+- direct item-keyed `collection.map(...)` children and explicit `List` boundaries at statically
+  known container locations;
 - React-managed event handlers; and
-- no refs, effects, custom child components, or keyed lists.
+- no refs, effects, or unsupported dynamic child structures.
 
 The generated component preserves React ownership of placement, props, events, SSR, and hydration.
 Local state cells batch updates into a microtask and patch only compiler-known DOM paths. For an
 eligible conditional, the runtime refreshes one small internal React boundary instead of executing
 the user component again. React mounts, replaces, or removes the selected branch, so events,
 unmounting, SSR, hydration, and error boundaries keep React semantics.
+
+For a common keyed map, no new API is required:
+
+```tsx
+<ul>
+  {items.map((item) => (
+    <li key={item.id}>{item.label}</li>
+  ))}
+</ul>
+```
+
+The compiler can isolate this direct map when it is the container's only meaningful child, the key
+comes from the item rather than the array index, and the callback is otherwise safe. A list update
+then refreshes only an internal React boundary instead of executing the outer user component.
+React still reconciles the keyed rows and owns their DOM, events, lifecycle, and state.
+
+For custom rows or an explicit key selector, use the public component:
+
+```tsx
+import { List } from "@farm.js/react/list";
+
+<div>
+  <List each={items} by={(item) => item.id}>
+    {(item) => <StatefulRow item={item} />}
+  </List>
+</div>;
+```
+
+`List` also works with the compiler disabled. `each` accepts an iterable, `null`, or `undefined`;
+`by` supplies the React key; and the child function returns one React element. Put Hooks inside the
+row component, not directly inside the iteration callback. With the compiler enabled, the
+optimized explicit shape requires inline `by` and child functions, a safe `each` expression, an
+item-derived key, and no meaningful siblings in the same host container. Other shapes keep normal
+React behavior.
 
 Conditional blocks deliberately start with a narrow contract. Each non-empty branch must have one
 lowercase host root and a static host-only subtree. An empty ternary branch may be `null` or `false`.
@@ -100,5 +136,7 @@ commit and updates its two bindings directly. This is a deterministic structural
 assertion; it is not presented as a cross-machine timing benchmark.
 
 Application and prototype calls, dynamic style objects, handlers outside JSX events, nested,
-computed, and rest props patterns, async handlers, keyed list lowering, unsupported conditional
-shapes, effects, and more advanced hook support intentionally stay on React in this release.
+computed, and rest props patterns, async handlers, unkeyed or index-keyed lists, chained maps,
+mixed list siblings, unsupported conditional shapes, effects, and more advanced hook support
+intentionally stay on React in this release. Farm does not perform compiler-owned LIS row moves;
+eligible keyed boundaries deliberately keep reconciliation under React.

--- a/packages/farm-react/package.json
+++ b/packages/farm-react/package.json
@@ -42,6 +42,11 @@
       "import": "./dist/compiler-runtime.mjs",
       "require": "./dist/compiler-runtime.cjs"
     },
+    "./list": {
+      "types": "./dist/list.d.ts",
+      "import": "./dist/list.mjs",
+      "require": "./dist/list.cjs"
+    },
     "./vite": {
       "types": "./dist/vite.d.ts",
       "import": "./dist/vite.mjs",

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -40,6 +40,7 @@ const testSource = String.raw`
   const { createRoot, hydrateRoot } = await import("react-dom/client");
   const { renderToString } = await import("react-dom/server");
   const { createCompiledComponent } = await import("@farm.js/react/compiler-runtime");
+  const { List } = await import("@farm.js/react/list");
 
   const Counter = createCompiledComponent({
     displayName: "CompatibilityCounter",
@@ -235,6 +236,72 @@ const testSource = String.raw`
   assert.equal(conditionalContainer.querySelector("output").textContent, "1");
   assert.equal(conditionalExecutions, initialConditionalExecutions);
   flushSync(() => conditionalRoot.unmount());
+
+  const explicitListContainer = document.createElement("div");
+  document.body.append(explicitListContainer);
+  const explicitListRoot = createRoot(explicitListContainer);
+  flushSync(() =>
+    explicitListRoot.render(
+      React.createElement(
+        "ul",
+        null,
+        React.createElement(List, {
+          each: [{ id: "a", label: "Alpha" }],
+          by: (item) => item.id,
+          children: (item) => React.createElement("li", null, item.label),
+        }),
+      ),
+    ),
+  );
+  assert.equal(explicitListContainer.textContent, "Alpha");
+  flushSync(() => explicitListRoot.unmount());
+
+  let keyedExecutions = 0;
+  const KeyedBlocks = createCompiledComponent({
+    displayName: "CompatibilityKeyedBlocks",
+    initialize: () => [[{ id: "a", label: "Alpha" }, { id: "b", label: "Beta" }]],
+    render(_props, state, blocks) {
+      keyedExecutions += 1;
+      return React.createElement(
+        "section",
+        null,
+        React.createElement(
+          "button",
+          { onClick: () => state[0].set((value) => [...value].reverse()) },
+          "Reverse",
+        ),
+        React.createElement(
+          "ul",
+          null,
+          React.createElement(blocks.KeyedList, {
+            id: 0,
+            render: () =>
+              state[0].get().map((item) =>
+                React.createElement("li", { key: item.id, "data-key": item.id }, item.label),
+              ),
+          }),
+        ),
+      );
+    },
+    bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+  });
+  const keyedContainer = document.createElement("div");
+  document.body.append(keyedContainer);
+  const keyedRoot = createRoot(keyedContainer);
+  flushSync(() => keyedRoot.render(React.createElement(KeyedBlocks)));
+  const initialKeyedExecutions = keyedExecutions;
+  const originalAlpha = keyedContainer.querySelector("[data-key='a']");
+  keyedContainer.querySelector("button").click();
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  flushSync(() => {});
+  assert.deepEqual(
+    [...keyedContainer.querySelectorAll("li")].map((row) => row.getAttribute("data-key")),
+    ["b", "a"],
+  );
+  assert.equal(keyedContainer.querySelector("[data-key='a']"), originalAlpha);
+  assert.equal(keyedExecutions, initialKeyedExecutions);
+  flushSync(() => keyedRoot.unmount());
 
   const hydrationContainer = document.createElement("div");
   hydrationContainer.innerHTML = renderToString(React.createElement(Counter));

--- a/packages/farm-react/src/__tests__/compiler-edge-cases.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-edge-cases.test.ts
@@ -36,7 +36,7 @@ describe("React AOT compiler safety boundaries", () => {
     expect(result.code).toContain("dependencies: [1]");
   });
 
-  it("falls back for an inline keyed list instead of stringifying React elements", async () => {
+  it("isolates an inline keyed list instead of stringifying React elements", async () => {
     const result = await compile(`
       import { useState } from "react";
       export function KeyedList() {
@@ -50,12 +50,13 @@ describe("React AOT compiler safety boundaries", () => {
       }
     `);
 
-    expect(result.compiled).toEqual([]);
-    expect(result.diagnostics[0]?.reason).toMatch(/dynamic child structures/i);
-    expect(result.code).not.toContain("compiler-runtime");
+    expect(result.compiled).toEqual(["KeyedList"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).toContain("compiler-runtime");
   });
 
-  it("keeps a keyed parent on React while compiling its stable row component", async () => {
+  it("isolates a keyed parent while compiling its stable row component", async () => {
     const result = await compile(`
       import { useState } from "react";
       export function List(props) {
@@ -68,13 +69,8 @@ describe("React AOT compiler safety boundaries", () => {
       }
     `);
 
-    expect(result.compiled).toEqual(["Row"]);
-    expect(result.diagnostics).toEqual([
-      expect.objectContaining({
-        component: "List",
-        reason: expect.stringMatching(/dynamic child structures/i),
-      }),
-    ]);
+    expect(result.compiled).toEqual(["List", "Row"]);
+    expect(result.diagnostics).toEqual([]);
     expect(result.code).toContain("createCompiledComponent");
   });
 
@@ -294,7 +290,7 @@ describe("React AOT compiler safety boundaries", () => {
     `);
 
     expect(result.compiled).toEqual([]);
-    expect(result.diagnostics[0]?.reason).toMatch(/dynamic child structures/i);
+    expect(result.diagnostics[0]?.reason).toMatch(/Hooks cannot be called directly/i);
   });
 
   it.each([

--- a/packages/farm-react/src/__tests__/compiler-keyed-lists.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-lists.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true);
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/KeyedLists.tsx", infer);
+}
+
+describe("React AOT keyed list compiler", () => {
+  it("automatically isolates a direct keyed map", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inventory() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
+        return (
+          <section>
+            <button onClick={() => setItems((current) => [...current, { id: "b", label: "Beta" }])}>
+              Add
+            </button>
+            <ul>
+              {items.map((item) => <li key={item.id}>{item.label}</li>)}
+            </ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).toContain('kind: "block"');
+    expect(result.code).toContain("dependencies: [0]");
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedLists.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("farmBlocks.KeyedList"),
+    });
+  });
+
+  it("isolates an aliased public List with a custom row component", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List as Keyed } from "@farm.js/react/list";
+      import { InventoryRow } from "./inventory-row";
+
+      export function Inventory() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
+        return (
+          <section>
+            <button onClick={() => setItems((current) => [...current].reverse())}>Reverse</button>
+            <ul>
+              <Keyed each={items} by={(item) => item.id}>
+                {(item) => <InventoryRow item={item} />}
+              </Keyed>
+            </ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).toContain("<Keyed each=");
+    expect(result.code).toContain("dependencies: [0]");
+  });
+
+  it.each([
+    {
+      name: "a missing key",
+      list: "items.map((item) => <li>{item.label}</li>)",
+      reason: /explicit item key/i,
+    },
+    {
+      name: "an index key",
+      list: "items.map((item, index) => <li key={index}>{item.label}</li>)",
+      reason: /cannot depend on the array index/i,
+    },
+    {
+      name: "a constant key",
+      list: 'items.map((item) => <li key="row">{item.label}</li>)',
+      reason: /must depend on the mapped item/i,
+    },
+    {
+      name: "a collection call chain",
+      list: "items.filter((item) => item.visible).map((item) => <li key={item.id}>{item.label}</li>)",
+      reason: /collection cannot use function calls/i,
+    },
+  ])("falls back for $name", async ({ list, reason }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function UnsupportedList() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha", visible: true }]);
+        return <ul onClick={() => setItems([...items])}>{${list}}</ul>;
+      }
+    `);
+
+    expect(result.compiled).toEqual([]);
+    expect(result.diagnostics[0]?.reason).toMatch(reason);
+  });
+
+  it("falls back when the list shares a container with another child", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function MixedList() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
+        return (
+          <ul onClick={() => setItems([...items])}>
+            <li>Static row</li>
+            {items.map((item) => <li key={item.id}>{item.label}</li>)}
+          </ul>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual([]);
+    expect(result.diagnostics[0]?.reason).toMatch(/only child of its host container/i);
+  });
+
+  it("falls back for an index-based explicit List key", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List } from "@farm.js/react/list";
+      export function IndexedList() {
+        const [items, setItems] = useState(["Alpha"]);
+        return (
+          <ul onClick={() => setItems([...items])}>
+            <List each={items} by={(_item, index) => index}>
+              {(item) => <li>{item}</li>}
+            </List>
+          </ul>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual([]);
+    expect(result.diagnostics[0]?.reason).toMatch(/cannot depend on the array index/i);
+  });
+
+  it("does not treat a locally named List as the public primitive", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      function List() { return <li>Local</li>; }
+      export function LocalList() {
+        const [active, setActive] = useState(false);
+        return <ul onClick={() => setActive(!active)}><List /></ul>;
+      }
+    `);
+
+    expect(result.compiled).toEqual([]);
+    expect(result.diagnostics.find((entry) => entry.component === "LocalList")?.reason).toMatch(
+      /host elements only/i,
+    );
+  });
+
+  it("assigns unique boundary ids when conditions and lists coexist", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function MixedBoundaries() {
+        const [visible, setVisible] = useState(true);
+        const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
+        return (
+          <section>
+            <button onClick={() => setVisible(!visible)}>Toggle</button>
+            <button onClick={() => setItems([...items].reverse())}>Reverse</button>
+            <div>{visible && <p>Visible</p>}</div>
+            <ul>{items.map((item) => <li key={item.id}>{item.label}</li>)}</ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["MixedBoundaries"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.Conditional");
+    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).toContain("id={0}");
+    expect(result.code).toContain("id={1}");
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-lists.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-lists.test.tsx
@@ -1,0 +1,397 @@
+import React, { StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createCompiledComponent, type CompilerStateUpdater } from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Item {
+  id: string;
+  label: string;
+}
+
+const roots: Array<{ unmount(): void }> = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("compiled React keyed list runtime", () => {
+  it("reorders and updates keyed rows without executing the outer component", async () => {
+    let executions = 0;
+    let listRenders = 0;
+    const Panel = createCompiledComponent({
+      displayName: "KeyedInventory",
+      initialize: () => [
+        [
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Beta" },
+          { id: "c", label: "Gamma" },
+        ],
+        0,
+      ],
+      render(_props: Record<string, never>, state, blocks) {
+        executions += 1;
+        const KeyedList = blocks.KeyedList;
+        return (
+          <section>
+            <button
+              data-action="reverse"
+              onClick={() => state[0].set((value) => [...(value as Item[])].reverse())}
+            >
+              Reverse
+            </button>
+            <button
+              data-action="rename"
+              onClick={() =>
+                state[0].set((value) =>
+                  (value as Item[]).map((item) =>
+                    item.id === "b" ? { ...item, label: "Bravo" } : item,
+                  ),
+                )
+              }
+            >
+              Rename
+            </button>
+            <button
+              data-action="unrelated"
+              onClick={() => state[1].set((value) => Number(value) + 1)}
+            >
+              Unrelated
+            </button>
+            <ul>
+              <KeyedList
+                id={0}
+                render={() => {
+                  listRenders += 1;
+                  return (state[0].get() as Item[]).map((item) => (
+                    <li data-key={item.id} key={item.id}>
+                      {item.label}
+                    </li>
+                  ));
+                }}
+              />
+            </ul>
+            <output>{Number(state[1].get())}</output>
+          </section>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        {
+          kind: "text",
+          path: [4],
+          dependencies: [1],
+          read: (_props, state) => state[1].get(),
+        },
+      ],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Panel />));
+
+    const rows = () => [...container.querySelectorAll<HTMLLIElement>("li")];
+    const original = new Map(rows().map((row) => [row.dataset.key, row]));
+    expect(executions).toBe(1);
+    expect(listRenders).toBe(1);
+
+    await act(async () => {
+      container.querySelector<HTMLElement>("[data-action='unrelated']")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("output")?.textContent).toBe("1");
+    expect(listRenders).toBe(1);
+
+    await act(async () => {
+      container.querySelector<HTMLElement>("[data-action='reverse']")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(rows().map((row) => row.dataset.key)).toEqual(["c", "b", "a"]);
+    for (const row of rows()) expect(row).toBe(original.get(row.dataset.key));
+
+    await act(async () => {
+      container.querySelector<HTMLElement>("[data-action='rename']")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(rows().map((row) => row.textContent)).toEqual(["Gamma", "Bravo", "Alpha"]);
+    expect(executions).toBe(1);
+    expect(listRenders).toBe(3);
+  });
+
+  it("preserves state in a custom keyed row while the compiled boundary reorders", async () => {
+    function Row({ item }: { item: Item }) {
+      const [clicks, setClicks] = useState(0);
+      return (
+        <button data-key={item.id} onClick={() => setClicks((value) => value + 1)}>
+          {item.label}:{clicks}
+        </button>
+      );
+    }
+
+    const ListPanel = createCompiledComponent({
+      displayName: "StatefulRows",
+      initialize: () => [
+        [
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Beta" },
+        ],
+      ],
+      render(_props: Record<string, never>, state, blocks) {
+        const KeyedList = blocks.KeyedList;
+        return (
+          <section>
+            <button
+              data-action="reverse"
+              onClick={() => state[0].set((value) => [...(value as Item[])].reverse())}
+            >
+              Reverse
+            </button>
+            <div>
+              <KeyedList
+                id={0}
+                render={() =>
+                  (state[0].get() as Item[]).map((item) => <Row item={item} key={item.id} />)
+                }
+              />
+            </div>
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<ListPanel />));
+    await act(async () => container.querySelector<HTMLElement>("[data-key='a']")!.click());
+    expect(container.querySelector("[data-key='a']")?.textContent).toBe("Alpha:1");
+
+    await act(async () => {
+      container.querySelector<HTMLElement>("[data-action='reverse']")!.click();
+      await flushCompilerUpdates();
+    });
+    const rows = [...container.querySelectorAll<HTMLElement>("[data-key]")];
+    expect(rows.map((row) => row.textContent)).toEqual(["Beta:0", "Alpha:1"]);
+  });
+
+  it("hydrates keyed rows and drops a queued refresh after unmount", async () => {
+    const errors: unknown[] = [];
+    const Inventory = createCompiledComponent({
+      displayName: "HydratedInventory",
+      initialize: () => [[{ id: "a", label: "Alpha" }]],
+      render(_props: Record<string, never>, state, blocks) {
+        const KeyedList = blocks.KeyedList;
+        return (
+          <section>
+            <button
+              onClick={() =>
+                state[0].set((value) => [...(value as Item[]), { id: "b", label: "Beta" }])
+              }
+            >
+              Add
+            </button>
+            <ul>
+              <KeyedList
+                id={0}
+                render={() =>
+                  (state[0].get() as Item[]).map((item) => <li key={item.id}>{item.label}</li>)
+                }
+              />
+            </ul>
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(<Inventory />);
+    document.body.append(container);
+    await act(async () => {
+      const root = hydrateRoot(container, <Inventory />, {
+        onRecoverableError: (error) => errors.push(error),
+      });
+      roots.push(root);
+    });
+    expect(errors).toEqual([]);
+    expect(container.querySelector("ul")?.textContent).toBe("Alpha");
+
+    const root = roots.pop()!;
+    await act(async () => {
+      container.querySelector("button")!.click();
+      root.unmount();
+      await flushCompilerUpdates();
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it("keeps subscriptions safe under StrictMode", async () => {
+    const Inventory = createCompiledComponent({
+      displayName: "StrictInventory",
+      initialize: () => [[{ id: "a", label: "Alpha" }]],
+      render(_props: Record<string, never>, state, blocks) {
+        const KeyedList = blocks.KeyedList;
+        return (
+          <section>
+            <button onClick={() => state[0].set([])}>Clear</button>
+            <ul>
+              <KeyedList
+                id={0}
+                render={() =>
+                  (state[0].get() as Item[]).map((item) => <li key={item.id}>{item.label}</li>)
+                }
+              />
+            </ul>
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <StrictMode>
+          <Inventory />
+        </StrictMode>,
+      ),
+    );
+    await act(async () => {
+      container.querySelector("button")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelectorAll("li")).toHaveLength(0);
+  });
+
+  it("matches normal React through 1,000 deterministic collection operations", async () => {
+    type Update = (items: Item[]) => Item[];
+    let compiledSet: (next: CompilerStateUpdater) => void = () => undefined;
+    let normalSet: React.Dispatch<React.SetStateAction<Item[]>> = () => undefined;
+    let compiledExecutions = 0;
+
+    const initial: Item[] = [
+      { id: "a", label: "A" },
+      { id: "b", label: "B" },
+      { id: "c", label: "C" },
+    ];
+    const Compiled = createCompiledComponent({
+      displayName: "RandomKeyedList",
+      initialize: () => [initial],
+      render(_props: Record<string, never>, state, blocks) {
+        compiledExecutions += 1;
+        compiledSet = (next) => state[0].set(next);
+        const KeyedList = blocks.KeyedList;
+        return (
+          <ul>
+            <KeyedList
+              id={0}
+              render={() =>
+                (state[0].get() as Item[]).map((item) => (
+                  <li data-key={item.id} key={item.id}>
+                    {item.label}
+                  </li>
+                ))
+              }
+            />
+          </ul>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    function Normal() {
+      const [items, setItems] = useState(initial);
+      normalSet = setItems;
+      return (
+        <ul>
+          {items.map((item) => (
+            <li data-key={item.id} key={item.id}>
+              {item.label}
+            </li>
+          ))}
+        </ul>
+      );
+    }
+
+    let seed = 0x51f15e;
+    let nextId = 0;
+    const random = () => {
+      seed = (seed * 1664525 + 1013904223) >>> 0;
+      return seed;
+    };
+    const updates: Update[] = Array.from({ length: 1000 }, () => {
+      const operation = random() % 5;
+      const selector = random();
+      const id = `n${nextId++}`;
+      if (operation === 0) return (items) => [...items, { id, label: id.toUpperCase() }];
+      if (operation === 1) return (items) => [{ id, label: id.toUpperCase() }, ...items];
+      if (operation === 2) {
+        return (items) =>
+          items.length === 0
+            ? items
+            : items.filter((_, index) => index !== selector % items.length);
+      }
+      if (operation === 3) return (items) => [...items].reverse();
+      return (items) =>
+        items.length === 0
+          ? items
+          : items.map((item, index) =>
+              index === selector % items.length ? { ...item, label: `${item.label}!` } : item,
+            );
+    });
+
+    const compiledContainer = document.createElement("div");
+    const normalContainer = document.createElement("div");
+    document.body.append(compiledContainer, normalContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const normalRoot = createRoot(normalContainer);
+    roots.push(compiledRoot, normalRoot);
+    await act(async () => {
+      compiledRoot.render(<Compiled />);
+      normalRoot.render(<Normal />);
+    });
+
+    for (let offset = 0; offset < updates.length; offset += 10) {
+      await act(async () => {
+        for (const update of updates.slice(offset, offset + 10)) {
+          compiledSet((value) => update(value as Item[]));
+          normalSet(update);
+        }
+        await flushCompilerUpdates();
+      });
+      const compiledRows = [...compiledContainer.querySelectorAll("li")].map((row) => [
+        row.getAttribute("data-key"),
+        row.textContent,
+      ]);
+      const normalRows = [...normalContainer.querySelectorAll("li")].map((row) => [
+        row.getAttribute("data-key"),
+        row.textContent,
+      ]);
+      expect(compiledRows).toEqual(normalRows);
+    }
+    expect(compiledExecutions).toBe(1);
+  });
+});

--- a/packages/farm-react/src/__tests__/list.test.tsx
+++ b/packages/farm-react/src/__tests__/list.test.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { List } from "../list";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+const roots: Array<{ unmount(): void }> = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+});
+
+describe("List", () => {
+  it("renders iterable values and preserves keyed child state across reorders", async () => {
+    function Row({ name }: { name: string }) {
+      const [clicks, setClicks] = useState(0);
+      return (
+        <button onClick={() => setClicks((value) => value + 1)}>
+          {name}:{clicks}
+        </button>
+      );
+    }
+
+    function Example() {
+      const [items, setItems] = useState(
+        new Set([
+          { id: "a", name: "Alpha" },
+          { id: "b", name: "Beta" },
+        ]),
+      );
+      return (
+        <section>
+          <button data-action="reverse" onClick={() => setItems(new Set([...items].reverse()))}>
+            Reverse
+          </button>
+          <List each={items} by={(item) => item.id}>
+            {(item) => <Row name={item.name} />}
+          </List>
+        </section>
+      );
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Example />));
+
+    const rowButtons = () => [...container.querySelectorAll("button:not([data-action])")];
+    await act(async () =>
+      rowButtons()[0].dispatchEvent(new MouseEvent("click", { bubbles: true })),
+    );
+    expect(rowButtons().map((button) => button.textContent)).toEqual(["Alpha:1", "Beta:0"]);
+
+    await act(async () =>
+      container
+        .querySelector<HTMLElement>("[data-action='reverse']")!
+        .dispatchEvent(new MouseEvent("click", { bubbles: true })),
+    );
+    expect(rowButtons().map((button) => button.textContent)).toEqual(["Beta:0", "Alpha:1"]);
+  });
+
+  it("treats nullish collections as empty", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <ul>
+          <List each={null} by={(item: string) => item}>
+            {(item) => <li>{item}</li>}
+          </List>
+        </ul>,
+      ),
+    );
+    expect(container.querySelectorAll("li")).toHaveLength(0);
+  });
+});

--- a/packages/farm-react/src/__tests__/vite.test.ts
+++ b/packages/farm-react/src/__tests__/vite.test.ts
@@ -80,11 +80,11 @@ describe("React renderer Vite integration", () => {
     expect(report.summary).toEqual({
       modules: 1,
       componentsConsidered: 2,
-      compiled: 1,
-      fallback: 1,
+      compiled: 2,
+      fallback: 0,
     });
-    expect(report.modules[0].compiled).toEqual(["Counter"]);
-    expect(report.modules[0].fallbacks[0].component).toBe("List");
+    expect(report.modules[0].compiled).toEqual(["Counter", "List"]);
+    expect(report.modules[0].fallbacks).toEqual([]);
 
     await writeFile(
       entry,

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -54,8 +54,14 @@ export interface CompilerConditionalBlockProps {
   render(): React.ReactNode;
 }
 
+export interface CompilerKeyedListBlockProps {
+  id: number;
+  render(): React.ReactNode;
+}
+
 export interface CompilerBlockRuntime {
   Conditional: React.ComponentType<CompilerConditionalBlockProps>;
+  KeyedList: React.ComponentType<CompilerKeyedListBlockProps>;
 }
 
 export type CompilerBinding<Props> =
@@ -363,6 +369,44 @@ function createConditionalBlockComponent(
   return FarmConditionalBlock;
 }
 
+function createKeyedListBlockComponent(
+  owner: Pick<ConditionalBlockOwner, "subscribe">,
+): React.ComponentType<CompilerKeyedListBlockProps> {
+  class FarmKeyedListBlock extends React.Component<CompilerKeyedListBlockProps> {
+    static displayName = "FarmCompiledKeyedListBlock";
+
+    private unsubscribe: (() => void) | undefined;
+
+    private refresh = (afterCommit?: () => void) => {
+      this.forceUpdate(afterCommit);
+    };
+
+    private subscribe(): void {
+      this.unsubscribe = owner.subscribe(this.props.id, this.refresh);
+    }
+
+    componentDidMount(): void {
+      this.subscribe();
+    }
+
+    componentDidUpdate(previous: CompilerKeyedListBlockProps): void {
+      if (previous.id === this.props.id) return;
+      this.unsubscribe?.();
+      this.subscribe();
+    }
+
+    componentWillUnmount(): void {
+      this.unsubscribe?.();
+    }
+
+    render(): React.ReactNode {
+      return this.props.render();
+    }
+  }
+
+  return FarmKeyedListBlock;
+}
+
 /**
  * Runtime target emitted by the AOT transform.
  *
@@ -425,6 +469,9 @@ export function createCompiledComponent<Props>(
       this.blockRuntime = {
         Conditional: createConditionalBlockComponent({
           setRoot: (id, root) => this.setBlockRoot(id, root),
+          subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
+        }),
+        KeyedList: createKeyedListBlockComponent({
           subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
         }),
       };

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -60,6 +60,13 @@ interface ConditionalBlockPlan {
   source: t.Expression;
 }
 
+interface KeyedListPlan {
+  id: number;
+  dependencies: number[];
+  source: t.Expression;
+  syntax: "map" | "list";
+}
+
 interface Candidate {
   name: string;
   path: NodePath<t.FunctionDeclaration | t.FunctionExpression | t.ArrowFunctionExpression>;
@@ -601,11 +608,316 @@ function lowerConditionalBlocks(
   return lowered;
 }
 
+function isMapCall(expression: t.Expression): expression is t.CallExpression {
+  return (
+    t.isCallExpression(expression) &&
+    t.isMemberExpression(expression.callee) &&
+    !expression.callee.computed &&
+    t.isExpression(expression.callee.object) &&
+    t.isIdentifier(expression.callee.property, { name: "map" })
+  );
+}
+
+function returnedExpression(
+  callback: t.ArrowFunctionExpression | t.FunctionExpression,
+): t.Expression | undefined {
+  if (t.isExpression(callback.body)) return callback.body;
+  if (callback.body.body.length !== 1 || !t.isReturnStatement(callback.body.body[0])) {
+    return undefined;
+  }
+  const value = callback.body.body[0].argument;
+  return value && t.isExpression(value) ? value : undefined;
+}
+
+function containsDirectHookCall(
+  callback: t.ArrowFunctionExpression | t.FunctionExpression,
+): boolean {
+  let found = false;
+  traverse(expressionFile(t.cloneNode(callback, true)), {
+    CallExpression(path) {
+      const callee = path.node.callee;
+      const name = t.isIdentifier(callee)
+        ? callee.name
+        : t.isMemberExpression(callee) && !callee.computed && t.isIdentifier(callee.property)
+          ? callee.property.name
+          : "";
+      if (/^use[A-Z0-9]/.test(name)) {
+        found = true;
+        path.stop();
+      }
+    },
+  });
+  return found;
+}
+
+function jsxKeyExpression(element: t.JSXElement): t.Expression | undefined {
+  for (const attribute of element.openingElement.attributes) {
+    if (!t.isJSXAttribute(attribute) || !t.isJSXIdentifier(attribute.name, { name: "key" })) {
+      continue;
+    }
+    if (t.isStringLiteral(attribute.value)) return t.stringLiteral(attribute.value.value);
+    if (
+      t.isJSXExpressionContainer(attribute.value) &&
+      !t.isJSXEmptyExpression(attribute.value.expression)
+    )
+      return attribute.value.expression;
+  }
+  return undefined;
+}
+
+function validateKeyFunction(
+  callback: t.ArrowFunctionExpression | t.FunctionExpression,
+  keyExpression: t.Expression,
+  safeGlobals: ReadonlySet<string>,
+): string | undefined {
+  if (
+    callback.async ||
+    callback.generator ||
+    callback.params.length < 1 ||
+    callback.params.length > 2 ||
+    !t.isIdentifier(callback.params[0]) ||
+    (callback.params[1] !== undefined && !t.isIdentifier(callback.params[1]))
+  ) {
+    return "keyed list callbacks must be synchronous and use item and optional index identifiers";
+  }
+  const item = callback.params[0].name;
+  const index = t.isIdentifier(callback.params[1]) ? callback.params[1].name : undefined;
+  if (index && referencesIdentifier(keyExpression, index)) {
+    return "keyed list keys cannot depend on the array index";
+  }
+  if (!referencesIdentifier(keyExpression, item)) {
+    return "keyed list keys must depend on the mapped item";
+  }
+  const unsupported = validateDerivedExpression(keyExpression, safeGlobals);
+  return unsupported ? `keyed list keys cannot use ${unsupported}` : undefined;
+}
+
+function isPublicListElement(element: t.JSXElement, listNames: ReadonlySet<string>): boolean {
+  const name = element.openingElement.name;
+  return t.isJSXIdentifier(name) && listNames.has(name.name);
+}
+
+function meaningfulJsxChildren(element: t.JSXElement): t.JSXElement["children"] {
+  return element.children.filter((child) => {
+    if (t.isJSXText(child)) return child.value.trim().length > 0;
+    return !(t.isJSXExpressionContainer(child) && t.isJSXEmptyExpression(child.expression));
+  });
+}
+
+function analyzeMapList(
+  expression: t.CallExpression,
+  statesByValue: ReadonlyMap<string, StateBinding>,
+  safeGlobals: ReadonlySet<string>,
+): { dependencies?: number[]; reason?: string } {
+  const callee = expression.callee as t.MemberExpression;
+  const collection = callee.object as t.Expression;
+  const collectionUnsupported = validateDerivedExpression(collection, safeGlobals);
+  if (collectionUnsupported) {
+    return { reason: `keyed list collection cannot use ${collectionUnsupported}` };
+  }
+  if (
+    expression.arguments.length !== 1 ||
+    (!t.isArrowFunctionExpression(expression.arguments[0]) &&
+      !t.isFunctionExpression(expression.arguments[0]))
+  ) {
+    return { reason: "keyed list map must use one inline render callback" };
+  }
+  const callback = expression.arguments[0];
+  if (containsDirectHookCall(callback)) {
+    return { reason: "Hooks cannot be called directly inside a keyed list callback" };
+  }
+  const row = returnedExpression(callback);
+  if (!row || !t.isJSXElement(row)) {
+    return { reason: "keyed list map callbacks must return one React element" };
+  }
+  const key = jsxKeyExpression(row);
+  if (!key) return { reason: "automatically compiled lists require an explicit item key" };
+  const keyReason = validateKeyFunction(callback, key, safeGlobals);
+  if (keyReason) return { reason: keyReason };
+  return { dependencies: collectStateDependencies(expression, statesByValue) };
+}
+
+function listAttributeExpression(element: t.JSXElement, name: string): t.Expression | undefined {
+  for (const attribute of element.openingElement.attributes) {
+    if (
+      t.isJSXAttribute(attribute) &&
+      t.isJSXIdentifier(attribute.name, { name }) &&
+      t.isJSXExpressionContainer(attribute.value) &&
+      !t.isJSXEmptyExpression(attribute.value.expression)
+    ) {
+      return attribute.value.expression;
+    }
+  }
+  return undefined;
+}
+
+function analyzePublicList(
+  element: t.JSXElement,
+  statesByValue: ReadonlyMap<string, StateBinding>,
+  safeGlobals: ReadonlySet<string>,
+): { dependencies?: number[]; reason?: string } {
+  if (element.openingElement.attributes.some((attribute) => t.isJSXSpreadAttribute(attribute))) {
+    return { reason: "compiled List boundaries do not support JSX attribute spreads" };
+  }
+  const each = listAttributeExpression(element, "each");
+  const by = listAttributeExpression(element, "by");
+  if (!each || !by) return { reason: "List requires explicit each and by properties" };
+  const collectionUnsupported = validateDerivedExpression(each, safeGlobals);
+  if (collectionUnsupported) {
+    return { reason: `List each cannot use ${collectionUnsupported}` };
+  }
+  if (!t.isArrowFunctionExpression(by) && !t.isFunctionExpression(by)) {
+    return { reason: "compiled List by must use an inline key function" };
+  }
+  const key = returnedExpression(by);
+  if (!key) return { reason: "compiled List by must return one key expression" };
+  const keyReason = validateKeyFunction(by, key, safeGlobals);
+  if (keyReason) return { reason: keyReason };
+
+  const children = meaningfulJsxChildren(element);
+  if (
+    children.length !== 1 ||
+    !t.isJSXExpressionContainer(children[0]) ||
+    t.isJSXEmptyExpression(children[0].expression) ||
+    (!t.isArrowFunctionExpression(children[0].expression) &&
+      !t.isFunctionExpression(children[0].expression))
+  ) {
+    return { reason: "compiled List children must use one inline render function" };
+  }
+  const render = children[0].expression;
+  if (!returnedExpression(render)) {
+    return { reason: "compiled List children must return one React element" };
+  }
+  if (containsDirectHookCall(render)) {
+    return { reason: "Hooks cannot be called directly inside List children" };
+  }
+  return { dependencies: collectStateDependencies(element, statesByValue) };
+}
+
+function analyzeKeyedLists(
+  root: t.JSXElement,
+  statesByValue: ReadonlyMap<string, StateBinding>,
+  safeGlobals: ReadonlySet<string>,
+  listNames: ReadonlySet<string>,
+  startingId: number,
+): { lists?: KeyedListPlan[]; reason?: string } {
+  const lists: KeyedListPlan[] = [];
+
+  const visit = (element: t.JSXElement): string | undefined => {
+    const meaningful = meaningfulJsxChildren(element);
+    for (const child of element.children) {
+      if (t.isJSXElement(child) && isPublicListElement(child, listNames)) {
+        if (meaningful.length !== 1) {
+          return "a compiled keyed list must be the only child of its host container";
+        }
+        const result = analyzePublicList(child, statesByValue, safeGlobals);
+        if (result.reason) return result.reason;
+        lists.push({
+          id: startingId + lists.length,
+          dependencies: result.dependencies || [],
+          source: child,
+          syntax: "list",
+        });
+        continue;
+      }
+      if (t.isJSXElement(child)) {
+        const reason = visit(child);
+        if (reason) return reason;
+        continue;
+      }
+      if (
+        !t.isJSXExpressionContainer(child) ||
+        t.isJSXEmptyExpression(child.expression) ||
+        !isMapCall(child.expression)
+      ) {
+        continue;
+      }
+      if (meaningful.length !== 1) {
+        return "a compiled keyed list must be the only child of its host container";
+      }
+      const result = analyzeMapList(child.expression, statesByValue, safeGlobals);
+      if (result.reason) return result.reason;
+      lists.push({
+        id: startingId + lists.length,
+        dependencies: result.dependencies || [],
+        source: child.expression,
+        syntax: "map",
+      });
+    }
+    return undefined;
+  };
+
+  const reason = visit(root);
+  return reason ? { reason } : { lists };
+}
+
+function keyedListBoundary(
+  blockRuntime: t.Identifier,
+  plan: KeyedListPlan,
+  source: t.Expression,
+): t.JSXElement {
+  const name = t.jsxMemberExpression(
+    t.jsxIdentifier(blockRuntime.name),
+    t.jsxIdentifier("KeyedList"),
+  );
+  return t.jsxElement(
+    t.jsxOpeningElement(
+      name,
+      [
+        t.jsxAttribute(t.jsxIdentifier("id"), t.jsxExpressionContainer(t.numericLiteral(plan.id))),
+        t.jsxAttribute(
+          t.jsxIdentifier("render"),
+          t.jsxExpressionContainer(t.arrowFunctionExpression([], cloneExpression(source))),
+        ),
+      ],
+      true,
+    ),
+    null,
+    [],
+    true,
+  );
+}
+
+function lowerKeyedLists(
+  root: t.JSXElement,
+  plans: readonly KeyedListPlan[],
+  blockRuntime: t.Identifier,
+  listNames: ReadonlySet<string>,
+): t.JSXElement {
+  const lowered = t.cloneNode(root, true);
+  let cursor = 0;
+  const visit = (element: t.JSXElement): void => {
+    element.children = element.children.map((child) => {
+      if (t.isJSXElement(child) && isPublicListElement(child, listNames)) {
+        const plan = plans[cursor++];
+        return keyedListBoundary(blockRuntime, plan, child);
+      }
+      if (t.isJSXElement(child)) {
+        visit(child);
+        return child;
+      }
+      if (
+        t.isJSXExpressionContainer(child) &&
+        !t.isJSXEmptyExpression(child.expression) &&
+        isMapCall(child.expression)
+      ) {
+        const plan = plans[cursor++];
+        return keyedListBoundary(blockRuntime, plan, child.expression);
+      }
+      return child;
+    });
+  };
+  visit(lowered);
+  return lowered;
+}
+
 function analyzeHostTree(
   root: t.JSXElement,
   statesByValue: ReadonlyMap<string, StateBinding>,
   safeGlobals: ReadonlySet<string>,
   conditionalExpressions: ReadonlySet<t.Expression>,
+  keyedExpressions: ReadonlySet<t.Expression>,
+  keyedElements: ReadonlySet<t.JSXElement>,
 ): { bindings?: PendingBinding[]; reason?: string } {
   const bindings: PendingBinding[] = [];
 
@@ -685,8 +997,8 @@ function analyzeHostTree(
       });
     }
 
-    const nestedElements = element.children.filter((child): child is t.JSXElement =>
-      t.isJSXElement(child),
+    const nestedElements = element.children.filter(
+      (child): child is t.JSXElement => t.isJSXElement(child) && !keyedElements.has(child),
     );
     const expressionChildren = element.children.filter((child): child is t.JSXExpressionContainer =>
       t.isJSXExpressionContainer(child),
@@ -694,16 +1006,23 @@ function analyzeHostTree(
     for (const child of expressionChildren) {
       if (t.isJSXEmptyExpression(child.expression)) continue;
       if (conditionalExpressions.has(child.expression)) continue;
+      if (keyedExpressions.has(child.expression)) continue;
       if (!isTextExpression(child.expression, statesByValue, safeGlobals)) {
         return "dynamic child structures require React reconciliation";
       }
     }
 
-    const hasConditionalBlocks = expressionChildren.some(
-      (child) =>
-        !t.isJSXEmptyExpression(child.expression) && conditionalExpressions.has(child.expression),
+    const hasKeyedElement = element.children.some(
+      (child) => t.isJSXElement(child) && keyedElements.has(child),
     );
-    if (nestedElements.length === 0 && !hasConditionalBlocks) {
+    const hasDynamicBlocks =
+      hasKeyedElement ||
+      expressionChildren.some(
+        (child) =>
+          !t.isJSXEmptyExpression(child.expression) &&
+          (conditionalExpressions.has(child.expression) || keyedExpressions.has(child.expression)),
+      );
+    if (nestedElements.length === 0 && !hasDynamicBlocks) {
       const dependencies = new Set<number>();
       const parts: t.Expression[] = [];
       for (const child of element.children) {
@@ -730,6 +1049,7 @@ function analyzeHostTree(
         if (
           !t.isJSXEmptyExpression(child.expression) &&
           !conditionalExpressions.has(child.expression) &&
+          !keyedExpressions.has(child.expression) &&
           collectStateDependencies(child.expression, statesByValue).length > 0
         ) {
           return "mixed element and stateful text children are not supported yet";
@@ -737,7 +1057,7 @@ function analyzeHostTree(
       }
       let elementIndex = 0;
       for (const child of element.children) {
-        if (!t.isJSXElement(child)) continue;
+        if (!t.isJSXElement(child) || keyedElements.has(child)) continue;
         const reason = visit(child, [...path, elementIndex]);
         if (reason) return reason;
         elementIndex += 1;
@@ -883,6 +1203,7 @@ function compileCandidate(
   createComponentIdentifier: t.Identifier,
   useStateNames: ReadonlySet<string>,
   reactNames: ReadonlySet<string>,
+  listNames: ReadonlySet<string>,
   moduleId: string,
 ): string | undefined {
   const { path, name, statementPath } = candidate;
@@ -1019,12 +1340,29 @@ function compileCandidate(
   const conditionalAnalysis = analyzeConditionalBlocks(expandedRoot, statesByValue, safeGlobals);
   if (conditionalAnalysis.reason) return conditionalAnalysis.reason;
   const conditionalBlocks = conditionalAnalysis.blocks || [];
+  const keyedAnalysis = analyzeKeyedLists(
+    expandedRoot,
+    statesByValue,
+    safeGlobals,
+    listNames,
+    conditionalBlocks.length,
+  );
+  if (keyedAnalysis.reason) return keyedAnalysis.reason;
+  const keyedLists = keyedAnalysis.lists || [];
   const conditionalExpressions = new Set(conditionalBlocks.map((block) => block.source));
+  const keyedExpressions = new Set(
+    keyedLists.filter((list) => list.syntax === "map").map((list) => list.source),
+  );
+  const keyedElements = new Set(
+    keyedLists.filter((list) => list.syntax === "list").map((list) => list.source as t.JSXElement),
+  );
   const analysis = analyzeHostTree(
     expandedRoot,
     statesByValue,
     safeGlobals,
     conditionalExpressions,
+    keyedExpressions,
+    keyedElements,
   );
   if (analysis.reason) return analysis.reason;
 
@@ -1032,7 +1370,8 @@ function compileCandidate(
   const blockParameter = path.scope.generateUidIdentifier("farmBlocks");
   const definitionIdentifier = path.scope.generateUidIdentifier(`${name}Compiled`);
   const propsParameter = propsPlan.definitionParameter;
-  const rootWithBlocks = lowerConditionalBlocks(expandedRoot, conditionalBlocks, blockParameter);
+  const rootWithLists = lowerKeyedLists(expandedRoot, keyedLists, blockParameter, listNames);
+  const rootWithBlocks = lowerConditionalBlocks(rootWithLists, conditionalBlocks, blockParameter);
   const rewrittenRoot = rewriteStateAccess(
     rootWithBlocks,
     stateParameter,
@@ -1093,6 +1432,11 @@ function compileCandidate(
               kind: "block" as const,
               id: block.id,
               dependencies: block.dependencies,
+            })),
+            ...keyedLists.map((list) => ({
+              kind: "block" as const,
+              id: list.id,
+              dependencies: list.dependencies,
             })),
           ].map((binding) =>
             bindingObject(binding, propsParameter, stateParameter, statesByValue, statesBySetter),
@@ -1175,8 +1519,21 @@ export async function compileReactModule(
         const moduleDirectives = new Set(directiveValues(programPath.node));
         const useStateNames = new Set<string>();
         const reactNames = new Set<string>();
+        const listNames = new Set<string>();
         for (const statement of programPath.node.body) {
-          if (!t.isImportDeclaration(statement) || statement.source.value !== "react") continue;
+          if (!t.isImportDeclaration(statement)) continue;
+          if (statement.source.value === "@farm.js/react/list") {
+            for (const specifier of statement.specifiers) {
+              if (
+                t.isImportSpecifier(specifier) &&
+                t.isIdentifier(specifier.imported, { name: "List" })
+              ) {
+                listNames.add(specifier.local.name);
+              }
+            }
+            continue;
+          }
+          if (statement.source.value !== "react") continue;
           for (const specifier of statement.specifiers) {
             if (t.isImportDefaultSpecifier(specifier) || t.isImportNamespaceSpecifier(specifier)) {
               reactNames.add(specifier.local.name);
@@ -1208,6 +1565,7 @@ export async function compileReactModule(
             createComponentIdentifier,
             useStateNames,
             reactNames,
+            listNames,
             id,
           );
           if (reason) {

--- a/packages/farm-react/src/list.tsx
+++ b/packages/farm-react/src/list.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+export interface ListProps<Item> {
+  /** Items to render. Nullish collections are treated as empty. */
+  each: Iterable<Item> | null | undefined;
+  /** Returns the stable React key for one item. */
+  by(item: Item, index: number): React.Key;
+  /** Renders one keyed row. */
+  children(item: Item, index: number): React.ReactElement;
+}
+
+/**
+ * An explicit keyed collection boundary for advanced list expressions.
+ *
+ * It behaves like ordinary React when the compiler is disabled. With the
+ * experimental compiler enabled, eligible usages are isolated so local list
+ * updates do not execute the surrounding user component.
+ */
+export function List<Item>({ each, by, children }: ListProps<Item>): React.ReactElement {
+  const rows = each ? Array.from(each) : [];
+  return React.createElement(
+    React.Fragment,
+    null,
+    ...rows.map((item, index) => {
+      const row = children(item, index);
+      if (!React.isValidElement(row)) {
+        throw new TypeError("@farm.js/react List children must return one React element.");
+      }
+      return React.cloneElement(row, { key: by(item, index) } as React.Attributes);
+    }),
+  );
+}

--- a/packages/farm-react/tsup.config.ts
+++ b/packages/farm-react/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     server: "src/server.ts",
     client: "src/client.ts",
     "compiler-runtime": "src/compiler-runtime.tsx",
+    list: "src/list.tsx",
     vite: "src/vite.ts",
   },
   format: ["cjs", "esm"],


### PR DESCRIPTION
## Summary

- automatically detect safe direct keyed `collection.map(...)` expressions
- add an explicit `List` primitive from `@farm.js/react/list` for custom and stateful rows
- isolate eligible list updates in a private React-owned compiler boundary
- preserve React key identity, reconciliation, events, lifecycle, SSR, and hydration
- fall back to normal React for unkeyed, index-keyed, chained, mixed-sibling, or otherwise unsupported list shapes
- document the automatic and explicit APIs, safety limits, ownership model, and future LIS direction
- extend the compiler example with automatic and explicit interactive keyed-list experiments

## Why

The initial AOT compiler could patch static bindings and refresh conditional blocks without rerunning the surrounding user component, but dynamic keyed lists still forced the complete component back onto the React path. This adds a safe intermediate optimization: the compiler isolates the list update while React remains the sole owner of row reconciliation and DOM/Fiber identity.

## Validation

- `pnpm --filter @farm.js/react test` — 110 tests passed
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react build`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8
- `pnpm --filter farm-react-compiler-example type-check`
- `pnpm --filter farm-react-compiler-example experiment` — production browser assertions passed
- 1,000 deterministic randomized collection operations matched normal React
- package/docs lint and formatting checks
- full docs production build


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds keyed list boundaries to the React AOT compiler so list updates don’t re-execute the outer component. Previously, keyed lists forced the whole component onto React; now direct item-keyed maps and explicit `List` boundaries refresh a small React-owned region while React preserves key identity, reconciliation, events, SSR, and hydration.

- Automatically recognizes direct `collection.map(item => <Row key={item.id} />)` and supports an explicit `List` from `@farm.js/react/list`.
- Lowers eligible lists to an internal `KeyedList` boundary with dependency tracking; React remains the sole owner of DOM/Fiber and list reconciliation (no compiler-owned LIS moves).
- Falls back for unkeyed/index-keyed/chained maps, mixed siblings in the same container, JSX spreads, or Hook calls inside map/List callbacks.
- Adds a new public export `@farm.js/react/list` (`each` accepts Iterable|null|undefined; `by` supplies keys); works as ordinary React when the compiler is off.
- Updates docs, examples, and tests; adds compatibility checks for React 18.3 and 19.2.

**Adoption**
- Use `List` for custom or stateful rows and supply a stable item-derived key via `by`.
- Ensure the keyed list is the only meaningful child of its host container to opt into the boundary.
- Do not call Hooks inside `.map` or `List` child functions; put Hooks in a keyed row component.
- Replace index keys if you want the optimization; unsupported shapes continue to run on React without behavior changes.

<sup>Written for commit 5c47858ecd12a236b84450b660bef50c48e5d169. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

