### PR TITLE
fix: enable telemetry by default

### DIFF
--- a/docs/src/app/docs/cli/page.md
+++ b/docs/src/app/docs/cli/page.md
@@ -53,11 +53,11 @@ React is the default renderer. `--renderer preact`, `--renderer solid`, `--rende
 | farm cron run dailyCleanup       | Invoke one cron route on a running app.                              |
 | farm dev --cron                  | Start the dev server with the opt-in in-memory cron scheduler.       |
 | farm telemetry status            | Show the anonymous product-telemetry preference.                     |
-| farm telemetry enable            | Opt in to anonymous Farm.js product telemetry.                       |
+| farm telemetry enable            | Enable anonymous Farm.js product telemetry.                          |
 | farm telemetry disable           | Opt out and delete the local anonymous installation ID.              |
 
 See [Anonymous telemetry](/docs/telemetry) for the exact event fields, environment overrides, and
-privacy guarantees. Telemetry is off by default during the beta.
+privacy guarantees. Telemetry is enabled by default for interactive local commands.
 
 ## Upgrade Farm packages
 

--- a/docs/src/app/docs/telemetry/page.md
+++ b/docs/src/app/docs/telemetry/page.md
@@ -1,20 +1,20 @@
 ---
 title: "Anonymous telemetry"
-description: "Understand and control Farm.js opt-in product telemetry."
+description: "Understand and control Farm.js anonymous product telemetry."
 section: "Reference"
 ---
 
 # Anonymous telemetry
 
 Farm.js includes optional anonymous product telemetry in `@farm.js/cli` and
-`@farm.js/create-app`. During the beta, telemetry is **off by default**. It helps the
+`@farm.js/create-app`. Telemetry is **enabled by default** for interactive local commands. It helps the
 maintainers understand which coarse framework paths are useful and where compatibility work should
 be focused.
 
 This is separate from [application observability](/docs/observability). OpenTelemetry describes what
 your application does and is configured by the application owner. Farm.js product telemetry only
 describes use of Farm's own CLI and starter generator, and is sent to Farm's infrastructure after
-you opt in.
+the CLI displays its one-time notice unless you opt out.
 
 ## Control telemetry
 
@@ -24,9 +24,10 @@ farm telemetry enable
 farm telemetry disable
 ```
 
-`farm telemetry enable` creates a random anonymous installation ID in the operating system's local
-configuration directory. `farm telemetry disable` opts out and deletes that ID. Enabling telemetry
-again creates a different ID.
+The first eligible event creates a random anonymous installation ID in the operating system's local
+configuration directory. `farm telemetry disable` opts out and deletes that ID. Running
+`farm telemetry enable` later creates a different ID. Saved opt-out preferences remain respected
+across upgrades.
 
 Environment variables can provide an explicit per-process or organization-wide policy:
 

