### PR TITLE
fix(core): re-create the storage driver after dispose

### DIFF
--- a/packages/farm/src/__tests__/storage.test.ts
+++ b/packages/farm/src/__tests__/storage.test.ts
@@ -9,6 +9,7 @@ import { createContext } from "../middleware/context";
 import {
   createFarmStorage,
   createStorageClient,
+  defineStorageClient,
   disposeStorage,
   getStorage,
   initStorage,
@@ -103,6 +104,64 @@ describe("Storage", () => {
     expect(await storage.getItem("greeting")).toEqual({ hello: "world" });
 
     await storage.dispose();
+  });
+
+  it("re-creates the driver after dispose instead of reviving the disposed one", async () => {
+    const created: Array<{ isDisposed: () => boolean }> = [];
+
+    function createScriptedDriver() {
+      const data = new Map<string, string>();
+      let disposed = false;
+      const assertOpen = () => {
+        if (disposed) throw new Error("driver used after dispose");
+      };
+      return {
+        isDisposed: () => disposed,
+        driver: {
+          name: "scripted",
+          hasItem: (key: string) => {
+            assertOpen();
+            return data.has(key);
+          },
+          getItem: (key: string) => {
+            assertOpen();
+            return data.get(key) ?? null;
+          },
+          setItem: (key: string, value: string) => {
+            assertOpen();
+            data.set(key, value);
+          },
+          removeItem: (key: string) => {
+            assertOpen();
+            data.delete(key);
+          },
+          getKeys: () => {
+            assertOpen();
+            return [...data.keys()];
+          },
+          dispose: () => {
+            disposed = true;
+          },
+        },
+      };
+    }
+
+    const client = defineStorageClient(() => {
+      const scripted = createScriptedDriver();
+      created.push(scripted);
+      return scripted.driver as never;
+    });
+
+    await client.setItem("greeting", "hello");
+    expect(created).toHaveLength(1);
+
+    await client.dispose();
+    expect(created[0].isDisposed()).toBe(true);
+
+    // A fresh driver must back post-dispose usage, not the disposed one.
+    await client.setItem("farewell", "goodbye");
+    expect(created).toHaveLength(2);
+    await expect(client.getItem("farewell")).resolves.toBe("goodbye");
   });
 
   it("supports mounted local namespaces with shorthand options", async () => {

--- a/packages/farm/src/storage/index.ts
+++ b/packages/farm/src/storage/index.ts
@@ -308,7 +308,11 @@ function createStorageClientFromResolver(resolveDriver: DriverResolver): FarmSto
 
           if (prop === "dispose") {
             return Promise.resolve(result).finally(() => {
+              // Disposing the storage also disposed the driver, so drop both
+              // cached promises: a later call must re-run the driver factory
+              // instead of rebuilding storage over the dead driver.
               storagePromise = undefined;
+              driverPromise = undefined;
             });
           }
 


### PR DESCRIPTION
## Summary

`createStorageClientFromResolver`'s proxy special-cases `dispose` to clear the cached `storagePromise` — but not `driverPromise`. Since `storage.dispose()` also disposes the underlying driver, the next call on the client rebuilt a fresh `Storage` wrapped around the **already-disposed driver**: for connection-backed drivers subsequent reads/writes fail or silently no-op against a closed connection.

```ts
const client = redisStorage({...});
await client.setItem("a", "1");
await client.dispose();
await client.setItem("b", "2"); // rebuilt over the closed connection
```

(Distinct from #428, which is about the db0 database connection not being closed at all.)

## Fix

Clear both cached promises on dispose, so post-dispose usage re-runs the driver factory. Ownership is preserved for caller-provided driver instances — their factory returns the same instance, so Farm never fabricates a new driver it doesn't own.

## Tests

New test with a scripted driver factory: after `dispose`, the old driver is disposed and the next operation creates a second driver and works. Fails against the old code (verified via stash); full storage suite passes (13/13), `tsc`/`oxlint`/`oxfmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds the storage driver after dispose to avoid reviving a disposed driver. Previously, dispose cleared the cached storage but kept the cached driver, so new operations rebuilt Storage over a dead driver; reads/writes failed or no-op. Now dispose clears both caches so the next call re-runs the driver factory and uses a fresh driver.

- Review notes: Clear `storagePromise` and `driverPromise` on dispose in `createStorageClientFromResolver`; this preserves ownership for caller-provided drivers (their factory still returns the same instance).
- Tests: Added a test that verifies a new driver backs post-dispose operations; this failed on the old behavior.
- Migration: None.

<sup>Written for commit 0a33873565481e9e7eda18887da8cb4a101ac4eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

