### PR TITLE
fix(svelte): make runtime generation safe under concurrent tasks

### DIFF
--- a/packages/farm-svelte/scripts/compile-runtime.mjs
+++ b/packages/farm-svelte/scripts/compile-runtime.mjs
@@ -1,27 +1,73 @@
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { compile } from "svelte/compiler";
 
-const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const sourcePath = path.join(packageRoot, "src", "compat-root.svelte");
-const outputDirectory = path.join(packageRoot, "src", "generated");
-const source = await fs.readFile(sourcePath, "utf8");
+/**
+ * Regenerates src/generated from src/compat-root.svelte.
+ *
+ * Several package scripts (build, type-check, test) each run this first, and
+ * turbo may run them concurrently in the same directory. Generation therefore
+ * must never leave a window where the outputs are missing: no directory wipe,
+ * atomic rename writes, and identical content is left untouched.
+ */
+export async function compileRuntime(packageRoot) {
+  const sourcePath = path.join(packageRoot, "src", "compat-root.svelte");
+  const outputDirectory = path.join(packageRoot, "src", "generated");
+  const source = await fs.readFile(sourcePath, "utf8");
 
-await fs.rm(outputDirectory, { recursive: true, force: true });
-await fs.mkdir(outputDirectory, { recursive: true });
+  await fs.mkdir(outputDirectory, { recursive: true });
 
-for (const generate of ["client", "server"]) {
-  const outputPath = path.join(outputDirectory, `compat-root.${generate}.ts`);
-  const compiled = compile(source, {
-    filename: outputPath,
-    generate,
-    css: "external",
-    dev: false,
-  });
-  await fs.writeFile(
-    outputPath,
-    `// @ts-nocheck\n// Generated from src/compat-root.svelte. Do not edit directly.\n${compiled.js.code}\n`,
-    "utf8",
-  );
+  for (const generate of ["client", "server"]) {
+    const outputPath = path.join(outputDirectory, `compat-root.${generate}.ts`);
+    const compiled = compile(source, {
+      filename: outputPath,
+      generate,
+      css: "external",
+      dev: false,
+    });
+    const contents = `// @ts-nocheck\n// Generated from src/compat-root.svelte. Do not edit directly.\n${compiled.js.code}\n`;
+
+    const existing = await fs.readFile(outputPath, "utf8").catch(() => null);
+    if (existing === contents) continue;
+
+    const temporaryPath = `${outputPath}.${randomUUID()}.tmp`;
+    await fs.writeFile(temporaryPath, contents, "utf8");
+    try {
+      await replaceFile(temporaryPath, outputPath, contents);
+    } finally {
+      await fs.rm(temporaryPath, { force: true });
+    }
+  }
+}
+
+/**
+ * Rename with Windows-aware handling: replacing a file another process holds
+ * open fails with EPERM/EBUSY there. Every concurrent regeneration writes
+ * identical content, so when the destination already matches, the race was
+ * won by a sibling and this run is done; otherwise retry briefly.
+ */
+async function replaceFile(temporaryPath, outputPath, contents) {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await fs.rename(temporaryPath, outputPath);
+      return;
+    } catch (error) {
+      const code = error && typeof error === "object" ? error.code : undefined;
+      if (code !== "EPERM" && code !== "EACCES" && code !== "EBUSY") throw error;
+      const current = await fs.readFile(outputPath, "utf8").catch(() => null);
+      if (current === contents) return;
+      if (attempt >= 10) throw error;
+      await new Promise((resolve) => setTimeout(resolve, 15));
+    }
+  }
+}
+
+const isDirectInvocation =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectInvocation) {
+  const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+  await compileRuntime(packageRoot);
 }

