### PR TITLE
fix(hmr): stop at accepting boundaries instead of skipping them

### DIFF
--- a/packages/farm/src/__tests__/hmr-manager.test.ts
+++ b/packages/farm/src/__tests__/hmr-manager.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from "vitest";
+import type { ModuleNode, ViteDevServer } from "vite";
+import { HMRManager } from "../hmr";
+
+interface FakeModuleInit {
+  url: string;
+  type?: "js" | "css";
+  isSelfAccepting?: boolean;
+}
+
+function createModule(init: FakeModuleInit): ModuleNode {
+  return {
+    url: init.url,
+    type: init.type ?? "js",
+    isSelfAccepting: init.isSelfAccepting ?? false,
+    importers: new Set<ModuleNode>(),
+    acceptedHmrDeps: new Set<ModuleNode>(),
+  } as unknown as ModuleNode;
+}
+
+function link(importer: ModuleNode, imported: ModuleNode, options: { accepts?: boolean } = {}) {
+  (imported.importers as Set<ModuleNode>).add(importer);
+  if (options.accepts) {
+    (importer.acceptedHmrDeps as Set<ModuleNode>).add(imported);
+  }
+}
+
+function createServer(changed: ModuleNode) {
+  const send = vi.fn();
+  const server = {
+    ws: { send },
+    moduleGraph: {
+      getModuleByUrl: vi.fn(async () => changed),
+      invalidateModule: vi.fn(),
+    },
+  } as unknown as ViteDevServer;
+  return { server, send };
+}
+
+function sentUpdatePaths(send: ReturnType<typeof vi.fn>): string[] {
+  const payload = send.mock.calls[0]?.[0];
+  return (payload?.updates ?? []).map((update: { path: string }) => update.path).sort();
+}
+
+describe("HMRManager affected-module traversal", () => {
+  it("includes the self-accepting boundary and stops above it", async () => {
+    // page -> widget(self-accepting) -> util(changed)
+    const util = createModule({ url: "/src/util.ts" });
+    const widget = createModule({ url: "/src/widget.ts", isSelfAccepting: true });
+    const page = createModule({ url: "/src/page.ts" });
+    link(widget, util);
+    link(page, widget);
+    const { server, send } = createServer(util);
+
+    await new HMRManager(server).handleFileChange("/src/util.ts");
+
+    // The boundary itself must receive the update; its importers must not.
+    expect(sentUpdatePaths(send)).toEqual(["/src/util.ts", "/src/widget.ts"]);
+  });
+
+  it("stops at the changed module when it accepts itself", async () => {
+    const widget = createModule({ url: "/src/widget.ts", isSelfAccepting: true });
+    const page = createModule({ url: "/src/page.ts" });
+    link(page, widget);
+    const { server, send } = createServer(widget);
+
+    await new HMRManager(server).handleFileChange("/src/widget.ts");
+
+    expect(sentUpdatePaths(send)).toEqual(["/src/widget.ts"]);
+  });
+
+  it("stops at an importer that accepts the changed dependency", async () => {
+    // page -> consumer(accepts dep) -> dep(changed)
+    const dep = createModule({ url: "/src/dep.ts" });
+    const consumer = createModule({ url: "/src/consumer.ts" });
+    const page = createModule({ url: "/src/page.ts" });
+    link(consumer, dep, { accepts: true });
+    link(page, consumer);
+    const { server, send } = createServer(dep);
+
+    await new HMRManager(server).handleFileChange("/src/dep.ts");
+
+    expect(sentUpdatePaths(send)).toEqual(["/src/consumer.ts", "/src/dep.ts"]);
+  });
+
+  it("keeps climbing through importers that do not accept", async () => {
+    // root -> mid -> leaf(changed), nobody accepts
+    const leaf = createModule({ url: "/src/leaf.ts" });
+    const mid = createModule({ url: "/src/mid.ts" });
+    const root = createModule({ url: "/src/root.ts" });
+    link(mid, leaf);
+    link(root, mid);
+    const { server, send } = createServer(leaf);
+
+    await new HMRManager(server).handleFileChange("/src/leaf.ts");
+
+    expect(sentUpdatePaths(send)).toEqual(["/src/leaf.ts", "/src/mid.ts", "/src/root.ts"]);
+  });
+
+  it("still climbs through a module that is a boundary for one edge but not another", async () => {
+    // shared imports both: a (accepted) and b (not accepted); changed module
+    // feeds both edges. The climb through b must not be blocked by shared's
+    // boundary role on the a edge.
+    const changed = createModule({ url: "/src/changed.ts" });
+    const a = createModule({ url: "/src/a.ts" });
+    const b = createModule({ url: "/src/b.ts" });
+    const shared = createModule({ url: "/src/shared.ts" });
+    const top = createModule({ url: "/src/top.ts" });
+    link(a, changed);
+    link(b, changed);
+    link(shared, a, { accepts: true });
+    link(shared, b);
+    link(top, shared);
+    const { server, send } = createServer(changed);
+
+    await new HMRManager(server).handleFileChange("/src/changed.ts");
+
+    expect(sentUpdatePaths(send)).toEqual([
+      "/src/a.ts",
+      "/src/b.ts",
+      "/src/changed.ts",
+      "/src/shared.ts",
+      "/src/top.ts",
+    ]);
+  });
+
+  it("survives importer cycles", async () => {
+    const one = createModule({ url: "/src/one.ts" });
+    const two = createModule({ url: "/src/two.ts" });
+    link(two, one);
+    link(one, two);
+    const { server, send } = createServer(one);
+
+    await new HMRManager(server).handleFileChange("/src/one.ts");
+
+    expect(sentUpdatePaths(send)).toEqual(["/src/one.ts", "/src/two.ts"]);
+  });
+});

