### PR TITLE
feat(react): compile controlled fields in keyed rows

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -540,10 +540,71 @@ which may predate a direct DOM patch.
 
 The initial event contract is deliberately conservative: the row and descendants must still be a
 statically known HTML host tree; the handler must be inline, synchronous, and free of Hooks,
-`this`, `super`, and `arguments`; and controlled row inputs with change, input, selection, or
-composition events stay entirely React-owned. Non-inline or async handlers, custom row components,
-fragments, refs, SVG, spreads, and other unproven shapes use the React-owned keyed boundary. The
-same hybrid path is available to an eligible inline host row rendered through `List`.
+`this`, `super`, and `arguments`. Non-inline or async handlers, custom row components, fragments,
+refs, SVG, spreads, and other unproven shapes use the React-owned keyed boundary. The same hybrid
+path is available to an eligible inline host row rendered through `List`.
+
+#### Controlled fields in keyed rows
+
+An eligible host row can contain ordinary controlled form fields:
+
+```tsx
+<ul>
+  {items.map((item) => (
+    <li key={item.id}>
+      <input
+        value={item.label}
+        onChange={(event) =>
+          setItems((current) =>
+            current.map((row) =>
+              row.id === item.id ? { ...row, label: event.currentTarget.value } : row,
+            ),
+          )
+        }
+      />
+      <input
+        type="checkbox"
+        checked={item.done}
+        onChange={(event) =>
+          setItems((current) =>
+            current.map((row) =>
+              row.id === item.id ? { ...row, done: event.currentTarget.checked } : row,
+            ),
+          )
+        }
+      />
+      <select value={item.priority} onChange={/* the same keyed update pattern */}>
+        <option value="low">Low</option>
+        <option value="high">High</option>
+      </select>
+    </li>
+  ))}
+</ul>
+```
+
+React still creates or hydrates the controls, dispatches `change`, `input`, selection, and
+composition events, and reconciles any key insertion, removal, or reorder. Farm prepares the
+`value` and `checked` property bindings at build time. A same-key edit flushes the collection cell,
+looks up that row instance, and writes only the affected form properties and dependent row output;
+the owner component and map do not execute again.
+
+This is property-based rather than attribute-only. Text inputs and textareas update `.value`,
+checkboxes and radios update `.checked`, and controlled single or multiple selects update their
+selected options. The runtime avoids assigning an equal value, captures the focused text control's
+selection before the compiler microtask, and restores the range after its keyed boundary commits.
+Composition handlers remain React event props, so IME event order is unchanged.
+
+React exposes `event.currentTarget` only while an event handler is running. If a functional
+compiler-state updater refers to one of its properties, the transform snapshots that property read
+before queuing the updater. This preserves the common keyed update shown above without retaining or
+replaying the SyntheticEvent, and it prevents React's controlled-field restoration from changing a
+deferred `.value` or `.checked` read.
+
+The initial optimized contract requires a static input `type` and static `<option>`/`<optgroup>`
+attributes. File input values, dynamic input types, dynamic option state, `contentEditable`, refs,
+custom controls, async or non-inline handlers, and a controlled textarea that also has children use
+the React fallback. Duplicate keys discovered at runtime also switch that mounted list to React.
+These limits apply equally to automatically detected maps and inline host rows inside `List`.
 
 #### Row-local host conditionals
 
@@ -695,9 +756,9 @@ The optimized host-row contract is deliberately narrow:
   properties, and individual inline style properties are supported.
 - Inline synchronous row events and dedicated logical or ternary host slots are supported by the
   hybrid path. Branch events, nested dynamic blocks, conditionals mixed with siblings in one slot,
-  non-inline or async handlers, controlled interactive form fields, custom components, fragments,
-  refs, SVG, attribute spreads, dangerous HTML, and dynamic text mixed beside nested elements stay
-  React-owned.
+  non-inline or async handlers, file inputs, dynamic form control types or options, custom
+  components, fragments, refs, SVG, attribute spreads, dangerous HTML, and dynamic text mixed
+  beside nested elements stay React-owned.
 - Unsupported or mutating collection methods, spread children, Hooks in callbacks, and other
   unproven shapes fall back to normal React.
 
@@ -942,6 +1003,8 @@ The package and example test suites verify more than generated code:
 - interactive host rows keep React event propagation and `currentTarget`, resolve the latest item
   and index after same-key replacements and reorders, let React own structural commits, and resume
   direct binding patches without stale virtual-prop output;
+- editable keyed rows preserve input and row identity, focused selection, IME ordering, checkbox,
+  radio, textarea, and select state while direct same-key edits add no owner or map executions;
 - interactive rows stay coherent across combined parent/local updates, Strict Mode, compatible Fast
   Refresh, recoverable hydration mismatches, and an unmount before the compiler microtask flush;
 - row-local host conditionals refresh only changed keyed slots, remain coherent with inline events
@@ -959,6 +1022,8 @@ The package and example test suites verify more than generated code:
   produce the same keyed output as normal React while preserving surviving DOM rows;
 - 4,000 deterministic interactive data, structure, and event transitions match normal React while
   the compiled owner remains at one execution;
+- 2,000 deterministic controlled-form and structural transitions match normal React across text,
+  textarea, checkbox, radio, and select properties while the compiled owner stays at one execution;
 - 2,000 deterministic row-conditional data and structural transitions match normal React while the
   compiled owner remains at one execution;
 - the production browser experiment derives a keyed window from 2,048 source rows without
@@ -967,8 +1032,9 @@ The package and example test suites verify more than generated code:
   keyed DOM identity and capture/stop-propagation behavior, and observes zero owner update
   executions;
 - the public `List` renders iterable and nullish collections correctly with the compiler off;
-- the packaged runtime, including interactive keyed-row events, row-local conditions, reorders,
-  identity, and hydration, is exercised separately with React 18.3 and React 19;
+- the packaged runtime, including editable and interactive keyed-row events, row-local conditions,
+  reorders, identity, selection, and hydration, is exercised separately with React 18.3 and React
+  19;
 - boolean `data-*` and `aria-*` attributes keep React-compatible string values; and
 - unsupported list shapes, effects, refs, and unsupported dynamic component-island shapes remain
   on React without corrupting output.

--- a/examples/react-compiler/README.md
+++ b/examples/react-compiler/README.md
@@ -38,6 +38,7 @@ assertions, checks for console/runtime errors and horizontal overflow, saves scr
 | Automatic keyed map         | stable row DOM, three LIS moves for a four-row reversal  | —                                              | AOT rows patch in place and use the minimum reorder moves.              |
 | Derived keyed collection    | 2,048 source rows filter, sort, slice, and reverse; executions `0` | —                                      | Collection dependencies feed keyed rows without rerunning the owner.    |
 | Interactive keyed rows      | latest item/index after updates and reorder; executions `0` | —                                           | React owns events/structure while Farm patches same-key row bindings.   |
+| Editable keyed rows         | caret, fields, identity, and a 256-row load; executions `0` | —                                           | Controlled form properties update by key without rerunning the owner.  |
 | Conditional row blocks      | only changed keyed branches refresh; owner executions `0`  | —                                           | Per-key snapshots isolate logical and ternary row content.              |
 | Explicit `List`             | stateful rows reorder, update executions `0`            | —                                              | React preserves custom-row state by key inside the isolated boundary.  |
 | Calculated style bindings   | value `6`, progress `50%`, update executions `0`        | —                                              | Safe calls and individual CSS properties use prepared dependencies.    |
@@ -99,7 +100,14 @@ the structure once; Farm then adopts the committed rows and resumes direct same-
 `04C` card verifies capture and stop-propagation behavior, latest-item lookup across three clicks,
 row identity through a reversal, and zero owner update executions.
 
-The `04D` card adds two branch slots to every keyed row. Each logical or ternary expression is the
+The `04D` card contains controlled text, select, and checkbox fields. React keeps event, hydration,
+and structural ownership; Farm patches the prepared form properties and row output for the changed
+key. The production test edits in the middle of a focused input, changes the other fields, rotates
+the rows while checking DOM and selection identity, loads 256 rows, and observes zero owner update
+executions. File inputs, dynamic control types or option attributes, content-editable trees, refs,
+custom controls, and async or non-inline handlers remain React fallbacks.
+
+The `04E` card adds two branch slots to every keyed row. Each logical or ternary expression is the
 only child of a persistent host container. Farm scopes the prepared test and branch-value snapshot
 to the row key, then asks React to refresh only a slot whose selected branch or active values
 changed. The card toggles status and details independently, rotates the rows, checks that their DOM
@@ -110,12 +118,11 @@ commit. This is why row conditionals do not use the manual insertion or LIS path
 components, fragments, refs, SVG, nested blocks, or a conditional mixed with another child in the
 same slot use the existing React-owned list fallback.
 
