### PR TITLE
feat(cli): add farm start command with resolvable preset

### DIFF
--- a/docs/src/app/docs/cli/page.md
+++ b/docs/src/app/docs/cli/page.md
@@ -34,6 +34,7 @@ React is the default renderer. `--renderer preact`, `--renderer solid`, `--rende
 | -------------------------------- | -------------------------------------------------------------------- |
 | farm dev                         | Start the dev server.                                                |
 | farm build                       | Build the app for the configured target.                             |
+| farm start                       | Run the Node server produced by farm build.                          |
 | farm upgrade --latest            | Upgrade installed Farm packages to the latest stable release.        |
 | farm upgrade --beta              | Upgrade installed Farm packages to the latest beta release.          |
 | farm doctor                      | Inspect a running app, or fall back to project configuration checks. |

--- a/docs/src/app/docs/deployment/page.md
+++ b/docs/src/app/docs/deployment/page.md
@@ -179,6 +179,8 @@ pnpm build
 HOST=0.0.0.0 PORT=3000 pnpm start
 ```
 
+`farm start` is equivalent for the `node` target and adds `--port`/`--host` flags plus clear errors when the configured target has no local server.
+
 For Docker, copy the app, install production dependencies, run `farm build`, expose the selected port, and start `node .output/server/index.mjs`. For a VPS, run the same start command behind nginx, Caddy, systemd, or a process manager such as PM2. Environment variables should be provided by the host at runtime, not committed into the bundle.
 
 ## Nitro preset pass-through

