### PR TITLE
feat(react): compile host-only conditional branches

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -335,7 +335,7 @@ satisfy all of these rules:
 | Text bindings       | State-driven text in a leaf host element.                                                                                                   |
 | Attribute bindings  | Basic attributes, controlled form properties, and individual properties in one inline `style` object.                                       |
 | Events              | Inline handlers and synchronous `const` or function-declaration handlers, used directly or called inside an inline JSX handler.             |
-| Conditional blocks  | `condition && <host />` or `condition ? <host /> : <host />`; host branches may contain supported nested blocks.                            |
+| Conditional blocks  | Logical/ternary host branches; dedicated host-only containers may use compiler-owned branch instances and bindings.                         |
 | Keyed lists         | Direct item-keyed maps and imported `List`; dedicated host-only containers may use compiler-owned rows and LIS.                             |
 | Component islands   | Stable imported or module-level component identifiers with explicit compiler-safe props and no JSX children, spread, `ref`, or `key`.       |
 
@@ -403,6 +403,8 @@ on React because their final property set or precedence can change.
 
 ### Conditional DOM blocks
 
+This optimization is automatic for components selected by the existing experimental compiler
+configuration. It does not require a conditional component, a new annotation, or another option.
 The compiler can isolate two common child structures when their position is known at build time:
 
 ```tsx
@@ -413,45 +415,45 @@ export function StatusPanel() {
   return (
     <section>
       <button onClick={() => setLoading(!loading)}>Toggle loading</button>
-      {loading && <p>Loading…</p>}
+      <div>{loading && <p>Loading…</p>}</div>
 
       <button onClick={() => setEnabled(!enabled)}>Toggle status</button>
-      {enabled ? <strong>Enabled</strong> : <span>Disabled</span>}
+      <div>{enabled ? <strong>Enabled</strong> : <span>Disabled</span>}</div>
     </section>
   );
 }
 ```
 
-At build time, Farm records the state cells used by each condition and replaces that child
-expression with a small internal block boundary. When one of those cells changes, the outer user
-component does not execute again. Only the matching boundary asks React to mount, replace, remove,
-or update its selected host branch. Other compiler bindings continue to patch their prepared DOM
-targets directly.
+At build time, Farm records the condition's state cells and prepares a descriptor plus exact
+text/attribute/style bindings for each host branch. React still creates the initial branch during
+client rendering, SSR, or hydration. After mount, Farm adopts that existing element. A later update
+to the same branch patches only its changed bindings and preserves its DOM identity; a condition
+change creates, removes, or replaces only that branch. The outer user component does not execute
+again, and the compiler does not add a marker node to server HTML.
 
-This is intentionally block-local React reconciliation, not manual DOM insertion. Keeping React at
-the boundary preserves delegated events, host property behavior, unmounting, error boundaries,
-Strict Mode, SSR, and hydration. The inactive branch is described by generated code but is not
-pre-mounted or cached in the DOM.
+The compiler-owned path is deliberately narrow:
 
-The initial safety limits are:
+- The conditional is the only meaningful child of a nested lowercase host container. A conditional
+  beside static siblings, or directly inside the component's outermost return element, keeps the
+  React-owned path.
+- The dedicated container itself has static attributes and no event handler. Dynamic properties and
+  events belong outside that ownership boundary or use the React-owned path.
+- Every non-empty branch has one lowercase HTML root and a statically known host-only descendant
+  tree. Text, attributes, and individual inline style properties may use supported expressions.
+- Branch events, `key`, custom components, fragments, refs, SVG, `dangerouslySetInnerHTML`, JSX
+  spreads, nested dynamic blocks, and dynamic text mixed beside nested elements require React
+  ownership.
+- A ternary may use `null` or `false` for an empty branch. For logical `&&`, a numeric falsy value
+  such as `0` can be visible React output, so the runtime remounts that container through React
+  instead of incorrectly treating it as empty.
+- The test and every prepared binding must use the same deterministic expression subset as other
+  compiler bindings.
 
-- Every non-empty branch has exactly one lowercase host root such as `p`, `strong`, `span`, or
-  `div`.
-- Descendants keep a statically known host tree. Stateful text, attributes, inline style
-  properties, and event handlers inside that tree are allowed and update when the block refreshes.
-- A branch may contain nested host-root conditionals, keyed-list boundaries, and supported
-  component islands. Each nested boundary receives the outer conditional as its runtime parent.
-- A ternary may use `null` or `false` for an empty branch.
-- The conditional must be a JSX child at one statically known location, and its test must use the
-  same deterministic expression subset as other compiler bindings.
-- A non-empty branch still needs one lowercase host root. A custom component cannot be the branch
-  root, but a supported component island may appear inside that host tree.
-- Hooks directly in branch expressions, fragments, refs, `dangerouslySetInnerHTML`, and attribute
-  spreads fall back to the original React component.
-
-The optimization boundary matters: the surrounding compiled component and its unrelated siblings
-do not rerender, but React still renders and commits the small conditional boundary. A branch with
-substantial work therefore still pays for that branch work.
+The existing React-owned conditional boundary remains the fallback for supported complex shapes.
+It can contain event handlers, nested host conditionals, keyed lists, and component islands while
+still skipping the surrounding compiled component. Unsupported roots or unprovable behavior keep
+the complete original React component. In all three cases, React remains responsible for delegated
+events, error boundaries, Strict Mode, SSR, and hydration semantics.
 
 ### Compiled keyed rows and React list boundaries
 
@@ -605,10 +607,10 @@ The refs produce no `data-*` marker or other extra server markup.
 
 ### Composable block graph
 
-Conditional, keyed-list, keyed-row, and component-island boundaries are analyzed together. The compiler
-assigns every boundary a component-wide ID, so IDs remain unique even when several block types
-share a container or are nested inside one conditional branch. Nested bindings also record the ID
-of their nearest outer conditional.
+Conditional, compiler-owned host-conditional, keyed-list, keyed-row, and component-island
+boundaries are analyzed together. The compiler assigns every boundary a component-wide ID, so IDs
+remain unique even when several block types share a container or are nested inside one conditional
+branch. Nested bindings also record the ID of their nearest outer conditional.
 
 When one update affects an outer conditional and one or more descendants, the runtime refreshes
 the mounted outer boundary once and suppresses redundant descendant refreshes for that flush.
@@ -624,23 +626,23 @@ put Hooks inside a keyed row component.
 
 ### What falls back to React
 
-| Unsupported shape                                                          | Why React keeps ownership                                                          |
-| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| Unkeyed/index-keyed/chained maps or element arrays                         | Their structure or item identity is outside the keyed-list contract.               |
-| Row events, components, fragments, refs, SVG, or mixed container children  | They require React ownership rather than compiler-created host rows.               |
-| Fragments or a custom component used as a conditional branch root          | Their structure is outside the current host-root conditional contract.             |
-| Dynamic/member component types, component spreads, refs, keys, or children | Their identity or ownership is outside the first component-island contract.        |
-| Effects or hooks other than the supported `useState` shape                 | Their lifecycle and ordering must remain under React's hook dispatcher.            |
-| `ref` or `dangerouslySetInnerHTML`                                         | They directly participate in DOM ownership.                                        |
-| Stateful `children` or `key` bindings outside an eligible boundary         | These need structure or identity semantics.                                        |
-| Conditional style objects, style spreads, methods, or computed names       | The final property set or precedence cannot be prepared statically.                |
-| JSX attribute spreads or namespaced attributes                             | The compiler cannot currently enumerate a stable binding contract.                 |
-| Multiple/conditional returns or impure/control-flow statements             | The compiler only lowers a single, statically analyzable render path.              |
-| Derived calls, assignments, identity-bearing values, functions, or JSX     | Their evaluation timing, side effects, or identity cannot yet be preserved safely. |
-| Nested, computed, or rest props destructuring                              | These patterns need additional parameter-shape and identity analysis.              |
-| Async/generator/generic handlers or named handlers outside JSX events      | Their scheduling, identity, or closure semantics are outside the current lowering. |
-| Async/generator or generic components                                      | These function shapes are outside the current lowering.                            |
-| Setters called outside JSX event handlers                                  | The compiler only controls and batches event-driven local updates.                 |
+| Unsupported shape                                                                                            | Why React keeps ownership                                                          |
+| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| Unkeyed/index-keyed/chained maps or element arrays                                                           | Their structure or item identity is outside the keyed-list contract.               |
+| Row events, components, fragments, refs, SVG, or mixed container children                                    | They require React ownership rather than compiler-created host rows.               |
+| Branch events, keys, components, fragments, refs, SVG, or nested blocks in a dedicated conditional container | They require the React-owned conditional path rather than compiler-created hosts.  |
+| Dynamic/member component types, component spreads, refs, keys, or children                                   | Their identity or ownership is outside the first component-island contract.        |
+| Effects or hooks other than the supported `useState` shape                                                   | Their lifecycle and ordering must remain under React's hook dispatcher.            |
+| `ref` or `dangerouslySetInnerHTML`                                                                           | They directly participate in DOM ownership.                                        |
+| Stateful `children` or `key` bindings outside an eligible boundary                                           | These need structure or identity semantics.                                        |
+| Conditional style objects, style spreads, methods, or computed names                                         | The final property set or precedence cannot be prepared statically.                |
+| JSX attribute spreads or namespaced attributes                                                               | The compiler cannot currently enumerate a stable binding contract.                 |
+| Multiple/conditional returns or impure/control-flow statements                                               | The compiler only lowers a single, statically analyzable render path.              |
+| Derived calls, assignments, identity-bearing values, functions, or JSX                                       | Their evaluation timing, side effects, or identity cannot yet be preserved safely. |
+| Nested, computed, or rest props destructuring                                                                | These patterns need additional parameter-shape and identity analysis.              |
+| Async/generator/generic handlers or named handlers outside JSX events                                        | Their scheduling, identity, or closure semantics are outside the current lowering. |
+| Async/generator or generic components                                                                        | These function shapes are outside the current lowering.                            |
+| Setters called outside JSX event handlers                                                                    | The compiler only controls and batches event-driven local updates.                 |
 
 Keys do not make list work disappear. A key identifies the row that survives an insert, removal,
 or move. On the compiler-owned host path, Farm compares those keys, reuses the matching row
@@ -683,16 +685,16 @@ do not receive the runtime import.
 The generated runtime wrapper is still a React component. Its responsibilities are split as
 follows:
 
-| React owns                                             | Compiler runtime owns                                                     |
-| ------------------------------------------------------ | ------------------------------------------------------------------------- |
-| Initial element creation, SSR markup, and hydration    | Local compiler-cell values                                                |
-| JSX event registration and dispatch                    | Queuing local setter calls into one microtask                             |
-| Parent-driven prop updates                             | Comparing flushed values and selecting dependent bindings                 |
-| Unsupported trees, hooks, refs, events, and lifecycles | Patching stable ref-owned text, attribute, and style targets              |
-| Host creation/removal inside an eligible conditional   | Refreshing only the matching internal conditional boundary                |
-| React-owned custom or structurally complex keyed rows  | Host-only keyed-row identity, bindings, insertion, removal, and LIS moves |
-| Component render, Hooks, context, and lifecycle        | Refreshing only a dependent React component-island boundary               |
-| Unmounting and the surrounding component tree          | Reapplying bindings after a parent-driven React update                    |
+| React owns                                              | Compiler runtime owns                                                        |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Initial element creation, SSR markup, and hydration     | Local compiler-cell values                                                   |
+| JSX event registration and dispatch                     | Queuing local setter calls into one microtask                                |
+| Parent-driven prop updates                              | Comparing flushed values and selecting dependent bindings                    |
+| Unsupported trees, hooks, refs, events, and lifecycles  | Patching stable ref-owned text, attribute, and style targets                 |
+| Complex conditional branches, events, and nested blocks | Host-only conditional identity, bindings, creation, removal, and replacement |
+| React-owned custom or structurally complex keyed rows   | Host-only keyed-row identity, bindings, insertion, removal, and LIS moves    |
+| Component render, Hooks, context, and lifecycle         | Refreshing only a dependent React component-island boundary                  |
+| Unmounting and the surrounding component tree           | Reapplying bindings after a parent-driven React update                       |
 
 Queued functional setters preserve the event's state snapshot. Two calls such as
 `setCount(value => value + 1)` are applied in order during the same microtask flush, while reads
