### PR TITLE
fix(create-app): pass shell: true to spawn on Windows

### DIFF
--- a/packages/create-farm-app/src/index.ts
+++ b/packages/create-farm-app/src/index.ts
@@ -843,12 +843,16 @@ export function installDependencies(
   packageManager: PackageManager,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
-    const command =
-      process.platform === "win32" ? `${packageManager.name}.cmd` : packageManager.name;
+    const isWindows = process.platform === "win32";
+    const command = isWindows ? `${packageManager.name}.cmd` : packageManager.name;
+    // Node rejects spawning .cmd/.bat files without a shell since the fix for
+    // CVE-2024-27980 (EINVAL). Safe here: the command is one of npm|pnpm|yarn|bun
+    // and the argument list is a literal.
     const child = spawn(command, ["install"], {
       cwd: projectPath,
       env: process.env,
       stdio: "inherit",
+      shell: isWindows,
     });
 
     child.on("error", reject);


### PR DESCRIPTION
## Summary

Fixes #384.

`pnpm create @farm.js/app@beta` crashed on Windows with `Error: spawn EINVAL` at the dependency-install step. Node's fix for CVE-2024-27980 (landed in 18.20.2 / 20.12.2 / 21.7.3) makes `child_process.spawn()` reject `.cmd`/`.bat` targets on Windows unless `shell: true` is set. Since `npm`, `pnpm`, and `yarn` are all `.cmd` shims on Windows, the install step failed for every package manager except `bun`, on every supported Node version.

## Change

`installDependencies()` in `packages/create-farm-app/src/index.ts` now passes `shell: isWindows` to `spawn()`. Behavior on macOS/Linux is unchanged (`shell: false`).

No injection surface is introduced: `packageManager.name` is constrained to `npm|pnpm|yarn|bun` by the regex in `detectPackageManager()` (defaulting to `pnpm`), and the argument list is the literal `["install"]`.

## Testing

- All 14 tests in `packages/create-farm-app` pass, including `installs dependencies with the invoking package manager`, which stubs a fake `pnpm`/`pnpm.cmd` on PATH and exercises this exact code path (and hits the EINVAL on Windows without this fix).
- `tsc --noEmit` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows install crashes in `create-farm-app` by spawning the package manager with `shell: true`. Previously, the dependency install step failed on Windows for `npm`/`pnpm`/`yarn` due to Node’s CVE-2024-27980 change rejecting `.cmd` without a shell; now installs succeed, and macOS/Linux behavior is unchanged.

- Change: `installDependencies()` in `packages/create-farm-app/src/index.ts` sets `shell: isWindows` and uses `<pm>.cmd` on Windows; arguments remain `["install"]`.
- Safety: `packageManager.name` is limited to `npm|pnpm|yarn|bun`, and the argument list is literal.
- Tests: All `packages/create-farm-app` tests pass, including the path that stubs a Windows `.cmd` binary.
- Migration: None.

<sup>Written for commit d208b221b295e2749a2244aa2279e0b11eebfe92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

