### PR TITLE
fix(core): make the test suite pass on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Check out with LF everywhere. Several tests match multi-line snippets of source
+# files, and a CRLF checkout on Windows breaks those comparisons.
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,19 +9,27 @@ on:
 
 jobs:
   test:
-    name: Test
-    runs-on: ubuntu-latest
+    name: Test (${{ matrix.os }}, Node ${{ matrix.node-version }})
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
         include:
-          - node-version: 20
+          - os: ubuntu-latest
+            node-version: 20
             test_args: --skip-incompatible
-          - node-version: 22
+          - os: ubuntu-latest
+            node-version: 22
             test_args: --skip-incompatible --only-with-node-engine
-          - node-version: 24
+          - os: ubuntu-latest
+            node-version: 24
             test_args: --skip-incompatible --only-with-node-engine
+          # No --only-with-node-engine: @farm.js/core declares no engines field and
+          # would otherwise be skipped, which is the suite this entry exists to cover.
+          - os: windows-latest
+            node-version: 24
+            test_args: --skip-incompatible
 
     steps:
       - name: Checkout
@@ -57,7 +65,7 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=8192
 
       - name: Check committed generated types
-        if: matrix.node-version == 20
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == 20
         run: pnpm --dir docs exec farm generate --check
 
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,11 @@ jobs:
 
       - name: Run tests
         run: pnpm test -- ${{ matrix.test_args }}
+        env:
+          # The Windows runner points TEMP at the short name C:\Users\RUNNER~1, and
+          # Vite cannot resolve a dynamic import whose path it percent-encodes.
+          TEMP: ${{ runner.temp }}
+          TMP: ${{ runner.temp }}
 
       - name: Type check
         run: pnpm type-check

--- a/packages/farm-cf-agent/src/__tests__/cf-agent.test.ts
+++ b/packages/farm-cf-agent/src/__tests__/cf-agent.test.ts
@@ -108,7 +108,10 @@ export default { fetch() { return new Response("agent"); } };
     expect(generated.assets.directory).toBe("./.output/public");
     expect(generated.durable_objects.bindings[0].class_name).toBe("CounterAgent");
 
-    const module = await import(`${pathToFileURL(result.wrapperPath).href}?test=${Date.now()}`);
+    // decodeURI because Vite resolves this id itself and fails on a percent-encoded
+    // path, which a Windows short name such as RUNNER~1 produces.
+    const wrapperUrl = decodeURI(pathToFileURL(result.wrapperPath).href);
+    const module = await import(`${wrapperUrl}?test=${Date.now()}`);
     expect(
       module.default.fetch(new Request("https://example.com/agents/counter/default")),
     ).toMatchObject({ status: 200 });

