### PR TITLE
feat(react): compile interactive keyed rows

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -323,21 +323,21 @@ policy.
 The current compiler deliberately supports a smaller subset than general React. A component must
 satisfy all of these rules:
 
-| Area                | Current supported shape                                                                                                                                    |
-| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Component discovery | A top-level, capitalized function declaration, function expression, or arrow component in application `.tsx` or `.jsx`.                                    |
-| Function shape      | Synchronous, non-generator, non-generic block body with zero parameters, one props identifier, or flat object props destructuring.                         |
-| Props               | Flat object destructuring supports shorthand names, aliases, and defaults. Nested, computed, and rest patterns fall back.                                  |
-| Body                | Top-level `useState` declarations, optional compiler-safe derived values and synchronous named handlers, then one unconditional JSX return.                |
-| State               | `const [value, setValue] = useState(initial)`, including lazy initializers, multiple cells, and queued functional updates.                                 |
-| Root                | Exactly one lowercase host JSX element such as `button`, `section`, `input`, or `div`.                                                                     |
-| Tree                | A statically known host tree around eligible conditional, keyed-list, compiled keyed-row, and component-island boundaries.                                 |
-| Text bindings       | State-driven text in a leaf host element.                                                                                                                  |
-| Attribute bindings  | Basic attributes, controlled form properties, and individual properties in one inline `style` object.                                                      |
-| Events              | Inline handlers and synchronous `const` or function-declaration handlers, used directly or called inside an inline JSX handler.                            |
-| Conditional blocks  | Logical/ternary host branches; dedicated host-only containers may use compiler-owned branch instances and bindings.                                        |
-| Keyed lists         | Item-keyed maps and imported `List`, including safe non-mutating collection pipelines; dedicated host-only containers may use compiler-owned rows and LIS. |
-| Component islands   | Stable imported or module-level component identifiers with explicit compiler-safe props and no JSX children, spread, `ref`, or `key`.                      |
+| Area                | Current supported shape                                                                                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Component discovery | A top-level, capitalized function declaration, function expression, or arrow component in application `.tsx` or `.jsx`.                                                           |
+| Function shape      | Synchronous, non-generator, non-generic block body with zero parameters, one props identifier, or flat object props destructuring.                                                |
+| Props               | Flat object destructuring supports shorthand names, aliases, and defaults. Nested, computed, and rest patterns fall back.                                                         |
+| Body                | Top-level `useState` declarations, optional compiler-safe derived values and synchronous named handlers, then one unconditional JSX return.                                       |
+| State               | `const [value, setValue] = useState(initial)`, including lazy initializers, multiple cells, and queued functional updates.                                                        |
+| Root                | Exactly one lowercase host JSX element such as `button`, `section`, `input`, or `div`.                                                                                            |
+| Tree                | A statically known host tree around eligible conditional, keyed-list, compiled keyed-row, and component-island boundaries.                                                        |
+| Text bindings       | State-driven text in a leaf host element.                                                                                                                                         |
+| Attribute bindings  | Basic attributes, controlled form properties, and individual properties in one inline `style` object.                                                                             |
+| Events              | Inline handlers and synchronous `const` or function-declaration handlers, including inline synchronous events in eligible host-only keyed rows.                                   |
+| Conditional blocks  | Logical/ternary host branches; dedicated host-only containers may use compiler-owned branch instances and bindings.                                                               |
+| Keyed lists         | Item-keyed maps and imported `List`, including safe collection pipelines; eligible host rows use direct bindings, with React-owned event and structure handling when interactive. |
+| Component islands   | Stable imported or module-level component identifiers with explicit compiler-safe props and no JSX children, spread, `ref`, or `key`.                                             |
 
 This component is eligible:
 
@@ -487,6 +487,64 @@ subsequence (LIS) of the old row positions. Rows in that subsequence stay in pla
 surviving rows move. LIS is a runtime move planner over compiler-prepared rows, not a claim that the
 future contents of an array are known at build time.
 
