### PR TITLE
chore(docs): align homepage tagline with full-stack pitch

### DIFF
--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -4,9 +4,9 @@ import { Databuddy } from "@databuddy/sdk/react";
 import "./globals.css";
 
 export const metadata = {
-  title: "farmjs.dev - Framework for integrated apps",
+  title: "farmjs.dev - The full-stack React framework for product-integrated apps",
   description:
-    "Farm.js is an easy and fast full-stack framework that blends app foundations and external services into one flow so teams can ship products faster.",
+    "Farm.js is a full-stack React framework with streaming SSR, Server Actions, typed file-based routing, and first-party product integrations.",
   icons: {
     icon: [{ url: "/favicon.svg", type: "image/svg+xml", sizes: "any" }],
   },

--- a/docs/src/app/opengraph-image.alt.txt
+++ b/docs/src/app/opengraph-image.alt.txt
@@ -1,1 +1,1 @@
-Farm.js, a framework for product-integrated apps by Farming Labs
+Farm.js, the full-stack React framework for product-integrated apps by Farming Labs

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -78,9 +78,9 @@ import type { FileTreeNode } from "../components/ui/file-tree";
 import { FlickeringGrid } from "../components/ui/flickering-grid";
 import { farmBenchmark, formatBenchmarkDuration } from "../lib/framework-benchmark";
 
-const homepageTitle = "Farm.js - Framework for modern integrated apps";
+const homepageTitle = "Farm.js - The full-stack React framework for product-integrated apps";
 const homepageDescription =
-  "Farm.js is the framework for modern integrated apps, unifying routing, typed APIs, middleware, integrations, docs, and deployment.";
+  "Farm.js is a full-stack React framework with streaming SSR, Server Actions, typed file-based routing, and first-party product integrations.";
 
 export const metadata = {
   metadataBase: "https://farmjs.dev",
@@ -925,13 +925,13 @@ function Hero() {
         </div>
         <HeroTitleFrame>
           <h1 className="max-w-full text-[1.125rem] font-medium leading-[1.02] tracking-normal text-white min-[360px]:text-[1.3125rem] min-[380px]:text-[1.4375rem] min-[400px]:text-[1.5rem] min-[420px]:text-[1.625rem] sm:text-[2.25rem] md:text-[2.625rem] lg:text-[3.25rem]">
-            <span className="block">a framework for</span>
-            <span className="block whitespace-nowrap">product-integrated apps</span>
+            <span className="block text-balance sm:whitespace-nowrap">the full-stack react framework</span>
+            <span className="block whitespace-nowrap">for product-integrated apps</span>
           </h1>
         </HeroTitleFrame>
         <p className="mt-5 max-w-[38rem] text-balance text-sm leading-6 text-white/56 sm:text-[15px] sm:leading-6">
-          Bring the stack you already use. Farm.js connects your app router, typed APIs, middleware,
-          integrations, docs, and deployment so they work together as one product.
+          Streaming SSR, Server Actions, and typed file-based routing, with first-party
+          integrations for auth, billing, email, and more. Everything ships together as one product.
         </p>
         <div className="mt-6 flex justify-center">
           <ButtonLink

--- a/docs/src/components/home/install-command.tsx
+++ b/docs/src/components/home/install-command.tsx
@@ -35,7 +35,7 @@ const commands: readonly CommandOption[] = [
   {
     label: "Agent",
     command: [
-      "Farm.js is the framework for modern product-integrated apps. Build this as a production-ready Farm.js product app.",
+      "Farm.js is the full-stack React framework for product-integrated apps. Build this as a production-ready Farm.js product app.",
       "Before editing:",
       "1. Read the Farm.js site skill at https://farmjs.dev/skill.md and the agent working rules at https://farmjs.dev/AGENTS.md.",
       "2. Use https://farmjs.dev/llms.txt as the compact framework map. Start with https://farmjs.dev/docs/getting-started.md, https://farmjs.dev/docs/project-structure.md, and https://farmjs.dev/docs/reference.md, then fetch the smallest task-specific pages linked from the map.",


### PR DESCRIPTION
updates the farmjs.dev copy to match the pitch we're using elsewhere: a full-stack react framework with streaming ssr, server actions, typed file-based routing and first-party product integrations.

changes:
- hero title is now "the full-stack react framework / for product-integrated apps" (kept the lowercase style, added `text-balance` + `sm:whitespace-nowrap` so it wraps cleanly on mobile and stays on two lines from tablet up)
- hero subtitle now leads with the actual capabilities instead of the abstract "bring the stack you already use" line
- homepage + layout meta titles/descriptions updated to match
- og image alt text updated
- the agent install prompt in the hero now says "full-stack react framework" too

verified in the dev server at desktop and mobile widths, no overflow.

note: the docs dev server shows a pre-existing `createServerQuery` overlay error from `docs/src/app/docs/server-queries/page.md` on main too, unrelated to this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the docs homepage copy and metadata with the “full-stack React framework” pitch for consistent messaging and better SEO. Previously the site described Farm.js as a framework for integrated apps; it now states “the full-stack React framework for product-integrated apps,” and updates hero wrapping for cleaner responsive layout.

- Updated meta title/description in `docs/src/app/layout.tsx` and homepage title/description in `docs/src/app/page.tsx`.
- Replaced hero headline/subtitle; added `text-balance` and `sm:whitespace-nowrap` to keep two lines from tablet up and wrap cleanly on mobile.
- Updated Open Graph alt text in `docs/src/app/opengraph-image.alt.txt`.
- Updated agent install prompt copy in `docs/src/components/home/install-command.tsx`.
- Verified no overflow at mobile/desktop widths; a pre-existing `createServerQuery` overlay error persists on main and is unrelated.

<sup>Written for commit 0fc4f733842e8cb5283e1774b2e563e769c2878b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

