### PR TITLE
feat(react): compose compiled reactive blocks

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -335,8 +335,8 @@ satisfy all of these rules:
 | Text bindings       | State-driven text in a leaf host element.                                                                                                   |
 | Attribute bindings  | Basic attributes, controlled form properties, and individual properties in one inline `style` object.                                       |
 | Events              | Inline handlers and synchronous `const` or function-declaration handlers, used directly or called inside an inline JSX handler.             |
-| Conditional blocks  | `condition && <host />` or `condition ? <host /> : <host />`; `null` and `false` are supported empty ternary branches.                      |
-| Keyed lists         | A direct keyed `items.map(...)`, or an explicit imported `List`, when it is the only meaningful child of its host container.                |
+| Conditional blocks  | `condition && <host />` or `condition ? <host /> : <host />`; host branches may contain supported nested blocks.                            |
+| Keyed lists         | A direct keyed `items.map(...)`, or an explicit imported `List`, alongside static siblings or other supported block boundaries.             |
 | Component islands   | Stable imported or module-level component identifiers with explicit compiler-safe props and no JSX children, spread, `ref`, or `key`.       |
 
 This component is eligible:
@@ -437,14 +437,17 @@ The initial safety limits are:
 
 - Every non-empty branch has exactly one lowercase host root such as `p`, `strong`, `span`, or
   `div`.
-- Descendants keep a static host-only tree. Stateful text, attributes, inline style properties, and
-  event handlers inside that tree are allowed and update when the block refreshes.
+- Descendants keep a statically known host tree. Stateful text, attributes, inline style
+  properties, and event handlers inside that tree are allowed and update when the block refreshes.
+- A branch may contain nested host-root conditionals, keyed-list boundaries, and supported
+  component islands. Each nested boundary receives the outer conditional as its runtime parent.
 - A ternary may use `null` or `false` for an empty branch.
 - The conditional must be a JSX child at one statically known location, and its test must use the
   same deterministic expression subset as other compiler bindings.
-- Custom components, hooks, fragments, nested conditional blocks, lists, refs,
-  `dangerouslySetInnerHTML`, and attribute spreads inside a branch fall back to the original React
-  component.
+- A non-empty branch still needs one lowercase host root. A custom component cannot be the branch
+  root, but a supported component island may appear inside that host tree.
+- Hooks directly in branch expressions, fragments, refs, `dangerouslySetInnerHTML`, and attribute
+  spreads fall back to the original React component.
 
 The optimization boundary matters: the surrounding compiled component and its unrelated siblings
 do not rerender, but React still renders and commits the small conditional boundary. A branch with
@@ -515,10 +518,10 @@ The first automatic contract is deliberately narrow:
   across insertion, removal, or reordering.
 - The optimized `List` shape uses inline `by` and child functions, a compiler-safe `each`
   expression, and an item-derived key.
-- The map or `List` must be the only meaningful child of its host container. This keeps the first
-  keyed-boundary contract narrow and easy to audit.
-- Chained expressions such as `items.filter(...).map(...)`, mixed static siblings, spread children,
-  hooks in the callback, and other unproven shapes fall back to normal React.
+- A map or `List` may appear beside static host children, other keyed lists, and eligible
+  conditional boundaries in the same container.
+- Chained expressions such as `items.filter(...).map(...)`, spread children, hooks in the callback,
+  and other unproven shapes fall back to normal React.
 
 Stable keys must be unique among siblings and come from the item's identity, such as a database ID.
 Farm does not implement an LIS move algorithm in this release. A compiler-owned LIS can only be
@@ -574,12 +577,30 @@ indexes. This matters when an earlier React-owned child changes its number of DO
 compiler still holds the exact target element and cannot accidentally patch a different sibling.
 The refs produce no `data-*` marker or other extra server markup.
 
+### Composable block graph
+
+Conditional, keyed-list, and component-island boundaries are analyzed together. The compiler
+assigns every boundary a component-wide ID, so IDs remain unique even when several block types
+share a container or are nested inside one conditional branch. Nested bindings also record the ID
+of their nearest outer conditional.
+
+When one update affects an outer conditional and one or more descendants, the runtime refreshes
+the mounted outer boundary once and suppresses redundant descendant refreshes for that flush.
+React then unmounts or replaces the branch normally. Inner boundaries unsubscribe during that
+unmount, so later updates while the branch is hidden do not target stale components. If the branch
+appears again, each boundary subscribes again and renders from the latest compiler-cell values.
+
+The compiler deliberately does not analyze block-shaped syntax inside a keyed list callback. That
+callback can execute once per row, so a single compile-time block ID would not identify one runtime
+instance. React owns the complete keyed row subtree instead; put Hooks and additional dynamic
+structure inside a keyed row component.
+
 ### What falls back to React
 
 | Unsupported shape                                                          | Why React keeps ownership                                                          |
 | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| Unkeyed/index-keyed/chained maps, mixed list siblings, or element arrays   | Their structure or item identity is outside the isolated keyed-boundary contract.  |
-| Fragments or unsupported/nested conditional JSX                            | Their structure is outside the current single-location host-block contract.        |
+| Unkeyed/index-keyed/chained maps or element arrays                         | Their structure or item identity is outside the isolated keyed-boundary contract.  |
+| Fragments or a custom component used as a conditional branch root          | Their structure is outside the current host-root conditional contract.             |
 | Dynamic/member component types, component spreads, refs, keys, or children | Their identity or ownership is outside the first component-island contract.        |
 | Effects or hooks other than the supported `useState` shape                 | Their lifecycle and ordering must remain under React's hook dispatcher.            |
 | `ref` or `dangerouslySetInnerHTML`                                         | They directly participate in DOM ownership.                                        |

--- a/examples/react-compiler/README.md
+++ b/examples/react-compiler/README.md
@@ -4,8 +4,9 @@ This production-browser experiment answers two questions:
 
 1. Why build this compiler? Eligible local `useState` updates can patch precomputed DOM targets
    without rerunning the component body or asking React to reconcile the same static tree again.
-2. Where must it stop? Eligible host-only conditionals and keyed lists use small React-owned
-   boundaries. Effects, refs, unsupported list shapes, and other unproven structures stay on React.
+2. Where must it stop? Eligible conditionals, keyed lists, and component islands use small
+   React-owned boundaries. Effects, refs, unsupported list shapes, and other unproven structures
+   stay on React.
 
 The default `compiler: true` configuration automatically considers components. No annotation is
 needed. A component can explicitly opt out with `"use no compiler"`.
@@ -39,6 +40,7 @@ assertions, checks for console/runtime errors and horizontal overflow, saves scr
 | Controlled form bindings   | textarea/select/checkbox update, executions `0`         | —                                              | Form properties and textarea selection stay coherent.                  |
 | Logical conditional block  | branch mounts, updates, and unmounts; executions `0`    | —                                              | Only the isolated React block refreshes.                               |
 | Ternary conditional block  | `strong` and `span` replace each other; executions `0`  | —                                              | React preserves branch and event semantics without the outer rerender. |
+| Composable nested blocks   | two lists, nested conditions, and one component island  | —                                              | One block graph mounts, updates, and cleans up nested subscriptions.    |
 
 The package runtime test also measures one equivalent update under a React `Profiler`:
 
