### PR TITLE
fix(autumn): make usage reporting idempotent

### DIFF
--- a/packages/farm-autumn/src/index.ts
+++ b/packages/farm-autumn/src/index.ts
@@ -292,6 +292,40 @@ type AutumnUpdateCustomizeItems = NonNullable<
 
 const pendingAutumnMeterProjection = new Map<string, number>();
 
+// Replay cache for /billing/report-usage idempotency. autumn-js 1.2.7 has no
+// provider-side event dedupe, so a retried report with the same key must be
+// answered from here instead of re-applying the usage. Per-instance, like the
+// projection map above; multi-instance deployments still need provider-side
+// dedupe once the SDK supports it.
+const REPORTED_USAGE_EVENT_TTL_MS = 24 * 60 * 60 * 1000;
+const REPORTED_USAGE_EVENT_LIMIT = 10_000;
+const reportedUsageEvents = new Map<
+  string,
+  { at: number; result: AutumnBillingReportUsageResult }
+>();
+
+function getReportedUsageEvent(key: string): AutumnBillingReportUsageResult | null {
+  const entry = reportedUsageEvents.get(key);
+  if (!entry) {
+    return null;
+  }
+  if (Date.now() - entry.at > REPORTED_USAGE_EVENT_TTL_MS) {
+    reportedUsageEvents.delete(key);
+    return null;
+  }
+  return entry.result;
+}
+
+function setReportedUsageEvent(key: string, result: AutumnBillingReportUsageResult): void {
+  reportedUsageEvents.set(key, { at: Date.now(), result });
+  if (reportedUsageEvents.size > REPORTED_USAGE_EVENT_LIMIT) {
+    const oldest = reportedUsageEvents.keys().next().value;
+    if (oldest !== undefined) {
+      reportedUsageEvents.delete(oldest);
+    }
+  }
+}
+
 type ResolvedAutumnIntegrationPath<
   TPath extends string | undefined,
   TDefault extends string,
