### PR TITLE
feat(docs): auto-delegate docs: {} to the farmjs docs framework (#483 phase 1)

### DIFF
--- a/packages/farm/src/__tests__/docs-framework-detect.test.ts
+++ b/packages/farm/src/__tests__/docs-framework-detect.test.ts
@@ -1,0 +1,249 @@
+// @vitest-environment node
+
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveConfig, resolveDocsConfig } from "../config";
+import {
+  applyFarmDocsFrameworkAutoDetection,
+  resetFarmDocsFrameworkDetectionNotices,
+} from "../docs/framework-detect";
+
+const tempDirs: string[] = [];
+
+async function createAppDir(options: { declareFramework?: boolean } = {}): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "farm-docs-detect-"));
+  tempDirs.push(dir);
+  await writeFile(
+    path.join(dir, "package.json"),
+    JSON.stringify({
+      name: "fixture-app",
+      ...(options.declareFramework ? { dependencies: { "@farming-labs/farmjs": "^0.2.111" } } : {}),
+    }),
+  );
+  return dir;
+}
+
+/**
+ * Install a fake @farming-labs/farmjs whose config entry mirrors the real
+ * withDocs(): prepend a Vite plugin and stamp the adapter descriptor.
+ */
+async function installFramework(
+  appDir: string,
+  options: { configSource?: string } = {},
+): Promise<void> {
+  const packageDir = path.join(appDir, "node_modules", "@farming-labs", "farmjs");
+  await mkdir(packageDir, { recursive: true });
+  await writeFile(
+    path.join(packageDir, "package.json"),
+    JSON.stringify({
+      name: "@farming-labs/farmjs",
+      version: "0.2.111",
+      type: "module",
+      exports: { "./config": "./config.js" },
+    }),
+  );
+  const source =
+    options.configSource ??
+    `const farmDocsRuntimeAdapter = {
+  id: "@farming-labs/farmjs",
+  protocol: 1,
+  server: "@farming-labs/farmjs/server",
+  react: "@farming-labs/farmjs/react",
+  vite: "@farming-labs/farmjs/vite",
+};
+export function withDocs(farmConfig, options = {}) {
+  const existing =
+    !farmConfig.docs || farmConfig.docs === true ? {} : farmConfig.docs;
+  const vite = farmConfig.vite ?? {};
+  return {
+    ...farmConfig,
+    vite: {
+      ...vite,
+      plugins: [{ name: "farmjs-docs-mdx" }, ...(vite.plugins ?? [])],
+    },
+    docs: { ...existing, enabled: true, adapter: farmDocsRuntimeAdapter },
+  };
+}
+`;
+  await writeFile(path.join(packageDir, "config.js"), source);
+}
+
+function detectionLoggers() {
+  return { log: vi.fn(), warn: vi.fn() };
+}
+
+beforeEach(() => {
+  resetFarmDocsFrameworkDetectionNotices();
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("docs framework auto-detection", () => {
+  it("applies the framework's withDocs when the package is installed", async () => {
+    const root = await createAppDir({ declareFramework: true });
+    await installFramework(root);
+    const { log, warn } = detectionLoggers();
+
+    const applied = await applyFarmDocsFrameworkAutoDetection(
+      { root, docs: { entry: "/handbook" }, vite: { plugins: [{ name: "app-plugin" }] } } as any,
+      { root, log, warn },
+    );
+
+    expect(applied.docs.adapter).toMatchObject({
+      id: "@farming-labs/farmjs",
+      protocol: 1,
+      server: "@farming-labs/farmjs/server",
+      react: "@farming-labs/farmjs/react",
+    });
+    // Existing docs options and vite plugins survive, MDX plugin is prepended.
+    expect(applied.docs.entry).toBe("/handbook");
+    expect((applied.vite as any).plugins.map((plugin: any) => plugin.name)).toEqual([
+      "farmjs-docs-mdx",
+      "app-plugin",
+    ]);
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("leaves configs with an explicit adapter or opt-out untouched", async () => {
+    const root = await createAppDir({ declareFramework: true });
+    await installFramework(root);
+    const { log, warn } = detectionLoggers();
+    const explicitAdapter = {
+      id: "custom",
+      protocol: 1,
+      server: "custom/server",
+      react: "custom/react",
+    };
+
+    const withExplicit = { root, docs: { adapter: explicitAdapter } } as any;
+    expect(await applyFarmDocsFrameworkAutoDetection(withExplicit, { root, log, warn })).toBe(
+      withExplicit,
+    );
+
+    const optedOut = { root, docs: { adapter: false } } as any;
+    expect(await applyFarmDocsFrameworkAutoDetection(optedOut, { root, log, warn })).toBe(optedOut);
+
+    const disabled = { root, docs: false } as any;
+    expect(await applyFarmDocsFrameworkAutoDetection(disabled, { root, log, warn })).toBe(disabled);
+
+    expect(log).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the embedded renderer with a one-time notice when not installed", async () => {
+    const root = await createAppDir();
+    const { log, warn } = detectionLoggers();
+    const config = { root, docs: {} } as any;
+
+    const detect = () => applyFarmDocsFrameworkAutoDetection(config, { root, log, warn });
+    expect(await detect()).toBe(config);
+    expect(await detect()).toBe(config);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("@farming-labs/farmjs");
+    expect(warn.mock.calls[0][0]).toContain("docs.adapter = false");
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("keeps the embedded renderer when the installed adapter protocol is unsupported", async () => {
+    const root = await createAppDir({ declareFramework: true });
+    await installFramework(root, {
+      configSource: `export function withDocs(farmConfig) {
+  return {
+    ...farmConfig,
+    docs: {
+      enabled: true,
+      adapter: { id: "@farming-labs/farmjs", protocol: 2, server: "x", react: "y" },
+    },
+  };
+}
+`,
+    });
+    const { log, warn } = detectionLoggers();
+    const config = { root, docs: {} } as any;
+
+    expect(await applyFarmDocsFrameworkAutoDetection(config, { root, log, warn })).toBe(config);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("protocol 1");
+  });
+
+  it("survives a framework config entry that throws", async () => {
+    const root = await createAppDir({ declareFramework: true });
+    await installFramework(root, {
+      configSource: `throw new Error("framework exploded");
+`,
+    });
+    const { log, warn } = detectionLoggers();
+    const config = { root, docs: {} } as any;
+
+    expect(await applyFarmDocsFrameworkAutoDetection(config, { root, log, warn })).toBe(config);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("framework exploded");
+  });
+});
+
+describe("resolveConfig docs delegation (#483 phase 1)", () => {
+  it("resolves docs: {} to the framework adapter when installed", async () => {
+    const root = await createAppDir({ declareFramework: true });
+    await installFramework(root);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const resolved = await resolveConfig({ root, docs: {} } as any, "development");
+
+    expect(resolved.docs.enabled).toBe(true);
+    expect(resolved.docs.adapter).toMatchObject({
+      protocol: 1,
+      server: "@farming-labs/farmjs/server",
+      react: "@farming-labs/farmjs/react",
+    });
+    expect((resolved.vite as any).plugins?.[0]?.name).toBe("farmjs-docs-mdx");
+  });
+
+  it("keeps the embedded handler for non-React renderers even when installed", async () => {
+    const root = await createAppDir({ declareFramework: true });
+    await installFramework(root);
+    const { warn } = detectionLoggers();
+    vi.spyOn(console, "warn").mockImplementation(warn);
+
+    const resolved = await resolveConfig(
+      {
+        root,
+        docs: {},
+        renderer: {
+          name: "svelte",
+          vite: "@farm.js/svelte/vite",
+          server: "@farm.js/svelte/server",
+          client: "@farm.js/svelte/client",
+        },
+      } as any,
+      "development",
+    );
+
+    expect(resolved.docs.enabled).toBe(true);
+    expect(resolved.docs.adapter).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("treats docs.adapter = false as the embedded renderer without notices", async () => {
+    const root = await createAppDir({ declareFramework: true });
+    await installFramework(root);
+    const { warn } = detectionLoggers();
+    vi.spyOn(console, "warn").mockImplementation(warn);
+
+    const resolved = await resolveConfig({ root, docs: { adapter: false } } as any, "development");
+
+    expect(resolved.docs.enabled).toBe(true);
+    expect(resolved.docs.adapter).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+
+    const docsOnly = await resolveDocsConfig({ adapter: false }, { root });
+    expect(docsOnly.enabled).toBe(true);
+    expect(docsOnly.adapter).toBeUndefined();
+  });
+});

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -80,8 +80,9 @@ import {
 } from "./security";
 import { resolveFarmThemeConfig } from "./theme/config";
 import type { ResolvedFarmThemeConfig } from "./theme/types";
-import { resolveFarmRenderer } from "./renderer";
+import { isReactRenderer, resolveFarmRenderer } from "./renderer";
 import type { FarmRenderer } from "./renderer";
+import { applyFarmDocsFrameworkAutoDetection } from "./docs/framework-detect";
 import { resolveFarmAPIConfig, type ResolvedFarmAPIConfig } from "./api/config";
 
 const FARM_RESOLVED_CUSTOM_CONTEXT = Symbol.for("farm.resolvedCustomContext");
@@ -857,6 +858,14 @@ export async function resolveConfig(
     mode,
   });
   userConfig = layerResolution.config;
+
+  // The docs adapter runtime is React-only today; other renderers keep the
+  // embedded docs handler without any migration notice.
+  if (isReactRenderer(resolveFarmRenderer(userConfig.renderer))) {
+    userConfig = await applyFarmDocsFrameworkAutoDetection(userConfig, {
+      root: userConfig.root || projectRoot,
+    });
+  }
 
   const redirects =
     typeof userConfig.redirects === "function"

--- a/packages/farm/src/docs/framework-detect.ts
+++ b/packages/farm/src/docs/framework-detect.ts
@@ -1,0 +1,166 @@
+import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import type { FarmDocsAdapterDescriptor, FarmDocsUserConfig } from "./types";
+
+const FRAMEWORK_PACKAGE = "@farming-labs/farmjs";
+const FRAMEWORK_CONFIG_ENTRY = "@farming-labs/farmjs/config";
+
+/**
+ * The adapter descriptor protocol this core release knows how to drive.
+ * Auto-detection must never wire up a descriptor from a future framework
+ * release that this core cannot interpret; explicit withDocs() usage stays
+ * the user's own call.
+ */
+const SUPPORTED_ADAPTER_PROTOCOL = 1;
+
+export interface FarmDocsFrameworkDetectionOptions {
+  root: string;
+  log?: (message: string) => void;
+  warn?: (message: string) => void;
+}
+
+/**
+ * Delegation triggers only for a dependency the app declared itself. A copy
+ * that is merely resolvable through hoisting or a transitive dependency must
+ * not silently change how the app's docs are served.
+ */
+async function frameworkDeclaredByApp(root: string): Promise<boolean> {
+  try {
+    const raw = await readFile(path.join(root, "package.json"), "utf8");
+    const manifest = JSON.parse(raw) as Record<string, unknown>;
+    for (const field of ["dependencies", "devDependencies", "peerDependencies"]) {
+      const section = manifest[field];
+      if (section && typeof section === "object" && FRAMEWORK_PACKAGE in section) {
+        return true;
+      }
+    }
+  } catch {
+    // Unreadable manifest: treat as not declared and keep the embedded renderer.
+  }
+  return false;
+}
+
+const emittedNotices = new Set<string>();
+
+/** Test hook: notices are once-per-process so dev-server restarts stay quiet. */
+export function resetFarmDocsFrameworkDetectionNotices(): void {
+  emittedNotices.clear();
+}
+
+function noticeOnce(key: string, emit: (message: string) => void, message: string): void {
+  if (emittedNotices.has(key)) return;
+  emittedNotices.add(key);
+  emit(message);
+}
+
+function docsWantsFrameworkDetection(docs: FarmDocsUserConfig | undefined): boolean {
+  if (docs === true) return true;
+  if (!docs || typeof docs !== "object") return false;
+  if (docs.enabled === false) return false;
+  // An explicit descriptor means the app already wired an adapter; an
+  // explicit `false` is the opt-out that pins the embedded renderer.
+  if (docs.adapter !== undefined) return false;
+  return true;
+}
+
+function isSupportedAdapterDescriptor(value: unknown): value is FarmDocsAdapterDescriptor {
+  if (!value || typeof value !== "object") return false;
+  const descriptor = value as Partial<FarmDocsAdapterDescriptor>;
+  return (
+    descriptor.protocol === SUPPORTED_ADAPTER_PROTOCOL &&
+    typeof descriptor.server === "string" &&
+    descriptor.server.length > 0 &&
+    typeof descriptor.react === "string" &&
+    descriptor.react.length > 0
+  );
+}
+
+/**
+ * Delegate `docs: {}` to the @farming-labs/farmjs docs framework when the app
+ * has it installed (#483 phase 1).
+ *
+ * Detection applies the framework's own withDocs() to the user config, so the
+ * result is byte-for-byte what a manual `withDocs(defineConfig(...))` produces:
+ * the MDX Vite plugin plus the versioned adapter descriptor. When the package
+ * is absent the embedded renderer keeps serving, with a one-time migration
+ * notice. Any failure falls back to the embedded renderer instead of breaking
+ * a working app.
+ */
+export async function applyFarmDocsFrameworkAutoDetection<
+  T extends { docs?: FarmDocsUserConfig; vite?: unknown },
+>(userConfig: T, options: FarmDocsFrameworkDetectionOptions): Promise<T> {
+  if (!docsWantsFrameworkDetection(userConfig.docs)) return userConfig;
+
+  const log = options.log ?? ((message: string) => console.log(message));
+  const warn = options.warn ?? ((message: string) => console.warn(message));
+  const root = path.resolve(options.root || process.cwd());
+
+  if (!(await frameworkDeclaredByApp(root))) {
+    noticeOnce(
+      "embedded-fallback",
+      warn,
+      `[farm] docs is served by the embedded renderer, which is being replaced by the ${FRAMEWORK_PACKAGE} docs framework. ` +
+        `Install ${FRAMEWORK_PACKAGE} (with @farming-labs/docs and @farming-labs/theme) to migrate now, ` +
+        "or set docs.adapter = false to keep the embedded renderer and silence this notice.",
+    );
+    return userConfig;
+  }
+
+  let configEntryPath: string;
+  try {
+    const requireFromApp = createRequire(path.join(root, "package.json"));
+    configEntryPath = requireFromApp.resolve(FRAMEWORK_CONFIG_ENTRY);
+  } catch {
+    noticeOnce(
+      "declared-not-installed",
+      warn,
+      `[farm] ${FRAMEWORK_PACKAGE} is declared in package.json but could not be resolved; ` +
+        "keeping the embedded docs renderer. Run your package manager's install to enable docs delegation.",
+    );
+    return userConfig;
+  }
+
+  try {
+    const frameworkConfig = await import(/* @vite-ignore */ pathToFileURL(configEntryPath).href);
+    const withDocs = frameworkConfig?.withDocs;
+    if (typeof withDocs !== "function") {
+      noticeOnce(
+        "missing-withdocs",
+        warn,
+        `[farm] ${FRAMEWORK_CONFIG_ENTRY} does not export withDocs(); keeping the embedded docs renderer.`,
+      );
+      return userConfig;
+    }
+
+    const applied = withDocs(userConfig);
+    const adapter = (applied as { docs?: { adapter?: unknown } } | undefined)?.docs?.adapter;
+    if (!isSupportedAdapterDescriptor(adapter)) {
+      noticeOnce(
+        "unsupported-descriptor",
+        warn,
+        `[farm] The installed ${FRAMEWORK_PACKAGE} release publishes a docs adapter this Farm version cannot drive ` +
+          `(need protocol ${SUPPORTED_ADAPTER_PROTOCOL}); keeping the embedded docs renderer. ` +
+          "Upgrading @farm.js/core usually resolves this.",
+      );
+      return userConfig;
+    }
+
+    noticeOnce(
+      "delegated",
+      log,
+      `[farm] docs: delegated to ${FRAMEWORK_PACKAGE} (detected in this app). ` +
+        "Set docs.adapter = false to keep the embedded renderer.",
+    );
+    return applied as T;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    noticeOnce(
+      "detect-failed",
+      warn,
+      `[farm] Failed to load ${FRAMEWORK_CONFIG_ENTRY} (${message}); keeping the embedded docs renderer.`,
+    );
+    return userConfig;
+  }
+}

--- a/packages/farm/src/docs/types.ts
+++ b/packages/farm/src/docs/types.ts
@@ -63,8 +63,12 @@ export type FarmDocsRuntimeConfig = Partial<DocsConfig> & {
 };
 
 export type FarmDocsConfigInput = FarmDocsRuntimeConfig & {
-  /** Versioned runtime descriptor supplied by an external docs adapter. */
-  adapter?: FarmDocsAdapterDescriptor;
+  /**
+   * Versioned runtime descriptor supplied by an external docs adapter.
+   * Set false to pin the embedded renderer and disable framework
+   * auto-detection.
+   */
+  adapter?: FarmDocsAdapterDescriptor | false;
   /**
    * Farm public route for docs, e.g. "/docs". When passed through
    * `config`, this is converted to the docs package's folder-style `entry`.


### PR DESCRIPTION
first phase of #483.

## what this does

when all of these hold:

- `docs` is enabled in farm.config with no `adapter` set
- the app's own package.json declares `@farming-labs/farmjs` as a dependency
- the renderer is react (the adapter runtime is react-only today)

config resolution now resolves `@farming-labs/farmjs/config` from the app and applies the framework's own `withDocs()` to the loaded config. the result is byte for byte what a manual `withDocs(defineConfig(...))` produces: the mdx vite plugin prepended plus the protocol-1 adapter descriptor, so the existing adapter path in dev dispatch and universal-build takes over from there. `docs: {}` stays the only user-facing config.

when the package is not declared, the embedded renderer keeps serving and a one-time notice suggests installing the framework or setting `docs.adapter = false` to pin the embedded renderer (new opt-out, also silences the notice).

## safety rails

detection can never take down a working app. every failure path falls back to the embedded renderer with a one-time warning instead of throwing:

- declared in package.json but not resolvable (install not run)
- config entry missing the `withDocs` export
- adapter descriptor with a protocol other than 1 (a future framework release this core can't drive)
- config entry that throws on import

two deliberate gates worth calling out:

- delegation only triggers on a dependency the app declared itself, not on a copy that happens to be resolvable through hoisting or a transitive dep. silently switching docs pipelines because some other package pulled the framework in would be a footgun.
- apps already using `withDocs` have `docs.adapter` set, so detection skips them entirely, no behavior change and no log lines.

## what phase 1 does not do

per the parity audit on the issue: the framework has no social image generation yet, so delegated docs (manual withDocs today, auto-detected now) don't emit docs og images. that's the blocker for phase 3 (deleting the embedded handler) and needs og support upstream first. the embedded handler is untouched here.

## testing

- new suite covers: happy-path delegation (adapter + vite plugin + preserved docs options), explicit adapter skip, `adapter: false` opt-out, not-installed fallback with one-time notice, unsupported protocol fallback, throwing config entry, resolveConfig-level integration, and the non-react renderer gate
- full farm package suite: 1230 passed, 154 files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delegates docs: {} to the `@farming-labs/farmjs` docs framework when the app declares it; previously `docs: {}` always used the embedded renderer. This matches manual `withDocs()` and includes safety fallbacks so existing apps keep working.

- Behavior
  - Delegation triggers only when all hold: docs enabled with no `adapter`, the app’s own package.json lists `@farming-labs/farmjs`, and the renderer is React.
  - Resolves `@farming-labs/farmjs/config` and applies `withDocs()`, which prepends the MDX Vite plugin and sets a protocol-1 adapter descriptor (identical to manual `withDocs()`).
  - No change for non-React renderers, or when `docs.adapter` is set, or when `docs.adapter` is `false`.
  - Safety rails: undeclared/unresolvable package, missing `withDocs`, unsupported adapter protocol, or import errors all fall back to the embedded renderer with a one-time notice; hoisted/transitive copies are ignored.
  - Types: `docs.adapter` now accepts `false` to pin the embedded renderer and silence notices.

- Rollout and migration
  - To migrate, add `@farming-labs/farmjs` (with `@farming-labs/docs` and `@farming-labs/theme`) to app dependencies; with `docs: {}` and React, delegation activates automatically.
  - To stay on the embedded docs, set `docs.adapter = false`.

<sup>Written for commit b856e0190735b9955ad4b82123c6f4d336a7c30f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