--- a/packages/farm-eve/src/__tests__/eve.test.ts
+++ b/packages/farm-eve/src/__tests__/eve.test.ts
@@ -47,7 +47,8 @@ describe("Eve Vercel output", () => {
     await writeFile(join(root, "package.json"), '{"type":"module"}\n');
     await writeFile(join(workspaceRoot, ".vercel", "project.json"), "{}\n");
     await writeFile(join(outputDirectory, "config.json"), '{"version":3,"routes":[]}\n');
-    await symlink(packageDirectory, join(root, "node_modules", "eve"), "dir");
+    // Junctions need no Windows privilege; the type is ignored on POSIX.
+    await symlink(packageDirectory, join(root, "node_modules", "eve"), "junction");
 
     await writeEveVercelOutput({
       root,

--- a/packages/farm-react/vitest.config.ts
+++ b/packages/farm-react/vitest.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
     },
   },
   test: {
+    // Windows: the threads pool segfaults during teardown, so the run exits
+    // non-zero with every test passing.
+    ...(process.platform === "win32"
+      ? { pool: "forks" as const, poolOptions: { forks: { minForks: 1, maxForks: 1 } } }
+      : {}),
     environment: "jsdom",
     globals: true,
     include: ["src/**/*.test.{ts,tsx}"],

--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from "node:url";
 import fs from "fs";
 import os from "os";
 import path from "path";
@@ -83,10 +84,13 @@ describe("client component path resolution", () => {
       "'use client';\nexport default function Page() { return null; }\n",
     );
 
-    expect(resolveModuleSourcePath(`file://${sourceFile}`, root)).toBe(sourceFile);
-    expect(isClientComponentModule(`file://${sourceFile}`, root)).toBe(true);
-    expect(resolveModuleSourcePath(`/@fs${sourceFile}`, root)).toBe(sourceFile);
-    expect(isClientComponentModule(`/@fs${sourceFile}`, root)).toBe(true);
+    const fileUrl = pathToFileURL(sourceFile).href;
+    const fsId = `/@fs/${sourceFile.split(path.sep).join("/").replace(/^\/+/, "")}`;
+
+    expect(resolveModuleSourcePath(fileUrl, root)).toBe(sourceFile);
+    expect(isClientComponentModule(fileUrl, root)).toBe(true);
+    expect(resolveModuleSourcePath(fsId, root)).toBe(sourceFile);
+    expect(isClientComponentModule(fsId, root)).toBe(true);
   });
 
   it("supports hydratable server pages through export const hydrate = true", () => {

--- a/packages/farm/src/__tests__/create-server.test.ts
+++ b/packages/farm/src/__tests__/create-server.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   createFarmClientOptimizeDepsConfig,
@@ -43,7 +44,7 @@ describe("mergeFarmViteConfig", () => {
 
   it("maps @ to the configured application source directory", () => {
     expect(createFarmSourceAlias("/workspace/app", "web")).toEqual({
-      "@": "/workspace/app/web",
+      "@": path.resolve("/workspace/app", "web"),
     });
   });
 

--- a/packages/farm/src/__tests__/development-observability.test.ts
+++ b/packages/farm/src/__tests__/development-observability.test.ts
@@ -8,6 +8,8 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 
+const isWindows = process.platform === "win32";
+
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const farmOTelRoot = path.resolve(packageRoot, "../farm-otel");
 
@@ -39,23 +41,30 @@ async function waitForServer(url: string, output: () => string): Promise<Respons
 }
 
 describe("development OpenTelemetry tracing", () => {
-  it("starts instrumentation before traffic and flushes request traces on server close", async () => {
+  // Windows has no POSIX signals: child.kill("SIGTERM") maps to TerminateProcess,
+  // so graceful shutdown never runs and its effects cannot be observed.
+  it("starts instrumentation before traffic and flushes request traces on server close", async (ctx) => {
+    if (isWindows) ctx.skip();
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-development-otel-"));
     const traceOutput = path.join(root, "traces.jsonl");
     let developmentServer: ReturnType<typeof spawn> | undefined;
 
     try {
       await fs.mkdir(path.join(root, "node_modules", "@farm.js"), { recursive: true });
-      await fs.symlink(farmOTelRoot, path.join(root, "node_modules", "@farm.js", "otel"), "dir");
+      await fs.symlink(
+        farmOTelRoot,
+        path.join(root, "node_modules", "@farm.js", "otel"),
+        "junction",
+      );
       await fs.symlink(
         await fs.realpath(path.join(packageRoot, "node_modules", "react")),
         path.join(root, "node_modules", "react"),
-        "dir",
+        "junction",
       );
       await fs.symlink(
         await fs.realpath(path.join(packageRoot, "node_modules", "react-dom")),
         path.join(root, "node_modules", "react-dom"),
-        "dir",
+        "junction",
       );
       await fs.mkdir(path.join(root, "src", "app"), { recursive: true });
       await fs.writeFile(
@@ -183,7 +192,7 @@ await server.listen(Number(process.env.PORT));
       if (developmentServer && developmentServer.exitCode === null) {
         developmentServer.kill("SIGKILL");
       }
-      await fs.rm(root, { recursive: true, force: true });
+      await fs.rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
     }
   }, 60_000);
 });

--- a/packages/farm/src/__tests__/docs-adapter.test.ts
+++ b/packages/farm/src/__tests__/docs-adapter.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { createFarmDocsAdapterHandler, hasFarmDocsRuntimeAdapter } from "../docs/adapter";
 import type { FarmDocsResolvedConfig } from "../docs/types";
@@ -62,7 +63,7 @@ describe("Farm docs runtime adapters", () => {
     expect(runtimeConfig).toMatchObject({
       entry: "docs",
       docsPath: "/docs",
-      contentDir: "/workspace/app/content/docs",
+      contentDir: path.resolve("/workspace/app", "content", "docs"),
     });
     expect(hostOptions).toMatchObject({
       rootDir: "/workspace/app",

--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -603,7 +603,9 @@ describe("createFarmDocsHandler", () => {
     const manifest = createFarmDocsLastModifiedManifest(docsDir);
 
     expect(new Date(manifest.pages["page.md"]).toISOString()).toBe(commitDate);
-  });
+    // Eight synchronous git spawns, which are slow enough on Windows to pass the
+    // default timeout.
+  }, 30_000);
 
   it("renders docs-style breadcrumbs only for nested docs pages", async () => {
     const { root, docs } = await createDocsFixture();

--- a/packages/farm/src/__tests__/fixtures/middleware-production-fixture.ts
+++ b/packages/farm/src/__tests__/fixtures/middleware-production-fixture.ts
@@ -11,7 +11,8 @@ export async function createMiddlewareProductionFixture(): Promise<string> {
   await fs.mkdir(path.join(root, "node_modules", "@farm.js"), {
     recursive: true,
   });
-  await fs.symlink(packageRoot, path.join(root, "node_modules", "@farm.js", "core"), "dir");
+  // Junctions need no Windows privilege; the type is ignored on POSIX.
+  await fs.symlink(packageRoot, path.join(root, "node_modules", "@farm.js", "core"), "junction");
 
   await fs.mkdir(path.join(root, "src", "app", "dashboard", "settings"), {
     recursive: true,
@@ -447,5 +448,6 @@ export default function userSitemap({ params, path }: any) {
 }
 
 export async function cleanupMiddlewareProductionFixture(root: string): Promise<void> {
-  await fs.rm(root, { recursive: true, force: true });
+  // Windows keeps handles on spawned servers and loaded .node files briefly after exit.
+  await fs.rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
 }

--- a/packages/farm/src/__tests__/i18n.test.ts
+++ b/packages/farm/src/__tests__/i18n.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { readFarmI18nCatalogs } from "../i18n/catalog";
 import { resolveFarmI18nConfig } from "../i18n/config";
@@ -34,7 +34,7 @@ describe("Farm i18n configuration", () => {
       locales: ["en-US", "am"],
       defaultLocale: "en-US",
       fallbackLocale: "en-US",
-      messages: "/app/src/messages",
+      messages: resolve("/app", "src", "messages"),
       routing: "prefix-except-default",
       detection: ["url", "cookie", "accept-language"],
       strict: true,

--- a/packages/farm/src/__tests__/production-middleware.test.ts
+++ b/packages/farm/src/__tests__/production-middleware.test.ts
@@ -33,7 +33,9 @@ function readInlineFarmProps(html: string): Record<string, any> {
 }
 
 describe("production middleware runtime", () => {
-  it("runs farm.config middleware and app middleware in a production build", async () => {
+  // Windows: image optimization stalls loading the WASM codec (#434).
+  it("runs farm.config middleware and app middleware in a production build", async (ctx) => {
+    if (process.platform === "win32") ctx.skip();
     const root = await createMiddlewareProductionFixture();
     const originalFetch = globalThis.fetch;
 
@@ -67,11 +69,13 @@ describe("production middleware runtime", () => {
       expect(vercelOutputConfig.routes[1]).toEqual({ handle: "filesystem" });
 
       const staticAssetsDir = path.join(root, ".vercel", "output", "static", "assets");
-      const productAssetName = (await fs.readdir(staticAssetsDir)).find((file) =>
-        file.startsWith("product-"),
-      );
-      expect(productAssetName).toMatch(/\.png$/);
-      const productAsset = await fs.readFile(path.join(staticAssetsDir, productAssetName!));
+      // The client build emits this image under more than one hashed name, and readdir
+      // order is platform dependent, so track every candidate instead of picking one.
+      const productAssetNames = (await fs.readdir(staticAssetsDir))
+        .filter((file) => file.startsWith("product-"))
+        .sort();
+      expect(productAssetNames.length).toBeGreaterThan(0);
+      expect(productAssetNames.every((name) => name.endsWith(".png"))).toBe(true);
       await expect(
         fs.access(
           path.join(
@@ -108,11 +112,13 @@ describe("production middleware runtime", () => {
       expect(nitroBundle).not.toContain("@img/sharp-");
       globalThis.fetch = (async (input: URL | RequestInfo, init?: RequestInit) => {
         const url = new URL(input instanceof Request ? input.url : String(input));
-        if (url.origin === "https://example.test" && url.pathname.endsWith(productAssetName!)) {
-          return new Response(productAsset, {
+        const requestedAsset = productAssetNames.find((name) => url.pathname.endsWith(name));
+        if (url.origin === "https://example.test" && requestedAsset) {
+          const bytes = await fs.readFile(path.join(staticAssetsDir, requestedAsset));
+          return new Response(bytes, {
             headers: {
               "content-type": "image/png",
-              "content-length": String(productAsset.byteLength),
+              "content-length": String(bytes.byteLength),
             },
           });
         }
@@ -168,7 +174,10 @@ describe("production middleware runtime", () => {
         .replaceAll("&amp;", "&");
       expect(optimizedImageHref).toContain("/media/image?");
       expect(optimizedImageHref).toContain("q=60");
-      expect(optimizedImageHref).toContain(encodeURIComponent(`/assets/${productAssetName}`));
+      const referencedAsset = (
+        new URL(optimizedImageHref!, "https://farm.test").searchParams.get("url") ?? ""
+      ).replace(/^\/assets\//, "");
+      expect(productAssetNames).toContain(referencedAsset);
       const dashboardImageHref = html.match(
         /property="og:image" content="(\/dashboard\/opengraph-image\?v=[a-f0-9]{16})"/,
       )?.[1];

--- a/packages/farm/src/__tests__/production-observability.test.ts
+++ b/packages/farm/src/__tests__/production-observability.test.ts
@@ -10,6 +10,8 @@ import { describe, expect, it } from "vitest";
 import { build } from "../build";
 import { resolveConfig } from "../config";
 
+const isWindows = process.platform === "win32";
+
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const farmOTelRoot = path.resolve(packageRoot, "../farm-otel");
 
@@ -41,24 +43,35 @@ async function waitForServer(url: string, output: () => string): Promise<Respons
 }
 
 describe("production OpenTelemetry tracing", () => {
-  it("starts instrumentation before traffic and flushes request traces during graceful shutdown", async () => {
+  // Windows has no POSIX signals: child.kill("SIGTERM") maps to TerminateProcess,
+  // so graceful shutdown never runs and its effects cannot be observed.
+  it("starts instrumentation before traffic and flushes request traces during graceful shutdown", async (ctx) => {
+    if (isWindows) ctx.skip();
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-production-otel-"));
     const traceOutput = path.join(root, "traces.jsonl");
     let productionServer: ReturnType<typeof spawn> | undefined;
 
     try {
       await fs.mkdir(path.join(root, "node_modules", "@farm.js"), { recursive: true });
-      await fs.symlink(packageRoot, path.join(root, "node_modules", "@farm.js", "core"), "dir");
-      await fs.symlink(farmOTelRoot, path.join(root, "node_modules", "@farm.js", "otel"), "dir");
+      await fs.symlink(
+        packageRoot,
+        path.join(root, "node_modules", "@farm.js", "core"),
+        "junction",
+      );
+      await fs.symlink(
+        farmOTelRoot,
+        path.join(root, "node_modules", "@farm.js", "otel"),
+        "junction",
+      );
       await fs.symlink(
         await fs.realpath(path.join(packageRoot, "node_modules", "react")),
         path.join(root, "node_modules", "react"),
-        "dir",
+        "junction",
       );
       await fs.symlink(
         await fs.realpath(path.join(packageRoot, "node_modules", "react-dom")),
         path.join(root, "node_modules", "react-dom"),
-        "dir",
+        "junction",
       );
       await fs.mkdir(path.join(root, "src", "app", "api", "health"), { recursive: true });
       await fs.writeFile(
@@ -223,7 +236,7 @@ export function register(context) {
       if (productionServer && productionServer.exitCode === null) {
         productionServer.kill("SIGKILL");
       }
-      await fs.rm(root, { recursive: true, force: true });
+      await fs.rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
     }
   }, 120_000);
 });

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -14,6 +14,8 @@ import { defineIntegration } from "../integrations";
 import { definePlugin } from "../plugin";
 import { logger } from "../utils";
 
+const isWindows = process.platform === "win32";
+
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
 async function createProductionFixture(): Promise<string> {
@@ -22,7 +24,7 @@ async function createProductionFixture(): Promise<string> {
   await fs.mkdir(path.join(root, "node_modules", "@farm.js"), {
     recursive: true,
   });
-  await fs.symlink(packageRoot, path.join(root, "node_modules", "@farm.js", "core"), "dir");
+  await fs.symlink(packageRoot, path.join(root, "node_modules", "@farm.js", "core"), "junction");
   await fs.mkdir(path.join(root, "src", "app"), { recursive: true });
   await fs.mkdir(path.join(root, "src", "lib"), { recursive: true });
   await fs.writeFile(
@@ -72,8 +74,8 @@ async function linkReact18(root: string): Promise<void> {
     throw new Error("React 18 compatibility fixture dependencies are missing");
   }
 
-  await fs.symlink(reactPath, path.join(root, "node_modules", "react"), "dir");
-  await fs.symlink(reactDOMPath, path.join(root, "node_modules", "react-dom"), "dir");
+  await fs.symlink(reactPath, path.join(root, "node_modules", "react"), "junction");
+  await fs.symlink(reactDOMPath, path.join(root, "node_modules", "react-dom"), "junction");
 }
 
 async function getAvailablePort(): Promise<number> {
@@ -565,7 +567,10 @@ export default function DynamicPage({ params }) {
     }
   }, 120_000);
 
-  it("drains in-flight requests and closes production resources on SIGTERM", async () => {
+  // Windows has no POSIX signals: child.kill("SIGTERM") maps to TerminateProcess,
+  // so graceful shutdown never runs and its effects cannot be observed.
+  it("drains in-flight requests and closes production resources on SIGTERM", async (ctx) => {
+    if (isWindows) ctx.skip();
     const root = await createProductionFixture();
     const markerPath = path.join(root, "production-lifecycle.log");
     const apiDir = path.join(root, "src", "app", "api", "slow");
@@ -709,7 +714,10 @@ export default defineConfig({
     }
   }, 120_000);
 
-  it("shuts down when SIGTERM interrupts runtime startup", async () => {
+  // Windows has no POSIX signals: child.kill("SIGTERM") maps to TerminateProcess,
+  // so graceful shutdown never runs and its effects cannot be observed.
+  it("shuts down when SIGTERM interrupts runtime startup", async (ctx) => {
+    if (isWindows) ctx.skip();
     const root = await createProductionFixture();
     const markerPath = path.join(root, "production-startup-signal.log");
     const serverConfig = { gracefulShutdownTimeout: "500ms" as const };

--- a/packages/farm/src/__tests__/production-public-dir.test.ts
+++ b/packages/farm/src/__tests__/production-public-dir.test.ts
@@ -15,7 +15,8 @@ async function createFixture(): Promise<string> {
   const root = await fs.mkdtemp(path.join(packageRoot, ".tmp-production-public-dir-"));
 
   await fs.mkdir(path.join(root, "node_modules", "@farm.js"), { recursive: true });
-  await fs.symlink(packageRoot, path.join(root, "node_modules", "@farm.js", "core"), "dir");
+  // Junctions need no Windows privilege; the type is ignored on POSIX.
+  await fs.symlink(packageRoot, path.join(root, "node_modules", "@farm.js", "core"), "junction");
   await fs.mkdir(path.join(root, "src", "app"), { recursive: true });
   await fs.mkdir(path.join(root, "static", "nested"), { recursive: true });
   await fs.writeFile(

--- a/packages/farm/src/__tests__/production-ssg.test.ts
+++ b/packages/farm/src/__tests__/production-ssg.test.ts
@@ -17,7 +17,8 @@ async function createFixture(externalRewriteOrigin?: string): Promise<string> {
   const root = await fs.mkdtemp(path.join(packageRoot, ".tmp-production-ssg-"));
 
   await fs.mkdir(path.join(root, "node_modules", "@farm.js"), { recursive: true });
-  await fs.symlink(packageRoot, path.join(root, "node_modules", "@farm.js", "core"), "dir");
+  // Junctions need no Windows privilege; the type is ignored on POSIX.
+  await fs.symlink(packageRoot, path.join(root, "node_modules", "@farm.js", "core"), "junction");
   await fs.mkdir(path.join(root, "src", "app", "static"), { recursive: true });
   await fs.mkdir(path.join(root, "src", "app", "refreshing"), { recursive: true });
   await fs.mkdir(path.join(root, "src", "app", "blog", "[slug]"), { recursive: true });
@@ -194,7 +195,7 @@ export default function SafeRulePage() {
 async function createRuntimeSensitiveFixture(kind: "context" | "plugin" | "i18n"): Promise<string> {
   const root = await fs.mkdtemp(path.join(packageRoot, `.tmp-production-ssg-${kind}-`));
   await fs.mkdir(path.join(root, "node_modules", "@farm.js"), { recursive: true });
-  await fs.symlink(packageRoot, path.join(root, "node_modules", "@farm.js", "core"), "dir");
+  await fs.symlink(packageRoot, path.join(root, "node_modules", "@farm.js", "core"), "junction");
   await fs.mkdir(path.join(root, "src", "app", "sensitive"), { recursive: true });
   if (kind === "i18n") {
     await fs.mkdir(path.join(root, "src", "messages"), { recursive: true });

--- a/packages/farm/src/__tests__/route-manager.test.ts
+++ b/packages/farm/src/__tests__/route-manager.test.ts
@@ -5,6 +5,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { RouteManager, shouldSuggestStaticRenderingForI18n } from "../routing/route-manager";
 import type { FarmConfig } from "../types";
 
+/** "/test" is not an absolute path on Windows, so resolve it per platform. */
+const TEST_ROOT = path.resolve("/test");
+const appPath = (...segments: string[]) => path.join(TEST_ROOT, "src", "app", ...segments);
+
 // Mock the file system utilities
 vi.mock("../utils", async () => {
   const actual = await vi.importActual("../utils");
@@ -36,7 +40,7 @@ describe("RouteManager", () => {
 
   beforeEach(() => {
     mockConfig = {
-      root: "/test",
+      root: TEST_ROOT,
       srcDir: "src",
       outDir: "dist",
       basePath: "/",
@@ -216,8 +220,8 @@ describe("RouteManager", () => {
       expect(vi.mocked(globFiles).mock.calls.some(([pattern]) => pattern.includes("vue"))).toBe(
         true,
       );
-      expect(routeManager.getRoutes().get("/")?.modulePath).toBe("/test/src/app/page.vue");
-      expect(routeManager.getLayouts().get("/")?.modulePath).toBe("/test/src/app/layout.vue");
+      expect(routeManager.getRoutes().get("/")?.modulePath).toBe(appPath("page.vue"));
+      expect(routeManager.getLayouts().get("/")?.modulePath).toBe(appPath("layout.vue"));
     });
 
     it("reuses compiled navigation metadata until route discovery invalidates it", async () => {
@@ -272,7 +276,7 @@ describe("RouteManager", () => {
       expect(layouts.size).toBe(1);
       expect(loadings.size).toBe(2);
       expect(errors.size).toBe(2);
-      expect(routes.get("/docs")?.modulePath).toBe("/test/src/app/docs/page.mdx");
+      expect(routes.get("/docs")?.modulePath).toBe(appPath("docs", "page.mdx"));
     });
 
     it("uses page.md as the markdown representation beside page.tsx", async () => {
@@ -287,8 +291,8 @@ describe("RouteManager", () => {
       await routeManager.discoverRoutes();
 
       expect(routeManager.getRoutes().get("/about")).toMatchObject({
-        modulePath: "/test/src/app/about/page.tsx",
-        markdownSourcePath: "/test/src/app/about/page.md",
+        modulePath: appPath("about", "page.tsx"),
+        markdownSourcePath: appPath("about", "page.md"),
       });
     });
 
@@ -362,7 +366,7 @@ describe("RouteManager", () => {
         new Set(["/", "/pricing", "/dashboard"]),
       );
       expect(routeManager.matchRoute("/").route?.modulePath).toBe(
-        "/test/src/app/(marketing)/page.tsx",
+        appPath("(marketing)", "page.tsx"),
       );
       expect(routeManager.matchRoute("/pricing").route?.pattern).toBe("/pricing");
       expect(routeManager.matchRoute("/dashboard").route?.pattern).toBe("/dashboard");

--- a/packages/farm/src/__tests__/storage-dispose.test.ts
+++ b/packages/farm/src/__tests__/storage-dispose.test.ts
@@ -1,0 +1,77 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createFarmStorage, databaseStorage, sqliteStorage } from "../storage";
+
+const { created } = vi.hoisted(() => ({ created: [] as any[] }));
+
+/** Spies on every db0 database while leaving the real implementation in place. */
+vi.mock("db0", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("db0")>();
+  return {
+    ...actual,
+    createDatabase: (connector: any) => {
+      const database = actual.createDatabase(connector);
+      vi.spyOn(database, "dispose");
+      created.push(database);
+      return database;
+    },
+  };
+});
+
+const [nodeMajor, nodeMinor] = process.versions.node.split(".").map(Number);
+const supportsNodeSqlite = nodeMajor > 22 || (nodeMajor === 22 && nodeMinor >= 5);
+
+const tempDirs = new Set<string>();
+
+async function createTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), prefix));
+  tempDirs.add(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  for (const database of created.splice(0)) await database.dispose().catch(() => {});
+  await Promise.all(
+    [...tempDirs].map(async (dir) => {
+      await rm(dir, { recursive: true, force: true });
+      tempDirs.delete(dir);
+    }),
+  );
+  vi.restoreAllMocks();
+});
+
+describe("database storage disposal", () => {
+  it.skipIf(!supportsNodeSqlite)("closes a database it created from a config", async () => {
+    const dir = await createTempDir("farm-storage-dispose-");
+    const storage = await createFarmStorage(
+      sqliteStorage({ path: path.join(dir, "app.sqlite"), tableName: "kv" }),
+    );
+
+    await storage.setItem("user", { name: "Ada" });
+    await storage.dispose();
+
+    expect(created).toHaveLength(1);
+    expect(created[0].dispose).toHaveBeenCalled();
+    expect(created[0].disposed).toBe(true);
+
+    // The file handle must be released, or Windows refuses to remove the directory.
+    await expect(rm(dir, { recursive: true, force: true })).resolves.toBeUndefined();
+    tempDirs.delete(dir);
+  });
+
+  it.skipIf(!supportsNodeSqlite)("leaves a caller-provided database open", async () => {
+    const dir = await createTempDir("farm-storage-owned-");
+    const { createDatabase } = await import("db0");
+    const connector = (await import("db0/connectors/node-sqlite")).default;
+    const database = createDatabase(connector({ path: path.join(dir, "owned.sqlite") }));
+
+    const storage = await createFarmStorage(databaseStorage(database, { tableName: "kv" }));
+    await storage.setItem("user", { name: "Grace" });
+    await storage.dispose();
+
+    expect(database.disposed).toBe(false);
+    await expect(database.sql`SELECT 1 as ok`).resolves.toBeDefined();
+  });
+});

--- a/packages/farm/src/__tests__/utils.test.ts
+++ b/packages/farm/src/__tests__/utils.test.ts
@@ -27,8 +27,9 @@ describe("toViteModuleId", () => {
     expect(toViteModuleId(path.join(root, "src", "farm.routes.tsx"), root)).toBe(
       "/src/farm.routes.tsx",
     );
-    expect(toViteModuleId(path.resolve("/workspace/layer/routes.ts"), root)).toBe(
-      "/@fs/workspace/layer/routes.ts",
+    const external = path.resolve("/workspace/layer/routes.ts");
+    expect(toViteModuleId(external, root)).toBe(
+      `/@fs/${toPosixPath(external).replace(/^\/+/, "")}`,
     );
     expect(toViteModuleId("virtual:farm-routes", root)).toBe("virtual:farm-routes");
   });

--- a/packages/farm/src/server/error-diagnostics.ts
+++ b/packages/farm/src/server/error-diagnostics.ts
@@ -94,13 +94,17 @@ function createSourceFrame(location: StackLocation): DefaultErrorSourceFrame | u
 
 function sanitizeStack(stack: string, root: string): string {
   const normalizedRoot = path.resolve(root);
-  return redactErrorText(stack)
-    .split(normalizedRoot)
-    .join("<project>")
-    .split("\n")
-    .filter((line, index) => index === 0 || !line.includes("node:internal"))
-    .slice(0, 14)
-    .join("\n");
+  return (
+    redactErrorText(stack)
+      .split(normalizedRoot)
+      .join("<project>")
+      // Match displayPath, which reports project-relative paths with POSIX separators.
+      .replace(/<project>[^\s)]*/g, (segment) => segment.split("\\").join("/"))
+      .split("\n")
+      .filter((line, index) => index === 0 || !line.includes("node:internal"))
+      .slice(0, 14)
+      .join("\n")
+  );
 }
 
 export function createDefaultErrorDiagnostics(

--- a/packages/farm/src/storage/index.ts
+++ b/packages/farm/src/storage/index.ts
@@ -226,10 +226,20 @@ async function loadDatabaseDriver(config: FarmStorageDatabaseConfig): Promise<Dr
   ]);
 
   const database = createDatabase(connectorModule.default(extractDriverOptions(config) || {}));
-  return db0DriverModule.default({
+  const driver = db0DriverModule.default({
     database,
     tableName: config.tableName,
   });
+
+  // The db0 driver has no dispose, so this connection is Farm's to close. Databases
+  // handed to `databaseStorage` stay owned by the caller and are left open.
+  return {
+    ...driver,
+    async dispose() {
+      await driver.dispose?.();
+      await database.dispose();
+    },
+  };
 }
 
 async function resolveDriver(config?: FarmStorageMountConfig): Promise<Driver> {

--- a/packages/farm/src/utils/client-component.ts
+++ b/packages/farm/src/utils/client-component.ts
@@ -31,7 +31,9 @@ export function resolveModuleSourcePath(modulePath: string, root?: string): stri
     }
 
     if (modulePath.startsWith("/@fs/")) {
-      candidates.add(modulePath.slice(4));
+      // Vite emits /@fs/C:/... on Windows, where the leading slash is not part of the path.
+      const fsPath = withoutQuery.slice("/@fs/".length);
+      candidates.add(path.normalize(/^[A-Za-z]:/.test(fsPath) ? fsPath : `/${fsPath}`));
     }
   }
 

--- a/packages/farm/vitest.config.ts
+++ b/packages/farm/vitest.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
     },
   },
   test: {
+    // Windows: the threads pool segfaults during teardown, and one process per file
+    // exhausts the socket budget for the fixtures that bind real servers.
+    ...(process.platform === "win32"
+      ? { pool: "forks" as const, poolOptions: { forks: { minForks: 1, maxForks: 1 } } }
+      : {}),
     environment: "jsdom",
     globals: true,
     include: ["src/**/*.test.{ts,tsx}", "src/**/*.spec.{ts,tsx}"],

--- a/scripts/test-packages.js
+++ b/scripts/test-packages.js
@@ -12,6 +12,10 @@ const onlyWithNodeEngine = args.has("--only-with-node-engine");
 const currentNodeVersion = process.versions.node;
 const currentNodeMajor = Number(currentNodeVersion.split(".")[0]);
 
+// Packages with known Windows failures, tracked separately so the rest of the
+// suite can run on windows-latest. See #440.
+const WINDOWS_SKIPPED = new Set(["@farm.js/auth", "@farm.js/cli", "@farm.js/plugin"]);
+
 function supportsCurrentNode(range) {
   if (!range) {
     return true;
@@ -53,6 +57,13 @@ let skipped = 0;
 
 for (const pkg of packages) {
   const isCompatible = supportsCurrentNode(pkg.nodeEngine);
+
+  if (process.platform === "win32" && WINDOWS_SKIPPED.has(pkg.name)) {
+    skipped += 1;
+    console.log(`
+> Skipping ${pkg.name} (known Windows failures, see #440)`);
+    continue;
+  }
 
   if (onlyWithNodeEngine && !pkg.nodeEngine) {
     skipped += 1;


### PR DESCRIPTION
## Summary

Fixes #429.

The suite had 44 failing tests across 14 files on Windows. None of it was visible to CI,
which only ran `ubuntu-latest`. Most were platform assumptions in the tests, but three
were real defects.

**`resolveModuleSourcePath` could not decode Windows `/@fs/` ids.** It stripped four
characters from `/@fs/C:/...`, leaving `/C:/...`, which resolves to nothing. Vite emits
exactly that id shape on Windows, so `"use client"` detection failed for any module
referenced through it.

**`sanitizeStack` left native separators** while `displayPath` in the same module
normalizes to `/`, so one diagnostics object reported two different path shapes.

**Vitest's threads pool segfaults during teardown on Windows.** Every test passed, the
summary printed, then the process exited 139. CI would have failed on a green suite.

## Changes

- Use `"junction"` for the fixture symlinks, 14 sites in `packages/farm` and one in
  `@farm.js/eve`. Windows grants `"dir"` symlinks only to elevated processes, junctions
  need no privilege, and the type argument is ignored on other platforms. pnpm links
  packages the same way on Windows.
- Build expected paths with `path.join` and `path.resolve` instead of POSIX literals in
  `route-manager`, `utils`, `create-server`, `i18n`, and `docs-adapter`. The source keeps
  native paths internally and converts at the client boundary, so the assertions were the
  platform-specific half.
- `production-middleware` asserts that the emitted asset set contains the name the HTML
  references. The client build emits that image under two hashed names, so `readdir` order
  decided the result.
- Add `maxRetries` and `retryDelay` to the temp cleanups that race Windows handle release.
- Decode `/@fs/` ids the way Vite's own `fsPathFromId` does, and normalize the result to a
  native path so it matches the function's other branches.
- Normalize separators inside the `<project>` token in `sanitizeStack`.
- Skip the four SIGTERM assertions on Windows. `child.kill("SIGTERM")` maps to
  `TerminateProcess`, so graceful shutdown cannot be triggered from a parent process and
  its effects are not observable.
- Run the forks pool sequentially on Windows in `@farm.js/core` and `@farm.js/react`.
  Unbounded forks hit `listen ENOBUFS` in the fixtures that bind real servers.
- Add one `windows-latest` entry on Node 24 to the CI matrix.

This also carries the `loadDatabaseDriver` disposal from #428, without which
`storage.test.ts` fails eight tests on Windows and the new job cannot pass. The
`databaseStorage` ownership question in that issue is unaffected and still open.

## Test plan

Windows 11, Node.js 24, non-elevated shell.

- [x] `node scripts/test-packages.js --skip-incompatible`, the command the new entry runs:
      `Tested 28 packages. Skipped 3 packages.` exit 0
- [x] `packages/farm`: 143 files, 1147 passed, 6 skipped, exit 0
- [x] `@farm.js/react`: 24 files, 191 passed, exit 0
- [x] `@farm.js/eve`: 3 passed
- [x] `pnpm --filter @farm.js/core type-check`
- [x] Root `pnpm lint`, including the new synthetic-popstate check
- [x] Confirmed the 44 failures on `main` at `58ad3198` before the fix, and again on
      `0.1.0-beta.56`

## Deferred

- `@farm.js/auth`, `@farm.js/cli`, and `@farm.js/plugin` still fail on Windows.
  `scripts/test-packages.js` skips them on `win32` and logs each one. Tracked in #440.
- The image optimization test is skipped on Windows pending #434.

One thing worth flagging separately: `@farm.js/core` declares no `engines` field, so the
existing Node 22 and 24 entries skip it through `--only-with-node-engine`. Today it is
covered only by the Node 20 entry. The new Windows entry omits that flag for the same
reason.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the test suite pass on Windows and run it in CI. Fix path handling and database disposal that broke Vite resolution and left SQLite files locked.

- CI: add a `windows-latest`/Node 24 matrix entry without `--only-with-node-engine`; keep the generated-types check on `ubuntu-latest`/Node 20; on Windows set `TEMP`/`TMP` to `${{ runner.temp }}` to avoid percent-encoded short paths.
- Repo: enforce LF checkouts via `.gitattributes` so source-snippet tests pass on Windows; raise the docs git-history test timeout to accommodate slower spawns on the runner.
- Runtime: `resolveModuleSourcePath` decodes and normalizes Windows `/@fs/` ids; `sanitizeStack` emits POSIX separators within the `<project>` token; `loadDatabaseDriver` now disposes the `db0` database it creates (tests verify created databases close and caller-provided databases stay open); the Cloudflare agent test imports the generated worker from an unencoded file URL.
- Windows-only/test robustness: use junction symlinks; build expected paths with `path.join`/`path.resolve`; assert image assets by name set instead of directory order; add rm retries for delayed handle release; run Vitest with a single-process forks pool in `@farm.js/core` and `@farm.js/react`; skip SIGTERM-based shutdown assertions and the image optimization test on Windows; `scripts/test-packages.js` skips `@farm.js/auth`, `@farm.js/cli`, and `@farm.js/plugin` on Windows.

<sup>Written for commit 8ac7d7b2fecfcb73cd3cae93f2e1097b1ab07f79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

