### PR TITLE
fix(stripe): prevent duplicate customers from concurrent ensureCustomer

### DIFF
--- a/packages/farm-stripe/src/storage.ts
+++ b/packages/farm-stripe/src/storage.ts
@@ -372,6 +372,65 @@ async function withPrismaDataFieldsFallback<T>(
   return await operation(nextData);
 }
 
+/**
+ * Serialize concurrent ensureCustomer calls per owner: the double-click /
+ * two-tab case lands in one process, where sharing the in-flight promise
+ * guarantees a single Stripe customer and a single billing row. Cross-process
+ * races are narrowed by the Stripe idempotency key in
+ * createStripeCustomerForOwner.
+ */
+function withSerializedEnsureCustomer(
+  adapter: StripeBillingStorageAdapter,
+): StripeBillingStorageAdapter {
+  const inflight = new Map<string, Promise<{ customerId: string }>>();
+
+  return {
+    ...adapter,
+    ensureCustomer(input) {
+      const key = `${input.owner.kind}:${input.owner.id}`;
+      const pending = inflight.get(key);
+      if (pending) {
+        return pending;
+      }
+      const task = adapter.ensureCustomer(input).finally(() => {
+        inflight.delete(key);
+      });
+      inflight.set(key, task);
+      return task;
+    },
+  };
+}
+
+async function createStripeCustomerForOwner(
+  stripe: Stripe,
+  owner: StripeBillingOwner,
+): Promise<Stripe.Customer> {
+  const params: Stripe.CustomerCreateParams = {
+    email: owner.email,
+    metadata: {
+      ownerId: owner.id,
+      ownerKind: owner.kind,
+    },
+  };
+
+  try {
+    // A stable per-owner idempotency key makes concurrent ensureCustomer
+    // calls (double-click, two tabs) receive the same customer from Stripe
+    // instead of creating one each.
+    return await stripe.customers.create(params, {
+      idempotencyKey: `farm-ensure-customer-${owner.kind}-${owner.id}`,
+    });
+  } catch (error) {
+    // The same key with different params (e.g. the owner's email changed
+    // within Stripe's idempotency window) is rejected by Stripe; fall back
+    // to a plain create rather than failing the request.
+    if ((error as { type?: string }).type === "StripeIdempotencyError") {
+      return stripe.customers.create(params);
+    }
+    throw error;
+  }
+}
+
 function createBillingRecordId(): string {
   const randomUuid = globalThis.crypto?.randomUUID?.();
   if (randomUuid) {
@@ -519,7 +578,7 @@ export function prismaStorageAdapter(options: PrismaStorageOptions): StripeBilli
     });
   }
 
-  return {
+  return withSerializedEnsureCustomer({
     async getBillingAccount(owner) {
       const record = await findByOwner(owner);
       return record ? toSnapshot(record) : null;
@@ -538,17 +597,21 @@ export function prismaStorageAdapter(options: PrismaStorageOptions): StripeBilli
         };
       }
 
-      const customer = await stripe.customers.create({
-        email: owner.email,
-        metadata: {
-          ownerId: owner.id,
-          ownerKind: owner.kind,
-        },
-      });
+      const customer = await createStripeCustomerForOwner(stripe, owner);
 
-      if (existing?.id) {
+      // A concurrent ensureCustomer may have persisted a customer while ours
+      // was created; settle on what is stored instead of writing a second row.
+      const latest = await findByOwner(owner);
+      if (typeof latest?.stripeCustomerId === "string" && latest.stripeCustomerId) {
+        return {
+          customerId: latest.stripeCustomerId,
+        };
+      }
+
+      const target = latest ?? existing;
+      if (target?.id) {
         await delegate.update({
-          where: { id: existing.id },
+          where: { id: target.id },
           data: {
             stripeCustomerId: customer.id,
           },
@@ -648,7 +711,7 @@ export function prismaStorageAdapter(options: PrismaStorageOptions): StripeBilli
         ["seatQuantity", "trialEndsAt", "productId"],
       );
     },
-  };
+  });
 }
 
 export function ormStorageAdapter(options: StripeOrmStorageOptions): StripeBillingStorageAdapter {
@@ -687,7 +750,7 @@ export function ormStorageAdapter(options: StripeOrmStorageOptions): StripeBilli
     });
   }
 
