### PR TITLE
fix(core): resolve Nitro runtime deps in SSG prerender under pnpm

### DIFF
--- a/packages/farm/src/__tests__/universal-build-prerender-resolver.test.ts
+++ b/packages/farm/src/__tests__/universal-build-prerender-resolver.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { createPrerenderRuntimeResolverPlugin } from "../nitro/universal-build";
+
+type ResolveCall = { id: string; importer: string | undefined; options: Record<string, unknown> };
+
+function createContext(resolutions: Record<string, string>) {
+  const calls: ResolveCall[] = [];
+  return {
+    calls,
+    async resolve(id: string, importer: string | undefined, options: Record<string, unknown>) {
+      calls.push({ id, importer, options });
+      const resolved = resolutions[id];
+      return resolved ? { id: resolved, external: false } : null;
+    },
+  };
+}
+
+const NITRO_ENTRY = "/workspace/app/node_modules/nitro/dist/index.mjs";
+
+async function resolveWithPlugin(
+  plugin: ReturnType<typeof createPrerenderRuntimeResolverPlugin>,
+  context: ReturnType<typeof createContext>,
+  id: string,
+  options: Record<string, unknown> = {},
+) {
+  const resolveId = plugin.resolveId as (
+    this: unknown,
+    id: string,
+    importer: string | undefined,
+    options: Record<string, unknown>,
+  ) => Promise<unknown>;
+  return resolveId.call(context, id, "\0#nitro-internal-virtual/storage", options);
+}
+
+describe("createPrerenderRuntimeResolverPlugin", () => {
+  it("retries unresolved bare ids from Nitro's package context", async () => {
+    // Nitro's virtual modules import unstorage/h3 with a virtual importer;
+    // under pnpm's strict layout these transitive deps only resolve from
+    // Nitro's own location (#403).
+    const plugin = createPrerenderRuntimeResolverPlugin("/workspace/app", () => NITRO_ENTRY);
+    const context = createContext({
+      unstorage:
+        "/workspace/app/node_modules/.pnpm/unstorage@1.0.0/node_modules/unstorage/dist/index.mjs",
+    });
+
+    const resolved = await resolveWithPlugin(plugin, context, "unstorage");
+
+    expect(resolved).toMatchObject({ external: false });
+    expect(context.calls[0]).toMatchObject({
+      id: "unstorage",
+      importer: NITRO_ENTRY,
+      options: { skipSelf: true, custom: { farmPrerenderRuntimeResolve: true } },
+    });
+  });
+
+  it("ignores relative, absolute, virtual, and builtin ids", async () => {
+    const plugin = createPrerenderRuntimeResolverPlugin("/workspace/app", () => NITRO_ENTRY);
+    const context = createContext({});
+
+    for (const id of [
+      "./chunk.mjs",
+      "/abs/path.mjs",
+      "\0virtual-id",
+      "#nitro-internal-virtual/storage",
+      "virtual:farm-ssr-entry",
+      "node:fs",
+      "fs",
+    ]) {
+      await expect(resolveWithPlugin(plugin, context, id)).resolves.toBeNull();
+    }
+    expect(context.calls).toHaveLength(0);
+  });
+
+  it("does not recurse when re-entered from its own retry", async () => {
+    const plugin = createPrerenderRuntimeResolverPlugin("/workspace/app", () => NITRO_ENTRY);
+    const context = createContext({});
+
+    await expect(
+      resolveWithPlugin(plugin, context, "unstorage", {
+        custom: { farmPrerenderRuntimeResolve: true },
+      }),
+    ).resolves.toBeNull();
+    expect(context.calls).toHaveLength(0);
+  });
+
+  it("returns null when Nitro's entry cannot be resolved", async () => {
+    const plugin = createPrerenderRuntimeResolverPlugin("/workspace/app", () => {
+      throw new Error("nitro not installed");
+    });
+    const context = createContext({});
+
+    await expect(resolveWithPlugin(plugin, context, "unstorage")).resolves.toBeNull();
+    expect(context.calls).toHaveLength(0);
+  });
+});

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -173,6 +173,55 @@ const FARM_SSR_OUTPUT_DIR = "farm-ssr";
 const FARM_CLIENT_BUILD_TARGET = ["es2020", "edge88", "firefox78", "chrome87", "safari14"];
 
 function resolveNitroRuntimeDependency(root: string, specifier: string): string {
+  return createRequire(resolveNitroPackageEntry(root)).resolve(specifier).split(path.sep).join("/");
+}
+
+/**
+ * Rollup fallback resolver for the temporary prerender server. Bare ids that
+ * the regular pipeline cannot resolve (Nitro virtual modules import Nitro's
+ * runtime dependencies without a real importer) are retried from Nitro's own
+ * package location, where pnpm's strict layout can supply them.
+ */
+export function createPrerenderRuntimeResolverPlugin(
+  root: string,
+  resolveNitroEntry: (projectRoot: string) => string = resolveNitroPackageEntry,
+): Rollup.Plugin {
+  let nitroEntry: string | null | undefined;
+
+  return {
+    name: "farm-prerender-runtime-resolver",
+    async resolveId(id, _importer, options) {
+      if (options.custom?.farmPrerenderRuntimeResolve) return null;
+      if (
+        id.startsWith("\0") ||
+        id.startsWith(".") ||
+        id.startsWith("#") ||
+        id.startsWith("virtual:") ||
+        path.isAbsolute(id) ||
+        NODE_BUILTIN_MODULES.has(id)
+      ) {
+        return null;
+      }
+
+      if (nitroEntry === undefined) {
+        try {
+          nitroEntry = resolveNitroEntry(root);
+        } catch {
+          nitroEntry = null;
+        }
+      }
+      if (!nitroEntry) return null;
+
+      return this.resolve(id, nitroEntry, {
+        ...options,
+        skipSelf: true,
+        custom: { ...options.custom, farmPrerenderRuntimeResolve: true },
+      });
+    },
+  };
+}
+
+function resolveNitroPackageEntry(root: string): string {
   const projectRequire = createRequire(path.join(root, "package.json"));
   let runtimeRequire = projectRequire;
   try {
@@ -180,8 +229,7 @@ function resolveNitroRuntimeDependency(root: string, specifier: string): string 
   } catch {
     // Source-only framework builds can resolve Nitro directly from the project.
   }
-  const nitroEntry = runtimeRequire.resolve("nitro");
-  return createRequire(nitroEntry).resolve(specifier).split(path.sep).join("/");
+  return runtimeRequire.resolve("nitro");
 }
 
 function cloneConfigValue<T>(value: T, seen = new WeakMap<object, unknown>()): T {
@@ -7309,6 +7357,27 @@ export default async function farmNitroEventHandler(event) {
       delete prerendererConfig.entry;
     });
   }
