### PR TITLE
fix(renderers): apply React style and event semantics in compat layers

### DIFF
--- a/packages/farm-renderer-tests/src/index.ts
+++ b/packages/farm-renderer-tests/src/index.ts
@@ -109,6 +109,19 @@ export function defineRendererServerConformance(runtime: RendererServerFixture):
       expect(typeof first).toBe("string");
       expect(second).toBe(first);
     });
+
+    it("serializes React numeric style values with px units", async () => {
+      const html = await runtime.renderToString(
+        runtime.createElement("div", {
+          style: { marginTop: 4, width: 100, opacity: 0.5, zIndex: 3 },
+        }),
+      );
+
+      expect(html).toMatch(/margin-top:\s*4px/);
+      expect(html).toMatch(/width:\s*100px/);
+      expect(html).toMatch(/opacity:\s*0?\.5/);
+      expect(html).toMatch(/z-index:\s*3(?!px)/);
+    });
   });
 }
 
@@ -138,6 +151,38 @@ export function defineRendererClientConformance(options: {
 
       root.unmount();
       await settleClientRender(() => expect(container.childNodes).toHaveLength(0));
+      container.remove();
+    });
+
+    it("applies numeric styles with px and wires onDoubleClick to dblclick", async () => {
+      const container = document.createElement("div");
+      document.body.append(container);
+      const root = options.client.createRoot(container);
+      let doubleClicks = 0;
+
+      root.render(
+        options.client.createElement(
+          "button",
+          {
+            style: { width: 100, opacity: 0.5 },
+            onDoubleClick: () => doubleClicks++,
+          },
+          "Double-click me",
+        ),
+      );
+      await settleClientRender(() => {
+        const button = container.querySelector("button");
+        expect(button).toBeTruthy();
+        expect(button!.style.width).toBe("100px");
+        expect(button!.style.opacity).toBe("0.5");
+      });
+
+      container
+        .querySelector("button")!
+        .dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+      expect(doubleClicks).toBe(1);
+
+      root.unmount();
       container.remove();
     });
 

--- a/packages/farm-solid/src/runtime.ts
+++ b/packages/farm-solid/src/runtime.ts
@@ -62,6 +62,67 @@ export function isValidElement(value: unknown): boolean {
   return value !== null && value !== undefined && value !== false;
 }
 
