### PR TITLE
fix(jobs): unwrap the declared scalar value encoding in trigger bodies

### DIFF
--- a/packages/farm-jobs/src/index.ts
+++ b/packages/farm-jobs/src/index.ts
@@ -574,7 +574,17 @@ function isLegacyScheduleBody(value: Record<string, unknown>) {
 
 function readInlinePayload(value: Record<string, unknown>, reservedKeys: readonly string[]) {
   const payload = stripReservedKeys(value, reservedKeys);
-  return Object.keys(payload).length > 0 ? payload : undefined;
+  const keys = Object.keys(payload);
+  if (keys.length === 0) {
+    return undefined;
+  }
+  // Scalar task inputs are declared as { value: TInput } in the typed body;
+  // unwrap that encoding so run() receives the scalar itself, matching the
+  // legacy { input } form. Object inputs spread inline and keep their shape.
+  if (keys.length === 1 && keys[0] === "value") {
+    return payload.value;
+  }
+  return payload;
 }
 
 async function parseRequestBody(request: Request) {

--- a/packages/farm/src/__tests__/jobs-trigger-payload.test.ts
+++ b/packages/farm/src/__tests__/jobs-trigger-payload.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createIntegrationServerClient } from "../integration-client";
+import { defineTasks, jobs, task, trigger } from "../../../farm-integrations/src/jobs/index";
+
+function jsonResponse(value: unknown, status = 200) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function createApi(tasks: Parameters<typeof jobs>[0]["tasks"]) {
+  const integration = jobs({
+    runtime: trigger({ apiKey: "tr_dev_test" }),
+    tasks,
+  });
+  return createIntegrationServerClient(
+    { integrations: { jobs: integration } },
+    { request: new Request("https://farmjs.dev/jobs") },
+  );
+}
+
+function sentPayload(fetchSpy: ReturnType<typeof vi.spyOn>, callIndex: number): unknown {
+  const init = fetchSpy.mock.calls[callIndex]?.[1] as RequestInit | undefined;
+  return JSON.parse(String(init?.body)).payload;
+}
+
+describe("jobs trigger payload shapes", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("delivers scalar { value } bodies unwrapped, matching the legacy input form", async () => {
+    const tasks = defineTasks({
+      countTokens: task({
+        description: "Scalar input task.",
+        async run(input: number) {
+          return { doubled: input * 2 };
+        },
+      }),
+    });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => jsonResponse({ id: "run_1" }));
+    const api = createApi(tasks);
+
+    // The typed body for a scalar TInput is { value: TInput }.
+    const typed = await api.jobs.countTokens.trigger({ body: { value: 42 } });
+    expect(typed.error).toBeNull();
+    expect(sentPayload(fetchSpy, 0)).toBe(42);
+
+    // The legacy { input } form must deliver the identical payload.
+    const legacy = await api.jobs.countTokens.trigger({ body: { input: 42 } });
+    expect(legacy.error).toBeNull();
+    expect(sentPayload(fetchSpy, 1)).toBe(42);
+  });
+
+  it("keeps object inputs inline, including ones with their own value field", async () => {
+    const tasks = defineTasks({
+      recordWeight: task({
+        description: "Object input task with a value field.",
+        async run(input: { value: number; unit: string }) {
+          return { stored: `${input.value}${input.unit}` };
+        },
+      }),
+    });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => jsonResponse({ id: "run_2" }));
+    const api = createApi(tasks);
+
+    const result = await api.jobs.recordWeight.trigger({
+      body: { value: 3, unit: "kg" },
+    });
+    expect(result.error).toBeNull();
+    expect(sentPayload(fetchSpy, 0)).toEqual({ value: 3, unit: "kg" });
+  });
+});


### PR DESCRIPTION
## Summary

`JobsTriggerBody<TInput>` declares scalar inputs as `{ value: TInput, $options? }` — but the server never unwrapped `value`. A task typed `task<number>` triggered through the generated client with `{ value: 42 }` delivered `{"payload": {"value": 42}}` to the provider, while the legacy `{ input: 42 }` form delivered `42`: two different `run(input)` shapes for one declared `TInput`, and `concurrencyKey`/`idempotencyKey` callbacks evaluated against the wrapper object.

## Fix

`readInlinePayload` (shared by trigger and schedule bodies) unwraps a body whose only non-reserved key is `value` — the exact scalar encoding the type declares. Object inputs spread inline keep their shape, including objects that carry their own `value` field alongside other keys. (An object input consisting of *only* a `value` key is inherently ambiguous under the declared contract; the scalar reading now matches the types.)

## Tests

New suite drives the real integration client with a spied fetch: the typed `{ value: 42 }` and legacy `{ input: 42 }` forms both deliver payload `42` (fails on the old build — the typed form delivered the wrapper; verified via stash-revert + rebuild), and an object input with a `value` field stays inline. Existing jobs-integration suite passes (9 tests total), `oxlint`/`oxfmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unwraps scalar trigger payloads so jobs and schedules deliver the declared scalar input instead of a { value } wrapper. Previously, typed bodies like { value: 42 } sent {"value":42} while the legacy { input: 42 } sent 42; now both deliver 42, and concurrencyKey/idempotencyKey evaluate against the scalar.

- readInlinePayload in `farm-jobs` unwraps when the only non-reserved key is value; object inputs stay inline, including objects that include a value field alongside others.
- Applies to trigger and schedule bodies; no API changes. If any provider or key-callback logic depended on the wrapper for typed clients, update it to accept the scalar.
- Adds integration tests in `farm` verifying both typed and legacy forms deliver identical payloads and that object inputs with value remain objects.

<sup>Written for commit 2821c1b59a1c1b2749cd0adcecce0110501c8b56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