+  nitroInstance.hooks.hook("prerender:init", (prerenderer) => {
+    prerenderer.hooks.hook("rollup:before", (_prerenderNitro, rollupConfig) => {
+      // Nitro's virtual modules (storage, tasks, ...) emit bare imports of
+      // Nitro's own runtime dependencies (unstorage, h3, ...). Their virtual
+      // importer is discarded during resolution, so under pnpm's strict
+      // node_modules layout these transitive dependencies cannot be resolved,
+      // and rollup silently leaves them as bare imports in the temporary
+      // prerender server. Importing that server from the output directory
+      // then fails with ERR_MODULE_NOT_FOUND (#403). Retry unresolved bare
+      // ids from Nitro's own package context so they bundle like the rest.
+      const configuredPlugins = rollupConfig.plugins;
+      rollupConfig.plugins = [
+        ...(Array.isArray(configuredPlugins)
+          ? configuredPlugins
+          : configuredPlugins
+            ? [configuredPlugins]
+            : []),
+        createPrerenderRuntimeResolverPlugin(config.root),
+      ];
+    });
+  });
   await nitro.prepare(nitroInstance);
   await nitro.copyPublicAssets(nitroInstance);
   if (prerenderRoutes.length > 0 && canReusePrebuiltSSR) {


### PR DESCRIPTION
## Summary

Fixes #403.

`farm build` with the Vercel preset failed during SSG pre-rendering (`export const dynamic = "force-static"`):

```
Cannot find package 'h3' imported from .vercel\output\server\chunks\_\nitro.mjs
```

## Root cause (not actually Windows-specific)

I reproduced this on macOS: it's a **pnpm** issue that the reporter hit on Windows. Nitro's virtual modules (storage, tasks, …) emit bare imports of Nitro's own runtime dependencies (`unstorage`, `unstorage/drivers/fs`, `h3`). During resolution the virtual importer is discarded, so node-resolve falls back to resolving from the project — where pnpm's strict `node_modules` layout cannot see Nitro's transitive deps. Rollup then silently leaves them as bare imports in the temporary prerender server (everything else gets rewritten to absolute `file://` URLs). When Nitro dynamic-imports that server from `.vercel/output/server/`, the bare ids can't resolve → `ERR_MODULE_NOT_FOUND`. npm's flat hoisting masks the bug, which is why it wasn't seen before — with npm the same build passes.

Repro matrix (basic template + `force-static` + vercel target, macOS): npm → ✅, pnpm → ❌ before this fix, ✅ after.

## Changes

- New `createPrerenderRuntimeResolverPlugin(root)` appended to the prerender build's rollup plugins via the `prerender:init` → `rollup:before` hooks: any bare id the regular pipeline failed to resolve is retried with **Nitro's own package entry as the importer**, so pnpm can supply it and it bundles like the rest of the runtime. Guards: skips relative/absolute/virtual/builtin ids and carries a custom flag to prevent re-entry.
- Extracted `resolveNitroPackageEntry()` out of `resolveNitroRuntimeDependency()` so both share the same nitro lookup (project → @farm.js/core → nitro).

## About the symlink error in the report

The `EPERM: symlink ... node_modules/.nitro/last-build` line comes from Nitro's `writeBuildInfo`, which wraps it in `.catch(console.warn)` — noisy but non-fatal, and unrelated to the actual failure (same conclusion as #399). Enabling Windows Developer Mode silences it.

## Testing

- End-to-end: scaffolded app + `force-static` route + vercel preset + pnpm — failed before with the exact error class from the issue, now builds and emits `.vercel/output/static/catalog/index.html` with the prerendered content.
- New unit tests for the resolver plugin: retries via Nitro's entry with the re-entry flag, ignores relative/absolute/virtual/builtin ids, no recursion, and graceful null when Nitro can't be located.
- `universal-build` suites pass (12/12 across the four files); `tsc --noEmit`, `oxlint`, `oxfmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SSG prerender failures under `pnpm` by resolving `Nitro` runtime deps from the `Nitro` package context during prerender. Previously `Nitro` virtual modules left bare imports like `unstorage`/`h3` unresolved, so importing the temporary prerender server from `.vercel/output` crashed with ERR_MODULE_NOT_FOUND; now those deps resolve and bundle.

- Adds `createPrerenderRuntimeResolverPlugin(root)` via `prerender:init` → `rollup:before` to retry unresolved bare ids with the `Nitro` package entry as importer; skips relative/absolute/virtual/builtins and uses a re-entry flag to avoid recursion.
- Extracts `resolveNitroPackageEntry()` from `resolveNitroRuntimeDependency()` so both share the project → `@farm.js/core` → `nitro` lookup.
- Tests cover retry behavior and guards; e2e verified with Vercel preset + `force-static` on `pnpm`. Only affects the prerender build; `npm` users see no change.

<sup>Written for commit 9d0c5e8f3967cd581490fb54213d7d14802d9bb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

