### PR TITLE
fix(core): fail client builds that bundle server query handlers

### DIFF
--- a/docs/src/app/docs/server-queries/page.md
+++ b/docs/src/app/docs/server-queries/page.md
@@ -13,6 +13,16 @@ deduplication, prefetching, `staleTime`, stale-while-revalidate, focus and recon
 invalidation, and optimistic cache writes. Farm implements this behavior in its own cache and
 generated server references; it does not install or wrap TanStack Query.
 
+> **Browser usage requires the server-function transform**
+>
+> The generated browser server references come from the `@farm.js/plugin/rsc` transform, enabled by
+> adding the plugin and setting `experimental.serverActions: true` in `farm.config.ts`. Without it,
+> `useServerQuery`, `prefetchServerQuery`, and `fetchServerQuery` can only run during server
+> rendering: importing a query module from `"use client"` code would bundle the server handler into
+> the browser, and Farm fails the build with a boundary error instead. In apps without the
+> transform, call queries from server components, or expose an API route and use
+> [`createAPIClient`](/docs/api-client) from client components.
+
 ## Declare a query
 
 **src/features/products/queries.ts**

--- a/packages/farm/src/__tests__/server-query-boundary.test.ts
+++ b/packages/farm/src/__tests__/server-query-boundary.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { findClientServerFnViolation, formatServerFnBoundaryError } from "../server-query-boundary";
+
+const QUERY_MODULE = `
+import { createServerQuery } from "@farm.js/core";
+import { assertSafeTarget } from "./dns-guard.server";
+
+export const scanQuery = createServerQuery({
+  key: () => ["scan"],
+  handler: async ({ input }) => assertSafeTarget(input.host),
+});
+`;
+
+describe("findClientServerFnViolation", () => {
+  it("flags createServerQuery definitions compiled for the client", () => {
+    expect(findClientServerFnViolation(QUERY_MODULE, "/app/src/lib/scan-query.ts")).toEqual({
+      factory: "createServerQuery",
+    });
+  });
+
+  it("flags createServerFn definitions", () => {
+    const code = `
+import { createServerFn } from "@farm.js/core/server";
+export const fn = createServerFn({ handler: async () => 1 });
+`;
+    expect(findClientServerFnViolation(code, "/app/src/fn.ts")).toEqual({
+      factory: "createServerFn",
+    });
+  });
+
+  it("ignores modules that only import other core APIs", () => {
+    const code = `
+import { useServerQuery } from "@farm.js/core/server-query/client";
+import { scanQuery } from "./scan-query";
+export function Panel() {
+  return useServerQuery(scanQuery, { host: "example.com" });
+}
+`;
+    expect(findClientServerFnViolation(code, "/app/src/panel.tsx")).toBeNull();
+  });
+
+  it("ignores type-only imports", () => {
+    const code = `
+import type { createServerQuery } from "@farm.js/core";
+export type Q = typeof createServerQuery;
+`;
+    expect(findClientServerFnViolation(code, "/app/src/types.ts")).toBeNull();
+  });
+
+  it("ignores imports without a call site", () => {
+    const code = `
+import { createServerQuery } from "@farm.js/core";
+export { createServerQuery };
+`;
+    expect(findClientServerFnViolation(code, "/app/src/reexport.ts")).toBeNull();
+  });
+
+  it("ignores similarly named local functions", () => {
+    const code = `
+import { defineConfig } from "@farm.js/core";
+const myCreateServerQuery = (options) => options;
+export const q = myCreateServerQuery({});
+`;
+    expect(findClientServerFnViolation(code, "/app/src/local.ts")).toBeNull();
+  });
+
+  it("ignores virtual modules and dependencies", () => {
+    expect(findClientServerFnViolation(QUERY_MODULE, "\0virtual:farm-entry")).toBeNull();
+    expect(findClientServerFnViolation(QUERY_MODULE, "virtual:farm-entry")).toBeNull();
+    expect(
+      findClientServerFnViolation(QUERY_MODULE, "/app/node_modules/some-lib/dist/index.js"),
+    ).toBeNull();
+  });
+});
+
+describe("formatServerFnBoundaryError", () => {
+  it("names the factory, the module, and both remediations", () => {
+    const message = formatServerFnBoundaryError(
+      { factory: "createServerQuery" },
+      "/app/src/lib/scan-query.ts",
+    );
+    expect(message).toContain("createServerQuery");
+    expect(message).toContain("/app/src/lib/scan-query.ts");
+    expect(message).toContain("experimental.serverActions");
+    expect(message).toContain("@farm.js/plugin/rsc");
+    expect(message).toContain("createAPIClient");
+  });
+});

