### PR TITLE
feat(react): compile derived collection pipelines

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -323,21 +323,21 @@ policy.
 The current compiler deliberately supports a smaller subset than general React. A component must
 satisfy all of these rules:
 
-| Area                | Current supported shape                                                                                                                     |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| Component discovery | A top-level, capitalized function declaration, function expression, or arrow component in application `.tsx` or `.jsx`.                     |
-| Function shape      | Synchronous, non-generator, non-generic block body with zero parameters, one props identifier, or flat object props destructuring.          |
-| Props               | Flat object destructuring supports shorthand names, aliases, and defaults. Nested, computed, and rest patterns fall back.                   |
-| Body                | Top-level `useState` declarations, optional compiler-safe derived values and synchronous named handlers, then one unconditional JSX return. |
-| State               | `const [value, setValue] = useState(initial)`, including lazy initializers, multiple cells, and queued functional updates.                  |
-| Root                | Exactly one lowercase host JSX element such as `button`, `section`, `input`, or `div`.                                                      |
-| Tree                | A statically known host tree around eligible conditional, keyed-list, compiled keyed-row, and component-island boundaries.                  |
-| Text bindings       | State-driven text in a leaf host element.                                                                                                   |
-| Attribute bindings  | Basic attributes, controlled form properties, and individual properties in one inline `style` object.                                       |
-| Events              | Inline handlers and synchronous `const` or function-declaration handlers, used directly or called inside an inline JSX handler.             |
-| Conditional blocks  | Logical/ternary host branches; dedicated host-only containers may use compiler-owned branch instances and bindings.                         |
-| Keyed lists         | Direct item-keyed maps and imported `List`; dedicated host-only containers may use compiler-owned rows and LIS.                             |
-| Component islands   | Stable imported or module-level component identifiers with explicit compiler-safe props and no JSX children, spread, `ref`, or `key`.       |
+| Area                | Current supported shape                                                                                                                                    |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Component discovery | A top-level, capitalized function declaration, function expression, or arrow component in application `.tsx` or `.jsx`.                                    |
+| Function shape      | Synchronous, non-generator, non-generic block body with zero parameters, one props identifier, or flat object props destructuring.                         |
+| Props               | Flat object destructuring supports shorthand names, aliases, and defaults. Nested, computed, and rest patterns fall back.                                  |
+| Body                | Top-level `useState` declarations, optional compiler-safe derived values and synchronous named handlers, then one unconditional JSX return.                |
+| State               | `const [value, setValue] = useState(initial)`, including lazy initializers, multiple cells, and queued functional updates.                                 |
+| Root                | Exactly one lowercase host JSX element such as `button`, `section`, `input`, or `div`.                                                                     |
+| Tree                | A statically known host tree around eligible conditional, keyed-list, compiled keyed-row, and component-island boundaries.                                 |
+| Text bindings       | State-driven text in a leaf host element.                                                                                                                  |
+| Attribute bindings  | Basic attributes, controlled form properties, and individual properties in one inline `style` object.                                                      |
+| Events              | Inline handlers and synchronous `const` or function-declaration handlers, used directly or called inside an inline JSX handler.                            |
+| Conditional blocks  | Logical/ternary host branches; dedicated host-only containers may use compiler-owned branch instances and bindings.                                        |
+| Keyed lists         | Item-keyed maps and imported `List`, including safe non-mutating collection pipelines; dedicated host-only containers may use compiler-owned rows and LIS. |
+| Component islands   | Stable imported or module-level component identifiers with explicit compiler-safe props and no JSX children, spread, `ref`, or `key`.                      |
 
 This component is eligible:
 
@@ -384,9 +384,11 @@ Derived values are expanded into the generated bindings, so they do not create a
 force a component rerender. They may use literals, props, state, operators, optional/member access,
 conditionals, templates, earlier derived values, and a small call whitelist. The whitelist contains
 `Boolean`, `Number`, `String`, and `Math.abs`, `ceil`, `floor`, `max`, `min`, `round`, `sign`, and
-`trunc`. A name is not treated as built-in when the component shadows it. Application helpers,
-prototype methods, `Math.random`, optional calls, assignments, identity-bearing object or array
-literals, functions, JSX, constructors, and other unproven expressions still fall back to React.
+`trunc`. Safe keyed collections additionally accept the non-mutating pipeline described below. A
+name is not treated as built-in when the component shadows it. Outside that pipeline, application
+helpers, prototype methods, `Math.random`, optional calls, assignments, identity-bearing object or
+array literals, functions, JSX, constructors, and other unproven expressions still fall back to
+React.
 
 For destructured props, the original component wrapper still performs JavaScript destructuring on
 every parent render. Defaults therefore apply only to `undefined`, aliases keep their normal local
@@ -485,6 +487,50 @@ subsequence (LIS) of the old row positions. Rows in that subsequence stay in pla
 surviving rows move. LIS is a runtime move planner over compiler-prepared rows, not a claim that the
 future contents of an array are known at build time.
 
+#### Derived collection pipelines
+
+The collection may be prepared through an inline, non-mutating pipeline before the final keyed
+`.map(...)` or before it is passed to `List`:
+
+```tsx
+const visibleItems = items.filter((item) => item.visible && item.rank >= minimumRank);
+const orderedItems = visibleItems.toSorted((left, right) => left.rank - right.rank);
+const pageItems = orderedItems.slice(offset, offset + pageSize).toReversed();
+
+return (
+  <ul>
+    {pageItems.map((item) => (
+      <li key={item.id}>{item.label}</li>
+    ))}
+  </ul>
+);
+```
+
+The compiler expands those derived locals, records the state cells used by the collection,
+predicate, comparator, and window arguments, and subscribes the keyed boundary to only those
+dependencies. When one changes, the pipeline runs once to produce the next collection. The existing
+keyed-row runtime then reuses surviving rows, patches their bindings, and applies LIS to the new key
+order. An unrelated state update does not rerun the pipeline or the outer component.
+
+The initial pipeline contract supports:
+
+- `filter` with one synchronous inline callback using an item and optional index;
+- `slice` with up to two compiler-safe arguments;
+- `toSorted` with no comparator or one synchronous inline two-item comparator;
+- `toReversed` without arguments; and
+- any sequence of those methods followed by one keyed `.map(...)` or used as `List each`.
+
+Callback bodies must contain one compiler-safe returned expression. Assignments, Hooks, async
+callbacks, spread arguments, calls to unproven helpers or prototype methods, external callbacks,
+and mutating methods such as `sort`, `reverse`, and `splice` keep the original React component. The
+compiler does not claim that filtering or sorting is free: it avoids unrelated component execution
+and React reconciliation, while the necessary collection work still runs when one of its own
+dependencies changes.
+
+Farm leaves these standard methods in the generated JavaScript; it does not inject a polyfill.
+Applications using `toSorted` or `toReversed` must target runtimes that provide them and include an
+ES2023 TypeScript library. `filter` and `slice` do not require that newer library.
+
 Use the public `List` component when the key should be separate from the row renderer, or when rows
 are custom components:
 