@@ -71,10 +73,10 @@ import { List } from "@farm.js/react/list";
 ```
 
 `List` is useful for custom stateful rows and still works as ordinary React when the compiler is
-off. Automatic maps and optimized `List` boundaries currently need to be the only meaningful child
-of their host container. Index keys, missing keys, chained maps, and mixed sibling structures fall
-back to the complete React component. Farm does not perform compiler-owned LIS moves in this stage;
-React remains the sole owner of row reconciliation.
+off. Automatic maps and optimized `List` boundaries may sit beside static children, other lists,
+and eligible conditional blocks. Index keys, missing keys, chained maps, and other unproven list
+expressions fall back to the complete React component. Farm does not perform compiler-owned LIS
+moves in this stage; React remains the sole owner of row reconciliation.
 
 Calling a Hook directly inside `items.map(...)` or a `List` render callback is invalid React because
 the number or order of Hook calls can change. Put the Hook inside a separate `Row` component and key
@@ -89,8 +91,14 @@ condition's state dependencies and lowers the child to a private React boundary.
 update refreshes that boundary while the user component's execution counter stays unchanged.
 
 This does not pre-mount both branches or bypass React's event system. React still creates, replaces,
-and removes the selected host branch. Custom components, hooks, fragments, nested conditionals,
-lists, refs, spreads, and dangerous HTML inside a branch intentionally fall back.
+and removes the selected host branch. A host branch may contain nested host conditionals, keyed-list
+boundaries, and supported component islands. Hooks directly in a branch, fragments, refs, spreads,
+and dangerous HTML intentionally fall back.
+
+The `08` card combines those boundary types under one outer conditional. It also proves that a
+hidden outer block removes its inner subscriptions: updates made while hidden do no render work,
+and remounting reads the newest compiler-cell values. Child-local React state resets after the
+outer branch unmounts, matching ordinary React semantics.
 
 ## Heavy compiler-on/off benchmark
 

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -31,6 +31,7 @@ for (const component of [
   "ExplicitKeyedListExperiment",
   "StatefulListRow",
   "ComponentIslandExperiment",
+  "ComposableBlockExperiment",
 ]) {
   assert.ok(compiledComponents.has(component), `${component} was not compiled`);
 }
@@ -454,6 +455,77 @@ try {
   assert.equal(islandOwnerFinalExecutions - islandOwnerInitialExecutions, 0);
   assert.equal(staticTreeFinalExecutions - staticTreeInitialExecutions, 0);
 
+  const composable = '[data-experiment="composable-blocks"]';
+  const composableOwnerInitialExecutions = await readNumber(
+    page,
+    `${composable} [data-metric="composable-owner-executions"]`,
+  );
+  await assertText(page, `${composable} [data-metric="composable-visible"]`, "shown");
+  await assertText(page, `${composable} [data-metric="composable-primary-count"]`, "2");
+  await assertText(page, `${composable} [data-metric="composable-secondary-count"]`, "1");
+  await page.evaluate(() => {
+    window.__farmComposableStatic = document.querySelector("[data-composable-static]");
+    window.__farmComposableAlpha = document.querySelector('[data-composable-primary="a"]');
+  });
+
+  await page.locator(`${composable} [data-action="composable-pin"]`).click();
+  await assertText(page, `${composable} [data-action="composable-pin"]`, "Pinned");
+  await page.locator(`${composable} [data-action="composable-update"]`).click();
+  await assertText(page, `${composable} [data-composable-count]`, "1");
+  await assertText(page, `${composable} [data-metric="composable-secondary-count"]`, "2");
+  assert.deepEqual(
+    await page.locator(`${composable} [data-composable-primary]`).allTextContents(),
+    ["Beta", "Alpha"],
+  );
+  assert.equal(
+    await page.evaluate(
+      () =>
+        window.__farmComposableAlpha ===
+        document.querySelector('[data-composable-primary="a"]'),
+    ),
+    true,
+    "React did not preserve the keyed row DOM node during a reverse",
+  );
+  await assertText(page, `${composable} [data-action="composable-pin"]`, "Pinned");
+
+  await page.locator(`${composable} [data-action="composable-details"]`).click();
+  await assertText(page, `${composable} [data-composable-details]`, "Nested value 1");
+  await assertText(page, `${composable} [data-composable-ready]`, "Nested host block ready");
+
+  await page.locator(`${composable} [data-action="composable-hide-update"]`).click();
+  await assertText(page, `${composable} [data-metric="composable-visible"]`, "hidden");
+  assert.equal(await page.locator(`${composable} [data-composable-outer]`).count(), 0);
+  await page.locator(`${composable} [data-action="composable-hidden-update"]`).click();
+  await assertText(page, `${composable} [data-metric="composable-secondary-count"]`, "4");
+  assert.equal(await page.locator(`${composable} [data-composable-outer]`).count(), 0);
+  assert.equal(
+    await page.evaluate(
+      () =>
+        window.__farmComposableStatic === document.querySelector("[data-composable-static]"),
+    ),
+    true,
+    "an unrelated static sibling was replaced",
+  );
+
+  await page.locator(`${composable} [data-action="composable-show"]`).click();
+  await assertText(page, `${composable} [data-metric="composable-visible"]`, "shown");
+  await assertText(page, `${composable} [data-composable-count]`, "3");
+  await assertText(page, `${composable} [data-composable-details]`, "Nested value 3");
+  await assertText(page, `${composable} [data-action="composable-pin"]`, "Pin child state");
+  assert.deepEqual(
+    await page.locator(`${composable} [data-composable-primary]`).allTextContents(),
+    ["Beta", "Alpha"],
+  );
+  assert.equal(
+    await page.locator(`${composable} [data-composable-secondary]`).count(),
+    4,
+  );
+  const composableOwnerFinalExecutions = await readNumber(
+    page,
+    `${composable} [data-metric="composable-owner-executions"]`,
+  );
+  assert.equal(composableOwnerFinalExecutions - composableOwnerInitialExecutions, 0);
+
   await page.screenshot({ path: screenshotPath, fullPage: true });
 
   const mobilePage = await browser.newPage({
@@ -579,6 +651,16 @@ try {
               islandOwnerFinalExecutions - islandOwnerInitialExecutions,
             staticSiblingUpdateExecutions:
               staticTreeFinalExecutions - staticTreeInitialExecutions,
+          },
+          composableBlocks: {
+            count: 3,
+            primaryOrder: ["Beta", "Alpha"],
+            secondaryItems: 4,
+            nestedConditional: "Nested value 3",
+            keyedDomIdentityPreserved: true,
+            childStateResetAfterOuterUnmount: true,
+            ownerUpdateExecutions:
+              composableOwnerFinalExecutions - composableOwnerInitialExecutions,
           },
         },
       },

--- a/examples/react-compiler/src/app/globals.css
+++ b/examples/react-compiler/src/app/globals.css
@@ -805,6 +805,73 @@ h1 span {
   margin-top: 1rem;
 }
 
+.composable-controls {
+  flex-wrap: wrap;
+}
+
+.composable-static {
+  margin: 1rem 0;
+  border-left: 2px solid #565650;
+  padding-left: 0.75rem;
+  color: #8d8d86;
+  font-size: 0.78rem;
+}
+
+.composable-stage {
+  display: grid;
+  gap: 1rem;
+  border: 1px solid #4d6334;
+  padding: 1rem;
+  background: rgb(184 255 91 / 0.035);
+}
+
+.composable-summary,
+.composable-row-set {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.composable-summary {
+  justify-content: space-between;
+}
+
+.composable-summary strong {
+  color: #d8ff9f;
+  font-size: 1.35rem;
+}
+
+.composable-summary button {
+  border: 1px solid #484842;
+  padding: 0.6rem 0.75rem;
+  color: inherit;
+  background: transparent;
+  cursor: pointer;
+}
+
+.composable-row-set {
+  flex-wrap: wrap;
+}
+
+.composable-row-set > span,
+.composable-row-set > strong,
+.composable-row-set > em {
+  border: 1px solid #3b3b37;
+  padding: 0.45rem 0.6rem;
+  font: 0.65rem "Geist Mono Variable", ui-monospace, monospace;
+  font-style: normal;
+}
+
+.composable-row-set > i {
+  width: 1px;
+  align-self: stretch;
+  background: #45453f;
+}
+
+.composable-fixed {
+  color: #8d8d86;
+}
+
 .heavy-metrics > div {
   min-width: 0;
   padding: 1.25rem 0;

--- a/examples/react-compiler/src/app/page.tsx
+++ b/examples/react-compiler/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { CompilerComparison } from "../components/compiler-comparison";
 import { CompilerEdgeLab } from "../components/compiler-edge-lab";
 import { CommonSyntaxExperiment } from "../components/common-syntax-experiment";
+import { ComposableBlockExperiment } from "../components/composable-block-experiment";
 import { ComponentIslandExperiment } from "../components/component-island-experiment";
 import { ConditionalBlockExperiment } from "../components/conditional-block-experiment";
 import { HeavyInteractionBenchmark } from "../components/heavy-interaction-benchmark";
@@ -71,6 +72,8 @@ export default function HomePage() {
       <HeavyInteractionBenchmark />
 
       <ComponentIslandExperiment />
+
+      <ComposableBlockExperiment />
 
       <section
         className="benchmark-report"

--- a/examples/react-compiler/src/components/composable-block-experiment.tsx
+++ b/examples/react-compiler/src/components/composable-block-experiment.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState } from "react";
+
+interface Item {
+  id: string;
+  label: string;
+}
+
+let composableOwnerExecutions = 0;
+let summaryExecutions = 0;
+
+function ComposableSummary({ count }: { count: number }) {
+  "use no compiler";
+
+  const [pinned, setPinned] = useState(false);
+  const execution = typeof window === "undefined" ? 1 : ++summaryExecutions;
+  return (
+    <div className="composable-summary" data-summary-executions={execution}>
+      <span>
+        Child value <strong data-composable-count>{count}</strong>
+      </span>
+      <button
+        data-action="composable-pin"
+        type="button"
+        onClick={() => setPinned((value) => !value)}
+      >
+        {pinned ? "Pinned" : "Pin child state"}
+      </button>
+    </div>
+  );
+}
+
+const initialPrimary: Item[] = [
+  { id: "a", label: "Alpha" },
+  { id: "b", label: "Beta" },
+];
+const initialSecondary: Item[] = [{ id: "c", label: "Gamma" }];
+
+export function ComposableBlockExperiment() {
+  const [visible, setVisible] = useState(true);
+  const [count, setCount] = useState(0);
+  const [primary, setPrimary] = useState(initialPrimary);
+  const [secondary, setSecondary] = useState(initialSecondary);
+  const [details, setDetails] = useState(false);
+
+  function updateNestedBlocks() {
+    setCount((value) => value + 1);
+    setPrimary((items) => [...items].reverse());
+    setSecondary((items) => [
+      ...items,
+      { id: `secondary-${items.length}`, label: `Item ${items.length + 1}` },
+    ]);
+  }
+
+  return (
+    <section className="heavy-benchmark" data-experiment="composable-blocks">
+      <header className="heavy-heading">
+        <div>
+          <span className="experiment-number">08</span>
+          <div>
+            <p className="heavy-kicker">COMPOSABLE REACTIVE BLOCKS</p>
+            <h2>Nested blocks share one safe update graph</h2>
+          </div>
+        </div>
+        <span className="node-badge">ONE OWNER / SIX BLOCKS</span>
+      </header>
+
+      <p className="heavy-copy">
+        Lists, conditions, static siblings, and a React component island can now share one compiled
+        tree. Hiding the outer branch removes every inner subscription; showing it again reads the
+        latest state.
+      </p>
+
+      <dl className="heavy-metrics" aria-live="polite">
+        <div>
+          <dt>Owner executions</dt>
+          <dd data-metric="composable-owner-executions">
+            {typeof window === "undefined" ? 1 : ++composableOwnerExecutions}
+          </dd>
+        </div>
+        <div>
+          <dt>Outer branch</dt>
+          <dd data-metric="composable-visible">{visible ? "shown" : "hidden"}</dd>
+        </div>
+        <div>
+          <dt>Primary rows</dt>
+          <dd data-metric="composable-primary-count">{primary.length}</dd>
+        </div>
+        <div>
+          <dt>Secondary rows</dt>
+          <dd data-metric="composable-secondary-count">{secondary.length}</dd>
+        </div>
+      </dl>
+
+      <div className="heavy-controls composable-controls">
+        <button data-action="composable-update" type="button" onClick={updateNestedBlocks}>
+          Update inner blocks <span aria-hidden="true">↗</span>
+        </button>
+        <button
+          data-action="composable-details"
+          type="button"
+          onClick={() => setDetails((value) => !value)}
+        >
+          Toggle nested condition
+        </button>
+        <button
+          data-action="composable-hide-update"
+          type="button"
+          onClick={() => {
+            setVisible(false);
+            updateNestedBlocks();
+          }}
+        >
+          Hide and update
+        </button>
+        <button data-action="composable-hidden-update" type="button" onClick={updateNestedBlocks}>
+          Update while hidden
+        </button>
+        <button data-action="composable-show" type="button" onClick={() => setVisible(true)}>
+          Show outer block
+        </button>
+      </div>
+
+      <p className="composable-static" data-composable-static>
+        Static sibling outside the conditional
+      </p>
+
+      {visible && (
+        <article className="composable-stage" data-composable-outer>
+          <ComposableSummary count={count} />
+          <div className="composable-row-set">
+            <span className="composable-fixed">Fixed sibling</span>
+            {primary.map((item) => (
+              <span data-composable-primary={item.id} key={item.id}>
+                {item.label}
+              </span>
+            ))}
+            <i aria-hidden="true" />
+            {secondary.map((item) => (
+              <span data-composable-secondary={item.id} key={item.id}>
+                {item.label}
+              </span>
+            ))}
+            {details ? (
+              <strong data-composable-details>Nested value {count}</strong>
+            ) : (
+              <span data-composable-details>Details hidden</span>
+            )}
+            {details && <em data-composable-ready>Nested host block ready</em>}
+          </div>
+        </article>
+      )}
+    </section>
+  );
+}

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -53,16 +53,16 @@ The directive is configurable and only has meaning in annotation mode.
 
 The current compiler handles components that it can prove have:
 
-- one host-element root and a statically known host-element tree around supported React component
-  islands;
+- one host-element root and a statically known host-element tree around supported conditional,
+  keyed-list, and React component-island boundaries;
 - an identifier props parameter or flat object destructuring with aliases and defaults;
 - top-level `useState` declarations;
 - optional compiler-safe derived `const` values declared after state and in source order;
 - whitelisted `Boolean`, `Number`, `String`, and deterministic `Math` calculations;
 - optional synchronous `const` or function-declaration handlers used by JSX events;
 - state-driven text, attributes, per-property inline styles, and controlled form properties;
-- host-only `condition && <element>` and `condition ? <element> : <element>` child blocks at
-  statically known locations;
+- host-rooted `condition && <element>` and `condition ? <element> : <element>` child blocks at
+  statically known locations, including supported nested boundaries;
 - direct item-keyed `collection.map(...)` children and explicit `List` boundaries at statically
   known container locations;
 - stable module-level child components with compiler-safe props;
@@ -85,10 +85,11 @@ For a common keyed map, no new API is required:
 </ul>
 ```
 
