### PR TITLE
fix(core): serve optimized images with the format actually encoded

### DIFF
--- a/packages/farm/src/__tests__/image-sharp.test.ts
+++ b/packages/farm/src/__tests__/image-sharp.test.ts
@@ -35,4 +35,59 @@ describe("Sharp image adapter", () => {
     expect(dimensions.width).toBe(2);
     expect(dimensions.height).toBe(1);
   });
+
+  it("keeps the source format when the Accept header matches nothing", async () => {
+    const source = await sharp({
+      create: {
+        width: 2,
+        height: 1,
+        channels: 4,
+        background: { r: 49, g: 130, b: 83, alpha: 0.5 },
+      },
+    })
+      .webp()
+      .toBuffer();
+    const transform = createSharpImageTransformer();
+
+    // curl / fetch() default Accept matches none of the configured formats.
+    const result = await transform({
+      source,
+      sourceUrl: new URL("https://example.test/photo.webp"),
+      sourceType: "image/webp",
+      width: 640,
+      quality: 75,
+      accept: "*/*",
+      formats: ["image/avif"],
+      signal: new AbortController().signal,
+    });
+
+    // The body must be what the content type claims: previously this was
+    // JPEG bytes served as image/webp (with nosniff), and transparency died.
+    expect(result.contentType).toBe("image/webp");
+    const metadata = await sharp(result.body).metadata();
+    expect(metadata.format).toBe("webp");
+    expect(metadata.hasAlpha).toBe(true);
+  });
+
+  it("rasterizes svg sources to png with a matching content type", async () => {
+    const source = Buffer.from(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="2" height="1"><rect width="2" height="1" fill="#318253" fill-opacity="0.5"/></svg>',
+    );
+    const transform = createSharpImageTransformer();
+
+    const result = await transform({
+      source,
+      sourceUrl: new URL("https://example.test/logo.svg"),
+      sourceType: "image/svg+xml",
+      width: 640,
+      quality: 75,
+      accept: "*/*",
+      formats: ["image/avif"],
+      signal: new AbortController().signal,
+    });
+
+    expect(result.contentType).toBe("image/png");
+    const metadata = await sharp(result.body).metadata();
+    expect(metadata.format).toBe("png");
+  });
 });

--- a/packages/farm/src/image-sharp.ts
+++ b/packages/farm/src/image-sharp.ts
@@ -22,23 +22,38 @@ export function createSharpImageTransformer(): FarmImageTransformer {
       .rotate()
       .resize({ width, fit: "inside", withoutEnlargement: true });
 
+    // When the Accept header matches none of the configured formats, keep the
+    // source's own format (svg rasterizes to png) instead of forcing JPEG —
+    // that preserved neither transparency nor the truth of the content type.
+    let encodedType: string;
     if (outputFormat === "image/avif") {
       pipeline = pipeline.avif({ quality });
+      encodedType = "image/avif";
     } else if (outputFormat === "image/webp") {
       pipeline = pipeline.webp({ quality });
-    } else if (sourceType === "image/png") {
+      encodedType = "image/webp";
+    } else if (sourceType === "image/png" || sourceType === "image/svg+xml") {
       pipeline = pipeline.png();
+      encodedType = "image/png";
     } else if (sourceType === "image/gif") {
       pipeline = pipeline.gif();
+      encodedType = "image/gif";
+    } else if (sourceType === "image/webp") {
+      pipeline = pipeline.webp({ quality });
+      encodedType = "image/webp";
+    } else if (sourceType === "image/avif") {
+      pipeline = pipeline.avif({ quality });
+      encodedType = "image/avif";
     } else {
       pipeline = pipeline.jpeg({ quality });
+      encodedType = "image/jpeg";
     }
 
     const body = await pipeline.toBuffer();
     throwIfAborted(signal);
     return {
       body,
-      contentType: outputFormat ?? normalizeSharpSourceType(sourceType),
+      contentType: encodedType,
     };
   };
 }
@@ -64,10 +79,6 @@ export function createNodeImageUrlValidator(config: ResolvedFarmImageConfig) {
       throw new FarmImageRequestError("PRIVATE_SOURCE", 400, "Private image source is not allowed");
     }
   };
-}
-
-function normalizeSharpSourceType(sourceType: string): string {
-  return sourceType === "image/svg+xml" ? "image/png" : sourceType;
 }
 
 function throwIfAborted(signal: AbortSignal): void {


### PR DESCRIPTION
## Summary

`createSharpImageTransformer` picks an output format from the Accept header; when nothing matched (curl and `fetch()` send `Accept: */*`; older Safari lacks webp/avif), the fallback encoded any non-png/gif source as **JPEG** but reported the **source** content type:

- webp source → JPEG bytes served as `image/webp`
- avif source → JPEG bytes served as `image/avif`
- svg source → JPEG bytes served as `image/png`

…all under `x-content-type-options: nosniff`, so browsers must trust the wrong label. The forced JPEG also flattened transparency.

## Fix

Unmatched requests re-encode in the source's own format (webp→webp, avif→avif, svg rasterizes to png — the evident intent of the old svg→png label), and `contentType` is now derived from the branch that actually encoded, so body and label can never disagree.

## Tests

Two new cases with the real sharp pipeline: a webp source with `Accept: */*` comes back as genuine webp **with alpha intact** (previously JPEG-as-webp with transparency destroyed), and an svg source rasterizes to real png. Both fail against the old code (verified via stash-revert); image suites pass 26/26, `tsc`/`oxlint`/`oxfmt` clean.