--- a/docs/src/app/docs/migrations/sveltekit/page.md
+++ b/docs/src/app/docs/migrations/sveltekit/page.md
@@ -43,7 +43,7 @@ Point the application scripts at Farm when the first route is ready:
   "scripts": {
     "dev": "farm dev",
     "build": "farm build",
-    "start": "farm start"
+    "start": "node .output/server/index.mjs"
   }
 }
 ```

--- a/packages/create-farm-app/templates/_renderers/preact/package.json
+++ b/packages/create-farm-app/templates/_renderers/preact/package.json
@@ -7,7 +7,6 @@
     "dev": "farm dev",
     "build": "farm build",
     "deploy": "farm deploy",
-    "start": "farm start",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/create-farm-app/templates/_renderers/solid/package.json
+++ b/packages/create-farm-app/templates/_renderers/solid/package.json
@@ -6,7 +6,6 @@
     "dev": "farm dev",
     "build": "farm build",
     "deploy": "farm deploy",
-    "start": "farm start",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/create-farm-app/templates/_renderers/vue/package.json
+++ b/packages/create-farm-app/templates/_renderers/vue/package.json
@@ -6,7 +6,6 @@
     "dev": "farm dev",
     "build": "farm build",
     "deploy": "farm deploy",
-    "start": "farm start",
     "type-check": "vue-tsc --noEmit"
   },
   "dependencies": {

--- a/packages/create-farm-app/templates/auth/package.json
+++ b/packages/create-farm-app/templates/auth/package.json
@@ -8,7 +8,6 @@
     "auth:migrate": "farm auth migrate",
     "check": "pnpm type-check && pnpm build",
     "deploy": "farm deploy",
-    "start": "farm start",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/create-farm-app/templates/basic/package.json
+++ b/packages/create-farm-app/templates/basic/package.json
@@ -6,7 +6,6 @@
     "dev": "farm dev",
     "build": "farm build",
     "deploy": "farm deploy",
-    "start": "farm start",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/create-farm-app/templates/better-auth/package.json
+++ b/packages/create-farm-app/templates/better-auth/package.json
@@ -7,7 +7,6 @@
     "build": "farm build",
     "check": "pnpm type-check && pnpm build",
     "deploy": "farm deploy",
-    "start": "farm start",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/farm-cli/bin/farm.js
+++ b/packages/farm-cli/bin/farm.js
@@ -123,6 +123,24 @@ program
     }
   });
 
+program
+  .command("start")
+  .description("Run the Node server produced by farm build")
+  .option("-r, --root <root>", "Root directory", process.cwd())
+  .option("-p, --port <port>", "Port for the server to listen on")
+  .option("-H, --host <host>", "Host for the server to bind to")
+  .action(async (options) => {
+    try {
+      const { startFarm } = require("../dist/index.js");
+      await startFarm(options);
+    } catch (error) {
+      const code = error?.name === "FarmStartError" ? ` [${error.code}]` : "";
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`Failed to start${code}: ${message}`);
+      process.exitCode = 1;
+    }
+  });
+
 const authCommand = program.command("auth").description("Manage Farm-native authentication");
 
 authCommand

--- a/packages/farm-cli/src/index.ts
+++ b/packages/farm-cli/src/index.ts
@@ -20,6 +20,14 @@ export {
   type FarmDeployPlan,
 } from "./deploy";
 export {
+  createFarmStartPlan,
+  FarmStartError,
+  startFarm,
+  type FarmStartErrorCode,
+  type FarmStartOptions,
+  type FarmStartPlan,
+} from "./start";
+export {
   createPreviewTunnelPlan,
   parsePreviewPublicUrl,
   previewFarm,

--- a/packages/farm-cli/src/start.ts
+++ b/packages/farm-cli/src/start.ts
@@ -75,7 +75,7 @@ export async function createFarmStartPlan(options: FarmStartOptions = {}): Promi
 
   return {
     root,
-    target,
+    target: "node",
     preset,
     outputDir,
     serverEntry,

--- a/packages/farm-cli/src/start.ts
+++ b/packages/farm-cli/src/start.ts
@@ -1,0 +1,125 @@
+import {
+	loadConfig,
+	logger,
+	resolveDeployConfig,
+	resolveDeployOutputPath,
+} from "@farm.js/core";
+import { spawn } from "child_process";
+import { existsSync } from "fs";
+import path from "path";
+
+export interface FarmStartOptions {
+	root?: string;
+	port?: string | number;
+	host?: string;
+}
+
+export type FarmStartErrorCode =
+	| "PLATFORM_TARGET"
+	| "UNSUPPORTED_PRESET"
+	| "MISSING_OUTPUT";
+
+export class FarmStartError extends Error {
+	readonly code: FarmStartErrorCode;
+
+	constructor(code: FarmStartErrorCode, message: string) {
+		super(message);
+		this.name = "FarmStartError";
+		this.code = code;
+	}
+}
+
+export interface FarmStartPlan {
+	root: string;
+	target: "node";
+	preset: string;
+	outputDir: string;
+	serverEntry: string;
+	command: { command: string; args: string[] };
+	env: Record<string, string>;
+}
+
+const PLATFORM_HINTS: Record<string, string> = {
+	vercel: "Deploy it with `farm deploy --vercel`",
+	cloudflare: "Deploy it with `farm deploy --cloudflare`",
+	netlify: "Deploy it with `farm deploy --netlify`",
+};
+
+export async function createFarmStartPlan(
+	options: FarmStartOptions = {},
+): Promise<FarmStartPlan> {
+	const root = path.resolve(options.root || process.cwd());
+	const userConfig = await loadConfig(root, undefined, "production");
+	const deployConfig = resolveDeployConfig(userConfig || {});
+	const target = deployConfig.target;
+	const preset = deployConfig.preset || "node-server";
+	const outputDir = resolveDeployOutputPath(root, deployConfig.outputDir);
+
+	if (target && target !== "node") {
+		throw new FarmStartError(
+			"PLATFORM_TARGET",
+			`The "${target}" target builds platform output with no local server to start. ` +
+				`${PLATFORM_HINTS[target]}, or set deploy.target: "node" in farm.config.ts to self-host.`,
+		);
+	}
+
+	if (!target) {
+		throw new FarmStartError(
+			"UNSUPPORTED_PRESET",
+			`Preset "${preset}" has no known local server entry. ` +
+				`Set deploy.target: "node" in farm.config.ts to self-host.`,
+		);
+	}
+
+	const serverEntry = path.join(outputDir, "server", "index.mjs");
+	if (!existsSync(serverEntry)) {
+		throw new FarmStartError(
+			"MISSING_OUTPUT",
+			`No build output found at ${serverEntry}. Run \`farm build\` first.`,
+		);
+	}
+
+	const env: Record<string, string> = {};
+	if (options.port !== undefined && options.port !== "")
+		env.NITRO_PORT = String(options.port);
+	if (options.host) env.NITRO_HOST = options.host;
+
+	return {
+		root,
+		target,
+		preset,
+		outputDir,
+		serverEntry,
+		command: { command: "node", args: [serverEntry] },
+		env,
+	};
+}
+
+export async function startFarm(options: FarmStartOptions = {}): Promise<void> {
+	const plan = await createFarmStartPlan(options);
+	logger.info(
+		`Starting Node server: node ${path.relative(plan.root, plan.serverEntry)}`,
+	);
+
+	const child = spawn(process.execPath, plan.command.args, {
+		cwd: plan.root,
+		stdio: "inherit",
+		env: { ...process.env, ...plan.env },
+	});
+
+	const forward = (signal: NodeJS.Signals) => {
+		const handler = () => child.kill(signal);
+		process.on(signal, handler);
+		return () => process.off(signal, handler);
+	};
+	const cleanups = [forward("SIGINT"), forward("SIGTERM")];
+
+	await new Promise<void>((resolve, reject) => {
+		child.on("error", reject);
+		child.on("exit", (code, signal) => {
+			for (const cleanup of cleanups) cleanup();
+			if (!signal && code !== null) process.exitCode = code;
+			resolve();
+		});
+	});
+}

