### PR TITLE
fix(core): quote virtual SSR entry import paths for Windows

### DIFF
--- a/packages/farm/src/__tests__/universal-build-import-specifiers.test.ts
+++ b/packages/farm/src/__tests__/universal-build-import-specifiers.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { toVirtualEntryImportSpecifier } from "../nitro/universal-build";
+
+describe("toVirtualEntryImportSpecifier", () => {
+  it("emits forward-slash specifiers for Windows paths", () => {
+    // A raw backslash path inside a generated import statement is read as
+    // escape sequences (`\f`, `\t`, ...), producing a specifier the bundler
+    // cannot resolve: Rolldown failed to resolve import "E:\..." (#393).
+    expect(toVirtualEntryImportSpecifier("E:\\farming\\app\\src\\app\\api\\scan\\route.ts")).toBe(
+      '"E:/farming/app/src/app/api/scan/route.ts"',
+    );
+  });
+
+  it("keeps POSIX paths unchanged apart from quoting", () => {
+    expect(toVirtualEntryImportSpecifier("/workspace/app/src/app/api/scan/route.ts")).toBe(
+      '"/workspace/app/src/app/api/scan/route.ts"',
+    );
+  });
+
+  it("produces a valid JavaScript string literal with no unescaped backslashes", () => {
+    const specifier = toVirtualEntryImportSpecifier("E:\\farming\\app\\src\\middleware.ts");
+    expect(specifier).not.toContain("\\");
+    expect(JSON.parse(specifier)).toBe("E:/farming/app/src/middleware.ts");
+  });
+});

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -3373,6 +3373,16 @@ export function generateFarmDocsRuntimeConfigExpression(docs: ResolvedFarmConfig
   : ${JSON.stringify(docs)}`;
 }
 
+/**
+ * Quote a filesystem path for use as an import specifier in generated code.
+ * Windows paths contain backslashes, which JavaScript string literals treat
+ * as escape sequences (e.g. `\f` in `E:\farm`), producing specifiers the
+ * bundler cannot resolve. Normalize to forward slashes and JSON-quote.
+ */
+export function toVirtualEntryImportSpecifier(modulePath: string): string {
+  return JSON.stringify(modulePath.replace(/\\/g, "/"));
+}
+
 function generateVirtualEntryCode(
   apiRoutes: Array<{ path: string; filePath: string; methods: string[] }>,
   pageRoutes: UniversalPageRoute[],
@@ -3420,7 +3430,9 @@ function generateVirtualEntryCode(
 
   apiRoutes.forEach((route, index) => {
     const varName = `apiRoute${index}`;
-    apiImports.push(`import * as ${varName} from "${route.filePath}";`);
+    apiImports.push(
+      `import * as ${varName} from ${toVirtualEntryImportSpecifier(route.filePath)};`,
+    );
     apiRegistrations.push(`
   {
     path: ${JSON.stringify(route.path)},
@@ -3462,7 +3474,9 @@ function generateVirtualEntryCode(
       return;
     }
 
-    pageImports.push(`import * as ${varName} from "${route.modulePath}";`);
+    pageImports.push(
+      `import * as ${varName} from ${toVirtualEntryImportSpecifier(route.modulePath)};`,
+    );
     const clientMetadata = getClientModuleMetadata(route.modulePath, config.root);
     pageRegistrations.push(`
   {
@@ -3488,7 +3502,9 @@ function generateVirtualEntryCode(
   layoutRoutes.forEach((layout, index) => {
     const varName = `layoutRoute${index}`;
     const clientMetadata = getClientModuleMetadata(layout.modulePath, config.root);
-    layoutImports.push(`import * as ${varName} from "${layout.modulePath}";`);
+    layoutImports.push(
+      `import * as ${varName} from ${toVirtualEntryImportSpecifier(layout.modulePath)};`,
+    );
     layoutRegistrations.push(`
   {
     pattern: ${JSON.stringify(layout.pattern)},
@@ -3502,7 +3518,9 @@ function generateVirtualEntryCode(
   const routeSlotRegistrations: string[] = [];
   routeSlots.forEach((slot, index) => {
     const varName = `routeSlot${index}`;
-    routeSlotImports.push(`import * as ${varName} from "${slot.modulePath}";`);
+    routeSlotImports.push(
+      `import * as ${varName} from ${toVirtualEntryImportSpecifier(slot.modulePath)};`,
+    );
     routeSlotRegistrations.push(`
   {
     name: ${JSON.stringify(slot.name)},
@@ -3521,7 +3539,9 @@ function generateVirtualEntryCode(
 
   errorRoutes.forEach((errorRoute, index) => {
     const varName = `errorRoute${index}`;
-    errorImports.push(`import * as ${varName} from "${errorRoute.modulePath}";`);
+    errorImports.push(
+      `import * as ${varName} from ${toVirtualEntryImportSpecifier(errorRoute.modulePath)};`,
+    );
     errorRegistrations.push(`
   {
     pattern: ${JSON.stringify(errorRoute.pattern)},
@@ -3533,9 +3553,11 @@ function generateVirtualEntryCode(
   const metadataImageRegistrations: string[] = [];
 
   metadataImageRoutes.forEach((image, index) => {
-    if (image.sourceType === "module") {
+    if (image.sourceType === "module" && image.modulePath) {
       const varName = `metadataImageRoute${index}`;
-      metadataImageImports.push(`import * as ${varName} from "${image.modulePath}";`);
+      metadataImageImports.push(
+        `import * as ${varName} from ${toVirtualEntryImportSpecifier(image.modulePath)};`,
+      );
       metadataImageRegistrations.push(`
   {
     pattern: ${JSON.stringify(image.pattern)},
@@ -3554,7 +3576,9 @@ function generateVirtualEntryCode(
   const applicationMetadataRegistrations: string[] = [];
   applicationMetadataRoutes.forEach((metadata, index) => {
     const varName = `applicationMetadataRoute${index}`;
-    applicationMetadataImports.push(`import * as ${varName} from "${metadata.modulePath}";`);
+    applicationMetadataImports.push(
+      `import * as ${varName} from ${toVirtualEntryImportSpecifier(metadata.modulePath)};`,
+    );
     applicationMetadataRegistrations.push(`
   {
     pattern: ${JSON.stringify(metadata.pattern)},
@@ -3570,7 +3594,9 @@ function generateVirtualEntryCode(
 
   middlewareRoutes.forEach((middlewareRoute, index) => {
     const varName = `fileMiddleware${index}`;
-    middlewareImports.push(`import * as ${varName} from "${middlewareRoute.filePath}";`);
+    middlewareImports.push(
+      `import * as ${varName} from ${toVirtualEntryImportSpecifier(middlewareRoute.filePath)};`,
+    );
     middlewareRegistrations.push(`
   {
     path: ${JSON.stringify(middlewareRoute.path)},
@@ -3580,7 +3606,9 @@ function generateVirtualEntryCode(
   });
 
   // Generate import for custom not-found page if exists
-  const notFoundImport = notFoundPath ? `import * as CustomNotFound from "${notFoundPath}";` : "";
+  const notFoundImport = notFoundPath
+    ? `import * as CustomNotFound from ${toVirtualEntryImportSpecifier(notFoundPath)};`
+    : "";
   const apiRouteHelpersImport =
     apiRoutes.length > 0
       ? `import { invokeAPIRouteEndpoint, matchAPIRoute } from "@farm.js/core/api/runtime";`
@@ -3666,7 +3694,7 @@ import { fileURLToPath as farmDocsFileURLToPath } from "node:url";`
         : path.join(config.root, config.mdx.components)
       : null;
   const mdxComponentsImport = mdxComponentsPath
-    ? `import * as FarmMdxComponentsModule from "${mdxComponentsPath.replace(/\\/g, "/")}";`
+    ? `import * as FarmMdxComponentsModule from ${toVirtualEntryImportSpecifier(mdxComponentsPath)};`
     : "";
   const layerConfigPaths = (config.layers || [])
     .map((layer) => layer.configFile)
@@ -3675,7 +3703,7 @@ import { fileURLToPath as farmDocsFileURLToPath } from "node:url";`
   const layerConfigImports = layerConfigPaths
     .map(
       (configFile, index) =>
-        `import * as FarmLayerConfigModule${index} from "${configFile.replace(/\\/g, "/")}";`,
+        `import * as FarmLayerConfigModule${index} from ${toVirtualEntryImportSpecifier(configFile)};`,
     )
     .join("\n");
   const layerConfigValues = layerConfigPaths.map(
@@ -3696,10 +3724,10 @@ import { fileURLToPath as farmDocsFileURLToPath } from "node:url";`
     ? `import { ${integrationRuntimeExports.join(", ")} } from "@farm.js/core/integrations";`
     : "";
   const instrumentationImport = instrumentationPath
-    ? `import * as FarmInstrumentationModule from "${instrumentationPath.replace(/\\/g, "/")}";`
+    ? `import * as FarmInstrumentationModule from ${toVirtualEntryImportSpecifier(instrumentationPath)};`
     : "";
   const integrationImports = `
-${configModulePath ? `import * as FarmUserConfigModule from "${configModulePath}";` : ""}
+${configModulePath ? `import * as FarmUserConfigModule from ${toVirtualEntryImportSpecifier(configModulePath)};` : ""}
 ${layerConfigImports}
 ${integrationRuntimeImport}
 `;


### PR DESCRIPTION
## Summary

Fixes #393.

On Windows, `farm build` failed during the SSR bundle step whenever the project had API routes (or middleware):

```
Rolldown failed to resolve import "E:\path\to\project\src\app\api\scan\route.ts" from "virtual:farm-ssr-entry"
```

## Root cause

`generateVirtualEntryCode()` interpolated raw filesystem paths into double-quoted import statements. Windows paths contain backslashes, which JavaScript string literals read as escape sequences (`\f`, `\t`, …), corrupting the specifier before the bundler ever sees it.

## Changes

- New exported `toVirtualEntryImportSpecifier()`: normalizes separators to forward slashes and JSON-quotes the result.
- Applied at **all 13** import-emission sites in the virtual entry — not just the two the issue found: API routes, pages, layouts, route slots, error boundaries, metadata images, application metadata, middleware, not-found, MDX components, layer configs, instrumentation, and the user config module. (Three of those sites already normalized backslashes but weren't quote-safe; the rest were fully raw.)
- Metadata image entries with no `modulePath` are now skipped instead of emitting `import * as x from "undefined"` — surfaced by the stricter typing of the helper.

## Testing

- New `universal-build-import-specifiers.test.ts`: Windows drive-letter paths produce forward-slash specifiers, POSIX paths are unchanged apart from quoting, and the emitted literal contains no unescaped backslashes (parses back via `JSON.parse`).
- `universal-build-docs` and `universal-build-stream-errors` suites pass; `tsc --noEmit`, `oxlint`, `oxfmt` clean.

Part of the Windows-support series (#385, #386, #388, #390); #394 and #395 are being addressed in separate PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quotes virtual SSR entry import paths to fix Windows SSR builds. Previously we interpolated raw Windows paths into import strings, where backslashes were read as escapes and broke resolution; now we normalize to forward slashes and JSON‑quote the specifier. POSIX behavior is unchanged.

- Introduces `toVirtualEntryImportSpecifier()` and applies it to all import emissions: API routes, pages, layouts, route slots, error boundaries, metadata images, application metadata, middleware, not-found, MDX components, layer configs, instrumentation, and the user config module.
- Skips metadata image entries without `modulePath` (avoids importing "undefined").
- Adds tests to verify Windows path normalization and valid quoted literals.

<sup>Written for commit 03cafb5f878ca460935256fe0effdbd729efb1f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

