### PR TITLE
fix(core): emit forward-slash module URLs in SSR manifests on Windows

### DIFF
--- a/packages/farm/src/__tests__/utils.test.ts
+++ b/packages/farm/src/__tests__/utils.test.ts
@@ -1,6 +1,12 @@
 import path from "path";
 import { describe, it, expect } from "vitest";
-import { parseRoutePath, matchRoute, segmentsToPattern, toViteModuleId } from "../utils";
+import {
+  parseRoutePath,
+  matchRoute,
+  segmentsToPattern,
+  toRootRelativeUrlPath,
+  toViteModuleId,
+} from "../utils";
 import { createCliColors } from "../cli-colors";
 
 describe("createCliColors", () => {
@@ -24,6 +30,39 @@ describe("toViteModuleId", () => {
       "/@fs/workspace/layer/routes.ts",
     );
     expect(toViteModuleId("virtual:farm-routes", root)).toBe("virtual:farm-routes");
+  });
+});
+
+describe("toRootRelativeUrlPath", () => {
+  it("slices POSIX project paths to root-relative URL paths", () => {
+    expect(toRootRelativeUrlPath("/workspace/app/src/app/page.tsx", "/workspace/app")).toBe(
+      "/src/app/page.tsx",
+    );
+  });
+
+  it("emits forward slashes for Windows project paths", () => {
+    // The client feeds these values to dynamic import(); `\src\app\page.tsx`
+    // is not a valid module specifier and breaks hydration on Windows.
+    expect(toRootRelativeUrlPath("E:\\farming\\app\\src\\app\\page.tsx", "E:\\farming\\app")).toBe(
+      "/src/app/page.tsx",
+    );
+    expect(
+      toRootRelativeUrlPath("E:\\farming\\app\\src\\app\\layout.tsx", "E:\\farming\\app"),
+    ).toBe("/src/app/layout.tsx");
+  });
+
+  it("returns undefined for paths outside the root", () => {
+    expect(toRootRelativeUrlPath("/other/place/page.tsx", "/workspace/app")).toBeUndefined();
+    expect(toRootRelativeUrlPath("D:\\elsewhere\\page.tsx", "E:\\farming\\app")).toBeUndefined();
+    expect(toRootRelativeUrlPath("virtual:farm-routes", "/workspace/app")).toBeUndefined();
+  });
+
+  it("does not treat sibling directories sharing a prefix as inside the root", () => {
+    expect(toRootRelativeUrlPath("/workspace/app2/src/page.tsx", "/workspace/app")).toBeUndefined();
+  });
+
+  it("returns an empty path for the root itself", () => {
+    expect(toRootRelativeUrlPath("/workspace/app", "/workspace/app")).toBe("");
   });
 });
 

--- a/packages/farm/src/manifest/generator.ts
+++ b/packages/farm/src/manifest/generator.ts
@@ -12,6 +12,7 @@ import type {
   RouterManagedTag,
 } from "./types";
 import { getClientModuleMetadata } from "../utils/client-component";
+import { toRootRelativeUrlPath } from "../utils";
 import { createFarmRouteRenderPlan } from "../navigation/render-plan";
 
 function layoutAppliesToRoute(layoutPattern: string, routePattern: string): boolean {
@@ -157,12 +158,8 @@ export async function generateDevManifest(
     ]),
   );
 
-  const toUrlPath = (absolutePath: string): string => {
-    if (absolutePath.startsWith(projectRoot)) {
-      return absolutePath.slice(projectRoot.length);
-    }
-    return absolutePath;
-  };
+  const toUrlPath = (absolutePath: string): string =>
+    toRootRelativeUrlPath(absolutePath, projectRoot) ?? absolutePath;
 
   const routeManifest: Record<string, RouteManifestEntry> = {};
   for (const route of routes) {
@@ -236,12 +233,8 @@ export async function generateProdManifest(
     ]),
   );
 
-  const toUrlPath = (absolutePath: string): string => {
-    if (absolutePath.startsWith(projectRoot)) {
-      return absolutePath.slice(projectRoot.length);
-    }
-    return absolutePath;
-  };
+  const toUrlPath = (absolutePath: string): string =>
+    toRootRelativeUrlPath(absolutePath, projectRoot) ?? absolutePath;
 
   // Map module paths to chunk info
   const moduleToChunk = new Map<string, ChunkInfo>();

--- a/packages/farm/src/routing/route-manager.ts
+++ b/packages/farm/src/routing/route-manager.ts
@@ -11,6 +11,7 @@ import {
   resolveAppPath,
   globFiles,
   logger,
+  toRootRelativeUrlPath,
   toViteModuleId,
 } from "../utils";
 import { collectSSGPages, resolveRouteRenderingConfigFromFile } from "../ssg";
