### PR TITLE
fix(core): keep every repeated value in loadSearchParams

### DIFF
--- a/packages/farm/src/__tests__/load-search-params.test.ts
+++ b/packages/farm/src/__tests__/load-search-params.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { asArrayOf, asInteger, asString } from "../query/parsers";
+import { loadSearchParams } from "../query/server";
+
+describe("loadSearchParams", () => {
+  it("keeps every value of an array-shaped prop", async () => {
+    const query = await loadSearchParams(Promise.resolve({ tag: ["react", "vite", "zod"] }), {
+      tag: asArrayOf(asString),
+    });
+
+    expect(query.tag).toEqual(["react", "vite", "zod"]);
+  });
+
+  it("keeps every value of a repeated URLSearchParams key", async () => {
+    const query = await loadSearchParams(
+      Promise.resolve(new URLSearchParams("tag=react&tag=vite&tag=zod")),
+      { tag: asArrayOf(asString) },
+    );
+
+    expect(query.tag).toEqual(["react", "vite", "zod"]);
+  });
+
+  it("still reads a single value", async () => {
+    const query = await loadSearchParams(Promise.resolve({ tag: "react" }), {
+      tag: asArrayOf(asString),
+    });
+
+    expect(query.tag).toEqual(["react"]);
+  });
+
+  it("still reads the comma form", async () => {
+    const query = await loadSearchParams(Promise.resolve({ tag: "react,vite,zod" }), {
+      tag: asArrayOf(asString),
+    });
+
+    expect(query.tag).toEqual(["react", "vite", "zod"]);
+  });
+
+  it("leaves a single value with a comma in it alone", async () => {
+    const query = await loadSearchParams(Promise.resolve({ q: "hello,world" }), { q: asString });
+
+    expect(query.q).toBe("hello,world");
+  });
+
+  it("parses each value of a repeated numeric parameter", async () => {
+    const query = await loadSearchParams(Promise.resolve({ id: ["1", "2", "3"] }), {
+      id: asArrayOf(asInteger),
+    });
+
+    expect(query.id).toEqual([1, 2, 3]);
+  });
+
+  it("preserves order", async () => {
+    const query = await loadSearchParams(Promise.resolve({ tag: ["c", "a", "b"] }), {
+      tag: asArrayOf(asString),
+    });
+
+    expect(query.tag).toEqual(["c", "a", "b"]);
+  });
+
+  it("falls back to the empty parse for a missing parameter", async () => {
+    const query = await loadSearchParams(Promise.resolve({}), {
+      tag: asArrayOf(asString),
+      name: asString,
+    });
+
+    expect(query.tag).toBeNull();
+    expect(query.name).toBeNull();
+  });
+});

--- a/packages/farm/src/query/server.ts
+++ b/packages/farm/src/query/server.ts
@@ -66,7 +66,12 @@ export async function loadSearchParams<T extends Record<string, Parser<any>>>(
   const result = {} as { [K in keyof T]: ReturnType<T[K]["parse"]> };
 
   for (const [key, parser] of Object.entries(parsers)) {
-    const value = urlParams.get(key);
+    // Read every value, not just the first. A repeated key is joined with commas,
+    // the format `asArrayOf` parses and its `serialize` writes, so a repeated
+    // parameter round-trips. A single value is passed through untouched, so a
+    // value that already contains commas keeps its meaning.
+    const values = urlParams.getAll(key);
+    const value = values.length > 1 ? values.join(",") : (values[0] ?? null);
 
     if (value !== null && value !== "") {
       try {


### PR DESCRIPTION
Fixes #492

## What changed

`packages/farm/src/query/server.ts` reads every value instead of just the first:

```ts
const values = urlParams.getAll(key);
const value = values.length > 1 ? values.join(",") : (values[0] ?? null);
```

New tests in `packages/farm/src/__tests__/load-search-params.test.ts`.

## Why

The function appended every value of a repeated parameter and then read it back with
`urlParams.get(key)`, which returns only the first, so the loop that collected the rest was dead
code. `asArrayOf` only ever saw one value unless the caller passed a comma-separated string.

The broken shapes are the normal ones. `loadSearchParams` takes the `searchParams` prop a page
receives, and since #365 that prop collects repeated keys into arrays at every site, so the array
form is what pages actually pass in. The `URLSearchParams` overload had the same problem.

`asArrayOf` is documented as "Repeated values" (`docs/src/app/docs/query/page.md:111`) and its
`serialize` joins with `,` (`query/parsers.ts:84`), so serialize and parse did not round-trip.

Joining with commas matches what `serialize` already writes, so the two now agree. A single value
is passed through untouched, so `?q=hello,world` with `asString` still yields `hello,world`
rather than being re-split.

## Behaviour note

A repeated parameter read through a single-value parser changes from the first value to the
joined value, so `?tag=a&tag=b` with `asString` now gives `a,b` instead of `a`. That follows from
reading every value rather than silently discarding all but one, and it is the same direction
#365 and #465 took. Nothing in the repo relied on the old result.

`loadSearchParams` is the only place this applied. The other `get` in this file
(`query/server.ts:121`) reads a page number, which is genuinely single-valued, so it is unchanged.

## Validation

Four of the eight new tests fail on `main` and pass with the change, verified by stashing only
`query/server.ts` and keeping the test file:

```
without the fix: Tests  4 failed | 4 passed (8)
  FAIL keeps every value of an array-shaped prop
  FAIL keeps every value of a repeated URLSearchParams key
  FAIL parses each value of a repeated numeric parameter
  FAIL preserves order

with the fix:    Tests  8 passed (8)
```

The other four cover a single value, the comma form, a single value containing a comma, and a
missing parameter. They pass either way and are there to catch over-correction.

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/load-search-params.test.ts`: 8 passed
- `pnpm --filter @farm.js/core exec tsc --noEmit`: clean
- `pnpm exec oxlint` on both changed files: 0 warnings, 0 errors
- `pnpm exec oxfmt --check` on both changed files: clean
- Full `@farm.js/core` suite run twice on this commit, once with the change and once with only
  `query/server.ts` reverted, then the failing test names compared. The four above fail without it
  and pass with it, and **nothing fails only with it**. Six failures are shared by both runs and
  unrelated (`autumn-usage-idempotency` x2, `polar-billing-usage` x2, `production-prebuilt-ssr`,
  `stripe-webhooks`). `production-public-dir` failed in the reverted run only and passes with the
  change, which is flakiness rather than anything this touches.

Note for anyone reproducing on Windows: `vitest run` over the whole suite exits 139 on my machine
after printing its results, a teardown segfault unrelated to any test outcome.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves all repeated query parameter values in `loadSearchParams` to align with `asArrayOf` round-trip behavior. Previously only the first value was read; now repeated keys use `URLSearchParams.getAll` and are joined with commas, so `?tag=a&tag=b` with `asString` returns `a,b` instead of `a`.

- Change is limited to `packages/farm/src/query/server.ts`; the single-valued page number read is unchanged.
- Single values and values that already contain commas are unchanged.
- Tests added in `packages/farm/src/__tests__/load-search-params.test.ts` cover repeated keys, order, numeric arrays, and edge cases.
- Migration: If you relied on first-value behavior for repeated keys, use `asArrayOf(asString)` and take the first element, or ensure only a single value is passed before parsing.

<sup>Written for commit decc2dc98318ce5ee6bf16a34a6717bb5f095e19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

