### PR TITLE
fix(core): correct unstable_cache identity and revalidate: 0 semantics

### DIFF
--- a/packages/farm/src/__tests__/cache.test.ts
+++ b/packages/farm/src/__tests__/cache.test.ts
@@ -272,6 +272,39 @@ describe("server cache primitives", () => {
     await expect(getStats()).resolves.toEqual({ calls: 2 });
   });
 
+  it("keeps same-named functions in separate cache entries", async () => {
+    // Two different functions that happen to share the name getUser, as two
+    // modules would. Before including the source in the identity, the second
+    // wrapper served the first wrapper's cached data.
+    const fromA = (() => {
+      const getUser = async () => ({ from: "A" });
+      return unstable_cache(getUser);
+    })();
+    const fromB = (() => {
+      const getUser = async () => ({ from: "B" });
+      return unstable_cache(getUser);
+    })();
+
+    await expect(fromA()).resolves.toEqual({ from: "A" });
+    await expect(fromB()).resolves.toEqual({ from: "B" });
+  });
+
+  it("treats revalidate: 0 as always stale", async () => {
+    let calls = 0;
+    const getPrices = unstable_cache(
+      async () => {
+        calls++;
+        return { calls };
+      },
+      ["prices"],
+      { revalidate: 0 },
+    );
+
+    await expect(getPrices()).resolves.toEqual({ calls: 1 });
+    await expect(getPrices()).resolves.toEqual({ calls: 2 });
+    expect(calls).toBe(2);
+  });
+
   it("dedupes concurrent cache fills", async () => {
     let calls = 0;
     const getProfile = unstable_cache(async () => {

--- a/packages/farm/src/cache.ts
+++ b/packages/farm/src/cache.ts
@@ -472,7 +472,7 @@ export class FarmDataCache {
   isStale(entry: FarmCacheStaleEntry, now = Date.now()): boolean {
     if (
       typeof entry.revalidate === "number" &&
-      entry.revalidate > 0 &&
+      entry.revalidate >= 0 &&
       now - entry.createdAt >= entry.revalidate * 1000
     ) {
       return true;
@@ -740,8 +740,6 @@ const farmDataCacheGlobal = globalThis as typeof globalThis & {
   [FARM_DATA_CACHE_SYMBOL]?: FarmDataCache;
 };
 const sharedFarmDataCache = (farmDataCacheGlobal[FARM_DATA_CACHE_SYMBOL] ??= new FarmDataCache());
-const functionIds = new WeakMap<Function, number>();
-let nextFunctionId = 0;
 
 export function getFarmDataCache(): FarmDataCache {
   return sharedFarmDataCache;
@@ -891,9 +889,10 @@ function normalizeRevalidate(revalidate: number | false | undefined): number | f
   if (revalidate === false || revalidate === undefined) {
     return revalidate;
   }
-  if (!Number.isFinite(revalidate) || revalidate <= 0) {
+  if (!Number.isFinite(revalidate) || revalidate < 0) {
     return undefined;
   }
+  // 0 is meaningful: the entry is stale immediately, i.e. always re-produced.
   return revalidate;
 }
 
@@ -987,16 +986,22 @@ function assertFarmCacheInvalidationTarget(
 }
 
 function getFunctionCacheIdentity(fn: Function): string {
-  if (fn.name) {
-    return `name:${fn.name}`;
-  }
+  // The name alone collides across modules — two different functions both
+  // named getUser would share cache entries. Include a hash of the source so
+  // only genuinely identical functions share, and the identity stays stable
+  // across processes and restarts.
+  const name = fn.name || "anonymous";
+  return `${name}:${hashFunctionSource(String(fn))}`;
+}
 
-  let id = functionIds.get(fn);
-  if (!id) {
-    id = ++nextFunctionId;
-    functionIds.set(fn, id);
+function hashFunctionSource(source: string): string {
+  // FNV-1a, 32-bit.
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < source.length; index++) {
+    hash ^= source.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
   }
-  return `anonymous:${id}`;
+  return (hash >>> 0).toString(36);
 }
 
 function stableSerialize(value: unknown, seen = new WeakSet<object>()): string {


### PR DESCRIPTION
## Summary

Two cache-correctness bugs in `cache.ts`:

**`unstable_cache` keys collide on function name.** The identity was `fn.name` alone, so two different functions that happen to share a name — `getUser` in two modules — produced identical cache keys and served each other's data. Anonymous functions used a per-process WeakMap counter, so their identities also weren't stable across restarts or workers.

**`revalidate: 0` meant "cache forever".** `normalizeRevalidate` coerced `0` to `undefined`, and `isStale` treats `undefined` as no TTL — so "stale after 0 seconds" silently became "never stale", the exact inverse of the documented meaning (and of the equivalent Next.js semantics).

## Fix

- The function identity is now `name:fnv1a(source)` — only genuinely identical functions share entries, and identities are deterministic across processes.
- `0` is kept by `normalizeRevalidate` and `isStale` treats it as immediately stale, so the entry is re-produced on every read (in-flight dedupe still applies).

## Tests

Two new tests: same-named functions with different bodies stay in separate entries, and `revalidate: 0` re-produces on every call. Both fail against the old code (verified via stash). Full cache suites pass (24/24), full core suite matches the pre-change baseline, `tsc`/`oxlint`/`oxfmt` clean.

Note: the identity format change invalidates existing persisted `unstable_cache` entries once on upgrade — they re-produce on first read.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two cache correctness bugs in unstable_cache. Function identities no longer collide on `fn.name`, and `revalidate: 0` now means “always stale” instead of “cache forever”.

- Function identity is now `name:<hash-of-source>` using FNV-1a, so only identical function bodies share entries and identities stay stable across processes.
- `normalizeRevalidate` preserves `0`; `isStale` treats it as immediately stale, so entries re-produce on each read (in-flight dedupe unchanged).

**Impact and migration**
- Existing persisted unstable_cache entries will miss once and regenerate due to the new identity format.
- To cache forever, pass `revalidate: false` or omit it; `revalidate: 0` now forces re-computation on every read.

<sup>Written for commit 46693c4c38089f7aaa255ae96255755a275ad45a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

