### PR TITLE
feat(react): add compiled component islands

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -331,12 +331,13 @@ satisfy all of these rules:
 | Body                | Top-level `useState` declarations, optional compiler-safe derived values and synchronous named handlers, then one unconditional JSX return. |
 | State               | `const [value, setValue] = useState(initial)`, including lazy initializers, multiple cells, and queued functional updates.                  |
 | Root                | Exactly one lowercase host JSX element such as `button`, `section`, `input`, or `div`.                                                      |
-| Tree                | A statically known host tree. Eligible conditional and keyed-list boundaries may change one compiler-isolated child location.               |
+| Tree                | A statically known host tree around eligible conditional, keyed-list, and React component-island boundaries.                                |
 | Text bindings       | State-driven text in a leaf host element.                                                                                                   |
 | Attribute bindings  | Basic attributes, controlled form properties, and individual properties in one inline `style` object.                                       |
 | Events              | Inline handlers and synchronous `const` or function-declaration handlers, used directly or called inside an inline JSX handler.             |
 | Conditional blocks  | `condition && <host />` or `condition ? <host /> : <host />`; `null` and `false` are supported empty ternary branches.                      |
 | Keyed lists         | A direct keyed `items.map(...)`, or an explicit imported `List`, when it is the only meaningful child of its host container.                |
+| Component islands   | Stable imported or module-level component identifiers with explicit compiler-safe props and no JSX children, spread, `ref`, or `key`.       |
 
 This component is eligible:
 
@@ -514,8 +515,8 @@ The first automatic contract is deliberately narrow:
   across insertion, removal, or reordering.
 - The optimized `List` shape uses inline `by` and child functions, a compiler-safe `each`
   expression, and an item-derived key.
-- The map or `List` must be the only meaningful child of its host container. This keeps all
-  compiler-prepared DOM paths outside the boundary stable.
+- The map or `List` must be the only meaningful child of its host container. This keeps the first
+  keyed-boundary contract narrow and easy to audit.
 - Chained expressions such as `items.filter(...).map(...)`, mixed static siblings, spread children,
   hooks in the callback, and other unproven shapes fall back to normal React.
 
@@ -524,24 +525,73 @@ Farm does not implement an LIS move algorithm in this release. A compiler-owned 
 safe after the compiler owns an entire host-only list island; this boundary intentionally keeps
 React as the sole DOM and Fiber owner.
 
+### React component islands
+
+Ordinary child components can stay under React while the compiler owns the surrounding update
+graph:
+
+```tsx
+import { Chart } from "./chart";
+import { Header } from "./header";
+
+export function Dashboard() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <main>
+      <Header title="Dashboard" />
+      <button onClick={() => setCount((value) => value + 1)}>Count: {count}</button>
+      <Chart value={count} />
+    </main>
+  );
+}
+```
+
+`Header` has no dependency on `count`, so a compiled local update leaves it mounted without
+rendering it again. `Chart` depends on `count`, so the compiler replaces that location with a small
+internal component boundary and records the exact state dependency. When `count` changes, the
+button binding is patched directly and only the `Chart` boundary asks React to update. The
+`Dashboard` function does not execute again.
+
+This does not compile or inspect `Chart`. React continues to own its render, Hooks, context, local
+state, effects, events, lifecycle, reconciliation, errors, SSR, and hydration. Keeping the same
+component type and boundary position preserves child state across parent-cell updates. Context
+updates still reach consumers inside the island even when the compiled owner is memoized.
+
+The first supported shape is intentionally conservative:
+
+- The component name is one direct imported or module-level identifier such as `Chart`.
+- Props are explicit strings, booleans, or compiler-safe expressions. Inline event handlers may
+  call supported setters.
+- A prop that depends on local compiler state makes the component a subscribed island. A component
+  with no local-state dependency remains an ordinary, unchanged React child.
+- The child may internally return `null`, fragments, multiple elements, or other components.
+- JSX children, spreads, `ref`, `key`, member expressions such as `UI.Chart`, prop-selected dynamic
+  component types, render props, and inline object/array/JSX values fall back to normal React.
+
+Direct DOM bindings now use generated private callback refs instead of depending only on sibling
+indexes. This matters when an earlier React-owned child changes its number of DOM nodes: the
+compiler still holds the exact target element and cannot accidentally patch a different sibling.
+The refs produce no `data-*` marker or other extra server markup.
+
 ### What falls back to React
 
-| Unsupported shape                                                        | Why React keeps ownership                                                           |
-| ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
-| Unkeyed/index-keyed/chained maps, mixed list siblings, or element arrays | Their structure or item identity is outside the isolated keyed-boundary contract.   |
-| Fragments or unsupported/nested conditional JSX                          | Their structure is outside the current single-location host-block contract.         |
-| Custom child components outside an eligible keyed-list boundary          | A child component has its own props, hooks, lifecycle, and reconciliation boundary. |
-| Effects or hooks other than the supported `useState` shape               | Their lifecycle and ordering must remain under React's hook dispatcher.             |
-| `ref` or `dangerouslySetInnerHTML`                                       | They directly participate in DOM ownership.                                         |
-| Stateful `children` or `key` bindings outside an eligible boundary       | These need structure or identity semantics.                                         |
-| Conditional style objects, style spreads, methods, or computed names     | The final property set or precedence cannot be prepared statically.                 |
-| JSX attribute spreads or namespaced attributes                           | The compiler cannot currently enumerate a stable binding contract.                  |
-| Multiple/conditional returns or impure/control-flow statements           | The compiler only lowers a single, statically analyzable render path.               |
-| Derived calls, assignments, identity-bearing values, functions, or JSX   | Their evaluation timing, side effects, or identity cannot yet be preserved safely.  |
-| Nested, computed, or rest props destructuring                            | These patterns need additional parameter-shape and identity analysis.               |
-| Async/generator/generic handlers or named handlers outside JSX events    | Their scheduling, identity, or closure semantics are outside the current lowering.  |
-| Async/generator or generic components                                    | These function shapes are outside the current lowering.                             |
-| Setters called outside JSX event handlers                                | The compiler only controls and batches event-driven local updates.                  |
+| Unsupported shape                                                          | Why React keeps ownership                                                          |
+| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Unkeyed/index-keyed/chained maps, mixed list siblings, or element arrays   | Their structure or item identity is outside the isolated keyed-boundary contract.  |
+| Fragments or unsupported/nested conditional JSX                            | Their structure is outside the current single-location host-block contract.        |
+| Dynamic/member component types, component spreads, refs, keys, or children | Their identity or ownership is outside the first component-island contract.        |
+| Effects or hooks other than the supported `useState` shape                 | Their lifecycle and ordering must remain under React's hook dispatcher.            |
+| `ref` or `dangerouslySetInnerHTML`                                         | They directly participate in DOM ownership.                                        |
+| Stateful `children` or `key` bindings outside an eligible boundary         | These need structure or identity semantics.                                        |
+| Conditional style objects, style spreads, methods, or computed names       | The final property set or precedence cannot be prepared statically.                |
+| JSX attribute spreads or namespaced attributes                             | The compiler cannot currently enumerate a stable binding contract.                 |
+| Multiple/conditional returns or impure/control-flow statements             | The compiler only lowers a single, statically analyzable render path.              |
+| Derived calls, assignments, identity-bearing values, functions, or JSX     | Their evaluation timing, side effects, or identity cannot yet be preserved safely. |
+| Nested, computed, or rest props destructuring                              | These patterns need additional parameter-shape and identity analysis.              |
+| Async/generator/generic handlers or named handlers outside JSX events      | Their scheduling, identity, or closure semantics are outside the current lowering. |
+| Async/generator or generic components                                      | These function shapes are outside the current lowering.                            |
+| Setters called outside JSX event handlers                                  | The compiler only controls and batches event-driven local updates.                 |
 
 Keys do not make list reconciliation unnecessary. A key tells React which child identity survives
 an insert, removal, or move; React still compares the dynamic children. The compiler uses that
