### PR TITLE
fix(core): emit file:// URLs for externals in config loader

### DIFF
--- a/packages/farm/src/__tests__/config-loader.test.ts
+++ b/packages/farm/src/__tests__/config-loader.test.ts
@@ -3,6 +3,7 @@
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { createFarmConfigResolutionPlugin, loadFarmConfigFile } from "../layers";
 
@@ -159,7 +160,10 @@ describe("Farm config resolution plugin", () => {
     }
   });
 
-  it("still externalizes bare package specifiers", async () => {
+  it("externalizes bare package specifiers as file:// URLs", async () => {
+    // Raw absolute paths are written verbatim into the compiled config's
+    // import statements; on Windows, Node's ESM loader parses `E:\...` as a
+    // URL with protocol "e:" and rejects it, so externals must be file:// URLs.
     await expect(
       resolveWithPlugin({
         path: "picocolors",
@@ -168,7 +172,38 @@ describe("Farm config resolution plugin", () => {
         resolveDir: "/project",
         kind: "import-statement",
       }),
-    ).resolves.toMatchObject({ external: true, path: "/resolved/picocolors" });
+    ).resolves.toMatchObject({
+      external: true,
+      path: pathToFileURL(path.resolve("/resolved/picocolors")).href,
+    });
+  });
+
+  it("keeps unresolvable bare specifiers external without rewriting them", async () => {
+    const callbacks: Array<{ filter: RegExp; callback: OnResolveCallback }> = [];
+    const pluginBuild = {
+      onResolve(options: { filter: RegExp }, callback: OnResolveCallback) {
+        callbacks.push({ filter: options.filter, callback });
+      },
+      async resolve(specifier: string) {
+        return { path: "", errors: [{ text: `cannot resolve ${specifier}` }], warnings: [] };
+      },
+    };
+
+    const plugin = createFarmConfigResolutionPlugin({
+      transform: async () => ({ code: "", map: "", warnings: [] }),
+    });
+    plugin.setup(pluginBuild as never);
+
+    const bareCallback = callbacks.find(({ filter }) => filter.test("some-missing-package"));
+    await expect(
+      bareCallback?.callback({
+        path: "some-missing-package",
+        importer: "/project/farm.config.ts",
+        namespace: "file",
+        resolveDir: "/project",
+        kind: "import-statement",
+      }),
+    ).resolves.toMatchObject({ external: true, path: "some-missing-package" });
   });
 });
 

--- a/packages/farm/src/layers.ts
+++ b/packages/farm/src/layers.ts
@@ -222,6 +222,14 @@ export function getFarmLayerAliases(
 // `:` or starts with `\`.
 const WINDOWS_ABSOLUTE_PATH_RE = /^(?:[A-Za-z]:[\\/]|\\\\)/;
 
+// External paths are written verbatim into the bundled config's import
+// statements. Node's ESM loader accepts `/abs/path` specifiers on POSIX, but a
+// raw Windows path like `E:\...` is parsed as a URL with protocol `e:` and
+// rejected, so absolute paths must be emitted as file:// URLs.
+function toExternalSpecifier(resolvedPath: string): string {
+  return path.isAbsolute(resolvedPath) ? pathToFileURL(resolvedPath).href : resolvedPath;
+}
+
 export function createFarmConfigResolutionPlugin(options: {
   transform: EsbuildTransform;
 }): import("esbuild").Plugin {
@@ -256,7 +264,7 @@ export function createFarmConfigResolutionPlugin(options: {
         if (resolved.errors.length > 0 || !resolved.path) return;
 
         return {
-          path: resolved.path,
+          path: toExternalSpecifier(resolved.path),
           external: true,
           warnings: resolved.warnings,
         };
@@ -288,7 +296,7 @@ export function createFarmConfigResolutionPlugin(options: {
         }
 
         return {
-          path: resolved.path,
+          path: toExternalSpecifier(resolved.path),
           external: true,
           warnings: resolved.warnings,
         };


### PR DESCRIPTION
## Summary

Fixes #387.

After #386, `farm dev` on Windows got past esbuild but crashed at import time:

```
Failed to load config from farm.config.ts: Only URLs with a scheme in: file, data, and node
are supported by the default ESM loader. On Windows, absolute paths must be valid file://
URLs. Received protocol 'e:'
```

## Root cause

Both `onResolve` handlers in `createFarmConfigResolutionPlugin` return `resolved.path` — a raw filesystem path — as an external specifier. esbuild writes that string verbatim into the compiled config's import statements. Node's ESM loader happens to accept `/abs/path` specifiers on POSIX, but a Windows path like `E:\...\config.mjs` gets parsed as a URL whose scheme is the drive letter, and only `file`, `data`, and `node` schemes are allowed.

The `@farm.js/core` handler hits this on every scaffolded app; the bare-specifier handler has the same latent bug for any other package a config imports.

## Changes

- Added a `toExternalSpecifier()` helper in `packages/farm/src/layers.ts`: absolute resolved paths are converted with `pathToFileURL()` before being returned as external, in both handlers. Unresolvable bare specifiers are still passed through untouched so Node's own resolution applies.
- This matches what the rest of the codebase already does — every other dynamic import of a computed path (`loadFarmConfigFile`'s own output module, `loadDocsConfig`, `auth-config.ts`, `instrumentation.ts`, `renderer.ts`, `farm-cli/auth.ts`) already wraps in `pathToFileURL`. I swept `packages/farm` and `packages/farm-cli` for other raw-path imports and custom `external: true` emissions; these two handlers were the only remaining offenders (the one in `nitro/universal-build.ts` externalizes a bare specifier constant, which is fine).

## Testing

- Updated the plugin unit tests: externalized bare specifiers must now be `file://` URLs (asserted via `pathToFileURL` so the expectation is platform-correct on Windows CI too), and unresolvable specifiers stay untouched.
- The existing end-to-end config-loader tests run real esbuild and then `import()` the bundled output, so they now exercise the `file://` external emission at runtime.
- 46/46 tests pass across `config-loader.test.ts` and `config.test.ts`; `tsc --noEmit` is clean.

Follow-up to #385 and #386 in the Windows-support series.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit file:// URLs for external specifiers in the config loader so Windows ESM imports succeed. Previously we emitted raw absolute paths (e.g., E:\...), which Node parsed as an invalid URL scheme; now absolute paths become file:// URLs. POSIX behavior is unchanged; unresolvable specifiers still pass through.

- Added `toExternalSpecifier()` in `packages/farm/src/layers.ts` and used it in both `createFarmConfigResolutionPlugin` onResolve handlers. Only absolute resolved paths are rewritten with `pathToFileURL`; others are untouched.
- Updated tests to expect file:// URLs for resolved externals and to verify passthrough for unresolvable specifiers. End-to-end config-loader tests now exercise this at runtime.

<sup>Written for commit 442238c7916c78bb69fe928e35482926bead58fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

