### PR TITLE
fix(core): normalize Nitro handler and task paths for Windows

### DIFF
--- a/packages/farm/src/__tests__/cron.test.ts
+++ b/packages/farm/src/__tests__/cron.test.ts
@@ -129,6 +129,12 @@ describe("Farm cron", () => {
       "0 * * * *": "farm:cron:syncPlans",
     });
 
+    for (const task of Object.values(prepared.tasks)) {
+      // Nitro receives these as module ids; backslash Windows paths break
+      // resolution in the generated build (#395).
+      expect(task.handler).not.toContain("\\");
+    }
+
     const wrapper = await fs.readFile(prepared.tasks["farm:cron:dailyCleanup"].handler, "utf8");
     expect(wrapper).toContain('import { defineTask, useNitroApp } from "nitro/runtime"');
     expect(wrapper).toContain('const path = "/api/maintenance/cleanup"');

--- a/packages/farm/src/__tests__/utils.test.ts
+++ b/packages/farm/src/__tests__/utils.test.ts
@@ -4,6 +4,7 @@ import {
   parseRoutePath,
   matchRoute,
   segmentsToPattern,
+  toPosixPath,
   toRootRelativeUrlPath,
   toViteModuleId,
 } from "../utils";
@@ -30,6 +31,17 @@ describe("toViteModuleId", () => {
       "/@fs/workspace/layer/routes.ts",
     );
     expect(toViteModuleId("virtual:farm-routes", root)).toBe("virtual:farm-routes");
+  });
+});
+
+describe("toPosixPath", () => {
+  it("normalizes Windows separators and leaves POSIX paths alone", () => {
+    expect(toPosixPath("E:\\farming\\app\\.farm\\.nitro\\farm-workflows\\http-handler.mjs")).toBe(
+      "E:/farming/app/.farm/.nitro/farm-workflows/http-handler.mjs",
+    );
+    expect(toPosixPath("/workspace/app/.farm/.nitro/nitro-entry.mjs")).toBe(
+      "/workspace/app/.farm/.nitro/nitro-entry.mjs",
+    );
   });
 });
 

--- a/packages/farm/src/__tests__/workflows.test.ts
+++ b/packages/farm/src/__tests__/workflows.test.ts
@@ -227,6 +227,11 @@ describe("Farm workflows", () => {
       workflows: { secret: "test-secret" },
       server: { bodySizeLimit: 1234 },
     });
+    expect(prepared.handlerPath).not.toContain("\\");
+    for (const task of Object.values(prepared.tasks)) {
+      expect(task.handler).not.toContain("\\");
+    }
+
     const handlerSource = await fs.readFile(prepared.handlerPath!, "utf8");
 
     expect(handlerSource).toContain("const bodySizeLimit = 1234");

