### PR TITLE
feat(react): compile row-local conditionals inside keyed rows

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -323,21 +323,21 @@ policy.
 The current compiler deliberately supports a smaller subset than general React. A component must
 satisfy all of these rules:
 
-| Area                | Current supported shape                                                                                                                                                           |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Component discovery | A top-level, capitalized function declaration, function expression, or arrow component in application `.tsx` or `.jsx`.                                                           |
-| Function shape      | Synchronous, non-generator, non-generic block body with zero parameters, one props identifier, or flat object props destructuring.                                                |
-| Props               | Flat object destructuring supports shorthand names, aliases, and defaults. Nested, computed, and rest patterns fall back.                                                         |
-| Body                | Top-level `useState` declarations, optional compiler-safe derived values and synchronous named handlers, then one unconditional JSX return.                                       |
-| State               | `const [value, setValue] = useState(initial)`, including lazy initializers, multiple cells, and queued functional updates.                                                        |
-| Root                | Exactly one lowercase host JSX element such as `button`, `section`, `input`, or `div`.                                                                                            |
-| Tree                | A statically known host tree around eligible conditional, keyed-list, compiled keyed-row, and component-island boundaries.                                                        |
-| Text bindings       | State-driven text in a leaf host element.                                                                                                                                         |
-| Attribute bindings  | Basic attributes, controlled form properties, and individual properties in one inline `style` object.                                                                             |
-| Events              | Inline handlers and synchronous `const` or function-declaration handlers, including inline synchronous events in eligible host-only keyed rows.                                   |
-| Conditional blocks  | Logical/ternary host branches; dedicated host-only containers may use compiler-owned branch instances and bindings.                                                               |
-| Keyed lists         | Item-keyed maps and imported `List`, including safe collection pipelines; eligible host rows use direct bindings, with React-owned event and structure handling when interactive. |
-| Component islands   | Stable imported or module-level component identifiers with explicit compiler-safe props and no JSX children, spread, `ref`, or `key`.                                             |
+| Area                | Current supported shape                                                                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Component discovery | A top-level, capitalized function declaration, function expression, or arrow component in application `.tsx` or `.jsx`.                                 |
+| Function shape      | Synchronous, non-generator, non-generic block body with zero parameters, one props identifier, or flat object props destructuring.                      |
+| Props               | Flat object destructuring supports shorthand names, aliases, and defaults. Nested, computed, and rest patterns fall back.                               |
+| Body                | Top-level `useState` declarations, optional compiler-safe derived values and synchronous named handlers, then one unconditional JSX return.             |
+| State               | `const [value, setValue] = useState(initial)`, including lazy initializers, multiple cells, and queued functional updates.                              |
+| Root                | Exactly one lowercase host JSX element such as `button`, `section`, `input`, or `div`.                                                                  |
+| Tree                | A statically known host tree around eligible conditional, keyed-list, compiled keyed-row, and component-island boundaries.                              |
+| Text bindings       | State-driven text in a leaf host element.                                                                                                               |
+| Attribute bindings  | Basic attributes, controlled form properties, and individual properties in one inline `style` object.                                                   |
+| Events              | Inline handlers and synchronous `const` or function-declaration handlers, including inline synchronous events in eligible host-only keyed rows.         |
+| Conditional blocks  | Logical/ternary host branches; dedicated host-only containers may use compiler-owned branch instances and bindings.                                     |
+| Keyed lists         | Item-keyed maps and imported `List`, including safe collection pipelines; eligible rows use direct bindings and keyed row-local conditional boundaries. |
+| Component islands   | Stable imported or module-level component identifiers with explicit compiler-safe props and no JSX children, spread, `ref`, or `key`.                   |
 
 This component is eligible:
 
@@ -545,6 +545,50 @@ composition events stay entirely React-owned. Non-inline or async handlers, cust
 fragments, refs, SVG, spreads, and other unproven shapes use the React-owned keyed boundary. The
 same hybrid path is available to an eligible inline host row rendered through `List`.
 
+#### Row-local host conditionals
+
+A keyed host row may contain logical or ternary branches without sending every same-key update
+through the complete list boundary:
+
+```tsx
+<ul>
+  {items.map((item) => (
+    <li key={item.id}>
+      <span>{item.label}</span>
+
+      <div className="status-slot">
+        {item.done ? <strong>{item.label} complete</strong> : <span>In progress</span>}
+      </div>
+
+      <section className="details-slot">{item.expanded && <p>{item.description}</p>}</section>
+    </li>
+  ))}
+</ul>
+```
+
+The `div` and `section` remain stable host containers. Each conditional is their only meaningful
+child. At build time, the compiler assigns row-local slot IDs and records the test plus the dynamic
+text, attribute, and style values in each host-only branch. At runtime, those IDs are scoped by the
+row key: slot `0` in row `"a"` cannot share data or a subscription with slot `0` in row `"b"`.
+
+When the collection cell changes but its key order does not, Farm computes the prepared snapshots
+for each keyed row. It asks React to refresh only a conditional whose selected branch or active
+branch values changed. Ordinary row bindings are still patched directly, the map callback is not
+executed, and unchanged conditional boundaries do not render. Inline row events may update these
+slots through the same latest-item proxy described above.
+
+React deliberately owns the conditional Fiber and every structural list commit. An insertion,
+removal, or reorder asks React to reconcile the keyed rows, after which Farm validates the static
+host skeleton, re-adopts it, and resumes targeted snapshots. This design preserves empty branches,
+SSR markup, hydration and recoverable hydration errors, error boundaries, Strict Mode, and Fast
+Refresh without adding marker elements to the server HTML.
+
+The first contract accepts `condition && <host />` and host-or-empty ternaries. A conditional must
+sit alone inside a persistent lowercase HTML container. Its branches must be statically known host
+trees without events, components, fragments, refs, SVG, spreads, dangerous HTML, or another dynamic
+block. A branch event, a conditional mixed with another child in the same slot, or any unsupported
+shape keeps the existing React-owned keyed-list boundary.
+
 #### Derived collection pipelines
 
 The collection may be prepared through an inline, non-mutating pipeline before the final keyed
@@ -630,8 +674,9 @@ The compiler uses three keyed-list tiers:
 
 1. A dedicated nested host container with one direct map or one `List`, returning a non-interactive
    host-only row, becomes compiler-owned keyed row instances. Farm patches bindings and uses LIS.
-2. The same host-only shape with eligible inline events keeps React event and structural ownership,
-   while Farm patches same-key row bindings through stable keyed event proxies.
+2. The same host-only shape with eligible inline events or dedicated row-local conditional slots
+   keeps React event and structural ownership, while Farm patches same-key row bindings and refreshes
+   only changed conditional boundaries.
 3. A safe keyed map or `List` that cannot use either optimized row shape becomes a small React-owned keyed
    boundary. React reconciles its rows, while the outer user component still avoids rerunning.
 
@@ -648,9 +693,11 @@ The optimized host-row contract is deliberately narrow:
   boundary for now.
 - The row is a statically known HTML host tree. Dynamic leaf text, attributes, controlled host
   properties, and individual inline style properties are supported.
-- Inline synchronous row events are supported by the hybrid path. Non-inline or async handlers,
-  controlled interactive form fields, custom components, fragments, refs, SVG, attribute spreads,
-  dangerous HTML, and dynamic text mixed beside nested elements stay React-owned.
+- Inline synchronous row events and dedicated logical or ternary host slots are supported by the
+  hybrid path. Branch events, nested dynamic blocks, conditionals mixed with siblings in one slot,
+  non-inline or async handlers, controlled interactive form fields, custom components, fragments,
+  refs, SVG, attribute spreads, dangerous HTML, and dynamic text mixed beside nested elements stay
+  React-owned.
 - Unsupported or mutating collection methods, spread children, Hooks in callbacks, and other
   unproven shapes fall back to normal React.
 
@@ -728,30 +775,31 @@ appears again, each boundary subscribes again and renders from the latest compil
 
 The compiler deliberately does not assign ordinary component-wide block IDs to syntax inside a
 keyed row callback. A host-only optimized row instead receives a separate runtime instance per key
-and a build-time binding list relative to that row root. Eligible inline events use the hybrid
-React-event path described above. If the row needs nested conditionals, component islands, Hooks,
-custom components, or other dynamic structure, React owns the complete row subtree; put Hooks
-inside a keyed row component.
+and a build-time binding list relative to that row root. Dedicated row-local conditional IDs are
+scoped by that key and retain React-owned Fibers. Eligible inline events use the hybrid React-event
+path described above. Component islands, Hooks, custom components, nested row blocks, and other
+dynamic structure remain on the complete React-owned row path; put Hooks inside a keyed row
+component.
 
 ### What falls back to React
 
-| Unsupported shape                                                                                                  | Why React keeps ownership                                                          |
-| ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
-| Unkeyed/index-keyed maps, unsupported or mutating collection pipelines, or element arrays                          | Their structure, purity, or item identity is outside the keyed-list contract.      |
-| Non-inline/async row events, controlled interactive row forms, components, fragments, refs, SVG, or mixed children | Their event, lifecycle, or structure contract requires the React-owned row path.   |
-| Branch events, keys, components, fragments, refs, SVG, or nested blocks in a dedicated conditional container       | They require the React-owned conditional path rather than compiler-created hosts.  |
-| Dynamic/member component types, component spreads, refs, keys, or children                                         | Their identity or ownership is outside the first component-island contract.        |
-| Effects or hooks other than the supported `useState` shape                                                         | Their lifecycle and ordering must remain under React's hook dispatcher.            |
-| `ref` or `dangerouslySetInnerHTML`                                                                                 | They directly participate in DOM ownership.                                        |
-| Stateful `children` or `key` bindings outside an eligible boundary                                                 | These need structure or identity semantics.                                        |
-| Conditional style objects, style spreads, methods, or computed names                                               | The final property set or precedence cannot be prepared statically.                |
-| JSX attribute spreads or namespaced attributes                                                                     | The compiler cannot currently enumerate a stable binding contract.                 |
-| Multiple/conditional returns or impure/control-flow statements                                                     | The compiler only lowers a single, statically analyzable render path.              |
-| Derived calls, assignments, identity-bearing values, functions, or JSX                                             | Their evaluation timing, side effects, or identity cannot yet be preserved safely. |
-| Nested, computed, or rest props destructuring                                                                      | These patterns need additional parameter-shape and identity analysis.              |
-| Async/generator/generic handlers or named handlers outside JSX events                                              | Their scheduling, identity, or closure semantics are outside the current lowering. |
-| Async/generator or generic components                                                                              | These function shapes are outside the current lowering.                            |
-| Setters called outside JSX event handlers                                                                          | The compiler only controls and batches event-driven local updates.                 |
+| Unsupported shape                                                                                            | Why React keeps ownership                                                          |
+| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| Unkeyed/index-keyed maps, unsupported or mutating collection pipelines, or element arrays                    | Their structure, purity, or item identity is outside the keyed-list contract.      |
+| Unsupported row events/forms, components, fragments, refs, SVG, nested blocks, or mixed conditional slots    | Their event, lifecycle, or structure contract requires the React-owned row path.   |
+| Branch events, keys, components, fragments, refs, SVG, or nested blocks in a dedicated conditional container | They require the React-owned conditional path rather than compiler-created hosts.  |
+| Dynamic/member component types, component spreads, refs, keys, or children                                   | Their identity or ownership is outside the first component-island contract.        |
+| Effects or hooks other than the supported `useState` shape                                                   | Their lifecycle and ordering must remain under React's hook dispatcher.            |
+| `ref` or `dangerouslySetInnerHTML`                                                                           | They directly participate in DOM ownership.                                        |
+| Stateful `children` or `key` bindings outside an eligible boundary                                           | These need structure or identity semantics.                                        |
+| Conditional style objects, style spreads, methods, or computed names                                         | The final property set or precedence cannot be prepared statically.                |
+| JSX attribute spreads or namespaced attributes                                                               | The compiler cannot currently enumerate a stable binding contract.                 |
+| Multiple/conditional returns or impure/control-flow statements                                               | The compiler only lowers a single, statically analyzable render path.              |
+| Derived calls, assignments, identity-bearing values, functions, or JSX                                       | Their evaluation timing, side effects, or identity cannot yet be preserved safely. |
+| Nested, computed, or rest props destructuring                                                                | These patterns need additional parameter-shape and identity analysis.              |
+| Async/generator/generic handlers or named handlers outside JSX events                                        | Their scheduling, identity, or closure semantics are outside the current lowering. |
+| Async/generator or generic components                                                                        | These function shapes are outside the current lowering.                            |
+| Setters called outside JSX event handlers                                                                    | The compiler only controls and batches event-driven local updates.                 |
 
 Keys do not make list work disappear. A key identifies the row that survives an insert, removal,
 or move. On the non-interactive compiler-owned host path, Farm compares those keys, reuses matching