-  return {
+  return withSerializedEnsureCustomer({
     async getBillingAccount(owner) {
       const record = await findByOwner(owner);
       return record ? toSnapshot(record) : null;
@@ -708,19 +771,25 @@ export function ormStorageAdapter(options: StripeOrmStorageOptions): StripeBilli
         };
       }
 
-      const customer = await stripe.customers.create({
-        email: owner.email,
-        metadata: {
-          ownerId: owner.id,
-          ownerKind: owner.kind,
-        },
-      });
+      const customer = await createStripeCustomerForOwner(stripe, owner);
 
+      // A concurrent ensureCustomer may have persisted a customer while ours
+      // was created; settle on what is stored instead of writing a second row.
+      const latest = await findByOwner(owner);
+      const latestCustomerId =
+        latest && getNullableString(latest, "stripeCustomerId", "stripe_customer_id");
+      if (latestCustomerId) {
+        return {
+          customerId: latestCustomerId,
+        };
+      }
+
+      const target = latest ?? existing;
       const model = await getModel();
-      if (existing?.id) {
+      if (target?.id) {
         await model.update({
           where: {
-            id: existing.id,
+            id: target.id,
           },
           data: {
             stripeCustomerId: customer.id,
@@ -803,7 +872,7 @@ export function ormStorageAdapter(options: StripeOrmStorageOptions): StripeBilli
         },
       });
     },
-  };
+  });
 }
 
 type SqliteDatabase = {
@@ -900,7 +969,7 @@ export function sqliteStorageAdapter(options: SqliteStorageOptions): StripeBilli
     return selectByOwner.get(owner.kind, owner.id) ?? null;
   }
 
-  return {
+  return withSerializedEnsureCustomer({
     async getBillingAccount(owner) {
       const record = readByOwner(owner);
       return record ? toSnapshot(record) : null;
@@ -921,15 +990,20 @@ export function sqliteStorageAdapter(options: SqliteStorageOptions): StripeBilli
         };
       }
 
-      const customer = await stripe.customers.create({
-        email: owner.email,
-        metadata: {
-          ownerId: owner.id,
-          ownerKind: owner.kind,
-        },
-      });
+      const customer = await createStripeCustomerForOwner(stripe, owner);
 
-      if (existing) {
+      // A concurrent ensureCustomer may have persisted a customer while ours
+      // was created; settle on what is stored instead of writing a second row.
+      const latest = readByOwner(owner);
+      const latestCustomerId =
+        latest && getNullableString(latest, "stripeCustomerId", "stripe_customer_id");
+      if (latestCustomerId) {
+        return {
+          customerId: latestCustomerId,
+        };
+      }
+
+      if (latest ?? existing) {
         updateCustomerByOwner.run(customer.id, owner.kind, owner.id);
       } else {
         insertRecord.run(
@@ -1005,7 +1079,7 @@ export function sqliteStorageAdapter(options: SqliteStorageOptions): StripeBilli
 
       clearByOwner.run(owner.kind, owner.id);
     },
-  };
+  });
 }
 
 type DrizzleStorageOptions = {
@@ -1056,7 +1130,7 @@ export function drizzleStorageAdapter(options: DrizzleStorageOptions): StripeBil
     return rows[0] ?? null;
   }
 