--- a/packages/farm-svelte/src/__tests__/compile-runtime.test.ts
+++ b/packages/farm-svelte/src/__tests__/compile-runtime.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment node
+
+import { cp, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+// @ts-expect-error plain .mjs build script without type declarations
+import { compileRuntime } from "../../scripts/compile-runtime.mjs";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const tempRoots = new Set<string>();
+
+async function createFixtureRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "farm-svelte-compile-"));
+  tempRoots.add(root);
+  await mkdir(path.join(root, "src"), { recursive: true });
+  await cp(
+    path.join(packageRoot, "src", "compat-root.svelte"),
+    path.join(root, "src", "compat-root.svelte"),
+  );
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    [...tempRoots].map(async (root) => {
+      await rm(root, { recursive: true, force: true });
+      tempRoots.delete(root);
+    }),
+  );
+});
+
+describe("compile-runtime generation", () => {
+  it("generates both runtime files", async () => {
+    const root = await createFixtureRoot();
+
+    await compileRuntime(root);
+
+    for (const name of ["compat-root.client.ts", "compat-root.server.ts"]) {
+      const contents = await readFile(path.join(root, "src", "generated", name), "utf8");
+      expect(contents).toContain("Generated from src/compat-root.svelte");
+    }
+  });
+
+  it("never removes existing generated output while regenerating", async () => {
+    const root = await createFixtureRoot();
+    await compileRuntime(root);
+
+    // Concurrent build/type-check/test scripts each run compileRuntime; a
+    // sibling process may be reading these files at any moment, so the
+    // directory must never be wiped.
+    const sentinelPath = path.join(root, "src", "generated", "concurrent-reader.txt");
+    await writeFile(sentinelPath, "still here\n");
+
+    await compileRuntime(root);
+
+    await expect(readFile(sentinelPath, "utf8")).resolves.toBe("still here\n");
+  });
+
+  it("leaves identical output untouched instead of rewriting it", async () => {
+    const root = await createFixtureRoot();
+    await compileRuntime(root);
+    const serverPath = path.join(root, "src", "generated", "compat-root.server.ts");
+    const before = await stat(serverPath);
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await compileRuntime(root);
+
+    const after = await stat(serverPath);
+    expect(after.mtimeMs).toBe(before.mtimeMs);
+  });
+
+  it("settles concurrent regenerations with complete files", async () => {
+    const root = await createFixtureRoot();
+
+    await Promise.all(Array.from({ length: 5 }, () => compileRuntime(root)));
+
+    for (const name of ["compat-root.client.ts", "compat-root.server.ts"]) {
+      const contents = await readFile(path.join(root, "src", "generated", name), "utf8");
+      expect(contents).toContain("Generated from src/compat-root.svelte");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`scripts/compile-runtime.mjs` began with `rm -rf src/generated` before regenerating the compiled compat-root modules. CI's Type check step runs `turbo type-check` (`dependsOn: [\"^build\"]`), which schedules `@farm.js/svelte#build` and `@farm.js/svelte#type-check` **concurrently in the same directory** — and `build`, `type-check`, and `test` all start with this script. One process's tsup DTS step could land exactly in the window where the other process had just wiped the directory:

```
src/server.ts(3,24): error TS2307: Cannot find module './generated/compat-root.server'
```

This flaked three PR runs in two days (#453, #462, #475); every rerun passed.

## Fix

Generation is now concurrency-safe:
- **no directory wipe** — outputs are replaced, never removed
- **atomic writes** — content goes to a uniquely-named temp file (`randomUUID`) renamed over the target, so readers always see a complete file
- **no-op on identical content** — repeat runs don't touch the files at all

The script also exports `compileRuntime(packageRoot)` (CLI behavior unchanged) so the properties are testable against a fixture root.

## Tests

New suite: generates both files; **preserves existing generated output while regenerating** (fails on the old wipe behavior); **leaves identical output untouched** (mtime-stable; fails on the old always-rewrite); five concurrent regenerations settle with complete files (this test also caught a temp-name collision in my first attempt — fixed with UUID names). 3 of 4 fail against the legacy behavior. Full farm-svelte suite passes 16/16, and three rounds of concurrent `build` + `type-check` — the exact CI race — completed with no missing-module errors. `oxlint`/`oxfmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Svelte runtime generation safe under concurrent tasks. Old behavior wiped `src/generated` before rewriting, causing missing-module errors when `turbo` ran `@farm.js/svelte` build and type-check together; new behavior preserves the directory, writes via atomic temp-file rename with Windows-safe retries, and skips writes when content is unchanged.

- No directory wipe; atomic writes using `randomUUID` temp files with EPERM/EACCES/EBUSY retry; identical output is a no-op (stable mtimes).
- Export `compileRuntime(packageRoot)` for tests; direct CLI invocation is unchanged via a direct-run guard.
- Tests cover generation, no-wipe regeneration, idempotent writes, and concurrent runs; removes the TS2307 flake in CI.

<sup>Written for commit 010801d6c1a2b78d19f7c52c4d874285edb713f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

