### PR TITLE
fix(core): detect platform build environments when no target is set

### DIFF
--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -9,6 +9,7 @@ import {
   defineFarmConfig,
   loadConfig,
   resolveConfig,
+  detectPlatformDeployTarget,
   resolveDeployConfig,
   resolveDocsConfig,
   resolveMigrationsConfig,
@@ -682,6 +683,48 @@ describe("resolveMigrationsConfig", () => {
         },
       ],
     });
+  });
+});
+
+describe("detectPlatformDeployTarget", () => {
+  it("maps platform build env vars to deploy targets", () => {
+    expect(detectPlatformDeployTarget({ VERCEL: "1" })).toBe("vercel");
+    expect(detectPlatformDeployTarget({ NETLIFY: "true" })).toBe("netlify");
+    expect(detectPlatformDeployTarget({ CF_PAGES: "1" })).toBe("cloudflare");
+    expect(detectPlatformDeployTarget({})).toBeUndefined();
+    expect(detectPlatformDeployTarget({ VERCEL: "" })).toBeUndefined();
+  });
+});
+
+describe("resolveDeployConfig platform detection", () => {
+  it("uses the detected platform when nothing selects a preset", () => {
+    const deploy = resolveDeployConfig({}, { env: { VERCEL: "1" } });
+    expect(deploy.target).toBe("vercel");
+    expect(deploy.preset).toBe("vercel");
+    expect(deploy.outputDir).toBe(".vercel/output");
+  });
+
+  it("never overrides an explicit target, even when it cannot deploy there", () => {
+    const deploy = resolveDeployConfig({ deploy: { target: "node" } }, { env: { VERCEL: "1" } });
+    expect(deploy.target).toBe("node");
+    expect(deploy.preset).toBe("node-server");
+  });
+
+  it("never overrides an explicit preset", () => {
+    const deploy = resolveDeployConfig({ preset: "node-server" }, { env: { NETLIFY: "true" } });
+    expect(deploy.target).toBe("node");
+    expect(deploy.preset).toBe("node-server");
+  });
+
+  it("respects CLI overrides above detection", () => {
+    const deploy = resolveDeployConfig({}, { target: "cloudflare", env: { VERCEL: "1" } });
+    expect(deploy.target).toBe("cloudflare");
+  });
+
+  it("keeps the node-server default outside platform CI", () => {
+    const deploy = resolveDeployConfig({}, { env: {} });
+    expect(deploy.target).toBe("node");
+    expect(deploy.preset).toBe("node-server");
   });
 });
 

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -49,6 +49,7 @@ import {
   type ResolvedFarmLayer,
 } from "./layers";
 import path from "path";
+import { logger } from "./utils";
 import { normalizeFarmDeploymentId } from "./deployment";
 import { resolveFarmDevtoolsConfig, type ResolvedFarmDevtoolsConfig } from "./devtools-config";
 import {
@@ -475,12 +476,35 @@ export function resolveDeployOutputPath(root: string, outputDir: string): string
   return path.isAbsolute(outputDir) ? outputDir : path.join(root, outputDir);
 }
 