@@ -715,9 +717,9 @@ microtask. Composition events remain React-owned, so IME input keeps its normal 
 the resulting value, selection, and dependent bindings are patched together.
 
 The server output is ordinary React HTML and contains no compiler marker. React hydrates that
-markup normally; direct binding updates begin after the component mounts. An eligible keyed-row
-container adopts the already-hydrated child elements by their current order and generated keys, so
-it does not replace valid server rows during hydration.
+markup normally; direct binding updates begin after the component mounts. Eligible conditional and
+keyed-row containers adopt their already-hydrated child elements, so valid server DOM is not
+replaced during hydration.
 
 During development, compiled components receive a module-and-component identity plus a state-layout
 signature. A compatible Fast Refresh replaces the compiled definition while retaining the React
@@ -732,9 +734,10 @@ normal recovery path.
 
 The compiler uses fallback as a semantic boundary, not as an error-recovery trick. Generated
 callback refs keep direct DOM targets stable even when a React component island returns `null`, a
-fragment, or multiple nodes. Conditional, React-owned keyed-list, and component boundaries give
-complex dynamic structure back to React. Compiler-owned rows are limited to complete host-only
-containers because manually inserted DOM has no React Fiber for row events, components, or Hooks.
+fragment, or multiple nodes. React-owned conditional, keyed-list, and component boundaries give
+complex dynamic structure back to React. Compiler-owned branches and rows are limited to complete
+host-only containers because manually inserted DOM has no React Fiber for their events, components,
+or Hooks.
 Unsupported dynamic component types, refs, effects, and other unproven shapes keep React ownership;
 fallback is the optimization's correctness mechanism.
 
@@ -758,6 +761,11 @@ The package and example test suites verify more than generated code:
 - simultaneous parent-prop and compiled-local updates remain coherent;
 - compatible Fast Refresh preserves state, while binding errors reach React error boundaries;
 - hydration mismatches follow React's recoverable-error path and remain interactive;
+- compiler-owned conditionals preserve a same-branch DOM instance, patch nested text, attributes,
+  styles, and focused input selection, replace only a changed branch, and fall back for numeric
+  logical output or any unproven structure;
+- 3,000 deterministic compiler-owned conditional transitions produce the same host output as
+  normal React while the compiled owner stays at one execution;
 - object, array, and nullish state transitions match normal React across 3,000 deterministic
   randomized updates;
 - automatic keyed maps and explicit `List` boundaries preserve keyed DOM nodes and stateful row

--- a/examples/react-compiler/README.md
+++ b/examples/react-compiler/README.md
@@ -4,9 +4,9 @@ This production-browser experiment answers two questions:
 
 1. Why build this compiler? Eligible local `useState` updates can patch precomputed DOM targets
    without rerunning the component body or asking React to reconcile the same static tree again.
-2. Where must it stop? Eligible conditionals, complex keyed lists, and component islands use small
-   React-owned boundaries. Dedicated host-only keyed lists can use compiler-owned rows and LIS.
-   Effects, refs, unsupported list shapes, and other unproven structures stay on React.
+2. Where must it stop? Dedicated host-only conditionals and keyed lists can use compiler-owned
+   branches or rows. Complex conditionals, custom rows, and component islands use small React-owned
+   boundaries. Effects, refs, unsupported shapes, and other unproven structures stay on React.
 
 The default `compiler: true` configuration automatically considers components. No annotation is
 needed. A component can explicitly opt out with `"use no compiler"`.
@@ -38,8 +38,8 @@ assertions, checks for console/runtime errors and horizontal overflow, saves scr
 | Explicit `List`             | stateful rows reorder, update executions `0`            | —                                              | React preserves custom-row state by key inside the isolated boundary.  |
 | Calculated style bindings   | value `6`, progress `50%`, update executions `0`        | —                                              | Safe calls and individual CSS properties use prepared dependencies.    |
 | Controlled form bindings   | textarea/select/checkbox update, executions `0`         | —                                              | Form properties and textarea selection stay coherent.                  |
-| Logical conditional block  | branch mounts, updates, and unmounts; executions `0`    | —                                              | Only the isolated React block refreshes.                               |
-| Ternary conditional block  | `strong` and `span` replace each other; executions `0`  | —                                              | React preserves branch and event semantics without the outer rerender. |
+| Logical conditional block  | stable branch patches, mounts, and unmounts; executions `0` | —                                           | A proven host branch updates without React reconciliation.             |
+| Ternary conditional block  | `strong` and `span` replace each other; executions `0`     | —                                           | Only the compiler-owned branch is replaced.                            |
 | Composable nested blocks   | two lists, nested conditions, and one component island  | —                                              | One block graph mounts, updates, and cleans up nested subscriptions.    |
 
 The package runtime test also measures one equivalent update under a React `Profiler`:
@@ -94,14 +94,16 @@ rejected rather than transformed.
 ## Conditional block boundary
 
 The `07A` and `07B` cards exercise `condition && <host />` and
-`condition ? <host /> : <host />` in the production browser build. The compiler records each
-condition's state dependencies and lowers the child to a private React boundary. A matching state
-update refreshes that boundary while the user component's execution counter stays unchanged.
+`condition ? <host /> : <host />` as the only child of a dedicated host container. The compiler
+records each condition and prepares descriptors plus text/attribute/style bindings for both host
+branches. React creates or hydrates the initial branch. After mount, a same-branch update patches
+that existing element, while a condition change mounts, removes, or replaces only the branch. The
+production assertion checks that updating `07A` keeps the exact same branch DOM node.
 
-This does not pre-mount both branches or bypass React's event system. React still creates, replaces,
-and removes the selected host branch. A host branch may contain nested host conditionals, keyed-list
-boundaries, and supported component islands. Hooks directly in a branch, fragments, refs, spreads,
-and dangerous HTML intentionally fall back.
+This does not pre-mount both branches or bypass React's event system. Branch events, custom
+components, fragments, refs, SVG, keys, spreads, nested dynamic blocks, and dangerous HTML keep a
+React-owned conditional boundary or fall back to the original component. A numeric logical value
+such as `0 && <p />` also remounts through React so visible primitive output is preserved exactly.
 
 The `08` card combines those boundary types under one outer conditional. It also proves that a
 hidden outer block removes its inner subscriptions: updates made while hidden do no render work,

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -326,12 +326,28 @@ try {
     `${logical} [data-branch="loading"]`,
     "Loading branch · update 0",
   );
+  await page.evaluate(() => {
+    window.__farmLogicalBranch = document.querySelector(
+      '[data-experiment="conditional-logical"] [data-branch="loading"]',
+    );
+  });
   await page.locator(`${logical} [data-action="increment-logical"]`).click();
   await assertText(page, `${logical} [data-metric="updates"]`, "1");
   await assertText(
     page,
     `${logical} [data-branch="loading"]`,
     "Loading branch · update 1",
+  );
+  assert.equal(
+    await page.evaluate(
+      () =>
+        window.__farmLogicalBranch ===
+        document.querySelector(
+          '[data-experiment="conditional-logical"] [data-branch="loading"]',
+        ),
+    ),
+    true,
+    "compiler-owned conditional replaced a stable branch while patching its text",
   );
   await page.locator(`${logical} [data-action="toggle-logical"]`).click();
   await assertText(page, `${logical} [data-metric="mounted"]`, "no");