--- a/packages/farm-cli/src/start.ts
+++ b/packages/farm-cli/src/start.ts
@@ -1,5 +1,6 @@
 import { loadConfig, logger, resolveDeployConfig, resolveDeployOutputPath } from "@farm.js/core";
 import { spawn } from "child_process";
+import { constants as osConstants } from "os";
 import { existsSync } from "fs";
 import path from "path";
 
@@ -79,7 +80,8 @@ export async function createFarmStartPlan(options: FarmStartOptions = {}): Promi
     preset,
     outputDir,
     serverEntry,
-    command: { command: "node", args: [serverEntry] },
+    // process.execPath avoids PATH lookup and Windows shim issues.
+    command: { command: process.execPath, args: [serverEntry] },
     env,
   };
 }
@@ -88,7 +90,7 @@ export async function startFarm(options: FarmStartOptions = {}): Promise<void> {
   const plan = await createFarmStartPlan(options);
   logger.info(`Starting Node server: node ${path.relative(plan.root, plan.serverEntry)}`);
 
-  const child = spawn(process.execPath, plan.command.args, {
+  const child = spawn(plan.command.command, plan.command.args, {
     cwd: plan.root,
     stdio: "inherit",
     env: { ...process.env, ...plan.env },
@@ -101,12 +103,20 @@ export async function startFarm(options: FarmStartOptions = {}): Promise<void> {
   };
   const cleanups = [forward("SIGINT"), forward("SIGTERM")];
 
-  await new Promise<void>((resolve, reject) => {
-    child.on("error", reject);
-    child.on("exit", (code, signal) => {
-      for (const cleanup of cleanups) cleanup();
-      if (!signal && code !== null) process.exitCode = code;
-      resolve();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      child.on("error", reject);
+      child.on("exit", (code, signal) => {
+        if (signal) {
+          // Conventional shell encoding for signal-terminated processes.
+          process.exitCode = 128 + (osConstants.signals[signal] ?? 1);
+        } else if (code !== null) {
+          process.exitCode = code;
+        }
+        resolve();
+      });
     });
-  });
+  } finally {
+    for (const cleanup of cleanups) cleanup();
+  }
 }

--- a/packages/farm-cli/src/start.ts
+++ b/packages/farm-cli/src/start.ts
@@ -1,125 +1,112 @@
-import {
-	loadConfig,
-	logger,
-	resolveDeployConfig,
-	resolveDeployOutputPath,
-} from "@farm.js/core";
+import { loadConfig, logger, resolveDeployConfig, resolveDeployOutputPath } from "@farm.js/core";
 import { spawn } from "child_process";
 import { existsSync } from "fs";
 import path from "path";
 
 export interface FarmStartOptions {
-	root?: string;
-	port?: string | number;
-	host?: string;
+  root?: string;
+  port?: string | number;
+  host?: string;
 }
 
-export type FarmStartErrorCode =
-	| "PLATFORM_TARGET"
-	| "UNSUPPORTED_PRESET"
-	| "MISSING_OUTPUT";
+export type FarmStartErrorCode = "PLATFORM_TARGET" | "UNSUPPORTED_PRESET" | "MISSING_OUTPUT";
 
 export class FarmStartError extends Error {
-	readonly code: FarmStartErrorCode;
+  readonly code: FarmStartErrorCode;
 
-	constructor(code: FarmStartErrorCode, message: string) {
-		super(message);
-		this.name = "FarmStartError";
-		this.code = code;
-	}
+  constructor(code: FarmStartErrorCode, message: string) {
+    super(message);
+    this.name = "FarmStartError";
+    this.code = code;
+  }
 }
 
 export interface FarmStartPlan {
-	root: string;
-	target: "node";
-	preset: string;
-	outputDir: string;
-	serverEntry: string;
-	command: { command: string; args: string[] };
-	env: Record<string, string>;
+  root: string;
+  target: "node";
+  preset: string;
+  outputDir: string;
+  serverEntry: string;
+  command: { command: string; args: string[] };
+  env: Record<string, string>;
 }
 
 const PLATFORM_HINTS: Record<string, string> = {
-	vercel: "Deploy it with `farm deploy --vercel`",
-	cloudflare: "Deploy it with `farm deploy --cloudflare`",
-	netlify: "Deploy it with `farm deploy --netlify`",
+  vercel: "Deploy it with `farm deploy --vercel`",
+  cloudflare: "Deploy it with `farm deploy --cloudflare`",
+  netlify: "Deploy it with `farm deploy --netlify`",
 };
 
-export async function createFarmStartPlan(
-	options: FarmStartOptions = {},
-): Promise<FarmStartPlan> {
-	const root = path.resolve(options.root || process.cwd());
-	const userConfig = await loadConfig(root, undefined, "production");
-	const deployConfig = resolveDeployConfig(userConfig || {});
-	const target = deployConfig.target;
-	const preset = deployConfig.preset || "node-server";
-	const outputDir = resolveDeployOutputPath(root, deployConfig.outputDir);
+export async function createFarmStartPlan(options: FarmStartOptions = {}): Promise<FarmStartPlan> {
+  const root = path.resolve(options.root || process.cwd());
+  const userConfig = await loadConfig(root, undefined, "production");
+  const deployConfig = resolveDeployConfig(userConfig || {});
+  const target = deployConfig.target;
+  const preset = deployConfig.preset || "node-server";
+  const outputDir = resolveDeployOutputPath(root, deployConfig.outputDir);
 
-	if (target && target !== "node") {
-		throw new FarmStartError(
-			"PLATFORM_TARGET",
-			`The "${target}" target builds platform output with no local server to start. ` +
-				`${PLATFORM_HINTS[target]}, or set deploy.target: "node" in farm.config.ts to self-host.`,
-		);
-	}
+  if (target && target !== "node") {
+    throw new FarmStartError(
+      "PLATFORM_TARGET",
+      `The "${target}" target builds platform output with no local server to start. ` +
+        `${PLATFORM_HINTS[target]}, or set deploy.target: "node" in farm.config.ts to self-host.`,
+    );
+  }
 
-	if (!target) {
-		throw new FarmStartError(
-			"UNSUPPORTED_PRESET",
-			`Preset "${preset}" has no known local server entry. ` +
-				`Set deploy.target: "node" in farm.config.ts to self-host.`,
-		);
-	}
+  if (!target) {
+    throw new FarmStartError(
+      "UNSUPPORTED_PRESET",
+      `Preset "${preset}" has no known local server entry. ` +
+        `Set deploy.target: "node" in farm.config.ts to self-host.`,
+    );
+  }
 
-	const serverEntry = path.join(outputDir, "server", "index.mjs");
-	if (!existsSync(serverEntry)) {
-		throw new FarmStartError(
-			"MISSING_OUTPUT",
-			`No build output found at ${serverEntry}. Run \`farm build\` first.`,
-		);
-	}
+  const serverEntry = path.join(outputDir, "server", "index.mjs");
+  if (!existsSync(serverEntry)) {
+    throw new FarmStartError(
+      "MISSING_OUTPUT",
+      `No build output found at ${serverEntry}. Run \`farm build\` first.`,
+    );
+  }
 
-	const env: Record<string, string> = {};
-	if (options.port !== undefined && options.port !== "")
-		env.NITRO_PORT = String(options.port);
-	if (options.host) env.NITRO_HOST = options.host;
+  const env: Record<string, string> = {};
+  if (options.port !== undefined && options.port !== "") env.NITRO_PORT = String(options.port);
+  if (options.host) env.NITRO_HOST = options.host;
 
-	return {
-		root,
-		target,
-		preset,
-		outputDir,
-		serverEntry,
-		command: { command: "node", args: [serverEntry] },
-		env,
-	};
+  return {
+    root,
+    target,
+    preset,
+    outputDir,
+    serverEntry,
+    command: { command: "node", args: [serverEntry] },
+    env,
+  };
 }
 
 export async function startFarm(options: FarmStartOptions = {}): Promise<void> {
-	const plan = await createFarmStartPlan(options);
-	logger.info(
-		`Starting Node server: node ${path.relative(plan.root, plan.serverEntry)}`,
-	);
+  const plan = await createFarmStartPlan(options);
+  logger.info(`Starting Node server: node ${path.relative(plan.root, plan.serverEntry)}`);
 
-	const child = spawn(process.execPath, plan.command.args, {
-		cwd: plan.root,
-		stdio: "inherit",
-		env: { ...process.env, ...plan.env },
-	});
+  const child = spawn(process.execPath, plan.command.args, {
+    cwd: plan.root,
+    stdio: "inherit",
+    env: { ...process.env, ...plan.env },
+  });
 
-	const forward = (signal: NodeJS.Signals) => {
-		const handler = () => child.kill(signal);
-		process.on(signal, handler);
-		return () => process.off(signal, handler);
-	};
-	const cleanups = [forward("SIGINT"), forward("SIGTERM")];
+  const forward = (signal: NodeJS.Signals) => {
+    const handler = () => child.kill(signal);
+    process.on(signal, handler);
+    return () => process.off(signal, handler);
+  };
+  const cleanups = [forward("SIGINT"), forward("SIGTERM")];
 
-	await new Promise<void>((resolve, reject) => {
-		child.on("error", reject);
-		child.on("exit", (code, signal) => {
-			for (const cleanup of cleanups) cleanup();
-			if (!signal && code !== null) process.exitCode = code;
-			resolve();
-		});
-	});
+  await new Promise<void>((resolve, reject) => {
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      for (const cleanup of cleanups) cleanup();
+      if (!signal && code !== null) process.exitCode = code;
+      resolve();
+    });
+  });
 }

--- a/packages/farm-cli/src/telemetry.ts
+++ b/packages/farm-cli/src/telemetry.ts
@@ -11,6 +11,7 @@ const REQUEST_TIMEOUT_MS = 750;
 const FARM_COMMANDS = [
   "dev",
   "build",
+  "start",
   "auth:migrate",
   "upgrade",
   "generate",

--- a/packages/farm-cli/test/start.test.mjs
+++ b/packages/farm-cli/test/start.test.mjs
@@ -9,91 +9,85 @@ const require = createRequire(import.meta.url);
 const { createFarmStartPlan } = require("../dist/index.js");
 
 async function withTempRoot(name, run) {
-	let root;
-	try {
-		root = await mkdtemp(path.join(tmpdir(), name));
-		await run(root);
-	} finally {
-		if (root) await rm(root, { recursive: true, force: true });
-	}
+  let root;
+  try {
+    root = await mkdtemp(path.join(tmpdir(), name));
+    await run(root);
+  } finally {
+    if (root) await rm(root, { recursive: true, force: true });
+  }
 }
 
 test("resolves a start plan for the node target and maps port/host to Nitro env vars", async () => {
-	await withTempRoot("farm-cli-start-node-", async (root) => {
-		await writeFile(
-			path.join(root, "farm.config.mjs"),
-			"export default { deploy: { target: 'node', output: '.output' } };\n",
-		);
-		const serverEntry = path.join(root, ".output", "server", "index.mjs");
-		await mkdir(path.dirname(serverEntry), { recursive: true });
-		await writeFile(serverEntry, "export {};\n");
+  await withTempRoot("farm-cli-start-node-", async (root) => {
+    await writeFile(
+      path.join(root, "farm.config.mjs"),
+      "export default { deploy: { target: 'node', output: '.output' } };\n",
+    );
+    const serverEntry = path.join(root, ".output", "server", "index.mjs");
+    await mkdir(path.dirname(serverEntry), { recursive: true });
+    await writeFile(serverEntry, "export {};\n");
 
-		const plan = await createFarmStartPlan({
-			root,
-			port: 4000,
-			host: "0.0.0.0",
-		});
+    const plan = await createFarmStartPlan({
+      root,
+      port: 4000,
+      host: "0.0.0.0",
+    });
 
-		assert.equal(plan.target, "node");
-		assert.equal(plan.preset, "node-server");
-		assert.equal(plan.serverEntry, serverEntry);
-		assert.deepEqual(plan.command, { command: "node", args: [serverEntry] });
-		assert.deepEqual(plan.env, { NITRO_PORT: "4000", NITRO_HOST: "0.0.0.0" });
-	});
+    assert.equal(plan.target, "node");
+    assert.equal(plan.preset, "node-server");
+    assert.equal(plan.serverEntry, serverEntry);
+    assert.deepEqual(plan.command, { command: "node", args: [serverEntry] });
+    assert.deepEqual(plan.env, { NITRO_PORT: "4000", NITRO_HOST: "0.0.0.0" });
+  });
 });
 
 test("defaults to the node-server preset when no deploy target is configured", async () => {
-	await withTempRoot("farm-cli-start-default-", async (root) => {
-		await writeFile(path.join(root, "farm.config.mjs"), "export default {};\n");
-		const serverEntry = path.join(
-			root,
-			".farm",
-			".output",
-			"server",
-			"index.mjs",
-		);
-		await mkdir(path.dirname(serverEntry), { recursive: true });
-		await writeFile(serverEntry, "export {};\n");
+  await withTempRoot("farm-cli-start-default-", async (root) => {
+    await writeFile(path.join(root, "farm.config.mjs"), "export default {};\n");
+    const serverEntry = path.join(root, ".farm", ".output", "server", "index.mjs");
+    await mkdir(path.dirname(serverEntry), { recursive: true });
+    await writeFile(serverEntry, "export {};\n");
 
-		const plan = await createFarmStartPlan({ root });
+    const plan = await createFarmStartPlan({ root });
 
-		assert.equal(plan.target, "node");
-		assert.equal(plan.preset, "node-server");
-		assert.equal(plan.serverEntry, serverEntry);
-		assert.deepEqual(plan.env, {});
-	});
+    assert.equal(plan.target, "node");
+    assert.equal(plan.preset, "node-server");
+    assert.equal(plan.serverEntry, serverEntry);
+    assert.deepEqual(plan.env, {});
+  });
 });
 
 test("rejects platform targets with a per-target hint instead of guessing", async () => {
-	await withTempRoot("farm-cli-start-vercel-", async (root) => {
-		await writeFile(
-			path.join(root, "farm.config.mjs"),
-			"export default { deploy: { target: 'vercel' } };\n",
-		);
+  await withTempRoot("farm-cli-start-vercel-", async (root) => {
+    await writeFile(
+      path.join(root, "farm.config.mjs"),
+      "export default { deploy: { target: 'vercel' } };\n",
+    );
 
-		await assert.rejects(createFarmStartPlan({ root }), (error) => {
-			assert.equal(error.name, "FarmStartError");
-			assert.equal(error.code, "PLATFORM_TARGET");
-			assert.match(error.message, /farm deploy --vercel/);
-			assert.match(error.message, /deploy\.target: "node"/);
-			return true;
-		});
-	});
+    await assert.rejects(createFarmStartPlan({ root }), (error) => {
+      assert.equal(error.name, "FarmStartError");
+      assert.equal(error.code, "PLATFORM_TARGET");
+      assert.match(error.message, /farm deploy --vercel/);
+      assert.match(error.message, /deploy\.target: "node"/);
+      return true;
+    });
+  });
 });
 
 test("reports missing build output and hints at farm build", async () => {
-	await withTempRoot("farm-cli-start-missing-", async (root) => {
-		await writeFile(
-			path.join(root, "farm.config.mjs"),
-			"export default { deploy: { target: 'node', output: '.output' } };\n",
-		);
+  await withTempRoot("farm-cli-start-missing-", async (root) => {
+    await writeFile(
+      path.join(root, "farm.config.mjs"),
+      "export default { deploy: { target: 'node', output: '.output' } };\n",
+    );
 
-		await assert.rejects(createFarmStartPlan({ root }), (error) => {
-			assert.equal(error.name, "FarmStartError");
-			assert.equal(error.code, "MISSING_OUTPUT");
-			assert.match(error.message, /farm build/);
-			assert.match(error.message, /index\.mjs/);
-			return true;
-		});
-	});
+    await assert.rejects(createFarmStartPlan({ root }), (error) => {
+      assert.equal(error.name, "FarmStartError");
+      assert.equal(error.code, "MISSING_OUTPUT");
+      assert.match(error.message, /farm build/);
+      assert.match(error.message, /index\.mjs/);
+      return true;
+    });
+  });
 });

--- a/packages/farm-cli/test/start.test.mjs
+++ b/packages/farm-cli/test/start.test.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const { createFarmStartPlan } = require("../dist/index.js");
+
+async function withTempRoot(name, run) {
+	let root;
+	try {
+		root = await mkdtemp(path.join(tmpdir(), name));
+		await run(root);
+	} finally {
+		if (root) await rm(root, { recursive: true, force: true });
+	}
+}
+
+test("resolves a start plan for the node target and maps port/host to Nitro env vars", async () => {
+	await withTempRoot("farm-cli-start-node-", async (root) => {
+		await writeFile(
+			path.join(root, "farm.config.mjs"),
+			"export default { deploy: { target: 'node', output: '.output' } };\n",
+		);
+		const serverEntry = path.join(root, ".output", "server", "index.mjs");
+		await mkdir(path.dirname(serverEntry), { recursive: true });
+		await writeFile(serverEntry, "export {};\n");
+
+		const plan = await createFarmStartPlan({
+			root,
+			port: 4000,
+			host: "0.0.0.0",
+		});
+
+		assert.equal(plan.target, "node");
+		assert.equal(plan.preset, "node-server");
+		assert.equal(plan.serverEntry, serverEntry);
+		assert.deepEqual(plan.command, { command: "node", args: [serverEntry] });
+		assert.deepEqual(plan.env, { NITRO_PORT: "4000", NITRO_HOST: "0.0.0.0" });
+	});
+});
+
+test("defaults to the node-server preset when no deploy target is configured", async () => {
+	await withTempRoot("farm-cli-start-default-", async (root) => {
+		await writeFile(path.join(root, "farm.config.mjs"), "export default {};\n");
+		const serverEntry = path.join(
+			root,
+			".farm",
+			".output",
+			"server",
+			"index.mjs",
+		);
+		await mkdir(path.dirname(serverEntry), { recursive: true });
+		await writeFile(serverEntry, "export {};\n");
+
+		const plan = await createFarmStartPlan({ root });
+
+		assert.equal(plan.target, "node");
+		assert.equal(plan.preset, "node-server");
+		assert.equal(plan.serverEntry, serverEntry);
+		assert.deepEqual(plan.env, {});
+	});
+});
+
+test("rejects platform targets with a per-target hint instead of guessing", async () => {
+	await withTempRoot("farm-cli-start-vercel-", async (root) => {
+		await writeFile(
+			path.join(root, "farm.config.mjs"),
+			"export default { deploy: { target: 'vercel' } };\n",
+		);
+
+		await assert.rejects(createFarmStartPlan({ root }), (error) => {
+			assert.equal(error.name, "FarmStartError");
+			assert.equal(error.code, "PLATFORM_TARGET");
+			assert.match(error.message, /farm deploy --vercel/);
+			assert.match(error.message, /deploy\.target: "node"/);
+			return true;
+		});
+	});
+});
+
+test("reports missing build output and hints at farm build", async () => {
+	await withTempRoot("farm-cli-start-missing-", async (root) => {
+		await writeFile(
+			path.join(root, "farm.config.mjs"),
+			"export default { deploy: { target: 'node', output: '.output' } };\n",
+		);
+
+		await assert.rejects(createFarmStartPlan({ root }), (error) => {
+			assert.equal(error.name, "FarmStartError");
+			assert.equal(error.code, "MISSING_OUTPUT");
+			assert.match(error.message, /farm build/);
+			assert.match(error.message, /index\.mjs/);
+			return true;
+		});
+	});
+});

--- a/packages/farm-cli/test/start.test.mjs
+++ b/packages/farm-cli/test/start.test.mjs
@@ -37,7 +37,7 @@ test("resolves a start plan for the node target and maps port/host to Nitro env 
     assert.equal(plan.target, "node");
     assert.equal(plan.preset, "node-server");
     assert.equal(plan.serverEntry, serverEntry);
-    assert.deepEqual(plan.command, { command: "node", args: [serverEntry] });
+    assert.deepEqual(plan.command, { command: process.execPath, args: [serverEntry] });
     assert.deepEqual(plan.env, { NITRO_PORT: "4000", NITRO_HOST: "0.0.0.0" });
   });
 });