@@ -531,8 +577,8 @@ The compiler uses two keyed-list tiers:
 
 The first compiler-owned row contract is deliberately narrow:
 
-- The map must be a direct `collection.map(...)` with one synchronous inline callback returning one
-  React element and an explicit item-derived `key`.
+- The map must use one synchronous inline callback returning one React element and an explicit
+  item-derived `key`. Its collection may be direct or use the supported non-mutating pipeline.
 - An array-index key is rejected for compiler isolation because it does not preserve item identity
   across insertion, removal, or reordering.
 - The optimized `List` shape uses inline `by` and child functions, a compiler-safe `each`
@@ -544,8 +590,8 @@ The first compiler-owned row contract is deliberately narrow:
   properties, and individual inline style properties are supported.
 - Row events, custom components, fragments, refs, SVG, attribute spreads, dangerous HTML, and
   dynamic text mixed beside nested elements stay React-owned.
-- Chained expressions such as `items.filter(...).map(...)`, spread children, hooks in the callback,
-  and other unproven shapes fall back to normal React.
+- Unsupported or mutating collection methods, spread children, Hooks in callbacks, and other
+  unproven shapes fall back to normal React.
 
 Stable keys must be unique among siblings and come from the item's identity, such as a database ID.
 If duplicate keys appear at runtime, Farm remounts that list container through its original React
@@ -628,7 +674,7 @@ put Hooks inside a keyed row component.
 
 | Unsupported shape                                                                                            | Why React keeps ownership                                                          |
 | ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
-| Unkeyed/index-keyed/chained maps or element arrays                                                           | Their structure or item identity is outside the keyed-list contract.               |
+| Unkeyed/index-keyed maps, unsupported or mutating collection pipelines, or element arrays                    | Their structure, purity, or item identity is outside the keyed-list contract.      |
 | Row events, components, fragments, refs, SVG, or mixed container children                                    | They require React ownership rather than compiler-created host rows.               |
 | Branch events, keys, components, fragments, refs, SVG, or nested blocks in a dedicated conditional container | They require the React-owned conditional path rather than compiler-created hosts.  |
 | Dynamic/member component types, component spreads, refs, keys, or children                                   | Their identity or ownership is outside the first component-island contract.        |
@@ -781,6 +827,10 @@ The package and example test suites verify more than generated code:
 - 1,000 deterministic object, array, and nullish component-prop transitions match normal React;
 - 1,000 deterministic randomized compiler-owned list operations produce the same ordered output as
   normal React while the list owner stays at one execution;
+- 5,000 deterministic filter, sort, slice, reverse, insertion, removal, and row-update transitions
+  produce the same keyed output as normal React while preserving surviving DOM rows;
+- the production browser experiment derives a keyed window from 2,048 source rows without
+  rerunning the owner component or corrupting the existing compiler experiments;
 - the public `List` renders iterable and nullish collections correctly with the compiler off;
 - the packaged runtime is exercised separately with React 18.3 and React 19;
 - boolean `data-*` and `aria-*` attributes keep React-compatible string values; and

--- a/examples/react-compiler/README.md
+++ b/examples/react-compiler/README.md
@@ -35,6 +35,7 @@ assertions, checks for console/runtime errors and horizontal overflow, saves scr
 | Batched functional updates  | count `2`, snapshot `0`, update executions `0`          | count `2`, snapshot `0`, update executions `1` | The compiler preserves queued updater and event snapshot behavior.     |
 | Two state cells             | text/class/data/input all update, update executions `0` | —                                              | AOT dependency lists update only bindings affected by each state cell. |
 | Automatic keyed map         | stable row DOM, three LIS moves for a four-row reversal  | —                                              | AOT rows patch in place and use the minimum reorder moves.              |
+| Derived keyed collection    | 2,048 source rows filter, sort, slice, and reverse; executions `0` | —                                      | Collection dependencies feed keyed rows without rerunning the owner.    |
 | Explicit `List`             | stateful rows reorder, update executions `0`            | —                                              | React preserves custom-row state by key inside the isolated boundary.  |
 | Calculated style bindings   | value `6`, progress `50%`, update executions `0`        | —                                              | Safe calls and individual CSS properties use prepared dependencies.    |
 | Controlled form bindings   | textarea/select/checkbox update, executions `0`         | —                                              | Form properties and textarea selection stay coherent.                  |
