### PR TITLE
fix: isolate telemetry CI environment tests

### DIFF
--- a/packages/farm-cli/test/telemetry.test.mjs
+++ b/packages/farm-cli/test/telemetry.test.mjs
@@ -13,12 +13,15 @@ import {
 } from "../dist/telemetry.mjs";
 
 const TELEMETRY_ENV_KEYS = [
+  "BUILDKITE",
   "CI",
+  "CIRCLECI",
   "DO_NOT_TRACK",
   "FARM_TELEMETRY",
   "FARM_TELEMETRY_CONFIG_DIR",
   "FARM_TELEMETRY_DISABLED",
   "FARM_TELEMETRY_ENDPOINT",
+  "GITHUB_ACTIONS",
   "NODE_ENV",
 ];
 
@@ -50,6 +53,23 @@ test("telemetry is enabled without creating an identity by default", async () =>
     assert.equal(status.source, "default");
     assert.match(status.reason, /non-interactive/);
     assert.equal(status.anonymousId, undefined);
+  });
+});
+
+test("telemetry remains inactive in recognized CI environments", async () => {
+  await withTelemetryEnvironment(async () => {
+    for (const key of ["CI", "GITHUB_ACTIONS", "BUILDKITE", "CIRCLECI"]) {
+      process.env[key] = "true";
+
+      const status = await getFarmTelemetryStatus();
+      assert.equal(status.enabled, true);
+      assert.equal(status.active, false);
+      assert.equal(status.source, "default");
+      assert.equal(status.reason, "CI environments are skipped");
+      assert.equal(status.anonymousId, undefined);
+
+      delete process.env[key];
+    }
   });
 });
 


### PR DESCRIPTION
## What changed

- clear every CI provider variable recognized by the telemetry implementation before each test
- restore those variables after each test
- add regression coverage for CI, GitHub Actions, Buildkite, and CircleCI

## Why

The default telemetry test removed `CI` but left `GITHUB_ACTIONS=true` on GitHub-hosted runners. The implementation therefore correctly returned `CI environments are skipped`, while the test expected the non-interactive reason. This caused the Node 20 CI job to fail on `main` and unrelated pull requests.

This change makes the test environment deterministic without changing production telemetry behavior.

## Validation

- `pnpm --filter @farm.js/cli test` — 74/74 tests pass
- `GITHUB_ACTIONS=true node --test packages/farm-cli/test/telemetry.test.mjs` — 7/7 tests pass
- `pnpm exec oxfmt --check packages/farm-cli/test/telemetry.test.mjs`
- `pnpm exec oxlint packages/farm-cli/test/telemetry.test.mjs`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates telemetry CI environment tests to make results deterministic on hosted runners. Previously tests only removed `CI`, leaving `GITHUB_ACTIONS=true` and yielding “CI environments are skipped” instead of the expected non-interactive reason; now tests clear and restore all recognized CI provider variables and add regression coverage. Production telemetry behavior does not change.

- Clears and restores recognized CI env keys (`CI`, `GITHUB_ACTIONS`, `BUILDKITE`, `CIRCLECI`, and related telemetry keys) around each test.
- Adds a test asserting telemetry stays inactive when any supported CI variable is set.

<sup>Written for commit e2e2a90ec90904bda99ff8c32dcd057a80abf7ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

