### PR TITLE
fix(core): prevent useQueryState from triggering SPA navigation (#415)

### DIFF
--- a/packages/farm/src/__tests__/query-client-shallow.test.tsx
+++ b/packages/farm/src/__tests__/query-client-shallow.test.tsx
@@ -1,0 +1,322 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSearchParams } from "../navigation";
+import { pushState as pushFarmPageState, readPageState, SPARouter } from "../client/spa-router";
+import { usePageState } from "../client/router";
+import {
+  FARM_URL_SEARCH_CHANGE_EVENT,
+  notifyUrlSearchObservers,
+} from "../client/url-search-sync";
+import { asString, useQueryState, useQueryStates } from "../query/client";
+
+describe("useQueryState shallow routing", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot> | undefined;
+  let spaRouter: SPARouter | undefined;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    window.history.replaceState(null, "", "/");
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount();
+      });
+    }
+    container.remove();
+    root = undefined;
+    spaRouter?.destroy();
+    spaRouter = undefined;
+    delete (window as any).__FARM_SPA_ROUTER__;
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    delete (globalThis as any).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  it("dispatches synthetic popstate when shallow is true and no Farm router is installed", async () => {
+    vi.useFakeTimers();
+    const popstate = vi.fn();
+    window.addEventListener("popstate", popstate);
+
+    let setUrl!: (value: string | null) => void;
+
+    function App() {
+      const [, set] = useQueryState("url", asString);
+      setUrl = set;
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    act(() => {
+      setUrl("https://example.com");
+    });
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(window.location.search).toBe("?url=https%3A%2F%2Fexample.com");
+    expect(popstate).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dispatch synthetic popstate when shallow is false", async () => {
+    vi.useFakeTimers();
+    const popstate = vi.fn();
+    window.addEventListener("popstate", popstate);
+
+    let setUrl!: (value: string | null) => void;
+
+    function App() {
+      const [, set] = useQueryState("url", asString, { shallow: false });
+      setUrl = set;
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    act(() => {
+      setUrl("https://example.com");
+    });
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(window.location.search).toBe("?url=https%3A%2F%2Fexample.com");
+    expect(popstate).not.toHaveBeenCalled();
+  });
+
+  it("does not trigger SPA navigation when shallow is true and Farm router is installed", async () => {
+    vi.useFakeTimers();
+    const popstate = vi.fn();
+    const urlSearchChange = vi.fn();
+    window.addEventListener("popstate", popstate);
+    window.addEventListener(FARM_URL_SEARCH_CHANGE_EVENT, urlSearchChange);
+
+    const fetchPage = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            props: {},
+            modulePath: "/src/app/page.tsx",
+            metadata: { title: "Next" },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchPage);
+
+    spaRouter = new SPARouter({ scrollRestoration: false });
+    const onNavigate = vi.fn();
+    spaRouter.setNavigationHandler(onNavigate);
+    (window as any).__FARM_SPA_ROUTER__ = spaRouter;
+
+    let setUrl!: (value: string | null) => void;
+
+    function App() {
+      const [, set] = useQueryState("url", asString);
+      setUrl = set;
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    act(() => {
+      setUrl("https://example.com");
+    });
+
+    await act(async () => {
+      vi.runAllTimers();
+      await Promise.resolve();
+    });
+
+    expect(window.location.search).toBe("?url=https%3A%2F%2Fexample.com");
+    expect(fetchPage).not.toHaveBeenCalled();
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(popstate).not.toHaveBeenCalled();
+    expect(urlSearchChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps sibling useQueryState hooks in sync via emitter when Farm router is installed", async () => {
+    vi.useFakeTimers();
+    spaRouter = new SPARouter({ scrollRestoration: false });
+    (window as any).__FARM_SPA_ROUTER__ = spaRouter;
+
+    let primaryValue: string | null = null;
+    let secondaryValue: string | null = null;
+    let setUrl!: (value: string | null) => void;
+
+    function App() {
+      const [value, set] = useQueryState("url", asString);
+      const [mirror] = useQueryState("url", asString);
+      primaryValue = value;
+      secondaryValue = mirror;
+      setUrl = set;
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    act(() => {
+      setUrl("https://example.com");
+    });
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(primaryValue).toBe("https://example.com");
+    expect(secondaryValue).toBe("https://example.com");
+  });
+
+  it("keeps useSearchParams in sync when Farm router is installed", async () => {
+    vi.useFakeTimers();
+    spaRouter = new SPARouter({ scrollRestoration: false });
+    (window as any).__FARM_SPA_ROUTER__ = spaRouter;
+
+    let searchParams: URLSearchParams | undefined;
+    let setUrl!: (value: string | null) => void;
+
+    function App() {
+      const [, set] = useQueryState("url", asString);
+      searchParams = useSearchParams();
+      setUrl = set;
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    act(() => {
+      setUrl("https://example.com");
+    });
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(searchParams?.get("url")).toBe("https://example.com");
+  });
+
+  it("covers useQueryStates with the same URL sync path", async () => {
+    vi.useFakeTimers();
+    const urlSearchChange = vi.fn();
+    window.addEventListener(FARM_URL_SEARCH_CHANGE_EVENT, urlSearchChange);
+
+    spaRouter = new SPARouter({ scrollRestoration: false });
+    (window as any).__FARM_SPA_ROUTER__ = spaRouter;
+
+    let setValues!: (updates: { q?: string | null }) => void;
+
+    function App() {
+      const [, set] = useQueryStates({ q: asString });
+      setValues = set;
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    act(() => {
+      setValues({ q: "farm" });
+    });
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(window.location.search).toBe("?q=farm");
+    expect(urlSearchChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves Farm page history state when updating query params", async () => {
+    vi.useFakeTimers();
+    spaRouter = new SPARouter({ scrollRestoration: false });
+    (window as any).__FARM_SPA_ROUTER__ = spaRouter;
+
+    pushFarmPageState({ modal: "open" });
+    expect(readPageState()).toEqual({ modal: "open" });
+
+    let setUrl!: (value: string | null) => void;
+    let pageState: { modal: string } | null = null;
+
+    function App() {
+      const [, set] = useQueryState("url", asString);
+      pageState = usePageState<{ modal: string }>();
+      setUrl = set;
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    act(() => {
+      setUrl("https://example.com");
+    });
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(window.location.search).toBe("?url=https%3A%2F%2Fexample.com");
+    expect(readPageState()).toEqual({ modal: "open" });
+    expect(pageState).toEqual({ modal: "open" });
+  });
+
+  it("does not leak SPA router popstate listeners across tests", async () => {
+    vi.useFakeTimers();
+    spaRouter = new SPARouter({ scrollRestoration: false });
+    (window as any).__FARM_SPA_ROUTER__ = spaRouter;
+
+    const fetchPage = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ props: {}, modulePath: "/page.tsx" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchPage);
+
+    notifyUrlSearchObservers(true);
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    spaRouter.destroy();
+    spaRouter = undefined;
+    delete (window as any).__FARM_SPA_ROUTER__;
+
+    fetchPage.mockClear();
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    await Promise.resolve();
+
+    expect(fetchPage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/farm/src/__tests__/query-client-shallow.test.tsx
+++ b/packages/farm/src/__tests__/query-client-shallow.test.tsx
@@ -7,10 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useSearchParams } from "../navigation";
 import { pushState as pushFarmPageState, readPageState, SPARouter } from "../client/spa-router";
 import { usePageState } from "../client/router";
-import {
-  FARM_URL_SEARCH_CHANGE_EVENT,
-  notifyUrlSearchObservers,
-} from "../client/url-search-sync";
+import { FARM_URL_SEARCH_CHANGE_EVENT, notifyUrlSearchObservers } from "../client/url-search-sync";
 import { asString, useQueryState, useQueryStates } from "../query/client";
 
 describe("useQueryState shallow routing", () => {
@@ -288,6 +285,9 @@ describe("useQueryState shallow routing", () => {
     expect(window.location.search).toBe("?url=https%3A%2F%2Fexample.com");
     expect(readPageState()).toEqual({ modal: "open" });
     expect(pageState).toEqual({ modal: "open" });
+    expect((window.history.state as { path?: string }).path).toBe(
+      "/?url=https%3A%2F%2Fexample.com",
+    );
   });
 
   it("does not leak SPA router popstate listeners across tests", async () => {

--- a/packages/farm/src/client/router.ts
+++ b/packages/farm/src/client/router.ts
@@ -6,6 +6,7 @@ import {
   type FarmNavigationBlockerContext,
   type FarmNavigationState,
 } from "./spa-router";
+import { subscribeUrlSearchObservers } from "./url-search-sync";
 import { getFarmI18nClientState } from "../i18n/client-runtime";
 import { stripFarmLocaleFromPathname } from "../i18n/routing";
 
@@ -55,8 +56,8 @@ export function useRouter(options: UseRouterOptions = {}) {
     };
 
     handlePopState();
-    window.addEventListener("popstate", handlePopState);
-    return () => window.removeEventListener("popstate", handlePopState);
+    const unsubscribe = subscribeUrlSearchObservers(handlePopState);
+    return unsubscribe;
   }, [basePath, routeMatcher]);
 
   const push = (href: string) => {

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -162,6 +162,14 @@ export class SPARouter {
     void this.handlePopState(event);
   };
 
+  private readonly onBeforeUnload = (event: BeforeUnloadEvent) => {
+    if (this.blockers.size > 0) {
+      event.preventDefault();
+      event.returnValue = "";
+    }
+    this.saveScrollPosition(window.location.pathname);
+  };
+
   constructor(options: RouterOptions = {}) {
     this.options = {
       prefetchTimeout: options.prefetchTimeout ?? 100,
@@ -176,13 +184,7 @@ export class SPARouter {
       window.addEventListener("popstate", this.onPopState);
 
       // Save scroll position before unload
-      window.addEventListener("beforeunload", (event) => {
-        if (this.blockers.size > 0) {
-          event.preventDefault();
-          event.returnValue = "";
-        }
-        this.saveScrollPosition(window.location.pathname);
-      });
+      window.addEventListener("beforeunload", this.onBeforeUnload);
     }
   }
 
@@ -190,6 +192,7 @@ export class SPARouter {
   destroy(): void {
     if (typeof window === "undefined") return;
     window.removeEventListener("popstate", this.onPopState);
+    window.removeEventListener("beforeunload", this.onBeforeUnload);
   }
 
   /**

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -158,6 +158,10 @@ export class SPARouter {
     | "failNavigation"
   >;
 
+  private readonly onPopState = (event: PopStateEvent) => {
+    void this.handlePopState(event);
+  };
+
   constructor(options: RouterOptions = {}) {
     this.options = {
       prefetchTimeout: options.prefetchTimeout ?? 100,
@@ -169,7 +173,7 @@ export class SPARouter {
 
     if (typeof window !== "undefined") {
       // Listen for popstate (back/forward navigation)
-      window.addEventListener("popstate", this.handlePopState.bind(this));
+      window.addEventListener("popstate", this.onPopState);
 
       // Save scroll position before unload
       window.addEventListener("beforeunload", (event) => {
@@ -180,6 +184,12 @@ export class SPARouter {
         this.saveScrollPosition(window.location.pathname);
       });
     }
+  }
+
+  /** Remove global listeners. Intended for tests and teardown. */
+  destroy(): void {
+    if (typeof window === "undefined") return;
+    window.removeEventListener("popstate", this.onPopState);
   }
 
   /**
@@ -765,13 +775,18 @@ function dispatchDeploymentMismatch(error: Error): void {
 /**
  * Get or create the global router instance
  */
+export function getInstalledFarmSPARouter(): SPARouter | undefined {
+  if (typeof window === "undefined") return undefined;
+  return (window as Window & { __FARM_SPA_ROUTER__?: SPARouter }).__FARM_SPA_ROUTER__;
+}
+
 export function getRouter(): SPARouter {
   if (typeof window === "undefined") {
     // Return a no-op router for SSR
     return new SPARouter();
   }
 
-  const installedRouter = (window as any).__FARM_SPA_ROUTER__ as SPARouter | undefined;
+  const installedRouter = getInstalledFarmSPARouter();
   if (installedRouter) {
     routerInstance = installedRouter;
     return installedRouter;

--- a/packages/farm/src/client/url-search-sync.ts
+++ b/packages/farm/src/client/url-search-sync.ts
@@ -1,0 +1,37 @@
+import { getInstalledFarmSPARouter } from "./spa-router";
+
+/** Fired after programmatic query-string updates when Farm SPA router is active. */
+export const FARM_URL_SEARCH_CHANGE_EVENT = "farm:urlsearchchange";
+
+/**
+ * Notify URL observers after history.pushState/replaceState updates the query string.
+ *
+ * nuqs uses `shallow: true` for client-only URL updates and dispatches synthetic
+ * `popstate` so other hooks resync. Farm's SPA router also listens to `popstate`
+ * for full document navigation, so when `__FARM_SPA_ROUTER__` is installed we emit a
+ * dedicated event instead and keep `popstate` for real back/forward navigation.
+ */
+export function notifyUrlSearchObservers(shallow: boolean): void {
+  if (!shallow || typeof window === "undefined") return;
+
+  setTimeout(() => {
+    if (getInstalledFarmSPARouter()) {
+      window.dispatchEvent(new CustomEvent(FARM_URL_SEARCH_CHANGE_EVENT));
+      return;
+    }
+
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }, 0);
+}
+
+export function subscribeUrlSearchObservers(listener: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+
+  window.addEventListener("popstate", listener);
+  window.addEventListener(FARM_URL_SEARCH_CHANGE_EVENT, listener);
+
+  return () => {
+    window.removeEventListener("popstate", listener);
+    window.removeEventListener(FARM_URL_SEARCH_CHANGE_EVENT, listener);
+  };
+}

--- a/packages/farm/src/query/client.ts
+++ b/packages/farm/src/query/client.ts
@@ -80,12 +80,19 @@ const updateURL = (
 
   if (newUrl !== currentUrl) {
     const update = () => {
+      // Preserve Farm's history state (page state, interception markers) and
+      // keep its recorded path in sync with the new query string so pops
+      // report the entry's real location.
       const historyState = window.history.state;
+      const nextHistoryState =
+        historyState && typeof historyState === "object" && "path" in historyState
+          ? { ...historyState, path: newUrl }
+          : historyState;
 
       if (history === "replaceState") {
-        window.history.replaceState(historyState, "", newUrl);
+        window.history.replaceState(nextHistoryState, "", newUrl);
       } else {
-        window.history.pushState(historyState, "", newUrl);
+        window.history.pushState(nextHistoryState, "", newUrl);
       }
 
       if (emitUpdate) {

--- a/packages/farm/src/query/client.ts
+++ b/packages/farm/src/query/client.ts
@@ -7,6 +7,7 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import { notifyUrlSearchObservers } from "../client/url-search-sync";
 import { emitter } from "./sync";
 export { parseRouteParams, loadRouteParams, type RouteParamsInput } from "./params";
 
@@ -79,10 +80,12 @@ const updateURL = (
 
   if (newUrl !== currentUrl) {
     const update = () => {
+      const historyState = window.history.state;
+
       if (history === "replaceState") {
-        window.history.replaceState(null, "", newUrl);
+        window.history.replaceState(historyState, "", newUrl);
       } else {
-        window.history.pushState(null, "", newUrl);
+        window.history.pushState(historyState, "", newUrl);
       }
 
       if (emitUpdate) {
@@ -90,11 +93,7 @@ const updateURL = (
         emitter.emitUpdate(actualSearchParams);
       }
 
-      if (shallow) {
-        setTimeout(() => {
-          window.dispatchEvent(new PopStateEvent("popstate"));
-        }, 0);
-      }
+      notifyUrlSearchObservers(shallow);
 
       if (scroll) {
         window.scrollTo(0, 0);

--- a/packages/farm/src/renderer-client.ts
+++ b/packages/farm/src/renderer-client.ts
@@ -7,6 +7,7 @@ import {
   type FarmNavigationState,
   type FarmNavigateOptions,
 } from "./client/spa-router";
+import { FARM_URL_SEARCH_CHANGE_EVENT } from "./client/url-search-sync";
 import { getFarmClientDataCache, type FarmClientCacheStatus } from "./client-cache";
 import type { ServerFn } from "./server-fn";
 import type { ServerQuery } from "./server-query";
@@ -76,10 +77,12 @@ export function createRendererRouter(options: FarmRendererRouterOptions = {}): F
       };
       const unsubscribeNavigation = router.subscribeNavigation(notify);
       window.addEventListener("popstate", notify);
+      window.addEventListener(FARM_URL_SEARCH_CHANGE_EVENT, notify);
       read();
       return () => {
         unsubscribeNavigation();
         window.removeEventListener("popstate", notify);
+        window.removeEventListener(FARM_URL_SEARCH_CHANGE_EVENT, notify);
       };
     },
     push(href, navigateOptions) {


### PR DESCRIPTION
## Summary

- Stop default `useQueryState` shallow updates from triggering full Farm SPA navigation by emitting `farm:urlsearchchange` instead of synthetic `popstate` when `__FARM_SPA_ROUTER__` is installed
- Keep `useRouter` and `useSearchParams` in sync via paired `notifyUrlSearchObservers` / `subscribeUrlSearchObservers` helpers in `url-search-sync.ts`
- Preserve `history.state` on query-only updates so Farm page state is not clobbered
- Add `SPARouter.destroy()` for test teardown and regression tests covering navigation, emitter sync, and page state preservation

Fixes #415

## Test plan

- [x] `pnpm exec vitest run src/__tests__/query-client-shallow.test.tsx`
- [x] `pnpm exec vitest run src/__tests__/query-params.test.ts src/__tests__/link.test.tsx src/__tests__/server-query-client.test.tsx`
- [x] `pnpm exec tsc --noEmit`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents useQueryState shallow updates from triggering Farm SPA navigation. Previously shallow updates dispatched synthetic popstate that the router treated as navigation; now they emit farm:urlsearchchange when a router is installed, keeping URL consumers in sync without refetching.

- Adds url-search-sync helpers: notifyUrlSearchObservers (emits farm:urlsearchchange when a router exists, falls back to synthetic popstate) and subscribeUrlSearchObservers.
- Updates useRouter and the renderer client to observe both events, keeping useRouter and useSearchParams aligned on query-only changes.
- Preserves history.state on query-only updates and keeps its path in sync with the new URL.
- Adds SPARouter.destroy() that unregisters popstate and beforeunload listeners; exposes getInstalledFarmSPARouter() for detection.
- Adds tests covering navigation avoidance, emitter sync across hooks, state preservation, and listener teardown.

<sup>Written for commit 7109fbc258db1d92cd1c9038a2727e9255d20cab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