@@ -803,7 +851,7 @@ follows:
 | Parent-driven prop updates                                | Comparing flushed values and selecting dependent bindings                    |
 | Unsupported trees, hooks, refs, handlers, and lifecycles  | Patching stable ref-owned text, attribute, and style targets                 |
 | Complex conditional branches, events, and nested blocks   | Host-only conditional identity, bindings, creation, removal, and replacement |
-| Interactive keyed-row inserts, removals, and reorders     | Same-key interactive row bindings and latest-item event lookup               |
+| Interactive or conditional-row structure and reorders     | Same-key row bindings, latest-item events, and changed conditional snapshots |
 | React-owned custom or structurally complex keyed rows     | Non-interactive host-row identity, bindings, insertion, removal, and LIS     |
 | Component render, Hooks, context, and lifecycle           | Refreshing only a dependent React component-island boundary                  |
 | Unmounting and the surrounding component tree             | Reapplying bindings after a parent-driven React update                       |
@@ -853,9 +901,9 @@ callback refs keep direct DOM targets stable even when a React component island 
 fragment, or multiple nodes. React-owned conditional, keyed-list, and component boundaries give
 complex dynamic structure back to React. Compiler-owned branches and non-interactive rows are
 limited to complete host-only containers because manually inserted DOM has no React Fiber for
-events, components, or Hooks. Interactive rows therefore never use the manual
-insertion/removal/LIS path: React reconciles their structure, and Farm only adopts committed host
-elements for binding patches.
+events, components, or Hooks. Interactive rows and rows with local conditional Fibers therefore
+never use the manual insertion/removal/LIS path: React reconciles their structure, and Farm only
+adopts committed host elements for binding patches and row-local snapshot refreshes.
 Unsupported dynamic component types, refs, effects, and other unproven shapes keep React ownership;
 fallback is the optimization's correctness mechanism.
 
@@ -896,6 +944,9 @@ The package and example test suites verify more than generated code:
   direct binding patches without stale virtual-prop output;
 - interactive rows stay coherent across combined parent/local updates, Strict Mode, compatible Fast
   Refresh, recoverable hydration mismatches, and an unmount before the compiler microtask flush;
+- row-local host conditionals refresh only changed keyed slots, remain coherent with inline events
+  and parent updates, preserve row identity through React reorders, switch duplicate keys to React,
+  route failures through error boundaries, and clean subscriptions on unmount;
 - component islands update only dependent children, preserve child-local state and context, route
   failures through React error boundaries, hydrate in Strict Mode, and safely drop queued updates
   after unmount;
@@ -908,14 +959,16 @@ The package and example test suites verify more than generated code:
   produce the same keyed output as normal React while preserving surviving DOM rows;
 - 4,000 deterministic interactive data, structure, and event transitions match normal React while
   the compiled owner remains at one execution;
+- 2,000 deterministic row-conditional data and structural transitions match normal React while the
+  compiled owner remains at one execution;
 - the production browser experiment derives a keyed window from 2,048 source rows without
   rerunning the owner component or corrupting the existing compiler experiments;
 - the production browser experiment also replaces and reorders interactive items, verifies current
   keyed DOM identity and capture/stop-propagation behavior, and observes zero owner update
   executions;
 - the public `List` renders iterable and nullish collections correctly with the compiler off;
-- the packaged runtime, including interactive keyed-row events, reorders, identity, and hydration,
-  is exercised separately with React 18.3 and React 19;
+- the packaged runtime, including interactive keyed-row events, row-local conditions, reorders,
+  identity, and hydration, is exercised separately with React 18.3 and React 19;
 - boolean `data-*` and `aria-*` attributes keep React-compatible string values; and
 - unsupported list shapes, effects, refs, and unsupported dynamic component-island shapes remain
   on React without corrupting output.

--- a/examples/react-compiler/README.md
+++ b/examples/react-compiler/README.md
@@ -5,8 +5,9 @@ This production-browser experiment answers two questions:
 1. Why build this compiler? Eligible local `useState` updates can patch precomputed DOM targets
    without rerunning the component body or asking React to reconcile the same static tree again.
 2. Where must it stop? Dedicated host-only conditionals and keyed lists can use compiler-owned
-   branches or rows. Complex conditionals, custom rows, and component islands use small React-owned
-   boundaries. Effects, refs, unsupported shapes, and other unproven structures stay on React.
+   branches or rows. Keyed rows can also use React-owned local conditional slots with compiler
+   snapshots. Complex conditionals, custom rows, and component islands use React-owned boundaries.
+   Effects, refs, unsupported shapes, and other unproven structures stay on React.
 
 The default `compiler: true` configuration automatically considers components. No annotation is
 needed. A component can explicitly opt out with `"use no compiler"`.
@@ -37,6 +38,7 @@ assertions, checks for console/runtime errors and horizontal overflow, saves scr
 | Automatic keyed map         | stable row DOM, three LIS moves for a four-row reversal  | —                                              | AOT rows patch in place and use the minimum reorder moves.              |
 | Derived keyed collection    | 2,048 source rows filter, sort, slice, and reverse; executions `0` | —                                      | Collection dependencies feed keyed rows without rerunning the owner.    |
 | Interactive keyed rows      | latest item/index after updates and reorder; executions `0` | —                                           | React owns events/structure while Farm patches same-key row bindings.   |
+| Conditional row blocks      | only changed keyed branches refresh; owner executions `0`  | —                                           | Per-key snapshots isolate logical and ternary row content.              |
 | Explicit `List`             | stateful rows reorder, update executions `0`            | —                                              | React preserves custom-row state by key inside the isolated boundary.  |
 | Calculated style bindings   | value `6`, progress `50%`, update executions `0`        | —                                              | Safe calls and individual CSS properties use prepared dependencies.    |
 | Controlled form bindings   | textarea/select/checkbox update, executions `0`         | —                                              | Form properties and textarea selection stay coherent.                  |
@@ -96,6 +98,17 @@ bindings without rerunning the map. When keys are inserted, removed, or reordere
 the structure once; Farm then adopts the committed rows and resumes direct same-key patches. The
 `04C` card verifies capture and stop-propagation behavior, latest-item lookup across three clicks,
 row identity through a reversal, and zero owner update executions.
