### PR TITLE
fix(core): only reload for same-origin chunk load failures

### DIFF
--- a/packages/farm/src/__tests__/chunk-recovery.test.ts
+++ b/packages/farm/src/__tests__/chunk-recovery.test.ts
@@ -55,6 +55,43 @@ describe("chunk error recovery", () => {
     expect(isChunkLoadError(linkEvent)).toBe(true);
   });
 
+  it("ignores load failures of cross-origin scripts and styles", () => {
+    const script = document.createElement("script");
+    script.src = "https://cdn.example.com/analytics.js";
+    const scriptEvent = new Event("error");
+    Object.defineProperty(scriptEvent, "target", { value: script });
+
+    const link = document.createElement("link");
+    link.href = "https://fonts.example.com/theme.css";
+    const linkEvent = new Event("error");
+    Object.defineProperty(linkEvent, "target", { value: link });
+
+    expect(isChunkLoadError(scriptEvent)).toBe(false);
+    expect(isChunkLoadError(linkEvent)).toBe(false);
+  });
+
+  it("does not reload when a third-party script keeps failing", () => {
+    const storage = new MemoryStorage();
+    const reload = vi.fn();
+    const cleanup = installChunkErrorRecovery({
+      storage,
+      reload,
+      now: () => 1000,
+    });
+
+    const script = document.createElement("script");
+    script.src = "https://cdn.example.com/blocked-by-adblock.js";
+    const event = new Event("error");
+    Object.defineProperty(event, "target", { value: script });
+
+    window.dispatchEvent(event);
+    window.dispatchEvent(event);
+
+    expect(reload).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
   it("reloads once for a chunk failure on the current page", () => {
     const storage = new MemoryStorage();
     const reload = vi.fn();

--- a/packages/farm/src/client/chunk-recovery.ts
+++ b/packages/farm/src/client/chunk-recovery.ts
@@ -43,8 +43,26 @@ export function isChunkLoadError(errorLike: unknown): boolean {
     return true;
   }
 
+  // Only treat same-origin script/style failures as chunk errors. A blocked
+  // or missing third-party asset (analytics, embeds) is not fixable by
+  // reloading, and reloading for it would loop for as long as it keeps
+  // failing.
   const targetUrl = getEventTargetAssetUrl(errorLike);
-  return Boolean(targetUrl && /\.(?:m?js|css)(?:[?#].*)?$/i.test(targetUrl));
+  return Boolean(
+    targetUrl && /\.(?:m?js|css)(?:[?#].*)?$/i.test(targetUrl) && isSameOriginAssetUrl(targetUrl),
+  );
+}
+
+function isSameOriginAssetUrl(url: string): boolean {
+  if (typeof window === "undefined" || !window.location) {
+    return false;
+  }
+
+  try {
+    return new URL(url, window.location.href).origin === window.location.origin;
+  } catch {
+    return false;
+  }
 }
 
 export function installChunkErrorRecovery(options: FarmChunkRecoveryOptions = {}): () => void {


### PR DESCRIPTION
## Summary

`isChunkLoadError`'s element-target fallback classified **every** `<script>`/`<link>` load error with a `.js`/`.css` URL as a chunk error — no origin check. `installChunkErrorRecovery()` is installed unconditionally in both runtimes, so a page including a third-party script that permanently fails (ad-blocked analytics, a down CDN embed) called `location.reload()`, the asset failed again after reload, and the page reloaded forever at the 30s recovery-guard interval for as long as the user stayed.

## Fix

Restrict the element-target fallback to same-origin URLs. Reloading can never fix a third-party failure, while real chunk errors stay covered:

- dynamic-import failures (the primary chunk mechanism) still match the message patterns, which are unchanged
- same-origin script/style tag failures still match the fallback

## Tests

Added: cross-origin script and stylesheet errors are not classified as chunk errors, and a repeatedly failing third-party script never triggers a reload. Existing same-origin and message-pattern cases still pass (6/6).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Only reload on same-origin chunk load failures to stop reload loops from third‑party script/style errors. Old behavior: any .js/.css script/link error triggered reload; new behavior: only same-origin script/style errors and dynamic-import errors trigger reload, preventing infinite reloads on ad‑blocked or down CDN assets.

- Review notes
  - `isChunkLoadError` now checks `isSameOriginAssetUrl` in the element-target fallback.
  - Dynamic-import message matching is unchanged; real chunk failures still reload once via `installChunkErrorRecovery()`.
  - Tests cover cross-origin ignores and no reload on repeatedly failing third-party assets; existing same-origin cases still pass.

<sup>Written for commit db3cf3590cea19707ea6165c15cab7397827e135. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

