### PR TITLE
fix(core): let renderer head titles take effect in SSR documents

### DIFF
--- a/packages/farm/src/__tests__/metadata.test.ts
+++ b/packages/farm/src/__tests__/metadata.test.ts
@@ -15,6 +15,22 @@ describe("metadata head rendering", () => {
     );
   });
 
+  it("distinguishes configured titles from the framework fallback", () => {
+    // The document assembly suppresses its fallback <title> when a renderer
+    // (e.g. <svelte:head>) emits one; that decision keys off this flag.
+    expect(renderMetadataHead({ title: "Dashboard" })).toMatchObject({
+      title: "Dashboard",
+      hasExplicitTitle: true,
+    });
+    expect(renderMetadataHead({})).toMatchObject({
+      title: "Farm.js App",
+      hasExplicitTitle: false,
+    });
+    expect(renderMetadataHead(undefined)).toMatchObject({
+      hasExplicitTitle: false,
+    });
+  });
+
   it("keeps the fallback available when only an Apple touch icon is configured", () => {
     const rendered = renderMetadataHead({
       icons: {

--- a/packages/farm/src/metadata.ts
+++ b/packages/farm/src/metadata.ts
@@ -15,6 +15,8 @@ export interface RenderedMetadataHead {
   title: string;
   tags: string;
   hasFavicon: boolean;
+  /** False when the title is the framework fallback rather than configured. */
+  hasExplicitTitle: boolean;
 }
 
 type MetadataRecord = Metadata & Record<string, any>;
@@ -75,7 +77,8 @@ export function addMetadataImageReference(
 export function renderMetadataHead(metadata: MetadataRecord | undefined): RenderedMetadataHead {
   const resolvedMetadata = metadata || {};
   const metadataBase = resolveMetadataBase(resolvedMetadata);
-  const title = resolveMetadataTitle(resolvedMetadata.title) || "Farm.js App";
+  const explicitTitle = resolveMetadataTitle(resolvedMetadata.title);
+  const title = explicitTitle || "Farm.js App";
   const tags: string[] = [];
 
   appendMetaName(tags, "description", resolvedMetadata.description);
@@ -125,6 +128,7 @@ export function renderMetadataHead(metadata: MetadataRecord | undefined): Render
     title: escapeText(title),
     tags: tags.length > 0 ? `\n  ${tags.join("\n  ")}` : "",
     hasFavicon,
+    hasExplicitTitle: Boolean(explicitTitle),
   };
 }
 

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -5326,7 +5326,12 @@ ${
     function() { return "<body" + bodyMatch[1] + ">" + rootMarkup + "</body>"; },
   );
   if (renderedRoot.head) {
-    // Renderer-emitted head markup (e.g. <svelte:head>).
+    // Renderer-emitted head markup (e.g. <svelte:head>). First <title> wins,
+    // so the prebuilt shell's fallback title yields when the renderer
+    // supplies one; explicit titles are left in place.
+    if (/<title[\\s>]/i.test(renderedRoot.head)) {
+      html = html.replace(/<title>Farm\\.js App<[/]title>/i, "");
+    }
     html = html.replace(/<[/]head>/i, function() { return renderedRoot.head + "\\n</head>"; });
   }
   if (!html.includes('href="/__farm_client_css_href__"')) {
@@ -6186,6 +6191,10 @@ async function handleFarmRequestInContext(
         }
         
         const rendererHead = renderedPage.head || "";
+        // First <title> wins: the fallback framework title yields to a
+        // renderer-emitted one; explicit metadata titles still come first.
+        const suppressDefaultTitle =
+          !renderedMetadata.hasExplicitTitle && /<title[\\s>]/i.test(rendererHead);
         let fullHtml;
         if (hasFullDocument) {
           // Layout provides full HTML structure - inject CSS and client script
@@ -6233,7 +6242,7 @@ async function handleFarmRequestInContext(
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   \${hasFavicon ? "" : '<link rel="icon" href="data:,">'}
-  <title>\${title}</title>\${metaTags}\${rendererHead ? "\\n  " + rendererHead : ""}
+  \${suppressDefaultTitle ? "" : "<title>" + title + "</title>"}\${metaTags}\${rendererHead ? "\\n  " + rendererHead : ""}
   <link rel="stylesheet" href="/__farm_client_css_href__">
   \${renderFarmRendererHydrationScript()}
 </head>

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -2028,7 +2028,14 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
         title,
         tags: metaTags,
         hasFavicon,
+        hasExplicitTitle,
       } = renderMetadataHead((req as any).__FARM_METADATA__);
+      // A renderer-emitted <title> (e.g. <svelte:head>) must take effect: the
+      // first <title> in a document wins, so the fallback framework title is
+      // suppressed when the renderer supplies one. Explicit metadata titles
+      // still come first and win.
+      const documentTitleTag =
+        !hasExplicitTitle && /<title[\s>]/i.test(rendererHead) ? "" : `<title>${title}</title>`;
       const i18nSnapshot = getFarmI18nClientSnapshot();
       const alternateTags = i18nSnapshot
         ? renderI18nAlternateLinks((req as any).__FARM_ROUTE__ || req.url || "/", i18nSnapshot)
@@ -2077,7 +2084,7 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="farm-deployment-id" content="${escapeHtmlAttribute(deploymentId)}">
   ${hasFavicon ? "" : '<link rel="icon" href="data:,">'}
-  <title>${title}</title>${metaTags}${alternateTags}${rendererHead ? `\n  ${rendererHead}` : ""}
+  ${documentTitleTag}${metaTags}${alternateTags}${rendererHead ? `\n  ${rendererHead}` : ""}
   ${renderFarmFontDevHead(this.config.root || process.cwd())}
   <link rel="stylesheet" href="/src/app/globals.css">
   <script type="module" src="/@vite/client"></script>


### PR DESCRIPTION
## Summary

Follow-up defect in #482, caught by a post-merge audit: renderer head markup was appended **after** the framework's unconditionally emitted `<title>`, and per spec the *first* title in a document wins. So `<svelte:head><title>Dashboard</title></svelte:head>` produced:

```html
<title>Farm.js App</title> ... <title>Dashboard</title>
```

— present in the markup, defeated everywhere it matters (browser tab, crawlers, no-JS consumers). Meta and link tags landed fine; the feature's headline use case didn't.

## Fix

`renderMetadataHead` now reports `hasExplicitTitle` (configured vs the `"Farm.js App"` fallback). Every buffered document-assembly site — dev shell, production shell, and the prebuilt-document path (which strips the known fallback title from the built shell) — suppresses the fallback `<title>` when the renderer head carries one.

**Priority is deliberate:** explicitly configured metadata titles still come first and win over renderer head titles; only the framework fallback yields.

## Tests

New metadata cases pin `hasExplicitTitle` for configured/fallback/absent metadata. Existing document-injection, production-prebuilt-ssr, ssg, and create-server suites pass (33 tests across the five affected suites), `tsc`/`oxlint`/`oxfmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renderer-emitted head titles now take effect in SSR documents. Previously the framework injected <title>Farm.js App</title> first, so a renderer title appeared but lost; now the fallback title is omitted when the renderer head provides a title, while explicit metadata titles still win.

- In `packages/farm/src/metadata.ts`, `renderMetadataHead` adds `hasExplicitTitle` to distinguish configured vs fallback titles.
- In `packages/farm/src/server/renderer.ts` and `packages/farm/src/nitro/universal-build.ts`, suppress the fallback <title> only when the renderer head includes a <title>; keep configured metadata titles first.
- In `packages/farm/src/__tests__/metadata.test.ts`, add coverage for `hasExplicitTitle`; all affected suites still pass.

<sup>Written for commit f68366725f3056a60e7fc9b7aa1fb65a009efb9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