--- a/packages/farm/src/cron.ts
+++ b/packages/farm/src/cron.ts
@@ -1,3 +1,5 @@
+import { toPosixPath } from "./utils";
+
 export type FarmCronSchedule = string | string[];
 
 export interface FarmCronJobConfig {
@@ -121,7 +123,7 @@ export async function prepareFarmCronForNitro(config: {
   const tasks: PreparedFarmCron["tasks"] = {};
   for (const job of cron.jobs) {
     const taskName = getFarmCronTaskName(job.name);
-    const wrapperPath = path.join(generatedDir, `${safeFileName(job.name)}.mjs`);
+    const wrapperPath = toPosixPath(path.join(generatedDir, `${safeFileName(job.name)}.mjs`));
     await fs.writeFile(wrapperPath, createNitroCronTaskWrapper(job, cron.secretEnv), "utf8");
     tasks[taskName] = {
       handler: wrapperPath,

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -22,7 +22,7 @@ import { constants as fsConstants, existsSync, readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { builtinModules, createRequire } from "module";
 import { isDeepStrictEqual } from "node:util";
-import { logger } from "../utils";
+import { logger, toPosixPath } from "../utils";
 import { getClientModuleMetadata } from "../utils/client-component";
 import { isFarmMarkdownPageFile } from "../app-markdown";
 import type { ProgrammaticRedirectRoute } from "../routes";
@@ -7124,7 +7124,7 @@ export default async function farmNitroEventHandler(event) {
         : []),
       {
         route: "/**",
-        handler: nitroEntryPath,
+        handler: toPosixPath(nitroEntryPath),
       },
     ],
     routeRules: {

--- a/packages/farm/src/utils.ts
+++ b/packages/farm/src/utils.ts
@@ -157,6 +157,15 @@ export function toRootRelativeUrlPath(
   return undefined;
 }
 
+/**
+ * Normalize a filesystem path to forward slashes. Node's fs accepts these on
+ * every platform, and module ids handed to bundlers (e.g. Nitro handler and
+ * task entries) must not contain backslashes.
+ */
+export function toPosixPath(filePath: string): string {
+  return filePath.replace(/\\/g, "/");
+}
+
 export function toViteModuleId(filePath: string, root: string): string {
   if (!path.isAbsolute(filePath)) return filePath;
 

--- a/packages/farm/src/workflows.ts
+++ b/packages/farm/src/workflows.ts
@@ -5,6 +5,7 @@ import {
   type FarmServerConfig,
   type ResolvedFarmServerConfig,
 } from "./server-http";
+import { toPosixPath } from "./utils";
 
 export type FarmWorkflowSchedule = string | string[];
 
@@ -311,7 +312,7 @@ export async function prepareFarmWorkflowsForNitro(config: {
   const scheduledTasks = createScheduledTasks(workflows);
 
   for (const workflow of workflows) {
-    const wrapperPath = path.join(generatedDir, `${safeFileName(workflow.id)}.mjs`);
+    const wrapperPath = toPosixPath(path.join(generatedDir, `${safeFileName(workflow.id)}.mjs`));
     await fs.writeFile(wrapperPath, createNitroTaskWrapper(workflow), "utf8");
     tasks[workflow.id] = {
       handler: wrapperPath,
@@ -319,7 +320,7 @@ export async function prepareFarmWorkflowsForNitro(config: {
     };
   }
 
-  const handlerPath = path.join(generatedDir, "http-handler.mjs");
+  const handlerPath = toPosixPath(path.join(generatedDir, "http-handler.mjs"));
   await fs.writeFile(
     handlerPath,
     createNitroWorkflowHTTPHandler(


### PR DESCRIPTION
## Summary

Fixes #395.

During `farm build` on Windows, Nitro handler and task entries were registered with backslash absolute paths (`handler: "E:\\...\\http-handler.mjs"`). Nitro passes these values on as module ids, where backslash paths break resolution in the generated build.

## Changes

- New shared `toPosixPath()` helper in `packages/farm/src/utils.ts`.
- Paths are normalized **at their source**, so every consumer inherits forward slashes:
  - `prepareFarmWorkflowsForNitro` (`workflows.ts`) — the workflow HTTP handler path and each generated task wrapper path. This covers both registration sites (`nitro/universal-build.ts` and `nitro/index.ts`) without touching them.
  - `prepareFarmCronForNitro` (`cron.ts`) — each generated cron task wrapper path.
- The catch-all `nitro-entry.mjs` handler in `nitro/universal-build.ts` is normalized at registration (its path is also used for fs writes and a `path.resolve` equality check, both of which accept forward slashes on Windows, so normalizing the handler value is safe).

Forward-slash absolute paths remain valid fs paths on every platform, so the `writeFile`/`readFile` call sites are unaffected.

## Testing

- New `toPosixPath` unit tests with Windows and POSIX inputs.
- The existing `prepareFarmWorkflowsForNitro` / `prepareFarmCronForNitro` tests now also assert that emitted `handlerPath` and every `tasks[].handler` contain no backslashes (meaningful on a Windows runner, harmless elsewhere).
- `utils`, `cron`, and `workflows` suites pass (43/43); `tsc --noEmit` and `oxfmt` clean.

Part of the Windows-support series; #393 is fixed in #396, and #394 is being addressed separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes Nitro handler and task paths to forward slashes on Windows to prevent module ID resolution errors in the generated build. Previously Windows builds registered backslash absolute paths; now all registrations use POSIX separators without changing file I/O behavior.

- Add `toPosixPath()` and apply at source in `prepareFarmWorkflowsForNitro` (`workflows.ts`), `prepareFarmCronForNitro` (`cron.ts`), and the catch-all Nitro entry registration (`nitro/universal-build.ts`).
- Forward-slash absolute paths are valid on Windows, so no migration or config changes are required.
- Tests: new `toPosixPath` unit tests; cron/workflow suites assert no backslashes in emitted handler paths.

<sup>Written for commit f863772a428d37196ebffe6de90931ea8c9a3704. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

