### PR TITLE
fix(dev): compose full-document root layouts instead of nesting them

### DIFF
--- a/packages/farm/src/__tests__/full-document.test.ts
+++ b/packages/farm/src/__tests__/full-document.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import {
+  composeFarmFullDocument,
+  extractFarmFullDocument,
+  isFarmFullDocument,
+  opensFarmFullDocument,
+} from "../server/full-document";
+
+// How a full-document root layout renders through the dev pipeline: the layout's
+// own <html> document, wrapped in Farm's display:contents boundary/stream divs.
+const wrappedFullDocument =
+  '<div style="display:contents">' +
+  '<div data-farm-layout-boundary="true" data-farm-layout-pattern="/" style="display:contents">' +
+  '<html lang="en"><head><title>App</title></head><body><main>hello</main></body></html>' +
+  "</div></div>";
+
+const fragmentMarkup =
+  '<div data-farm-layout-boundary="true" data-farm-layout-pattern="/" style="display:contents">' +
+  '<main class="page">hello</main></div>';
+
+describe("full-document detection", () => {
+  it("extracts the document from Farm's display:contents wrappers", () => {
+    expect(extractFarmFullDocument(wrappedFullDocument)).toBe(
+      '<html lang="en"><head><title>App</title></head><body><main>hello</main></body></html>',
+    );
+  });
+
+  it("treats a fragment layout as not-a-document", () => {
+    expect(extractFarmFullDocument(fragmentMarkup)).toBeNull();
+    expect(isFarmFullDocument(fragmentMarkup)).toBe(false);
+  });
+
+  it("recognises a raw <!DOCTYPE> document", () => {
+    expect(isFarmFullDocument("<!DOCTYPE html><html><body>x</body></html>")).toBe(true);
+  });
+
+  it("opensFarmFullDocument sees a streamed prefix before </html> arrives", () => {
+    const prefix = '<div style="display:contents"><html lang="en"><head><title>A';
+    expect(opensFarmFullDocument(prefix)).toBe(true);
+    expect(extractFarmFullDocument(prefix)).toBeNull(); // no closing tag yet
+    expect(opensFarmFullDocument(fragmentMarkup)).toBe(false);
+  });
+});
+
+describe("full-document composition", () => {
+  it("produces exactly one html/head/body with Farm assets merged in", () => {
+    const document = extractFarmFullDocument(wrappedFullDocument)!;
+    const html = composeFarmFullDocument(document, {
+      htmlAttributes: ' data-theme="dark"',
+      headAssets: '<link rel="stylesheet" href="/globals.css" />',
+      bodyFooter: '<script type="module" src="/@farm/client.js"></script>',
+    });
+
+    expect(html.match(/<html[\s>]/gi)).toHaveLength(1);
+    expect(html.match(/<head[\s>]/gi)).toHaveLength(1);
+    expect(html.match(/<body[\s>]/gi)).toHaveLength(1);
+    expect(html.startsWith("<!DOCTYPE html>")).toBe(true);
+    expect(html).toContain('data-theme="dark"');
+    expect(html).toContain('<link rel="stylesheet" href="/globals.css" />');
+    expect(html).toContain('id="root"');
+    // Head asset lands inside <head>, footer inside <body>.
+    expect(html.indexOf("/globals.css")).toBeLessThan(html.indexOf("</head>"));
+    expect(html.indexOf("/@farm/client.js")).toBeLessThan(html.indexOf("</body>"));
+  });
+
+  it("inserts injected markup literally even with $-replacement sequences", () => {
+    const document = "<html><head></head><body>$&amp; $` $' $$</body></html>";
+    const html = composeFarmFullDocument(document, {
+      headAssets: "<meta name=x>",
+      bodyFooter: "<script>1</script>",
+    });
+    // The $-sequences in the document survive untouched (no expansion).
+    expect(html).toContain("$&amp; $` $' $$");
+    expect(html).toContain("<script>1</script>");
+  });
+});