@@ -80,11 +81,18 @@ use the same compiler-owned row path. A custom stateful row such as `<Row item={
 React-owned keyed boundary so React preserves its Hooks, events, lifecycle, and Fiber state. The
 outer compiled component can still avoid rerunning.
 
-The compiler-owned path requires one direct map or `List` as the only meaningful child of a nested
-host container. Row events, custom components, fragments, refs, SVG, static siblings in that same
-container, index or missing keys, chained maps, and other unproven shapes use React reconciliation.
-Duplicate keys discovered at runtime also remount that container through React. LIS reduces moves;
-it does not make insertions, removals, key comparison, or DOM updates disappear.
+The compiler-owned path requires one keyed map or `List` as the only meaningful child of a nested
+host container. Its collection may chain synchronous inline `filter`, `slice`, `toSorted`, and
+`toReversed` operations. The compiler records the state dependencies used by those operations and
+reruns the pipeline only when one changes; it still performs the necessary filtering or sorting.
+Mutating methods, external or async callbacks, Hooks, assignments, spread arguments, and unproven
+calls fall back to React. Row events, custom components, fragments, refs, SVG, static siblings in
+that same container, and index or missing keys also use React reconciliation. Duplicate keys
+discovered at runtime remount that container through React. LIS reduces moves; it does not make
+insertions, removals, key comparison, collection work, or DOM updates disappear.
+
+The example includes ES2023 TypeScript library declarations because `toSorted` and `toReversed`
+are standard runtime methods that the compiler preserves rather than polyfills.
 
 Calling a Hook directly inside `items.map(...)` or a `List` render callback is invalid React because
 the number or order of Hook calls can change. Put the Hook inside a separate `Row` component and key

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -28,6 +28,7 @@ for (const component of [
   "LogicalBlockPanel",
   "TernaryBlockPanel",
   "AutomaticKeyedListExperiment",
+  "DerivedCollectionExperiment",
   "ExplicitKeyedListExperiment",
   "StatefulListRow",
   "ComponentIslandExperiment",
@@ -445,6 +446,68 @@ try {
     "reversing four keyed rows should move only the three rows outside the LIS",
   );
 
+  const derivedCollection = '[data-experiment="derived-collection"]';
+  const derivedCollectionInitialExecutions = await readNumber(
+    page,
+    `${derivedCollection} [data-metric="executions"]`,
+  );
+  assert.deepEqual(
+    await page.locator(`${derivedCollection} li`).allTextContents(),
+    ["Delta", "Alpha", "Beta"],
+  );
+  await page.evaluate(() => {
+    window.__farmDerivedAlpha = document.querySelector(
+      '[data-experiment="derived-collection"] [data-key="a"]',
+    );
+  });
+  await page.locator(`${derivedCollection} [data-action="filter-items"]`).click();
+  await assertText(page, `${derivedCollection} [data-metric="minimum-rank"]`, "2");
+  assert.deepEqual(await page.locator(`${derivedCollection} li`).allTextContents(), [
+    "Delta",
+    "Alpha",
+  ]);
+  await page.locator(`${derivedCollection} [data-action="sort-items"]`).click();
+  await assertText(page, `${derivedCollection} [data-metric="direction"]`, "descending");
+  assert.deepEqual(await page.locator(`${derivedCollection} li`).allTextContents(), [
+    "Alpha",
+    "Delta",
+  ]);
+  await page.locator(`${derivedCollection} [data-action="update-derived-row"]`).click();
+  assert.deepEqual(await page.locator(`${derivedCollection} li`).allTextContents(), [
+    "Delta",
+    "Axiom",
+  ]);
+  await page.locator(`${derivedCollection} [data-action="filter-items"]`).click();
+  await page.locator(`${derivedCollection} [data-action="resize-page"]`).click();
+  assert.deepEqual(await page.locator(`${derivedCollection} li`).allTextContents(), [
+    "Delta",
+    "Axiom",
+  ]);
+  await page.locator(`${derivedCollection} [data-action="resize-page"]`).click();
+  const derivedCollectionOrder = await page.locator(`${derivedCollection} li`).allTextContents();
+  assert.deepEqual(derivedCollectionOrder, [
+    "Beta",
+    "Delta",
+    "Axiom",
+  ]);
+  assert.equal(
+    await page.evaluate(
+      () =>
+        window.__farmDerivedAlpha ===
+        document.querySelector('[data-experiment="derived-collection"] [data-key="a"]'),
+    ),
+    true,
+    "the derived collection did not preserve a surviving keyed row",
+  );
+  await page.locator(`${derivedCollection} [data-action="stress-items"]`).click();
+  const derivedStressRows = await page.locator(`${derivedCollection} li`).allTextContents();
+  assert.deepEqual(derivedStressRows, ["Row 484", "Row 290", "Row 96"]);
+  const derivedCollectionFinalExecutions = await readNumber(
+    page,
+    `${derivedCollection} [data-metric="executions"]`,
+  );
+  assert.equal(derivedCollectionFinalExecutions - derivedCollectionInitialExecutions, 0);
+
   const explicitList = '[data-experiment="keyed-explicit"]';
   const explicitListInitialExecutions = await readNumber(
     page,
@@ -685,6 +748,15 @@ try {
             keyedDomIdentityPreserved: true,
             lisMoves: 3,
             owner: "Farm keyed rows",
+          },
+          derivedCollection: {
+            order: derivedCollectionOrder,
+            stressSourceRows: 2048,
+            stressMountedRows: derivedStressRows.length,
+            updateExecutions:
+              derivedCollectionFinalExecutions - derivedCollectionInitialExecutions,
+            keyedDomIdentityPreserved: true,
+            operations: ["filter", "toSorted", "slice", "toReversed"],
           },
           explicitKeyedList: {
             order: ["Beta", "Alpha"],

--- a/examples/react-compiler/src/components/compiler-edge-lab.tsx
+++ b/examples/react-compiler/src/components/compiler-edge-lab.tsx
@@ -7,6 +7,7 @@ let compiledBatchExecutions = 0;
 let reactBatchExecutions = 0;
 let multipleBindingExecutions = 0;
 let automaticListExecutions = 0;
+let derivedCollectionExecutions = 0;
 let explicitListExecutions = 0;
 
 export function CompiledBatchExperiment() {
@@ -224,6 +225,117 @@ export function AutomaticKeyedListExperiment() {
   );
 }
 
+interface PipelineItem extends ListItem {
+  rank: number;
+  visible: boolean;
+}
+
+export function DerivedCollectionExperiment() {
+  const [items, setItems] = useState<PipelineItem[]>([
+    { id: "a", label: "Alpha", rank: 3, visible: true },
+    { id: "b", label: "Beta", rank: 1, visible: true },
+    { id: "c", label: "Gamma", rank: 2, visible: false },
+    { id: "d", label: "Delta", rank: 4, visible: true },
+  ]);
+  const [minimumRank, setMinimumRank] = useState(0);
+  const [pageSize, setPageSize] = useState(3);
+  const [descending, setDescending] = useState(false);
+  const visibleItems = items.filter(
+    (item) => item.visible && item.rank >= minimumRank,
+  );
+  const orderedItems = visibleItems.toSorted((left, right) =>
+    descending ? right.rank - left.rank : left.rank - right.rank,
+  );
+  const pageItems = orderedItems.slice(0, pageSize).toReversed();
+
+  return (
+    <article className="edge-card" data-experiment="derived-collection">
+      <header>
+        <span className="experiment-number">04B</span>
+        <div>
+          <h3>Derived keyed collection</h3>
+          <p>Filter, order, and window dependencies feed the same keyed-row runtime.</p>
+        </div>
+      </header>
+      <dl className="compact-metrics" aria-live="polite">
+        <div>
+          <dt>Minimum rank</dt>
+          <dd data-metric="minimum-rank">{minimumRank}</dd>
+        </div>
+        <div>
+          <dt>Direction</dt>
+          <dd data-metric="direction">{descending ? "descending" : "ascending"}</dd>
+        </div>
+        <div>
+          <dt>Executions</dt>
+          <dd data-metric="executions">
+            {typeof window === "undefined" ? 1 : ++derivedCollectionExecutions}
+          </dd>
+        </div>
+      </dl>
+      <ol data-list="derived-collection">
+        {pageItems.map((item) => (
+          <li data-key={item.id} data-rank={item.rank} key={item.id}>
+            {item.label}
+          </li>
+        ))}
+      </ol>
+      <div className="button-row">
+        <button
+          type="button"
+          data-action="filter-items"
+          onClick={() => setMinimumRank((value) => (value === 0 ? 2 : 0))}
+        >
+          Toggle filter
+        </button>
+        <button
+          type="button"
+          data-action="sort-items"
+          onClick={() => setDescending((value) => !value)}
+        >
+          Reverse order
+        </button>
+        <button
+          type="button"
+          data-action="resize-page"
+          onClick={() => setPageSize((value) => (value === 3 ? 2 : 3))}
+        >
+          Resize window
+        </button>
+        <button
+          type="button"
+          data-action="update-derived-row"
+          onClick={() =>
+            setItems((value) =>
+              value.map((item) =>
+                item.id === "a" ? { ...item, label: "Axiom", rank: 5 } : item,
+              ),
+            )
+          }
+        >
+          Update row
+        </button>
+        <button
+          type="button"
+          data-action="stress-items"
+          onClick={() =>
+            setItems(
+              Array.from({ length: 2048 }, (_, index) => ({
+                id: `stress-${index}`,
+                label: `Row ${index}`,
+                rank: index % 97,
+                visible: index % 2 === 0,
+              })),
+            )
+          }
+        >
+          Load 2,048 rows
+        </button>
+      </div>
+    </article>
+  );
+}
+
 function StatefulListRow({ item }: { item: ListItem }) {
   const [clicks, setClicks] = useState(0);
   return (
@@ -242,7 +354,7 @@ export function ExplicitKeyedListExperiment() {
   return (
     <article className="edge-card" data-experiment="keyed-explicit">
       <header>
-        <span className="experiment-number">04B</span>
+        <span className="experiment-number">04C</span>
         <div>
           <h3>Explicit List boundary</h3>
           <p>A key selector supports custom rows while React preserves their state.</p>
@@ -301,6 +413,7 @@ export function CompilerEdgeLab() {
       </div>
       <div className="edge-grid">
         <AutomaticKeyedListExperiment />
+        <DerivedCollectionExperiment />
         <ExplicitKeyedListExperiment />
       </div>
 

--- a/examples/react-compiler/tsconfig.json
+++ b/examples/react-compiler/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -63,8 +63,8 @@ The current compiler handles components that it can prove have:
 - state-driven text, attributes, per-property inline styles, and controlled form properties;
 - host-rooted `condition && <element>` and `condition ? <element> : <element>` child blocks at
   statically known locations, including supported nested boundaries;
-- direct item-keyed `collection.map(...)` children and explicit `List` boundaries at statically
-  known container locations;
+- item-keyed `collection.map(...)` children and explicit `List` boundaries at statically known
+  container locations, including supported non-mutating collection pipelines;
 - stable module-level child components with compiler-safe props;
 - React-managed event handlers; and
 - no refs, effects, or unsupported dynamic child structures.
@@ -108,6 +108,36 @@ build time. After React performs the initial render or hydration, Farm adopts th
 Later list updates patch surviving rows by key, create or remove only the changed rows, and use a
 longest increasing subsequence (LIS) to minimize DOM moves during a reorder. The outer user
 component and the list callback do not rerun for those compiler-cell updates.
+
+A keyed collection may use derived locals or an inline chain of `filter`, `slice`, `toSorted`, and
+`toReversed`:
+
+```tsx
+const visible = items.filter((item) => item.visible && item.rank >= minimumRank);
+const page = visible
+  .toSorted((left, right) => left.rank - right.rank)
+  .slice(offset, offset + pageSize)
+  .toReversed();
+
+return (
+  <ul>
+    {page.map((item) => (
+      <li key={item.id}>{item.label}</li>
+    ))}
+  </ul>
+);
+```
+
+The compiler records dependencies used by the source collection, inline predicate, inline
+comparator, and slice arguments. It reruns the pipeline only when one of those compiler cells
+changes, then gives the result to the existing keyed-row and LIS runtime. The required filtering or
+sorting still runs; unrelated local updates avoid that work and do not rerun the outer component.
+Callbacks must be synchronous, inline, and contain one compiler-safe returned expression. Mutating
+`sort`, `reverse`, and `splice`, external or async callbacks, Hooks, assignments, spread arguments,
+and unproven calls use the original React fallback.
+
+`toSorted` and `toReversed` are emitted as standard runtime calls rather than polyfilled. Configure
+the TypeScript `lib` with ES2023 and target a runtime that supports them when using those methods.
 
 React remains the fallback and compatibility boundary. A map beside static children, a row with
 events, a fragment, a ref, or a custom component, and other unsupported shapes use the existing

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -446,6 +446,88 @@ const testSource = String.raw`
   assert.equal(keyedRowExecutions, initialKeyedRowExecutions);
   flushSync(() => keyedRowsRoot.unmount());
 
