### PR TITLE
fix(core): interpolate optional catch-all redirect destinations

### DIFF
--- a/packages/farm/src/__tests__/route-manager.test.ts
+++ b/packages/farm/src/__tests__/route-manager.test.ts
@@ -2,7 +2,11 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { RouteManager, shouldSuggestStaticRenderingForI18n } from "../routing/route-manager";
+import {
+  interpolateRedirectDestination,
+  RouteManager,
+  shouldSuggestStaticRenderingForI18n,
+} from "../routing/route-manager";
 import type { FarmConfig } from "../types";
 
 // Mock the file system utilities
@@ -670,5 +674,17 @@ describe("static rendering suggestions with i18n", () => {
         detection: ["url"],
       }),
     ).toBe(false);
+  });
+});
+
+describe("interpolateRedirectDestination", () => {
+  it("interpolates every bracket and colon parameter form", () => {
+    const params = { slug: "a/b", id: "42" };
+
+    expect(interpolateRedirectDestination("/new/[[...slug]]", params)).toBe("/new/a/b");
+    expect(interpolateRedirectDestination("/new/[...slug]", params)).toBe("/new/a/b");
+    expect(interpolateRedirectDestination("/new/[id]", params)).toBe("/new/42");
+    expect(interpolateRedirectDestination("/new/:slug*", params)).toBe("/new/a/b");
+    expect(interpolateRedirectDestination("/new/:id", params)).toBe("/new/42");
   });
 });

--- a/packages/farm/src/routing/route-manager.ts
+++ b/packages/farm/src/routing/route-manager.ts
@@ -1283,15 +1283,16 @@ export class RouteManager {
   }
 }
 
-function interpolateRedirectDestination(
+export function interpolateRedirectDestination(
   destination: string,
   params: Record<string, string>,
 ): string {
   let result = destination;
 
   for (const [key, value] of Object.entries(params)) {
-    result = replaceAll(result, `[...${key}]`, value);
+    // Longest token first: [[...key]] contains [...key], which contains [key].
     result = replaceAll(result, `[[...${key}]]`, value);
+    result = replaceAll(result, `[...${key}]`, value);
     result = replaceAll(result, `[${key}]`, value);
     result = replaceAll(result, `:${key}*`, value);
     result = replaceAll(result, `:${key}`, value);


### PR DESCRIPTION
## Summary

`interpolateRedirectDestination` replaced `[...key]` before `[[...key]]`. Since the optional catch-all token contains the required one as a substring, a redirect `{ source: "/old/[[...slug]]", destination: "/new/[[...slug]]" }` matching `/old/a/b` interpolated the inner token first and redirected the client to the literal URL `/new/[a/b]`. The colon-style tokens already had the right order (`:key*` before `:key`); the bracket order was inverted.

## Fix

Replace the longest token first: `[[...key]]`, then `[...key]`, then `[key]`. The helper is now exported for direct testing.

## Tests

New test covers all five parameter forms; demonstrated the old order produces `/new/[a/b]`. Full route-manager suite passes 31/31, `tsc`/`oxlint`/`oxfmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes interpolation of optional catch-all redirect destinations in `RouteManager`. Previously `[...key]` replaced before `[[...key]]`, yielding literal bracket segments (e.g., `/new/[a/b]`); now the longest token replaces first, producing `/new/a/b` while colon tokens remain unchanged.

- Replace order: `[[...key]]` → `[...key]` → `[key]`; `:key*` before `:key` stays the same.
- Export `interpolateRedirectDestination` from `packages/farm` for direct testing and add tests covering all bracket and colon parameter forms.

<sup>Written for commit 022f111331d261d3afd15c7e920bd33943ff0269. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

