### PR TITLE
fix(preview-gateway): prevent active preview names from being hijacked

### DIFF
--- a/packages/farm-preview-gateway/src/index.ts
+++ b/packages/farm-preview-gateway/src/index.ts
@@ -210,7 +210,10 @@ export class MemoryPreviewGatewayStore implements PreviewGatewayStore {
   async touchSession(session: PreviewGatewaySession, ttlMs: number): Promise<void> {
     session.expiresAt = Date.now() + ttlMs;
     this.sessions.set(session.id, session);
-    this.names.set(session.name, session.id);
+    const nameOwner = this.names.get(session.name);
+    if (!nameOwner || nameOwner === session.id) {
+      this.names.set(session.name, session.id);
+    }
   }
 
   async enqueueRequest(sessionId: string, request: PreviewGatewayRequest): Promise<void> {
@@ -245,7 +248,11 @@ export class MemoryPreviewGatewayStore implements PreviewGatewayStore {
 
   async deleteSession(session: PreviewGatewaySession): Promise<void> {
     this.sessions.delete(session.id);
-    this.names.delete(session.name);
+    // The name may have been taken over by a newer session; only remove the
+    // mapping if it still points at the session being deleted.
+    if (this.names.get(session.name) === session.id) {
+      this.names.delete(session.name);
+    }
     this.queues.delete(session.id);
   }
 }
@@ -281,7 +288,10 @@ export class RedisRestPreviewGatewayStore implements PreviewGatewayStore {
       "PX",
       ttlMs,
     );
-    await this.command("SET", this.nameKey(session.name), session.id, "PX", ttlMs);
+    const nameOwner = await this.command<string | null>("GET", this.nameKey(session.name));
+    if (!nameOwner || nameOwner === session.id) {
+      await this.command("SET", this.nameKey(session.name), session.id, "PX", ttlMs);
+    }
     await this.command("EXPIRE", this.queueKey(session.id), Math.ceil(ttlMs / 1000));
   }
 
@@ -333,12 +343,14 @@ export class RedisRestPreviewGatewayStore implements PreviewGatewayStore {
   }
 
   async deleteSession(session: PreviewGatewaySession): Promise<void> {
-    await this.command(
-      "DEL",
-      this.sessionKey(session.id),
-      this.nameKey(session.name),
-      this.queueKey(session.id),
-    );
+    const keys = [this.sessionKey(session.id), this.queueKey(session.id)];
+    // The name may have been taken over by a newer session; only remove the
+    // mapping if it still points at the session being deleted.
+    const nameOwner = await this.command<string | null>("GET", this.nameKey(session.name));
+    if (nameOwner === session.id) {
+      keys.push(this.nameKey(session.name));
+    }
+    await this.command("DEL", ...keys);
   }
 
   private async command<T = unknown>(...args: Array<string | number>) {
@@ -394,7 +406,30 @@ async function createSession(
     name?: string;
     localUrl?: string;
   };
-  const name = sanitizePreviewName(input.name) || randomPreviewName();
+  const requestedName = sanitizePreviewName(input.name);
+  let name = requestedName || randomPreviewName();
+
+  // A name that is still owned by a live session cannot be claimed by a new
+  // one — otherwise any caller could repoint an active preview's public URL
+  // to their own session. Stale sessions (missed heartbeats) may be taken
+  // over, matching how public routing treats them.
+  for (let attempt = 0; ; attempt++) {
+    const existing = await store.getSessionByName(name);
+    if (!existing || !isPreviewClientOnline(existing, config)) {
+      break;
+    }
+    if (requestedName) {
+      return text(
+        `A Farm preview named "${name}" is already active. Choose another name or stop the running preview.`,
+        409,
+      );
+    }
+    if (attempt >= 4) {
+      return text("Could not allocate a unique preview name. Try again.", 503);
+    }
+    name = randomPreviewName();
+  }
+
   const hostname = `${name}.${config.domain}`;
   const session: PreviewGatewaySession = {
     id: randomId("sess"),

--- a/packages/farm-preview-gateway/test/gateway.test.mjs
+++ b/packages/farm-preview-gateway/test/gateway.test.mjs
@@ -93,6 +93,100 @@ test("expires stale preview clients before queueing public requests", async () =
   }
 });
 
+test("rejects claiming a preview name that is actively in use", async () => {
+  const store = new MemoryPreviewGatewayStore();
+  const gateway = await createGatewayServer(store);
+
+  try {
+    const first = await fetch(`${gateway.url}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "demo", localUrl: "http://localhost:4321" }),
+    });
+    assert.equal(first.status, 200);
+    const firstSession = await first.json();
+
+    const second = await fetch(`${gateway.url}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "demo", localUrl: "http://localhost:9999" }),
+    });
+    assert.equal(second.status, 409);
+    assert.match(await second.text(), /already active/);
+
+    // The original session still owns its name.
+    const session = await store.getSessionByName("demo");
+    assert.equal(session.id, firstSession.id);
+  } finally {
+    await gateway.close();
+  }
+});
+
+test("keeps a taken-over name routable after the stale session is deleted", async () => {
+  const store = new MemoryPreviewGatewayStore();
+  const gateway = await createGatewayServer(store, {
+    clientHeartbeatTimeoutMs: 20,
+    requestTimeoutMs: 2000,
+  });
+
+  try {
+    const first = await fetch(`${gateway.url}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "demo", localUrl: "http://localhost:4321" }),
+    });
+    assert.equal(first.status, 200);
+    const stale = await first.json();
+
+    // Let the first session miss its heartbeat window, then take the name over.
+    await delay(50);
+    const second = await fetch(`${gateway.url}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "demo", localUrl: "http://localhost:4322" }),
+    });
+    assert.equal(second.status, 200);
+    const takeover = await second.json();
+
+    // Deleting the stale session must not unroute the takeover session.
+    const deletion = await fetch(`${gateway.url}/api/sessions/${stale.id}?token=${stale.token}`, {
+      method: "DELETE",
+    });
+    assert.equal(deletion.status, 200);
+
+    const session = await store.getSessionByName("demo");
+    assert.ok(session, "expected the takeover session to still own the name");
+    assert.equal(session.id, takeover.id);
+
+    // Public traffic still reaches the takeover session's queue.
+    const publicRequest = fetch(`${gateway.url}/__preview/demo/health`);
+    const poll = await fetch(
+      `${gateway.url}/api/sessions/${takeover.id}/requests?token=${takeover.token}&wait=1000`,
+    ).then((response) => response.json());
+    assert.equal(poll.requests.length, 1);
+    assert.equal(poll.requests[0].path, "/health");
+
+    await fetch(
+      `${gateway.url}/api/sessions/${takeover.id}/responses/${poll.requests[0].id}?token=${takeover.token}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          status: 200,
+          headers: { "content-type": "text/plain" },
+          body: Buffer.from("takeover-ok").toString("base64"),
+          encoding: "base64",
+        }),
+      },
+    );
+    const response = await publicRequest;
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), "takeover-ok");
+  } finally {
+    await gateway.close();
+  }
+});
+
 async function createGatewayServer(store, options = {}) {
   const handler = createNodePreviewGatewayHandler({
     store,


### PR DESCRIPTION
## Summary

`createSession` never checked whether a requested preview name was already claimed. Anyone could POST `/api/sessions` with `{"name":"demo"}` while someone else's `demo` preview was live, and the gateway silently repointed `names["demo"]` — all public traffic for that name — to the new session. The WebSocket relay in `farm-preview-tunnel` explicitly rejects duplicate names; the gateway did not.

Compounding it, `deleteSession` (memory and Redis stores) deleted the name mapping unconditionally, so when either session later expired or was DELETEd, the surviving session's public URL started returning 404 even though its client was still heartbeating.

## Fix

- `createSession` returns **409** when the requested name belongs to a session that is still heartbeating. Stale sessions (missed heartbeat window) may be taken over — the same liveness rule public routing already applies — and randomly generated names retry on collision.
- `deleteSession` in both stores only removes the name mapping when it still points at the session being deleted.
- `touchSession` no longer lets a session re-claim a name it lost while stale (zombie-client guard).

## Tests

Two new integration tests through the real HTTP handler: an active name returns 409 and keeps its owner; a stale session's name can be taken over, and deleting the stale session leaves the takeover session fully routable (public request round-trips through its queue). 4/4 pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents hijacking of active preview names and keeps takeovers routable in `packages/farm-preview-gateway`. Previously, creating a session with an active name silently repointed public traffic and deletions unconditionally removed name mappings; now the gateway rejects active duplicates (409), only deletes name mappings when owned by the session, and blocks stale clients from reclaiming names on heartbeat.

**Client impact**
- Creating a named session can return 409 if the name is active; choose a different name or stop the running preview.
- Random-name allocation retries on collisions and may return 503; retry the request on 503.

<sup>Written for commit ba5470c0952dc91ea3d944dbac8f82cb068ca772. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

