### PR TITLE
feat(react): add compiled keyed rows with LIS

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -331,12 +331,12 @@ satisfy all of these rules:
 | Body                | Top-level `useState` declarations, optional compiler-safe derived values and synchronous named handlers, then one unconditional JSX return. |
 | State               | `const [value, setValue] = useState(initial)`, including lazy initializers, multiple cells, and queued functional updates.                  |
 | Root                | Exactly one lowercase host JSX element such as `button`, `section`, `input`, or `div`.                                                      |
-| Tree                | A statically known host tree around eligible conditional, keyed-list, and React component-island boundaries.                                |
+| Tree                | A statically known host tree around eligible conditional, keyed-list, compiled keyed-row, and component-island boundaries.                  |
 | Text bindings       | State-driven text in a leaf host element.                                                                                                   |
 | Attribute bindings  | Basic attributes, controlled form properties, and individual properties in one inline `style` object.                                       |
 | Events              | Inline handlers and synchronous `const` or function-declaration handlers, used directly or called inside an inline JSX handler.             |
 | Conditional blocks  | `condition && <host />` or `condition ? <host /> : <host />`; host branches may contain supported nested blocks.                            |
-| Keyed lists         | A direct keyed `items.map(...)`, or an explicit imported `List`, alongside static siblings or other supported block boundaries.             |
+| Keyed lists         | Direct item-keyed maps and imported `List`; dedicated host-only containers may use compiler-owned rows and LIS.                             |
 | Component islands   | Stable imported or module-level component identifiers with explicit compiler-safe props and no JSX children, spread, `ref`, or `key`.       |
 
 This component is eligible:
@@ -453,7 +453,7 @@ The optimization boundary matters: the surrounding compiled component and its un
 do not rerender, but React still renders and commits the small conditional boundary. A branch with
 substantial work therefore still pays for that branch work.
 
-### Keyed list boundaries
+### Compiled keyed rows and React list boundaries
 
 The compiler automatically recognizes a direct keyed map in a safe, statically known container:
 
@@ -471,10 +471,17 @@ export function Inventory() {
 }
 ```
 
-Farm records the list's state dependencies and replaces the map location with a small internal
-React boundary. Updating `items` refreshes that boundary without executing `Inventory` again.
-React still receives the keyed elements and performs the insert, removal, move, render, lifecycle,
-and commit work inside the list. The optimization isolates that work; it does not remove it.
+This dedicated `ul` has one meaningful child and each row is a host-only tree. Farm can therefore
+prepare the row's host descriptor, key reader, and exact text, attribute, and style bindings at
+build time. React still creates the initial elements during client render or hydration. After the
+component mounts, Farm adopts those elements as keyed row instances.
+
+Updating `items` then does not execute `Inventory` or its map callback. Surviving rows are found by
+key and their prepared bindings are patched directly. Missing keys remove only their row, and new
+keys create only their prepared host tree. During a reorder, Farm calculates the longest increasing
+subsequence (LIS) of the old row positions. Rows in that subsequence stay in place; only the other
+surviving rows move. LIS is a runtime move planner over compiler-prepared rows, not a claim that the
+future contents of an array are known at build time.
 
 Use the public `List` component when the key should be separate from the row renderer, or when rows
 are custom components:
@@ -507,10 +514,20 @@ function InventoryRow({ item }) {
 `List` is an ordinary React component, not compiler-only syntax. It accepts an `Iterable`, `null`,
 or `undefined`; calls `by(item, index)` to create each React key; and requires its child function to
 return one React element. It therefore renders correctly when the experimental compiler is off or
-when this particular use cannot be optimized. Hooks belong inside a row component such as
-`InventoryRow`, never directly inside the `List` child function or a `.map()` callback.
+when this particular use cannot be optimized. The `InventoryRow` example stays in a React-owned
+keyed boundary because a custom component may contain Hooks, events, context, effects, and local
+state. The surrounding compiled component can still avoid executing again. Hooks belong inside a
+row component such as `InventoryRow`, never directly inside the `List` child function or a
+`.map()` callback.
 
-The first automatic contract is deliberately narrow:
+The compiler uses two keyed-list tiers:
+
+1. A dedicated nested host container with one direct map or one `List`, returning a host-only row,
+   becomes compiler-owned keyed row instances. This is the path that patches bindings and uses LIS.
+2. A safe keyed map or `List` that cannot use compiler-owned rows becomes a small React-owned keyed
+   boundary. React reconciles its rows, while the outer user component still avoids rerunning.
+
+The first compiler-owned row contract is deliberately narrow:
 
 - The map must be a direct `collection.map(...)` with one synchronous inline callback returning one
   React element and an explicit item-derived `key`.
@@ -518,15 +535,24 @@ The first automatic contract is deliberately narrow:
   across insertion, removal, or reordering.
 - The optimized `List` shape uses inline `by` and child functions, a compiler-safe `each`
   expression, and an item-derived key.
-- A map or `List` may appear beside static host children, other keyed lists, and eligible
-  conditional boundaries in the same container.
+- The list must be the only meaningful child of its own nested lowercase host container. The
+  component's outermost return element and a container with static siblings use the React-owned
+  boundary for now.
+- The row is a statically known HTML host tree. Dynamic leaf text, attributes, controlled host
+  properties, and individual inline style properties are supported.
+- Row events, custom components, fragments, refs, SVG, attribute spreads, dangerous HTML, and
+  dynamic text mixed beside nested elements stay React-owned.
 - Chained expressions such as `items.filter(...).map(...)`, spread children, hooks in the callback,
   and other unproven shapes fall back to normal React.
 
 Stable keys must be unique among siblings and come from the item's identity, such as a database ID.
-Farm does not implement an LIS move algorithm in this release. A compiler-owned LIS can only be
-safe after the compiler owns an entire host-only list island; this boundary intentionally keeps
-React as the sole DOM and Fiber owner.
+If duplicate keys appear at runtime, Farm remounts that list container through its original React
+render instead of guessing which row owns the identity. Later updates remain on the React fallback
+for that mounted list. Unsupported source shapes also keep React ownership from the beginning.
+
+For example, changing `[A, B, C, D]` to `[D, A, B, C]` keeps `[A, B, C]` as the LIS and moves only
+`D`. Reversing four rows needs three moves because the LIS has length one. Insertions and removals
+still do their necessary DOM work; LIS only minimizes moves among surviving keys.
 
 ### React component islands
 
@@ -579,7 +605,7 @@ The refs produce no `data-*` marker or other extra server markup.
 
 ### Composable block graph
 
-Conditional, keyed-list, and component-island boundaries are analyzed together. The compiler
+Conditional, keyed-list, keyed-row, and component-island boundaries are analyzed together. The compiler
 assigns every boundary a component-wide ID, so IDs remain unique even when several block types
 share a container or are nested inside one conditional branch. Nested bindings also record the ID
 of their nearest outer conditional.
@@ -590,16 +616,18 @@ React then unmounts or replaces the branch normally. Inner boundaries unsubscrib
 unmount, so later updates while the branch is hidden do not target stale components. If the branch
 appears again, each boundary subscribes again and renders from the latest compiler-cell values.
 
-The compiler deliberately does not analyze block-shaped syntax inside a keyed list callback. That
-callback can execute once per row, so a single compile-time block ID would not identify one runtime
-instance. React owns the complete keyed row subtree instead; put Hooks and additional dynamic
-structure inside a keyed row component.
+The compiler deliberately does not assign ordinary component-wide block IDs to syntax inside a
+keyed row callback. A host-only optimized row instead receives a separate runtime instance per key
+and a build-time binding list relative to that row root. If the row needs nested conditionals,
+component islands, Hooks, events, or other dynamic structure, React owns the complete row subtree;
+put Hooks inside a keyed row component.
 
 ### What falls back to React
 
 | Unsupported shape                                                          | Why React keeps ownership                                                          |
 | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| Unkeyed/index-keyed/chained maps or element arrays                         | Their structure or item identity is outside the isolated keyed-boundary contract.  |
+| Unkeyed/index-keyed/chained maps or element arrays                         | Their structure or item identity is outside the keyed-list contract.               |
+| Row events, components, fragments, refs, SVG, or mixed container children  | They require React ownership rather than compiler-created host rows.               |
 | Fragments or a custom component used as a conditional branch root          | Their structure is outside the current host-root conditional contract.             |
 | Dynamic/member component types, component spreads, refs, keys, or children | Their identity or ownership is outside the first component-island contract.        |
 | Effects or hooks other than the supported `useState` shape                 | Their lifecycle and ordering must remain under React's hook dispatcher.            |
@@ -614,11 +642,12 @@ structure inside a keyed row component.
 | Async/generator or generic components                                      | These function shapes are outside the current lowering.                            |
 | Setters called outside JSX event handlers                                  | The compiler only controls and batches event-driven local updates.                 |
 
-Keys do not make list reconciliation unnecessary. A key tells React which child identity survives
-an insert, removal, or move; React still compares the dynamic children. The compiler uses that
-identity to decide when a list can have its own refresh boundary, then hands the keyed elements to
-React. Calling a Hook directly inside a list iteration is invalid React because the number or order
-of calls can change. Put the Hook inside a keyed child component instead.
+Keys do not make list work disappear. A key identifies the row that survives an insert, removal,
+or move. On the compiler-owned host path, Farm compares those keys, reuses the matching row
+instances, and applies LIS to minimize moves. On the fallback path, React compares the keyed
+elements and owns reconciliation. Calling a Hook directly inside a list iteration is invalid React
+because the number or order of calls can change. Put the Hook inside a keyed child component
+instead; that custom row intentionally uses the React-owned path.
 
 ### Build-time transformation
 
@@ -654,17 +683,16 @@ do not receive the runtime import.
 The generated runtime wrapper is still a React component. Its responsibilities are split as
 follows:
 
-| React owns                                      | Compiler runtime owns                                                |
-| ----------------------------------------------- | -------------------------------------------------------------------- |
-| Initial element creation and placement          | Local compiler-cell values                                           |
-| SSR markup and hydration                        | Queuing local setter calls into one microtask                        |
-| JSX event registration and dispatch             | Comparing flushed values with `Object.is`                            |
-| Parent-driven prop updates                      | Selecting bindings whose state dependencies changed                  |
-| Unsupported trees, hooks, refs, and lifecycles  | Patching stable ref-owned text/attribute targets after local updates |
-| Host creation/removal inside an eligible block  | Refreshing only the matching internal conditional boundary           |
-| Keyed row identity, reconciliation, and DOM     | Refreshing only the matching internal keyed-list boundary            |
-| Component render, Hooks, context, and lifecycle | Refreshing only a dependent React component-island boundary          |
-| Unmounting and the surrounding component tree   | Reapplying bindings after a parent-driven React update               |
+| React owns                                             | Compiler runtime owns                                                     |
+| ------------------------------------------------------ | ------------------------------------------------------------------------- |
+| Initial element creation, SSR markup, and hydration    | Local compiler-cell values                                                |
+| JSX event registration and dispatch                    | Queuing local setter calls into one microtask                             |
+| Parent-driven prop updates                             | Comparing flushed values and selecting dependent bindings                 |
+| Unsupported trees, hooks, refs, events, and lifecycles | Patching stable ref-owned text, attribute, and style targets              |
+| Host creation/removal inside an eligible conditional   | Refreshing only the matching internal conditional boundary                |
+| React-owned custom or structurally complex keyed rows  | Host-only keyed-row identity, bindings, insertion, removal, and LIS moves |
+| Component render, Hooks, context, and lifecycle        | Refreshing only a dependent React component-island boundary               |
+| Unmounting and the surrounding component tree          | Reapplying bindings after a parent-driven React update                    |
 
 Queued functional setters preserve the event's state snapshot. Two calls such as
 `setCount(value => value + 1)` are applied in order during the same microtask flush, while reads
@@ -687,7 +715,9 @@ microtask. Composition events remain React-owned, so IME input keeps its normal 
 the resulting value, selection, and dependent bindings are patched together.
 
 The server output is ordinary React HTML and contains no compiler marker. React hydrates that
-markup normally; direct binding updates begin after the component mounts.
+markup normally; direct binding updates begin after the component mounts. An eligible keyed-row
+container adopts the already-hydrated child elements by their current order and generated keys, so
+it does not replace valid server rows during hydration.
 
 During development, compiled components receive a module-and-component identity plus a state-layout
 signature. A compatible Fast Refresh replaces the compiled definition while retaining the React
@@ -702,9 +732,11 @@ normal recovery path.
 
 The compiler uses fallback as a semantic boundary, not as an error-recovery trick. Generated
 callback refs keep direct DOM targets stable even when a React component island returns `null`, a
-fragment, or multiple nodes. Conditional, keyed-list, and component boundaries give dynamic
-structure back to React. Unsupported dynamic component types, refs, effects, and other unproven
-shapes keep the complete component on React; fallback is the optimization's correctness mechanism.
+fragment, or multiple nodes. Conditional, React-owned keyed-list, and component boundaries give
+complex dynamic structure back to React. Compiler-owned rows are limited to complete host-only
+containers because manually inserted DOM has no React Fiber for row events, components, or Hooks.
+Unsupported dynamic component types, refs, effects, and other unproven shapes keep React ownership;
+fallback is the optimization's correctness mechanism.
 
 Parent-driven prop updates also remain React updates. After React reconciles the new props, the
 runtime reapplies compiler-owned bindings from the current local cells so prop changes and local
@@ -730,13 +762,17 @@ The package and example test suites verify more than generated code:
   randomized updates;
 - automatic keyed maps and explicit `List` boundaries preserve keyed DOM nodes and stateful row
   identity across inserts, removals, updates, and reorders without rerunning the outer component;
+- compiler-owned host rows patch text, attributes, and styles in place, preserve focus and text
+  selection, use the LIS minimum for measured rotations and reversals, and remount through React
+  when runtime keys are duplicated;
 - component islands update only dependent children, preserve child-local state and context, route
   failures through React error boundaries, hydrate in Strict Mode, and safely drop queued updates
   after unmount;
 - stable ref targets remain correct when an earlier island switches among `null`, one node, and a
   multi-node fragment;
 - 1,000 deterministic object, array, and nullish component-prop transitions match normal React;
-- 1,000 deterministic randomized list operations produce the same ordered output as normal React;
+- 1,000 deterministic randomized compiler-owned list operations produce the same ordered output as
+  normal React while the list owner stays at one execution;
 - the public `List` renders iterable and nullish collections correctly with the compiler off;
 - the packaged runtime is exercised separately with React 18.3 and React 19;
 - boolean `data-*` and `aria-*` attributes keep React-compatible string values; and

--- a/examples/react-compiler/README.md
+++ b/examples/react-compiler/README.md
@@ -4,9 +4,9 @@ This production-browser experiment answers two questions:
 
 1. Why build this compiler? Eligible local `useState` updates can patch precomputed DOM targets
    without rerunning the component body or asking React to reconcile the same static tree again.
-2. Where must it stop? Eligible conditionals, keyed lists, and component islands use small
-   React-owned boundaries. Effects, refs, unsupported list shapes, and other unproven structures
-   stay on React.
+2. Where must it stop? Eligible conditionals, complex keyed lists, and component islands use small
+   React-owned boundaries. Dedicated host-only keyed lists can use compiler-owned rows and LIS.
+   Effects, refs, unsupported list shapes, and other unproven structures stay on React.
 
 The default `compiler: true` configuration automatically considers components. No annotation is
 needed. A component can explicitly opt out with `"use no compiler"`.
@@ -34,7 +34,7 @@ assertions, checks for console/runtime errors and horizontal overflow, saves scr
 | Two direct updates          | state `2`, update executions `0`                        | state `2`, update executions `2`               | Eligible updates skip post-mount component executions.                 |
 | Batched functional updates  | count `2`, snapshot `0`, update executions `0`          | count `2`, snapshot `0`, update executions `1` | The compiler preserves queued updater and event snapshot behavior.     |
 | Two state cells             | text/class/data/input all update, update executions `0` | —                                              | AOT dependency lists update only bindings affected by each state cell. |
-| Automatic keyed map         | insert and reverse rows, update executions `0`          | —                                              | A direct item-keyed map gets its own React refresh boundary.           |
+| Automatic keyed map         | stable row DOM, three LIS moves for a four-row reversal  | —                                              | AOT rows patch in place and use the minimum reorder moves.              |
 | Explicit `List`             | stateful rows reorder, update executions `0`            | —                                              | React preserves custom-row state by key inside the isolated boundary.  |
 | Calculated style bindings   | value `6`, progress `50%`, update executions `0`        | —                                              | Safe calls and individual CSS properties use prepared dependencies.    |
 | Controlled form bindings   | textarea/select/checkbox update, executions `0`         | —                                              | Form properties and textarea selection stay coherent.                  |
@@ -55,10 +55,13 @@ speed depends on event work, DOM work, layout, paint, application shape, and dev
 
 ## Keys and Hooks boundary
 
-For a direct `items.map(item => <Row key={item.id} />)`, the compiler can isolate the list update
-from the outer component. Keys tell React which row identity survived an insert, delete, or move;
-they do not make reconciliation unnecessary. React still compares the rows and owns their DOM,
-events, lifecycle, and state.
+For a dedicated host container such as
+`<ul>{items.map(item => <li key={item.id}>{item.label}</li>)}</ul>`, the compiler can prepare the
+row host tree and its dynamic bindings at build time. React creates or hydrates the initial rows.
+After mount, the list runtime keeps one row instance per key, patches surviving text, attributes,
+and styles directly, and inserts or removes only changed host rows. For reorders, a longest
+increasing subsequence (LIS) identifies the rows already in a valid relative order, so only the
+remaining rows move.
 
 The explicit equivalent separates collection, key, and rendering:
 
@@ -72,11 +75,16 @@ import { List } from "@farm.js/react/list";
 </div>;
 ```
 
