### PR TITLE
chore(docs): remove redundant asset declaration

### DIFF
--- a/docs/src/assets.d.ts
+++ b/docs/src/assets.d.ts
@@ -1,4 +1,0 @@
-declare module "*.woff2?url" {
-  const url: string;
-  export default url;
-}


### PR DESCRIPTION
## Summary

- remove the manually maintained `docs/src/assets.d.ts` declaration
- keep generated `docs/src/farm.d.ts` as the single declaration file under `docs/src`
- rely on Farm’s shipped `*?url` asset typing through `@farm.js/core/image`

## Verification

- `farm generate --check`
- focused type-artifact suite: 6 tests passed
- isolated TypeScript probe confirms the generated `farm.d.ts` asset imports type `.woff2?url` without `assets.d.ts`
- confirmed the current `@farming-labs/docs` generator does not create `assets.d.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the manual `docs/src/assets.d.ts` and rely on Farm’s generated declarations and shipped `*?url` asset typing instead. Previously we declared `*.woff2?url` in `assets.d.ts`; now `*.woff2?url` resolves via `docs/src/farm.d.ts` and `@farm.js/core/image`, reducing duplication with no TypeScript or runtime behavior change.

- `docs/src/farm.d.ts` remains the single declaration file under `docs/src`.
- Asset imports like `.woff2?url` continue to type-check via Farm’s `*?url` typing.
- No migration required; if types appear stale, run `farm generate --check`.

<sup>Written for commit b219d878a275ffe4c71ae645b9bee82ea014c514. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