@@ -566,6 +616,7 @@ createCompiledComponent({
     {
       kind: "text",
       path: [],
+      target: 0,
       dependencies: [0],
       read: (_props, state) => ["Count: ", state[0].get()],
     },
@@ -582,16 +633,17 @@ do not receive the runtime import.
 The generated runtime wrapper is still a React component. Its responsibilities are split as
 follows:
 
-| React owns                                     | Compiler runtime owns                                           |
-| ---------------------------------------------- | --------------------------------------------------------------- |
-| Initial element creation and placement         | Local compiler-cell values                                      |
-| SSR markup and hydration                       | Queuing local setter calls into one microtask                   |
-| JSX event registration and dispatch            | Comparing flushed values with `Object.is`                       |
-| Parent-driven prop updates                     | Selecting bindings whose state dependencies changed             |
-| Unsupported trees, hooks, refs, and lifecycles | Patching precomputed text/attribute targets after local updates |
-| Host creation/removal inside an eligible block | Refreshing only the matching internal conditional boundary      |
-| Keyed row identity, reconciliation, and DOM    | Refreshing only the matching internal keyed-list boundary       |
-| Unmounting and the surrounding component tree  | Reapplying bindings after a parent-driven React update          |
+| React owns                                      | Compiler runtime owns                                                |
+| ----------------------------------------------- | -------------------------------------------------------------------- |
+| Initial element creation and placement          | Local compiler-cell values                                           |
+| SSR markup and hydration                        | Queuing local setter calls into one microtask                        |
+| JSX event registration and dispatch             | Comparing flushed values with `Object.is`                            |
+| Parent-driven prop updates                      | Selecting bindings whose state dependencies changed                  |
+| Unsupported trees, hooks, refs, and lifecycles  | Patching stable ref-owned text/attribute targets after local updates |
+| Host creation/removal inside an eligible block  | Refreshing only the matching internal conditional boundary           |
+| Keyed row identity, reconciliation, and DOM     | Refreshing only the matching internal keyed-list boundary            |
+| Component render, Hooks, context, and lifecycle | Refreshing only a dependent React component-island boundary          |
+| Unmounting and the surrounding component tree   | Reapplying bindings after a parent-driven React update               |
 
 Queued functional setters preserve the event's state snapshot. Two calls such as
 `setCount(value => value + 1)` are applied in order during the same microtask flush, while reads
@@ -627,12 +679,11 @@ normal recovery path.
 
 ### Safety reasoning
 
-The compiler uses fallback as a semantic boundary, not as an error-recovery trick. A precomputed
-path is only correct while the host tree has the same shape. Conditional and keyed-list boundaries
-isolate the dynamic location and give its structure back to React. Other dynamic children, custom
-components outside those boundaries, refs, and effects can change ownership or lifecycle in ways
-the current compiler does not yet model. Letting React handle them is the optimization's
-correctness mechanism.
+The compiler uses fallback as a semantic boundary, not as an error-recovery trick. Generated
+callback refs keep direct DOM targets stable even when a React component island returns `null`, a
+fragment, or multiple nodes. Conditional, keyed-list, and component boundaries give dynamic
+structure back to React. Unsupported dynamic component types, refs, effects, and other unproven
+shapes keep the complete component on React; fallback is the optimization's correctness mechanism.
 
 Parent-driven prop updates also remain React updates. After React reconciles the new props, the
 runtime reapplies compiler-owned bindings from the current local cells so prop changes and local
@@ -658,23 +709,32 @@ The package and example test suites verify more than generated code:
   randomized updates;
 - automatic keyed maps and explicit `List` boundaries preserve keyed DOM nodes and stateful row
   identity across inserts, removals, updates, and reorders without rerunning the outer component;
+- component islands update only dependent children, preserve child-local state and context, route
+  failures through React error boundaries, hydrate in Strict Mode, and safely drop queued updates
+  after unmount;
+- stable ref targets remain correct when an earlier island switches among `null`, one node, and a
+  multi-node fragment;
+- 1,000 deterministic object, array, and nullish component-prop transitions match normal React;
 - 1,000 deterministic randomized list operations produce the same ordered output as normal React;
 - the public `List` renders iterable and nullish collections correctly with the compiler off;
 - the packaged runtime is exercised separately with React 18.3 and React 19;
 - boolean `data-*` and `aria-*` attributes keep React-compatible string values; and
-- unsupported list shapes, effects, refs, and custom child components outside a keyed boundary
-  remain on React without corrupting output.
+- unsupported list shapes, effects, refs, and unsupported dynamic component-island shapes remain
+  on React without corrupting output.
 
-The heavy example uses a fixed 768-host-node tree with three state cells and sparse bindings. Its
-compiler-off → compiler-on crossover run measures a deliberately favorable supported workload. The
-reference run reported 88.2% lower median update latency, 86% lower p95 latency, and zero added
-component executions on the compiled path. These numbers describe that warm update path, not page
-load, build time, browser layout/paint, network work, effects, child-component updates, or general
-React performance.
+The heavy example measures both a fixed 768-host-node tree with sparse bindings and a component
+island beside a React-owned 768-node static component. Its compiler-off → compiler-on crossover
+run measures deliberately favorable supported workloads. An Apple M1 and Chromium 145 reference
+run measured the direct-binding median at `0.175 ms` without the compiler and `0.015 ms` with it—
+91.4% lower, or 11.7× faster—with zero added component executions. The component-island result
+separately includes the dependent child React render and verifies that the static sibling and
+compiled owner add zero update executions. Its median child-commit latency fell from `0.165 ms` to
+`0.025 ms`—84.8% lower, or 6.6× faster. These are warm update-path measurements, not page load,
+build, layout, paint, network, or general React performance claims.
 
-Run the benchmark on target devices before using its timing as a product estimate. The structural
-result—no extra component execution or React commit for an eligible local update—is the more stable
-property.
+Run the benchmark on target devices before using its timing as a product estimate. The more stable
+structural result is zero owner and unchanged-sibling executions; direct bindings also avoid a
+React commit, while a dependent component island still performs its required child commit.
 
 ### Recommended rollout
 
@@ -688,8 +748,8 @@ property.
 
 The [`examples/react-compiler`](https://github.com/farming-labs/farm.js/tree/main/examples/react-compiler)
 app contains batching, multiple-binding, common-syntax, calculated-style, controlled-form,
-automatic and explicit keyed-list, compiler-on/off, and heavy-interaction experiments. The standalone starter
-intentionally keeps the first experience focused.
+automatic and explicit keyed-list, component-island, compiler-on/off, and heavy-interaction
+experiments. The standalone starter intentionally keeps the first experience focused.
 
 ## React-specific FARMJS APIs
 

--- a/examples/react-compiler/README.md
+++ b/examples/react-compiler/README.md
@@ -94,9 +94,13 @@ lists, refs, spreads, and dangerous HTML inside a branch intentionally fall back
 
 ## Heavy compiler-on/off benchmark
 
-The page also contains `HeavyInteractionBenchmark`: one component with 768 static host nodes, three
-local state cells, and a small number of dynamic text/attribute targets. It represents a workload
-the current compiler is designed to optimize—a large stable tree with sparse local updates.
+The page contains two measured workloads:
+
+- `HeavyInteractionBenchmark` has one component with 768 static host nodes, three local state
+  cells, and a small number of dynamic text/attribute targets.
+- `ComponentIslandExperiment` has one state-dependent React child beside a React-owned component
+  that produces 768 static host nodes. The child keeps local Hook state while the compiler skips
+  the outer owner and unchanged static sibling.
 
 Run the full crossover benchmark:
 
@@ -112,19 +116,32 @@ sample measures browser button dispatch through the observed DOM mutation. It al
 state, browser errors, component executions, the number of rendered workload nodes, and whether the
 production bundle actually contains the compiled component marker.
 
+The component-island sample waits for the dependent React child to commit, so its latency includes
+that child render. It does not stop at the earlier direct owner binding.
+
 Repeated reference run on Apple M1, Chromium 145:
 
 | Metric                       |    Compiler off | Compiler on |                        Change |
 | ---------------------------- | --------------: | ----------: | ----------------------------: |
-| Median update latency        |        0.170 ms |    0.020 ms | **88.2% lower / 8.5× faster** |
-| p95 update latency           |        0.215 ms |    0.030 ms |               **86.0% lower** |
+| Median update latency        |        0.175 ms |    0.015 ms | **91.4% lower / 11.7× faster** |
+| p95 update latency           |        0.210 ms |    0.030 ms |                **85.7% lower** |
 | Component executions added   | 2,430 per trial |           0 |  All update rerenders removed |
-| Production page chunk (gzip) |         3,953 B |     5,221 B |                  **+1,268 B** |
+| Production page chunk (gzip) |         6,948 B |    10,792 B |                  **+3,844 B** |
+
+Component-island reference run from the same crossover method:
+
+| Metric                              | Compiler off | Compiler on |                         Change |
+| ----------------------------------- | -----------: | ----------: | -----------------------------: |
+| Median child-commit latency         |     0.165 ms |    0.025 ms | **84.8% lower / 6.6× faster**  |
+| p95 child-commit latency            |     0.180 ms |    0.110 ms |                **38.9% lower** |
+| Owner executions added per trial    |        2,430 |           0 |       Owner rerenders removed |
+| Static sibling executions per trial |        2,430 |           0 | Static rerenders removed      |
 
 The timing result is intentionally narrow. It does not include browser layout/paint, network work,
-effects, child component updates, or keyed-list reconciliation. Those add costs outside the
-measured update path. Unsupported dynamic structures still fall back to React. Run the command on
-target devices before using the reference number for a product decision.
+effects or keyed-list reconciliation. The component-island row does include its dependent child
+update, but not layout, paint, or unrelated application work. Unsupported dynamic structures still
+fall back to React. Run the command on target devices before using the reference number for a
+product decision.
 
 The environment flag controls the two production builds; omission defaults to enabled:
 

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -30,6 +30,7 @@ for (const component of [
   "AutomaticKeyedListExperiment",
   "ExplicitKeyedListExperiment",
   "StatefulListRow",
+  "ComponentIslandExperiment",
 ]) {
   assert.ok(compiledComponents.has(component), `${component} was not compiled`);
 }
@@ -415,6 +416,44 @@ try {
   );
   assert.equal(explicitListFinalExecutions - explicitListInitialExecutions, 0);
 
+  const componentIslands = '[data-benchmark="component-islands"]';
+  const islandOwnerInitialExecutions = await readNumber(
+    page,
+    `${componentIslands} [data-metric="island-owner-executions"]`,
+  );
+  const staticTreeInitialExecutions = Number(
+    await page.locator(`${componentIslands} [data-static-executions]`).getAttribute(
+      "data-static-executions",
+    ),
+  );
+  await page.locator(`${componentIslands} [data-action="island-pin"]`).click();
+  await assertText(
+    page,
+    `${componentIslands} [data-action="island-pin"]`,
+    "Pinned",
+  );
+  for (let update = 0; update < 3; update += 1) {
+    await page.locator(`${componentIslands} [data-action="island-update"]`).click();
+  }
+  await assertText(page, `${componentIslands} [data-metric="island-tick"]`, "3");
+  await assertText(page, `${componentIslands} [data-island-tick]`, "3");
+  await assertText(
+    page,
+    `${componentIslands} [data-action="island-pin"]`,
+    "Pinned",
+  );
+  const islandOwnerFinalExecutions = await readNumber(
+    page,
+    `${componentIslands} [data-metric="island-owner-executions"]`,
+  );
+  const staticTreeFinalExecutions = Number(
+    await page.locator(`${componentIslands} [data-static-executions]`).getAttribute(
+      "data-static-executions",
+    ),
+  );
+  assert.equal(islandOwnerFinalExecutions - islandOwnerInitialExecutions, 0);
+  assert.equal(staticTreeFinalExecutions - staticTreeInitialExecutions, 0);
+
   await page.screenshot({ path: screenshotPath, fullPage: true });
 
   const mobilePage = await browser.newPage({
@@ -532,6 +571,14 @@ try {
             updateExecutions:
               explicitListFinalExecutions - explicitListInitialExecutions,
             owner: "React",
+          },
+          componentIsland: {
+            state: 3,
+            childStatePreserved: true,
+            ownerUpdateExecutions:
+              islandOwnerFinalExecutions - islandOwnerInitialExecutions,
+            staticSiblingUpdateExecutions:
+              staticTreeFinalExecutions - staticTreeInitialExecutions,
           },
         },
       },

--- a/examples/react-compiler/scripts/verify-heavy-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-heavy-experiment.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { once } from "node:events";
-import { readFile, readdir, writeFile } from "node:fs/promises";
+import { readFile, readdir, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { gzipSync } from "node:zlib";
@@ -66,11 +66,18 @@ async function inspectBundle(compilerEnabled) {
   const source = sources.join("\n");
   const heavyComponentCompiled =
     /displayName:[`"]HeavyInteractionBenchmark[`"]/.test(source);
+  const componentIslandCompiled =
+    /displayName:[`"]ComponentIslandExperiment[`"]/.test(source);
 
   assert.equal(
     heavyComponentCompiled,
     compilerEnabled,
     `HeavyInteractionBenchmark compiler marker did not match compiler=${compilerEnabled}.`,
+  );
+  assert.equal(
+    componentIslandCompiled,
+    compilerEnabled,
+    `ComponentIslandExperiment compiler marker did not match compiler=${compilerEnabled}.`,
   );
 
   return {
@@ -78,6 +85,7 @@ async function inspectBundle(compilerEnabled) {
     rawBytes: Buffer.byteLength(source),
     gzipBytes: gzipSync(source).byteLength,
     heavyComponentCompiled,
+    componentIslandCompiled,
   };
 }
 
@@ -110,6 +118,7 @@ async function stopServer(server) {
 async function measureTrial(browser, trial, compilerEnabled, port) {
   const mode = compilerEnabled ? "on" : "off";
   process.stdout.write(`[heavy] building compiler ${mode} (${trial})...\n`);
+  await rm(path.resolve(".farm"), { force: true, recursive: true });
   await runCommand("pnpm", ["run", "build"], {
     FARM_REACT_COMPILER: String(compilerEnabled),
   });
@@ -156,85 +165,118 @@ async function measureTrial(browser, trial, compilerEnabled, port) {
       await root.locator(".workload-cell, .workload-cell i").count(),
       768,
     );
+    const islandRoot = page.locator('[data-benchmark="component-islands"]');
+    assert.equal(await islandRoot.locator(".component-island-workload .workload-cell").count(), 192);
+    assert.equal(
+      await islandRoot.locator(
+        ".component-island-workload .workload-cell, .component-island-workload .workload-cell i",
+      ).count(),
+      768,
+    );
 
     const result = await page.evaluate(
       async ({ measuredSamples, updatesPerSample, warmupUpdates }) => {
-        const root = document.querySelector('[data-benchmark="heavy"]');
-        const button = root?.querySelector('[data-action="heavy-update"]');
-        const tick = root?.querySelector('[data-metric="heavy-tick"]');
-        const executions = root?.querySelector(
-          '[data-metric="heavy-executions"]',
-        );
-        if (
-          !(root instanceof HTMLElement) ||
-          !(button instanceof HTMLButtonElement)
-        ) {
-          throw new Error("The heavy benchmark controls did not render.");
-        }
-        if (
-          !(tick instanceof HTMLElement) ||
-          !(executions instanceof HTMLElement)
-        ) {
-          throw new Error("The heavy benchmark metrics did not render.");
-        }
-
-        const updateOnce = () =>
-          new Promise((resolve, reject) => {
-            const expected = Number(tick.textContent) + 1;
-            let timeout;
-            const finish = () => {
-              if (Number(tick.textContent) !== expected) return;
-              observer.disconnect();
-              clearTimeout(timeout);
-              resolve();
-            };
-            const observer = new MutationObserver(finish);
-            observer.observe(tick, {
-              characterData: true,
-              childList: true,
-              subtree: true,
-            });
-            timeout = setTimeout(() => {
-              observer.disconnect();
-              reject(new Error(`Update ${expected} did not reach the DOM.`));
-            }, 2_000);
-            button.click();
-            finish();
-          });
-
-        const initialExecutions = Number(executions.textContent);
-        for (let index = 0; index < warmupUpdates; index += 1)
-          await updateOnce();
-
-        const samples = [];
-        for (let index = 0; index < measuredSamples; index += 1) {
-          const startedAt = performance.now();
-          for (let update = 0; update < updatesPerSample; update += 1) {
-            await updateOnce();
+        const measure = async ({ rootSelector, buttonSelector, tickSelector, executionSelector }) => {
+          const root = document.querySelector(rootSelector);
+          const button = root?.querySelector(buttonSelector);
+          const tick = root?.querySelector(tickSelector);
+          const executions = root?.querySelector(executionSelector);
+          if (
+            !(root instanceof HTMLElement) ||
+            !(button instanceof HTMLButtonElement) ||
+            !(tick instanceof HTMLElement) ||
+            !(executions instanceof HTMLElement)
+          ) {
+            throw new Error(`Benchmark controls did not render for ${rootSelector}.`);
           }
-          samples.push((performance.now() - startedAt) / updatesPerSample);
-        }
 
+          const staticWorkload = root.querySelector("[data-static-executions]");
+          const initialStaticExecutions = Number(
+            staticWorkload?.getAttribute("data-static-executions") || 0,
+          );
+          const updateOnce = () =>
+            new Promise((resolve, reject) => {
+              const expected = Number(tick.textContent) + 1;
+              let timeout;
+              const finish = () => {
+                if (Number(tick.textContent) !== expected) return;
+                observer.disconnect();
+                clearTimeout(timeout);
+                resolve();
+              };
+              const observer = new MutationObserver(finish);
+              observer.observe(tick, {
+                characterData: true,
+                childList: true,
+                subtree: true,
+              });
+              timeout = setTimeout(() => {
+                observer.disconnect();
+                reject(new Error(`Update ${expected} did not reach the DOM.`));
+              }, 2_000);
+              button.click();
+              finish();
+            });
+
+          const initialExecutions = Number(executions.textContent);
+          for (let index = 0; index < warmupUpdates; index += 1) await updateOnce();
+
+          const samples = [];
+          for (let index = 0; index < measuredSamples; index += 1) {
+            const startedAt = performance.now();
+            for (let update = 0; update < updatesPerSample; update += 1) {
+              await updateOnce();
+            }
+            samples.push((performance.now() - startedAt) / updatesPerSample);
+          }
+
+          return {
+            executionsAdded: Number(executions.textContent) - initialExecutions,
+            finalTick: Number(root.getAttribute("data-tick")),
+            samples,
+            staticExecutionsAdded:
+              Number(staticWorkload?.getAttribute("data-static-executions") || 0) -
+              initialStaticExecutions,
+          };
+        };
+
+        const heavy = await measure({
+          rootSelector: '[data-benchmark="heavy"]',
+          buttonSelector: '[data-action="heavy-update"]',
+          tickSelector: '[data-metric="heavy-tick"]',
+          executionSelector: '[data-metric="heavy-executions"]',
+        });
+        const heavyRoot = document.querySelector('[data-benchmark="heavy"]');
+        const islands = await measure({
+          rootSelector: '[data-benchmark="component-islands"]',
+          buttonSelector: '[data-action="island-update"]',
+          tickSelector: "[data-island-tick]",
+          executionSelector: '[data-metric="island-owner-executions"]',
+        });
         return {
-          active: root.getAttribute("data-active"),
-          executionsAdded: Number(executions.textContent) - initialExecutions,
-          finalLevel: Number(root.getAttribute("data-level")),
-          finalTick: Number(root.getAttribute("data-tick")),
-          readout: root
-            .querySelector('[data-metric="heavy-readout"]')
-            ?.textContent?.trim(),
-          samples,
+          heavy: {
+            ...heavy,
+            active: heavyRoot?.getAttribute("data-active"),
+            finalLevel: Number(heavyRoot?.getAttribute("data-level")),
+            readout: heavyRoot
+              ?.querySelector('[data-metric="heavy-readout"]')
+              ?.textContent?.trim(),
+          },
+          islands,
         };
       },
       { measuredSamples, updatesPerSample, warmupUpdates },
     );
 
     const totalUpdates = warmupUpdates + measuredSamples * updatesPerSample;
-    assert.equal(result.finalTick, totalUpdates);
-    assert.equal(result.finalLevel, (totalUpdates * 7) % 100);
-    assert.equal(result.active, String(totalUpdates % 2 === 1));
-    assert.equal(result.readout, `Frame ${totalUpdates}`);
-    assert.equal(result.executionsAdded, compilerEnabled ? 0 : totalUpdates);
+    assert.equal(result.heavy.finalTick, totalUpdates);
+    assert.equal(result.heavy.finalLevel, (totalUpdates * 7) % 100);
+    assert.equal(result.heavy.active, String(totalUpdates % 2 === 1));
+    assert.equal(result.heavy.readout, `Frame ${totalUpdates}`);
+    assert.equal(result.heavy.executionsAdded, compilerEnabled ? 0 : totalUpdates);
+    assert.equal(result.islands.finalTick, totalUpdates);
+    assert.equal(result.islands.executionsAdded, compilerEnabled ? 0 : totalUpdates);
+    assert.equal(result.islands.staticExecutionsAdded, compilerEnabled ? 0 : totalUpdates);
     assert.deepEqual(browserErrors, []);
 
     const screenshot = `/tmp/farm-react-heavy-compiler-${mode}-${trial}.png`;
@@ -245,15 +287,19 @@ async function measureTrial(browser, trial, compilerEnabled, port) {
       trial,
       bundle,
       browserErrors,
-      executionsAdded: result.executionsAdded,
+      executionsAdded: result.heavy.executionsAdded,
+      componentIslandExecutionsAdded: result.islands.executionsAdded,
+      staticComponentExecutionsAdded: result.islands.staticExecutionsAdded,
       finalState: {
-        active: result.active,
-        level: result.finalLevel,
-        tick: result.finalTick,
+        active: result.heavy.active,
+        level: result.heavy.finalLevel,
+        tick: result.heavy.finalTick,
       },
-      samples: result.samples,
+      samples: result.heavy.samples,
+      componentIslandSamples: result.islands.samples,
       screenshot,
-      timing: timingSummary(result.samples),
+      timing: timingSummary(result.heavy.samples),
+      componentIslandTiming: timingSummary(result.islands.samples),
     };
   } finally {
     await context.close();
@@ -290,6 +336,20 @@ const medianReductionPercent =
   100;
 const p95ReductionPercent =
   ((baselineTiming.p95Ms - compiledTiming.p95Ms) / baselineTiming.p95Ms) * 100;
+const baselineComponentIslandTiming = timingSummary(
+  baselines.flatMap((trial) => trial.componentIslandSamples),
+);
+const compiledComponentIslandTiming = timingSummary(compiled.componentIslandSamples);
+const componentIslandSpeedup =
+  baselineComponentIslandTiming.medianMs / compiledComponentIslandTiming.medianMs;
+const componentIslandMedianReductionPercent =
+  ((baselineComponentIslandTiming.medianMs - compiledComponentIslandTiming.medianMs) /
+    baselineComponentIslandTiming.medianMs) *
+  100;
+const componentIslandP95ReductionPercent =
+  ((baselineComponentIslandTiming.p95Ms - compiledComponentIslandTiming.p95Ms) /
+    baselineComponentIslandTiming.p95Ms) *
+  100;
 
 const report = {
   result:
@@ -325,6 +385,25 @@ const report = {
     p95ReductionPercent,
     speedup,
   },
+  componentIslands: {
+    baseline: {
+      executionsAddedPerTrial: baselines.map(
+        (trial) => trial.componentIslandExecutionsAdded,
+      ),
+      staticComponentExecutionsAddedPerTrial: baselines.map(
+        (trial) => trial.staticComponentExecutionsAdded,
+      ),
+      timing: baselineComponentIslandTiming,
+    },
+    compiler: {
+      executionsAdded: compiled.componentIslandExecutionsAdded,
+      staticComponentExecutionsAdded: compiled.staticComponentExecutionsAdded,
+      timing: compiledComponentIslandTiming,
+    },
+    medianReductionPercent: componentIslandMedianReductionPercent,
+    p95ReductionPercent: componentIslandP95ReductionPercent,
+    speedup: componentIslandSpeedup,
+  },
   screenshots: trials.map((trial) => trial.screenshot),
 };
 
@@ -334,4 +413,8 @@ console.log(JSON.stringify({ ...report, reportPath }, null, 2));
 assert(
   compiledTiming.medianMs < baselineTiming.medianMs,
   `Compiler median ${compiledTiming.medianMs.toFixed(3)}ms did not beat baseline ${baselineTiming.medianMs.toFixed(3)}ms.`,
+);
+assert(
+  compiledComponentIslandTiming.medianMs < baselineComponentIslandTiming.medianMs,
+  `Component-island compiler median ${compiledComponentIslandTiming.medianMs.toFixed(3)}ms did not beat baseline ${baselineComponentIslandTiming.medianMs.toFixed(3)}ms.`,
 );

--- a/examples/react-compiler/src/app/globals.css
+++ b/examples/react-compiler/src/app/globals.css
@@ -760,6 +760,51 @@ h1 span {
   border-block: 1px solid #33332f;
 }
 
+.heavy-metrics--islands {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.component-island-live {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin: 1rem 0;
+  border: 1px solid #4d6334;
+  padding: 1rem;
+  background: rgb(184 255 91 / 0.045);
+}
+
+.component-island-live > div {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.component-island-live span {
+  color: #8d8d86;
+  font: 0.62rem "Geist Mono Variable", ui-monospace, monospace;
+  letter-spacing: 0.055em;
+  text-transform: uppercase;
+}
+
+.component-island-live strong {
+  color: #d8ff9f;
+  font-size: 1.5rem;
+}
+
+.component-island-live button {
+  border: 1px solid #484842;
+  padding: 0.65rem 0.8rem;
+  color: inherit;
+  background: transparent;
+  cursor: pointer;
+}
+
+.component-island-workload {
+  margin-top: 1rem;
+}
+
 .heavy-metrics > div {
   min-width: 0;
   padding: 1.25rem 0;
@@ -1072,6 +1117,11 @@ code {
   }
 
   .heavy-controls {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .component-island-live {
     align-items: stretch;
     flex-direction: column;
   }

--- a/examples/react-compiler/src/app/page.tsx
+++ b/examples/react-compiler/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { CompilerComparison } from "../components/compiler-comparison";
 import { CompilerEdgeLab } from "../components/compiler-edge-lab";
 import { CommonSyntaxExperiment } from "../components/common-syntax-experiment";
+import { ComponentIslandExperiment } from "../components/component-island-experiment";
 import { ConditionalBlockExperiment } from "../components/conditional-block-experiment";
 import { HeavyInteractionBenchmark } from "../components/heavy-interaction-benchmark";
 import { StaticBindingExperiment } from "../components/static-binding-experiment";
@@ -68,6 +69,8 @@ export default function HomePage() {
       <ConditionalBlockExperiment />
 
       <HeavyInteractionBenchmark />
+
+      <ComponentIslandExperiment />
 
       <section
         className="benchmark-report"

--- a/examples/react-compiler/src/components/component-island-experiment.tsx
+++ b/examples/react-compiler/src/components/component-island-experiment.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState } from "react";
+
+let ownerExecutions = 0;
+let staticTreeExecutions = 0;
+let islandExecutions = 0;
+
+function StaticWorkload({ seed }: { seed: number }) {
+  const execution =
+    typeof window === "undefined" ? 1 : ++staticTreeExecutions;
+  return (
+    <div
+      aria-hidden="true"
+      className="workload-grid component-island-workload"
+      data-static-executions={execution}
+    >
+      {Array.from({ length: 192 }, (_, index) => (
+        <span className="workload-cell" data-cell={index + seed} key={index}>
+          <i />
+          <i />
+          <i />
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function LiveIsland({ tick }: { tick: number }) {
+  "use no compiler";
+
+  const [pinned, setPinned] = useState(false);
+  const execution = typeof window === "undefined" ? 1 : ++islandExecutions;
+  return (
+    <div className="component-island-live" data-island-executions={execution}>
+      <div>
+        <span>React-owned island</span>
+        <strong data-island-tick>{tick}</strong>
+      </div>
+      <button data-action="island-pin" type="button" onClick={() => setPinned((value) => !value)}>
+        {pinned ? "Pinned" : "Pin child state"}
+      </button>
+    </div>
+  );
+}
+
+export function ComponentIslandExperiment() {
+  const [tick, setTick] = useState(0);
+
+  return (
+    <section className="heavy-benchmark" data-benchmark="component-islands" data-tick={tick}>
+      <header className="heavy-heading">
+        <div>
+          <span className="experiment-number">06</span>
+          <div>
+            <p className="heavy-kicker">REACT COMPONENT ISLAND</p>
+            <h2>Update one child, leave the heavy sibling alone</h2>
+          </div>
+        </div>
+        <span className="node-badge">768 REACT-OWNED HOST NODES</span>
+      </header>
+
+      <p className="heavy-copy">
+        The compiler patches the owner&apos;s prepared targets and asks React to render only the child
+        whose prop changed. The static component stays mounted, and the live child keeps its Hooks,
+        context, events, and local state.
+      </p>
+
+      <dl className="heavy-metrics heavy-metrics--islands" aria-live="polite">
+        <div>
+          <dt>Interaction</dt>
+          <dd data-metric="island-tick">{tick}</dd>
+        </div>
+        <div>
+          <dt>Owner executions</dt>
+          <dd data-metric="island-owner-executions">
+            {typeof window === "undefined" ? 1 : ++ownerExecutions}
+          </dd>
+        </div>
+      </dl>
+
+      <div className="heavy-controls">
+        <button
+          data-action="island-update"
+          type="button"
+          onClick={() => setTick((value) => value + 1)}
+        >
+          Update component island
+          <span aria-hidden="true">↗</span>
+        </button>
+      </div>
+
+      <LiveIsland tick={tick} />
+      <StaticWorkload seed={7} />
+    </section>
+  );
+}

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -53,7 +53,8 @@ The directive is configurable and only has meaning in annotation mode.
 
 The current compiler handles components that it can prove have:
 
-- one host-element root and a statically known host-element tree;
+- one host-element root and a statically known host-element tree around supported React component
+  islands;
 - an identifier props parameter or flat object destructuring with aliases and defaults;
 - top-level `useState` declarations;
 - optional compiler-safe derived `const` values declared after state and in source order;
@@ -64,11 +65,12 @@ The current compiler handles components that it can prove have:
   statically known locations;
 - direct item-keyed `collection.map(...)` children and explicit `List` boundaries at statically
   known container locations;
+- stable module-level child components with compiler-safe props;
 - React-managed event handlers; and
 - no refs, effects, or unsupported dynamic child structures.
 
 The generated component preserves React ownership of placement, props, events, SSR, and hydration.
-Local state cells batch updates into a microtask and patch only compiler-known DOM paths. For an
+Local state cells batch updates into a microtask and patch only compiler-known DOM targets. For an
 eligible conditional, the runtime refreshes one small internal React boundary instead of executing
 the user component again. React mounts, replaces, or removes the selected branch, so events,
 unmounting, SSR, hydration, and error boundaries keep React semantics.
@@ -106,6 +108,24 @@ row component, not directly inside the iteration callback. With the compiler ena
 optimized explicit shape requires inline `by` and child functions, a safe `each` expression, an
 item-derived key, and no meaningful siblings in the same host container. Other shapes keep normal
 React behavior.
+
+A normal child component can become an automatic React-owned island:
+
+```tsx
+<Header title="Dashboard" />
+<Chart value={count} />
+```
+
+If `count` changes, the compiler leaves the outer component and `Header` alone and asks React to
+render only the `Chart` boundary. `Chart` remains ordinary React and may use Hooks, context, local
+state, effects, lifecycle, and error boundaries. The first contract accepts stable imported or
+module-level identifiers with explicit compiler-safe props. Component children, spreads, `ref`,
+`key`, member-expression or prop-selected component types, and identity-bearing inline prop values
+fall back to the complete React component.
+
+Generated callback refs give directly patched host elements stable private target identities. A
+React-owned component may therefore return `null`, a fragment, or multiple host nodes without
+shifting an unrelated compiler binding. These refs do not add attributes to SSR output.
 
 Conditional blocks deliberately start with a narrow contract. Each non-empty branch must have one
 lowercase host root and a static host-only subtree. An empty ternary branch may be `null` or `false`.

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -303,6 +303,70 @@ const testSource = String.raw`
   assert.equal(keyedExecutions, initialKeyedExecutions);
   flushSync(() => keyedRoot.unmount());
 
+  let islandExecutions = 0;
+  let islandChildExecutions = 0;
+  function IslandChild({ value }) {
+    islandChildExecutions += 1;
+    const [selected, setSelected] = React.useState(false);
+    return React.createElement(
+      "button",
+      { "data-island": true, onClick: () => setSelected((current) => !current) },
+      value,
+      ":",
+      selected ? "selected" : "idle",
+    );
+  }
+  const ComponentIslands = createCompiledComponent({
+    displayName: "CompatibilityComponentIslands",
+    initialize: () => [0],
+    render(_props, state, blocks) {
+      islandExecutions += 1;
+      return React.createElement(
+        "section",
+        null,
+        React.createElement(
+          "button",
+          { "data-update": true, onClick: () => state[0].set((value) => Number(value) + 1) },
+          "Update",
+        ),
+        React.createElement(
+          "output",
+          { ref: blocks.target(0) },
+          Number(state[0].get()),
+        ),
+        React.createElement(blocks.Component, {
+          id: 0,
+          render: () => React.createElement(IslandChild, { value: Number(state[0].get()) }),
+        }),
+      );
+    },
+    bindings: [
+      {
+        kind: "text",
+        path: [1],
+        target: 0,
+        dependencies: [0],
+        read: (_props, state) => state[0].get(),
+      },
+      { kind: "block", id: 0, dependencies: [0] },
+    ],
+  });
+  const islandContainer = document.createElement("div");
+  document.body.append(islandContainer);
+  const islandRoot = createRoot(islandContainer);
+  flushSync(() => islandRoot.render(React.createElement(ComponentIslands)));
+  islandContainer.querySelector("[data-island]").click();
+  flushSync(() => {});
+  islandContainer.querySelector("[data-update]").click();
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  flushSync(() => {});
+  assert.equal(islandContainer.querySelector("output").textContent, "1");
+  assert.equal(islandContainer.querySelector("[data-island]").textContent, "1:selected");
+  assert.equal(islandExecutions, 1);
+  assert.equal(islandChildExecutions, 3);
+  flushSync(() => islandRoot.unmount());
+
   const hydrationContainer = document.createElement("div");
   hydrationContainer.innerHTML = renderToString(React.createElement(Counter));
   document.body.append(hydrationContainer);

--- a/packages/farm-react/src/__tests__/compiler-component-islands.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-component-islands.test.ts
@@ -1,0 +1,191 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true);
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/ComponentIslands.tsx", infer);
+}
+
+describe("React AOT component island compiler", () => {
+  it("isolates a state-dependent imported component and emits stable DOM targets", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { Chart } from "./chart";
+      import { Header } from "./header";
+
+      export function Dashboard() {
+        const [count, setCount] = useState(0);
+        return (
+          <main data-count={count}>
+            <Header title="Dashboard" />
+            <button onClick={() => setCount((value) => value + 1)}>Count: {count}</button>
+            <Chart value={count} />
+          </main>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Dashboard"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.Component");
+    expect(result.code).toContain("farmBlocks.target(");
+    expect(result.code).toContain('kind: "block"');
+    expect(result.code).toContain("target:");
+    expect(result.code.match(/farmBlocks\.Component/g)).toHaveLength(1);
+    await expect(
+      transformWithEsbuild(result.code, "/app/ComponentIslands.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("farmBlocks.Component"),
+    });
+  });
+
+  it("keeps state-independent components as ordinary React children", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { Header } from "./header";
+      export function Dashboard() {
+        const [count, setCount] = useState(0);
+        return (
+          <main>
+            <Header title="Dashboard" />
+            <button onClick={() => setCount(count + 1)}>{count}</button>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Dashboard"]);
+    expect(result.code).toContain('<Header title="Dashboard"');
+    expect(result.code).not.toContain("farmBlocks.Component");
+  });
+
+  it("tracks multiple state dependencies and component event handlers", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { Editor } from "./editor";
+      export function Form() {
+        const [value, setValue] = useState("");
+        const [valid, setValid] = useState(false);
+        return (
+          <form>
+            <Editor
+              value={value}
+              valid={valid}
+              onChange={(next) => {
+                setValue(next);
+                setValid(Boolean(next));
+              }}
+            />
+          </form>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Form"]);
+    expect(result.code).toContain("dependencies: [0, 1]");
+    expect(result.code).toContain("farmState[0].set");
+    expect(result.code).toContain("farmState[1].set");
+  });
+
+  it("assigns unique ids across conditional, keyed, and component boundaries", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { Chart } from "./chart";
+      export function Dashboard() {
+        const [visible, setVisible] = useState(true);
+        const [items, setItems] = useState([{ id: "a", label: "A" }]);
+        return (
+          <main>
+            <button onClick={() => setVisible(!visible)}>Toggle</button>
+            <button onClick={() => setItems([...items].reverse())}>Reverse</button>
+            <div>{visible && <p>Visible</p>}</div>
+            <ul>{items.map((item) => <li key={item.id}>{item.label}</li>)}</ul>
+            <Chart visible={visible} />
+          </main>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Dashboard"]);
+    expect(result.code).toContain("farmBlocks.Conditional");
+    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).toContain("farmBlocks.Component");
+    expect(result.code).toContain("id={0}");
+    expect(result.code).toContain("id={1}");
+    expect(result.code).toContain("id={2}");
+  });
+
+  it.each([
+    {
+      name: "a component supplied through props",
+      declaration: "",
+      parameter: "{ Component }",
+      child: "<Component value={count} />",
+      reason: /stable module-level component/i,
+    },
+    {
+      name: "a member-expression component",
+      declaration: 'import * as UI from "./ui";',
+      parameter: "",
+      child: "<UI.Chart value={count} />",
+      reason: /direct component identifier/i,
+    },
+    {
+      name: "a mutable module component binding",
+      declaration: "let Chart = () => <span />;",
+      parameter: "",
+      child: "<Chart value={count} />",
+      reason: /stable module-level component/i,
+    },
+    {
+      name: "spread props",
+      declaration: 'import { Chart } from "./chart";',
+      parameter: "props",
+      child: "<Chart {...props} value={count} />",
+      reason: /attribute spreads/i,
+    },
+    {
+      name: "a component ref",
+      declaration: 'import { Chart } from "./chart";',
+      parameter: "props",
+      child: "<Chart ref={props.chartRef} value={count} />",
+      reason: /does not support ref/i,
+    },
+    {
+      name: "component children",
+      declaration: 'import { Chart } from "./chart";',
+      parameter: "",
+      child: "<Chart value={count}>Content</Chart>",
+      reason: /does not support children/i,
+    },
+    {
+      name: "an object literal prop",
+      declaration: 'import { Chart } from "./chart";',
+      parameter: "",
+      child: "<Chart value={count} options={{ animated: true }} />",
+      reason: /object literals/i,
+    },
+  ])("falls back safely for $name", async ({ declaration, parameter, child, reason }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      ${declaration}
+      export function Unsupported(${parameter}) {
+        const [count, setCount] = useState(0);
+        return <main onClick={() => setCount(count + 1)}>${child}</main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual([]);
+    expect(result.diagnostics.find((entry) => entry.component === "Unsupported")?.reason).toMatch(
+      reason,
+    );
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-edge-cases.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-edge-cases.test.ts
@@ -317,18 +317,6 @@ describe("React AOT compiler safety boundaries", () => {
       reason: /ref requires React ownership/i,
     },
     {
-      name: "custom child component",
-      source: `
-        import { useState } from "react";
-        import { Label } from "./label";
-        export function Parent() {
-          const [count, setCount] = useState(0);
-          return <div onClick={() => setCount(count + 1)}><Label value={count} /></div>;
-        }
-      `,
-      reason: /host elements only/i,
-    },
-    {
       name: "effect lifecycle",
       source: `
         import { useEffect, useState } from "react";

--- a/packages/farm-react/src/__tests__/compiler-keyed-lists.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-lists.test.ts
@@ -145,7 +145,7 @@ describe("React AOT keyed list compiler", () => {
     expect(result.diagnostics[0]?.reason).toMatch(/cannot depend on the array index/i);
   });
 
-  it("does not treat a locally named List as the public primitive", async () => {
+  it("treats a locally named List as an ordinary static component island", async () => {
     const result = await compile(`
       import { useState } from "react";
       function List() { return <li>Local</li>; }
@@ -155,10 +155,9 @@ describe("React AOT keyed list compiler", () => {
       }
     `);
 
-    expect(result.compiled).toEqual([]);
-    expect(result.diagnostics.find((entry) => entry.component === "LocalList")?.reason).toMatch(
-      /host elements only/i,
-    );
+    expect(result.compiled).toContain("LocalList");
+    expect(result.code).toContain("<List />");
+    expect(result.code).not.toContain("farmBlocks.KeyedList");
   });
 
   it("assigns unique boundary ids when conditions and lists coexist", async () => {

--- a/packages/farm-react/src/__tests__/compiler-runtime-component-islands.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-component-islands.test.tsx
@@ -1,0 +1,448 @@
+import React, {
+  StrictMode,
+  createContext,
+  memo,
+  useContext,
+  useState,
+  type ReactNode,
+} from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createCompiledComponent, type CompilerStateUpdater } from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+const roots: Array<{ unmount(): void }> = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function trackRoot(root: Root): Root {
+  roots.push(root);
+  return root;
+}
+
+describe("compiled React component island runtime", () => {
+  it("updates only a dependent island and preserves child-local state", async () => {
+    let outerRenders = 0;
+    let staticRenders = 0;
+    let chartRenders = 0;
+
+    function StaticHeader() {
+      staticRenders += 1;
+      return <h1>Dashboard</h1>;
+    }
+
+    function Chart({ value }: { value: number }) {
+      chartRenders += 1;
+      const [selected, setSelected] = useState(false);
+      return (
+        <button data-chart onClick={() => setSelected((current) => !current)}>
+          {value}:{selected ? "selected" : "idle"}
+        </button>
+      );
+    }
+
+    const Dashboard = createCompiledComponent({
+      displayName: "Dashboard",
+      initialize: () => [0],
+      render(_props: Record<string, never>, state, blocks) {
+        outerRenders += 1;
+        const Component = blocks.Component;
+        return (
+          <main>
+            <StaticHeader />
+            <button data-increment onClick={() => state[0].set((value) => Number(value) + 1)}>
+              Increment
+            </button>
+            <output ref={blocks.target(0)}>{Number(state[0].get())}</output>
+            <Component id={0} render={() => <Chart value={Number(state[0].get())} />} />
+          </main>
+        );
+      },
+      bindings: [
+        {
+          kind: "text",
+          path: [2],
+          target: 0,
+          dependencies: [0],
+          read: (_props, state) => state[0].get(),
+        },
+        { kind: "block", id: 0, dependencies: [0] },
+      ],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = trackRoot(createRoot(container));
+    await act(async () => root.render(<Dashboard />));
+
+    await act(async () => container.querySelector<HTMLElement>("[data-chart]")!.click());
+    expect(container.querySelector("[data-chart]")?.textContent).toBe("0:selected");
+
+    await act(async () => {
+      container.querySelector<HTMLElement>("[data-increment]")!.click();
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector("output")?.textContent).toBe("1");
+    expect(container.querySelector("[data-chart]")?.textContent).toBe("1:selected");
+    expect(outerRenders).toBe(1);
+    expect(staticRenders).toBe(1);
+    expect(chartRenders).toBe(3);
+  });
+
+  it("keeps stable DOM targets when an earlier island returns null, fragments, or many nodes", async () => {
+    function VariableShape({ mode }: { mode: number }) {
+      if (mode === 0) return null;
+      if (mode === 1) return <i data-shape="one">One</i>;
+      return (
+        <>
+          <i data-shape="two-a">Two A</i>
+          <i data-shape="two-b">Two B</i>
+        </>
+      );
+    }
+
+    const Panel = createCompiledComponent({
+      displayName: "StableIslandTargets",
+      initialize: () => [0, 0],
+      render(_props: Record<string, never>, state, blocks) {
+        const Component = blocks.Component;
+        return (
+          <section>
+            <button
+              data-update
+              onClick={() => {
+                state[0].set((value) => (Number(value) + 1) % 3);
+                state[1].set((value) => Number(value) + 1);
+              }}
+            >
+              Update
+            </button>
+            <Component id={0} render={() => <VariableShape mode={Number(state[0].get())} />} />
+            <output ref={blocks.target(0)}>{Number(state[1].get())}</output>
+          </section>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        {
+          kind: "text",
+          path: [1],
+          target: 0,
+          dependencies: [1],
+          read: (_props, state) => state[1].get(),
+        },
+      ],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = trackRoot(createRoot(container));
+    await act(async () => root.render(<Panel />));
+
+    for (const [expectedShape, expectedCount] of [
+      ["one", "1"],
+      ["two-a", "2"],
+      [undefined, "3"],
+      ["one", "4"],
+    ] as const) {
+      await act(async () => {
+        container.querySelector<HTMLElement>("[data-update]")!.click();
+        await flushCompilerUpdates();
+      });
+      expect(container.querySelector("output")?.textContent).toBe(expectedCount);
+      expect(container.querySelector("[data-shape]")?.getAttribute("data-shape")).toBe(
+        expectedShape,
+      );
+    }
+  });
+
+  it("preserves context propagation through a memoized compiled owner", async () => {
+    const Theme = createContext("light");
+    function Consumer({ count }: { count: number }) {
+      return (
+        <output data-consumer>
+          {useContext(Theme)}:{count}
+        </output>
+      );
+    }
+    const Panel = createCompiledComponent({
+      displayName: "ContextIsland",
+      initialize: () => [0],
+      render(_props: Record<string, never>, state, blocks) {
+        const Component = blocks.Component;
+        return (
+          <section>
+            <button onClick={() => state[0].set((value) => Number(value) + 1)}>Increment</button>
+            <Component id={0} render={() => <Consumer count={Number(state[0].get())} />} />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const MemoPanel = memo(Panel);
+    function App() {
+      const [theme, setTheme] = useState("light");
+      return (
+        <Theme.Provider value={theme}>
+          <button data-theme onClick={() => setTheme("dark")}>
+            Theme
+          </button>
+          <MemoPanel />
+        </Theme.Provider>
+      );
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = trackRoot(createRoot(container));
+    await act(async () => root.render(<App />));
+    await act(async () => container.querySelector<HTMLElement>("[data-theme]")!.click());
+    expect(container.querySelector("[data-consumer]")?.textContent).toBe("dark:0");
+  });
+
+  it("supports StrictMode, hydration, and dropping a queued island update after unmount", async () => {
+    function Value({ value }: { value: number }) {
+      return <output>{value}</output>;
+    }
+    const Panel = createCompiledComponent({
+      displayName: "HardenedIsland",
+      initialize: () => [0],
+      render(_props: Record<string, never>, state, blocks) {
+        const Component = blocks.Component;
+        return (
+          <section>
+            <button onClick={() => state[0].set((value) => Number(value) + 1)}>Update</button>
+            <Component id={0} render={() => <Value value={Number(state[0].get())} />} />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const html = renderToString(
+      <StrictMode>
+        <Panel />
+      </StrictMode>,
+    );
+    const container = document.createElement("div");
+    container.innerHTML = html;
+    document.body.append(container);
+    let root!: Root;
+    await act(async () => {
+      root = hydrateRoot(
+        container,
+        <StrictMode>
+          <Panel />
+        </StrictMode>,
+      );
+    });
+    trackRoot(root);
+
+    await act(async () => {
+      container.querySelector("button")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("output")?.textContent).toBe("1");
+
+    await act(async () => {
+      container.querySelector("button")!.click();
+      root.unmount();
+      roots.splice(roots.indexOf(root), 1);
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("");
+  });
+
+  it("routes island render failures through React error boundaries", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    function Risky({ fail }: { fail: boolean }) {
+      if (fail) throw new Error("island failed");
+      return <span>Safe</span>;
+    }
+    class Boundary extends React.Component<{ children: ReactNode }, { failed: boolean }> {
+      state = { failed: false };
+      static getDerivedStateFromError() {
+        return { failed: true };
+      }
+      render() {
+        return this.state.failed ? <p>Recovered</p> : this.props.children;
+      }
+    }
+    const Panel = createCompiledComponent({
+      displayName: "ErrorIsland",
+      initialize: () => [false],
+      render(_props: Record<string, never>, state, blocks) {
+        const Component = blocks.Component;
+        return (
+          <section>
+            <button onClick={() => state[0].set(true)}>Fail</button>
+            <Component id={0} render={() => <Risky fail={Boolean(state[0].get())} />} />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = trackRoot(createRoot(container));
+    await act(async () =>
+      root.render(
+        <Boundary>
+          <Panel />
+        </Boundary>,
+      ),
+    );
+    await act(async () => {
+      container.querySelector("button")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("Recovered");
+  });
+
+  it("keeps parent prop updates and compiled local updates coherent in one event", async () => {
+    function Value({ value }: { value: number }) {
+      return <output>{value}</output>;
+    }
+    const Panel = createCompiledComponent<{ offset: number; updateParent(): void }>({
+      displayName: "PropAndCellIsland",
+      initialize: () => [0],
+      render(props, state, blocks) {
+        const Component = blocks.Component;
+        return (
+          <section>
+            <button
+              onClick={() => {
+                state[0].set((value) => Number(value) + 1);
+                props.updateParent();
+              }}
+            >
+              Update both
+            </button>
+            <Component
+              id={0}
+              render={() => <Value value={props.offset + Number(state[0].get())} />}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    function App() {
+      const [offset, setOffset] = useState(10);
+      return <Panel offset={offset} updateParent={() => setOffset((value) => value + 1)} />;
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = trackRoot(createRoot(container));
+    await act(async () => root.render(<App />));
+    await act(async () => {
+      container.querySelector("button")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("output")?.textContent).toBe("12");
+  });
+
+  it("matches React across 1,000 deterministic object, array, and nullish prop transitions", async () => {
+    type Value = number | null | { count: number } | number[];
+    type Update = (value: Value) => Value;
+    const serialize = (value: Value) =>
+      value === null
+        ? "null"
+        : Array.isArray(value)
+          ? `array:${value.join(",")}`
+          : typeof value === "object"
+            ? `object:${value.count}`
+            : `number:${value}`;
+    let seed = 0x7f4a7c15;
+    const random = () => {
+      seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0;
+      return seed;
+    };
+    const updates: Update[] = Array.from({ length: 1000 }, () => {
+      const kind = random() % 4;
+      const amount = (random() % 9) - 4;
+      if (kind === 0) return () => null;
+      if (kind === 1) return (value) => [Array.isArray(value) ? value.length : 0, amount];
+      if (kind === 2) return () => ({ count: amount });
+      return (value) =>
+        (typeof value === "number" ? value : value && !Array.isArray(value) ? value.count : 0) +
+        amount;
+    });
+    let compiledSet: (next: CompilerStateUpdater) => void = () => undefined;
+    let reactSet: React.Dispatch<React.SetStateAction<Value>> = () => undefined;
+    let compiledOwnerRenders = 0;
+
+    function Readout({ value }: { value: Value }) {
+      return <output>{serialize(value)}</output>;
+    }
+    const Compiled = createCompiledComponent({
+      displayName: "RandomIslandProps",
+      initialize: () => [0],
+      render(_props: Record<string, never>, state, blocks) {
+        compiledOwnerRenders += 1;
+        compiledSet = (next) => state[0].set(next);
+        const Component = blocks.Component;
+        return (
+          <section>
+            <Component id={0} render={() => <Readout value={state[0].get() as Value} />} />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    function Normal() {
+      const [value, setValue] = useState<Value>(0);
+      reactSet = setValue;
+      return (
+        <section>
+          <Readout value={value} />
+        </section>
+      );
+    }
+
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = trackRoot(createRoot(compiledContainer));
+    const reactRoot = trackRoot(createRoot(reactContainer));
+    await act(async () => {
+      compiledRoot.render(<Compiled />);
+      reactRoot.render(<Normal />);
+    });
+
+    for (let offset = 0; offset < updates.length; offset += 10) {
+      await act(async () => {
+        for (const update of updates.slice(offset, offset + 10)) {
+          compiledSet((value) => update(value as Value));
+          reactSet(update);
+        }
+        await flushCompilerUpdates();
+      });
+      expect(compiledContainer.textContent).toBe(reactContainer.textContent);
+    }
+    expect(compiledOwnerRenders).toBe(1);
+  });
+});

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -23,6 +23,8 @@ interface InputSelectionSnapshot {
 export interface CompilerTextBinding<Props> {
   kind: "text";
   path: readonly number[];
+  /** Stable ref target emitted by newer compiler versions. */
+  target?: number;
   dependencies: readonly number[];
   read(props: Props, state: readonly CompilerCell[]): unknown;
 }
@@ -30,6 +32,8 @@ export interface CompilerTextBinding<Props> {
 export interface CompilerAttributeBinding<Props> {
   kind: "attribute";
   path: readonly number[];
+  /** Stable ref target emitted by newer compiler versions. */
+  target?: number;
   dependencies: readonly number[];
   name: string;
   read(props: Props, state: readonly CompilerCell[]): unknown;
@@ -38,6 +42,8 @@ export interface CompilerAttributeBinding<Props> {
 export interface CompilerStyleBinding<Props> {
   kind: "style";
   path: readonly number[];
+  /** Stable ref target emitted by newer compiler versions. */
+  target?: number;
   dependencies: readonly number[];
   name: string;
   read(props: Props, state: readonly CompilerCell[]): unknown;
@@ -59,9 +65,16 @@ export interface CompilerKeyedListBlockProps {
   render(): React.ReactNode;
 }
 
+export interface CompilerComponentBlockProps {
+  id: number;
+  render(): React.ReactNode;
+}
+
 export interface CompilerBlockRuntime {
   Conditional: React.ComponentType<CompilerConditionalBlockProps>;
   KeyedList: React.ComponentType<CompilerKeyedListBlockProps>;
+  Component: React.ComponentType<CompilerComponentBlockProps>;
+  target(id: number): React.RefCallback<Element>;
 }
 
 export type CompilerBinding<Props> =
@@ -407,6 +420,44 @@ function createKeyedListBlockComponent(
   return FarmKeyedListBlock;
 }
 
+function createComponentBlockComponent(
+  owner: Pick<ConditionalBlockOwner, "subscribe">,
+): React.ComponentType<CompilerComponentBlockProps> {
+  class FarmComponentBlock extends React.Component<CompilerComponentBlockProps> {
+    static displayName = "FarmCompiledComponentIsland";
+
+    private unsubscribe: (() => void) | undefined;
+
+    private refresh = (afterCommit?: () => void) => {
+      this.forceUpdate(afterCommit);
+    };
+
+    private subscribe(): void {
+      this.unsubscribe = owner.subscribe(this.props.id, this.refresh);
+    }
+
+    componentDidMount(): void {
+      this.subscribe();
+    }
+
+    componentDidUpdate(previous: CompilerComponentBlockProps): void {
+      if (previous.id === this.props.id) return;
+      this.unsubscribe?.();
+      this.subscribe();
+    }
+
+    componentWillUnmount(): void {
+      this.unsubscribe?.();
+    }
+
+    render(): React.ReactNode {
+      return this.props.render();
+    }
+  }
+
+  return FarmComponentBlock;
+}
+
 /**
  * Runtime target emitted by the AOT transform.
  *
@@ -443,6 +494,8 @@ export function createCompiledComponent<Props>(
     private readonly blockRefreshListeners = new Map<number, (afterCommit?: () => void) => void>();
     private readonly blockRoots = new Map<number, Element>();
     private readonly blockRootElements = new Set<Element>();
+    private readonly bindingTargets = new Map<number, Element>();
+    private readonly bindingTargetRefs = new Map<number, React.RefCallback<Element>>();
     private readonly blockRuntime: CompilerBlockRuntime;
 
     constructor(props: Props) {
@@ -474,6 +527,10 @@ export function createCompiledComponent<Props>(
         KeyedList: createKeyedListBlockComponent({
           subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
         }),
+        Component: createComponentBlockComponent({
+          subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
+        }),
+        target: (id) => this.bindingTarget(id),
       };
     }
 
@@ -484,6 +541,20 @@ export function createCompiledComponent<Props>(
     private refreshDefinition = () => {
       if (this.mounted) this.forceUpdate();
     };
+
+    private bindingTarget(id: number): React.RefCallback<Element> {
+      const existing = this.bindingTargetRefs.get(id);
+      if (existing) return existing;
+      const capture: React.RefCallback<Element> = (element) => {
+        if (element) {
+          this.bindingTargets.set(id, element);
+        } else {
+          this.bindingTargets.delete(id);
+        }
+      };
+      this.bindingTargetRefs.set(id, capture);
+      return capture;
+    }
 
     private captureInputSelection(): void {
       const active = this.root?.ownerDocument.activeElement;
@@ -576,7 +647,12 @@ export function createCompiledComponent<Props>(
 
     private applyBinding(binding: CompilerBinding<Props>): void {
       if (!this.root || binding.kind === "block") return;
-      const target = findBindingTarget(this.root, binding.path, this.blockRootElements);
+      const target =
+        binding.target === undefined
+          ? findBindingTarget(this.root, binding.path, this.blockRootElements)
+          : binding.path.length === 0
+            ? this.root
+            : this.bindingTargets.get(binding.target) || null;
       if (!target) return;
       const value = binding.read(this.props, this.cells);
       if (binding.kind === "text") {
@@ -610,6 +686,8 @@ export function createCompiledComponent<Props>(
       this.blockRefreshListeners.clear();
       this.blockRoots.clear();
       this.blockRootElements.clear();
+      this.bindingTargets.clear();
+      this.bindingTargetRefs.clear();
       refreshListeners.delete(this.refreshDefinition);
     }
 

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -41,6 +41,7 @@ interface PropsPlan {
 interface PendingDomBinding {
   kind: "text" | "attribute" | "style";
   path: number[];
+  target?: number;
   dependencies: number[];
   name?: string;
   value: t.Expression;
@@ -67,6 +68,18 @@ interface KeyedListPlan {
   syntax: "map" | "list";
 }
 
+interface ComponentIslandPlan {
+  id: number;
+  dependencies: number[];
+  location: number[];
+}
+
+interface ComponentIslandAnalysis {
+  islands?: ComponentIslandPlan[];
+  components?: Set<t.JSXElement>;
+  reason?: string;
+}
+
 interface Candidate {
   name: string;
   path: NodePath<t.FunctionDeclaration | t.FunctionExpression | t.ArrowFunctionExpression>;
@@ -78,6 +91,11 @@ const SAFE_MATH_CALLS = new Set(["abs", "ceil", "floor", "max", "min", "round", 
 
 function isComponentName(name: string): boolean {
   return /^[A-Z]/.test(name);
+}
+
+function isHostElement(element: t.JSXElement): boolean {
+  const name = element.openingElement.name;
+  return t.isJSXIdentifier(name) && /^[a-z]/.test(name.name);
 }
 
 function directiveValues(node: { directives?: readonly t.Directive[] | null }): string[] {
@@ -174,6 +192,7 @@ function rewriteDestructuredPropAccess<T extends t.Expression>(
   traverse(file, {
     ReferencedIdentifier(path) {
       if (!names.has(path.node.name) || path.scope.hasBinding(path.node.name)) return;
+      if (path.parentPath.isJSXOpeningElement() || path.parentPath.isJSXClosingElement()) return;
       path.replaceWith(
         t.memberExpression(t.cloneNode(propsParameter), t.identifier(path.node.name)),
       );
@@ -911,6 +930,194 @@ function lowerKeyedLists(
   return lowered;
 }
 
+function analyzeComponentIslands(
+  root: t.JSXElement,
+  statesByValue: ReadonlyMap<string, StateBinding>,
+  safeGlobals: ReadonlySet<string>,
+  allowedComponentNames: ReadonlySet<string>,
+  keyedElements: ReadonlySet<t.JSXElement>,
+  startingId: number,
+): ComponentIslandAnalysis {
+  const islands: ComponentIslandPlan[] = [];
+  const components = new Set<t.JSXElement>();
+
+  const visit = (element: t.JSXElement, location: number[]): string | undefined => {
+    for (let childIndex = 0; childIndex < element.children.length; childIndex += 1) {
+      const child = element.children[childIndex];
+      if (!t.isJSXElement(child) || keyedElements.has(child)) continue;
+      if (isHostElement(child)) {
+        const reason = visit(child, [...location, childIndex]);
+        if (reason) return reason;
+        continue;
+      }
+
+      const name = child.openingElement.name;
+      if (!t.isJSXIdentifier(name) || !isComponentName(name.name)) {
+        return "component islands require a direct component identifier";
+      }
+      if (!allowedComponentNames.has(name.name)) {
+        return `component island ${name.name} must reference a stable module-level component`;
+      }
+      if (meaningfulJsxChildren(child).length > 0) {
+        return `component island ${name.name} does not support children yet`;
+      }
+
+      const dependencies = new Set<number>();
+      for (const attribute of child.openingElement.attributes) {
+        if (t.isJSXSpreadAttribute(attribute)) {
+          return `component island ${name.name} does not support JSX attribute spreads`;
+        }
+        const attributeName = jsxAttributeName(attribute);
+        if (!attributeName) {
+          return `component island ${name.name} does not support namespaced JSX attributes`;
+        }
+        if (attributeName === "ref" || attributeName === "key" || attributeName === "children") {
+          return `component island ${name.name} does not support ${attributeName} yet`;
+        }
+        if (
+          !t.isJSXExpressionContainer(attribute.value) ||
+          t.isJSXEmptyExpression(attribute.value.expression)
+        ) {
+          continue;
+        }
+
+        const expression = attribute.value.expression;
+        const isEventFunction =
+          /^on[A-Z]/.test(attributeName) &&
+          (t.isArrowFunctionExpression(expression) || t.isFunctionExpression(expression));
+        if (!isEventFunction) {
+          const unsupported = validateDerivedExpression(expression, safeGlobals);
+          if (unsupported) {
+            return `component island ${name.name} prop ${attributeName} cannot use ${unsupported}`;
+          }
+        }
+        collectStateDependencies(expression, statesByValue).forEach((dependency) =>
+          dependencies.add(dependency),
+        );
+      }
+
+      components.add(child);
+      if (dependencies.size > 0) {
+        islands.push({
+          id: startingId + islands.length,
+          dependencies: [...dependencies].sort((left, right) => left - right),
+          location: [...location, childIndex],
+        });
+      }
+    }
+    return undefined;
+  };
+
+  const reason = visit(root, []);
+  return reason ? { reason } : { islands, components };
+}
+
+function componentIslandBoundary(
+  blockRuntime: t.Identifier,
+  plan: ComponentIslandPlan,
+  source: t.JSXElement,
+): t.JSXElement {
+  const name = t.jsxMemberExpression(
+    t.jsxIdentifier(blockRuntime.name),
+    t.jsxIdentifier("Component"),
+  );
+  return t.jsxElement(
+    t.jsxOpeningElement(
+      name,
+      [
+        t.jsxAttribute(t.jsxIdentifier("id"), t.jsxExpressionContainer(t.numericLiteral(plan.id))),
+        t.jsxAttribute(
+          t.jsxIdentifier("render"),
+          t.jsxExpressionContainer(t.arrowFunctionExpression([], t.cloneNode(source, true))),
+        ),
+      ],
+      true,
+    ),
+    null,
+    [],
+    true,
+  );
+}
+
+function lowerComponentIslands(
+  root: t.JSXElement,
+  plans: readonly ComponentIslandPlan[],
+  blockRuntime: t.Identifier,
+): t.JSXElement {
+  if (plans.length === 0) return t.cloneNode(root, true);
+  const lowered = t.cloneNode(root, true);
+  const plansByLocation = new Map(plans.map((plan) => [plan.location.join("."), plan]));
+
+  const visit = (element: t.JSXElement, location: number[]): void => {
+    element.children = element.children.map((child, childIndex) => {
+      if (!t.isJSXElement(child)) return child;
+      const childLocation = [...location, childIndex];
+      const plan = plansByLocation.get(childLocation.join("."));
+      if (plan) return componentIslandBoundary(blockRuntime, plan, child);
+      if (isHostElement(child)) visit(child, childLocation);
+      return child;
+    });
+  };
+
+  visit(lowered, []);
+  return lowered;
+}
+
+function assignStableBindingTargets(bindings: readonly PendingBinding[]): void {
+  const targetByPath = new Map<string, number>();
+  for (const binding of bindings) {
+    if (binding.kind === "block") continue;
+    const key = binding.path.join(".");
+    let target = targetByPath.get(key);
+    if (target === undefined) {
+      target = targetByPath.size;
+      targetByPath.set(key, target);
+    }
+    binding.target = target;
+  }
+}
+
+function lowerStableBindingTargets(
+  root: t.JSXElement,
+  bindings: readonly PendingBinding[],
+  blockRuntime: t.Identifier,
+): t.JSXElement {
+  const lowered = t.cloneNode(root, true);
+  const targetByPath = new Map<string, number>();
+  for (const binding of bindings) {
+    if (binding.kind !== "block" && binding.target !== undefined) {
+      targetByPath.set(binding.path.join("."), binding.target);
+    }
+  }
+
+  const visit = (element: t.JSXElement, path: number[]): void => {
+    const target = targetByPath.get(path.join("."));
+    if (target !== undefined && path.length > 0) {
+      element.openingElement.attributes.push(
+        t.jsxAttribute(
+          t.jsxIdentifier("ref"),
+          t.jsxExpressionContainer(
+            t.callExpression(
+              t.memberExpression(t.cloneNode(blockRuntime), t.identifier("target")),
+              [t.numericLiteral(target)],
+            ),
+          ),
+        ),
+      );
+    }
+
+    let elementIndex = 0;
+    for (const child of element.children) {
+      if (!t.isJSXElement(child) || !isHostElement(child)) continue;
+      visit(child, [...path, elementIndex]);
+      elementIndex += 1;
+    }
+  };
+
+  visit(lowered, []);
+  return lowered;
+}
+
 function analyzeHostTree(
   root: t.JSXElement,
   statesByValue: ReadonlyMap<string, StateBinding>,
@@ -918,6 +1125,7 @@ function analyzeHostTree(
   conditionalExpressions: ReadonlySet<t.Expression>,
   keyedExpressions: ReadonlySet<t.Expression>,
   keyedElements: ReadonlySet<t.JSXElement>,
+  componentElements: ReadonlySet<t.JSXElement>,
 ): { bindings?: PendingBinding[]; reason?: string } {
   const bindings: PendingBinding[] = [];
 
@@ -998,7 +1206,8 @@ function analyzeHostTree(
     }
 
     const nestedElements = element.children.filter(
-      (child): child is t.JSXElement => t.isJSXElement(child) && !keyedElements.has(child),
+      (child): child is t.JSXElement =>
+        t.isJSXElement(child) && isHostElement(child) && !keyedElements.has(child),
     );
     const expressionChildren = element.children.filter((child): child is t.JSXExpressionContainer =>
       t.isJSXExpressionContainer(child),
@@ -1015,8 +1224,12 @@ function analyzeHostTree(
     const hasKeyedElement = element.children.some(
       (child) => t.isJSXElement(child) && keyedElements.has(child),
     );
+    const hasComponentElement = element.children.some(
+      (child) => t.isJSXElement(child) && componentElements.has(child),
+    );
     const hasDynamicBlocks =
       hasKeyedElement ||
+      hasComponentElement ||
       expressionChildren.some(
         (child) =>
           !t.isJSXEmptyExpression(child.expression) &&
@@ -1057,7 +1270,7 @@ function analyzeHostTree(
       }
       let elementIndex = 0;
       for (const child of element.children) {
-        if (!t.isJSXElement(child) || keyedElements.has(child)) continue;
+        if (!t.isJSXElement(child) || !isHostElement(child) || keyedElements.has(child)) continue;
         const reason = visit(child, [...path, elementIndex]);
         if (reason) return reason;
         elementIndex += 1;
@@ -1178,6 +1391,13 @@ function bindingObject(
       t.arrayExpression(binding.path.map((part) => t.numericLiteral(part))),
     ),
   );
+  if (binding.target !== undefined) {
+    properties.splice(
+      2,
+      0,
+      t.objectProperty(t.identifier("target"), t.numericLiteral(binding.target)),
+    );
+  }
   if (binding.name)
     properties.push(t.objectProperty(t.identifier("name"), t.stringLiteral(binding.name)));
   properties.push(
@@ -1356,6 +1576,38 @@ function compileCandidate(
   const keyedElements = new Set(
     keyedLists.filter((list) => list.syntax === "list").map((list) => list.source as t.JSXElement),
   );
+  const referencedComponentNames = new Set<string>();
+  traverse(expressionFile(t.cloneNode(expandedRoot, true)), {
+    JSXOpeningElement(componentPath) {
+      const componentName = componentPath.node.name;
+      if (t.isJSXIdentifier(componentName) && isComponentName(componentName.name)) {
+        referencedComponentNames.add(componentName.name);
+      }
+    },
+  });
+  const allowedComponentNames = new Set(
+    [...referencedComponentNames].filter((componentName) => {
+      if (listNames.has(componentName)) return false;
+      const binding = path.scope.getBinding(componentName);
+      return Boolean(
+        binding?.constant &&
+        binding.scope.path.isProgram() &&
+        binding.kind !== "let" &&
+        binding.kind !== "var",
+      );
+    }),
+  );
+  const componentAnalysis = analyzeComponentIslands(
+    expandedRoot,
+    statesByValue,
+    safeGlobals,
+    allowedComponentNames,
+    keyedElements,
+    conditionalBlocks.length + keyedLists.length,
+  );
+  if (componentAnalysis.reason) return componentAnalysis.reason;
+  const componentIslands = componentAnalysis.islands || [];
+  const componentElements = componentAnalysis.components || new Set<t.JSXElement>();
   const analysis = analyzeHostTree(
     expandedRoot,
     statesByValue,
@@ -1363,14 +1615,22 @@ function compileCandidate(
     conditionalExpressions,
     keyedExpressions,
     keyedElements,
+    componentElements,
   );
   if (analysis.reason) return analysis.reason;
+  assignStableBindingTargets(analysis.bindings || []);
 
   const stateParameter = path.scope.generateUidIdentifier("farmState");
   const blockParameter = path.scope.generateUidIdentifier("farmBlocks");
   const definitionIdentifier = path.scope.generateUidIdentifier(`${name}Compiled`);
   const propsParameter = propsPlan.definitionParameter;
-  const rootWithLists = lowerKeyedLists(expandedRoot, keyedLists, blockParameter, listNames);
+  const rootWithTargets = lowerStableBindingTargets(
+    expandedRoot,
+    analysis.bindings || [],
+    blockParameter,
+  );
+  const rootWithIslands = lowerComponentIslands(rootWithTargets, componentIslands, blockParameter);
+  const rootWithLists = lowerKeyedLists(rootWithIslands, keyedLists, blockParameter, listNames);
   const rootWithBlocks = lowerConditionalBlocks(rootWithLists, conditionalBlocks, blockParameter);
   const rewrittenRoot = rewriteStateAccess(
     rootWithBlocks,
@@ -1437,6 +1697,11 @@ function compileCandidate(
               kind: "block" as const,
               id: list.id,
               dependencies: list.dependencies,
+            })),
+            ...componentIslands.map((island) => ({
+              kind: "block" as const,
+              id: island.id,
+              dependencies: island.dependencies,
             })),
           ].map((binding) =>
             bindingObject(binding, propsParameter, stateParameter, statesByValue, statesBySetter),


### PR DESCRIPTION
## Summary

- add automatic React-owned component islands for stable imported and module-level child components
- add stable ref-owned DOM binding targets so child output changes cannot shift unrelated bindings
- preserve safe React fallback for dynamic or member component types, spreads, refs, keys, children, and inline identity-bearing values
- add compiler/runtime tests, React 18 and React 19 compatibility coverage, documentation, and a production browser benchmark

## Why

The experimental AOT compiler already handled host trees, conditional blocks, and keyed lists, but a state-dependent custom component forced its owner back to normal React rendering. Component islands let the compiler update only that child boundary while React continues to own Hooks, context, local state, lifecycle, events, SSR, hydration, and error behavior.

Unsupported structures still fall back to React.

## Performance

Measured on Apple M1 with Chromium 145 in the included off/on/off production benchmark:

- median child-commit latency: 0.165 ms to 0.025 ms (84.8% lower, 6.6x)
- owner executions per trial: 2430 to 0
- unchanged static sibling executions per trial: 2430 to 0
- expanded example page chunk: 6,948 B to 10,792 B gzip (+3,844 B)

These results describe this benchmark workload, not a general React performance claim.

## Validation

- pnpm --filter @farm.js/react type-check
- pnpm --filter @farm.js/react test — 127 tests
- pnpm --filter @farm.js/react test:compat — React 18.3.1 and React 19.2.8
- pnpm --filter farm-react-compiler-example type-check
- pnpm --filter farm-react-compiler-example experiment — desktop and mobile production E2E
- pnpm --filter farm-react-compiler-example experiment:heavy — off/on/off crossover benchmark
- pnpm exec oxlint, pnpm exec oxfmt, and git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds React-owned component islands and stable ref-owned DOM targets in `@farm-react`. Previously, a stateful child component forced the owner to rerender. Now the compiler isolates eligible children as islands and asks React to update only that boundary when a dependent prop changes; the owner and unchanged siblings do not execute. Direct bindings use generated callback refs so DOM targeting stays correct even if earlier React-owned children change shape. SSR markup stays unchanged.

- Compiler: detects islands for stable imported or module-level component identifiers with explicit compiler-safe props and no JSX children, spreads, `ref`, or `key`; assigns unique block ids across conditional/keyed/component boundaries; emits `blocks.Component` for islands and `target(id)` ids for bindings; lowers host trees to attach `ref` callbacks via `blocks.target(id)`; unsupported shapes fall back to React.
- Runtime: adds a Component block that subscribes to island ids and refreshes only that boundary; exposes `target(id)` to capture stable binding elements; patches text/attribute/style bindings via these targets; preserves existing conditional and keyed-list behavior; supports Strict Mode, hydration, and dropping queued updates after unmount; routes island errors through React error boundaries.
- Validation and examples: adds compiler/runtime tests for island updates, context propagation through memoized owners, stable ref targets across null/fragment/multi-node shapes, deterministic object/array/nullish prop transitions, and React 18/19 compatibility; documents island contract and fallback cases; adds a component-island experiment and extends the heavy benchmark to report owner and static-sibling executions and child-commit latency. Reference runs: direct-binding median fell from 0.175 ms to 0.015 ms (~11.7×), island child-commit median from 0.165 ms to 0.025 ms (~6.6×); owner/static-sibling executions added: 0; production page chunk +3,844 B gzip.

<sup>Written for commit 2557cfad942ffcd16e0bb61d1da469ce5ae4efff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

