### PR TITLE
test(create-app): assert renderer versions from the workspace

### DIFF
--- a/packages/create-farm-app/test/create-app.test.mjs
+++ b/packages/create-farm-app/test/create-app.test.mjs
@@ -10,6 +10,11 @@ import { fileURLToPath } from "node:url";
 
 const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
+async function workspaceRendererVersion(rendererPackage) {
+  const manifestPath = path.resolve(packageDir, "..", rendererPackage, "package.json");
+  return JSON.parse(await readFile(manifestPath, "utf8")).version;
+}
+
 test("spaces the CLI banner and matches the website hero copy", async () => {
   const { showBanner } = await import("../dist/utils.mjs");
   const lines = [];
@@ -422,7 +427,10 @@ test("generates a Solid starter while keeping React as the default renderer", as
     const apiClient = await readFile(path.join(generatedDir, "src/lib/api-client.ts"), "utf8");
     const tsconfig = JSON.parse(await readFile(path.join(generatedDir, "tsconfig.json"), "utf8"));
 
-    assert.equal(packageJson.dependencies["@farm.js/solid"], "0.1.0-beta.26");
+    assert.equal(
+      packageJson.dependencies["@farm.js/solid"],
+      await workspaceRendererVersion("farm-solid"),
+    );
     assert.equal(packageJson.dependencies["solid-js"], "1.9.14");
     assert.equal(packageJson.dependencies.react, undefined);
     assert.equal(packageJson.dependencies["react-dom"], undefined);
@@ -518,7 +526,10 @@ test("generates a Vue SFC starter with typed server interaction", async () => {
     const layout = await readFile(path.join(generatedDir, "src/app/layout.vue"), "utf8");
     const tsconfig = JSON.parse(await readFile(path.join(generatedDir, "tsconfig.json"), "utf8"));
 
-    assert.equal(packageJson.dependencies["@farm.js/vue"], "0.1.0-beta.26");
+    assert.equal(
+      packageJson.dependencies["@farm.js/vue"],
+      await workspaceRendererVersion("farm-vue"),
+    );
     assert.equal(packageJson.dependencies.vue, "3.5.41");
     assert.equal(packageJson.dependencies.react, undefined);
     assert.equal(packageJson.dependencies["react-dom"], undefined);


### PR DESCRIPTION
## Summary

The Solid and Vue starter tests hardcoded `@farm.js/solid`/`@farm.js/vue` at `0.1.0-beta.26`. The renderer release bump to `beta.27` (commit 950490a1) desynced them, and since starters sync to workspace versions, **every PR's CI now fails** on these two assertions — #487's cross-platform test failures were exactly this.

## Fix

The assertions read the expected version from each renderer's workspace `package.json` (the same source of truth `sync-release-versions` writes from), so renderer releases can never desync them again.

## Tests

Full create-app suite passes 15/15 locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes create-app starter tests by asserting renderer versions from the workspace manifest, preventing CI breaks on renderer releases. Previously tests pinned `@farm.js/solid` and `@farm.js/vue` to `0.1.0-beta.26`; now they read each renderer’s version from its workspace `package.json`.

- Adds a `workspaceRendererVersion()` helper to read versions from `farm-solid` and `farm-vue` manifests (same source used by `sync-release-versions`).
- Tests only; no runtime or starter templates changed. Unblocks CI after `beta.27` and future releases.

<sup>Written for commit 9f813ddb33e8fa93a4d0921b2dbad85469f35379. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