@@ -55,6 +55,23 @@ test("defaults to the node-server preset when no deploy target is configured", a
     assert.equal(plan.preset, "node-server");
     assert.equal(plan.serverEntry, serverEntry);
     assert.deepEqual(plan.env, {});
+  });
+});
+
+test("rejects presets without a known local server entry", async () => {
+  await withTempRoot("farm-cli-start-preset-", async (root) => {
+    await writeFile(
+      path.join(root, "farm.config.mjs"),
+      "export default { deploy: { preset: 'deno' } };\n",
+    );
+
+    await assert.rejects(createFarmStartPlan({ root }), (error) => {
+      assert.equal(error.name, "FarmStartError");
+      assert.equal(error.code, "UNSUPPORTED_PRESET");
+      assert.match(error.message, /deno/);
+      assert.match(error.message, /deploy\.target: "node"/);
+      return true;
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Implements `farm start` and cleans up the scaffolded templates, as agreed in #416.

Every template shipped `"start": "farm start"` while the CLI never registered the command, so `pnpm start` failed on first use in new projects. This adds a preset-aware `start` command that either runs a real server or says exactly why it cannot and what to do instead — it never falls back to `dev` or `preview`.

## Behaviour

| Situation | Result |
| --- | --- |
| `deploy.target: "node"` | Spawns `node <output>/server/index.mjs` with inherited stdio, forwards `SIGINT`/`SIGTERM`, propagates the child exit code |
| `--port` / `--host` | Mapped to `NITRO_PORT` / `NITRO_HOST`, the variables the node-server entry reads (`nitro/node-server-entry.ts`) |
| No deploy config | Follows `resolveDeployConfig`'s `node-server` default, per the discussion in #416 |
| `vercel` / `cloudflare` / `netlify` | Exit 1 with a per-target hint: deploy with `farm deploy --<target>`, or set `deploy.target: "node"` to self-host |
| Unknown preset with no target | Exit 1 with `UNSUPPORTED_PRESET` |
| Output directory missing | Exit 1 pointing at the expected path and `farm build` |

Config and output resolution reuse the same core helpers `build` and `deploy` use (`loadConfig` → `resolveDeployConfig` → `resolveDeployOutputPath`), so the three commands cannot disagree about where output lives. No changes to `@farm.js/core` were needed: `resolveDeployConfig` already computes `outputDir` via `getDefaultDeployOutputDir` internally.

## Changes

- `packages/farm-cli/src/start.ts` — `createFarmStartPlan()` (pure resolution, exported for tests, mirroring `createFarmDeployPlan`) and `startFarm()` (spawn/signal handling)
- `packages/farm-cli/bin/farm.js` — registers `start` with `-r, --root`, `-p, --port`, `-H, --host`, matching the `deploy` error-handling style
- `packages/farm-cli/src/telemetry.ts` — adds `start` to `FARM_COMMANDS` so it is tracked like other commands
- Templates — removes the `start` script from the six vercel-default templates. Two templates keep it because the command is now real for them: `react-compiler` sets `deploy.target: "node"` explicitly, and the svelte renderer has no deploy config, which resolves to the node-server default
- Docs — fixes `migrations/sveltekit` (`"start": "farm start"` → `node .output/server/index.mjs`, matching the Nuxt page) and adds `farm start` to the CLI reference table

## Test plan

- [x] `packages/farm-cli/test/start.test.mjs` (new, follows `deploy.test.mjs` conventions): node-target plan with port/host env mapping, node-server default when nothing is configured, platform target rejected with the per-target hint, missing output hinting `farm build` — 4/4 pass
- [x] Full CLI suite: 76 pass / 4 fail — the 4 failures (`doctor` ×3, `deploy` ×1) are pre-existing Windows path-separator issues, reproduced on a clean `main` checkout before this change
- [x] End-to-end with the built bin: node target spawns the server and receives `NITRO_PORT`; a vercel-target project exits 1 with the deploy hint; missing output exits 1 with the `farm build` hint; `farm start --help` renders
- [x] Template `package.json` files re-validated as JSON after the script removal

Fixes #416

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a real farm start that runs the built Node server, fixing template “pnpm start” failures and aligning output resolution with build/deploy. Previously there was no start; now it resolves the deploy preset, runs the Node entry for the node target, and fails fast with actionable errors otherwise.

- Node target: spawns the built server entry via process.execPath, forwards SIGINT/SIGTERM, exits with 128+signal on signal termination, propagates child exit codes, and maps --port/--host to NITRO_PORT/NITRO_HOST. The start plan returns the literal "node" target for correct type narrowing.
- No deploy config: follows `resolveDeployConfig`’s node-server default so start, build, and deploy agree on output paths via `@farm.js/core`.
- Platform targets (vercel, cloudflare, netlify): exits 1 with a hint to use farm deploy --<target> or set deploy.target: "node" to self-host.
- Unknown preset with no target: exits 1 with UNSUPPORTED_PRESET and a hint to set deploy.target: "node".
- Missing output: exits 1 pointing to the expected entry and to run farm build.

**Review/rollout**
- CLI: new start plan/runner in packages/farm-cli/src/start.ts; command registered in packages/farm-cli/bin/farm.js; exports in packages/farm-cli/src/index.ts; telemetry adds start; logs the relative Node entry.
- Docs: add farm start to the CLI table and cross-link it from deployment self‑hosting; SvelteKit migration uses node .output/server/index.mjs.
- Templates: remove the start script from vercel-default templates; keep it where node is valid (react-compiler, svelte renderer).

<sup>Written for commit 5ff5f1b901ebe0c94e4a7cfc86710430032e7720. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

