### PR TITLE
fix(windows): run auth, cli, and plugin tests again

### DIFF
--- a/packages/farm-auth/src/internal.ts
+++ b/packages/farm-auth/src/internal.ts
@@ -1,6 +1,7 @@
 import type { ResolvedFarmAuthConfig } from "./types.js";
 import {
   configureFarmAuth,
+  disposeFarmAuth as runDispose,
   getFarmAuthRuntime,
   migrateFarmAuth as runMigration,
 } from "./runtime.js";
@@ -48,4 +49,8 @@ export function createFarmAuthIntegration(
 
 export async function migrateFarmAuth(): Promise<void> {
   await runMigration();
+}
+
+export async function disposeFarmAuth(): Promise<void> {
+  await runDispose();
 }

--- a/packages/farm-auth/src/runtime.ts
+++ b/packages/farm-auth/src/runtime.ts
@@ -23,6 +23,8 @@ interface RuntimeState {
   config?: ResolvedFarmAuthConfig;
   options?: FarmAuthRuntimeOptions;
   runtime?: Promise<BetterAuthRuntime>;
+  /** Kept so the connection opened for the runtime can be closed again. */
+  database?: unknown;
 }
 
 type GlobalAuthState = typeof globalThis & {
@@ -49,7 +51,10 @@ export function configureFarmAuth(
   state.config = config;
   state.options = options;
   if (changed) {
+    const previous = state.database;
     state.runtime = undefined;
+    state.database = undefined;
+    if (previous) void closeDatabase(previous).catch(() => {});
   }
 }
 
@@ -77,6 +82,21 @@ export function getFarmAuthRequest(request?: Request): Request {
   return current;
 }
 
+/**
+ * Close the connection opened for the runtime and drop the cached instance.
+ *
+ * The runtime is cached on globalThis and its connection stays open for the life
+ * of the process, which leaves a file lock behind on SQLite and a pool open on
+ * every other driver. Call this from a teardown hook.
+ */
+export async function disposeFarmAuth(): Promise<void> {
+  const state = getState();
+  const database = state.database;
+  state.runtime = undefined;
+  state.database = undefined;
+  await closeDatabase(database);
+}
+
 export async function migrateFarmAuth(): Promise<void> {
   const state = getState();
   if (!state.config?.enabled || !state.options) {
@@ -100,6 +120,7 @@ async function createRuntime(
   options: FarmAuthRuntimeOptions,
 ): Promise<BetterAuthRuntime> {
   const authOptions = await createBetterAuthOptions(config, options);
+  getState().database = authOptions.database;
 
   if (options.mode === "development" && config.database.migrateInDevelopment) {
     const { getMigrations } = await import("better-auth/db/migration");

--- a/packages/farm-auth/src/runtime.ts
+++ b/packages/farm-auth/src/runtime.ts
@@ -66,7 +66,18 @@ export async function getFarmAuthRuntime(): Promise<BetterAuthRuntime> {
     );
   }
 
-  state.runtime ||= createRuntime(state.config, state.options);
+  if (!state.runtime) {
+    const runtime = createRuntime(state.config, state.options, (database) => {
+      // A dispose or reconfigure that raced this creation already closed what it
+      // knew about, so an orphaned connection closes itself instead of leaking.
+      if (state.runtime === runtime) {
+        state.database = database;
+      } else {
+        void closeDatabase(database).catch(() => {});
+      }
+    });
+    state.runtime = runtime;
+  }
   return state.runtime;
 }
 
@@ -91,6 +102,9 @@ export function getFarmAuthRequest(request?: Request): Request {
  */
 export async function disposeFarmAuth(): Promise<void> {
   const state = getState();
+  // Let an in-flight creation finish so its connection is registered and closed
+  // here, instead of resolving before the handle even exists.
+  if (state.runtime) await state.runtime.catch(() => {});
   const database = state.database;
   state.runtime = undefined;
   state.database = undefined;
@@ -118,9 +132,10 @@ export async function migrateFarmAuth(): Promise<void> {
 async function createRuntime(
   config: ResolvedFarmAuthConfig,
   options: FarmAuthRuntimeOptions,
+  onDatabase: (database: unknown) => void,
 ): Promise<BetterAuthRuntime> {
   const authOptions = await createBetterAuthOptions(config, options);
-  getState().database = authOptions.database;
+  onDatabase(authOptions.database);
 
   if (options.mode === "development" && config.database.migrateInDevelopment) {
     const { getMigrations } = await import("better-auth/db/migration");

--- a/packages/farm-auth/test/runtime.test.ts
+++ b/packages/farm-auth/test/runtime.test.ts
@@ -6,10 +6,12 @@ import { createFarmAuthIntegration, disposeFarmAuth } from "../src/internal.js";
 import { auth } from "../src/server.js";
 
 const root = await mkdtemp(path.join(os.tmpdir(), "farm-auth-test-"));
+const disposeRoot = await mkdtemp(path.join(os.tmpdir(), "farm-auth-dispose-"));
 
 afterAll(async () => {
   await disposeFarmAuth();
   await rm(root, { recursive: true, force: true });
+  await rm(disposeRoot, { recursive: true, force: true });
 });
 
 describe("Farm Auth runtime", () => {
@@ -65,8 +67,25 @@ describe("Farm Auth runtime", () => {
     expect(session.user.email).toBe("person@farm.test");
   });
 
+  it("returns a 401 response for a required anonymous session", async () => {
+    try {
+      await auth.session({
+        request: new Request("http://localhost:3000/dashboard"),
+        required: true,
+      });
+      throw new Error("Expected auth.session to reject");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Response);
+      expect((error as Response).status).toBe(401);
+      await expect((error as Response).json()).resolves.toMatchObject({
+        code: "FARM_AUTH_REQUIRED",
+      });
+    }
+  });
+
+  // Kept last: it reconfigures the global runtime against disposeRoot, so any
+  // test running after it would recreate the runtime there.
   it("releases the database handle when the runtime is disposed", async () => {
-    const disposeRoot = await mkdtemp(path.join(os.tmpdir(), "farm-auth-dispose-"));
     const databasePath = path.join(disposeRoot, ".farm", "auth.sqlite");
     const integration = createFarmAuthIntegration(
       {
@@ -102,22 +121,5 @@ describe("Farm Auth runtime", () => {
 
     // Windows refuses to unlink a file whose handle is still open.
     await expect(rm(databasePath)).resolves.toBeUndefined();
-    await rm(disposeRoot, { recursive: true, force: true });
-  });
-
-  it("returns a 401 response for a required anonymous session", async () => {
-    try {
-      await auth.session({
-        request: new Request("http://localhost:3000/dashboard"),
-        required: true,
-      });
-      throw new Error("Expected auth.session to reject");
-    } catch (error) {
-      expect(error).toBeInstanceOf(Response);
-      expect((error as Response).status).toBe(401);
-      await expect((error as Response).json()).resolves.toMatchObject({
-        code: "FARM_AUTH_REQUIRED",
-      });
-    }
   });
 });

--- a/packages/farm-auth/test/runtime.test.ts
+++ b/packages/farm-auth/test/runtime.test.ts
@@ -1,13 +1,14 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { access, mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { createFarmAuthIntegration } from "../src/internal.js";
+import { createFarmAuthIntegration, disposeFarmAuth } from "../src/internal.js";
 import { auth } from "../src/server.js";
 
 const root = await mkdtemp(path.join(os.tmpdir(), "farm-auth-test-"));
 
 afterAll(async () => {
+  await disposeFarmAuth();
   await rm(root, { recursive: true, force: true });
 });
 
@@ -62,6 +63,46 @@ describe("Farm Auth runtime", () => {
     });
 
     expect(session.user.email).toBe("person@farm.test");
+  });
+
+  it("releases the database handle when the runtime is disposed", async () => {
+    const disposeRoot = await mkdtemp(path.join(os.tmpdir(), "farm-auth-dispose-"));
+    const databasePath = path.join(disposeRoot, ".farm", "auth.sqlite");
+    const integration = createFarmAuthIntegration(
+      {
+        enabled: true,
+        basePath: "/api/auth",
+        emailAndPassword: {
+          enabled: true,
+          requireEmailVerification: false,
+          minPasswordLength: 8,
+          maxPasswordLength: 128,
+        },
+        session: { expiresIn: 60 * 60 * 24 * 7, updateAge: 60 * 60 * 24 },
+        database: { path: ".farm/auth.sqlite", migrateInDevelopment: true },
+      },
+      { root: disposeRoot, mode: "development" },
+    );
+
+    const response = await integration.routes[0].handler(
+      new Request("http://localhost:3000/api/auth/sign-up/email", {
+        method: "POST",
+        headers: { "content-type": "application/json", origin: "http://localhost:3000" },
+        body: JSON.stringify({
+          name: "Farm User",
+          email: "dispose@farm.test",
+          password: "secret123",
+        }),
+      }),
+    );
+    expect(response.status).toBe(200);
+    await expect(access(databasePath)).resolves.toBeUndefined();
+
+    await disposeFarmAuth();
+
+    // Windows refuses to unlink a file whose handle is still open.
+    await expect(rm(databasePath)).resolves.toBeUndefined();
+    await rm(disposeRoot, { recursive: true, force: true });
   });
 
   it("returns a 401 response for a required anonymous session", async () => {

--- a/packages/farm-auth/vitest.config.ts
+++ b/packages/farm-auth/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vitest/config";
+import { farmTestDefaults } from "../../vitest.shared";
 
 export default defineConfig({
   css: {
@@ -7,6 +8,7 @@ export default defineConfig({
     },
   },
   test: {
+    ...farmTestDefaults,
     environment: "node",
     include: ["test/**/*.test.ts"],
   },

--- a/packages/farm-cli/src/deploy.ts
+++ b/packages/farm-cli/src/deploy.ts
@@ -699,8 +699,14 @@ function formatCommand(executable: string, args: string[]): string {
   return [executable, ...args].map(formatCommandArgument).join(" ");
 }
 
+const SAFE_ARGUMENT =
+  process.platform === "win32"
+    ? // A backslash is an ordinary path separator here, not a shell escape.
+      /^[A-Za-z0-9_.\\/:=@+-]+$/
+    : /^[A-Za-z0-9_./:=@+-]+$/;
+
 function formatCommandArgument(argument: string): string {
-  if (/^[A-Za-z0-9_./:=@+-]+$/.test(argument)) return argument;
+  if (SAFE_ARGUMENT.test(argument)) return argument;
   return `'${argument.replace(/'/g, `'"'"'`)}'`;
 }
 

--- a/packages/farm-cli/src/doctor.ts
+++ b/packages/farm-cli/src/doctor.ts
@@ -219,6 +219,11 @@ async function fetchLiveSnapshot(
   }
 }
 
+/** Reported paths are shown to the user, so keep them POSIX on every platform. */
+function toPosix(value: string) {
+  return value.split(path.sep).join("/");
+}
+
 function createLiveReport(
   snapshot: LiveSnapshot,
   baseUrl: string,
@@ -313,7 +318,7 @@ async function createProjectReport(
         code: "CONFIG_VALID",
         title: "Farm config loads successfully",
         message: configFile
-          ? path.relative(root, configFile) || path.basename(configFile)
+          ? toPosix(path.relative(root, configFile)) || path.basename(configFile)
           : "Resolved config",
       });
     }
@@ -370,7 +375,7 @@ function applySafeProjectFixes(
       fixes.push({
         code: "ROOT_LAYOUT_CREATED",
         title: "Created the missing root layout",
-        filePath: path.relative(root, layoutPath),
+        filePath: toPosix(path.relative(root, layoutPath)),
       });
     }
   }

--- a/packages/farm-eve/vitest.config.ts
+++ b/packages/farm-eve/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vitest/config";
+import { farmTestDefaults } from "../../vitest.shared";
 
 export default defineConfig({
   css: {
@@ -7,10 +8,7 @@ export default defineConfig({
     },
   },
   test: {
-    // The Vercel output test spawns the Eve adapter, which can pass the 5s default
-    // when the whole suite competes for the machine.
-    testTimeout: process.env.CI ? 60_000 : 30_000,
-    hookTimeout: process.env.CI ? 60_000 : 30_000,
+    ...farmTestDefaults,
     environment: "node",
   },
 });

--- a/packages/farm/vitest.config.ts
+++ b/packages/farm/vitest.config.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import { defineConfig } from "vitest/config";
+import { farmTestDefaults } from "../../vitest.shared";
 
 export default defineConfig({
   root: path.resolve(__dirname),
@@ -9,11 +10,7 @@ export default defineConfig({
     },
   },
   test: {
-    // Fixtures that bundle a config or run a real build finish in about two seconds
-    // on their own, but can pass the 5s default when the whole suite competes for
-    // the machine. Vite's own config scales this the same way.
-    testTimeout: process.env.CI ? 60_000 : 30_000,
-    hookTimeout: process.env.CI ? 60_000 : 30_000,
+    ...farmTestDefaults,
     environment: "jsdom",
     globals: true,
     include: ["src/**/*.test.{ts,tsx}", "src/**/*.spec.{ts,tsx}"],

--- a/packages/farmjs-plugin/src/rsc/core-external.test.ts
+++ b/packages/farmjs-plugin/src/rsc/core-external.test.ts
@@ -45,20 +45,24 @@ async function stopProcess(child: ChildProcess): Promise<void> {
   await Promise.race([once(child, "exit"), delay(2_000)]);
   if (child.exitCode === null) {
     child.kill("SIGKILL");
-    await once(child, "exit");
+    // Bounded: Windows maps both signals to TerminateProcess, and waiting forever
+    // for an exit event that has already fired turns a failure into a hung run.
+    await Promise.race([once(child, "exit"), delay(5_000)]);
   }
 }
 
 describe("RSC core runtime bundling", () => {
   it("does not prefix absolute Vite environment output paths with the project root", () => {
-    const root = "/workspace/app";
+    const root = path.resolve("/workspace/app");
+    const absoluteOutDir = path.join(root, ".nitro", "vite", "dist", "rsc");
 
-    expect(resolveRscBuildOutputPath(root, "/workspace/app/.nitro/vite/dist/rsc", "index.js")).toBe(
-      "/workspace/app/.nitro/vite/dist/rsc/index.js",
+    // An absolute outDir is used as given, not resolved against the root again.
+    expect(resolveRscBuildOutputPath(root, absoluteOutDir, "index.js")).toBe(
+      path.join(absoluteOutDir, "index.js"),
     );
-    expect(resolveRscBuildOutputPath(root, ".nitro/vite/dist/ssr", "index.js")).toBe(
-      "/workspace/app/.nitro/vite/dist/ssr/index.js",
-    );
+    expect(
+      resolveRscBuildOutputPath(root, path.join(".nitro", "vite", "dist", "ssr"), "index.js"),
+    ).toBe(path.join(root, ".nitro", "vite", "dist", "ssr", "index.js"));
   });
 
   it("rewrites root runtime imports to focused standalone subpaths", async () => {

--- a/packages/farmjs-plugin/src/rsc/core-external.test.ts
+++ b/packages/farmjs-plugin/src/rsc/core-external.test.ts
@@ -48,6 +48,9 @@ async function stopProcess(child: ChildProcess): Promise<void> {
     // Bounded: Windows maps both signals to TerminateProcess, and waiting forever
     // for an exit event that has already fired turns a failure into a hung run.
     await Promise.race([once(child, "exit"), delay(5_000)]);
+    if (child.exitCode === null && child.signalCode === null) {
+      throw new Error("Child process did not exit within 5s of SIGKILL");
+    }
   }
 }
 

--- a/packages/farmjs-plugin/src/rsc/nitro-build.test.ts
+++ b/packages/farmjs-plugin/src/rsc/nitro-build.test.ts
@@ -42,6 +42,9 @@ async function stopProcess(child: ChildProcess): Promise<void> {
     // Bounded: Windows maps both signals to TerminateProcess, and waiting forever
     // for an exit event that has already fired turns a failure into a hung run.
     await Promise.race([once(child, "exit"), delay(5_000)]);
+    if (child.exitCode === null && child.signalCode === null) {
+      throw new Error("Child process did not exit within 5s of SIGKILL");
+    }
   }
 }
 

--- a/packages/farmjs-plugin/src/rsc/nitro-build.test.ts
+++ b/packages/farmjs-plugin/src/rsc/nitro-build.test.ts
@@ -39,7 +39,9 @@ async function stopProcess(child: ChildProcess): Promise<void> {
   await Promise.race([once(child, "exit"), delay(2_000)]);
   if (child.exitCode === null) {
     child.kill("SIGKILL");
-    await once(child, "exit");
+    // Bounded: Windows maps both signals to TerminateProcess, and waiting forever
+    // for an exit event that has already fired turns a failure into a hung run.
+    await Promise.race([once(child, "exit"), delay(5_000)]);
   }
 }
 

--- a/packages/farmjs-plugin/src/rsc/nitro-build.ts
+++ b/packages/farmjs-plugin/src/rsc/nitro-build.ts
@@ -332,8 +332,17 @@ export async function buildRscNitro(options: BuildRscNitroOptions): Promise<void
     },
     // Externalize rsc/ssr so we don't bundle (they reference Vite-generated manifest). We copy dist into server output after build.
     rollupConfig: {
-      external: (id: string) =>
-        id.includes("../dist/") || id.includes("dist/rsc") || id.includes("dist/ssr"),
+      external: (id: string) => {
+        // Ids reach this predicate in both separator forms on Windows, and matching
+        // only the POSIX one makes the same module external in one pass and not in
+        // the next, which Rollup rejects.
+        const normalized = id.split("\\").join("/");
+        return (
+          normalized.includes("../dist/") ||
+          normalized.includes("dist/rsc") ||
+          normalized.includes("dist/ssr")
+        );
+      },
     },
     compatibilityDate: "2024-12-01",
     minify: true,

--- a/scripts/test-packages.js
+++ b/scripts/test-packages.js
@@ -12,10 +12,6 @@ const onlyWithNodeEngine = args.has("--only-with-node-engine");
 const currentNodeVersion = process.versions.node;
 const currentNodeMajor = Number(currentNodeVersion.split(".")[0]);
 
-// Packages with known Windows failures, tracked separately so the rest of the
-// suite can run on windows-latest. See #440.
-const WINDOWS_SKIPPED = new Set(["@farm.js/auth", "@farm.js/cli", "@farm.js/plugin"]);
-
 function supportsCurrentNode(range) {
   if (!range) {
     return true;
@@ -57,13 +53,6 @@ let skipped = 0;
 
 for (const pkg of packages) {
   const isCompatible = supportsCurrentNode(pkg.nodeEngine);
-
-  if (process.platform === "win32" && WINDOWS_SKIPPED.has(pkg.name)) {
-    skipped += 1;
-    console.log(`
-> Skipping ${pkg.name} (known Windows failures, see #440)`);
-    continue;
-  }
 
   if (onlyWithNodeEngine && !pkg.nodeEngine) {
     skipped += 1;

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -1,0 +1,14 @@
+/**
+ * Test defaults shared by every package's vitest config.
+ *
+ * Vitest allows a test 5s, which is not enough for the fixtures that bundle a config,
+ * run a real build, or spawn a subprocess. Those take a couple of seconds on their own
+ * and longer once the whole suite competes for the machine. Windows is slower again for
+ * the same work, so it gets the same headroom as CI, as nuxt and next.js both do.
+ */
+const timeout = process.platform === "win32" || process.env.CI ? 60_000 : 30_000;
+
+export const farmTestDefaults = {
+  testTimeout: timeout,
+  hookTimeout: timeout,
+} as const;


### PR DESCRIPTION
## Summary

Closes #440.

The three packages #448 skipped on `win32` now run again, so
`scripts/test-packages.js` no longer needs its skip list. Each had a real bug behind it.

**`@farm.js/auth` never closed the database it opened.** The better-auth runtime is cached
on `globalThis`, but the reference to its connection was dropped, so nothing could close
it. On SQLite that held a file lock and failed the temp cleanup with `EBUSY`; on every
other driver it left a pool open for the life of the process.

**`@farm.js/cli` single quoted Windows paths in the commands it prints.**
`formatCommandArgument` treated a backslash as unsafe, so `--config C:\...\wrangler.jsonc`
was displayed wrapped in POSIX quotes, which is not valid in a Windows shell. Separately,
`doctor` reported project relative paths with native separators where the rest of the
package already uses `toPosix`.

**`@farm.js/plugin` matched externals with forward slash substrings.**
`id.includes("dist/rsc")` never matches `C:\...\dist\rsc\index.js`, so the same module was
external in one pass and not in the next, and Rollup rejected it with `is resolved as a
module now, but it was an external module before`.

## Changes

- `disposeFarmAuth()` closes the connection and drops the cached runtime, exported from
  `internal.ts` beside `migrateFarmAuth`. A reconfigure closes the connection the previous
  runtime was using. Execution paths that hand out a database are untouched.
- `formatCommandArgument` accepts a backslash on `win32` only, keeping the quote style, so
  untrusted values are still quoted. `doctor` reports paths through `toPosix`.
- The externals predicate normalises the id before matching.
- Both plugin build fixtures waited unbounded for a child exit after `SIGKILL`. Windows
  maps both signals to `TerminateProcess`, so an exit event that had already fired left the
  run hanging rather than failing. Bounded to 5s.
- `@farm.js/auth` gets the timeouts `@farm.js/core` and `@farm.js/eve` took in #456.
- Remove `WINDOWS_SKIPPED` from `scripts/test-packages.js`.

## Test plan

Windows 11, Node.js 24, on top of #456.

- [x] `node scripts/test-packages.js --skip-incompatible`: `Tested 31 packages. Skipped 0 packages.` exit 0
- [x] `@farm.js/auth`: 2 files, 6 tests
- [x] `@farm.js/cli`: 81 passed
- [x] `@farm.js/plugin`: 10 files, 43 passed, 1 skipped
- [x] `pnpm --filter @farm.js/core type-check`
- [x] Root `pnpm lint`

The auth dispose was written test first: the new test failed with
`disposeFarmAuth is not a function` before the implementation existed.

## Notes

One fixture stays skipped on Windows: `core-external.test.ts` builds an RSC app whose
dependency graph makes Nitro exhaust file handles reading the pnpm store, reported in #458.
Windows caps concurrent C runtime descriptors and Node cannot raise it, so that one may be
machine dependent and is worth confirming on a runner.

Fixing the unbounded teardown is what made this diagnosable. Both tests previously ran for
400 seconds without completing, which read as a hung build. The build had finished and the
assertions had passed; only the teardown was stuck.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enables Windows tests for `@farm.js/auth`, `@farm.js/cli`, and `@farm.js/plugin` by fixing resource cleanup, path quoting, and external matching. Handles dispose/reconfigure races in the auth runtime and removes the Windows skip list so these packages run on Windows again.

- `@farm.js/auth`: Keep and close the database handle; export `disposeFarmAuth()`; close on dispose and on reconfigure; wait for in-flight runtime creation to register before closing; tests ensure temp files self-clean.
- `@farm.js/cli`: Treat backslashes as safe on win32 so printed commands aren’t POSIX-quoted; `doctor` reports POSIX paths consistently.
- `@farm.js/plugin`: Normalize ids before external matching to avoid Windows inconsistencies; bound child-process teardown to 5s and fail if the child does not exit; one RSC build fixture remains skipped on Windows pending #458.
- `scripts/test-packages.js`: Remove the Windows skip list.
- `vitest`: Share higher test/hook timeouts via `vitest.shared.ts` and apply in multiple packages.

**Migration**
- If tests create an `@farm.js/auth` runtime, call `disposeFarmAuth()` in teardown to release SQLite file handles.

<sup>Written for commit 3fdd98d73f470cb109d568d941398a656708f029. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

