### PR TITLE
chore: retry staged npm publishes in publish:beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "pnpm -r --filter \"./packages/*\" build",
     "dev": "turbo --filter \"./packages/*\" dev",
-    "test": "node --test scripts/release-beta.test.js && node scripts/test-packages.js",
+    "test": "node --test scripts/release-beta.test.js scripts/publish-beta.test.js && node scripts/test-packages.js",
     "test:farm": "pnpm --filter @farm.js/core test",
     "test:renderers": "node scripts/test-renderers.mjs",
     "test:ci": "node scripts/run-tests.js",
@@ -52,7 +52,7 @@
     "release:canary": "bumpp --preid canary && pnpm run publish:canary",
     "publish:dry-run": "pnpm -r --filter \"./packages/*\" publish --dry-run --access public --tag beta --publish-branch main",
     "publish:latest": "pnpm -r --filter \"./packages/*\" publish --access public --tag latest --publish-branch main",
-    "publish:beta": "pnpm -r --filter \"./packages/*\" publish --access public --tag beta --publish-branch main && pnpm run dist-tags:promote-betas",
+    "publish:beta": "node scripts/publish-beta.js",
     "publish:canary": "pnpm -r --filter \"./packages/*\" publish --access public --tag canary --publish-branch main",
     "dist-tags:promote-betas": "node scripts/promote-betas.js"
   },

