### PR TITLE
fix(core): read zod 4 schema internals in the openapi generator

### DIFF
--- a/packages/farm/src/__tests__/openapi-generator.test.ts
+++ b/packages/farm/src/__tests__/openapi-generator.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import { OpenAPIGenerator } from "../openapi/generator";
 
 const tempDirs: string[] = [];
@@ -43,6 +44,80 @@ describe("OpenAPIGenerator", () => {
           },
         },
       },
+    });
+  });
+});
+
+describe("OpenAPIGenerator zod schema conversion", () => {
+  function processed(schema: z.ZodType<any>): any {
+    const generator = new OpenAPIGenerator("/tmp", { title: "t" });
+    const result = (generator as any).processZodType(schema);
+    return JSON.parse(JSON.stringify(result));
+  }
+
+  it("converts primitive types", () => {
+    expect(processed(z.string())).toEqual({ type: "string" });
+    expect(processed(z.number())).toEqual({ type: "number" });
+    expect(processed(z.boolean())).toEqual({ type: "boolean" });
+  });
+
+  it("converts enums with their values", () => {
+    expect(processed(z.enum(["asc", "desc"]))).toEqual({
+      type: "string",
+      enum: ["asc", "desc"],
+    });
+  });
+
+  it("converts string length constraints", () => {
+    expect(processed(z.string().min(2).max(5))).toEqual({
+      type: "string",
+      minLength: 2,
+      maxLength: 5,
+    });
+  });
+
+  it("converts numeric range constraints", () => {
+    expect(processed(z.number().min(1).max(9))).toEqual({
+      type: "number",
+      minimum: 1,
+      maximum: 9,
+    });
+  });
+
+  it("converts the coerced number with a default from the docs example", () => {
+    const schema = processed(z.coerce.number().int().positive().default(20));
+    expect(schema).toMatchObject({ type: "number", default: 20 });
+  });
+
+  it("converts arrays without throwing", () => {
+    expect(processed(z.array(z.string()))).toEqual({
+      type: "array",
+      items: { type: "string" },
+    });
+  });
+
+  it("converts objects containing arrays", () => {
+    expect(processed(z.object({ name: z.string(), tags: z.array(z.string()) }))).toEqual({
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        tags: { type: "array", items: { type: "string" } },
+      },
+      required: ["name", "tags"],
+    });
+  });
+
+  it("marks optional types as nullable", () => {
+    expect(processed(z.number().optional())).toEqual({
+      type: "number",
+      nullable: true,
+    });
+  });
+
+  it("keeps descriptions", () => {
+    expect(processed(z.number().describe("a count"))).toEqual({
+      type: "number",
+      description: "a count",
     });
   });
 });

