### PR TITLE
fix(core): collect repeated API route query params into arrays

### DIFF
--- a/packages/farm/src/__tests__/api-route-query-params.test.ts
+++ b/packages/farm/src/__tests__/api-route-query-params.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { createEndpoint } from "../api/endpoint";
+import { invokeAPIRouteEndpoint } from "../api/runtime";
+
+/** Calls the endpoint and returns the query object the handler was given. */
+async function queryGivenToHandler(
+  schema: z.ZodTypeAny | undefined,
+  search: string,
+): Promise<{ status: number; query: any }> {
+  let query: any;
+  const endpoint = createEndpoint(
+    { method: "GET", ...(schema ? { query: schema } : {}) } as any,
+    async (ctx: any) => {
+      query = ctx.query;
+      return Response.json({ ok: true });
+    },
+  );
+
+  const response = await invokeAPIRouteEndpoint(
+    endpoint as any,
+    new Request(`http://localhost/api/posts${search}`),
+    {},
+  );
+  return { status: response.status, query };
+}
+
+describe("API route query parameters", () => {
+  it("collects a repeated parameter into an array", async () => {
+    const { status, query } = await queryGivenToHandler(
+      z.object({ tag: z.array(z.string()), page: z.string() }),
+      "?tag=react&tag=vite&tag=zod&page=2",
+    );
+
+    expect(status).toBe(200);
+    expect(query).toEqual({ tag: ["react", "vite", "zod"], page: "2" });
+  });
+
+  it("keeps a single value a string", async () => {
+    const { status, query } = await queryGivenToHandler(
+      z.object({ tag: z.string() }),
+      "?tag=react",
+    );
+
+    expect(status).toBe(200);
+    expect(query).toEqual({ tag: "react" });
+  });
+
+  it("preserves the order of a repeated parameter", async () => {
+    const { query } = await queryGivenToHandler(
+      z.object({ tag: z.array(z.string()) }),
+      "?tag=c&tag=a&tag=b",
+    );
+
+    expect(query.tag).toEqual(["c", "a", "b"]);
+  });
+
+  it("passes a repeated parameter through when there is no query schema", async () => {
+    const { status, query } = await queryGivenToHandler(undefined, "?tag=react&tag=vite");
+
+    expect(status).toBe(200);
+    expect(query).toEqual({ tag: ["react", "vite"] });
+  });
+
+  it("ignores query keys that would poison the prototype", async () => {
+    const { status, query } = await queryGivenToHandler(
+      undefined,
+      "?__proto__=polluted&constructor=x&prototype=y&safe=ok",
+    );
+
+    expect(status).toBe(200);
+    expect(query).toEqual({ safe: "ok" });
+    expect(Object.getPrototypeOf({})).toBe(Object.prototype);
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  it("still rejects a query that does not match its schema", async () => {
+    const endpoint = createEndpoint(
+      { method: "GET", query: z.object({ page: z.string() }) },
+      async () => Response.json({ ok: true }),
+    );
+
+    const response = await invokeAPIRouteEndpoint(
+      endpoint as any,
+      new Request("http://localhost/api/posts"),
+      {},
+    );
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/packages/farm/src/api/runtime.ts
+++ b/packages/farm/src/api/runtime.ts
@@ -85,10 +85,14 @@ async function invokeAPIRouteEndpointInContext(
   }
 
   const url = new URL(request.url);
-  const query: Record<string, string> = {};
-  url.searchParams.forEach((value, key) => {
-    query[key] = value;
-  });
+  // Repeated keys collect into arrays, the same representation the rest of the
+  // framework hands to routes, and the same helper this path already uses for
+  // urlencoded and multipart bodies. Spread back onto a normal object so an
+  // endpoint without a query schema still receives the object shape it did
+  // before; `entriesToObject` has already dropped the prototype-poisoning keys.
+  const query: Record<string, string | string[]> = {
+    ...searchParamsToObject(url.searchParams),
+  };
 
   let body: any = undefined;
   if (request.method.toUpperCase() !== "GET" && request.method.toUpperCase() !== "HEAD") {


### PR DESCRIPTION
Fixes #457

## What changed

`packages/farm/src/api/runtime.ts` now builds the query object with the array-aware
`searchParamsToObject` that already sits in the same file, instead of an overwriting `forEach`:

```ts
const query: Record<string, string | string[]> = {
  ...searchParamsToObject(url.searchParams),
};
```

New tests in `packages/farm/src/__tests__/api-route-query-params.test.ts`.

## Why

`GET /api/posts?tag=react&tag=vite&tag=zod` reached the handler as `{ tag: "zod" }`, so an
`z.array(z.string())` query schema could never validate and the route answered 400 with
"expected array, received string". The handler never ran, and there was no schema that accepted a
repeated parameter. With a plain `z.string()` schema it returned 200 and silently dropped every
value but the last.

This is the site #365 missed. That PR removed exactly this overwriting `forEach` from the
generated SSR entry, the SPA page-data endpoint, the generated client runtime, the dev renderer,
`testing.ts` and `vite.ts`, and added `src/search-params.ts` so the environments could not drift
again. It did not touch `api/runtime.ts`, whose query branch predates it (`69f0948b`,
2026-07-22, against #365 merging 2026-08-17).

Since #431 the OpenAPI generator emits `type: "array"` query parameters correctly, so the
generated document was advertising array query parameters that the runtime rejected.

## Notes on the change

- It uses the local `searchParamsToObject` (`:278`) rather than the shared
  `src/search-params.ts`. The local one is what this request path already uses for urlencoded and
  multipart bodies, so query and body now agree within an API route, and it drops `__proto__`,
  `constructor` and `prototype` keys, which the previous query branch assigned straight onto an
  object literal. Unifying the two helpers looks worthwhile but is a wider change than this fix,
  so I left it alone. Happy to follow up if you want them merged.
- The result is spread back onto a normal object. `entriesToObject` builds with
  `Object.create(null)`, and an endpoint with no query schema receives this object unchanged, so
  spreading keeps the shape those handlers already saw. The poisoning keys are filtered before
  the spread, so it cannot reintroduce them.

## Validation

Four of the six new tests fail on `main` and pass with the change. Verified by stashing only
`api/runtime.ts` and keeping the test file:

```
without the fix: Tests  4 failed | 2 passed (6)
  FAIL collects a repeated parameter into an array
  FAIL preserves the order of a repeated parameter
  FAIL passes a repeated parameter through when there is no query schema
  FAIL ignores query keys that would poison the prototype

with the fix:    Tests  6 passed (6)
```

The other two, a single value staying a string and a mismatched query still returning 400, pass
either way and are there to catch over-correction.

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/api-route-query-params.test.ts`: 6 passed
- `pnpm --filter @farm.js/core exec tsc --noEmit`: clean
- `pnpm exec oxlint` on both changed files: 0 warnings, 0 errors
- `pnpm exec oxfmt --check` on both changed files: clean
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`: ESM, CJS and DTS all succeed
- Full `@farm.js/core` suite run twice on this commit, once with the change and once with only
  `api/runtime.ts` reverted, then the failing test names compared. Exactly the four tests above
  fail without it and pass with it, and **nothing fails only with it**. The six that fail either
  way are unrelated and pre-existing on this commit (`client-component`, `document-injection`,
  `polar-billing-usage` x2, `production-prebuilt-ssr`, `stripe-webhooks`).
  `api-route-manager.test.ts` passes in both runs.

## Related, not included

`loadSearchParams` in `packages/farm/src/query/server.ts:69` has the same problem from the other
side: it appends every value of an array parameter at `:55-63` and then reads it back with
`urlParams.get(key)`, which returns only the first, so that multi-value branch never takes
effect. Kept out of this PR to keep the diff to one subsystem. I can send it separately.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collects repeated API route query parameters into arrays and filters unsafe keys. Previously, repeated keys overwrote each other and only the last value was exposed as a string; now repeated keys are arrays in order, matching body parsing and OpenAPI expectations.

- Uses the existing array-aware parser in the API runtime, which also drops __proto__/constructor/prototype keys; single-value keys remain strings.
- Handlers without a query schema still receive a plain object, but repeated keys now appear as arrays.
- If a route depended on last-value-wins for repeated query keys, update its schema/logic to accept arrays or reject duplicates.
- Adds focused tests in `@farm.js/core` covering repeated params, order preservation, prototype-poisoning filtering, and unchanged single-value behavior.

<sup>Written for commit 2b84fba99be5c29af972268868e48d2171a88164. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