--- a/packages/farm/src/server/full-document.ts
+++ b/packages/farm/src/server/full-document.ts
@@ -1,0 +1,95 @@
+// Handling for a root layout that returns a full `<html>…</html>` document.
+//
+// Farm owns the document shell — a layout is expected to return a fragment (its
+// children), like the docs example does. When a layout instead returns a whole
+// document, the dev renderer must compose that document as the response rather
+// than nesting it inside the generated shell, which would emit invalid nested
+// `<html>`/`<head>`/`<body>`. This mirrors the production (Nitro) build's
+// `hasFullDocument` path so dev and prod agree.
+
+/** Peel Farm's leading `display:contents` wrapper divs (the stream root and any
+ * layout-boundary divs) so the layout's own markup is exposed for inspection. */
+function stripContentsWrappers(markup: string): string {
+  let out = markup.replace(/^\s+/, "");
+  const opener = /^<div\b[^>]*style="display\s*:\s*contents"[^>]*>/i;
+  let match: RegExpExecArray | null;
+  while ((match = opener.exec(out))) {
+    out = out.slice(match[0].length).replace(/^\s+/, "");
+  }
+  return out;
+}
+
+/**
+ * When `markup` (a rendered layout tree, possibly wrapped in Farm's
+ * `display:contents` boundary divs) is a full HTML document, return just that
+ * `<html>…</html>` document (leading `<!DOCTYPE>` preserved when present);
+ * otherwise return `null`.
+ */
+export function extractFarmFullDocument(markup: string): string | null {
+  const inner = stripContentsWrappers(markup);
+  if (!/^<!doctype/i.test(inner) && !/^<html[\s>]/i.test(inner)) return null;
+  const start = markup.search(/<!doctype|<html[\s>]/i);
+  const closeIndex = markup.toLowerCase().lastIndexOf("</html>");
+  if (start < 0 || closeIndex < 0) return null;
+  return markup.slice(start, closeIndex + "</html>".length);
+}
+
+/** True when a rendered layout tree is (or wraps) a full HTML document. */
+export function isFarmFullDocument(markup: string): boolean {
+  return extractFarmFullDocument(markup) !== null;
+}
+
+/**
+ * True when `markup` *begins* a full HTML document once Farm's wrappers are
+ * peeled — usable on a streamed prefix, before the closing `</html>` has been
+ * flushed.
+ */
+export function opensFarmFullDocument(markup: string): boolean {
+  const inner = stripContentsWrappers(markup);
+  return /^<!doctype/i.test(inner) || /^<html[\s>]/i.test(inner);
+}
+
+export interface FarmFullDocumentAssets {
+  /** Farm-managed `<head>` markup (styles, client/runtime scripts, metadata). */
+  headAssets: string;
+  /** Markup injected just before `</body>` (client bootstrap / entry scripts). */
+  bodyFooter: string;
+  /** Extra `<html>` attributes to merge (theme, direction). */
+  htmlAttributes?: string;
+}
+
+/**
+ * Compose a layout's own full document with Farm's managed head + body assets,
+ * instead of nesting it inside the shell. String replacements use function
+ * replacers so any `$`-sequences (`$&`, `$'`, `$$`) in the injected markup or
+ * the document are inserted literally rather than expanded.
+ */
+export function composeFarmFullDocument(
+  documentHtml: string,
+  assets: FarmFullDocumentAssets,
+): string {
+  let html = documentHtml;
+
+  if (assets.htmlAttributes) {
+    html = html.replace(
+      /<html\b([^>]*)>/i,
+      (_match, attrs: string) => `<html${attrs}${assets.htmlAttributes}>`,
+    );
+  }
+
+  // Ensure a hydration root exists so the client can mount, matching the shell.
+  if (!/\sid=["']root["']/i.test(html)) {
+    html = html
+      .replace(/<body\b([^>]*)>/i, '<body$1><div id="root">')
+      .replace(/<\/body>/i, "</div></body>");
+  }
+
+  if (assets.headAssets) {
+    html = html.replace(/<\/head>/i, () => `  ${assets.headAssets}\n</head>`);
+  }
+  if (assets.bodyFooter) {
+    html = html.replace(/<\/body>/i, () => `  ${assets.bodyFooter}\n</body>`);
+  }
+
+  return /^\s*<!doctype/i.test(html) ? html : `<!DOCTYPE html>\n${html}`;
+}

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -11,6 +11,11 @@ import type {
 } from "../types";
 import type { MatchedRouteSlot, RouteManager } from "../routing/route-manager";
 import { logger, toRootRelativeUrlPath } from "../utils";
+import {
+  composeFarmFullDocument,
+  extractFarmFullDocument,
+  opensFarmFullDocument,
+} from "./full-document";
 import { getClientModuleMetadata } from "../utils/client-component";
 import { Writable } from "stream";
 import {
@@ -135,6 +140,26 @@ function warnSuppressedAsyncHydrationOnce(modulePath: string): void {
       `server-rendered and its client imports are not interactive. Move the ` +
       `interactive UI into a "use client" child rendered by a synchronous page, ` +
       `or enable experimental server components support.`,
+  );
+}
+
+// Routes whose layout was observed to render a full `<html>` document. The
+// streaming path can't rewrite a document after its shell is flushed, so once a
+// route is seen to be full-document it is served through the buffered path
+// (which composes the document correctly) on every subsequent request.
+const fullDocumentRoutes = new Set<string>();
+
+let warnedFullDocumentLayout = false;
+
+function warnFarmFullDocumentLayout(): void {
+  if (warnedFullDocumentLayout) return;
+  warnedFullDocumentLayout = true;
+  logger.warn(
+    `A root layout returned a full <html> document. Farm.js owns the document ` +
+      `shell, so a layout should return a fragment (its children) — like the docs ` +
+      `example — and let the framework provide <html>/<head>/<body>. The document ` +
+      `has been composed into the response, but returning a fragment avoids the ` +
+      `ambiguity and keeps dev and production identical.`,
   );
 }
 
@@ -1982,10 +2007,38 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
         this.config.basePath,
         getFarmTheme(),
       );
