### PR TITLE
fix(core): give popstate blockers a real from and revert blocked pops

### DIFF
--- a/packages/farm/src/__tests__/spa-router-popstate.test.ts
+++ b/packages/farm/src/__tests__/spa-router-popstate.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { SPARouter, type FarmNavigationBlockerContext } from "../client/spa-router";
+
+const routers: SPARouter[] = [];
+
+function createRouter(): SPARouter {
+  const router = new SPARouter();
+  routers.push(router);
+  return router;
+}
+
+async function settle(assertion: () => void): Promise<void> {
+  let error: unknown;
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (caught) {
+      error = caught;
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+  }
+  throw error;
+}
+
+afterEach(() => {
+  while (routers.length > 0) {
+    routers.pop()!.destroy();
+  }
+  window.history.replaceState(null, "", "/");
+});
+
+describe("SPA router popstate blocking", () => {
+  it("passes the rendered page as from, not the destination entry", async () => {
+    const router = createRouter();
+    router.pushState(null, "/edit");
+
+    const seen: FarmNavigationBlockerContext[] = [];
+    router.addBlocker((context) => {
+      seen.push(context);
+      return true;
+    });
+
+    window.history.back();
+    await settle(() => expect(seen.length).toBeGreaterThan(0));
+
+    expect(seen[0]).toEqual({ from: "/edit", to: "/", action: "pop" });
+  });
+
+  it("reverts the URL when a back navigation is blocked", async () => {
+    const router = createRouter();
+    router.pushState(null, "/edit");
+
+    let blocks = 0;
+    router.addBlocker(() => {
+      blocks++;
+      return true;
+    });
+
+    window.history.back();
+    await settle(() => expect(blocks).toBe(1));
+    // The revert traversal restores the rendered page's URL.
+    await settle(() => expect(window.location.pathname).toBe("/edit"));
+
+    // The suppression is consumed: a second back asks the blocker again.
+    window.history.back();
+    await settle(() => expect(blocks).toBe(2));
+    await settle(() => expect(window.location.pathname).toBe("/edit"));
+  });
+
+  it("updates tracking when a pop is allowed", async () => {
+    const router = createRouter();
+    (router as unknown as { fetchPageData: () => Promise<unknown> }).fetchPageData = async () => ({
+      props: {},
+      modulePath: "/src/app/page.tsx",
+    });
+    router.setNavigationHandler(async () => {});
+    router.pushState(null, "/edit");
+
+    const seen: FarmNavigationBlockerContext[] = [];
+    router.addBlocker((context) => {
+      seen.push(context);
+      return false;
+    });
+
+    window.history.back();
+    await settle(() => expect(seen.length).toBe(1));
+    expect(seen[0]).toEqual({ from: "/edit", to: "/", action: "pop" });
+    await settle(() => expect(window.location.pathname).toBe("/"));
+
+    // Going forward again reports the new rendered page as from.
+    window.history.forward();
+    await settle(() => expect(seen.length).toBe(2));
+    expect(seen[1]).toEqual({ from: "/", to: "/edit", action: "pop" });
+  });
+});

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -117,6 +117,13 @@ export type FarmNavigationListener = (state: FarmNavigationState) => void;
 
 const FARM_PAGE_STATE_KEY = "__farmPageState";
 const FARM_INTERCEPT_FROM_KEY = "__farmInterceptFrom";
