### PR TITLE
fix(core): stop production page-state writes from navigating

### DIFF
--- a/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
+++ b/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { FARM_HISTORY_CHANGE_EVENT } from "../client/history-sync";
+import { generateUniversalRouterStateProperties } from "../nitro/universal-build";
+
+describe("generateUniversalRouterStateProperties", () => {
+  // Shared by both production runtime variants (node and edge templates).
+  const runtime = generateUniversalRouterStateProperties();
+
+  it("announces page-state writes on the dedicated history channel", () => {
+    // The runtime's own popstate listener performs a full navigation, so a
+    // synthetic popstate here reintroduces #420 in production builds (#424).
+    expect(runtime).not.toContain("new PopStateEvent");
+    expect(runtime).toContain(`new CustomEvent("${FARM_HISTORY_CHANGE_EVENT}"`);
+    expect(runtime).toContain('kind: "page-state"');
+  });
+
+  it("keeps the page-state write API intact", () => {
+    expect(runtime).toContain("pushState: function(state, href)");
+    expect(runtime).toContain("replaceState: function(state, href)");
+    expect(runtime).toContain("writePageState: function(action, state, href)");
+  });
+});

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1501,7 +1501,7 @@ function createHistoryState(path, pageState, currentState) {
 `.trim();
 }
 
-function generateUniversalRouterStateProperties(): string {
+export function generateUniversalRouterStateProperties(): string {
   return `
   blockers: new Set(),
   navigationListeners: new Set(),
@@ -1572,7 +1572,13 @@ function generateUniversalRouterStateProperties(): string {
     } else {
       window.history.pushState(nextState, "", url);
     }
-    window.dispatchEvent(new PopStateEvent("popstate", { state: nextState }));
+    // Announce on the dedicated history channel; a synthetic popstate would
+    // be treated as back/forward by the popstate listener below and trigger
+    // a full navigation for a shallow page-state write. The bundled client
+    // hooks subscribe to this event via subscribeHistoryChange.
+    window.dispatchEvent(
+      new CustomEvent("farm:historychange", { detail: { kind: "page-state" } }),
+    );
   },
 
   registerScrollElement: function(key, element) {


### PR DESCRIPTION
## Summary

Fixes #424 — the production-runtime remainder of #420.

The Nitro build generates its own standalone SPA runtime; its `writePageState` still dispatched a synthetic `popstate`, and its popstate listener runs a full `navigate()`. Because that runtime installs itself as `window.__FARM_SPA_ROUTER__` and `getRouter()` returns the installed router, **production** apps kept fetching page data on every `pushState`/`replaceState` even after #421.

## Changes

- The shared router-state template (`generateUniversalRouterStateProperties`, used by **both** production runtime variants) now dispatches `farm:historychange` with `detail: { kind: "page-state" }` instead of the synthetic popstate. The bundled client hooks already subscribe to that event via `subscribeHistoryChange` since #421, so no client-side changes are needed.
- The real popstate listener is untouched — back/forward still navigates.
- Exported the template generator so the emitted code is unit-testable.

## Testing

- New `universal-build-router-runtime.test.ts`: the generated template contains the `farm:historychange` CustomEvent (name asserted against the `FARM_HISTORY_CHANGE_EVENT` constant so they can't drift), `kind: "page-state"`, no `new PopStateEvent`, and the page-state API surface intact.
- **Real build verification**: scaffolded app + local core + vercel preset — the emitted `.vercel/output/static/farm-client-*.js` contains exactly one `farm:historychange` dispatch and zero `new PopStateEvent`.
- `universal-build` suites pass; `tsc --noEmit`, `oxlint`, `oxfmt` clean.

#425 is being fixed separately. The issue's longer-term note about deduplicating the codegen runtime against `src/client/spa-router.ts` stands.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop production page-state writes from triggering navigation and data fetches. The generated SPA runtime no longer dispatches a synthetic popstate in `writePageState`; it now emits a `farm:historychange` event with `detail: { kind: "page-state" }`.

- Apply the change in the shared router-state template used by both production runtimes; bundled client hooks already listen via `subscribeHistoryChange`, so no app changes are required.
- Keep the real popstate listener unchanged; back/forward still navigates.
- Export the template generator for tests and add a unit test to assert the event and API surface; verified builds include a single `farm:historychange` and no `PopStateEvent`.

<sup>Written for commit 241872ef53689624dec5a893f189f7e1374d46d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

