### PR TITLE
chore(core): remove noisy browser logs

### DIFF
--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -2641,7 +2641,6 @@ if (import.meta.hot) {
         typeof wrapProviders === 'function' ? wrapProviders(nextElement) : nextElement
       ).then((wrappedElement) => {
         window.__FARM_REACT_ROOT__.render(wrappedElement);
-        console.log('[Farm.js] ⚡ HMR update applied');
       });
     }
   });
@@ -4170,7 +4169,6 @@ async function tryHydrateImportedPage(
       window.__FARM_REACT_ROOT__ = reactRoot;
       return true;
     } catch (error) {
-      console.log('[Farm.js] Hydration mismatch, using createRoot');
       appRoot = createRoot(container);
       appRoot.render(wrappedElement);
       window.__FARM_REACT_ROOT__ = appRoot;
@@ -4428,7 +4426,6 @@ async function renderPage(pageData) {
     activeLayoutPatterns = layoutPatterns;
     activeLayoutShouldHydrate = layoutShouldHydrate;
     window.__FARM_LOADING_MODULE__ = route.loadingModulePath || null;
-    console.log('[Farm.js] ⚡ Fragment navigated to:', path);
     return true;
   };
 
@@ -4450,7 +4447,6 @@ async function hydrate() {
   }
 
   if (await hydrateFarmDocsAdapterRuntime()) {
-    console.log('[Farm.js] ✅ Hydrated docs adapter');
     return;
   }
 
@@ -4486,7 +4482,6 @@ async function hydrate() {
     const hydratedSlots = await hydrateInitialRouteSlots();
     if (!shouldHydrate) {
       if (hydratedSlots) replayPreHydrationClicks();
-      console.log('[Farm.js] Server component - SPA router ready')
       return
     }
 
@@ -4514,7 +4509,6 @@ async function hydrate() {
       : document.getElementById('__farm_page__') || rootContainer;
 
     if (!pageContainer) {
-      console.log('[Farm.js] Server component - SPA router ready')
       return
     }
 
@@ -4584,11 +4578,8 @@ async function hydrate() {
           if (hydrated) {
             // The scheduler owns queue draining and exactly-once click replay.
             markFarmHydrated();
-            console.log('[Farm.js] ✅ Hydrated:', modulePath, '(' + islandStrategy + ')');
             return;
           }
-
-          console.log('[Farm.js] Server component - SPA router ready')
         },
       });
     } finally {
@@ -4666,13 +4657,10 @@ document.addEventListener('click', function(event) {
 
 if (import.meta.hot) {
   import.meta.hot.on('vite:beforeUpdate', () => {
-    console.log('[Farm.js] ⚡ Update detected')
     // Clear module cache on HMR to pick up changes
     pageModuleCache.clear();
   })
 }
-
-console.log('[Farm.js] 🌱 SPA Router initialized');
 `;
 }
 


### PR DESCRIPTION
the client runtime was logging a bunch of info noise to the browser console on every page load (router init, hydration status, hmr updates, fragment navigations, etc).

this strips all the informational `console.log` calls from the generated client code. `console.error` and `console.warn` are untouched since those only fire when something is actually broken, and server side terminal logging is unchanged.

removed:
- `🌱 SPA Router initialized`
- `✅ Hydrated: <module> (<strategy>)` / `✅ Hydrated docs adapter`
- `Server component - SPA router ready` (x3)
- `⚡ HMR update applied` / `⚡ Update detected`
- `⚡ Fragment navigated to: <path>`
- `Hydration mismatch, using createRoot`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove informational browser console logs from the generated client runtime to reduce noise. Previously it logged router init, hydration status, HMR updates, and fragment navigations; now only warnings and errors remain, with no behavior change.

- Strips console.log messages such as: "🌱 SPA Router initialized", "✅ Hydrated: …", "⚡ HMR update applied/detected", "⚡ Fragment navigated to: …", "Hydration mismatch, using createRoot", and "Server component - SPA router ready".
- Keeps console.error and console.warn; server-side terminal logging is unchanged.
- If tests or tooling rely on these messages, remove or update those assertions.

<sup>Written for commit fc4013a5e5efc5dd90ed6d3ffadddf870585cb4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