+const PLATFORM_BUILD_ENV_TARGETS: ReadonlyArray<[string, FarmDeployTarget]> = [
+  ["VERCEL", "vercel"],
+  ["NETLIFY", "netlify"],
+  ["CF_PAGES", "cloudflare"],
+];
+
+/**
+ * Deploy target announced by the build environment (VERCEL=1, NETLIFY=true,
+ * CF_PAGES=1), or undefined outside platform CI.
+ */
+export function detectPlatformDeployTarget(
+  env: NodeJS.ProcessEnv = process.env,
+): FarmDeployTarget | undefined {
+  for (const [key, target] of PLATFORM_BUILD_ENV_TARGETS) {
+    if (env[key]) return target;
+  }
+  return undefined;
+}
+
+const warnedPlatformMismatches = new Set<string>();
+
 export function resolveDeployConfig(
   config: Pick<FarmUserConfig, "deploy" | "preset" | "distDir">,
   overrides: {
     target?: FarmDeployTarget;
     preset?: BaseFarmConfig["preset"];
     outputDir?: string;
+    /** Build environment consulted for platform detection. Tests inject this. */
+    env?: NodeJS.ProcessEnv;
   } = {},
 ): ResolvedFarmDeployConfig {
   const deploy = config.deploy || {};
@@ -491,11 +515,32 @@ export function resolveDeployConfig(
   // a node server into .vercel/output — a directory Vercel will deploy as
   // Build Output API content.
   const overrideTarget = normalizeDeployTarget(overrides.target);
-  const target = overrideTarget
+  let target = overrideTarget
     ? overrideTarget
     : overrides.preset
       ? getDeployTargetForPreset(overrides.preset)
       : normalizeDeployTarget(deploy.target);
+
+  // A platform build environment (Vercel, Netlify, Cloudflare Pages) can only
+  // deploy its own output shape. When nothing selects a preset, the
+  // node-server fallback would build an artifact the platform cannot serve,
+  // so honor the detected platform instead. An explicit configuration always
+  // wins; it just gets a warning when it cannot run where it is being built.
+  const detectedTarget = detectPlatformDeployTarget(overrides.env);
+  if (detectedTarget) {
+    const hasExplicitSelection = Boolean(
+      target || overrides.preset || deploy.preset || config.preset,
+    );
+    if (!hasExplicitSelection) {
+      target = detectedTarget;
+      if (!warnedPlatformMismatches.has(`select:${detectedTarget}`)) {
+        warnedPlatformMismatches.add(`select:${detectedTarget}`);
+        logger.info(
+          `Detected ${detectedTarget} build environment; using the ${detectedTarget} preset. Set deploy.target in farm.config.ts to override.`,
+        );
+      }
+    }
+  }
   const preset =
     overrides.preset ||
     deploy.preset ||
@@ -503,6 +548,15 @@ export function resolveDeployConfig(
     getPresetForDeployTarget(target) ||
     "node-server";
   const resolvedTarget = target || getDeployTargetForPreset(preset);
+  if (detectedTarget && resolvedTarget !== detectedTarget) {
+    const mismatchKey = `mismatch:${resolvedTarget}:${detectedTarget}`;
+    if (!warnedPlatformMismatches.has(mismatchKey)) {
+      warnedPlatformMismatches.add(mismatchKey);
+      logger.warn(
+        `The configured deploy target "${resolvedTarget ?? preset}" cannot be served by ${detectedTarget}, but this build is running in a ${detectedTarget} build environment. Set deploy.target: "${detectedTarget}" in farm.config.ts to deploy there.`,
+      );
+    }
+  }
   const platformOutput =
     resolvedTarget === "vercel"
       ? deploy.vercel?.outputDirectory


### PR DESCRIPTION
## Summary

Fixes #445.

Deploying on Vercel without `deploy.target: "vercel"` silently built the default `node-server` preset — an artifact Vercel cannot serve — and the deploy failed later with the unhelpful `No Output Directory named "output" found`.

## Changes

All in `resolveDeployConfig` (the single choke point shared by `build`/`deploy`/`start`):

- New `detectPlatformDeployTarget(env)` maps `VERCEL` / `NETLIFY` / `CF_PAGES` build-env vars to deploy targets.
- **Nothing configured** (no `deploy.target`/`deploy.preset`/`config.preset`/CLI override) **+ platform env detected** → resolve to the platform's preset, with an info log naming the override knob. The node-server fallback was never a user choice, so honoring the platform beats producing an undeployable artifact.
- **Explicit configuration always wins** — but when it can't be served where the build is running, a once-per-process warning explains exactly what to change. No silent switcheroo for people intentionally building node artifacts on platform CI.
- Detection takes the env as a parameter (`overrides.env`, defaulting to `process.env`) so tests inject it and never flake on host environment.
- Outside platform CI: behaviour byte-for-byte unchanged.

## Testing

- New tests: env-var mapping (incl. empty-string vars not counting), auto-selection resolving target/preset/outputDir to vercel, explicit target/preset/CLI-override each beating detection, and unchanged node-server default with an empty env. Full `config.test.ts` suite passes (44/44).
- `tsc --noEmit`, `oxlint`, root `pnpm lint` (incl. the popstate guard) all clean.
- The docs app already sets `deploy.target: "vercel"` explicitly, so its deploys are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-detects Vercel/Netlify/Cloudflare Pages build environments and selects the matching preset when no target or preset is set. Previously we defaulted to the node-server preset (undeployable on these platforms); now we use the platform preset by default, with explicit configs unchanged and clear logs when they conflict with the detected platform.

**Review notes**
- Applies only when nothing selects a target or preset; detection maps `VERCEL`/`NETLIFY`/`CF_PAGES` to `vercel`/`netlify`/`cloudflare` and logs an info with how to override via `deploy.target`.
- Explicit target/preset or CLI override always wins; if it cannot run on the detected platform, emit a once-per-process warning with the exact change to make.
- Behavior outside platform CI is unchanged; detection reads an injectable `env` to keep tests stable.
- Tests cover env mapping, precedence, and default behavior; changes are limited to `resolveDeployConfig` and the new `detectPlatformDeployTarget`.
- Migration (only if you intentionally build a node artifact on platform CI): set `deploy.target: "node"` or pass a CLI override to retain the node-server output.

<sup>Written for commit d1b7b645cc1018c2e276f380184c999108e67b56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

