### PR TITLE
fix(stripe): read renewal period end from subscription items

### DIFF
--- a/packages/farm-stripe/src/index.ts
+++ b/packages/farm-stripe/src/index.ts
@@ -2364,6 +2364,19 @@ function getSubscriptionCurrentPeriodEnd(subscription: Stripe.Subscription): str
   return typeof endTime === "number" ? new Date(endTime * 1000).toISOString() : null;
 }
 
+function getSubscriptionEventCurrentPeriodEnd(data: Record<string, unknown>): Date | null {
+  // Stripe API versions before 2025-03-31 carry current_period_end on the
+  // subscription itself; newer versions moved it to the subscription items.
+  const topLevel = (data as { current_period_end?: unknown }).current_period_end;
+  if (typeof topLevel === "number") {
+    return new Date(topLevel * 1000);
+  }
+
+  const items = (data as { items?: { data?: Array<{ current_period_end?: unknown }> } }).items;
+  const endTime = items?.data?.[0]?.current_period_end;
+  return typeof endTime === "number" ? new Date(endTime * 1000) : null;
+}
+
 function deriveFallbackCurrentPeriodStart(
   currentPeriodEnd: string | null,
   product: ResolvedStripeProduct | null,
@@ -3524,10 +3537,8 @@ export function stripe<TInput extends StripeIntegrationInput = {}>(
                         ? event.data.id
                         : existing.stripeSubscriptionId,
                     currentPeriodEnd:
-                      "current_period_end" in event.data &&
-                      typeof event.data.current_period_end === "number"
-                        ? new Date(event.data.current_period_end * 1000)
-                        : existing.currentPeriodEnd,
+                      getSubscriptionEventCurrentPeriodEnd(event.data as Record<string, unknown>) ??
+                      existing.currentPeriodEnd,
                     trialEndsAt:
                       "trial_end" in event.data && typeof event.data.trial_end === "number"
                         ? new Date(event.data.trial_end * 1000)

--- a/packages/farm/src/__tests__/stripe-webhooks.test.ts
+++ b/packages/farm/src/__tests__/stripe-webhooks.test.ts
@@ -182,4 +182,94 @@ describe("stripe webhooks", () => {
       "connect:account.updated:stripe",
     ]);
   });
+
+  it("advances currentPeriodEnd from item-level data on subscription renewals", async () => {
+    const previousPeriodEnd = new Date("2026-08-01T00:00:00Z");
+    const renewedPeriodEnd = Math.floor(new Date("2026-09-01T00:00:00Z").getTime() / 1000);
+    const saved: Array<Record<string, unknown>> = [];
+
+    const integration = stripe({
+      instance: {
+        async createCheckoutSession() {
+          return { id: "cs_test", url: "https://example.com/checkout" };
+        },
+        async createPortalSession() {
+          return { url: "https://example.com/portal" };
+        },
+        async retrieveCheckoutSession() {
+          throw new Error("not used");
+        },
+        async constructWebhookEvent(input: { payload: string }) {
+          return {
+            ...(JSON.parse(input.payload) as {
+              id: string;
+              type: string;
+              data: Record<string, unknown>;
+            }),
+            raw: input.payload,
+          };
+        },
+      },
+      webhooks: {
+        path: "/billing/webhook",
+        secret: "whsec_test",
+      },
+      billing: {
+        resolveOwner() {
+          return { kind: "user" as const, id: "user_1" };
+        },
+        hooks: {
+          async getBillingAccountByStripeCustomerId() {
+            return {
+              owner: { kind: "user" as const, id: "user_1" },
+              planId: "pro",
+              status: "active" as const,
+              stripeCustomerId: "cus_1",
+              stripeSubscriptionId: "sub_1",
+              currentPeriodEnd: previousPeriodEnd,
+              trialEndsAt: null,
+              trialUsedAt: null,
+              cancelAtPeriodEnd: false,
+            };
+          },
+          async saveBillingSnapshot(snapshot: Record<string, unknown>) {
+            saved.push(snapshot);
+          },
+        },
+      },
+    });
+
+    const route = integration.routes.find(
+      (candidate) => candidate.path === "/billing/webhook" && candidate.method === "POST",
+    );
+    expect(route).toBeTruthy();
+
+    const request = new Request("http://example.com/billing/webhook", {
+      method: "POST",
+      headers: { "stripe-signature": "signature" },
+      body: JSON.stringify({
+        id: "evt_renewal",
+        type: "customer.subscription.updated",
+        data: {
+          id: "sub_1",
+          customer: "cus_1",
+          status: "active",
+          // API >= 2025-03-31 carries the billing period on items, not the
+          // subscription itself.
+          items: {
+            data: [{ current_period_end: renewedPeriodEnd }],
+          },
+        },
+      }),
+    });
+
+    const response = await route!.handler(
+      request,
+      createContext(request, "POST", "/billing/webhook", integration.instance),
+    );
+
+    expect(response.status).toBe(200);
+    expect(saved).toHaveLength(1);
+    expect(saved[0].currentPeriodEnd).toEqual(new Date(renewedPeriodEnd * 1000));
+  });
 });


### PR DESCRIPTION
## Summary

The `customer.subscription.updated` webhook branch read top-level `current_period_end` from the event payload. Stripe removed that field from Subscription in API version 2025-03-31 — it now lives on `items.data[*]` — and the repo pins `stripe@20.4.1` / API `2026-02-25.clover`. The SDK-facing helper in the same file (`getSubscriptionCurrentPeriodEnd`) already reads the item-level location, so on modern API versions the webhook condition was always false: the persisted `currentPeriodEnd` silently never advanced past the first billing period, leaving period-keyed meter projections, status responses, and trial/period UI on a stale period forever.

## Fix

New `getSubscriptionEventCurrentPeriodEnd` resolves the period end from the top-level field when present (pre-Basil API versions) and falls back to `items.data[0].current_period_end`. The webhook branch uses it and keeps the existing-snapshot fallback.

## Tests

New webhook test drives `customer.subscription.updated` with a modern items-shaped payload through the integration with in-memory persistence hooks and asserts the saved snapshot's `currentPeriodEnd` advances to the renewed period. Verified the test fails against the old read (period stays stale) and passes with the fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes renewal period detection for Stripe `customer.subscription.updated` events. Old behavior read only top-level `current_period_end`; new behavior reads top-level when present or `items.data[0].current_period_end`. This advances `currentPeriodEnd` and keeps period-keyed projections, status responses, and trial/period UI current.

**Review notes**
- Add `getSubscriptionEventCurrentPeriodEnd` in `packages/farm-stripe/src/index.ts`; the webhook uses it and keeps the existing-snapshot fallback.
- Add an integration test in `packages/farm/src/__tests__/stripe-webhooks.test.ts` asserting advancement with an items-shaped payload.
- No migration or config changes. Compatible with pre- and post-2025-03-31 Stripe API responses under `stripe@20.4.1`.

<sup>Written for commit 46667f980a97ddb267e6fdcc0954459ca203b624. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

