### PR TITLE
fix(core): error on a missing explicitly supplied config path

### DIFF
--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -114,6 +114,25 @@ describe("loadConfig", () => {
     expect(config).toMatchObject({ value: "ready" });
   });
 
+  it("throws when an explicitly supplied config path does not exist", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-config-missing-"));
+    // A default config exists, but the explicit path must not fall back to it.
+    await fs.writeFile(path.join(root, "farm.config.mjs"), "export default { value: 'default' };");
+
+    await expect(loadConfig(root, "farm.config.prod.ts", "production")).rejects.toThrow(
+      "Config file not found at farm.config.prod.ts",
+    );
+  });
+
+  it("loads an explicitly supplied config path that exists", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-config-explicit-"));
+    await fs.writeFile(path.join(root, "farm.config.mjs"), "export default { value: 'default' };");
+    await fs.writeFile(path.join(root, "custom.config.mjs"), "export default { value: 'custom' };");
+
+    const config = await loadConfig(root, "custom.config.mjs", "production");
+    expect(config).toMatchObject({ value: "custom" });
+  });
+
   it("loads env files before importing farm.config", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-config-env-"));
 

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -1009,6 +1009,17 @@ export async function loadConfig(
       process.env[key] = value;
     }
   }
+  // An explicitly supplied config path must resolve — silently falling back
+  // to the default config would run against the wrong configuration.
+  if (configPath) {
+    const explicitPath = path.resolve(
+      path.isAbsolute(configPath) ? configPath : path.join(root, configPath),
+    );
+    if (!existsSync(explicitPath)) {
+      throw new Error(`Config file not found at ${configPath} (resolved to ${explicitPath}).`);
+    }
+  }
+
   const searchPaths = [
     configPath,
     "farm.config.ts",


### PR DESCRIPTION
## Summary

`loadConfig` put the explicit `configPath` at the head of the search list and skipped it with `continue` when the file didn't exist — falling through to `farm.config.ts`/`config.ts`. Every CLI command that forwards `--config` (`farm migrate`, `explain`, `doctor`, `cron`, `auth`, `generate`) would run against the wrong configuration on a path typo, silently. `findDocsConfigPath` in the same file already errors for the analogous case.

## Fix

When `configPath` is supplied and doesn't resolve, throw with both the given and resolved path. The default search behavior is unchanged.

## Tests

New tests: a missing explicit path throws even when a default config exists (fails against the old code — it silently loaded the default), and an existing explicit path loads over the default. Full config suite passes 46/46, `tsc`/`oxlint`/`oxfmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail fast when an explicit `--config` path is missing. Previously `loadConfig` fell back to default `farm.config.ts`/`config.ts`, so CLI commands could run against the wrong configuration on a typo.

- Review notes
  - Adds an early check in `loadConfig` before building search paths; throws with both the provided and resolved paths, aligning with `findDocsConfigPath`.
  - Affects CLIs that forward `--config` (`farm migrate`, `explain`, `doctor`, `cron`, `auth`, `generate`): they now error on typos instead of loading defaults; default discovery remains unchanged when no explicit path is given.
  - Tests cover missing explicit path (throws despite a default present) and explicit path present (loads that config).

<sup>Written for commit 70e64ff0667b11bae3c0ca41f48658148fac3dbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