+// CSS properties whose numeric values are unitless in React's style objects.
+const UNITLESS_STYLE_PROPERTIES = new Set([
+  "animation-iteration-count",
+  "aspect-ratio",
+  "border-image-outset",
+  "border-image-slice",
+  "border-image-width",
+  "column-count",
+  "columns",
+  "fill-opacity",
+  "flex",
+  "flex-grow",
+  "flex-shrink",
+  "flood-opacity",
+  "font-weight",
+  "grid-area",
+  "grid-column",
+  "grid-column-end",
+  "grid-column-start",
+  "grid-row",
+  "grid-row-end",
+  "grid-row-start",
+  "line-clamp",
+  "line-height",
+  "opacity",
+  "order",
+  "orphans",
+  "stop-opacity",
+  "stroke-dasharray",
+  "stroke-dashoffset",
+  "stroke-miterlimit",
+  "stroke-opacity",
+  "stroke-width",
+  "tab-size",
+  "widows",
+  "z-index",
+  "zoom",
+]);
+
+function farmStyleObjectToCss(style: Record<string, unknown>): string {
+  return Object.entries(style)
+    .filter(([, value]) => value !== null && value !== undefined && value !== false)
+    .map(([name, value]) => {
+      const property = name.startsWith("--")
+        ? name
+        : name
+            .replace(/[A-Z]/g, (character) => `-${character.toLowerCase()}`)
+            .replace(/^ms-/, "-ms-");
+      // React appends px to non-zero numbers outside the unitless set.
+      const cssValue =
+        typeof value === "number" &&
+        value !== 0 &&
+        !property.startsWith("--") &&
+        !UNITLESS_STYLE_PROPERTIES.has(property)
+          ? `${value}px`
+          : String(value);
+      return `${property}: ${cssValue}`;
+    })
+    .join("; ");
+}
+
 function normalizeProps(element: FarmSolidElement): Record<string, unknown> {
   const props = { ...element.props };
 
@@ -77,6 +138,16 @@ function normalizeProps(element: FarmSolidElement): Record<string, unknown> {
     const html = props.dangerouslySetInnerHTML as { __html?: unknown } | undefined;
     props.innerHTML = html?.__html == null ? "" : String(html.__html);
     delete props.dangerouslySetInnerHTML;
+  }
+  // React-shaped style objects: camelCase keys, numeric px values. Serialize
+  // to a CSS string so Solid renders them identically on server and client.
+  if (props.style && typeof props.style === "object" && !Array.isArray(props.style)) {
+    props.style = farmStyleObjectToCss(props.style as Record<string, unknown>);
+  }
+  // Solid's DOM event prop for dblclick is onDblClick.
+  if ("onDoubleClick" in props && !("onDblClick" in props)) {
+    props.onDblClick = props.onDoubleClick;
+    delete props.onDoubleClick;
   }
   delete props.suppressHydrationWarning;
 

--- a/packages/farm-svelte/src/runtime.ts
+++ b/packages/farm-svelte/src/runtime.ts
@@ -46,6 +46,72 @@ export function getFarmSvelteChildren(element: FarmSvelteElement): unknown[] {
   return Array.isArray(propChildren) ? [...propChildren] : [propChildren];
 }
 
+// CSS properties whose numeric values are unitless in React's style objects.
+const UNITLESS_STYLE_PROPERTIES = new Set([
+  "animation-iteration-count",
+  "aspect-ratio",
+  "border-image-outset",
+  "border-image-slice",
+  "border-image-width",
+  "column-count",
+  "columns",
+  "fill-opacity",
+  "flex",
+  "flex-grow",
+  "flex-shrink",
+  "flood-opacity",
+  "font-weight",
+  "grid-area",
+  "grid-column",
+  "grid-column-end",
+  "grid-column-start",
+  "grid-row",
+  "grid-row-end",
+  "grid-row-start",
+  "line-clamp",
+  "line-height",
+  "opacity",
+  "order",
+  "orphans",
+  "stop-opacity",
+  "stroke-dasharray",
+  "stroke-dashoffset",
+  "stroke-miterlimit",
+  "stroke-opacity",
+  "stroke-width",
+  "tab-size",
+  "widows",
+  "z-index",
+  "zoom",
+]);
+
+export function farmStyleObjectToCss(style: Record<string, unknown>): string {
+  return Object.entries(style)
+    .filter(([, value]) => value !== null && value !== undefined && value !== false)
+    .map(([name, value]) => {
+      const property = name.startsWith("--")
+        ? name
+        : name
+            .replace(/[A-Z]/g, (character) => `-${character.toLowerCase()}`)
+            .replace(/^ms-/, "-ms-");
+      // React appends px to non-zero numbers outside the unitless set.
+      const cssValue =
+        typeof value === "number" &&
+        value !== 0 &&
+        !property.startsWith("--") &&
+        !UNITLESS_STYLE_PROPERTIES.has(property)
+          ? `${value}px`
+          : String(value);
+      return `${property}: ${cssValue}`;
+    })
+    .join("; ");
+}
+
+// React event props whose DOM event name is not just the lowercased suffix.
+const REACT_EVENT_ALIASES: Record<string, string> = {
+  doubleclick: "dblclick",
+};
+
 export function normalizeFarmSvelteProps(element: FarmSvelteElement): Record<string, unknown> {
   const props = { ...element.props };
   delete props.children;
@@ -65,22 +131,13 @@ export function normalizeFarmSvelteProps(element: FarmSvelteElement): Record<str
     delete props.dangerouslySetInnerHTML;
   }
   if (props.style && typeof props.style === "object" && !Array.isArray(props.style)) {
-    props.style = Object.entries(props.style as Record<string, unknown>)
-      .filter(([, value]) => value !== null && value !== undefined && value !== false)
-      .map(([name, value]) => {
-        const property = name.startsWith("--")
-          ? name
-          : name
-              .replace(/[A-Z]/g, (character) => `-${character.toLowerCase()}`)
-              .replace(/^ms-/, "-ms-");
-        return `${property}: ${String(value)}`;
-      })
-      .join("; ");
+    props.style = farmStyleObjectToCss(props.style as Record<string, unknown>);
   }
 
   for (const key of Object.keys(props)) {
     if (/^on[A-Z]/.test(key)) {
-      const svelteEventName = `on${key.slice(2).toLowerCase()}`;
+      const lowered = key.slice(2).toLowerCase();
+      const svelteEventName = `on${REACT_EVENT_ALIASES[lowered] ?? lowered}`;
       if (!(svelteEventName in props)) props[svelteEventName] = props[key];
       delete props[key];
     }

--- a/packages/farm-vue/src/runtime.ts
+++ b/packages/farm-vue/src/runtime.ts
@@ -82,6 +82,67 @@ export function isValidElement(value: unknown): boolean {
   return isFarmVueElement(value) || isVNode(value) || Boolean(value);
 }
 
+// CSS properties whose numeric values are unitless in React's style objects.
+const UNITLESS_STYLE_PROPERTIES = new Set([
+  "animation-iteration-count",
+  "aspect-ratio",
+  "border-image-outset",
+  "border-image-slice",
+  "border-image-width",
+  "column-count",
+  "columns",
+  "fill-opacity",
+  "flex",
+  "flex-grow",
+  "flex-shrink",
+  "flood-opacity",
+  "font-weight",
+  "grid-area",
+  "grid-column",
+  "grid-column-end",
+  "grid-column-start",
+  "grid-row",
+  "grid-row-end",
+  "grid-row-start",
+  "line-clamp",
+  "line-height",
+  "opacity",
+  "order",
+  "orphans",
+  "stop-opacity",
+  "stroke-dasharray",
+  "stroke-dashoffset",
+  "stroke-miterlimit",
+  "stroke-opacity",
+  "stroke-width",
+  "tab-size",
+  "widows",
+  "z-index",
+  "zoom",
+]);
+
+function farmStyleObjectToCss(style: Record<string, unknown>): string {
+  return Object.entries(style)
+    .filter(([, value]) => value !== null && value !== undefined && value !== false)
+    .map(([name, value]) => {
+      const property = name.startsWith("--")
+        ? name
+        : name
+            .replace(/[A-Z]/g, (character) => `-${character.toLowerCase()}`)
+            .replace(/^ms-/, "-ms-");
+      // React appends px to non-zero numbers outside the unitless set.
+      const cssValue =
+        typeof value === "number" &&
+        value !== 0 &&
+        !property.startsWith("--") &&
+        !UNITLESS_STYLE_PROPERTIES.has(property)
+          ? `${value}px`
+          : String(value);
+      return `${property}: ${cssValue}`;
+    })
+    .join("; ");
+}
+
 function normalizeProps(element: FarmVueElement): {
   props: Record<string, unknown>;
   children: unknown[];
@@ -102,6 +163,16 @@ function normalizeProps(element: FarmVueElement): {
     const html = props.dangerouslySetInnerHTML as { __html?: unknown } | undefined;
     props.innerHTML = html?.__html == null ? "" : String(html.__html);
     delete props.dangerouslySetInnerHTML;
+  }
+  // React-shaped style objects: camelCase keys, numeric px values. Serialize
+  // to a CSS string so Vue renders them identically on server and client.
+  if (props.style && typeof props.style === "object" && !Array.isArray(props.style)) {
+    props.style = farmStyleObjectToCss(props.style as Record<string, unknown>);
+  }
+  // Vue's DOM event prop for dblclick is onDblclick.
+  if ("onDoubleClick" in props && !("onDblclick" in props)) {
+    props.onDblclick = props.onDoubleClick;
+    delete props.onDoubleClick;
   }
   delete props.suppressHydrationWarning;
 


### PR DESCRIPTION
## Summary

The Svelte, Solid, and Vue compat layers accept React-shaped props (they already normalize `className`, `htmlFor`, `dangerouslySetInnerHTML`) but diverged from React on two points:

**Numeric styles lost `px`.** `createElement("div", { style: { marginTop: 4, width: 100, opacity: 0.5 } })`:
- Svelte rendered `width: 100` — invalid CSS, dropped by the browser
- Vue SSR emitted `width:100` while the client dropped it — hydration mismatch plus lost layout
- Solid SSR serialized camelCase names verbatim (`marginTop:4`) — invalid CSS *and* a guaranteed server/client mismatch

React/Preact render `margin-top:4px;width:100px;opacity:0.5`. The same renderer-neutral component silently lost its layout on 3 of 5 renderers.

**`onDoubleClick` was dead.** Svelte mapped it to the nonexistent `ondoubleclick` event; Solid and Vue passed it through untranslated. The DOM event is `dblclick`.

## Fix

- A style serializer implementing React's numeric rule (non-zero numbers outside the unitless-property set get `px`; custom properties and unitless values pass through) in each of the three runtimes, used for both SSR and client.
- `onDoubleClick` maps to `dblclick` (`onDblClick` in Solid, `onDblclick` in Vue, alias table in Svelte's event loop).

## Tests

Two new cases in the shared `@farm.js/renderer-tests` conformance suite, so **all five** renderers are pinned: SSR output contains `margin-top: 4px`/`width: 100px` with unitless `opacity`/`z-index`, and a client render applies `width: 100px` and fires `onDoubleClick` on a `dblclick` event. React and Preact pass unchanged (confirming the semantics match React); Svelte/Solid/Vue each fail these cases before the fix (verified via patch-revert). Full suites: svelte 12/12, solid 10/10 + 3/3 client, vue 14/14, react 191/191, preact 11/11.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Svelte, Solid, and Vue compat layers with React for style and event props. Numeric style numbers now get px where React does, and onDoubleClick maps to DOM dblclick, fixing invalid CSS, hydration mismatches, and dead double-click handlers.

- Style serialization mirrors React: non-zero numbers outside the unitless set receive px; zeros and CSS custom properties pass through; camelCase keys become kebab-case. Applied for SSR and client in `packages/farm-svelte`, `packages/farm-solid`, and `packages/farm-vue`.
- Event mapping: `onDoubleClick` now targets `dblclick` (Svelte alias, Solid `onDblClick`, Vue `onDblclick`).
- Conformance tests in `@farm.js/renderer-tests` pin SSR output (e.g., margin-top: 4px, width: 100px; unitless opacity/z-index) and verify client applies width: 100px and fires onDoubleClick on dblclick.
- No migration required; existing React-shaped props behave consistently across all renderers.

<sup>Written for commit aa97f53c299bc4ca6c415b624f24a844c6f3c535. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

