### PR TITLE
fix(core): serve dotted metadata routes from the dev server

### DIFF
--- a/packages/farm/src/__tests__/dev-static.test.ts
+++ b/packages/farm/src/__tests__/dev-static.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { devServableFileExists } from "../dev-static";
+import { devServableFileExists, shouldBypassFarmRouterForDottedPath } from "../dev-static";
 
 describe("devServableFileExists", () => {
   let root: string;
@@ -56,5 +56,80 @@ describe("devServableFileExists", () => {
   it("ignores non-string base dirs", () => {
     expect(devServableFileExists("/favicon.ico", [false, undefined, publicDir])).toBe(true);
     expect(devServableFileExists("/favicon.ico", [false, undefined])).toBe(false);
+  });
+});
+
+describe("shouldBypassFarmRouterForDottedPath", () => {
+  let root: string;
+  let publicDir: string;
+
+  beforeAll(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-dev-dotted-"));
+    publicDir = path.join(root, "public");
+    fs.mkdirSync(publicDir, { recursive: true });
+    fs.writeFileSync(path.join(publicDir, "favicon.ico"), "icon");
+  });
+
+  afterAll(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  function createRouteManager(matches: { page?: string[]; metadata?: string[]; image?: string[] }) {
+    return {
+      matchRoute: (pathname: string) => (matches.page?.includes(pathname) ? { route: {} } : null),
+      matchMetadataRoute: (pathname: string) => (matches.metadata?.includes(pathname) ? {} : null),
+      matchMetadataImage: (pathname: string) => (matches.image?.includes(pathname) ? {} : null),
+    };
+  }
+
+  it("keeps metadata routes with dotted URLs on the Farm renderer", () => {
+    // /manifest.webmanifest is served by manifest.ts auto-discovery, not a
+    // page route; bypassing the renderer 404s it in dev (#407).
+    const routeManager = createRouteManager({
+      metadata: ["/manifest.webmanifest", "/sitemap.xml", "/robots.txt"],
+    });
+    for (const pathname of ["/manifest.webmanifest", "/sitemap.xml", "/robots.txt"]) {
+      expect(shouldBypassFarmRouterForDottedPath(pathname, routeManager, [publicDir, root])).toBe(
+        false,
+      );
+    }
+  });
+
+  it("keeps generated metadata images on the Farm renderer", () => {
+    const routeManager = createRouteManager({ image: ["/opengraph-image.png"] });
+    expect(
+      shouldBypassFarmRouterForDottedPath("/opengraph-image.png", routeManager, [publicDir, root]),
+    ).toBe(false);
+  });
+
+  it("keeps dotted page routes on the Farm renderer", () => {
+    const routeManager = createRouteManager({ page: ["/kinfish/farm.js"] });
+    expect(
+      shouldBypassFarmRouterForDottedPath("/kinfish/farm.js", routeManager, [publicDir, root]),
+    ).toBe(false);
+  });
+
+  it("bypasses the router for unmatched dotted paths", () => {
+    const routeManager = createRouteManager({});
+    expect(
+      shouldBypassFarmRouterForDottedPath("/missing.webmanifest", routeManager, [publicDir, root]),
+    ).toBe(true);
+  });
+
+  it("lets a real file shadow a matching metadata route", () => {
+    const routeManager = createRouteManager({ metadata: ["/favicon.ico"] });
+    expect(
+      shouldBypassFarmRouterForDottedPath("/favicon.ico", routeManager, [publicDir, root]),
+    ).toBe(true);
+  });
+
+  it("never bypasses undotted or html paths", () => {
+    const routeManager = createRouteManager({});
+    expect(shouldBypassFarmRouterForDottedPath("/about", routeManager, [publicDir, root])).toBe(
+      false,
+    );
+    expect(shouldBypassFarmRouterForDottedPath("/page.html", routeManager, [publicDir, root])).toBe(
+      false,
+    );
   });
 });

--- a/packages/farm/src/dev-static.ts
+++ b/packages/farm/src/dev-static.ts
@@ -1,6 +1,35 @@
 import * as fs from "fs";
 import * as path from "path";
 
+interface DottedPathRouteMatcher {
+  matchRoute(pathname: string): { route: unknown } | null | undefined;
+  matchMetadataRoute(pathname: string): object | null;
+  matchMetadataImage(pathname: string): object | null;
+}
+
+/**
+ * Decide whether the dev server should hand a dotted request path to the
+ * static pipeline instead of Farm's renderer. Dotted paths are usually asset
+ * requests, but they are also how page routes with dotted segments and
+ * application metadata routes (/manifest.webmanifest, /sitemap.xml,
+ * /robots.txt, generated metadata images) are addressed, so the router is
+ * only bypassed when nothing in the app matches the pathname or a real file
+ * shadows it.
+ */
+export function shouldBypassFarmRouterForDottedPath(
+  pathname: string,
+  routeManager: DottedPathRouteMatcher | null | undefined,
+  baseDirs: Array<string | false | undefined>,
+): boolean {
+  if (!pathname.includes(".") || pathname.endsWith(".html")) return false;
+  const matchesAppRoute = Boolean(
+    routeManager?.matchRoute(pathname)?.route ||
+    routeManager?.matchMetadataRoute(pathname) ||
+    routeManager?.matchMetadataImage(pathname),
+  );
+  return !matchesAppRoute || devServableFileExists(pathname, baseDirs);
+}
+
 /**
  * Route segments may legitimately contain dots (e.g. /kinfish/farm.js), so a
  * dot alone cannot classify a dev request as a static asset. A dotted path is

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -47,7 +47,7 @@ import { farmEnvironmentFunctionsPlugin } from "./environment-vite";
 import { FARM_VERSION } from "./version";
 import { createDeferredDataResponse } from "./deferred";
 import { _withAfterNodeMiddleware } from "./after";
-import { devServableFileExists } from "./dev-static";
+import { shouldBypassFarmRouterForDottedPath } from "./dev-static";
 import {
   createFarmDeploymentMismatchResponse,
   FARM_DEPLOYMENT_ID_HEADER,
@@ -1742,19 +1742,18 @@ window.__FARM_MANIFEST__ = ${inlineValue({
           }
 
           // Dotted paths are usually static assets (modules, images, source
-          // maps), but dots are also valid inside route segments. Only skip
-          // the router when the request maps to a real file on disk or no app
-          // route matches the pathname.
-          if (requestPathname.includes(".") && !requestPathname.endsWith(".html")) {
-            const matchesAppRoute = Boolean(
-              farmApp?.getRouteManager()?.matchRoute(requestPathname)?.route,
-            );
-            if (
-              !matchesAppRoute ||
-              devServableFileExists(requestPathname, [server.config.publicDir, server.config.root])
-            ) {
-              return next();
-            }
+          // maps), but dots are also valid inside route segments and in
+          // application metadata routes (/manifest.webmanifest, /sitemap.xml,
+          // /robots.txt, metadata images). Only skip the router when the
+          // request maps to a real file on disk or nothing in the app matches
+          // the pathname.
+          if (
+            shouldBypassFarmRouterForDottedPath(requestPathname, farmApp?.getRouteManager(), [
+              server.config.publicDir,
+              server.config.root,
+            ])
+          ) {
+            return next();
           }
 
           // Handle SPA page-data requests for client-side navigation


### PR DESCRIPTION
## Summary

Fixes #407.

In `farm dev`, `GET /manifest.webmanifest` (and `/sitemap.xml`, `/robots.txt`) returned 404 even though `src/app/manifest.ts` auto-discovery injected the correct `<link rel="manifest">` and production served the route fine.

## Root cause

Exactly as diagnosed in the issue: the dev middleware's dotted-path check only consulted `matchRoute()` (page routes) before handing the request to Vite's static pipeline. Application metadata routes are matched separately via `matchMetadataRoute()`, which was never reached, so the request fell through to Vite and 404'd.

## Changes

- Extracted the bypass decision into `shouldBypassFarmRouterForDottedPath()` in `dev-static.ts` so it's unit-testable, and it now consults `matchMetadataRoute()` **and** `matchMetadataImage()` (generated `opengraph-image.png`-style URLs had the same exposure) alongside page routes.
- Behavior otherwise unchanged: a real file on disk still shadows a matching route, undotted and `.html` paths never bypass.

## Testing

- **End-to-end**: scaffolded app + `src/app/manifest.ts` (no `public/` file) + `farm dev` → `GET /manifest.webmanifest` now returns **200** with `Content-Type: application/manifest+json; charset=utf-8` and the generated JSON body; unmatched dotted paths still 404.
- New unit tests: metadata routes (manifest/sitemap/robots) stay on the renderer, metadata images stay on the renderer, dotted page routes keep working, unmatched dotted paths bypass, real files shadow matching routes, undotted/html paths never bypass.
- `dev-static` + `metadata-route` suites pass (19/19); `tsc --noEmit`, `oxlint`, `oxfmt` clean.

#408 is being addressed separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve dotted metadata routes in `farm dev` instead of 404. Previously, dotted requests like `/manifest.webmanifest`, `/sitemap.xml`, `/robots.txt`, and generated metadata images bypassed the router and fell through to Vite; now the dev server consults metadata matchers so these routes stay on the renderer, aligning dev with production.

- Extracts the bypass decision to `shouldBypassFarmRouterForDottedPath` in `packages/farm/src/dev-static.ts`, used by `packages/farm/src/vite.ts`.
- Considers page routes, metadata routes, and metadata images before bypassing; only bypasses when no app match exists or a real file on disk shadows the route.
- Behavior unchanged otherwise: real files still shadow; undotted and `.html` paths never bypass.
- Adds focused unit tests covering metadata routes, metadata images, dotted page routes, unmatched dotted paths, and file shadowing.

<sup>Written for commit e3a3db64543c3438cb05aad093a45be3016ff6b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

