### PR TITLE
fix(types): ship CSS import declarations

### DIFF
--- a/docs/src/app/docs/project-structure/page.md
+++ b/docs/src/app/docs/project-structure/page.md
@@ -125,7 +125,9 @@ public endpoints can stay in `farm.config.ts`.
 
 ## Generated files
 
-Farm keeps project-specific route, environment, and internationalization declarations in one generated `src/farm.d.ts` file. Static image declarations come from `@farm.js/core`, so they do not add another file to your source tree. Generated API clients remain in `src/lib/api.generated.ts` because applications import that module directly.
+Farm keeps project-specific route, environment, and internationalization declarations in one generated `src/farm.d.ts` file. Static image and stylesheet declarations come from `@farm.js/core`, so global CSS side-effect imports and CSS Modules type-check without an application-owned declaration file. Generated API clients remain in `src/lib/api.generated.ts` because applications import that module directly.
+
+After upgrading an older project, run `farm generate` once to record the current framework type references. Existing generated files that import only `@farm.js/core/image` remain compatible with the stylesheet declarations.
 
 `farm dev` keeps generated types current as source files change; run the command manually when the dev server is not running.
 

--- a/docs/src/farm.d.ts
+++ b/docs/src/farm.d.ts
@@ -4,6 +4,7 @@
  */
 
 import "@farm.js/core/image";
+import "@farm.js/core/css";
 
 /**
  * Auto-generated route types from src/app.

--- a/packages/create-farm-app/templates/react-compiler/src/farm.d.ts
+++ b/packages/create-farm-app/templates/react-compiler/src/farm.d.ts
@@ -4,6 +4,7 @@
  */
 
 import "@farm.js/core/image";
+import "@farm.js/core/css";
 
 /**
  * Auto-generated route types from src/app.

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -132,6 +132,9 @@
       "agent-runtime": [
         "./dist/agent-runtime.d.ts"
       ],
+      "css": [
+        "./types/css.d.ts"
+      ],
       "image": [
         "./types/image.d.ts",
         "./dist/image.d.ts"
@@ -501,6 +504,9 @@
       "types": "./dist/agent-runtime.d.ts",
       "import": "./dist/agent-runtime.mjs",
       "require": "./dist/agent-runtime.cjs"
+    },
+    "./css": {
+      "types": "./types/css.d.ts"
     },
     "./image": {
       "types": "./types/image.d.ts",

--- a/packages/farm/src/__tests__/type-artifacts.test.ts
+++ b/packages/farm/src/__tests__/type-artifacts.test.ts
@@ -9,6 +9,7 @@ import {
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 import { generateFarmTypeArtifacts } from "../type-artifacts";
 
@@ -71,6 +72,7 @@ describe("generateFarmTypeArtifacts", () => {
     expect(types).toContain('export type RoutePath =\n  | "/"');
     expect(types).toContain('_: import("./farm").RoutePath');
     expect(types).toContain('import "@farm.js/core/image"');
+    expect(types).toContain('import "@farm.js/core/css"');
     expect(readFileSync(apiTypesPath, "utf8")).toContain("hello: {");
     expect(readFileSync(apiTypesPath, "utf8")).toContain("post: typeof POST_hello;");
     expect(types).toContain('import type FarmConfig from "../farm.config"');
@@ -80,6 +82,74 @@ describe("generateFarmTypeArtifacts", () => {
     expect(imageTypes).toContain('declare module "*.png"');
     expect(imageTypes).toContain('import("@farm.js/core/image").StaticImageData');
     expect(imageTypes).toContain('declare module "*?url"');
+    const imageEntryTypes = readFileSync(path.join(process.cwd(), "types", "image.d.ts"), "utf8");
+    expect(imageEntryTypes).toContain('reference path="./css.d.ts"');
+    const cssTypes = readFileSync(path.join(process.cwd(), "types", "css.d.ts"), "utf8");
+    expect(cssTypes).toContain('declare module "*.css"');
+    expect(cssTypes).toContain('declare module "*.module.css"');
+
+    const packageJson = JSON.parse(
+      readFileSync(path.join(process.cwd(), "package.json"), "utf8"),
+    ) as {
+      exports: Record<string, { types?: string }>;
+      typesVersions: Record<string, Record<string, string[]>>;
+    };
+    expect(packageJson.exports["./css"]?.types).toBe("./types/css.d.ts");
+    expect(packageJson.typesVersions["*"]?.css).toEqual(["./types/css.d.ts"]);
+  });
+
+  it("types global CSS side effects and CSS Modules", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "farm-css-types-"));
+    const srcDir = path.join(root, "src");
+    mkdirSync(srcDir, { recursive: true });
+
+    const farmTypesPath = path.join(srcDir, "farm.d.ts");
+    const legacyFarmTypesPath = path.join(srcDir, "legacy-farm.d.ts");
+    const typeTestPath = path.join(srcDir, "styles.test.ts");
+    writeFileSync(farmTypesPath, 'import "@farm.js/core/css";\n');
+    writeFileSync(legacyFarmTypesPath, 'import "@farm.js/core/image";\n');
+    writeFileSync(path.join(srcDir, "globals.css"), "body {}\n");
+    writeFileSync(path.join(srcDir, "card.module.css"), ".card {}\n");
+    writeFileSync(
+      typeTestPath,
+      [
+        'import "./globals.css";',
+        'import styles from "./card.module.css";',
+        "const className: string = styles.card;",
+        "void className;",
+        "",
+      ].join("\n"),
+    );
+
+    const compilerOptions: ts.CompilerOptions = {
+      strict: true,
+      noEmit: true,
+      noUncheckedSideEffectImports: true,
+      skipLibCheck: true,
+      target: ts.ScriptTarget.ES2020,
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      baseUrl: process.cwd(),
+      paths: {
+        "@farm.js/core/css": ["./types/css.d.ts"],
+        "@farm.js/core/image": ["./types/image.d.ts"],
+      },
+    };
+
+    for (const frameworkTypesPath of [farmTypesPath, legacyFarmTypesPath]) {
+      const program = ts.createProgram({
+        rootNames: [frameworkTypesPath, typeTestPath],
+        options: compilerOptions,
+      });
+      const diagnostics = ts.getPreEmitDiagnostics(program);
+      const formattedDiagnostics = ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+        getCanonicalFileName: (fileName) => fileName,
+        getCurrentDirectory: () => process.cwd(),
+        getNewLine: () => "\n",
+      });
+
+      expect(formattedDiagnostics).toBe("");
+    }
   });
 
   it("generates one typed application from layer and project sources", async () => {

--- a/packages/farm/src/type-artifacts.ts
+++ b/packages/farm/src/type-artifacts.ts
@@ -207,6 +207,7 @@ export async function generateFarmTypeArtifacts(
  */
 
 import "@farm.js/core/image";
