### PR TITLE
fix(ci): serialize prisma generate across workspace tasks

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "dev": "pnpm --filter @farm.js/core build && pnpm --filter @farm.js/cli build && pnpm run prisma:generate && farm dev",
     "build": "pnpm --filter @farm.js/core build:runtime && pnpm --filter @farm.js/cli build && pnpm run prisma:generate && NODE_OPTIONS=--max-old-space-size=6144 farm build",
     "preview": "farm preview",
-    "prisma:generate": "DATABASE_URL=${DATABASE_URL:-postgresql://user:password@localhost:5432/farmjs} prisma generate",
+    "prisma:generate": "DATABASE_URL=${DATABASE_URL:-postgresql://user:password@localhost:5432/farmjs} node ../scripts/run-prisma-generate.mjs",
     "db:push": "prisma db push"
   },
   "dependencies": {

--- a/examples/stripe-integrations/prisma-org/package.json
+++ b/examples/stripe-integrations/prisma-org/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "farm dev --port 3001",
-    "build": "prisma generate && farm build",
-    "type-check": "prisma generate && tsc --noEmit",
+    "build": "node ../../../scripts/run-prisma-generate.mjs && farm build",
+    "type-check": "node ../../../scripts/run-prisma-generate.mjs && tsc --noEmit",
     "generate": "farm generate"
   },
   "dependencies": {

--- a/examples/stripe-integrations/prisma/package.json
+++ b/examples/stripe-integrations/prisma/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "farm dev",
-    "build": "prisma generate && farm build",
-    "type-check": "prisma generate && tsc --noEmit",
+    "build": "node ../../../scripts/run-prisma-generate.mjs && farm build",
+    "type-check": "node ../../../scripts/run-prisma-generate.mjs && tsc --noEmit",
     "generate": "farm generate"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "pnpm -r --filter \"./packages/*\" build",
     "dev": "turbo --filter \"./packages/*\" dev",
-    "test": "node --test scripts/release-beta.test.js scripts/publish-beta.test.js && node scripts/test-packages.js",
+    "test": "node --test scripts/release-beta.test.js scripts/publish-beta.test.js scripts/run-prisma-generate.test.js && node scripts/test-packages.js",
     "test:farm": "pnpm --filter @farm.js/core test",
     "test:renderers": "node scripts/test-renderers.mjs",
     "test:ci": "node scripts/run-tests.js",

--- a/scripts/run-prisma-generate.mjs
+++ b/scripts/run-prisma-generate.mjs
@@ -1,0 +1,100 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+/**
+ * Serializes `prisma generate` across concurrent workspace tasks.
+ *
+ * Every workspace consumer of the same prisma install shares one physical
+ * package directory in the pnpm store, and `prisma generate` copies the query
+ * engine into it with a plain rename. When turbo runs two packages' generate
+ * at once (both stripe examples under `turbo type-check`/`build`, plus docs),
+ * the second rename intermittently fails on Windows with EPERM because the
+ * first process still holds the engine file open. One repo-wide lock removes
+ * the race for any number of participants.
+ */
+
+const STALE_LOCK_MS = 5 * 60_000;
+const POLL_INTERVAL_MS = 250;
+
+export async function withPrismaGenerateLock(lockKey, run) {
+  const digest = createHash("sha256").update(lockKey).digest("hex").slice(0, 16);
+  const lockDirectory = path.join(os.tmpdir(), `farm-prisma-generate-${digest}.lock`);
+
+  for (;;) {
+    try {
+      fs.mkdirSync(lockDirectory);
+      break;
+    } catch (error) {
+      if (error && error.code !== "EEXIST") throw error;
+      let heldSinceMs;
+      try {
+        heldSinceMs = fs.statSync(lockDirectory).mtimeMs;
+      } catch {
+        continue; // The holder released between mkdir and stat; retry now.
+      }
+      if (Date.now() - heldSinceMs > STALE_LOCK_MS) {
+        // A crashed holder never releases; break its lock and retry.
+        try {
+          fs.rmdirSync(lockDirectory);
+        } catch {
+          // Another waiter broke it first.
+        }
+        continue;
+      }
+      await delay(POLL_INTERVAL_MS);
+    }
+  }
+
+  try {
+    return await run();
+  } finally {
+    try {
+      fs.rmdirSync(lockDirectory);
+    } catch {
+      // Nothing actionable: the stale-lock path may have reclaimed it.
+    }
+  }
+}
+
+function runPrismaGenerate(extraArgs) {
+  return new Promise((resolve, reject) => {
+    const isWindows = process.platform === "win32";
+    // Windows needs the .cmd shim run through a shell (Node rejects direct
+    // .cmd spawns since the CVE-2024-27980 fix).
+    const child = spawn(isWindows ? "prisma.cmd" : "prisma", ["generate", ...extraArgs], {
+      stdio: "inherit",
+      env: process.env,
+      shell: isWindows,
+    });
+    child.on("error", reject);
+    child.on("close", (code, signal) => {
+      if (code === 0) {
+        resolve(undefined);
+        return;
+      }
+      reject(
+        new Error(
+          `prisma generate failed with ${signal ? `signal ${signal}` : `exit code ${code ?? "unknown"}`}.`,
+        ),
+      );
+    });
+  });
+}
+
+const isDirectInvocation =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectInvocation) {
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+  try {
+    await withPrismaGenerateLock(repoRoot, () => runPrismaGenerate(process.argv.slice(2)));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/run-prisma-generate.test.js
+++ b/scripts/run-prisma-generate.test.js
@@ -1,0 +1,70 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+const { setTimeout: delay } = require("node:timers/promises");
+
+async function loadLock() {
+  const { withPrismaGenerateLock } = await import("./run-prisma-generate.mjs");
+  return withPrismaGenerateLock;
+}
+
+test("serializes concurrent critical sections", async () => {
+  const withPrismaGenerateLock = await loadLock();
+  const lockKey = `serialize-${process.pid}-${Date.now()}`;
+  let active = 0;
+  let maxActive = 0;
+  const order = [];
+
+  await Promise.all(
+    Array.from({ length: 5 }, (_, index) =>
+      withPrismaGenerateLock(lockKey, async () => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        order.push(index);
+        await delay(20);
+        active -= 1;
+      }),
+    ),
+  );
+
+  assert.equal(maxActive, 1, "critical sections must never overlap");
+  assert.equal(order.length, 5, "every waiter must eventually run");
+});
+
+test("releases the lock when the critical section throws", async () => {
+  const withPrismaGenerateLock = await loadLock();
+  const lockKey = `release-${process.pid}-${Date.now()}`;
+
+  await assert.rejects(
+    withPrismaGenerateLock(lockKey, async () => {
+      throw new Error("generate exploded");
+    }),
+    /generate exploded/,
+  );
+
+  let ran = false;
+  await withPrismaGenerateLock(lockKey, async () => {
+    ran = true;
+  });
+  assert.equal(ran, true, "a failed holder must not leave the lock held");
+});
+
+test("breaks a stale lock left by a crashed holder", async () => {
+  const fs = require("node:fs");
+  const os = require("node:os");
+  const path = require("node:path");
+  const { createHash } = require("node:crypto");
+  const withPrismaGenerateLock = await loadLock();
+
+  const lockKey = `stale-${process.pid}-${Date.now()}`;
+  const digest = createHash("sha256").update(lockKey).digest("hex").slice(0, 16);
+  const lockDirectory = path.join(os.tmpdir(), `farm-prisma-generate-${digest}.lock`);
+  fs.mkdirSync(lockDirectory);
+  const staleTime = new Date(Date.now() - 10 * 60_000);
+  fs.utimesSync(lockDirectory, staleTime, staleTime);
+
+  let ran = false;
+  await withPrismaGenerateLock(lockKey, async () => {
+    ran = true;
+  });
+  assert.equal(ran, true, "a stale lock must be reclaimed instead of waiting forever");
+});


### PR DESCRIPTION
## Summary

`turbo type-check` (and `build`) runs `prisma generate` concurrently in both `examples/stripe-integrations` packages — and docs' build joins under `turbo build`. Every consumer shares one physical prisma install in the pnpm store, and Prisma copies its query engine there with a plain rename:

```
EPERM: operation not permitted, rename '...prisma/query_engine-windows.dll.node.tmp3388'
  -> '...prisma/query_engine-windows.dll.node'
```

This intermittently failed windows-latest CI (seen on #477's run 32643355681 rerun); reruns passed.

## Fix

All `prisma generate` invocations now go through `scripts/run-prisma-generate.mjs`, which wraps the generate in a **repo-wide lock**: atomic `mkdir` in the OS temp dir keyed by repo root, 250ms polling, stale-lock reclaim after 5 minutes (crashed holders can't wedge CI), released on error. The wrapper forwards arguments, inherits PATH so each package resolves its own `prisma` binary, and uses a shell for the Windows `.cmd` shim (same CVE-2024-27980 handling as `create-farm-app`).

Wired into: both stripe examples' `build`/`type-check`, docs' `prisma:generate` (its `DATABASE_URL` prefix unchanged), and the root `test` script now includes the lock's tests.

## Tests

`node --test scripts/run-prisma-generate.test.js` (3/3): five concurrent critical sections never overlap and all run; the lock is released when the section throws; a pre-seeded stale lock (10-minute-old mtime) is reclaimed instead of waiting forever. End-to-end: both example `type-check` scripts run **concurrently** through the wrapper — both generated Prisma Client into the shared store path (the exact race surface) and both passed. `oxlint`/`oxfmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serializes `prisma generate` across workspace tasks to stop intermittent Windows EPERM failures. Previously `turbo` ran `prisma generate` concurrently; now all calls use a repo-wide lock to avoid races on the shared `pnpm` store query engine.

- Adds `scripts/run-prisma-generate.mjs` and routes both `examples/stripe-integrations` packages’ `build`/`type-check` and `docs` `prisma:generate` through it; the `DATABASE_URL` prefix in `docs` is unchanged. The wrapper uses an atomic temp-dir lock with 5-minute stale-lock reclaim, forwards args, resolves `prisma` via each package’s PATH, and uses a shell on Windows for the `.cmd` shim.
- Adds `scripts/run-prisma-generate.test.js` and includes it in the root `test` script; tests cover mutual exclusion, error unlock, and stale-lock reclaim.

<sup>Written for commit 57998fc84626313f63a401939770f81914945d46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