+#### Interactive host rows
+
+An otherwise eligible host-only row may contain inline synchronous React events:
+
+```tsx
+export function Inventory() {
+  const [items, setItems] = useState(initialItems);
+
+  return (
+    <ul>
+      {items.map((item, index) => (
+        <li data-selected={item.selected} key={item.id}>
+          <span>{item.label}</span>
+          <button
+            data-index={index}
+            onClick={(event) => {
+              event.stopPropagation();
+              setItems((current) =>
+                current.map((row) =>
+                  row.id === item.id ? { ...row, selected: !item.selected } : row,
+                ),
+              );
+            }}
+            type="button"
+          >
+            Toggle
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+This uses a hybrid ownership model. React creates or hydrates every row, installs the event props,
+and performs every structural insert, removal, or reorder. Farm does not call `addEventListener`
+and does not create an eventful row outside React's Fiber tree. At build time, the compiler replaces
+each eligible row event prop with a stable keyed proxy and prepares the row's ordinary bindings.
+
+When React dispatches the event, the proxy resolves that key's current row instance and passes the
+latest item and index to the original handler. Replacing `{ id: "a", label: "Alpha" }` with a new
+object for key `"a"`, or moving it to a new index, therefore cannot leave the handler with the item
+or index captured by an older map execution.
+
+If an update keeps the exact key sequence, Farm patches changed text, attributes, and styles without
+executing the owner component or map callback. If keys are inserted, removed, or reordered, the
+internal boundary renders once and lets React reconcile. After that commit, Farm validates and
+re-adopts the host rows, reapplies every current binding, and resumes direct same-key updates. The
+reapply step is important because React compares its next props with its previous virtual props,
+which may predate a direct DOM patch.
+
+The initial event contract is deliberately conservative: the row and descendants must still be a
+statically known HTML host tree; the handler must be inline, synchronous, and free of Hooks,
+`this`, `super`, and `arguments`; and controlled row inputs with change, input, selection, or
+composition events stay entirely React-owned. Non-inline or async handlers, custom row components,
+fragments, refs, SVG, spreads, and other unproven shapes use the React-owned keyed boundary. The
+same hybrid path is available to an eligible inline host row rendered through `List`.
+
 #### Derived collection pipelines
 
 The collection may be prepared through an inline, non-mutating pipeline before the final keyed
@@ -568,14 +626,16 @@ state. The surrounding compiled component can still avoid executing again. Hooks
 row component such as `InventoryRow`, never directly inside the `List` child function or a
 `.map()` callback.
 
-The compiler uses two keyed-list tiers:
+The compiler uses three keyed-list tiers:
 
-1. A dedicated nested host container with one direct map or one `List`, returning a host-only row,
-   becomes compiler-owned keyed row instances. This is the path that patches bindings and uses LIS.
-2. A safe keyed map or `List` that cannot use compiler-owned rows becomes a small React-owned keyed
+1. A dedicated nested host container with one direct map or one `List`, returning a non-interactive
+   host-only row, becomes compiler-owned keyed row instances. Farm patches bindings and uses LIS.
+2. The same host-only shape with eligible inline events keeps React event and structural ownership,
+   while Farm patches same-key row bindings through stable keyed event proxies.
+3. A safe keyed map or `List` that cannot use either optimized row shape becomes a small React-owned keyed
    boundary. React reconciles its rows, while the outer user component still avoids rerunning.
 
-The first compiler-owned row contract is deliberately narrow:
+The optimized host-row contract is deliberately narrow:
 
 - The map must use one synchronous inline callback returning one React element and an explicit
   item-derived `key`. Its collection may be direct or use the supported non-mutating pipeline.
@@ -588,15 +648,17 @@ The first compiler-owned row contract is deliberately narrow:
   boundary for now.
 - The row is a statically known HTML host tree. Dynamic leaf text, attributes, controlled host
   properties, and individual inline style properties are supported.
-- Row events, custom components, fragments, refs, SVG, attribute spreads, dangerous HTML, and
-  dynamic text mixed beside nested elements stay React-owned.
+- Inline synchronous row events are supported by the hybrid path. Non-inline or async handlers,
+  controlled interactive form fields, custom components, fragments, refs, SVG, attribute spreads,
+  dangerous HTML, and dynamic text mixed beside nested elements stay React-owned.
 - Unsupported or mutating collection methods, spread children, Hooks in callbacks, and other
   unproven shapes fall back to normal React.
 
 Stable keys must be unique among siblings and come from the item's identity, such as a database ID.
 If duplicate keys appear at runtime, Farm remounts that list container through its original React
 render instead of guessing which row owns the identity. Later updates remain on the React fallback
-for that mounted list. Unsupported source shapes also keep React ownership from the beginning.
+for that mounted list. Interactive fallback handlers use ordinary per-render item/index closures,
+not ambiguous keyed lookup. Unsupported source shapes also keep React ownership from the beginning.
 
 For example, changing `[A, B, C, D]` to `[D, A, B, C]` keeps `[A, B, C]` as the LIS and moves only
 `D`. Reversing four rows needs three moves because the LIS has length one. Insertions and removals
@@ -666,36 +728,39 @@ appears again, each boundary subscribes again and renders from the latest compil
 
 The compiler deliberately does not assign ordinary component-wide block IDs to syntax inside a
 keyed row callback. A host-only optimized row instead receives a separate runtime instance per key
-and a build-time binding list relative to that row root. If the row needs nested conditionals,
-component islands, Hooks, events, or other dynamic structure, React owns the complete row subtree;
-put Hooks inside a keyed row component.
+and a build-time binding list relative to that row root. Eligible inline events use the hybrid
+React-event path described above. If the row needs nested conditionals, component islands, Hooks,
+custom components, or other dynamic structure, React owns the complete row subtree; put Hooks
+inside a keyed row component.
 
 ### What falls back to React
 
-| Unsupported shape                                                                                            | Why React keeps ownership                                                          |
-| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
-| Unkeyed/index-keyed maps, unsupported or mutating collection pipelines, or element arrays                    | Their structure, purity, or item identity is outside the keyed-list contract.      |
-| Row events, components, fragments, refs, SVG, or mixed container children                                    | They require React ownership rather than compiler-created host rows.               |
-| Branch events, keys, components, fragments, refs, SVG, or nested blocks in a dedicated conditional container | They require the React-owned conditional path rather than compiler-created hosts.  |
-| Dynamic/member component types, component spreads, refs, keys, or children                                   | Their identity or ownership is outside the first component-island contract.        |
-| Effects or hooks other than the supported `useState` shape                                                   | Their lifecycle and ordering must remain under React's hook dispatcher.            |
-| `ref` or `dangerouslySetInnerHTML`                                                                           | They directly participate in DOM ownership.                                        |
-| Stateful `children` or `key` bindings outside an eligible boundary                                           | These need structure or identity semantics.                                        |
-| Conditional style objects, style spreads, methods, or computed names                                         | The final property set or precedence cannot be prepared statically.                |
-| JSX attribute spreads or namespaced attributes                                                               | The compiler cannot currently enumerate a stable binding contract.                 |
-| Multiple/conditional returns or impure/control-flow statements                                               | The compiler only lowers a single, statically analyzable render path.              |
-| Derived calls, assignments, identity-bearing values, functions, or JSX                                       | Their evaluation timing, side effects, or identity cannot yet be preserved safely. |
-| Nested, computed, or rest props destructuring                                                                | These patterns need additional parameter-shape and identity analysis.              |
-| Async/generator/generic handlers or named handlers outside JSX events                                        | Their scheduling, identity, or closure semantics are outside the current lowering. |
-| Async/generator or generic components                                                                        | These function shapes are outside the current lowering.                            |
-| Setters called outside JSX event handlers                                                                    | The compiler only controls and batches event-driven local updates.                 |
+| Unsupported shape                                                                                                  | Why React keeps ownership                                                          |
+| ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| Unkeyed/index-keyed maps, unsupported or mutating collection pipelines, or element arrays                          | Their structure, purity, or item identity is outside the keyed-list contract.      |
+| Non-inline/async row events, controlled interactive row forms, components, fragments, refs, SVG, or mixed children | Their event, lifecycle, or structure contract requires the React-owned row path.   |
+| Branch events, keys, components, fragments, refs, SVG, or nested blocks in a dedicated conditional container       | They require the React-owned conditional path rather than compiler-created hosts.  |
+| Dynamic/member component types, component spreads, refs, keys, or children                                         | Their identity or ownership is outside the first component-island contract.        |
+| Effects or hooks other than the supported `useState` shape                                                         | Their lifecycle and ordering must remain under React's hook dispatcher.            |
+| `ref` or `dangerouslySetInnerHTML`                                                                                 | They directly participate in DOM ownership.                                        |
+| Stateful `children` or `key` bindings outside an eligible boundary                                                 | These need structure or identity semantics.                                        |
+| Conditional style objects, style spreads, methods, or computed names                                               | The final property set or precedence cannot be prepared statically.                |
+| JSX attribute spreads or namespaced attributes                                                                     | The compiler cannot currently enumerate a stable binding contract.                 |
+| Multiple/conditional returns or impure/control-flow statements                                                     | The compiler only lowers a single, statically analyzable render path.              |
+| Derived calls, assignments, identity-bearing values, functions, or JSX                                             | Their evaluation timing, side effects, or identity cannot yet be preserved safely. |
+| Nested, computed, or rest props destructuring                                                                      | These patterns need additional parameter-shape and identity analysis.              |
+| Async/generator/generic handlers or named handlers outside JSX events                                              | Their scheduling, identity, or closure semantics are outside the current lowering. |
+| Async/generator or generic components                                                                              | These function shapes are outside the current lowering.                            |
+| Setters called outside JSX event handlers                                                                          | The compiler only controls and batches event-driven local updates.                 |
 
 Keys do not make list work disappear. A key identifies the row that survives an insert, removal,
-or move. On the compiler-owned host path, Farm compares those keys, reuses the matching row
-instances, and applies LIS to minimize moves. On the fallback path, React compares the keyed
-elements and owns reconciliation. Calling a Hook directly inside a list iteration is invalid React
-because the number or order of calls can change. Put the Hook inside a keyed child component
-instead; that custom row intentionally uses the React-owned path.
+or move. On the non-interactive compiler-owned host path, Farm compares those keys, reuses matching
+row instances, and applies LIS to minimize moves. On the hybrid interactive path, React compares
+the keyed elements for structural changes while Farm uses the same key to find the newest row data
+for direct same-key bindings and event dispatch. On the fallback path, React owns the complete row
+update. Calling a Hook directly inside a list iteration is invalid React because the number or
+order of calls can change. Put the Hook inside a keyed child component instead; that custom row
+intentionally uses the React-owned path.
 
 ### Build-time transformation
 
@@ -731,16 +796,17 @@ do not receive the runtime import.
 The generated runtime wrapper is still a React component. Its responsibilities are split as
 follows:
 
-| React owns                                              | Compiler runtime owns                                                        |
-| ------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| Initial element creation, SSR markup, and hydration     | Local compiler-cell values                                                   |
-| JSX event registration and dispatch                     | Queuing local setter calls into one microtask                                |
-| Parent-driven prop updates                              | Comparing flushed values and selecting dependent bindings                    |
-| Unsupported trees, hooks, refs, events, and lifecycles  | Patching stable ref-owned text, attribute, and style targets                 |
-| Complex conditional branches, events, and nested blocks | Host-only conditional identity, bindings, creation, removal, and replacement |
-| React-owned custom or structurally complex keyed rows   | Host-only keyed-row identity, bindings, insertion, removal, and LIS moves    |
-| Component render, Hooks, context, and lifecycle         | Refreshing only a dependent React component-island boundary                  |
-| Unmounting and the surrounding component tree           | Reapplying bindings after a parent-driven React update                       |
+| React owns                                                | Compiler runtime owns                                                        |
+| --------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Initial element creation, SSR markup, and hydration       | Local compiler-cell values                                                   |
+| JSX event registration and dispatch, including row events | Queuing local setter calls into one microtask                                |
+| Parent-driven prop updates                                | Comparing flushed values and selecting dependent bindings                    |
+| Unsupported trees, hooks, refs, handlers, and lifecycles  | Patching stable ref-owned text, attribute, and style targets                 |
+| Complex conditional branches, events, and nested blocks   | Host-only conditional identity, bindings, creation, removal, and replacement |
+| Interactive keyed-row inserts, removals, and reorders     | Same-key interactive row bindings and latest-item event lookup               |
+| React-owned custom or structurally complex keyed rows     | Non-interactive host-row identity, bindings, insertion, removal, and LIS     |
+| Component render, Hooks, context, and lifecycle           | Refreshing only a dependent React component-island boundary                  |
+| Unmounting and the surrounding component tree             | Reapplying bindings after a parent-driven React update                       |
 
 Queued functional setters preserve the event's state snapshot. Two calls such as
 `setCount(value => value + 1)` are applied in order during the same microtask flush, while reads
@@ -764,13 +830,17 @@ the resulting value, selection, and dependent bindings are patched together.
 
 The server output is ordinary React HTML and contains no compiler marker. React hydrates that
 markup normally; direct binding updates begin after the component mounts. Eligible conditional and
-keyed-row containers adopt their already-hydrated child elements, so valid server DOM is not
-replaced during hydration.
+keyed-row containers validate and adopt their already-hydrated child elements, so valid server DOM
+is not replaced during hydration. Interactive rows keep their React event props throughout this
+process. A hydration mismatch stays on React's recoverable-error path; Farm adopts only the host
+shape React committed.
 
 During development, compiled components receive a module-and-component identity plus a state-layout
 signature. A compatible Fast Refresh replaces the compiled definition while retaining the React
-component type and its local cells. If the compiler-owned state layout changes, the identity is not
-reused and React remounts it instead of preserving incompatible state.
+component type and its local cells. An interactive keyed boundary lets React commit the refreshed
+event layout before Farm re-adopts it, and keyed proxies read the current definition, so a refreshed
+handler cannot keep executing its older closure. If the compiler-owned state layout changes, the
+identity is not reused and React remounts it instead of preserving incompatible state.
 
 If a direct binding evaluation throws, the runtime schedules a React update and rethrows from the
 component render. This lets the nearest React error boundary handle the failure through React's
@@ -781,9 +851,11 @@ normal recovery path.
 The compiler uses fallback as a semantic boundary, not as an error-recovery trick. Generated
 callback refs keep direct DOM targets stable even when a React component island returns `null`, a
 fragment, or multiple nodes. React-owned conditional, keyed-list, and component boundaries give
-complex dynamic structure back to React. Compiler-owned branches and rows are limited to complete
-host-only containers because manually inserted DOM has no React Fiber for their events, components,
-or Hooks.
+complex dynamic structure back to React. Compiler-owned branches and non-interactive rows are
+limited to complete host-only containers because manually inserted DOM has no React Fiber for
+events, components, or Hooks. Interactive rows therefore never use the manual
+insertion/removal/LIS path: React reconciles their structure, and Farm only adopts committed host
+elements for binding patches.
 Unsupported dynamic component types, refs, effects, and other unproven shapes keep React ownership;
 fallback is the optimization's correctness mechanism.
 
@@ -819,6 +891,11 @@ The package and example test suites verify more than generated code:
 - compiler-owned host rows patch text, attributes, and styles in place, preserve focus and text
   selection, use the LIS minimum for measured rotations and reversals, and remount through React
   when runtime keys are duplicated;
+- interactive host rows keep React event propagation and `currentTarget`, resolve the latest item
+  and index after same-key replacements and reorders, let React own structural commits, and resume
+  direct binding patches without stale virtual-prop output;
+- interactive rows stay coherent across combined parent/local updates, Strict Mode, compatible Fast
+  Refresh, recoverable hydration mismatches, and an unmount before the compiler microtask flush;
 - component islands update only dependent children, preserve child-local state and context, route
   failures through React error boundaries, hydrate in Strict Mode, and safely drop queued updates
   after unmount;
@@ -829,10 +906,16 @@ The package and example test suites verify more than generated code:
   normal React while the list owner stays at one execution;
 - 5,000 deterministic filter, sort, slice, reverse, insertion, removal, and row-update transitions
   produce the same keyed output as normal React while preserving surviving DOM rows;
+- 4,000 deterministic interactive data, structure, and event transitions match normal React while
+  the compiled owner remains at one execution;
 - the production browser experiment derives a keyed window from 2,048 source rows without
   rerunning the owner component or corrupting the existing compiler experiments;
+- the production browser experiment also replaces and reorders interactive items, verifies current
+  keyed DOM identity and capture/stop-propagation behavior, and observes zero owner update
+  executions;
 - the public `List` renders iterable and nullish collections correctly with the compiler off;
-- the packaged runtime is exercised separately with React 18.3 and React 19;
+- the packaged runtime, including interactive keyed-row events, reorders, identity, and hydration,
+  is exercised separately with React 18.3 and React 19;
 - boolean `data-*` and `aria-*` attributes keep React-compatible string values; and
 - unsupported list shapes, effects, refs, and unsupported dynamic component-island shapes remain
   on React without corrupting output.

--- a/examples/react-compiler/README.md
+++ b/examples/react-compiler/README.md
@@ -36,6 +36,7 @@ assertions, checks for console/runtime errors and horizontal overflow, saves scr
 | Two state cells             | text/class/data/input all update, update executions `0` | —                                              | AOT dependency lists update only bindings affected by each state cell. |
 | Automatic keyed map         | stable row DOM, three LIS moves for a four-row reversal  | —                                              | AOT rows patch in place and use the minimum reorder moves.              |
 | Derived keyed collection    | 2,048 source rows filter, sort, slice, and reverse; executions `0` | —                                      | Collection dependencies feed keyed rows without rerunning the owner.    |
+| Interactive keyed rows      | latest item/index after updates and reorder; executions `0` | —                                           | React owns events/structure while Farm patches same-key row bindings.   |
 | Explicit `List`             | stateful rows reorder, update executions `0`            | —                                              | React preserves custom-row state by key inside the isolated boundary.  |
 | Calculated style bindings   | value `6`, progress `50%`, update executions `0`        | —                                              | Safe calls and individual CSS properties use prepared dependencies.    |
 | Controlled form bindings   | textarea/select/checkbox update, executions `0`         | —                                              | Form properties and textarea selection stay coherent.                  |
@@ -86,10 +87,22 @@ host container. Its collection may chain synchronous inline `filter`, `slice`, `
 `toReversed` operations. The compiler records the state dependencies used by those operations and
 reruns the pipeline only when one changes; it still performs the necessary filtering or sorting.
 Mutating methods, external or async callbacks, Hooks, assignments, spread arguments, and unproven
