### PR TITLE
fix(cli): deliver telemetry asynchronously

### DIFF
--- a/docs/src/app/api/telemetry/v1/events/route.ts
+++ b/docs/src/app/api/telemetry/v1/events/route.ts
@@ -1,6 +1,14 @@
 import { createHmac } from "node:crypto";
 import { getPrisma } from "../../../../../lib/prisma";
 import { z } from "zod";
+import {
+  FARM_CREATE_APP_TELEMETRY_COMMANDS,
+  FARM_TELEMETRY_COMMANDS,
+  FARM_TELEMETRY_DEPLOY_TARGETS,
+  FARM_TELEMETRY_PACKAGE_MANAGERS,
+  FARM_TELEMETRY_RENDERERS,
+  FARM_TELEMETRY_TEMPLATES,
+} from "../../../../../../../packages/farm-cli/src/telemetry-contract";
 
 const MAX_BODY_BYTES = 8 * 1024;
 const RATE_LIMIT_WINDOW_MS = 60_000;
@@ -9,44 +17,6 @@ const IDENTITY_RATE_LIMIT = 120;
 const MAX_RATE_LIMIT_ENTRIES = 4_096;
 const PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1_000;
 const DEFAULT_RETENTION_DAYS = 90;
-
-const farmCommands = [
-  "dev",
-  "build",
-  "auth:migrate",
-  "upgrade",
-  "generate",
-  "doctor",
-  "explain",
-  "preview",
-  "migrate",
-  "cron:list",
-  "cron:run",
-  "add:integration",
-  "deploy",
-] as const;
-
-const createAppCommands = ["create", "list-templates"] as const;
-
-const templates = [
-  "basic",
-  "react-compiler",
-  "auth",
-  "better-auth",
-  "ai",
-  "auth0",
-  "authjs",
-  "autumn",
-  "clerk",
-  "jobs-inngest",
-  "jobs-trigger",
-  "polar",
-  "resend",
-  "stripe",
-  "supabase",
-  "unkey",
-  "workos",
-] as const;
 
 const runtimeFields = {
   schemaVersion: z.literal(1),
@@ -68,8 +38,8 @@ const farmCommandEventSchema = z
     eventType: z.literal("command_invoked"),
     source: z.literal("cli"),
     packageName: z.literal("@farm.js/cli"),
-    command: z.enum(farmCommands),
-    deployTarget: z.enum(["vercel", "cloudflare", "netlify", "node", "custom"]).optional(),
+    command: z.enum(FARM_TELEMETRY_COMMANDS),
+    deployTarget: z.enum(FARM_TELEMETRY_DEPLOY_TARGETS).optional(),
   })
   .strict();
 
@@ -79,7 +49,7 @@ const createAppCommandEventSchema = z
     eventType: z.literal("command_invoked"),
     source: z.literal("create-app"),
     packageName: z.literal("@farm.js/create-app"),
-    command: z.enum(createAppCommands),
+    command: z.enum(FARM_CREATE_APP_TELEMETRY_COMMANDS),
   })
   .strict();
 
@@ -89,9 +59,9 @@ const projectCreatedEventSchema = z
     eventType: z.literal("project_created"),
     source: z.literal("create-app"),
     packageName: z.literal("@farm.js/create-app"),
-    template: z.enum(templates).optional(),
-    renderer: z.enum(["react", "preact", "solid", "vue", "svelte"]).optional(),
-    packageManager: z.enum(["npm", "pnpm", "yarn", "bun"]).optional(),
+    template: z.enum(FARM_TELEMETRY_TEMPLATES).optional(),
+    renderer: z.enum(FARM_TELEMETRY_RENDERERS).optional(),
+    packageManager: z.enum(FARM_TELEMETRY_PACKAGE_MANAGERS).optional(),
     typescript: z.boolean().optional(),
     installedDependencies: z.boolean().optional(),
   })

--- a/docs/src/app/docs/telemetry/page.md
+++ b/docs/src/app/docs/telemetry/page.md
@@ -38,6 +38,7 @@ Environment variables can provide an explicit per-process or organization-wide p
 | `FARM_TELEMETRY=0`          | Disables telemetry for the process.                                 |
 | `FARM_TELEMETRY_DISABLED=1` | Disables telemetry for the process.                                 |
 | `DO_NOT_TRACK=1`            | Disables telemetry and takes precedence over Farm's enable setting. |
+| `FARM_TELEMETRY_DEBUG=1`    | Prints delivery status without event contents or identifiers.       |
 
 Without the explicit `FARM_TELEMETRY=1` override, Farm skips test, CI, and non-interactive
 processes even when the saved local preference is enabled.