--- a/packages/farm/src/hmr.ts
+++ b/packages/farm/src/hmr.ts
@@ -78,11 +78,19 @@ export class HMRManager {
       seen.add(mod);
       affected.add(mod);
 
-      // Traverse importers
+      // A self-accepting module is the HMR boundary: it re-runs with the
+      // update, so nothing above it is affected.
+      if (mod.isSelfAccepting) return;
+
       for (const importer of mod.importers) {
-        if (!importer.isSelfAccepting) {
-          traverse(importer);
+        // An importer that accepts this dependency is likewise a boundary:
+        // it receives the update, but its own importers do not. Accepting is
+        // per-edge, so the importer stays traversable via other dependencies.
+        if (importer.acceptedHmrDeps?.has(mod)) {
+          affected.add(importer);
+          continue;
         }
+        traverse(importer);
       }
     };
 


### PR DESCRIPTION
`HMRManager.getAffectedModules` had its boundary handling inverted: `if (!importer.isSelfAccepting) traverse(importer)` dropped self-accepting importers from the affected set entirely and kept climbing through everything else. the boundary is exactly the module that must receive the update, and nothing above it is affected, so the old traversal produced updates that miss the one module able to apply them.

## what changed

- a self-accepting module is included in the affected set and the climb stops there (including when the changed module itself self-accepts, which previously still dragged all its importers in)
- an importer that accepts the changed dependency via `acceptedHmrDeps` is treated the same way: it gets the update, its own importers don't
- accepting is per edge, so a module that is a boundary for one dependency stays traversable through its other, non-accepted edges

## testing

six new tests over a fake module graph: boundary inclusion + stop, self-accepting root, `acceptedHmrDeps` boundary, non-accepting climb-through, the per-edge case where one module is a boundary for one edge and a plain importer for another, and importer cycles. the three boundary tests fail on the old code. full farm suite: 1236 passed.

note: `HMRManager` is exported from the package root but unused internally, so this only affects external consumers of the class.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes HMR traversal to stop at accepting boundaries instead of skipping them. Previously `HMRManager.getAffectedModules` skipped self-accepting importers and continued climbing, which could miss the only module capable of applying the update; now self-accepting modules and importers that accept a changed dependency receive the update and terminate traversal.

- Includes a self-accepting module in the affected set and stops above it (including when the changed module self-accepts).
- Treats an importer that accepts a dependency via `acceptedHmrDeps` as a boundary; accepting is per edge, so other non-accepted edges remain traversable.
- Keeps climbing through non-accepting importers; handles importer cycles.

**Notes for reviewers**
- Adds focused tests over a fake module graph; boundary cases fail on the old code.
- Only affects external consumers of `HMRManager`; no internal usage changes.
- No migration required, but downstream code that relied on the previous over-traversal will see fewer upstream modules in the affected set.

<sup>Written for commit 041217342ab7b39618e302dfc68b49c3292c895b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

