### PR TITLE
fix(polar): correct metered charge estimates and gauge usage projection

### DIFF
--- a/packages/farm-polar/src/index.ts
+++ b/packages/farm-polar/src/index.ts
@@ -685,17 +685,19 @@ function resolveHardLimit(
   return null;
 }
 
-function getMeterIncrement(
-  aggregation: PolarBillingMeter["aggregation"],
-  quantity: number,
-): number {
-  switch (aggregation) {
+function projectMeterUsage(input: {
+  aggregation: PolarBillingMeter["aggregation"];
+  currentUsed: number;
+  quantity: number;
+}): number {
+  switch (input.aggregation) {
     case "count":
-      return 1;
+      return input.currentUsed + 1;
     case "last":
-      return quantity;
+      // Gauge semantics: the newest reported value replaces the previous one.
+      return input.quantity;
     default:
-      return quantity;
+      return input.currentUsed + input.quantity;
   }
 }
 
@@ -733,7 +735,8 @@ function toEstimatedMeterChargeAmount(input: {
     return null;
   }
 
-  const uncappedAmount = Math.round(input.currentUsed * parsedUnitAmount * 100);
+  // Polar's metered unit amount is already expressed in cents.
+  const uncappedAmount = Math.round(input.currentUsed * parsedUnitAmount);
   if (typeof input.capAmount === "number") {
     return Math.min(uncappedAmount, input.capAmount);
   }
@@ -1574,8 +1577,11 @@ export function polar<TInput extends PolarIntegrationInput>(
             );
           }
 
-          const increment = getMeterIncrement(meter.aggregation, body.quantity);
-          const projectedCurrentPeriodUsed = currentUsed + increment;
+          const projectedCurrentPeriodUsed = projectMeterUsage({
+            aggregation: meter.aggregation,
+            currentUsed,
+            quantity: body.quantity,
+          });
           if (typeof hardLimit === "number" && projectedCurrentPeriodUsed > hardLimit) {
             return new Response(
               "The configured metered hard cap has been reached for the current billing period. Reported usage is blocked until the next cycle or a plan change.",

--- a/packages/farm/src/__tests__/polar-billing-usage.test.ts
+++ b/packages/farm/src/__tests__/polar-billing-usage.test.ts
@@ -1,0 +1,281 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from "vitest";
+import type { FarmIntegrationHandlerContext } from "../integrations";
+import { polar, type PolarIntegrationInstance } from "../../../farm-integrations/src/polar/index";
+
+function createRequestContextStore() {
+  return {
+    get() {
+      return undefined;
+    },
+    set() {},
+    has() {
+      return false;
+    },
+    delete() {
+      return false;
+    },
+    clear() {},
+    snapshot() {
+      return new Map<string, unknown>();
+    },
+  };
+}
+
+function createContext(
+  request: Request,
+  method: string,
+  path: string,
+  instance: unknown,
+): FarmIntegrationHandlerContext {
+  const req = createRequestContextStore();
+
+  return {
+    request,
+    requestId: "req_test",
+    url: new URL(request.url),
+    pathname: new URL(request.url).pathname,
+    method,
+    params: {},
+    input: {},
+    data: {},
+    integration: {
+      category: "payment",
+      slot: "payment",
+      type: "polar",
+      instance,
+    },
+    route: {
+      kind: "route",
+      path,
+      methods: [method],
+    },
+    req,
+    requestContext: req,
+    config: {} as FarmIntegrationHandlerContext["config"],
+    isDev: true,
+    isProd: false,
+  };
+}
+
+function createFakeSdk(state: unknown, product?: unknown) {
+  return {
+    customers: {
+      getStateExternal: vi.fn(async () => state),
+    },
+    events: {
+      ingest: vi.fn(async () => ({ inserted: 1 })),
+    },
+    products: {
+      get: vi.fn(async () => product),
+    },
+  };
+}
+
+async function callRoute(
+  integration: ReturnType<typeof polar>,
+  path: string,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  const route = integration.routes.find(
+    (candidate) => candidate.path === path && candidate.method === "POST",
+  );
+  expect(route).toBeTruthy();
+
+  const request = new Request(`http://example.com${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return route!.handler(request, createContext(request, "POST", path, integration.instance));
+}
+
+describe("polar billing usage", () => {
+  it("lets a gauge (last) meter report a decrease without tripping the hard cap", async () => {
+    const sdk = createFakeSdk({
+      id: "cus_gauge",
+      activeSubscriptions: [],
+      activeMeters: [{ meterId: "mtr_gauge", consumedUnits: 90, creditedUnits: 0, balance: 0 }],
+    });
+    const integration = polar({
+      instance: sdk as unknown as PolarIntegrationInstance,
+      billing: {
+        resolveOwner: () => ({ kind: "user", id: "gauge-user" }),
+        meters: {
+          concurrency: {
+            aggregation: "last",
+            eventName: "concurrency.sampled",
+            meterId: "mtr_gauge",
+            guard: { hardLimit: 100 },
+          },
+        },
+      },
+    });
+
+    const response = await callRoute(integration, "/billing/report-usage", {
+      key: "concurrency",
+      quantity: 50,
+      idempotencyKey: "evt-gauge-1",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      key: "concurrency",
+      currentPeriodUsed: 90,
+      projectedCurrentPeriodUsed: 50,
+      state: "ok",
+    });
+    expect(sdk.events.ingest).toHaveBeenCalledTimes(1);
+  });
+
+  it("still blocks sum meters whose projection exceeds the hard cap", async () => {
+    const sdk = createFakeSdk({
+      id: "cus_sum",
+      activeSubscriptions: [],
+      activeMeters: [{ meterId: "mtr_sum", consumedUnits: 90, creditedUnits: 0, balance: 0 }],
+    });
+    const integration = polar({
+      instance: sdk as unknown as PolarIntegrationInstance,
+      billing: {
+        resolveOwner: () => ({ kind: "user", id: "sum-user" }),
+        meters: {
+          api_calls: {
+            aggregation: "sum",
+            eventName: "api.called",
+            meterId: "mtr_sum",
+            guard: { hardLimit: 100 },
+          },
+        },
+      },
+    });
+
+    const response = await callRoute(integration, "/billing/report-usage", {
+      key: "api_calls",
+      quantity: 20,
+      idempotencyKey: "evt-sum-1",
+    });
+
+    expect(response.status).toBe(409);
+    expect(sdk.events.ingest).not.toHaveBeenCalled();
+  });
+
+  it("estimates catalog meter charges in cents without scaling by 100 again", async () => {
+    const sdk = createFakeSdk(
+      {
+        id: "cus_charge",
+        activeSubscriptions: [
+          {
+            id: "sub_1",
+            productId: "prod_1",
+            status: "active",
+            createdAt: new Date("2026-08-01T00:00:00Z"),
+            currentPeriodEnd: new Date("2026-09-01T00:00:00Z"),
+            amount: 1500,
+            currency: "usd",
+            meters: [{ meterId: "mtr_calls", consumedUnits: 500, creditedUnits: 0 }],
+          },
+        ],
+        activeMeters: [{ meterId: "mtr_calls", consumedUnits: 500, creditedUnits: 0, balance: 0 }],
+      },
+      {
+        prices: [
+          {
+            amountType: "metered_unit",
+            meterId: "mtr_calls",
+            // Polar expresses the metered unit amount in cents.
+            unitAmount: "2",
+            capAmount: null,
+            meter: { name: "API calls" },
+          },
+        ],
+      },
+    );
+    const integration = polar({
+      instance: sdk as unknown as PolarIntegrationInstance,
+      billing: {
+        resolveOwner: () => ({ kind: "user", id: "charge-user" }),
+        products: {
+          pro: { kind: "subscription", planId: "pro", productId: "prod_1" },
+        },
+        plans: { pro: {} },
+        meters: {
+          api_calls: { aggregation: "sum", eventName: "api.called", meterId: "mtr_calls" },
+        },
+      },
+    });
+
+    const response = await callRoute(integration, "/billing/meter-usage", {
+      key: "api_calls",
+    });
+
+    expect(response.status).toBe(200);
+    const result = await response.json();
+    // 500 units at 2 cents each: 1000 cents, not 100000.
+    expect(result).toMatchObject({
+      key: "api_calls",
+      currentPeriodUsed: 500,
+      chargeSource: "catalog_rate",
+      baseSubscriptionAmount: 1500,
+      estimatedMeterChargeAmount: 1000,
+      estimatedCombinedAmount: 2500,
+    });
+  });
+
+  it("caps the estimated charge at the configured cap amount", async () => {
+    const sdk = createFakeSdk(
+      {
+        id: "cus_cap",
+        activeSubscriptions: [
+          {
+            id: "sub_2",
+            productId: "prod_2",
+            status: "active",
+            createdAt: new Date("2026-08-01T00:00:00Z"),
+            currentPeriodEnd: new Date("2026-09-01T00:00:00Z"),
+            amount: 0,
+            currency: "usd",
+            meters: [{ meterId: "mtr_capped", consumedUnits: 5000, creditedUnits: 0 }],
+          },
+        ],
+        activeMeters: [
+          { meterId: "mtr_capped", consumedUnits: 5000, creditedUnits: 0, balance: 0 },
+        ],
+      },
+      {
+        prices: [
+          {
+            amountType: "metered_unit",
+            meterId: "mtr_capped",
+            unitAmount: "2",
+            capAmount: 5000,
+            meter: { name: "API calls" },
+          },
+        ],
+      },
+    );
+    const integration = polar({
+      instance: sdk as unknown as PolarIntegrationInstance,
+      billing: {
+        resolveOwner: () => ({ kind: "user", id: "cap-user" }),
+        products: {
+          pro: { kind: "subscription", planId: "pro", productId: "prod_2" },
+        },
+        plans: { pro: {} },
+        meters: {
+          api_calls: { aggregation: "sum", eventName: "api.called", meterId: "mtr_capped" },
+        },
+      },
+    });
+
+    const response = await callRoute(integration, "/billing/meter-usage", {
+      key: "api_calls",
+    });
+
+    expect(response.status).toBe(200);
+    const result = await response.json();
+    // 5000 units at 2 cents is 10000 cents, capped at 5000. Before the fix the
+    // uncapped estimate (1,000,000) pinned every reading at the cap.
+    expect(result.estimatedMeterChargeAmount).toBe(5000);
+  });
+});


### PR DESCRIPTION
## Summary

Two metered-billing bugs in `@farm.js/polar`:

**Estimated meter charges were 100× too large.** `toEstimatedMeterChargeAmount` computed `currentUsed * unitAmount * 100`, but Polar's metered `unitAmount` is already expressed in cents (per the SDK's own type docs). A $10 pending charge was reported as $1,000, `capAmount` comparisons pinned at the cap after 1/100th of real usage, and the same response field mixed cents (from `subscriptionMeter.amount`) with cents×100 (from the catalog rate).

**Gauge meters (`aggregation: "last"`) were projected additively.** Reporting a *lower* gauge value (90 → 50) was projected as 140 and rejected with HTTP 409 once the sum crossed the hard cap. Replaced `getMeterIncrement` with `projectMeterUsage` matching the Autumn integration's semantics: `last` replaces, `count` adds one, `sum` adds the quantity.

Both fixes also flow through `packages/farm-integrations`, which re-exports this package.

## Tests

New `polar-billing-usage.test.ts` drives `/billing/report-usage` and `/billing/meter-usage` through the real integration routes with a stubbed SDK `instance`:

- gauge decrease passes the hard cap and ingests the event
- `sum` meters that would exceed the cap still return 409 without ingesting
- catalog estimate is 1,000 cents for 500 units × 2¢ and combines correctly with the base subscription amount
- `capAmount` still clamps the estimate

Reintroducing either old behavior makes exactly the corresponding tests fail. Note: verified against a stubbed SDK, not a live Polar sandbox — the token in `examples/polar-integration/.env.example` is expired, so a live check needs a fresh sandbox token.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects metered charge estimates and gauge usage projection in `@farm.js/polar`. Previously, estimates multiplied Polar’s metered unitAmount by 100 and gauge (`last`) meters added the reported quantity; now estimates treat unitAmount as cents and gauge replaces the previous value, fixing early cap pinning and false 409s on gauge decreases. Changes flow through `farm-integrations`.

- Projection semantics: `last` replaces, `count` adds one, `sum` adds the quantity (via `projectMeterUsage`). Gauge decreases no longer trip the hard cap.
- Estimates: `toEstimatedMeterChargeAmount` no longer scales by 100; `capAmount` comparisons and combined totals operate on cents.
- Tests: Adds handler-level tests for `/billing/report-usage` and `/billing/meter-usage` covering gauge decreases, sum cap blocking, correct catalog-rate estimates, and cap clamping.

<sup>Written for commit 4f5d9591b21c760137a9e238c521cf2eb06accc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

