### PR TITLE
fix(core): escape module paths in SSR virtual entry imports on Windows

### DIFF
--- a/packages/farm/src/__tests__/utils.test.ts
+++ b/packages/farm/src/__tests__/utils.test.ts
@@ -4,6 +4,7 @@ import {
   parseRoutePath,
   matchRoute,
   segmentsToPattern,
+  toModuleImportPath,
   toRootRelativeUrlPath,
   toViteModuleId,
 } from "../utils";
@@ -16,6 +17,21 @@ describe("createCliColors", () => {
 
   it("keeps redirected output plain", () => {
     expect(createCliColors(false).green("Farm.js")).toBe("Farm.js");
+  });
+});
+
+describe("toModuleImportPath", () => {
+  it("escapes Windows drive-letter paths for generated static imports", () => {
+    const modulePath = "E:\\workspace\\app\\src\\app\\api\\hello\\route.ts";
+    const importStatement = `import * as apiRoute0 from ${toModuleImportPath(modulePath)};`;
+
+    expect(importStatement).toBe(`import * as apiRoute0 from ${JSON.stringify(modulePath)};`);
+    expect(importStatement.includes("\f")).toBe(false);
+  });
+
+  it("keeps POSIX project paths unchanged aside from quoting", () => {
+    const modulePath = "/workspace/app/src/app/api/hello/route.ts";
+    expect(toModuleImportPath(modulePath)).toBe(JSON.stringify(modulePath));
   });
 });
 

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -22,7 +22,7 @@ import { constants as fsConstants, existsSync, readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { builtinModules, createRequire } from "module";
 import { isDeepStrictEqual } from "node:util";
-import { logger } from "../utils";
+import { logger, toModuleImportPath } from "../utils";
 import { getClientModuleMetadata } from "../utils/client-component";
 import { isFarmMarkdownPageFile } from "../app-markdown";
 import type { ProgrammaticRedirectRoute } from "../routes";
@@ -3420,7 +3420,7 @@ function generateVirtualEntryCode(
 
   apiRoutes.forEach((route, index) => {
     const varName = `apiRoute${index}`;
-    apiImports.push(`import * as ${varName} from "${route.filePath}";`);
+    apiImports.push(`import * as ${varName} from ${toModuleImportPath(route.filePath)};`);
     apiRegistrations.push(`
   {
     path: ${JSON.stringify(route.path)},
@@ -3462,7 +3462,7 @@ function generateVirtualEntryCode(
       return;
     }
 
-    pageImports.push(`import * as ${varName} from "${route.modulePath}";`);
+    pageImports.push(`import * as ${varName} from ${toModuleImportPath(route.modulePath)};`);
     const clientMetadata = getClientModuleMetadata(route.modulePath, config.root);
     pageRegistrations.push(`
   {
@@ -3488,7 +3488,7 @@ function generateVirtualEntryCode(
   layoutRoutes.forEach((layout, index) => {
     const varName = `layoutRoute${index}`;
     const clientMetadata = getClientModuleMetadata(layout.modulePath, config.root);
-    layoutImports.push(`import * as ${varName} from "${layout.modulePath}";`);
+    layoutImports.push(`import * as ${varName} from ${toModuleImportPath(layout.modulePath)};`);
     layoutRegistrations.push(`
   {
     pattern: ${JSON.stringify(layout.pattern)},
@@ -3502,7 +3502,7 @@ function generateVirtualEntryCode(
   const routeSlotRegistrations: string[] = [];
   routeSlots.forEach((slot, index) => {
     const varName = `routeSlot${index}`;
-    routeSlotImports.push(`import * as ${varName} from "${slot.modulePath}";`);
+    routeSlotImports.push(`import * as ${varName} from ${toModuleImportPath(slot.modulePath)};`);
     routeSlotRegistrations.push(`
   {
     name: ${JSON.stringify(slot.name)},
@@ -3521,7 +3521,7 @@ function generateVirtualEntryCode(
 
   errorRoutes.forEach((errorRoute, index) => {
     const varName = `errorRoute${index}`;
-    errorImports.push(`import * as ${varName} from "${errorRoute.modulePath}";`);
+    errorImports.push(`import * as ${varName} from ${toModuleImportPath(errorRoute.modulePath)};`);
     errorRegistrations.push(`
   {
     pattern: ${JSON.stringify(errorRoute.pattern)},
@@ -3533,9 +3533,11 @@ function generateVirtualEntryCode(
   const metadataImageRegistrations: string[] = [];
 
   metadataImageRoutes.forEach((image, index) => {
-    if (image.sourceType === "module") {
+    if (image.sourceType === "module" && image.modulePath) {
       const varName = `metadataImageRoute${index}`;
-      metadataImageImports.push(`import * as ${varName} from "${image.modulePath}";`);
+      metadataImageImports.push(
+        `import * as ${varName} from ${toModuleImportPath(image.modulePath)};`,
+      );
       metadataImageRegistrations.push(`
   {
     pattern: ${JSON.stringify(image.pattern)},
@@ -3554,7 +3556,9 @@ function generateVirtualEntryCode(
   const applicationMetadataRegistrations: string[] = [];
   applicationMetadataRoutes.forEach((metadata, index) => {
     const varName = `applicationMetadataRoute${index}`;
-    applicationMetadataImports.push(`import * as ${varName} from "${metadata.modulePath}";`);
+    applicationMetadataImports.push(
+      `import * as ${varName} from ${toModuleImportPath(metadata.modulePath)};`,
+    );
     applicationMetadataRegistrations.push(`
   {
     pattern: ${JSON.stringify(metadata.pattern)},
@@ -3570,7 +3574,7 @@ function generateVirtualEntryCode(
 
   middlewareRoutes.forEach((middlewareRoute, index) => {
     const varName = `fileMiddleware${index}`;
-    middlewareImports.push(`import * as ${varName} from "${middlewareRoute.filePath}";`);
+    middlewareImports.push(`import * as ${varName} from ${toModuleImportPath(middlewareRoute.filePath)};`);
     middlewareRegistrations.push(`
   {
     path: ${JSON.stringify(middlewareRoute.path)},
@@ -3580,7 +3584,9 @@ function generateVirtualEntryCode(
   });
 
   // Generate import for custom not-found page if exists
-  const notFoundImport = notFoundPath ? `import * as CustomNotFound from "${notFoundPath}";` : "";
+  const notFoundImport = notFoundPath
+    ? `import * as CustomNotFound from ${toModuleImportPath(notFoundPath)};`
+    : "";
   const apiRouteHelpersImport =
     apiRoutes.length > 0
       ? `import { invokeAPIRouteEndpoint, matchAPIRoute } from "@farm.js/core/api/runtime";`
@@ -3666,7 +3672,7 @@ import { fileURLToPath as farmDocsFileURLToPath } from "node:url";`
         : path.join(config.root, config.mdx.components)
       : null;
   const mdxComponentsImport = mdxComponentsPath
-    ? `import * as FarmMdxComponentsModule from "${mdxComponentsPath.replace(/\\/g, "/")}";`
+    ? `import * as FarmMdxComponentsModule from ${toModuleImportPath(mdxComponentsPath)};`
     : "";
   const layerConfigPaths = (config.layers || [])
     .map((layer) => layer.configFile)
@@ -3675,7 +3681,7 @@ import { fileURLToPath as farmDocsFileURLToPath } from "node:url";`
   const layerConfigImports = layerConfigPaths
     .map(
       (configFile, index) =>
-        `import * as FarmLayerConfigModule${index} from "${configFile.replace(/\\/g, "/")}";`,
+        `import * as FarmLayerConfigModule${index} from ${toModuleImportPath(configFile)};`,
     )
     .join("\n");
   const layerConfigValues = layerConfigPaths.map(
@@ -3696,10 +3702,10 @@ import { fileURLToPath as farmDocsFileURLToPath } from "node:url";`
     ? `import { ${integrationRuntimeExports.join(", ")} } from "@farm.js/core/integrations";`
     : "";
   const instrumentationImport = instrumentationPath
-    ? `import * as FarmInstrumentationModule from "${instrumentationPath.replace(/\\/g, "/")}";`
+    ? `import * as FarmInstrumentationModule from ${toModuleImportPath(instrumentationPath)};`
     : "";
   const integrationImports = `
-${configModulePath ? `import * as FarmUserConfigModule from "${configModulePath}";` : ""}
+${configModulePath ? `import * as FarmUserConfigModule from ${toModuleImportPath(configModulePath)};` : ""}
 ${layerConfigImports}
 ${integrationRuntimeImport}
 `;

--- a/packages/farm/src/utils.ts
+++ b/packages/farm/src/utils.ts
@@ -140,6 +140,15 @@ export function resolveAppPath(root: string, ...paths: string[]): string {
 }
 
 /**
+ * Format a module path for the specifier in a generated static import statement.
+ * JSON.stringify escapes backslashes on Windows so paths like `E:\workspace\app\...`
+ * do not produce invalid escape sequences in emitted source.
+ */
+export function toModuleImportPath(modulePath: string): string {
+  return JSON.stringify(modulePath);
+}
+
+/**
  * Convert an absolute module path inside the project root to a root-relative
  * URL path with forward slashes (e.g. `/src/app/page.tsx`), for values the
  * client passes to dynamic `import()`. On Windows the naive root-prefix slice


### PR DESCRIPTION
## Summary

Fixes #393.

On Windows, `farm build` with the Vercel preset failed during the SSR bundle step when API routes were present. `generateVirtualEntryCode()` embedded raw filesystem paths in static import statements; backslashes in drive-letter paths produced invalid escape sequences and Rolldown could not resolve the modules.

This change introduces `toModuleImportPath()` and uses it for module specifiers emitted in the SSR virtual entry (API routes, middleware, pages, layouts, and related imports).

## Changes

- Add `toModuleImportPath()` in `packages/farm/src/utils.ts` (`JSON.stringify` for safe generated imports).
- Apply it throughout `generateVirtualEntryCode()` in `packages/farm/src/nitro/universal-build.ts`.
- Add unit tests in `packages/farm/src/__tests__/utils.test.ts`.

## Test plan

- [x] `pnpm --filter @farm.js/core test -- src/__tests__/utils.test.ts -t toModuleImportPath`
- [x] `pnpm --filter @farm.js/core exec tsc --noEmit`
- [ ] `pnpm --filter @farm.js/core test` (full package suite)
- [ ] Windows production build with an API route and Vercel preset


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escapes module paths in generated SSR virtual entry imports to fix Windows builds. Previously we emitted raw Windows paths; backslashes created invalid escape sequences and broke module resolution.

- Add `toModuleImportPath(modulePath)` (uses `JSON.stringify`) and apply it to all module specifiers emitted in the SSR virtual entry (API routes, pages, layouts, route slots, error routes, middleware, metadata images, application metadata, not-found page, MDX components, layer configs, instrumentation, and user config).
- Behavior: POSIX unchanged; on Windows, specifiers are now quoted and escaped, preventing Rolldown parse errors.
- Add unit tests for `toModuleImportPath`.
- No migration or config changes required.

<sup>Written for commit 2a767fa1de0aeef542d701f4176ba4cf1aa3b594. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