-The compiler can isolate this direct map when it is the container's only meaningful child, the key
-comes from the item rather than the array index, and the callback is otherwise safe. A list update
-then refreshes only an internal React boundary instead of executing the outer user component.
-React still reconciles the keyed rows and owns their DOM, events, lifecycle, and state.
+The compiler can isolate this direct map when the key comes from the item rather than the array
+index and the callback is otherwise safe. The map may sit beside static children, other lists, and
+eligible conditionals. A list update then refreshes only an internal React boundary instead of
+executing the outer user component. React still reconciles the keyed rows and owns their DOM,
+events, lifecycle, and state.
 
 For custom rows or an explicit key selector, use the public component:
 
@@ -106,8 +107,7 @@ import { List } from "@farm.js/react/list";
 `by` supplies the React key; and the child function returns one React element. Put Hooks inside the
 row component, not directly inside the iteration callback. With the compiler enabled, the
 optimized explicit shape requires inline `by` and child functions, a safe `each` expression, an
-item-derived key, and no meaningful siblings in the same host container. Other shapes keep normal
-React behavior.
+item-derived key, and a statically known location. Other shapes keep normal React behavior.
 
 A normal child component can become an automatic React-owned island:
 
@@ -127,11 +127,20 @@ Generated callback refs give directly patched host elements stable private targe
 React-owned component may therefore return `null`, a fragment, or multiple host nodes without
 shifting an unrelated compiler binding. These refs do not add attributes to SSR output.
 
-Conditional blocks deliberately start with a narrow contract. Each non-empty branch must have one
-lowercase host root and a static host-only subtree. An empty ternary branch may be `null` or `false`.
-Custom components, hooks, fragments, nested conditionals, lists, refs, attribute spreads, and
-`dangerouslySetInnerHTML` inside the block fall back to the normal React component. Both branch
-expressions are isolated at build time, but the inactive branch is not pre-mounted or cached.
+Conditional blocks deliberately keep a host-rooted contract. Each non-empty branch must have one
+lowercase host root, and an empty ternary branch may be `null` or `false`. That host tree may contain
+nested host conditionals, keyed lists, and supported component islands. A custom component used as
+the branch root, hooks directly in branch expressions, fragments, refs, attribute spreads, and
+`dangerouslySetInnerHTML` fall back to the normal React component. Both branch expressions are
+isolated at build time, but the inactive branch is not pre-mounted or cached.
+
+All supported boundary types share one component-wide block graph and one ID sequence. A nested
+binding records its nearest conditional parent. If one state flush affects both an outer
+conditional and its descendants, the runtime refreshes the mounted outer boundary once and skips
+the redundant descendant refreshes. React unmounts inner boundaries normally, their subscriptions
+are removed, and a later remount reads the latest compiler-cell values. List callback contents are
+not recursively compiled because one source location can create several keyed row instances;
+React owns each complete row subtree instead.
 
 Unsupported components fall back to React by default. Use `onUnsupported: "warn"` for diagnostics
 or `onUnsupported: "error"` while tightening an annotated migration.
@@ -157,6 +166,6 @@ assertion; it is not presented as a cross-machine timing benchmark.
 
 Application and prototype calls, dynamic style objects, handlers outside JSX events, nested,
 computed, and rest props patterns, async handlers, unkeyed or index-keyed lists, chained maps,
-mixed list siblings, unsupported conditional shapes, effects, and more advanced hook support
+unsupported conditional roots, effects, and more advanced hook support
 intentionally stay on React in this release. Farm does not perform compiler-owned LIS row moves;
 eligible keyed boundaries deliberately keep reconciliation under React.

