### PR TITLE
feat(svelte): ship svelte:head content through SSR documents

### DIFF
--- a/packages/farm-renderer-tests/src/index.ts
+++ b/packages/farm-renderer-tests/src/index.ts
@@ -25,6 +25,9 @@ export interface RendererServerFixture {
   createElement(type: unknown, props?: unknown, ...children: unknown[]): unknown;
   isValidElement(value: unknown): boolean;
   renderToString(element: unknown): string | Promise<string>;
+  renderToStringWithHead?(
+    element: unknown,
+  ): { html: string; head: string } | Promise<{ html: string; head: string }>;
   generateHydrationScript?: () => string;
 }
 
@@ -108,6 +111,16 @@ export function defineRendererServerConformance(runtime: RendererServerFixture):
       const second = runtime.generateHydrationScript?.() ?? "";
       expect(typeof first).toBe("string");
       expect(second).toBe(first);
+    });
+
+    it("keeps renderToStringWithHead consistent with renderToString", async () => {
+      if (!runtime.renderToStringWithHead) return;
+
+      const element = runtime.createElement("p", null, `Head-capable ${runtime.name}`);
+      const rendered = await runtime.renderToStringWithHead(element);
+
+      expect(rendered.html).toBe(await runtime.renderToString(element));
+      expect(typeof rendered.head).toBe("string");
     });
 
     it("serializes React numeric style values with px units", async () => {

--- a/packages/farm-svelte/src/__tests__/renderer.test.ts
+++ b/packages/farm-svelte/src/__tests__/renderer.test.ts
@@ -42,4 +42,46 @@ describe("Svelte renderer", () => {
   it("does not require a renderer-specific hydration bootstrap", () => {
     expect(generateHydrationScript()).toBe("");
   });
+
+  it("carries svelte:head markup through renderToStringWithHead", async () => {
+    const { mkdir, rm, writeFile } = await import("node:fs/promises");
+    const path = await import("node:path");
+    const { fileURLToPath, pathToFileURL } = await import("node:url");
+    const { compile } = await import("svelte/compiler");
+
+    const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+    const fixtureDirectory = path.join(testDirectory, ".head-fixture");
+    await mkdir(fixtureDirectory, { recursive: true });
+    try {
+      const source = [
+        "<svelte:head>",
+        "  <title>Docs Page</title>",
+        '  <meta name="description" content="from svelte head" />',
+        "</svelte:head>",
+        "<h1>Docs body</h1>",
+      ].join("\n");
+      const compiled = compile(source, {
+        filename: "head-page.svelte",
+        generate: "server",
+        css: "external",
+      });
+      const modulePath = path.join(fixtureDirectory, "head-page.js");
+      await writeFile(modulePath, compiled.js.code);
+      const { default: HeadPage } = await import(pathToFileURL(modulePath).href);
+
+      const { renderToStringWithHead } = await import("../server");
+      const rendered = await renderToStringWithHead(createElement(HeadPage));
+
+      expect(rendered.html).toContain("Docs body");
+      expect(rendered.html).not.toContain("Docs Page");
+      expect(rendered.head).toContain("<title>Docs Page</title>");
+      expect(rendered.head).toContain('content="from svelte head"');
+
+      // The body-only export stays unchanged for callers without a head channel.
+      const bodyOnly = await renderToString(createElement(HeadPage));
+      expect(bodyOnly).toBe(rendered.html);
+    } finally {
+      await rm(fixtureDirectory, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/farm-svelte/src/server.ts
+++ b/packages/farm-svelte/src/server.ts
@@ -25,4 +25,15 @@ export async function renderToString(element: unknown): Promise<string> {
   return rendered.body;
 }
 
+/**
+ * Svelte components can emit document-head markup through <svelte:head>;
+ * Farm injects the returned head into the assembled document.
+ */
+export async function renderToStringWithHead(
+  element: unknown,
+): Promise<{ html: string; head: string }> {
+  const rendered = render(CompatRoot as Component<{ element: unknown }>, { props: { element } });
+  return { html: rendered.body, head: rendered.head };
+}
+
 export default SvelteCompat;

--- a/packages/farm/src/__tests__/document-injection.test.ts
+++ b/packages/farm/src/__tests__/document-injection.test.ts
@@ -39,37 +39,77 @@ function renderFarmClientBootstrapScript(
   );
 }
 
+function createInjector() {
+  return new Function(
+    "html",
+    "title",
+    "metaTags",
+    "rendererHead",
+    "pageProps",
+    "routeSlotPayload",
+    "clientPageProps",
+    "renderFarmClientBootstrapScript",
+    "renderFarmRendererHydrationScript",
+    "let fullHtml;\n" + extractEmittedFullDocumentInjection() + "\nreturn fullHtml;",
+  ) as (
+    html: string,
+    title: string,
+    metaTags: string,
+    rendererHead: string,
+    pageProps: Record<string, unknown>,
+    routeSlotPayload: unknown[],
+    clientPageProps: Record<string, unknown>,
+    bootstrap: typeof renderFarmClientBootstrapScript,
+    hydration: () => string,
+  ) => string;
+}
+
 describe("generated full-document injection", () => {
   it("keeps $-sequences in page props literal when injecting the bootstrap script", () => {
-    const inject = new Function(
-      "html",
-      "title",
-      "metaTags",
-      "pageProps",
-      "routeSlotPayload",
-      "clientPageProps",
-      "renderFarmClientBootstrapScript",
-      "renderFarmRendererHydrationScript",
-      "let fullHtml;\n" + extractEmittedFullDocumentInjection() + "\nreturn fullHtml;",
-    );
+    const inject = createInjector();
 
     const clientPageProps = { note: "totals: $$ then $& then $' then $`" };
     const fullHtml = inject(
       "<html><head><title>App</title></head><body><main>page</main></body></html>",
       "Farm.js App",
       "",
+      "",
       { __farmCanonicalPath: "/notes" },
       [],
       clientPageProps,
       renderFarmClientBootstrapScript,
       () => "",
-    ) as string;
+    );
 
     // A string replacement would expand $& into </body> and $' into the rest of
     // the document, corrupting window.__FARM_PROPS__ and duplicating markup.
     expect(fullHtml).toContain(serializeFarmInlineValue(clientPageProps));
     expect(fullHtml.match(/<\/body>/gi)).toHaveLength(1);
     expect(fullHtml.match(/<\/html>/gi)).toHaveLength(1);
+  });
+
+  it("injects renderer-emitted head markup literally into the document head", () => {
+    const inject = createInjector();
+
+    // Svelte-style head payload with hydration markers and hostile
+    // $-sequences; a string replacement would expand them into markup.
+    const rendererHead = "<!--farm-head--><title>Docs $& $' page</title>";
+    const fullHtml = inject(
+      '<html><head><meta charset="utf-8"></head><body><main>page</main></body></html>',
+      "Farm.js App",
+      "",
+      rendererHead,
+      { __farmCanonicalPath: "/docs" },
+      [],
+      {},
+      renderFarmClientBootstrapScript,
+      () => "",
+    );
+
+    const headEnd = fullHtml.indexOf("</head>");
+    expect(fullHtml.indexOf(rendererHead)).toBeGreaterThan(-1);
+    expect(fullHtml.indexOf(rendererHead)).toBeLessThan(headEnd);
+    expect(fullHtml.split(rendererHead)).toHaveLength(2);
   });
 
   it("never passes dynamic markup as a string replacement in the generated document pipeline", () => {

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -4394,8 +4394,17 @@ async function renderFarmElement(ReactDOMServer, element) {
     };
   }
 
+  if (ReactDOMServer.renderToStringWithHead) {
+    const rendered = await ReactDOMServer.renderToStringWithHead(element);
+    return {
+      html: rendered.html,
+      head: rendered.head || "",
+      shellHtml: rendered.html,
+      streamErrors,
+    };
+  }
   const html = await ReactDOMServer.renderToString(element);
-  return { html, shellHtml: html, streamErrors };
+  return { html, head: "", shellHtml: html, streamErrors };
 }
 
 async function renderFarmElementToString(ReactDOMServer, element) {
@@ -5302,15 +5311,24 @@ ${
     }
   }
 
-  const rootMarkup = await renderFarmElementToString(
+  const renderedRoot = await renderFarmElement(
     ReactDOMServer,
     React.createElement("div", { id: "root" }, wrappedElement),
   );
+  let rootMarkup = renderedRoot.html;
+  if (rootMarkup === undefined) {
+    rootMarkup = await new Response(renderedRoot.stream).text();
+    if (renderedRoot.streamErrors.length > 0) throw renderedRoot.streamErrors[0];
+  }
   let html = source.replace(
     bodyMatch[0],
     // Function replacement: rendered markup may contain $-sequences ($&, $', $$).
     function() { return "<body" + bodyMatch[1] + ">" + rootMarkup + "</body>"; },
   );
+  if (renderedRoot.head) {
+    // Renderer-emitted head markup (e.g. <svelte:head>).
+    html = html.replace(/<[/]head>/i, function() { return renderedRoot.head + "\\n</head>"; });
+  }
   if (!html.includes('href="/__farm_client_css_href__"')) {
     const clientStylesheet = '  <link rel="stylesheet" href="/__farm_client_css_href__">\\n';
     const firstStyleIndex = html.search(/<style(?:\\s|>)/i);
@@ -6167,6 +6185,7 @@ async function handleFarmRequestInContext(
           }
         }
         
+        const rendererHead = renderedPage.head || "";
         let fullHtml;
         if (hasFullDocument) {
           // Layout provides full HTML structure - inject CSS and client script
@@ -6181,6 +6200,9 @@ async function handleFarmRequestInContext(
                 nextHeadContent += "\\n  <title>" + title + "</title>";
               }
               if (metaTags) nextHeadContent += metaTags;
+              // Renderer-emitted head markup (e.g. <svelte:head>). Function
+              // replacement below keeps $-sequences literal.
+              if (rendererHead) nextHeadContent += "\\n  " + rendererHead;
               return nextHeadContent === headContent
                 ? match
                 : "<head" + attrs + ">" + nextHeadContent + "\\n</head>";
@@ -6211,7 +6233,7 @@ async function handleFarmRequestInContext(
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   \${hasFavicon ? "" : '<link rel="icon" href="data:,">'}
-  <title>\${title}</title>\${metaTags}
+  <title>\${title}</title>\${metaTags}\${rendererHead ? "\\n  " + rendererHead : ""}
   <link rel="stylesheet" href="/__farm_client_css_href__">
   \${renderFarmRendererHydrationScript()}
 </head>

--- a/packages/farm/src/renderer.ts
+++ b/packages/farm/src/renderer.ts
@@ -110,6 +110,15 @@ export interface FarmServerRendererRuntime {
   createElement(type: unknown, props?: unknown, ...children: unknown[]): unknown;
   isValidElement(value: unknown): boolean;
   renderToString(element: unknown): string | Promise<string>;
+  /**
+   * Optional variant for renderers whose components emit document-head markup
+   * during render (e.g. <svelte:head>). `html` is the body markup exactly as
+   * renderToString would produce it; `head` is injected into the assembled
+   * document's <head>.
+   */
+  renderToStringWithHead?(
+    element: unknown,
+  ): { html: string; head: string } | Promise<{ html: string; head: string }>;
   /** Optional runtime copy of the descriptor capabilities for diagnostics. */
   readonly capabilities?: FarmRendererCapabilities;
   /** Optional bootstrap required before this renderer hydrates server markup. */

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -518,6 +518,20 @@ export class ServerRenderer {
   }
 
   /**
+   * Buffered render carrying document-head markup for renderers that emit it
+   * during render (e.g. <svelte:head>). Other renderers return an empty head.
+   */
+  private async renderElementToDocumentParts(
+    element: unknown,
+  ): Promise<{ html: string; head: string }> {
+    if (this.rendererRuntime.renderToStringWithHead) {
+      const rendered = await this.rendererRuntime.renderToStringWithHead(element);
+      return { html: rendered.html, head: rendered.head || "" };
+    }
+    return { html: await this.rendererRuntime.renderToString(element), head: "" };
+  }
+
+  /**
    * Render the route tree used by client navigation without producing a second
    * document response. Layout markers let the browser preserve the longest
    * common shell and replace only the first changed boundary.
@@ -2008,7 +2022,8 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
 </script>`;
       const deferredScript = createDeferredHydrationScript(deferredProps.records);
       const rendererHydrationScript = this.rendererRuntime.generateHydrationScript?.() || "";
-      const content = await this.rendererRuntime.renderToString(element);
+      const { html: content, head: rendererHead } =
+        await this.renderElementToDocumentParts(element);
       const {
         title,
         tags: metaTags,
@@ -2038,6 +2053,7 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
             `<meta name="farm-deployment-id" content="${escapeHtmlAttribute(deploymentId)}">`,
             metaTags,
             alternateTags,
+            rendererHead,
             renderFarmFontDevHead(this.config.root || process.cwd()),
             `<link rel="stylesheet" href="/src/app/globals.css">`,
             `<script type="module" src="/@vite/client"></script>`,
@@ -2061,7 +2077,7 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="farm-deployment-id" content="${escapeHtmlAttribute(deploymentId)}">
   ${hasFavicon ? "" : '<link rel="icon" href="data:,">'}
-  <title>${title}</title>${metaTags}${alternateTags}
+  <title>${title}</title>${metaTags}${alternateTags}${rendererHead ? `\n  ${rendererHead}` : ""}
   ${renderFarmFontDevHead(this.config.root || process.cwd())}
   <link rel="stylesheet" href="/src/app/globals.css">
   <script type="module" src="/@vite/client"></script>


### PR DESCRIPTION
## Summary

`farm-svelte`'s `renderToString` returned only `rendered.body` from Svelte's server renderer — the `head` half was discarded, so `<svelte:head>` titles/meta/links silently never reached SSR documents, and Svelte's client-side head hydration had no markers to adopt.

## Design

The server renderer contract gains one **optional** method:

```ts
renderToStringWithHead?(element): { html: string; head: string } | Promise<...>
```

- `farm-svelte` implements it from the same single render pass (`html` is byte-identical to `renderToString`'s output, including Svelte's head hydration markers in `head`)
- returning per call — rather than a `collectRenderedHead()`-style side channel — makes concurrent SSR requests race-free by construction
- renderers without the method are completely untouched; streaming renderers (React) keep hoisting head content themselves

Core injects the head at every buffered document-assembly site: dev SSR (shell template + full-document layout compose), the production shell and full-document paths in the nitro runtime, and the prebuilt-document path (which now renders through `renderFarmElement` to carry the head).

## Tests

- `farm-svelte`: compiles a real `<svelte:head>` component at test time and asserts the title/meta land in `head`, the body excludes them, and `renderToString` output is unchanged (18/18)
- shared renderer conformance: when `renderToStringWithHead` exists, its `html` must equal `renderToString`'s output — all five renderers pass (react 208, preact 12, vue 15, solid 14, svelte 18)
- core: `tsc` clean; the production document suites (prebuilt-ssr, ssg, create-server — 27 tests) execute the modified generated-runtime code end to end

**Coverage note:** the svelte contract and every document template are unit/integration tested, but there is no local e2e that boots a full svelte app through `farm dev`/`farm build` and asserts the final document head — the svelte-renderer example under the e2e workflow is the place that exercises that composition in CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delivers Svelte `<svelte:head>` content in SSR output so head tags render and hydrate. Previously `farm-svelte` returned only body HTML and dropped head markup; now an optional renderer API returns `{ html, head }`, and Core injects `head` across all document assembly paths with safe replacements.

- API: adds optional `renderToStringWithHead(element): { html, head }`; `farm-svelte` implements it from a single render pass. `renderToString` output is unchanged and must equal `html`.
- Core integration: injects `head` in dev SSR (shell and full-document compose), production shell and full-document paths in `nitro`, and the prebuilt-document path via `renderFarmElement`. Non-supporting renderers receive an empty `head`; streaming renderers continue hoisting head content.
- Safety: uses function replacements so `head` inserts literally inside `<head>` exactly once, guarding `$`-sequences (`$&`, `$'`, etc.) from expansion.
- Concurrency: per-call return avoids shared collectors and is race-free for concurrent SSR.
- Tests: adds renderer conformance for `renderToStringWithHead` parity; Svelte fixture proves `<svelte:head>` capture; core adds generated-document injection tests covering renderer head and `$`-sequence safety; production document suites run end to end.
- Migration: none. Other renderers do not need to implement `renderToStringWithHead`; add it only if the renderer can emit document-head markup.

<sup>Written for commit f80ab78a888be93eefd635595cf2c8dfce256e27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