@@ -561,12 +562,8 @@ export class RouteManager {
     }
 
     const toUrlPath = (absolutePath: string) => {
-      if (
-        absolutePath === normalizedProjectRoot ||
-        absolutePath.startsWith(`${normalizedProjectRoot}${path.sep}`)
-      ) {
-        return absolutePath.slice(normalizedProjectRoot.length);
-      }
+      const rootRelative = toRootRelativeUrlPath(absolutePath, normalizedProjectRoot);
+      if (rootRelative !== undefined) return rootRelative;
       if (path.isAbsolute(absolutePath)) {
         const normalized = absolutePath.replace(/\\/g, "/");
         return normalized.startsWith("/") ? `/@fs${normalized}` : `/@fs/${normalized}`;

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -10,7 +10,7 @@ import type {
   SSGPage,
 } from "../types";
 import type { MatchedRouteSlot, RouteManager } from "../routing/route-manager";
-import { logger } from "../utils";
+import { logger, toRootRelativeUrlPath } from "../utils";
 import { getClientModuleMetadata } from "../utils/client-component";
 import { Writable } from "stream";
 import {
@@ -1192,9 +1192,7 @@ export class ServerRenderer {
       );
       const clientLayouts = layouts.map((layout, index) => ({
         pattern: layout.pattern,
-        modulePath: layout.modulePath.startsWith(this.config.root)
-          ? layout.modulePath.slice(this.config.root.length)
-          : layout.modulePath,
+        modulePath: toRootRelativeUrlPath(layout.modulePath, this.config.root) ?? layout.modulePath,
         shouldHydrate: layoutHydrationMetadata[index]?.shouldHydrate === true,
         islandStrategy: layoutHydrationMetadata[index]?.islandStrategy ?? null,
       }));
@@ -1936,8 +1934,8 @@ export class ServerRenderer {
         (slot: Record<string, any>) => ({
           ...slot,
           modulePath:
-            typeof slot.modulePath === "string" && slot.modulePath.startsWith(this.config.root)
-              ? slot.modulePath.slice(this.config.root.length)
+            typeof slot.modulePath === "string"
+              ? (toRootRelativeUrlPath(slot.modulePath, this.config.root) ?? slot.modulePath)
               : slot.modulePath,
         }),
       );
@@ -1947,9 +1945,7 @@ export class ServerRenderer {
       });
       const pagePath = (req as any).__FARM_PAGE_PATH__;
       const relativePath = pagePath
-        ? pagePath.startsWith(this.config.root)
-          ? pagePath.slice(this.config.root.length)
-          : pagePath
+        ? (toRootRelativeUrlPath(pagePath, this.config.root) ?? pagePath)
         : "/src/app/page.tsx";
       const deploymentId = this.getDeploymentId();
       const bootstrapScript = `<script>
@@ -2070,9 +2066,7 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
       const pagePath = (req as any).__FARM_PAGE_PATH__;
       const isClientComponent = (req as any).__FARM_IS_CLIENT_COMPONENT__ === true;
       const relativePath = pagePath
-        ? pagePath.startsWith(this.config.root)
-          ? pagePath.slice(this.config.root.length)
-          : pagePath
+        ? (toRootRelativeUrlPath(pagePath, this.config.root) ?? pagePath)
         : "/src/app/page.tsx";
 
       // Generate manifest for client-side SPA navigation (TanStack Start pattern)
@@ -2136,8 +2130,8 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
         (slot: Record<string, any>) => ({
           ...slot,
           modulePath:
-            typeof slot.modulePath === "string" && slot.modulePath.startsWith(this.config.root)
-              ? slot.modulePath.slice(this.config.root.length)
+            typeof slot.modulePath === "string"
+              ? (toRootRelativeUrlPath(slot.modulePath, this.config.root) ?? slot.modulePath)
               : slot.modulePath,
         }),
       );

--- a/packages/farm/src/utils.ts
+++ b/packages/farm/src/utils.ts
@@ -151,10 +151,7 @@ export function toRootRelativeUrlPath(
   projectRoot: string,
 ): string | undefined {
   if (absolutePath === projectRoot) return "";
-  if (
-    absolutePath.startsWith(`${projectRoot}/`) ||
-    absolutePath.startsWith(`${projectRoot}\\`)
-  ) {
+  if (absolutePath.startsWith(`${projectRoot}/`) || absolutePath.startsWith(`${projectRoot}\\`)) {
     return absolutePath.slice(projectRoot.length).replace(/\\/g, "/");
   }
   return undefined;

--- a/packages/farm/src/utils.ts
+++ b/packages/farm/src/utils.ts
@@ -139,6 +139,27 @@ export function resolveAppPath(root: string, ...paths: string[]): string {
   return path.resolve(root, ...paths);
 }
 
+/**
+ * Convert an absolute module path inside the project root to a root-relative
+ * URL path with forward slashes (e.g. `/src/app/page.tsx`), for values the
+ * client passes to dynamic `import()`. On Windows the naive root-prefix slice
+ * yields `\src\app\page.tsx`, which is not a valid module specifier. Returns
+ * undefined for paths outside the root so callers keep their own fallbacks.
+ */
+export function toRootRelativeUrlPath(
+  absolutePath: string,
+  projectRoot: string,
+): string | undefined {
+  if (absolutePath === projectRoot) return "";
+  if (
+    absolutePath.startsWith(`${projectRoot}/`) ||
+    absolutePath.startsWith(`${projectRoot}\\`)
+  ) {
+    return absolutePath.slice(projectRoot.length).replace(/\\/g, "/");
+  }
+  return undefined;
+}
+
 export function toViteModuleId(filePath: string, root: string): string {
   if (!path.isAbsolute(filePath)) return filePath;
 


### PR DESCRIPTION
## Summary

Fixes #389.

On Windows, `farm dev` served correct SSR HTML but hydration failed with:

```
Failed to resolve module specifier '\src\app\page.tsx'
```

`window.__FARM_PAGE_MODULE__` and the `modulePath`/`preloads` fields in `window.__FARM_MANIFEST__` were emitted with backslash separators, and the client passes them straight to dynamic `import()`, which rejects them — so every page rendered inert (no event handlers, no state).

## Root cause

Several sites derive client-facing module URLs by slicing the project-root prefix off an absolute filesystem path without converting separators. On POSIX the remainder is already a valid URL path; on Windows it is `\src\app\page.tsx`.

## Changes

- New shared helper `toRootRelativeUrlPath(absolutePath, projectRoot)` in `packages/farm/src/utils.ts`: slices the root prefix and normalizes `\` to `/` (pure string operations, so behavior is identical on all platforms). Returns `undefined` for paths outside the root so each call site keeps its existing fallback (`/@fs` in the route manager, pass-through elsewhere).
- Used at every site that emitted raw slices:
  - `RouteManager.generateClientManifest` (`routing/route-manager.ts`) — routes, layouts, and slots
  - `server/renderer.ts` — `__FARM_PAGE_MODULE__` in both `renderBufferedSSR` and `renderWithSSR`, client layout entries, and both route-slot payloads
  - `manifest/generator.ts` — `toUrlPath` in both `generateDevManifest` and `generateProdManifest`
- `preloads` are derived from `modulePath`, so they inherit the fix.
- Side fix the helper brings for free: the root-prefix match now requires a path separator after the root, so a sibling directory like `/workspace/app2` is no longer mis-sliced when the root is `/workspace/app` (the old generator/renderer checks used a bare `startsWith`).

Not touched: `sharedAssets[].attrs.href` was already correct (hardcoded literal, as noted in the issue).

## Testing

- New unit tests for `toRootRelativeUrlPath` cover POSIX and Windows-style roots (drive letters, backslashes), outside-root paths, the sibling-prefix case, and virtual module ids — these run on non-Windows CI since the helper is platform-independent by construction.
- Full suites for the touched areas pass: `utils`, `route-manager`, `route-slots`, `server-renderer-route-states` (77/77), and `tsc --noEmit` is clean.
- The full-package vitest run shows the same 27 pre-existing failures as clean `main` in my environment (missing built workspace artifacts), with no new failures from this change.

Fourth entry in the Windows-support series after #385, #386, #388.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit forward-slash module URLs in SSR bootstrap and manifests on Windows to restore hydration. Previously we sliced absolute paths and left backslashes (e.g., "\src\app\page.tsx"), which dynamic import rejected; now we emit root‑relative URL paths (e.g., "/src/app/page.tsx").

- Introduce toRootRelativeUrlPath(absolutePath, projectRoot): slices the root prefix, normalizes "\" to "/", requires a path separator after the root to avoid sibling-prefix matches, returns undefined for outside-root paths, and returns "" when the path is the root itself.
- Apply the helper in RouteManager client manifest generation, server renderer (page module, client layout/slot paths in both render paths), and dev/prod manifest generators; preloads inherit the fix from modulePath. sharedAssets[].attrs.href is unchanged.
- Add unit tests for the helper (POSIX/Windows roots, outside-root, sibling-prefix, virtual ids, root-is-self); existing suites pass. No migrations; outside-root paths keep the current "/@fs" fallback.

<sup>Written for commit e7371ce8e1431c1b741d82b0f62d967715e4fed2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