-Non-inline or async row handlers, controlled interactive form fields, custom components, fragments,
-refs, SVG, static siblings in that same container, and index or missing keys use the React-owned
-list path. Duplicate keys discovered at runtime remount that container through React. LIS applies
-to non-interactive compiler-owned rows; interactive structural changes intentionally stay with
-React. Neither path makes insertions, removals, key comparison, collection work, or DOM updates
-disappear.
+Non-inline or async row handlers, unsupported form shapes, custom components, fragments, refs, SVG,
+static siblings in that same container, and index or missing keys use the React-owned list path.
+Duplicate keys discovered at runtime remount that container through React. LIS applies to
+non-interactive compiler-owned rows; interactive structural changes intentionally stay with React.
+Neither path makes insertions, removals, key comparison, collection work, or DOM updates disappear.
 
 The example includes ES2023 TypeScript library declarations because `toSorted` and `toReversed`
 are standard runtime methods that the compiler preserves rather than polyfills.

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -30,6 +30,7 @@ for (const component of [
   "AutomaticKeyedListExperiment",
   "DerivedCollectionExperiment",
   "InteractiveKeyedListExperiment",
+  "EditableKeyedListExperiment",
   "RowConditionalListExperiment",
   "ExplicitKeyedListExperiment",
   "StatefulListRow",
@@ -560,6 +561,98 @@ try {
   );
   assert.equal(interactiveListFinalExecutions - interactiveListInitialExecutions, 0);
 
+  const editableList = '[data-experiment="keyed-editable"]';
+  const editableListInitialExecutions = await readNumber(
+    page,
+    `${editableList} [data-metric="executions"]`,
+  );
+  const editableAlpha = `${editableList} [data-key="a"]`;
+  const editableAlphaName = page.locator(`${editableAlpha} [data-control="name"]`);
+  await page.evaluate(() => {
+    window.__farmEditableAlpha = document.querySelector(
+      '[data-experiment="keyed-editable"] [data-key="a"]',
+    );
+    window.__farmEditableAlphaName = document.querySelector(
+      '[data-experiment="keyed-editable"] [data-key="a"] [data-control="name"]',
+    );
+  });
+  await editableAlphaName.evaluate((input) => {
+    input.focus();
+    input.setSelectionRange(8, 8);
+  });
+  await page.keyboard.insertText("X");
+  assert.equal(await editableAlphaName.inputValue(), "CompilerX graph");
+  assert.deepEqual(
+    await editableAlphaName.evaluate((input) => [input.selectionStart, input.selectionEnd]),
+    [9, 9],
+  );
+  await page.locator(`${editableAlpha} [data-control="priority"]`).selectOption("low");
+  await page.locator(`${editableAlpha} [data-control="done"]`).check();
+  await assertText(page, `${editableList} [data-metric="edits"]`, "3");
+  await assertText(
+    page,
+    `${editableAlpha} [data-row-output="a"]`,
+    "ROW 1 · CompilerX graph · low · done",
+  );
+  await editableAlphaName.evaluate((input) => {
+    input.focus();
+    input.setSelectionRange(2, 6);
+  });
+  await page
+    .locator(`${editableList} [data-action="rotate-editable-rows"]`)
+    .evaluate((button) => button.click());
+  await page.waitForFunction(
+    () =>
+      [...document.querySelectorAll('[data-experiment="keyed-editable"] [data-list="editable"] > li')]
+        .map((row) => row.getAttribute("data-key"))
+        .join(",") === "c,a,b",
+  );
+  assert.deepEqual(
+    await page
+      .locator(`${editableList} [data-list="editable"] > li`)
+      .evaluateAll((rows) => rows.map((row) => row.getAttribute("data-key"))),
+    ["c", "a", "b"],
+  );
+  assert.equal(
+    await page.evaluate(
+      () =>
+        window.__farmEditableAlpha ===
+          document.querySelector('[data-experiment="keyed-editable"] [data-key="a"]') &&
+        window.__farmEditableAlphaName ===
+          document.querySelector(
+            '[data-experiment="keyed-editable"] [data-key="a"] [data-control="name"]',
+          ),
+    ),
+    true,
+    "React did not preserve the editable keyed row and input through the reorder",
+  );
+  assert.deepEqual(
+    await editableAlphaName.evaluate((input) => [
+      document.activeElement === input,
+      input.selectionStart,
+      input.selectionEnd,
+    ]),
+    [true, 2, 6],
+  );
+  await assertText(
+    page,
+    `${editableAlpha} [data-row-output="a"]`,
+    "ROW 2 · CompilerX graph · low · done",
+  );
+  const editableListAfterInteractions = await readNumber(
+    page,
+    `${editableList} [data-metric="executions"]`,
+  );
+  assert.equal(editableListAfterInteractions - editableListInitialExecutions, 0);
+  await page.locator(`${editableList} [data-action="load-editable-rows"]`).click();
+  await assertText(page, `${editableList} [data-metric="rows"]`, "256");
+  assert.equal(await page.locator(`${editableList} [data-list="editable"] > li`).count(), 256);
+  const editableListFinalExecutions = await readNumber(
+    page,
+    `${editableList} [data-metric="executions"]`,
+  );
+  assert.equal(editableListFinalExecutions - editableListInitialExecutions, 0);
+
   const rowConditionals = '[data-experiment="keyed-row-conditionals"]';
   const rowConditionalsInitialExecutions = await readNumber(
     page,
@@ -830,6 +923,14 @@ try {
               controlledFinalExecutions - controlledInitialExecutions,
             selectionPreserved: true,
             compositionObserved: true,
+          },
+          editableKeyedRows: {
+            edits: 3,
+            stressRows: 256,
+            updateExecutions:
+              editableListFinalExecutions - editableListInitialExecutions,
+            selectionPreserved: true,
+            identityPreserved: true,
           },
           calculatedBindings: {
             value: 6,

--- a/examples/react-compiler/src/app/globals.css
+++ b/examples/react-compiler/src/app/globals.css
@@ -671,6 +671,83 @@ h1 span {
   padding: 0.4rem 0.6rem;
 }
 
+.edge-card .editable-keyed-list {
+  display: grid;
+  max-height: 28rem;
+  align-items: stretch;
+  gap: 0.55rem;
+  overflow-y: auto;
+}
+
+.edge-card .editable-keyed-row {
+  display: grid;
+  width: 100%;
+  grid-template-columns: minmax(0, 1.25fr) minmax(7rem, 0.75fr);
+  gap: 0.65rem;
+  padding: 0.75rem;
+  background: #0d0d0c;
+  transition:
+    border-color 160ms ease,
+    background 160ms ease;
+}
+
+.edge-card .editable-keyed-row--done {
+  border-color: rgb(184 255 91 / 0.52);
+  background: rgb(184 255 91 / 0.045);
+}
+
+.editable-keyed-row > label:not(.editable-keyed-check) {
+  display: grid;
+  min-width: 0;
+  gap: 0.35rem;
+  color: #777771;
+  font-size: 0.56rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.editable-keyed-row :is(input[type="text"], input:not([type]), select) {
+  width: 100%;
+  min-width: 0;
+  height: 2.35rem;
+  border: 1px solid #3b3b37;
+  border-radius: 0;
+  padding: 0 0.65rem;
+  color: #e1e1da;
+  background: #10100f;
+  font: 0.66rem "Geist Mono Variable", ui-monospace, monospace;
+  outline: none;
+}
+
+.editable-keyed-row :is(input[type="text"], input:not([type]), select):focus-visible {
+  border-color: #b8ff5b;
+  box-shadow: 0 0 0 1px #b8ff5b;
+}
+
+.editable-keyed-check {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: #999992;
+  font-size: 0.62rem;
+}
+
+.editable-keyed-check input {
+  width: 1rem;
+  height: 1rem;
+  accent-color: #b8ff5b;
+}
+
+.editable-keyed-row output {
+  overflow: hidden;
+  grid-column: 1 / -1;
+  color: #8d8d86;
+  font-size: 0.58rem;
+  letter-spacing: 0.035em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .edge-card .conditional-row-list {
   display: grid;
   align-items: stretch;
@@ -1303,6 +1380,10 @@ code {
   }
 
   .edge-card .conditional-row {
+    grid-template-columns: 1fr;
+  }
+
+  .edge-card .editable-keyed-row {
     grid-template-columns: 1fr;
   }
 

--- a/examples/react-compiler/src/components/compiler-edge-lab.tsx
+++ b/examples/react-compiler/src/components/compiler-edge-lab.tsx
@@ -9,6 +9,7 @@ let multipleBindingExecutions = 0;
 let automaticListExecutions = 0;
 let derivedCollectionExecutions = 0;
 let interactiveListExecutions = 0;
+let editableListExecutions = 0;
 let rowConditionalListExecutions = 0;
 let explicitListExecutions = 0;
 
@@ -422,6 +423,144 @@ export function InteractiveKeyedListExperiment() {
   );
 }
 
+interface EditableListItem extends InteractiveListItem {
+  priority: "low" | "high";
+}
+
+export function EditableKeyedListExperiment() {
+  const [items, setItems] = useState<EditableListItem[]>([
+    { id: "a", label: "Compiler graph", done: false, priority: "high" },
+    { id: "b", label: "Hydration pass", done: true, priority: "low" },
+    { id: "c", label: "Runtime cleanup", done: false, priority: "high" },
+  ]);
+  const [edits, setEdits] = useState(0);
+
+  return (
+    <article className="edge-card" data-experiment="keyed-editable">
+      <header>
+        <span className="experiment-number">04D</span>
+        <div>
+          <h3>Editable keyed rows</h3>
+          <p>Each input stays with its key while Farm patches values, checks, and row output.</p>
+        </div>
+      </header>
+      <dl className="compact-metrics" aria-live="polite">
+        <div>
+          <dt>Rows</dt>
+          <dd data-metric="rows">{items.length}</dd>
+        </div>
+        <div>
+          <dt>Edits</dt>
+          <dd data-metric="edits">{edits}</dd>
+        </div>
+        <div>
+          <dt>Executions</dt>
+          <dd data-metric="executions">
+            {typeof window === "undefined" ? 1 : ++editableListExecutions}
+          </dd>
+        </div>
+      </dl>
+      <ul className="editable-keyed-list" data-list="editable">
+        {items.map((item, index) => (
+          <li
+            className={
+              item.done ? "editable-keyed-row editable-keyed-row--done" : "editable-keyed-row"
+            }
+            data-key={item.id}
+            key={item.id}
+          >
+            <label>
+              <span>Name</span>
+              <input
+                aria-label={`Name for ${item.id}`}
+                data-control="name"
+                onChange={(event) => {
+                  setItems((current) =>
+                    current.map((row) =>
+                      row.id === item.id ? { ...row, label: event.currentTarget.value } : row,
+                    ),
+                  );
+                  setEdits((value) => value + 1);
+                }}
+                value={item.label}
+              />
+            </label>
+            <label>
+              <span>Priority</span>
+              <select
+                aria-label={`Priority for ${item.id}`}
+                data-control="priority"
+                onChange={(event) => {
+                  setItems((current) =>
+                    current.map((row) =>
+                      row.id === item.id
+                        ? {
+                            ...row,
+                            priority: event.currentTarget.value as EditableListItem["priority"],
+                          }
+                        : row,
+                    ),
+                  );
+                  setEdits((value) => value + 1);
+                }}
+                value={item.priority}
+              >
+                <option value="low">Low</option>
+                <option value="high">High</option>
+              </select>
+            </label>
+            <label className="editable-keyed-check">
+              <input
+                aria-label={`Done for ${item.id}`}
+                checked={item.done}
+                data-control="done"
+                onChange={(event) => {
+                  setItems((current) =>
+                    current.map((row) =>
+                      row.id === item.id ? { ...row, done: event.currentTarget.checked } : row,
+                    ),
+                  );
+                  setEdits((value) => value + 1);
+                }}
+                type="checkbox"
+              />
+              <span>Completed</span>
+            </label>
+            <output data-row-output={item.id}>
+              ROW {index + 1} · {item.label} · {item.priority} · {item.done ? "done" : "open"}
+            </output>
+          </li>
+        ))}
+      </ul>
+      <div className="button-row">
+        <button
+          data-action="rotate-editable-rows"
+          onClick={() => setItems((current) => [current[2], current[0], current[1]])}
+          type="button"
+        >
+          Rotate rows
+        </button>
+        <button
+          data-action="load-editable-rows"
+          onClick={() =>
+            setItems(
+              Array.from({ length: 256 }, (_, index) => ({
+                id: `editable-${index}`,
+                label: `Task ${index}`,
+                done: index % 3 === 0,
+                priority: index % 2 === 0 ? "high" : "low",
+              })),
+            )
+          }
+          type="button"
+        >
+          Load 256 rows
+        </button>
+      </div>
+    </article>
+  );
+}
+
 interface ConditionalListItem extends InteractiveListItem {
   expanded: boolean;
 }
@@ -440,7 +579,7 @@ export function RowConditionalListExperiment() {
   return (
     <article className="edge-card" data-experiment="keyed-row-conditionals">
       <header>
-        <span className="experiment-number">04D</span>
+        <span className="experiment-number">04E</span>
         <div>
           <h3>Conditional row blocks</h3>
           <p>Each key owns small branch boundaries that update independently.</p>
@@ -540,7 +679,7 @@ export function ExplicitKeyedListExperiment() {
   return (
     <article className="edge-card" data-experiment="keyed-explicit">
       <header>
-        <span className="experiment-number">04E</span>
+        <span className="experiment-number">04F</span>
         <div>
           <h3>Explicit List boundary</h3>
           <p>A key selector supports custom rows while React preserves their state.</p>
@@ -601,6 +740,7 @@ export function CompilerEdgeLab() {
         <AutomaticKeyedListExperiment />
         <DerivedCollectionExperiment />
         <InteractiveKeyedListExperiment />
+        <EditableKeyedListExperiment />
         <RowConditionalListExperiment />
         <ExplicitKeyedListExperiment />
       </div>

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -189,10 +189,40 @@ and unproven calls use the original React fallback.
 the TypeScript `lib` with ES2023 and target a runtime that supports them when using those methods.
 
 React remains the fallback and compatibility boundary. A map beside static children, a row with a
-non-inline or async handler, a controlled interactive form field, a fragment, a ref, a custom
+non-inline or async handler, a file input or dynamic form control shape, a fragment, a ref, a custom
 component, or a conditional mixed directly beside other children in the same host slot uses the
 existing React-owned keyed boundary. The outer compiled component can still be skipped, but React
 reconciles that list's rows and owns their events, lifecycle, and state.
+
+Controlled host fields can use the hybrid keyed-row path:
+
+```tsx
+<ul>
+  {items.map((item) => (
+    <li key={item.id}>
+      <input
+        value={item.label}
+        onChange={(event) =>
+          setItems((current) =>
+            current.map((row) =>
+              row.id === item.id ? { ...row, label: event.currentTarget.value } : row,
+            ),
+          )
+        }
+      />
+      <input type="checkbox" checked={item.done} onChange={/* keyed update */} />
+    </li>
+  ))}
+</ul>
+```
+
+React owns the controls, events, hydration, and every structural commit. Farm patches `value`,
+`checked`, selected options, and dependent row bindings by stable key. It preserves focused text
+selection and leaves composition events on React. When `event.currentTarget` is referenced inside
+a queued functional compiler-state updater, generated code snapshots the referenced property while
+the handler is active. Static input types and static option attributes are required. File inputs,
+dynamic types or options, `contentEditable`, refs, custom controls, textarea children beside
+`value`, and async or non-inline handlers keep the React fallback.
 
 For custom rows or an explicit key selector, use the public component:
 
@@ -279,5 +309,5 @@ unsupported conditional roots, effects, and more advanced hook support intention
 in this release. Compiler-owned keyed rows are limited to a dedicated container with one host-only
 map or `List`. Inline synchronous events and dedicated row-local host conditional slots can use the
 hybrid keyed-row path, but branch events, nested dynamic blocks, conditionals mixed with siblings in
-one slot, non-inline or async row handlers, controlled interactive row forms, custom components,
-fragments, refs, SVG, and duplicate runtime keys keep or switch to React ownership.
+one slot, non-inline or async row handlers, unsupported form shapes, custom components, fragments,
+refs, SVG, and duplicate runtime keys keep or switch to React ownership.

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -613,6 +613,155 @@ const testSource = String.raw`
   assert.deepEqual(interactiveCalls, ["Alpha:0:0", "Alpha!:0:0", "Alpha!!:1:1"]);
   flushSync(() => interactiveRoot.unmount());
 
+  let editableRowExecutions = 0;
+  let editableListRenders = 0;
+  let setEditableItems = () => undefined;
+  const EditableKeyedRows = createCompiledComponent({
+    displayName: "CompatibilityEditableKeyedRows",
+    initialize: () => [[
+      { id: "a", label: "Alpha", done: false },
+      { id: "b", label: "Beta", done: true },
+    ]],
+    render(_props, state, blocks) {
+      editableRowExecutions += 1;
+      setEditableItems = (next) => state[0].set(next);
+      const items = () => state[0].get();
+      const update = (id, patch) =>
+        state[0].set((current) =>
+          current.map((item) => (item.id === id ? { ...item, ...patch } : item)),
+        );
+      return React.createElement(
+        "section",
+        null,
+        React.createElement(blocks.KeyedRows, {
+          id: 0,
+          render: (rowEvent) => {
+            editableListRenders += 1;
+            return React.createElement(
+              "ul",
+              null,
+              items().map((item, index) =>
+                React.createElement(
+                  "li",
+                  { key: item.id, "data-key": item.id },
+                  React.createElement("input", {
+                    "aria-label": "Label " + item.id,
+                    onInput: rowEvent(item, index, 0),
+                    value: item.label,
+                  }),
+                  React.createElement("input", {
+                    "aria-label": "Done " + item.id,
+                    checked: item.done,
+                    onChange: rowEvent(item, index, 1),
+                    type: "checkbox",
+                  }),
+                  React.createElement(
+                    "output",
+                    null,
+                    index + ":" + item.label + ":" + (item.done ? "done" : "open"),
+                  ),
+                ),
+              ),
+            );
+          },
+          items,
+          rowKey: (item) => item.id,
+          create: (item, index) => ({
+            kind: "element",
+            tag: "li",
+            attributes: [{ name: "data-key", value: item.id }],
+            styles: [],
+            children: [
+              {
+                kind: "element",
+                tag: "input",
+                attributes: [
+                  { name: "aria-label", value: "Label " + item.id },
+                  { name: "value", value: item.label },
+                ],
+                styles: [],
+                children: [],
+              },
+              {
+                kind: "element",
+                tag: "input",
+                attributes: [
+                  { name: "aria-label", value: "Done " + item.id },
+                  { name: "checked", value: item.done },
+                  { name: "type", value: "checkbox" },
+                ],
+                styles: [],
+                children: [],
+              },
+              {
+                kind: "element",
+                tag: "output",
+                attributes: [],
+                styles: [],
+                children: [index + ":" + item.label + ":" + (item.done ? "done" : "open")],
+              },
+            ],
+          }),
+          bindings: [
+            { kind: "attribute", path: [0], name: "value", read: (item) => item.label },
+            { kind: "attribute", path: [1], name: "checked", read: (item) => item.done },
+            {
+              kind: "text",
+              path: [2],
+              read: (item, index) => [index, ":", item.label, ":", item.done ? "done" : "open"],
+            },
+          ],
+          events: [
+            {
+              name: "onInput",
+              invoke: (item, _index, event) => update(item.id, { label: event.currentTarget.value }),
+            },
+            {
+              name: "onChange",
+              invoke: (item, _index, event) => update(item.id, { done: event.currentTarget.checked }),
+            },
+          ],
+        }),
+      );
+    },
+    bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+  });
+
+  const editableContainer = document.createElement("div");
+  document.body.append(editableContainer);
+  const editableRoot = createRoot(editableContainer);
+  flushSync(() => editableRoot.render(React.createElement(EditableKeyedRows)));
+  const initialEditableExecutions = editableRowExecutions;
+  const initialEditableRenders = editableListRenders;
+  const editableAlpha = editableContainer.querySelector("[data-key='a']");
+  const editableInput = editableAlpha.querySelector("[aria-label='Label a']");
+  editableInput.focus();
+  editableInput.value = "AlXpha";
+  editableInput.setSelectionRange(3, 3);
+  editableInput.dispatchEvent(new dom.window.InputEvent("input", { bubbles: true, data: "X" }));
+  editableInput.value = "Alpha";
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(editableInput.value, "AlXpha");
+  assert.equal(editableInput.selectionStart, 3);
+  assert.equal(editableInput.selectionEnd, 3);
+  editableAlpha.querySelector("[aria-label='Done a']").click();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(editableAlpha.querySelector("[aria-label='Done a']").checked, true);
+  assert.equal(editableAlpha.querySelector("output").textContent, "0:AlXpha:done");
+  assert.equal(editableRowExecutions, initialEditableExecutions);
+  assert.equal(editableListRenders, initialEditableRenders);
+  setEditableItems((current) => [...current].reverse());
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  flushSync(() => {});
+  assert.equal(editableContainer.querySelector("[data-key='a']"), editableAlpha);
+  assert.equal(editableContainer.querySelector("[aria-label='Label a']"), editableInput);
+  assert.equal(editableAlpha.querySelector("output").textContent, "1:AlXpha:done");
+  assert.equal(editableListRenders, initialEditableRenders + 1);
+  flushSync(() => editableRoot.unmount());
+
   const interactiveHydrationContainer = document.createElement("div");
   interactiveHydrationContainer.innerHTML = renderToString(
     React.createElement(InteractiveKeyedRows),

--- a/packages/farm-react/src/__tests__/compiler-interactive-keyed-rows.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-interactive-keyed-rows.test.ts
@@ -134,19 +134,153 @@ describe("React AOT interactive keyed-row compiler", () => {
     expect(result.code).not.toContain("farmBlocks.KeyedRows");
   });
 
-  it("keeps controlled interactive row inputs under React ownership", async () => {
+  it("compiles controlled host form fields while React keeps their events", async () => {
     const result = await compile(`
       import { useState } from "react";
       export function Tasks() {
+        const [items, setItems] = useState([
+          { id: "a", label: "Alpha", note: "Ready", done: false, priority: "high" },
+        ]);
+        return (
+          <section>
+            <ul>
+              {items.map((item, index) => (
+                <li key={item.id}>
+                  <input
+                    onChange={(event) => setItems((current) => current.map((row) => row.id === item.id ? { ...row, label: event.currentTarget.value } : row))}
+                    value={item.label}
+                  />
+                  <textarea
+                    onInput={(event) => setItems((current) => current.map((row) => row.id === item.id ? { ...row, note: event.currentTarget.value } : row))}
+                    value={item.note}
+                  />
+                  <input
+                    checked={item.done}
+                    onChange={(event) => setItems((current) => current.map((row) => row.id === item.id ? { ...row, done: event.currentTarget.checked } : row))}
+                    type="checkbox"
+                  />
+                  <select
+                    onChange={(event) => setItems((current) => current.map((row) => row.id === item.id ? { ...row, priority: event.currentTarget.value } : row))}
+                    value={item.priority}
+                  >
+                    <option value="low">Low</option>
+                    <option value="high">High</option>
+                  </select>
+                  <output>{index}:{item.label}:{item.note}:{item.done ? "done" : "open"}:{item.priority}</output>
+                </li>
+              ))}
+            </ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Tasks"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedRows");
+    expect(result.code).toContain('name: "value"');
+    expect(result.code).toContain('name: "checked"');
+    expect(result.code).toContain('name: "onChange"');
+    expect(result.code).toContain('name: "onInput"');
+    expect(result.code).toContain("const _farmCurrentTargetValue = event.currentTarget.value");
+    expect(result.code).toContain("const _farmCurrentTargetChecked = event.currentTarget.checked");
+    expect(result.code).toContain("label: _farmCurrentTargetValue");
+    expect(result.code).toContain("done: _farmCurrentTargetChecked");
+    expect(result.code).not.toContain("addEventListener");
+    await expect(
+      transformWithEsbuild(result.code, "/app/InteractiveRows.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({ code: expect.stringContaining("farmBlocks.KeyedRows") });
+  });
+
+  it("supports controlled keyed-row inputs through the public List boundary", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List } from "@farm.js/react/list";
+      export function Tasks() {
         const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
+        return (
+          <section>
+            <ul>
+              <List each={items} by={(item) => item.id}>
+                {(item) => (
+                  <li>
+                    <input
+                      onChange={(event) => setItems((current) => current.map((row) => row.id === item.id ? { ...row, label: event.currentTarget.value } : row))}
+                      value={item.label}
+                    />
+                  </li>
+                )}
+              </List>
+            </ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Tasks"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedRows");
+    expect(result.code).toContain("_farmRowEvent(item, 0, 0)");
+  });
+
+  it.each([
+    {
+      name: "a file input value",
+      control: '<input type="file" value={item.label} onChange={(event) => setItems([])} />',
+    },
+    {
+      name: "a dynamic input type",
+      control: "<input type={item.type} value={item.label} onChange={(event) => setItems([])} />",
+    },
+    {
+      name: "dynamic select options",
+      control:
+        "<select value={item.label} onChange={(event) => setItems([])}><option value={item.label}>{item.label}</option></select>",
+    },
+    {
+      name: "textarea children alongside value",
+      control:
+        "<textarea value={item.label} onChange={(event) => setItems([])}>{item.label}</textarea>",
+    },
+    {
+      name: "content-editable state",
+      control: "<div contentEditable onInput={(event) => setItems([])}>{item.label}</div>",
+    },
+  ])("keeps $name in the React-owned list fallback", async ({ control }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Tasks() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha", type: "text" }]);
+        return (
+          <section>
+            <ul>{items.map((item) => <li key={item.id}>${control}</li>)}</ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Tasks"]);
+    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).not.toContain("farmBlocks.KeyedRows");
+  });
+
+  it("snapshots deferred form values even when the row falls back to React", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Tasks() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha", type: "text" }]);
         return (
           <section>
             <ul>
               {items.map((item) => (
                 <li key={item.id}>
                   <input
-                    onChange={(event) => setItems([{ ...item, label: event.currentTarget.value }])}
+                    type={item.type}
                     value={item.label}
+                    onChange={(event) => setItems((current) => current.map((row) => row.id === item.id ? { ...row, label: event.currentTarget.value } : row))}
                   />
                 </li>
               ))}
@@ -159,5 +293,7 @@ describe("React AOT interactive keyed-row compiler", () => {
     expect(result.compiled).toEqual(["Tasks"]);
     expect(result.code).toContain("farmBlocks.KeyedList");
     expect(result.code).not.toContain("farmBlocks.KeyedRows");
+    expect(result.code).toContain("const _farmCurrentTargetValue = event.currentTarget.value");
+    expect(result.code).toContain("label: _farmCurrentTargetValue");
   });
 });

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-row-forms.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-row-forms.test.tsx
@@ -1,0 +1,648 @@
+import React, { StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createCompiledComponent,
+  type CompilerKeyedRowElement,
+  type CompilerStateUpdater,
+} from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface EditableItem {
+  id: string;
+  label: string;
+  note: string;
+  done: boolean;
+  priority: "low" | "high";
+}
+
+interface EditableModel {
+  items: EditableItem[];
+  selected: string;
+}
+
+const roots = new Set<Root>();
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots) root.unmount();
+  });
+  roots.clear();
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function editableRowDescriptor(
+  item: EditableItem,
+  index: number,
+  selected: string,
+): CompilerKeyedRowElement {
+  return {
+    kind: "element",
+    tag: "li",
+    attributes: [{ name: "data-key", value: item.id }],
+    styles: [],
+    children: [
+      {
+        kind: "element",
+        tag: "input",
+        attributes: [
+          { name: "aria-label", value: `Label ${item.id}` },
+          { name: "value", value: item.label },
+        ],
+        styles: [],
+        children: [],
+      },
+      {
+        kind: "element",
+        tag: "textarea",
+        attributes: [
+          { name: "aria-label", value: `Note ${item.id}` },
+          { name: "value", value: item.note },
+        ],
+        styles: [],
+        children: [],
+      },
+      {
+        kind: "element",
+        tag: "input",
+        attributes: [
+          { name: "aria-label", value: `Done ${item.id}` },
+          { name: "checked", value: item.done },
+          { name: "type", value: "checkbox" },
+        ],
+        styles: [],
+        children: [],
+      },
+      {
+        kind: "element",
+        tag: "select",
+        attributes: [
+          { name: "aria-label", value: `Priority ${item.id}` },
+          { name: "value", value: item.priority },
+        ],
+        styles: [],
+        children: [
+          {
+            kind: "element",
+            tag: "option",
+            attributes: [{ name: "value", value: "low" }],
+            styles: [],
+            children: ["Low"],
+          },
+          {
+            kind: "element",
+            tag: "option",
+            attributes: [{ name: "value", value: "high" }],
+            styles: [],
+            children: ["High"],
+          },
+        ],
+      },
+      {
+        kind: "element",
+        tag: "input",
+        attributes: [
+          { name: "aria-label", value: `Selected ${item.id}` },
+          { name: "checked", value: selected === item.id },
+          { name: "name", value: "selected-row" },
+          { name: "type", value: "radio" },
+        ],
+        styles: [],
+        children: [],
+      },
+      {
+        kind: "element",
+        tag: "output",
+        attributes: [],
+        styles: [],
+        children: [
+          `${index}:${item.label}:${item.note}:${item.done ? "done" : "open"}:${item.priority}:${selected === item.id ? "selected" : "idle"}`,
+        ],
+      },
+    ],
+  };
+}
+
+function defineEditableRows(metrics: { executions: number; listRenders: number }) {
+  let updateModel: (next: CompilerStateUpdater) => void = () => undefined;
+  let readModel: () => EditableModel = () => ({ items: [], selected: "" });
+  const compositionEvents: string[] = [];
+  const initial: EditableModel = {
+    items: [
+      { id: "a", label: "Alpha", note: "Ready", done: false, priority: "low" },
+      { id: "b", label: "Beta", note: "Review", done: true, priority: "high" },
+    ],
+    selected: "a",
+  };
+
+  const EditableRows = createCompiledComponent({
+    displayName: "EditableKeyedRows",
+    initialize: () => [initial],
+    render(_props: Record<string, never>, state, blocks) {
+      metrics.executions += 1;
+      updateModel = (next) => state[0].set(next);
+      const model = () => state[0].get() as EditableModel;
+      readModel = model;
+      const items = () => model().items;
+      const updateItem = (id: string, patch: Partial<EditableItem>) =>
+        state[0].set((current) => {
+          const value = current as EditableModel;
+          return {
+            ...value,
+            items: value.items.map((item) => (item.id === id ? { ...item, ...patch } : item)),
+          };
+        });
+      const KeyedRows = blocks.KeyedRows;
+      return (
+        <main>
+          <KeyedRows
+            bindings={[
+              {
+                kind: "attribute",
+                name: "value",
+                path: [0],
+                read: (item) => (item as EditableItem).label,
+              },
+              {
+                kind: "attribute",
+                name: "value",
+                path: [1],
+                read: (item) => (item as EditableItem).note,
+              },
+              {
+                kind: "attribute",
+                name: "checked",
+                path: [2],
+                read: (item) => (item as EditableItem).done,
+              },
+              {
+                kind: "attribute",
+                name: "value",
+                path: [3],
+                read: (item) => (item as EditableItem).priority,
+              },
+              {
+                kind: "attribute",
+                name: "checked",
+                path: [4],
+                read: (item) => model().selected === (item as EditableItem).id,
+              },
+              {
+                kind: "text",
+                path: [5],
+                read: (item, index) => {
+                  const row = item as EditableItem;
+                  return [
+                    index,
+                    ":",
+                    row.label,
+                    ":",
+                    row.note,
+                    ":",
+                    row.done ? "done" : "open",
+                    ":",
+                    row.priority,
+                    ":",
+                    model().selected === row.id ? "selected" : "idle",
+                  ];
+                },
+              },
+            ]}
+            create={(item, index) =>
+              editableRowDescriptor(item as EditableItem, index, model().selected)
+            }
+            events={[
+              {
+                name: "onInput",
+                invoke: (item, _index, event) =>
+                  updateItem((item as EditableItem).id, {
+                    label: (event.currentTarget as HTMLInputElement).value,
+                  }),
+              },
+              {
+                name: "onInput",
+                invoke: (item, _index, event) =>
+                  updateItem((item as EditableItem).id, {
+                    note: (event.currentTarget as HTMLTextAreaElement).value,
+                  }),
+              },
+              {
+                name: "onChange",
+                invoke: (item, _index, event) =>
+                  updateItem((item as EditableItem).id, {
+                    done: (event.currentTarget as HTMLInputElement).checked,
+                  }),
+              },
+              {
+                name: "onChange",
+                invoke: (item, _index, event) =>
+                  updateItem((item as EditableItem).id, {
+                    priority: (event.currentTarget as HTMLSelectElement)
+                      .value as EditableItem["priority"],
+                  }),
+              },
+              {
+                name: "onChange",
+                invoke: (item) =>
+                  state[0].set((current) => ({
+                    ...(current as EditableModel),
+                    selected: (item as EditableItem).id,
+                  })),
+              },
+              {
+                name: "onCompositionStart",
+                invoke: (item) => compositionEvents.push(`start:${(item as EditableItem).id}`),
+              },
+              {
+                name: "onCompositionUpdate",
+                invoke: (item) => compositionEvents.push(`update:${(item as EditableItem).id}`),
+              },
+              {
+                name: "onCompositionEnd",
+                invoke: (item) => compositionEvents.push(`end:${(item as EditableItem).id}`),
+              },
+            ]}
+            id={0}
+            items={items}
+            render={(rowEvent) => {
+              metrics.listRenders += 1;
+              return (
+                <ul>
+                  {items().map((item, index) => (
+                    <li data-key={item.id} key={item.id}>
+                      <input
+                        aria-label={`Label ${item.id}`}
+                        onInput={rowEvent(item, index, 0)}
+                        value={item.label}
+                      />
+                      <textarea
+                        aria-label={`Note ${item.id}`}
+                        onCompositionEnd={rowEvent(item, index, 7)}
+                        onCompositionStart={rowEvent(item, index, 5)}
+                        onCompositionUpdate={rowEvent(item, index, 6)}
+                        onInput={rowEvent(item, index, 1)}
+                        value={item.note}
+                      />
+                      <input
+                        aria-label={`Done ${item.id}`}
+                        checked={item.done}
+                        onChange={rowEvent(item, index, 2)}
+                        type="checkbox"
+                      />
+                      <select
+                        aria-label={`Priority ${item.id}`}
+                        onChange={rowEvent(item, index, 3)}
+                        value={item.priority}
+                      >
+                        <option value="low">Low</option>
+                        <option value="high">High</option>
+                      </select>
+                      <input
+                        aria-label={`Selected ${item.id}`}
+                        checked={model().selected === item.id}
+                        name="selected-row"
+                        onChange={rowEvent(item, index, 4)}
+                        type="radio"
+                      />
+                      <output>
+                        {index}:{item.label}:{item.note}:{item.done ? "done" : "open"}:
+                        {item.priority}:{model().selected === item.id ? "selected" : "idle"}
+                      </output>
+                    </li>
+                  ))}
+                </ul>
+              );
+            }}
+            rowKey={(item) => (item as EditableItem).id}
+          />
+        </main>
+      );
+    },
+    bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+  });
+
+  return {
+    EditableRows,
+    compositionEvents,
+    initial,
+    readModel: () => readModel(),
+    updateModel: (next: CompilerStateUpdater) => updateModel(next),
+  };
+}
+
+describe("compiled editable keyed-row runtime", () => {
+  it("patches text, textarea, checkbox, select, and radio state by key without rerendering", async () => {
+    const metrics = { executions: 0, listRenders: 0 };
+    const { EditableRows } = defineEditableRows(metrics);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.add(root);
+    await act(async () => root.render(<EditableRows />));
+    const initialExecutions = metrics.executions;
+    const initialListRenders = metrics.listRenders;
+    const alphaRow = container.querySelector<HTMLLIElement>('[data-key="a"]')!;
+    const betaRow = container.querySelector<HTMLLIElement>('[data-key="b"]')!;
+    const alphaLabel = alphaRow.querySelector<HTMLInputElement>('[aria-label="Label a"]')!;
+
+    await act(async () => {
+      alphaLabel.focus();
+      alphaLabel.value = "AlXpha";
+      alphaLabel.setSelectionRange(3, 3);
+      alphaLabel.dispatchEvent(new InputEvent("input", { bubbles: true, data: "X" }));
+      alphaLabel.value = "Alpha";
+      await flushCompilerUpdates();
+    });
+    expect(alphaLabel.value).toBe("AlXpha");
+    expect(alphaLabel.selectionStart).toBe(3);
+    expect(alphaLabel.selectionEnd).toBe(3);
+
+    await act(async () => {
+      alphaRow.querySelector<HTMLInputElement>('[aria-label="Done a"]')!.click();
+      const priority = alphaRow.querySelector<HTMLSelectElement>('[aria-label="Priority a"]')!;
+      priority.value = "high";
+      priority.dispatchEvent(new Event("change", { bubbles: true }));
+      betaRow.querySelector<HTMLInputElement>('[aria-label="Selected b"]')!.click();
+      await flushCompilerUpdates();
+    });
+
+    expect(alphaRow.querySelector<HTMLInputElement>('[aria-label="Done a"]')!.checked).toBe(true);
+    expect(alphaRow.querySelector<HTMLSelectElement>('[aria-label="Priority a"]')!.value).toBe(
+      "high",
+    );
+    expect(alphaRow.querySelector<HTMLInputElement>('[aria-label="Selected a"]')!.checked).toBe(
+      false,
+    );
+    expect(betaRow.querySelector<HTMLInputElement>('[aria-label="Selected b"]')!.checked).toBe(
+      true,
+    );
+    expect(alphaRow.querySelector("output")?.textContent).toBe("0:AlXpha:Ready:done:high:idle");
+    expect(metrics.executions).toBe(initialExecutions);
+    expect(metrics.listRenders).toBe(initialListRenders);
+  });
+
+  it("keeps IME composition order, the final value, and caret under React ownership", async () => {
+    const metrics = { executions: 0, listRenders: 0 };
+    const { EditableRows, compositionEvents } = defineEditableRows(metrics);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.add(root);
+    await act(async () => root.render(<EditableRows />));
+    const note = container.querySelector<HTMLTextAreaElement>('[aria-label="Note a"]')!;
+    const initialExecutions = metrics.executions;
+
+    await act(async () => {
+      note.focus();
+      note.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true, data: "" }));
+      note.value = "Ready 日本";
+      note.setSelectionRange(8, 8);
+      note.dispatchEvent(
+        new CompositionEvent("compositionupdate", { bubbles: true, data: "日本" }),
+      );
+      note.dispatchEvent(
+        new InputEvent("input", { bubbles: true, data: "日本", isComposing: true }),
+      );
+      note.dispatchEvent(new CompositionEvent("compositionend", { bubbles: true, data: "日本" }));
+      note.value = "Ready";
+      await flushCompilerUpdates();
+    });
+
+    expect(compositionEvents).toEqual(["start:a", "update:a", "end:a"]);
+    expect(note.value).toBe("Ready 日本");
+    expect(note.selectionStart).toBe(8);
+    expect(note.selectionEnd).toBe(8);
+    expect(container.querySelector('[data-key="a"] output')?.textContent).toContain("Ready 日本");
+    expect(metrics.executions).toBe(initialExecutions);
+  });
+
+  it("preserves the focused control, selection, DOM identity, and latest index across reorders", async () => {
+    const metrics = { executions: 0, listRenders: 0 };
+    const { EditableRows, updateModel } = defineEditableRows(metrics);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.add(root);
+    await act(async () => root.render(<EditableRows />));
+    const betaRow = container.querySelector<HTMLLIElement>('[data-key="b"]')!;
+    const betaInput = betaRow.querySelector<HTMLInputElement>('[aria-label="Label b"]')!;
+    betaInput.focus();
+    betaInput.setSelectionRange(1, 3);
+
+    await act(async () => {
+      updateModel((current) => ({
+        ...(current as EditableModel),
+        items: [...(current as EditableModel).items].reverse(),
+      }));
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector('[data-key="b"]')).toBe(betaRow);
+    expect(container.querySelector('[aria-label="Label b"]')).toBe(betaInput);
+    expect(document.activeElement).toBe(betaInput);
+    expect(betaInput.selectionStart).toBe(1);
+    expect(betaInput.selectionEnd).toBe(3);
+    expect(betaRow.querySelector("output")?.textContent).toBe("0:Beta:Review:done:high:idle");
+    expect(metrics.executions).toBe(1);
+    expect(metrics.listRenders).toBe(2);
+
+    await act(async () => {
+      betaInput.value = "Beta moved";
+      betaInput.dispatchEvent(new InputEvent("input", { bubbles: true }));
+      await flushCompilerUpdates();
+    });
+    expect(betaRow.querySelector("output")?.textContent).toContain("0:Beta moved:");
+    expect(metrics.listRenders).toBe(2);
+  });
+
+  it("hydrates in StrictMode, recovers mismatches, and drops a queued edit after unmount", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const metrics = { executions: 0, listRenders: 0 };
+    const { EditableRows } = defineEditableRows(metrics);
+    const serverHtml = renderToString(
+      <StrictMode>
+        <EditableRows />
+      </StrictMode>,
+    );
+    const container = document.createElement("div");
+    container.innerHTML = serverHtml.replace(
+      /<output>.*?<\/output>/,
+      "<output>Server mismatch</output>",
+    );
+    document.body.append(container);
+    const recoverable = vi.fn();
+    const root = hydrateRoot(
+      container,
+      <StrictMode>
+        <EditableRows />
+      </StrictMode>,
+      { onRecoverableError: recoverable },
+    );
+    roots.add(root);
+    await act(async () => flushCompilerUpdates());
+
+    const input = container.querySelector<HTMLInputElement>('[aria-label="Label a"]')!;
+    expect(input.value).toBe("Alpha");
+    expect(recoverable).toHaveBeenCalled();
+    await act(async () => {
+      input.value = "Hydrated";
+      input.dispatchEvent(new InputEvent("input", { bubbles: true }));
+      await flushCompilerUpdates();
+    });
+    expect(input.value).toBe("Hydrated");
+
+    await act(async () => {
+      input.value = "Dropped";
+      input.dispatchEvent(new InputEvent("input", { bubbles: true }));
+      root.unmount();
+      await flushCompilerUpdates();
+    });
+    roots.delete(root);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("matches normal React across 2,000 deterministic edits and structural transitions", async () => {
+    const metrics = { executions: 0, listRenders: 0 };
+    const compiled = defineEditableRows(metrics);
+    let normalModel = compiled.initial;
+    let setNormal: React.Dispatch<React.SetStateAction<EditableModel>> = () => undefined;
+
+    function NormalRows() {
+      const [model, setModel] = useState(compiled.initial);
+      normalModel = model;
+      setNormal = setModel;
+      return (
+        <ul>
+          {model.items.map((item, index) => (
+            <li data-key={item.id} key={item.id}>
+              <input aria-label={`Label ${item.id}`} readOnly value={item.label} />
+              <textarea aria-label={`Note ${item.id}`} readOnly value={item.note} />
+              <input aria-label={`Done ${item.id}`} checked={item.done} readOnly type="checkbox" />
+              <select aria-label={`Priority ${item.id}`} readOnly value={item.priority}>
+                <option value="low">Low</option>
+                <option value="high">High</option>
+              </select>
+              <input
+                aria-label={`Selected ${item.id}`}
+                checked={model.selected === item.id}
+                name="normal-selected-row"
+                readOnly
+                type="radio"
+              />
+              <output>
+                {index}:{item.label}:{item.note}:{item.done ? "done" : "open"}:{item.priority}:
+                {model.selected === item.id ? "selected" : "idle"}
+              </output>
+            </li>
+          ))}
+        </ul>
+      );
+    }
+
+    const compiledContainer = document.createElement("div");
+    const normalContainer = document.createElement("div");
+    document.body.append(compiledContainer, normalContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const normalRoot = createRoot(normalContainer);
+    roots.add(compiledRoot);
+    roots.add(normalRoot);
+    await act(async () => {
+      compiledRoot.render(<compiled.EditableRows />);
+      normalRoot.render(<NormalRows />);
+    });
+
+    let seed = 0x5a17c9e3;
+    const random = () => {
+      seed = (seed * 1664525 + 1013904223) >>> 0;
+      return seed;
+    };
+    const operations = Array.from({ length: 2000 }, (_, step) => ({
+      operation: random() % 8,
+      selector: random(),
+      step,
+    }));
+    const update = (model: EditableModel, step: number): EditableModel => {
+      const { operation, selector } = operations[step];
+      if (operation <= 4 && model.items.length > 0) {
+        const target = selector % model.items.length;
+        const item = model.items[target];
+        const items = model.items.map((row, index) => {
+          if (index !== target) return row;
+          if (operation === 0) return { ...row, label: `${row.label}.${step}` };
+          if (operation === 1) return { ...row, note: step % 3 === 0 ? "" : `Note ${step}` };
+          if (operation === 2) return { ...row, done: !row.done };
+          if (operation === 3) {
+            return { ...row, priority: row.priority === "low" ? "high" : "low" };
+          }
+          return row;
+        });
+        return operation === 4 ? { ...model, selected: item.id } : { ...model, items };
+      }
+      if (operation === 5 && model.items.length < 24) {
+        const id = `n${step}`;
+        return {
+          ...model,
+          items: [...model.items, { id, label: id, note: "", done: false, priority: "low" }],
+        };
+      }
+      if (operation === 6 && model.items.length > 1) {
+        return { ...model, items: [...model.items].reverse() };
+      }
+      if (model.items.length > 2) {
+        const removed = selector % model.items.length;
+        const items = model.items.filter((_, index) => index !== removed);
+        return {
+          items,
+          selected: items.some((item) => item.id === model.selected) ? model.selected : items[0].id,
+        };
+      }
+      return model;
+    };
+    const snapshot = (container: Element) =>
+      [...container.querySelectorAll<HTMLLIElement>("li")].map((row) => {
+        const inputs = row.querySelectorAll<HTMLInputElement>("input");
+        return [
+          row.dataset.key,
+          inputs[0].value,
+          row.querySelector("textarea")?.value,
+          inputs[1].checked,
+          row.querySelector("select")?.value,
+          inputs[2].checked,
+          row.querySelector("output")?.textContent,
+        ];
+      });
+
+    for (let offset = 0; offset < 2000; offset += 20) {
+      await act(async () => {
+        for (let step = offset; step < offset + 20; step += 1) {
+          const updater = (current: EditableModel) => update(current, step);
+          compiled.updateModel((current) => updater(current as EditableModel));
+          setNormal(updater);
+        }
+        await flushCompilerUpdates();
+      });
+      expect(compiled.readModel(), `model after batch ${offset}`).toEqual(normalModel);
+      expect(snapshot(compiledContainer), `DOM after batch ${offset}`).toEqual(
+        snapshot(normalContainer),
+      );
+    }
+
+    expect(metrics.executions).toBe(1);
+    expect(metrics.listRenders).toBeLessThanOrEqual(101);
+  }, 30_000);
+});

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -494,6 +494,42 @@ function jsxAttributeName(attribute: t.JSXAttribute): string | undefined {
   return t.isJSXIdentifier(attribute.name) ? attribute.name.name : undefined;
 }
 
+function jsxAttribute(element: t.JSXElement, name: string): t.JSXAttribute | undefined {
+  return element.openingElement.attributes.find(
+    (attribute): attribute is t.JSXAttribute =>
+      t.isJSXAttribute(attribute) && jsxAttributeName(attribute) === name,
+  );
+}
+
+function staticJsxAttributeString(attribute: t.JSXAttribute | undefined): string | undefined {
+  if (!attribute?.value) return attribute ? "" : undefined;
+  if (t.isStringLiteral(attribute.value)) return attribute.value.value;
+  if (
+    t.isJSXExpressionContainer(attribute.value) &&
+    t.isStringLiteral(attribute.value.expression)
+  ) {
+    return attribute.value.expression.value;
+  }
+  return undefined;
+}
+
+function controlledSelectHasDynamicOptions(element: t.JSXElement): boolean {
+  let dynamic = false;
+  t.traverseFast(element, (node) => {
+    if (dynamic || !t.isJSXElement(node)) return;
+    const tag = node.openingElement.name;
+    if (!t.isJSXIdentifier(tag) || (tag.name !== "option" && tag.name !== "optgroup")) return;
+    dynamic = node.openingElement.attributes.some(
+      (attribute) =>
+        t.isJSXSpreadAttribute(attribute) ||
+        (t.isJSXAttribute(attribute) &&
+          t.isJSXExpressionContainer(attribute.value) &&
+          !t.isJSXEmptyExpression(attribute.value.expression)),
+    );
+  });
+  return dynamic;
+}
+
 interface ConditionalBlockShape {
   test: t.Expression;
   logical: boolean;
@@ -854,10 +890,127 @@ function validateKeyedRowEventHandler(
   return reason;
 }
 
+function stabilizeDeferredEventCurrentTarget(
+  handler: t.ArrowFunctionExpression | t.FunctionExpression,
+  compilerSetters: ReadonlySet<string>,
+): t.ArrowFunctionExpression | t.FunctionExpression {
+  const cloned = t.cloneNode(handler, true);
+  const eventParameter = cloned.params[0];
+  if (!t.isIdentifier(eventParameter) || compilerSetters.size === 0) return cloned;
+  const file = expressionFile(cloned);
+  const expression = (file.program.body[0] as t.ExpressionStatement).expression;
+  if (!t.isArrowFunctionExpression(expression) && !t.isFunctionExpression(expression)) {
+    return cloned;
+  }
+  const rootBindingIdentifier = expression.params[0];
+  const snapshots: Array<{ identifier: t.Identifier; value: t.Expression }> = [];
+  const snapshotsByProperty = new Map<string, t.Identifier>();
+  const replaceCurrentTarget = (
+    path: NodePath<t.MemberExpression | t.OptionalMemberExpression>,
+  ) => {
+    const property = path.node.property;
+    const isCurrentTarget = path.node.computed
+      ? t.isStringLiteral(property, { value: "currentTarget" })
+      : t.isIdentifier(property, { name: "currentTarget" });
+    if (!isCurrentTarget || !t.isIdentifier(path.node.object, { name: eventParameter.name }))
+      return;
+    const binding = path.scope.getBinding(eventParameter.name);
+    if (!binding || binding.identifier !== rootBindingIdentifier) return;
+    const setterCall = path.findParent(
+      (parent) =>
+        parent.isCallExpression() &&
+        t.isIdentifier(parent.node.callee) &&
+        compilerSetters.has(parent.node.callee.name),
+    );
+    if (!setterCall) return;
+    const deferredFunction = path.findParent(
+      (parent) => parent.isFunction() && parent.node !== expression,
+    );
+    if (!deferredFunction || !deferredFunction.findParent((parent) => parent === setterCall))
+      return;
+
+    const parent = path.parentPath;
+    const propertyRead =
+      (parent?.isMemberExpression() || parent?.isOptionalMemberExpression()) &&
+      parent.node.object === path.node
+        ? parent
+        : path;
+    const snapshotProperty =
+      propertyRead === path
+        ? "element"
+        : propertyRead.node.computed
+          ? t.isStringLiteral(propertyRead.node.property)
+            ? propertyRead.node.property.value
+            : `computed${snapshots.length}`
+          : t.isIdentifier(propertyRead.node.property)
+            ? propertyRead.node.property.name
+            : `property${snapshots.length}`;
+    let snapshot = snapshotsByProperty.get(snapshotProperty);
+    if (!snapshot) {
+      const suffix = snapshotProperty
+        .replace(/[^A-Za-z0-9_$]/g, " ")
+        .replace(/(?:^|\s+)([A-Za-z0-9_$])/g, (_match, character: string) =>
+          character.toUpperCase(),
+        )
+        .replace(/\s/g, "");
+      snapshot = uniqueLocalIdentifier(`_farmCurrentTarget${suffix}`, [
+        expression,
+        ...snapshots.map((entry) => entry.identifier),
+      ]);
+      snapshotsByProperty.set(snapshotProperty, snapshot);
+      snapshots.push({
+        identifier: snapshot,
+        value: t.cloneNode(propertyRead.node, true) as t.Expression,
+      });
+    }
+    propertyRead.replaceWith(t.cloneNode(snapshot));
+    propertyRead.skip();
+  };
+  traverse(file, {
+    MemberExpression: replaceCurrentTarget,
+    OptionalMemberExpression: replaceCurrentTarget,
+  });
+  if (snapshots.length === 0) return expression;
+
+  const declarations = snapshots.map(({ identifier, value }) =>
+    t.variableDeclaration("const", [t.variableDeclarator(t.cloneNode(identifier), value)]),
+  );
+  if (t.isBlockStatement(expression.body)) {
+    expression.body.body.unshift(...declarations);
+  } else {
+    expression.body = t.blockStatement([...declarations, t.returnStatement(expression.body)]);
+  }
+  return expression;
+}
+
+function stabilizeDeferredEventCurrentTargets(
+  root: t.JSXElement,
+  compilerSetters: ReadonlySet<string>,
+): t.JSXElement {
+  const file = expressionFile(t.cloneNode(root, true));
+  traverse(file, {
+    JSXAttribute(path) {
+      if (!t.isJSXIdentifier(path.node.name) || !/^on[A-Z]/.test(path.node.name.name)) return;
+      const value = path.node.value;
+      if (
+        !t.isJSXExpressionContainer(value) ||
+        (!t.isArrowFunctionExpression(value.expression) &&
+          !t.isFunctionExpression(value.expression))
+      ) {
+        return;
+      }
+      value.expression = stabilizeDeferredEventCurrentTarget(value.expression, compilerSetters);
+    },
+  });
+  const expression = (file.program.body[0] as t.ExpressionStatement).expression;
+  return t.isJSXElement(expression) ? expression : t.cloneNode(root, true);
+}
+
 function analyzeKeyedRowTree(
   row: t.JSXElement,
   renderCallback: t.ArrowFunctionExpression | t.FunctionExpression,
   safeGlobals: ReadonlySet<string>,
+  compilerSetters: ReadonlySet<string>,
 ): {
   bindings?: PendingKeyedRowBinding[];
   events?: PendingKeyedRowEvent[];
@@ -890,12 +1043,25 @@ function analyzeKeyedRowTree(
         .map(jsxAttributeName)
         .filter((name): name is string => name !== undefined),
     );
-    if (
-      (tag.name === "input" || tag.name === "textarea" || tag.name === "select") &&
-      (attributeNames.has("value") || attributeNames.has("checked")) &&
-      [...attributeNames].some((name) => /^on[A-Z]/.test(name))
-    ) {
-      return "controlled form elements in interactive compiled keyed rows require React ownership";
+    const controlled = attributeNames.has("value") || attributeNames.has("checked");
+    if (attributeNames.has("contentEditable")) {
+      return "content-editable keyed rows require React ownership";
+    }
+    if (tag.name === "input" && controlled) {
+      const type = jsxAttribute(element, "type");
+      const staticType = staticJsxAttributeString(type);
+      if (type && staticType === undefined) {
+        return "controlled keyed row inputs require a static type";
+      }
+      if (attributeNames.has("value") && staticType?.toLowerCase() === "file") {
+        return "file inputs require React ownership";
+      }
+    }
+    if (tag.name === "textarea" && controlled && meaningfulJsxChildren(element).length > 0) {
+      return "controlled keyed row textareas cannot also use children";
+    }
+    if (tag.name === "select" && controlled && controlledSelectHasDynamicOptions(element)) {
+      return "controlled keyed row selects require static options";
     }
 
     for (const attribute of element.openingElement.attributes) {
@@ -931,7 +1097,7 @@ function analyzeKeyedRowTree(
           id: events.length,
           path: [...path],
           name,
-          value: t.cloneNode(handler, true),
+          value: stabilizeDeferredEventCurrentTarget(handler, compilerSetters),
         });
         continue;
       }
@@ -1167,7 +1333,12 @@ function analyzeKeyedRowsContainer(
     return undefined;
   }
 
-  const rowAnalysis = analyzeKeyedRowTree(row, renderCallback, safeGlobals);
+  const rowAnalysis = analyzeKeyedRowTree(
+    row,
+    renderCallback,
+    safeGlobals,
+    new Set([...statesByValue.values()].map((state) => state.setterName)),
+  );
   if (rowAnalysis.reason) return undefined;
   return {
     collection,
@@ -2804,10 +2975,14 @@ function compileCandidate(
   const handlerRewrite = rewriteHandlerAccess(rootWithDerived, handlersByName);
   if (handlerRewrite.reason) return handlerRewrite.reason;
   if (!handlerRewrite.root) return "event handlers could not be prepared safely";
-  const expandedRoot = rewriteDestructuredPropAccess(
+  const expandedRootWithDeferredEvents = rewriteDestructuredPropAccess(
     handlerRewrite.root,
     propsPlan.destructuredNames,
     propsPlan.definitionParameter,
+  );
+  const expandedRoot = stabilizeDeferredEventCurrentTargets(
+    expandedRootWithDeferredEvents,
+    new Set(states.map((state) => state.setterName)),
   );
   const setterReason = validateSetterUsage(expandedRoot, statesBySetter);
   if (setterReason) return setterReason;


### PR DESCRIPTION
## Summary

- compile `value` and `checked` bindings for eligible controlled inputs, textareas, checkboxes, radios, and selects inside keyed host rows
- keep React in charge of events, hydration, composition, and structural list commits while Farm patches same-key form properties and dependent row output
- snapshot deferred `event.currentTarget.value` and `event.currentTarget.checked` reads while the event handler is active, including React-owned fallback boundaries
- preserve conservative fallbacks for file inputs, dynamic input types or option attributes, `contentEditable`, refs, custom controls, and unsupported handlers
- add an editable keyed-row production experiment and expand the experimental compiler documentation

## Verification

- `pnpm --filter @farm.js/react test` — 27 files and 218 tests passed
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react build`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and React 19.2.8
- `pnpm --filter farm-react-compiler-example experiment`
- 2,000 deterministic compiled-versus-React controlled-form and structural transitions
- production browser verification with 256 editable rows, zero owner update executions, preserved selection, and preserved keyed DOM identity

## Stack

This follows #433 and targets its branch so the PR contains only editable keyed-row form support.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compiles controlled fields in keyed React rows so Farm patches per-key form state while React owns events, hydration, and structure. Previously these fields forced the React-owned fallback; now eligible inputs, textareas, checkboxes, radios, and selects bind `value`/`checked`, preserve selection and IME order, and avoid rerunning the owner.

**Reviewer notes**
- Extends the `@farm.js/react` compiler to emit property bindings for `.value`/`.checked` (including select option selection) and to snapshot deferred `event.currentTarget.value/checked` reads in functional updaters.
- Keeps fallbacks for file inputs, dynamic input types or `<option>/<optgroup>` attributes, `contentEditable`, textarea children alongside `value`, refs/custom controls, and async or non-inline handlers; duplicate keys switch a mounted list back to React. The same rules apply inside `@farm.js/react/list`. No migration required; use static types/options to opt in.
- Adds an editable keyed-row experiment, expands docs, and introduces tests and verification (React 18.3/19) to assert zero owner executions, selection preservation, and DOM identity across reorders.

<sup>Written for commit 363630b86cb426f609c43873cf1b4721ef344cc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