--- a/packages/farm-react/src/__tests__/compiler-composable-blocks.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-composable-blocks.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true);
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/ComposableBlocks.tsx", infer);
+}
+
+describe("React AOT composable block compiler", () => {
+  it("builds one globally identified graph for sibling and nested block kinds", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List } from "@farm.js/react/list";
+
+      function Summary({ total }: { total: number }) {
+        return <output data-summary>{total}</output>;
+      }
+
+      function Row({ item }: { item: { id: string; label: string } }) {
+        return <li>{item.label}</li>;
+      }
+
+      export function ComposableDashboard() {
+        const [open, setOpen] = useState(true);
+        const [nested, setNested] = useState(false);
+        const [left, setLeft] = useState([{ id: "a", label: "Alpha" }]);
+        const [right, setRight] = useState([{ id: "b", label: "Beta" }]);
+        const [count, setCount] = useState(0);
+        return (
+          <main>
+            <button onClick={() => setOpen(!open)}>Open</button>
+            <h1>Static heading</h1>
+            {open && (
+              <section>
+                <Summary total={count} />
+                <ul>
+                  <li>Static row</li>
+                  {left.map((item) => <li key={item.id}>{item.label}</li>)}
+                  {nested && <li data-nested>{count}</li>}
+                </ul>
+                <List each={right} by={(item) => item.id}>
+                  {(item) => <Row item={item} />}
+                </List>
+              </section>
+            )}
+            <aside>
+              <p>Second list</p>
+              {right.map((item) => <span key={item.id}>{item.label}</span>)}
+            </aside>
+            {nested ? <strong>Nested on</strong> : <span>Nested off</span>}
+            <footer>Static footer</footer>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["ComposableDashboard"]);
+    expect(
+      result.diagnostics.find((diagnostic) => diagnostic.component === "ComposableDashboard"),
+    ).toBeUndefined();
+    expect(result.code.match(/farmBlocks\.Conditional/g)).toHaveLength(3);
+    expect(result.code.match(/farmBlocks\.KeyedList/g)).toHaveLength(3);
+    expect(result.code.match(/farmBlocks\.Component/g)).toHaveLength(1);
+
+    const ids = [...result.code.matchAll(/id=\{(\d+)\}/g)].map((match) => Number(match[1]));
+    expect(ids).toEqual([0, 1, 2, 3, 4, 5, 6]);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(result.code.match(/parent: 0/g)).toHaveLength(4);
+
+    await expect(
+      transformWithEsbuild(result.code, "/app/ComposableBlocks.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("farmBlocks.Component"),
+    });
+  });
+
+  it("keeps list callback contents under React ownership", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      function StatefulRow({ label }: { label: string }) {
+        const [selected, setSelected] = useState(false);
+        return <button onClick={() => setSelected(!selected)}>{label}</button>;
+      }
+      export function Rows() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
+        return (
+          <section>
+            <h2>Rows</h2>
+            <div>
+              {items.map((item) => <StatefulRow key={item.id} label={item.label} />)}
+            </div>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toContain("Rows");
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code.match(/\.KeyedList/g)).toHaveLength(1);
+    expect(result.code).not.toContain(".Component");
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-conditional-blocks.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-conditional-blocks.test.ts
@@ -111,18 +111,6 @@ describe("React AOT conditional block compiler", () => {
       reason: /dynamic child structures/i,
     },
     {
-      name: "a nested conditional branch",
-      body: "{visible && <div>{enabled && <span>Enabled</span>}</div>}",
-      extra: "",
-      reason: /nested conditional blocks/i,
-    },
-    {
-      name: "a list branch",
-      body: "{visible && <ul>{items.map((item) => <li key={item}>{item}</li>)}</ul>}",
-      extra: "const items = ['a', 'b'];",
-      reason: /static host tree/i,
-    },
-    {
       name: "a hook call inside a branch",
       body: "{visible && <p>{useValue()}</p>}",
       extra: "function useValue() { return 'value'; }",
@@ -168,5 +156,37 @@ describe("React AOT conditional block compiler", () => {
       result.diagnostics.find((diagnostic) => diagnostic.component === "Unsupported")?.reason,
     ).toMatch(reason);
     expect(result.code).not.toContain("compiler-runtime");
+  });
+
+  it("composes nested host conditionals and keyed lists inside a branch", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function NestedBlocks() {
+        const [visible, setVisible] = useState(true);
+        const [enabled, setEnabled] = useState(false);
+        const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
+        return (
+          <section>
+            <button onClick={() => setVisible(!visible)}>Visible</button>
+            {visible && (
+              <article>
+                <h2>Inventory</h2>
+                {enabled ? <strong>Enabled</strong> : <span>Disabled</span>}
+                <ul>{items.map((item) => <li key={item.id}>{item.label}</li>)}</ul>
+              </article>
+            )}
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["NestedBlocks"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code.match(/farmBlocks\.Conditional/g)).toHaveLength(2);
+    expect(result.code.match(/farmBlocks\.KeyedList/g)).toHaveLength(1);
+    expect(result.code).toContain("id={0}");
+    expect(result.code).toContain("id={1}");
+    expect(result.code).toContain("id={2}");
+    expect(result.code.match(/parent: 0/g)).toHaveLength(2);
   });
 });

--- a/packages/farm-react/src/__tests__/compiler-keyed-lists.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-lists.test.ts
@@ -107,7 +107,7 @@ describe("React AOT keyed list compiler", () => {
     expect(result.diagnostics[0]?.reason).toMatch(reason);
   });
 
-  it("falls back when the list shares a container with another child", async () => {
+  it("isolates a keyed list alongside static siblings", async () => {
     const result = await compile(`
       import { useState } from "react";
       export function MixedList() {
@@ -121,8 +121,11 @@ describe("React AOT keyed list compiler", () => {
       }
     `);
 
-    expect(result.compiled).toEqual([]);
-    expect(result.diagnostics[0]?.reason).toMatch(/only child of its host container/i);
+    expect(result.compiled).toEqual(["MixedList"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("<li>Static row</li>");
+    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).toContain("id={0}");
   });
 
   it("falls back for an index-based explicit List key", async () => {

--- a/packages/farm-react/src/__tests__/compiler-runtime-composable-blocks.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-composable-blocks.test.tsx
@@ -1,0 +1,461 @@
+import React, { StrictMode, useEffect, useState } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createCompiledComponent } from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Item {
+  id: string;
+  label: string;
+}
+
+const roots: Array<{ unmount(): void }> = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function click(container: Element, selector: string): void {
+  const target = container.querySelector<HTMLElement>(selector);
+  if (!target) throw new Error(`Missing test target: ${selector}`);
+  target.click();
+}
+
+describe("compiled React composable block runtime", () => {
+  it("coalesces nested refreshes and cleans subscriptions up with their outer branch", async () => {
+    let ownerRenders = 0;
+    let outerRenders = 0;
+    let summaryRenders = 0;
+    let listRenders = 0;
+    let nestedRenders = 0;
+    let summaryMounts = 0;
+    let summaryUnmounts = 0;
+
+    function Summary({ count }: { count: number }) {
+      summaryRenders += 1;
+      useEffect(() => {
+        summaryMounts += 1;
+        return () => {
+          summaryUnmounts += 1;
+        };
+      }, []);
+      return <output data-summary>{count}</output>;
+    }
+
+    const Dashboard = createCompiledComponent({
+      displayName: "NestedComposableDashboard",
+      initialize: () => [
+        true,
+        0,
+        [
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Beta" },
+        ],
+        true,
+      ],
+      render(_props: Record<string, never>, state, blocks) {
+        ownerRenders += 1;
+        const Conditional = blocks.Conditional;
+        const Component = blocks.Component;
+        const KeyedList = blocks.KeyedList;
+        const updateInner = () => {
+          state[1].set((value) => Number(value) + 1);
+          state[2].set((value) => [...(value as Item[])].reverse());
+          state[3].set((value) => !value);
+        };
+        return (
+          <main>
+            <button data-action="inner" onClick={updateInner}>
+              Inner
+            </button>
+            <button
+              data-action="hide-update"
+              onClick={() => {
+                state[0].set(false);
+                updateInner();
+              }}
+            >
+              Hide and update
+            </button>
+            <button data-action="hidden-update" onClick={updateInner}>
+              Update while hidden
+            </button>
+            <button data-action="show" onClick={() => state[0].set(true)}>
+              Show
+            </button>
+            <h1 data-static>Static sibling</h1>
+            <Conditional
+              id={0}
+              render={() => {
+                outerRenders += 1;
+                return state[0].get() ? (
+                  <section data-outer>
+                    <Component id={1} render={() => <Summary count={Number(state[1].get())} />} />
+                    <ul>
+                      <li data-static-row>Static row</li>
+                      <KeyedList
+                        id={2}
+                        render={() => {
+                          listRenders += 1;
+                          return (state[2].get() as Item[]).map((item) => (
+                            <li data-key={item.id} key={item.id}>
+                              {item.label}
+                            </li>
+                          ));
+                        }}
+                      />
+                    </ul>
+                    <Conditional
+                      id={3}
+                      render={() => {
+                        nestedRenders += 1;
+                        return state[3].get() ? (
+                          <strong data-nested>{Number(state[1].get())}</strong>
+                        ) : null;
+                      }}
+                    />
+                  </section>
+                ) : null;
+              }}
+            />
+          </main>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        { kind: "block", id: 1, parent: 0, dependencies: [1] },
+        { kind: "block", id: 2, parent: 0, dependencies: [2] },
+        { kind: "block", id: 3, parent: 0, dependencies: [1, 3] },
+      ],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <StrictMode>
+          <Dashboard />
+        </StrictMode>,
+      ),
+    );
+
+    const staticHeading = container.querySelector("[data-static]");
+    const initialOwnerRenders = ownerRenders;
+    const initialOuterRenders = outerRenders;
+
+    await act(async () => {
+      click(container, "[data-action='inner']");
+      await flushCompilerUpdates();
+    });
+    expect(ownerRenders).toBe(initialOwnerRenders);
+    expect(outerRenders).toBe(initialOuterRenders);
+    expect(container.querySelector("[data-summary]")?.textContent).toBe("1");
+    expect(
+      [...container.querySelectorAll<HTMLElement>("[data-key]")].map((row) => row.dataset.key),
+    ).toEqual(["b", "a"]);
+    expect(container.querySelector("[data-nested]")).toBeNull();
+    expect(container.querySelector("[data-static]")).toBe(staticHeading);
+
+    const childRendersBeforeHide = [summaryRenders, listRenders, nestedRenders];
+    const unmountsBeforeHide = summaryUnmounts;
+    await act(async () => {
+      click(container, "[data-action='hide-update']");
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("[data-outer]")).toBeNull();
+    expect([summaryRenders, listRenders, nestedRenders]).toEqual(childRendersBeforeHide);
+    expect(summaryUnmounts).toBeGreaterThan(unmountsBeforeHide);
+
+    await act(async () => {
+      click(container, "[data-action='hidden-update']");
+      await flushCompilerUpdates();
+    });
+    expect([summaryRenders, listRenders, nestedRenders]).toEqual(childRendersBeforeHide);
+
+    await act(async () => {
+      click(container, "[data-action='show']");
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("[data-summary]")?.textContent).toBe("3");
+    expect(
+      [...container.querySelectorAll<HTMLElement>("[data-key]")].map((row) => row.dataset.key),
+    ).toEqual(["b", "a"]);
+    expect(container.querySelector("[data-nested]")).toBeNull();
+    expect(summaryMounts).toBeGreaterThan(0);
+    expect(ownerRenders).toBe(initialOwnerRenders);
+  });
+
+  it("updates multiple sibling lists and conditions without replacing static siblings", async () => {
+    let ownerRenders = 0;
+    const Panel = createCompiledComponent({
+      displayName: "SiblingBlocks",
+      initialize: () => [[{ id: "a", label: "Alpha" }], [{ id: "b", label: "Beta" }], true, false],
+      render(_props: Record<string, never>, state, blocks) {
+        ownerRenders += 1;
+        const KeyedList = blocks.KeyedList;
+        const Conditional = blocks.Conditional;
+        return (
+          <section>
+            <button
+              onClick={() => {
+                state[0].set((items) => [...(items as Item[]), { id: "c", label: "Charlie" }]);
+                state[1].set((items) => [...(items as Item[])].reverse());
+                state[2].set((value) => !value);
+                state[3].set((value) => !value);
+              }}
+            >
+              Update all
+            </button>
+            <h2 data-static>Static</h2>
+            <ul data-list="left">
+              <li>Fixed</li>
+              <KeyedList
+                id={0}
+                render={() =>
+                  (state[0].get() as Item[]).map((item) => <li key={item.id}>{item.label}</li>)
+                }
+              />
+            </ul>
+            <div data-list="right">
+              <KeyedList
+                id={1}
+                render={() =>
+                  (state[1].get() as Item[]).map((item) => <span key={item.id}>{item.label}</span>)
+                }
+              />
+            </div>
+            <Conditional
+              id={2}
+              render={() => (state[2].get() ? <strong>On</strong> : <i>Off</i>)}
+            />
+            <Conditional id={3} render={() => Boolean(state[3].get()) && <em>Ready</em>} />
+          </section>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        { kind: "block", id: 1, dependencies: [1] },
+        { kind: "block", id: 2, dependencies: [2] },
+        { kind: "block", id: 3, dependencies: [3] },
+      ],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Panel />));
+    const staticHeading = container.querySelector("[data-static]");
+
+    await act(async () => {
+      click(container, "button");
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector("[data-list='left']")?.textContent).toBe("FixedAlphaCharlie");
+    expect(container.querySelector("[data-list='right']")?.textContent).toBe("Beta");
+    expect(container.querySelector("i")?.textContent).toBe("Off");
+    expect(container.querySelector("em")?.textContent).toBe("Ready");
+    expect(container.querySelector("[data-static]")).toBe(staticHeading);
+    expect(ownerRenders).toBe(1);
+  });
+
+  it("matches React through 1,000 deterministic updates across a nested block graph", async () => {
+    type Action =
+      | { kind: "show" }
+      | { kind: "nested" }
+      | { kind: "count"; amount: number }
+      | { kind: "reverse" }
+      | { kind: "rename"; suffix: number }
+      | { kind: "append"; item: Item }
+      | { kind: "remove" };
+
+    let seed = 0x4f1bbcdc;
+    const random = () => {
+      seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0;
+      return seed;
+    };
+    const actions: Action[] = Array.from({ length: 1000 }, (_, index) => {
+      switch (random() % 7) {
+        case 0:
+          return { kind: "show" };
+        case 1:
+          return { kind: "nested" };
+        case 2:
+          return { kind: "count", amount: (random() % 5) + 1 };
+        case 3:
+          return { kind: "reverse" };
+        case 4:
+          return { kind: "rename", suffix: random() % 100 };
+        case 5:
+          return {
+            kind: "append",
+            item: { id: `generated-${index}`, label: `Generated ${index}` },
+          };
+        default:
+          return { kind: "remove" };
+      }
+    });
+
+    let compiledDispatch: (action: Action) => void = () => undefined;
+    let reactDispatch: (action: Action) => void = () => undefined;
+    let compiledOwnerRenders = 0;
+
+    function Readout({ count }: { count: number }) {
+      return <output data-count>{count}</output>;
+    }
+
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ];
+    const Compiled = createCompiledComponent({
+      displayName: "RandomComposableGraph",
+      initialize: () => [true, 0, initialItems, false],
+      render(_props: Record<string, never>, state, blocks) {
+        compiledOwnerRenders += 1;
+        compiledDispatch = (action) => {
+          if (action.kind === "show") state[0].set((value) => !value);
+          if (action.kind === "nested") state[3].set((value) => !value);
+          if (action.kind === "count") {
+            state[1].set((value) => Number(value) + action.amount);
+          }
+          if (action.kind === "reverse") {
+            state[2].set((items) => [...(items as Item[])].reverse());
+          }
+          if (action.kind === "rename") {
+            state[2].set((items) =>
+              (items as Item[]).map((item, index) =>
+                index === 0 ? { ...item, label: `${item.label}:${action.suffix}` } : item,
+              ),
+            );
+          }
+          if (action.kind === "append") {
+            state[2].set((items) => [...(items as Item[]), action.item]);
+          }
+          if (action.kind === "remove") {
+            state[2].set((items) => (items as Item[]).slice(1));
+          }
+        };
+        const Conditional = blocks.Conditional;
+        const Component = blocks.Component;
+        const KeyedList = blocks.KeyedList;
+        return (
+          <section>
+            <Conditional
+              id={0}
+              render={() =>
+                state[0].get() ? (
+                  <article>
+                    <Component id={1} render={() => <Readout count={Number(state[1].get())} />} />
+                    <ul>
+                      <KeyedList
+                        id={2}
+                        render={() =>
+                          (state[2].get() as Item[]).map((item) => (
+                            <li key={item.id}>{item.label}</li>
+                          ))
+                        }
+                      />
+                    </ul>
+                    <Conditional
+                      id={3}
+                      render={() =>
+                        state[3].get() ? <strong>{Number(state[1].get())}</strong> : <i>off</i>
+                      }
+                    />
+                  </article>
+                ) : null
+              }
+            />
+          </section>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        { kind: "block", id: 1, parent: 0, dependencies: [1] },
+        { kind: "block", id: 2, parent: 0, dependencies: [2] },
+        { kind: "block", id: 3, parent: 0, dependencies: [1, 3] },
+      ],
+    });
+
+    function Normal() {
+      const [show, setShow] = useState(true);
+      const [count, setCount] = useState(0);
+      const [items, setItems] = useState(initialItems);
+      const [nested, setNested] = useState(false);
+      reactDispatch = (action) => {
+        if (action.kind === "show") setShow((value) => !value);
+        if (action.kind === "nested") setNested((value) => !value);
+        if (action.kind === "count") setCount((value) => value + action.amount);
+        if (action.kind === "reverse") setItems((value) => [...value].reverse());
+        if (action.kind === "rename") {
+          setItems((value) =>
+            value.map((item, index) =>
+              index === 0 ? { ...item, label: `${item.label}:${action.suffix}` } : item,
+            ),
+          );
+        }
+        if (action.kind === "append") setItems((value) => [...value, action.item]);
+        if (action.kind === "remove") setItems((value) => value.slice(1));
+      };
+      return (
+        <section>
+          {show ? (
+            <article>
+              <Readout count={count} />
+              <ul>
+                {items.map((item) => (
+                  <li key={item.id}>{item.label}</li>
+                ))}
+              </ul>
+              {nested ? <strong>{count}</strong> : <i>off</i>}
+            </article>
+          ) : null}
+        </section>
+      );
+    }
+
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<Compiled />);
+      reactRoot.render(<Normal />);
+    });
+
+    for (let offset = 0; offset < actions.length; offset += 10) {
+      await act(async () => {
+        for (const action of actions.slice(offset, offset + 10)) {
+          compiledDispatch(action);
+          reactDispatch(action);
+        }
+        await flushCompilerUpdates();
+      });
+      expect(compiledContainer.innerHTML).toBe(reactContainer.innerHTML);
+    }
+    expect(compiledOwnerRenders).toBe(1);
+  });
+});

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -52,6 +52,8 @@ export interface CompilerStyleBinding<Props> {
 export interface CompilerConditionalBlockBinding {
   kind: "block";
   id: number;
+  /** Nearest conditional boundary that owns this block, when nested. */
+  parent?: number;
   dependencies: readonly number[];
 }
 
@@ -622,21 +624,60 @@ export function createCompiledComponent<Props>(
         this.dirtyState.clear();
         if (dirty.size === 0) return;
         try {
-          let blockRefreshScheduled = false;
-          for (const binding of definitionReference.current.bindings) {
+          const bindings = definitionReference.current.bindings;
+          const blockBindings = new Map<number, CompilerConditionalBlockBinding>();
+          const affectedBlockIds = new Set<number>();
+
+          for (const binding of bindings) {
+            if (binding.kind !== "block") continue;
+            blockBindings.set(binding.id, binding);
             if (binding.dependencies.some((dependency) => dirty.has(dependency))) {
-              if (binding.kind === "block") {
-                const refresh = this.blockRefreshListeners.get(binding.id);
-                if (refresh) {
-                  blockRefreshScheduled = true;
-                  refresh(() => this.restoreInputSelection(inputSelection));
-                }
-              } else {
-                this.applyBinding(binding);
-              }
+              affectedBlockIds.add(binding.id);
             }
           }
-          if (!blockRefreshScheduled) this.restoreInputSelection(inputSelection);
+
+          const hasAffectedMountedAncestor = (
+            binding: CompilerConditionalBlockBinding,
+          ): boolean => {
+            let parent = binding.parent;
+            while (parent !== undefined) {
+              if (affectedBlockIds.has(parent) && this.blockRefreshListeners.has(parent)) {
+                return true;
+              }
+              parent = blockBindings.get(parent)?.parent;
+            }
+            return false;
+          };
+
+          const blockRefreshes = [...affectedBlockIds]
+            .map((id) => {
+              const binding = blockBindings.get(id);
+              const refresh = this.blockRefreshListeners.get(id);
+              return binding && refresh && !hasAffectedMountedAncestor(binding)
+                ? refresh
+                : undefined;
+            })
+            .filter(
+              (refresh): refresh is (afterCommit?: () => void) => void => refresh !== undefined,
+            );
+
+          for (const binding of bindings) {
+            if (
+              binding.kind !== "block" &&
+              binding.dependencies.some((dependency) => dirty.has(dependency))
+            ) {
+              this.applyBinding(binding);
+            }
+          }
+
+          let pendingBlockCommits = blockRefreshes.length;
+          for (const refresh of blockRefreshes) {
+            refresh(() => {
+              pendingBlockCommits -= 1;
+              if (pendingBlockCommits === 0) this.restoreInputSelection(inputSelection);
+            });
+          }
+          if (blockRefreshes.length === 0) this.restoreInputSelection(inputSelection);
         } catch (error) {
           this.bindingError = error;
           this.hasBindingError = true;

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -50,35 +50,38 @@ interface PendingDomBinding {
 interface PendingConditionalBlockBinding {
   kind: "block";
   id: number;
+  parent?: number;
   dependencies: number[];
 }
 
 type PendingBinding = PendingDomBinding | PendingConditionalBlockBinding;
 
 interface ConditionalBlockPlan {
+  kind: "conditional";
   id: number;
+  parent?: number;
   dependencies: number[];
   source: t.Expression;
 }
 
 interface KeyedListPlan {
+  kind: "keyed-list";
   id: number;
+  parent?: number;
   dependencies: number[];
   source: t.Expression;
   syntax: "map" | "list";
 }
 
 interface ComponentIslandPlan {
+  kind: "component";
   id: number;
+  parent?: number;
   dependencies: number[];
-  location: number[];
+  source: t.JSXElement;
 }
 
-interface ComponentIslandAnalysis {
-  islands?: ComponentIslandPlan[];
-  components?: Set<t.JSXElement>;
-  reason?: string;
-}
+type ComposableBlockPlan = ConditionalBlockPlan | KeyedListPlan | ComponentIslandPlan;
 
 interface Candidate {
   name: string;
@@ -462,171 +465,6 @@ function conditionalBlockShape(expression: t.Expression): ConditionalBlockShape 
   };
 }
 
-function validateConditionalHostTree(
-  root: t.JSXElement,
-  statesByValue: ReadonlyMap<string, StateBinding>,
-  safeGlobals: ReadonlySet<string>,
-): string | undefined {
-  const visit = (element: t.JSXElement): string | undefined => {
-    const tag = element.openingElement.name;
-    if (!t.isJSXIdentifier(tag) || !/^[a-z]/.test(tag.name)) {
-      return "conditional blocks currently support host elements only";
-    }
-
-    for (const attribute of element.openingElement.attributes) {
-      if (t.isJSXSpreadAttribute(attribute)) {
-        return "conditional blocks do not support JSX attribute spreads";
-      }
-      const name = jsxAttributeName(attribute);
-      if (!name) return "conditional blocks do not support namespaced JSX attributes";
-      if (name === "ref" || name === "dangerouslySetInnerHTML") {
-        return `conditional block ${name} requires React ownership`;
-      }
-      if (
-        !t.isJSXExpressionContainer(attribute.value) ||
-        t.isJSXEmptyExpression(attribute.value.expression) ||
-        /^on[A-Z]/.test(name)
-      ) {
-        continue;
-      }
-
-      const expression = attribute.value.expression;
-      if (name === "style") {
-        if (!t.isObjectExpression(expression)) {
-          return "conditional block styles must use one inline object literal";
-        }
-        for (const property of expression.properties) {
-          if (!t.isObjectProperty(property) || property.computed) {
-            return "conditional block styles do not support spreads, methods, or computed properties";
-          }
-          if (!t.isExpression(property.value)) {
-            return "conditional block style properties must use expression values";
-          }
-          const unsupported = validateDerivedExpression(property.value, safeGlobals);
-          if (unsupported) return `conditional block style cannot use ${unsupported}`;
-        }
-        continue;
-      }
-
-      const unsupported = validateDerivedExpression(expression, safeGlobals);
-      if (unsupported) return `conditional block attribute ${name} cannot use ${unsupported}`;
-    }
-
-    for (const child of element.children) {
-      if (t.isJSXElement(child)) {
-        const reason = visit(child);
-        if (reason) return reason;
-        continue;
-      }
-      if (t.isJSXFragment(child)) {
-        return "conditional blocks do not support fragments yet";
-      }
-      if (!t.isJSXExpressionContainer(child) || t.isJSXEmptyExpression(child.expression)) {
-        continue;
-      }
-      if (conditionalBlockShape(child.expression)) {
-        return "nested conditional blocks are not supported yet";
-      }
-      if (!isTextExpression(child.expression, statesByValue, safeGlobals)) {
-        return "conditional block children must keep one static host tree";
-      }
-    }
-    return undefined;
-  };
-
-  return visit(root);
-}
-
-function analyzeConditionalBlocks(
-  root: t.JSXElement,
-  statesByValue: ReadonlyMap<string, StateBinding>,
-  safeGlobals: ReadonlySet<string>,
-): { blocks?: ConditionalBlockPlan[]; reason?: string } {
-  const blocks: ConditionalBlockPlan[] = [];
-
-  const visit = (element: t.JSXElement): string | undefined => {
-    for (const child of element.children) {
-      if (t.isJSXElement(child)) {
-        const reason = visit(child);
-        if (reason) return reason;
-        continue;
-      }
-      if (!t.isJSXExpressionContainer(child) || t.isJSXEmptyExpression(child.expression)) {
-        continue;
-      }
-      const shape = conditionalBlockShape(child.expression);
-      if (!shape) continue;
-      const unsupported = validateDerivedExpression(shape.test, safeGlobals);
-      if (unsupported) return `conditional block test cannot use ${unsupported}`;
-      for (const branch of shape.branches) {
-        const reason = validateConditionalHostTree(branch, statesByValue, safeGlobals);
-        if (reason) return reason;
-      }
-      blocks.push({
-        id: blocks.length,
-        dependencies: collectStateDependencies(child.expression, statesByValue),
-        source: child.expression,
-      });
-    }
-    return undefined;
-  };
-
-  const reason = visit(root);
-  return reason ? { reason } : { blocks };
-}
-
-function lowerConditionalBlocks(
-  root: t.JSXElement,
-  plans: readonly ConditionalBlockPlan[],
-  blockRuntime: t.Identifier,
-): t.JSXElement {
-  const lowered = t.cloneNode(root, true);
-  let cursor = 0;
-  const visit = (element: t.JSXElement): void => {
-    element.children = element.children.map((child) => {
-      if (t.isJSXElement(child)) {
-        visit(child);
-        return child;
-      }
-      if (
-        !t.isJSXExpressionContainer(child) ||
-        t.isJSXEmptyExpression(child.expression) ||
-        !conditionalBlockShape(child.expression)
-      ) {
-        return child;
-      }
-      const plan = plans[cursor++];
-      const name = t.jsxMemberExpression(
-        t.jsxIdentifier(blockRuntime.name),
-        t.jsxIdentifier("Conditional"),
-      );
-      return t.jsxElement(
-        t.jsxOpeningElement(
-          name,
-          [
-            t.jsxAttribute(
-              t.jsxIdentifier("id"),
-              t.jsxExpressionContainer(t.numericLiteral(plan.id)),
-            ),
-            t.jsxAttribute(
-              t.jsxIdentifier("render"),
-              t.jsxExpressionContainer(
-                t.arrowFunctionExpression([], cloneExpression(child.expression)),
-              ),
-            ),
-          ],
-          true,
-        ),
-        null,
-        [],
-        true,
-      );
-    });
-  };
-  visit(lowered);
-  return lowered;
-}
-
 function isMapCall(expression: t.Expression): expression is t.CallExpression {
   return (
     t.isCallExpression(expression) &&
@@ -813,63 +651,6 @@ function analyzePublicList(
   return { dependencies: collectStateDependencies(element, statesByValue) };
 }
 
-function analyzeKeyedLists(
-  root: t.JSXElement,
-  statesByValue: ReadonlyMap<string, StateBinding>,
-  safeGlobals: ReadonlySet<string>,
-  listNames: ReadonlySet<string>,
-  startingId: number,
-): { lists?: KeyedListPlan[]; reason?: string } {
-  const lists: KeyedListPlan[] = [];
-
-  const visit = (element: t.JSXElement): string | undefined => {
-    const meaningful = meaningfulJsxChildren(element);
-    for (const child of element.children) {
-      if (t.isJSXElement(child) && isPublicListElement(child, listNames)) {
-        if (meaningful.length !== 1) {
-          return "a compiled keyed list must be the only child of its host container";
-        }
-        const result = analyzePublicList(child, statesByValue, safeGlobals);
-        if (result.reason) return result.reason;
-        lists.push({
-          id: startingId + lists.length,
-          dependencies: result.dependencies || [],
-          source: child,
-          syntax: "list",
-        });
-        continue;
-      }
-      if (t.isJSXElement(child)) {
-        const reason = visit(child);
-        if (reason) return reason;
-        continue;
-      }
-      if (
-        !t.isJSXExpressionContainer(child) ||
-        t.isJSXEmptyExpression(child.expression) ||
-        !isMapCall(child.expression)
-      ) {
-        continue;
-      }
-      if (meaningful.length !== 1) {
-        return "a compiled keyed list must be the only child of its host container";
-      }
-      const result = analyzeMapList(child.expression, statesByValue, safeGlobals);
-      if (result.reason) return result.reason;
-      lists.push({
-        id: startingId + lists.length,
-        dependencies: result.dependencies || [],
-        source: child.expression,
-        syntax: "map",
-      });
-    }
-    return undefined;
-  };
-
-  const reason = visit(root);
-  return reason ? { reason } : { lists };
-}
-
 function keyedListBoundary(
   blockRuntime: t.Identifier,
   plan: KeyedListPlan,
@@ -897,119 +678,62 @@ function keyedListBoundary(
   );
 }
 
-function lowerKeyedLists(
-  root: t.JSXElement,
-  plans: readonly KeyedListPlan[],
-  blockRuntime: t.Identifier,
-  listNames: ReadonlySet<string>,
-): t.JSXElement {
-  const lowered = t.cloneNode(root, true);
-  let cursor = 0;
-  const visit = (element: t.JSXElement): void => {
-    element.children = element.children.map((child) => {
-      if (t.isJSXElement(child) && isPublicListElement(child, listNames)) {
-        const plan = plans[cursor++];
-        return keyedListBoundary(blockRuntime, plan, child);
-      }
-      if (t.isJSXElement(child)) {
-        visit(child);
-        return child;
-      }
-      if (
-        t.isJSXExpressionContainer(child) &&
-        !t.isJSXEmptyExpression(child.expression) &&
-        isMapCall(child.expression)
-      ) {
-        const plan = plans[cursor++];
-        return keyedListBoundary(blockRuntime, plan, child.expression);
-      }
-      return child;
-    });
-  };
-  visit(lowered);
-  return lowered;
-}
-
-function analyzeComponentIslands(
-  root: t.JSXElement,
+function analyzeComponentIslandElement(
+  element: t.JSXElement,
   statesByValue: ReadonlyMap<string, StateBinding>,
   safeGlobals: ReadonlySet<string>,
   allowedComponentNames: ReadonlySet<string>,
-  keyedElements: ReadonlySet<t.JSXElement>,
-  startingId: number,
-): ComponentIslandAnalysis {
-  const islands: ComponentIslandPlan[] = [];
-  const components = new Set<t.JSXElement>();
+): { dependencies?: number[]; reason?: string } {
+  const name = element.openingElement.name;
+  if (!t.isJSXIdentifier(name) || !isComponentName(name.name)) {
+    return { reason: "component islands require a direct component identifier" };
+  }
+  if (!allowedComponentNames.has(name.name)) {
+    return {
+      reason: `component island ${name.name} must reference a stable module-level component`,
+    };
+  }
+  if (meaningfulJsxChildren(element).length > 0) {
+    return { reason: `component island ${name.name} does not support children yet` };
+  }
 
-  const visit = (element: t.JSXElement, location: number[]): string | undefined => {
-    for (let childIndex = 0; childIndex < element.children.length; childIndex += 1) {
-      const child = element.children[childIndex];
-      if (!t.isJSXElement(child) || keyedElements.has(child)) continue;
-      if (isHostElement(child)) {
-        const reason = visit(child, [...location, childIndex]);
-        if (reason) return reason;
-        continue;
-      }
+  const dependencies = new Set<number>();
+  for (const attribute of element.openingElement.attributes) {
+    if (t.isJSXSpreadAttribute(attribute)) {
+      return { reason: `component island ${name.name} does not support JSX attribute spreads` };
+    }
+    const attributeName = jsxAttributeName(attribute);
+    if (!attributeName) {
+      return { reason: `component island ${name.name} does not support namespaced JSX attributes` };
+    }
+    if (attributeName === "ref" || attributeName === "key" || attributeName === "children") {
+      return { reason: `component island ${name.name} does not support ${attributeName} yet` };
+    }
+    if (
+      !t.isJSXExpressionContainer(attribute.value) ||
+      t.isJSXEmptyExpression(attribute.value.expression)
+    ) {
+      continue;
+    }
 
-      const name = child.openingElement.name;
-      if (!t.isJSXIdentifier(name) || !isComponentName(name.name)) {
-        return "component islands require a direct component identifier";
-      }
-      if (!allowedComponentNames.has(name.name)) {
-        return `component island ${name.name} must reference a stable module-level component`;
-      }
-      if (meaningfulJsxChildren(child).length > 0) {
-        return `component island ${name.name} does not support children yet`;
-      }
-
-      const dependencies = new Set<number>();
-      for (const attribute of child.openingElement.attributes) {
-        if (t.isJSXSpreadAttribute(attribute)) {
-          return `component island ${name.name} does not support JSX attribute spreads`;
-        }
-        const attributeName = jsxAttributeName(attribute);
-        if (!attributeName) {
-          return `component island ${name.name} does not support namespaced JSX attributes`;
-        }
-        if (attributeName === "ref" || attributeName === "key" || attributeName === "children") {
-          return `component island ${name.name} does not support ${attributeName} yet`;
-        }
-        if (
-          !t.isJSXExpressionContainer(attribute.value) ||
-          t.isJSXEmptyExpression(attribute.value.expression)
-        ) {
-          continue;
-        }
-
-        const expression = attribute.value.expression;
-        const isEventFunction =
-          /^on[A-Z]/.test(attributeName) &&
-          (t.isArrowFunctionExpression(expression) || t.isFunctionExpression(expression));
-        if (!isEventFunction) {
-          const unsupported = validateDerivedExpression(expression, safeGlobals);
-          if (unsupported) {
-            return `component island ${name.name} prop ${attributeName} cannot use ${unsupported}`;
-          }
-        }
-        collectStateDependencies(expression, statesByValue).forEach((dependency) =>
-          dependencies.add(dependency),
-        );
-      }
-
-      components.add(child);
-      if (dependencies.size > 0) {
-        islands.push({
-          id: startingId + islands.length,
-          dependencies: [...dependencies].sort((left, right) => left - right),
-          location: [...location, childIndex],
-        });
+    const expression = attribute.value.expression;
+    const isEventFunction =
+      /^on[A-Z]/.test(attributeName) &&
+      (t.isArrowFunctionExpression(expression) || t.isFunctionExpression(expression));
+    if (!isEventFunction) {
+      const unsupported = validateDerivedExpression(expression, safeGlobals);
+      if (unsupported) {
+        return {
+          reason: `component island ${name.name} prop ${attributeName} cannot use ${unsupported}`,
+        };
       }
     }
-    return undefined;
-  };
+    collectStateDependencies(expression, statesByValue).forEach((dependency) =>
+      dependencies.add(dependency),
+    );
+  }
 
-  const reason = visit(root, []);
-  return reason ? { reason } : { islands, components };
+  return { dependencies: [...dependencies].sort((left, right) => left - right) };
 }
 
 function componentIslandBoundary(
@@ -1039,28 +763,322 @@ function componentIslandBoundary(
   );
 }
 
-function lowerComponentIslands(
-  root: t.JSXElement,
-  plans: readonly ComponentIslandPlan[],
-  blockRuntime: t.Identifier,
-): t.JSXElement {
-  if (plans.length === 0) return t.cloneNode(root, true);
-  const lowered = t.cloneNode(root, true);
-  const plansByLocation = new Map(plans.map((plan) => [plan.location.join("."), plan]));
+interface ComposableBlockAnalysis {
+  plans?: ComposableBlockPlan[];
+  componentElements?: Set<t.JSXElement>;
+  conditionalExpressions?: Set<t.Expression>;
+  keyedElements?: Set<t.JSXElement>;
+  keyedExpressions?: Set<t.Expression>;
+  reason?: string;
+}
 
-  const visit = (element: t.JSXElement, location: number[]): void => {
-    element.children = element.children.map((child, childIndex) => {
-      if (!t.isJSXElement(child)) return child;
-      const childLocation = [...location, childIndex];
-      const plan = plansByLocation.get(childLocation.join("."));
-      if (plan) return componentIslandBoundary(blockRuntime, plan, child);
-      if (isHostElement(child)) visit(child, childLocation);
+function analyzeComposableBlocks(
+  root: t.JSXElement,
+  statesByValue: ReadonlyMap<string, StateBinding>,
+  safeGlobals: ReadonlySet<string>,
+  listNames: ReadonlySet<string>,
+  allowedComponentNames: ReadonlySet<string>,
+): ComposableBlockAnalysis {
+  const plans: ComposableBlockPlan[] = [];
+  const componentElements = new Set<t.JSXElement>();
+  const conditionalExpressions = new Set<t.Expression>();
+  const keyedElements = new Set<t.JSXElement>();
+  const keyedExpressions = new Set<t.Expression>();
+  let nextId = 0;
+
+  const mergeDependencies = (target: Set<number>, dependencies: Iterable<number>) => {
+    for (const dependency of dependencies) target.add(dependency);
+  };
+
+  const visitHost = (
+    element: t.JSXElement,
+    parent: number | undefined,
+    insideConditional: boolean,
+  ): { dependencies: Set<number>; reason?: string } => {
+    const dependencies = new Set<number>();
+    if (!isHostElement(element)) {
+      return {
+        dependencies,
+        reason: insideConditional
+          ? "conditional blocks currently support host elements only"
+          : "compiled trees currently support host elements only",
+      };
+    }
+
+    if (insideConditional) {
+      for (const attribute of element.openingElement.attributes) {
+        if (t.isJSXSpreadAttribute(attribute)) {
+          return {
+            dependencies,
+            reason: "conditional blocks do not support JSX attribute spreads",
+          };
+        }
+        const name = jsxAttributeName(attribute);
+        if (!name) {
+          return {
+            dependencies,
+            reason: "conditional blocks do not support namespaced JSX attributes",
+          };
+        }
+        if (name === "ref" || name === "dangerouslySetInnerHTML") {
+          return {
+            dependencies,
+            reason: `conditional block ${name} requires React ownership`,
+          };
+        }
+        if (
+          !t.isJSXExpressionContainer(attribute.value) ||
+          t.isJSXEmptyExpression(attribute.value.expression) ||
+          /^on[A-Z]/.test(name)
+        ) {
+          continue;
+        }
+
+        const expression = attribute.value.expression;
+        if (name === "style") {
+          if (!t.isObjectExpression(expression)) {
+            return {
+              dependencies,
+              reason: "conditional block styles must use one inline object literal",
+            };
+          }
+          for (const property of expression.properties) {
+            if (!t.isObjectProperty(property) || property.computed) {
+              return {
+                dependencies,
+                reason:
+                  "conditional block styles do not support spreads, methods, or computed properties",
+              };
+            }
+            if (!t.isExpression(property.value)) {
+              return {
+                dependencies,
+                reason: "conditional block style properties must use expression values",
+              };
+            }
+            const unsupported = validateDerivedExpression(property.value, safeGlobals);
+            if (unsupported) {
+              return {
+                dependencies,
+                reason: `conditional block style cannot use ${unsupported}`,
+              };
+            }
+            mergeDependencies(
+              dependencies,
+              collectStateDependencies(property.value, statesByValue),
+            );
+          }
+          continue;
+        }
+
+        const unsupported = validateDerivedExpression(expression, safeGlobals);
+        if (unsupported) {
+          return {
+            dependencies,
+            reason: `conditional block attribute ${name} cannot use ${unsupported}`,
+          };
+        }
+        mergeDependencies(dependencies, collectStateDependencies(expression, statesByValue));
+      }
+    }
+
+    for (const child of element.children) {
+      if (t.isJSXFragment(child)) {
+        if (insideConditional) {
+          return {
+            dependencies,
+            reason: "conditional blocks do not support fragments yet",
+          };
+        }
+        continue;
+      }
+
+      if (t.isJSXElement(child)) {
+        if (isHostElement(child)) {
+          const nested = visitHost(child, parent, insideConditional);
+          if (nested.reason) return { dependencies, reason: nested.reason };
+          mergeDependencies(dependencies, nested.dependencies);
+          continue;
+        }
+
+        if (isPublicListElement(child, listNames)) {
+          const result = analyzePublicList(child, statesByValue, safeGlobals);
+          if (result.reason) return { dependencies, reason: result.reason };
+          const plan: KeyedListPlan = {
+            kind: "keyed-list",
+            id: nextId++,
+            parent,
+            dependencies: result.dependencies || [],
+            source: child,
+            syntax: "list",
+          };
+          plans.push(plan);
+          keyedElements.add(child);
+          continue;
+        }
+
+        const result = analyzeComponentIslandElement(
+          child,
+          statesByValue,
+          safeGlobals,
+          allowedComponentNames,
+        );
+        if (result.reason) return { dependencies, reason: result.reason };
+        componentElements.add(child);
+        if ((result.dependencies || []).length > 0) {
+          plans.push({
+            kind: "component",
+            id: nextId++,
+            parent,
+            dependencies: result.dependencies || [],
+            source: child,
+          });
+        }
+        continue;
+      }
+
+      if (!t.isJSXExpressionContainer(child) || t.isJSXEmptyExpression(child.expression)) {
+        continue;
+      }
+
+      const expression = child.expression;
+      const shape = conditionalBlockShape(expression);
+      if (shape) {
+        const unsupported = validateDerivedExpression(shape.test, safeGlobals);
+        if (unsupported) {
+          return {
+            dependencies,
+            reason: `conditional block test cannot use ${unsupported}`,
+          };
+        }
+        const plan: ConditionalBlockPlan = {
+          kind: "conditional",
+          id: nextId++,
+          parent,
+          dependencies: collectStateDependencies(shape.test, statesByValue),
+          source: expression,
+        };
+        plans.push(plan);
+        conditionalExpressions.add(expression);
+        const ownedDependencies = new Set(plan.dependencies);
+        for (const branch of shape.branches) {
+          const nested = visitHost(branch, plan.id, true);
+          if (nested.reason) return { dependencies, reason: nested.reason };
+          mergeDependencies(ownedDependencies, nested.dependencies);
+        }
+        plan.dependencies = [...ownedDependencies].sort((left, right) => left - right);
+        continue;
+      }
+
+      if (isMapCall(expression)) {
+        const result = analyzeMapList(expression, statesByValue, safeGlobals);
+        if (result.reason) return { dependencies, reason: result.reason };
+        plans.push({
+          kind: "keyed-list",
+          id: nextId++,
+          parent,
+          dependencies: result.dependencies || [],
+          source: expression,
+          syntax: "map",
+        });
+        keyedExpressions.add(expression);
+        continue;
+      }
+
+      if (insideConditional) {
+        if (!isTextExpression(expression, statesByValue, safeGlobals)) {
+          return {
+            dependencies,
+            reason: "conditional block children must keep one supported block or static host tree",
+          };
+        }
+        mergeDependencies(dependencies, collectStateDependencies(expression, statesByValue));
+      }
+    }
+
+    return { dependencies };
+  };
+
+  const result = visitHost(root, undefined, false);
+  if (result.reason) return { reason: result.reason };
+  return {
+    plans,
+    componentElements,
+    conditionalExpressions,
+    keyedElements,
+    keyedExpressions,
+  };
+}
+
+function conditionalBlockBoundary(
+  blockRuntime: t.Identifier,
+  plan: ConditionalBlockPlan,
+  source: t.Expression,
+): t.JSXElement {
+  const name = t.jsxMemberExpression(
+    t.jsxIdentifier(blockRuntime.name),
+    t.jsxIdentifier("Conditional"),
+  );
+  return t.jsxElement(
+    t.jsxOpeningElement(
+      name,
+      [
+        t.jsxAttribute(t.jsxIdentifier("id"), t.jsxExpressionContainer(t.numericLiteral(plan.id))),
+        t.jsxAttribute(
+          t.jsxIdentifier("render"),
+          t.jsxExpressionContainer(t.arrowFunctionExpression([], cloneExpression(source))),
+        ),
+      ],
+      true,
+    ),
+    null,
+    [],
+    true,
+  );
+}
+
+function lowerComposableBlocks(
+  root: t.JSXElement,
+  plans: readonly ComposableBlockPlan[],
+  blockRuntime: t.Identifier,
+  listNames: ReadonlySet<string>,
+): t.JSXElement {
+  const planBySource = new Map<t.Node, ComposableBlockPlan>(
+    plans.map((plan) => [plan.source, plan]),
+  );
+
+  const visit = (element: t.JSXElement): void => {
+    element.children = element.children.map((child) => {
+      if (t.isJSXElement(child)) {
+        const plan = planBySource.get(child);
+        if (plan?.kind === "component") {
+          return componentIslandBoundary(blockRuntime, plan, child);
+        }
+        if (plan?.kind === "keyed-list" && isPublicListElement(child, listNames)) {
+          return keyedListBoundary(blockRuntime, plan, child);
+        }
+        if (isHostElement(child)) visit(child);
+        return child;
+      }
+      if (!t.isJSXExpressionContainer(child) || t.isJSXEmptyExpression(child.expression)) {
+        return child;
+      }
+
+      const plan = planBySource.get(child.expression);
+      if (plan?.kind === "conditional") {
+        const shape = conditionalBlockShape(child.expression);
+        for (const branch of shape?.branches || []) visit(branch);
+        return conditionalBlockBoundary(blockRuntime, plan, child.expression);
+      }
+      if (plan?.kind === "keyed-list") {
+        return keyedListBoundary(blockRuntime, plan, child.expression);
+      }
       return child;
     });
   };
 
-  visit(lowered, []);
-  return lowered;
+  visit(root);
+  return root;
 }
 
 function assignStableBindingTargets(bindings: readonly PendingBinding[]): void {
@@ -1082,7 +1100,6 @@ function lowerStableBindingTargets(
   bindings: readonly PendingBinding[],
   blockRuntime: t.Identifier,
 ): t.JSXElement {
-  const lowered = t.cloneNode(root, true);
   const targetByPath = new Map<string, number>();
   for (const binding of bindings) {
     if (binding.kind !== "block" && binding.target !== undefined) {
@@ -1114,8 +1131,8 @@ function lowerStableBindingTargets(
     }
   };
 
-  visit(lowered, []);
-  return lowered;
+  visit(root, []);
+  return root;
 }
 
 function analyzeHostTree(
@@ -1381,6 +1398,9 @@ function bindingObject(
   ];
   if (binding.kind === "block") {
     properties.push(t.objectProperty(t.identifier("id"), t.numericLiteral(binding.id)));
+    if (binding.parent !== undefined) {
+      properties.push(t.objectProperty(t.identifier("parent"), t.numericLiteral(binding.parent)));
+    }
     return t.objectExpression(properties);
   }
   properties.splice(
@@ -1557,25 +1577,6 @@ function compileCandidate(
   );
   const setterReason = validateSetterUsage(expandedRoot, statesBySetter);
   if (setterReason) return setterReason;
-  const conditionalAnalysis = analyzeConditionalBlocks(expandedRoot, statesByValue, safeGlobals);
-  if (conditionalAnalysis.reason) return conditionalAnalysis.reason;
-  const conditionalBlocks = conditionalAnalysis.blocks || [];
-  const keyedAnalysis = analyzeKeyedLists(
-    expandedRoot,
-    statesByValue,
-    safeGlobals,
-    listNames,
-    conditionalBlocks.length,
-  );
-  if (keyedAnalysis.reason) return keyedAnalysis.reason;
-  const keyedLists = keyedAnalysis.lists || [];
-  const conditionalExpressions = new Set(conditionalBlocks.map((block) => block.source));
-  const keyedExpressions = new Set(
-    keyedLists.filter((list) => list.syntax === "map").map((list) => list.source),
-  );
-  const keyedElements = new Set(
-    keyedLists.filter((list) => list.syntax === "list").map((list) => list.source as t.JSXElement),
-  );
   const referencedComponentNames = new Set<string>();
   traverse(expressionFile(t.cloneNode(expandedRoot, true)), {
     JSXOpeningElement(componentPath) {
@@ -1597,25 +1598,23 @@ function compileCandidate(
       );
     }),
   );
-  const componentAnalysis = analyzeComponentIslands(
+  const blockAnalysis = analyzeComposableBlocks(
     expandedRoot,
     statesByValue,
     safeGlobals,
+    listNames,
     allowedComponentNames,
-    keyedElements,
-    conditionalBlocks.length + keyedLists.length,
   );
-  if (componentAnalysis.reason) return componentAnalysis.reason;
-  const componentIslands = componentAnalysis.islands || [];
-  const componentElements = componentAnalysis.components || new Set<t.JSXElement>();
+  if (blockAnalysis.reason) return blockAnalysis.reason;
+  const blockPlans = blockAnalysis.plans || [];
   const analysis = analyzeHostTree(
     expandedRoot,
     statesByValue,
     safeGlobals,
-    conditionalExpressions,
-    keyedExpressions,
-    keyedElements,
-    componentElements,
+    blockAnalysis.conditionalExpressions || new Set<t.Expression>(),
+    blockAnalysis.keyedExpressions || new Set<t.Expression>(),
+    blockAnalysis.keyedElements || new Set<t.JSXElement>(),
+    blockAnalysis.componentElements || new Set<t.JSXElement>(),
   );
   if (analysis.reason) return analysis.reason;
   assignStableBindingTargets(analysis.bindings || []);
@@ -1629,9 +1628,12 @@ function compileCandidate(
     analysis.bindings || [],
     blockParameter,
   );
-  const rootWithIslands = lowerComponentIslands(rootWithTargets, componentIslands, blockParameter);
-  const rootWithLists = lowerKeyedLists(rootWithIslands, keyedLists, blockParameter, listNames);
-  const rootWithBlocks = lowerConditionalBlocks(rootWithLists, conditionalBlocks, blockParameter);
+  const rootWithBlocks = lowerComposableBlocks(
+    rootWithTargets,
+    blockPlans,
+    blockParameter,
+    listNames,
+  );
   const rewrittenRoot = rewriteStateAccess(
     rootWithBlocks,
     stateParameter,
@@ -1688,20 +1690,11 @@ function compileCandidate(
         t.arrayExpression(
           [
             ...(analysis.bindings || []),
-            ...conditionalBlocks.map((block) => ({
+            ...blockPlans.map((block) => ({
               kind: "block" as const,
               id: block.id,
+              parent: block.parent,
               dependencies: block.dependencies,
-            })),
-            ...keyedLists.map((list) => ({
-              kind: "block" as const,
-              id: list.id,
-              dependencies: list.dependencies,
-            })),
-            ...componentIslands.map((island) => ({
-              kind: "block" as const,
-              id: island.id,
-              dependencies: island.dependencies,
             })),
           ].map((binding) =>
             bindingObject(binding, propsParameter, stateParameter, statesByValue, statesBySetter),


### PR DESCRIPTION
## Summary

- replace the separate conditional, keyed-list, and component-island compiler passes with one recursive composable block graph
- assign globally unique block IDs across each compiled component and record nearest conditional parents
- support keyed lists beside static siblings, multiple lists and conditionals in one container, component islands and keyed lists inside host-rooted conditional branches, and nested host conditionals
- coalesce outer and descendant refreshes while preserving React-owned mounting, reconciliation, keyed identity, lifecycle, and cleanup
- add a production composable-block experiment and document the supported contract and fallback boundaries

## Safety

React remains the DOM and Fiber owner. List callback contents are not recursively compiled because one source location may create multiple keyed runtime instances. Unsupported structures continue to fall back to ordinary React.

When an outer conditional unmounts, nested block components unsubscribe through their normal React lifecycle. Updates made while hidden do not target stale listeners, and remounting reads the latest compiler-cell values.

## Validation

- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test` — 131 tests passed
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and React 19.2.8 passed
- `pnpm --filter farm-react-compiler-example type-check`
- `pnpm --filter farm-react-compiler-example experiment` — production build and Playwright verification passed
- 1,000 deterministic combined updates matched ordinary React
- production verification confirmed zero compiled-owner update executions, keyed DOM identity preservation, correct hidden-update/remount behavior, no browser errors, and no mobile overflow
- targeted formatting, lint, and diff checks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compose conditional, keyed-list, and component-island updates into one recursive block graph. Previously, separate passes disallowed nested blocks and required lists to be the only child; now blocks have globally unique IDs with a `parent`, support nesting and mixed siblings, and coalesce refreshes while preserving React ownership.

- Contract changes:
  - Conditionals: branch must have a host root; branches may contain nested host conditionals, keyed lists, and supported component islands. A custom component cannot be the branch root. Hooks in branch expressions, fragments, refs, spreads, and `dangerouslySetInnerHTML` fall back.
  - Keyed lists: direct keyed `map(...)` and `List` from `@farm.js/react/list` may sit beside static siblings, other lists, and eligible conditionals. Index keys, chained maps, spread children, and hooks in the callback fall back. List callback bodies are not recursively compiled.
  - Component islands: stable module-level components with compiler-safe props; no children, `key`, `ref`, or spreads.
- Runtime and compiler:
  - `compiler-runtime` tracks block `id` with optional `parent`. When a flush touches an outer conditional and descendants, the mounted outer block refreshes once and descendant refreshes are skipped; input selection is restored after the last block commit. Hidden branches remove inner subscriptions; remounts read the latest compiler-cell values.
  - Replaces multiple passes with a single composable analysis and lowering (`analyzeComposableBlocks`/`lowerComposableBlocks`) that assigns component-wide IDs and `parent` links.
  - Adds tests for nested/coalesced updates, DOM identity, and 1,000-update determinism; updates docs and examples, including a new “Composable block graph” section, a `ComposableBlockExperiment`, and `examples` verification. Updates `@farm.js/react` README to reflect the new contracts.

<sup>Written for commit 79bdc1ac608484d09240849a048dd9de4fe592d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

