### PR TITLE
Refine runtime error overlay styling

### DIFF
--- a/packages/farm/src/__tests__/error-page.test.ts
+++ b/packages/farm/src/__tests__/error-page.test.ts
@@ -136,6 +136,11 @@ describe("default error page", () => {
     expect(DEFAULT_ERROR_STYLES).toContain("@media (max-width: 620px)");
     expect(DEFAULT_ERROR_STYLES).toContain("@media (prefers-reduced-motion: reduce)");
     expect(DEFAULT_ERROR_STYLES).toContain("border: 1px solid var(--farm-error-line)");
+    expect(DEFAULT_ERROR_STYLES).toContain("border: 1px solid var(--farm-error-line-strong)");
+    expect(DEFAULT_ERROR_STYLES).toContain("outline: 1px solid var(--farm-error-fg)");
+    expect(DEFAULT_ERROR_STYLES).toContain(
+      'font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;',
+    );
     expect(DEFAULT_ERROR_STYLES).toContain("font-size: clamp(76px, 13vw, 112px)");
   });
 });

--- a/packages/farm/src/client/runtime-error-overlay.ts
+++ b/packages/farm/src/client/runtime-error-overlay.ts
@@ -168,6 +168,11 @@ const OVERLAY_STYLES = `
   min-width: 166px;
 }
 
+.farm-runtime-error__action:focus {
+  outline: 1px solid var(--farm-error-fg);
+  outline-offset: 2px;
+}
+
 .farm-runtime-error__viewport .farm-default-error__panel {
   border: 0;
   box-shadow: inset 0 0 0 0.5px var(--farm-error-line-strong);

--- a/packages/farm/src/components/error-styles.ts
+++ b/packages/farm/src/components/error-styles.ts
@@ -13,8 +13,8 @@ body {
   --farm-error-bg: #fafafa;
   --farm-error-fg: #171717;
   --farm-error-muted: #737373;
-  --farm-error-line: rgba(0, 0, 0, 0.16);
-  --farm-error-line-strong: rgba(0, 0, 0, 0.34);
+  --farm-error-line: rgba(0, 0, 0, 0.1);
+  --farm-error-line-strong: rgba(0, 0, 0, 0.22);
   --farm-error-panel: rgba(0, 0, 0, 0.018);
   --farm-error-button-fg: #ffffff;
   --farm-error-source-line: rgba(185, 28, 28, 0.08);
@@ -57,8 +57,8 @@ body {
 @supports (-webkit-text-stroke: 1px currentColor) {
   .farm-default-error__code {
     color: var(--farm-error-bg);
-    -webkit-text-stroke: 2px var(--farm-error-fg);
-    text-shadow: 4px 4px 0 var(--farm-error-fg);
+    -webkit-text-stroke: 1.5px var(--farm-error-fg);
+    text-shadow: 2px 2px 0 var(--farm-error-fg);
   }
 }
 
@@ -129,10 +129,8 @@ body {
 .farm-default-error__label,
 .farm-default-error__value,
 .farm-default-error__details-title,
-.farm-default-error__copy,
 .farm-default-error__source-path,
-.farm-default-error__meta,
-.farm-default-error__action {
+.farm-default-error__meta {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
@@ -184,10 +182,11 @@ body {
   border-radius: 0;
   color: var(--farm-error-fg);
   background: transparent;
-  font-size: 11px;
-  font-weight: 500;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 12px;
+  font-weight: 600;
   line-height: 1;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.01em;
   cursor: pointer;
   transition: border-color 150ms ease-out, background 150ms ease-out;
 }
@@ -224,7 +223,7 @@ body {
   display: grid;
   grid-template-columns: 68px minmax(0, 1fr);
   padding: 0 14px 0 0;
-  border-left: 2px solid transparent;
+  border-left: 1px solid transparent;
 }
 
 .farm-default-error__source-line--active {
@@ -280,20 +279,22 @@ body {
   align-items: center;
   justify-content: center;
   padding: 0 20px;
-  border: 1px solid var(--farm-error-fg);
+  border: 1px solid var(--farm-error-line-strong);
   border-radius: 0;
   color: var(--farm-error-fg);
   background: transparent;
-  font-size: 12px;
-  font-weight: 500;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 13px;
+  font-weight: 600;
   line-height: 1;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.01em;
   text-decoration: none;
   cursor: pointer;
   transition: opacity 150ms ease-out, transform 100ms ease-out;
 }
 
 .farm-default-error__action--primary {
+  border-color: var(--farm-error-fg);
   color: var(--farm-error-button-fg);
   background: var(--farm-error-fg);
 }
@@ -328,8 +329,8 @@ body {
 
 .farm-default-error__copy:focus-visible,
 .farm-default-error__action:focus-visible {
-  outline: 2px solid var(--farm-error-fg);
-  outline-offset: 3px;
+  outline: 1px solid var(--farm-error-fg);
+  outline-offset: 2px;
 }
 
 @media (max-width: 620px) {
@@ -384,8 +385,8 @@ body {
     --farm-error-bg: #0a0a0a;
     --farm-error-fg: #ededed;
     --farm-error-muted: #a1a1a1;
-    --farm-error-line: rgba(255, 255, 255, 0.14);
-    --farm-error-line-strong: rgba(255, 255, 255, 0.3);
+    --farm-error-line: rgba(255, 255, 255, 0.1);
+    --farm-error-line-strong: rgba(255, 255, 255, 0.22);
     --farm-error-panel: rgba(255, 255, 255, 0.018);
     --farm-error-button-fg: #0a0a0a;
     --farm-error-source-line: rgba(248, 113, 113, 0.12);
@@ -400,8 +401,8 @@ body {
   --farm-error-bg: #0a0a0a;
   --farm-error-fg: #ededed;
   --farm-error-muted: #a1a1a1;
-  --farm-error-line: rgba(255, 255, 255, 0.14);
-  --farm-error-line-strong: rgba(255, 255, 255, 0.3);
+  --farm-error-line: rgba(255, 255, 255, 0.1);
+  --farm-error-line-strong: rgba(255, 255, 255, 0.22);
   --farm-error-panel: rgba(255, 255, 255, 0.018);
   --farm-error-button-fg: #0a0a0a;
   --farm-error-source-line: rgba(248, 113, 113, 0.12);
@@ -415,8 +416,8 @@ body {
   --farm-error-bg: #fafafa;
   --farm-error-fg: #171717;
   --farm-error-muted: #737373;
-  --farm-error-line: rgba(0, 0, 0, 0.16);
-  --farm-error-line-strong: rgba(0, 0, 0, 0.34);
+  --farm-error-line: rgba(0, 0, 0, 0.1);
+  --farm-error-line-strong: rgba(0, 0, 0, 0.22);
   --farm-error-panel: rgba(0, 0, 0, 0.018);
   --farm-error-button-fg: #ffffff;
   --farm-error-source-line: rgba(185, 28, 28, 0.08);

--- a/tests/e2e/runtime-error-overlay.spec.ts
+++ b/tests/e2e/runtime-error-overlay.spec.ts
@@ -26,9 +26,13 @@ test.describe("Development runtime error overlay", () => {
     await expect(overlay.locator(".farm-default-error__source-line--active")).toContainText(
       "setDisplayName(response.user.profile.formatDisplayName());",
     );
-    await expect(overlay.getByRole("button", { name: "Copy debug report" })).toBeVisible();
+    const copyButton = overlay.getByRole("button", { name: "Copy debug report" });
+    await expect(copyButton).toBeVisible();
+    await expect(copyButton).toHaveCSS("font-family", /Inter|system-ui/);
     const issueLink = overlay.getByRole("link", { name: "Open GitHub issue" });
     await expect(issueLink).toBeVisible();
+    await expect(issueLink).toHaveCSS("font-family", /Inter|system-ui/);
+    await expect(issueLink).toHaveCSS("outline-width", "1px");
     const issueUrl = new URL((await issueLink.getAttribute("href")) || "");
     expect(issueUrl.origin + issueUrl.pathname).toBe(
       "https://github.com/farming-labs/farm.js/issues/new",


### PR DESCRIPTION
## Summary

- soften error-page separators, panel outlines, active source markers, and the outlined 500 treatment
- use sans-serif typography for copy and action controls while keeping diagnostic labels, paths, and code monospaced
- reduce the runtime overlay's focused primary-action frame and add browser coverage for the typography and focus treatment

## Verification

- `pnpm exec oxfmt --check packages/farm/src/client/runtime-error-overlay.ts packages/farm/src/components/error-styles.ts packages/farm/src/__tests__/error-page.test.ts tests/e2e/runtime-error-overlay.spec.ts`
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/error-page.test.ts src/__tests__/runtime-error-overlay.test.ts` (14 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/core build:runtime`
- `NODE_DISABLE_COMPILE_CACHE=1 pnpm exec playwright test tests/e2e/runtime-error-overlay.spec.ts` (3 tests: desktop, dark mode, mobile)

## Note

A full `pnpm --filter @farm.js/core build` produced the ESM and CJS bundles, then the declaration worker exceeded the local machine's memory limit. The focused runtime build and TypeScript check both completed successfully.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refines the runtime error overlay and default error page to improve readability and focus visibility. Previously, buttons/links used monospaced fonts and heavier borders; now they use sans‑serif typography with lighter separators and a tighter focus outline.

- Softens line tokens: `--farm-error-line` and `--farm-error-line-strong` are reduced in both light and dark themes; active source line border goes from 2px to 1px.
- Switches actions and copy controls to sans‑serif with increased weight; preserves monospaced diagnostics and paths. Adds overlay focus rule and sets focus outlines to 1px with 2px offset.
- Tweaks 500 code treatment: smaller WebKit text stroke and shadow.
- Updates tests to assert new tokens, font-family, and focus outline width. No API or behavior changes beyond styling.

<sup>Written for commit 2ef4b06825756c814a6439df54215fa426b67c51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