-`List` is useful for custom stateful rows and still works as ordinary React when the compiler is
-off. Automatic maps and optimized `List` boundaries may sit beside static children, other lists,
-and eligible conditional blocks. Index keys, missing keys, chained maps, and other unproven list
-expressions fall back to the complete React component. Farm does not perform compiler-owned LIS
-moves in this stage; React remains the sole owner of row reconciliation.
+`List` still works as ordinary React when the compiler is off. An inline host-only `List` row can
+use the same compiler-owned row path. A custom stateful row such as `<Row item={item} />` stays in a
+React-owned keyed boundary so React preserves its Hooks, events, lifecycle, and Fiber state. The
+outer compiled component can still avoid rerunning.
+
+The compiler-owned path requires one direct map or `List` as the only meaningful child of a nested
+host container. Row events, custom components, fragments, refs, SVG, static siblings in that same
+container, index or missing keys, chained maps, and other unproven shapes use React reconciliation.
+Duplicate keys discovered at runtime also remount that container through React. LIS reduces moves;
+it does not make insertions, removals, key comparison, or DOM updates disappear.
 
 Calling a Hook directly inside `items.map(...)` or a `List` render callback is invalid React because
 the number or order of Hook calls can change. Put the Hook inside a separate `Row` component and key
@@ -146,7 +154,7 @@ Component-island reference run from the same crossover method:
 | Static sibling executions per trial |        2,430 |           0 | Static rerenders removed      |
 
 The timing result is intentionally narrow. It does not include browser layout/paint, network work,
-effects or keyed-list reconciliation. The component-island row does include its dependent child
+effects, or compiler-owned keyed-row work. The component-island row does include its dependent child
 update, but not layout, paint, or unrelated application work. Unsupported dynamic structures still
 fall back to React. Run the command on target devices before using the reference number for a
 product decision.

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -381,6 +381,21 @@ try {
     page,
     `${automaticList} [data-metric="executions"]`,
   );
+  await page.evaluate(() => {
+    const list = document.querySelector('[data-experiment="keyed-automatic"] [data-list="keyed"]');
+    window.__farmAutomaticAlpha = document.querySelector(
+      '[data-experiment="keyed-automatic"] [data-key="a"]',
+    );
+    window.__farmAutomaticBeta = document.querySelector(
+      '[data-experiment="keyed-automatic"] [data-key="b"]',
+    );
+    window.__farmAutomaticMoves = 0;
+    const insertBefore = list.insertBefore.bind(list);
+    list.insertBefore = (node, anchor) => {
+      if (node.parentNode === list) window.__farmAutomaticMoves += 1;
+      return insertBefore(node, anchor);
+    };
+  });
   await page.locator(`${automaticList} [data-action="add-item"]`).click();
   await page.locator(`${automaticList} [data-action="add-item"]`).click();
   await assertText(page, `${automaticList} [data-metric="items"]`, "4");
@@ -397,6 +412,22 @@ try {
     "Beta",
     "Alpha",
   ]);
