### PR TITLE
fix(core): tolerate malformed percent-encoding in request paths

### DIFF
--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -184,6 +184,21 @@ describe("createFarmDocsHandler", () => {
     return { root, docs, docsDir };
   }
 
+  it("answers malformed percent-encoded docs paths instead of throwing", async () => {
+    const { root, docs } = await createDocsFixture();
+    const handler = createFarmDocsHandler(docs, { root, srcDir: "src" });
+
+    // decodeURIComponent throws on these; the handler must resolve them to a
+    // non-matching slug rather than crash the process (#481).
+    const response = await handler(
+      new Request("http://farm.test/docs/caf%E9", {
+        headers: { accept: "text/html" },
+      }),
+    );
+
+    expect(response == null || response.status === 404).toBe(true);
+  });
+
   it("serves docs markdown files as HTML", async () => {
     const { root, docs } = await createDocsFixture();
     const handler = createFarmDocsHandler(docs, { root, srcDir: "src" });
@@ -759,6 +774,15 @@ describe("createDocsAPI", () => {
     );
     return root;
   }
+
+  it("answers malformed percent-encoded docs API paths instead of throwing", async () => {
+    const root = await createDocsFixture();
+    const handler = createFarmDocsAPIHandler({ rootDir: root, srcDir: "src" });
+
+    const response = await handler(new Request("http://farm.test/api/docs/%E0.md"));
+    expect(response).not.toBeNull();
+    expect(response!.status).toBe(404);
+  });
 
   it("creates a built-in Farm docs API handler for automatic /api/docs routing", async () => {
     const root = await createDocsFixture();

--- a/packages/farm/src/__tests__/integrations.test.ts
+++ b/packages/farm/src/__tests__/integrations.test.ts
@@ -12,6 +12,7 @@ import {
   getIntegrationSchemas,
   getRegisteredIntegrationSchemas,
   integrationRoute,
+  matchIntegrationRoute,
   matchRegisteredIntegrationRoute,
   resolveIntegrationPlugins,
   type FarmIntegrationSchema,
@@ -196,6 +197,32 @@ describe("integrations runtime", () => {
     expect(plugins[1].name).toBe(contributedPlugin.name);
     expect(getFarmIntegrationPluginServerRuntime(plugins[1])).toBe(false);
     expect(getFarmIntegrationPluginOwner(plugins[1])?.source).toBe("contribution");
+  });
+
+  it("matches routes with malformed percent-encoded segments instead of throwing", () => {
+    const integration = defineIntegration({
+      category: "agent",
+      type: "proxy",
+      instance: {},
+      routes: [
+        integrationRoute.get("/agents/[...path]", { handler: async () => new Response("ok") }),
+        integrationRoute.get("/items/[id]", { handler: async () => new Response("ok") }),
+      ],
+    });
+
+    // decodeURIComponent throws on these segments; matching must keep the
+    // raw value instead of throwing before any handler runs.
+    const catchAll = matchIntegrationRoute(
+      { agent: integration },
+      { pathname: "/agents/%E0/logs", method: "GET" },
+    );
+    expect(catchAll?.params).toEqual({ path: ["%E0", "logs"] });
+
+    const dynamic = matchIntegrationRoute(
+      { agent: integration },
+      { pathname: "/items/%E0", method: "GET" },
+    );
+    expect(dynamic?.params).toEqual({ id: "%E0" });
   });
 
   it("rejects duplicate plugin names from one integration", () => {

--- a/packages/farm/src/docs/api.ts
+++ b/packages/farm/src/docs/api.ts
@@ -217,7 +217,14 @@ function normalizeDocsApiSlug(
     slug = slug.slice(entry.length + 1);
   }
 
-  return decodeURIComponent(slug).replace(/\.(mdx?|markdown)$/i, "");
+  let decoded = slug;
+  try {
+    decoded = decodeURIComponent(slug);
+  } catch {
+    // Malformed percent-encoding resolves to a non-matching slug (404),
+    // not an exception out of the handler.
+  }
+  return decoded.replace(/\.(mdx?|markdown)$/i, "");
 }
 
 function getDocsAPIPathTarget(request: Request): DocsAPIPathTarget {

--- a/packages/farm/src/docs/handler.ts
+++ b/packages/farm/src/docs/handler.ts
@@ -85,8 +85,18 @@ function normalizeEntry(entry: string | undefined): string {
   return `/${trimSlashes(entry)}`;
 }
 
+function decodeDocsPath(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    // Malformed percent-encoding in a request path must resolve to a
+    // non-matching slug (a 404), not throw out of the handler.
+    return value;
+  }
+}
+
 function normalizeSlug(value: string): string {
-  return trimSlashes(decodeURIComponent(value)).replace(/\.(mdx?|markdown)$/i, "");
+  return trimSlashes(decodeDocsPath(value)).replace(/\.(mdx?|markdown)$/i, "");
 }
 
 function resolveFarmDocsFavicon(

--- a/packages/farm/src/integrations.ts
+++ b/packages/farm/src/integrations.ts
@@ -3175,6 +3175,16 @@ function matchesPath(pattern: string, pathname: string): boolean {
   return extractPathParams(pattern, pathname) !== null;
 }
 
+function decodeRouteSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    // Request paths are not guaranteed to be validly percent-encoded; a
+    // malformed segment must not throw out of route matching.
+    return segment;
+  }
+}
+
 function extractPathParams(pattern: string, pathname: string): FarmIntegrationRouteParams | null {
   const routeSegments = splitPath(pattern);
   const pathSegments = splitPath(pathname);
@@ -3190,12 +3200,12 @@ function extractPathParams(pattern: string, pathname: string): FarmIntegrationRo
     if (isCatchAllSegment(routeSegment)) {
       params[getSegmentParamName(routeSegment)] = pathSegments
         .slice(pathIndex)
-        .map((segment) => decodeURIComponent(segment));
+        .map((segment) => decodeRouteSegment(segment));
       return params;
     }
 
     if (isDynamicSegment(routeSegment)) {
-      params[getSegmentParamName(routeSegment)] = decodeURIComponent(pathSegment);
+      params[getSegmentParamName(routeSegment)] = decodeRouteSegment(pathSegment);
       routeIndex += 1;
       pathIndex += 1;
       continue;


### PR DESCRIPTION
## Summary

Fixes #481. Three sites decoded request-derived paths with a bare `decodeURIComponent`, so one request with malformed percent-encoding (e.g. `/docs/caf%E9`) threw `URIError` out of the handler:

- **docs handler** `normalizeSlug` — in dev the docs dispatch has no try/catch on that path and connect ignores the rejected promise, so the unhandled rejection **kills the dev server process** (the issue's repro); in production it 500s what should be a 404
- **docs API** `normalizeDocsApiSlug` — same class via `/api/docs/<slug>.md` paths
- **integrations** `extractPathParams` — dynamic and catch-all segments threw during route *matching*, before any handler ran; agent-runtime proxy prefixes (`/agents/...`, `/eve/...`) receive raw client paths, exactly where malformed encodings arrive

## Fix

All three decode through a raw-value fallback, so malformed paths resolve to non-matching slugs/params — a 404 — matching the existing guards for cookies (#438), API route params (`decodePathSegment`), and the docs social-image slug (which already had one; these were the missed sites).

## Tests

Three new cases: the docs handler passes through `/docs/caf%E9` without throwing, the docs API answers `/api/docs/%E0.md` with 404, and integration route matching returns raw-segment params for `%E0` in dynamic and catch-all positions. All three fail against the old code (verified via patch-revert: 3 failed); both suites pass 50/50, `tsc`/`oxlint`/`oxfmt` clean.

The systemic request-boundary hardening this issue's sibling #484 asks for is a separate change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tolerates malformed percent-encoding in request paths so they no longer crash docs, docs API, or integrations. Previously `decodeURIComponent` threw `URIError` (dev: unhandled rejection killed the server; prod: 500); now we fall back to the raw segment, so requests 404 or handlers receive raw params.

- Apply safe decoding in docs slug normalization, docs API slug normalization, and integrations route param extraction; return the raw value when decoding fails.
- Verify: `/docs/caf%E9` no longer crashes; `/api/docs/%E0.md` returns 404; integration routes match `%E0` in dynamic and catch-all segments and pass the raw value to handlers.
- Valid encodings are unchanged. No migration required.

<sup>Written for commit 1711b08fbc345502bf5a10a82ff5642c53ffe32f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

