### PR TITLE
fix(core): apply middleware rewrites to dev API dispatch

### DIFF
--- a/packages/farm/src/__tests__/api-vite-plugin-rewrite.test.ts
+++ b/packages/farm/src/__tests__/api-vite-plugin-rewrite.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment node
+
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { farmApiPlugin } from "../api/vite-plugin";
+
+const tempDirs = new Set<string>();
+
+function decodeChunk(chunk: unknown): string {
+  if (typeof chunk === "string") return chunk;
+  if (chunk instanceof Uint8Array) return Buffer.from(chunk).toString("utf8");
+  return String(chunk);
+}
+
+afterEach(async () => {
+  await Promise.all(
+    [...tempDirs].map(async (dir) => {
+      await rm(dir, { recursive: true, force: true });
+      tempDirs.delete(dir);
+    }),
+  );
+});
+
+interface DevHarness {
+  dispatch(
+    url: string,
+    rewriteTo?: string | null,
+  ): Promise<{
+    status: number;
+    body: string | null;
+    passedToNext: boolean;
+  }>;
+}
+
+/**
+ * Boots the plugin's dev middleware against a real temp app dir, with a
+ * middleware stub that mimics ctx.rewrite() by mutating req.url — exactly
+ * what middleware/context.ts does.
+ */
+async function createDevHarness(routes: Record<string, string>): Promise<DevHarness> {
+  const root = await mkdtemp(path.join(tmpdir(), "farm-api-rewrite-"));
+  tempDirs.add(root);
+
+  for (const [routePath, source] of Object.entries(routes)) {
+    const dir = path.join(root, "src", "api", routePath);
+    await mkdir(dir, { recursive: true });
+    await writeFile(path.join(dir, "route.js"), source);
+  }
+
+  const plugin = farmApiPlugin() as any;
+  let handlerFn: ((req: any, res: any, next: () => void) => Promise<void>) | undefined;
+
+  const server = {
+    config: { root },
+    ssrLoadModule: (filePath: string) => import(pathToFileURL(filePath).href),
+    middlewares: {
+      use(fn: typeof handlerFn) {
+        handlerFn = fn;
+      },
+    },
+    watcher: { on() {} },
+  };
+
+  const register = await plugin.configureServer(server);
+  register?.();
+  await (server as any).__farmApi__?.waitForDiscovery?.();
+  if (!handlerFn) throw new Error("dev middleware was not registered");
+
+  return {
+    async dispatch(url, rewriteTo = null) {
+      (server as any).__farmMiddleware__ = {
+        waitForDiscovery: async () => {},
+        async execute(req: any) {
+          if (rewriteTo) req.url = rewriteTo;
+          return false;
+        },
+      };
+
+      let passedToNext = false;
+      let body: string | null = null;
+      const req = {
+        url,
+        method: "GET",
+        headers: { host: "localhost:3000" },
+      };
+      const res: any = {
+        statusCode: 200,
+        headersSent: false,
+        writableEnded: false,
+        setHeader() {},
+        getHeader() {
+          return undefined;
+        },
+        writeHead(status: number) {
+          res.statusCode = status;
+          res.headersSent = true;
+          return res;
+        },
+        write(chunk: unknown) {
+          body = (body ?? "") + decodeChunk(chunk);
+          return true;
+        },
+        end(chunk?: unknown) {
+          if (chunk !== undefined) body = (body ?? "") + decodeChunk(chunk);
+          res.writableEnded = true;
+        },
+        on() {},
+        once() {},
+        emit() {},
+      };
+
+      await handlerFn!(req, res, () => {
+        passedToNext = true;
+      });
+      // sendWebResponse may finish asynchronously.
+      for (let waited = 0; waited < 200 && !res.writableEnded && !passedToNext; waited += 5) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      return { status: res.statusCode, body, passedToNext };
+    },
+  };
+}
+
+describe("dev API dispatch after middleware rewrites", () => {
+  it("dispatches the rewritten endpoint like production", async () => {
+    const harness = await createDevHarness({
+      "v1/users": `export const GET = async () => Response.json({ version: "v1" });\n`,
+      "v2/users": `export const GET = async () => Response.json({ version: "v2" });\n`,
+    });
+
+    const direct = await harness.dispatch("/api/v1/users");
+    expect(direct.passedToNext).toBe(false);
+    expect(JSON.parse(direct.body ?? "")).toEqual({ version: "v1" });
+
+    const rewritten = await harness.dispatch("/api/v1/users", "/api/v2/users");
+    expect(rewritten.passedToNext).toBe(false);
+    expect(JSON.parse(rewritten.body ?? "")).toEqual({ version: "v2" });
+  });
+
+  it("hands rewrites that leave the API surface to the page pipeline", async () => {
+    const harness = await createDevHarness({
+      "v1/users": `export const GET = async () => Response.json({ version: "v1" });\n`,
+    });
+
+    const result = await harness.dispatch("/api/v1/users", "/dashboard");
+    expect(result.passedToNext).toBe(true);
+    expect(result.body).toBeNull();
+  });
+});