+  let derivedCollectionExecutions = 0;
+  const DerivedCollections = createCompiledComponent({
+    displayName: "CompatibilityDerivedCollections",
+    initialize: () => [
+      [
+        { id: "a", label: "Alpha", rank: 1, visible: true },
+        { id: "b", label: "Beta", rank: 3, visible: true },
+        { id: "c", label: "Gamma", rank: 2, visible: false },
+      ],
+      0,
+    ],
+    render(_props, state, blocks) {
+      derivedCollectionExecutions += 1;
+      const items = () =>
+        state[0]
+          .get()
+          .filter((item) => item.visible && item.rank >= Number(state[1].get()))
+          .toSorted((left, right) => left.rank - right.rank)
+          .slice(0, 2)
+          .toReversed();
+      return React.createElement(
+        "section",
+        null,
+        React.createElement(
+          "button",
+          {
+            onClick: () => {
+              state[0].set((value) =>
+                value.map((item) =>
+                  item.id === "b" ? { ...item, label: "Bravo", rank: 4 } : item,
+                ),
+              );
+              state[1].set(2);
+            },
+          },
+          "Update pipeline",
+        ),
+        React.createElement(blocks.KeyedRows, {
+          id: 0,
+          render: () =>
+            React.createElement(
+              "ol",
+              null,
+              items().map((item) =>
+                React.createElement("li", { key: item.id, "data-key": item.id }, item.label),
+              ),
+            ),
+          items,
+          rowKey: (item) => item.id,
+          create: (item) => ({
+            kind: "element",
+            tag: "li",
+            attributes: [{ name: "data-key", value: item.id }],
+            styles: [],
+            children: [item.label],
+          }),
+          bindings: [{ kind: "text", path: [], read: (item) => [item.label] }],
+        }),
+      );
+    },
+    bindings: [{ kind: "block", id: 0, dependencies: [0, 1] }],
+  });
+  const derivedCollectionContainer = document.createElement("div");
+  document.body.append(derivedCollectionContainer);
+  const derivedCollectionRoot = createRoot(derivedCollectionContainer);
+  flushSync(() => derivedCollectionRoot.render(React.createElement(DerivedCollections)));
+  const initialDerivedCollectionExecutions = derivedCollectionExecutions;
+  const originalBeta = derivedCollectionContainer.querySelector("[data-key='b']");
+  derivedCollectionContainer.querySelector("button").click();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.deepEqual(
+    [...derivedCollectionContainer.querySelectorAll("li")].map((row) => [
+      row.getAttribute("data-key"),
+      row.textContent,
+    ]),
+    [["b", "Bravo"]],
+  );
+  assert.equal(derivedCollectionContainer.querySelector("[data-key='b']"), originalBeta);
+  assert.equal(derivedCollectionExecutions, initialDerivedCollectionExecutions);
+  flushSync(() => derivedCollectionRoot.unmount());
+
   let islandExecutions = 0;
   let islandChildExecutions = 0;
   function IslandChild({ value }) {

--- a/packages/farm-react/src/__tests__/compiler-derived-collections.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-derived-collections.test.ts
@@ -1,0 +1,263 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true);
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/DerivedCollections.tsx", infer);
+}
+
+describe("React AOT derived collection compiler", () => {
+  it("lowers a safe filter, sort, and slice pipeline into compiled keyed rows", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function VisibleInventory() {
+        const [items, setItems] = useState([
+          { id: "a", label: "Alpha", rank: 2, visible: true },
+          { id: "b", label: "Beta", rank: 1, visible: false },
+        ]);
+        const [minimumRank, setMinimumRank] = useState(0);
+        const [limit, setLimit] = useState(10);
+        const [unrelated, setUnrelated] = useState(false);
+        return (
+          <section>
+            <button onClick={() => setMinimumRank((value) => value + 1)}>Raise rank</button>
+            <button onClick={() => setLimit((value) => value - 1)}>Shrink page</button>
+            <button onClick={() => setItems([...items].reverse())}>Reverse</button>
+            <button onClick={() => setUnrelated(!unrelated)}>{unrelated ? "On" : "Off"}</button>
+            <ul>
+              {items
+                .filter((item) => item.visible && item.rank >= minimumRank)
+                .toSorted((left, right) => left.rank - right.rank)
+                .slice(0, limit)
+                .map((item) => (
+                  <li data-rank={item.rank} key={item.id}>{item.label}</li>
+                ))}
+            </ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["VisibleInventory"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedRows");
+    expect(result.code).toContain(".filter(item => item.visible && item.rank >=");
+    expect(result.code).toContain(".toSorted((left, right) => left.rank - right.rank)");
+    expect(result.code).toContain(".slice(0,");
+    expect(result.code).toContain("dependencies: [0, 1, 2]");
+    expect(result.code).toContain('name: "data-rank"');
+    await expect(
+      transformWithEsbuild(result.code, "/app/DerivedCollections.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("farmBlocks.KeyedRows"),
+    });
+  });
+
+  it("expands derived collection locals without losing their dependencies", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function PagedInventory() {
+        const [items, setItems] = useState([
+          { id: "a", rank: 1, visible: true },
+          { id: "b", rank: 2, visible: false },
+        ]);
+        const [minimumRank, setMinimumRank] = useState(0);
+        const [pageSize, setPageSize] = useState(1);
+        const visible = items.filter((item) => item.visible && item.rank >= minimumRank);
+        const ordered = visible.toSorted((left, right) => right.rank - left.rank);
+        const page = ordered.slice(0, pageSize).toReversed();
+        return (
+          <section>
+            <button onClick={() => setItems([...items].reverse())}>Reverse</button>
+            <button onClick={() => setMinimumRank(minimumRank + 1)}>Filter</button>
+            <button onClick={() => setPageSize(pageSize + 1)}>Grow page</button>
+            <ol>{page.map((item) => <li key={item.id}>{item.rank}</li>)}</ol>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["PagedInventory"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedRows");
+    expect(result.code).toContain(".filter(item => item.visible && item.rank >=");
+    expect(result.code).toContain(".toReversed()");
+    expect(result.code).toContain("dependencies: [0, 1, 2]");
+  });
+
+  it("supports a safe pipeline as the collection of the public List boundary", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List } from "@farm.js/react/list";
+      export function ReversedInventory() {
+        const [items, setItems] = useState([
+          { id: "a", active: true },
+          { id: "b", active: false },
+        ]);
+        const active = items.filter((item) => item.active).toReversed();
+        return (
+          <div>
+            <button onClick={() => setItems([...items].reverse())}>Reverse</button>
+            <ul>
+              <List each={active} by={(item) => item.id}>
+                {(item) => <li>{item.id}</li>}
+              </List>
+            </ul>
+          </div>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["ReversedInventory"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedRows");
+    expect(result.code).toContain(".filter(item => item.active).toReversed()");
+  });
+
+  it("keeps custom component rows under React while isolating their derived collection", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List } from "@farm.js/react/list";
+      import { Row } from "./row";
+      export function FilteredComponents() {
+        const [items, setItems] = useState([
+          { id: "a", active: true },
+          { id: "b", active: false },
+        ]);
+        const active = items.filter((item) => item.active).slice(0, 10);
+        return (
+          <section>
+            <button onClick={() => setItems([...items].reverse())}>Reverse</button>
+            <List each={active} by={(item) => item.id}>
+              {(item) => <Row item={item} />}
+            </List>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["FilteredComponents"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).not.toContain("farmBlocks.KeyedRows");
+    expect(result.code).toContain(".filter(item => item.active).slice(0, 10)");
+  });
+
+  it("accepts a single-return filter body and the optional filter index", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function IndexedFilter() {
+        const [items, setItems] = useState([{ id: "a", visible: true }]);
+        const [offset, setOffset] = useState(0);
+        return (
+          <ul onClick={() => { setItems([...items]); setOffset(offset + 1); }}>
+            {items
+              .filter((item, index) => { return item.visible && index >= offset; })
+              .map((item) => <li key={item.id}>{item.id}</li>)}
+          </ul>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["IndexedFilter"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).toContain("dependencies: [0, 1]");
+  });
+
+  it.each([
+    {
+      name: "a mutating sort",
+      collection: "items.sort((left, right) => left.rank - right.rank)",
+      reason: /collection cannot use function calls/i,
+    },
+    {
+      name: "an external filter callback",
+      prefix: "const visible = (item) => item.visible;",
+      collection: "items.filter(visible)",
+      reason: /filter requires one inline callback/i,
+    },
+    {
+      name: "an async filter callback",
+      collection: "items.filter(async (item) => item.visible)",
+      reason: /filter callbacks must be synchronous/i,
+    },
+    {
+      name: "an assigning filter callback",
+      collection: "items.filter((item) => (item.visible = true))",
+      reason: /filter callbacks cannot use assignments/i,
+    },
+    {
+      name: "an unproven predicate call",
+      collection: "items.filter((item) => item.label.includes(query))",
+      reason: /filter callbacks cannot use function calls/i,
+    },
+    {
+      name: "a spread slice argument",
+      collection: "items.slice(...bounds)",
+      reason: /slice does not support spread arguments/i,
+    },
+    {
+      name: "arguments passed to toReversed",
+      collection: "items.toReversed(1)",
+      reason: /toReversed accepts at most 0/i,
+    },
+    {
+      name: "an invalid comparator shape",
+      collection: "items.toSorted((item) => item.rank)",
+      reason: /toSorted callbacks must be synchronous and use two items/i,
+    },
+    {
+      name: "an unproven collection source",
+      collection: "getItems().filter((item) => item.visible)",
+      reason: /collection cannot use function calls/i,
+    },
+  ])("falls back safely for $name", async ({ collection, prefix = "", reason }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      const getItems = () => [];
+      const bounds = [0, 1];
+      ${prefix}
+      export function UnsupportedPipeline() {
+        const [items, setItems] = useState([
+          { id: "a", label: "Alpha", rank: 1, visible: true },
+        ]);
+        const [query, setQuery] = useState("A");
+        return (
+          <ul onClick={() => { setItems([...items]); setQuery(query + "x"); }}>
+            {${collection}.map((item) => <li key={item.id}>{item.label}</li>)}
+          </ul>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual([]);
+    expect(result.diagnostics[0]?.reason).toMatch(reason);
+    expect(result.code).not.toContain("createCompiledComponent");
+  });
+
+  it("rejects an unsafe derived collection before it reaches JSX lowering", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function UnsafeDerivedPipeline() {
+        const [items, setItems] = useState([{ id: "a", visible: true }]);
+        const visible = items.filter((item) => {
+          console.log(item);
+          return item.visible;
+        });
+        return <ul onClick={() => setItems([...items])}>{visible.map((item) => <li key={item.id}>{item.id}</li>)}</ul>;
+      }
+    `);
+
+    expect(result.compiled).toEqual([]);
+    expect(result.diagnostics[0]?.reason).toMatch(/filter callbacks must return one expression/i);
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-keyed-lists.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-lists.test.ts
@@ -92,9 +92,9 @@ describe("React AOT keyed list compiler", () => {
       reason: /must depend on the mapped item/i,
     },
     {
-      name: "a collection call chain",
-      list: "items.filter((item) => item.visible).map((item) => <li key={item.id}>{item.label}</li>)",
-      reason: /collection cannot use function calls/i,
+      name: "an unproven collection callback call",
+      list: 'items.filter((item) => item.label.includes("a")).map((item) => <li key={item.id}>{item.label}</li>)',
+      reason: /filter callbacks cannot use function calls/i,
     },
   ])("falls back for $name", async ({ list, reason }) => {
     const result = await compile(`

--- a/packages/farm-react/src/__tests__/compiler-runtime-derived-collections.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-derived-collections.test.tsx
@@ -1,0 +1,406 @@
+import React, { useState } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createCompiledComponent,
+  type CompilerKeyedRowElement,
+  type CompilerStateUpdater,
+} from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Item {
+  id: string;
+  label: string;
+  rank: number;
+  visible: boolean;
+}
+
+interface Model {
+  items: Item[];
+  minimumRank: number;
+  offset: number;
+  limit: number;
+  descending: boolean;
+}
+
+type Action =
+  | { kind: "add"; item: Item }
+  | { kind: "remove"; selector: number }
+  | { kind: "toggle"; selector: number }
+  | { kind: "update"; selector: number; rank: number; suffix: number }
+  | { kind: "rotate"; amount: number }
+  | { kind: "minimum"; value: number }
+  | { kind: "offset"; value: number }
+  | { kind: "limit"; value: number }
+  | { kind: "direction" };
+
+const roots: Array<{ unmount(): void }> = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function derivedItems(model: Model): Item[] {
+  return model.items
+    .filter((item) => item.visible && item.rank >= model.minimumRank)
+    .toSorted((left, right) => (model.descending ? right.rank - left.rank : left.rank - right.rank))
+    .slice(model.offset, model.offset + model.limit)
+    .toReversed();
+}
+
+function rowDescriptor(item: Item): CompilerKeyedRowElement {
+  return {
+    kind: "element",
+    tag: "li",
+    attributes: [
+      { name: "data-key", value: item.id },
+      { name: "data-rank", value: item.rank },
+    ],
+    styles: [],
+    children: [`${item.label}:${item.rank}`],
+  };
+}
+
+function updateModel(model: Model, action: Action): Model {
+  if (action.kind === "add") {
+    const items =
+      model.items.length >= 40
+        ? [...model.items.slice(1), action.item]
+        : [...model.items, action.item];
+    return { ...model, items };
+  }
+  if (action.kind === "remove") {
+    if (model.items.length === 0) return model;
+    const index = action.selector % model.items.length;
+    return { ...model, items: model.items.filter((_item, itemIndex) => itemIndex !== index) };
+  }
+  if (action.kind === "toggle") {
+    if (model.items.length === 0) return model;
+    const index = action.selector % model.items.length;
+    return {
+      ...model,
+      items: model.items.map((item, itemIndex) =>
+        itemIndex === index ? { ...item, visible: !item.visible } : item,
+      ),
+    };
+  }
+  if (action.kind === "update") {
+    if (model.items.length === 0) return model;
+    const index = action.selector % model.items.length;
+    return {
+      ...model,
+      items: model.items.map((item, itemIndex) =>
+        itemIndex === index
+          ? { ...item, label: `${item.label}-${action.suffix}`, rank: action.rank }
+          : item,
+      ),
+    };
+  }
+  if (action.kind === "rotate") {
+    if (model.items.length < 2) return model;
+    const amount = action.amount % model.items.length;
+    return {
+      ...model,
+      items: [...model.items.slice(amount), ...model.items.slice(0, amount)],
+    };
+  }
+  if (action.kind === "minimum") return { ...model, minimumRank: action.value };
+  if (action.kind === "offset") return { ...model, offset: action.value };
+  if (action.kind === "limit") return { ...model, limit: action.value };
+  return { ...model, descending: !model.descending };
+}
+
+function createCompiledCollection(initial: Model, onExecution: () => void) {
+  let setModel: (next: CompilerStateUpdater) => void = () => undefined;
+  const Component = createCompiledComponent({
+    displayName: "DerivedCollection",
+    initialize: () => [initial],
+    render(_props: Record<string, never>, state, blocks) {
+      onExecution();
+      setModel = (next) => state[0].set(next);
+      const model = () => state[0].get() as Model;
+      const items = () => derivedItems(model());
+      const KeyedRows = blocks.KeyedRows;
+      return (
+        <section data-version="compiled">
+          <KeyedRows
+            id={0}
+            render={() => (
+              <ol>
+                {items().map((item) => (
+                  <li data-key={item.id} data-rank={item.rank} key={item.id}>
+                    {item.label}:{item.rank}
+                  </li>
+                ))}
+              </ol>
+            )}
+            items={items}
+            rowKey={(item) => (item as Item).id}
+            create={(item) => rowDescriptor(item as Item)}
+            bindings={[
+              {
+                kind: "attribute",
+                path: [],
+                name: "data-key",
+                read: (item) => (item as Item).id,
+              },
+              {
+                kind: "attribute",
+                path: [],
+                name: "data-rank",
+                read: (item) => (item as Item).rank,
+              },
+              {
+                kind: "text",
+                path: [],
+                read: (item) => [`${(item as Item).label}:${(item as Item).rank}`],
+              },
+            ]}
+          />
+        </section>
+      );
+    },
+    bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+  });
+  return { Component, setModel: (next: CompilerStateUpdater) => setModel(next) };
+}
+
+function snapshot(container: Element): string[][] {
+  return [...container.querySelectorAll("li")].map((row) => [
+    row.getAttribute("data-key") || "",
+    row.getAttribute("data-rank") || "",
+    row.textContent || "",
+  ]);
+}
+
+describe("compiled derived collection runtime", () => {
+  it("does not rerun the pipeline for an unrelated compiler cell", async () => {
+    let setMinimum: (next: CompilerStateUpdater) => void = () => undefined;
+    let setUnrelated: (next: CompilerStateUpdater) => void = () => undefined;
+    let executions = 0;
+    let pipelineReads = 0;
+    const Inventory = createCompiledComponent({
+      displayName: "DerivedCollectionDependencies",
+      initialize: () => [
+        [
+          { id: "a", label: "Alpha", rank: 1, visible: true },
+          { id: "b", label: "Beta", rank: 2, visible: true },
+        ],
+        0,
+        0,
+      ],
+      render(_props: Record<string, never>, state, blocks) {
+        executions += 1;
+        setMinimum = (next) => state[1].set(next);
+        setUnrelated = (next) => state[2].set(next);
+        const items = () => {
+          pipelineReads += 1;
+          return (state[0].get() as Item[])
+            .filter((item) => item.rank >= Number(state[1].get()))
+            .toSorted((left, right) => left.rank - right.rank);
+        };
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <section>
+            <output>{Number(state[2].get())}</output>
+            <KeyedRows
+              id={0}
+              render={() => (
+                <ul>
+                  {items().map((item) => (
+                    <li data-key={item.id} key={item.id}>
+                      {item.label}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              items={items}
+              rowKey={(item) => (item as Item).id}
+              create={(item) => rowDescriptor(item as Item)}
+              bindings={[{ kind: "text", path: [], read: (item) => [(item as Item).label] }]}
+            />
+          </section>
+        );
+      },
+      bindings: [
+        {
+          kind: "text",
+          path: [0],
+          dependencies: [2],
+          read: (_props, state) => state[2].get(),
+        },
+        { kind: "block", id: 0, dependencies: [0, 1] },
+      ],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Inventory />));
+    const initialPipelineReads = pipelineReads;
+
+    await act(async () => {
+      setUnrelated(1);
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("output")?.textContent).toBe("1");
+    expect(pipelineReads).toBe(initialPipelineReads);
+
+    await act(async () => {
+      setMinimum(2);
+      await flushCompilerUpdates();
+    });
+    expect(pipelineReads).toBeGreaterThan(initialPipelineReads);
+    expect(snapshot(container)).toEqual([["b", "", "Beta"]]);
+    expect(executions).toBe(1);
+  });
+
+  it("preserves surviving keyed rows across filter, order, and window changes", async () => {
+    const initial: Model = {
+      items: [
+        { id: "a", label: "Alpha", rank: 1, visible: true },
+        { id: "b", label: "Beta", rank: 2, visible: true },
+        { id: "c", label: "Gamma", rank: 3, visible: false },
+      ],
+      minimumRank: 0,
+      offset: 0,
+      limit: 3,
+      descending: false,
+    };
+    let executions = 0;
+    const compiled = createCompiledCollection(initial, () => {
+      executions += 1;
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<compiled.Component />));
+    const beta = container.querySelector<HTMLElement>('[data-key="b"]')!;
+
+    await act(async () => {
+      compiled.setModel((value) => ({
+        ...(value as Model),
+        descending: true,
+        minimumRank: 2,
+        items: (value as Model).items.map((item) =>
+          item.id === "b" ? { ...item, label: "Bravo", rank: 4 } : item,
+        ),
+      }));
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector('[data-key="b"]')).toBe(beta);
+    expect(snapshot(container)).toEqual([["b", "4", "Bravo:4"]]);
+    expect(executions).toBe(1);
+  });
+
+  it("matches React across 5,000 deterministic pipeline and keyed-row transitions", async () => {
+    const initial: Model = {
+      items: Array.from({ length: 16 }, (_, index) => ({
+        id: `i${index}`,
+        label: `Item ${index}`,
+        rank: index % 11,
+        visible: index % 3 !== 0,
+      })),
+      minimumRank: 0,
+      offset: 0,
+      limit: 12,
+      descending: false,
+    };
+    let compiledExecutions = 0;
+    const compiled = createCompiledCollection(initial, () => {
+      compiledExecutions += 1;
+    });
+    let setReact: React.Dispatch<React.SetStateAction<Model>> = () => undefined;
+    function Normal() {
+      const [model, setModel] = useState(initial);
+      setReact = setModel;
+      return (
+        <section data-version="react">
+          <ol>
+            {derivedItems(model).map((item) => (
+              <li data-key={item.id} data-rank={item.rank} key={item.id}>
+                {item.label}:{item.rank}
+              </li>
+            ))}
+          </ol>
+        </section>
+      );
+    }
+
+    let seed = 0x51ced123;
+    let nextId = 0;
+    const random = () => {
+      seed = (seed * 1664525 + 1013904223) >>> 0;
+      return seed;
+    };
+    const actions: Action[] = Array.from({ length: 5000 }, () => {
+      const operation = random() % 9;
+      const selector = random();
+      if (operation === 0) {
+        const id = `n${nextId++}`;
+        return {
+          kind: "add",
+          item: {
+            id,
+            label: id.toUpperCase(),
+            rank: random() % 19,
+            visible: (random() & 1) === 0,
+          },
+        };
+      }
+      if (operation === 1) return { kind: "remove", selector };
+      if (operation === 2) return { kind: "toggle", selector };
+      if (operation === 3) {
+        return { kind: "update", selector, rank: random() % 19, suffix: random() % 97 };
+      }
+      if (operation === 4) return { kind: "rotate", amount: selector };
+      if (operation === 5) return { kind: "minimum", value: selector % 12 };
+      if (operation === 6) return { kind: "offset", value: selector % 5 };
+      if (operation === 7) return { kind: "limit", value: (selector % 16) + 1 };
+      return { kind: "direction" };
+    });
+
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<compiled.Component />);
+      reactRoot.render(<Normal />);
+    });
+
+    for (let offset = 0; offset < actions.length; offset += 20) {
+      const batch = actions.slice(offset, offset + 20);
+      await act(async () => {
+        for (const action of batch) {
+          compiled.setModel((value) => updateModel(value as Model, action));
+          setReact((value) => updateModel(value, action));
+        }
+        await flushCompilerUpdates();
+      });
+      expect(snapshot(compiledContainer)).toEqual(snapshot(reactContainer));
+    }
+    expect(compiledExecutions).toBe(1);
+  }, 30_000);
+});

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -536,6 +536,100 @@ function returnedExpression(
   return value && t.isExpression(value) ? value : undefined;
 }
 
+const SAFE_COLLECTION_PIPELINE_METHODS = new Set(["filter", "slice", "toReversed", "toSorted"]);
+
+function collectionPipelineMethod(expression: t.Expression): string | undefined {
+  if (
+    !t.isCallExpression(expression) ||
+    !t.isMemberExpression(expression.callee) ||
+    expression.callee.computed ||
+    !t.isExpression(expression.callee.object) ||
+    !t.isIdentifier(expression.callee.property)
+  ) {
+    return undefined;
+  }
+  return SAFE_COLLECTION_PIPELINE_METHODS.has(expression.callee.property.name)
+    ? expression.callee.property.name
+    : undefined;
+}
+
+function validateCollectionCallback(
+  callback: t.ArrowFunctionExpression | t.FunctionExpression,
+  method: "filter" | "toSorted",
+  safeGlobals: ReadonlySet<string>,
+): string | undefined {
+  const expectedParameters = method === "filter" ? "one item and an optional index" : "two items";
+  const validParameterCount =
+    method === "filter"
+      ? callback.params.length >= 1 && callback.params.length <= 2
+      : callback.params.length === 2;
+  if (
+    callback.async ||
+    callback.generator ||
+    !validParameterCount ||
+    callback.params.some((parameter) => !t.isIdentifier(parameter))
+  ) {
+    return `${method} callbacks must be synchronous and use ${expectedParameters}`;
+  }
+  if (containsDirectHookCall(callback)) {
+    return `Hooks cannot be called inside a ${method} callback`;
+  }
+  const value = returnedExpression(callback);
+  if (!value) return `${method} callbacks must return one expression`;
+  const unsupported = validateDerivedExpression(value, safeGlobals);
+  return unsupported ? `${method} callbacks cannot use ${unsupported}` : undefined;
+}
+
+function validateCollectionPipeline(
+  expression: t.Expression,
+  safeGlobals: ReadonlySet<string>,
+): string | undefined {
+  const method = collectionPipelineMethod(expression);
+  if (!method || !t.isCallExpression(expression)) {
+    return validateDerivedExpression(expression, safeGlobals);
+  }
+
+  const source = (expression.callee as t.MemberExpression).object as t.Expression;
+  const sourceUnsupported = collectionPipelineMethod(source)
+    ? validateCollectionPipeline(source, safeGlobals)
+    : validateDerivedExpression(source, safeGlobals);
+  if (sourceUnsupported) return sourceUnsupported;
+
+  if (method === "filter") {
+    if (
+      expression.arguments.length !== 1 ||
+      (!t.isArrowFunctionExpression(expression.arguments[0]) &&
+        !t.isFunctionExpression(expression.arguments[0]))
+    ) {
+      return "filter requires one inline callback";
+    }
+    return validateCollectionCallback(expression.arguments[0], "filter", safeGlobals);
+  }
+
+  if (method === "toSorted") {
+    if (expression.arguments.length === 0) return undefined;
+    if (
+      expression.arguments.length !== 1 ||
+      (!t.isArrowFunctionExpression(expression.arguments[0]) &&
+        !t.isFunctionExpression(expression.arguments[0]))
+    ) {
+      return "toSorted requires an optional inline comparator";
+    }
+    return validateCollectionCallback(expression.arguments[0], "toSorted", safeGlobals);
+  }
+
+  const maximumArguments = method === "slice" ? 2 : 0;
+  if (expression.arguments.length > maximumArguments) {
+    return `${method} accepts at most ${maximumArguments} compiler-safe arguments`;
+  }
+  for (const argument of expression.arguments) {
+    if (!t.isExpression(argument)) return `${method} does not support spread arguments`;
+    const unsupported = validateDerivedExpression(argument, safeGlobals);
+    if (unsupported) return `${method} arguments cannot use ${unsupported}`;
+  }
+  return undefined;
+}
+
 function containsDirectHookCall(
   callback: t.ArrowFunctionExpression | t.FunctionExpression,
 ): boolean {
@@ -618,7 +712,7 @@ function analyzeMapList(
 ): { dependencies?: number[]; reason?: string } {
   const callee = expression.callee as t.MemberExpression;
   const collection = callee.object as t.Expression;
-  const collectionUnsupported = validateDerivedExpression(collection, safeGlobals);
+  const collectionUnsupported = validateCollectionPipeline(collection, safeGlobals);
   if (collectionUnsupported) {
     return { reason: `keyed list collection cannot use ${collectionUnsupported}` };
   }
@@ -669,7 +763,7 @@ function analyzePublicList(
   const each = listAttributeExpression(element, "each");
   const by = listAttributeExpression(element, "by");
   if (!each || !by) return { reason: "List requires explicit each and by properties" };
-  const collectionUnsupported = validateDerivedExpression(each, safeGlobals);
+  const collectionUnsupported = validateCollectionPipeline(each, safeGlobals);
   if (collectionUnsupported) {
     return { reason: `List each cannot use ${collectionUnsupported}` };
   }
@@ -2289,7 +2383,9 @@ function compileCandidate(
       });
       continue;
     }
-    const unsupported = validateDerivedExpression(expanded, safeGlobals);
+    const unsupported = collectionPipelineMethod(expanded)
+      ? validateCollectionPipeline(expanded, safeGlobals)
+      : validateDerivedExpression(expanded, safeGlobals);
     if (unsupported) {
       return `derived local ${binding.name} cannot use ${unsupported}`;
     }


### PR DESCRIPTION
## Summary

- compile safe non-mutating `filter`, `slice`, `toSorted`, and `toReversed` pipelines feeding keyed map and `List` boundaries
- expand derived collection locals into dependency-aware keyed boundaries while reusing compiler-owned rows, DOM identity, and LIS
- preserve React fallback for mutating methods, unsafe callbacks, Hooks, assignments, spread arguments, and other unproven behavior
- document the experimental contract, ES2023 runtime and type requirement, limitations, and fallback behavior
- add an interactive production experiment including a 2,048-row source stress case

## Safety and compatibility

- no compiler runtime API changes; existing keyed-row and React-owned fallback paths are reused
- only synchronous inline pure callbacks and compiler-safe arguments are accepted
- unrelated compiler-cell updates do not rerun the collection pipeline
- unsupported sources remain unchanged React components
- `toSorted` and `toReversed` remain standard runtime calls and are not polyfilled

## Verification

- `pnpm --filter @farm.js/react test` — 22 files and 178 tests passed
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter farm-react-compiler-example type-check`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and React 19.2.8 passed
- production example build and browser E2E passed on desktop and mobile
- 5,000 deterministic transitions matched normal React
- 2,048-row production stress source preserved keyed identity with zero owner executions
- formatting and `git diff --check` passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compiles safe, non-mutating derived collection pipelines into compiler-owned keyed rows for React. Previously, chained `filter`/`slice`/`toSorted`/`toReversed` fell back to React; now validated pipelines before `.map(...)` or as `List each` compile, reducing rerenders while preserving DOM identity and LIS moves. Unsupported or mutating shapes still use the React fallback.

**What to review**
- Compiler: validation and lowering for `filter` (inline sync predicate), `slice` (0–2 safe args), `toSorted` (optional inline two-item comparator), and `toReversed` (no args); dependency capture for source, predicate/comparator, and window args; integrates with existing keyed row and LIS runtime; no runtime API changes.
- Fallbacks: reject mutating methods (`sort`, `reverse`, `splice`), async/external callbacks, Hooks, assignments, spread args, and unproven calls; unsupported sources remain React components.
- Tests and compatibility: new unit and runtime tests for pipelines, a 5,000-transition determinism suite, and React 18/19 compatibility checks; example app adds a 2,048-row stress experiment.
- Docs and examples: guidance for the pipeline contract, limitations, and behavior; example `tsconfig` moves to ES2023.

**Rollout**
- No API changes; existing keyed lists and `List` continue to work.
- If you use `toSorted`/`toReversed`, ensure your runtime supports them and set TypeScript `lib` to ES2023 (the example shows this).

<sup>Written for commit 9a72205d6f9dc86ec9b24c0fac7b4e21212778a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