@@ -1779,6 +1813,11 @@ export function autumn<TInput extends AutumnIntegrationInput>(
           if (typeof body.quantity !== "number" || !Number.isFinite(body.quantity)) {
             return new Response("A numeric quantity is required.", { status: 400 });
           }
+          if (!body.idempotencyKey) {
+            return new Response("An idempotencyKey is required for Autumn usage reporting.", {
+              status: 400,
+            });
+          }
 
           const meter = billing.meters?.[body.key];
           if (!meter) {
@@ -1792,6 +1831,15 @@ export function autumn<TInput extends AutumnIntegrationInput>(
           }
 
           const resolved = await requireOwner(ctx, billing, sdk);
+
+          // A retried report with the same key replays the original result
+          // instead of applying the usage a second time.
+          const idempotencyCacheKey = `${resolved.externalCustomerId}:${featureId}:${body.idempotencyKey}`;
+          const replayed = getReportedUsageEvent(idempotencyCacheKey);
+          if (replayed) {
+            return Response.json(replayed);
+          }
+
           const active = resolveActiveProduct(resolved.customer, products);
           const planId = active.product?.planId ?? "free";
           const plan = plans[planId] ?? {};
@@ -1892,7 +1940,7 @@ export function autumn<TInput extends AutumnIntegrationInput>(
             resolved.tools,
           );
 
-          return Response.json({
+          const result = {
             key: body.key,
             quantity: body.quantity,
             customerId: resolved.customer.id,
@@ -1915,7 +1963,10 @@ export function autumn<TInput extends AutumnIntegrationInput>(
                 : typeof softLimit === "number" && nextUsed >= softLimit
                   ? "Included usage has been exhausted. Additional usage is billable."
                   : null,
-          } satisfies AutumnBillingReportUsageResult);
+          } satisfies AutumnBillingReportUsageResult;
+
+          setReportedUsageEvent(idempotencyCacheKey, result);
+          return Response.json(result);
         },
       }),
       integrationRoute.post(checkPath, {

--- a/packages/farm/src/__tests__/autumn-usage-idempotency.test.ts
+++ b/packages/farm/src/__tests__/autumn-usage-idempotency.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from "vitest";
+import type { FarmIntegrationHandlerContext } from "../integrations";
+import {
+  autumn,
+  type AutumnIntegrationInstance,
+} from "../../../farm-integrations/src/autumn/index";
+
+function createRequestContextStore() {
+  return {
+    get() {
+      return undefined;
+    },
+    set() {},
+    has() {
+      return false;
+    },
+    delete() {
+      return false;
+    },
+    clear() {},
+    snapshot() {
+      return new Map<string, unknown>();
+    },
+  };
+}
+
+function createContext(
+  request: Request,
+  method: string,
+  path: string,
+  instance: unknown,
+): FarmIntegrationHandlerContext {
+  const req = createRequestContextStore();
+
+  return {
+    request,
+    requestId: "req_test",
+    url: new URL(request.url),
+    pathname: new URL(request.url).pathname,
+    method,
+    params: {},
+    input: {},
+    data: {},
+    integration: {
+      category: "payment",
+      slot: "payment",
+      type: "autumn",
+      instance,
+    },
+    route: {
+      kind: "route",
+      path,
+      methods: [method],
+    },
+    req,
+    requestContext: req,
+    config: {} as FarmIntegrationHandlerContext["config"],
+    isDev: true,
+    isProd: false,
+  };
+}
+
+function createFakeSdk(customer: Record<string, unknown>) {
+  return {
+    customers: {
+      getOrCreate: vi.fn(async () => customer),
+    },
+    plans: {
+      get: vi.fn(async () => ({ id: "plan", items: [] })),
+      list: vi.fn(async () => ({ list: [] })),
+    },
+    balances: {
+      update: vi.fn(async () => ({})),
+    },
+    billing: {
+      update: vi.fn(async () => ({})),
+    },
+  };
+}
+
+function createIntegration(sdk: ReturnType<typeof createFakeSdk>, ownerId: string) {
+  return autumn({
+    instance: sdk as unknown as AutumnIntegrationInstance,
+    billing: {
+      resolveOwner: () => ({ kind: "user" as const, id: ownerId }),
+      meters: {
+        credits: { aggregation: "sum" as const, featureId: "credits" },
+      },
+    },
+  });
+}
+
+async function report(
+  integration: ReturnType<typeof autumn>,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  const path = "/billing/report-usage";
+  const route = integration.routes.find(
+    (candidate) => candidate.path === path && candidate.method === "POST",
+  );
+  expect(route).toBeTruthy();
+
+  const request = new Request(`http://example.com${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return route!.handler(request, createContext(request, "POST", path, integration.instance));
+}
+
+describe("autumn usage-report idempotency", () => {
+  it("applies a report once and replays retries with the same key", async () => {
+    const sdk = createFakeSdk({
+      id: "cus_1",
+      balances: { credits: { usage: 0, granted: 100 } },
+      subscriptions: [],
+    });
+    const integration = createIntegration(sdk, "idem-user");
+
+    const first = await report(integration, {
+      key: "credits",
+      quantity: 10,
+      idempotencyKey: "evt-1",
+    });
+    expect(first.status).toBe(200);
+    const firstBody = await first.json();
+    expect(firstBody).toMatchObject({
+      eventIdentifier: "evt-1",
+      projectedCurrentPeriodUsed: 10,
+    });
+    expect(sdk.balances.update).toHaveBeenCalledTimes(1);
+    expect(sdk.balances.update).toHaveBeenCalledWith(
+      expect.objectContaining({ featureId: "credits", usage: 10 }),
+    );
+
+    // The lost-response retry: same key, same payload.
+    const retry = await report(integration, {
+      key: "credits",
+      quantity: 10,
+      idempotencyKey: "evt-1",
+    });
+    expect(retry.status).toBe(200);
+    expect(await retry.json()).toEqual(firstBody);
+    // No second write: the customer is not billed twice for one event.
+    expect(sdk.balances.update).toHaveBeenCalledTimes(1);
+
+    // A genuinely new event still applies.
+    const second = await report(integration, {
+      key: "credits",
+      quantity: 5,
+      idempotencyKey: "evt-2",
+    });
+    expect(second.status).toBe(200);
+    expect(await second.json()).toMatchObject({ projectedCurrentPeriodUsed: 15 });
+    expect(sdk.balances.update).toHaveBeenCalledTimes(2);
+    expect(sdk.balances.update).toHaveBeenLastCalledWith(
+      expect.objectContaining({ featureId: "credits", usage: 15 }),
+    );
+  });
+
+  it("rejects reports without an idempotencyKey", async () => {
+    const sdk = createFakeSdk({
+      id: "cus_2",
+      balances: { credits: { usage: 0, granted: 100 } },
+      subscriptions: [],
+    });
+    const integration = createIntegration(sdk, "no-key-user");
+
+    const response = await report(integration, { key: "credits", quantity: 10 });
+    expect(response.status).toBe(400);
+    expect(sdk.balances.update).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

`/billing/report-usage` declares `idempotencyKey: string` as required input and echoes it back as `eventIdentifier` — promising idempotency — but never consulted it. The handler does a read-modify-write (`usage = currentUsed + quantity`) via `sdk.balances.update`, so the standard failure mode of a lost response + client retry with the same key **billed the customer twice for one event**.

## Approach

Checked the installed `autumn-js` 1.2.7 first: no idempotency/event-id support anywhere in its types (`TrackParams` has none; `TrackLock` is a balance hold, not dedupe). So provider-side dedupe isn't available, and the dedupe lives in Farm:

- a per-instance replay cache keyed by `externalCustomerId:featureId:idempotencyKey` (24h TTL, 10k-entry bound) — same architecture as the handler's existing pending-projection map
- a retry hits the cache and gets the **original response replayed**, with no second `balances.update`
- `idempotencyKey` is now validated at runtime (400 when missing), matching the declared type and the Polar handler
- only successful reports are cached; hard-cap rejections re-evaluate on retry

Limitation, documented in-code: the cache is per-instance, like the projection map. Multi-instance deployments need provider-side dedupe once the SDK exposes it.

## Tests

New handler-level suite with a stubbed SDK instance: first report applies usage 10, the same-key retry replays the identical body with **no second write**, a new key applies again (usage 15), and a keyless report is rejected with 400. Both tests fail against the old build (verified by rebuilding from unfixed source); `oxlint`/`oxfmt` clean, package `tsc` build passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `/billing/report-usage` idempotent to prevent double billing on client retries. Previously the handler ignored the required `idempotencyKey` and re-applied usage; now it replays the original response and returns 400 when the key is missing.

- Add a per-instance replay cache keyed by customer, feature, and `idempotencyKey` (24h TTL, 10k limit). Only successful reports are cached; rejections re-evaluate. `autumn-js` 1.2.7 has no provider-side dedupe, so this lives in `farm-autumn`; multi-instance deployments still need provider-side dedupe when available.
- Validate `idempotencyKey` at runtime and add tests that cover replay on retry, new key application, and 400 for missing keys.
- Migration: clients must include an `idempotencyKey` when posting to `/billing/report-usage`.

<sup>Written for commit ce841664d49d6825b13275cef18c34077fa88f34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

