### PR TITLE
fix(core): accept i18n message keys named after Object.prototype members

### DIFF
--- a/packages/farm/src/__tests__/i18n.test.ts
+++ b/packages/farm/src/__tests__/i18n.test.ts
@@ -219,6 +219,36 @@ describe("Farm ICU catalogs", () => {
     expect(runtime.translate("en", "cart.items", { count: 3 })).toBe("You have 3 items");
   });
 
+  it("accepts message keys that collide with Object.prototype members", async () => {
+    const root = await createCatalogFixture({
+      en: { labels: { toString: "As text", constructor: "Builder" }, valueOf: "Value" },
+      am: { labels: { toString: "Text", constructor: "Builder" }, valueOf: "Value" },
+    });
+    const config = resolveFarmI18nConfig(
+      { locales: ["en", "am"], defaultLocale: "en", strict: true },
+      { root },
+    );
+
+    const bundle = await readFarmI18nCatalogs(config);
+    expect(bundle.catalogs.en["labels.toString"]).toBe("As text");
+    expect(bundle.catalogs.en["valueOf"]).toBe("Value");
+  });
+
+  it("still reports prototype-named keys missing from a locale in strict mode", async () => {
+    const root = await createCatalogFixture({
+      en: { toString: "As text" },
+      am: {},
+    });
+    const config = resolveFarmI18nConfig(
+      { locales: ["en", "am"], defaultLocale: "en", strict: true },
+      { root },
+    );
+
+    await expect(readFarmI18nCatalogs(config)).rejects.toThrow(
+      "does not match the default catalog",
+    );
+  });
+
   it("fails strict validation when locale keys or variables differ", async () => {
     const root = await createCatalogFixture({
       en: { greeting: "Hello, {name}!", complete: "Done" },

--- a/packages/farm/src/i18n/catalog.ts
+++ b/packages/farm/src/i18n/catalog.ts
@@ -59,7 +59,11 @@ export function flattenFarmI18nCatalog(input: unknown, source = "i18n catalog"):
     if (typeof value === "string") {
       const key = segments.join(".");
       if (!key) throw new Error(`${source} contains an empty message key.`);
-      if (key in output) throw new Error(`${source} contains duplicate message key "${key}".`);
+      // Own-property check: `in` would see Object.prototype members, falsely
+      // rejecting legitimate keys like "toString" as duplicates.
+      if (Object.prototype.hasOwnProperty.call(output, key)) {
+        throw new Error(`${source} contains duplicate message key "${key}".`);
+      }
       output[key] = value;
       return;
     }
@@ -105,8 +109,12 @@ function validateFarmI18nCatalogs(
   for (const locale of config.locales) {
     const catalog = catalogs[locale] || {};
     const localeKeys = Object.keys(catalog).sort();
-    const missing = referenceKeys.filter((key) => !(key in catalog));
-    const extra = localeKeys.filter((key) => !(key in signatures));
+    const missing = referenceKeys.filter(
+      (key) => !Object.prototype.hasOwnProperty.call(catalog, key),
+    );
+    const extra = localeKeys.filter(
+      (key) => !Object.prototype.hasOwnProperty.call(signatures, key),
+    );
 
     if (config.strict && (missing.length > 0 || extra.length > 0)) {
       const details = [


### PR DESCRIPTION
## Summary

`flattenFarmI18nCatalog` checked duplicates with `key in output` on a plain `{}`, so inherited `Object.prototype` member names were always "present": a catalog containing `{"toString": "As text"}` (or `constructor`, `valueOf`, `hasOwnProperty`) failed `farm generate`/dev startup with a false `contains duplicate message key` error on its very first occurrence.

The strict-mode validation had the inverse bug on the same operator: a prototype-named key missing from a locale was never reported missing (`"toString" in catalog` is always true), and never reported as extra either.

## Fix

`Object.hasOwn` for all three key checks (duplicate, missing, extra).

## Tests

Two new cases: a catalog using `toString`/`constructor`/`valueOf` keys loads and flattens correctly, and a locale missing a prototype-named key still fails strict validation. Both fail against the old code; full i18n suite passes 18/18, `tsc`/`oxlint`/`oxfmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts i18n message keys named after Object.prototype members and fixes strict validation. Previously, keys like "toString", "constructor", or "valueOf" were rejected as duplicates and strict checks skipped them; now we use own-property checks so duplicates, missing, and extra keys are detected correctly.

- Strict locales missing prototype-named keys now fail validation; add those keys to non-default locales or temporarily disable strict mode.

<sup>Written for commit 9a96d661cbfc477163aaca8399c31c299561b462. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