--- a/packages/farm/src/server-query-boundary.ts
+++ b/packages/farm/src/server-query-boundary.ts
@@ -1,0 +1,50 @@
+const SERVER_FN_FACTORIES = ["createServerQuery", "createServerFn"] as const;
+
+const FARM_CORE_IMPORT_RE =
+  /import\s*(?!type\b)(?:[\w$]+\s*,\s*)?\{([^}]*)\}\s*from\s*(["'])@farm\.js\/core(?:\/[\w./-]+)?\2/g;
+
+export type ServerFnBoundaryViolation = {
+  factory: (typeof SERVER_FN_FACTORIES)[number];
+};
+
+/**
+ * Detect a module that defines a Farm server function (createServerQuery /
+ * createServerFn) while being compiled for the client environment. Without
+ * the server-function transform (@farm.js/plugin/rsc with
+ * experimental.serverActions enabled) there is no client stub: the server
+ * handler and its dependency graph would be bundled into the browser and
+ * executed there, surfacing as confusing Vite externalization errors for
+ * Node built-ins (#408).
+ */
+export function findClientServerFnViolation(
+  code: string,
+  id: string,
+): ServerFnBoundaryViolation | null {
+  if (id.startsWith("\0") || id.startsWith("virtual:") || id.includes("node_modules")) return null;
+  if (!code.includes("@farm.js/core")) return null;
+
+  for (const match of code.matchAll(FARM_CORE_IMPORT_RE)) {
+    const specifiers = match[1];
+    for (const factory of SERVER_FN_FACTORIES) {
+      if (!new RegExp(`(?:^|[\\s{,])${factory}(?:[\\s},]|$)`).test(specifiers)) continue;
+      // Only a call site makes the module a server-function definition; a
+      // type-only or re-exported symbol never executes a handler.
+      if (new RegExp(`(?<![\\w$.])${factory}\\s*(?:<[^>]*>)?\\s*\\(`).test(code)) {
+        return { factory };
+      }
+    }
+  }
+  return null;
+}
+
+export function formatServerFnBoundaryError(
+  violation: ServerFnBoundaryViolation,
+  id: string,
+): string {
+  return [
+    `${violation.factory} handlers run only on the server, but ${id} is being bundled into the client.`,
+    `Importing a ${violation.factory} module from client code executes the server handler (and its Node-only imports) in the browser.`,
+    `Either enable the server-function transform (add @farm.js/plugin/rsc and set experimental.serverActions: true in farm.config.ts) so client imports become server references,`,
+    `or keep the query on the server: call it from server components, or expose an API route and use createAPIClient from the client.`,
+  ].join("\n");
+}

--- a/packages/farm/src/server-query-runtime.ts
+++ b/packages/farm/src/server-query-runtime.ts
@@ -40,6 +40,30 @@ const serverQueryClientState = (serverQueryClientGlobal[FARM_SERVER_QUERY_CLIENT
   active: [],
 });
 
+// Global symbol registry key set on raw server query implementations by
+// createServerQuery. Referenced via Symbol.for instead of importing
+// server-query.ts, which would pull the server handler pipeline into the
+// client bundle.
+const RAW_SERVER_QUERY_SYMBOL = Symbol.for("farm.server-query");
+
+/**
+ * A query reaching the browser should be a transformed server reference. The
+ * raw implementation carries the server query symbol; executing it here would
+ * run the server handler in the browser (#408). During SSR the raw
+ * implementation is expected and runs directly.
+ */
+function assertNotRawServerQueryInBrowser(query: unknown): void {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
+  if (!(query as Record<symbol, unknown> | null)?.[RAW_SERVER_QUERY_SYMBOL]) return;
+  throw new Error(
+    [
+      "useServerQuery received a raw server query implementation in the browser.",
+      "Server query handlers run only on the server. Enable the server-function transform (add @farm.js/plugin/rsc and set experimental.serverActions: true in farm.config.ts) so client imports become server references,",
+      "or call the query from server code / an API route (createAPIClient) instead.",
+    ].join("\n"),
+  );
+}
+
 export function beginFarmServerQueryAction(
   actionId: string,
   args: readonly unknown[],
@@ -134,6 +158,7 @@ async function executeServerQuery<TInput, TData>(
   provisionalKey: string,
   options: ServerQueryFetchOptions,
 ): Promise<TData> {
+  assertNotRawServerQueryInBrowser(query);
   const cache = getFarmClientDataCache();
   const inflight = cache.getInflight<TData>(provisionalKey);
   if (inflight) return inflight;

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -48,6 +48,7 @@ import { FARM_VERSION } from "./version";
 import { createDeferredDataResponse } from "./deferred";
 import { _withAfterNodeMiddleware } from "./after";
 import { shouldBypassFarmRouterForDottedPath } from "./dev-static";
+import { findClientServerFnViolation, formatServerFnBoundaryError } from "./server-query-boundary";
 import {
   createFarmDeploymentMismatchResponse,
   FARM_DEPLOYMENT_ID_HEADER,
@@ -2554,6 +2555,21 @@ export const manifest = getManifest();
     },
 
     async transform(code, id, transformOptions) {
+      if (!transformOptions?.ssr) {
+        const currentConfig = (farmApp?.getConfig() ?? options) as FarmVitePluginOptions;
+        if (currentConfig.experimental?.serverActions !== true) {
+          // Without the server-function transform there is no client stub for
+          // server queries: bundling the defining module into the browser
+          // executes the server handler there. Fail with an actionable
+          // boundary error instead of Vite's Node-builtin externalization
+          // failure at runtime.
+          const violation = findClientServerFnViolation(code, id);
+          if (violation) {
+            this.error(formatServerFnBoundaryError(violation, id));
+          }
+        }
+      }
+
       if (typeof imageImports.transform === "function") {
         const imageModule = await imageImports.transform.call(this, code, id, transformOptions);
         if (imageModule) return imageModule;


### PR DESCRIPTION
## Summary

Fixes #408.

In core-only apps (no `@farm.js/plugin/rsc`), importing a `createServerQuery` module from `"use client"` code bundled the server handler and its whole dependency graph into the browser. Node-only imports then exploded at hydration with the confusing:

```
Module "node:dns/promises" has been externalized for browser compatibility.
```

and `useServerQuery` would otherwise execute the server handler client-side.

## Approach

The issue offered three options; this implements **option 2 (build-time boundary error) plus a runtime guard and the docs fix** — porting the full RSC server-reference transform into core is a larger feature that can follow separately.

- **Build/dev-time guard** (`server-query-boundary.ts`, wired into the farm plugin's transform): when a module compiled for the **client** environment imports `createServerQuery`/`createServerFn` from `@farm.js/core` (any subpath) and calls it, the build fails with an actionable error naming the module and both remediations — enable the transform (`@farm.js/plugin/rsc` + `experimental.serverActions: true`), or keep the query server-side / use an API route with `createAPIClient`. Skipped entirely when `experimental.serverActions` is enabled, since the RSC transform (`enforce: "pre"`) rewrites those modules before core sees them. Type-only imports, call-less re-exports, look-alike local identifiers, `node_modules`, and virtual modules are ignored.
- **Runtime guard** (`executeServerQuery`): a raw server query implementation reaching the **browser** — identified by the `Symbol.for("farm.server-query")` marker, which transformed server references never carry — now throws the same actionable error instead of silently running the server handler client-side. SSR still executes the raw implementation directly; the symbol is referenced via the global registry so the client runtime doesn't import the server pipeline.
- **Docs**: the server-queries page now states the browser-usage requirement up front and points core-only apps at the API-client alternative (previously it implied the boundary always exists).

## Testing

- **End-to-end** (scaffolded app + local build): the exact repro from the issue — `createServerQuery` importing `node:dns/promises`, consumed via `useServerQuery` from a `"use client"` component — previously produced the externalization failure; the client build now fails immediately with the boundary error naming `src/lib/scan-query.ts`. Removing the client import restores a fully green build (no false positives; the SSR environment is never flagged).
- New unit tests for the detector: flags `createServerQuery` and `createServerFn` definitions, ignores consumer modules (`useServerQuery` imports), type-only imports, call-less re-exports, similarly named locals, virtual modules, and dependencies; error message contents pinned.
- Existing `server-query-client` jsdom suite passes unchanged (its stand-in queries don't carry the raw-implementation marker).
- `tsc --noEmit`, `oxlint`, `oxfmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fails client builds that would bundle server query handlers into the browser. Previously, importing a `createServerQuery`/`createServerFn` module from client code could ship and run the handler in the browser, often crashing at hydration with Node builtin externalization errors; now the build fails with a clear boundary error, and any raw query reaching the browser throws at runtime with guidance.

- Adds a client-only guard in the Farm Vite plugin: detects modules that import from `@farm.js/core` and call `createServerQuery`/`createServerFn`, then fails with an actionable error naming the module and remedies. Skips when `experimental.serverActions: true` with `@farm.js/plugin/rsc`, and ignores type-only imports, call-less re-exports, `node_modules`, and virtual modules.
- Adds a runtime guard in `executeServerQuery`: raw server queries in the browser throw with guidance; SSR is unchanged.
- Updates docs to state the transform requirement; adds unit tests for detection.

- Migration
  - To call queries from client components, enable `@farm.js/plugin/rsc` and set `experimental.serverActions: true` in `farm.config.ts`.
  - Otherwise, call queries from server components or expose an API route and use `createAPIClient` from client code.

<sup>Written for commit 18715bd6fcf13e11d7952c7f6e31de95951756d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