+import "@farm.js/core/css";
 
 ${unifiedSections.map(normalizeUnifiedTypeSection).join("\n\n")}
 `,
@@ -225,7 +226,7 @@ ${unifiedSections.map(normalizeUnifiedTypeSection).join("\n\n")}
 }
 
 function normalizeUnifiedTypeSection(section: string): string {
-  // The unified artifact already imports @farm.js/core/image, so it is a module.
+  // The unified artifact already imports Farm's asset types, so it is a module.
   // Individual generators add this marker for standalone declaration files, but
   // formatters remove the now-redundant export and make `farm generate --check`
   // report a false stale-file failure.

--- a/packages/farm/types/css.d.ts
+++ b/packages/farm/types/css.d.ts
@@ -1,0 +1,7 @@
+/** Stylesheet imports available to every Farm application. */
+declare module "*.module.css" {
+  const classes: Readonly<Record<string, string>>;
+  export default classes;
+}
+
+declare module "*.css" {}

--- a/packages/farm/types/image.d.ts
+++ b/packages/farm/types/image.d.ts
@@ -1,3 +1,4 @@
+/// <reference path="./css.d.ts" />
 /// <reference path="./images.d.ts" />
 
 export * from "../dist/image";


### PR DESCRIPTION
## Summary

- ship global CSS and CSS Module declarations through `@farm.js/core/css`
- include stylesheet types in generated `farm.d.ts` while preserving compatibility with older image-only references
- document the upgrade behavior and add compiler-level regression coverage

Closes #400

## Testing

- `corepack pnpm --filter @farm.js/core exec vitest run --reporter=dot` (1,093 passed, 1 skipped)
- `corepack pnpm --filter @farm.js/core type-check`
- focused type-artifact tests (6 passed)
- packed-package TypeScript consumer checks for the new and legacy type references
- scoped `oxfmt`, `oxlint`, and `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ship CSS import declarations via `@farm.js/core/css` and include them in generated `farm.d.ts`, so global CSS side-effect imports and CSS Modules type-check out of the box. Previously we shipped only image declarations; now TypeScript recognizes CSS imports without app-owned declarations, with no runtime changes.

- Rollout
  - After upgrading, run `farm generate` once to refresh `src/farm.d.ts`.
  - No code changes required: projects that only import `@farm.js/core/image` remain compatible because `image.d.ts` references `css.d.ts`.

- Review notes
  - Add a `./css` typed export and `typesVersions` mapping in `packages/farm/package.json`; this is types-only.
  - The generator now writes `import "@farm.js/core/css"` alongside the image import.
  - New `types/css.d.ts`; `types/image.d.ts` references it. Tests cover CSS side-effect imports and CSS Modules; docs note the upgrade behavior.

<sup>Written for commit efe954f05a701985e5daf7550347d083c41ef05b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

