### PR TITLE
suspended: unoptimized generic approach for reading repeated values

### DIFF
--- a/packages/farm/src/__tests__/query-params.test.ts
+++ b/packages/farm/src/__tests__/query-params.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { asInteger, asString } from "../query/parsers";
+import { asArrayOf, asInteger, asString } from "../query/parsers";
 import { loadRouteParams, parseRouteParams } from "../query/params";
+import { loadSearchParams } from "../query/server";
 
 describe("query route params parsing", () => {
   it("parses route params synchronously with parser types", () => {
@@ -36,5 +37,46 @@ describe("query route params parsing", () => {
         { strict: true },
       ),
     ).toThrow('Failed to parse route param "id"');
+  });
+});
+
+describe("loadSearchParams", () => {
+  it("keeps every value of a repeated parameter", async () => {
+    // The searchParams page prop collects repeated keys into arrays.
+    await expect(
+      loadSearchParams(Promise.resolve({ tag: ["react", "vite", "zod"] }), {
+        tag: asArrayOf(asString),
+      }),
+    ).resolves.toEqual({ tag: ["react", "vite", "zod"] });
+
+    await expect(
+      loadSearchParams(Promise.resolve(new URLSearchParams("tag=react&tag=vite&tag=zod")), {
+        tag: asArrayOf(asString),
+      }),
+    ).resolves.toEqual({ tag: ["react", "vite", "zod"] });
+  });
+
+  it("keeps single and comma-joined values working unchanged", async () => {
+    await expect(
+      loadSearchParams(Promise.resolve({ tag: "react,vite" }), {
+        tag: asArrayOf(asString),
+      }),
+    ).resolves.toEqual({ tag: ["react", "vite"] });
+
+    await expect(
+      loadSearchParams(Promise.resolve({ q: "farm" }), {
+        q: asString,
+      }),
+    ).resolves.toEqual({ q: "farm" });
+  });
+
+  it("round-trips asArrayOf serialize output", async () => {
+    const parser = asArrayOf(asString);
+    const serialized = parser.serialize(["react", "vite", "zod"]);
+    await expect(
+      loadSearchParams(Promise.resolve(new URLSearchParams({ tag: serialized })), {
+        tag: parser,
+      }),
+    ).resolves.toEqual({ tag: ["react", "vite", "zod"] });
   });
 });

--- a/packages/farm/src/query/server.ts
+++ b/packages/farm/src/query/server.ts
@@ -66,7 +66,11 @@ export async function loadSearchParams<T extends Record<string, Parser<any>>>(
   const result = {} as { [K in keyof T]: ReturnType<T[K]["parse"]> };
 
   for (const [key, parser] of Object.entries(parsers)) {
-    const value = urlParams.get(key);
+    // Repeated parameters must all reach the parser: asArrayOf splits on
+    // commas — the same format its serialize writes — so joining the values
+    // round-trips, while single values pass through unchanged.
+    const values = urlParams.getAll(key);
+    const value = values.length > 1 ? values.join(",") : (values[0] ?? null);
 
     if (value !== null && value !== "") {
       try {


### PR DESCRIPTION
## Summary

Fixes #492. `loadSearchParams` carefully `append`ed every value of a repeated parameter into its `URLSearchParams` — then read back only the first with `.get()`. The multi-value branch could never take effect: `asArrayOf` received `["react"]` for `tag=react&tag=vite&tag=zod`, and the array-shaped `searchParams` page prop (the framework's own output since #365) had the same fate. Only the comma-joined string form worked, a shape the framework never produces.

## Fix

Read with `.getAll()` and join repeats with commas — precisely the format `asArrayOf.serialize` writes and its `parse` splits — so serialize/parse now round-trip. Single values (including ones containing commas) pass through exactly as before.

## Tests

First tests for `loadSearchParams`: repeated values via the array prop and via `URLSearchParams` (both fail on the old code — the repeated-values case verified via stash-revert), single values, comma-joined strings, and an `asArrayOf.serialize` round-trip. Suite passes 6/6, `tsc`/`oxlint`/`oxfmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Read every repeated query parameter in `loadSearchParams` to preserve arrays and make `asArrayOf` work with the framework’s array-shaped `searchParams`. Previously, it appended repeats but then read only the first via `.get()`, so only comma-joined strings worked.

- Replaces `.get()` with `.getAll()` and joins repeats with commas to match `asArrayOf.serialize`/`parse`; single values (including commas) remain unchanged.
- Adds tests for repeated params via array-shaped `searchParams` and `URLSearchParams`, single values, comma-joined strings, and serialize/parse round-trip.

<sup>Written for commit 5c44208b20f3b5058e96ba981e385ecb94a331ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