@@ -74,8 +75,10 @@ Farm does **not** collect or store:
 - environment variable names or values, database URLs, credentials, tokens, or other secrets;
 - IP addresses or user-agent strings.
 
-The client uses a short timeout and ignores network or server failures. Telemetry can never make a
-Farm command fail. There is no persistent retry queue.
+The client schedules delivery in the background so telemetry does not delay command execution, and
+network delivery does not keep a short-lived process open. A request has a three-second timeout and
+transient network, rate-limit, and server failures receive two bounded retries while the process
+remains alive. Telemetry can never make a Farm command fail, and there is no persistent retry queue.
 
 ## Endpoint, validation, and retention
 

--- a/packages/create-farm-app/src/index.ts
+++ b/packages/create-farm-app/src/index.ts
@@ -7,11 +7,7 @@ import {
   type AddFarmIntegrationResult,
   type FarmIntegrationProvider,
 } from "@farm.js/cli/add-integration";
-import {
-  showFarmTelemetryNotice,
-  trackFarmCreateAppCommand,
-  trackFarmProjectCreated,
-} from "@farm.js/cli/telemetry";
+import { trackFarmCreateAppCommand, trackFarmProjectCreated } from "@farm.js/cli/telemetry";
 import { logger, showBanner } from "./utils";
 
 interface CreateAppOptions {
@@ -209,8 +205,7 @@ export interface PackageManager {
 
 export async function createApp(projectName?: string, options: CreateAppOptions = {}) {
   showBanner();
-  await showFarmTelemetryNotice();
-  await trackFarmCreateAppCommand({
+  void trackFarmCreateAppCommand({
     command: options.listTemplates ? "list-templates" : "create",
     packageVersion: options.telemetryPackageVersion ?? "unknown",
   });
@@ -427,7 +422,7 @@ export async function createApp(projectName?: string, options: CreateAppOptions 
     }
   }
 
-  await trackFarmProjectCreated({
+  void trackFarmProjectCreated({
     packageVersion: options.telemetryPackageVersion ?? "unknown",
     template,
     renderer,

--- a/packages/farm-cli/bin/farm.js
+++ b/packages/farm-cli/bin/farm.js
@@ -54,19 +54,14 @@ function telemetryDeployTarget(commandPath, options) {
   return undefined;
 }
 
-program.hook("preAction", async (_command, actionCommand) => {
+program.hook("preAction", (_command, actionCommand) => {
   const commandPath = telemetryCommandPath(actionCommand);
   if (commandPath.startsWith("telemetry")) return;
-  const {
-    resolveFarmTelemetryCommand,
-    showFarmTelemetryNotice,
-    trackFarmCommand,
-  } = require("../dist/telemetry.js");
-  await showFarmTelemetryNotice();
+  const { resolveFarmTelemetryCommand, trackFarmCommand } = require("../dist/telemetry.js");
   const command = resolveFarmTelemetryCommand(commandPath);
   if (!command) return;
   const options = actionCommand.opts();
-  await trackFarmCommand({
+  void trackFarmCommand({
     command,
     packageVersion: version,
     deployTarget: telemetryDeployTarget(commandPath, options),

--- a/packages/farm-cli/src/index.ts
+++ b/packages/farm-cli/src/index.ts
@@ -113,6 +113,7 @@ export {
   type FarmUpgradeResult,
 } from "./upgrade";
 export {
+  flushFarmTelemetry,
   getFarmTelemetryConfigFile,
   getFarmTelemetryStatus,
   resolveFarmCreateAppTelemetryCommand,

--- a/packages/farm-cli/src/telemetry-contract.ts
+++ b/packages/farm-cli/src/telemetry-contract.ts
@@ -1,0 +1,48 @@
+export const FARM_TELEMETRY_COMMANDS = [
+  "dev",
+  "build",
+  "start",
+  "auth:migrate",
+  "upgrade",
+  "generate",
+  "doctor",
+  "explain",
+  "preview",
+  "migrate",
+  "cron:list",
+  "cron:run",
+  "add:integration",
+  "deploy",
+] as const;
+
+export const FARM_CREATE_APP_TELEMETRY_COMMANDS = ["create", "list-templates"] as const;
+
+export const FARM_TELEMETRY_TEMPLATES = [
+  "basic",
+  "react-compiler",
+  "auth",
+  "better-auth",
+  "ai",
+  "auth0",
+  "authjs",
+  "autumn",
+  "clerk",
+  "jobs-inngest",
+  "jobs-trigger",
+  "polar",
+  "resend",
+  "stripe",
+  "supabase",
+  "unkey",
+  "workos",
+] as const;
+
+export const FARM_TELEMETRY_RENDERERS = ["react", "preact", "solid", "vue", "svelte"] as const;
+export const FARM_TELEMETRY_PACKAGE_MANAGERS = ["npm", "pnpm", "yarn", "bun"] as const;
+export const FARM_TELEMETRY_DEPLOY_TARGETS = [
+  "vercel",
+  "cloudflare",
+  "netlify",
+  "node",
+  "custom",
+] as const;

--- a/packages/farm-cli/src/telemetry.ts
+++ b/packages/farm-cli/src/telemetry.ts
@@ -1,62 +1,30 @@
 import { randomUUID } from "node:crypto";
 import { chmod, mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
 import os from "node:os";
 import path from "node:path";
+import {
+  FARM_CREATE_APP_TELEMETRY_COMMANDS,
+  FARM_TELEMETRY_COMMANDS,
+  FARM_TELEMETRY_DEPLOY_TARGETS,
+  FARM_TELEMETRY_PACKAGE_MANAGERS,
+  FARM_TELEMETRY_RENDERERS,
+  FARM_TELEMETRY_TEMPLATES,
+} from "./telemetry-contract";
 
 const TELEMETRY_SCHEMA_VERSION = 1 as const;
 const DEFAULT_TELEMETRY_ENDPOINT = "https://farmjs.dev/api/telemetry/v1/events";
 const TELEMETRY_NOTICE_URL = "https://farmjs.dev/docs/telemetry";
-const REQUEST_TIMEOUT_MS = 750;
+const REQUEST_TIMEOUT_MS = 3_000;
+const RETRY_DELAYS_MS = [250, 750] as const;
 
-const FARM_COMMANDS = [
-  "dev",
-  "build",
-  "start",
-  "auth:migrate",
-  "upgrade",
-  "generate",
-  "doctor",
-  "explain",
-  "preview",
-  "migrate",
-  "cron:list",
-  "cron:run",
-  "add:integration",
-  "deploy",
-] as const;
-
-const CREATE_APP_COMMANDS = ["create", "list-templates"] as const;
-
-const FARM_TEMPLATES = [
-  "basic",
-  "react-compiler",
-  "auth",
-  "better-auth",
-  "ai",
-  "auth0",
-  "authjs",
-  "autumn",
-  "clerk",
-  "jobs-inngest",
-  "jobs-trigger",
-  "polar",
-  "resend",
-  "stripe",
-  "supabase",
-  "unkey",
-  "workos",
-] as const;
-
-const RENDERERS = ["react", "preact", "solid", "vue", "svelte"] as const;
-const PACKAGE_MANAGERS = ["npm", "pnpm", "yarn", "bun"] as const;
-const DEPLOY_TARGETS = ["vercel", "cloudflare", "netlify", "node", "custom"] as const;
-
-export type FarmTelemetryCommand = (typeof FARM_COMMANDS)[number];
-export type FarmCreateAppTelemetryCommand = (typeof CREATE_APP_COMMANDS)[number];
-export type FarmTelemetryTemplate = (typeof FARM_TEMPLATES)[number];
-export type FarmTelemetryRenderer = (typeof RENDERERS)[number];
-export type FarmTelemetryPackageManager = (typeof PACKAGE_MANAGERS)[number];
-export type FarmTelemetryDeployTarget = (typeof DEPLOY_TARGETS)[number];
+export type FarmTelemetryCommand = (typeof FARM_TELEMETRY_COMMANDS)[number];
+export type FarmCreateAppTelemetryCommand = (typeof FARM_CREATE_APP_TELEMETRY_COMMANDS)[number];
+export type FarmTelemetryTemplate = (typeof FARM_TELEMETRY_TEMPLATES)[number];
+export type FarmTelemetryRenderer = (typeof FARM_TELEMETRY_RENDERERS)[number];
+export type FarmTelemetryPackageManager = (typeof FARM_TELEMETRY_PACKAGE_MANAGERS)[number];
+export type FarmTelemetryDeployTarget = (typeof FARM_TELEMETRY_DEPLOY_TARGETS)[number];
 
 interface FarmTelemetryConfig {
   version: 1;
@@ -144,6 +112,10 @@ type FarmTelemetryGeneratedFields = Pick<
 type FarmTelemetryEventInput<T = FarmTelemetryEvent> = T extends FarmTelemetryEvent
   ? Omit<T, keyof FarmTelemetryGeneratedFields>
   : never;
+
+const pendingDeliveries = new Set<Promise<void>>();
+const retryTimers = new Set<NodeJS.Timeout>();
+let telemetryFlushWaiters = 0;
 
 function defaultConfig(): FarmTelemetryConfig {
   return {
@@ -335,7 +307,7 @@ export async function showFarmTelemetryNotice(): Promise<void> {
 }
 
 export function resolveFarmTelemetryCommand(value: string): FarmTelemetryCommand | undefined {
-  return (FARM_COMMANDS as readonly string[]).includes(value)
+  return (FARM_TELEMETRY_COMMANDS as readonly string[]).includes(value)
     ? (value as FarmTelemetryCommand)
     : undefined;
 }
@@ -343,56 +315,89 @@ export function resolveFarmTelemetryCommand(value: string): FarmTelemetryCommand
 export function resolveFarmCreateAppTelemetryCommand(
   value: string,
 ): FarmCreateAppTelemetryCommand | undefined {
-  return (CREATE_APP_COMMANDS as readonly string[]).includes(value)
+  return (FARM_CREATE_APP_TELEMETRY_COMMANDS as readonly string[]).includes(value)
     ? (value as FarmCreateAppTelemetryCommand)
     : undefined;
 }
 
-export async function trackFarmCommand(input: FarmCommandTelemetryInput): Promise<void> {
-  const deployTarget = allowlisted(input.deployTarget, DEPLOY_TARGETS);
-  await track({
-    eventType: "command_invoked",
-    source: "cli",
-    packageName: "@farm.js/cli",
-    packageVersion: sanitizeVersion(input.packageVersion),
-    command: input.command,
-    ...(deployTarget ? { deployTarget } : {}),
+export function trackFarmCommand(input: FarmCommandTelemetryInput): Promise<void> {
+  return schedule(async () => {
+    await showFarmTelemetryNotice();
+    const deployTarget = allowlisted(input.deployTarget, FARM_TELEMETRY_DEPLOY_TARGETS);
+    await track({
+      eventType: "command_invoked",
+      source: "cli",
+      packageName: "@farm.js/cli",
+      packageVersion: sanitizeVersion(input.packageVersion),
+      command: input.command,
+      ...(deployTarget ? { deployTarget } : {}),
+    });
   });
 }
 
-export async function trackFarmCreateAppCommand(
+export function trackFarmCreateAppCommand(
   input: FarmCreateAppCommandTelemetryInput,
 ): Promise<void> {
-  const command = allowlisted(input.command, CREATE_APP_COMMANDS);
-  if (!command) return;
-  await track({
-    eventType: "command_invoked",
-    source: "create-app",
-    packageName: "@farm.js/create-app",
-    packageVersion: sanitizeVersion(input.packageVersion),
-    command,
+  return schedule(async () => {
+    await showFarmTelemetryNotice();
+    const command = allowlisted(input.command, FARM_CREATE_APP_TELEMETRY_COMMANDS);
+    if (!command) return;
+    await track({
+      eventType: "command_invoked",
+      source: "create-app",
+      packageName: "@farm.js/create-app",
+      packageVersion: sanitizeVersion(input.packageVersion),
+      command,
+    });
   });
 }
 
-export async function trackFarmProjectCreated(
-  input: FarmProjectCreatedTelemetryInput,
-): Promise<void> {
-  const template = allowlisted(input.template, FARM_TEMPLATES);
-  const renderer = allowlisted(input.renderer, RENDERERS);
-  const packageManager = allowlisted(input.packageManager, PACKAGE_MANAGERS);
-  await track({
-    eventType: "project_created",
-    source: "create-app",
-    packageName: "@farm.js/create-app",
-    packageVersion: sanitizeVersion(input.packageVersion),
-    ...(template ? { template } : {}),
-    ...(renderer ? { renderer } : {}),
-    ...(packageManager ? { packageManager } : {}),
-    ...(typeof input.typescript === "boolean" ? { typescript: input.typescript } : {}),
-    ...(typeof input.installedDependencies === "boolean"
-      ? { installedDependencies: input.installedDependencies }
-      : {}),
+export function trackFarmProjectCreated(input: FarmProjectCreatedTelemetryInput): Promise<void> {
+  return schedule(async () => {
+    const template = allowlisted(input.template, FARM_TELEMETRY_TEMPLATES);
+    const renderer = allowlisted(input.renderer, FARM_TELEMETRY_RENDERERS);
+    const packageManager = allowlisted(input.packageManager, FARM_TELEMETRY_PACKAGE_MANAGERS);
+    await track({
+      eventType: "project_created",
+      source: "create-app",
+      packageName: "@farm.js/create-app",
+      packageVersion: sanitizeVersion(input.packageVersion),
+      ...(template ? { template } : {}),
+      ...(renderer ? { renderer } : {}),
+      ...(packageManager ? { packageManager } : {}),
+      ...(typeof input.typescript === "boolean" ? { typescript: input.typescript } : {}),
+      ...(typeof input.installedDependencies === "boolean"
+        ? { installedDependencies: input.installedDependencies }
+        : {}),
+    });
   });
+}
+
+function schedule(delivery: () => Promise<void>): Promise<void> {
+  const pending = Promise.resolve()
+    .then(delivery)
+    .catch(() => {
+      // Telemetry is best-effort and must never surface as an unhandled rejection.
+    });
+  pendingDeliveries.add(pending);
+  void pending.finally(() => pendingDeliveries.delete(pending));
+  return Promise.resolve();
+}
+
+/** Wait for background telemetry. Intended for tests and explicit process shutdown hooks. */
+export async function flushFarmTelemetry(): Promise<void> {
+  telemetryFlushWaiters += 1;
+  for (const timer of retryTimers) timer.ref?.();
+  try {
+    while (pendingDeliveries.size > 0) {
+      await Promise.allSettled(pendingDeliveries);
+    }
+  } finally {
+    telemetryFlushWaiters -= 1;
+    if (telemetryFlushWaiters === 0) {
+      for (const timer of retryTimers) timer.unref?.();
+    }
+  }
 }
 
 async function track(event: FarmTelemetryEventInput): Promise<void> {
@@ -419,22 +424,96 @@ async function track(event: FarmTelemetryEventInput): Promise<void> {
 }
 
 async function send(payload: FarmTelemetryEvent): Promise<void> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-  timeout.unref?.();
-  try {
-    await fetch(getEndpoint(), {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(payload),
-      signal: controller.signal,
-      keepalive: true,
-    });
-  } catch {
-    // Network and endpoint failures are intentionally ignored.
-  } finally {
-    clearTimeout(timeout);
+  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt += 1) {
+    const result = await sendOnce(payload);
+    if (result === "delivered" || result === "rejected") return;
+    const delay = RETRY_DELAYS_MS[attempt];
+    if (delay !== undefined) await wait(delay);
   }
+  debug("delivery failed after retries");
+}
+
+async function sendOnce(payload: FarmTelemetryEvent): Promise<"delivered" | "retry" | "rejected"> {
+  let endpoint: URL;
+  try {
+    endpoint = new URL(getEndpoint());
+  } catch {
+    debug("invalid endpoint URL");
+    return "rejected";
+  }
+
+  const requestTransport = endpoint.protocol === "http:" ? httpRequest : httpsRequest;
+  if (endpoint.protocol !== "http:" && endpoint.protocol !== "https:") {
+    debug(`unsupported endpoint protocol ${endpoint.protocol}`);
+    return "rejected";
+  }
+
+  const body = JSON.stringify(payload);
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result: "delivered" | "retry" | "rejected") => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve(result);
+    };
+    const request = requestTransport(
+      endpoint,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-length": Buffer.byteLength(body),
+        },
+      },
+      (response) => {
+        response.on("error", () => {
+          // The status code is sufficient; response bodies are never telemetry input.
+        });
+        response.resume();
+        const status = response.statusCode ?? 0;
+        if (status >= 200 && status < 300) return finish("delivered");
+        if (status === 408 || status === 425 || status === 429) {
+          debug(`temporary HTTP ${status}; retrying`);
+          return finish("retry");
+        }
+        if (status >= 500) {
+          debug(`server HTTP ${status}; retrying`);
+          return finish("retry");
+        }
+        debug(`event rejected with HTTP ${status}`);
+        return finish("rejected");
+      },
+    );
+    const timeout = setTimeout(() => {
+      request.destroy();
+      debug("network request timed out; retrying");
+      finish("retry");
+    }, REQUEST_TIMEOUT_MS);
+    timeout.unref?.();
+    request.once("socket", (socket) => socket.unref());
+    request.once("error", () => {
+      debug("network request failed; retrying");
+      finish("retry");
+    });
+    request.end(body);
+  });
+}
+
+function wait(delay: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      retryTimers.delete(timeout);
+      resolve();
+    }, delay);
+    retryTimers.add(timeout);
+    if (telemetryFlushWaiters === 0) timeout.unref?.();
+  });
+}
+
+function debug(message: string): void {
+  if (!isTrue(process.env.FARM_TELEMETRY_DEBUG)) return;
+  process.stderr.write(`[farm.telemetry] ${message}\n`);
 }
 
 function sanitizeVersion(value: string): string {

--- a/packages/farm-cli/test/telemetry.test.mjs
+++ b/packages/farm-cli/test/telemetry.test.mjs
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
 import {
+  flushFarmTelemetry,
   getFarmTelemetryConfigFile,
   getFarmTelemetryStatus,
   resolveFarmCreateAppTelemetryCommand,
@@ -23,6 +27,7 @@ const TELEMETRY_ENV_KEYS = [
   "FARM_TELEMETRY",
   "FARM_TELEMETRY_CONFIG_DIR",
   "FARM_TELEMETRY_DISABLED",
+  "FARM_TELEMETRY_DEBUG",
   "FARM_TELEMETRY_ENDPOINT",
   "GITHUB_ACTIONS",
   "NODE_ENV",
@@ -31,7 +36,6 @@ const TELEMETRY_ENV_KEYS = [
 async function withTelemetryEnvironment(run) {
   const directory = await mkdtemp(path.join(os.tmpdir(), "farm-cli-telemetry-"));
   const previous = Object.fromEntries(TELEMETRY_ENV_KEYS.map((key) => [key, process.env[key]]));
-  const previousFetch = globalThis.fetch;
   for (const key of TELEMETRY_ENV_KEYS) delete process.env[key];
   process.env.FARM_TELEMETRY_CONFIG_DIR = directory;
   process.env.FARM_TELEMETRY_ENDPOINT = "http://127.0.0.1:43199/events";
@@ -39,13 +43,49 @@ async function withTelemetryEnvironment(run) {
   try {
     await run(directory);
   } finally {
-    globalThis.fetch = previousFetch;
     for (const key of TELEMETRY_ENV_KEYS) {
       if (previous[key] === undefined) delete process.env[key];
       else process.env[key] = previous[key];
     }
     await rm(directory, { recursive: true, force: true });
   }
+}
+
+async function withTelemetryServer(handler, run) {
+  const sockets = new Set();
+  const server = createServer((request, response) => {
+    Promise.resolve(handler(request, response)).catch(() => {
+      response.destroy();
+    });
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  assert.notEqual(address, null);
+  assert.equal(typeof address, "object");
+  process.env.FARM_TELEMETRY_ENDPOINT = `http://127.0.0.1:${address.port}/events`;
+
+  try {
+    await run();
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+async function readRequestBody(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function accept(response, status = 202) {
+  response.writeHead(status);
+  response.end();
 }
 
 test("telemetry is enabled without creating an identity by default", async () => {
@@ -96,43 +136,112 @@ test("enable persists an anonymous ID and disable removes it", async () => {
   });
 });
 
+test("tracking returns before background delivery completes", async () => {
+  await withTelemetryEnvironment(async () => {
+    process.env.FARM_TELEMETRY = "1";
+    let finishRequest;
+    let requestStarted;
+    const started = new Promise((resolve) => {
+      requestStarted = resolve;
+    });
+
+    await withTelemetryServer(
+      async (request, response) => {
+        await readRequestBody(request);
+        requestStarted();
+        await new Promise((resolve) => {
+          finishRequest = () => {
+            accept(response);
+            resolve();
+          };
+        });
+      },
+      async () => {
+        await trackFarmCommand({ command: "dev", packageVersion: "0.1.0-beta.58" });
+        assert.equal(finishRequest, undefined);
+
+        await started;
+        finishRequest();
+        await flushFarmTelemetry();
+      },
+    );
+  });
+});
+
+test("pending telemetry does not keep a short-lived process open", async () => {
+  await withTelemetryEnvironment(async (directory) => {
+    process.env.FARM_TELEMETRY = "1";
+    await withTelemetryServer(
+      async (request) => {
+        await readRequestBody(request);
+        // Deliberately leave the response open. The client socket must not keep the child alive.
+      },
+      async () => {
+        const telemetryModule = new URL("../dist/telemetry.mjs", import.meta.url).href;
+        const script = `import { trackFarmCommand } from ${JSON.stringify(
+          telemetryModule,
+        )}; void trackFarmCommand({ command: "build", packageVersion: "test" });`;
+        const startedAt = Date.now();
+        const child = spawn(process.execPath, ["--input-type=module", "--eval", script], {
+          env: {
+            ...process.env,
+            FARM_TELEMETRY: "1",
+            FARM_TELEMETRY_CONFIG_DIR: directory,
+          },
+          stdio: "ignore",
+        });
+        const [exitCode, signal] = await once(child, "exit");
+        const elapsed = Date.now() - startedAt;
+
+        assert.equal(signal, null);
+        assert.equal(exitCode, 0);
+        assert.ok(elapsed < 2_000, `telemetry kept the process open for ${elapsed}ms`);
+      },
+    );
+  });
+});
+
 test("explicit telemetry sends only the strict command payload", async () => {
   await withTelemetryEnvironment(async () => {
     process.env.FARM_TELEMETRY = "1";
     let request;
-    globalThis.fetch = async (url, init) => {
-      request = { url: String(url), init };
-      return { ok: true };
-    };
+    await withTelemetryServer(
+      async (incoming, response) => {
+        request = { url: incoming.url, body: await readRequestBody(incoming) };
+        accept(response);
+      },
+      async () => {
+        void trackFarmCommand({
+          command: "deploy",
+          packageVersion: "0.1.0-beta.36",
+          deployTarget: "vercel",
+        });
+        await flushFarmTelemetry();
 
-    await trackFarmCommand({
-      command: "deploy",
-      packageVersion: "0.1.0-beta.36",
-      deployTarget: "vercel",
-    });
-
-    assert.equal(request.url, "http://127.0.0.1:43199/events");
-    const payload = JSON.parse(request.init.body);
-    assert.deepEqual(
-      Object.keys(payload).sort(),
-      [
-        "anonymousId",
-        "architecture",
-        "command",
-        "deployTarget",
-        "eventId",
-        "eventType",
-        "nodeMajor",
-        "packageName",
-        "packageVersion",
-        "platform",
-        "schemaVersion",
-        "source",
-      ].sort(),
+        assert.equal(request.url, "/events");
+        const payload = JSON.parse(request.body);
+        assert.deepEqual(
+          Object.keys(payload).sort(),
+          [
+            "anonymousId",
+            "architecture",
+            "command",
+            "deployTarget",
+            "eventId",
+            "eventType",
+            "nodeMajor",
+            "packageName",
+            "packageVersion",
+            "platform",
+            "schemaVersion",
+            "source",
+          ].sort(),
+        );
+        assert.equal(payload.eventType, "command_invoked");
+        assert.equal(payload.command, "deploy");
+        assert.equal(JSON.stringify(payload).includes(process.cwd()), false);
+      },
     );
-    assert.equal(payload.eventType, "command_invoked");
-    assert.equal(payload.command, "deploy");
-    assert.equal(JSON.stringify(payload).includes(process.cwd()), false);
   });
 });
 
@@ -140,6 +249,7 @@ test("published CLI command paths are explicitly allowlisted", () => {
   for (const command of [
     "dev",
     "build",
+    "start",
     "auth:migrate",
     "upgrade",
     "generate",
@@ -165,21 +275,25 @@ test("create-app commands use the generator package identity", async () => {
   await withTelemetryEnvironment(async () => {
     process.env.FARM_TELEMETRY = "1";
     let payload;
-    globalThis.fetch = async (_url, init) => {
-      payload = JSON.parse(init.body);
-      return { ok: true };
-    };
+    await withTelemetryServer(
+      async (request, response) => {
+        payload = JSON.parse(await readRequestBody(request));
+        accept(response);
+      },
+      async () => {
+        void trackFarmCreateAppCommand({
+          command: "list-templates",
+          packageVersion: "0.1.0-beta.52",
+        });
+        await flushFarmTelemetry();
 
-    await trackFarmCreateAppCommand({
-      command: "list-templates",
-      packageVersion: "0.1.0-beta.52",
-    });
-
-    assert.equal(payload.eventType, "command_invoked");
-    assert.equal(payload.source, "create-app");
-    assert.equal(payload.packageName, "@farm.js/create-app");
-    assert.equal(payload.command, "list-templates");
-    assert.equal(payload.deployTarget, undefined);
+        assert.equal(payload.eventType, "command_invoked");
+        assert.equal(payload.source, "create-app");
+        assert.equal(payload.packageName, "@farm.js/create-app");
+        assert.equal(payload.command, "list-templates");
+        assert.equal(payload.deployTarget, undefined);
+      },
+    );
   });
 });
 
@@ -187,26 +301,30 @@ test("project metadata is allowlisted instead of forwarding arbitrary strings", 
   await withTelemetryEnvironment(async () => {
     process.env.FARM_TELEMETRY = "1";
     let payload;
-    globalThis.fetch = async (_url, init) => {
-      payload = JSON.parse(init.body);
-      return { ok: true };
-    };
+    await withTelemetryServer(
+      async (request, response) => {
+        payload = JSON.parse(await readRequestBody(request));
+        accept(response);
+      },
+      async () => {
+        void trackFarmProjectCreated({
+          packageVersion: "../../../secret",
+          template: "/private/project",
+          renderer: "react",
+          packageManager: "pnpm",
+          typescript: true,
+          installedDependencies: false,
+        });
+        await flushFarmTelemetry();
 
-    await trackFarmProjectCreated({
-      packageVersion: "../../../secret",
-      template: "/private/project",
-      renderer: "react",
-      packageManager: "pnpm",
-      typescript: true,
-      installedDependencies: false,
-    });
-
-    assert.equal(payload.packageVersion, "unknown");
-    assert.equal(payload.template, undefined);
-    assert.equal(payload.renderer, "react");
-    assert.equal(payload.packageManager, "pnpm");
-    assert.equal(payload.typescript, true);
-    assert.equal(payload.installedDependencies, false);
+        assert.equal(payload.packageVersion, "unknown");
+        assert.equal(payload.template, undefined);
+        assert.equal(payload.renderer, "react");
+        assert.equal(payload.packageManager, "pnpm");
+        assert.equal(payload.typescript, true);
+        assert.equal(payload.installedDependencies, false);
+      },
+    );
   });
 });
 
@@ -215,27 +333,60 @@ test("DO_NOT_TRACK wins over an explicit enable flag", async () => {
     process.env.FARM_TELEMETRY = "1";
     process.env.DO_NOT_TRACK = "1";
     let called = false;
-    globalThis.fetch = async () => {
-      called = true;
-      return { ok: true };
-    };
-
-    await trackFarmCommand({ command: "build", packageVersion: "0.1.0-beta.36" });
-    const status = await getFarmTelemetryStatus();
-    assert.equal(called, false);
-    assert.equal(status.enabled, false);
-    assert.match(status.reason, /DO_NOT_TRACK/);
+    await withTelemetryServer(
+      (_request, response) => {
+        called = true;
+        accept(response);
+      },
+      async () => {
+        void trackFarmCommand({ command: "build", packageVersion: "0.1.0-beta.36" });
+        await flushFarmTelemetry();
+        const status = await getFarmTelemetryStatus();
+        assert.equal(called, false);
+        assert.equal(status.enabled, false);
+        assert.match(status.reason, /DO_NOT_TRACK/);
+      },
+    );
   });
 });
 
 test("transport failures never reject a Farm command", async () => {
   await withTelemetryEnvironment(async () => {
     process.env.FARM_TELEMETRY = "1";
-    globalThis.fetch = async () => {
-      throw new Error("offline");
-    };
+    const unavailable = createServer();
+    unavailable.listen(0, "127.0.0.1");
+    await once(unavailable, "listening");
+    const address = unavailable.address();
+    assert.notEqual(address, null);
+    assert.equal(typeof address, "object");
+    process.env.FARM_TELEMETRY_ENDPOINT = `http://127.0.0.1:${address.port}/events`;
+    await new Promise((resolve) => unavailable.close(resolve));
+
     await assert.doesNotReject(
-      trackFarmCommand({ command: "doctor", packageVersion: "0.1.0-beta.36" }),
+      trackFarmCommand({
+        command: "doctor",
+        packageVersion: "0.1.0-beta.36",
+      }),
+    );
+    await assert.doesNotReject(flushFarmTelemetry());
+  });
+});
+
+test("transient HTTP failures are retried in the background", async () => {
+  await withTelemetryEnvironment(async () => {
+    process.env.FARM_TELEMETRY = "1";
+    const statuses = [503, 202];
+    let attempts = 0;
+    await withTelemetryServer(
+      async (request, response) => {
+        await readRequestBody(request);
+        accept(response, statuses[attempts++] ?? 202);
+      },
+      async () => {
+        void trackFarmCommand({ command: "build", packageVersion: "0.1.0-beta.58" });
+        await flushFarmTelemetry();
+        assert.equal(attempts, 2);
+      },
     );
   });
 });


### PR DESCRIPTION
## Summary

- schedule CLI and create-app telemetry in the background without delaying command execution or process shutdown
- retry transient network, rate-limit, and server failures with bounded timeouts while the process remains alive
- share client/server event allowlists so `farm start` telemetry is accepted by the ingestion route
- add opt-in delivery diagnostics that never print event contents or identifiers

## Testing

- `pnpm --filter @farm.js/cli test` (86 passed)
- `pnpm --filter @farm.js/create-app test` (15 passed)
- `pnpm exec oxlint` on all changed source files
- `pnpm exec oxfmt --check` on all changed files
- `pnpm --dir docs build`
- `npm pack --dry-run --json` for `@farm.js/cli`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deliver CLI and create-app telemetry in the background with bounded retries so commands don’t block and short-lived processes don’t stay open. The client previously awaited a single fetch with a ~750ms timeout; it now schedules delivery asynchronously with a 3s timeout and two retries (250ms, 750ms), and unrefs timers/sockets.

- Server now validates events using a shared contract in `packages/farm-cli/src/telemetry-contract`, so `farm start` and other allowlisted values are accepted by the ingestion route.
- New `FARM_TELEMETRY_DEBUG=1` prints delivery status (no event payloads or identifiers).
- `trackFarmCommand`, `trackFarmCreateAppCommand`, and `trackFarmProjectCreated` return immediately; use `flushFarmTelemetry` to await background delivery in tests or explicit shutdown hooks.

<sup>Written for commit 09a99e97377a35e15952d339db1dbca080a9fbaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