--- a/examples/react-compiler/src/components/conditional-block-experiment.tsx
+++ b/examples/react-compiler/src/components/conditional-block-experiment.tsx
@@ -15,7 +15,7 @@ export function LogicalBlockPanel() {
         <span className="experiment-number">07A</span>
         <div>
           <h3>Mount or remove one block</h3>
-          <p>The build isolates an eligible logical branch at one known location.</p>
+          <p>The build prepares this host branch and its exact DOM bindings.</p>
         </div>
       </header>
       <div className="conditional-stage" aria-live="polite">
@@ -42,7 +42,11 @@ export function LogicalBlockPanel() {
         </div>
       </dl>
       <div className="button-row">
-        <button data-action="toggle-logical" type="button" onClick={() => setLoading(!loading)}>
+        <button
+          data-action="toggle-logical"
+          type="button"
+          onClick={() => setLoading((value) => !value)}
+        >
           {loading ? "Remove branch" : "Mount branch"}
         </button>
         <button
@@ -66,7 +70,7 @@ export function TernaryBlockPanel() {
         <span className="experiment-number">07B</span>
         <div>
           <h3>Replace one branch</h3>
-          <p>React swaps the prepared host branch without rerunning this component body.</p>
+          <p>The compiler swaps the prepared host branch without rerunning this component body.</p>
         </div>
       </header>
       <div className="conditional-stage" aria-live="polite">
@@ -87,7 +91,7 @@ export function TernaryBlockPanel() {
         </div>
         <div>
           <dt>Owner</dt>
-          <dd>React</dd>
+          <dd>Compiler</dd>
         </div>
         <div>
           <dt>Executions</dt>
@@ -96,7 +100,11 @@ export function TernaryBlockPanel() {
           </dd>
         </div>
       </dl>
-      <button data-action="toggle-ternary" type="button" onClick={() => setEnabled(!enabled)}>
+      <button
+        data-action="toggle-ternary"
+        type="button"
+        onClick={() => setEnabled((value) => !value)}
+      >
         Replace branch
       </button>
     </article>
@@ -112,8 +120,8 @@ export function ConditionalBlockExperiment() {
         <span>CONDITIONAL BLOCKS / PRODUCTION PROOF</span>
         <h2 id="conditional-blocks-title">Change the branch, not the whole component.</h2>
         <p>
-          Logical and ternary host branches get a small React-owned boundary. A local condition
-          refreshes that boundary while the surrounding compiled component stays still.
+          A dedicated host container starts with React for SSR and hydration. After mount, the
+          compiler patches, mounts, removes, or replaces its proven host-only branch directly.
         </p>
       </div>
       <div className="edge-grid edge-grid--paired">

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -71,11 +71,26 @@ The current compiler handles components that it can prove have:
 
 The generated component preserves React ownership of initial placement, props, events, SSR, and
 hydration. Local state cells batch updates into a microtask and patch only compiler-known DOM
-targets. For an eligible conditional, the runtime refreshes one small internal React boundary
-instead of executing the user component again. React mounts, replaces, or removes the selected
-branch, so events, unmounting, SSR, hydration, and error boundaries keep React semantics. The one
-intentional post-mount ownership exception is a proven host-only keyed-row container, described
-below.
+targets. Two proven, dedicated host containers can transfer child ownership after mount:
+host-only conditional branches and host-only keyed rows. React still creates or hydrates their
+initial DOM. Anything outside those narrow contracts uses a small React-owned boundary or the
+complete original component.
+
+For a common dedicated conditional, no new component or annotation is required:
+
+```tsx
+<div className="status-slot">
+  {enabled ? <strong>Enabled {count}</strong> : <span>Disabled {count}</span>}
+</div>
+```
+
+When the conditional is the container's only meaningful child, the container has only static
+properties, and each branch is a statically known host tree without events, refs, custom components,
+or other dynamic structures, the compiler emits
+both host descriptors and their exact text/attribute/style bindings. After the initial React render
+or hydration, a same-branch update patches those bindings without replacing the element. A condition
+change creates, removes, or replaces only the selected branch. No marker node is added to SSR output.
+More complex conditional shapes keep the existing React-owned conditional boundary.
 
 For a common keyed map, no new API is required:
 
@@ -138,12 +153,14 @@ Generated callback refs give directly patched host elements stable private targe
 React-owned component may therefore return `null`, a fragment, or multiple host nodes without
 shifting an unrelated compiler binding. These refs do not add attributes to SSR output.
 
-Conditional blocks deliberately keep a host-rooted contract. Each non-empty branch must have one
-lowercase host root, and an empty ternary branch may be `null` or `false`. That host tree may contain
-nested host conditionals, keyed lists, and supported component islands. A custom component used as
-the branch root, hooks directly in branch expressions, fragments, refs, attribute spreads, and
-`dangerouslySetInnerHTML` fall back to the normal React component. Both branch expressions are
-isolated at build time, but the inactive branch is not pre-mounted or cached.
+Conditional blocks have two safe ownership levels. A dedicated container with exactly one proven
+host-only conditional child can use compiler-owned branch instances. Events, keys, custom
+components, fragments, refs, SVG, attribute spreads, `dangerouslySetInnerHTML`, nested dynamic
+blocks, and static siblings in that container keep React ownership. The more general React-owned
+conditional path still accepts supported nested conditionals, keyed lists, and component islands.
+An empty ternary branch may be `null` or `false`. The inactive branch is described at build time but
+is never pre-mounted or cached. If a logical `&&` evaluates to a number such as `0`, the runtime also
+falls back to React so JavaScript and React rendering semantics remain exact.
 
 All supported boundary types share one component-wide block graph and one ID sequence. A nested
 binding records its nearest conditional parent. If one state flush affects both an outer

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -237,6 +237,82 @@ const testSource = String.raw`
   assert.equal(conditionalExecutions, initialConditionalExecutions);
   flushSync(() => conditionalRoot.unmount());
 
+  let hostConditionalExecutions = 0;
+  const HostConditionalBlocks = createCompiledComponent({
+    displayName: "CompatibilityHostConditionalBlocks",
+    initialize: () => [true, 0],
+    render(_props, state, blocks) {
+      hostConditionalExecutions += 1;
+      return React.createElement(
+        "section",
+        null,
+        React.createElement(
+          "button",
+          { "data-increment": true, onClick: () => state[1].set((value) => Number(value) + 1) },
+          "Increment branch",
+        ),
+        React.createElement(
+          "button",
+          { "data-toggle": true, onClick: () => state[0].set((value) => !value) },
+          "Toggle branch",
+        ),
+        React.createElement(blocks.HostConditional, {
+          id: 0,
+          render: () =>
+            React.createElement(
+              "div",
+              { "data-slot": true },
+              state[0].get()
+                ? React.createElement("strong", { "data-branch": "enabled" }, "Enabled ", state[1].get())
+                : React.createElement("span", { "data-branch": "disabled" }, "Disabled ", state[1].get()),
+            ),
+          test: () => state[0].get(),
+          truthy: {
+            create: () => ({
+              kind: "element",
+              tag: "strong",
+              attributes: [{ name: "data-branch", value: "enabled" }],
+              styles: [],
+              children: [["Enabled ", state[1].get()]],
+            }),
+            bindings: [{ kind: "text", path: [], read: () => ["Enabled ", state[1].get()] }],
+          },
+          falsy: {
+            create: () => ({
+              kind: "element",
+              tag: "span",
+              attributes: [{ name: "data-branch", value: "disabled" }],
+              styles: [],
+              children: [["Disabled ", state[1].get()]],
+            }),
+            bindings: [{ kind: "text", path: [], read: () => ["Disabled ", state[1].get()] }],
+          },
+        }),
+      );
+    },
+    bindings: [{ kind: "block", id: 0, dependencies: [0, 1] }],
+  });
+  const hostConditionalContainer = document.createElement("div");
+  document.body.append(hostConditionalContainer);
+  const hostConditionalRoot = createRoot(hostConditionalContainer);
+  flushSync(() => hostConditionalRoot.render(React.createElement(HostConditionalBlocks)));
+  const initialHostConditionalExecutions = hostConditionalExecutions;
+  const initialHostBranch = hostConditionalContainer.querySelector("[data-branch='enabled']");
+  hostConditionalContainer.querySelector("[data-increment]").click();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(hostConditionalContainer.querySelector("[data-branch='enabled']"), initialHostBranch);
+  assert.equal(initialHostBranch.textContent, "Enabled 1");
+  hostConditionalContainer.querySelector("[data-toggle]").click();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(
+    hostConditionalContainer.querySelector("[data-branch='disabled']").textContent,
+    "Disabled 1",
+  );
+  assert.equal(hostConditionalExecutions, initialHostConditionalExecutions);
+  flushSync(() => hostConditionalRoot.unmount());
+
   const explicitListContainer = document.createElement("div");
   document.body.append(explicitListContainer);
   const explicitListRoot = createRoot(explicitListContainer);

--- a/packages/farm-react/src/__tests__/compiler-component-islands.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-component-islands.test.ts
@@ -115,7 +115,7 @@ describe("React AOT component island compiler", () => {
     `);
 
     expect(result.compiled).toEqual(["Dashboard"]);
-    expect(result.code).toContain("farmBlocks.Conditional");
+    expect(result.code).toContain("farmBlocks.HostConditional");
     expect(result.code).toContain("farmBlocks.KeyedRows");
     expect(result.code).toContain("farmBlocks.Component");
     expect(result.code).toContain("id={0}");

--- a/packages/farm-react/src/__tests__/compiler-conditional-blocks.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-conditional-blocks.test.ts
@@ -97,6 +97,78 @@ describe("React AOT conditional block compiler", () => {
     expect(result.code.match(/farmBlocks\.Conditional/g)).toHaveLength(2);
   });
 
+  it("transfers a dedicated host-only container to the compiler runtime", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function PreparedStatus() {
+        const [enabled, setEnabled] = useState(true);
+        const [count, setCount] = useState(1);
+        return (
+          <main>
+            <button onClick={() => { setEnabled(!enabled); setCount(count + 1); }}>Change</button>
+            <div className="status-slot">
+              {enabled ? (
+                <strong className={count > 1 ? "ready" : "idle"} style={{ opacity: count / 10 }}>
+                  <span>Enabled {count}</span>
+                </strong>
+              ) : (
+                <span data-count={count}>Disabled {count}</span>
+              )}
+            </div>
+            <output>{count}</output>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.compiled).toEqual(["PreparedStatus"]);
+    expect(result.code.match(/farmBlocks\.HostConditional/g)).toHaveLength(1);
+    expect(result.code).not.toContain("farmBlocks.Conditional");
+    expect(result.code).toContain("truthy={{");
+    expect(result.code).toContain("falsy={{");
+    expect(result.code).toContain('tag: "strong"');
+    expect(result.code).toContain('tag: "span"');
+    expect(result.code).toContain('kind: "style"');
+    expect(result.code).toContain('kind: "attribute"');
+    expect(result.code).toContain('kind: "text"');
+    expect(result.code).toContain("dependencies: [0, 1]");
+    expect(result.code).toMatch(/<output ref=\{[^}]+\.target\(0\)\}>/);
+    await expect(
+      transformWithEsbuild(result.code, "/app/Conditional.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("farmBlocks.HostConditional"),
+    });
+  });
+
+  it("prepares logical empty branches but keeps unsafe branch structures with React", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function SafeFallbacks() {
+        const [visible, setVisible] = useState(false);
+        return (
+          <main>
+            <button onClick={() => setVisible(!visible)}>Toggle</button>
+            <div>{visible && <p data-visible={visible}>Visible</p>}</div>
+            <div>{visible ? <button onClick={() => setVisible(false)}>Close</button> : null}</div>
+            <div><small>Static sibling</small>{visible && <b>Visible</b>}</div>
+            <div data-visible={visible}>{visible && <i>Dynamic container</i>}</div>
+            <div onClick={() => setVisible(false)}>{visible && <em>Event container</em>}</div>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.compiled).toEqual(["SafeFallbacks"]);
+    expect(result.code.match(/farmBlocks\.HostConditional/g)).toHaveLength(1);
+    expect(result.code.match(/farmBlocks\.Conditional/g)).toHaveLength(4);
+    expect(result.code).toContain("logical");
+  });
+
   it.each([
     {
       name: "a custom component branch",

--- a/packages/farm-react/src/__tests__/compiler-keyed-lists.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-lists.test.ts
@@ -247,7 +247,7 @@ describe("React AOT keyed list compiler", () => {
 
     expect(result.compiled).toEqual(["MixedBoundaries"]);
     expect(result.diagnostics).toEqual([]);
-    expect(result.code).toContain("farmBlocks.Conditional");
+    expect(result.code).toContain("farmBlocks.HostConditional");
     expect(result.code).toContain("farmBlocks.KeyedRows");
     expect(result.code).toContain("id={0}");
     expect(result.code).toContain("id={1}");

--- a/packages/farm-react/src/__tests__/compiler-runtime-host-conditionals.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-host-conditionals.test.tsx
@@ -1,0 +1,985 @@
+import React, { StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createCompiledComponent,
+  type CompiledComponentDefinition,
+  type CompilerStateUpdater,
+} from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+const roots: Array<{ unmount(): void }> = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("compiler-owned host conditional runtime", () => {
+  it("patches a stable branch and replaces only the branch when its condition changes", async () => {
+    let executions = 0;
+    let setEnabled: (next: CompilerStateUpdater) => void = () => undefined;
+    let setCount: (next: CompilerStateUpdater) => void = () => undefined;
+    const Status = createCompiledComponent({
+      displayName: "CompiledHostStatus",
+      initialize: () => [true, 1],
+      render(_props: Record<string, never>, state, blocks) {
+        executions += 1;
+        setEnabled = (next) => state[0].set(next);
+        setCount = (next) => state[1].set(next);
+        const HostConditional = blocks.HostConditional;
+        return (
+          <main>
+            <HostConditional
+              id={0}
+              render={() => (
+                <div data-slot="status">
+                  {state[0].get() ? (
+                    <strong className={Number(state[1].get()) > 1 ? "ready" : "idle"}>
+                      <span>Enabled {Number(state[1].get())}</span>
+                    </strong>
+                  ) : (
+                    <span data-count={Number(state[1].get())}>
+                      Disabled {Number(state[1].get())}
+                    </span>
+                  )}
+                </div>
+              )}
+              test={() => state[0].get()}
+              truthy={{
+                create: () => ({
+                  kind: "element",
+                  tag: "strong",
+                  attributes: [
+                    {
+                      name: "className",
+                      value: Number(state[1].get()) > 1 ? "ready" : "idle",
+                    },
+                  ],
+                  styles: [],
+                  children: [
+                    {
+                      kind: "element",
+                      tag: "span",
+                      attributes: [],
+                      styles: [],
+                      children: [["Enabled ", Number(state[1].get())]],
+                    },
+                  ],
+                }),
+                bindings: [
+                  {
+                    kind: "attribute",
+                    path: [],
+                    name: "className",
+                    read: () => (Number(state[1].get()) > 1 ? "ready" : "idle"),
+                  },
+                  {
+                    kind: "text",
+                    path: [0],
+                    read: () => ["Enabled ", Number(state[1].get())],
+                  },
+                ],
+              }}
+              falsy={{
+                create: () => ({
+                  kind: "element",
+                  tag: "span",
+                  attributes: [{ name: "data-count", value: Number(state[1].get()) }],
+                  styles: [],
+                  children: [["Disabled ", Number(state[1].get())]],
+                }),
+                bindings: [
+                  {
+                    kind: "attribute",
+                    path: [],
+                    name: "data-count",
+                    read: () => Number(state[1].get()),
+                  },
+                  {
+                    kind: "text",
+                    path: [],
+                    read: () => ["Disabled ", Number(state[1].get())],
+                  },
+                ],
+              }}
+            />
+          </main>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0, 1] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Status />));
+    const initialBranch = container.querySelector("strong")!;
+
+    await act(async () => {
+      setCount(2);
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("strong")).toBe(initialBranch);
+    expect(initialBranch.className).toBe("ready");
+    expect(initialBranch.textContent).toBe("Enabled 2");
+
+    await act(async () => {
+      setEnabled(false);
+      await flushCompilerUpdates();
+    });
+    expect(initialBranch.isConnected).toBe(false);
+    expect(container.querySelector("[data-slot='status']")?.textContent).toBe("Disabled 2");
+    expect(container.querySelector("span")?.getAttribute("data-count")).toBe("2");
+    expect(executions).toBe(1);
+  });
+
+  it("mounts and removes a logical branch without adding a marker node", async () => {
+    let setVisible: (next: CompilerStateUpdater) => void = () => undefined;
+    const Panel = createCompiledComponent({
+      displayName: "LogicalHostConditional",
+      initialize: () => [false],
+      render(_props: Record<string, never>, state, blocks) {
+        setVisible = (next) => state[0].set(next);
+        const HostConditional = blocks.HostConditional;
+        return (
+          <section>
+            <HostConditional
+              id={0}
+              logical
+              render={() => (
+                <div data-slot="logical">
+                  {Boolean(state[0].get()) && <p data-branch="visible">Visible</p>}
+                </div>
+              )}
+              test={() => state[0].get()}
+              truthy={{
+                create: () => ({
+                  kind: "element",
+                  tag: "p",
+                  attributes: [{ name: "data-branch", value: "visible" }],
+                  styles: [],
+                  children: ["Visible"],
+                }),
+                bindings: [],
+              }}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Panel />));
+    const slot = container.querySelector("[data-slot='logical']")!;
+    expect(slot.childNodes).toHaveLength(0);
+
+    await act(async () => {
+      setVisible(true);
+      await flushCompilerUpdates();
+    });
+    expect(slot.children).toHaveLength(1);
+    expect(slot.firstElementChild?.tagName).toBe("P");
+
+    await act(async () => {
+      setVisible(false);
+      await flushCompilerUpdates();
+    });
+    expect(slot.childNodes).toHaveLength(0);
+  });
+
+  it("falls back to React when logical && produces a visible numeric primitive", async () => {
+    let setValue: (next: CompilerStateUpdater) => void = () => undefined;
+    let branchRenders = 0;
+    const Panel = createCompiledComponent({
+      displayName: "NumericLogicalFallback",
+      initialize: () => [false],
+      render(_props: Record<string, never>, state, blocks) {
+        setValue = (next) => state[0].set(next);
+        const HostConditional = blocks.HostConditional;
+        return (
+          <section>
+            <HostConditional
+              id={0}
+              logical
+              render={() => {
+                branchRenders += 1;
+                return (
+                  <div data-slot="numeric">
+                    {(state[0].get() as boolean | number) && <p>Visible</p>}
+                  </div>
+                );
+              }}
+              test={() => state[0].get()}
+              truthy={{
+                create: () => ({
+                  kind: "element",
+                  tag: "p",
+                  attributes: [],
+                  styles: [],
+                  children: ["Visible"],
+                }),
+                bindings: [],
+              }}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Panel />));
+
+    await act(async () => {
+      setValue(0);
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("[data-slot='numeric']")?.textContent).toBe("0");
+    expect(branchRenders).toBeGreaterThan(1);
+
+    await act(async () => {
+      setValue(true);
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("[data-slot='numeric']")?.textContent).toBe("Visible");
+  });
+
+  it("combines a parent prop commit and local branch update in the same event", async () => {
+    let childExecutions = 0;
+    const Child = createCompiledComponent({
+      displayName: "PropHostConditional",
+      initialize: () => [0],
+      render(props: { prefix: string }, state, blocks) {
+        childExecutions += 1;
+        const HostConditional = blocks.HostConditional;
+        return (
+          <article>
+            <button onClick={() => state[0].set((value) => Number(value) + 1)}>Update</button>
+            <HostConditional
+              id={0}
+              render={() => (
+                <div>
+                  {Number(state[0].get()) > 0 ? (
+                    <strong>
+                      {props.prefix}:{Number(state[0].get())}
+                    </strong>
+                  ) : (
+                    <span>Empty</span>
+                  )}
+                </div>
+              )}
+              test={() => Number(state[0].get()) > 0}
+              truthy={{
+                create: () => ({
+                  kind: "element",
+                  tag: "strong",
+                  attributes: [],
+                  styles: [],
+                  children: [[props.prefix, ":", state[0].get()]],
+                }),
+                bindings: [
+                  { kind: "text", path: [], read: () => [props.prefix, ":", state[0].get()] },
+                ],
+              }}
+              falsy={{
+                create: () => ({
+                  kind: "element",
+                  tag: "span",
+                  attributes: [],
+                  styles: [],
+                  children: ["Empty"],
+                }),
+                bindings: [],
+              }}
+            />
+          </article>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    function Parent() {
+      const [prefix, setPrefix] = useState("Before");
+      return (
+        <div onClick={() => setPrefix("After")}>
+          <Child prefix={prefix} />
+        </div>
+      );
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Parent />));
+    const initialExecutions = childExecutions;
+    await act(async () => {
+      container.querySelector("button")!.click();
+      await flushCompilerUpdates();
+    });
+    await flushCompilerUpdates();
+    expect(container.querySelector("strong")?.textContent).toBe("After:1");
+    expect(childExecutions).toBe(initialExecutions + 1);
+  });
+
+  it("cleans a nested branch subscription when its outer React block disappears", async () => {
+    let setOuter: (next: CompilerStateUpdater) => void = () => undefined;
+    let setInner: (next: CompilerStateUpdater) => void = () => undefined;
+    let innerReads = 0;
+    const Panel = createCompiledComponent({
+      displayName: "NestedHostConditional",
+      initialize: () => [true, true],
+      render(_props: Record<string, never>, state, blocks) {
+        setOuter = (next) => state[0].set(next);
+        setInner = (next) => state[1].set(next);
+        const Conditional = blocks.Conditional;
+        const HostConditional = blocks.HostConditional;
+        const readInner = () => {
+          innerReads += 1;
+          return Boolean(state[1].get());
+        };
+        return (
+          <main>
+            <Conditional
+              id={0}
+              render={() =>
+                Boolean(state[0].get()) && (
+                  <section>
+                    <HostConditional
+                      id={1}
+                      render={() => (
+                        <div>{readInner() ? <p>Enabled</p> : <span>Disabled</span>}</div>
+                      )}
+                      test={readInner}
+                      truthy={{
+                        create: () => ({
+                          kind: "element",
+                          tag: "p",
+                          attributes: [],
+                          styles: [],
+                          children: ["Enabled"],
+                        }),
+                        bindings: [],
+                      }}
+                      falsy={{
+                        create: () => ({
+                          kind: "element",
+                          tag: "span",
+                          attributes: [],
+                          styles: [],
+                          children: ["Disabled"],
+                        }),
+                        bindings: [],
+                      }}
+                    />
+                  </section>
+                )
+              }
+            />
+          </main>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        { kind: "block", id: 1, parent: 0, dependencies: [1] },
+      ],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Panel />));
+    await act(async () => {
+      setOuter(false);
+      await flushCompilerUpdates();
+    });
+    const readsAfterUnmount = innerReads;
+    await act(async () => {
+      setInner(false);
+      await flushCompilerUpdates();
+    });
+    expect(innerReads).toBe(readsAfterUnmount);
+
+    await act(async () => {
+      setOuter(true);
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("span")?.textContent).toBe("Disabled");
+  });
+
+  it("hydrates in StrictMode and drops queued work after unmount", async () => {
+    const errors: unknown[] = [];
+    const Panel = createCompiledComponent({
+      displayName: "HydratedHostConditional",
+      initialize: () => [true, "Alpha"],
+      render(_props: Record<string, never>, state, blocks) {
+        const HostConditional = blocks.HostConditional;
+        return (
+          <section>
+            <button onClick={() => state[1].set("Beta")}>Update</button>
+            <HostConditional
+              id={0}
+              render={() => <div>{state[0].get() ? <p>{String(state[1].get())}</p> : null}</div>}
+              test={() => state[0].get()}
+              truthy={{
+                create: () => ({
+                  kind: "element",
+                  tag: "p",
+                  attributes: [],
+                  styles: [],
+                  children: [String(state[1].get())],
+                }),
+                bindings: [{ kind: "text", path: [], read: () => String(state[1].get()) }],
+              }}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0, 1] }],
+    });
+
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(
+      <StrictMode>
+        <Panel />
+      </StrictMode>,
+    );
+    document.body.append(container);
+    const serverBranch = container.querySelector("p")!;
+    await act(async () => {
+      const root = hydrateRoot(
+        container,
+        <StrictMode>
+          <Panel />
+        </StrictMode>,
+        {
+          onRecoverableError: (error) => errors.push(error),
+        },
+      );
+      roots.push(root);
+    });
+    expect(errors).toEqual([]);
+    expect(container.querySelector("p")).toBe(serverBranch);
+
+    await act(async () => {
+      container.querySelector("button")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("p")).toBe(serverBranch);
+    expect(serverBranch.textContent).toBe("Beta");
+
+    const root = roots.pop()!;
+    await act(async () => {
+      container.querySelector("button")!.click();
+      root.unmount();
+      await flushCompilerUpdates();
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it("lets React recover a hydration mismatch before adopting the branch", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const errors: unknown[] = [];
+    const Panel = createCompiledComponent({
+      displayName: "MismatchedHostConditional",
+      initialize: () => ["Alpha"],
+      render(_props: Record<string, never>, state, blocks) {
+        const HostConditional = blocks.HostConditional;
+        return (
+          <section>
+            <button onClick={() => state[0].set("Beta")}>Update</button>
+            <HostConditional
+              id={0}
+              render={() => (
+                <div>
+                  <p>{String(state[0].get())}</p>
+                </div>
+              )}
+              test={() => true}
+              truthy={{
+                create: () => ({
+                  kind: "element",
+                  tag: "p",
+                  attributes: [],
+                  styles: [],
+                  children: [String(state[0].get())],
+                }),
+                bindings: [{ kind: "text", path: [], read: () => String(state[0].get()) }],
+              }}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(<Panel />).replace("<p>Alpha</p>", "<span>Wrong</span>");
+    document.body.append(container);
+    await act(async () => {
+      const root = hydrateRoot(container, <Panel />, {
+        onRecoverableError: (error) => errors.push(error),
+      });
+      roots.push(root);
+    });
+    expect(errors.length).toBeGreaterThan(0);
+    expect(container.querySelector("p")?.textContent).toBe("Alpha");
+
+    await act(async () => {
+      container.querySelector("button")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("p")?.textContent).toBe("Beta");
+  });
+
+  it("creates and updates a selected option after switching to a form branch", async () => {
+    let setVisible: (next: CompilerStateUpdater) => void = () => undefined;
+    let setMode: (next: CompilerStateUpdater) => void = () => undefined;
+    const Field = createCompiledComponent({
+      displayName: "SelectHostConditional",
+      initialize: () => [false, "fast"],
+      render(_props: Record<string, never>, state, blocks) {
+        setVisible = (next) => state[0].set(next);
+        setMode = (next) => state[1].set(next);
+        const HostConditional = blocks.HostConditional;
+        return (
+          <form>
+            <HostConditional
+              id={0}
+              render={() => (
+                <div>
+                  {state[0].get() ? (
+                    <select disabled value={String(state[1].get())}>
+                      <option value="safe">Safe</option>
+                      <option value="fast">Fast</option>
+                    </select>
+                  ) : (
+                    <span>Hidden</span>
+                  )}
+                </div>
+              )}
+              test={() => state[0].get()}
+              truthy={{
+                create: () => ({
+                  kind: "element",
+                  tag: "select",
+                  attributes: [
+                    { name: "disabled", value: true },
+                    { name: "value", value: state[1].get() },
+                  ],
+                  styles: [],
+                  children: [
+                    {
+                      kind: "element",
+                      tag: "option",
+                      attributes: [{ name: "value", value: "safe" }],
+                      styles: [],
+                      children: ["Safe"],
+                    },
+                    {
+                      kind: "element",
+                      tag: "option",
+                      attributes: [{ name: "value", value: "fast" }],
+                      styles: [],
+                      children: ["Fast"],
+                    },
+                  ],
+                }),
+                bindings: [
+                  { kind: "attribute", path: [], name: "value", read: () => state[1].get() },
+                ],
+              }}
+              falsy={{
+                create: () => ({
+                  kind: "element",
+                  tag: "span",
+                  attributes: [],
+                  styles: [],
+                  children: ["Hidden"],
+                }),
+                bindings: [],
+              }}
+            />
+          </form>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0, 1] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Field />));
+    await act(async () => {
+      setVisible(true);
+      await flushCompilerUpdates();
+    });
+    const select = container.querySelector("select")!;
+    expect(select.value).toBe("fast");
+    expect(select.selectedIndex).toBe(1);
+
+    await act(async () => {
+      setMode("safe");
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("select")).toBe(select);
+    expect(select.value).toBe("safe");
+    expect(select.selectedIndex).toBe(0);
+  });
+
+  it("preserves focused input identity and selection while patching a branch", async () => {
+    let setValue: (next: CompilerStateUpdater) => void = () => undefined;
+    const Field = createCompiledComponent({
+      displayName: "FocusedHostConditional",
+      initialize: () => [true, "Alpha"],
+      render(_props: Record<string, never>, state, blocks) {
+        setValue = (next) => state[1].set(next);
+        const HostConditional = blocks.HostConditional;
+        return (
+          <form>
+            <HostConditional
+              id={0}
+              render={() => (
+                <div>
+                  {state[0].get() ? <input readOnly value={String(state[1].get())} /> : null}
+                </div>
+              )}
+              test={() => state[0].get()}
+              truthy={{
+                create: () => ({
+                  kind: "element",
+                  tag: "input",
+                  attributes: [
+                    { name: "readOnly", value: true },
+                    { name: "value", value: state[1].get() },
+                  ],
+                  styles: [],
+                  children: [],
+                }),
+                bindings: [
+                  { kind: "attribute", path: [], name: "value", read: () => state[1].get() },
+                ],
+              }}
+            />
+          </form>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0, 1] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Field />));
+    const input = container.querySelector("input")!;
+    input.focus();
+    input.setSelectionRange(1, 4, "forward");
+    await act(async () => {
+      setValue("Alpine");
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("input")).toBe(input);
+    expect(input.value).toBe("Alpine");
+    expect(document.activeElement).toBe(input);
+    expect([input.selectionStart, input.selectionEnd]).toEqual([1, 4]);
+  });
+
+  it("preserves state and branch identity through a compatible Fast Refresh", async () => {
+    const hmrId = `host-conditional-refresh-${Math.random()}`;
+    const definition = (prefix: string): CompiledComponentDefinition<Record<string, never>> => ({
+      displayName: "RefreshHostConditional",
+      hmrId,
+      stateSignature: "1",
+      initialize: () => ["Alpha"],
+      render(_props, state, blocks) {
+        const HostConditional = blocks.HostConditional;
+        return (
+          <section>
+            <button onClick={() => state[0].set("Updated")}>Update</button>
+            <HostConditional
+              id={0}
+              render={() => (
+                <div>
+                  <p>
+                    {prefix}
+                    {String(state[0].get())}
+                  </p>
+                </div>
+              )}
+              test={() => true}
+              truthy={{
+                create: () => ({
+                  kind: "element",
+                  tag: "p",
+                  attributes: [],
+                  styles: [],
+                  children: [[prefix, state[0].get()]],
+                }),
+                bindings: [{ kind: "text", path: [], read: () => [prefix, state[0].get()] }],
+              }}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const Initial = createCompiledComponent(definition("Before: "));
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Initial />));
+    const branch = container.querySelector("p")!;
+    await act(async () => {
+      const Updated = createCompiledComponent(definition("After: "));
+      expect(Updated).toBe(Initial);
+      await flushCompilerUpdates();
+    });
+    await flushCompilerUpdates();
+    expect(container.querySelector("p")).toBe(branch);
+    expect(branch.textContent).toBe("After: Alpha");
+
+    await act(async () => {
+      container.querySelector("button")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("p")).toBe(branch);
+    expect(branch.textContent).toBe("After: Updated");
+  });
+
+  it("routes binding failures through the nearest React error boundary", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    class Boundary extends React.Component<{ children: React.ReactNode }, { failed: boolean }> {
+      state = { failed: false };
+      static getDerivedStateFromError() {
+        return { failed: true };
+      }
+      render() {
+        return this.state.failed ? <p>Recovered by boundary</p> : this.props.children;
+      }
+    }
+    const Panel = createCompiledComponent({
+      displayName: "ThrowingHostConditional",
+      initialize: () => [0],
+      render(_props: Record<string, never>, state, blocks) {
+        const read = () => {
+          const value = Number(state[0].get());
+          if (value > 0) throw new Error("broken conditional binding");
+          return value;
+        };
+        const HostConditional = blocks.HostConditional;
+        return (
+          <section>
+            <button onClick={() => state[0].set(1)}>Break</button>
+            <HostConditional
+              id={0}
+              render={() => (
+                <div>
+                  <p>{read()}</p>
+                </div>
+              )}
+              test={() => true}
+              truthy={{
+                create: () => ({
+                  kind: "element",
+                  tag: "p",
+                  attributes: [],
+                  styles: [],
+                  children: [read()],
+                }),
+                bindings: [{ kind: "text", path: [], read }],
+              }}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <Boundary>
+          <Panel />
+        </Boundary>,
+      ),
+    );
+    await act(async () => {
+      container.querySelector("button")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("Recovered by boundary");
+  });
+
+  it("matches React across 3,000 deterministic randomized branch transitions", async () => {
+    interface Model {
+      visible: boolean;
+      count: number;
+      label: string | null;
+      active: boolean;
+    }
+    let setCompiled: (next: CompilerStateUpdater) => void = () => undefined;
+    let setReact: React.Dispatch<React.SetStateAction<Model>> = () => undefined;
+    let compiledExecutions = 0;
+    const initial: Model = { visible: true, count: 0, label: null, active: false };
+    const Compiled = createCompiledComponent({
+      displayName: "RandomHostConditional",
+      initialize: () => [initial],
+      render(_props: Record<string, never>, state, blocks) {
+        compiledExecutions += 1;
+        setCompiled = (next) => state[0].set(next);
+        const model = () => state[0].get() as Model;
+        const HostConditional = blocks.HostConditional;
+        return (
+          <section data-version="compiled">
+            <HostConditional
+              id={0}
+              render={() => (
+                <div>
+                  {model().visible ? (
+                    <strong
+                      className={model().active ? "active" : "idle"}
+                      data-count={model().count}
+                    >
+                      {model().label ?? "none"}:{model().count}
+                    </strong>
+                  ) : (
+                    <span data-count={model().count}>hidden:{model().label ?? "none"}</span>
+                  )}
+                </div>
+              )}
+              test={() => model().visible}
+              truthy={{
+                create: () => ({
+                  kind: "element",
+                  tag: "strong",
+                  attributes: [
+                    { name: "className", value: model().active ? "active" : "idle" },
+                    { name: "data-count", value: model().count },
+                  ],
+                  styles: [],
+                  children: [[model().label ?? "none", ":", model().count]],
+                }),
+                bindings: [
+                  {
+                    kind: "attribute",
+                    path: [],
+                    name: "className",
+                    read: () => (model().active ? "active" : "idle"),
+                  },
+                  { kind: "attribute", path: [], name: "data-count", read: () => model().count },
+                  {
+                    kind: "text",
+                    path: [],
+                    read: () => [model().label ?? "none", ":", model().count],
+                  },
+                ],
+              }}
+              falsy={{
+                create: () => ({
+                  kind: "element",
+                  tag: "span",
+                  attributes: [{ name: "data-count", value: model().count }],
+                  styles: [],
+                  children: [["hidden:", model().label ?? "none"]],
+                }),
+                bindings: [
+                  { kind: "attribute", path: [], name: "data-count", read: () => model().count },
+                  { kind: "text", path: [], read: () => ["hidden:", model().label ?? "none"] },
+                ],
+              }}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    function Normal() {
+      const [model, update] = useState(initial);
+      setReact = update;
+      return (
+        <section data-version="react">
+          <div>
+            {model.visible ? (
+              <strong className={model.active ? "active" : "idle"} data-count={model.count}>
+                {model.label ?? "none"}:{model.count}
+              </strong>
+            ) : (
+              <span data-count={model.count}>hidden:{model.label ?? "none"}</span>
+            )}
+          </div>
+        </section>
+      );
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <>
+          <Compiled />
+          <Normal />
+        </>,
+      ),
+    );
+    let seed = 0x5eed1234;
+    const random = () => {
+      seed = (seed * 1664525 + 1013904223) >>> 0;
+      return seed;
+    };
+    let model = initial;
+    for (let index = 0; index < 3000; index += 1) {
+      const value = random();
+      model = {
+        visible: (value & 1) === 0,
+        count: value % 97,
+        label: value % 5 === 0 ? null : `item-${value % 31}`,
+        active: (value & 4) !== 0,
+      };
+      const next = model;
+      await act(async () => {
+        setCompiled(next);
+        setReact(next);
+        await flushCompilerUpdates();
+      });
+      const compiled = container.querySelector("[data-version='compiled'] > div")!;
+      const normal = container.querySelector("[data-version='react'] > div")!;
+      expect(compiled.innerHTML).toBe(normal.innerHTML);
+    }
+    expect(compiledExecutions).toBe(1);
+  }, 30_000);
+});

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -67,12 +67,36 @@ export interface CompilerKeyedListBlockProps {
   render(): React.ReactNode;
 }
 
-export interface CompilerKeyedRowElement {
+export interface CompilerHostElement {
   kind: "element";
   tag: string;
   attributes: readonly { name: string; value: unknown }[];
   styles: readonly { name: string; value: unknown }[];
-  children: readonly (CompilerKeyedRowElement | unknown)[];
+  children: readonly (CompilerHostElement | unknown)[];
+}
+
+export type CompilerKeyedRowElement = CompilerHostElement;
+
+export interface CompilerHostConditionalBinding {
+  kind: "text" | "attribute" | "style";
+  path: readonly number[];
+  name?: string;
+  read(): unknown;
+}
+
+export interface CompilerHostConditionalBranch {
+  create(): CompilerHostElement;
+  bindings: readonly CompilerHostConditionalBinding[];
+}
+
+export interface CompilerHostConditionalBlockProps {
+  id: number;
+  render(): React.ReactElement;
+  test(): unknown;
+  /** Logical && can produce a visible number instead of an empty branch. */
+  logical?: boolean;
+  truthy?: CompilerHostConditionalBranch;
+  falsy?: CompilerHostConditionalBranch;
 }
 
 export interface CompilerKeyedRowBinding {
@@ -98,6 +122,7 @@ export interface CompilerComponentBlockProps {
 
 export interface CompilerBlockRuntime {
   Conditional: React.ComponentType<CompilerConditionalBlockProps>;
+  HostConditional: React.ComponentType<CompilerHostConditionalBlockProps>;
   KeyedList: React.ComponentType<CompilerKeyedListBlockProps>;
   KeyedRows: React.ComponentType<CompilerKeyedRowsBlockProps>;
   Component: React.ComponentType<CompilerComponentBlockProps>;
@@ -447,43 +472,63 @@ function createKeyedListBlockComponent(
   return FarmKeyedListBlock;
 }
 
-interface CompilerKeyedRowInstance {
-  key: string;
+interface CompilerHostInstance {
   element: Element;
   values: unknown[];
 }
 
-function keyedRowIdentity(key: React.Key): string {
-  return String(key);
-}
-
-function isKeyedRowElement(value: unknown): value is CompilerKeyedRowElement {
+function isCompilerHostElement(value: unknown): value is CompilerHostElement {
   return (
     typeof value === "object" && value !== null && (value as { kind?: unknown }).kind === "element"
   );
 }
 
-function createKeyedRowElement(document: Document, descriptor: CompilerKeyedRowElement): Element {
+function createCompilerHostElement(document: Document, descriptor: CompilerHostElement): Element {
   const element = document.createElement(descriptor.tag);
   for (const attribute of descriptor.attributes) {
     updateAttribute(element, attribute.name, attribute.value);
   }
   for (const style of descriptor.styles) updateStyle(element, style.name, style.value);
   for (const child of descriptor.children) {
-    if (isKeyedRowElement(child)) {
-      element.append(createKeyedRowElement(document, child));
+    if (isCompilerHostElement(child)) {
+      element.append(createCompilerHostElement(document, child));
       continue;
     }
     const text = renderTextValue(child);
     if (text) element.append(document.createTextNode(text));
   }
+  // Select options and textarea text must exist before their controlled value
+  // is finalized. Reapplying is harmless for other attributes and avoids a
+  // transient/default selection becoming the compiled branch's final state.
+  for (const attribute of descriptor.attributes) {
+    if (attribute.name === "value" && (isSelectElement(element) || isTextAreaElement(element))) {
+      updateAttribute(element, attribute.name, attribute.value);
+    }
+  }
   return element;
 }
 
-function findKeyedRowTarget(root: Element, path: readonly number[]): Element | null {
+function matchesCompilerHostElement(element: Element, descriptor: CompilerHostElement): boolean {
+  if (element.tagName.toLowerCase() !== descriptor.tag.toLowerCase()) return false;
+  const expectedChildren = descriptor.children.filter(isCompilerHostElement);
+  if (element.children.length !== expectedChildren.length) return false;
+  return expectedChildren.every((child, index) =>
+    matchesCompilerHostElement(element.children[index], child),
+  );
+}
+
+function findCompilerHostTarget(root: Element, path: readonly number[]): Element | null {
   let current: Element | null = root;
   for (const index of path) current = current?.children[index] || null;
   return current;
+}
+
+interface CompilerKeyedRowInstance extends CompilerHostInstance {
+  key: string;
+}
+
+function keyedRowIdentity(key: React.Key): string {
+  return String(key);
 }
 
 function normalizedKeyedRowBindingValue(binding: CompilerKeyedRowBinding, value: unknown): unknown {
@@ -512,7 +557,7 @@ function applyKeyedRowBindings(
     const value = normalizedKeyedRowBindingValue(binding, rawValue);
     if (Object.is(instance.values[bindingIndex], value)) continue;
     instance.values[bindingIndex] = value;
-    const target = findKeyedRowTarget(instance.element, binding.path);
+    const target = findCompilerHostTarget(instance.element, binding.path);
     if (!target) continue;
     if (binding.kind === "text") {
       target.textContent = value as string;
@@ -522,6 +567,214 @@ function applyKeyedRowBindings(
       updateAttribute(target, binding.name, rawValue);
     }
   }
+}
+
+type CompilerHostConditionalSelection =
+  | { kind: "branch"; key: "truthy" | "falsy"; branch: CompilerHostConditionalBranch }
+  | { kind: "empty" }
+  | { kind: "fallback" };
+
+function hostConditionalSelection(
+  props: CompilerHostConditionalBlockProps,
+): CompilerHostConditionalSelection {
+  const test = props.test();
+  if (props.logical && !test) {
+    // React renders 0, NaN, and (where supported) 0n from `value && <Element />`.
+    // The host-only fast path cannot represent that primitive branch, so retain
+    // React's exact behavior rather than coercing it to an empty branch.
+    if (typeof test === "number" || typeof test === "bigint") return { kind: "fallback" };
+    return { kind: "empty" };
+  }
+  const key = test ? "truthy" : "falsy";
+  const branch = key === "truthy" ? props.truthy : props.falsy;
+  return branch ? { kind: "branch", key, branch } : { kind: "empty" };
+}
+
+function normalizedHostConditionalBindingValue(
+  binding: CompilerHostConditionalBinding,
+  value: unknown,
+): unknown {
+  return binding.kind === "text" ? renderTextValue(value) : value;
+}
+
+function readHostConditionalBindingValues(branch: CompilerHostConditionalBranch): unknown[] {
+  return branch.bindings.map((binding) =>
+    normalizedHostConditionalBindingValue(binding, binding.read()),
+  );
+}
+
+function applyHostConditionalBindings(
+  branch: CompilerHostConditionalBranch,
+  instance: CompilerHostInstance,
+): void {
+  for (let bindingIndex = 0; bindingIndex < branch.bindings.length; bindingIndex += 1) {
+    const binding = branch.bindings[bindingIndex];
+    const rawValue = binding.read();
+    const value = normalizedHostConditionalBindingValue(binding, rawValue);
+    if (Object.is(instance.values[bindingIndex], value)) continue;
+    instance.values[bindingIndex] = value;
+    const target = findCompilerHostTarget(instance.element, binding.path);
+    if (!target) continue;
+    if (binding.kind === "text") {
+      target.textContent = value as string;
+    } else if (binding.kind === "style" && binding.name) {
+      updateStyle(target, binding.name, rawValue);
+    } else if (binding.kind === "attribute" && binding.name) {
+      updateAttribute(target, binding.name, rawValue);
+    }
+  }
+}
+
+function createHostConditionalBlockComponent(
+  owner: Pick<ConditionalBlockOwner, "subscribe">,
+): React.ComponentType<CompilerHostConditionalBlockProps> {
+  interface State {
+    fallback: boolean;
+  }
+
+  class FarmHostConditionalBlock extends React.Component<CompilerHostConditionalBlockProps, State> {
+    static displayName = "FarmCompiledHostConditional";
+
+    state: State = { fallback: false };
+    private root: Element | null = null;
+    private mounted = false;
+    private fallbackRequested = false;
+    private fallbackVersion = 0;
+    private propSyncQueued = false;
+    private currentProps = this.props;
+    private unsubscribe: (() => void) | undefined;
+    private activeBranch: "truthy" | "falsy" | null = null;
+    private instance: CompilerHostInstance | null = null;
+
+    private captureRoot = (root: Element | null) => {
+      this.root = root;
+    };
+
+    private adopt(): boolean {
+      if (!this.root) return false;
+      const selection = hostConditionalSelection(this.currentProps);
+      if (selection.kind === "fallback") return false;
+      if (selection.kind === "empty") {
+        if (this.root.childNodes.length !== 0) return false;
+        this.activeBranch = null;
+        this.instance = null;
+        return true;
+      }
+      if (
+        this.root.childNodes.length !== 1 ||
+        this.root.firstElementChild === null ||
+        this.root.firstElementChild !== this.root.firstChild
+      ) {
+        return false;
+      }
+      const descriptor = selection.branch.create();
+      const element = this.root.firstElementChild;
+      if (!matchesCompilerHostElement(element, descriptor)) return false;
+      this.activeBranch = selection.key;
+      this.instance = {
+        element,
+        values: readHostConditionalBindingValues(selection.branch),
+      };
+      return true;
+    }
+
+    private activateFallback(afterCommit?: () => void): void {
+      if (!this.mounted || this.state.fallback || this.fallbackRequested) {
+        afterCommit?.();
+        return;
+      }
+      this.fallbackRequested = true;
+      this.setState({ fallback: true }, afterCommit);
+    }
+
+    private reconcile(afterCommit?: () => void): void {
+      if (!this.mounted || !this.root) {
+        afterCommit?.();
+        return;
+      }
+      if (this.state.fallback) {
+        this.fallbackVersion += 1;
+        this.forceUpdate(afterCommit);
+        return;
+      }
+
+      const selection = hostConditionalSelection(this.currentProps);
+      if (selection.kind === "fallback") {
+        this.activateFallback(afterCommit);
+        return;
+      }
+      if (selection.kind === "empty") {
+        if (this.instance) this.instance.element.remove();
+        this.activeBranch = null;
+        this.instance = null;
+        afterCommit?.();
+        return;
+      }
+      if (this.activeBranch === selection.key && this.instance) {
+        applyHostConditionalBindings(selection.branch, this.instance);
+        afterCommit?.();
+        return;
+      }
+
+      const element = createCompilerHostElement(this.root.ownerDocument, selection.branch.create());
+      this.root.replaceChildren(element);
+      this.activeBranch = selection.key;
+      this.instance = {
+        element,
+        values: readHostConditionalBindingValues(selection.branch),
+      };
+      afterCommit?.();
+    }
+
+    private refresh = (afterCommit?: () => void) => {
+      this.reconcile(afterCommit);
+    };
+
+    private schedulePropSync(): void {
+      if (this.propSyncQueued) return;
+      this.propSyncQueued = true;
+      queueMicrotask(() => {
+        this.propSyncQueued = false;
+        if (this.mounted && !this.state.fallback) this.reconcile();
+      });
+    }
+
+    shouldComponentUpdate(nextProps: CompilerHostConditionalBlockProps, nextState: State): boolean {
+      this.currentProps = nextProps;
+      if (nextState.fallback || this.state.fallback) return true;
+      this.schedulePropSync();
+      return false;
+    }
+
+    componentDidMount(): void {
+      this.mounted = true;
+      this.unsubscribe = owner.subscribe(this.props.id, this.refresh);
+      if (!this.adopt()) this.activateFallback();
+    }
+
+    componentWillUnmount(): void {
+      this.mounted = false;
+      this.unsubscribe?.();
+      this.root = null;
+      this.activeBranch = null;
+      this.instance = null;
+    }
+
+    render(): React.ReactNode {
+      const container = this.currentProps.render();
+      if (!React.isValidElement(container) || typeof container.type !== "string") {
+        throw new TypeError(
+          `Compiled host conditional ${this.currentProps.id} must own one host container.`,
+        );
+      }
+      return React.cloneElement(container, {
+        key: this.state.fallback ? `react-${this.fallbackVersion}` : "compiled",
+        ref: this.captureRoot,
+      } as React.Attributes);
+    }
+  }
+
+  return FarmHostConditionalBlock;
 }
 
 /** Returns positions forming the LIS while ignoring newly inserted (-1) entries. */
@@ -648,7 +901,7 @@ function createKeyedRowsBlockComponent(
           nextInstances.push(existing);
           continue;
         }
-        const element = createKeyedRowElement(
+        const element = createCompilerHostElement(
           this.root.ownerDocument,
           this.currentProps.create(rows.items[index], index),
         );
@@ -834,6 +1087,9 @@ export function createCompiledComponent<Props>(
       this.blockRuntime = {
         Conditional: createConditionalBlockComponent({
           setRoot: (id, root) => this.setBlockRoot(id, root),
+          subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
+        }),
+        HostConditional: createHostConditionalBlockComponent({
           subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
         }),
         KeyedList: createKeyedListBlockComponent({

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -80,6 +80,20 @@ interface PendingKeyedRowBinding {
   value: t.Expression;
 }
 
+interface HostConditionalPlan {
+  kind: "host-conditional";
+  id: number;
+  parent?: number;
+  dependencies: number[];
+  source: t.JSXElement;
+  test: t.Expression;
+  logical: boolean;
+  truthy?: t.JSXElement;
+  falsy?: t.JSXElement;
+  truthyBindings: PendingKeyedRowBinding[];
+  falsyBindings: PendingKeyedRowBinding[];
+}
+
 interface KeyedRowsPlan {
   kind: "keyed-rows";
   id: number;
@@ -103,6 +117,7 @@ interface ComponentIslandPlan {
 
 type ComposableBlockPlan =
   | ConditionalBlockPlan
+  | HostConditionalPlan
   | KeyedListPlan
   | KeyedRowsPlan
   | ComponentIslandPlan;
@@ -460,6 +475,9 @@ function jsxAttributeName(attribute: t.JSXAttribute): string | undefined {
 
 interface ConditionalBlockShape {
   test: t.Expression;
+  logical: boolean;
+  truthy?: t.JSXElement;
+  falsy?: t.JSXElement;
   branches: t.JSXElement[];
 }
 
@@ -473,7 +491,12 @@ function conditionalBlockShape(expression: t.Expression): ConditionalBlockShape 
     t.isExpression(expression.left) &&
     t.isJSXElement(expression.right)
   ) {
-    return { test: expression.left, branches: [expression.right] };
+    return {
+      test: expression.left,
+      logical: true,
+      truthy: expression.right,
+      branches: [expression.right],
+    };
   }
   if (!t.isConditionalExpression(expression)) return null;
   const branches = [expression.consequent, expression.alternate];
@@ -485,6 +508,9 @@ function conditionalBlockShape(expression: t.Expression): ConditionalBlockShape 
   }
   return {
     test: expression.test,
+    logical: false,
+    truthy: t.isJSXElement(expression.consequent) ? expression.consequent : undefined,
+    falsy: t.isJSXElement(expression.alternate) ? expression.alternate : undefined,
     branches: branches.filter((branch): branch is t.JSXElement => t.isJSXElement(branch)),
   };
 }
@@ -919,6 +945,201 @@ function analyzeKeyedRowsContainer(
   };
 }
 
+function analyzeHostConditionalTree(
+  branch: t.JSXElement,
+  safeGlobals: ReadonlySet<string>,
+): { bindings?: PendingKeyedRowBinding[]; reason?: string } {
+  const bindings: PendingKeyedRowBinding[] = [];
+  const visit = (element: t.JSXElement, path: number[]): string | undefined => {
+    const tag = element.openingElement.name;
+    if (!t.isJSXIdentifier(tag) || !/^[a-z]/.test(tag.name)) {
+      return "compiler-owned conditionals support host elements only";
+    }
+    if (tag.name === "svg") return "compiler-owned conditionals do not support SVG yet";
+
+    for (const attribute of element.openingElement.attributes) {
+      if (t.isJSXSpreadAttribute(attribute)) {
+        return "compiler-owned conditionals do not support JSX attribute spreads";
+      }
+      const name = jsxAttributeName(attribute);
+      if (!name) return "compiler-owned conditionals do not support namespaced JSX attributes";
+      if (name === "ref" || name === "dangerouslySetInnerHTML" || name === "key") {
+        return `compiler-owned conditional ${name} requires React ownership`;
+      }
+      if (/^on[A-Z]/.test(name)) {
+        return "compiler-owned conditional events require React ownership";
+      }
+      if (
+        !t.isJSXExpressionContainer(attribute.value) ||
+        t.isJSXEmptyExpression(attribute.value.expression)
+      ) {
+        continue;
+      }
+
+      const expression = attribute.value.expression;
+      if (name === "style") {
+        if (!t.isObjectExpression(expression)) {
+          return "compiler-owned conditional styles must use one inline object literal";
+        }
+        for (const property of expression.properties) {
+          if (
+            !t.isObjectProperty(property) ||
+            property.computed ||
+            !t.isExpression(property.value)
+          ) {
+            return "compiler-owned conditional styles do not support spreads, methods, or computed properties";
+          }
+          const propertyName = t.isIdentifier(property.key)
+            ? property.key.name
+            : t.isStringLiteral(property.key)
+              ? property.key.value
+              : undefined;
+          if (!propertyName || (propertyName.includes("-") && !propertyName.startsWith("--"))) {
+            return "compiler-owned conditional style names must use camelCase or a CSS custom property";
+          }
+          const unsupported = validateDerivedExpression(property.value, safeGlobals);
+          if (unsupported) {
+            return `compiler-owned conditional style ${propertyName} cannot use ${unsupported}`;
+          }
+          bindings.push({
+            kind: "style",
+            path: [...path],
+            name: propertyName,
+            value: cloneExpression(property.value),
+          });
+        }
+        continue;
+      }
+
+      if (name === "children") {
+        return "compiler-owned conditional children props are not supported yet";
+      }
+      const unsupported = validateDerivedExpression(expression, safeGlobals);
+      if (unsupported) return `compiler-owned conditional ${name} cannot use ${unsupported}`;
+      bindings.push({
+        kind: "attribute",
+        path: [...path],
+        name,
+        value: cloneExpression(expression),
+      });
+    }
+
+    const nestedElements = element.children.filter((child): child is t.JSXElement =>
+      t.isJSXElement(child),
+    );
+    if (element.children.some((child) => t.isJSXFragment(child))) {
+      return "compiler-owned conditionals do not support fragments yet";
+    }
+    const expressions = element.children.filter(
+      (child): child is t.JSXExpressionContainer =>
+        t.isJSXExpressionContainer(child) && !t.isJSXEmptyExpression(child.expression),
+    );
+    for (const child of expressions) {
+      const unsupported = validateDerivedExpression(child.expression as t.Expression, safeGlobals);
+      if (unsupported) return `compiler-owned conditional text cannot use ${unsupported}`;
+    }
+    if (nestedElements.length > 0 && expressions.length > 0) {
+      return "compiler-owned conditionals do not support dynamic text beside nested elements yet";
+    }
+    if (nestedElements.length === 0 && expressions.length > 0) {
+      const parts: t.Expression[] = [];
+      for (const child of element.children) {
+        if (t.isJSXText(child)) {
+          const text = cleanJsxText(child.value);
+          if (text) parts.push(t.stringLiteral(text));
+        } else if (t.isJSXExpressionContainer(child) && !t.isJSXEmptyExpression(child.expression)) {
+          parts.push(cloneExpression(child.expression));
+        }
+      }
+      bindings.push({ kind: "text", path: [...path], value: t.arrayExpression(parts) });
+    }
+
+    let elementIndex = 0;
+    for (const child of element.children) {
+      if (!t.isJSXElement(child)) continue;
+      const reason = visit(child, [...path, elementIndex]);
+      if (reason) return reason;
+      elementIndex += 1;
+    }
+    return undefined;
+  };
+
+  const reason = visit(branch, []);
+  return reason ? { reason } : { bindings };
+}
+
+function analyzeHostConditionalContainer(
+  container: t.JSXElement,
+  statesByValue: ReadonlyMap<string, StateBinding>,
+  safeGlobals: ReadonlySet<string>,
+): Omit<HostConditionalPlan, "kind" | "id" | "parent" | "source"> | undefined {
+  const containerName = container.openingElement.name;
+  if (
+    !t.isJSXIdentifier(containerName) ||
+    !/^[a-z]/.test(containerName.name) ||
+    containerName.name === "svg"
+  ) {
+    return undefined;
+  }
+  if (
+    container.openingElement.attributes.some(
+      (attribute) =>
+        t.isJSXSpreadAttribute(attribute) ||
+        (t.isJSXAttribute(attribute) &&
+          t.isJSXIdentifier(attribute.name) &&
+          (attribute.name.name === "ref" || attribute.name.name === "dangerouslySetInnerHTML")),
+    )
+  ) {
+    return undefined;
+  }
+  for (const attribute of container.openingElement.attributes) {
+    if (!t.isJSXAttribute(attribute) || !t.isJSXIdentifier(attribute.name)) return undefined;
+    if (/^on[A-Z]/.test(attribute.name.name) || attribute.name.name === "key") return undefined;
+    // React does not revisit the adopted container on compiler-cell or parent-prop updates.
+    // Keep every container property static; dynamic work belongs to the owned branch bindings.
+    if (
+      t.isJSXExpressionContainer(attribute.value) &&
+      !t.isJSXEmptyExpression(attribute.value.expression)
+    )
+      return undefined;
+  }
+
+  const children = meaningfulJsxChildren(container);
+  if (
+    children.length !== 1 ||
+    !t.isJSXExpressionContainer(children[0]) ||
+    t.isJSXEmptyExpression(children[0].expression)
+  ) {
+    return undefined;
+  }
+  const shape = conditionalBlockShape(children[0].expression);
+  if (!shape || validateDerivedExpression(shape.test, safeGlobals)) return undefined;
+
+  const truthyAnalysis = shape.truthy
+    ? analyzeHostConditionalTree(shape.truthy, safeGlobals)
+    : { bindings: [] as PendingKeyedRowBinding[] };
+  const falsyAnalysis = shape.falsy
+    ? analyzeHostConditionalTree(shape.falsy, safeGlobals)
+    : { bindings: [] as PendingKeyedRowBinding[] };
+  if (truthyAnalysis.reason || falsyAnalysis.reason) return undefined;
+
+  const dependencies = new Set(collectStateDependencies(shape.test, statesByValue));
+  for (const binding of [...(truthyAnalysis.bindings || []), ...(falsyAnalysis.bindings || [])]) {
+    for (const dependency of collectStateDependencies(binding.value, statesByValue)) {
+      dependencies.add(dependency);
+    }
+  }
+  return {
+    dependencies: [...dependencies].sort((left, right) => left - right),
+    test: cloneExpression(shape.test),
+    logical: shape.logical,
+    truthy: shape.truthy,
+    falsy: shape.falsy,
+    truthyBindings: truthyAnalysis.bindings || [],
+    falsyBindings: falsyAnalysis.bindings || [],
+  };
+}
+
 function keyedListBoundary(
   blockRuntime: t.Identifier,
   plan: KeyedListPlan,
@@ -946,7 +1167,7 @@ function keyedListBoundary(
   );
 }
 
-function keyedRowElementDescriptor(element: t.JSXElement): t.ObjectExpression {
+function hostElementDescriptor(element: t.JSXElement): t.ObjectExpression {
   const tag = element.openingElement.name as t.JSXIdentifier;
   const attributes: t.ObjectExpression[] = [];
   const styles: t.ObjectExpression[] = [];
@@ -998,7 +1219,7 @@ function keyedRowElementDescriptor(element: t.JSXElement): t.ObjectExpression {
       const text = cleanJsxText(child.value);
       if (text) children.push(t.stringLiteral(text));
     } else if (t.isJSXElement(child)) {
-      children.push(keyedRowElementDescriptor(child));
+      children.push(hostElementDescriptor(child));
     } else if (t.isJSXExpressionContainer(child) && !t.isJSXEmptyExpression(child.expression)) {
       children.push(cloneExpression(child.expression));
     }
@@ -1069,7 +1290,7 @@ function keyedRowsBoundary(blockRuntime: t.Identifier, plan: KeyedRowsPlan): t.J
           t.jsxExpressionContainer(
             t.arrowFunctionExpression(
               parameters.map((parameter) => t.cloneNode(parameter, true)),
-              keyedRowElementDescriptor(plan.row),
+              hostElementDescriptor(plan.row),
             ),
           ),
         ),
@@ -1088,6 +1309,61 @@ function keyedRowsBoundary(blockRuntime: t.Identifier, plan: KeyedRowsPlan): t.J
     [],
     true,
   );
+}
+
+function hostConditionalBranchObject(
+  branch: t.JSXElement,
+  bindings: readonly PendingKeyedRowBinding[],
+): t.ObjectExpression {
+  return t.objectExpression([
+    t.objectProperty(
+      t.identifier("create"),
+      t.arrowFunctionExpression([], hostElementDescriptor(branch)),
+    ),
+    t.objectProperty(
+      t.identifier("bindings"),
+      t.arrayExpression(bindings.map((binding) => keyedRowBindingObject(binding, []))),
+    ),
+  ]);
+}
+
+function hostConditionalBoundary(
+  blockRuntime: t.Identifier,
+  plan: HostConditionalPlan,
+): t.JSXElement {
+  const name = t.jsxMemberExpression(
+    t.jsxIdentifier(blockRuntime.name),
+    t.jsxIdentifier("HostConditional"),
+  );
+  const attributes: t.JSXAttribute[] = [
+    t.jsxAttribute(t.jsxIdentifier("id"), t.jsxExpressionContainer(t.numericLiteral(plan.id))),
+    t.jsxAttribute(
+      t.jsxIdentifier("render"),
+      t.jsxExpressionContainer(t.arrowFunctionExpression([], t.cloneNode(plan.source, true))),
+    ),
+    t.jsxAttribute(
+      t.jsxIdentifier("test"),
+      t.jsxExpressionContainer(t.arrowFunctionExpression([], cloneExpression(plan.test))),
+    ),
+  ];
+  if (plan.logical) attributes.push(t.jsxAttribute(t.jsxIdentifier("logical")));
+  if (plan.truthy) {
+    attributes.push(
+      t.jsxAttribute(
+        t.jsxIdentifier("truthy"),
+        t.jsxExpressionContainer(hostConditionalBranchObject(plan.truthy, plan.truthyBindings)),
+      ),
+    );
+  }
+  if (plan.falsy) {
+    attributes.push(
+      t.jsxAttribute(
+        t.jsxIdentifier("falsy"),
+        t.jsxExpressionContainer(hostConditionalBranchObject(plan.falsy, plan.falsyBindings)),
+      ),
+    );
+  }
+  return t.jsxElement(t.jsxOpeningElement(name, attributes, true), null, [], true);
 }
 
 function analyzeComponentIslandElement(
@@ -1179,7 +1455,7 @@ interface ComposableBlockAnalysis {
   plans?: ComposableBlockPlan[];
   componentElements?: Set<t.JSXElement>;
   conditionalExpressions?: Set<t.Expression>;
-  keyedElements?: Set<t.JSXElement>;
+  ownedElements?: Set<t.JSXElement>;
   keyedExpressions?: Set<t.Expression>;
   reason?: string;
 }
@@ -1194,7 +1470,7 @@ function analyzeComposableBlocks(
   const plans: ComposableBlockPlan[] = [];
   const componentElements = new Set<t.JSXElement>();
   const conditionalExpressions = new Set<t.Expression>();
-  const keyedElements = new Set<t.JSXElement>();
+  const ownedElements = new Set<t.JSXElement>();
   const keyedExpressions = new Set<t.Expression>();
   let nextId = 0;
 
@@ -1307,6 +1583,22 @@ function analyzeComposableBlocks(
 
       if (t.isJSXElement(child)) {
         if (isHostElement(child)) {
+          const hostConditional = analyzeHostConditionalContainer(
+            child,
+            statesByValue,
+            safeGlobals,
+          );
+          if (hostConditional) {
+            plans.push({
+              kind: "host-conditional",
+              id: nextId++,
+              parent,
+              source: child,
+              ...hostConditional,
+            });
+            ownedElements.add(child);
+            continue;
+          }
           const keyedRows = analyzeKeyedRowsContainer(child, statesByValue, safeGlobals, listNames);
           if (keyedRows) {
             plans.push({
@@ -1321,7 +1613,7 @@ function analyzeComposableBlocks(
               row: keyedRows.row,
               bindings: keyedRows.bindings,
             });
-            keyedElements.add(child);
+            ownedElements.add(child);
             continue;
           }
           const nested = visitHost(child, parent, insideConditional);
@@ -1342,7 +1634,7 @@ function analyzeComposableBlocks(
             syntax: "list",
           };
           plans.push(plan);
-          keyedElements.add(child);
+          ownedElements.add(child);
           continue;
         }
 
@@ -1434,7 +1726,7 @@ function analyzeComposableBlocks(
     plans,
     componentElements,
     conditionalExpressions,
-    keyedElements,
+    ownedElements,
     keyedExpressions,
   };
 }
@@ -1480,6 +1772,9 @@ function lowerComposableBlocks(
     element.children = element.children.map((child) => {
       if (t.isJSXElement(child)) {
         const plan = planBySource.get(child);
+        if (plan?.kind === "host-conditional") {
+          return hostConditionalBoundary(blockRuntime, plan);
+        }
         if (plan?.kind === "keyed-rows") {
           return keyedRowsBoundary(blockRuntime, plan);
         }
@@ -1531,6 +1826,7 @@ function lowerStableBindingTargets(
   root: t.JSXElement,
   bindings: readonly PendingBinding[],
   blockRuntime: t.Identifier,
+  ownedElements: ReadonlySet<t.JSXElement>,
 ): t.JSXElement {
   const targetByPath = new Map<string, number>();
   for (const binding of bindings) {
@@ -1558,6 +1854,7 @@ function lowerStableBindingTargets(
     let elementIndex = 0;
     for (const child of element.children) {
       if (!t.isJSXElement(child) || !isHostElement(child)) continue;
+      if (ownedElements.has(child)) continue;
       visit(child, [...path, elementIndex]);
       elementIndex += 1;
     }
@@ -1573,7 +1870,7 @@ function analyzeHostTree(
   safeGlobals: ReadonlySet<string>,
   conditionalExpressions: ReadonlySet<t.Expression>,
   keyedExpressions: ReadonlySet<t.Expression>,
-  keyedElements: ReadonlySet<t.JSXElement>,
+  ownedElements: ReadonlySet<t.JSXElement>,
   componentElements: ReadonlySet<t.JSXElement>,
 ): { bindings?: PendingBinding[]; reason?: string } {
   const bindings: PendingBinding[] = [];
@@ -1656,7 +1953,7 @@ function analyzeHostTree(
 
     const nestedElements = element.children.filter(
       (child): child is t.JSXElement =>
-        t.isJSXElement(child) && isHostElement(child) && !keyedElements.has(child),
+        t.isJSXElement(child) && isHostElement(child) && !ownedElements.has(child),
     );
     const expressionChildren = element.children.filter((child): child is t.JSXExpressionContainer =>
       t.isJSXExpressionContainer(child),
@@ -1670,14 +1967,14 @@ function analyzeHostTree(
       }
     }
 
-    const hasKeyedElement = element.children.some(
-      (child) => t.isJSXElement(child) && keyedElements.has(child),
+    const hasOwnedElement = element.children.some(
+      (child) => t.isJSXElement(child) && ownedElements.has(child),
     );
     const hasComponentElement = element.children.some(
       (child) => t.isJSXElement(child) && componentElements.has(child),
     );
     const hasDynamicBlocks =
-      hasKeyedElement ||
+      hasOwnedElement ||
       hasComponentElement ||
       expressionChildren.some(
         (child) =>
@@ -1719,7 +2016,7 @@ function analyzeHostTree(
       }
       let elementIndex = 0;
       for (const child of element.children) {
-        if (!t.isJSXElement(child) || !isHostElement(child) || keyedElements.has(child)) continue;
+        if (!t.isJSXElement(child) || !isHostElement(child) || ownedElements.has(child)) continue;
         const reason = visit(child, [...path, elementIndex]);
         if (reason) return reason;
         elementIndex += 1;
@@ -2045,7 +2342,7 @@ function compileCandidate(
     safeGlobals,
     blockAnalysis.conditionalExpressions || new Set<t.Expression>(),
     blockAnalysis.keyedExpressions || new Set<t.Expression>(),
-    blockAnalysis.keyedElements || new Set<t.JSXElement>(),
+    blockAnalysis.ownedElements || new Set<t.JSXElement>(),
     blockAnalysis.componentElements || new Set<t.JSXElement>(),
   );
   if (analysis.reason) return analysis.reason;
@@ -2059,6 +2356,7 @@ function compileCandidate(
     expandedRoot,
     analysis.bindings || [],
     blockParameter,
+    blockAnalysis.ownedElements || new Set<t.JSXElement>(),
   );
   const rootWithBlocks = lowerComposableBlocks(
     rootWithTargets,


### PR DESCRIPTION
## Summary

- compile eligible host-only logical and ternary branches into AOT descriptors with exact text, attribute, and style bindings
- adopt the DOM created by React during client rendering, SSR, or hydration, then patch a stable branch in place or create, remove, and replace only the conditional branch
- preserve React ownership for events, custom components, refs, SVG, nested dynamic shapes, numeric logical output, and every unsupported structure
- expand the experimental compiler docs, package guide, and browser experiment with the ownership contract, fallback behavior, SSR and hydration details, and verification coverage

## Safety and compatibility

- requires one conditional as the only meaningful child of a dedicated static host container
- keeps React responsible for initial placement, delegated events, Strict Mode, error boundaries, SSR, hydration, and unsupported cases
- cleans subscriptions when outer blocks unmount and restores current compiler-cell values when they remount
- retains all existing keyed-list, keyed-row, component-island, controlled-form, and composable-block behavior

## Verification

- `pnpm --filter @farm.js/react test` — 20 files, 160 tests passed
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and React 19.2.8 passed
- `pnpm --filter farm-react-compiler-example build && node scripts/verify-experiment.mjs` — production browser experiment passed on desktop and mobile
- 3,000 deterministic randomized conditional transitions compared with normal React
- formatting and `git diff --check` passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compiles eligible host-only conditional branches and moves their child DOM to the compiler after mount. Previously React re-ran the component or reconciled a small boundary; now the compiler patches text/attribute/style bindings on a stable branch and swaps only the conditional branch, while SSR and hydration still use React.

- Compiler: detects logical and ternary host-only containers and emits `HostConditional` with precomputed DOM and exact bindings.
- Runtime: adopts React-created or hydrated DOM, patches a stable branch in place, and only creates/removes/replaces the conditional branch; falls back to React for events, custom components, refs, SVG, nested dynamic shapes, and numeric logical outputs.
- Safety and constraints: requires a dedicated host-only container with one conditional child; cleans subscriptions on unmount and restores compiler state on remount; unchanged behavior for keyed lists, component islands, controlled forms.
- Docs and verification: expands React compiler docs and browser experiment; adds comprehensive runtime tests; `@farm.js/react` passes type-checks and compatibility tests on React 18.3.1 and 19.2.8.

<sup>Written for commit ca46dbcbac06907457af5f9bc6358fefee178953. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

