### PR TITLE
fix(cli): separate SQL and double-quoted string escaping in generate

### DIFF
--- a/packages/farm-cli/src/generate.ts
+++ b/packages/farm-cli/src/generate.ts
@@ -579,7 +579,7 @@ function renderPrismaModel(model: CollectedSchemaModel) {
     }
 
     if (field.name !== fieldKey) {
-      attributes.push(`@map("${escapeString(field.name)}")`);
+      attributes.push(`@map("${escapeDoubleQuoted(field.name)}")`);
     }
 
     if (attributes.length) {
@@ -590,7 +590,7 @@ function renderPrismaModel(model: CollectedSchemaModel) {
 
     if (field.index) {
       modelLevelConstraints.push(
-        `@@index([${fieldKey}], map: "${escapeString(`${model.modelName}_${field.name}_idx`)}")`,
+        `@@index([${fieldKey}], map: "${escapeDoubleQuoted(`${model.modelName}_${field.name}_idx`)}")`,
       );
     }
   }
@@ -598,11 +598,11 @@ function renderPrismaModel(model: CollectedSchemaModel) {
   for (const constraint of model.model.constraints || []) {
     const fields = constraint.fields.join(", ");
     const attribute = constraint.type === "unique" ? "@@unique" : "@@index";
-    const suffix = constraint.name ? `, map: "${escapeString(constraint.name)}"` : "";
+    const suffix = constraint.name ? `, map: "${escapeDoubleQuoted(constraint.name)}"` : "";
     modelLevelConstraints.push(`${attribute}([${fields}]${suffix})`);
   }
 
-  lines.push(`  @@map("${escapeString(model.modelName)}")`);
+  lines.push(`  @@map("${escapeDoubleQuoted(model.modelName)}")`);
 
   for (const constraint of modelLevelConstraints) {
     lines.push(`  ${constraint}`);
@@ -639,7 +639,7 @@ function getPrismaDefaultAttribute(field: ResolvedSchemaField) {
   }
 
   if (typeof field.default === "string") {
-    return `@default("${escapeString(field.default)}")`;
+    return `@default("${escapeDoubleQuoted(field.default)}")`;
   }
 
   if (typeof field.default === "number" || typeof field.default === "boolean") {
@@ -714,7 +714,7 @@ function renderDrizzleModel(
   for (const [fieldKey, field] of Object.entries(model.model.fields)) {
     if (field.index) {
       lines.push(
-        `  ${fieldKey}Idx: index("${escapeString(`${model.modelName}_${field.name}_idx`)}").on(table.${fieldKey}),`,
+        `  ${fieldKey}Idx: index("${escapeDoubleQuoted(`${model.modelName}_${field.name}_idx`)}").on(table.${fieldKey}),`,
       );
     }
   }
@@ -725,7 +725,9 @@ function renderDrizzleModel(
     const name =
       constraint.name ||
       `${model.modelName}_${constraint.fields.map((fieldKey) => model.model.fields[fieldKey]?.name || fieldKey).join("_")}_${constraint.type}`;
-    lines.push(`  ${toCamelCase(name)}: ${builder}("${escapeString(name)}").on(${accessor}),`);
+    lines.push(
+      `  ${toCamelCase(name)}: ${builder}("${escapeDoubleQuoted(name)}").on(${accessor}),`,
+    );
   }
 
   lines.push("}));");
@@ -874,7 +876,7 @@ function getDrizzleDefaultExpression(field: ResolvedSchemaField, dialect: Genera
   }
 
   if (typeof field.default === "string") {
-    return `.default("${escapeString(field.default)}")`;
+    return `.default("${escapeDoubleQuoted(field.default)}")`;
   }
 
   if (typeof field.default === "number" || typeof field.default === "boolean") {
@@ -1077,7 +1079,7 @@ function getSqlDefaultExpression(field: ResolvedSchemaField, dialect: GenerateFa
   }
 
   if (typeof field.default === "string") {
-    return `'${escapeString(field.default)}'`;
+    return `'${escapeSqlString(field.default)}'`;
   }
 
   if (typeof field.default === "number") {
@@ -1104,7 +1106,9 @@ function generateMongoBootstrap(models: readonly CollectedSchemaModel[]) {
 
   for (const model of models) {
     lines.push(`  // Integration "${model.integrationKey}" model "${model.modelKey}"`);
-    lines.push(`  const ${model.exportName} = db.collection("${escapeString(model.modelName)}");`);
+    lines.push(
+      `  const ${model.exportName} = db.collection("${escapeDoubleQuoted(model.modelName)}");`,
+    );
 
     for (const [fieldKey, field] of Object.entries(model.model.fields)) {
       if (field.unique) {
@@ -1112,13 +1116,13 @@ function generateMongoBootstrap(models: readonly CollectedSchemaModel[]) {
         if (isNullableField(field)) {
           options.push("sparse: true");
         }
-        options.push(`name: "${escapeString(`${model.modelName}_${field.name}_unique`)}"`);
+        options.push(`name: "${escapeDoubleQuoted(`${model.modelName}_${field.name}_unique`)}"`);
         lines.push(
           `  await ${model.exportName}.createIndex({ ${JSON.stringify(field.name)}: 1 }, { ${options.join(", ")} });`,
         );
       } else if (field.index) {
         lines.push(
-          `  await ${model.exportName}.createIndex({ ${JSON.stringify(field.name)}: 1 }, { name: "${escapeString(`${model.modelName}_${field.name}_idx`)}" });`,
+          `  await ${model.exportName}.createIndex({ ${JSON.stringify(field.name)}: 1 }, { name: "${escapeDoubleQuoted(`${model.modelName}_${field.name}_idx`)}" });`,
         );
       }
 
@@ -1138,8 +1142,8 @@ function generateMongoBootstrap(models: readonly CollectedSchemaModel[]) {
         `${model.modelName}_${constraint.fields.map((fieldKey) => model.model.fields[fieldKey]?.name || fieldKey).join("_")}_${constraint.type}`;
       const options =
         constraint.type === "unique"
-          ? `{ unique: true, name: "${escapeString(indexName)}" }`
-          : `{ name: "${escapeString(indexName)}" }`;
+          ? `{ unique: true, name: "${escapeDoubleQuoted(indexName)}" }`
+          : `{ name: "${escapeDoubleQuoted(indexName)}" }`;
       lines.push(`  await ${model.exportName}.createIndex({ ${indexSpec} }, ${options});`);
     }
 
@@ -1194,8 +1198,14 @@ function toCamelCase(value: string) {
   return pascal ? pascal.charAt(0).toLowerCase() + pascal.slice(1) : pascal;
 }
 
-function escapeString(value: string) {
-  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/'/g, "''");
+export function escapeDoubleQuoted(value: string) {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+export function escapeSqlString(value: string) {
+  // Standard-conforming SQL string literal: only quote doubling; backslashes
+  // are literal characters.
+  return value.replace(/'/g, "''");
 }
 
 function escapeRegExp(value: string) {

--- a/packages/farm-cli/src/index.ts
+++ b/packages/farm-cli/src/index.ts
@@ -53,6 +53,8 @@ export {
   type RunNativePreviewTunnelOptions,
 } from "./preview-native";
 export {
+  escapeDoubleQuoted,
+  escapeSqlString,
   FarmGeneratedArtifactsStaleError,
   generateFarmArtifacts,
   type GenerateFarmOptions,

--- a/packages/farm-cli/test/generate-escaping.test.mjs
+++ b/packages/farm-cli/test/generate-escaping.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const { escapeDoubleQuoted, escapeSqlString } = require("../dist/index.js");
+
+test("double-quoted escaping leaves single quotes alone", () => {
+  assert.equal(escapeDoubleQuoted("it's"), "it's");
+  assert.equal(escapeDoubleQuoted('say "hi"'), 'say \\"hi\\"');
+  assert.equal(escapeDoubleQuoted("back\\slash"), "back\\\\slash");
+});
+
+test("sql escaping doubles single quotes and keeps everything else literal", () => {
+  assert.equal(escapeSqlString("it's"), "it''s");
+  assert.equal(escapeSqlString('say "hi"'), 'say "hi"');
+  assert.equal(escapeSqlString("back\\slash"), "back\\slash");
+});


### PR DESCRIPTION
## Summary

`generate.ts` used one `escapeString` for two incompatible quoting contexts. It backslash-escaped `"` (right for TS/Prisma double-quoted strings, wrong inside SQL single-quoted literals) **and** doubled `'` (right for SQL, wrong for TS/Prisma):

- `default: "it's"` with `--orm drizzle` emitted `.default("it''s")` — syntactically valid TS whose runtime value is the wrong string `it''s`; same corruption in Prisma `@default`
- `default: 'say "hi"'` with `--orm postgres` emitted `DEFAULT 'say \"hi\"'` — literal backslashes stored in the column default

## Fix

Two context-specific escapers:
- `escapeDoubleQuoted` (backslash + `"`) for the 13 TS/Prisma/Mongo double-quoted call sites
- `escapeSqlString` (`'` doubling only — standard-conforming SQL treats backslash literally) for the single SQL-literal site

Both are exported and their contracts pinned by a new test file.

## Tests

New `generate-escaping.test.mjs`: single quotes pass through double-quoted escaping untouched, and SQL escaping doubles quotes while leaving `"`/backslash literal — both assertions the old shared function violated. Full CLI suite passes 83/83, `oxlint`/`oxfmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separates SQL and double-quoted string escaping in the CLI generator to prevent corrupted defaults. Previously one escaper backslash-escaped " and doubled ' everywhere; now double-quoted contexts and SQL literals use context-appropriate escaping.

- Replace shared `escapeString` with `escapeDoubleQuoted` (escapes backslash and ") for TS/Prisma/Mongo strings and `escapeSqlString` (doubles ') for SQL single-quoted literals.
- Use `escapeDoubleQuoted` at 13 call sites (e.g., Prisma `@map`, `@default`, Drizzle `.default`, index names) and `escapeSqlString` only for the SQL default path.
- Export `escapeDoubleQuoted` and `escapeSqlString` from `packages/farm-cli/src/index.ts`; add `generate-escaping.test.mjs` to pin contracts (single quotes pass through double-quoted escaping; SQL escaping doubles only ').

<sup>Written for commit 229afecf77dd1a305c3757ef394e4bdc24ef25d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

