### PR TITLE
fix(core): resolve hash anchors by id instead of querySelector

### DIFF
--- a/packages/farm/src/__tests__/spa-router-hash.test.ts
+++ b/packages/farm/src/__tests__/spa-router-hash.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { getHashTargetElement } from "../client/spa-router";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("getHashTargetElement", () => {
+  it("finds ids that are invalid CSS selectors", () => {
+    document.body.innerHTML = `<h2 id="2-installation">Installation</h2><p id="a.b">dots</p>`;
+
+    expect(getHashTargetElement("#2-installation")?.id).toBe("2-installation");
+    expect(getHashTargetElement("#a.b")?.id).toBe("a.b");
+  });
+
+  it("decodes percent-encoded fragments", () => {
+    document.body.innerHTML = `<h2 id="é">accent</h2>`;
+
+    expect(getHashTargetElement("#%C3%A9")?.id).toBe("é");
+  });
+
+  it("keeps the raw fragment when percent-encoding is malformed", () => {
+    document.body.innerHTML = `<h2 id="100%">raw</h2>`;
+
+    expect(getHashTargetElement("#100%")?.id).toBe("100%");
+  });
+
+  it("falls back to anchor names", () => {
+    document.body.innerHTML = `<a name="legacy-anchor">old-style</a>`;
+
+    expect(getHashTargetElement("#legacy-anchor")).not.toBeNull();
+  });
+
+  it("returns null without throwing when nothing matches", () => {
+    expect(getHashTargetElement("#missing")).toBeNull();
+    expect(getHashTargetElement("#")).toBeNull();
+  });
+});

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -469,7 +469,7 @@ export class SPARouter {
 
     if (options.scroll) {
       if (options.url.hash) {
-        const element = document.querySelector(options.url.hash);
+        const element = getHashTargetElement(options.url.hash);
         if (element) {
           element.scrollIntoView();
         }
@@ -868,4 +868,29 @@ function createNavigationLocation(url: URL): FarmNavigationLocation {
 
 function getScrollElementStorageKey(path: string, key: string): string {
   return `farm-scroll-${path}:${key}`;
+}
+
+export function getHashTargetElement(hash: string): Element | null {
+  // The fragment is not a CSS selector: ids starting with a digit or
+  // containing selector characters (#2-installation, #a.b) throw in
+  // querySelector. Match by id (decoded first, then raw) and fall back to
+  // anchor name, mirroring native fragment navigation.
+  const fragment = hash.startsWith("#") ? hash.slice(1) : hash;
+  if (!fragment) {
+    return null;
+  }
+
+  let decoded = fragment;
+  try {
+    decoded = decodeURIComponent(fragment);
+  } catch {
+    // Keep the raw fragment when the percent-encoding is malformed.
+  }
+
+  return (
+    document.getElementById(decoded) ||
+    document.getElementById(fragment) ||
+    document.getElementsByName(decoded)[0] ||
+    null
+  );
 }


### PR DESCRIPTION
## Summary

The SPA router's `commitNavigation` scrolled to hash anchors with `document.querySelector(options.url.hash)`. A URL fragment is not a CSS selector: ids beginning with a digit (`#2-installation`), containing selector characters (`#a.b`), or percent-encoded (`#%C3%A9`) throw `SyntaxError` — after the navigation has already rendered and pushed history. The error is caught by `navigate()`'s catch, which fails the navigation and falls back to a full page load; in dev the runtime error overlay pops up over a perfectly rendered page.

## Fix

New `getHashTargetElement` mirrors native fragment navigation: `getElementById` on the decoded fragment, raw fragment as a fallback for malformed percent-encoding, then anchor `name`. Never throws.

## Tests

New jsdom suite covers digit-leading ids, ids with dots, percent-encoded fragments, malformed encoding, legacy `<a name>` anchors, and the no-match case. Neighboring router suites (history-sync, navigation-state) still pass — 26/26 across the three files, `tsc` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SPA hash scrolling by resolving fragments via element id instead of CSS selectors. Previously `document.querySelector(hash)` treated fragments as selectors, throwing on digits, dots, or percent-encoded ids and forcing a full page load; now we match by decoded id, raw id, then anchor name so navigation does not throw and SPA control is preserved.

- `commitNavigation` now uses `getHashTargetElement` and scrolls only when a target exists, preventing `SyntaxError` and history/overlay side effects.
- `getHashTargetElement` decodes the fragment, tries `getElementById` (decoded then raw), then anchor `name`; it mirrors native behavior and never throws.
- Adds a jsdom test suite covering digit-leading ids, dots, percent-encoded and malformed fragments, legacy `<a name>`, and no-match; existing router suites still pass. No migration required.

<sup>Written for commit 5f1fcbfb60a2e490f74d866d3ea7ade1c56f79b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

