### PR TITLE
test: check whether #458 reproduces on windows-latest

### DIFF
--- a/packages/farm-auth/src/internal.ts
+++ b/packages/farm-auth/src/internal.ts
@@ -1,6 +1,7 @@
 import type { ResolvedFarmAuthConfig } from "./types.js";
 import {
   configureFarmAuth,
+  disposeFarmAuth as runDispose,
   getFarmAuthRuntime,
   migrateFarmAuth as runMigration,
 } from "./runtime.js";
@@ -48,4 +49,8 @@ export function createFarmAuthIntegration(
 
 export async function migrateFarmAuth(): Promise<void> {
   await runMigration();
+}
+
+export async function disposeFarmAuth(): Promise<void> {
+  await runDispose();
 }

--- a/packages/farm-auth/src/runtime.ts
+++ b/packages/farm-auth/src/runtime.ts
@@ -23,6 +23,8 @@ interface RuntimeState {
   config?: ResolvedFarmAuthConfig;
   options?: FarmAuthRuntimeOptions;
   runtime?: Promise<BetterAuthRuntime>;
+  /** Kept so the connection opened for the runtime can be closed again. */
+  database?: unknown;
 }
 
 type GlobalAuthState = typeof globalThis & {
@@ -49,7 +51,10 @@ export function configureFarmAuth(
   state.config = config;
   state.options = options;
   if (changed) {
+    const previous = state.database;
     state.runtime = undefined;
+    state.database = undefined;
+    if (previous) void closeDatabase(previous).catch(() => {});
   }
 }
 
@@ -77,6 +82,21 @@ export function getFarmAuthRequest(request?: Request): Request {
   return current;
 }
 
+/**
+ * Close the connection opened for the runtime and drop the cached instance.
+ *
+ * The runtime is cached on globalThis and its connection stays open for the life
+ * of the process, which leaves a file lock behind on SQLite and a pool open on
+ * every other driver. Call this from a teardown hook.
+ */
+export async function disposeFarmAuth(): Promise<void> {
+  const state = getState();
+  const database = state.database;
+  state.runtime = undefined;
+  state.database = undefined;
+  await closeDatabase(database);
+}
+
 export async function migrateFarmAuth(): Promise<void> {
   const state = getState();
   if (!state.config?.enabled || !state.options) {
@@ -100,6 +120,7 @@ async function createRuntime(
   options: FarmAuthRuntimeOptions,
 ): Promise<BetterAuthRuntime> {
   const authOptions = await createBetterAuthOptions(config, options);
+  getState().database = authOptions.database;
 
   if (options.mode === "development" && config.database.migrateInDevelopment) {
     const { getMigrations } = await import("better-auth/db/migration");

--- a/packages/farm-auth/test/runtime.test.ts
+++ b/packages/farm-auth/test/runtime.test.ts
@@ -1,13 +1,14 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { access, mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { createFarmAuthIntegration } from "../src/internal.js";
+import { createFarmAuthIntegration, disposeFarmAuth } from "../src/internal.js";
 import { auth } from "../src/server.js";
 
 const root = await mkdtemp(path.join(os.tmpdir(), "farm-auth-test-"));
 
 afterAll(async () => {
+  await disposeFarmAuth();
   await rm(root, { recursive: true, force: true });
 });
 
@@ -62,6 +63,46 @@ describe("Farm Auth runtime", () => {
     });
 
     expect(session.user.email).toBe("person@farm.test");
+  });
+
+  it("releases the database handle when the runtime is disposed", async () => {
+    const disposeRoot = await mkdtemp(path.join(os.tmpdir(), "farm-auth-dispose-"));
+    const databasePath = path.join(disposeRoot, ".farm", "auth.sqlite");
+    const integration = createFarmAuthIntegration(
+      {
+        enabled: true,
+        basePath: "/api/auth",
+        emailAndPassword: {
+          enabled: true,
+          requireEmailVerification: false,
+          minPasswordLength: 8,
+          maxPasswordLength: 128,
+        },
+        session: { expiresIn: 60 * 60 * 24 * 7, updateAge: 60 * 60 * 24 },
+        database: { path: ".farm/auth.sqlite", migrateInDevelopment: true },
+      },
+      { root: disposeRoot, mode: "development" },
+    );
+
+    const response = await integration.routes[0].handler(
+      new Request("http://localhost:3000/api/auth/sign-up/email", {
+        method: "POST",
+        headers: { "content-type": "application/json", origin: "http://localhost:3000" },
+        body: JSON.stringify({
+          name: "Farm User",
+          email: "dispose@farm.test",
+          password: "secret123",
+        }),
+      }),
+    );
+    expect(response.status).toBe(200);
+    await expect(access(databasePath)).resolves.toBeUndefined();
+
+    await disposeFarmAuth();
+
+    // Windows refuses to unlink a file whose handle is still open.
+    await expect(rm(databasePath)).resolves.toBeUndefined();
+    await rm(disposeRoot, { recursive: true, force: true });
   });
 
   it("returns a 401 response for a required anonymous session", async () => {

--- a/packages/farm-auth/vitest.config.ts
+++ b/packages/farm-auth/vitest.config.ts
@@ -7,6 +7,10 @@ export default defineConfig({
     },
   },
   test: {
+    // Each runtime here runs better-auth migrations against SQLite, which takes a few
+    // seconds and can pass the 5s default once the whole suite competes for the machine.
+    testTimeout: process.env.CI ? 60_000 : 30_000,
+    hookTimeout: process.env.CI ? 60_000 : 30_000,
     environment: "node",
     include: ["test/**/*.test.ts"],
   },

--- a/packages/farm-cli/src/deploy.ts
+++ b/packages/farm-cli/src/deploy.ts
@@ -699,8 +699,14 @@ function formatCommand(executable: string, args: string[]): string {
   return [executable, ...args].map(formatCommandArgument).join(" ");
 }
 
+const SAFE_ARGUMENT =
+  process.platform === "win32"
+    ? // A backslash is an ordinary path separator here, not a shell escape.
+      /^[A-Za-z0-9_.\\/:=@+-]+$/
+    : /^[A-Za-z0-9_./:=@+-]+$/;
+
 function formatCommandArgument(argument: string): string {
-  if (/^[A-Za-z0-9_./:=@+-]+$/.test(argument)) return argument;
+  if (SAFE_ARGUMENT.test(argument)) return argument;
   return `'${argument.replace(/'/g, `'"'"'`)}'`;
 }
 

--- a/packages/farm-cli/src/doctor.ts
+++ b/packages/farm-cli/src/doctor.ts
@@ -219,6 +219,11 @@ async function fetchLiveSnapshot(
   }
 }
 
+/** Reported paths are shown to the user, so keep them POSIX on every platform. */
+function toPosix(value: string) {
+  return value.split(path.sep).join("/");
+}
+
 function createLiveReport(
   snapshot: LiveSnapshot,
   baseUrl: string,
@@ -313,7 +318,7 @@ async function createProjectReport(
         code: "CONFIG_VALID",
         title: "Farm config loads successfully",
         message: configFile
-          ? path.relative(root, configFile) || path.basename(configFile)
+          ? toPosix(path.relative(root, configFile)) || path.basename(configFile)
           : "Resolved config",
       });
     }
@@ -370,7 +375,7 @@ function applySafeProjectFixes(
       fixes.push({
         code: "ROOT_LAYOUT_CREATED",
         title: "Created the missing root layout",
-        filePath: path.relative(root, layoutPath),
+        filePath: toPosix(path.relative(root, layoutPath)),
       });
     }
   }

--- a/packages/farmjs-plugin/src/rsc/core-external.test.ts
+++ b/packages/farmjs-plugin/src/rsc/core-external.test.ts
@@ -45,20 +45,24 @@ async function stopProcess(child: ChildProcess): Promise<void> {
   await Promise.race([once(child, "exit"), delay(2_000)]);
   if (child.exitCode === null) {
     child.kill("SIGKILL");
-    await once(child, "exit");
+    // Bounded: Windows maps both signals to TerminateProcess, and waiting forever
+    // for an exit event that has already fired turns a failure into a hung run.
+    await Promise.race([once(child, "exit"), delay(5_000)]);
   }
 }
 
 describe("RSC core runtime bundling", () => {
   it("does not prefix absolute Vite environment output paths with the project root", () => {
-    const root = "/workspace/app";
+    const root = path.resolve("/workspace/app");
+    const absoluteOutDir = path.join(root, ".nitro", "vite", "dist", "rsc");
 
-    expect(resolveRscBuildOutputPath(root, "/workspace/app/.nitro/vite/dist/rsc", "index.js")).toBe(
-      "/workspace/app/.nitro/vite/dist/rsc/index.js",
+    // An absolute outDir is used as given, not resolved against the root again.
+    expect(resolveRscBuildOutputPath(root, absoluteOutDir, "index.js")).toBe(
+      path.join(absoluteOutDir, "index.js"),
     );
-    expect(resolveRscBuildOutputPath(root, ".nitro/vite/dist/ssr", "index.js")).toBe(
-      "/workspace/app/.nitro/vite/dist/ssr/index.js",
-    );
+    expect(
+      resolveRscBuildOutputPath(root, path.join(".nitro", "vite", "dist", "ssr"), "index.js"),
+    ).toBe(path.join(root, ".nitro", "vite", "dist", "ssr", "index.js"));
   });
 
   it("rewrites root runtime imports to focused standalone subpaths", async () => {
@@ -183,7 +187,9 @@ export const schema = z.string();`;
     ).toThrow(/@farm.js\/core\/storage is not supported.*isolated server output/s);
   });
 
-  it("builds and boots a real RSC app with exact-root runtime imports outside the workspace", async () => {
+  // Windows: the Nitro build exhausts file handles reading the pnpm store (#458).
+  it("builds and boots a real RSC app with exact-root runtime imports outside the workspace", async (ctx) => {
+    if (process.platform === "win32") ctx.skip();
     const fixtureRoot = mkdtempSync(path.join(tmpdir(), "farm-rsc-root-runtime-"));
     const isolatedRoot = mkdtempSync(path.join(tmpdir(), "farm-rsc-root-output-"));
     const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");

--- a/packages/farmjs-plugin/src/rsc/core-external.test.ts
+++ b/packages/farmjs-plugin/src/rsc/core-external.test.ts
@@ -187,9 +187,7 @@ export const schema = z.string();`;
     ).toThrow(/@farm.js\/core\/storage is not supported.*isolated server output/s);
   });
 
-  // Windows: the Nitro build exhausts file handles reading the pnpm store (#458).
-  it("builds and boots a real RSC app with exact-root runtime imports outside the workspace", async (ctx) => {
-    if (process.platform === "win32") ctx.skip();
+  it("builds and boots a real RSC app with exact-root runtime imports outside the workspace", async () => {
     const fixtureRoot = mkdtempSync(path.join(tmpdir(), "farm-rsc-root-runtime-"));
     const isolatedRoot = mkdtempSync(path.join(tmpdir(), "farm-rsc-root-output-"));
     const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");

--- a/packages/farmjs-plugin/src/rsc/nitro-build.test.ts
+++ b/packages/farmjs-plugin/src/rsc/nitro-build.test.ts
@@ -39,7 +39,9 @@ async function stopProcess(child: ChildProcess): Promise<void> {
   await Promise.race([once(child, "exit"), delay(2_000)]);
   if (child.exitCode === null) {
     child.kill("SIGKILL");
-    await once(child, "exit");
+    // Bounded: Windows maps both signals to TerminateProcess, and waiting forever
+    // for an exit event that has already fired turns a failure into a hung run.
+    await Promise.race([once(child, "exit"), delay(5_000)]);
   }
 }
 

--- a/packages/farmjs-plugin/src/rsc/nitro-build.ts
+++ b/packages/farmjs-plugin/src/rsc/nitro-build.ts
@@ -332,8 +332,17 @@ export async function buildRscNitro(options: BuildRscNitroOptions): Promise<void
     },
     // Externalize rsc/ssr so we don't bundle (they reference Vite-generated manifest). We copy dist into server output after build.
     rollupConfig: {
-      external: (id: string) =>
-        id.includes("../dist/") || id.includes("dist/rsc") || id.includes("dist/ssr"),
+      external: (id: string) => {
+        // Ids reach this predicate in both separator forms on Windows, and matching
+        // only the POSIX one makes the same module external in one pass and not in
+        // the next, which Rollup rejects.
+        const normalized = id.split("\\").join("/");
+        return (
+          normalized.includes("../dist/") ||
+          normalized.includes("dist/rsc") ||
+          normalized.includes("dist/ssr")
+        );
+      },
     },
     compatibilityDate: "2024-12-01",
     minify: true,

--- a/scripts/test-packages.js
+++ b/scripts/test-packages.js
@@ -12,10 +12,6 @@ const onlyWithNodeEngine = args.has("--only-with-node-engine");
 const currentNodeVersion = process.versions.node;
 const currentNodeMajor = Number(currentNodeVersion.split(".")[0]);
 
-// Packages with known Windows failures, tracked separately so the rest of the
-// suite can run on windows-latest. See #440.
-const WINDOWS_SKIPPED = new Set(["@farm.js/auth", "@farm.js/cli", "@farm.js/plugin"]);
-
 function supportsCurrentNode(range) {
   if (!range) {
     return true;
@@ -57,13 +53,6 @@ let skipped = 0;
 
 for (const pkg of packages) {
   const isCompatible = supportsCurrentNode(pkg.nodeEngine);
-
-  if (process.platform === "win32" && WINDOWS_SKIPPED.has(pkg.name)) {
-    skipped += 1;
-    console.log(`
-> Skipping ${pkg.name} (known Windows failures, see #440)`);
-    continue;
-  }
 
   if (onlyWithNodeEngine && !pkg.nodeEngine) {
     skipped += 1;


### PR DESCRIPTION
Do not merge. This exists to answer one question from #458: does the `EMFILE` in the RSC
Nitro build reproduce on `windows-latest`, or only on a local machine?

Windows caps concurrent C runtime file descriptors per process and the limit varies by
machine, so a local failure is not evidence that CI hits it. The only change here is
removing the `win32` skip from `core-external.test.ts`, on top of #464.

If the Windows job fails with `EMFILE`, it reproduces on the runner and the fix belongs in
our RSC build, with the trace cross-linked to nitrojs/nitro#3376. If it passes, the skip
should come out of #464 instead of being carried indefinitely.

Closing this either way once the Windows job reports.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks Windows CI and verifies whether the RSC Nitro build hits EMFILE on `windows-latest`. Previously Windows runs leaked auth DB handles, misquoted CLI paths, and mismatched Rollup externals; now connections close, CLI paths/quoting are OS‑aware, and externals matching is separator‑agnostic. The RSC build fixture is temporarily unskipped to confirm EMFILE reproduction.

- Review focus
  - `@farm.js/auth`: Cache and close the database handle. New `disposeFarmAuth()` drops the cached runtime and closes its connection; reconfigure closes the previous connection. Tests add teardown and longer timeouts for CI.
  - `@farm.js/cli`: Treat backslash as safe on win32 in command formatting; report POSIX paths in doctor output.
  - `@farm.js/plugin`: Normalize path separators before Rollup externals checks; bound child exit waits in build fixtures; fix path resolution tests.
  - CI/tests: Remove the Windows skip list so `@farm.js/auth`, `@farm.js/cli`, and `@farm.js/plugin` run on Windows; temporarily unskip the RSC build fixture to detect EMFILE.

<sup>Written for commit 1f4a66c0ec40e9bf419a3fa68d7eedc13f8bc3ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