+  assert.equal(
+    await page.evaluate(
+      () =>
+        window.__farmAutomaticAlpha ===
+          document.querySelector('[data-experiment="keyed-automatic"] [data-key="a"]') &&
+        window.__farmAutomaticBeta ===
+          document.querySelector('[data-experiment="keyed-automatic"] [data-key="b"]'),
+    ),
+    true,
+    "compiled keyed rows did not preserve surviving DOM identities",
+  );
+  assert.equal(
+    await page.evaluate(() => window.__farmAutomaticMoves),
+    3,
+    "reversing four keyed rows should move only the three rows outside the LIS",
+  );
 
   const explicitList = '[data-experiment="keyed-explicit"]';
   const explicitListInitialExecutions = await readNumber(
@@ -635,7 +666,9 @@ try {
             first: "Item 4",
             updateExecutions:
               automaticListFinalExecutions - automaticListInitialExecutions,
-            owner: "React boundary",
+            keyedDomIdentityPreserved: true,
+            lisMoves: 3,
+            owner: "Farm keyed rows",
           },
           explicitKeyedList: {
             order: ["Beta", "Alpha"],

--- a/examples/react-compiler/src/components/compiler-edge-lab.tsx
+++ b/examples/react-compiler/src/components/compiler-edge-lab.tsx
@@ -172,8 +172,8 @@ export function AutomaticKeyedListExperiment() {
       <header>
         <span className="experiment-number">04A</span>
         <div>
-          <h3>Automatic keyed boundary</h3>
-          <p>The build recognizes a direct keyed map and isolates the list.</p>
+          <h3>Compiled keyed rows</h3>
+          <p>AOT row instances patch and reorder host rows without rerunning the list.</p>
         </div>
       </header>
       <dl className="compact-metrics" aria-live="polite">
@@ -308,8 +308,8 @@ export function CompilerEdgeLab() {
         <span>HOOKS + KEYS</span>
         <p>
           Never call a Hook directly inside <code>items.map(...)</code>. Put the
-          Hook in a separate keyed row component. Automatic maps and the explicit
-          <code>List</code> boundary keep row identity and lifecycle under React.
+          Hook in a separate keyed row component. A host-only map can use compiled
+          rows; a component row keeps identity, Hooks, and lifecycle under React.
         </p>
       </aside>
     </section>

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -69,11 +69,13 @@ The current compiler handles components that it can prove have:
 - React-managed event handlers; and
 - no refs, effects, or unsupported dynamic child structures.
 
-The generated component preserves React ownership of placement, props, events, SSR, and hydration.
-Local state cells batch updates into a microtask and patch only compiler-known DOM targets. For an
-eligible conditional, the runtime refreshes one small internal React boundary instead of executing
-the user component again. React mounts, replaces, or removes the selected branch, so events,
-unmounting, SSR, hydration, and error boundaries keep React semantics.
+The generated component preserves React ownership of initial placement, props, events, SSR, and
+hydration. Local state cells batch updates into a microtask and patch only compiler-known DOM
+targets. For an eligible conditional, the runtime refreshes one small internal React boundary
+instead of executing the user component again. React mounts, replaces, or removes the selected
+branch, so events, unmounting, SSR, hydration, and error boundaries keep React semantics. The one
+intentional post-mount ownership exception is a proven host-only keyed-row container, described
+below.
 
 For a common keyed map, no new API is required:
 
@@ -85,11 +87,17 @@ For a common keyed map, no new API is required:
 </ul>
 ```
 
-The compiler can isolate this direct map when the key comes from the item rather than the array
-index and the callback is otherwise safe. The map may sit beside static children, other lists, and
-eligible conditionals. A list update then refreshes only an internal React boundary instead of
-executing the outer user component. React still reconciles the keyed rows and owns their DOM,
-events, lifecycle, and state.
+When this map is the only meaningful child of a dedicated host container and its rows are host-only,
+the compiler prepares a row descriptor, a key reader, and exact text/attribute/style bindings at
+build time. After React performs the initial render or hydration, Farm adopts those row elements.
+Later list updates patch surviving rows by key, create or remove only the changed rows, and use a
+longest increasing subsequence (LIS) to minimize DOM moves during a reorder. The outer user
+component and the list callback do not rerun for those compiler-cell updates.
+
+React remains the fallback and compatibility boundary. A map beside static children, a row with
+events, a fragment, a ref, or a custom component, and other unsupported shapes use the existing
+React-owned keyed boundary. The outer compiled component can still be skipped, but React reconciles
+that list's rows and owns their events, lifecycle, and state.
 
 For custom rows or an explicit key selector, use the public component:
 
@@ -104,10 +112,13 @@ import { List } from "@farm.js/react/list";
 ```
 
 `List` also works with the compiler disabled. `each` accepts an iterable, `null`, or `undefined`;
-`by` supplies the React key; and the child function returns one React element. Put Hooks inside the
-row component, not directly inside the iteration callback. With the compiler enabled, the
-optimized explicit shape requires inline `by` and child functions, a safe `each` expression, an
-item-derived key, and a statically known location. Other shapes keep normal React behavior.
+`by` supplies the React key; and the child function returns one React element. An inline host-only
+row inside a dedicated container can use compiler-owned keyed rows. A custom row such as
+`StatefulRow` remains a React-owned keyed boundary, which is necessary for its Hooks, events,
+lifecycle, and Fiber state. Put Hooks inside the row component, not directly inside the iteration
+callback. The optimized explicit shape also requires inline `by` and child functions, a safe
+`each` expression, an item-derived key, and a statically known location. Other shapes keep normal
+React behavior.
 
 A normal child component can become an automatic React-owned island:
 
@@ -138,9 +149,9 @@ All supported boundary types share one component-wide block graph and one ID seq
 binding records its nearest conditional parent. If one state flush affects both an outer
 conditional and its descendants, the runtime refreshes the mounted outer boundary once and skips
 the redundant descendant refreshes. React unmounts inner boundaries normally, their subscriptions
-are removed, and a later remount reads the latest compiler-cell values. List callback contents are
-not recursively compiled because one source location can create several keyed row instances;
-React owns each complete row subtree instead.
+are removed, and a later remount reads the latest compiler-cell values. Host-only keyed rows have
+separate runtime instances per key. Unsupported row subtrees stay complete React-owned keyed
+boundaries instead of receiving ambiguous shared block IDs.
 
 Unsupported components fall back to React by default. Use `onUnsupported: "warn"` for diagnostics
 or `onUnsupported: "error"` while tightening an annotated migration.
@@ -166,6 +177,7 @@ assertion; it is not presented as a cross-machine timing benchmark.
 
 Application and prototype calls, dynamic style objects, handlers outside JSX events, nested,
 computed, and rest props patterns, async handlers, unkeyed or index-keyed lists, chained maps,
-unsupported conditional roots, effects, and more advanced hook support
-intentionally stay on React in this release. Farm does not perform compiler-owned LIS row moves;
-eligible keyed boundaries deliberately keep reconciliation under React.
+unsupported conditional roots, effects, and more advanced hook support intentionally stay on React
+in this release. Compiler-owned keyed rows are limited to a dedicated container with one host-only
+map or `List`. Row events, custom components, fragments, refs, SVG, mixed static siblings, and
+duplicate runtime keys keep or switch to React ownership.

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -303,6 +303,73 @@ const testSource = String.raw`
   assert.equal(keyedExecutions, initialKeyedExecutions);
   flushSync(() => keyedRoot.unmount());
 
+  let keyedRowExecutions = 0;
+  const KeyedRows = createCompiledComponent({
+    displayName: "CompatibilityKeyedRows",
+    initialize: () => [["a", "b", "c", "d"]],
+    render(_props, state, blocks) {
+      keyedRowExecutions += 1;
+      const items = () => state[0].get();
+      return React.createElement(
+        "section",
+        null,
+        React.createElement(
+          "button",
+          { onClick: () => state[0].set((value) => [value[3], value[0], value[1], value[2]]) },
+          "Rotate",
+        ),
+        React.createElement(blocks.KeyedRows, {
+          id: 0,
+          render: () =>
+            React.createElement(
+              "ol",
+              null,
+              items().map((item) =>
+                React.createElement("li", { key: item, "data-key": item }, item.toUpperCase()),
+              ),
+            ),
+          items,
+          rowKey: (item) => item,
+          create: (item) => ({
+            kind: "element",
+            tag: "li",
+            attributes: [{ name: "data-key", value: item }],
+            styles: [],
+            children: [item.toUpperCase()],
+          }),
+          bindings: [
+            { kind: "text", path: [], read: (item) => [item.toUpperCase()] },
+          ],
+        }),
+      );
+    },
+    bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+  });
+  const keyedRowsContainer = document.createElement("div");
+  document.body.append(keyedRowsContainer);
+  const keyedRowsRoot = createRoot(keyedRowsContainer);
+  flushSync(() => keyedRowsRoot.render(React.createElement(KeyedRows)));
+  const initialKeyedRowExecutions = keyedRowExecutions;
+  const originalA = keyedRowsContainer.querySelector("[data-key='a']");
+  const keyedRowsList = keyedRowsContainer.querySelector("ol");
+  const originalInsertBefore = keyedRowsList.insertBefore.bind(keyedRowsList);
+  let keyedRowMoves = 0;
+  keyedRowsList.insertBefore = (node, anchor) => {
+    if (node.parentNode === keyedRowsList) keyedRowMoves += 1;
+    return originalInsertBefore(node, anchor);
+  };
+  keyedRowsContainer.querySelector("button").click();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.deepEqual(
+    [...keyedRowsContainer.querySelectorAll("li")].map((row) => row.getAttribute("data-key")),
+    ["d", "a", "b", "c"],
+  );
+  assert.equal(keyedRowsContainer.querySelector("[data-key='a']"), originalA);
+  assert.equal(keyedRowMoves, 1);
+  assert.equal(keyedRowExecutions, initialKeyedRowExecutions);
+  flushSync(() => keyedRowsRoot.unmount());
+
   let islandExecutions = 0;
   let islandChildExecutions = 0;
   function IslandChild({ value }) {

--- a/packages/farm-react/src/__tests__/compiler-component-islands.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-component-islands.test.ts
@@ -116,7 +116,7 @@ describe("React AOT component island compiler", () => {
 
     expect(result.compiled).toEqual(["Dashboard"]);
     expect(result.code).toContain("farmBlocks.Conditional");
-    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).toContain("farmBlocks.KeyedRows");
     expect(result.code).toContain("farmBlocks.Component");
     expect(result.code).toContain("id={0}");
     expect(result.code).toContain("id={1}");

--- a/packages/farm-react/src/__tests__/compiler-conditional-blocks.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-conditional-blocks.test.ts
@@ -183,7 +183,7 @@ describe("React AOT conditional block compiler", () => {
     expect(result.compiled).toEqual(["NestedBlocks"]);
     expect(result.diagnostics).toEqual([]);
     expect(result.code.match(/farmBlocks\.Conditional/g)).toHaveLength(2);
-    expect(result.code.match(/farmBlocks\.KeyedList/g)).toHaveLength(1);
+    expect(result.code.match(/farmBlocks\.KeyedRows/g)).toHaveLength(1);
     expect(result.code).toContain("id={0}");
     expect(result.code).toContain("id={1}");
     expect(result.code).toContain("id={2}");

--- a/packages/farm-react/src/__tests__/compiler-edge-cases.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-edge-cases.test.ts
@@ -52,7 +52,7 @@ describe("React AOT compiler safety boundaries", () => {
 
     expect(result.compiled).toEqual(["KeyedList"]);
     expect(result.diagnostics).toEqual([]);
-    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).toContain("farmBlocks.KeyedRows");
     expect(result.code).toContain("compiler-runtime");
   });
 

--- a/packages/farm-react/src/__tests__/compiler-keyed-lists.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-lists.test.ts
@@ -32,7 +32,9 @@ describe("React AOT keyed list compiler", () => {
 
     expect(result.compiled).toEqual(["Inventory"]);
     expect(result.diagnostics).toEqual([]);
-    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).toContain("farmBlocks.KeyedRows");
+    expect(result.code).toContain("rowKey={item => item.id}");
+    expect(result.code).toContain('kind: "element"');
     expect(result.code).toContain('kind: "block"');
     expect(result.code).toContain("dependencies: [0]");
     await expect(
@@ -41,7 +43,7 @@ describe("React AOT keyed list compiler", () => {
         jsx: "automatic",
       }),
     ).resolves.toMatchObject({
-      code: expect.stringContaining("farmBlocks.KeyedList"),
+      code: expect.stringContaining("farmBlocks.KeyedRows"),
     });
   });
 
@@ -128,6 +130,69 @@ describe("React AOT keyed list compiler", () => {
     expect(result.code).toContain("id={0}");
   });
 
+  it("compiles host-only public List rows while preserving the ordinary List fallback", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List } from "@farm.js/react/list";
+      export function ExplicitRows() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha", active: false }]);
+        return (
+          <section>
+            <button onClick={() => setItems([...items].reverse())}>Reverse</button>
+            <ul>
+              <List each={items} by={(item) => item.id}>
+                {(item) => (
+                  <li className={item.active ? "active" : "idle"}>
+                    <span>{item.label}</span>
+                  </li>
+                )}
+              </List>
+            </ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["ExplicitRows"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedRows");
+    expect(result.code).toContain("rowKey={item => item.id}");
+    expect(result.code).toContain('name: "className"');
+    expect(result.code).toContain("path: [0]");
+  });
+
+  it.each([
+    {
+      name: "row events",
+      row: "<li key={item.id} onClick={() => setItems([])}>{item.label}</li>",
+    },
+    {
+      name: "custom row components",
+      row: "<InventoryRow key={item.id} item={item} />",
+    },
+    {
+      name: "row fragments",
+      row: "<li key={item.id}><>{item.label}</></li>",
+    },
+  ])("keeps $name in the React-owned list boundary", async ({ row }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { InventoryRow } from "./inventory-row";
+      export function ReactOwnedRows() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
+        return (
+          <section>
+            <ul>{items.map((item) => ${row})}</ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["ReactOwnedRows"]);
+    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).not.toContain("farmBlocks.KeyedRows");
+  });
+
   it("falls back for an index-based explicit List key", async () => {
     const result = await compile(`
       import { useState } from "react";
@@ -183,7 +248,7 @@ describe("React AOT keyed list compiler", () => {
     expect(result.compiled).toEqual(["MixedBoundaries"]);
     expect(result.diagnostics).toEqual([]);
     expect(result.code).toContain("farmBlocks.Conditional");
-    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).toContain("farmBlocks.KeyedRows");
     expect(result.code).toContain("id={0}");
     expect(result.code).toContain("id={1}");
   });

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-rows.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-rows.test.tsx
@@ -5,6 +5,7 @@ import { renderToString } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createCompiledComponent,
+  type CompiledComponentDefinition,
   type CompilerKeyedRowElement,
   type CompilerStateUpdater,
 } from "../compiler-runtime";
@@ -656,6 +657,152 @@ describe("compiled keyed-row runtime", () => {
       await flushCompilerUpdates();
     });
     expect(errors).toEqual([]);
+  });
+
+  it("preserves compiler state and row identity across a compatible Fast Refresh", async () => {
+    const hmrId = `keyed-rows-refresh-${Math.random()}`;
+    const definition = (prefix: string): CompiledComponentDefinition<Record<string, never>> => ({
+      displayName: "RefreshKeyedRows",
+      hmrId,
+      stateSignature: "1",
+      initialize: () => [[{ id: "a", label: "Alpha" }]],
+      render(_props, state, blocks) {
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <section>
+            <button onClick={() => state[0].set([{ id: "a", label: "Updated" }])}>Update</button>
+            <KeyedRows
+              id={0}
+              render={() => (
+                <ul>
+                  {items().map((item) => (
+                    <li data-key={item.id} key={item.id}>
+                      {prefix}
+                      {item.label}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              items={items}
+              rowKey={(item: unknown) => (item as Item).id}
+              create={(item: unknown) => ({
+                kind: "element" as const,
+                tag: "li",
+                attributes: [{ name: "data-key", value: (item as Item).id }],
+                styles: [],
+                children: [[prefix, (item as Item).label]],
+              })}
+              bindings={[
+                {
+                  kind: "text" as const,
+                  path: [],
+                  read: (item: unknown) => [prefix, (item as Item).label],
+                },
+              ]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block" as const, id: 0, dependencies: [0] }],
+    });
+
+    const Initial = createCompiledComponent(definition("Before: "));
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Initial />));
+    const row = container.querySelector("li")!;
+
+    await act(async () => {
+      const Updated = createCompiledComponent(definition("After: "));
+      expect(Updated).toBe(Initial);
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("li")).toBe(row);
+    expect(row.textContent).toBe("After: Alpha");
+
+    await act(async () => {
+      container.querySelector("button")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("li")).toBe(row);
+    expect(row.textContent).toBe("After: Updated");
+  });
+
+  it("routes keyed-row binding failures through the nearest error boundary", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    class Boundary extends React.Component<{ children: React.ReactNode }, { failed: boolean }> {
+      state = { failed: false };
+
+      static getDerivedStateFromError() {
+        return { failed: true };
+      }
+
+      render() {
+        return this.state.failed ? <p>Recovered by boundary</p> : this.props.children;
+      }
+    }
+
+    const Inventory = createCompiledComponent({
+      displayName: "ThrowingKeyedRows",
+      initialize: () => [[{ id: "a", label: "Safe", selected: false }]],
+      render(_props: Record<string, never>, state, blocks) {
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <section>
+            <button onClick={() => state[0].set([{ id: "a", label: "Broken", selected: true }])}>
+              Break binding
+            </button>
+            <KeyedRows
+              id={0}
+              render={() => (
+                <ul>
+                  {items().map((item) => (
+                    <li key={item.id}>{item.label}</li>
+                  ))}
+                </ul>
+              )}
+              items={items}
+              rowKey={(item) => (item as Item).id}
+              create={(item) => rowDescriptor(item as Item)}
+              bindings={[
+                {
+                  kind: "text",
+                  path: [],
+                  read: (item) => {
+                    if ((item as Item).selected) throw new Error("keyed row binding failed");
+                    return [(item as Item).label];
+                  },
+                },
+              ]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <Boundary>
+          <Inventory />
+        </Boundary>,
+      ),
+    );
+
+    await act(async () => {
+      container.querySelector("button")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("Recovered by boundary");
   });
 
   it("matches React across 1,000 deterministic keyed operations", async () => {

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-rows.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-rows.test.tsx
@@ -1,0 +1,793 @@
+import React, { StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createCompiledComponent,
+  type CompilerKeyedRowElement,
+  type CompilerStateUpdater,
+} from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Item {
+  id: string;
+  label: string;
+  selected?: boolean;
+}
+
+const roots: Array<{ unmount(): void }> = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function rowDescriptor(item: Item): CompilerKeyedRowElement {
+  return {
+    kind: "element",
+    tag: "li",
+    attributes: [
+      { name: "data-key", value: item.id },
+      { name: "aria-selected", value: Boolean(item.selected) },
+    ],
+    styles: [],
+    children: [item.label],
+  };
+}
+
+describe("compiled keyed-row runtime", () => {
+  it("patches, inserts, removes, and reorders persistent row instances", async () => {
+    let executions = 0;
+    let listRenders = 0;
+    const Inventory = createCompiledComponent({
+      displayName: "CompiledRows",
+      initialize: () => [
+        [
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Beta" },
+          { id: "c", label: "Gamma" },
+        ],
+      ],
+      render(_props: Record<string, never>, state, blocks) {
+        executions += 1;
+        const KeyedRows = blocks.KeyedRows;
+        const items = () => state[0].get() as Item[];
+        return (
+          <section>
+            <button
+              data-action="update"
+              onClick={() =>
+                state[0].set(() => [
+                  { id: "c", label: "Gamma" },
+                  { id: "b", label: "Bravo", selected: true },
+                  { id: "d", label: "Delta" },
+                ])
+              }
+            >
+              Update
+            </button>
+            <KeyedRows
+              id={0}
+              render={() => {
+                listRenders += 1;
+                return (
+                  <ul>
+                    {items().map((item) => (
+                      <li aria-selected={Boolean(item.selected)} data-key={item.id} key={item.id}>
+                        {item.label}
+                      </li>
+                    ))}
+                  </ul>
+                );
+              }}
+              items={items}
+              rowKey={(item) => (item as Item).id}
+              create={(item) => rowDescriptor(item as Item)}
+              bindings={[
+                {
+                  kind: "attribute",
+                  path: [],
+                  name: "data-key",
+                  read: (item) => (item as Item).id,
+                },
+                {
+                  kind: "attribute",
+                  path: [],
+                  name: "aria-selected",
+                  read: (item) => Boolean((item as Item).selected),
+                },
+                {
+                  kind: "text",
+                  path: [],
+                  read: (item) => [(item as Item).label],
+                },
+              ]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Inventory />));
+
+    const initial = new Map(
+      [...container.querySelectorAll<HTMLLIElement>("li")].map((row) => [row.dataset.key, row]),
+    );
+    expect(executions).toBe(1);
+    expect(listRenders).toBe(1);
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("button")!.click();
+      await flushCompilerUpdates();
+    });
+
+    const rows = [...container.querySelectorAll<HTMLLIElement>("li")];
+    expect(rows.map((row) => [row.dataset.key, row.textContent])).toEqual([
+      ["c", "Gamma"],
+      ["b", "Bravo"],
+      ["d", "Delta"],
+    ]);
+    expect(rows[0]).toBe(initial.get("c"));
+    expect(rows[1]).toBe(initial.get("b"));
+    expect(rows[1].getAttribute("aria-selected")).toBe("true");
+    expect(initial.get("a")?.isConnected).toBe(false);
+    expect(executions).toBe(1);
+    expect(listRenders).toBe(1);
+  });
+
+  it("uses LIS to move only the rows outside the stable subsequence", async () => {
+    let setItems: (next: CompilerStateUpdater) => void = () => undefined;
+    const Inventory = createCompiledComponent({
+      displayName: "LisRows",
+      initialize: () => [["a", "b", "c", "d"]],
+      render(_props: Record<string, never>, state, blocks) {
+        setItems = (next) => state[0].set(next);
+        const items = () => state[0].get() as string[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <section>
+            <KeyedRows
+              id={0}
+              render={() => (
+                <ol>
+                  {items().map((item) => (
+                    <li key={item}>{item.toUpperCase()}</li>
+                  ))}
+                </ol>
+              )}
+              items={items}
+              rowKey={(item) => item as string}
+              create={(item) => ({
+                kind: "element",
+                tag: "li",
+                attributes: [],
+                styles: [],
+                children: [String(item).toUpperCase()],
+              })}
+              bindings={[{ kind: "text", path: [], read: (item) => [String(item).toUpperCase()] }]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Inventory />));
+    const list = container.querySelector("ol")!;
+    const insertBefore = vi.spyOn(list, "insertBefore");
+
+    await act(async () => {
+      setItems(["d", "a", "b", "c"]);
+      await flushCompilerUpdates();
+    });
+
+    expect([...list.children].map((row) => row.textContent)).toEqual(["D", "A", "B", "C"]);
+    expect(insertBefore).toHaveBeenCalledTimes(1);
+  });
+
+  it("remounts the list under React when runtime keys are duplicated", async () => {
+    let setItems: (next: CompilerStateUpdater) => void = () => undefined;
+    let listRenders = 0;
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const Inventory = createCompiledComponent({
+      displayName: "DuplicateRowsFallback",
+      initialize: () => [[{ id: "a", label: "Alpha" }]],
+      render(_props: Record<string, never>, state, blocks) {
+        setItems = (next) => state[0].set(next);
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <KeyedRows
+              id={0}
+              render={() => {
+                listRenders += 1;
+                return (
+                  <ul>
+                    {items().map((item) => (
+                      <li key={item.id}>{item.label}</li>
+                    ))}
+                  </ul>
+                );
+              }}
+              items={items}
+              rowKey={(item) => (item as Item).id}
+              create={(item) => rowDescriptor(item as Item)}
+              bindings={[{ kind: "text", path: [], read: (item) => [(item as Item).label] }]}
+            />
+          </main>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Inventory />));
+
+    await act(async () => {
+      setItems([
+        { id: "duplicate", label: "First" },
+        { id: "duplicate", label: "Second" },
+      ]);
+      await flushCompilerUpdates();
+    });
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "First",
+      "Second",
+    ]);
+    expect(listRenders).toBeGreaterThan(1);
+
+    await act(async () => {
+      setItems([{ id: "safe", label: "Safe again" }]);
+      await flushCompilerUpdates();
+    });
+    expect(listRenders).toBeGreaterThan(2);
+    expect(container.querySelector("li")?.textContent).toBe("Safe again");
+  });
+
+  it("combines parent props and local row updates without losing the newest values", async () => {
+    let setPrefix: React.Dispatch<React.SetStateAction<string>> = () => undefined;
+    let setItems: (next: CompilerStateUpdater) => void = () => undefined;
+    const Inventory = createCompiledComponent({
+      displayName: "PropDrivenRows",
+      initialize: () => [[{ id: "a", label: "Alpha" }]],
+      render(props: { prefix: string }, state, blocks) {
+        setItems = (next) => state[0].set(next);
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <section>
+            <KeyedRows
+              id={0}
+              render={() => (
+                <ul>
+                  {items().map((item) => (
+                    <li key={item.id}>
+                      {props.prefix}:{item.label}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              items={items}
+              rowKey={(item) => (item as Item).id}
+              create={(item) => ({
+                kind: "element",
+                tag: "li",
+                attributes: [],
+                styles: [],
+                children: [[props.prefix, ":", (item as Item).label]],
+              })}
+              bindings={[
+                {
+                  kind: "text",
+                  path: [],
+                  read: (item) => [props.prefix, ":", (item as Item).label],
+                },
+              ]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    function Parent() {
+      const [prefix, updatePrefix] = useState("Old");
+      setPrefix = updatePrefix;
+      return <Inventory prefix={prefix} />;
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Parent />));
+    await act(async () => {
+      setPrefix("New");
+      setItems([{ id: "a", label: "Updated" }]);
+      await flushCompilerUpdates();
+    });
+    await flushCompilerUpdates();
+    expect(container.querySelector("li")?.textContent).toBe("New:Updated");
+  });
+
+  it("patches nested row text, attributes, and styles without replacing the row", async () => {
+    let setItems: (next: CompilerStateUpdater) => void = () => undefined;
+    const Inventory = createCompiledComponent({
+      displayName: "NestedCompiledRows",
+      initialize: () => [[{ id: "a", label: "Alpha", selected: false }]],
+      render(_props: Record<string, never>, state, blocks) {
+        setItems = (next) => state[0].set(next);
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <section>
+            <KeyedRows
+              id={0}
+              render={() => (
+                <div>
+                  {items().map((item) => (
+                    <article key={item.id}>
+                      <span
+                        data-selected={Boolean(item.selected)}
+                        style={{ opacity: item.selected ? 1 : 0.5 }}
+                      >
+                        {item.label}
+                      </span>
+                    </article>
+                  ))}
+                </div>
+              )}
+              items={items}
+              rowKey={(item) => (item as Item).id}
+              create={(item) => ({
+                kind: "element",
+                tag: "article",
+                attributes: [],
+                styles: [],
+                children: [
+                  {
+                    kind: "element",
+                    tag: "span",
+                    attributes: [
+                      { name: "data-selected", value: Boolean((item as Item).selected) },
+                    ],
+                    styles: [{ name: "opacity", value: (item as Item).selected ? 1 : 0.5 }],
+                    children: [(item as Item).label],
+                  },
+                ],
+              })}
+              bindings={[
+                {
+                  kind: "attribute",
+                  path: [0],
+                  name: "data-selected",
+                  read: (item) => Boolean((item as Item).selected),
+                },
+                {
+                  kind: "style",
+                  path: [0],
+                  name: "opacity",
+                  read: (item) => ((item as Item).selected ? 1 : 0.5),
+                },
+                { kind: "text", path: [0], read: (item) => [(item as Item).label] },
+              ]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Inventory />));
+    const row = container.querySelector("article")!;
+
+    await act(async () => {
+      setItems([{ id: "a", label: "Selected", selected: true }]);
+      await flushCompilerUpdates();
+    });
+
+    const span = container.querySelector("span")!;
+    expect(container.querySelector("article")).toBe(row);
+    expect(span.textContent).toBe("Selected");
+    expect(span.getAttribute("data-selected")).toBe("true");
+    expect(span.style.opacity).toBe("1");
+  });
+
+  it("preserves focused input identity and selection while rows reorder", async () => {
+    let setItems: (next: CompilerStateUpdater) => void = () => undefined;
+    const Inventory = createCompiledComponent({
+      displayName: "FocusedRows",
+      initialize: () => [
+        [
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Bravo" },
+        ],
+      ],
+      render(_props: Record<string, never>, state, blocks) {
+        setItems = (next) => state[0].set(next);
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <section>
+            <KeyedRows
+              id={0}
+              render={() => (
+                <div>
+                  {items().map((item) => (
+                    <input data-key={item.id} key={item.id} readOnly value={item.label} />
+                  ))}
+                </div>
+              )}
+              items={items}
+              rowKey={(item) => (item as Item).id}
+              create={(item) => ({
+                kind: "element",
+                tag: "input",
+                attributes: [
+                  { name: "data-key", value: (item as Item).id },
+                  { name: "readOnly", value: true },
+                  { name: "value", value: (item as Item).label },
+                ],
+                styles: [],
+                children: [],
+              })}
+              bindings={[
+                {
+                  kind: "attribute",
+                  path: [],
+                  name: "data-key",
+                  read: (item) => (item as Item).id,
+                },
+                {
+                  kind: "attribute",
+                  path: [],
+                  name: "value",
+                  read: (item) => (item as Item).label,
+                },
+              ]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Inventory />));
+    const focused = container.querySelector<HTMLInputElement>("[data-key='b']")!;
+    focused.focus();
+    focused.setSelectionRange(1, 4, "forward");
+
+    await act(async () => {
+      setItems((value) => [...(value as Item[])].reverse());
+      await flushCompilerUpdates();
+    });
+    expect(document.activeElement).toBe(focused);
+    expect(focused.selectionStart).toBe(1);
+    expect(focused.selectionEnd).toBe(4);
+    expect([...container.querySelectorAll("input")].map((input) => input.dataset.key)).toEqual([
+      "b",
+      "a",
+    ]);
+  });
+
+  it("cleans row subscriptions when an owning conditional unmounts", async () => {
+    let setVisible: (next: CompilerStateUpdater) => void = () => undefined;
+    let setItems: (next: CompilerStateUpdater) => void = () => undefined;
+    let listRenders = 0;
+    const Inventory = createCompiledComponent({
+      displayName: "ConditionalCompiledRows",
+      initialize: () => [true, [{ id: "a", label: "Alpha" }]],
+      render(_props: Record<string, never>, state, blocks) {
+        setVisible = (next) => state[0].set(next);
+        setItems = (next) => state[1].set(next);
+        const items = () => state[1].get() as Item[];
+        const Conditional = blocks.Conditional;
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <Conditional
+              id={0}
+              render={() =>
+                Boolean(state[0].get()) && (
+                  <section>
+                    <KeyedRows
+                      id={1}
+                      render={() => {
+                        listRenders += 1;
+                        return (
+                          <ul>
+                            {items().map((item) => (
+                              <li key={item.id}>{item.label}</li>
+                            ))}
+                          </ul>
+                        );
+                      }}
+                      items={items}
+                      rowKey={(item) => (item as Item).id}
+                      create={(item) => rowDescriptor(item as Item)}
+                      bindings={[
+                        {
+                          kind: "text",
+                          path: [],
+                          read: (item) => [(item as Item).label],
+                        },
+                      ]}
+                    />
+                  </section>
+                )
+              }
+            />
+          </main>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        { kind: "block", id: 1, parent: 0, dependencies: [1] },
+      ],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Inventory />));
+    expect(listRenders).toBe(1);
+
+    await act(async () => {
+      setVisible(false);
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("ul")).toBeNull();
+
+    await act(async () => {
+      setItems((value) => [...(value as Item[]), { id: "b", label: "Beta" }]);
+      await flushCompilerUpdates();
+    });
+    expect(listRenders).toBe(1);
+
+    await act(async () => {
+      setVisible(true);
+      await flushCompilerUpdates();
+    });
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Alpha",
+      "Beta",
+    ]);
+    expect(listRenders).toBe(2);
+  });
+
+  it("hydrates, survives StrictMode, and ignores a queued update after unmount", async () => {
+    const errors: unknown[] = [];
+    const Inventory = createCompiledComponent({
+      displayName: "HydratedCompiledRows",
+      initialize: () => [[{ id: "a", label: "Alpha" }]],
+      render(_props: Record<string, never>, state, blocks) {
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <section>
+            <button
+              onClick={() =>
+                state[0].set((value) => [...(value as Item[]), { id: "b", label: "Beta" }])
+              }
+            >
+              Add
+            </button>
+            <KeyedRows
+              id={0}
+              render={() => (
+                <ul>
+                  {items().map((item) => (
+                    <li key={item.id}>{item.label}</li>
+                  ))}
+                </ul>
+              )}
+              items={items}
+              rowKey={(item) => (item as Item).id}
+              create={(item) => rowDescriptor(item as Item)}
+              bindings={[{ kind: "text", path: [], read: (item) => [(item as Item).label] }]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(
+      <StrictMode>
+        <Inventory />
+      </StrictMode>,
+    );
+    document.body.append(container);
+    await act(async () => {
+      const root = hydrateRoot(
+        container,
+        <StrictMode>
+          <Inventory />
+        </StrictMode>,
+        { onRecoverableError: (error) => errors.push(error) },
+      );
+      roots.push(root);
+    });
+    expect(errors).toEqual([]);
+
+    const root = roots.pop()!;
+    await act(async () => {
+      container.querySelector("button")!.click();
+      root.unmount();
+      await flushCompilerUpdates();
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it("matches React across 1,000 deterministic keyed operations", async () => {
+    type Update = (items: Item[]) => Item[];
+    let compiledSet: (next: CompilerStateUpdater) => void = () => undefined;
+    let reactSet: React.Dispatch<React.SetStateAction<Item[]>> = () => undefined;
+    let compiledRenders = 0;
+    const initial: Item[] = [
+      { id: "a", label: "A" },
+      { id: "b", label: "B" },
+      { id: "c", label: "C" },
+    ];
+
+    const Compiled = createCompiledComponent({
+      displayName: "RandomCompiledRows",
+      initialize: () => [initial],
+      render(_props: Record<string, never>, state, blocks) {
+        compiledSet = (next) => state[0].set(next);
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <KeyedRows
+              id={0}
+              render={() => {
+                compiledRenders += 1;
+                return (
+                  <ul>
+                    {items().map((item) => (
+                      <li data-key={item.id} key={item.id}>
+                        {item.label}
+                      </li>
+                    ))}
+                  </ul>
+                );
+              }}
+              items={items}
+              rowKey={(item) => (item as Item).id}
+              create={(item) => rowDescriptor(item as Item)}
+              bindings={[
+                {
+                  kind: "attribute",
+                  path: [],
+                  name: "data-key",
+                  read: (item) => (item as Item).id,
+                },
+                { kind: "text", path: [], read: (item) => [(item as Item).label] },
+              ]}
+            />
+          </main>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    function Normal() {
+      const [items, setItems] = useState(initial);
+      reactSet = setItems;
+      return (
+        <ul>
+          {items.map((item) => (
+            <li data-key={item.id} key={item.id}>
+              {item.label}
+            </li>
+          ))}
+        </ul>
+      );
+    }
+
+    let seed = 0x5eed1234;
+    let nextId = 0;
+    const random = () => {
+      seed = (seed * 1664525 + 1013904223) >>> 0;
+      return seed;
+    };
+    const updates: Update[] = Array.from({ length: 1000 }, () => {
+      const operation = random() % 6;
+      const selector = random();
+      const id = `n${nextId++}`;
+      if (operation === 0) return (items) => [...items, { id, label: id.toUpperCase() }];
+      if (operation === 1) return (items) => [{ id, label: id.toUpperCase() }, ...items];
+      if (operation === 2) {
+        return (items) =>
+          items.length === 0
+            ? items
+            : items.filter((_, index) => index !== selector % items.length);
+      }
+      if (operation === 3) return (items) => [...items].reverse();
+      if (operation === 4) {
+        return (items) => {
+          if (items.length < 2) return items;
+          const next = [...items];
+          const from = selector % next.length;
+          const [moved] = next.splice(from, 1);
+          next.splice(random() % (next.length + 1), 0, moved);
+          return next;
+        };
+      }
+      return (items) =>
+        items.length === 0
+          ? items
+          : items.map((item, index) =>
+              index === selector % items.length ? { ...item, label: `${item.label}!` } : item,
+            );
+    });
+
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<Compiled />);
+      reactRoot.render(<Normal />);
+    });
+
+    for (let offset = 0; offset < updates.length; offset += 10) {
+      await act(async () => {
+        for (const update of updates.slice(offset, offset + 10)) {
+          compiledSet((value) => update(value as Item[]));
+          reactSet(update);
+        }
+        await flushCompilerUpdates();
+      });
+      const snapshot = (container: Element) =>
+        [...container.querySelectorAll("li")].map((row) => [
+          row.getAttribute("data-key"),
+          row.textContent,
+        ]);
+      expect(snapshot(compiledContainer)).toEqual(snapshot(reactContainer));
+    }
+    expect(compiledRenders).toBe(1);
+  });
+});

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -67,6 +67,30 @@ export interface CompilerKeyedListBlockProps {
   render(): React.ReactNode;
 }
 
+export interface CompilerKeyedRowElement {
+  kind: "element";
+  tag: string;
+  attributes: readonly { name: string; value: unknown }[];
+  styles: readonly { name: string; value: unknown }[];
+  children: readonly (CompilerKeyedRowElement | unknown)[];
+}
+
+export interface CompilerKeyedRowBinding {
+  kind: "text" | "attribute" | "style";
+  path: readonly number[];
+  name?: string;
+  read(item: unknown, index: number): unknown;
+}
+
+export interface CompilerKeyedRowsBlockProps {
+  id: number;
+  render(): React.ReactElement;
+  items(): Iterable<unknown> | null | undefined;
+  rowKey(item: unknown, index: number): React.Key;
+  create(item: unknown, index: number): CompilerKeyedRowElement;
+  bindings: readonly CompilerKeyedRowBinding[];
+}
+
 export interface CompilerComponentBlockProps {
   id: number;
   render(): React.ReactNode;
@@ -75,6 +99,7 @@ export interface CompilerComponentBlockProps {
 export interface CompilerBlockRuntime {
   Conditional: React.ComponentType<CompilerConditionalBlockProps>;
   KeyedList: React.ComponentType<CompilerKeyedListBlockProps>;
+  KeyedRows: React.ComponentType<CompilerKeyedRowsBlockProps>;
   Component: React.ComponentType<CompilerComponentBlockProps>;
   target(id: number): React.RefCallback<Element>;
 }
@@ -422,6 +447,290 @@ function createKeyedListBlockComponent(
   return FarmKeyedListBlock;
 }
 
+interface CompilerKeyedRowInstance {
+  key: string;
+  element: Element;
+  values: unknown[];
+}
+
+function keyedRowIdentity(key: React.Key): string {
+  return String(key);
+}
+
+function isKeyedRowElement(value: unknown): value is CompilerKeyedRowElement {
+  return (
+    typeof value === "object" && value !== null && (value as { kind?: unknown }).kind === "element"
+  );
+}
+
+function createKeyedRowElement(document: Document, descriptor: CompilerKeyedRowElement): Element {
+  const element = document.createElement(descriptor.tag);
+  for (const attribute of descriptor.attributes) {
+    updateAttribute(element, attribute.name, attribute.value);
+  }
+  for (const style of descriptor.styles) updateStyle(element, style.name, style.value);
+  for (const child of descriptor.children) {
+    if (isKeyedRowElement(child)) {
+      element.append(createKeyedRowElement(document, child));
+      continue;
+    }
+    const text = renderTextValue(child);
+    if (text) element.append(document.createTextNode(text));
+  }
+  return element;
+}
+
+function findKeyedRowTarget(root: Element, path: readonly number[]): Element | null {
+  let current: Element | null = root;
+  for (const index of path) current = current?.children[index] || null;
+  return current;
+}
+
+function normalizedKeyedRowBindingValue(binding: CompilerKeyedRowBinding, value: unknown): unknown {
+  return binding.kind === "text" ? renderTextValue(value) : value;
+}
+
+function readKeyedRowBindingValues(
+  props: CompilerKeyedRowsBlockProps,
+  item: unknown,
+  index: number,
+): unknown[] {
+  return props.bindings.map((binding) =>
+    normalizedKeyedRowBindingValue(binding, binding.read(item, index)),
+  );
+}
+
+function applyKeyedRowBindings(
+  props: CompilerKeyedRowsBlockProps,
+  instance: CompilerKeyedRowInstance,
+  item: unknown,
+  index: number,
+): void {
+  for (let bindingIndex = 0; bindingIndex < props.bindings.length; bindingIndex += 1) {
+    const binding = props.bindings[bindingIndex];
+    const rawValue = binding.read(item, index);
+    const value = normalizedKeyedRowBindingValue(binding, rawValue);
+    if (Object.is(instance.values[bindingIndex], value)) continue;
+    instance.values[bindingIndex] = value;
+    const target = findKeyedRowTarget(instance.element, binding.path);
+    if (!target) continue;
+    if (binding.kind === "text") {
+      target.textContent = value as string;
+    } else if (binding.kind === "style" && binding.name) {
+      updateStyle(target, binding.name, rawValue);
+    } else if (binding.kind === "attribute" && binding.name) {
+      updateAttribute(target, binding.name, rawValue);
+    }
+  }
+}
+
+/** Returns positions forming the LIS while ignoring newly inserted (-1) entries. */
+function longestIncreasingSubsequencePositions(sequence: readonly number[]): Set<number> {
+  const tails: number[] = [];
+  const previous = Array.from({ length: sequence.length }, () => -1);
+
+  for (let index = 0; index < sequence.length; index += 1) {
+    if (sequence[index] < 0) continue;
+    let low = 0;
+    let high = tails.length;
+    while (low < high) {
+      const middle = (low + high) >> 1;
+      if (sequence[tails[middle]] < sequence[index]) low = middle + 1;
+      else high = middle;
+    }
+    if (low > 0) previous[index] = tails[low - 1];
+    tails[low] = index;
+  }
+
+  const positions = new Set<number>();
+  let cursor = tails.at(-1) ?? -1;
+  while (cursor >= 0) {
+    positions.add(cursor);
+    cursor = previous[cursor];
+  }
+  return positions;
+}
+
+function createKeyedRowsBlockComponent(
+  owner: Pick<ConditionalBlockOwner, "subscribe">,
+): React.ComponentType<CompilerKeyedRowsBlockProps> {
+  interface State {
+    fallback: boolean;
+  }
+
+  class FarmKeyedRowsBlock extends React.Component<CompilerKeyedRowsBlockProps, State> {
+    static displayName = "FarmCompiledKeyedRows";
+
+    state: State = { fallback: false };
+    private root: Element | null = null;
+    private mounted = false;
+    private fallbackRequested = false;
+    private fallbackVersion = 0;
+    private propSyncQueued = false;
+    private currentProps = this.props;
+    private unsubscribe: (() => void) | undefined;
+    private instances = new Map<string, CompilerKeyedRowInstance>();
+
+    private captureRoot = (root: Element | null) => {
+      this.root = root;
+    };
+
+    private readRows(
+      props: CompilerKeyedRowsBlockProps,
+    ): { items: unknown[]; keys: string[] } | null {
+      const source = props.items();
+      const items = source ? Array.from(source) : [];
+      const keys = items.map((item, index) => keyedRowIdentity(props.rowKey(item, index)));
+      if (new Set(keys).size !== keys.length) return null;
+      return { items, keys };
+    }
+
+    private adopt(): boolean {
+      if (!this.root) return false;
+      const rows = this.readRows(this.currentProps);
+      const elements = [...this.root.children];
+      if (!rows || rows.items.length !== elements.length) return false;
+      const instances = new Map<string, CompilerKeyedRowInstance>();
+      for (let index = 0; index < rows.items.length; index += 1) {
+        instances.set(rows.keys[index], {
+          key: rows.keys[index],
+          element: elements[index],
+          values: readKeyedRowBindingValues(this.currentProps, rows.items[index], index),
+        });
+      }
+      this.instances = instances;
+      return true;
+    }
+
+    private activateFallback(afterCommit?: () => void): void {
+      if (!this.mounted || this.state.fallback || this.fallbackRequested) {
+        afterCommit?.();
+        return;
+      }
+      this.fallbackRequested = true;
+      this.setState({ fallback: true }, afterCommit);
+    }
+
+    private reconcile(afterCommit?: () => void): void {
+      if (!this.mounted || !this.root) {
+        afterCommit?.();
+        return;
+      }
+      if (this.state.fallback) {
+        this.fallbackVersion += 1;
+        this.forceUpdate(afterCommit);
+        return;
+      }
+
+      const rows = this.readRows(this.currentProps);
+      if (!rows) {
+        this.activateFallback(afterCommit);
+        return;
+      }
+
+      const oldIndices = new Map<string, number>();
+      const activeElement = this.root.ownerDocument.activeElement;
+      const restoreFocus = Boolean(activeElement && this.root.contains(activeElement));
+      [...this.instances].forEach(([key], index) => oldIndices.set(key, index));
+      const nextKeys = new Set(rows.keys);
+      for (const [key, instance] of this.instances) {
+        if (!nextKeys.has(key)) instance.element.remove();
+      }
+
+      const sequence = rows.keys.map((key) => oldIndices.get(key) ?? -1);
+      const stablePositions = longestIncreasingSubsequencePositions(sequence);
+      const nextInstances: CompilerKeyedRowInstance[] = [];
+      for (let index = 0; index < rows.items.length; index += 1) {
+        const key = rows.keys[index];
+        const existing = this.instances.get(key);
+        if (existing) {
+          applyKeyedRowBindings(this.currentProps, existing, rows.items[index], index);
+          nextInstances.push(existing);
+          continue;
+        }
+        const element = createKeyedRowElement(
+          this.root.ownerDocument,
+          this.currentProps.create(rows.items[index], index),
+        );
+        nextInstances.push({
+          key,
+          element,
+          values: readKeyedRowBindingValues(this.currentProps, rows.items[index], index),
+        });
+      }
+
+      let anchor: ChildNode | null = null;
+      for (let index = nextInstances.length - 1; index >= 0; index -= 1) {
+        const instance = nextInstances[index];
+        if (sequence[index] < 0) {
+          this.root.insertBefore(instance.element, anchor);
+        } else if (!stablePositions.has(index) && instance.element.nextSibling !== anchor) {
+          this.root.insertBefore(instance.element, anchor);
+        }
+        anchor = instance.element;
+      }
+      this.instances = new Map(nextInstances.map((instance) => [instance.key, instance]));
+      if (
+        restoreFocus &&
+        activeElement?.isConnected &&
+        activeElement.ownerDocument.activeElement !== activeElement &&
+        "focus" in activeElement
+      ) {
+        (activeElement as HTMLElement).focus({ preventScroll: true });
+      }
+      afterCommit?.();
+    }
+
+    private refresh = (afterCommit?: () => void) => {
+      this.reconcile(afterCommit);
+    };
+
+    private schedulePropSync(): void {
+      if (this.propSyncQueued) return;
+      this.propSyncQueued = true;
+      queueMicrotask(() => {
+        this.propSyncQueued = false;
+        if (this.mounted && !this.state.fallback) this.reconcile();
+      });
+    }
+
+    shouldComponentUpdate(nextProps: CompilerKeyedRowsBlockProps, nextState: State): boolean {
+      this.currentProps = nextProps;
+      if (nextState.fallback || this.state.fallback) return true;
+      this.schedulePropSync();
+      return false;
+    }
+
+    componentDidMount(): void {
+      this.mounted = true;
+      this.unsubscribe = owner.subscribe(this.props.id, this.refresh);
+      if (!this.adopt()) this.activateFallback();
+    }
+
+    componentWillUnmount(): void {
+      this.mounted = false;
+      this.unsubscribe?.();
+      this.root = null;
+      this.instances.clear();
+    }
+
+    render(): React.ReactNode {
+      const container = this.currentProps.render();
+      if (!React.isValidElement(container) || typeof container.type !== "string") {
+        throw new TypeError(
+          `Compiled keyed rows ${this.currentProps.id} must own one host container.`,
+        );
+      }
+      return React.cloneElement(container, {
+        key: this.state.fallback ? `react-${this.fallbackVersion}` : "compiled",
+        ref: this.captureRoot,
+      } as React.Attributes);
+    }
+  }
+
+  return FarmKeyedRowsBlock;
+}
+
 function createComponentBlockComponent(
   owner: Pick<ConditionalBlockOwner, "subscribe">,
 ): React.ComponentType<CompilerComponentBlockProps> {
@@ -463,8 +772,9 @@ function createComponentBlockComponent(
 /**
  * Runtime target emitted by the AOT transform.
  *
- * React owns component placement, SSR, hydration, props, and event semantics.
- * Compiler cells own local state updates and patch only precomputed DOM paths.
+ * React owns initial placement, SSR, hydration, props, and event semantics.
+ * Compiler cells own local updates and precomputed DOM paths. A proven host-only
+ * keyed container may transfer its child-row ownership after mount.
  */
 export function createCompiledComponent<Props>(
   definition: CompiledComponentDefinition<Props>,
@@ -527,6 +837,9 @@ export function createCompiledComponent<Props>(
           subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
         }),
         KeyedList: createKeyedListBlockComponent({
+          subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
+        }),
+        KeyedRows: createKeyedRowsBlockComponent({
           subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
         }),
         Component: createComponentBlockComponent({

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -73,6 +73,26 @@ interface KeyedListPlan {
   syntax: "map" | "list";
 }
 
+interface PendingKeyedRowBinding {
+  kind: "text" | "attribute" | "style";
+  path: number[];
+  name?: string;
+  value: t.Expression;
+}
+
+interface KeyedRowsPlan {
+  kind: "keyed-rows";
+  id: number;
+  parent?: number;
+  dependencies: number[];
+  source: t.JSXElement;
+  collection: t.Expression;
+  keyCallback: t.ArrowFunctionExpression | t.FunctionExpression;
+  renderCallback: t.ArrowFunctionExpression | t.FunctionExpression;
+  row: t.JSXElement;
+  bindings: PendingKeyedRowBinding[];
+}
+
 interface ComponentIslandPlan {
   kind: "component";
   id: number;
@@ -81,7 +101,11 @@ interface ComponentIslandPlan {
   source: t.JSXElement;
 }
 
-type ComposableBlockPlan = ConditionalBlockPlan | KeyedListPlan | ComponentIslandPlan;
+type ComposableBlockPlan =
+  | ConditionalBlockPlan
+  | KeyedListPlan
+  | KeyedRowsPlan
+  | ComponentIslandPlan;
 
 interface Candidate {
   name: string;
@@ -651,6 +675,250 @@ function analyzePublicList(
   return { dependencies: collectStateDependencies(element, statesByValue) };
 }
 
+interface KeyedRowsShape {
+  collection: t.Expression;
+  keyCallback: t.ArrowFunctionExpression | t.FunctionExpression;
+  renderCallback: t.ArrowFunctionExpression | t.FunctionExpression;
+  row: t.JSXElement;
+  dependencies: number[];
+  bindings: PendingKeyedRowBinding[];
+}
+
+function analyzeKeyedRowTree(
+  row: t.JSXElement,
+  renderCallback: t.ArrowFunctionExpression | t.FunctionExpression,
+  safeGlobals: ReadonlySet<string>,
+): { bindings?: PendingKeyedRowBinding[]; reason?: string } {
+  if (
+    renderCallback.async ||
+    renderCallback.generator ||
+    renderCallback.params.length < 1 ||
+    renderCallback.params.length > 2 ||
+    !t.isIdentifier(renderCallback.params[0]) ||
+    (renderCallback.params[1] !== undefined && !t.isIdentifier(renderCallback.params[1]))
+  ) {
+    return { reason: "compiled keyed rows require item and optional index identifiers" };
+  }
+
+  const bindings: PendingKeyedRowBinding[] = [];
+  const visit = (element: t.JSXElement, path: number[]): string | undefined => {
+    const tag = element.openingElement.name;
+    if (!t.isJSXIdentifier(tag) || !/^[a-z]/.test(tag.name)) {
+      return "compiled keyed rows support host elements only";
+    }
+    if (tag.name === "svg") return "compiled keyed rows do not support SVG yet";
+
+    for (const attribute of element.openingElement.attributes) {
+      if (t.isJSXSpreadAttribute(attribute)) {
+        return "compiled keyed rows do not support JSX attribute spreads";
+      }
+      const name = jsxAttributeName(attribute);
+      if (!name) return "compiled keyed rows do not support namespaced JSX attributes";
+      if (name === "ref" || name === "dangerouslySetInnerHTML") {
+        return `compiled keyed row ${name} requires React ownership`;
+      }
+      if (/^on[A-Z]/.test(name)) {
+        return "compiled keyed row events require React ownership";
+      }
+      if (name === "key") continue;
+      if (
+        !t.isJSXExpressionContainer(attribute.value) ||
+        t.isJSXEmptyExpression(attribute.value.expression)
+      ) {
+        continue;
+      }
+
+      const expression = attribute.value.expression;
+      if (name === "style") {
+        if (!t.isObjectExpression(expression)) {
+          return "compiled keyed row styles must use one inline object literal";
+        }
+        for (const property of expression.properties) {
+          if (
+            !t.isObjectProperty(property) ||
+            property.computed ||
+            !t.isExpression(property.value)
+          ) {
+            return "compiled keyed row styles do not support spreads, methods, or computed properties";
+          }
+          const propertyName = t.isIdentifier(property.key)
+            ? property.key.name
+            : t.isStringLiteral(property.key)
+              ? property.key.value
+              : undefined;
+          if (!propertyName || (propertyName.includes("-") && !propertyName.startsWith("--"))) {
+            return "compiled keyed row style names must use camelCase or a CSS custom property";
+          }
+          const unsupported = validateDerivedExpression(property.value, safeGlobals);
+          if (unsupported) {
+            return `compiled keyed row style ${propertyName} cannot use ${unsupported}`;
+          }
+          bindings.push({
+            kind: "style",
+            path: [...path],
+            name: propertyName,
+            value: cloneExpression(property.value),
+          });
+        }
+        continue;
+      }
+
+      if (name === "children") return "compiled keyed row children props are not supported yet";
+      const unsupported = validateDerivedExpression(expression, safeGlobals);
+      if (unsupported) return `compiled keyed row ${name} cannot use ${unsupported}`;
+      bindings.push({
+        kind: "attribute",
+        path: [...path],
+        name,
+        value: cloneExpression(expression),
+      });
+    }
+
+    const nestedElements = element.children.filter((child): child is t.JSXElement =>
+      t.isJSXElement(child),
+    );
+    if (element.children.some((child) => t.isJSXFragment(child))) {
+      return "compiled keyed rows do not support fragments yet";
+    }
+    const expressions = element.children.filter(
+      (child): child is t.JSXExpressionContainer =>
+        t.isJSXExpressionContainer(child) && !t.isJSXEmptyExpression(child.expression),
+    );
+    for (const child of expressions) {
+      const unsupported = validateDerivedExpression(child.expression as t.Expression, safeGlobals);
+      if (unsupported) return `compiled keyed row text cannot use ${unsupported}`;
+    }
+    if (nestedElements.length > 0 && expressions.length > 0) {
+      return "compiled keyed rows do not support dynamic text beside nested elements yet";
+    }
+    if (nestedElements.length === 0 && expressions.length > 0) {
+      const parts: t.Expression[] = [];
+      for (const child of element.children) {
+        if (t.isJSXText(child)) {
+          const text = cleanJsxText(child.value);
+          if (text) parts.push(t.stringLiteral(text));
+        } else if (t.isJSXExpressionContainer(child) && !t.isJSXEmptyExpression(child.expression)) {
+          parts.push(cloneExpression(child.expression));
+        }
+      }
+      bindings.push({ kind: "text", path: [...path], value: t.arrayExpression(parts) });
+    }
+
+    let elementIndex = 0;
+    for (const child of element.children) {
+      if (!t.isJSXElement(child)) continue;
+      const reason = visit(child, [...path, elementIndex]);
+      if (reason) return reason;
+      elementIndex += 1;
+    }
+    return undefined;
+  };
+
+  const reason = visit(row, []);
+  return reason ? { reason } : { bindings };
+}
+
+function analyzeKeyedRowsContainer(
+  container: t.JSXElement,
+  statesByValue: ReadonlyMap<string, StateBinding>,
+  safeGlobals: ReadonlySet<string>,
+  listNames: ReadonlySet<string>,
+): KeyedRowsShape | undefined {
+  if (
+    container.openingElement.attributes.some(
+      (attribute) =>
+        t.isJSXSpreadAttribute(attribute) ||
+        (t.isJSXAttribute(attribute) &&
+          t.isJSXIdentifier(attribute.name) &&
+          (attribute.name.name === "ref" || attribute.name.name === "dangerouslySetInnerHTML")),
+    )
+  ) {
+    return undefined;
+  }
+  for (const attribute of container.openingElement.attributes) {
+    if (
+      t.isJSXAttribute(attribute) &&
+      t.isJSXIdentifier(attribute.name) &&
+      t.isJSXExpressionContainer(attribute.value) &&
+      !t.isJSXEmptyExpression(attribute.value.expression) &&
+      !/^on[A-Z]/.test(attribute.name.name) &&
+      collectStateDependencies(attribute.value.expression, statesByValue).length > 0
+    ) {
+      return undefined;
+    }
+  }
+
+  const children = meaningfulJsxChildren(container);
+  if (children.length !== 1) return undefined;
+
+  let collection: t.Expression;
+  let keyCallback: t.ArrowFunctionExpression | t.FunctionExpression;
+  let renderCallback: t.ArrowFunctionExpression | t.FunctionExpression;
+  let row: t.JSXElement;
+  let dependencies: number[];
+
+  const child = children[0];
+  if (
+    t.isJSXExpressionContainer(child) &&
+    !t.isJSXEmptyExpression(child.expression) &&
+    isMapCall(child.expression)
+  ) {
+    const result = analyzeMapList(child.expression, statesByValue, safeGlobals);
+    if (result.reason) return undefined;
+    const callback = child.expression.arguments[0];
+    if (!t.isArrowFunctionExpression(callback) && !t.isFunctionExpression(callback))
+      return undefined;
+    const returned = returnedExpression(callback);
+    if (!returned || !t.isJSXElement(returned)) return undefined;
+    const key = jsxKeyExpression(returned);
+    if (!key) return undefined;
+    collection = (child.expression.callee as t.MemberExpression).object as t.Expression;
+    keyCallback = t.arrowFunctionExpression(
+      callback.params.map((parameter) => t.cloneNode(parameter, true)) as t.Identifier[],
+      cloneExpression(key),
+    );
+    renderCallback = callback;
+    row = returned;
+    dependencies = result.dependencies || [];
+  } else if (t.isJSXElement(child) && isPublicListElement(child, listNames)) {
+    const result = analyzePublicList(child, statesByValue, safeGlobals);
+    if (result.reason) return undefined;
+    const each = listAttributeExpression(child, "each");
+    const by = listAttributeExpression(child, "by");
+    const renderChild = meaningfulJsxChildren(child)[0];
+    if (
+      !each ||
+      (!t.isArrowFunctionExpression(by) && !t.isFunctionExpression(by)) ||
+      !t.isJSXExpressionContainer(renderChild) ||
+      t.isJSXEmptyExpression(renderChild.expression) ||
+      (!t.isArrowFunctionExpression(renderChild.expression) &&
+        !t.isFunctionExpression(renderChild.expression))
+    ) {
+      return undefined;
+    }
+    const returned = returnedExpression(renderChild.expression);
+    if (!returned || !t.isJSXElement(returned)) return undefined;
+    collection = each;
+    keyCallback = by;
+    renderCallback = renderChild.expression;
+    row = returned;
+    dependencies = result.dependencies || [];
+  } else {
+    return undefined;
+  }
+
+  const rowAnalysis = analyzeKeyedRowTree(row, renderCallback, safeGlobals);
+  if (rowAnalysis.reason) return undefined;
+  return {
+    collection,
+    keyCallback,
+    renderCallback,
+    row,
+    dependencies,
+    bindings: rowAnalysis.bindings || [],
+  };
+}
+
 function keyedListBoundary(
   blockRuntime: t.Identifier,
   plan: KeyedListPlan,
@@ -668,6 +936,150 @@ function keyedListBoundary(
         t.jsxAttribute(
           t.jsxIdentifier("render"),
           t.jsxExpressionContainer(t.arrowFunctionExpression([], cloneExpression(source))),
+        ),
+      ],
+      true,
+    ),
+    null,
+    [],
+    true,
+  );
+}
+
+function keyedRowElementDescriptor(element: t.JSXElement): t.ObjectExpression {
+  const tag = element.openingElement.name as t.JSXIdentifier;
+  const attributes: t.ObjectExpression[] = [];
+  const styles: t.ObjectExpression[] = [];
+
+  for (const attribute of element.openingElement.attributes) {
+    if (!t.isJSXAttribute(attribute)) continue;
+    const name = jsxAttributeName(attribute);
+    if (!name || name === "key" || /^on[A-Z]/.test(name)) continue;
+    if (name === "style") {
+      if (
+        t.isJSXExpressionContainer(attribute.value) &&
+        t.isObjectExpression(attribute.value.expression)
+      ) {
+        for (const property of attribute.value.expression.properties) {
+          if (!t.isObjectProperty(property) || !t.isExpression(property.value)) continue;
+          const propertyName = t.isIdentifier(property.key)
+            ? property.key.name
+            : (property.key as t.StringLiteral).value;
+          styles.push(
+            t.objectExpression([
+              t.objectProperty(t.identifier("name"), t.stringLiteral(propertyName)),
+              t.objectProperty(t.identifier("value"), cloneExpression(property.value)),
+            ]),
+          );
+        }
+      }
+      continue;
+    }
+
+    const value = attribute.value
+      ? t.isStringLiteral(attribute.value)
+        ? t.stringLiteral(attribute.value.value)
+        : t.isJSXExpressionContainer(attribute.value) &&
+            !t.isJSXEmptyExpression(attribute.value.expression)
+          ? cloneExpression(attribute.value.expression)
+          : t.identifier("undefined")
+      : t.booleanLiteral(true);
+    attributes.push(
+      t.objectExpression([
+        t.objectProperty(t.identifier("name"), t.stringLiteral(name)),
+        t.objectProperty(t.identifier("value"), value),
+      ]),
+    );
+  }
+
+  const children: t.Expression[] = [];
+  for (const child of element.children) {
+    if (t.isJSXText(child)) {
+      const text = cleanJsxText(child.value);
+      if (text) children.push(t.stringLiteral(text));
+    } else if (t.isJSXElement(child)) {
+      children.push(keyedRowElementDescriptor(child));
+    } else if (t.isJSXExpressionContainer(child) && !t.isJSXEmptyExpression(child.expression)) {
+      children.push(cloneExpression(child.expression));
+    }
+  }
+
+  return t.objectExpression([
+    t.objectProperty(t.identifier("kind"), t.stringLiteral("element")),
+    t.objectProperty(t.identifier("tag"), t.stringLiteral(tag.name)),
+    t.objectProperty(t.identifier("attributes"), t.arrayExpression(attributes)),
+    t.objectProperty(t.identifier("styles"), t.arrayExpression(styles)),
+    t.objectProperty(t.identifier("children"), t.arrayExpression(children)),
+  ]);
+}
+
+function keyedRowBindingObject(
+  binding: PendingKeyedRowBinding,
+  parameters: readonly t.Identifier[],
+): t.ObjectExpression {
+  const properties: t.ObjectProperty[] = [
+    t.objectProperty(t.identifier("kind"), t.stringLiteral(binding.kind)),
+    t.objectProperty(
+      t.identifier("path"),
+      t.arrayExpression(binding.path.map((part) => t.numericLiteral(part))),
+    ),
+  ];
+  if (binding.name) {
+    properties.push(t.objectProperty(t.identifier("name"), t.stringLiteral(binding.name)));
+  }
+  properties.push(
+    t.objectProperty(
+      t.identifier("read"),
+      t.arrowFunctionExpression(
+        parameters.map((parameter) => t.cloneNode(parameter, true)),
+        cloneExpression(binding.value),
+      ),
+    ),
+  );
+  return t.objectExpression(properties);
+}
+
+function keyedRowsBoundary(blockRuntime: t.Identifier, plan: KeyedRowsPlan): t.JSXElement {
+  const name = t.jsxMemberExpression(
+    t.jsxIdentifier(blockRuntime.name),
+    t.jsxIdentifier("KeyedRows"),
+  );
+  const parameters = plan.renderCallback.params.map((parameter) =>
+    t.cloneNode(parameter, true),
+  ) as t.Identifier[];
+  return t.jsxElement(
+    t.jsxOpeningElement(
+      name,
+      [
+        t.jsxAttribute(t.jsxIdentifier("id"), t.jsxExpressionContainer(t.numericLiteral(plan.id))),
+        t.jsxAttribute(
+          t.jsxIdentifier("render"),
+          t.jsxExpressionContainer(t.arrowFunctionExpression([], t.cloneNode(plan.source, true))),
+        ),
+        t.jsxAttribute(
+          t.jsxIdentifier("items"),
+          t.jsxExpressionContainer(t.arrowFunctionExpression([], cloneExpression(plan.collection))),
+        ),
+        t.jsxAttribute(
+          t.jsxIdentifier("rowKey"),
+          t.jsxExpressionContainer(t.cloneNode(plan.keyCallback, true)),
+        ),
+        t.jsxAttribute(
+          t.jsxIdentifier("create"),
+          t.jsxExpressionContainer(
+            t.arrowFunctionExpression(
+              parameters.map((parameter) => t.cloneNode(parameter, true)),
+              keyedRowElementDescriptor(plan.row),
+            ),
+          ),
+        ),
+        t.jsxAttribute(
+          t.jsxIdentifier("bindings"),
+          t.jsxExpressionContainer(
+            t.arrayExpression(
+              plan.bindings.map((binding) => keyedRowBindingObject(binding, parameters)),
+            ),
+          ),
         ),
       ],
       true,
@@ -895,6 +1307,23 @@ function analyzeComposableBlocks(
 
       if (t.isJSXElement(child)) {
         if (isHostElement(child)) {
+          const keyedRows = analyzeKeyedRowsContainer(child, statesByValue, safeGlobals, listNames);
+          if (keyedRows) {
+            plans.push({
+              kind: "keyed-rows",
+              id: nextId++,
+              parent,
+              dependencies: keyedRows.dependencies,
+              source: child,
+              collection: keyedRows.collection,
+              keyCallback: keyedRows.keyCallback,
+              renderCallback: keyedRows.renderCallback,
+              row: keyedRows.row,
+              bindings: keyedRows.bindings,
+            });
+            keyedElements.add(child);
+            continue;
+          }
           const nested = visitHost(child, parent, insideConditional);
           if (nested.reason) return { dependencies, reason: nested.reason };
           mergeDependencies(dependencies, nested.dependencies);
@@ -1051,6 +1480,9 @@ function lowerComposableBlocks(
     element.children = element.children.map((child) => {
       if (t.isJSXElement(child)) {
         const plan = planBySource.get(child);
+        if (plan?.kind === "keyed-rows") {
+          return keyedRowsBoundary(blockRuntime, plan);
+        }
         if (plan?.kind === "component") {
           return componentIslandBoundary(blockRuntime, plan, child);
         }


### PR DESCRIPTION
## Summary

- compile eligible dedicated host-only keyed lists into persistent row instances
- patch row text, attributes, controlled properties, and inline styles without rerunning the list owner
- insert and remove only changed rows and use a longest increasing subsequence (LIS) to minimize DOM moves during reorders
- preserve React-owned keyed boundaries for custom components, Hooks, row events, fragments, refs, SVG, mixed-content containers, and other unsupported shapes
- fall back to a React remount when duplicate runtime keys make ownership ambiguous
- document the optimization contract and extend the production browser example with DOM-identity and LIS-move assertions

## Why

The existing keyed-list boundary prevented the outer compiled component from rerunning, but React still rendered and reconciled every row. Proven host-only rows have a complete build-time shape, so the compiler can safely prepare their creation and binding work while retaining stable key identity.

This adds the missing per-key runtime instances. LIS is used only as the reorder planner: future collection contents still remain dynamic, and insertion, removal, binding updates, and unsupported structures retain their required runtime or React work.

## Safety

React continues to own the initial client render, SSR, and hydration. The runtime adopts valid hydrated rows after mount. Unsupported source shapes use the existing React-owned list boundary, and duplicate runtime keys switch the container to React instead of guessing identity.

Coverage includes Strict Mode, unmount-before-flush cleanup, simultaneous parent and local updates, nested conditional cleanup, hydration, focused input selection, duplicate keys, nested bindings, compatible Fast Refresh, React error boundaries, and randomized differential testing against normal React.

## Validation

- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test` — 19 files, 146 tests
- targeted Oxlint — 0 warnings and 0 errors
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and React 19.2.8
- `pnpm --dir examples/react-compiler experiment` — production browser PASS
- 1,000 deterministic randomized list operations matched normal React
- `[A,B,C,D] → [D,A,B,C]` performs one move; reversing four rows performs the LIS minimum of three moves