-calls fall back to React. Row events, custom components, fragments, refs, SVG, static siblings in
-that same container, and index or missing keys also use React reconciliation. Duplicate keys
-discovered at runtime remount that container through React. LIS reduces moves; it does not make
-insertions, removals, key comparison, collection work, or DOM updates disappear.
+calls fall back to React.
+
+An otherwise eligible host row can include inline synchronous events. React installs and dispatches
+those event props; Farm does not add a native listener. A stable proxy resolves the newest item and
+index for that key when the event fires. With the same key sequence, Farm patches the prepared row
+bindings without rerunning the map. When keys are inserted, removed, or reordered, React reconciles
+the structure once; Farm then adopts the committed rows and resumes direct same-key patches. The
+`04C` card verifies capture and stop-propagation behavior, latest-item lookup across three clicks,
+row identity through a reversal, and zero owner update executions.
+
+Non-inline or async row handlers, controlled interactive form fields, custom components, fragments,
+refs, SVG, static siblings in that same container, and index or missing keys use the React-owned
+list path. Duplicate keys discovered at runtime remount that container through React. LIS applies
+to non-interactive compiler-owned rows; interactive structural changes intentionally stay with
+React. Neither path makes insertions, removals, key comparison, collection work, or DOM updates
+disappear.
 
 The example includes ES2023 TypeScript library declarations because `toSorted` and `toReversed`
 are standard runtime methods that the compiler preserves rather than polyfills.

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -29,6 +29,7 @@ for (const component of [
   "TernaryBlockPanel",
   "AutomaticKeyedListExperiment",
   "DerivedCollectionExperiment",
+  "InteractiveKeyedListExperiment",
   "ExplicitKeyedListExperiment",
   "StatefulListRow",
   "ComponentIslandExperiment",
@@ -508,6 +509,56 @@ try {
   );
   assert.equal(derivedCollectionFinalExecutions - derivedCollectionInitialExecutions, 0);
 
+  const interactiveList = '[data-experiment="keyed-interactive"]';
+  const interactiveListInitialExecutions = await readNumber(
+    page,
+    `${interactiveList} [data-metric="executions"]`,
+  );
+  await page.evaluate(() => {
+    window.__farmInteractiveAlpha = document.querySelector(
+      '[data-experiment="keyed-interactive"] [data-list="interactive"] [data-key="a"]',
+    );
+  });
+  const interactiveAlpha = `${interactiveList} li[data-key="a"]`;
+  await page.locator(`${interactiveAlpha} [data-action="toggle-interactive-row"]`).click();
+  await assertText(page, `${interactiveAlpha} span`, "Alpha! · done");
+  assert.equal(await page.locator(interactiveAlpha).getAttribute("data-done"), "true");
+  await page.locator(`${interactiveAlpha} [data-action="toggle-interactive-row"]`).click();
+  await assertText(page, `${interactiveAlpha} span`, "Alpha!! · open");
+  assert.equal(await page.locator(interactiveAlpha).getAttribute("data-done"), "false");
+  await assertText(page, `${interactiveList} [data-metric="captured"]`, "2");
+  await page.locator(`${interactiveList} [data-action="reverse-interactive-rows"]`).click();
+  await assertText(page, `${interactiveList} [data-metric="first"]`, "Gamma");
+  assert.deepEqual(
+    await page.locator(`${interactiveList} li > span`).allTextContents(),
+    ["Gamma · open", "Beta · open", "Alpha!! · open"],
+  );
+  assert.equal(
+    await page.evaluate(
+      () =>
+        window.__farmInteractiveAlpha ===
+        document.querySelector(
+          '[data-experiment="keyed-interactive"] [data-list="interactive"] [data-key="a"]',
+        ),
+    ),
+    true,
+    "React structural reconciliation did not preserve the interactive row identity",
+  );
+  await page.locator(`${interactiveAlpha} [data-action="toggle-interactive-row"]`).click();
+  await assertText(page, `${interactiveAlpha} span`, "Alpha!!! · done");
+  assert.equal(
+    await page
+      .locator(`${interactiveAlpha} [data-action="toggle-interactive-row"]`)
+      .getAttribute("data-index"),
+    "2",
+  );
+  await assertText(page, `${interactiveList} [data-metric="captured"]`, "3");
+  const interactiveListFinalExecutions = await readNumber(
+    page,
+    `${interactiveList} [data-metric="executions"]`,
+  );
+  assert.equal(interactiveListFinalExecutions - interactiveListInitialExecutions, 0);
+
   const explicitList = '[data-experiment="keyed-explicit"]';
   const explicitListInitialExecutions = await readNumber(
     page,
@@ -757,6 +808,15 @@ try {
               derivedCollectionFinalExecutions - derivedCollectionInitialExecutions,
             keyedDomIdentityPreserved: true,
             operations: ["filter", "toSorted", "slice", "toReversed"],
+          },
+          interactiveKeyedList: {
+            alpha: "Alpha!!! · done",
+            capturedClicks: 3,
+            updateExecutions:
+              interactiveListFinalExecutions - interactiveListInitialExecutions,
+            keyedDomIdentityPreserved: true,
+            structuralOwner: "React",
+            bindingOwner: "Farm",
           },
           explicitKeyedList: {
             order: ["Beta", "Alpha"],

--- a/examples/react-compiler/src/app/globals.css
+++ b/examples/react-compiler/src/app/globals.css
@@ -649,6 +649,28 @@ h1 span {
     monospace;
 }
 
+.interactive-keyed-list .interactive-row {
+  display: flex;
+  min-width: min(100%, 14rem);
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+  padding: 0.35rem 0.35rem 0.35rem 0.65rem;
+  transition:
+    border-color 160ms ease,
+    background 160ms ease;
+}
+
+.interactive-keyed-list .interactive-row--done {
+  border-color: rgb(184 255 91 / 0.6);
+  background: rgb(184 255 91 / 0.07);
+}
+
+.interactive-keyed-list .interactive-row button {
+  min-height: 2.4rem;
+  padding: 0.4rem 0.6rem;
+}
+
 .keyed-row-stage {
   display: flex;
   min-height: 2.8rem;

--- a/examples/react-compiler/src/components/compiler-edge-lab.tsx
+++ b/examples/react-compiler/src/components/compiler-edge-lab.tsx
@@ -8,6 +8,7 @@ let reactBatchExecutions = 0;
 let multipleBindingExecutions = 0;
 let automaticListExecutions = 0;
 let derivedCollectionExecutions = 0;
+let interactiveListExecutions = 0;
 let explicitListExecutions = 0;
 
 export function CompiledBatchExperiment() {
@@ -336,6 +337,90 @@ export function DerivedCollectionExperiment() {
   );
 }
 
+interface InteractiveListItem extends ListItem {
+  done: boolean;
+}
+
+export function InteractiveKeyedListExperiment() {
+  const [items, setItems] = useState<InteractiveListItem[]>([
+    { id: "a", label: "Alpha", done: false },
+    { id: "b", label: "Beta", done: false },
+    { id: "c", label: "Gamma", done: false },
+  ]);
+  const [captured, setCaptured] = useState(0);
+
+  return (
+    <article className="edge-card" data-experiment="keyed-interactive">
+      <header>
+        <span className="experiment-number">04C</span>
+        <div>
+          <h3>Interactive compiled rows</h3>
+          <p>React owns events and reorders; Farm patches same-key data without stale items.</p>
+        </div>
+      </header>
+      <dl className="compact-metrics" aria-live="polite">
+        <div>
+          <dt>First row</dt>
+          <dd data-metric="first">{items[0]?.label}</dd>
+        </div>
+        <div>
+          <dt>Captured clicks</dt>
+          <dd data-metric="captured">{captured}</dd>
+        </div>
+        <div>
+          <dt>Executions</dt>
+          <dd data-metric="executions">
+            {typeof window === "undefined" ? 1 : ++interactiveListExecutions}
+          </dd>
+        </div>
+      </dl>
+      <ul
+        className="interactive-keyed-list"
+        data-list="interactive"
+        onClickCapture={() => setCaptured((value) => value + 1)}
+      >
+        {items.map((item, index) => (
+          <li
+            className={item.done ? "interactive-row interactive-row--done" : "interactive-row"}
+            data-done={item.done}
+            data-key={item.id}
+            key={item.id}
+          >
+            <span>
+              {item.label} · {item.done ? "done" : "open"}
+            </span>
+            <button
+              data-action="toggle-interactive-row"
+              data-index={index}
+              data-key={item.id}
+              onClick={(event) => {
+                event.stopPropagation();
+                setItems((current) =>
+                  current.map((row) =>
+                    row.id === item.id
+                      ? { ...row, done: !item.done, label: `${item.label}!` }
+                      : row,
+                  ),
+                );
+              }}
+              type="button"
+            >
+              Toggle
+            </button>
+          </li>
+        ))}
+      </ul>
+      <button
+        data-action="reverse-interactive-rows"
+        onClick={() => setItems((current) => [...current].reverse())}
+        type="button"
+      >
+        Reverse interactive rows
+      </button>
+    </article>
+  );
+}
+
 function StatefulListRow({ item }: { item: ListItem }) {
   const [clicks, setClicks] = useState(0);
   return (
@@ -354,7 +439,7 @@ export function ExplicitKeyedListExperiment() {
   return (
     <article className="edge-card" data-experiment="keyed-explicit">
       <header>
-        <span className="experiment-number">04C</span>
+        <span className="experiment-number">04D</span>
         <div>
           <h3>Explicit List boundary</h3>
           <p>A key selector supports custom rows while React preserves their state.</p>
@@ -414,6 +499,7 @@ export function CompilerEdgeLab() {
       <div className="edge-grid">
         <AutomaticKeyedListExperiment />
         <DerivedCollectionExperiment />
+        <InteractiveKeyedListExperiment />
         <ExplicitKeyedListExperiment />
       </div>
 

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -65,16 +65,18 @@ The current compiler handles components that it can prove have:
   statically known locations, including supported nested boundaries;
 - item-keyed `collection.map(...)` children and explicit `List` boundaries at statically known
   container locations, including supported non-mutating collection pipelines;
+- inline synchronous events inside otherwise eligible host-only keyed rows;
 - stable module-level child components with compiler-safe props;
 - React-managed event handlers; and
 - no refs, effects, or unsupported dynamic child structures.
 
 The generated component preserves React ownership of initial placement, props, events, SSR, and
 hydration. Local state cells batch updates into a microtask and patch only compiler-known DOM
-targets. Two proven, dedicated host containers can transfer child ownership after mount:
-host-only conditional branches and host-only keyed rows. React still creates or hydrates their
-initial DOM. Anything outside those narrow contracts uses a small React-owned boundary or the
-complete original component.
+targets. Proven, dedicated host containers can transfer child ownership after mount for host-only
+conditional branches and non-interactive host-only keyed rows. An interactive host-only row uses a
+hybrid boundary instead: React retains its event handlers and structural reconciliation, while Farm
+patches same-key bindings. React still creates or hydrates all initial DOM. Anything outside those
+narrow contracts uses a small React-owned boundary or the complete original component.
 
 For a common dedicated conditional, no new component or annotation is required:
 
@@ -109,6 +111,27 @@ Later list updates patch surviving rows by key, create or remove only the change
 longest increasing subsequence (LIS) to minimize DOM moves during a reorder. The outer user
 component and the list callback do not rerun for those compiler-cell updates.
 
+An otherwise eligible host row may also contain an inline synchronous React event:
+
+```tsx
+<ul>
+  {items.map((item, index) => (
+    <li key={item.id}>
+      <span>{item.label}</span>
+      <button onClick={() => select(item.id, index)}>Select</button>
+    </li>
+  ))}
+</ul>
+```
+
+The compiler leaves the event prop on the React element and emits no native listener. Its stable
+keyed proxy looks up the latest item and index when React dispatches the event, so a same-key item
+replacement cannot leave a stale row closure. If the key order is unchanged, Farm patches the
+prepared text, attribute, and style bindings without rerunning the component or map callback. An
+insert, removal, or reorder asks React to reconcile the rows, adopts the committed host elements,
+reapplies current bindings, and then resumes direct same-key patches. This avoids creating eventful
+DOM outside React's Fiber tree.
+
 A keyed collection may use derived locals or an inline chain of `filter`, `slice`, `toSorted`, and
 `toReversed`:
 
@@ -139,10 +162,11 @@ and unproven calls use the original React fallback.
 `toSorted` and `toReversed` are emitted as standard runtime calls rather than polyfilled. Configure
 the TypeScript `lib` with ES2023 and target a runtime that supports them when using those methods.
 
-React remains the fallback and compatibility boundary. A map beside static children, a row with
-events, a fragment, a ref, or a custom component, and other unsupported shapes use the existing
-React-owned keyed boundary. The outer compiled component can still be skipped, but React reconciles
-that list's rows and owns their events, lifecycle, and state.
+React remains the fallback and compatibility boundary. A map beside static children, a row with a
+non-inline or async handler, a controlled interactive form field, a fragment, a ref, or a custom
+component, and other unsupported shapes use the existing React-owned keyed boundary. The outer
+compiled component can still be skipped, but React reconciles that list's rows and owns their
+events, lifecycle, and state.
 
 For custom rows or an explicit key selector, use the public component:
 
@@ -159,8 +183,8 @@ import { List } from "@farm.js/react/list";
 `List` also works with the compiler disabled. `each` accepts an iterable, `null`, or `undefined`;
 `by` supplies the React key; and the child function returns one React element. An inline host-only
 row inside a dedicated container can use compiler-owned keyed rows. A custom row such as
-`StatefulRow` remains a React-owned keyed boundary, which is necessary for its Hooks, events,
-lifecycle, and Fiber state. Put Hooks inside the row component, not directly inside the iteration
+`StatefulRow` remains a React-owned keyed boundary, which is necessary for its Hooks, lifecycle,
+and Fiber state. Put Hooks inside the row component, not directly inside the iteration
 callback. The optimized explicit shape also requires inline `by` and child functions, a safe
 `each` expression, an item-derived key, and a statically known location. Other shapes keep normal
 React behavior.
@@ -226,5 +250,6 @@ Application and prototype calls, dynamic style objects, handlers outside JSX eve
 computed, and rest props patterns, async handlers, unkeyed or index-keyed lists, chained maps,
 unsupported conditional roots, effects, and more advanced hook support intentionally stay on React
 in this release. Compiler-owned keyed rows are limited to a dedicated container with one host-only
-map or `List`. Row events, custom components, fragments, refs, SVG, mixed static siblings, and
-duplicate runtime keys keep or switch to React ownership.
+map or `List`. Inline synchronous events can use the hybrid keyed-row path, but non-inline or async
+row handlers, controlled interactive row forms, custom components, fragments, refs, SVG, mixed
+static siblings, and duplicate runtime keys keep or switch to React ownership.

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -446,6 +446,159 @@ const testSource = String.raw`
   assert.equal(keyedRowExecutions, initialKeyedRowExecutions);
   flushSync(() => keyedRowsRoot.unmount());
 
+  let interactiveRowExecutions = 0;
+  let interactiveListRenders = 0;
+  let setInteractiveItems = () => undefined;
+  const interactiveCalls = [];
+  const InteractiveKeyedRows = createCompiledComponent({
+    displayName: "CompatibilityInteractiveKeyedRows",
+    initialize: () => [[
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+    ]],
+    render(_props, state, blocks) {
+      interactiveRowExecutions += 1;
+      setInteractiveItems = (next) => state[0].set(next);
+      const items = () => state[0].get();
+      return React.createElement(
+        "section",
+        null,
+        React.createElement(blocks.KeyedRows, {
+          id: 0,
+          render: (rowEvent) => {
+            interactiveListRenders += 1;
+            return React.createElement(
+              "ol",
+              null,
+              items().map((item, index) =>
+                React.createElement(
+                  "li",
+                  { key: item.id, "data-key": item.id },
+                  React.createElement("span", null, item.label),
+                  React.createElement(
+                    "button",
+                    {
+                      "data-index": index,
+                      onClick: rowEvent(item, index, 0),
+                      type: "button",
+                    },
+                    "Update",
+                  ),
+                ),
+              ),
+            );
+          },
+          items,
+          rowKey: (item) => item.id,
+          create: (item, index) => ({
+            kind: "element",
+            tag: "li",
+            attributes: [{ name: "data-key", value: item.id }],
+            styles: [],
+            children: [
+              {
+                kind: "element",
+                tag: "span",
+                attributes: [],
+                styles: [],
+                children: [item.label],
+              },
+              {
+                kind: "element",
+                tag: "button",
+                attributes: [
+                  { name: "data-index", value: index },
+                  { name: "type", value: "button" },
+                ],
+                styles: [],
+                children: ["Update"],
+              },
+            ],
+          }),
+          bindings: [
+            { kind: "text", path: [0], read: (item) => [item.label] },
+            { kind: "attribute", path: [1], name: "data-index", read: (_item, index) => index },
+          ],
+          events: [
+            {
+              name: "onClick",
+              invoke: (item, index, event) => {
+                interactiveCalls.push(item.label + ":" + index + ":" + event.currentTarget.dataset.index);
+                state[0].set((current) =>
+                  current.map((row) =>
+                    row.id === item.id ? { ...row, label: item.label + "!" } : row,
+                  ),
+                );
+              },
+            },
+          ],
+        }),
+      );
+    },
+    bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+  });
+
+  const interactiveContainer = document.createElement("div");
+  document.body.append(interactiveContainer);
+  const interactiveRoot = createRoot(interactiveContainer);
+  flushSync(() => interactiveRoot.render(React.createElement(InteractiveKeyedRows)));
+  const initialInteractiveExecutions = interactiveRowExecutions;
+  const initialInteractiveRenders = interactiveListRenders;
+  const interactiveAlpha = interactiveContainer.querySelector("[data-key='a']");
+  interactiveAlpha.querySelector("button").click();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(interactiveAlpha.querySelector("span").textContent, "Alpha!");
+  assert.deepEqual(interactiveCalls, ["Alpha:0:0"]);
+  assert.equal(interactiveRowExecutions, initialInteractiveExecutions);
+  assert.equal(interactiveListRenders, initialInteractiveRenders);
+
+  const interactiveStateButton = interactiveAlpha.querySelector("button");
+  interactiveStateButton.click();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(interactiveAlpha.querySelector("span").textContent, "Alpha!!");
+  assert.deepEqual(interactiveCalls, ["Alpha:0:0", "Alpha!:0:0"]);
+  assert.equal(interactiveContainer.querySelector("[data-key='a']"), interactiveAlpha);
+
+  setInteractiveItems((current) => [...current].reverse());
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  flushSync(() => {});
+  assert.deepEqual(
+    [...interactiveContainer.querySelectorAll("li")].map((row) => row.getAttribute("data-key")),
+    ["b", "a"],
+  );
+  assert.equal(interactiveContainer.querySelector("[data-key='a']"), interactiveAlpha);
+  assert.equal(interactiveListRenders, initialInteractiveRenders + 1);
+  interactiveAlpha.querySelector("button").click();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(interactiveAlpha.querySelector("span").textContent, "Alpha!!!");
+  assert.deepEqual(interactiveCalls, ["Alpha:0:0", "Alpha!:0:0", "Alpha!!:1:1"]);
+  flushSync(() => interactiveRoot.unmount());
+
+  const interactiveHydrationContainer = document.createElement("div");
+  interactiveHydrationContainer.innerHTML = renderToString(
+    React.createElement(InteractiveKeyedRows),
+  );
+  document.body.append(interactiveHydrationContainer);
+  const hydratedInteractiveAlpha = interactiveHydrationContainer.querySelector("[data-key='a']");
+  const interactiveHydrationRoot = hydrateRoot(
+    interactiveHydrationContainer,
+    React.createElement(InteractiveKeyedRows),
+  );
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(
+    interactiveHydrationContainer.querySelector("[data-key='a']"),
+    hydratedInteractiveAlpha,
+  );
+  hydratedInteractiveAlpha.querySelector("button").click();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(hydratedInteractiveAlpha.querySelector("span").textContent, "Alpha!");
+  flushSync(() => interactiveHydrationRoot.unmount());
+
   let derivedCollectionExecutions = 0;
   const DerivedCollections = createCompiledComponent({
     displayName: "CompatibilityDerivedCollections",

--- a/packages/farm-react/src/__tests__/compiler-interactive-keyed-rows.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-interactive-keyed-rows.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true);
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/InteractiveRows.tsx", infer);
+}
+
+describe("React AOT interactive keyed-row compiler", () => {
+  it("keeps row events in React while compiling row bindings", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Tasks() {
+        const [items, setItems] = useState([
+          { id: "a", label: "Alpha", done: false },
+          { id: "b", label: "Beta", done: false },
+        ]);
+        const [selected, setSelected] = useState("a");
+        function select(id) {
+          setSelected(id);
+        }
+        return (
+          <section>
+            <ul>
+              {items.map((item, index) => (
+                <li
+                  aria-selected={selected === item.id}
+                  className={item.done ? "done" : "open"}
+                  key={item.id}
+                  onClickCapture={(event) => event.currentTarget.dataset.index}
+                >
+                  <span>{item.label}</span>
+                  <button
+                    data-index={index}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      select(item.id);
+                    }}
+                    type="button"
+                  >
+                    Select
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Tasks"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedRows");
+    expect(result.code).toContain('name: "onClickCapture"');
+    expect(result.code).toContain('name: "onClick"');
+    expect(result.code).toContain("events={[");
+    expect(result.code).toMatch(/onClickCapture=\{_farmRowEvent\(item, index, 0\)\}/);
+    expect(result.code).toMatch(/onClick=\{_farmRowEvent\(item, index, 1\)\}/);
+    expect(result.code).toContain("farmState[1].set");
+    expect(result.code).not.toContain("addEventListener");
+    await expect(
+      transformWithEsbuild(result.code, "/app/InteractiveRows.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({ code: expect.stringContaining("farmBlocks.KeyedRows") });
+  });
+
+  it("supports interactive host rows through the public List boundary", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List } from "@farm.js/react/list";
+      export function Tasks() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
+        return (
+          <section>
+            <ul>
+              <List each={items} by={(item) => item.id}>
+                {(item, index) => (
+                  <li>
+                    <span>{item.label}</span>
+                    <button onClick={() => setItems((current) => current.filter((row) => row.id !== item.id))}>
+                      Remove {index}
+                    </button>
+                  </li>
+                )}
+              </List>
+            </ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Tasks"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedRows");
+    expect(result.code).toContain("_farmRowEvent(item, index, 0)");
+    expect(result.code).toContain('name: "onClick"');
+  });
+
+  it.each([
+    {
+      name: "a non-inline handler prop",
+      event: "onClick={onSelect}",
+    },
+    {
+      name: "an async handler",
+      event: "onClick={async () => setItems([])}",
+    },
+    {
+      name: "arguments access",
+      event: "onClick={function () { setItems(arguments.length ? [] : items); }}",
+    },
+  ])("keeps $name in the React-owned list boundary", async ({ event }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Tasks({ onSelect }) {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
+        return (
+          <section>
+            <ul>{items.map((item) => <li key={item.id} ${event}>{item.label}</li>)}</ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Tasks"]);
+    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).not.toContain("farmBlocks.KeyedRows");
+  });
+
+  it("keeps controlled interactive row inputs under React ownership", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Tasks() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
+        return (
+          <section>
+            <ul>
+              {items.map((item) => (
+                <li key={item.id}>
+                  <input
+                    onChange={(event) => setItems([{ ...item, label: event.currentTarget.value }])}
+                    value={item.label}
+                  />
+                </li>
+              ))}
+            </ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Tasks"]);
+    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).not.toContain("farmBlocks.KeyedRows");
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-keyed-lists.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-lists.test.ts
@@ -163,10 +163,6 @@ describe("React AOT keyed list compiler", () => {
 
   it.each([
     {
-      name: "row events",
-      row: "<li key={item.id} onClick={() => setItems([])}>{item.label}</li>",
-    },
-    {
       name: "custom row components",
       row: "<InventoryRow key={item.id} item={item} />",
     },

--- a/packages/farm-react/src/__tests__/compiler-runtime-interactive-keyed-rows.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-interactive-keyed-rows.test.tsx
@@ -1,0 +1,1078 @@
+import React, { StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createCompiledComponent,
+  type CompilerKeyedRowElement,
+  type CompilerStateUpdater,
+} from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Item {
+  id: string;
+  label: string;
+  done?: boolean;
+}
+
+const roots: Array<{ unmount(): void }> = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function interactiveRowDescriptor(item: Item, index: number): CompilerKeyedRowElement {
+  return {
+    kind: "element",
+    tag: "li",
+    attributes: [
+      { name: "data-key", value: item.id },
+      { name: "data-done", value: Boolean(item.done) },
+    ],
+    styles: [],
+    children: [
+      {
+        kind: "element",
+        tag: "span",
+        attributes: [],
+        styles: [],
+        children: [item.label],
+      },
+      {
+        kind: "element",
+        tag: "button",
+        attributes: [
+          { name: "data-index", value: index },
+          { name: "type", value: "button" },
+        ],
+        styles: [],
+        children: ["Select"],
+      },
+      {
+        kind: "element",
+        tag: "button",
+        attributes: [{ name: "type", value: "button" }],
+        styles: [],
+        children: ["Stop"],
+      },
+    ],
+  };
+}
+
+describe("interactive compiled keyed-row runtime", () => {
+  it("patches same-key rows without rerendering and invokes events with the newest item", async () => {
+    let executions = 0;
+    let listRenders = 0;
+    const calls: string[] = [];
+    const Tasks = createCompiledComponent({
+      displayName: "InteractiveTasks",
+      initialize: () => [
+        [
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Beta" },
+        ],
+      ],
+      render(_props: Record<string, never>, state, blocks) {
+        executions += 1;
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <section>
+            <button
+              data-action="replace"
+              onClick={() =>
+                state[0].set((current) =>
+                  (current as Item[]).map((item) =>
+                    item.id === "b" ? { ...item, label: "Beta newest", done: true } : item,
+                  ),
+                )
+              }
+              type="button"
+            >
+              Replace
+            </button>
+            <KeyedRows
+              bindings={[
+                {
+                  kind: "attribute",
+                  name: "data-done",
+                  path: [],
+                  read: (item) => Boolean((item as Item).done),
+                },
+                {
+                  kind: "text",
+                  path: [0],
+                  read: (item) => [(item as Item).label],
+                },
+                {
+                  kind: "attribute",
+                  name: "data-index",
+                  path: [1],
+                  read: (_item, index) => index,
+                },
+              ]}
+              create={(item, index) => interactiveRowDescriptor(item as Item, index)}
+              events={[
+                {
+                  name: "onClick",
+                  invoke: (item, index, event) => {
+                    const button = event.currentTarget as HTMLButtonElement;
+                    calls.push(`select:${(item as Item).label}:${index}:${button.dataset.index}`);
+                  },
+                },
+                {
+                  name: "onClick",
+                  invoke: (item, _index, event) => {
+                    calls.push(`stop:${(item as Item).label}`);
+                    event.stopPropagation();
+                  },
+                },
+              ]}
+              id={0}
+              items={items}
+              render={(rowEvent) => {
+                listRenders += 1;
+                return (
+                  <ul
+                    onClick={() => calls.push("bubble")}
+                    onClickCapture={() => calls.push("capture")}
+                  >
+                    {items().map((item, index) => (
+                      <li data-done={Boolean(item.done)} data-key={item.id} key={item.id}>
+                        <span>{item.label}</span>
+                        <button data-index={index} onClick={rowEvent(item, index, 0)} type="button">
+                          Select
+                        </button>
+                        <button onClick={rowEvent(item, index, 1)} type="button">
+                          Stop
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                );
+              }}
+              rowKey={(item) => (item as Item).id}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Tasks />));
+    const beta = container.querySelector<HTMLLIElement>('[data-key="b"]')!;
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-action="replace"]')!.click();
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector('[data-key="b"]')).toBe(beta);
+    expect(beta.querySelector("span")?.textContent).toBe("Beta newest");
+    expect(beta.dataset.done).toBe("true");
+    expect(executions).toBe(1);
+    expect(listRenders).toBe(1);
+
+    await act(async () => beta.querySelectorAll("button")[0].click());
+    expect(calls).toEqual(["capture", "select:Beta newest:1:1", "bubble"]);
+
+    calls.length = 0;
+    await act(async () => beta.querySelectorAll("button")[1].click());
+    expect(calls).toEqual(["capture", "stop:Beta newest"]);
+  });
+
+  it("asks React to reconcile structural changes, then resumes direct patches", async () => {
+    let executions = 0;
+    let listRenders = 0;
+    let updateItems: (next: CompilerStateUpdater) => void = () => undefined;
+    const selected: string[] = [];
+    const Tasks = createCompiledComponent({
+      displayName: "StructuralInteractiveTasks",
+      initialize: () => [
+        [
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Beta" },
+        ],
+      ],
+      render(_props: Record<string, never>, state, blocks) {
+        executions += 1;
+        updateItems = (next) => state[0].set(next);
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <KeyedRows
+              bindings={[
+                {
+                  kind: "text",
+                  path: [0],
+                  read: (item) => [(item as Item).label],
+                },
+                {
+                  kind: "attribute",
+                  name: "data-index",
+                  path: [1],
+                  read: (_item, index) => index,
+                },
+              ]}
+              create={(item, index) => interactiveRowDescriptor(item as Item, index)}
+              events={[
+                {
+                  name: "onClick",
+                  invoke: (item, index) => selected.push(`${(item as Item).label}:${index}`),
+                },
+              ]}
+              id={0}
+              items={items}
+              render={(rowEvent) => {
+                listRenders += 1;
+                return (
+                  <ul>
+                    {items().map((item, index) => (
+                      <li data-key={item.id} key={item.id}>
+                        <span>{item.label}</span>
+                        <button data-index={index} onClick={rowEvent(item, index, 0)} type="button">
+                          Select
+                        </button>
+                        <button type="button">Stop</button>
+                      </li>
+                    ))}
+                  </ul>
+                );
+              }}
+              rowKey={(item) => (item as Item).id}
+            />
+          </main>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Tasks />));
+    const original = new Map(
+      [...container.querySelectorAll<HTMLLIElement>("li")].map((row) => [row.dataset.key, row]),
+    );
+
+    await act(async () => {
+      updateItems([
+        { id: "c", label: "Gamma" },
+        { id: "b", label: "Beta moved" },
+        { id: "a", label: "Alpha moved" },
+      ]);
+      await flushCompilerUpdates();
+    });
+
+    const rows = [...container.querySelectorAll<HTMLLIElement>("li")];
+    expect(rows.map((row) => row.dataset.key)).toEqual(["c", "b", "a"]);
+    expect(rows[1]).toBe(original.get("b"));
+    expect(rows[2]).toBe(original.get("a"));
+    expect(listRenders).toBe(2);
+    expect(executions).toBe(1);
+
+    await act(async () => rows[1].querySelector("button")!.click());
+    expect(selected).toEqual(["Beta moved:1"]);
+
+    await act(async () => {
+      updateItems((current) =>
+        (current as Item[]).map((item) =>
+          item.id === "b" ? { ...item, label: "Beta patched" } : item,
+        ),
+      );
+      await flushCompilerUpdates();
+    });
+    expect(rows[1].querySelector("span")?.textContent).toBe("Beta patched");
+    expect(listRenders).toBe(2);
+
+    await act(async () => rows[1].querySelector("button")!.click());
+    expect(selected).toEqual(["Beta moved:1", "Beta patched:1"]);
+  });
+
+  it("uses per-render event closures after duplicate keys switch the rows to React fallback", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    let updateItems: (next: CompilerStateUpdater) => void = () => undefined;
+    const observed: string[] = [];
+    const Tasks = createCompiledComponent({
+      displayName: "DuplicateInteractiveTasks",
+      initialize: () => [
+        [
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Beta" },
+        ],
+      ],
+      render(_props: Record<string, never>, state, blocks) {
+        updateItems = (next) => state[0].set(next);
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <KeyedRows
+              bindings={[
+                {
+                  kind: "text",
+                  path: [0],
+                  read: (item) => [(item as Item).label],
+                },
+              ]}
+              create={(item, index) => interactiveRowDescriptor(item as Item, index)}
+              events={[
+                {
+                  name: "onClick",
+                  invoke: (item, index) => observed.push(`${(item as Item).label}:${index}`),
+                },
+              ]}
+              id={0}
+              items={items}
+              render={(rowEvent) => (
+                <ul>
+                  {items().map((item, index) => (
+                    <li data-done={false} data-key={item.id} key={item.id}>
+                      <span>{item.label}</span>
+                      <button data-index={index} onClick={rowEvent(item, index, 0)} type="button">
+                        Select
+                      </button>
+                      <button type="button">Stop</button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+            />
+          </main>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Tasks />));
+
+    await act(async () => {
+      updateItems([
+        { id: "a", label: "Alpha first" },
+        { id: "a", label: "Alpha second" },
+      ]);
+      await flushCompilerUpdates();
+    });
+    let buttons = [...container.querySelectorAll<HTMLButtonElement>("li button:first-of-type")];
+    await act(async () => {
+      buttons[0].click();
+      buttons[1].click();
+    });
+    expect(observed).toEqual(["Alpha first:0", "Alpha second:1"]);
+
+    await act(async () => {
+      updateItems([
+        { id: "a", label: "First newest" },
+        { id: "a", label: "Second newest" },
+      ]);
+      await flushCompilerUpdates();
+    });
+    buttons = [...container.querySelectorAll<HTMLButtonElement>("li button:first-of-type")];
+    await act(async () => buttons[1].click());
+    expect(observed[observed.length - 1]).toBe("Second newest:1");
+  });
+
+  it("hydrates in StrictMode, recovers mismatched text, and drops queued work after unmount", async () => {
+    let executions = 0;
+    const observed: string[] = [];
+    const Tasks = createCompiledComponent({
+      displayName: "HydratedInteractiveTasks",
+      initialize: () => [[{ id: "a", label: "Alpha" }]],
+      render(_props: Record<string, never>, state, blocks) {
+        executions += 1;
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <section>
+            <button
+              data-action="update"
+              onClick={() => state[0].set([{ id: "a", label: "Client newest" }])}
+              type="button"
+            >
+              Update
+            </button>
+            <KeyedRows
+              bindings={[
+                {
+                  kind: "text",
+                  path: [0],
+                  read: (item) => [(item as Item).label],
+                },
+              ]}
+              create={(item, index) => interactiveRowDescriptor(item as Item, index)}
+              events={[
+                {
+                  name: "onClick",
+                  invoke: (item) => observed.push((item as Item).label),
+                },
+              ]}
+              id={0}
+              items={items}
+              render={(rowEvent) => (
+                <ul>
+                  {items().map((item, index) => (
+                    <li data-key={item.id} key={item.id}>
+                      <span>{item.label}</span>
+                      <button data-index={index} onClick={rowEvent(item, index, 0)} type="button">
+                        Select
+                      </button>
+                      <button type="button">Stop</button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const serverHtml = renderToString(
+      <StrictMode>
+        <Tasks />
+      </StrictMode>,
+    );
+    const container = document.createElement("div");
+    container.innerHTML = serverHtml.replace("Alpha", "Server mismatch");
+    document.body.append(container);
+    const recoverable = vi.fn();
+    const root = hydrateRoot(
+      container,
+      <StrictMode>
+        <Tasks />
+      </StrictMode>,
+      { onRecoverableError: recoverable },
+    );
+    roots.push(root);
+    await act(async () => flushCompilerUpdates());
+
+    expect(container.querySelector("li span")?.textContent).toBe("Alpha");
+    expect(recoverable).toHaveBeenCalled();
+    const mountedExecutions = executions;
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-action="update"]')!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("li span")?.textContent).toBe("Client newest");
+    expect(executions).toBe(mountedExecutions);
+
+    await act(async () =>
+      container.querySelector<HTMLLIElement>("li")!.querySelector("button")!.click(),
+    );
+    expect(observed).toEqual(["Client newest"]);
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-action="update"]')!.click();
+      root.unmount();
+      await flushCompilerUpdates();
+    });
+    roots.splice(roots.indexOf(root), 1);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("keeps a parent prop commit and a local row event coherent in the same turn", async () => {
+    const observed: string[] = [];
+
+    interface TasksProps {
+      onPrefixChange(): void;
+      prefix: string;
+    }
+
+    const Tasks = createCompiledComponent({
+      displayName: "ParentInteractiveTasks",
+      initialize: () => [[{ id: "a", label: "Alpha" }]],
+      render(props: TasksProps, state, blocks) {
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <section>
+            <KeyedRows
+              bindings={[
+                {
+                  kind: "text",
+                  path: [0],
+                  read: (item) => [`${props.prefix}:${(item as Item).label}`],
+                },
+              ]}
+              create={(item) => ({
+                ...interactiveRowDescriptor(item as Item, 0),
+                children: [
+                  {
+                    kind: "element",
+                    tag: "span",
+                    attributes: [],
+                    styles: [],
+                    children: [`${props.prefix}:${(item as Item).label}`],
+                  },
+                  ...interactiveRowDescriptor(item as Item, 0).children.slice(1),
+                ],
+              })}
+              events={[
+                {
+                  name: "onClick",
+                  invoke: (item) => {
+                    observed.push(`${props.prefix}:${(item as Item).label}`);
+                    props.onPrefixChange();
+                    state[0].set((current) =>
+                      (current as Item[]).map((row) =>
+                        row.id === (item as Item).id
+                          ? { ...row, label: `${(item as Item).label}!` }
+                          : row,
+                      ),
+                    );
+                  },
+                },
+              ]}
+              id={0}
+              items={items}
+              render={(rowEvent) => (
+                <ul>
+                  {items().map((item, index) => (
+                    <li data-done={false} data-key={item.id} key={item.id}>
+                      <span>
+                        {props.prefix}:{item.label}
+                      </span>
+                      <button data-index={index} onClick={rowEvent(item, index, 0)} type="button">
+                        Select
+                      </button>
+                      <button type="button">Stop</button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    function Parent() {
+      const [prefix, setPrefix] = useState("old");
+      return <Tasks onPrefixChange={() => setPrefix("new")} prefix={prefix} />;
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Parent />));
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("li button")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("li span")?.textContent).toBe("new:Alpha!");
+    expect(observed).toEqual(["old:Alpha"]);
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("li button")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("li span")?.textContent).toBe("new:Alpha!!");
+    expect(observed).toEqual(["old:Alpha", "new:Alpha!"]);
+  });
+
+  it("preserves row state and replaces event behavior through compatible Fast Refresh", async () => {
+    const hmrId = `interactive-keyed-rows-refresh-${Math.random()}`;
+    const observed: string[] = [];
+
+    const defineTasks = (version: string) =>
+      createCompiledComponent({
+        displayName: "RefreshableInteractiveTasks",
+        hmrId,
+        stateSignature: "items",
+        initialize: () => [[{ id: "a", label: "Alpha" }]],
+        render(_props: Record<string, never>, state, blocks) {
+          const items = () => state[0].get() as Item[];
+          const KeyedRows = blocks.KeyedRows;
+          return (
+            <section>
+              <KeyedRows
+                bindings={[
+                  {
+                    kind: "text",
+                    path: [0],
+                    read: (item) => [(item as Item).label],
+                  },
+                ]}
+                create={(item, index) => interactiveRowDescriptor(item as Item, index)}
+                events={[
+                  ...(version === "v2"
+                    ? [
+                        {
+                          name: "onMouseEnter",
+                          invoke: (item: unknown) => observed.push(`hover:${(item as Item).label}`),
+                        },
+                      ]
+                    : []),
+                  {
+                    name: "onClick",
+                    invoke: (item) => {
+                      observed.push(`${version}:${(item as Item).label}`);
+                      state[0].set((current) =>
+                        (current as Item[]).map((row) =>
+                          row.id === (item as Item).id
+                            ? { ...row, label: `${(item as Item).label}!` }
+                            : row,
+                        ),
+                      );
+                    },
+                  },
+                ]}
+                id={0}
+                items={items}
+                render={(rowEvent) => (
+                  <ul>
+                    {items().map((item, index) => (
+                      <li data-done={false} data-key={item.id} key={item.id}>
+                        <span>{item.label}</span>
+                        <button
+                          data-index={index}
+                          onClick={rowEvent(item, index, version === "v2" ? 1 : 0)}
+                          onMouseEnter={version === "v2" ? rowEvent(item, index, 0) : undefined}
+                          type="button"
+                        >
+                          Select
+                        </button>
+                        <button type="button">Stop</button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                rowKey={(item) => (item as Item).id}
+              />
+            </section>
+          );
+        },
+        bindings: [{ kind: "block" as const, id: 0, dependencies: [0] }],
+      });
+
+    const InitialTasks = defineTasks("v1");
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<InitialTasks />));
+    const row = container.querySelector("li");
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("li button")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("li span")?.textContent).toBe("Alpha!");
+    expect(observed).toEqual(["v1:Alpha"]);
+
+    let RefreshedTasks = InitialTasks;
+    await act(async () => {
+      RefreshedTasks = defineTasks("v2");
+      root.render(<RefreshedTasks />);
+      await flushCompilerUpdates();
+    });
+    expect(RefreshedTasks).toBe(InitialTasks);
+    expect(container.querySelector("li")).toBe(row);
+    expect(container.querySelector("li span")?.textContent).toBe("Alpha!");
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("li button")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("li span")?.textContent).toBe("Alpha!!");
+    expect(observed).toEqual(["v1:Alpha", "v2:Alpha!"]);
+  });
+
+  it("routes an interactive row binding failure through the nearest React error boundary", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    class Boundary extends React.Component<
+      { children: React.ReactNode },
+      { message: string | null }
+    > {
+      state = { message: null as string | null };
+
+      static getDerivedStateFromError(error: Error) {
+        return { message: error.message };
+      }
+
+      render() {
+        return this.state.message ? <p data-error>{this.state.message}</p> : this.props.children;
+      }
+    }
+
+    const Tasks = createCompiledComponent({
+      displayName: "FailingInteractiveTasks",
+      initialize: () => [[{ id: "a", label: "Alpha" }]],
+      render(_props: Record<string, never>, state, blocks) {
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <section>
+            <KeyedRows
+              bindings={[
+                {
+                  kind: "text",
+                  path: [0],
+                  read: (item) => {
+                    if ((item as Item).label === "Crash") throw new Error("row binding failed");
+                    return [(item as Item).label];
+                  },
+                },
+              ]}
+              create={(item, index) => interactiveRowDescriptor(item as Item, index)}
+              events={[
+                {
+                  name: "onClick",
+                  invoke: (item) =>
+                    state[0].set((current) =>
+                      (current as Item[]).map((row) =>
+                        row.id === (item as Item).id ? { ...row, label: "Crash" } : row,
+                      ),
+                    ),
+                },
+              ]}
+              id={0}
+              items={items}
+              render={(rowEvent) => (
+                <ul>
+                  {items().map((item, index) => (
+                    <li data-done={false} data-key={item.id} key={item.id}>
+                      <span>{item.label}</span>
+                      <button data-index={index} onClick={rowEvent(item, index, 0)} type="button">
+                        Select
+                      </button>
+                      <button type="button">Stop</button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <Boundary>
+          <Tasks />
+        </Boundary>,
+      ),
+    );
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("li button")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("[data-error]")?.textContent).toBe("row binding failed");
+  });
+
+  it("matches React across 4,000 deterministic data, structure, and event transitions", async () => {
+    interface Model {
+      items: Item[];
+      selected: string | null;
+    }
+    type Update = (model: Model) => Model;
+    const initial: Model = {
+      items: Array.from({ length: 12 }, (_, index) => ({
+        id: `i${index}`,
+        label: `Item ${index}`,
+        done: false,
+      })),
+      selected: null,
+    };
+    let compiledSet: (next: CompilerStateUpdater) => void = () => undefined;
+    let reactSet: React.Dispatch<React.SetStateAction<Model>> = () => undefined;
+    let compiledRead: () => Model = () => initial;
+    let normalCurrent = initial;
+    let compiledExecutions = 0;
+    let compiledListRenders = 0;
+
+    const Compiled = createCompiledComponent({
+      displayName: "DifferentialInteractiveRows",
+      initialize: () => [initial],
+      render(_props: Record<string, never>, state, blocks) {
+        compiledExecutions += 1;
+        compiledSet = (next) => state[0].set(next);
+        const model = () => state[0].get() as Model;
+        compiledRead = model;
+        const items = () => model().items;
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <KeyedRows
+              bindings={[
+                {
+                  kind: "attribute",
+                  name: "data-done",
+                  path: [],
+                  read: (item) => Boolean((item as Item).done),
+                },
+                {
+                  kind: "attribute",
+                  name: "data-selected",
+                  path: [],
+                  read: (item) => model().selected === (item as Item).id,
+                },
+                {
+                  kind: "text",
+                  path: [0],
+                  read: (item) => [(item as Item).label],
+                },
+              ]}
+              create={(item) => {
+                const row = item as Item;
+                return {
+                  kind: "element",
+                  tag: "li",
+                  attributes: [
+                    { name: "data-key", value: row.id },
+                    { name: "data-done", value: Boolean(row.done) },
+                    { name: "data-selected", value: model().selected === row.id },
+                  ],
+                  styles: [],
+                  children: [
+                    {
+                      kind: "element",
+                      tag: "span",
+                      attributes: [],
+                      styles: [],
+                      children: [row.label],
+                    },
+                    {
+                      kind: "element",
+                      tag: "button",
+                      attributes: [{ name: "type", value: "button" }],
+                      styles: [],
+                      children: ["Toggle"],
+                    },
+                  ],
+                };
+              }}
+              events={[
+                {
+                  name: "onClick",
+                  invoke: (item) => {
+                    const id = (item as Item).id;
+                    state[0].set((current) => {
+                      const value = current as Model;
+                      return {
+                        items: value.items.map((row) =>
+                          row.id === id ? { ...row, done: !row.done } : row,
+                        ),
+                        selected: id,
+                      };
+                    });
+                  },
+                },
+              ]}
+              id={0}
+              items={items}
+              render={(rowEvent) => {
+                compiledListRenders += 1;
+                return (
+                  <ul>
+                    {items().map((item, index) => (
+                      <li
+                        data-done={Boolean(item.done)}
+                        data-key={item.id}
+                        data-selected={model().selected === item.id}
+                        key={item.id}
+                      >
+                        <span>{item.label}</span>
+                        <button onClick={rowEvent(item, index, 0)} type="button">
+                          Toggle
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                );
+              }}
+              rowKey={(item) => (item as Item).id}
+            />
+          </main>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    function Normal() {
+      const [model, setModel] = useState(initial);
+      normalCurrent = model;
+      reactSet = setModel;
+      return (
+        <ul>
+          {model.items.map((item) => (
+            <li
+              data-done={Boolean(item.done)}
+              data-key={item.id}
+              data-selected={model.selected === item.id}
+              key={item.id}
+            >
+              <span>{item.label}</span>
+              <button
+                onClick={() =>
+                  setModel((current) => ({
+                    items: current.items.map((row) =>
+                      row.id === item.id ? { ...row, done: !row.done } : row,
+                    ),
+                    selected: item.id,
+                  }))
+                }
+                type="button"
+              >
+                Toggle
+              </button>
+            </li>
+          ))}
+        </ul>
+      );
+    }
+
+    let seed = 0x1a2b3c4d;
+    let nextId = 0;
+    const random = () => {
+      seed = (seed * 1664525 + 1013904223) >>> 0;
+      return seed;
+    };
+    const updates: Update[] = Array.from({ length: 4000 }, () => {
+      const operation = random() % 8;
+      const selector = random();
+      if (operation <= 3) {
+        return (model) => {
+          if (model.items.length === 0) return model;
+          const selected = selector % model.items.length;
+          return {
+            ...model,
+            items: model.items.map((item, index) =>
+              index === selected
+                ? {
+                    ...item,
+                    done: operation === 0 ? !item.done : item.done,
+                    label: operation === 0 ? item.label : `${item.label}!`,
+                  }
+                : item,
+            ),
+          };
+        };
+      }
+      if (operation === 4) {
+        const id = `n${nextId++}`;
+        return (model) =>
+          model.items.length >= 32
+            ? model
+            : {
+                ...model,
+                items: [...model.items, { id, label: id.toUpperCase(), done: false }],
+              };
+      }
+      if (operation === 5) {
+        return (model) =>
+          model.items.length === 0
+            ? model
+            : {
+                ...model,
+                items: model.items.filter((_, index) => index !== selector % model.items.length),
+              };
+      }
+      if (operation === 6) {
+        return (model) => ({ ...model, items: [...model.items].reverse() });
+      }
+      const destination = random();
+      return (model) => {
+        if (model.items.length < 2) return model;
+        const items = [...model.items];
+        const [item] = items.splice(selector % items.length, 1);
+        items.splice(destination % (items.length + 1), 0, item);
+        return { ...model, items };
+      };
+    });
+
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<Compiled />);
+      reactRoot.render(<Normal />);
+    });
+
+    const snapshot = (container: Element) =>
+      [...container.querySelectorAll("li")].map((row) => [
+        row.getAttribute("data-key"),
+        row.getAttribute("data-done"),
+        row.getAttribute("data-selected"),
+        row.querySelector("span")?.textContent,
+      ]);
+
+    for (let offset = 0; offset < updates.length; offset += 20) {
+      await act(async () => {
+        for (const update of updates.slice(offset, offset + 20)) {
+          compiledSet((value) => update(value as Model));
+          reactSet(update);
+        }
+        await flushCompilerUpdates();
+      });
+      expect(compiledRead(), `model after update batch ${offset}`).toEqual(normalCurrent);
+      expect(snapshot(compiledContainer), `DOM after update batch ${offset}`).toEqual(
+        snapshot(reactContainer),
+      );
+
+      const compiledButton = compiledContainer.querySelector<HTMLButtonElement>("li button");
+      const reactButton = reactContainer.querySelector<HTMLButtonElement>("li button");
+      if (compiledButton && reactButton) {
+        await act(async () => {
+          compiledButton.click();
+          reactButton.click();
+          await flushCompilerUpdates();
+        });
+        expect(compiledRead(), `model after event batch ${offset}`).toEqual(normalCurrent);
+        expect(snapshot(compiledContainer), `DOM after event batch ${offset}`).toEqual(
+          snapshot(reactContainer),
+        );
+      }
+    }
+
+    expect(compiledExecutions).toBe(1);
+    expect(compiledListRenders).toBeLessThanOrEqual(201);
+  }, 30_000);
+});

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -77,6 +77,11 @@ export interface CompilerHostElement {
 
 export type CompilerKeyedRowElement = CompilerHostElement;
 
+export interface CompilerKeyedRowEvent {
+  name: string;
+  invoke(item: unknown, index: number, event: React.SyntheticEvent): unknown;
+}
+
 export interface CompilerHostConditionalBinding {
   kind: "text" | "attribute" | "style";
   path: readonly number[];
@@ -108,11 +113,18 @@ export interface CompilerKeyedRowBinding {
 
 export interface CompilerKeyedRowsBlockProps {
   id: number;
-  render(): React.ReactElement;
+  render(
+    event: (
+      item: unknown,
+      index: number,
+      eventId: number,
+    ) => React.EventHandler<React.SyntheticEvent>,
+  ): React.ReactElement;
   items(): Iterable<unknown> | null | undefined;
   rowKey(item: unknown, index: number): React.Key;
   create(item: unknown, index: number): CompilerKeyedRowElement;
   bindings: readonly CompilerKeyedRowBinding[];
+  events?: readonly CompilerKeyedRowEvent[];
 }
 
 export interface CompilerComponentBlockProps {
@@ -525,7 +537,11 @@ function findCompilerHostTarget(root: Element, path: readonly number[]): Element
 
 interface CompilerKeyedRowInstance extends CompilerHostInstance {
   key: string;
+  item: unknown;
+  index: number;
 }
+
+const UNSET_KEYED_ROW_BINDING = Symbol("unset interactive keyed-row binding");
 
 function keyedRowIdentity(key: React.Key): string {
   return String(key);
@@ -823,6 +839,10 @@ function createKeyedRowsBlockComponent(
     private currentProps = this.props;
     private unsubscribe: (() => void) | undefined;
     private instances = new Map<string, CompilerKeyedRowInstance>();
+    private readonly eventHandlers = new Map<
+      string,
+      Map<number, React.EventHandler<React.SyntheticEvent>>
+    >();
 
     private captureRoot = (root: Element | null) => {
       this.root = root;
@@ -838,6 +858,43 @@ function createKeyedRowsBlockComponent(
       return { items, keys };
     }
 
+    private rowEvent = (
+      item: unknown,
+      index: number,
+      eventId: number,
+    ): React.EventHandler<React.SyntheticEvent> => {
+      if (this.state.fallback) {
+        return (event) => this.currentProps.events?.[eventId]?.invoke(item, index, event);
+      }
+      const key = keyedRowIdentity(this.currentProps.rowKey(item, index));
+      let handlers = this.eventHandlers.get(key);
+      if (!handlers) {
+        handlers = new Map();
+        this.eventHandlers.set(key, handlers);
+      }
+      const existing = handlers.get(eventId);
+      if (existing) return existing;
+      const handler: React.EventHandler<React.SyntheticEvent> = (event) => {
+        const instance = this.instances.get(key);
+        const descriptor = this.currentProps.events?.[eventId];
+        if (!instance || !descriptor) return;
+        return descriptor.invoke(instance.item, instance.index, event);
+      };
+      handlers.set(eventId, handler);
+      return handler;
+    };
+
+    private hasInteractiveRows(): boolean {
+      return Boolean(this.currentProps.events?.length);
+    }
+
+    private pruneEventHandlers(keys: readonly string[]): void {
+      const active = new Set(keys);
+      for (const key of this.eventHandlers.keys()) {
+        if (!active.has(key)) this.eventHandlers.delete(key);
+      }
+    }
+
     private adopt(): boolean {
       if (!this.root) return false;
       const rows = this.readRows(this.currentProps);
@@ -845,13 +902,35 @@ function createKeyedRowsBlockComponent(
       if (!rows || rows.items.length !== elements.length) return false;
       const instances = new Map<string, CompilerKeyedRowInstance>();
       for (let index = 0; index < rows.items.length; index += 1) {
-        instances.set(rows.keys[index], {
+        if (
+          this.hasInteractiveRows() &&
+          !matchesCompilerHostElement(
+            elements[index],
+            this.currentProps.create(rows.items[index], index),
+          )
+        ) {
+          return false;
+        }
+        const instance: CompilerKeyedRowInstance = {
           key: rows.keys[index],
           element: elements[index],
-          values: readKeyedRowBindingValues(this.currentProps, rows.items[index], index),
-        });
+          values: this.hasInteractiveRows()
+            ? this.currentProps.bindings.map(() => UNSET_KEYED_ROW_BINDING)
+            : readKeyedRowBindingValues(this.currentProps, rows.items[index], index),
+          item: rows.items[index],
+          index,
+        };
+        if (this.hasInteractiveRows()) {
+          // React compares the next row against its previous virtual props, not
+          // against DOM values patched by Farm between commits. Reapply every
+          // binding after a structural React commit so both views converge
+          // before direct same-key patches resume.
+          applyKeyedRowBindings(this.currentProps, instance, rows.items[index], index);
+        }
+        instances.set(rows.keys[index], instance);
       }
       this.instances = instances;
+      this.pruneEventHandlers(rows.keys);
       return true;
     }
 
@@ -862,6 +941,20 @@ function createKeyedRowsBlockComponent(
       }
       this.fallbackRequested = true;
       this.setState({ fallback: true }, afterCommit);
+    }
+
+    private synchronizeInteractiveRows(afterCommit?: () => void): void {
+      this.forceUpdate(() => {
+        if (!this.mounted) {
+          afterCommit?.();
+          return;
+        }
+        if (!this.adopt()) {
+          this.activateFallback(afterCommit);
+          return;
+        }
+        afterCommit?.();
+      });
     }
 
     private reconcile(afterCommit?: () => void): void {
@@ -878,6 +971,16 @@ function createKeyedRowsBlockComponent(
       const rows = this.readRows(this.currentProps);
       if (!rows) {
         this.activateFallback(afterCommit);
+        return;
+      }
+
+      const previousKeys = [...this.instances.keys()];
+      if (
+        this.hasInteractiveRows() &&
+        (rows.keys.length !== previousKeys.length ||
+          rows.keys.some((key, index) => key !== previousKeys[index]))
+      ) {
+        this.synchronizeInteractiveRows(afterCommit);
         return;
       }
 
@@ -898,6 +1001,8 @@ function createKeyedRowsBlockComponent(
         const existing = this.instances.get(key);
         if (existing) {
           applyKeyedRowBindings(this.currentProps, existing, rows.items[index], index);
+          existing.item = rows.items[index];
+          existing.index = index;
           nextInstances.push(existing);
           continue;
         }
@@ -909,6 +1014,8 @@ function createKeyedRowsBlockComponent(
           key,
           element,
           values: readKeyedRowBindingValues(this.currentProps, rows.items[index], index),
+          item: rows.items[index],
+          index,
         });
       }
 
@@ -923,6 +1030,7 @@ function createKeyedRowsBlockComponent(
         anchor = instance.element;
       }
       this.instances = new Map(nextInstances.map((instance) => [instance.key, instance]));
+      this.pruneEventHandlers(rows.keys);
       if (
         restoreFocus &&
         activeElement?.isConnected &&
@@ -948,10 +1056,31 @@ function createKeyedRowsBlockComponent(
     }
 
     shouldComponentUpdate(nextProps: CompilerKeyedRowsBlockProps, nextState: State): boolean {
+      const wasInteractive = Boolean(this.currentProps.events?.length);
+      const willBeInteractive = Boolean(nextProps.events?.length);
       this.currentProps = nextProps;
       if (nextState.fallback || this.state.fallback) return true;
+      if (wasInteractive || willBeInteractive) {
+        // Parent prop updates and Fast Refresh definitions must pass through
+        // React so event locations, static row markup, and proxy identities
+        // cannot remain tied to an older render definition.
+        this.eventHandlers.clear();
+        return true;
+      }
       this.schedulePropSync();
       return false;
+    }
+
+    componentDidUpdate(previousProps: CompilerKeyedRowsBlockProps): void {
+      if (
+        this.state.fallback ||
+        previousProps === this.props ||
+        (!previousProps.events?.length && !this.props.events?.length) ||
+        this.adopt()
+      ) {
+        return;
+      }
+      this.activateFallback();
     }
 
     componentDidMount(): void {
@@ -965,10 +1094,11 @@ function createKeyedRowsBlockComponent(
       this.unsubscribe?.();
       this.root = null;
       this.instances.clear();
+      this.eventHandlers.clear();
     }
 
     render(): React.ReactNode {
-      const container = this.currentProps.render();
+      const container = this.currentProps.render(this.rowEvent);
       if (!React.isValidElement(container) || typeof container.type !== "string") {
         throw new TypeError(
           `Compiled keyed rows ${this.currentProps.id} must own one host container.`,

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -80,6 +80,13 @@ interface PendingKeyedRowBinding {
   value: t.Expression;
 }
 
+interface PendingKeyedRowEvent {
+  id: number;
+  path: number[];
+  name: string;
+  value: t.ArrowFunctionExpression | t.FunctionExpression;
+}
+
 interface HostConditionalPlan {
   kind: "host-conditional";
   id: number;
@@ -105,6 +112,8 @@ interface KeyedRowsPlan {
   renderCallback: t.ArrowFunctionExpression | t.FunctionExpression;
   row: t.JSXElement;
   bindings: PendingKeyedRowBinding[];
+  events: PendingKeyedRowEvent[];
+  syntax: "map" | "list";
 }
 
 interface ComponentIslandPlan {
@@ -802,13 +811,45 @@ interface KeyedRowsShape {
   row: t.JSXElement;
   dependencies: number[];
   bindings: PendingKeyedRowBinding[];
+  events: PendingKeyedRowEvent[];
+  syntax: "map" | "list";
+}
+
+function validateKeyedRowEventHandler(
+  handler: t.ArrowFunctionExpression | t.FunctionExpression,
+): string | undefined {
+  let reason: string | undefined;
+  traverse(expressionFile(t.cloneNode(handler, true)), {
+    MetaProperty(path) {
+      reason = "meta properties";
+      path.stop();
+    },
+    ReferencedIdentifier(path) {
+      if (path.node.name !== "arguments") return;
+      reason = "arguments access";
+      path.stop();
+    },
+    Super(path) {
+      reason = "super access";
+      path.stop();
+    },
+    ThisExpression(path) {
+      reason = "this access";
+      path.stop();
+    },
+  });
+  return reason;
 }
 
 function analyzeKeyedRowTree(
   row: t.JSXElement,
   renderCallback: t.ArrowFunctionExpression | t.FunctionExpression,
   safeGlobals: ReadonlySet<string>,
-): { bindings?: PendingKeyedRowBinding[]; reason?: string } {
+): {
+  bindings?: PendingKeyedRowBinding[];
+  events?: PendingKeyedRowEvent[];
+  reason?: string;
+} {
   if (
     renderCallback.async ||
     renderCallback.generator ||
@@ -821,12 +862,26 @@ function analyzeKeyedRowTree(
   }
 
   const bindings: PendingKeyedRowBinding[] = [];
+  const events: PendingKeyedRowEvent[] = [];
   const visit = (element: t.JSXElement, path: number[]): string | undefined => {
     const tag = element.openingElement.name;
     if (!t.isJSXIdentifier(tag) || !/^[a-z]/.test(tag.name)) {
       return "compiled keyed rows support host elements only";
     }
     if (tag.name === "svg") return "compiled keyed rows do not support SVG yet";
+    const attributeNames = new Set(
+      element.openingElement.attributes
+        .filter((attribute): attribute is t.JSXAttribute => t.isJSXAttribute(attribute))
+        .map(jsxAttributeName)
+        .filter((name): name is string => name !== undefined),
+    );
+    if (
+      (tag.name === "input" || tag.name === "textarea" || tag.name === "select") &&
+      (attributeNames.has("value") || attributeNames.has("checked")) &&
+      [...attributeNames].some((name) => /^on[A-Z]/.test(name))
+    ) {
+      return "controlled form elements in interactive compiled keyed rows require React ownership";
+    }
 
     for (const attribute of element.openingElement.attributes) {
       if (t.isJSXSpreadAttribute(attribute)) {
@@ -837,10 +892,34 @@ function analyzeKeyedRowTree(
       if (name === "ref" || name === "dangerouslySetInnerHTML") {
         return `compiled keyed row ${name} requires React ownership`;
       }
-      if (/^on[A-Z]/.test(name)) {
-        return "compiled keyed row events require React ownership";
-      }
       if (name === "key") continue;
+      if (/^on[A-Z]/.test(name)) {
+        if (
+          !t.isJSXExpressionContainer(attribute.value) ||
+          (!t.isArrowFunctionExpression(attribute.value.expression) &&
+            !t.isFunctionExpression(attribute.value.expression))
+        ) {
+          return "interactive compiled keyed rows require inline synchronous event handlers";
+        }
+        const handler = attribute.value.expression;
+        if (handler.async || handler.generator) {
+          return "interactive compiled keyed row handlers must be synchronous";
+        }
+        if (containsDirectHookCall(handler)) {
+          return "Hooks cannot be called inside compiled keyed row handlers";
+        }
+        const unsupported = validateKeyedRowEventHandler(handler);
+        if (unsupported) {
+          return `interactive compiled keyed row handlers cannot use ${unsupported}`;
+        }
+        events.push({
+          id: events.length,
+          path: [...path],
+          name,
+          value: t.cloneNode(handler, true),
+        });
+        continue;
+      }
       if (
         !t.isJSXExpressionContainer(attribute.value) ||
         t.isJSXEmptyExpression(attribute.value.expression)
@@ -935,7 +1014,7 @@ function analyzeKeyedRowTree(
   };
 
   const reason = visit(row, []);
-  return reason ? { reason } : { bindings };
+  return reason ? { reason } : { bindings, events };
 }
 
 function analyzeKeyedRowsContainer(
@@ -976,6 +1055,7 @@ function analyzeKeyedRowsContainer(
   let renderCallback: t.ArrowFunctionExpression | t.FunctionExpression;
   let row: t.JSXElement;
   let dependencies: number[];
+  let syntax: "map" | "list";
 
   const child = children[0];
   if (
@@ -1000,6 +1080,7 @@ function analyzeKeyedRowsContainer(
     renderCallback = callback;
     row = returned;
     dependencies = result.dependencies || [];
+    syntax = "map";
   } else if (t.isJSXElement(child) && isPublicListElement(child, listNames)) {
     const result = analyzePublicList(child, statesByValue, safeGlobals);
     if (result.reason) return undefined;
@@ -1023,6 +1104,7 @@ function analyzeKeyedRowsContainer(
     renderCallback = renderChild.expression;
     row = returned;
     dependencies = result.dependencies || [];
+    syntax = "list";
   } else {
     return undefined;
   }
@@ -1036,6 +1118,8 @@ function analyzeKeyedRowsContainer(
     row,
     dependencies,
     bindings: rowAnalysis.bindings || [],
+    events: rowAnalysis.events || [],
+    syntax,
   };
 }
 
@@ -1354,6 +1438,119 @@ function keyedRowBindingObject(
   return t.objectExpression(properties);
 }
 
+function uniqueLocalIdentifier(base: string, nodes: readonly t.Node[]): t.Identifier {
+  const names = new Set<string>();
+  for (const node of nodes) {
+    t.traverseFast(node, (child) => {
+      if (t.isIdentifier(child)) names.add(child.name);
+    });
+  }
+  let name = base;
+  let suffix = 2;
+  while (names.has(name)) name = `${base}${suffix++}`;
+  return t.identifier(name);
+}
+
+function rewriteKeyedRowEventAttributes(
+  row: t.JSXElement,
+  events: readonly PendingKeyedRowEvent[],
+  eventFactory: t.Identifier,
+  item: t.Identifier,
+  index: t.Expression,
+): void {
+  const eventByLocation = new Map(
+    events.map((event) => [`${event.path.join(".")}:${event.name}`, event] as const),
+  );
+  const visit = (element: t.JSXElement, path: number[]): void => {
+    for (const attribute of element.openingElement.attributes) {
+      if (!t.isJSXAttribute(attribute)) continue;
+      const name = jsxAttributeName(attribute);
+      if (!name || !/^on[A-Z]/.test(name)) continue;
+      const event = eventByLocation.get(`${path.join(".")}:${name}`);
+      if (!event) continue;
+      attribute.value = t.jsxExpressionContainer(
+        t.callExpression(t.cloneNode(eventFactory), [
+          t.cloneNode(item),
+          t.cloneNode(index),
+          t.numericLiteral(event.id),
+        ]),
+      );
+    }
+
+    let elementIndex = 0;
+    for (const child of element.children) {
+      if (!t.isJSXElement(child)) continue;
+      visit(child, [...path, elementIndex]);
+      elementIndex += 1;
+    }
+  };
+  visit(row, []);
+}
+
+function keyedRowsRenderSource(plan: KeyedRowsPlan, eventFactory: t.Identifier): t.JSXElement {
+  const source = t.cloneNode(plan.source, true);
+  if (plan.events.length === 0) return source;
+  const child = meaningfulJsxChildren(source)[0];
+  let callback: t.ArrowFunctionExpression | t.FunctionExpression | undefined;
+  if (
+    plan.syntax === "map" &&
+    t.isJSXExpressionContainer(child) &&
+    !t.isJSXEmptyExpression(child.expression) &&
+    isMapCall(child.expression)
+  ) {
+    const candidate = child.expression.arguments[0];
+    if (t.isArrowFunctionExpression(candidate) || t.isFunctionExpression(candidate)) {
+      callback = candidate;
+    }
+  } else if (plan.syntax === "list" && t.isJSXElement(child)) {
+    const renderChild = meaningfulJsxChildren(child)[0];
+    if (
+      t.isJSXExpressionContainer(renderChild) &&
+      !t.isJSXEmptyExpression(renderChild.expression) &&
+      (t.isArrowFunctionExpression(renderChild.expression) ||
+        t.isFunctionExpression(renderChild.expression))
+    ) {
+      callback = renderChild.expression;
+    }
+  }
+  const row = callback && returnedExpression(callback);
+  const item = callback?.params[0];
+  const index = callback?.params[1];
+  if (!callback || !t.isJSXElement(row) || !t.isIdentifier(item)) return source;
+  rewriteKeyedRowEventAttributes(
+    row,
+    plan.events,
+    eventFactory,
+    item,
+    t.isIdentifier(index) ? index : t.numericLiteral(0),
+  );
+  return source;
+}
+
+function keyedRowEventObject(
+  event: PendingKeyedRowEvent,
+  renderParameters: readonly t.Identifier[],
+): t.ObjectExpression {
+  const nodes = [event.value, ...renderParameters];
+  const index = renderParameters[1]
+    ? t.cloneNode(renderParameters[1], true)
+    : uniqueLocalIdentifier("_farmRowIndex", nodes);
+  const syntheticEvent = uniqueLocalIdentifier("_farmEvent", [...nodes, index]);
+  const parameters = [t.cloneNode(renderParameters[0], true), index, syntheticEvent];
+  return t.objectExpression([
+    t.objectProperty(t.identifier("name"), t.stringLiteral(event.name)),
+    t.objectProperty(
+      t.identifier("invoke"),
+      t.arrowFunctionExpression(
+        parameters,
+        t.callExpression(t.parenthesizedExpression(t.cloneNode(event.value, true)), [
+          t.cloneNode(syntheticEvent),
+        ]),
+      ),
+    ),
+  ]);
+}
+
 function keyedRowsBoundary(blockRuntime: t.Identifier, plan: KeyedRowsPlan): t.JSXElement {
   const name = t.jsxMemberExpression(
     t.jsxIdentifier(blockRuntime.name),
@@ -1362,6 +1559,11 @@ function keyedRowsBoundary(blockRuntime: t.Identifier, plan: KeyedRowsPlan): t.J
   const parameters = plan.renderCallback.params.map((parameter) =>
     t.cloneNode(parameter, true),
   ) as t.Identifier[];
+  const eventFactory = uniqueLocalIdentifier("_farmRowEvent", [
+    plan.source,
+    ...plan.events.map((event) => event.value),
+  ]);
+  const renderSource = keyedRowsRenderSource(plan, eventFactory);
   return t.jsxElement(
     t.jsxOpeningElement(
       name,
@@ -1369,7 +1571,12 @@ function keyedRowsBoundary(blockRuntime: t.Identifier, plan: KeyedRowsPlan): t.J
         t.jsxAttribute(t.jsxIdentifier("id"), t.jsxExpressionContainer(t.numericLiteral(plan.id))),
         t.jsxAttribute(
           t.jsxIdentifier("render"),
-          t.jsxExpressionContainer(t.arrowFunctionExpression([], t.cloneNode(plan.source, true))),
+          t.jsxExpressionContainer(
+            t.arrowFunctionExpression(
+              plan.events.length > 0 ? [t.cloneNode(eventFactory)] : [],
+              renderSource,
+            ),
+          ),
         ),
         t.jsxAttribute(
           t.jsxIdentifier("items"),
@@ -1396,6 +1603,18 @@ function keyedRowsBoundary(blockRuntime: t.Identifier, plan: KeyedRowsPlan): t.J
             ),
           ),
         ),
+        ...(plan.events.length > 0
+          ? [
+              t.jsxAttribute(
+                t.jsxIdentifier("events"),
+                t.jsxExpressionContainer(
+                  t.arrayExpression(
+                    plan.events.map((event) => keyedRowEventObject(event, parameters)),
+                  ),
+                ),
+              ),
+            ]
+          : []),
       ],
       true,
     ),
@@ -1706,6 +1925,8 @@ function analyzeComposableBlocks(
               renderCallback: keyedRows.renderCallback,
               row: keyedRows.row,
               bindings: keyedRows.bindings,
+              events: keyedRows.events,
+              syntax: keyedRows.syntax,
             });
             ownedElements.add(child);
             continue;


### PR DESCRIPTION
## Summary

- compile safe host-only bindings inside interactive keyed rows while React continues to own event dispatch and structural reconciliation
- route row events through stable keyed proxies so handlers always receive the latest item and index without rerunning the row owner for same-key updates
- preserve React behavior through conservative fallbacks for controlled forms, unsupported handlers, duplicate keys, hydration, Fast Refresh, and error boundaries
- document the behavior and add an interactive production example

## Verification

- pnpm --filter @farm.js/react test — 24 files and 191 tests passed
- pnpm --filter @farm.js/react type-check
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/react test:compat — React 18 and React 19 passed
- pnpm --filter farm-react-compiler-example type-check
- production example build and browser verification on desktop and mobile
- pnpm --filter farmjs-docs build — 73 routes generated

The test coverage includes StrictMode, hydration recovery, unmount cleanup, parent and local updates in one turn, bubbling and capture, stale-closure prevention, duplicate-key fallback, HMR handler changes, React error boundaries, structural reorders, and 4,000 randomized differential transitions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compiles interactive keyed rows in `@farm.js/react` so host-only row bindings update in place while React continues to own event dispatch and structural reconciliation. Previously, rows with events fell back to React-only updates; now safe inline row events use keyed proxies so handlers always see the latest item and index without rerunning the row owner.

- Adds event proxying in keyed rows: collects supported inline handlers, routes them through stable keyed proxies, and compiles text/attr/style bindings for same-key rows.
- Preserves React behavior via fallbacks for controlled inputs, unsupported handlers, duplicate keys, hydration, Fast Refresh, and error boundaries.
- Updates docs and ships a production interactive example; expands test coverage (React 18/19, StrictMode, hydration recovery, reorders, stale-closure prevention, and randomized transitions).

**Review notes**
- Compiler/runtime changes: `KeyedRowsBlockProps.render` now receives an `event(item, index, eventId)` factory; new `events` metadata and `CompilerKeyedRowEvent` support.
- Verify the conservative fallbacks in `compiler-runtime.tsx` and the event handler validation in `compiler.ts`.
- Example and verification script exercise latest-item/index delivery across updates and reorders with zero extra executions.

**Rollout**
- No app-facing API changes for compiled components.
- If you construct components manually with `createCompiledComponent`, update keyed-row blocks to call `render(event)` and pass supported row handlers; otherwise behavior falls back to React.

<sup>Written for commit fcb96fb934ea57ba682bae8ce8f9dc6bbcae065f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

