### PR TITLE
fix(core): keep generated API type import aliases unique

### DIFF
--- a/packages/farm/src/__tests__/type-generator.test.ts
+++ b/packages/farm/src/__tests__/type-generator.test.ts
@@ -19,8 +19,45 @@ describe("APITypeGenerator", () => {
 
     expect(content).not.toContain("Generated at:");
     expect(content).toContain('"storage-demo": {');
-    expect(content).toContain("get: typeof GET_storagedemo;");
-    expect(content).toContain("post: typeof POST_storagedemo;");
+    expect(content).toContain("get: typeof GET_storage_demo;");
+    expect(content).toContain("post: typeof POST_storage_demo;");
+  });
+
+  it("keeps import aliases unique for routes that normalize alike", () => {
+    const generator = new APITypeGenerator("/tmp/app");
+
+    const content = generator.generateAPIRouter([
+      {
+        path: "/api/id",
+        methods: ["GET"],
+        filePath: "/tmp/app/api/id/route.ts",
+        relativePath: "api/id/route.ts",
+      },
+      {
+        path: "/api/[id]",
+        methods: ["GET"],
+        filePath: "/tmp/app/api/[id]/route.ts",
+        relativePath: "api/[id]/route.ts",
+      },
+      {
+        path: "/api/user-profile",
+        methods: ["GET"],
+        filePath: "/tmp/app/api/user-profile/route.ts",
+        relativePath: "api/user-profile/route.ts",
+      },
+      {
+        path: "/api/user_profile",
+        methods: ["GET"],
+        filePath: "/tmp/app/api/user_profile/route.ts",
+        relativePath: "api/user_profile/route.ts",
+      },
+    ]);
+
+    const aliases = [...content.matchAll(/import type \{ GET as (\w+) \}/g)].map(
+      (match) => match[1],
+    );
+    expect(aliases).toHaveLength(4);
+    expect(new Set(aliases).size).toBe(4);
   });
 
   it("creates the output directory before writing generated API types", () => {

--- a/packages/farm/src/type-generator.ts
+++ b/packages/farm/src/type-generator.ts
@@ -125,11 +125,12 @@ export class APITypeGenerator {
 
     // Build nested structure
     const nestedStructure: any = {};
+    const usedRouteNames = new Map<string, number>();
 
     for (const [path, routeList] of routeGroups) {
       const route = routeList[0];
       const importPath = this.getRouteImportPath(route, options.outFile);
-      const routeName = this.pathToRouteName(route.path);
+      const routeName = this.uniqueRouteName(route.path, usedRouteNames);
       const cleanPath = path === "/api" ? "" : path.replace(/^\/api\//, "");
       const parts = cleanPath ? cleanPath.split("/") : [];
 
@@ -206,9 +207,20 @@ ${typeExports}
   }
 
   private pathToRouteName(path: string): string {
+    // Replace (not strip) invalid identifier characters, so /api/id and
+    // /api/[id] do not normalize to the same name.
     return (path === "/api" ? "root" : path.replace(/^\/api\//, ""))
       .replace(/\//g, "_")
-      .replace(/[^a-zA-Z0-9_]/g, "");
+      .replace(/[^a-zA-Z0-9_]/g, "_");
+  }
+
+  private uniqueRouteName(path: string, usedNames: Map<string, number>): string {
+    const base = this.pathToRouteName(path);
+    const seen = usedNames.get(base);
+    usedNames.set(base, (seen ?? 0) + 1);
+    // Suffix any remaining collision so the generated import aliases are
+    // always distinct identifiers.
+    return seen ? `${base}_${seen + 1}` : base;
   }
 
   private structureToTypeString(obj: any, indent: number): string {


### PR DESCRIPTION
## Summary

`pathToRouteName` stripped all non-identifier characters after replacing `/` with `_`, so distinct route paths normalized to the same import alias. An app with both `api/id/route.ts` and `api/[id]/route.ts` (each exporting `GET`) generated:

```ts
import type { GET as GET_id } from "../app/api/id/route";
import type { GET as GET_id } from "../app/api/[id]/route";
```

which fails to compile (`Duplicate identifier 'GET_id'`), breaking the entire generated `APIRouter` type. Same for `user-profile` vs `userprofile`. Reachable through `generateFarmTypeArtifacts` — i.e. `farm generate` / `farm dev`.

## Fix

- Invalid identifier characters are replaced with `_` instead of stripped (`[id]` → `_id_`), which keeps most paths naturally distinct.
- Any remaining collision gets a counter suffix, so aliases are always unique identifiers.

Aliases are internal to the generated type-only file, so the rename has no external consumers.

## Tests

New test: four colliding-shape routes (`id`, `[id]`, `user-profile`, `user_profile`) produce four distinct aliases. Updated the existing assertion from `GET_storagedemo` to `GET_storage_demo` (it was pinning the lossy normalization). Both fail against the old code (verified via stash); `tsc`/`oxlint`/`oxfmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure generated API type import aliases are unique to restore successful compilation of the `APIRouter` types. Previously `pathToRouteName` stripped non-identifier characters so distinct routes (e.g., /api/id and /api/[id]) collapsed to the same alias; now we replace invalid characters with underscores and suffix any remaining collisions with a counter. Aliases change internally (e.g., storagedemo → storage_demo) with no external API changes.

**Review notes**
- Applies to generated API types via `farm generate` / `farm dev` (`generateFarmTypeArtifacts`).
- No migration required. Tests verify unique aliases for colliding shapes and update the storage demo alias.

<sup>Written for commit 1b5a19b8356b6265ee58406ca14d440b43f0668f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