--- a/packages/farm/src/openapi/generator.ts
+++ b/packages/farm/src/openapi/generator.ts
@@ -45,7 +45,15 @@ export class OpenAPIGenerator {
    * Get type from Zod type
    */
   private getTypeFromZodType(zodType: z.ZodType<any>): AllowedType {
-    const typeName = (zodType as any)._def?.typeName;
+    const def = (zodType as any)._def;
+    // Zod 4 stores a lowercase name on `_def.type`; Zod 3 stored `_def.typeName`.
+    // In Zod 3 `_def.type` can also be the element schema of an array, so only
+    // trust it when it is a string.
+    const v4Type = typeof def?.type === "string" ? def.type : undefined;
+    if (v4Type && allowedType.has(v4Type)) {
+      return v4Type as AllowedType;
+    }
+    const typeName = def?.typeName;
     if (typeName) {
       if (typeName === "ZodString") return "string";
       if (typeName === "ZodNumber") return "number";
@@ -93,9 +101,24 @@ export class OpenAPIGenerator {
       }
     }
 
+    // Handle ZodDefault
+    if (zodType instanceof z.ZodDefault) {
+      const def = (zodType as any)._def;
+      const innerSchema = this.processZodType(def.innerType);
+      // Zod 3 stores a thunk, Zod 4 stores the value itself.
+      const defaultValue =
+        typeof def.defaultValue === "function" ? def.defaultValue() : def.defaultValue;
+      return {
+        ...innerSchema,
+        default: defaultValue,
+      };
+    }
+
     // Handle ZodArray
     if (zodType instanceof z.ZodArray) {
-      const itemType = (zodType as any)._def.type;
+      const def = (zodType as any)._def;
+      // Zod 4 stores the element schema on `_def.element`; Zod 3 stored it on `_def.type`.
+      const itemType = def.element ?? def.type;
       return {
         type: "array",
         items: this.processZodType(itemType),
@@ -107,7 +130,8 @@ export class OpenAPIGenerator {
     if (zodType instanceof z.ZodEnum) {
       return {
         type: "string",
-        enum: (zodType as any)._def.values,
+        // `.options` is public in both majors; `_def.values` only existed in Zod 3.
+        enum: (zodType as any).options ?? (zodType as any)._def.values,
         description: (zodType as any).description,
       };
     }
@@ -118,18 +142,35 @@ export class OpenAPIGenerator {
       description: (zodType as any).description,
     };
 
-    // Add constraints if available
-    if ("minLength" in zodType && (zodType as any).minLength) {
-      baseSchema.minLength = (zodType as any).minLength;
-    }
-    if ("maxLength" in zodType && (zodType as any).maxLength) {
-      baseSchema.maxLength = (zodType as any).maxLength;
-    }
-    if ("min" in zodType && (zodType as any).min !== undefined) {
-      baseSchema.minimum = (zodType as any).min;
-    }
-    if ("max" in zodType && (zodType as any).max !== undefined) {
-      baseSchema.maximum = (zodType as any).max;
+    // Add constraints if available. `.minLength`/`.maxLength` and
+    // `.minValue`/`.maxValue` hold the values in both Zod majors, while
+    // `.min`/`.max` are the builder methods.
+    if (baseSchema.type === "string") {
+      const { minLength, maxLength } = zodType as any;
+      if (typeof minLength === "number") {
+        baseSchema.minLength = minLength;
+      }
+      if (typeof maxLength === "number") {
+        baseSchema.maxLength = maxLength;
+      }
+    } else if (baseSchema.type === "number") {
+      const { minValue, maxValue } = zodType as any;
+      // Zod 4's `.int()` bounds numbers to ±MAX_SAFE_INTEGER; skip those
+      // implicit bounds so only user-provided constraints are documented.
+      if (
+        typeof minValue === "number" &&
+        Number.isFinite(minValue) &&
+        minValue !== Number.MIN_SAFE_INTEGER
+      ) {
+        baseSchema.minimum = minValue;
+      }
+      if (
+        typeof maxValue === "number" &&
+        Number.isFinite(maxValue) &&
+        maxValue !== Number.MAX_SAFE_INTEGER
+      ) {
+        baseSchema.maximum = maxValue;
+      }
     }
 
     return baseSchema;


### PR DESCRIPTION
## Summary

Fixes #430.

`OpenAPIGenerator` read Zod 3 private fields while the package ships `zod ^4.1.12`, so the generated document was wrong for nearly every schema:

- `_def.typeName` no longer exists → numbers, booleans, and enums were all documented as `string`
- `_def.type` on a Zod 4 array is the string `"array"`, not the element schema → every array schema threw, and the two callers swallow the error, silently dropping parameters or the whole request body
- `_def.values` is gone → enum values were dropped
- numeric bounds were read from `.min`/`.max`, which are builder methods, so numeric constraints never reached the document in either major

## Fix

Read the shapes both majors expose:

- type tag: `_def.type` (v4) with `_def.typeName` (v3) fallback
- array element: `_def.element ?? _def.type`
- enum values: public `.options`
- numeric bounds: `.minValue`/`.maxValue`, skipping the implicit ±`MAX_SAFE_INTEGER` bounds Zod 4's `.int()` adds
- new `ZodDefault` branch so e.g. the docs example `z.coerce.number().int().positive().default(20)` emits `{type: "number", default: 20}`

## Tests

Added 9 cases to `openapi-generator.test.ts` covering primitives, enums, string/number constraints, arrays, nested objects, optionals, defaults, and descriptions. 8 of them fail before the fix (matching the issue repro exactly); all pass after.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect OpenAPI output by reading `zod` v4 schema internals instead of v3 private fields. Previously numbers/booleans/enums were emitted as string, arrays threw and dropped parameters or request bodies, and enum values and numeric constraints were omitted; now the generator emits correct types, array items, enum values, numeric bounds, and defaults.

**Review notes**
- Type detection: use `_def.type` (v4) with `_def.typeName` (v3) fallback.
- Arrays: read element via `_def.element ?? _def.type`.
- Enums: use public `.options` to include values.
- Numbers: read `.minValue`/`.maxValue`; ignore implicit ±MAX_SAFE_INTEGER from `.int()`.
- Defaults: unwrap `ZodDefault` to retain inner schema and default value; preserve descriptions and mark optionals as nullable.
- Tests: add 9 cases covering primitives, enums, constraints, arrays, nested objects, optionals, defaults, and descriptions.

<sup>Written for commit 060d1f3ced69af7e739cad264a9e3058eb51d2ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

