### PR TITLE
fix(react): stop remounting fallback blocks on every update

### DIFF
--- a/packages/farm-react/src/__tests__/compiler-runtime-host-conditionals.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-host-conditionals.test.tsx
@@ -270,6 +270,83 @@ describe("compiler-owned host conditional runtime", () => {
     expect(container.querySelector("[data-slot='numeric']")?.textContent).toBe("Visible");
   });
 
+  it("keeps DOM state across updates while in permanent fallback", async () => {
+    let setFlag: (next: CompilerStateUpdater) => void = () => undefined;
+    let setLabel: (next: CompilerStateUpdater) => void = () => undefined;
+    const Panel = createCompiledComponent({
+      displayName: "FallbackDomStatePanel",
+      initialize: () => [true, "one"],
+      render(_props: Record<string, never>, state, blocks) {
+        setFlag = (next) => state[0].set(next);
+        setLabel = (next) => state[1].set(next);
+        const HostConditional = blocks.HostConditional;
+        return (
+          <section>
+            <HostConditional
+              id={0}
+              render={() => (
+                // The whitespace text nodes around the branch make adopt()
+                // fail its single-element check, so the block enters
+                // permanent React fallback at mount.
+                <div data-slot="box">
+                  {" "}
+                  {state[0].get() ? (
+                    <b title={String(state[1].get())}>
+                      <input data-slot="field" />
+                    </b>
+                  ) : (
+                    <i>off</i>
+                  )}{" "}
+                </div>
+              )}
+              test={() => state[0].get()}
+              truthy={{
+                create: () => ({
+                  kind: "element",
+                  tag: "b",
+                  attributes: [],
+                  styles: [],
+                  children: [],
+                }),
+                bindings: [],
+              }}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0, 1] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Panel />));
+
+    const input = container.querySelector<HTMLInputElement>("[data-slot='field']");
+    expect(input).not.toBeNull();
+    input!.value = "typed";
+
+    // An update to a dependency the branch renders must reconcile in place.
+    await act(async () => {
+      setLabel("two");
+      await flushCompilerUpdates();
+    });
+
+    const afterUpdate = container.querySelector<HTMLInputElement>("[data-slot='field']");
+    expect(container.querySelector("b")?.getAttribute("title")).toBe("two");
+    expect(afterUpdate).toBe(input);
+    expect(afterUpdate!.value).toBe("typed");
+
+    // Branch switches still work through React's normal reconciliation.
+    await act(async () => {
+      setFlag(false);
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("[data-slot='field']")).toBeNull();
+    expect(container.querySelector("i")?.textContent).toBe("off");
+  });
+
   it("combines a parent prop commit and local branch update in the same event", async () => {
     let childExecutions = 0;
     const Child = createCompiledComponent({

--- a/packages/farm-react/src/__tests__/compiler-runtime-interactive-keyed-rows.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-interactive-keyed-rows.test.tsx
@@ -400,6 +400,101 @@ describe("interactive compiled keyed-row runtime", () => {
     expect(observed[observed.length - 1]).toBe("Second newest:1");
   });
 
+  it("keeps row DOM state across updates while in duplicate-key fallback", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    let updateItems: (next: CompilerStateUpdater) => void = () => undefined;
+    const Tasks = createCompiledComponent({
+      displayName: "FallbackRowDomState",
+      initialize: () => [
+        [
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Beta" },
+        ],
+      ],
+      render(_props: Record<string, never>, state, blocks) {
+        updateItems = (next) => state[0].set(next);
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <KeyedRows
+              bindings={[
+                {
+                  kind: "text",
+                  path: [0],
+                  read: (item) => [(item as Item).label],
+                },
+              ]}
+              create={(item, index) => interactiveRowDescriptor(item as Item, index)}
+              events={[]}
+              id={0}
+              items={items}
+              render={() => (
+                <ul>
+                  {items().map((item, index) => (
+                    <li data-done={false} data-key={item.id} key={`${item.id}-${index}`}>
+                      <span>{item.label}</span>
+                      <input data-row={index} />
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+            />
+          </main>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Tasks />));
+
+    // Duplicate keys force the block into permanent React fallback.
+    await act(async () => {
+      updateItems([
+        { id: "a", label: "Alpha first" },
+        { id: "a", label: "Alpha second" },
+      ]);
+      await flushCompilerUpdates();
+    });
+
+    // Back to unique keys: still fallback, but reconciliation is safe again
+    // (one final remount is allowed for this transition).
+    await act(async () => {
+      updateItems([
+        { id: "a", label: "Alpha" },
+        { id: "b", label: "Beta" },
+      ]);
+      await flushCompilerUpdates();
+    });
+
+    const input = container.querySelector<HTMLInputElement>("input[data-row='0']");
+    expect(input).not.toBeNull();
+    input!.value = "typed";
+
+    // Unique-key updates while in fallback must reconcile in place instead of
+    // remounting the list and wiping uncontrolled inputs.
+    await act(async () => {
+      updateItems([
+        { id: "a", label: "Alpha renamed" },
+        { id: "b", label: "Beta renamed" },
+      ]);
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li span")].map((node) => node.textContent)).toEqual([
+      "Alpha renamed",
+      "Beta renamed",
+    ]);
+    const afterUpdate = container.querySelector<HTMLInputElement>("input[data-row='0']");
+    expect(afterUpdate).toBe(input);
+    expect(afterUpdate!.value).toBe("typed");
+  });
+
   it("hydrates in StrictMode, recovers mismatched text, and drops queued work after unmount", async () => {
     let executions = 0;
     const observed: string[] = [];

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -700,6 +700,9 @@ function createHostConditionalBlockComponent(
         return;
       }
       this.fallbackRequested = true;
+      // One key change on entry: the compiled path mutated the DOM behind
+      // React's back, so the first fallback render must rebuild the subtree.
+      this.fallbackVersion += 1;
       this.setState({ fallback: true }, afterCommit);
     }
 
@@ -709,7 +712,9 @@ function createHostConditionalBlockComponent(
         return;
       }
       if (this.state.fallback) {
-        this.fallbackVersion += 1;
+        // React owns the container while in fallback; re-render with the
+        // stable key so updates reconcile in place instead of remounting the
+        // subtree (which would wipe uncontrolled inputs, focus, and scroll).
         this.forceUpdate(afterCommit);
         return;
       }
@@ -835,6 +840,7 @@ function createKeyedRowsBlockComponent(
     private mounted = false;
     private fallbackRequested = false;
     private fallbackVersion = 0;
+    private fallbackKeysWereUnsafe = false;
     private propSyncQueued = false;
     private currentProps = this.props;
     private unsubscribe: (() => void) | undefined;
@@ -934,12 +940,24 @@ function createKeyedRowsBlockComponent(
       return true;
     }
 
+    private hasUnsafeFallbackKeys(): boolean {
+      try {
+        return this.readRows(this.currentProps) === null;
+      } catch {
+        return true;
+      }
+    }
+
     private activateFallback(afterCommit?: () => void): void {
       if (!this.mounted || this.state.fallback || this.fallbackRequested) {
         afterCommit?.();
         return;
       }
       this.fallbackRequested = true;
+      this.fallbackKeysWereUnsafe = this.hasUnsafeFallbackKeys();
+      // One key change on entry: the compiled path mutated the DOM behind
+      // React's back, so the first fallback render must rebuild the subtree.
+      this.fallbackVersion += 1;
       this.setState({ fallback: true }, afterCommit);
     }
 
@@ -963,7 +981,17 @@ function createKeyedRowsBlockComponent(
         return;
       }
       if (this.state.fallback) {
-        this.fallbackVersion += 1;
+        // React owns the container while in fallback; keep the key stable so
+        // updates reconcile in place instead of remounting the subtree (which
+        // would wipe uncontrolled inputs, focus, and scroll). The exception
+        // is duplicate runtime keys: React's reconciliation of a keyed list
+        // with duplicates is unreliable, so any render touched by them (this
+        // one, or the previously committed one) still remounts.
+        const unsafeKeys = this.hasUnsafeFallbackKeys();
+        if (unsafeKeys || this.fallbackKeysWereUnsafe) {
+          this.fallbackVersion += 1;
+        }
+        this.fallbackKeysWereUnsafe = unsafeKeys;
         this.forceUpdate(afterCommit);
         return;
       }


### PR DESCRIPTION
## Summary

Once a compiled `HostConditional` or `KeyedRows` block entered permanent React fallback (e.g. ordinary whitespace like `<div> {cond} </div>` failing `adopt()`'s single-element check, or duplicate runtime keys), **every** compiler-cell refresh bumped `fallbackVersion` — used as the container's React key — forcing a full unmount/remount of the subtree per update. Typing in an uncontrolled input and clicking any unrelated button wiped the input, focus, and scroll. Plain React preserves all of it.

## Fix

The key changes only when a rebuild is genuinely required:

- **once on fallback entry** — the compiled path mutated the DOM behind React's back, so the first fallback render must start from a clean subtree
- **keyed rows with duplicate runtime keys** — React's reconciliation of a keyed list containing duplicates is unreliable (updates get dropped), so any render touched by duplicates (current or previously committed) still remounts; this preserves the existing stronger-than-React duplicate-key guarantees that `compiler-runtime-keyed-rows` pins

Every other fallback update re-renders with a stable key and reconciles in place.

## Tests

Two new regression tests: a whitespace-fallback host conditional keeps input identity + typed value across a dependency update (and still switches branches correctly), and a keyed-rows block that entered fallback via duplicates preserves row input state once keys are unique again. Both fail against the old code (verified via patch-revert). The full farm-react suite passes **193/193**, including the 3,000- and 4,000-transition randomized React-conformance tests and the pre-existing duplicate-key fallback tests. `tsc`/`oxlint`/`oxfmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop remounting React fallback subtrees for compiled HostConditional and KeyedRows blocks. Previously, every update remounted and wiped uncontrolled inputs, focus, and scroll; now the key stays stable and only changes when a rebuild is required.

- HostConditional: bump the container key once on entering fallback; subsequent fallback updates reconcile in place.
- KeyedRows: bump on fallback entry; during fallback, remount only if duplicate runtime keys are present or were present in the previous commit. Otherwise keep the key stable to preserve DOM state.
- Tests: add two regressions that verify input identity and value persist in whitespace-induced fallback and in keyed rows after resolving duplicates; full suite passes.

<sup>Written for commit c53932344184c20bacd1a2194dd8b595dc186987. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