-  return {
+  return withSerializedEnsureCustomer({
     async getBillingAccount(owner) {
       const record = await firstByOwner(owner);
       return record ? toSnapshot(record) : null;
@@ -1075,22 +1149,26 @@ export function drizzleStorageAdapter(options: DrizzleStorageOptions): StripeBil
         };
       }
 
-      const customer = await stripe.customers.create({
-        email: owner.email,
-        metadata: {
-          ownerId: owner.id,
-          ownerKind: owner.kind,
-        },
-      });
+      const customer = await createStripeCustomerForOwner(stripe, owner);
 
-      if (existing?.id != null) {
+      // A concurrent ensureCustomer may have persisted a customer while ours
+      // was created; settle on what is stored instead of writing a second row.
+      const latest = await firstByOwner(owner);
+      if (typeof latest?.stripeCustomerId === "string" && latest.stripeCustomerId) {
+        return {
+          customerId: latest.stripeCustomerId,
+        };
+      }
+
+      const target = latest ?? existing;
+      if (target?.id != null) {
         await db
           .update(table)
           .set({
             stripeCustomerId: customer.id,
             updatedAt: new Date(),
           })
-          .where(eq(table.id, existing.id));
+          .where(eq(table.id, target.id));
       } else {
         await db.insert(table).values({
           ownerId: owner.id,
@@ -1169,5 +1247,5 @@ export function drizzleStorageAdapter(options: DrizzleStorageOptions): StripeBil
         })
         .where(eq(table.id, existing.id));
     },
-  };
+  });
 }

