### PR TITLE
fix(core): escape user data shaped like the deferred marker

### DIFF
--- a/packages/farm/src/__tests__/deferred.test.ts
+++ b/packages/farm/src/__tests__/deferred.test.ts
@@ -52,6 +52,26 @@ describe("deferred route data", () => {
     expect(resolved.self).toBe(revived.value);
   });
 
+  it("round-trips user data shaped like the deferred marker", async () => {
+    const payload = {
+      meta: { $farmDeferred: "external-id" },
+      alreadyEscaped: { $farmDeferred: "!keep-bang" },
+      notAMarker: { $farmDeferred: "x", extra: 1 },
+    };
+    const prepared = prepareDeferredData(payload);
+
+    const revived = reviveDeferredData(
+      prepared.data,
+      snapshotDeferredData(prepared.records),
+    ) as typeof payload;
+
+    expect(revived.meta).toEqual({ $farmDeferred: "external-id" });
+    expect(revived.alreadyEscaped).toEqual({ $farmDeferred: "!keep-bang" });
+    expect(revived.notAMarker).toEqual({ $farmDeferred: "x", extra: 1 });
+    // None of these become promises.
+    expect(typeof (revived.meta as any).then).toBe("undefined");
+  });
+
   it("returns immediate data while deferred fields continue streaming", async () => {
     const source = createControlledPromise<string[]>();
     const response = createDeferredDataResponse({

--- a/packages/farm/src/deferred.ts
+++ b/packages/farm/src/deferred.ts
@@ -331,6 +331,12 @@ function encodeDeferredValue(
     output[key] = encodeDeferredValue(item, context, ancestors);
   }
   ancestors.delete(value);
+  // User data that happens to have the marker shape must not be revived as a
+  // deferred reference. Real ids never start with "!", so prefix-escape the
+  // value; revive strips one "!" back off.
+  if (isDeferredMarker(output)) {
+    return { [FARM_DEFERRED_MARKER]: `!${output[FARM_DEFERRED_MARKER]}` };
+  }
   return output;
 }
 
@@ -342,6 +348,10 @@ function reviveDeferredValue(
 ): unknown {
   if (isDeferredMarker(value)) {
     const id = value[FARM_DEFERRED_MARKER];
+    // Escaped user data, not a deferred reference — restore the original.
+    if (id.startsWith("!")) {
+      return { [FARM_DEFERRED_MARKER]: id.slice(1) };
+    }
     const controller = getControlledDeferred(id, controllers);
     const settlement = settlements?.[id];
     if (settlement && controller.promise.status === "pending") {


### PR DESCRIPTION
## Summary

`encodeDeferredValue` never escaped user data against the internal marker shape, so a route loader returning `{ meta: { $farmDeferred: "external-id" } }` had that object misidentified on revival: `isDeferredMarker` matched, no controller/settlement existed for `"external-id"`, and the component received a rejected `DeferredDataError` promise instead of the object. Serializers with this design (React Flight, devalue) escape colliding shapes on encode; this one didn't.

## Fix

Real deferred ids are `d<number>` and never start with `!`. Encode prefix-escapes the value of any plain object matching the marker shape (`{$farmDeferred: s}` → `{$farmDeferred: "!" + s}`); revive strips one `!` and returns the object as data. Already-prefixed strings double up and round-trip correctly. Objects with extra keys never matched the marker shape and are unchanged.

## Tests

New round-trip test: marker-shaped user data, an already-`!`-prefixed variant, and a multi-key non-marker all survive encode/revive as plain data. Fails against the old code (the marker-shaped field came back as a promise); full deferred suite passes 10/10, `tsc`/`oxlint`/`oxfmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escapes user data shaped like the deferred marker to prevent false positives during revive. Previously, objects like { $farmDeferred: "external-id" } were treated as deferred references and became rejected DeferredDataError promises; now encode prefix-escapes with "!" and revive returns the original object.

- Encode: only for plain objects exactly matching the marker; transform {$farmDeferred: s} to {$farmDeferred: "!"+s}. Real deferred ids are d<number> and never start with "!".
- Revive: if the id starts with "!", strip one "!" and treat it as data; otherwise resolve via controllers/settlements.
- Tests: add round-trip cases for marker-shaped data, already "!"-prefixed values (double-escape), and non-marker objects; confirm none become promises.

<sup>Written for commit cec8bac41f87365736c031e55afaae8bc03da9da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