--- a/packages/farm/src/api/vite-plugin.ts
+++ b/packages/farm/src/api/vite-plugin.ts
@@ -354,8 +354,18 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
                 }
               }
 
+              // ctx.rewrite() mutates req.url; dispatch from the current
+              // value so dev matches production, where the rewritten request
+              // reaches the API router.
+              const currentUrl = req.url || url;
+              const currentPathname = currentUrl.split("?")[0];
+              if (currentPathname !== pathname && !matchAPIRoute(apiRoutesCache, currentPathname)) {
+                // Rewritten off the API surface; let the page pipeline serve it.
+                return next();
+              }
+
               // Convert Node request to Web Request
-              const fullUrl = `http://${req.headers.host || "localhost:3000"}${url}`;
+              const fullUrl = `http://${req.headers.host || "localhost:3000"}${currentUrl}`;
               const headers = new Headers();
               for (const [key, value] of Object.entries(req.headers)) {
                 if (value) {
@@ -382,7 +392,7 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
               const response = await apiRouterHandler(request);
 
               const duration = Date.now() - startTime;
-              logResponse(method, pathname, response.status, duration);
+              logResponse(method, currentPathname, response.status, duration);
 
               await sendWebResponse(res, response);
             } catch (error: any) {


### PR DESCRIPTION
## Summary

The dev API middleware in `api/vite-plugin.ts` captured `req.url` into a const **before** executing Farm middleware, then built the Web Request from that stale value. `ctx.rewrite()` mutates `req.url` (that is its dev-mode contract in `middleware/context.ts`), so under `farm dev`:

- middleware rewriting `/api/v1/users` → `/api/v2/users` still invoked the **v1** endpoint
- middleware rewriting an API request to a page path was ignored entirely

Production applies the rewritten request before `handleAPIRequest`, so the same app behaved differently between `farm dev` and the production build.

## Fix

After middleware executes (and didn't handle the response), re-read `req.url`:

- the Web Request is built from the current URL, so the API router dispatches the rewritten endpoint — matching production
- if the rewrite left the API surface, the handler calls `next()` so the page pipeline serves it

## Tests

New suite boots the real plugin's `configureServer` against a temp app dir with real route discovery (`ssrLoadModule` backed by dynamic import) and a middleware stub that mutates `req.url` exactly like `ctx.rewrite()`: a v1→v2 rewrite now serves v2 (served v1 before — both tests fail against the old code via patch-revert), and an API→page rewrite falls through to `next()`. Related suites pass (api-route-manager, endpoint-middleware, middleware — 109 tests), `tsc`/`oxlint`/`oxfmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dev API dispatch now applies middleware URL rewrites, matching production. Previously, dev built the Web Request from the pre-middleware req.url, so ctx.rewrite() did not retarget endpoints and rewrites to non-API paths did not fall through.

- Re-read req.url after middleware and build the Web Request from the current URL; log uses the rewritten pathname.
- If the rewrite leaves the API surface, call next() so the page pipeline serves it.
- Add tests that boot the real dev plugin and simulate ctx.rewrite(): v1→v2 serves v2; API→page rewrite falls through.
- No migration required; behavior changes only in dev to align with production.

<sup>Written for commit bc69ccf2c220abc534b9e00ff645c05650a76560. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