--- a/packages/farm/src/__tests__/stripe-ensure-customer-race.test.ts
+++ b/packages/farm/src/__tests__/stripe-ensure-customer-race.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { ormStorageAdapter } from "../../../farm-stripe/src/storage";
+
+type Row = Record<string, unknown> & { id: string };
+
+function createFakeOrm() {
+  const rows: Row[] = [];
+  let nextId = 1;
+
+  const matches = (row: Row, where: Record<string, unknown>) =>
+    Object.entries(where).every(([key, value]) => row[key] === value);
+
+  return {
+    rows,
+    orm: {
+      billingAccount: {
+        async findFirst({ where }: { where: Record<string, unknown> }) {
+          return rows.find((row) => matches(row, where)) ?? null;
+        },
+        async create({ data }: { data: Record<string, unknown> }) {
+          const row: Row = { id: `row_${nextId++}`, ...data };
+          rows.push(row);
+          return row;
+        },
+        async update({
+          where,
+          data,
+        }: {
+          where: Record<string, unknown>;
+          data: Record<string, unknown>;
+        }) {
+          const row = rows.find((candidate) => matches(candidate, where));
+          if (row) Object.assign(row, data);
+          return row ?? null;
+        },
+      },
+    },
+  };
+}
+
+/**
+ * Fake Stripe client that honors idempotency keys the way Stripe does: the
+ * same key returns the same customer. Creation is gated so the test can hold
+ * both concurrent calls inside the race window.
+ */
+function createFakeStripe() {
+  const created: Array<{ id: string; idempotencyKey?: string }> = [];
+  const byIdempotencyKey = new Map<string, { id: string }>();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  return {
+    created,
+    release: () => release(),
+    client: {
+      customers: {
+        async create(
+          _params: Record<string, unknown>,
+          requestOptions?: { idempotencyKey?: string },
+        ) {
+          await gate;
+          const key = requestOptions?.idempotencyKey;
+          if (key && byIdempotencyKey.has(key)) {
+            return byIdempotencyKey.get(key)!;
+          }
+          const customer = { id: `cus_${created.length + 1}` };
+          created.push({ id: customer.id, idempotencyKey: key });
+          if (key) byIdempotencyKey.set(key, customer);
+          return customer;
+        },
+      },
+    },
+  };
+}
+
+describe("stripe ensureCustomer race", () => {
+  it("settles concurrent calls on one customer and one billing row", async () => {
+    const fakeOrm = createFakeOrm();
+    const fakeStripe = createFakeStripe();
+    const adapter = ormStorageAdapter({ orm: fakeOrm.orm });
+    const owner = { kind: "user" as const, id: "user_1", email: "ada@example.com" };
+
+    // Both requests pass the "no existing customer" check before either
+    // create resolves — the double-click / two-tab scenario.
+    const first = adapter.ensureCustomer({ owner, stripe: fakeStripe.client as never });
+    const second = adapter.ensureCustomer({ owner, stripe: fakeStripe.client as never });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    fakeStripe.release();
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    // One Stripe customer, not two.
+    expect(fakeStripe.created).toHaveLength(1);
+    expect(fakeStripe.created[0].idempotencyKey).toBe("farm-ensure-customer-user-user_1");
+    // Both callers agree on it.
+    expect(firstResult.customerId).toBe(fakeStripe.created[0].id);
+    expect(secondResult.customerId).toBe(fakeStripe.created[0].id);
+    // And only one billing row exists.
+    const customerRows = fakeOrm.rows.filter((row) => row.stripeCustomerId);
+    expect(customerRows).toHaveLength(1);
+    expect(customerRows[0].stripeCustomerId).toBe(firstResult.customerId);
+  });
+
+  it("returns the stored customer on later calls without touching Stripe", async () => {
+    const fakeOrm = createFakeOrm();
+    const fakeStripe = createFakeStripe();
+    fakeStripe.release();
+    const adapter = ormStorageAdapter({ orm: fakeOrm.orm });
+    const owner = { kind: "user" as const, id: "user_2", email: "grace@example.com" };
+
+    const created = await adapter.ensureCustomer({ owner, stripe: fakeStripe.client as never });
+    const again = await adapter.ensureCustomer({ owner, stripe: fakeStripe.client as never });
+
+    expect(again.customerId).toBe(created.customerId);
+    expect(fakeStripe.created).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

`ensureCustomer` in every storage adapter did an unguarded check-then-act: find-by-owner → if no customer, `stripe.customers.create` → insert/update. Two concurrent requests for the same owner (double-click on Subscribe, two open tabs) both passed the check, created **two real Stripe customers**, and persisted conflicting rows — checkout completes against `cus_B` while `getBillingAccountByStripeCustomerId` webhook updates and status reads may target the `cus_A` row, so a paying customer can render as "free".

## Fix — three layers, no schema migration

1. **Same-process serialization:** all four adapter factories wrap `ensureCustomer` so concurrent calls per owner share one in-flight promise — the common case (one server handles the double-click) performs exactly one create and one row.
2. **Stripe idempotency key** (`farm-ensure-customer-<kind>-<id>`) on `customers.create`: racing calls from *different* processes receive the same customer from Stripe instead of one each. If Stripe rejects the key (same key, changed params within the idempotency window), the adapter falls back to a plain create.
3. **Post-create re-check:** before inserting, adapters re-read storage and settle on whatever a concurrent request already persisted.

Applied to prisma, orm, sqlite, **and drizzle** — the drizzle adapter had the same race (the original scan counted three copies; there are four).

## Tests

New suite drives the real `ormStorageAdapter` with a gated fake Stripe client that honors idempotency keys: two concurrent `ensureCustomer` calls held inside the race window settle on **one customer, one row, same id for both callers** (fails against the old code — it created two rows), and a later call returns the stored customer without touching Stripe. All existing Stripe suites pass (orm-storage, webhooks, trial-hooks), `tsc` package build clean, `oxlint`/`oxfmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent duplicate Stripe customers from concurrent `ensureCustomer` calls. Previously two requests could both create separate customers and rows; now calls for the same owner converge on one Stripe customer and one stored row, with no schema changes.

- Serialize `ensureCustomer` per owner within a process by wrapping all adapters with a shared in-flight promise.
- Call `stripe.customers.create` with a stable per-owner idempotency key (`farm-ensure-customer-<kind>-<id>`); fall back to a plain create on `StripeIdempotencyError`.
- Re-check storage after creation and use any row a concurrent request already persisted before updating/inserting.
- Applied to `prisma`, `orm`, `sqlite`, and `drizzle` adapters in `farm-stripe`; adds a concurrency test in `farm` that verifies one customer and one row. No migrations or config changes.

<sup>Written for commit 169ad3104feb4ae18067372073fd6b53b93e5da1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