--- a/scripts/publish-beta.js
+++ b/scripts/publish-beta.js
@@ -1,0 +1,182 @@
+/**
+ * Publish every public workspace package to the beta dist-tag, verify each
+ * version is actually visible on the registry, and only then promote betas.
+ *
+ * The npm registry occasionally leaves a publish in a "staged" state: the
+ * publish command reports success, but the version is not installable and
+ * re-publishing fails with `E409 Cannot publish over previously staged
+ * version` until the registry finalizes it (observed repeatedly for the same
+ * trailing packages during v0.1.0-beta.52/53). This script absorbs that by
+ * polling for visibility and retrying stragglers before promotion.
+ *
+ * Usage: node scripts/publish-beta.js [--verify-only] [--help]
+ *   --verify-only  Skip the initial bulk publish and only verify, retry
+ *                  stragglers, and promote. Useful to resume after a failure.
+ */
+const { execFileSync, execFile } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const workspaceRoot = path.resolve(__dirname, "..");
+const packagesRoot = path.join(workspaceRoot, "packages");
+
+const VERIFY_ATTEMPTS = 30;
+const VERIFY_DELAY_MS = 30_000;
+
+const supportedFlags = new Set(["--help", "--verify-only"]);
+const helpText = `Usage: node scripts/publish-beta.js [--verify-only]
+
+Options:
+  --verify-only  Skip the bulk publish; verify registry visibility, retry
+                 staged packages, and promote betas.`;
+
+function parsePublishBetaArgs(args) {
+  const unknownFlags = args.filter((arg) => !supportedFlags.has(arg));
+  if (unknownFlags.length > 0) {
+    throw new Error(`Unknown publish:beta option(s): ${unknownFlags.join(", ")}`);
+  }
+  return {
+    help: args.includes("--help"),
+    verifyOnly: args.includes("--verify-only"),
+  };
+}
+
+/**
+ * A staged publish surfaces as a 409 conflict; the version becomes visible
+ * once the registry finalizes it, so the failure is retryable by waiting.
+ */
+function isRetryableStagedPublishError(output) {
+  return /previously staged version|E409|409 Conflict/i.test(output);
+}
+
+function readPublicPackages() {
+  return fs
+    .readdirSync(packagesRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => ({
+      dir: path.join(packagesRoot, entry.name),
+      packageJsonPath: path.join(packagesRoot, entry.name, "package.json"),
+    }))
+    .filter(({ packageJsonPath }) => fs.existsSync(packageJsonPath))
+    .map(({ dir, packageJsonPath }) => ({
+      dir,
+      ...JSON.parse(fs.readFileSync(packageJsonPath, "utf8")),
+    }))
+    .filter((packageJson) => packageJson.name && packageJson.version && !packageJson.private)
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function run(command, commandArgs, options = {}) {
+  execFileSync(command, commandArgs, {
+    cwd: workspaceRoot,
+    stdio: "inherit",
+    ...options,
+  });
+}
+
+function isVersionVisible(name, version) {
+  try {
+    execFileSync("npm", ["view", `${name}@${version}`, "version"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function tryPublishPackage(pkg) {
+  try {
+    execFileSync(
+      "pnpm",
+      ["publish", "--access", "public", "--tag", "beta", "--publish-branch", "main"],
+      { cwd: pkg.dir, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    console.log(`Republished ${pkg.name}@${pkg.version}.`);
+  } catch (error) {
+    const output = `${error.stdout ?? ""}${error.stderr ?? ""}${error.message ?? ""}`;
+    if (isRetryableStagedPublishError(output)) {
+      console.log(`${pkg.name}@${pkg.version} is staged on the registry; waiting for it to finalize.`);
+      return;
+    }
+    throw new Error(`Failed to republish ${pkg.name}@${pkg.version}:\n${output}`);
+  }
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function verifyAndRetryPublishes(packages) {
+  let missing = packages;
+  for (let attempt = 1; attempt <= VERIFY_ATTEMPTS; attempt += 1) {
+    missing = missing.filter((pkg) => !isVersionVisible(pkg.name, pkg.version));
+    if (missing.length === 0) return;
+
+    console.log(
+      `${missing.length} package(s) not yet visible on the registry (attempt ${attempt}/${VERIFY_ATTEMPTS}): ${missing
+        .map((pkg) => pkg.name)
+        .join(", ")}`,
+    );
+    for (const pkg of missing) {
+      tryPublishPackage(pkg);
+    }
+    if (attempt < VERIFY_ATTEMPTS) await sleep(VERIFY_DELAY_MS);
+  }
+
+  missing = missing.filter((pkg) => !isVersionVisible(pkg.name, pkg.version));
+  if (missing.length > 0) {
+    throw new Error(
+      [
+        `Timed out waiting for ${missing.length} package(s) to become visible on the registry:`,
+        ...missing.map((pkg) => `- ${pkg.name}@${pkg.version}`),
+        "Once the registry finalizes them, resume with: node scripts/publish-beta.js --verify-only",
+      ].join("\n"),
+    );
+  }
+}
+
+async function main(args = process.argv.slice(2)) {
+  const options = parsePublishBetaArgs(args);
+  if (options.help) {
+    console.log(helpText);
+    return;
+  }
+
+  const packages = readPublicPackages();
+  if (packages.length === 0) {
+    throw new Error("No public packages found under packages/.");
+  }
+
+  if (!options.verifyOnly) {
+    try {
+      run("pnpm", [
+        "-r",
+        "--filter",
+        "./packages/*",
+        "publish",
+        "--access",
+        "public",
+        "--tag",
+        "beta",
+        "--publish-branch",
+        "main",
+      ]);
+    } catch {
+      // A partial bulk publish is recoverable: verification below finds the
+      // gaps and retries them individually.
+      console.warn("Bulk publish exited with an error; verifying per-package state.");
+    }
+  }
+
+  await verifyAndRetryPublishes(packages);
+  run("pnpm", ["run", "dist-tags:promote-betas"]);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.message || error);
+    process.exit(1);
+  });
+}
+
+module.exports = { parsePublishBetaArgs, isRetryableStagedPublishError };

--- a/scripts/publish-beta.js
+++ b/scripts/publish-beta.js
@@ -13,7 +13,7 @@
  *   --verify-only  Skip the initial bulk publish and only verify, retry
  *                  stragglers, and promote. Useful to resume after a failure.
  */
-const { execFileSync, execFile } = require("node:child_process");
+const { execFileSync } = require("node:child_process");
 const fs = require("node:fs");
 const path = require("node:path");
 

--- a/scripts/publish-beta.js
+++ b/scripts/publish-beta.js
@@ -97,7 +97,9 @@ function tryPublishPackage(pkg) {
   } catch (error) {
     const output = `${error.stdout ?? ""}${error.stderr ?? ""}${error.message ?? ""}`;
     if (isRetryableStagedPublishError(output)) {
-      console.log(`${pkg.name}@${pkg.version} is staged on the registry; waiting for it to finalize.`);
+      console.log(
+        `${pkg.name}@${pkg.version} is staged on the registry; waiting for it to finalize.`,
+      );
       return;
     }
     throw new Error(`Failed to republish ${pkg.name}@${pkg.version}:\n${output}`);

--- a/scripts/publish-beta.test.js
+++ b/scripts/publish-beta.test.js
@@ -1,0 +1,34 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const { parsePublishBetaArgs, isRetryableStagedPublishError } = require("./publish-beta");
+
+test("publishes and verifies by default", () => {
+  assert.deepEqual(parsePublishBetaArgs([]), { help: false, verifyOnly: false });
+});
+
+test("supports resuming with --verify-only", () => {
+  assert.deepEqual(parsePublishBetaArgs(["--verify-only"]), { help: false, verifyOnly: true });
+});
+
+test("rejects unknown options", () => {
+  assert.throws(() => parsePublishBetaArgs(["--force"]), /Unknown publish:beta option/);
+});
+
+test("treats staged-version conflicts as retryable", () => {
+  assert.ok(
+    isRetryableStagedPublishError(
+      'npm error 409 Conflict - PUT https://registry.npmjs.org/@farm.js%2fauth - Cannot publish over previously staged version "0.1.0-beta.53".',
+    ),
+  );
+  assert.ok(isRetryableStagedPublishError("npm error code E409"));
+});
+
+test("does not retry unrelated publish failures", () => {
+  assert.equal(isRetryableStagedPublishError("npm error code E403 Forbidden"), false);
+  assert.equal(isRetryableStagedPublishError("npm error code ENEEDAUTH"), false);
+  assert.equal(
+    isRetryableStagedPublishError("npm error 404 Not Found - PUT https://registry.npmjs.org/x"),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary

The npm registry occasionally leaves a publish in a **staged** state: `pnpm publish` reports success, but the version isn't installable, dist-tags don't move, and re-publishing fails with `E409 Cannot publish over previously staged version` until the registry finalizes it minutes later. This hit `@farm.js/auth` and `@farm.js/eve` on **both** the beta.52 and beta.53 releases, failing `dist-tags:promote-betas` and requiring manual recovery each time.

## Changes

- New `scripts/publish-beta.js` replaces the inline `publish:beta` pipeline:
  1. Bulk `pnpm -r publish` exactly as before (a partial failure no longer aborts — verification finds the gaps).
  2. Verify every public package's version is actually **visible** on the registry (`npm view`).
  3. Retry stragglers individually; staged 409s are treated as wait-and-poll (30 attempts × 30s ≈ 15 min), while unrelated failures (auth, forbidden, 404) still fail fast with the package named.
  4. Only then run `dist-tags:promote-betas`.
- `--verify-only` resumes after a failure or timeout without re-running the bulk publish; `--help`/unknown-flag handling mirrors `release-beta.js`.
- Tests (`scripts/publish-beta.test.js`, added to the root `test` script): arg parsing, staged-409 detection, and non-retryable error classification.

## Validation

- 8/8 script tests pass; requiring the module is side-effect free; unknown flags exit 1.
- Ran `node scripts/publish-beta.js --verify-only` against the live beta.53 release: verified all 23 packages visible and completed an idempotent promotion.

No behavior change for healthy releases — same commands, same order, plus the verification gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `publish:beta` resilient to staged npm publishes by replacing the inline pipeline with a verify-and-retry script. Previously, `pnpm -r publish` could report success while versions stayed staged, breaking `dist-tags:promote-betas`; now we verify registry visibility, retry staged 409s with polling (~15 minutes), and promote only after all versions are visible.

- `publish:beta` now runs `node scripts/publish-beta.js`; healthy releases follow the same flow behind a verification gate.
- Verification uses `npm view` per public package; non-retryable errors (auth/403/404) fail fast with the package name.
- Add `--verify-only` to resume without re-running bulk publish; `--help` and strict unknown-flag handling included.
- Tests cover arg parsing and staged-409 classification and are added to the root `test` script.

<sup>Written for commit 9b6cded0a94205712a507eb052c05515f5267118. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

