### PR TITLE
fix(core): tolerate EPERM when assembling Vercel output on Windows

### DIFF
--- a/packages/farm/src/__tests__/universal-build-vercel-output.test.ts
+++ b/packages/farm/src/__tests__/universal-build-vercel-output.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+
+import * as fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { moveVercelOutputPath } from "../nitro/universal-build";
+
+const temporaryRoots = new Set<string>();
+
+afterEach(async () => {
+  await Promise.all([...temporaryRoots].map((root) => rmTemp(root)));
+  temporaryRoots.clear();
+});
+
+async function rmTemp(root: string) {
+  await fs.rm(root, { recursive: true, force: true });
+}
+
+async function createFixture(): Promise<{ src: string; dest: string }> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-vercel-output-"));
+  temporaryRoots.add(root);
+  const src = path.join(root, "server", "chunks");
+  const dest = path.join(root, "functions", "__nitro.func", "chunks");
+  await fs.mkdir(src, { recursive: true });
+  await fs.mkdir(path.dirname(dest), { recursive: true });
+  await fs.writeFile(path.join(src, "entry.mjs"), "export default 1;\n");
+  return { src, dest };
+}
+
+describe("moveVercelOutputPath", () => {
+  it("moves directories with rename when permitted", async () => {
+    const { src, dest } = await createFixture();
+
+    await moveVercelOutputPath(src, dest, fs);
+
+    await expect(fs.readFile(path.join(dest, "entry.mjs"), "utf8")).resolves.toContain("default 1");
+    await expect(fs.stat(src)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("falls back to copy-and-remove when rename fails with EPERM", async () => {
+    // On Windows, rename fails with EPERM when another process holds a handle
+    // on the directory (antivirus, indexing, a running dev server) (#394).
+    const { src, dest } = await createFixture();
+    const fsWithLockedRename = {
+      ...fs,
+      rename: async () => {
+        throw Object.assign(new Error("EPERM: operation not permitted, rename"), {
+          code: "EPERM",
+        });
+      },
+    } as unknown as typeof fs;
+
+    await moveVercelOutputPath(src, dest, fsWithLockedRename);
+
+    await expect(fs.readFile(path.join(dest, "entry.mjs"), "utf8")).resolves.toContain("default 1");
+    await expect(fs.stat(src)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rethrows errors the fallback cannot help with", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-vercel-output-"));
+    temporaryRoots.add(root);
+
+    await expect(
+      moveVercelOutputPath(path.join(root, "missing"), path.join(root, "dest"), fs),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -7469,6 +7469,30 @@ async function registerPrebuiltSSRPackageImport(
 }
 
 /**
+ * Move a file or directory, falling back to copy-and-remove when rename is
+ * not permitted. On Windows, fs.rename fails with EPERM/EACCES when another
+ * process (antivirus, indexing, a running dev server) holds a handle on the
+ * directory, and with EXDEV across drives; a copy is slower but succeeds.
+ */
+export async function moveVercelOutputPath(
+  src: string,
+  dest: string,
+  fs: typeof import("fs/promises"),
+): Promise<void> {
+  try {
+    await fs.rename(src, dest);
+    return;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (code !== "EPERM" && code !== "EACCES" && code !== "EXDEV" && code !== "ENOTEMPTY") {
+      throw error;
+    }
+  }
+  await fs.cp(src, dest, { recursive: true, force: true });
+  await fs.rm(src, { recursive: true, force: true });
+}
+
+/**
  * Post-process Vercel output to match Build Output API v3
  * Moves server/ to functions/__nitro.func/ and updates routes
  */
@@ -7494,17 +7518,18 @@ async function postProcessVercelOutput(
   for (const file of serverContents) {
     const src = path.join(serverDir, file);
     const dest = path.join(nitroFuncDir, file);
-    await fs.rename(src, dest);
+    await moveVercelOutputPath(src, dest, fs);
   }
 
-  // Remove empty server directory
-  await fs.rmdir(serverDir);
+  // Remove the emptied server directory
+  await fs.rm(serverDir, { recursive: true, force: true });
 
   // Rename public to static (Vercel expects static files in static/)
   try {
-    await fs.rename(publicDir, staticDir);
-  } catch {
+    await moveVercelOutputPath(publicDir, staticDir, fs);
+  } catch (error) {
     // public might not exist
+    if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") throw error;
   }
 
   // Add runtime assets before cloning route-specific functions.


### PR DESCRIPTION
## Summary

Fixes #394.

On Windows, `farm build` with the Vercel preset could fail **after** a successful Nitro server build, during Build Output API post-processing:

```
Error: EPERM: operation not permitted, rename '...\.vercel\output\server\chunks' -> '...\.vercel\output\functions\__nitro.func\chunks'
```

leaving partial output under `.vercel/output`.

## Root cause

`postProcessVercelOutput()` used bare `fs.rename` to move `server/` contents into `functions/__nitro.func/` and `public/` to `static/`. On Windows, rename fails with `EPERM`/`EACCES` when another process holds a handle on the directory (antivirus, indexing, a still-running dev server), and with `EXDEV` across drives.

## Changes

- New `moveVercelOutputPath()`: tries `fs.rename`, and on `EPERM`/`EACCES`/`EXDEV`/`ENOTEMPTY` falls back to `fs.cp(recursive)` + `fs.rm` — slower but immune to handle locks. Used for both moves.
- The `public → static` step previously swallowed **every** error, so a Windows EPERM silently produced broken output (missing `static/`); it now tolerates only `ENOENT` (no public dir) and lets real failures surface after the fallback.
- The emptied `server/` directory is removed with recursive force `rm` instead of bare `rmdir`, so stray empty subdirectories can't fail the build.

## About the symlink error in the report

`EPERM: operation not permitted, symlink ... node_modules/.nitro/last-build` comes from Nitro's own `writeBuildInfo`, not farm code. The Nitro version farm pins (3.0.1-alpha.0) already wraps that symlink in `.catch(console.warn)` — it prints the error but does not abort, and the artifact doesn't need the link. No farm-side change required; enabling Windows Developer Mode silences the warning.

## Testing

- New `universal-build-vercel-output.test.ts`: happy-path rename, EPERM-injected fallback (mock `fs.rename` throwing EPERM, real copy/remove underneath — verifies content arrives and source is gone), and rethrow of non-recoverable errors (`ENOENT`).
- `universal-build-docs` suite passes; `tsc --noEmit`, `oxlint`, `oxfmt` clean.

Closes out the trio with #396 (#393) and #398 (#395).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tolerates Windows rename failures when assembling Vercel Build Output to prevent post-build errors and partially written `.vercel/output`. Previously we used bare renames that could fail with EPERM/EACCES/EXDEV and abort; now we fall back to copy-and-remove on those errors.

- Introduces `moveVercelOutputPath(src, dest, fs)`: try rename, then fall back on EPERM/EACCES/EXDEV/ENOTEMPTY. Used for `server/* → functions/__nitro.func/*` and `public → static`.
- `public → static` now only ignores `ENOENT`; other errors surface. Emptied `server/` is removed via recursive `rm`.
- Adds `universal-build-vercel-output.test.ts` covering rename success, EPERM fallback, and rethrow of non-recoverable errors.
- Impact: Windows builds succeed even with directory locks; the fallback path is slower when triggered. No migration required.

<sup>Written for commit 1e22fa7753a7a6165793d634b50326588425d534. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

