### PR TITLE
fix(core): detect hydrate in multi-name export lists

### DIFF
--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -71,6 +71,15 @@ describe("client component path resolution", () => {
     );
   });
 
+  it("detects hydrate inside multi-name export lists and renames", () => {
+    expect(hasHydrateExport("const hydrate = true;\nexport { hydrate, Widget };")).toBe(true);
+    expect(hasHydrateExport("const hydrate = true;\nexport { Widget, hydrate };")).toBe(true);
+    expect(hasHydrateExport("const flag = true;\nexport { flag as hydrate };")).toBe(true);
+    // The exported name is what matters: hydrate renamed away is not an opt-in.
+    expect(hasHydrateExport("const hydrate = true;\nexport { hydrate as flag };")).toBe(false);
+    expect(hasHydrateExport("export { Widget };")).toBe(false);
+  });
+
   it("resolves project-relative /src module paths", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-client-path-"));
     tempDirs.push(root);

--- a/packages/farm/src/utils/client-component.ts
+++ b/packages/farm/src/utils/client-component.ts
@@ -126,10 +126,21 @@ export function hasHydrateExport(content: string | null): boolean {
   if (!content) {
     return false;
   }
-  return (
-    /\bexport\s+const\s+hydrate\s*=\s*true\b/.test(content) ||
-    /\bexport\s*\{\s*hydrate\s*\}\b/.test(content)
-  );
+  if (/\bexport\s+const\s+hydrate\s*=\s*true\b/.test(content)) {
+    return true;
+  }
+  // Export lists may carry several specifiers and as-renames; the module
+  // opts in when any specifier's *exported* name is hydrate.
+  for (const match of content.matchAll(/\bexport\s*\{([^}]*)\}/g)) {
+    for (const specifier of match[1].split(",")) {
+      const parts = specifier.trim().split(/\s+as\s+/);
+      const exportedName = (parts[1] ?? parts[0])?.trim();
+      if (exportedName === "hydrate") {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 interface ModuleSourceToken {


### PR DESCRIPTION
## Summary

`hasHydrateExport` matched `export const hydrate = true` and `export { hydrate }` — but the list pattern required `hydrate` to be the **only** specifier. A module written as:

```ts
const hydrate = true;
export { hydrate, Widget };
```

was not detected, so the route rendered without hydration despite the explicit opt-in.

## Fix

Scan every `export { ... }` clause and compare each specifier's *exported* name, which also gets as-renames right in both directions: `export { flag as hydrate }` opts in; `export { hydrate as flag }` (the binding renamed away) does not.

## Tests

New cases: hydrate first/last in multi-name lists, renamed-to-hydrate, renamed-away, and unrelated lists. The multi-name case fails against the old code (verified via patch-revert); full client-component suite passes 30/30, `tsc`/`oxlint`/`oxfmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hydrate opt-in detection when `hydrate` appears in multi-name export lists or via `as` renames. Previously only `export const hydrate = true` and `export { hydrate }` were detected; cases like `export { hydrate, Widget }` were missed, causing routes to render without hydration.

- Implementation: `hasHydrateExport` now scans all `export { ... }` clauses and checks each specifier’s exported name. `export { flag as hydrate }` opts in; `export { hydrate as flag }` does not.
- Tests: added cases for hydrate at start/end of a list, renamed-to-hydrate, renamed-away, and unrelated lists.

<sup>Written for commit 78cc0e6b8586d986a33524f9a8b65018662980a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

