### PR TITLE
fix(docs): prevent Nitro build heap exhaustion

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "pnpm --filter @farm.js/core build && pnpm --filter @farm.js/cli build && pnpm run prisma:generate && farm dev",
-    "build": "pnpm --filter @farm.js/core build:runtime && pnpm --filter @farm.js/cli build && pnpm run prisma:generate && farm build",
+    "build": "pnpm --filter @farm.js/core build:runtime && pnpm --filter @farm.js/cli build && pnpm run prisma:generate && NODE_OPTIONS=--max-old-space-size=6144 farm build",
     "preview": "farm preview",
     "prisma:generate": "DATABASE_URL=${DATABASE_URL:-postgresql://user:password@localhost:5432/farmjs} prisma generate",
     "db:push": "prisma db push"

--- a/packages/farm/src/__tests__/universal-build-docs.test.ts
+++ b/packages/farm/src/__tests__/universal-build-docs.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+
+import { transform } from "esbuild";
+import { describe, expect, it } from "vitest";
+import type { FarmDocsResolvedConfig } from "../config";
+import { generateFarmDocsRuntimeConfigExpression } from "../nitro/universal-build";
+
+const docsConfig: FarmDocsResolvedConfig = {
+  enabled: true,
+  entry: "/docs",
+  contentDir: "src/app/docs",
+  configPath: "/workspace/docs/docs.config.ts",
+  config: {
+    entry: "docs",
+    docsPath: "/docs",
+    contentDir: "src/app/docs",
+  },
+};
+
+describe("universal docs build", () => {
+  it("emits one contentDir key per bundled docs config object", async () => {
+    const expression = generateFarmDocsRuntimeConfigExpression(docsConfig);
+    const transformed = await transform(
+      `const farmDocsBundledContentDir = "/output/farm-docs-content"; const docs = ${expression};`,
+      {
+        loader: "js",
+        logLevel: "silent",
+      },
+    );
+
+    expect(transformed.warnings).toEqual([]);
+
+    const resolveRuntimeConfig = new Function(
+      "farmDocsBundledContentDir",
+      `return ${expression};`,
+    ) as (contentDir: string | null) => FarmDocsResolvedConfig;
+
+    expect(resolveRuntimeConfig("/output/farm-docs-content")).toMatchObject({
+      enabled: true,
+      entry: "/docs",
+      contentDir: "/output/farm-docs-content",
+      configPath: "/workspace/docs/docs.config.ts",
+      config: {
+        entry: "docs",
+        docsPath: "/docs",
+        contentDir: "/output/farm-docs-content",
+      },
+    });
+    expect(resolveRuntimeConfig(null)).toEqual(docsConfig);
+  });
+
+  it("disables the docs runtime without emitting a conditional object", () => {
+    expect(
+      generateFarmDocsRuntimeConfigExpression({
+        enabled: false,
+        entry: "/docs",
+        config: { entry: "docs" },
+      }),
+    ).toBe("null");
+  });
+});

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -3348,6 +3348,31 @@ async function buildSSRInMemory(
  * Generate virtual entry code that bundles all routes
  * This creates managers at runtime from bundled code
  */
+export function generateFarmDocsRuntimeConfigExpression(docs: ResolvedFarmConfig["docs"]): string {
+  if (!docs.enabled) return "null";
+
+  const baseConfig = {
+    ...docs,
+    contentDir: undefined,
+    config: undefined,
+  };
+  const nestedConfig = {
+    ...docs.config,
+    contentDir: undefined,
+  };
+
+  return `farmDocsBundledContentDir
+  ? {
+      ...${JSON.stringify(baseConfig)},
+      contentDir: farmDocsBundledContentDir,
+      config: {
+        ...${JSON.stringify(nestedConfig)},
+        contentDir: farmDocsBundledContentDir,
+      },
+    }
+  : ${JSON.stringify(docs)}`;
+}
+
 function generateVirtualEntryCode(
   apiRoutes: Array<{ path: string; filePath: string; methods: string[] }>,
   pageRoutes: UniversalPageRoute[],
@@ -3385,9 +3410,6 @@ function generateVirtualEntryCode(
   );
   const hasMiddlewareRuntime =
     middlewareRoutes.length > 0 || hasFarmMiddlewareConfig(config.middleware);
-  const farmDocsBaseConfig = config.docs?.enabled
-    ? { ...config.docs, config: undefined }
-    : undefined;
   const farmDocsFontAssets = config.docs?.enabled
     ? toFarmDocsPublicFontAssets(resolveFarmDocsFontAssets(config.root))
     : [];
@@ -3950,20 +3972,7 @@ const farmDocsBundledContentDir = ${
 })()`
       : "null"
   };
-const farmDocsResolvedConfig = ${
-    config.docs?.enabled
-      ? `farmDocsBundledContentDir
-  ? {
-      ...${JSON.stringify(farmDocsBaseConfig)},
-      contentDir: farmDocsBundledContentDir,
-      config: {
-        ...${JSON.stringify(config.docs.config)},
-        contentDir: farmDocsBundledContentDir,
-      },
-    }
-  : ${JSON.stringify(config.docs)}`
-      : "null"
-  };
+const farmDocsResolvedConfig = ${generateFarmDocsRuntimeConfigExpression(config.docs)};
 const farmDocsRuntimeRoot = farmDocsBundledContentDir || ${JSON.stringify(config.root)};
 globalThis.__FARM_DOCS_RUNTIME_CONFIG__ = {
   root: farmDocsRuntimeRoot,


### PR DESCRIPTION
## Summary

- give the docs production build a 6 GB Node heap for Nitro bundling
- omit pre-existing `contentDir` keys before generated runtime overrides are emitted
- add regression coverage for bundled and fallback docs configuration semantics and esbuild warnings

## Root cause

The docs SSR bundle was already close to the default Node ~4 GB old-space limit. Additional documentation content pushed Nitro Rollup over that limit. The Vercel build then spent time in garbage collection before being terminated.

The duplicate `contentDir` messages were non-fatal esbuild warnings, not the deployment failure. They came from the same generated SSR entry and are cleaned up by this patch.

This fix is isolated from the experimental React compiler. The docs configuration does not enable that compiler, and this PR changes no compiler runtime behavior.

## Validation

- reproduced the default-heap failure at approximately 4.08 GB with exit 134
- `pnpm --filter @farm.js/core test` — 132 files passed; 1,070 tests passed; 1 skipped
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter farmjs-docs build` — completed with the docs package heap limit and no duplicate-key warnings
- targeted formatter, lint, and `git diff --check` passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent docs SSR bundle from exhausting the Node heap and remove duplicate `contentDir` keys that produced esbuild warnings. Builds previously hit the ~4 GB old-space limit and were terminated; the docs build now uses a 6 GB heap and emits a single `contentDir`, so Nitro bundling completes cleanly.

- `docs/package.json`: sets `NODE_OPTIONS=--max-old-space-size=6144` for the production docs build.
- `packages/farm/src/nitro/universal-build.ts`: adds `generateFarmDocsRuntimeConfigExpression` and uses it to compute `farmDocsResolvedConfig`, injecting `contentDir` only when bundling and returning `null` when docs are disabled; removes duplicate keys and esbuild warnings.
- Tests: `packages/farm/src/__tests__/universal-build-docs.test.ts` covers bundled vs fallback docs config and asserts zero esbuild warnings.
- Impact: higher memory use only during the docs build; no runtime behavior change; unrelated to the experimental React compiler. Validated by reproducing the failure at ~4.08 GB and confirming builds/tests pass.

<sup>Written for commit 3e10e634b4122a8339aca4904b82756d1ab92bae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

