### PR TITLE
chore: treat unpropagated-publish 403s as retryable in publish:beta

### DIFF
--- a/scripts/publish-beta.js
+++ b/scripts/publish-beta.js
@@ -42,11 +42,14 @@ function parsePublishBetaArgs(args) {
 }
 
 /**
- * A staged publish surfaces as a 409 conflict; the version becomes visible
- * once the registry finalizes it, so the failure is retryable by waiting.
+ * A publish the registry has accepted but not yet made visible surfaces on
+ * retry as either a 409 ("previously staged version") or a 403 ("cannot
+ * publish over the previously published versions"). Both mean the version
+ * will appear once the registry finishes propagating, so the failure is
+ * retryable by waiting; other 403s (auth, policy) are not matched.
  */
 function isRetryableStagedPublishError(output) {
-  return /previously staged version|E409|409 Conflict/i.test(output);
+  return /previously staged version|previously published versions|E409|409 Conflict/i.test(output);
 }
 
 function readPublicPackages() {

--- a/scripts/publish-beta.test.js
+++ b/scripts/publish-beta.test.js
@@ -22,6 +22,13 @@ test("treats staged-version conflicts as retryable", () => {
     ),
   );
   assert.ok(isRetryableStagedPublishError("npm error code E409"));
+  // The registry reports an accepted-but-unpropagated version as a 403 on
+  // republish; observed on the v0.1.0-beta.54 release.
+  assert.ok(
+    isRetryableStagedPublishError(
+      "npm error 403 403 Forbidden - PUT https://registry.npmjs.org/@farm.js%2fauth - You cannot publish over the previously published versions: 0.1.0-beta.54.",
+    ),
+  );
 });
 
 test("does not retry unrelated publish failures", () => {


### PR DESCRIPTION
Follow-up to #412, surfaced by the very first release through the new pipeline (beta.54).

The verification gate worked — it caught `@farm.js/auth` and `@farm.js/eve` invisible after the bulk publish (same two packages as beta.52/53) — but the retry hit a second error variant: the registry had **accepted** the publish without propagating it to reads, so republishing returned `403 You cannot publish over the previously published versions` instead of the staged `E409`. The matcher didn't recognize it and the loop aborted.

Treat that 403 variant as retryable-wait as well (regression test included, using the exact observed error). Unrelated 403s (auth/policy, no "previously published versions" phrase) still fail fast, covered by the existing negative tests.

Validated: `node scripts/publish-beta.js --verify-only` with this fix completed the beta.54 release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `publish:beta` treat unpropagated publishes as retryable when npm returns 403 "You cannot publish over the previously published versions," preventing the verification loop from aborting. Previously only 409 conflicts were retried; now both 409 and this 403 variant wait-and-retry. Other 403s (auth/policy) still fail fast.

- Extend `isRetryableStagedPublishError` to match the "previously published versions" phrase without broadening to unrelated 403s.
- Add a regression test using the exact 403 output seen on v0.1.0-beta.54 for `@farm.js/auth` and `@farm.js/eve`.
- No migration. To validate locally: run `node scripts/publish-beta.js --verify-only`.

<sup>Written for commit 80e798f70eb56a4cdb69546f8fe4e0e6f344cb06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

