### PR TITLE
fix(core): keep the dev server alive when a request handler throws

### DIFF
--- a/packages/farm/src/__tests__/request-boundary.test.ts
+++ b/packages/farm/src/__tests__/request-boundary.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment node
+
+import { IncomingMessage, ServerResponse } from "node:http";
+import { Socket } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withFarmRequestTracing } from "../vite";
+
+function createNodeRequest(url: string): IncomingMessage {
+  const socket = new Socket();
+  const req = new IncomingMessage(socket);
+  req.url = url;
+  req.method = "GET";
+  req.headers = { host: "localhost:3000" };
+  return req;
+}
+
+function createNodeResponse() {
+  const res = new ServerResponse(createNodeRequest("/"));
+  const chunks: string[] = [];
+  let ended = false;
+  Object.defineProperty(res, "writableEnded", { get: () => ended, configurable: true });
+  res.setHeader = vi.fn();
+  res.end = vi.fn().mockImplementation((chunk?: unknown) => {
+    if (typeof chunk === "string") chunks.push(chunk);
+    ended = true;
+    return res;
+  }) as typeof res.end;
+  res.destroy = vi.fn().mockReturnValue(res);
+  return { res, chunks };
+}
+
+async function settle(): Promise<void> {
+  // The boundary settles asynchronously; give rejections time to surface.
+  for (let i = 0; i < 10; i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+describe("dev request boundary", () => {
+  const unhandled: unknown[] = [];
+  const onUnhandled = (reason: unknown) => {
+    unhandled.push(reason);
+  };
+
+  afterEach(() => {
+    process.removeListener("unhandledRejection", onUnhandled);
+    unhandled.length = 0;
+    vi.restoreAllMocks();
+  });
+
+  it("answers 500 when a handler throws synchronously and keeps the process alive", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    process.on("unhandledRejection", onUnhandled);
+
+    const middleware = withFarmRequestTracing(() => {
+      throw new URIError("URI malformed");
+    });
+
+    const { res, chunks } = createNodeResponse();
+    middleware(createNodeRequest("/docs/caf%E9"), res, () => {});
+    await settle();
+
+    expect(res.statusCode).toBe(500);
+    expect(chunks.join("")).toContain("Internal server error");
+    // The throw must not escape as an unhandled rejection — that is what
+    // killed the dev server in #481.
+    expect(unhandled).toEqual([]);
+  });
+
+  it("answers 500 when a handler rejects asynchronously", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    process.on("unhandledRejection", onUnhandled);
+
+    const middleware = withFarmRequestTracing(async () => {
+      await Promise.resolve();
+      throw new Error("async boom");
+    });
+
+    const { res, chunks } = createNodeResponse();
+    middleware(createNodeRequest("/page"), res, () => {});
+    await settle();
+
+    expect(res.statusCode).toBe(500);
+    expect(chunks.join("")).toContain("Internal server error");
+    expect(unhandled).toEqual([]);
+  });
+
+  it("destroys the socket instead of double-sending when headers already went out", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    process.on("unhandledRejection", onUnhandled);
+
+    const middleware = withFarmRequestTracing(async (_req, res) => {
+      (res as { headersSent: boolean }).headersSent = true;
+      throw new Error("mid-stream boom");
+    });
+
+    const { res } = createNodeResponse();
+    Object.defineProperty(res, "headersSent", { value: true, configurable: true });
+    middleware(createNodeRequest("/stream"), res, () => {});
+    await settle();
+
+    expect(res.destroy).toHaveBeenCalled();
+    expect(res.end).not.toHaveBeenCalled();
+    expect(unhandled).toEqual([]);
+  });
+
+  it("leaves successful handlers untouched", async () => {
+    const middleware = withFarmRequestTracing(async (_req, res) => {
+      res.statusCode = 204;
+      res.end();
+    });
+
+    const { res } = createNodeResponse();
+    middleware(createNodeRequest("/ok"), res, () => {});
+    await settle();
+
+    expect(res.statusCode).toBe(204);
+  });
+});

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -263,15 +263,35 @@ function createRequestFromNodeRequest(
   });
 }
 
-function withFarmRequestTracing(
+/** Exported for tests: the request boundary all Farm dev middlewares share. */
+export function withFarmRequestTracing(
   handler: Parameters<typeof _withAfterNodeMiddleware>[0],
 ): Connect.NextHandleFunction {
   const middleware = _withAfterNodeMiddleware(handler);
   return (req, res, next) => {
     const traceUrl = new URL(`http://${req.headers.host || "localhost:3000"}${req.url || "/"}`);
     const traceRequest = createRequestFromNodeRequest(req, traceUrl);
-    return runWithFarmRequestSpan(traceRequest, () => middleware(req, res, next), {
+    const result = runWithFarmRequestSpan(traceRequest, () => middleware(req, res, next), {
       getStatusCode: () => res.statusCode || 200,
+    });
+    // connect ignores returned promises, so a rejection from the handler
+    // becomes an unhandled rejection and kills the dev server process. A
+    // throw from one request must cost that request a 500, not an outage.
+    return Promise.resolve(result).catch((error) => {
+      console.error(
+        `[FARM] Unhandled error while handling ${req.method || "GET"} ${req.url || "/"}:`,
+        error,
+      );
+      if (res.writableEnded) {
+        return;
+      }
+      if (res.headersSent) {
+        res.destroy?.(error instanceof Error ? error : new Error(String(error)));
+        return;
+      }
+      res.statusCode = 500;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "Internal server error" }));
     });
   };
 }


### PR DESCRIPTION
## Summary

Fixes #484. connect ignores promises returned by middlewares, so any rejection out of Farm's async dev pipeline — page rendering, docs, markdown sources, everything registered through `withFarmRequestTracing` — became an **unhandled rejection that killed the dev server process**. #481's docs `URIError` was one instance (fixed specifically in #487); this hardens the shared boundary so the next uncaught throw, wherever it comes from, costs one 500 response instead of an outage.

## Fix

`withFarmRequestTracing` — the single entry all Farm dev middlewares share — now catches rejections from the wrapped middleware:

- logs the error with the request method and URL (never masked)
- answers a 500 JSON body when the response hasn't started
- destroys the socket when headers already went out (no double-send)
- already-completed responses are left alone

Per the issue's policy question: failures outside a request scope are unaffected — this catch only wraps per-request handler execution. Production entries already sit behind h3's handler boundary (nitro answers 500 there, as #481 observed).

## Tests

The regression suite the issue asked for: a synchronously-throwing handler and an async-rejecting handler both produce 500 with **zero unhandled rejections** (asserted via a `process.on("unhandledRejection")` probe — exactly the mechanism that killed the process), the headers-sent case destroys instead of double-sending, and successful handlers pass through untouched. All four fail against the old code. `tsc`/`oxlint`/`oxfmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the dev server alive when a request handler throws by catching async errors in the shared dev request boundary. Previously, rejections from dev middleware (ignored by `connect`) became unhandled and crashed the process; now we log and return 500 for that request, or destroy the socket if headers already sent.

- Wraps the shared boundary in `withFarmRequestTracing` to catch rejections from dev middleware.
- Logs the error with request method and URL.
- Sends a 500 JSON body when the response has not started; destroys the socket if headers already went out; leaves completed responses unchanged.
- No production change (prod paths already sit behind `h3`’s handler boundary).
- Exports `withFarmRequestTracing` for tests and adds coverage to assert zero unhandled rejections and correct 500/destroy behavior.

<sup>Written for commit ed860bfd4633abee4ee7e902ceb92a55ade8faff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

