### PR TITLE
chore: prevent synthetic PopStateEvent dispatches in lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "build:examples": "node scripts/build-examples.js",
     "benchmark:frameworks": "node benchmarks/frameworks/run.mjs",
     "benchmark:preview": "pnpm --filter @farm.js/preview-tunnel build && node benchmarks/preview-tunnel/run.mjs",
-    "lint": "oxlint . && oxfmt --check .",
+    "lint": "oxlint . && oxfmt --check . && node scripts/check-synthetic-popstate.mjs",
     "format": "oxlint --fix . && oxfmt .",
     "lint:fix": "oxlint --fix . && oxfmt .",
     "format:check": "oxfmt --check .",

--- a/scripts/check-synthetic-popstate.mjs
+++ b/scripts/check-synthetic-popstate.mjs
@@ -1,0 +1,80 @@
+/**
+ * Guard against reintroducing synthetic PopStateEvent dispatches.
+ *
+ * Farm's SPA router treats popstate as real back/forward navigation, so code
+ * that fakes the event to announce URL or state changes triggers spurious
+ * full navigations (#415, #420, #424, #425). Programmatic history changes
+ * must be announced through client/history-sync instead; its no-router
+ * compat fallback is the single place allowed to dispatch a synthetic
+ * popstate.
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const packagesRoot = path.join(repoRoot, "packages");
+
+const PATTERN = "new PopStateEvent";
+const ALLOWED_FILES = new Set([path.join("packages", "farm", "src", "client", "history-sync.ts")]);
+const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+
+function isTestPath(relativePath) {
+  return (
+    relativePath.split(path.sep).includes("__tests__") ||
+    /\.(test|spec)\.[cm]?[jt]sx?$/.test(relativePath)
+  );
+}
+
+function* walkSourceFiles(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "dist") continue;
+      yield* walkSourceFiles(fullPath);
+      continue;
+    }
+    if (SOURCE_EXTENSIONS.has(path.extname(entry.name))) yield fullPath;
+  }
+}
+
+const violations = [];
+for (const packageEntry of readdirSync(packagesRoot)) {
+  const srcDir = path.join(packagesRoot, packageEntry, "src");
+  let srcStat;
+  try {
+    srcStat = statSync(srcDir);
+  } catch {
+    continue;
+  }
+  if (!srcStat.isDirectory()) continue;
+
+  for (const filePath of walkSourceFiles(srcDir)) {
+    const relativePath = path.relative(repoRoot, filePath);
+    if (ALLOWED_FILES.has(relativePath) || isTestPath(relativePath)) continue;
+
+    const content = readFileSync(filePath, "utf8");
+    if (!content.includes(PATTERN)) continue;
+
+    content.split("\n").forEach((line, index) => {
+      if (line.includes(PATTERN)) violations.push(`${relativePath}:${index + 1}: ${line.trim()}`);
+    });
+  }
+}
+
+if (violations.length > 0) {
+  console.error(
+    [
+      "Synthetic PopStateEvent dispatch found outside client/history-sync:",
+      ...violations.map((violation) => `- ${violation}`),
+      "",
+      "Farm's routers treat popstate as real back/forward navigation, so faking",
+      "it causes spurious full navigations (#415, #420, #424, #425). Announce",
+      "programmatic history changes with notifyHistoryChange from",
+      "packages/farm/src/client/history-sync.ts instead.",
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+console.log("No synthetic PopStateEvent dispatches outside client/history-sync.");


### PR DESCRIPTION
## Summary

Codifies the regression check from the #415 → #427 synthetic-popstate saga into CI, so the pattern can't sneak back in.

## Changes

- New `scripts/check-synthetic-popstate.mjs`: walks every `packages/*/src` source file (skipping tests, `node_modules`, `dist`) and fails if `new PopStateEvent` appears anywhere except `packages/farm/src/client/history-sync.ts` — the one intentional no-router compat fallback. The error message names the issue lineage and points offenders at `notifyHistoryChange`.
- Chained into the root `lint` script, so the existing CI Lint job (and local `pnpm lint`) runs it — no workflow changes needed.
- Covers the codegen case too: the #424 bug lived inside a template *string* in `universal-build.ts`, and a string reintroduction still matches the source scan.

## Validation

- Passes on current `main` (post-#427: only the history-sync fallback remains).
- Failure mode verified: a probe file with a synthetic dispatch fails the script with exit 1 and the guidance message; removing it restores green.
- `pnpm lint` (with the new step chained) passes end to end; the script itself is `oxfmt`-clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a lint-stage guard that fails when synthetic `PopStateEvent` dispatches appear outside the allowed fallback, preventing router regressions from re-entering the codebase. Previously these could slip into source or codegen; now `pnpm lint` and CI will block them and direct authors to the supported API.

- Introduces `scripts/check-synthetic-popstate.mjs` to scan `packages/*/src` (skips tests, `node_modules`, `dist`) for `new PopStateEvent`, including matches inside template strings.
- Only `packages/farm/src/client/history-sync.ts` is allowed; all other occurrences fail lint with guidance.
- Chains into the root `lint` script; no workflow changes.

**Migration**
- Do not dispatch `PopStateEvent`. Announce programmatic history changes via `notifyHistoryChange` from `packages/farm/src/client/history-sync.ts`.
- If lint fails, remove the synthetic dispatch or refactor to use `notifyHistoryChange`.

<sup>Written for commit aa923d8eadc2b154770c4a3bb6ba8c8985a565f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

