### PR TITLE
fix(core): tolerate malformed percent-encoding in cookie values

### DIFF
--- a/packages/farm/src/__tests__/middleware.test.ts
+++ b/packages/farm/src/__tests__/middleware.test.ts
@@ -1381,6 +1381,18 @@ describe("Cookie Management Advanced", () => {
     expect(ctx.cookies.get("special")).toBe("test+value");
   });
 
+  it("should keep malformed percent-encoded cookie values raw instead of throwing", () => {
+    const req = createMockRequest("/test");
+    req.headers.cookie = "track=100%; broken=%E0%A4%A; session=abc123";
+    const res = createMockResponse();
+
+    const ctx = createContext(req, res);
+
+    expect(ctx.cookies.get("track")).toBe("100%");
+    expect(ctx.cookies.get("broken")).toBe("%E0%A4%A");
+    expect(ctx.cookies.get("session")).toBe("abc123");
+  });
+
   it("should set secure and httpOnly flags", () => {
     const req = createMockRequest("/test");
     const res = createMockResponse();

--- a/packages/farm/src/__tests__/production-middleware-http.test.ts
+++ b/packages/farm/src/__tests__/production-middleware-http.test.ts
@@ -34,6 +34,27 @@ describe("production middleware HTTP behavior", () => {
     ]);
   });
 
+  it("serves requests with malformed percent-encoded cookies instead of throwing", async () => {
+    const seen: Record<string, string | undefined> = {};
+    const runner = createProductionMiddlewareRunner({
+      config: {
+        handler(ctx) {
+          seen.track = ctx.cookies.get("track");
+          seen.session = ctx.cookies.get("session");
+        },
+      },
+    });
+
+    const result = await runner(
+      new Request("https://example.com/", {
+        headers: { cookie: "track=100%; session=abc123" },
+      }),
+    );
+
+    expect(result.response).toBeNull();
+    expect(seen).toEqual({ track: "100%", session: "abc123" });
+  });
+
   it("ignores forwarded client addresses unless trustProxy is enabled", async () => {
     const createRunner = (trustProxy: boolean) =>
       createProductionMiddlewareRunner({

--- a/packages/farm/src/middleware/context.ts
+++ b/packages/farm/src/middleware/context.ts
@@ -9,6 +9,16 @@ import type { MiddlewareContext, CookieJar, CookieOptions } from "./types";
 /**
  * Parse cookies from Cookie header
  */
+function decodeCookieValue(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    // Cookies are not required to be percent-encoded; keep the raw value
+    // instead of failing the whole request on malformed encoding.
+    return value;
+  }
+}
+
 function parseCookies(cookieHeader?: string): Record<string, string> {
   if (!cookieHeader) return {};
 
@@ -17,7 +27,7 @@ function parseCookies(cookieHeader?: string): Record<string, string> {
       const [name, ...rest] = cookie.split("=");
       const value = rest.join("=").trim();
       if (name && value) {
-        cookies[name.trim()] = decodeURIComponent(value);
+        cookies[name.trim()] = decodeCookieValue(value);
       }
       return cookies;
     },

--- a/packages/farm/src/middleware/production-runtime.ts
+++ b/packages/farm/src/middleware/production-runtime.ts
@@ -102,6 +102,16 @@ class WebResponseHeaderMap extends Map<string, string> {
   }
 }
 
+function decodeCookieValue(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    // Cookies are not required to be percent-encoded; keep the raw value
+    // instead of failing the whole request on malformed encoding.
+    return value;
+  }
+}
+
 function parseCookies(cookieHeader?: string | null): Record<string, string> {
   if (!cookieHeader) return {};
 
@@ -110,7 +120,7 @@ function parseCookies(cookieHeader?: string | null): Record<string, string> {
       const [name, ...rest] = cookie.split("=");
       const value = rest.join("=").trim();
       if (name && value) {
-        cookies[name.trim()] = decodeURIComponent(value);
+        cookies[name.trim()] = decodeCookieValue(value);
       }
       return cookies;
     },


### PR DESCRIPTION
## Summary

`parseCookies` calls `decodeURIComponent` unguarded in both the dev middleware context (`middleware/context.ts`) and the production runtime (`middleware/production-runtime.ts`). Cookies are not required to be percent-encoded, so a client carrying e.g. `Cookie: track=100%` (common from third-party cookies) throws a `URIError` during context creation — before any route matching — and every middleware-enabled route returns 500 for that client on every request.

`decodeCookiePart` in `headers.ts` already guards the identical operation with a try/catch, confirming intended behavior; the two middleware copies just never got the same treatment.

## Fix

Decode through a `decodeCookieValue` helper that falls back to the raw value when decoding throws, in both copies.

## Tests

- dev context: `track=100%; broken=%E0%A4%A; session=abc123` parses with raw values kept for the malformed entries and normal decoding for the rest
- production runtime: a request with a malformed cookie flows through `createProductionMiddlewareRunner` without throwing and the handler reads the values

All 99 tests across the three middleware suites pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tolerates malformed percent-encoding in cookie values to prevent 500s during middleware context creation. Previously, unguarded `decodeURIComponent` calls in dev and production middleware threw `URIError` (e.g., `track=100%`), blocking routing; now decoding falls back to the raw value on failure while still decoding well-formed values.

- Introduces `decodeCookieValue` and uses it in `middleware/context.ts` and `middleware/production-runtime.ts`.
- Aligns behavior with `decodeCookiePart` in `headers.ts` by keeping raw values on decode errors.
- Adds tests covering dev and production paths; no behavior change for valid cookies and no migration required.

<sup>Written for commit e4259f18e129d209cb94e06683cf29ef72e6d38b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

