### PR TITLE
fix(core): sort cache key object entries by codepoint

### DIFF
--- a/packages/farm/src/__tests__/cache.test.ts
+++ b/packages/farm/src/__tests__/cache.test.ts
@@ -49,6 +49,14 @@ describe("server cache primitives", () => {
     );
   });
 
+  it("serializes object keys in locale-independent codepoint order", () => {
+    // localeCompare would order these a, ä, b, B under an English locale and
+    // a, b, B, z, ä under Swedish — the key must not depend on the host
+    // locale.
+    const key = createFarmCacheKey([{ b: 1, a: 2, B: 3, ä: 4 }]);
+    expect(key).toBe('[{"B":number:3,"a":number:2,"b":number:1,"ä":number:4}]');
+  });
+
   it("rejects invalid values returned by defined cache key factories", () => {
     const invalidKey = defineCacheKey<unknown>()((() => ({ scope: "product" })) as any);
 

--- a/packages/farm/src/cache.ts
+++ b/packages/farm/src/cache.ts
@@ -1040,8 +1040,11 @@ function stableSerialize(value: unknown, seen = new WeakSet<object>()): string {
     }
     seen.add(value);
 
+    // Codepoint comparison, not localeCompare: the host locale must not
+    // change how a "stable" key serializes, or invalidations computed on one
+    // server can miss entries written by another.
     const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
-      a.localeCompare(b),
+      a < b ? -1 : a > b ? 1 : 0,
     );
     const serialized = entries
       .map(([key, item]) => `${JSON.stringify(key)}:${stableSerialize(item, seen)}`)


### PR DESCRIPTION
## Summary

`stableSerialize` — the basis of every structured cache key and tag — sorted object keys with `a.localeCompare(b)`, which uses the host's default locale. The same object produces different orderings under different locales (verified: `['b','a','B','ä','z']` sorts `a,ä,b,B,z` under English but `a,b,B,z,ä` under Swedish). On a fleet sharing one cache adapter with heterogeneous server locales, an `invalidate({ key })` computed on one server can hash to a different key than the entry written by another — the invalidation silently misses and stale data is served indefinitely.

## Fix

Plain codepoint comparison (`a < b ? -1 : a > b ? 1 : 0`), deterministic on every host. Keys containing only ASCII lowercase are unaffected; mixed-case/non-ASCII keys change once on upgrade (entries re-produce on first read, same as any key-format change).

## Tests

New test pins the exact serialized form for keys `b, a, B, ä` in codepoint order (`B,a,b,ä`) — under the common English CI locale, `localeCompare` produces `a,ä,b,B`, so the test fails against the old code (verified via patch-revert). Full cache suite passes 22/22, `tsc`/`oxlint`/`oxfmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sorts object keys in cache key serialization by codepoint instead of locale-dependent ordering. Previously `stableSerialize` used `localeCompare`, producing different keys across hosts with different locales; now keys are deterministic and invalidations hit consistently.

- Behavior change: Only keys with mixed case or non-ASCII characters rehash; lowercase ASCII keys are unchanged.
- Migration: Expect a one-time key change after deploy. Entries will repopulate on first read; optionally flush shared caches to remove orphaned entries.
- Test: Adds a serialization test that pins codepoint order (e.g., B,a,b,ä).

<sup>Written for commit 5702d8567dd5c689671b41483e8a5f87cd8d6f04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