--- a/docs/src/app/telemetry/page.tsx
+++ b/docs/src/app/telemetry/page.tsx
@@ -446,7 +446,7 @@ export default async function TelemetryPage({ searchParams }: TelemetryPageProps
                 Farm.js telemetry
               </h1>
               <p className="mt-3 max-w-2xl text-sm leading-6 text-white/50">
-                Coarse, opt-in CLI and project-creation signals. No paths, repositories, source,
+                Coarse, anonymous CLI and project-creation signals. No paths, repositories, source,
                 credentials, user identities, IP addresses, or user-agent strings are stored.
               </p>
             </div>

--- a/packages/farm-cli/bin/farm.js
+++ b/packages/farm-cli/bin/farm.js
@@ -539,7 +539,7 @@ telemetryCommand
 
 telemetryCommand
   .command("enable")
-  .description("Opt in to anonymous Farm.js product telemetry")
+  .description("Enable anonymous Farm.js product telemetry")
   .action(async () => {
     const { setFarmTelemetryEnabled } = require("../dist/telemetry.js");
     const status = await setFarmTelemetryEnabled(true);

--- a/packages/farm-cli/src/telemetry.ts
+++ b/packages/farm-cli/src/telemetry.ts
@@ -61,6 +61,11 @@ interface FarmTelemetryConfig {
   anonymousId?: string;
 }
 
+interface FarmTelemetryConfigState {
+  config: FarmTelemetryConfig;
+  stored: boolean;
+}
+
 interface FarmTelemetryEventBase {
   schemaVersion: typeof TELEMETRY_SCHEMA_VERSION;
   eventId: string;
@@ -124,7 +129,7 @@ type FarmTelemetryEventInput<T = FarmTelemetryEvent> = T extends FarmTelemetryEv
 function defaultConfig(): FarmTelemetryConfig {
   return {
     version: TELEMETRY_SCHEMA_VERSION,
-    enabled: false,
+    enabled: true,
     noticeShown: false,
   };
 }
@@ -149,20 +154,25 @@ export function getFarmTelemetryConfigFile(): string {
   return path.join(configDirectory(), "telemetry.json");
 }
 
-async function readConfig(): Promise<FarmTelemetryConfig> {
+async function readConfig(): Promise<FarmTelemetryConfigState> {
   try {
     const parsed = JSON.parse(
       await readFile(getFarmTelemetryConfigFile(), "utf8"),
     ) as Partial<FarmTelemetryConfig>;
-    if (parsed.version !== TELEMETRY_SCHEMA_VERSION) return defaultConfig();
+    if (parsed.version !== TELEMETRY_SCHEMA_VERSION) {
+      return { config: defaultConfig(), stored: false };
+    }
     return {
-      version: TELEMETRY_SCHEMA_VERSION,
-      enabled: parsed.enabled === true,
-      noticeShown: parsed.noticeShown === true,
-      anonymousId: isUuid(parsed.anonymousId) ? parsed.anonymousId : undefined,
+      config: {
+        version: TELEMETRY_SCHEMA_VERSION,
+        enabled: parsed.enabled === true,
+        noticeShown: parsed.noticeShown === true,
+        anonymousId: isUuid(parsed.anonymousId) ? parsed.anonymousId : undefined,
+      },
+      stored: true,
     };
   } catch {
-    return defaultConfig();
+    return { config: defaultConfig(), stored: false };
   }
 }
 
@@ -244,15 +254,11 @@ async function resolveState(): Promise<{
   source: FarmTelemetryStatus["source"];
   reason?: string;
 }> {
-  const config = await readConfig();
+  const { config, stored } = await readConfig();
   const environment = environmentDecision();
   const enabled = environment.enabled ?? config.enabled;
   const source =
-    environment.enabled !== undefined
-      ? "environment"
-      : config.enabled
-        ? "configuration"
-        : "default";
+    environment.enabled !== undefined ? "environment" : stored ? "configuration" : "default";
 
   if (!enabled) return { config, enabled, active: false, source, reason: environment.reason };
   if (environment.enabled === true) return { config, enabled, active: true, source };
@@ -288,7 +294,7 @@ export async function getFarmTelemetryStatus(): Promise<FarmTelemetryStatus> {
 }
 
 export async function setFarmTelemetryEnabled(enabled: boolean): Promise<FarmTelemetryStatus> {
-  const current = await readConfig();
+  const { config: current } = await readConfig();
   await writeConfig({
     version: TELEMETRY_SCHEMA_VERSION,
     enabled,
@@ -301,10 +307,10 @@ export async function setFarmTelemetryEnabled(enabled: boolean): Promise<FarmTel
 export async function showFarmTelemetryNotice(): Promise<void> {
   if (!isInteractive() || isContinuousIntegration() || process.env.NODE_ENV === "test") return;
   if (environmentDecision().enabled !== undefined) return;
-  const config = await readConfig();
+  const { config } = await readConfig();
   if (config.noticeShown) return;
   process.stderr.write(
-    `Farm.js anonymous telemetry is off during beta. Run "farm telemetry enable" to opt in.\nLearn more: ${TELEMETRY_NOTICE_URL}\n`,
+    `Farm.js collects anonymous CLI telemetry by default. Run "farm telemetry disable" to opt out.\nLearn more: ${TELEMETRY_NOTICE_URL}\n`,
   );
   await writeConfig({ ...config, noticeShown: true });
 }

--- a/packages/farm-cli/test/telemetry.test.mjs
+++ b/packages/farm-cli/test/telemetry.test.mjs
@@ -42,11 +42,13 @@ async function withTelemetryEnvironment(run) {
   }
 }
 
-test("telemetry is opt-in and does not create an identity by default", async () => {
+test("telemetry is enabled without creating an identity by default", async () => {
   await withTelemetryEnvironment(async () => {
     const status = await getFarmTelemetryStatus();
-    assert.equal(status.enabled, false);
+    assert.equal(status.enabled, true);
     assert.equal(status.active, false);
+    assert.equal(status.source, "default");
+    assert.match(status.reason, /non-interactive/);
     assert.equal(status.anonymousId, undefined);
   });
 });
@@ -61,6 +63,9 @@ test("enable persists an anonymous ID and disable removes it", async () => {
     const disabledConfig = JSON.parse(await readFile(getFarmTelemetryConfigFile(), "utf8"));
     assert.equal(disabledConfig.enabled, false);
     assert.equal(disabledConfig.anonymousId, undefined);
+    const disabledStatus = await getFarmTelemetryStatus();
+    assert.equal(disabledStatus.enabled, false);
+    assert.equal(disabledStatus.source, "configuration");
 
     await setFarmTelemetryEnabled(true);
     const secondConfig = JSON.parse(await readFile(getFarmTelemetryConfigFile(), "utf8"));


### PR DESCRIPTION
## Summary

- enable anonymous telemetry by default for interactive local Farm CLI commands
- preserve environment overrides and existing saved opt-outs while reporting the preference source correctly
- update the one-time CLI notice, telemetry dashboard copy, and documentation for the new default

## Root cause

Telemetry was disabled for every fresh installation during beta, so upgrading Farm packages or running Farm commands could not produce usage events unless the user separately opted in. This left the production dashboard empty even when current packages were in use.

## User impact

Fresh installations now collect the existing strict, anonymous event payloads after displaying the one-time notice. `farm telemetry disable`, `FARM_TELEMETRY=0`, `FARM_TELEMETRY_DISABLED=1`, and `DO_NOT_TRACK=1` remain respected. Existing stored opt-outs are preserved, and CI, test, and non-interactive commands remain skipped without an explicit `FARM_TELEMETRY=1` override.

## Validation

- `pnpm --filter @farm.js/cli test` (73 tests passed)
- `pnpm --filter @farm.js/cli type-check`
- `pnpm docs:check-navigation`
- targeted `oxfmt --check`
- `pnpm --filter farmjs-docs build`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable anonymous telemetry by default for interactive local commands in `@farm.js/cli`, replacing the previous off-by-default behavior. This keeps environment overrides and saved opt-outs effective and continues to skip CI/test/non-interactive runs unless explicitly enabled.

- Default config now sets `enabled: true`; we track whether a config file exists to report the status source as "default", "configuration", or "environment".
- Environment variables (`FARM_TELEMETRY`, `FARM_TELEMETRY_DISABLED`, `DO_NOT_TRACK`) still take precedence; no anonymous ID is created until the first eligible event.
- One-time notice copy, CLI help text, and docs updated; tests reflect the new default. `@farm.js/create-app` docs now describe the default-on behavior.

**Rollout**
- No migration required. Existing saved opt-outs remain honored. To disable org-wide, set `DO_NOT_TRACK=1` or `FARM_TELEMETRY_DISABLED=1`. To enable in CI, set `FARM_TELEMETRY=1`.

<sup>Written for commit f80fd0ec0787aa7b84f031a3d0802139c96aeb65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

