### PR TITLE
fix(core): delegate useRouter push/replace to the SPA router

### DIFF
--- a/packages/farm/src/__tests__/router-push-delegation.test.tsx
+++ b/packages/farm/src/__tests__/router-push-delegation.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useRouter } from "../client/router";
+import { pushState as pushFarmPageState, readPageState, SPARouter } from "../client/spa-router";
+
+let router: SPARouter | undefined;
+let container: HTMLDivElement;
+let root: ReturnType<typeof createRoot> | undefined;
+
+function renderHook() {
+  let api!: ReturnType<typeof useRouter>;
+  function Probe() {
+    api = useRouter();
+    return null;
+  }
+  root = createRoot(container);
+  act(() => root?.render(createElement(Probe)));
+  return () => api;
+}
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 50));
+
+beforeEach(() => {
+  window.history.replaceState(null, "", "/");
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  container.remove();
+  root = undefined;
+  router?.destroy();
+  router = undefined;
+  delete (window as unknown as { __FARM_SPA_ROUTER__?: SPARouter }).__FARM_SPA_ROUTER__;
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function installRouter() {
+  router = new SPARouter({ scrollRestoration: false });
+  (window as unknown as { __FARM_SPA_ROUTER__?: SPARouter }).__FARM_SPA_ROUTER__ = router;
+  return router;
+}
+
+describe("useRouter push/replace delegation", () => {
+  it("delegates push to the installed router with the push action", async () => {
+    const spa = installRouter();
+    const navigate = vi.spyOn(spa, "navigate").mockResolvedValue();
+    const getApi = renderHook();
+
+    act(() => getApi().push("/about"));
+    await settle();
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith("/about", { replace: false });
+    // The URL must not be rewritten before the router (and its blockers) run.
+    expect(window.location.pathname).toBe("/");
+  });
+
+  it("delegates replace to the installed router", async () => {
+    const spa = installRouter();
+    const navigate = vi.spyOn(spa, "navigate").mockResolvedValue();
+    const getApi = renderHook();
+
+    act(() => getApi().replace("/pricing"));
+    await settle();
+
+    expect(navigate).toHaveBeenCalledWith("/pricing", { replace: true });
+  });
+
+  it("leaves the URL unchanged when a blocker cancels the navigation", async () => {
+    const spa = installRouter();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("{}", { status: 200 })),
+    );
+    const removeBlocker = spa.addBlocker(() => true);
+    const getApi = renderHook();
+
+    act(() => getApi().push("/about"));
+    await settle();
+
+    expect(window.location.pathname).toBe("/");
+    removeBlocker();
+  });
+
+  it("preserves Farm page history state across delegated pushes", async () => {
+    const spa = installRouter();
+    vi.spyOn(spa, "navigate").mockResolvedValue();
+    pushFarmPageState({ modal: "open" });
+    const getApi = renderHook();
+
+    act(() => getApi().push("/about"));
+    await settle();
+
+    expect(readPageState()).toEqual({ modal: "open" });
+  });
+
+  it("falls back to a direct history write plus synthetic popstate without a router", async () => {
+    const popstate = vi.fn();
+    window.addEventListener("popstate", popstate);
+    const getApi = renderHook();
+
+    act(() => getApi().push("/about"));
+    await settle();
+
+    window.removeEventListener("popstate", popstate);
+    expect(window.location.pathname).toBe("/about");
+    expect(popstate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/farm/src/client/router.ts
+++ b/packages/farm/src/client/router.ts
@@ -1,12 +1,13 @@
 import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import { createFarmRouter, type FarmRouter, type FarmRouterRouteInput } from "../router";
 import {
+  getInstalledFarmSPARouter,
   getRouter as getSPARouter,
   readPageState,
   type FarmNavigationBlockerContext,
   type FarmNavigationState,
 } from "./spa-router";
-import { subscribeHistoryChange } from "./history-sync";
+import { notifyHistoryChange, subscribeHistoryChange } from "./history-sync";
 import { getFarmI18nClientState } from "../i18n/client-runtime";
 import { stripFarmLocaleFromPathname } from "../i18n/routing";
 
@@ -35,6 +36,32 @@ export interface UseBlockerReturn {
 /**
  * Hook for accessing router state and navigation
  */
+/**
+ * Imperative navigation for useRouter. Delegates to the installed SPA router
+ * so blockers run before the URL changes, history state is written by the
+ * router, and the action is labelled push/replace rather than pop. Without a
+ * Farm router (embedded usage) the URL is written directly and announced on
+ * the shared history channel, whose no-router fallback is the nuqs-style
+ * synthetic popstate this code previously hand-rolled.
+ */
+function navigateViaRouter(href: string, basePath: string, replace: boolean): void {
+  if (typeof window === "undefined") return;
+
+  const url = href.startsWith("/") ? basePath + href : href;
+  const spaRouter = getInstalledFarmSPARouter();
+  if (spaRouter) {
+    void spaRouter.navigate(url, { replace });
+    return;
+  }
+
+  if (replace) {
+    window.history.replaceState(null, "", url);
+  } else {
+    window.history.pushState(null, "", url);
+  }
+  notifyHistoryChange("url-search");
+}
+
 export function useRouter(options: UseRouterOptions = {}) {
   const basePath = options.basePath || "";
   const routes = options.routes;
@@ -61,19 +88,11 @@ export function useRouter(options: UseRouterOptions = {}) {
   }, [basePath, routeMatcher]);
 
   const push = (href: string) => {
-    if (typeof window === "undefined") return;
-
-    const url = href.startsWith("/") ? basePath + href : href;
-    window.history.pushState(null, "", url);
-    window.dispatchEvent(new PopStateEvent("popstate"));
+    navigateViaRouter(href, basePath, false);
   };
 
   const replace = (href: string) => {
-    if (typeof window === "undefined") return;
-
-    const url = href.startsWith("/") ? basePath + href : href;
-    window.history.replaceState(null, "", url);
-    window.dispatchEvent(new PopStateEvent("popstate"));
+    navigateViaRouter(href, basePath, true);
   };
 
   const pushState = <TState>(pageState: TState, href?: string) => {


### PR DESCRIPTION
## Summary

Fixes #425 — the last synthetic-popstate emitter outside `history-sync`'s intentional fallback.

`useRouter().push/replace` navigated by rewriting the URL and then faking a `popstate` for the router to notice. Three defects: blockers ran **after** the URL had changed (a blocked navigation stranded the address bar on a page the app never visited), `pushState(null)` clobbered Farm's history state, and the navigation took the back/forward path mislabelled as `pop`, skipping the router's cache/scroll/transition handling.

## Changes

- `push`/`replace` now delegate to `getInstalledFarmSPARouter().navigate(url, { replace })` — blockers run before any URL change, history state is written properly, action labelled correctly.
- Without an installed router (embedded usage) the direct history write remains, announced via `notifyHistoryChange` — whose no-router fallback is the same nuqs-style synthetic popstate as before, now kept in the one shared module.

## Testing

New `router-push-delegation.test.tsx` (5 tests): push delegates with `{ replace: false }` and leaves the URL untouched before the router runs; replace delegates with `{ replace: true }`; **a blocker cancelling navigation leaves the URL unchanged** (previously it stranded the URL); Farm page history state survives delegated pushes; and the no-router fallback still updates the URL and fires exactly one synthetic popstate.

`router`, `history-sync`, and `query-client-shallow` suites pass alongside (30/30); `tsc --noEmit`, `oxlint`, repo-wide `oxfmt --check` clean.

With this and #426, `grep -rn "new PopStateEvent" packages/farm/src --include="*.ts"` outside `history-sync.ts` and tests returns nothing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delegates `useRouter().push`/`replace` to the SPA router to run blockers before any URL change, preserve history state, and label actions as push/replace. Previously these methods rewrote the URL and fired a synthetic `popstate`, which ran blockers late, clobbered page state with `pushState(null)`, and skipped router cache/scroll/transition handling.

- Uses `getInstalledFarmSPARouter().navigate(url, { replace })`; without a router, falls back to a direct history write and `notifyHistoryChange` (synthetic `popstate` centralized in `history-sync`).
- Introduces `navigateViaRouter` in `router.ts` and removes ad-hoc `PopStateEvent` usage outside `history-sync`.
- Adds tests for delegation, replace, blocked navigation (URL unchanged), history state preservation, and the no-router fallback.
- No migration required; `useRouter().push/replace` callers keep the same API.

<sup>Written for commit 197df6594f51f192703b7885fa572e015b2a2dc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

