### PR TITLE
fix(core): stop externalizing Windows entry points in config loader

### DIFF
--- a/packages/farm/src/__tests__/config-loader.test.ts
+++ b/packages/farm/src/__tests__/config-loader.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { loadFarmConfigFile } from "../layers";
+import { createFarmConfigResolutionPlugin, loadFarmConfigFile } from "../layers";
 
 const temporaryRoots = new Set<string>();
 
@@ -88,6 +88,87 @@ describe("Farm config helper import fast path", () => {
       extends: ["./base"],
       helperEntry: "config",
     });
+  });
+});
+
+describe("Farm config resolution plugin", () => {
+  type OnResolveArgs = {
+    path: string;
+    importer: string;
+    namespace: string;
+    resolveDir: string;
+    kind: string;
+    pluginData?: Record<string, unknown>;
+  };
+  type OnResolveCallback = (args: OnResolveArgs) => Promise<unknown>;
+
+  async function resolveWithPlugin(args: OnResolveArgs): Promise<unknown> {
+    const callbacks: Array<{ filter: RegExp; callback: OnResolveCallback }> = [];
+    const pluginBuild = {
+      onResolve(options: { filter: RegExp }, callback: OnResolveCallback) {
+        callbacks.push({ filter: options.filter, callback });
+      },
+      async resolve(specifier: string) {
+        return { path: `/resolved/${specifier}`, errors: [], warnings: [] };
+      },
+    };
+
+    const plugin = createFarmConfigResolutionPlugin({
+      transform: async () => ({ code: "", map: "", warnings: [] }),
+    });
+    plugin.setup(pluginBuild as never);
+
+    for (const { filter, callback } of callbacks) {
+      if (!filter.test(args.path)) continue;
+      const result = await callback(args);
+      if (result !== undefined) return result;
+    }
+    return undefined;
+  }
+
+  it("does not mark Windows entry points as external", async () => {
+    // Windows absolute paths match the bare-specifier filter (/^[^./]/); the
+    // entry point must not be externalized or esbuild fails with
+    // "The entry point ... cannot be marked as external".
+    await expect(
+      resolveWithPlugin({
+        path: "E:\\farming\\stacklens\\farm.config.ts",
+        importer: "",
+        namespace: "file",
+        resolveDir: "",
+        kind: "entry-point",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not externalize Windows absolute import paths", async () => {
+    for (const importPath of [
+      "E:\\farming\\stacklens\\shared-config.ts",
+      "E:/farming/stacklens/shared-config.ts",
+      "\\\\server\\share\\shared-config.ts",
+    ]) {
+      await expect(
+        resolveWithPlugin({
+          path: importPath,
+          importer: "E:\\farming\\stacklens\\farm.config.ts",
+          namespace: "file",
+          resolveDir: "E:\\farming\\stacklens",
+          kind: "import-statement",
+        }),
+      ).resolves.toBeUndefined();
+    }
+  });
+
+  it("still externalizes bare package specifiers", async () => {
+    await expect(
+      resolveWithPlugin({
+        path: "picocolors",
+        importer: "/project/farm.config.ts",
+        namespace: "file",
+        resolveDir: "/project",
+        kind: "import-statement",
+      }),
+    ).resolves.toMatchObject({ external: true, path: "/resolved/picocolors" });
   });
 });
 

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -970,7 +970,7 @@ export async function loadConfig(
   for (const relativePath of searchPaths) {
     try {
       // Use path.join for proper path construction
-      const absolutePath = relativePath.startsWith("/")
+      const absolutePath = path.isAbsolute(relativePath)
         ? relativePath
         : path.join(root, relativePath);
 

--- a/packages/farm/src/layers.ts
+++ b/packages/farm/src/layers.ts
@@ -215,6 +215,88 @@ export function getFarmLayerAliases(
   );
 }
 
+// Matches Windows drive-letter (`E:\`, `E:/`) and UNC (`\\server\share`) paths,
+// which would otherwise pass the "bare specifier" filter below. `path.isAbsolute`
+// only recognizes these on Windows, but esbuild can hand us such paths on any
+// platform (e.g. in cross-platform tests), and no valid package name contains
+// `:` or starts with `\`.
+const WINDOWS_ABSOLUTE_PATH_RE = /^(?:[A-Za-z]:[\\/]|\\\\)/;
+
+export function createFarmConfigResolutionPlugin(options: {
+  transform: EsbuildTransform;
+}): import("esbuild").Plugin {
+  const configEntryChecks = new Map<string, Promise<boolean>>();
+
+  return {
+    name: "farm-config-package-resolution",
+    setup(pluginBuild) {
+      pluginBuild.onResolve({ filter: /^@farm\.js\/core$/ }, async (args) => {
+        if (
+          args.pluginData?.farmConfigExternal ||
+          args.kind !== "import-statement" ||
+          !args.importer
+        ) {
+          return;
+        }
+
+        let configEntryCheck = configEntryChecks.get(args.importer);
+        if (!configEntryCheck) {
+          configEntryCheck = onlyImportsFarmConfigHelpers(args.importer, options.transform);
+          configEntryChecks.set(args.importer, configEntryCheck);
+        }
+        if (!(await configEntryCheck)) return;
+
+        const resolved = await pluginBuild.resolve(FARM_CONFIG_ENTRY, {
+          importer: args.importer,
+          kind: args.kind,
+          namespace: args.namespace,
+          resolveDir: args.resolveDir,
+          pluginData: { farmConfigExternal: true },
+        });
+        if (resolved.errors.length > 0 || !resolved.path) return;
+
+        return {
+          path: resolved.path,
+          external: true,
+          warnings: resolved.warnings,
+        };
+      });
+
+      pluginBuild.onResolve({ filter: /^[^./]/ }, async (args) => {
+        // The filter is meant to catch bare package specifiers, but Windows
+        // absolute paths (`E:\...`) match it too — including the entry point
+        // itself, which esbuild rejects when marked external.
+        if (
+          args.kind === "entry-point" ||
+          path.isAbsolute(args.path) ||
+          WINDOWS_ABSOLUTE_PATH_RE.test(args.path)
+        ) {
+          return;
+        }
+        if (args.pluginData?.farmConfigExternal) return;
+
+        const resolved = await pluginBuild.resolve(args.path, {
+          importer: args.importer,
+          kind: args.kind,
+          namespace: args.namespace,
+          resolveDir: args.resolveDir,
+          pluginData: { farmConfigExternal: true },
+        });
+
+        if (resolved.errors.length > 0 || !resolved.path) {
+          return { path: args.path, external: true };
+        }
+
+        return {
+          path: resolved.path,
+          external: true,
+          warnings: resolved.warnings,
+        };
+      });
+    },
+  };
+}
+
 export async function loadFarmConfigFile<TConfig = Record<string, any>>(
   configPath: string,
   options: { root: string; cacheRoot?: string },
@@ -222,7 +304,6 @@ export async function loadFarmConfigFile<TConfig = Record<string, any>>(
   const { build, transform } = await import("esbuild");
   const cacheRoot = path.resolve(options.cacheRoot || options.root);
   const configCacheDir = path.join(cacheRoot, ".farm", ".config-loader");
-  const configEntryChecks = new Map<string, Promise<boolean>>();
   await mkdir(configCacheDir, { recursive: true });
 
   const modulePath = path.join(
@@ -238,66 +319,7 @@ export async function loadFarmConfigFile<TConfig = Record<string, any>>(
     format: "esm",
     platform: "node",
     target: `node${process.versions.node.split(".")[0]}`,
-    plugins: [
-      {
-        name: "farm-config-package-resolution",
-        setup(pluginBuild) {
-          pluginBuild.onResolve({ filter: /^@farm.js\/core$/ }, async (args) => {
-            if (
-              args.pluginData?.farmConfigExternal ||
-              args.kind !== "import-statement" ||
-              !args.importer
-            ) {
-              return;
-            }
-
-            let configEntryCheck = configEntryChecks.get(args.importer);
-            if (!configEntryCheck) {
-              configEntryCheck = onlyImportsFarmConfigHelpers(args.importer, transform);
-              configEntryChecks.set(args.importer, configEntryCheck);
-            }
-            if (!(await configEntryCheck)) return;
-
-            const resolved = await pluginBuild.resolve(FARM_CONFIG_ENTRY, {
-              importer: args.importer,
-              kind: args.kind,
-              namespace: args.namespace,
-              resolveDir: args.resolveDir,
-              pluginData: { farmConfigExternal: true },
-            });
-            if (resolved.errors.length > 0 || !resolved.path) return;
-
-            return {
-              path: resolved.path,
-              external: true,
-              warnings: resolved.warnings,
-            };
-          });
-
-          pluginBuild.onResolve({ filter: /^[^./]/ }, async (args) => {
-            if (args.pluginData?.farmConfigExternal) return;
-
-            const resolved = await pluginBuild.resolve(args.path, {
-              importer: args.importer,
-              kind: args.kind,
-              namespace: args.namespace,
-              resolveDir: args.resolveDir,
-              pluginData: { farmConfigExternal: true },
-            });
-
-            if (resolved.errors.length > 0 || !resolved.path) {
-              return { path: args.path, external: true };
-            }
-
-            return {
-              path: resolved.path,
-              external: true,
-              warnings: resolved.warnings,
-            };
-          });
-        },
-      },
-    ],
+    plugins: [createFarmConfigResolutionPlugin({ transform })],
     jsx: "automatic",
     logLevel: "silent",
     sourcemap: "inline",


### PR DESCRIPTION
## Summary

`farm dev` (and any command that loads `farm.config.ts`) crashes on Windows before the dev server starts:

```
Failed to load config from farm.config.ts: Build failed with 1 error:
error: The entry point "E:\\farming\\stacklens\\farm.config.ts" cannot be marked as external
```

## Root cause

`loadFarmConfigFile()` bundles the user's config with esbuild and uses a plugin to mark bare package specifiers as external via the filter `/^[^./]/` ("doesn't start with `.` or `/`"). That test is only correct on POSIX. On Windows the resolved entry point is `E:\...\farm.config.ts`, which starts with `E` and therefore matches the filter; esbuild routes entry points through `onResolve` too, so the plugin marked the config file itself as external — which esbuild rejects with the error above.

## Changes

- The bare-specifier `onResolve` callback now returns early for `kind === "entry-point"`, `path.isAbsolute()` paths, and Windows drive-letter/UNC paths (`path.isAbsolute` only recognizes those on Windows). Only real bare specifiers get externalized.
- `loadConfig()` used `relativePath.startsWith("/")` to detect an explicitly passed absolute config path, which mangles Windows absolute paths via `path.join(root, ...)`; now uses `path.isAbsolute()`.
- Escaped the unescaped dot in the `/^@farm\.js\/core$/` resolve filter.
- Extracted the plugin into an exported `createFarmConfigResolutionPlugin()` so the resolution rules are unit-testable on non-Windows CI. No behavior change beyond the guards above.

## Testing

- New tests in `config-loader.test.ts` drive the plugin's `onResolve` callbacks directly with Windows-style paths: the entry point is not externalized, Windows absolute/UNC import paths are not externalized, and bare specifiers still are.
- Existing config-loader and config test suites pass; `tsc --noEmit` is clean. (The pre-existing `layers.test.ts` failure about resolving `@farm.js/core`'s package entry reproduces identically on `main` in my environment and is unrelated.)

Related: #384 fixed the Windows `spawn EINVAL` in `create-farm-app` (#385); this is the next blocker a scaffolded app hits on Windows when running `farm dev`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows crashes when loading `farm.config.ts` by preventing the esbuild plugin from externalizing the entry point and absolute Windows paths. Previously Windows drive-letter/UNC paths matched the bare-specifier filter and the entry point was marked external; now only bare package specifiers are externalized.

**Review notes**
- Guard the resolution plugin against entry points, `path.isAbsolute()` paths, and Windows drive-letter/UNC paths; continue externalizing true bare specifiers.
- Use `path.isAbsolute()` in `loadConfig()` to correctly handle explicitly provided Windows absolute paths.
- Escape the dot in the `@farm\.js/core` resolve filter.
- Extract the plugin as `createFarmConfigResolutionPlugin` and add tests that cover Windows path cases.

<sup>Written for commit c0d38d0342edff167c2e6fe3ed5c238ee67278f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

