### PR TITLE
fix(core): stop leaking handlers when a client disconnects mid-stream

### DIFF
--- a/packages/farm/src/__tests__/send-web-response.test.ts
+++ b/packages/farm/src/__tests__/send-web-response.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment node
+
+import { createServer, type Server } from "node:http";
+import { connect } from "node:net";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { sendWebResponse } from "../server/response";
+
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.closeAllConnections?.();
+          server.close(() => resolve());
+        }),
+    ),
+  );
+});
+
+function createChunkStream(chunkCount: number, chunkBytes: number): ReadableStream<Uint8Array> {
+  let sent = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (sent >= chunkCount) {
+        controller.close();
+        return;
+      }
+      sent += 1;
+      controller.enqueue(new Uint8Array(chunkBytes).fill(120));
+    },
+  });
+}
+
+async function listen(server: Server): Promise<number> {
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return (server.address() as AddressInfo).port;
+}
+
+describe("sendWebResponse", () => {
+  it("settles when the client disconnects mid-stream under backpressure", async () => {
+    let handlerSettled: "pending" | "returned" | "threw" = "pending";
+    const server = createServer((_req, res) => {
+      void sendWebResponse(
+        res,
+        new Response(createChunkStream(2_000, 64 * 1024), {
+          headers: { "content-type": "application/octet-stream" },
+        }),
+      ).then(
+        () => {
+          handlerSettled = "returned";
+        },
+        () => {
+          handlerSettled = "threw";
+        },
+      );
+    });
+    const port = await listen(server);
+
+    // Read one chunk, then vanish — the closed-tab / cancelled-download case.
+    await new Promise<void>((resolve, reject) => {
+      const socket = connect(port, "127.0.0.1", () => {
+        socket.write("GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: keep-alive\r\n\r\n");
+      });
+      socket.once("data", () => {
+        socket.destroy();
+        resolve();
+      });
+      socket.once("error", reject);
+    });
+
+    // The old code awaited a drain that never comes and stayed pending forever.
+    const deadline = Date.now() + 5_000;
+    while (handlerSettled === "pending" && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    expect(handlerSettled).toBe("returned");
+  });
+
+  it("delivers complete bodies to clients that read normally", async () => {
+    const chunkCount = 64;
+    const chunkBytes = 16 * 1024;
+    const server = createServer((_req, res) => {
+      void sendWebResponse(
+        res,
+        new Response(createChunkStream(chunkCount, chunkBytes), {
+          headers: { "content-type": "application/octet-stream" },
+        }),
+      );
+    });
+    const port = await listen(server);
+
+    const received = await fetch(`http://127.0.0.1:${port}/`).then((response) =>
+      response.arrayBuffer(),
+    );
+    expect(received.byteLength).toBe(chunkCount * chunkBytes);
+  });
+});

--- a/packages/farm/src/server/response.ts
+++ b/packages/farm/src/server/response.ts
@@ -1,6 +1,31 @@
 import { once } from "node:events";
 import type { ServerResponse } from "node:http";
 
+/**
+ * Waits until the response can accept more writes. Resolves false when the
+ * client is gone (close or error): a disconnected socket never emits drain,
+ * so waiting on drain alone leaks the pending handler, its reader lock, and
+ * the response body for the life of the process.
+ */
+async function waitForWritable(res: ServerResponse): Promise<boolean> {
+  if (res.writableEnded || res.destroyed) {
+    return false;
+  }
+
+  const abort = new AbortController();
+  try {
+    return await Promise.race([
+      once(res, "drain", { signal: abort.signal }).then(() => true),
+      once(res, "close", { signal: abort.signal }).then(() => false),
+    ]);
+  } catch {
+    // events.once rejects when the emitter emits "error".
+    return false;
+  } finally {
+    abort.abort();
+  }
+}
+
 export async function sendWebResponse(res: ServerResponse, response: Response): Promise<void> {
   res.statusCode = response.status;
 
@@ -34,6 +59,13 @@ export async function sendWebResponse(res: ServerResponse, response: Response): 
 
   try {
     while (true) {
+      if (res.destroyed) {
+        // The client disconnected mid-response; drop the rest of the body so
+        // the handler can return.
+        await reader.cancel().catch(() => {});
+        return;
+      }
+
       const { done, value } = await reader.read();
       if (done) {
         break;
@@ -44,7 +76,10 @@ export async function sendWebResponse(res: ServerResponse, response: Response): 
       }
 
       if (!res.write(value)) {
-        await once(res, "drain");
+        if (!(await waitForWritable(res))) {
+          await reader.cancel().catch(() => {});
+          return;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

Fixes #480. `sendWebResponse`'s backpressure wait was `await once(res, "drain")` — but a client that disconnects emits `close`, never `drain`. The promise never settled: the request handler stayed pending forever, the stream reader lock was never released, and the response body was held for the life of the process. A closed tab or cancelled download was enough, on any response large enough to fill the socket buffer. This is the response path for API routes and all four integration dispatch sites.

## Fix

- the wait races `drain` against `close` (socket `error` is handled via `events.once`'s rejection), with the listeners cleaned up through an `AbortController`
- a lost client stops the write loop, **cancels the body reader** (freeing the source stream), and lets the handler return normally — a disconnect is a normal outcome, not an error
- `res.destroyed` is also checked before each read, so the loop exits promptly even when the disconnect happens between chunks

## Tests

Real-socket regression test: an HTTP server streams 2,000 × 64KB chunks, the client reads one chunk and destroys the socket — on the old code the handler is still `pending` after 5 seconds (verified via stash-revert: exactly that failure); with the fix it settles as returned. A second test confirms normally-reading clients still receive complete bodies byte-for-byte. `tsc`/`oxlint`/`oxfmt` clean.

Note: CI will show the create-app version failure until #488 merges (pre-existing on main; every open PR has it) — this branch will be updated after #488 lands.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents handler leaks when a client disconnects mid-stream under backpressure. Previously, `sendWebResponse` awaited `drain` only; after a `close` it never fired, so the handler hung and held the body. Now it races `drain` with `close`, cancels the body reader, and returns normally; disconnects are treated as a normal outcome.

- Adds `waitForWritable` that races `drain` vs `close`, cleans listeners via `AbortController`, and rejects on `error`.
- On disconnect, stops the write loop, cancels the reader, and exits; also checks `res.destroyed` before each read to exit between chunks.
- Adds real-socket regression test for mid-stream disconnect and a test confirming complete delivery for normal readers.

<sup>Written for commit 7f0d047934cd03b7191fa22dfe3fb4146489dcf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