-      const html = `<!DOCTYPE html>
+
+      // A layout that returns its own full `<html>` document is composed as the
+      // document (Farm assets merged in) rather than nested inside the shell,
+      // matching the production build and avoiding invalid nested documents.
+      const fullDocument = extractFarmFullDocument(content);
+      let html: string;
+      if (fullDocument) {
+        warnFarmFullDocumentLayout();
+        html = composeFarmFullDocument(fullDocument, {
+          htmlAttributes: `${i18nSnapshot ? ` dir="${i18nSnapshot.direction}"` : ""}${themeDocument.attributes}`,
+          headAssets: [
+            themeDocument.head,
+            `<meta name="farm-deployment-id" content="${escapeHtmlAttribute(deploymentId)}">`,
+            metaTags,
+            alternateTags,
+            renderFarmFontDevHead(this.config.root || process.cwd()),
+            `<link rel="stylesheet" href="/src/app/globals.css">`,
+            `<script type="module" src="/@vite/client"></script>`,
+            rendererHydrationScript,
+            bootstrapScript,
+          ]
+            .filter(Boolean)
+            .join("\n  "),
+          bodyFooter: [deferredScript, `<script type="module" src="/@farm/client.js"></script>`]
+            .filter(Boolean)
+            .join("\n  "),
+        });
+      } else {
+        html = `<!DOCTYPE html>
 <html lang="${escapeHtmlAttribute(i18nSnapshot?.locale || "en")}"${
-        i18nSnapshot ? ` dir="${i18nSnapshot.direction}"` : ""
-      }${themeDocument.attributes}>
+          i18nSnapshot ? ` dir="${i18nSnapshot.direction}"` : ""
+        }${themeDocument.attributes}>
 <head>
   ${themeDocument.head}
   <meta charset="utf-8">
