### PR TITLE
fix(cli): spawn package managers through a shell on Windows

### DIFF
--- a/packages/farm-cli/src/upgrade.ts
+++ b/packages/farm-cli/src/upgrade.ts
@@ -255,11 +255,16 @@ function getDependencySectionFlags(
 
 function runFarmUpgradeCommand(command: FarmUpgradeCommand): Promise<void> {
   return new Promise((resolve, reject) => {
-    const executable = process.platform === "win32" ? `${command.command}.cmd` : command.command;
+    const isWindows = process.platform === "win32";
+    const executable = isWindows ? `${command.command}.cmd` : command.command;
+    // Node rejects spawning .cmd/.bat files without a shell since the fix for
+    // CVE-2024-27980 (EINVAL). Safe here: the command is one of npm|pnpm|yarn|bun
+    // and the arguments are literal flags plus name@channel package specs.
     const child = spawn(executable, command.args, {
       cwd: command.cwd,
       env: process.env,
       stdio: "inherit",
+      shell: isWindows,
     });
 
     child.on("error", reject);


### PR DESCRIPTION
## Summary

`farm upgrade` spawned `npm.cmd`/`pnpm.cmd`/`yarn.cmd`/`bun.cmd` without `shell: true`. Node rejects spawning `.cmd`/`.bat` files without a shell with `EINVAL` since the CVE-2024-27980 fix (Node 18.20.x / 20.12.x / 21.7.x+), so on Windows with any current Node release the upgrade builds a valid plan and then every install command fails immediately.

`create-farm-app` already handles this exact case (`installDependencies` passes `shell: isWindows` with a comment citing the CVE); `upgrade.ts` never got the same treatment.

## Fix

Same guarded spawn as `create-farm-app`: `shell: isWindows`. Injection-safe because the command is one of the four known package managers and the arguments are literal flags plus `name@channel` package specs (no shell metacharacters).

## Tests

All 81 existing farm-cli tests pass. The failing path is Windows-only (spawn of `.cmd`), so it can't be exercised from a POSIX test environment — the change mirrors the proven pattern in `create-farm-app` byte for byte.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows `farm upgrade` by spawning `npm`/`pnpm`/`yarn`/`bun` via a shell. Previously we spawned `*.cmd` directly, which current Node rejects with EINVAL after CVE-2024-27980; installs failed on Windows. Non-Windows behavior is unchanged.

- **Review notes**
  - Windows-only: sets `shell: true` when `process.platform === "win32"`.
  - Mirrors the guarded spawn in `create-farm-app`.
  - Injection-safe: command limited to `npm`/`pnpm`/`yarn`/`bun`; args are flags and `name@channel`.

<sup>Written for commit c1bcdb4f096f70b5e664b27b15e7c0f10aad652f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

