### PR TITLE
fix(core): key the PPR shell cache by locale

### DIFF
--- a/packages/farm/src/__tests__/ppr-shell-locale.test.ts
+++ b/packages/farm/src/__tests__/ppr-shell-locale.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { resolveFarmI18nConfig } from "../i18n/config";
+import { FarmI18nRuntime } from "../i18n/runtime";
+import { getFarmI18nClientSnapshot } from "../i18n/server";
+import { ServerRenderer } from "../server/renderer";
+
+function createRenderer(routing: "none" | "prefix-except-default" = "none") {
+  const i18n = resolveFarmI18nConfig(
+    { locales: ["en", "fr"], defaultLocale: "en", routing },
+    { root: "/test", mode: "production" },
+  );
+  const config = { root: "/test", srcDir: "src", outDir: "dist", basePath: "/", i18n };
+  const renderer = new ServerRenderer(config as any, {} as any, new FarmI18nRuntime(i18n));
+  return renderer as any;
+}
+
+function request(locale: string, pathname: string) {
+  return new Request(`http://localhost${pathname}`, {
+    headers: { "accept-language": locale },
+  });
+}
+
+// The shell cache is a process-wide singleton, so each test uses its own path.
+describe("PPR shell cache and locale", () => {
+  it("does not serve a shell cached in one locale to another locale", async () => {
+    const renderer = createRenderer();
+    const french = '<html lang="fr" dir="ltr">bonjour</html>';
+
+    await renderer.cachePPRShell({ pathname: "/cross", search: "", locale: "fr" }, french);
+
+    expect(await renderer.getCachedPPRShell("/cross", "", "en")).toBeFalsy();
+  });
+
+  it("serves a cached shell back to the same locale", async () => {
+    const renderer = createRenderer();
+    const french = '<html lang="fr" dir="ltr">bonjour</html>';
+
+    await renderer.cachePPRShell({ pathname: "/same", search: "", locale: "fr" }, french);
+
+    // Guards the read and write sides against drifting apart, which would silently
+    // stop the shell cache from ever hitting.
+    expect((await renderer.getCachedPPRShell("/same", "", "fr"))?.value?.html).toBe(french);
+  });
+
+  it("keeps a separate shell per locale for one path", async () => {
+    const renderer = createRenderer();
+    const french = '<html lang="fr">bonjour</html>';
+    const english = '<html lang="en">hello</html>';
+
+    await renderer.cachePPRShell({ pathname: "/both", search: "", locale: "fr" }, french);
+    await renderer.cachePPRShell({ pathname: "/both", search: "", locale: "en" }, english);
+
+    expect((await renderer.getCachedPPRShell("/both", "", "fr"))?.value?.html).toBe(french);
+    expect((await renderer.getCachedPPRShell("/both", "", "en"))?.value?.html).toBe(english);
+  });
+
+  it("still separates entries by search params within one locale", async () => {
+    const renderer = createRenderer();
+    const first = "<html>page one</html>";
+
+    await renderer.cachePPRShell({ pathname: "/search", search: "?page=1", locale: "fr" }, first);
+
+    expect((await renderer.getCachedPPRShell("/search", "?page=1", "fr"))?.value?.html).toBe(first);
+    expect(await renderer.getCachedPPRShell("/search", "?page=2", "fr")).toBeFalsy();
+  });
+
+  it("captures the locale the request resolved to", async () => {
+    const renderer = createRenderer();
+
+    const resolved = async (locale: string) =>
+      renderer.runWithRequestContext(
+        request(locale, "/resolved"),
+        async () => getFarmI18nClientSnapshot()?.locale ?? "",
+      );
+
+    expect(await resolved("fr")).toBe("fr");
+    expect(await resolved("en")).toBe("en");
+  });
+
+  it("puts the locale in the key without dropping the path or search", async () => {
+    const renderer = createRenderer();
+
+    expect(renderer.getPPRCacheKey("/dashboard", "?a=1", "fr")).not.toBe(
+      renderer.getPPRCacheKey("/dashboard", "?a=1", "en"),
+    );
+    expect(renderer.getPPRCacheKey("/dashboard", "", "fr")).not.toBe(
+      renderer.getPPRCacheKey("/other", "", "fr"),
+    );
+    expect(renderer.getPPRCacheKey("/dashboard", "?a=1", "fr")).not.toBe(
+      renderer.getPPRCacheKey("/dashboard", "?a=2", "fr"),
+    );
+  });
+});

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -99,6 +99,14 @@ interface CachedPPRShell {
 interface PPRShellCacheOptions {
   pathname: string;
   search: string;
+  /**
+   * Locale the shell was rendered in, resolved once when these options are built.
+   * The shell carries `lang`, `dir`, the message catalog and the alternate links, so
+   * it cannot be shared across locales. It is captured rather than read at write
+   * time because the shell is stored from a streaming `onComplete` callback, which
+   * can run outside the request context that resolved the locale.
+   */
+  locale: string;
   revalidate?: number;
 }
 
@@ -624,8 +632,8 @@ export class ServerRenderer {
     return createFarmCacheKey(["ssg", normalizeRevalidatePath(urlPath)]);
   }
 
-  private getPPRCacheKey(pathname: string, search = ""): string {
-    return createFarmCacheKey(["ppr", normalizeRevalidatePath(pathname), search]);
+  private getPPRCacheKey(pathname: string, search = "", locale = ""): string {
+    return createFarmCacheKey(["ppr", locale, normalizeRevalidatePath(pathname), search]);
   }
 
   private getCachedSSGPage(urlPath: string) {
@@ -651,12 +659,14 @@ export class ServerRenderer {
     );
   }
 
-  private getCachedPPRShell(pathname: string, search: string) {
-    return this.dataCache.getEntryAsync<CachedPPRShell>(this.getPPRCacheKey(pathname, search));
+  private getCachedPPRShell(pathname: string, search: string, locale = "") {
+    return this.dataCache.getEntryAsync<CachedPPRShell>(
+      this.getPPRCacheKey(pathname, search, locale),
+    );
   }
 
   private async cachePPRShell(options: PPRShellCacheOptions, html: string): Promise<void> {
-    const key = this.getPPRCacheKey(options.pathname, options.search);
+    const key = this.getPPRCacheKey(options.pathname, options.search, options.locale);
     await this.dataCache.setAsync(
       key,
       { html },
@@ -1066,6 +1076,7 @@ export class ServerRenderer {
         ? {
             pathname,
             search: url.search,
+            locale: getFarmI18nClientSnapshot()?.locale ?? "",
             revalidate: renderingConfig.revalidate,
           }
         : undefined;
@@ -1089,8 +1100,13 @@ export class ServerRenderer {
       }
 
       if (pprShellOptions) {
-        const pprCacheKey = this.getPPRCacheKey(pathname, url.search);
-        const cachedPPRShell = await this.getCachedPPRShell(pathname, url.search);
+        // Same locale for the lookup and the later store, so the two cannot diverge.
+        const pprCacheKey = this.getPPRCacheKey(pathname, url.search, pprShellOptions.locale);
+        const cachedPPRShell = await this.getCachedPPRShell(
+          pathname,
+          url.search,
+          pprShellOptions.locale,
+        );
         if (cachedPPRShell) {
           emitFarmEvent({
             type: "ppr.shell.hit",


### PR DESCRIPTION
Fixes #435

## What changed

In `packages/farm/src/server/renderer.ts`:

- `getPPRCacheKey` now takes a locale and puts it in the key, in the same position the
  generated Nitro runtime uses: `["ppr", locale, pathname, search]`.
- `PPRShellCacheOptions` carries a `locale`, resolved once from
  `getFarmI18nClientSnapshot()?.locale ?? ""` when the options are built.
- `getCachedPPRShell` takes the locale too, and the lookup in the render path reads it from the
  same `pprShellOptions` object that the later store uses.
- New tests in `packages/farm/src/__tests__/ppr-shell-locale.test.ts`.

## Why

The shell key was `["ppr", pathname, search]`, so one cached shell was shared by every language.
The shell is not language neutral: it holds `<html lang>`, `dir`, the serialized
`window.__FARM_I18N__` catalog and the `hreflang` links. With `i18n.routing: "none"` there is no
locale in the URL and no redirect, so two requests differing only by `Accept-Language` hit the
same entry and the second one gets the first one's language.

Nothing else stopped it. `getPPRShellBypassReason` bypasses on method, cookie, authorization,
refresh header and middleware or plugin context, but not on language. The response does get
`Vary: ["Cookie", "Accept-Language"]`, so a CDN splits these correctly; only Farm's own shell
cache did not.

`docs/src/app/docs/internationalization/page.md:298` already documents the intended behaviour:
"PPR shell keys also include the locale." The generated production runtime
(`nitro/universal-build.ts:5379`) already did this, so this also removes a difference between
the dev server and production.

## Why the locale is captured instead of read at write time

`cachePPRShell` is called from a streaming `onComplete` callback (`renderer.ts:1446`), which can
run outside the request context that resolved the locale. Reading the snapshot there could yield
`""` while the lookup used `"fr"`, and the two sides would then never agree, which would silently
stop the shell cache from hitting instead of fixing it. Resolving the locale once when
`pprShellOptions` is built and using that value for both sides avoids this by construction.

## Validation

The three tests that assert locale separation fail on `main` and pass with this change. Verified
by stashing only `renderer.ts` and keeping the test file:

```
without the fix: Tests  3 failed | 3 passed (6)
  FAIL does not serve a shell cached in one locale to another locale
  FAIL keeps a separate shell per locale for one path
  FAIL puts the locale in the key without dropping the path or search

with the fix:    Tests  6 passed (6)
```

The other three cover the round trip in one locale, separation by search params, and that the
locale a request resolves to is the one captured. They pass either way and are there to catch the
read and write sides drifting apart.

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/ppr-shell-locale.test.ts`: 6 passed
- `pnpm --filter @farm.js/core exec tsc --noEmit`: clean
- `pnpm exec oxlint` on both changed files: 0 warnings, 0 errors
- `pnpm exec oxfmt --check` on both changed files: clean
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`: ESM, CJS and DTS all succeed
- Full `@farm.js/core` suite run twice on this commit, once with the change and once with only
  `renderer.ts` reverted, then the failing test names compared. The only tests that fail without
  the change and pass with it are the three above. The only three that appear in the other
  direction are `app-markdown`, `layers` and `observability`, all `Test timed out in 5000ms`.
  Those are flaky under load rather than caused by this change: `app-markdown` and
  `observability` pass when run on their own, and `layers` fails the same way with
  `renderer.ts` reverted. Everything else failing is the pre-existing Windows set tracked in
  #429.

## Note

The key shape changes, so shells cached by an older build are no longer read and are rendered
once more after deploying. Nothing else reads that key.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keys the PPR shell cache by locale to prevent cross-language shells. Old behavior: key was ["ppr", pathname, search]; new behavior: ["ppr", locale, pathname, search], aligning the dev server with production and the docs.

**Changes**
- Resolve the locale once when building PPR shell options and reuse it for both lookup and store to avoid request-context drift during streaming completion.
- `getPPRCacheKey` and `getCachedPPRShell` now accept a locale; lookups and writes use the same locale.
- Add tests to verify per-locale separation and that path and search remain part of the key.

**Rollout**
- Key shape change invalidates prior entries; existing shells will miss and re-render once after deploy.
- No app-level config or API changes; CDN behavior unchanged (responses still vary on Accept-Language).

<sup>Written for commit fcd529e050e9057faa3ac876a5d93dd7833b54ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