+const FARM_HISTORY_INDEX_KEY = "__farmHistoryIndex";
+
+function readHistoryIndex(state: unknown): number | null {
+  if (!state || typeof state !== "object") return null;
+  const value = (state as Record<string, unknown>)[FARM_HISTORY_INDEX_KEY];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
 const IDLE_NAVIGATION_STATE: FarmNavigationState = {
   state: "idle",
   pending: false,
@@ -146,6 +153,9 @@ export class SPARouter {
   private blockers: Set<FarmNavigationBlocker> = new Set();
   private navigationListeners: Set<FarmNavigationListener> = new Set();
   private navigationState: FarmNavigationState = IDLE_NAVIGATION_STATE;
+  private currentHistoryPath: string | null = null;
+  private currentHistoryIndex: number | null = null;
+  private suppressNextPopState = false;
   private scrollElements: Map<string, HTMLElement> = new Map();
   private options: Required<Omit<RouterOptions, "deploymentId">> &
     Pick<RouterOptions, "deploymentId">;
@@ -186,6 +196,28 @@ export class SPARouter {
 
       // Save scroll position before unload
       window.addEventListener("beforeunload", this.onBeforeUnload);
+
+      // Track the rendered location and its position in the history stack so
+      // popstate can report a real `from` and revert blocked traversals.
+      this.currentHistoryPath = window.location.pathname + window.location.search;
+      const existingIndex = readHistoryIndex(window.history.state);
+      if (existingIndex == null) {
+        try {
+          window.history.replaceState(
+            {
+              ...((window.history.state as object | null) ?? {}),
+              [FARM_HISTORY_INDEX_KEY]: 0,
+            },
+            "",
+            window.location.href,
+          );
+          this.currentHistoryIndex = 0;
+        } catch {
+          this.currentHistoryIndex = null;
+        }
+      } else {
+        this.currentHistoryIndex = existingIndex;
+      }
     }
   }
 
@@ -440,12 +472,25 @@ export class SPARouter {
       options.state,
       undefined,
       options.pageData.interception?.from ?? null,
-    );
+    ) as Record<string, unknown>;
+    const nextHistoryIndex =
+      this.currentHistoryIndex == null
+        ? null
+        : options.replace
+          ? this.currentHistoryIndex
+          : this.currentHistoryIndex + 1;
+    if (nextHistoryIndex != null) {
+      historyState[FARM_HISTORY_INDEX_KEY] = nextHistoryIndex;
+    }
     if (options.replace) {
       window.history.replaceState(historyState, "", historyPath);
     } else {
       window.history.pushState(historyState, "", historyPath);
     }
+    this.currentHistoryIndex = nextHistoryIndex;
+    this.currentHistoryPath =
+      new URL(historyPath, window.location.origin).pathname +
+      new URL(historyPath, window.location.origin).search;
 
     if (options.pageData.metadata?.title) {
       document.title = options.pageData.metadata.title;
@@ -560,25 +605,71 @@ export class SPARouter {
   }
 
   /**
+   * Put the browser URL back on the rendered page after a blocked pop. When
+   * both entries carry a Farm history index the traversal is reversed
+   * exactly; otherwise the current path is pushed again, which restores the
+   * address bar at the cost of one extra history entry.
+   */
+  private revertBlockedPopState(event: PopStateEvent, from: string): void {
+    const eventIndex = readHistoryIndex(event.state);
+    if (eventIndex != null && this.currentHistoryIndex != null) {
+      const delta = eventIndex - this.currentHistoryIndex;
+      if (delta !== 0) {
+        this.suppressNextPopState = true;
+        window.history.go(-delta);
+        return;
+      }
+    }
+
+    try {
+      const restoredState: Record<string, unknown> = {
+        path: from,
+      };
+      if (this.currentHistoryIndex != null && eventIndex != null) {
+        restoredState[FARM_HISTORY_INDEX_KEY] = eventIndex + 1;
+        this.currentHistoryIndex = eventIndex + 1;
+      }
+      window.history.pushState(restoredState, "", from);
+    } catch {
+      // Leave the URL as-is if the history API rejects the write; the
+      // rendered page is still the blocked-from page.
+    }
+  }
+
+  /**
    * Handle browser back/forward navigation
    */
   private async handlePopState(event: PopStateEvent): Promise<void> {
     if (document.documentElement.dataset.farmDocsRuntime === "true") return;
 
+    if (this.suppressNextPopState) {
+      // This traversal is our own revert of a blocked pop; the rendered page
+      // never changed.
+      this.suppressNextPopState = false;
+      return;
+    }
+
     const path = window.location.pathname + window.location.search;
+    // The browser has already moved to the destination entry, so its state
+    // describes `to`; the page still rendered is the tracked current path.
+    const from = this.currentHistoryPath ?? path;
 
     if (
       await this.shouldBlockNavigation({
-        from: event.state?.path || path,
+        from,
         to: path,
         action: "pop",
       })
     ) {
+      this.revertBlockedPopState(event, from);
       return;
     }
 
+    this.currentHistoryPath = path;
+    this.currentHistoryIndex = readHistoryIndex(event.state);
+
     this.startNavigation({
-      from: event.state?.path || path,
+      from,
       to: createNavigationLocation(new URL(window.location.href)),
       action: "pop",
     });
@@ -686,17 +777,23 @@ export class SPARouter {
     if (typeof window === "undefined") return;
 
     const url = href ? new URL(href, window.location.origin).toString() : window.location.href;
-    const nextState = createHistoryState(
-      new URL(url).pathname + new URL(url).search,
-      state,
-      window.history.state,
-    );
+    const nextPath = new URL(url).pathname + new URL(url).search;
+    const nextState = createHistoryState(nextPath, state, window.history.state) as Record<
+      string,
+      unknown
+    >;
 
     if (action === "replace") {
       window.history.replaceState(nextState, "", url);
     } else {
+      if (this.currentHistoryIndex != null) {
+        nextState[FARM_HISTORY_INDEX_KEY] = this.currentHistoryIndex + 1;
+      }
       window.history.pushState(nextState, "", url);
+      this.currentHistoryIndex =
+        this.currentHistoryIndex == null ? null : this.currentHistoryIndex + 1;
     }
+    this.currentHistoryPath = nextPath;
 
     notifyHistoryChange("page-state");
   }


### PR DESCRIPTION
## Summary

Two related defects in `handlePopState`:

**Blockers received `from === to`.** `popstate` fires after the browser has already moved, so `event.state?.path` belongs to the **destination** entry. A navigation blocker registered via `useBlocker` got `{ from: "/list", to: "/list" }` when leaving `/edit` — any blocker checking `from !== to` never fired.

**Blocked pops desynced the URL.** When a blocker returned true the handler just `return`ed: the address bar showed the new URL while the old page stayed rendered. A reload or shared link then landed on the wrong page.

## Fix

The router tracks the rendered location and stamps a per-entry index into `history.state` on every push/replace:

- blockers receive the tracked rendered path as `from`
- a blocked pop is reverted with `history.go(-delta)` computed from the entry indices, and the resulting popstate is suppressed so the revert itself doesn't re-enter navigation; entries without a Farm index (external pushes) fall back to re-pushing the current path, which restores the URL at the cost of one extra entry
- allowed pops update the tracked location, so subsequent traversals report the correct `from`

## Tests

New jsdom suite using real history traversal (`history.back()`/`forward()`, no synthetic `PopStateEvent` — the `check-synthetic-popstate` guard passes): blocker context carries the rendered page as `from`; a blocked back reverts the URL and re-asks the blocker on the next back; an allowed pop updates tracking so the following forward reports the new `from`. All 3 fail against the old code (verified via patch-revert); `spa-router-hash` suite still passes, `tsc`/`oxlint`/`oxfmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SPA router popstate handling so blockers see the real rendered page as from and blocked back/forward navigations revert the URL to match the rendered page. Previously, blockers saw from === to (because popstate fires after the move), and blocking left the address bar on the wrong URL.

- Tracks the rendered path and stamps a per-entry `__farmHistoryIndex` in `history.state` on push/replace.
- Uses the tracked rendered path as from in `handlePopState`; allowed pops update the tracker.
- Reverts blocked pops via `history.go(-delta)` computed from entry indices and suppresses the resulting popstate; falls back to re-pushing the current path when indices are missing.
- Adds a jsdom test suite that drives real history traversal and verifies correct from, URL reversion on block, and tracker updates.

<sup>Written for commit 7f385a75a28bc7b155b2a89acc2189e8e2589dfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

