### PR TITLE
fix(core): escape regex metacharacters in redirect glob patterns

### DIFF
--- a/packages/farm/src/__tests__/middleware.test.ts
+++ b/packages/farm/src/__tests__/middleware.test.ts
@@ -277,6 +277,38 @@ describe("Middleware Chain", () => {
     expect(res.writeHead).toHaveBeenCalledWith(308, expect.any(Object));
   });
 
+  it("treats redirect source patterns literally except for glob stars", async () => {
+    const run = async (source: string, pathname: string): Promise<boolean> => {
+      const chain = middleware().redirect(source, "/moved");
+      const { handlers } = chain.build();
+      const req = createMockRequest(pathname);
+      const res = createMockResponse();
+      const ctx = createContext(req, res);
+      let index = 0;
+      const executeNext = async (): Promise<void> => {
+        if (index < handlers.length && !ctx._handled) {
+          const handler = handlers[index++];
+          await handler(ctx, executeNext);
+        }
+      };
+      await executeNext();
+      return ctx._handled;
+    };
+
+    // A dot must not act as a regex wildcard.
+    await expect(run("/promo.html", "/promo.html")).resolves.toBe(true);
+    await expect(run("/promo.html", "/promoXhtml")).resolves.toBe(false);
+
+    // Regex metacharacters in the pattern must not throw at request time.
+    await expect(run("/a(1)", "/a(1)")).resolves.toBe(true);
+    await expect(run("/a(1)", "/a1")).resolves.toBe(false);
+
+    // Glob stars keep their meaning.
+    await expect(run("/docs/*", "/docs/intro")).resolves.toBe(true);
+    await expect(run("/docs/*", "/docs/intro/deep")).resolves.toBe(false);
+    await expect(run("/docs/**", "/docs/intro/deep")).resolves.toBe(true);
+  });
+
   it("should support rewrite helper for route-specific middleware", async () => {
     // Simulate route-specific middleware at /old-url
     const chain = middleware("/old-url").rewrite("/new-url");

--- a/packages/farm/src/middleware/chain.ts
+++ b/packages/farm/src/middleware/chain.ts
@@ -194,11 +194,15 @@ function matchPattern(pattern: string | RegExp, pathname: string): boolean {
     return pattern.test(pathname);
   }
 
+  // Protect glob stars, escape every regex metacharacter, then restore the
+  // globs — otherwise "/promo.html" also matches "/promoXhtml" and a pattern
+  // containing "(" throws at request time.
   const regexPattern = pattern
     .replace(/\*\*/g, "__DOUBLE_STAR__")
-    .replace(/\*/g, "[^/]+")
+    .replace(/\*/g, "__SINGLE_STAR__")
+    .replace(/[.+?^${}()|[\]\\/]/g, "\\$&")
     .replace(/__DOUBLE_STAR__/g, ".*")
-    .replace(/\//g, "\\/");
+    .replace(/__SINGLE_STAR__/g, "[^/]+");
 
   const regex = new RegExp(`^${regexPattern}$`);
   return regex.test(pathname);


### PR DESCRIPTION
## Summary

`matchPattern` in `middleware/chain.ts` (used by `middleware().redirect()`) converts glob patterns to a `RegExp` but only handles `*`, `**`, and `/`. Every other regex metacharacter keeps its regex meaning:

- `middleware().redirect("/promo.html", "/new")` builds `/^\/promo.html$/` — the unescaped `.` matches any character, so `/promoXhtml` is also redirected
- a pattern containing `(` (e.g. `"/a(1)"`) throws `SyntaxError` from `new RegExp` at request time, 500ing the request

`manager.ts` already has `escapeRegex` for the same conversion; this copy never got it.

## Fix

Protect the glob stars with placeholders, escape all regex metacharacters, then restore the globs (`**` → `.*`, `*` → `[^/]+`).

## Tests

New test drives `middleware().redirect()` through the chain: dots are literal, parentheses don't throw and match literally, and `*`/`**` keep their glob semantics. Fails against the old code (verified via patch-revert); full middleware suite passes 86/86, `tsc`/`oxlint`/`oxfmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escapes regex metacharacters in redirect glob patterns so string patterns are treated literally except for glob stars. Previously only `*`, `**`, and `/` were special; dots acted as regex wildcards and parentheses could throw at runtime. Now non-glob metacharacters are escaped, preventing unintended matches and 500s.

- Notes for reviewers
  - Updates `matchPattern` in `middleware/chain.ts` to protect glob stars, escape metacharacters, then restore `**` → `.*` and `*` → `[^/]+`.
  - Adds an integration test for `middleware().redirect()` confirming dots and parentheses match literally while `*`/`**` keep glob semantics.

- Migration
  - If you relied on regex behavior in string patterns, pass a `RegExp` or escape characters. No changes are required for standard glob use.

<sup>Written for commit e6cca466ded238d29a8e6667e57e7519c5404888. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