+
+The `04D` card adds two branch slots to every keyed row. Each logical or ternary expression is the
+only child of a persistent host container. Farm scopes the prepared test and branch-value snapshot
+to the row key, then asks React to refresh only a slot whose selected branch or active values
+changed. The card toggles status and details independently, rotates the rows, checks that their DOM
+identity survives, and verifies zero outer component executions for same-key updates.
+
+React still owns the branch Fiber, initial render, hydration, errors, and every structural list
+commit. This is why row conditionals do not use the manual insertion or LIS path. Branch events,
+components, fragments, refs, SVG, nested blocks, or a conditional mixed with another child in the
+same slot use the existing React-owned list fallback.
 
 Non-inline or async row handlers, controlled interactive form fields, custom components, fragments,
 refs, SVG, static siblings in that same container, and index or missing keys use the React-owned

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -30,6 +30,7 @@ for (const component of [
   "AutomaticKeyedListExperiment",
   "DerivedCollectionExperiment",
   "InteractiveKeyedListExperiment",
+  "RowConditionalListExperiment",
   "ExplicitKeyedListExperiment",
   "StatefulListRow",
   "ComponentIslandExperiment",
@@ -559,6 +560,67 @@ try {
   );
   assert.equal(interactiveListFinalExecutions - interactiveListInitialExecutions, 0);
 
+  const rowConditionals = '[data-experiment="keyed-row-conditionals"]';
+  const rowConditionalsInitialExecutions = await readNumber(
+    page,
+    `${rowConditionals} [data-metric="executions"]`,
+  );
+  await assertText(page, `${rowConditionals} [data-metric="details"]`, "2");
+  await assertText(page, `${rowConditionals} [data-metric="completed"]`, "1");
+  await page.evaluate(() => {
+    window.__farmConditionalRowA = document.querySelector(
+      '[data-experiment="keyed-row-conditionals"] [data-key="a"]',
+    );
+  });
+
+  const conditionalRowA = `${rowConditionals} [data-key="a"]`;
+  const conditionalRowB = `${rowConditionals} [data-key="b"]`;
+  await page.locator(`${conditionalRowA} [data-action="toggle-row-status"]`).click();
+  await assertText(page, `${conditionalRowA} [data-slot="status"]`, "In progress");
+  await assertText(page, `${rowConditionals} [data-metric="completed"]`, "0");
+  await assertText(
+    page,
+    `${conditionalRowA} [data-slot="details"]`,
+    "Compiler graph keeps its keyed DOM identity.",
+  );
+
+  await page.locator(`${conditionalRowB} [data-action="toggle-row-details"]`).click();
+  await assertText(
+    page,
+    `${conditionalRowB} [data-slot="details"]`,
+    "Hydration checks keeps its keyed DOM identity.",
+  );
+  await assertText(page, `${rowConditionals} [data-metric="details"]`, "3");
+
+  await page.locator(`${rowConditionals} [data-action="rotate-conditional-rows"]`).click();
+  assert.deepEqual(
+    await page
+      .locator(`${rowConditionals} [data-list="row-conditionals"] > li`)
+      .evaluateAll((rows) => rows.map((row) => row.getAttribute("data-key"))),
+    ["c", "a", "b"],
+  );
+  assert.equal(
+    await page.evaluate(
+      () =>
+        window.__farmConditionalRowA ===
+        document.querySelector('[data-experiment="keyed-row-conditionals"] [data-key="a"]'),
+    ),
+    true,
+    "React did not preserve a row-local conditional boundary through the reorder",
+  );
+  await page.locator(`${conditionalRowB} [data-action="toggle-row-status"]`).click();
+  await assertText(
+    page,
+    `${conditionalRowB} [data-slot="status"]`,
+    "Hydration checks complete",
+  );
+  await assertText(page, `${rowConditionals} [data-metric="completed"]`, "1");
+  const rowConditionalsFinalExecutions = await readNumber(
+    page,
+    `${rowConditionals} [data-metric="executions"]`,
+  );
+  assert.equal(rowConditionalsFinalExecutions - rowConditionalsInitialExecutions, 0);
+
   const explicitList = '[data-experiment="keyed-explicit"]';
   const explicitListInitialExecutions = await readNumber(
     page,
@@ -817,6 +879,16 @@ try {
             keyedDomIdentityPreserved: true,
             structuralOwner: "React",
             bindingOwner: "Farm",
+          },
+          keyedRowConditionals: {
+            order: ["c", "a", "b"],
+            openDetails: 3,
+            completed: 1,
+            updateExecutions:
+              rowConditionalsFinalExecutions - rowConditionalsInitialExecutions,
+            keyedDomIdentityPreserved: true,
+            structuralOwner: "React",
+            conditionalScheduling: "Farm snapshots",
           },
           explicitKeyedList: {
             order: ["Beta", "Alpha"],

--- a/examples/react-compiler/src/app/globals.css
+++ b/examples/react-compiler/src/app/globals.css
@@ -671,6 +671,102 @@ h1 span {
   padding: 0.4rem 0.6rem;
 }
 
+.edge-card .conditional-row-list {
+  display: grid;
+  align-items: stretch;
+  gap: 0.55rem;
+}
+
+.edge-card .conditional-row {
+  display: grid;
+  width: 100%;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.7rem 1rem;
+  padding: 0.75rem;
+  background: #0d0d0c;
+  transition:
+    border-color 160ms ease,
+    background 160ms ease;
+}
+
+.edge-card .conditional-row:hover {
+  border-color: #696963;
+  background: #10100f;
+}
+
+.conditional-row__summary {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.conditional-row__summary span {
+  overflow: hidden;
+  color: #e9e9e3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.conditional-row__summary small {
+  flex: 0 0 auto;
+  color: #696963;
+  font-size: 0.56rem;
+  letter-spacing: 0.07em;
+}
+
+.conditional-row__status {
+  min-width: 7rem;
+  text-align: right;
+}
+
+.conditional-row__status :is(strong, span) {
+  font-size: 0.58rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.conditional-row__status strong {
+  color: #b8ff5b;
+}
+
+.conditional-row__status span {
+  color: #777771;
+}
+
+.conditional-row__details {
+  min-height: 1.2rem;
+  grid-column: 1 / -1;
+  border-top: 1px solid #2a2a27;
+  padding-top: 0.55rem;
+}
+
+.conditional-row__details:empty {
+  display: none;
+}
+
+.conditional-row__details p {
+  margin: 0;
+  color: #8d8d86;
+  font-family: "Geist Sans Variable", sans-serif;
+  font-size: 0.68rem;
+  line-height: 1.45;
+}
+
+.conditional-row__actions {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.conditional-row__actions button {
+  min-height: 2.25rem;
+  padding: 0.35rem 0.55rem;
+}
+
 .keyed-row-stage {
   display: flex;
   min-height: 2.8rem;
@@ -1201,8 +1297,18 @@ code {
 
   .compact-metrics,
   .button-row,
+  .conditional-row__actions,
   .binding-form {
     grid-template-columns: 1fr;
+  }
+
+  .edge-card .conditional-row {
+    grid-template-columns: 1fr;
+  }
+
+  .conditional-row__status {
+    min-width: 0;
+    text-align: left;
   }
 
   .heavy-controls {

--- a/examples/react-compiler/src/components/compiler-edge-lab.tsx
+++ b/examples/react-compiler/src/components/compiler-edge-lab.tsx
@@ -9,6 +9,7 @@ let multipleBindingExecutions = 0;
 let automaticListExecutions = 0;
 let derivedCollectionExecutions = 0;
 let interactiveListExecutions = 0;
+let rowConditionalListExecutions = 0;
 let explicitListExecutions = 0;
 
 export function CompiledBatchExperiment() {
@@ -421,6 +422,106 @@ export function InteractiveKeyedListExperiment() {
   );
 }
 
+interface ConditionalListItem extends InteractiveListItem {
+  expanded: boolean;
+}
+
+export function RowConditionalListExperiment() {
+  const [items, setItems] = useState<ConditionalListItem[]>([
+    { id: "a", label: "Compiler graph", done: true, expanded: true },
+    { id: "b", label: "Hydration checks", done: false, expanded: false },
+    { id: "c", label: "Runtime cleanup", done: false, expanded: true },
+  ]);
+  const visibleDetails =
+    Number(items[0]?.expanded) + Number(items[1]?.expanded) + Number(items[2]?.expanded);
+  const completedItems =
+    Number(items[0]?.done) + Number(items[1]?.done) + Number(items[2]?.done);
+
+  return (
+    <article className="edge-card" data-experiment="keyed-row-conditionals">
+      <header>
+        <span className="experiment-number">04D</span>
+        <div>
+          <h3>Conditional row blocks</h3>
+          <p>Each key owns small branch boundaries that update independently.</p>
+        </div>
+      </header>
+      <dl className="compact-metrics" aria-live="polite">
+        <div>
+          <dt>Open details</dt>
+          <dd data-metric="details">{visibleDetails}</dd>
+        </div>
+        <div>
+          <dt>Completed</dt>
+          <dd data-metric="completed">{completedItems}</dd>
+        </div>
+        <div>
+          <dt>Executions</dt>
+          <dd data-metric="executions">
+            {typeof window === "undefined" ? 1 : ++rowConditionalListExecutions}
+          </dd>
+        </div>
+      </dl>
+      <ul className="conditional-row-list" data-list="row-conditionals">
+        {items.map((item, index) => (
+          <li className="conditional-row" data-key={item.id} key={item.id}>
+            <div className="conditional-row__summary">
+              <span>{item.label}</span>
+              <small>ROW {index + 1}</small>
+            </div>
+            <div className="conditional-row__status" data-slot="status">
+              {item.done ? (
+                <strong>{item.label} complete</strong>
+              ) : (
+                <span>In progress</span>
+              )}
+            </div>
+            <div className="conditional-row__details" data-slot="details">
+              {item.expanded && <p>{item.label} keeps its keyed DOM identity.</p>}
+            </div>
+            <div className="conditional-row__actions">
+              <button
+                data-action="toggle-row-status"
+                onClick={() =>
+                  setItems((current) =>
+                    current.map((row) =>
+                      row.id === item.id ? { ...row, done: !item.done } : row,
+                    ),
+                  )
+                }
+                type="button"
+              >
+                {item.done ? "Reopen" : "Complete"}
+              </button>
+              <button
+                aria-expanded={item.expanded}
+                data-action="toggle-row-details"
+                onClick={() =>
+                  setItems((current) =>
+                    current.map((row) =>
+                      row.id === item.id ? { ...row, expanded: !item.expanded } : row,
+                    ),
+                  )
+                }
+                type="button"
+              >
+                {item.expanded ? "Hide details" : "Show details"}
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <button
+        data-action="rotate-conditional-rows"
+        onClick={() => setItems((current) => [current[2], current[0], current[1]])}
+        type="button"
+      >
+        Rotate keyed rows
+      </button>
+    </article>
+  );
+}
+
 function StatefulListRow({ item }: { item: ListItem }) {
   const [clicks, setClicks] = useState(0);
   return (
@@ -439,7 +540,7 @@ export function ExplicitKeyedListExperiment() {
   return (
     <article className="edge-card" data-experiment="keyed-explicit">
       <header>
-        <span className="experiment-number">04D</span>
+        <span className="experiment-number">04E</span>
         <div>
           <h3>Explicit List boundary</h3>
           <p>A key selector supports custom rows while React preserves their state.</p>
@@ -500,6 +601,7 @@ export function CompilerEdgeLab() {
         <AutomaticKeyedListExperiment />
         <DerivedCollectionExperiment />
         <InteractiveKeyedListExperiment />
+        <RowConditionalListExperiment />
         <ExplicitKeyedListExperiment />
       </div>
 

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -66,6 +66,7 @@ The current compiler handles components that it can prove have:
 - item-keyed `collection.map(...)` children and explicit `List` boundaries at statically known
   container locations, including supported non-mutating collection pipelines;
 - inline synchronous events inside otherwise eligible host-only keyed rows;
+- row-local logical and ternary host branches inside stable keyed-row containers;
 - stable module-level child components with compiler-safe props;
 - React-managed event handlers; and
 - no refs, effects, or unsupported dynamic child structures.
@@ -73,9 +74,10 @@ The current compiler handles components that it can prove have:
 The generated component preserves React ownership of initial placement, props, events, SSR, and
 hydration. Local state cells batch updates into a microtask and patch only compiler-known DOM
 targets. Proven, dedicated host containers can transfer child ownership after mount for host-only
-conditional branches and non-interactive host-only keyed rows. An interactive host-only row uses a
-hybrid boundary instead: React retains its event handlers and structural reconciliation, while Farm
-patches same-key bindings. React still creates or hydrates all initial DOM. Anything outside those
+conditional branches and non-interactive host-only keyed rows. An interactive row or a row with
+local conditional slots uses a hybrid boundary instead: React retains its events, conditional
+Fibers, and structural reconciliation, while Farm patches same-key bindings and refreshes only
+changed row-local branches. React still creates or hydrates all initial DOM. Anything outside those
 narrow contracts uses a small React-owned boundary or the complete original component.
 
 For a common dedicated conditional, no new component or annotation is required:
@@ -132,6 +134,30 @@ insert, removal, or reorder asks React to reconcile the rows, adopts the committ
 reapplies current bindings, and then resumes direct same-key patches. This avoids creating eventful
 DOM outside React's Fiber tree.
 
+A keyed row may also contain dedicated conditional slots:
+
+```tsx
+<ul>
+  {items.map((item) => (
+    <li key={item.id}>
+      <span>{item.label}</span>
+      <div className="status-slot">
+        {item.done ? <strong>{item.label} complete</strong> : <span>In progress</span>}
+      </div>
+      <section className="details-slot">{item.expanded && <p>{item.description}</p>}</section>
+    </li>
+  ))}
+</ul>
+```
+
+Each conditional must be the only meaningful child of its persistent lowercase host container.
+The compiler records its test and branch bindings per row key. A same-key collection update compares
+those prepared snapshots and asks React to render only the conditional boundaries whose selected
+branch or branch values changed. Other conditional rows and the outer map stay untouched. Inserts,
+removals, and reorders remain React structural commits for these rows, after which Farm re-adopts
+the host skeleton and resumes row-local updates. This keeps empty branches, SSR, hydration,
+recoverable hydration errors, error boundaries, and Fast Refresh inside React's ownership.
+
 A keyed collection may use derived locals or an inline chain of `filter`, `slice`, `toSorted`, and
 `toReversed`:
 
@@ -163,10 +189,10 @@ and unproven calls use the original React fallback.
 the TypeScript `lib` with ES2023 and target a runtime that supports them when using those methods.
 
 React remains the fallback and compatibility boundary. A map beside static children, a row with a
-non-inline or async handler, a controlled interactive form field, a fragment, a ref, or a custom
-component, and other unsupported shapes use the existing React-owned keyed boundary. The outer
-compiled component can still be skipped, but React reconciles that list's rows and owns their
-events, lifecycle, and state.
+non-inline or async handler, a controlled interactive form field, a fragment, a ref, a custom
+component, or a conditional mixed directly beside other children in the same host slot uses the
+existing React-owned keyed boundary. The outer compiled component can still be skipped, but React
+reconciles that list's rows and owns their events, lifecycle, and state.
 
 For custom rows or an explicit key selector, use the public component:
 
@@ -216,13 +242,14 @@ An empty ternary branch may be `null` or `false`. The inactive branch is describ
 is never pre-mounted or cached. If a logical `&&` evaluates to a number such as `0`, the runtime also
 falls back to React so JavaScript and React rendering semantics remain exact.
 
-All supported boundary types share one component-wide block graph and one ID sequence. A nested
+All component-level boundary types share one block graph and one ID sequence. A nested
 binding records its nearest conditional parent. If one state flush affects both an outer
 conditional and its descendants, the runtime refreshes the mounted outer boundary once and skips
 the redundant descendant refreshes. React unmounts inner boundaries normally, their subscriptions
 are removed, and a later remount reads the latest compiler-cell values. Host-only keyed rows have
-separate runtime instances per key. Unsupported row subtrees stay complete React-owned keyed
-boundaries instead of receiving ambiguous shared block IDs.
+separate runtime instances per key. Row-local conditional IDs are scoped to that instance and
+paired with its stable key, so two rows can use the same build-time slot ID without sharing data or
+subscriptions. Unsupported row subtrees stay complete React-owned keyed boundaries.
 
 Unsupported components fall back to React by default. Use `onUnsupported: "warn"` for diagnostics
 or `onUnsupported: "error"` while tightening an annotated migration.
@@ -250,6 +277,7 @@ Application and prototype calls, dynamic style objects, handlers outside JSX eve
 computed, and rest props patterns, async handlers, unkeyed or index-keyed lists, chained maps,
 unsupported conditional roots, effects, and more advanced hook support intentionally stay on React
 in this release. Compiler-owned keyed rows are limited to a dedicated container with one host-only
-map or `List`. Inline synchronous events can use the hybrid keyed-row path, but non-inline or async
-row handlers, controlled interactive row forms, custom components, fragments, refs, SVG, mixed
-static siblings, and duplicate runtime keys keep or switch to React ownership.
+map or `List`. Inline synchronous events and dedicated row-local host conditional slots can use the
+hybrid keyed-row path, but branch events, nested dynamic blocks, conditionals mixed with siblings in
+one slot, non-inline or async row handlers, controlled interactive row forms, custom components,
+fragments, refs, SVG, and duplicate runtime keys keep or switch to React ownership.

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -453,8 +453,8 @@ const testSource = String.raw`
   const InteractiveKeyedRows = createCompiledComponent({
     displayName: "CompatibilityInteractiveKeyedRows",
     initialize: () => [[
-      { id: "a", label: "Alpha" },
-      { id: "b", label: "Beta" },
+      { id: "a", label: "Alpha", done: false },
+      { id: "b", label: "Beta", done: true },
     ]],
     render(_props, state, blocks) {
       interactiveRowExecutions += 1;
@@ -465,7 +465,7 @@ const testSource = String.raw`
         null,
         React.createElement(blocks.KeyedRows, {
           id: 0,
-          render: (rowEvent) => {
+          render: (rowEvent, rowConditional) => {
             interactiveListRenders += 1;
             return React.createElement(
               "ol",
@@ -475,6 +475,15 @@ const testSource = String.raw`
                   "li",
                   { key: item.id, "data-key": item.id },
                   React.createElement("span", null, item.label),
+                  React.createElement(
+                    "div",
+                    { "data-status": true },
+                    rowConditional(item, index, 0, (current) =>
+                      current.done
+                        ? React.createElement("strong", null, current.label + " done")
+                        : React.createElement("small", null, "Open"),
+                    ),
+                  ),
                   React.createElement(
                     "button",
                     {
@@ -505,6 +514,13 @@ const testSource = String.raw`
               },
               {
                 kind: "element",
+                tag: "div",
+                attributes: [{ name: "data-status", value: true }],
+                styles: [],
+                children: [],
+              },
+              {
+                kind: "element",
                 tag: "button",
                 attributes: [
                   { name: "data-index", value: index },
@@ -517,7 +533,21 @@ const testSource = String.raw`
           }),
           bindings: [
             { kind: "text", path: [0], read: (item) => [item.label] },
-            { kind: "attribute", path: [1], name: "data-index", read: (_item, index) => index },
+            { kind: "attribute", path: [2], name: "data-index", read: (_item, index) => index },
+          ],
+          conditionals: [
+            {
+              id: 0,
+              path: [1],
+              logical: false,
+              test: (item) => item.done,
+              truthy: {
+                bindings: [
+                  { kind: "text", path: [], read: (item) => [item.label] },
+                ],
+              },
+              falsy: { bindings: [] },
+            },
           ],
           events: [
             {
@@ -526,7 +556,9 @@ const testSource = String.raw`
                 interactiveCalls.push(item.label + ":" + index + ":" + event.currentTarget.dataset.index);
                 state[0].set((current) =>
                   current.map((row) =>
-                    row.id === item.id ? { ...row, label: item.label + "!" } : row,
+                    row.id === item.id
+                      ? { ...row, label: item.label + "!", done: !item.done }
+                      : row,
                   ),
                 );
               },
@@ -549,6 +581,7 @@ const testSource = String.raw`
   await Promise.resolve();
   await Promise.resolve();
   assert.equal(interactiveAlpha.querySelector("span").textContent, "Alpha!");
+  assert.equal(interactiveAlpha.querySelector("[data-status]").textContent, "Alpha! done");
   assert.deepEqual(interactiveCalls, ["Alpha:0:0"]);
   assert.equal(interactiveRowExecutions, initialInteractiveExecutions);
   assert.equal(interactiveListRenders, initialInteractiveRenders);
@@ -558,6 +591,7 @@ const testSource = String.raw`
   await Promise.resolve();
   await Promise.resolve();
   assert.equal(interactiveAlpha.querySelector("span").textContent, "Alpha!!");
+  assert.equal(interactiveAlpha.querySelector("[data-status]").textContent, "Open");
   assert.deepEqual(interactiveCalls, ["Alpha:0:0", "Alpha!:0:0"]);
   assert.equal(interactiveContainer.querySelector("[data-key='a']"), interactiveAlpha);
 
@@ -575,6 +609,7 @@ const testSource = String.raw`
   await Promise.resolve();
   await Promise.resolve();
   assert.equal(interactiveAlpha.querySelector("span").textContent, "Alpha!!!");
+  assert.equal(interactiveAlpha.querySelector("[data-status]").textContent, "Alpha!!! done");
   assert.deepEqual(interactiveCalls, ["Alpha:0:0", "Alpha!:0:0", "Alpha!!:1:1"]);
   flushSync(() => interactiveRoot.unmount());
 
@@ -597,6 +632,10 @@ const testSource = String.raw`
   await Promise.resolve();
   await Promise.resolve();
   assert.equal(hydratedInteractiveAlpha.querySelector("span").textContent, "Alpha!");
+  assert.equal(
+    hydratedInteractiveAlpha.querySelector("[data-status]").textContent,
+    "Alpha! done",
+  );
   flushSync(() => interactiveHydrationRoot.unmount());
 
   let derivedCollectionExecutions = 0;

--- a/packages/farm-react/src/__tests__/compiler-keyed-row-conditionals.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-row-conditionals.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true);
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/RowConditionals.tsx", infer);
+}
+
+describe("React AOT keyed-row conditional compiler", () => {
+  it("isolates host conditionals inside keyed rows", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Tasks() {
+        const [items, setItems] = useState([
+          { id: "a", label: "Alpha", done: false, expanded: true },
+        ]);
+        return (
+          <main>
+            <button onClick={() => setItems((rows) => rows)}>Refresh</button>
+            <ul>
+              {items.map((item, index) => (
+                <li data-index={index} key={item.id}>
+                  <span>{item.label}</span>
+                  <div className="status">
+                    {item.done && <strong data-state={item.label}>Completed</strong>}
+                  </div>
+                  <section className="details">
+                    {item.expanded
+                      ? <p title={item.label}>{item.label} details</p>
+                      : <small>Collapsed</small>}
+                  </section>
+                </li>
+              ))}
+            </ul>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Tasks"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedRows");
+    expect(result.code).toContain("conditionals={[");
+    expect(result.code).toContain("_farmRowConditional(item, index, 0");
+    expect(result.code).toContain("_farmRowConditional(item, index, 1");
+    expect(result.code).toContain("logical: true");
+    expect(result.code).toContain("logical: false");
+    expect(result.code).not.toContain("farmBlocks.KeyedList");
+    await expect(
+      transformWithEsbuild(result.code, "/app/RowConditionals.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({ code: expect.stringContaining("farmBlocks.KeyedRows") });
+  });
+
+  it("composes row events and conditionals through the public List boundary", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List } from "@farm.js/react/list";
+      export function Tasks() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha", done: false }]);
+        return (
+          <main>
+            <ul>
+              <List each={items} by={(item) => item.id}>
+                {(item) => (
+                  <li>
+                    <button onClick={() => setItems([{ ...item, done: !item.done }])}>Toggle</button>
+                    <div>{item.done ? <strong>{item.label}</strong> : <span>Open</span>}</div>
+                  </li>
+                )}
+              </List>
+            </ul>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Tasks"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedRows");
+    expect(result.code).toContain("_farmRowEvent(item, 0, 0)");
+    expect(result.code).toContain("_farmRowConditional(item, 0, 0");
+    expect(result.code).toContain('name: "onClick"');
+    expect(result.code).toContain("conditionals={[");
+  });
+
+  it.each([
+    {
+      name: "a conditional beside another child in the same host",
+      content: "<span>Always</span>{item.done && <strong>Done</strong>}",
+    },
+    {
+      name: "an event inside the conditional branch",
+      content: "{item.done && <button onClick={() => setItems([])}>Done</button>}",
+    },
+    {
+      name: "a component inside the conditional branch",
+      content: "{item.done && <Status value={item.label} />}",
+      declaration: "function Status({ value }) { return <strong>{value}</strong>; }",
+    },
+    {
+      name: "a fragment conditional branch",
+      content: "{item.done ? <><strong>Done</strong></> : <span>Open</span>}",
+    },
+  ])("keeps $name on the React-owned keyed boundary", async ({ content, declaration = "" }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      ${declaration}
+      export function Tasks() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha", done: false }]);
+        return (
+          <main>
+            <ul>
+              {items.map((item) => (
+                <li key={item.id}>
+                  <div>${content}</div>
+                </li>
+              ))}
+            </ul>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Tasks"]);
+    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).not.toContain("farmBlocks.KeyedRows");
+    expect(result.code).not.toContain("_farmRowConditional");
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-row-conditionals.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-row-conditionals.test.tsx
@@ -1,0 +1,1011 @@
+import React, { StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createCompiledComponent,
+  type CompilerKeyedRowElement,
+  type CompilerStateUpdater,
+} from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Item {
+  id: string;
+  label: string;
+  done: boolean;
+  expanded?: boolean;
+  fail?: boolean;
+}
+
+const roots: Array<{ unmount(): void }> = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function rowDescriptor(item: Item, index: number): CompilerKeyedRowElement {
+  return {
+    kind: "element",
+    tag: "li",
+    attributes: [
+      { name: "data-key", value: item.id },
+      { name: "data-index", value: index },
+    ],
+    styles: [],
+    children: [
+      {
+        kind: "element",
+        tag: "span",
+        attributes: [],
+        styles: [],
+        children: [item.label],
+      },
+      {
+        kind: "element",
+        tag: "div",
+        attributes: [{ name: "data-status", value: "" }],
+        styles: [],
+        children: [],
+      },
+      {
+        kind: "element",
+        tag: "section",
+        attributes: [{ name: "data-details", value: "" }],
+        styles: [],
+        children: [],
+      },
+    ],
+  };
+}
+
+function rowBindings() {
+  return [
+    {
+      kind: "attribute" as const,
+      name: "data-index",
+      path: [] as const,
+      read: (_item: unknown, index: number) => index,
+    },
+    {
+      kind: "text" as const,
+      path: [0] as const,
+      read: (item: unknown) => [(item as Item).label],
+    },
+  ];
+}
+
+function rowConditionals() {
+  return [
+    {
+      id: 0,
+      path: [1],
+      logical: false,
+      test: (item: unknown) => (item as Item).done,
+      truthy: {
+        bindings: [
+          {
+            kind: "text" as const,
+            path: [] as const,
+            read: (item: unknown) => [(item as Item).label],
+          },
+        ],
+      },
+      falsy: { bindings: [] },
+    },
+    {
+      id: 1,
+      path: [2],
+      logical: true,
+      test: (item: unknown) => (item as Item).expanded,
+      truthy: {
+        bindings: [
+          {
+            kind: "text" as const,
+            path: [] as const,
+            read: (item: unknown) => [(item as Item).label],
+          },
+        ],
+      },
+    },
+  ];
+}
+
+describe("compiled keyed-row conditionals runtime", () => {
+  it("refreshes only the changed conditional in the changed keyed row", async () => {
+    let executions = 0;
+    let listRenders = 0;
+    let setItems: (next: CompilerStateUpdater) => void = () => undefined;
+    const conditionalRenders = new Map<string, number>();
+    const Tasks = createCompiledComponent({
+      displayName: "RowLocalConditionals",
+      initialize: () => [
+        [
+          { id: "a", label: "Alpha", done: false, expanded: false },
+          { id: "b", label: "Beta", done: false, expanded: true },
+        ],
+      ],
+      render(_props: Record<string, never>, state, blocks) {
+        executions += 1;
+        setItems = (next) => state[0].set(next);
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <KeyedRows
+              bindings={rowBindings()}
+              conditionals={rowConditionals()}
+              create={(item, index) => rowDescriptor(item as Item, index)}
+              id={0}
+              items={items}
+              render={(_rowEvent, rowConditional) => {
+                listRenders += 1;
+                return (
+                  <ul>
+                    {items().map((item, index) => (
+                      <li data-index={index} data-key={item.id} key={item.id}>
+                        <span>{item.label}</span>
+                        <div data-status>
+                          {rowConditional(item, index, 0, (current) => {
+                            const latest = current as Item;
+                            conditionalRenders.set(
+                              `status:${latest.id}`,
+                              (conditionalRenders.get(`status:${latest.id}`) || 0) + 1,
+                            );
+                            return latest.done ? (
+                              <strong>{latest.label} completed</strong>
+                            ) : (
+                              <small>Open</small>
+                            );
+                          })}
+                        </div>
+                        <section data-details>
+                          {rowConditional(item, index, 1, (current) => {
+                            const latest = current as Item;
+                            conditionalRenders.set(
+                              `details:${latest.id}`,
+                              (conditionalRenders.get(`details:${latest.id}`) || 0) + 1,
+                            );
+                            return latest.expanded ? <p>{latest.label} details</p> : null;
+                          })}
+                        </section>
+                      </li>
+                    ))}
+                  </ul>
+                );
+              }}
+              rowKey={(item) => (item as Item).id}
+            />
+          </main>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Tasks />));
+
+    const alpha = container.querySelector<HTMLLIElement>('[data-key="a"]')!;
+    const beta = container.querySelector<HTMLLIElement>('[data-key="b"]')!;
+    const initialRenders = new Map(conditionalRenders);
+
+    await act(async () => {
+      setItems((current) =>
+        (current as Item[]).map((item) =>
+          item.id === "b" ? { ...item, label: "Beta newest", done: true } : item,
+        ),
+      );
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-key="b"]')).toBe(beta);
+    expect(beta.querySelector("span")?.textContent).toBe("Beta newest");
+    expect(beta.querySelector("[data-status]")?.textContent).toBe("Beta newest completed");
+    expect(beta.querySelector("[data-details]")?.textContent).toBe("Beta newest details");
+    expect(conditionalRenders.get("status:a")).toBe(initialRenders.get("status:a"));
+    expect(conditionalRenders.get("details:a")).toBe(initialRenders.get("details:a"));
+    expect(conditionalRenders.get("status:b")).toBe((initialRenders.get("status:b") || 0) + 1);
+    expect(conditionalRenders.get("details:b")).toBe((initialRenders.get("details:b") || 0) + 1);
+    expect(executions).toBe(1);
+    expect(listRenders).toBe(1);
+  });
+
+  it("lets React reorder row-local boundaries, preserves keyed DOM, then resumes direct refreshes", async () => {
+    let executions = 0;
+    let listRenders = 0;
+    let setItems: (next: CompilerStateUpdater) => void = () => undefined;
+    const Tasks = createCompiledComponent({
+      displayName: "StructuralRowConditionals",
+      initialize: () => [
+        [
+          { id: "a", label: "Alpha", done: false },
+          { id: "b", label: "Beta", done: true },
+          { id: "c", label: "Gamma", done: false },
+        ],
+      ],
+      render(_props: Record<string, never>, state, blocks) {
+        executions += 1;
+        setItems = (next) => state[0].set(next);
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <KeyedRows
+              bindings={rowBindings()}
+              conditionals={rowConditionals().slice(0, 1)}
+              create={(item, index) => rowDescriptor(item as Item, index)}
+              id={0}
+              items={items}
+              render={(_rowEvent, rowConditional) => {
+                listRenders += 1;
+                return (
+                  <ul>
+                    {items().map((item, index) => (
+                      <li data-index={index} data-key={item.id} key={item.id}>
+                        <span>{item.label}</span>
+                        <div data-status>
+                          {rowConditional(item, index, 0, (current) =>
+                            (current as Item).done ? (
+                              <strong>{(current as Item).label} completed</strong>
+                            ) : (
+                              <small>Open</small>
+                            ),
+                          )}
+                        </div>
+                        <section data-details />
+                      </li>
+                    ))}
+                  </ul>
+                );
+              }}
+              rowKey={(item) => (item as Item).id}
+            />
+          </main>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Tasks />));
+    const original = new Map(
+      [...container.querySelectorAll<HTMLLIElement>("li")].map((row) => [row.dataset.key, row]),
+    );
+
+    await act(async () => {
+      setItems([
+        { id: "c", label: "Gamma", done: true },
+        { id: "a", label: "Alpha", done: false },
+        { id: "b", label: "Beta newest", done: true },
+      ]);
+      await flushCompilerUpdates();
+    });
+
+    const rows = [...container.querySelectorAll<HTMLLIElement>("li")];
+    expect(rows.map((row) => row.dataset.key)).toEqual(["c", "a", "b"]);
+    expect(rows.every((row) => row === original.get(row.dataset.key))).toBe(true);
+    expect(rows[0].querySelector("[data-status]")?.textContent).toBe("Gamma completed");
+    expect(rows[2].querySelector("[data-status]")?.textContent).toBe("Beta newest completed");
+    expect(executions).toBe(1);
+    expect(listRenders).toBe(2);
+
+    await act(async () => {
+      setItems((current) =>
+        (current as Item[]).map((item) => (item.id === "a" ? { ...item, done: true } : item)),
+      );
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector('[data-key="a"] [data-status]')?.textContent).toBe(
+      "Alpha completed",
+    );
+    expect(listRenders).toBe(2);
+  });
+
+  it("updates a row conditional from a React event without stale item data", async () => {
+    const observed: string[] = [];
+    let listRenders = 0;
+    const Tasks = createCompiledComponent({
+      displayName: "InteractiveRowConditionals",
+      initialize: () => [[{ id: "a", label: "Alpha", done: false }]],
+      render(_props: Record<string, never>, state, blocks) {
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <KeyedRows
+              bindings={rowBindings()}
+              conditionals={rowConditionals().slice(0, 1)}
+              create={(item, index) => ({
+                ...rowDescriptor(item as Item, index),
+                children: [
+                  ...rowDescriptor(item as Item, index).children.slice(0, 2),
+                  {
+                    kind: "element",
+                    tag: "section",
+                    attributes: [{ name: "data-details", value: "" }],
+                    styles: [],
+                    children: [
+                      {
+                        kind: "element",
+                        tag: "button",
+                        attributes: [{ name: "type", value: "button" }],
+                        styles: [],
+                        children: ["Toggle"],
+                      },
+                    ],
+                  },
+                ],
+              })}
+              events={[
+                {
+                  name: "onClick",
+                  invoke: (item) => {
+                    const current = item as Item;
+                    observed.push(`${current.label}:${current.done}`);
+                    state[0].set([{ ...current, label: `${current.label}!`, done: !current.done }]);
+                  },
+                },
+              ]}
+              id={0}
+              items={items}
+              render={(rowEvent, rowConditional) => {
+                listRenders += 1;
+                return (
+                  <ul>
+                    {items().map((item, index) => (
+                      <li data-index={index} data-key={item.id} key={item.id}>
+                        <span>{item.label}</span>
+                        <div data-status>
+                          {rowConditional(item, index, 0, (current) =>
+                            (current as Item).done ? <strong>Done</strong> : <small>Open</small>,
+                          )}
+                        </div>
+                        <section data-details>
+                          <button onClick={rowEvent(item, index, 0)} type="button">
+                            Toggle
+                          </button>
+                        </section>
+                      </li>
+                    ))}
+                  </ul>
+                );
+              }}
+              rowKey={(item) => (item as Item).id}
+            />
+          </main>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Tasks />));
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("button")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("li span")?.textContent).toBe("Alpha!");
+    expect(container.querySelector("[data-status]")?.textContent).toBe("Done");
+    expect(listRenders).toBe(1);
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("button")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("li span")?.textContent).toBe("Alpha!!");
+    expect(container.querySelector("[data-status]")?.textContent).toBe("Open");
+    expect(observed).toEqual(["Alpha:false", "Alpha!:true"]);
+    expect(listRenders).toBe(1);
+  });
+
+  it("keeps a parent prop commit and row-local conditional update coherent in one turn", async () => {
+    interface TasksProps {
+      prefix: string;
+      changePrefix(): void;
+    }
+
+    const Tasks = createCompiledComponent({
+      displayName: "ParentRowConditionals",
+      initialize: () => [[{ id: "a", label: "Alpha", done: false }]],
+      render(props: TasksProps, state, blocks) {
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        const conditionals = rowConditionals().slice(0, 1);
+        conditionals[0] = {
+          ...conditionals[0],
+          truthy: {
+            bindings: [
+              {
+                kind: "text",
+                path: [],
+                read: (item) => [`${props.prefix}:${(item as Item).label}`],
+              },
+            ],
+          },
+        };
+        return (
+          <main>
+            <KeyedRows
+              bindings={rowBindings()}
+              conditionals={conditionals}
+              create={(item, index) => ({
+                ...rowDescriptor(item as Item, index),
+                children: [
+                  ...rowDescriptor(item as Item, index).children.slice(0, 2),
+                  {
+                    kind: "element",
+                    tag: "section",
+                    attributes: [{ name: "data-details", value: "" }],
+                    styles: [],
+                    children: [
+                      {
+                        kind: "element",
+                        tag: "button",
+                        attributes: [{ name: "type", value: "button" }],
+                        styles: [],
+                        children: ["Update"],
+                      },
+                    ],
+                  },
+                ],
+              })}
+              events={[
+                {
+                  name: "onClick",
+                  invoke: (item) => {
+                    props.changePrefix();
+                    state[0].set([{ ...(item as Item), label: "Newest", done: true }]);
+                  },
+                },
+              ]}
+              id={0}
+              items={items}
+              render={(rowEvent, rowConditional) => (
+                <ul>
+                  {items().map((item, index) => (
+                    <li data-index={index} data-key={item.id} key={item.id}>
+                      <span>{item.label}</span>
+                      <div data-status>
+                        {rowConditional(item, index, 0, (current) =>
+                          (current as Item).done ? (
+                            <strong>
+                              {props.prefix}:{(current as Item).label}
+                            </strong>
+                          ) : (
+                            <small>Open</small>
+                          ),
+                        )}
+                      </div>
+                      <section data-details>
+                        <button onClick={rowEvent(item, index, 0)} type="button">
+                          Update
+                        </button>
+                      </section>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+            />
+          </main>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    function Parent() {
+      const [prefix, setPrefix] = useState("old");
+      return <Tasks changePrefix={() => setPrefix("new")} prefix={prefix} />;
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Parent />));
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("button")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("li span")?.textContent).toBe("Newest");
+    expect(container.querySelector("[data-status]")?.textContent).toBe("new:Newest");
+  });
+
+  it("switches duplicate runtime keys to ordinary React conditional rendering", async () => {
+    let setItems: (next: CompilerStateUpdater) => void = () => undefined;
+    let listRenders = 0;
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const Tasks = createCompiledComponent({
+      displayName: "DuplicateRowConditionals",
+      initialize: () => [[{ id: "a", label: "Alpha", done: false }]],
+      render(_props: Record<string, never>, state, blocks) {
+        setItems = (next) => state[0].set(next);
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <KeyedRows
+              bindings={rowBindings()}
+              conditionals={rowConditionals().slice(0, 1)}
+              create={(item, index) => rowDescriptor(item as Item, index)}
+              id={0}
+              items={items}
+              render={(_rowEvent, rowConditional) => {
+                listRenders += 1;
+                return (
+                  <ul>
+                    {items().map((item, index) => (
+                      <li data-index={index} data-key={item.id} key={`${item.id}:${index}`}>
+                        <span>{item.label}</span>
+                        <div data-status>
+                          {rowConditional(item, index, 0, (current) =>
+                            (current as Item).done ? <strong>Done</strong> : <small>Open</small>,
+                          )}
+                        </div>
+                        <section data-details />
+                      </li>
+                    ))}
+                  </ul>
+                );
+              }}
+              rowKey={(item) => (item as Item).id}
+            />
+          </main>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Tasks />));
+
+    await act(async () => {
+      setItems([
+        { id: "a", label: "First", done: false },
+        { id: "a", label: "Second", done: true },
+      ]);
+      await flushCompilerUpdates();
+    });
+    expect(
+      [...container.querySelectorAll("[data-status]")].map((node) => node.textContent),
+    ).toEqual(["Open", "Done"]);
+
+    await act(async () => {
+      setItems([
+        { id: "a", label: "First newest", done: true },
+        { id: "a", label: "Second newest", done: false },
+      ]);
+      await flushCompilerUpdates();
+    });
+    expect(
+      [...container.querySelectorAll("[data-status]")].map((node) => node.textContent),
+    ).toEqual(["Done", "Open"]);
+    expect(listRenders).toBeGreaterThan(1);
+  });
+
+  it("preserves keyed state and replaces conditional behavior through compatible Fast Refresh", async () => {
+    const hmrId = `keyed-row-conditionals-refresh-${Math.random()}`;
+
+    const defineTasks = (version: "v1" | "v2") =>
+      createCompiledComponent({
+        displayName: "RefreshableRowConditionals",
+        hmrId,
+        stateSignature: "items",
+        initialize: () => [[{ id: "a", label: "Alpha", done: true, expanded: true }]],
+        render(_props: Record<string, never>, state, blocks) {
+          const items = () => state[0].get() as Item[];
+          const KeyedRows = blocks.KeyedRows;
+          const conditionals = rowConditionals().slice(0, version === "v2" ? 2 : 1);
+          conditionals[0] = {
+            ...conditionals[0],
+            truthy: {
+              bindings: [
+                {
+                  kind: "text",
+                  path: [],
+                  read: (item) => [`${version}:${(item as Item).label}`],
+                },
+              ],
+            },
+          };
+          return (
+            <main>
+              <button
+                onClick={() => state[0].set([{ ...items()[0], label: "Updated" }])}
+                type="button"
+              >
+                Update
+              </button>
+              <KeyedRows
+                bindings={rowBindings()}
+                conditionals={conditionals}
+                create={(item, index) => rowDescriptor(item as Item, index)}
+                id={0}
+                items={items}
+                render={(_rowEvent, rowConditional) => (
+                  <ul>
+                    {items().map((item, index) => (
+                      <li data-index={index} data-key={item.id} key={item.id}>
+                        <span>{item.label}</span>
+                        <div data-status>
+                          {rowConditional(item, index, 0, (current) =>
+                            (current as Item).done ? (
+                              <strong>
+                                {version}:{(current as Item).label}
+                              </strong>
+                            ) : null,
+                          )}
+                        </div>
+                        <section data-details>
+                          {version === "v2"
+                            ? rowConditional(item, index, 1, (current) =>
+                                (current as Item).expanded ? <p>Expanded</p> : null,
+                              )
+                            : null}
+                        </section>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                rowKey={(item) => (item as Item).id}
+              />
+            </main>
+          );
+        },
+        bindings: [{ kind: "block" as const, id: 0, dependencies: [0] }],
+      });
+
+    const Initial = defineTasks("v1");
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Initial />));
+    const row = container.querySelector("li");
+
+    let Refreshed = Initial;
+    await act(async () => {
+      Refreshed = defineTasks("v2");
+      root.render(<Refreshed />);
+      await flushCompilerUpdates();
+    });
+    expect(Refreshed).toBe(Initial);
+    expect(container.querySelector("li")).toBe(row);
+    expect(container.querySelector("[data-status]")?.textContent).toBe("v2:Alpha");
+    expect(container.querySelector("[data-details]")?.textContent).toBe("Expanded");
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("button")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("[data-status]")?.textContent).toBe("v2:Updated");
+  });
+
+  it("hydrates in StrictMode, recovers mismatches, and drops queued conditional work on unmount", async () => {
+    let setItems: (next: CompilerStateUpdater) => void = () => undefined;
+    const Tasks = createCompiledComponent({
+      displayName: "HydratedRowConditionals",
+      initialize: () => [[{ id: "a", label: "Alpha", done: false }]],
+      render(_props: Record<string, never>, state, blocks) {
+        setItems = (next) => state[0].set(next);
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <KeyedRows
+              bindings={rowBindings()}
+              conditionals={rowConditionals().slice(0, 1)}
+              create={(item, index) => rowDescriptor(item as Item, index)}
+              id={0}
+              items={items}
+              render={(_rowEvent, rowConditional) => (
+                <ul>
+                  {items().map((item, index) => (
+                    <li data-index={index} data-key={item.id} key={item.id}>
+                      <span>{item.label}</span>
+                      <div data-status>
+                        {rowConditional(item, index, 0, (current) =>
+                          (current as Item).done ? <strong>Done</strong> : <small>Open</small>,
+                        )}
+                      </div>
+                      <section data-details />
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+            />
+          </main>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const serverHtml = renderToString(
+      <StrictMode>
+        <Tasks />
+      </StrictMode>,
+    );
+    const container = document.createElement("div");
+    container.innerHTML = serverHtml.replace("Open", "Server mismatch");
+    document.body.append(container);
+    const recoverable = vi.fn();
+    const root = hydrateRoot(
+      container,
+      <StrictMode>
+        <Tasks />
+      </StrictMode>,
+      { onRecoverableError: recoverable },
+    );
+    roots.push(root);
+    await act(async () => flushCompilerUpdates());
+
+    expect(container.querySelector("[data-status]")?.textContent).toBe("Open");
+    expect(recoverable).toHaveBeenCalled();
+
+    await act(async () => {
+      setItems([{ id: "a", label: "Client", done: true }]);
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("li span")?.textContent).toBe("Client");
+    expect(container.querySelector("[data-status]")?.textContent).toBe("Done");
+
+    await act(async () => {
+      setItems([{ id: "a", label: "Queued", done: false }]);
+      root.unmount();
+      await flushCompilerUpdates();
+    });
+    roots.splice(roots.indexOf(root), 1);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("routes conditional snapshot failures through the nearest React error boundary", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    class Boundary extends React.Component<
+      { children: React.ReactNode },
+      { message: string | null }
+    > {
+      state = { message: null as string | null };
+
+      static getDerivedStateFromError(error: Error) {
+        return { message: error.message };
+      }
+
+      render() {
+        return this.state.message ? <p data-error>{this.state.message}</p> : this.props.children;
+      }
+    }
+
+    const conditionals = rowConditionals().slice(0, 1);
+    conditionals[0] = {
+      ...conditionals[0],
+      truthy: {
+        bindings: [
+          {
+            kind: "text",
+            path: [],
+            read: (item) => {
+              if ((item as Item).fail) throw new Error("row conditional failed");
+              return [(item as Item).label];
+            },
+          },
+        ],
+      },
+    };
+    const Tasks = createCompiledComponent({
+      displayName: "FailingRowConditional",
+      initialize: () => [[{ id: "a", label: "Alpha", done: false }]],
+      render(_props: Record<string, never>, state, blocks) {
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <button
+              onClick={() => state[0].set([{ id: "a", label: "Broken", done: true, fail: true }])}
+              type="button"
+            >
+              Break
+            </button>
+            <KeyedRows
+              bindings={rowBindings()}
+              conditionals={conditionals}
+              create={(item, index) => rowDescriptor(item as Item, index)}
+              id={0}
+              items={items}
+              render={(_rowEvent, rowConditional) => (
+                <ul>
+                  {items().map((item, index) => (
+                    <li data-index={index} data-key={item.id} key={item.id}>
+                      <span>{item.label}</span>
+                      <div data-status>
+                        {rowConditional(item, index, 0, (current) =>
+                          (current as Item).done ? (
+                            <strong>{(current as Item).label}</strong>
+                          ) : null,
+                        )}
+                      </div>
+                      <section data-details />
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+            />
+          </main>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <Boundary>
+          <Tasks />
+        </Boundary>,
+      ),
+    );
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("button")!.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("[data-error]")?.textContent).toBe("row conditional failed");
+  });
+
+  it("matches React through 2,000 deterministic data and structural transitions", async () => {
+    let compiledSet: (next: CompilerStateUpdater) => void = () => undefined;
+    let reactSet: React.Dispatch<React.SetStateAction<Item[]>> = () => undefined;
+    let compiledExecutions = 0;
+    const initial: Item[] = [
+      { id: "a", label: "A", done: false },
+      { id: "b", label: "B", done: true },
+      { id: "c", label: "C", done: false },
+    ];
+
+    const view = (items: Item[]) => (
+      <main>
+        <ul>
+          {items.map((item, index) => (
+            <li data-index={index} data-key={item.id} key={item.id}>
+              <span>{item.label}</span>
+              <div data-status>
+                {item.done ? <strong>{item.label} done</strong> : <small>Open</small>}
+              </div>
+              <section data-details />
+            </li>
+          ))}
+        </ul>
+      </main>
+    );
+
+    const Compiled = createCompiledComponent({
+      displayName: "DifferentialRowConditionals",
+      initialize: () => [initial],
+      render(_props: Record<string, never>, state, blocks) {
+        compiledExecutions += 1;
+        compiledSet = (next) => state[0].set(next);
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <KeyedRows
+              bindings={rowBindings()}
+              conditionals={rowConditionals().slice(0, 1)}
+              create={(item, index) => rowDescriptor(item as Item, index)}
+              id={0}
+              items={items}
+              render={(_rowEvent, rowConditional) => (
+                <ul>
+                  {items().map((item, index) => (
+                    <li data-index={index} data-key={item.id} key={item.id}>
+                      <span>{item.label}</span>
+                      <div data-status>
+                        {rowConditional(item, index, 0, (current) =>
+                          (current as Item).done ? (
+                            <strong>{(current as Item).label} done</strong>
+                          ) : (
+                            <small>Open</small>
+                          ),
+                        )}
+                      </div>
+                      <section data-details />
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+            />
+          </main>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    function Baseline() {
+      const [items, setItems] = useState(initial);
+      reactSet = setItems;
+      return view(items);
+    }
+
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<Compiled />);
+      reactRoot.render(<Baseline />);
+    });
+
+    for (let step = 0; step < 2_000; step += 1) {
+      const update = (items: Item[]): Item[] => {
+        const next = items.map((item) => ({ ...item }));
+        const operation = step % 5;
+        if (operation === 0 && next.length > 0) {
+          const index = step % next.length;
+          next[index] = {
+            ...next[index],
+            label: `${next[index].id}-${step}`,
+            done: !next[index].done,
+          };
+        } else if (operation === 1 && next.length > 1) {
+          next.unshift(next.pop()!);
+        } else if (operation === 2 && next.length < 7) {
+          const id = `n${step}`;
+          next.splice(step % (next.length + 1), 0, { id, label: id, done: step % 2 === 0 });
+        } else if (operation === 3 && next.length > 2) {
+          next.splice(step % next.length, 1);
+        } else {
+          next.reverse();
+        }
+        return next;
+      };
+
+      await act(async () => {
+        compiledSet((current) => update(current as Item[]));
+        reactSet((current) => update(current));
+        await flushCompilerUpdates();
+      });
+      expect(compiledContainer.innerHTML).toBe(reactContainer.innerHTML);
+    }
+
+    expect(compiledExecutions).toBe(1);
+  }, 20_000);
+});

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { flushSync } from "react-dom";
 
 export type CompilerStateUpdater = unknown | ((previous: unknown) => unknown);
 
@@ -82,6 +83,20 @@ export interface CompilerKeyedRowEvent {
   invoke(item: unknown, index: number, event: React.SyntheticEvent): unknown;
 }
 
+export interface CompilerKeyedRowConditionalBranch {
+  bindings: readonly CompilerKeyedRowBinding[];
+}
+
+export interface CompilerKeyedRowConditional {
+  id: number;
+  /** Host-container path relative to the keyed row root. */
+  path: readonly number[];
+  test(item: unknown, index: number): unknown;
+  logical: boolean;
+  truthy?: CompilerKeyedRowConditionalBranch;
+  falsy?: CompilerKeyedRowConditionalBranch;
+}
+
 export interface CompilerHostConditionalBinding {
   kind: "text" | "attribute" | "style";
   path: readonly number[];
@@ -119,12 +134,19 @@ export interface CompilerKeyedRowsBlockProps {
       index: number,
       eventId: number,
     ) => React.EventHandler<React.SyntheticEvent>,
+    conditional: (
+      item: unknown,
+      index: number,
+      conditionalId: number,
+      render: (item: unknown, index: number) => React.ReactNode,
+    ) => React.ReactNode,
   ): React.ReactElement;
   items(): Iterable<unknown> | null | undefined;
   rowKey(item: unknown, index: number): React.Key;
   create(item: unknown, index: number): CompilerKeyedRowElement;
   bindings: readonly CompilerKeyedRowBinding[];
   events?: readonly CompilerKeyedRowEvent[];
+  conditionals?: readonly CompilerKeyedRowConditional[];
 }
 
 export interface CompilerComponentBlockProps {
@@ -520,12 +542,18 @@ function createCompilerHostElement(document: Document, descriptor: CompilerHostE
   return element;
 }
 
-function matchesCompilerHostElement(element: Element, descriptor: CompilerHostElement): boolean {
+function matchesCompilerHostElement(
+  element: Element,
+  descriptor: CompilerHostElement,
+  opaquePaths: ReadonlySet<string> = new Set(),
+  path: readonly number[] = [],
+): boolean {
   if (element.tagName.toLowerCase() !== descriptor.tag.toLowerCase()) return false;
+  if (opaquePaths.has(path.join("."))) return true;
   const expectedChildren = descriptor.children.filter(isCompilerHostElement);
   if (element.children.length !== expectedChildren.length) return false;
   return expectedChildren.every((child, index) =>
-    matchesCompilerHostElement(element.children[index], child),
+    matchesCompilerHostElement(element.children[index], child, opaquePaths, [...path, index]),
   );
 }
 
@@ -539,6 +567,7 @@ interface CompilerKeyedRowInstance extends CompilerHostInstance {
   key: string;
   item: unknown;
   index: number;
+  conditionalValues: Map<number, readonly unknown[]>;
 }
 
 const UNSET_KEYED_ROW_BINDING = Symbol("unset interactive keyed-row binding");
@@ -583,6 +612,50 @@ function applyKeyedRowBindings(
       updateAttribute(target, binding.name, rawValue);
     }
   }
+}
+
+function keyedRowConditionalSnapshot(
+  conditional: CompilerKeyedRowConditional,
+  item: unknown,
+  index: number,
+): readonly unknown[] {
+  const test = conditional.test(item, index);
+  if (conditional.logical && !test) {
+    return typeof test === "number" || typeof test === "bigint" ? ["primitive", test] : ["empty"];
+  }
+  const key = test ? "truthy" : "falsy";
+  const branch = key === "truthy" ? conditional.truthy : conditional.falsy;
+  if (!branch) return ["empty"];
+  return [
+    key,
+    ...branch.bindings.map((binding) =>
+      normalizedKeyedRowBindingValue(binding, binding.read(item, index)),
+    ),
+  ];
+}
+
+function readKeyedRowConditionalValues(
+  props: CompilerKeyedRowsBlockProps,
+  item: unknown,
+  index: number,
+): Map<number, readonly unknown[]> {
+  return new Map(
+    (props.conditionals || []).map((conditional) => [
+      conditional.id,
+      keyedRowConditionalSnapshot(conditional, item, index),
+    ]),
+  );
+}
+
+function keyedRowConditionalChanged(
+  previous: readonly unknown[] | undefined,
+  next: readonly unknown[],
+): boolean {
+  return (
+    !previous ||
+    previous.length !== next.length ||
+    next.some((value, index) => !Object.is(value, previous[index]))
+  );
 }
 
 type CompilerHostConditionalSelection =
@@ -827,6 +900,83 @@ function createKeyedRowsBlockComponent(
     fallback: boolean;
   }
 
+  type RowConditionalRefresh = (item: unknown, index: number, afterCommit?: () => void) => void;
+
+  interface RowConditionalOwner {
+    subscribe(key: string, id: number, refresh: RowConditionalRefresh): () => void;
+  }
+
+  interface RowConditionalProps {
+    owner: RowConditionalOwner;
+    rowKey: string;
+    id: number;
+    renderVersion: number;
+    item: unknown;
+    index: number;
+    render(item: unknown, index: number): React.ReactNode;
+  }
+
+  interface RowConditionalState {
+    renderVersion: number;
+    item: unknown;
+    index: number;
+  }
+
+  class FarmKeyedRowConditional extends React.Component<RowConditionalProps, RowConditionalState> {
+    static displayName = "FarmCompiledKeyedRowConditional";
+
+    state: RowConditionalState = {
+      renderVersion: this.props.renderVersion,
+      item: this.props.item,
+      index: this.props.index,
+    };
+    private unsubscribe: (() => void) | undefined;
+
+    static getDerivedStateFromProps(
+      props: RowConditionalProps,
+      state: RowConditionalState,
+    ): Partial<RowConditionalState> | null {
+      if (props.renderVersion === state.renderVersion) return null;
+      return {
+        renderVersion: props.renderVersion,
+        item: props.item,
+        index: props.index,
+      };
+    }
+
+    private refresh: RowConditionalRefresh = (item, index, afterCommit) => {
+      this.setState({ item, index }, afterCommit);
+    };
+
+    private subscribe(): void {
+      this.unsubscribe = this.props.owner.subscribe(this.props.rowKey, this.props.id, this.refresh);
+    }
+
+    componentDidMount(): void {
+      this.subscribe();
+    }
+
+    componentDidUpdate(previous: RowConditionalProps): void {
+      if (
+        previous.owner === this.props.owner &&
+        previous.rowKey === this.props.rowKey &&
+        previous.id === this.props.id
+      ) {
+        return;
+      }
+      this.unsubscribe?.();
+      this.subscribe();
+    }
+
+    componentWillUnmount(): void {
+      this.unsubscribe?.();
+    }
+
+    render(): React.ReactNode {
+      return this.props.render(this.state.item, this.state.index);
+    }
+  }
+
   class FarmKeyedRowsBlock extends React.Component<CompilerKeyedRowsBlockProps, State> {
     static displayName = "FarmCompiledKeyedRows";
 
@@ -839,10 +989,15 @@ function createKeyedRowsBlockComponent(
     private currentProps = this.props;
     private unsubscribe: (() => void) | undefined;
     private instances = new Map<string, CompilerKeyedRowInstance>();
+    private renderVersion = 0;
     private readonly eventHandlers = new Map<
       string,
       Map<number, React.EventHandler<React.SyntheticEvent>>
     >();
+    private readonly conditionalListeners = new Map<string, Map<number, RowConditionalRefresh>>();
+    private readonly conditionalOwner: RowConditionalOwner = {
+      subscribe: (key, id, refresh) => this.subscribeToRowConditional(key, id, refresh),
+    };
 
     private captureRoot = (root: Element | null) => {
       this.root = root;
@@ -884,8 +1039,47 @@ function createKeyedRowsBlockComponent(
       return handler;
     };
 
-    private hasInteractiveRows(): boolean {
-      return Boolean(this.currentProps.events?.length);
+    private rowConditional = (
+      item: unknown,
+      index: number,
+      conditionalId: number,
+      render: (item: unknown, index: number) => React.ReactNode,
+    ): React.ReactNode => {
+      if (this.state.fallback) return render(item, index);
+      const key = keyedRowIdentity(this.currentProps.rowKey(item, index));
+      return React.createElement(FarmKeyedRowConditional, {
+        key: `${key}:${conditionalId}`,
+        owner: this.conditionalOwner,
+        rowKey: key,
+        id: conditionalId,
+        renderVersion: this.renderVersion,
+        item,
+        index,
+        render,
+      });
+    };
+
+    private subscribeToRowConditional(
+      key: string,
+      id: number,
+      refresh: RowConditionalRefresh,
+    ): () => void {
+      let listeners = this.conditionalListeners.get(key);
+      if (!listeners) {
+        listeners = new Map();
+        this.conditionalListeners.set(key, listeners);
+      }
+      listeners.set(id, refresh);
+      return () => {
+        const current = this.conditionalListeners.get(key);
+        if (current?.get(id) !== refresh) return;
+        current.delete(id);
+        if (current.size === 0) this.conditionalListeners.delete(key);
+      };
+    }
+
+    private hasReactOwnedRows(props: CompilerKeyedRowsBlockProps = this.currentProps): boolean {
+      return Boolean(props.events?.length || props.conditionals?.length);
     }
 
     private pruneEventHandlers(keys: readonly string[]): void {
@@ -895,18 +1089,29 @@ function createKeyedRowsBlockComponent(
       }
     }
 
+    private pruneConditionalListeners(keys: readonly string[]): void {
+      const active = new Set(keys);
+      for (const key of this.conditionalListeners.keys()) {
+        if (!active.has(key)) this.conditionalListeners.delete(key);
+      }
+    }
+
     private adopt(): boolean {
       if (!this.root) return false;
       const rows = this.readRows(this.currentProps);
       const elements = [...this.root.children];
       if (!rows || rows.items.length !== elements.length) return false;
+      const opaqueConditionalPaths = new Set(
+        (this.currentProps.conditionals || []).map((conditional) => conditional.path.join(".")),
+      );
       const instances = new Map<string, CompilerKeyedRowInstance>();
       for (let index = 0; index < rows.items.length; index += 1) {
         if (
-          this.hasInteractiveRows() &&
+          this.hasReactOwnedRows() &&
           !matchesCompilerHostElement(
             elements[index],
             this.currentProps.create(rows.items[index], index),
+            opaqueConditionalPaths,
           )
         ) {
           return false;
@@ -914,13 +1119,18 @@ function createKeyedRowsBlockComponent(
         const instance: CompilerKeyedRowInstance = {
           key: rows.keys[index],
           element: elements[index],
-          values: this.hasInteractiveRows()
+          values: this.hasReactOwnedRows()
             ? this.currentProps.bindings.map(() => UNSET_KEYED_ROW_BINDING)
             : readKeyedRowBindingValues(this.currentProps, rows.items[index], index),
           item: rows.items[index],
           index,
+          conditionalValues: readKeyedRowConditionalValues(
+            this.currentProps,
+            rows.items[index],
+            index,
+          ),
         };
-        if (this.hasInteractiveRows()) {
+        if (this.hasReactOwnedRows()) {
           // React compares the next row against its previous virtual props, not
           // against DOM values patched by Farm between commits. Reapply every
           // binding after a structural React commit so both views converge
@@ -931,6 +1141,7 @@ function createKeyedRowsBlockComponent(
       }
       this.instances = instances;
       this.pruneEventHandlers(rows.keys);
+      this.pruneConditionalListeners(rows.keys);
       return true;
     }
 
@@ -943,7 +1154,7 @@ function createKeyedRowsBlockComponent(
       this.setState({ fallback: true }, afterCommit);
     }
 
-    private synchronizeInteractiveRows(afterCommit?: () => void): void {
+    private synchronizeReactOwnedRows(afterCommit?: () => void): void {
       this.forceUpdate(() => {
         if (!this.mounted) {
           afterCommit?.();
@@ -954,6 +1165,36 @@ function createKeyedRowsBlockComponent(
           return;
         }
         afterCommit?.();
+      });
+    }
+
+    private notifyConditionalChanges(
+      changes: readonly {
+        key: string;
+        id: number;
+        item: unknown;
+        index: number;
+      }[],
+      afterCommit?: () => void,
+    ): void {
+      if (changes.length === 0) {
+        afterCommit?.();
+        return;
+      }
+      let pending = changes.length;
+      const committed = () => {
+        pending -= 1;
+        if (pending === 0) afterCommit?.();
+      };
+      // The normal row bindings above are patched synchronously. Flush the
+      // React-owned conditional boundaries in the same turn as well so React
+      // 18 cannot expose a transient row where text and branch disagree.
+      flushSync(() => {
+        for (const change of changes) {
+          const refresh = this.conditionalListeners.get(change.key)?.get(change.id);
+          if (refresh) refresh(change.item, change.index, committed);
+          else committed();
+        }
       });
     }
 
@@ -976,11 +1217,11 @@ function createKeyedRowsBlockComponent(
 
       const previousKeys = [...this.instances.keys()];
       if (
-        this.hasInteractiveRows() &&
+        this.hasReactOwnedRows() &&
         (rows.keys.length !== previousKeys.length ||
           rows.keys.some((key, index) => key !== previousKeys[index]))
       ) {
-        this.synchronizeInteractiveRows(afterCommit);
+        this.synchronizeReactOwnedRows(afterCommit);
         return;
       }
 
@@ -996,11 +1237,28 @@ function createKeyedRowsBlockComponent(
       const sequence = rows.keys.map((key) => oldIndices.get(key) ?? -1);
       const stablePositions = longestIncreasingSubsequencePositions(sequence);
       const nextInstances: CompilerKeyedRowInstance[] = [];
+      const conditionalChanges: Array<{
+        key: string;
+        id: number;
+        item: unknown;
+        index: number;
+      }> = [];
       for (let index = 0; index < rows.items.length; index += 1) {
         const key = rows.keys[index];
         const existing = this.instances.get(key);
         if (existing) {
           applyKeyedRowBindings(this.currentProps, existing, rows.items[index], index);
+          const conditionalValues = readKeyedRowConditionalValues(
+            this.currentProps,
+            rows.items[index],
+            index,
+          );
+          for (const [id, values] of conditionalValues) {
+            if (keyedRowConditionalChanged(existing.conditionalValues.get(id), values)) {
+              conditionalChanges.push({ key, id, item: rows.items[index], index });
+            }
+          }
+          existing.conditionalValues = conditionalValues;
           existing.item = rows.items[index];
           existing.index = index;
           nextInstances.push(existing);
@@ -1016,6 +1274,11 @@ function createKeyedRowsBlockComponent(
           values: readKeyedRowBindingValues(this.currentProps, rows.items[index], index),
           item: rows.items[index],
           index,
+          conditionalValues: readKeyedRowConditionalValues(
+            this.currentProps,
+            rows.items[index],
+            index,
+          ),
         });
       }
 
@@ -1031,6 +1294,7 @@ function createKeyedRowsBlockComponent(
       }
       this.instances = new Map(nextInstances.map((instance) => [instance.key, instance]));
       this.pruneEventHandlers(rows.keys);
+      this.pruneConditionalListeners(rows.keys);
       if (
         restoreFocus &&
         activeElement?.isConnected &&
@@ -1039,7 +1303,7 @@ function createKeyedRowsBlockComponent(
       ) {
         (activeElement as HTMLElement).focus({ preventScroll: true });
       }
-      afterCommit?.();
+      this.notifyConditionalChanges(conditionalChanges, afterCommit);
     }
 
     private refresh = (afterCommit?: () => void) => {
@@ -1056,11 +1320,11 @@ function createKeyedRowsBlockComponent(
     }
 
     shouldComponentUpdate(nextProps: CompilerKeyedRowsBlockProps, nextState: State): boolean {
-      const wasInteractive = Boolean(this.currentProps.events?.length);
-      const willBeInteractive = Boolean(nextProps.events?.length);
+      const wasReactOwned = this.hasReactOwnedRows(this.currentProps);
+      const willBeReactOwned = this.hasReactOwnedRows(nextProps);
       this.currentProps = nextProps;
       if (nextState.fallback || this.state.fallback) return true;
-      if (wasInteractive || willBeInteractive) {
+      if (wasReactOwned || willBeReactOwned) {
         // Parent prop updates and Fast Refresh definitions must pass through
         // React so event locations, static row markup, and proxy identities
         // cannot remain tied to an older render definition.
@@ -1075,7 +1339,7 @@ function createKeyedRowsBlockComponent(
       if (
         this.state.fallback ||
         previousProps === this.props ||
-        (!previousProps.events?.length && !this.props.events?.length) ||
+        (!this.hasReactOwnedRows(previousProps) && !this.hasReactOwnedRows(this.props)) ||
         this.adopt()
       ) {
         return;
@@ -1095,10 +1359,12 @@ function createKeyedRowsBlockComponent(
       this.root = null;
       this.instances.clear();
       this.eventHandlers.clear();
+      this.conditionalListeners.clear();
     }
 
     render(): React.ReactNode {
-      const container = this.currentProps.render(this.rowEvent);
+      this.renderVersion += 1;
+      const container = this.currentProps.render(this.rowEvent, this.rowConditional);
       if (!React.isValidElement(container) || typeof container.type !== "string") {
         throw new TypeError(
           `Compiled keyed rows ${this.currentProps.id} must own one host container.`,

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -87,6 +87,17 @@ interface PendingKeyedRowEvent {
   value: t.ArrowFunctionExpression | t.FunctionExpression;
 }
 
+interface PendingKeyedRowConditional {
+  id: number;
+  path: number[];
+  test: t.Expression;
+  logical: boolean;
+  truthy?: t.JSXElement;
+  falsy?: t.JSXElement;
+  truthyBindings: PendingKeyedRowBinding[];
+  falsyBindings: PendingKeyedRowBinding[];
+}
+
 interface HostConditionalPlan {
   kind: "host-conditional";
   id: number;
@@ -113,6 +124,7 @@ interface KeyedRowsPlan {
   row: t.JSXElement;
   bindings: PendingKeyedRowBinding[];
   events: PendingKeyedRowEvent[];
+  conditionals: PendingKeyedRowConditional[];
   syntax: "map" | "list";
 }
 
@@ -812,6 +824,7 @@ interface KeyedRowsShape {
   dependencies: number[];
   bindings: PendingKeyedRowBinding[];
   events: PendingKeyedRowEvent[];
+  conditionals: PendingKeyedRowConditional[];
   syntax: "map" | "list";
 }
 
@@ -848,6 +861,7 @@ function analyzeKeyedRowTree(
 ): {
   bindings?: PendingKeyedRowBinding[];
   events?: PendingKeyedRowEvent[];
+  conditionals?: PendingKeyedRowConditional[];
   reason?: string;
 } {
   if (
@@ -863,6 +877,7 @@ function analyzeKeyedRowTree(
 
   const bindings: PendingKeyedRowBinding[] = [];
   const events: PendingKeyedRowEvent[] = [];
+  const conditionals: PendingKeyedRowConditional[] = [];
   const visit = (element: t.JSXElement, path: number[]): string | undefined => {
     const tag = element.openingElement.name;
     if (!t.isJSXIdentifier(tag) || !/^[a-z]/.test(tag.name)) {
@@ -973,6 +988,49 @@ function analyzeKeyedRowTree(
       });
     }
 
+    const meaningfulChildren = meaningfulJsxChildren(element);
+    const conditionalChild = meaningfulChildren.find(
+      (child): child is t.JSXExpressionContainer =>
+        t.isJSXExpressionContainer(child) &&
+        !t.isJSXEmptyExpression(child.expression) &&
+        conditionalBlockShape(child.expression) !== null,
+    );
+    if (conditionalChild && !t.isJSXEmptyExpression(conditionalChild.expression)) {
+      if (meaningfulChildren.length !== 1) {
+        return "compiled keyed row conditionals must be the only child of a host container";
+      }
+      const shape = conditionalBlockShape(conditionalChild.expression);
+      if (!shape) return "compiled keyed row conditional shape is not supported";
+      const testUnsupported = validateDerivedExpression(shape.test, safeGlobals);
+      if (testUnsupported) {
+        return `compiled keyed row conditional test cannot use ${testUnsupported}`;
+      }
+      const truthyAnalysis = shape.truthy
+        ? analyzeHostConditionalTree(shape.truthy, safeGlobals)
+        : { bindings: [] as PendingKeyedRowBinding[] };
+      const falsyAnalysis = shape.falsy
+        ? analyzeHostConditionalTree(shape.falsy, safeGlobals)
+        : { bindings: [] as PendingKeyedRowBinding[] };
+      if (truthyAnalysis.reason || falsyAnalysis.reason) {
+        return (
+          truthyAnalysis.reason ||
+          falsyAnalysis.reason ||
+          "compiled keyed row conditional branch is not supported"
+        );
+      }
+      conditionals.push({
+        id: conditionals.length,
+        path: [...path],
+        test: cloneExpression(shape.test),
+        logical: shape.logical,
+        truthy: shape.truthy ? t.cloneNode(shape.truthy, true) : undefined,
+        falsy: shape.falsy ? t.cloneNode(shape.falsy, true) : undefined,
+        truthyBindings: truthyAnalysis.bindings || [],
+        falsyBindings: falsyAnalysis.bindings || [],
+      });
+      return undefined;
+    }
+
     const nestedElements = element.children.filter((child): child is t.JSXElement =>
       t.isJSXElement(child),
     );
@@ -1014,7 +1072,7 @@ function analyzeKeyedRowTree(
   };
 
   const reason = visit(row, []);
-  return reason ? { reason } : { bindings, events };
+  return reason ? { reason } : { bindings, events, conditionals };
 }
 
 function analyzeKeyedRowsContainer(
@@ -1119,6 +1177,7 @@ function analyzeKeyedRowsContainer(
     dependencies,
     bindings: rowAnalysis.bindings || [],
     events: rowAnalysis.events || [],
+    conditionals: rowAnalysis.conditionals || [],
     syntax,
   };
 }
@@ -1487,9 +1546,59 @@ function rewriteKeyedRowEventAttributes(
   visit(row, []);
 }
 
-function keyedRowsRenderSource(plan: KeyedRowsPlan, eventFactory: t.Identifier): t.JSXElement {
+function rewriteKeyedRowConditionalExpressions(
+  row: t.JSXElement,
+  conditionals: readonly PendingKeyedRowConditional[],
+  conditionalFactory: t.Identifier,
+  item: t.Identifier,
+  index: t.Expression,
+  renderParameters: readonly t.Identifier[],
+): void {
+  const conditionalByLocation = new Map(
+    conditionals.map((conditional) => [conditional.path.join("."), conditional] as const),
+  );
+  const visit = (element: t.JSXElement, path: number[]): void => {
+    const conditional = conditionalByLocation.get(path.join("."));
+    if (conditional) {
+      element.children = element.children.map((child) => {
+        if (
+          !t.isJSXExpressionContainer(child) ||
+          t.isJSXEmptyExpression(child.expression) ||
+          !conditionalBlockShape(child.expression)
+        ) {
+          return child;
+        }
+        return t.jsxExpressionContainer(
+          t.callExpression(t.cloneNode(conditionalFactory), [
+            t.cloneNode(item),
+            t.cloneNode(index),
+            t.numericLiteral(conditional.id),
+            t.arrowFunctionExpression(
+              renderParameters.map((parameter) => t.cloneNode(parameter, true)),
+              cloneExpression(child.expression),
+            ),
+          ]),
+        );
+      });
+      return;
+    }
+
+    let elementIndex = 0;
+    for (const child of element.children) {
+      if (!t.isJSXElement(child)) continue;
+      visit(child, [...path, elementIndex]);
+      elementIndex += 1;
+    }
+  };
+  visit(row, []);
+}
+
+function keyedRowsRenderSource(
+  plan: KeyedRowsPlan,
+  eventFactory: t.Identifier,
+  conditionalFactory: t.Identifier,
+): t.JSXElement {
   const source = t.cloneNode(plan.source, true);
-  if (plan.events.length === 0) return source;
   const child = meaningfulJsxChildren(source)[0];
   let callback: t.ArrowFunctionExpression | t.FunctionExpression | undefined;
   if (
@@ -1517,13 +1626,20 @@ function keyedRowsRenderSource(plan: KeyedRowsPlan, eventFactory: t.Identifier):
   const item = callback?.params[0];
   const index = callback?.params[1];
   if (!callback || !t.isJSXElement(row) || !t.isIdentifier(item)) return source;
-  rewriteKeyedRowEventAttributes(
-    row,
-    plan.events,
-    eventFactory,
-    item,
-    t.isIdentifier(index) ? index : t.numericLiteral(0),
-  );
+  const runtimeIndex = t.isIdentifier(index) ? index : t.numericLiteral(0);
+  if (plan.events.length > 0) {
+    rewriteKeyedRowEventAttributes(row, plan.events, eventFactory, item, runtimeIndex);
+  }
+  if (plan.conditionals.length > 0) {
+    rewriteKeyedRowConditionalExpressions(
+      row,
+      plan.conditionals,
+      conditionalFactory,
+      item,
+      runtimeIndex,
+      callback.params as t.Identifier[],
+    );
+  }
   return source;
 }
 
@@ -1551,6 +1667,56 @@ function keyedRowEventObject(
   ]);
 }
 
+function keyedRowConditionalBranchObject(
+  bindings: readonly PendingKeyedRowBinding[],
+  parameters: readonly t.Identifier[],
+): t.ObjectExpression {
+  return t.objectExpression([
+    t.objectProperty(
+      t.identifier("bindings"),
+      t.arrayExpression(bindings.map((binding) => keyedRowBindingObject(binding, parameters))),
+    ),
+  ]);
+}
+
+function keyedRowConditionalObject(
+  conditional: PendingKeyedRowConditional,
+  parameters: readonly t.Identifier[],
+): t.ObjectExpression {
+  const properties: t.ObjectProperty[] = [
+    t.objectProperty(t.identifier("id"), t.numericLiteral(conditional.id)),
+    t.objectProperty(
+      t.identifier("path"),
+      t.arrayExpression(conditional.path.map((part) => t.numericLiteral(part))),
+    ),
+    t.objectProperty(
+      t.identifier("test"),
+      t.arrowFunctionExpression(
+        parameters.map((parameter) => t.cloneNode(parameter, true)),
+        cloneExpression(conditional.test),
+      ),
+    ),
+    t.objectProperty(t.identifier("logical"), t.booleanLiteral(conditional.logical)),
+  ];
+  if (conditional.truthy) {
+    properties.push(
+      t.objectProperty(
+        t.identifier("truthy"),
+        keyedRowConditionalBranchObject(conditional.truthyBindings, parameters),
+      ),
+    );
+  }
+  if (conditional.falsy) {
+    properties.push(
+      t.objectProperty(
+        t.identifier("falsy"),
+        keyedRowConditionalBranchObject(conditional.falsyBindings, parameters),
+      ),
+    );
+  }
+  return t.objectExpression(properties);
+}
+
 function keyedRowsBoundary(blockRuntime: t.Identifier, plan: KeyedRowsPlan): t.JSXElement {
   const name = t.jsxMemberExpression(
     t.jsxIdentifier(blockRuntime.name),
@@ -1563,7 +1729,17 @@ function keyedRowsBoundary(blockRuntime: t.Identifier, plan: KeyedRowsPlan): t.J
     plan.source,
     ...plan.events.map((event) => event.value),
   ]);
-  const renderSource = keyedRowsRenderSource(plan, eventFactory);
+  const conditionalFactory = uniqueLocalIdentifier("_farmRowConditional", [
+    plan.source,
+    ...plan.conditionals.map((conditional) => conditional.test),
+  ]);
+  const renderSource = keyedRowsRenderSource(plan, eventFactory, conditionalFactory);
+  const renderFactoryParameters =
+    plan.conditionals.length > 0
+      ? [t.cloneNode(eventFactory), t.cloneNode(conditionalFactory)]
+      : plan.events.length > 0
+        ? [t.cloneNode(eventFactory)]
+        : [];
   return t.jsxElement(
     t.jsxOpeningElement(
       name,
@@ -1572,10 +1748,7 @@ function keyedRowsBoundary(blockRuntime: t.Identifier, plan: KeyedRowsPlan): t.J
         t.jsxAttribute(
           t.jsxIdentifier("render"),
           t.jsxExpressionContainer(
-            t.arrowFunctionExpression(
-              plan.events.length > 0 ? [t.cloneNode(eventFactory)] : [],
-              renderSource,
-            ),
+            t.arrowFunctionExpression(renderFactoryParameters, renderSource),
           ),
         ),
         t.jsxAttribute(
@@ -1610,6 +1783,20 @@ function keyedRowsBoundary(blockRuntime: t.Identifier, plan: KeyedRowsPlan): t.J
                 t.jsxExpressionContainer(
                   t.arrayExpression(
                     plan.events.map((event) => keyedRowEventObject(event, parameters)),
+                  ),
+                ),
+              ),
+            ]
+          : []),
+        ...(plan.conditionals.length > 0
+          ? [
+              t.jsxAttribute(
+                t.jsxIdentifier("conditionals"),
+                t.jsxExpressionContainer(
+                  t.arrayExpression(
+                    plan.conditionals.map((conditional) =>
+                      keyedRowConditionalObject(conditional, parameters),
+                    ),
                   ),
                 ),
               ),
@@ -1926,6 +2113,7 @@ function analyzeComposableBlocks(
               row: keyedRows.row,
               bindings: keyedRows.bindings,
               events: keyedRows.events,
+              conditionals: keyedRows.conditionals,
               syntax: keyedRows.syntax,
             });
             ownedElements.add(child);


### PR DESCRIPTION
## Summary

- detect host-only logical and ternary conditionals inside automatic keyed maps and the public List boundary
- emit per-row conditional descriptors and scope runtime subscriptions by stable row key and slot ID
- patch ordinary row bindings directly while asking React to refresh only changed conditional boundaries
- retain React ownership for hydration, error boundaries, StrictMode, Fast Refresh, and structural list reconciliation
- add a polished interactive example and expand the experimental compiler documentation

## Safety and fallback

- conditionals must be the only meaningful child of a persistent lowercase host container
- unsupported branch events, components, fragments, refs, SVG, spreads, nested dynamic blocks, mixed children, and duplicate runtime keys stay on the React fallback path
- React 18 conditional commits are synchronized with direct row patches to avoid transient stale branches

## Validation

- `pnpm --filter @farm.js/react test` — 26 files, 206 tests passed
- 2,000 deterministic data and structural transitions matched ordinary React output
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and React 19.2.8 passed
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter farm-react-compiler-example type-check`
- production compiler example build and browser experiment passed with zero owner update executions and preserved keyed DOM identity
- production compiler report confirms RowConditionalListExperiment compiled
- desktop and mobile visual verification passed
- `pnpm --filter farmjs-docs build` — 73-route Vercel documentation build passed
- formatting and diff checks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compiles host-only logical and ternary conditionals inside keyed rows and `List` boundaries in `@farm.js/react`, improving per-row update granularity. Previously these conditionals fell back to React-managed boundaries; now the compiler emits per-row conditional descriptors keyed by row and slot, patches row bindings directly, and asks React to refresh only changed conditional slots while preserving SSR, hydration, and error boundary behavior.

- Review notes
  - Detects conditionals in automatic keyed maps and public `List` boundaries. Conditionals must be the only meaningful child of a persistent lowercase host container.
  - Scopes runtime subscriptions by stable row key and slot ID. Synchronizes direct row patches with React 18 commits. Retains React ownership for hydration, StrictMode, Fast Refresh, and structural list reconciliation.
  - Unsupported shapes (branch events, components, fragments, refs, SVG, spreads, nested dynamic blocks, mixed children, duplicate runtime keys) continue on the React fallback path.
- Validation
  - New compiler and runtime tests added; deterministic transitions match ordinary React. Compatibility suites pass on React 18.3.1 and 19.2.8.
  - Example app adds a keyed-row conditionals demo with verification coverage for execution counts and keyed DOM identity.
  - Docs updated to describe supported shapes and constraints.

<sup>Written for commit 98ca4ff7deb4f87830b755a726cf9f4f463f72c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