@@ -2005,6 +2058,7 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
   <script type="module" src="/@farm/client.js"></script>
 </body>
 </html>`;
+      }
 
       emitFarmEvent({
         type: "render.stream.shellReady",
@@ -2042,7 +2096,12 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
     } = {},
   ): Promise<void> {
     const renderToPipeableStream = this.rendererRuntime.renderToPipeableStream;
-    if (!renderToPipeableStream) {
+    const fullDocumentRouteKey =
+      options.observabilityRoute || (req as any).__FARM_ROUTE__ || req.url || "/";
+    // A full-document layout can't be composed once the stream's shell is
+    // flushed, so a route previously seen to render one is served through the
+    // buffered path, which produces a valid single document.
+    if (!renderToPipeableStream || fullDocumentRoutes.has(fullDocumentRouteKey)) {
       return this.renderBufferedSSR(element, req, res, clearMiddlewareData, options);
     }
 
@@ -2225,6 +2284,7 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
           staticShellParts?.push(shell);
 
           let firstChunk = true;
+          let checkedFullDocument = false;
           const writableStream = new Writable({
             write(chunk, encoding, callback) {
               if (firstChunk && process.env.FARM_VERBOSE) {
@@ -2232,6 +2292,16 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
                 firstChunk = false;
               }
               const chunkText = Buffer.isBuffer(chunk) ? chunk.toString() : String(chunk);
+              // The shell was already flushed, so this response still nests the
+              // document; record the route so later requests take the buffered
+              // path (which composes it correctly) and warn the developer once.
+              if (!checkedFullDocument) {
+                checkedFullDocument = true;
+                if (opensFarmFullDocument(chunkText)) {
+                  fullDocumentRoutes.add(fullDocumentRouteKey);
+                  warnFarmFullDocumentLayout();
+                }
+              }
               htmlParts.push(chunkText);
 
               if (staticShellParts && !staticShellClosed) {
@@ -2480,6 +2550,31 @@ ${i18nSnapshot ? `window.__FARM_I18N__ = ${serializeInlineValue(i18nSnapshot)};`
       getFarmTheme(),
     );
     const rendererHydrationScript = this.rendererRuntime.generateHydrationScript?.() || "";
+
+    // A layout that returns its own full `<html>` document must not be nested
+    // inside this shell (that yields invalid nested `<html>`/`<head>`/`<body>`).
+    // Compose Farm's managed assets into the layout's document instead, matching
+    // the production build's `hasFullDocument` path.
+    const fullDocument = extractFarmFullDocument(content);
+    if (fullDocument) {
+      warnFarmFullDocumentLayout();
+      return composeFarmFullDocument(fullDocument, {
+        htmlAttributes: `${i18nSnapshot ? ` dir="${i18nSnapshot.direction}"` : ""}${themeDocument.attributes}`,
+        headAssets: [
+          themeDocument.head,
+          `<meta name="farm-deployment-id" content="${escapeHtmlAttribute(this.getDeploymentId())}">`,
+          alternateLinks,
+          fontHead,
+          `<link rel="stylesheet" href="/src/app/globals.css" />`,
+          `<script type="module" src="/@vite/client"></script>`,
+          rendererHydrationScript,
+          integrationManifestScript,
+        ]
+          .filter(Boolean)
+          .join("\n  "),
+        bodyFooter: clientScript.trim(),
+      });
+    }
 
     return `<!DOCTYPE html>
 <html lang="${escapeHtmlAttribute(i18nSnapshot?.locale || "en")}"${


### PR DESCRIPTION
Fixes #373.

## Problem

The **dev** renderer wraps every layout in a `display:contents` `data-farm-layout-boundary` div and nests it inside Farm's generated `<html>/<head>/<body>` shell. When a root layout returns its **own** full `<html>` document (the Next.js-style convention), the response contains **nested `<html>/<head>/<body>`** — invalid HTML — and diverges from production, which special-cases `hasFullDocument` (`nitro/universal-build.ts`). `server/renderer.ts` had no such guard (`grep -c hasFullDocument` → 0), so the malformed output was silent.

## Fix

New `server/full-document.ts`:
- `extractFarmFullDocument` / `isFarmFullDocument` — detect a full document behind Farm's `display:contents` wrapper divs and return just the `<html>…</html>`.
- `opensFarmFullDocument` — a streaming-safe check that works on a partial prefix (before `</html>` is flushed).
- `composeFarmFullDocument` — merge Farm's managed head assets, body scripts, `<html>` attributes (theme/dir), and a `#root` mount into the layout's own document. Uses **function replacers** so `$`-sequences (`$&`, `$'`, `$$`) in dynamic markup aren't expanded — same hazard the Nitro path guards.

Wired into the renderer:
- **Buffered paths** (`createFullHTML` and `renderBufferedSSR`) now compose a full document instead of nesting it → one valid `<html>/<head>/<body>`, matching prod.
- **Streaming path**: the shell is flushed before the document is known, so the first chunk of a full-document route is detected, the route is recorded, a **one-time dev warning** fires (pointing at the fragment-layout convention), and every subsequent request to that route is served through the buffered (composed) path.
- **Fragment layouts are unaffected** — they're never recorded and keep streaming exactly as before.

## Behavior

| | before | after |
|---|---|---|
| Fragment layout (recommended) | streams, valid | unchanged |
| Full-document layout, 1st request | nested, invalid, silent | still streamed once, **warns** |
| Full-document layout, later requests | nested, invalid | **composed, one valid document** |

## Tests
`src/__tests__/full-document.test.ts` — extraction from Farm wrappers, fragment vs document, raw `<!DOCTYPE>`, the streaming-prefix detector, composition invariants (exactly one `html/head/body`, assets land in the right section, theme attrs merged, `#root` added, DOCTYPE prepended), and a `$`-sequence case.

Gate: `tsc --noEmit`, `@farm.js/core` build, `oxlint`/`oxfmt` all clean; existing `renderer` and `server-renderer-route-states` suites still pass (34 tests green locally).

## Notes
Found while building a real full-document-layout app (a GitHub-style host) on `@farm.js/core@0.1.0-beta.29`. The cleanest app-side fix remains returning a fragment from the root layout (as the docs app does); this change makes the framework do the right thing (and warn) either way.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Composes full-document root layouts in the dev renderer instead of nesting them under the shell, matching production and preventing invalid nested html/head/body.

- Adds `server/full-document.ts` with `extractFarmFullDocument`, `isFarmFullDocument`, `opensFarmFullDocument`, and `composeFarmFullDocument` to merge head assets, body footer, and `<html>` attributes, preserve `$`-sequences, and ensure a `#root` mount when missing.
- Buffered SSR (`createFullHTML`, `renderBufferedSSR`) composes detected full documents into a single valid page.
- Streaming SSR detects a full document on the first chunk, warns once, records the route, and serves later requests for that route via the buffered path; fragment layouts are unchanged and keep streaming.
- Adds `__tests__/full-document.test.ts` covering extraction, streaming-prefix detection, composition invariants, DOCTYPE handling, and `$`-sequence cases.

<sup>Written for commit 484c29871969407d6d5a5188b5ac54c80da3c153. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

