### PR TITLE
feat(react): compile keyed ranges between static siblings

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -731,15 +731,55 @@ state. The surrounding compiled component can still avoid executing again. Hooks
 row component such as `InventoryRow`, never directly inside the `List` child function or a
 `.map()` callback.
 
-The compiler uses three keyed-list tiers:
+The compiler uses four keyed-list tiers:
 
 1. A dedicated nested host container with one direct map or one `List`, returning a non-interactive
    host-only row, becomes compiler-owned keyed row instances. Farm patches bindings and uses LIS.
-2. The same host-only shape with eligible inline events or dedicated row-local conditional slots
+2. A nested host container with static host siblings and one or more non-interactive keyed host
+   ranges becomes one compiler-owned range block. Farm preserves the static segments and applies
+   the same row descriptors and LIS reconciliation independently inside each range.
+3. The dedicated single-list shape with eligible inline events or row-local conditional slots
    keeps React event and structural ownership, while Farm patches same-key row bindings and refreshes
    only changed conditional boundaries.
-3. A safe keyed map or `List` that cannot use either optimized row shape becomes a small React-owned keyed
+4. A safe keyed map or `List` that cannot use an optimized row shape becomes a small React-owned keyed
    boundary. React reconciles its rows, while the outer user component still avoids rerunning.
+
+#### Keyed DOM ranges
+
+Static siblings no longer force ordinary host rows onto the React-owned list tier:
+
+```tsx
+<ul>
+  <li className="heading">Primary</li>
+  {primary.map((item) => (
+    <li key={item.id}>{item.label}</li>
+  ))}
+
+  <li className="heading">Secondary</li>
+  {secondary.map((item) => (
+    <li key={item.id}>{item.label}</li>
+  ))}
+
+  <li>{primary.length + secondary.length} total</li>
+</ul>
+```
+
+React renders or hydrates the original `ul` without wrapper elements or marker nodes. After mount,
+the range block partitions its direct element children into static segments and keyed ranges using
+the build-time shape and current collection lengths. Static header, divider, and footer elements
+retain their DOM identity. Each range keeps its own key-to-row table and LIS calculation, so an
+update in one range cannot reorder another range or its surrounding static elements. Stateful text,
+attributes, and styles inside the static host siblings continue to use the outer component's direct
+bindings.
+
+The first range-owned contract is deliberately non-interactive. Every meaningful direct child of
+the container must be either a lowercase host element or an eligible keyed map/`List`; every range
+must return a statically known host tree without events or row-local conditional slots. The
+component's outermost return container, fragments, components between ranges, interactive or
+controlled rows, and nested dynamic structures use the existing React-owned boundaries. Parent
+prop or compatible Fast Refresh changes remount this one range container through React so static
+markup cannot become stale. Duplicate keys or a mount/hydration shape that cannot be adopted also
+switch the complete container to React before later updates.
 
 The optimized host-row contract is deliberately narrow:
 
@@ -749,9 +789,9 @@ The optimized host-row contract is deliberately narrow:
   across insertion, removal, or reordering.
 - The optimized `List` shape uses inline `by` and child functions, a compiler-safe `each`
   expression, and an item-derived key.
-- The list must be the only meaningful child of its own nested lowercase host container. The
-  component's outermost return element and a container with static siblings use the React-owned
-  boundary for now.
+- A single interactive list must be the only meaningful child of its nested lowercase host
+  container. Non-interactive host rows may instead occupy one or more ranges separated by direct
+  host siblings. The component's outermost return container remains React-owned for now.
 - The row is a statically known HTML host tree. Dynamic leaf text, attributes, controlled host
   properties, and individual inline style properties are supported.
 - Inline synchronous row events and dedicated logical or ternary host slots are supported by the
@@ -848,6 +888,7 @@ component.
 | ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
 | Unkeyed/index-keyed maps, unsupported or mutating collection pipelines, or element arrays                    | Their structure, purity, or item identity is outside the keyed-list contract.      |
 | Unsupported row events/forms, components, fragments, refs, SVG, nested blocks, or mixed conditional slots    | Their event, lifecycle, or structure contract requires the React-owned row path.   |
+| Interactive ranges beside siblings, non-host range siblings, or a range in the component root                | The first range owner requires one nested host container and non-interactive rows. |
 | Branch events, keys, components, fragments, refs, SVG, or nested blocks in a dedicated conditional container | They require the React-owned conditional path rather than compiler-created hosts.  |
 | Dynamic/member component types, component spreads, refs, keys, or children                                   | Their identity or ownership is outside the first component-island contract.        |
 | Effects or hooks other than the supported `useState` shape                                                   | Their lifecycle and ordering must remain under React's hook dispatcher.            |
@@ -1000,6 +1041,9 @@ The package and example test suites verify more than generated code:
 - compiler-owned host rows patch text, attributes, and styles in place, preserve focus and text
   selection, use the LIS minimum for measured rotations and reversals, and remount through React
   when runtime keys are duplicated;
+- keyed DOM ranges preserve static siblings around multiple lists, support adjacent empty ranges,
+  apply LIS independently per range, and remount the complete container through React when keys or
+  parent-driven static markup invalidate adoption;
 - interactive host rows keep React event propagation and `currentTarget`, resolve the latest item
   and index after same-key replacements and reorders, let React own structural commits, and resume
   direct binding patches without stale virtual-prop output;
@@ -1018,6 +1062,8 @@ The package and example test suites verify more than generated code:
 - 1,000 deterministic object, array, and nullish component-prop transitions match normal React;
 - 1,000 deterministic randomized compiler-owned list operations produce the same ordered output as
   normal React while the list owner stays at one execution;
+- 2,000 deterministic updates across two keyed ranges match normal React while every static sibling
+  and surviving row keeps its DOM identity and the owner stays at one execution;
 - 5,000 deterministic filter, sort, slice, reverse, insertion, removal, and row-update transitions
   produce the same keyed output as normal React while preserving surviving DOM rows;
 - 4,000 deterministic interactive data, structure, and event transitions match normal React while
@@ -1032,9 +1078,9 @@ The package and example test suites verify more than generated code:
   keyed DOM identity and capture/stop-propagation behavior, and observes zero owner update
   executions;
 - the public `List` renders iterable and nullish collections correctly with the compiler off;
-- the packaged runtime, including editable and interactive keyed-row events, row-local conditions,
-  reorders, identity, selection, and hydration, is exercised separately with React 18.3 and React
-  19;
+- the packaged runtime, including keyed ranges, editable and interactive keyed-row events,
+  row-local conditions, reorders, identity, selection, and hydration, is exercised separately with
+  React 18.3 and React 19;
 - boolean `data-*` and `aria-*` attributes keep React-compatible string values; and
 - unsupported list shapes, effects, refs, and unsupported dynamic component-island shapes remain
   on React without corrupting output.

--- a/examples/react-compiler/README.md
+++ b/examples/react-compiler/README.md
@@ -41,6 +41,7 @@ assertions, checks for console/runtime errors and horizontal overflow, saves scr
 | Editable keyed rows         | caret, fields, identity, and a 256-row load; executions `0` | —                                           | Controlled form properties update by key without rerunning the owner.  |
 | Conditional row blocks      | only changed keyed branches refresh; owner executions `0`  | —                                           | Per-key snapshots isolate logical and ternary row content.              |
 | Explicit `List`             | stateful rows reorder, update executions `0`            | —                                              | React preserves custom-row state by key inside the isolated boundary.  |
+| Keyed DOM ranges            | two ranges, static-shell identity, three LIS moves, 1,024-row load | —                                    | Multiple host lists reconcile independently inside one container.      |
 | Calculated style bindings   | value `6`, progress `50%`, update executions `0`        | —                                              | Safe calls and individual CSS properties use prepared dependencies.    |
 | Controlled form bindings   | textarea/select/checkbox update, executions `0`         | —                                              | Form properties and textarea selection stay coherent.                  |
 | Logical conditional block  | stable branch patches, mounts, and unmounts; executions `0` | —                                           | A proven host branch updates without React reconciliation.             |
@@ -85,12 +86,12 @@ use the same compiler-owned row path. A custom stateful row such as `<Row item={
 React-owned keyed boundary so React preserves its Hooks, events, lifecycle, and Fiber state. The
 outer compiled component can still avoid rerunning.
 
-The compiler-owned path requires one keyed map or `List` as the only meaningful child of a nested
-host container. Its collection may chain synchronous inline `filter`, `slice`, `toSorted`, and
-`toReversed` operations. The compiler records the state dependencies used by those operations and
-reruns the pipeline only when one changes; it still performs the necessary filtering or sorting.
-Mutating methods, external or async callbacks, Hooks, assignments, spread arguments, and unproven
-calls fall back to React.
+The compiler-owned path supports one dedicated keyed map/`List`, or multiple non-interactive host
+ranges separated by direct host siblings in one nested container. A collection may chain
+synchronous inline `filter`, `slice`, `toSorted`, and `toReversed` operations. The compiler records
+the state dependencies used by those operations and reruns the pipeline only when one changes; it
+still performs the necessary filtering or sorting. Mutating methods, external or async callbacks,
+Hooks, assignments, spread arguments, and unproven calls fall back to React.
 
 An otherwise eligible host row can include inline synchronous events. React installs and dispatches
 those event props; Farm does not add a native listener. A stable proxy resolves the newest item and
@@ -118,8 +119,14 @@ commit. This is why row conditionals do not use the manual insertion or LIS path
 components, fragments, refs, SVG, nested blocks, or a conditional mixed with another child in the
 same slot use the existing React-owned list fallback.
 
+The `04G` card places two non-interactive maps between a shared header, divider, and footer. React
+renders the original `ul`; Farm adopts the direct element ranges after mount without inserting a
+wrapper or hydration marker. The production test rotates both ranges, observes three total LIS
+moves, preserves both surviving rows and all static siblings, crosses empty ranges, loads 1,024
+rows, and records zero owner update executions.
+
 Non-inline or async row handlers, unsupported form shapes, custom components, fragments, refs, SVG,
-static siblings in that same container, and index or missing keys use the React-owned list path.
+interactive ranges beside siblings, and index or missing keys use the React-owned list path.
 Duplicate keys discovered at runtime remount that container through React. LIS applies to
 non-interactive compiler-owned rows; interactive structural changes intentionally stay with React.
 Neither path makes insertions, removals, key comparison, collection work, or DOM updates disappear.

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -33,6 +33,7 @@ for (const component of [
   "EditableKeyedListExperiment",
   "RowConditionalListExperiment",
   "ExplicitKeyedListExperiment",
+  "KeyedRangeExperiment",
   "StatefulListRow",
   "ComponentIslandExperiment",
   "ComposableBlockExperiment",
@@ -653,6 +654,91 @@ try {
   );
   assert.equal(editableListFinalExecutions - editableListInitialExecutions, 0);
 
+  const keyedRanges = '[data-experiment="keyed-ranges"]';
+  const keyedRangesInitialExecutions = await readNumber(
+    page,
+    `${keyedRanges} [data-metric="executions"]`,
+  );
+  await page.evaluate(() => {
+    const list = document.querySelector(
+      '[data-experiment="keyed-ranges"] [data-list="ranges"]',
+    );
+    window.__farmRangeHeader = list.querySelector('[data-static="range-header"]');
+    window.__farmRangeDivider = list.querySelector('[data-static="range-divider"]');
+    window.__farmRangeFooter = list.querySelector('[data-static="range-footer"]');
+    window.__farmRangeA = list.querySelector('[data-key="a"]');
+    window.__farmRangeX = list.querySelector('[data-key="x"]');
+    window.__farmRangeMoves = 0;
+    const insertBefore = list.insertBefore.bind(list);
+    list.insertBefore = (node, anchor) => {
+      if (node.parentNode === list && node.matches?.("[data-key]")) {
+        window.__farmRangeMoves += 1;
+      }
+      return insertBefore(node, anchor);
+    };
+  });
+  await page.locator(`${keyedRanges} [data-action="rotate-ranges"]`).click();
+  const primaryRangeOrder = await page
+    .locator(`${keyedRanges} [data-range="primary"]`)
+    .evaluateAll((rows) => rows.map((row) => row.getAttribute("data-key")));
+  const secondaryRangeOrder = await page
+    .locator(`${keyedRanges} [data-range="secondary"]`)
+    .evaluateAll((rows) => rows.map((row) => row.getAttribute("data-key")));
+  assert.deepEqual(primaryRangeOrder, ["d", "a", "b", "c"]);
+  assert.deepEqual(secondaryRangeOrder, ["z", "y", "x"]);
+  assert.equal(
+    await page.locator(`${keyedRanges} [data-list="ranges"]`).getAttribute("data-rows"),
+    "7",
+  );
+  assert.equal(await page.evaluate(() => window.__farmRangeMoves), 3);
+  assert.equal(
+    await page.evaluate(
+      () =>
+        window.__farmRangeHeader ===
+          document.querySelector(
+            '[data-experiment="keyed-ranges"] [data-static="range-header"]',
+          ) &&
+        window.__farmRangeDivider ===
+          document.querySelector(
+            '[data-experiment="keyed-ranges"] [data-static="range-divider"]',
+          ) &&
+        window.__farmRangeFooter ===
+          document.querySelector(
+            '[data-experiment="keyed-ranges"] [data-static="range-footer"]',
+          ) &&
+        window.__farmRangeA ===
+          document.querySelector('[data-experiment="keyed-ranges"] [data-key="a"]') &&
+        window.__farmRangeX ===
+          document.querySelector('[data-experiment="keyed-ranges"] [data-key="x"]'),
+    ),
+    true,
+    "keyed ranges did not preserve their rows and static shell",
+  );
+  await page.locator(`${keyedRanges} [data-action="clear-ranges"]`).click();
+  await assertText(page, `${keyedRanges} [data-metric="rows"]`, "0");
+  assert.equal(
+    await page.locator(`${keyedRanges} [data-list="ranges"]`).getAttribute("data-rows"),
+    "0",
+  );
+  assert.equal(await page.locator(`${keyedRanges} [data-key]`).count(), 0);
+  await assertText(
+    page,
+    `${keyedRanges} [data-static="range-footer"]`,
+    "0 ROWS / STATIC SHELL",
+  );
+  await page.locator(`${keyedRanges} [data-action="stress-ranges"]`).click();
+  await assertText(page, `${keyedRanges} [data-metric="rows"]`, "1024");
+  assert.equal(
+    await page.locator(`${keyedRanges} [data-list="ranges"]`).getAttribute("data-rows"),
+    "1024",
+  );
+  assert.equal(await page.locator(`${keyedRanges} [data-key]`).count(), 1024);
+  const keyedRangesFinalExecutions = await readNumber(
+    page,
+    `${keyedRanges} [data-metric="executions"]`,
+  );
+  assert.equal(keyedRangesFinalExecutions - keyedRangesInitialExecutions, 0);
+
   const rowConditionals = '[data-experiment="keyed-row-conditionals"]';
   const rowConditionalsInitialExecutions = await readNumber(
     page,
@@ -962,6 +1048,20 @@ try {
             keyedDomIdentityPreserved: true,
             lisMoves: 3,
             owner: "Farm keyed rows",
+          },
+          keyedRanges: {
+            ranges: 2,
+            rotation: {
+              primary: primaryRangeOrder,
+              secondary: secondaryRangeOrder,
+              lisMoves: 3,
+            },
+            stressRows: 1024,
+            updateExecutions:
+              keyedRangesFinalExecutions - keyedRangesInitialExecutions,
+            staticSiblingIdentityPreserved: true,
+            keyedDomIdentityPreserved: true,
+            owner: "Farm keyed ranges",
           },
           derivedCollection: {
             order: derivedCollectionOrder,

--- a/examples/react-compiler/src/app/globals.css
+++ b/examples/react-compiler/src/app/globals.css
@@ -649,6 +649,43 @@ h1 span {
     monospace;
 }
 
+.edge-card .keyed-range-list {
+  max-height: 19rem;
+  align-content: flex-start;
+  overflow-y: auto;
+  padding: 0.55rem;
+  border: 1px solid #33332f;
+  background: #0d0d0c;
+}
+
+.keyed-range-list [data-range] {
+  min-width: 6.5rem;
+  background: #111110;
+}
+
+.keyed-range-list [data-range="secondary"] {
+  border-color: #5a5a52;
+  color: #aaa9a1;
+}
+
+.keyed-range-list .keyed-range-static {
+  flex: 1 0 100%;
+  border-color: rgb(184 255 91 / 0.28);
+  color: #91b864;
+  background: rgb(184 255 91 / 0.035);
+  font-size: 0.56rem;
+  letter-spacing: 0.075em;
+}
+
+.keyed-range-list [data-static="range-divider"] {
+  margin-top: 0.15rem;
+}
+
+.keyed-range-list [data-static="range-footer"] {
+  color: #d8ff9f;
+  text-align: right;
+}
+
 .interactive-keyed-list .interactive-row {
   display: flex;
   min-width: min(100%, 14rem);

--- a/examples/react-compiler/src/components/compiler-edge-lab.tsx
+++ b/examples/react-compiler/src/components/compiler-edge-lab.tsx
@@ -12,6 +12,7 @@ let interactiveListExecutions = 0;
 let editableListExecutions = 0;
 let rowConditionalListExecutions = 0;
 let explicitListExecutions = 0;
+let keyedRangeExecutions = 0;
 
 export function CompiledBatchExperiment() {
   const [count, setCount] = useState(0);
@@ -717,6 +718,116 @@ export function ExplicitKeyedListExperiment() {
   );
 }
 
+export function KeyedRangeExperiment() {
+  const [primary, setPrimary] = useState<ListItem[]>([
+    { id: "a", label: "Alpha" },
+    { id: "b", label: "Beta" },
+    { id: "c", label: "Gamma" },
+    { id: "d", label: "Delta" },
+  ]);
+  const [secondary, setSecondary] = useState<ListItem[]>([
+    { id: "x", label: "Xray" },
+    { id: "y", label: "Yankee" },
+    { id: "z", label: "Zulu" },
+  ]);
+  const total = primary.length + secondary.length;
+
+  return (
+    <article className="edge-card" data-experiment="keyed-ranges">
+      <header>
+        <span className="experiment-number">04G</span>
+        <div>
+          <h3>Keyed DOM ranges</h3>
+          <p>Two lists move independently while their shared header, divider, and footer stay put.</p>
+        </div>
+      </header>
+      <dl className="compact-metrics" aria-live="polite">
+        <div>
+          <dt>Ranges</dt>
+          <dd data-metric="ranges">2</dd>
+        </div>
+        <div>
+          <dt>Rows</dt>
+          <dd data-metric="rows">{total}</dd>
+        </div>
+        <div>
+          <dt>Executions</dt>
+          <dd data-metric="executions">
+            {typeof window === "undefined" ? 1 : ++keyedRangeExecutions}
+          </dd>
+        </div>
+      </dl>
+      <ul className="keyed-range-list" data-list="ranges" data-rows={total}>
+        <li className="keyed-range-static" data-static="range-header">
+          PRIMARY RANGE
+        </li>
+        {primary.map((item, index) => (
+          <li data-index={index} data-key={item.id} data-range="primary" key={item.id}>
+            {index + 1}. {item.label}
+          </li>
+        ))}
+        <li className="keyed-range-static" data-static="range-divider">
+          SECONDARY RANGE
+        </li>
+        {secondary.map((item, index) => (
+          <li data-index={index} data-key={item.id} data-range="secondary" key={item.id}>
+            {index + 1}. {item.label}
+          </li>
+        ))}
+        <li className="keyed-range-static" data-static="range-footer">
+          {total} ROWS / STATIC SHELL
+        </li>
+      </ul>
+      <div className="button-row">
+        <button
+          data-action="rotate-ranges"
+          onClick={() => {
+            setPrimary((items) =>
+              items.length > 1
+                ? [items[items.length - 1], ...items.slice(0, items.length - 1)]
+                : items,
+            );
+            setSecondary((items) => [...items].reverse());
+          }}
+          type="button"
+        >
+          Rotate both ranges
+        </button>
+        <button
+          data-action="clear-ranges"
+          onClick={() => {
+            setPrimary([]);
+            setSecondary([]);
+          }}
+          type="button"
+        >
+          Empty ranges
+        </button>
+        <button
+          data-action="stress-ranges"
+          onClick={() => {
+            setPrimary(
+              Array.from({ length: 512 }, (_, index) => ({
+                id: `primary-${index}`,
+                label: `Primary ${index}`,
+              })),
+            );
+            setSecondary(
+              Array.from({ length: 512 }, (_, index) => ({
+                id: `secondary-${index}`,
+                label: `Secondary ${index}`,
+              })),
+            );
+          }}
+          type="button"
+        >
+          Load 1,024 rows
+        </button>
+      </div>
+    </article>
+  );
+}
+
 export function CompilerEdgeLab() {
   return (
     <section className="edge-lab" aria-labelledby="edge-lab-title">
@@ -743,6 +854,7 @@ export function CompilerEdgeLab() {
         <EditableKeyedListExperiment />
         <RowConditionalListExperiment />
         <ExplicitKeyedListExperiment />
+        <KeyedRangeExperiment />
       </div>
 
       <aside className="hook-warning">

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -188,11 +188,36 @@ and unproven calls use the original React fallback.
 `toSorted` and `toReversed` are emitted as standard runtime calls rather than polyfilled. Configure
 the TypeScript `lib` with ES2023 and target a runtime that supports them when using those methods.
 
-React remains the fallback and compatibility boundary. A map beside static children, a row with a
-non-inline or async handler, a file input or dynamic form control shape, a fragment, a ref, a custom
-component, or a conditional mixed directly beside other children in the same host slot uses the
-existing React-owned keyed boundary. The outer compiled component can still be skipped, but React
-reconciles that list's rows and owns their events, lifecycle, and state.
+React remains the fallback and compatibility boundary. An interactive map beside static children,
+a non-host sibling between ranges, a row with a non-inline or async handler, a file input or dynamic
+form control shape, a fragment, a ref, a custom component, or a conditional mixed directly beside
+other children in the same host slot uses the existing React-owned keyed boundary. The outer
+compiled component can still be skipped, but React reconciles that list's rows and owns their
+events, lifecycle, and state.
+
+Non-interactive host maps can share one nested container with static host siblings:
+
+```tsx
+<ul>
+  <li>Primary</li>
+  {primary.map((item) => (
+    <li key={item.id}>{item.label}</li>
+  ))}
+  <li>Secondary</li>
+  {secondary.map((item) => (
+    <li key={item.id}>{item.label}</li>
+  ))}
+  <li>{primary.length + secondary.length} total</li>
+</ul>
+```
+
+The compiler emits one range block for that host container. React renders and hydrates the original
+markup. After mount, Farm records the static element segments and reconciles each keyed range with
+its own row table and LIS pass. It does not add wrappers or hydration markers. Stateful bindings in
+the static siblings still patch normally. Direct children must be host elements or eligible maps
+or `List` ranges; events, controlled rows, row conditionals, components, fragments, root-container
+ranges, and nested dynamic structures keep the React boundary. Duplicate keys, an adoption shape
+mismatch, or a parent-driven static markup change remounts the complete container through React.
 
 Controlled host fields can use the hybrid keyed-row path:
 
@@ -306,8 +331,9 @@ assertion; it is not presented as a cross-machine timing benchmark.
 Application and prototype calls, dynamic style objects, handlers outside JSX events, nested,
 computed, and rest props patterns, async handlers, unkeyed or index-keyed lists, chained maps,
 unsupported conditional roots, effects, and more advanced hook support intentionally stay on React
-in this release. Compiler-owned keyed rows are limited to a dedicated container with one host-only
-map or `List`. Inline synchronous events and dedicated row-local host conditional slots can use the
-hybrid keyed-row path, but branch events, nested dynamic blocks, conditionals mixed with siblings in
-one slot, non-inline or async row handlers, unsupported form shapes, custom components, fragments,
-refs, SVG, and duplicate runtime keys keep or switch to React ownership.
+in this release. Compiler-owned keyed rows support either one dedicated host-only map/`List` or
+multiple non-interactive ranges separated by host siblings. Inline synchronous events and dedicated
+row-local host conditional slots can use the single-list hybrid path, but branch events, interactive
+ranges beside siblings, nested dynamic blocks, conditionals mixed with siblings in one slot,
+non-inline or async row handlers, unsupported form shapes, custom components, fragments, refs, SVG,
+and duplicate runtime keys keep or switch to React ownership.

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -446,6 +446,103 @@ const testSource = String.raw`
   assert.equal(keyedRowExecutions, initialKeyedRowExecutions);
   flushSync(() => keyedRowsRoot.unmount());
 
+  let keyedRangeExecutions = 0;
+  const KeyedRanges = createCompiledComponent({
+    displayName: "CompatibilityKeyedRanges",
+    initialize: () => [{ primary: ["a", "b", "c"], secondary: ["x", "y"] }],
+    render(_props, state, blocks) {
+      keyedRangeExecutions += 1;
+      const model = () => state[0].get();
+      const descriptor = (before, items) => ({
+        before,
+        items,
+        rowKey: (item) => item,
+        create: (item, index) => ({
+          kind: "element",
+          tag: "li",
+          attributes: [
+            { name: "data-key", value: item },
+            { name: "data-index", value: index },
+          ],
+          styles: [],
+          children: [index + ":" + item.toUpperCase()],
+        }),
+        bindings: [
+          { kind: "attribute", path: [], name: "data-index", read: (_item, index) => index },
+          { kind: "text", path: [], read: (item, index) => [index, ":", item.toUpperCase()] },
+        ],
+      });
+      return React.createElement(
+        "section",
+        null,
+        React.createElement(
+          "button",
+          {
+            onClick: () =>
+              state[0].set((current) => ({
+                primary: [...current.primary].reverse(),
+                secondary: [current.secondary[1], "z", current.secondary[0]],
+              })),
+          },
+          "Update ranges",
+        ),
+        React.createElement(blocks.KeyedRanges, {
+          id: 0,
+          render: () =>
+            React.createElement(
+              "ul",
+              null,
+              React.createElement("li", { "data-static": "header" }, "Primary"),
+              model().primary.map((item, index) =>
+                React.createElement(
+                  "li",
+                  { key: item, "data-key": item, "data-index": index },
+                  index + ":" + item.toUpperCase(),
+                ),
+              ),
+              React.createElement("li", { "data-static": "divider" }, "Secondary"),
+              model().secondary.map((item, index) =>
+                React.createElement(
+                  "li",
+                  { key: item, "data-key": item, "data-index": index },
+                  index + ":" + item.toUpperCase(),
+                ),
+              ),
+              React.createElement("li", { "data-static": "footer" }, "End"),
+            ),
+          ranges: [
+            descriptor(1, () => model().primary),
+            descriptor(1, () => model().secondary),
+          ],
+          trailing: 1,
+        }),
+      );
+    },
+    bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+  });
+  const keyedRangesContainer = document.createElement("div");
+  document.body.append(keyedRangesContainer);
+  const keyedRangesRoot = createRoot(keyedRangesContainer);
+  flushSync(() => keyedRangesRoot.render(React.createElement(KeyedRanges)));
+  const initialKeyedRangeExecutions = keyedRangeExecutions;
+  const rangeHeader = keyedRangesContainer.querySelector("[data-static='header']");
+  const rangeDivider = keyedRangesContainer.querySelector("[data-static='divider']");
+  const rangeFooter = keyedRangesContainer.querySelector("[data-static='footer']");
+  const rangeA = keyedRangesContainer.querySelector("[data-key='a']");
+  keyedRangesContainer.querySelector("button").click();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.deepEqual(
+    [...keyedRangesContainer.querySelectorAll("[data-key]")].map((row) => row.dataset.key),
+    ["c", "b", "a", "y", "z", "x"],
+  );
+  assert.equal(keyedRangesContainer.querySelector("[data-static='header']"), rangeHeader);
+  assert.equal(keyedRangesContainer.querySelector("[data-static='divider']"), rangeDivider);
+  assert.equal(keyedRangesContainer.querySelector("[data-static='footer']"), rangeFooter);
+  assert.equal(keyedRangesContainer.querySelector("[data-key='a']"), rangeA);
+  assert.equal(keyedRangeExecutions, initialKeyedRangeExecutions);
+  flushSync(() => keyedRangesRoot.unmount());
+
   let interactiveRowExecutions = 0;
   let interactiveListRenders = 0;
   let setInteractiveItems = () => undefined;

--- a/packages/farm-react/src/__tests__/compiler-composable-blocks.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-composable-blocks.test.ts
@@ -64,7 +64,8 @@ describe("React AOT composable block compiler", () => {
       result.diagnostics.find((diagnostic) => diagnostic.component === "ComposableDashboard"),
     ).toBeUndefined();
     expect(result.code.match(/farmBlocks\.Conditional/g)).toHaveLength(3);
-    expect(result.code.match(/farmBlocks\.KeyedList/g)).toHaveLength(3);
+    expect(result.code.match(/farmBlocks\.KeyedList/g)).toHaveLength(2);
+    expect(result.code.match(/farmBlocks\.KeyedRanges/g)).toHaveLength(1);
     expect(result.code.match(/farmBlocks\.Component/g)).toHaveLength(1);
 
     const ids = [...result.code.matchAll(/id=\{(\d+)\}/g)].map((match) => Number(match[1]));

--- a/packages/farm-react/src/__tests__/compiler-keyed-ranges.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-ranges.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true);
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/KeyedRanges.tsx", infer);
+}
+
+describe("React AOT keyed-range compiler", () => {
+  it("compiles multiple keyed host ranges between static siblings", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Board() {
+        const [primary, setPrimary] = useState([
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Beta" },
+        ]);
+        const [secondary, setSecondary] = useState([{ id: "c", label: "Gamma" }]);
+        return (
+          <main>
+            <ul data-count={primary.length + secondary.length}>
+              <li data-static="header">Primary</li>
+              {primary.map((item, index) => (
+                <li data-index={index} key={item.id}>{item.label}</li>
+              ))}
+              <li data-static="divider">Secondary</li>
+              {secondary.map((item, index) => (
+                <li data-index={index} key={item.id}>{item.label}</li>
+              ))}
+              <li data-static="footer">{primary.length + secondary.length} total</li>
+            </ul>
+            <button onClick={() => setPrimary((items) => [...items].reverse())}>Primary</button>
+            <button onClick={() => setSecondary((items) => [...items].reverse())}>Secondary</button>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Board"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedRanges");
+    expect(result.code).toContain("ranges={[");
+    expect(result.code.match(/before: 1/g)).toHaveLength(2);
+    expect(result.code).toContain("trailing={1}");
+    expect(result.code).toContain("farmBlocks.target");
+    expect(result.code).toMatch(/rootRef=\{_?farmBlocks\.target\(/);
+    expect(result.code).not.toContain("farmBlocks.KeyedList");
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedRanges.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({ code: expect.stringContaining("farmBlocks.KeyedRanges") });
+  });
+
+  it("supports an explicit List as one range beside host siblings", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List } from "@farm.js/react/list";
+      export function Tasks() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
+        return (
+          <section>
+            <ul>
+              <li data-static="header">Tasks</li>
+              <List each={items} by={(item) => item.id}>
+                {(item) => <li>{item.label}</li>}
+              </List>
+              <li data-static="footer">End</li>
+            </ul>
+            <button onClick={() => setItems([])}>Clear</button>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Tasks"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedRanges");
+    expect(result.code).not.toContain("farmBlocks.KeyedList");
+  });
+
+  it("keeps interactive sibling ranges on the React-owned keyed boundary", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Tasks() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
+        return (
+          <section>
+            <ul>
+              <li data-static="header">Tasks</li>
+              {items.map((item) => (
+                <li key={item.id}>
+                  <button onClick={() => setItems([])}>{item.label}</button>
+                </li>
+              ))}
+              <li data-static="footer">End</li>
+            </ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Tasks"]);
+    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).not.toContain("farmBlocks.KeyedRanges");
+  });
+
+  it("keeps a keyed map in the component root on the existing React boundary", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Tasks() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
+        return (
+          <ul>
+            <li data-static="header">Tasks</li>
+            {items.map((item) => <li key={item.id}>{item.label}</li>)}
+            <li data-static="footer">End</li>
+          </ul>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Tasks"]);
+    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).not.toContain("farmBlocks.KeyedRanges");
+  });
+
+  it("keeps a component sibling outside the range-owned contract", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      function Heading() {
+        return <li>Tasks</li>;
+      }
+      export function Tasks() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
+        return (
+          <section>
+            <ul>
+              <Heading />
+              {items.map((item) => <li key={item.id}>{item.label}</li>)}
+              <li>End</li>
+            </ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toContain("Tasks");
+    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).not.toContain("farmBlocks.KeyedRanges");
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-ranges.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-ranges.test.tsx
@@ -220,7 +220,6 @@ describe("compiled keyed DOM ranges", () => {
   });
 
   it("handles adjacent empty ranges and transitions in both directions", async () => {
-    const metrics = { executions: 0, rangeRenders: 0 };
     let update: (next: CompilerStateUpdater) => void = () => undefined;
     const AdjacentRanges = createCompiledComponent({
       displayName: "AdjacentRanges",

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-ranges.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-ranges.test.tsx
@@ -1,0 +1,503 @@
+import React, { StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createCompiledComponent,
+  type CompilerKeyedRange,
+  type CompilerStateUpdater,
+} from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface RangeItem {
+  id: string;
+  label: string;
+}
+
+interface RangeModel {
+  primary: RangeItem[];
+  secondary: RangeItem[];
+}
+
+interface RangeBoardProps {
+  title?: string;
+}
+
+const roots = new Set<Root>();
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots) root.unmount();
+  });
+  roots.clear();
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function rangeDescriptor(before: number, readItems: () => RangeItem[]): CompilerKeyedRange {
+  return {
+    before,
+    items: readItems,
+    rowKey: (item) => (item as RangeItem).id,
+    create: (item, index) => ({
+      kind: "element",
+      tag: "li",
+      attributes: [
+        { name: "data-key", value: (item as RangeItem).id },
+        { name: "data-index", value: index },
+      ],
+      styles: [],
+      children: [`${index}:${(item as RangeItem).label}`],
+    }),
+    bindings: [
+      {
+        kind: "attribute",
+        name: "data-index",
+        path: [],
+        read: (_item, index) => index,
+      },
+      {
+        kind: "text",
+        path: [],
+        read: (item, index) => [index, ":", (item as RangeItem).label],
+      },
+    ],
+  };
+}
+
+function defineRangeBoard(metrics: { executions: number; rangeRenders: number }) {
+  const initial: RangeModel = {
+    primary: [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+    ],
+    secondary: [
+      { id: "x", label: "Xray" },
+      { id: "y", label: "Yankee" },
+    ],
+  };
+  let updateModel: (next: CompilerStateUpdater) => void = () => undefined;
+  let readModel: () => RangeModel = () => initial;
+
+  const RangeBoard = createCompiledComponent<RangeBoardProps>({
+    displayName: "RangeBoard",
+    initialize: () => [initial],
+    render(props, state, blocks) {
+      metrics.executions += 1;
+      const model = () => state[0].get() as RangeModel;
+      readModel = model;
+      updateModel = (next) => state[0].set(next);
+      const KeyedRanges = blocks.KeyedRanges;
+      return (
+        <main>
+          <h1>{props.title || "Ranges"}</h1>
+          <KeyedRanges
+            id={0}
+            ranges={[
+              rangeDescriptor(1, () => model().primary),
+              rangeDescriptor(1, () => model().secondary),
+            ]}
+            render={() => {
+              metrics.rangeRenders += 1;
+              return (
+                <ul data-board="ranges">
+                  <li data-static="header">{props.title || "Primary"}</li>
+                  {model().primary.map((item, index) => (
+                    <li data-index={index} data-key={item.id} key={item.id}>
+                      {index}:{item.label}
+                    </li>
+                  ))}
+                  <li data-static="divider">Secondary</li>
+                  {model().secondary.map((item, index) => (
+                    <li data-index={index} data-key={item.id} key={item.id}>
+                      {index}:{item.label}
+                    </li>
+                  ))}
+                  <li data-static="footer" ref={blocks.target(0)}>
+                    {model().primary.length + model().secondary.length} total
+                  </li>
+                </ul>
+              );
+            }}
+            trailing={1}
+          />
+        </main>
+      );
+    },
+    bindings: [
+      {
+        kind: "text",
+        path: [1, 2],
+        target: 0,
+        dependencies: [0],
+        read: (_props, state) => {
+          const model = state[0].get() as RangeModel;
+          return [model.primary.length + model.secondary.length, " total"];
+        },
+      },
+      { kind: "block", id: 0, dependencies: [0] },
+    ],
+  });
+
+  return {
+    RangeBoard,
+    initial,
+    readModel: () => readModel(),
+    updateModel: (next: CompilerStateUpdater) => updateModel(next),
+  };
+}
+
+function rangeSnapshot(container: Element): string[] {
+  return [...container.querySelectorAll<HTMLLIElement>("[data-key]")].map(
+    (row) => `${row.dataset.key}:${row.dataset.index}:${row.textContent}`,
+  );
+}
+
+describe("compiled keyed DOM ranges", () => {
+  it("reconciles two ranges while preserving every static sibling", async () => {
+    const metrics = { executions: 0, rangeRenders: 0 };
+    const board = defineRangeBoard(metrics);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.add(root);
+    await act(async () => root.render(<board.RangeBoard />));
+
+    const list = container.querySelector<HTMLUListElement>("[data-board='ranges']")!;
+    const header = list.querySelector('[data-static="header"]')!;
+    const divider = list.querySelector('[data-static="divider"]')!;
+    const footer = list.querySelector('[data-static="footer"]')!;
+    const alpha = list.querySelector('[data-key="a"]')!;
+    const xray = list.querySelector('[data-key="x"]')!;
+    const insertBefore = vi.spyOn(list, "insertBefore");
+    const initialExecutions = metrics.executions;
+    const initialRangeRenders = metrics.rangeRenders;
+
+    await act(async () => {
+      board.updateModel((current) => {
+        const model = current as RangeModel;
+        return {
+          primary: [...model.primary].reverse(),
+          secondary: [model.secondary[1], { id: "z", label: "Zulu" }, model.secondary[0]],
+        };
+      });
+      await flushCompilerUpdates();
+    });
+
+    expect(list.querySelector('[data-static="header"]')).toBe(header);
+    expect(list.querySelector('[data-static="divider"]')).toBe(divider);
+    expect(list.querySelector('[data-static="footer"]')).toBe(footer);
+    expect(list.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(list.querySelector('[data-key="x"]')).toBe(xray);
+    expect(rangeSnapshot(list)).toEqual([
+      "d:0:0:Delta",
+      "c:1:1:Gamma",
+      "b:2:2:Beta",
+      "a:3:3:Alpha",
+      "y:0:0:Yankee",
+      "z:1:1:Zulu",
+      "x:2:2:Xray",
+    ]);
+    expect(footer.textContent).toBe("7 total");
+    expect(insertBefore).toHaveBeenCalledTimes(5);
+    expect(metrics.executions).toBe(initialExecutions);
+    expect(metrics.rangeRenders).toBe(initialRangeRenders);
+  });
+
+  it("handles adjacent empty ranges and transitions in both directions", async () => {
+    const metrics = { executions: 0, rangeRenders: 0 };
+    let update: (next: CompilerStateUpdater) => void = () => undefined;
+    const AdjacentRanges = createCompiledComponent({
+      displayName: "AdjacentRanges",
+      initialize: () => [{ primary: [], secondary: [] } satisfies RangeModel],
+      render(_props: Record<string, never>, state, blocks) {
+        update = (next) => state[0].set(next);
+        const model = () => state[0].get() as RangeModel;
+        const KeyedRanges = blocks.KeyedRanges;
+        return (
+          <main>
+            <KeyedRanges
+              id={0}
+              ranges={[
+                rangeDescriptor(1, () => model().primary),
+                rangeDescriptor(0, () => model().secondary),
+              ]}
+              render={() => (
+                <ol>
+                  <li data-static="header">Header</li>
+                  {model().primary.map((item, index) => (
+                    <li data-index={index} data-key={item.id} key={item.id}>
+                      {index}:{item.label}
+                    </li>
+                  ))}
+                  {model().secondary.map((item, index) => (
+                    <li data-index={index} data-key={item.id} key={item.id}>
+                      {index}:{item.label}
+                    </li>
+                  ))}
+                  <li data-static="footer">Footer</li>
+                </ol>
+              )}
+              trailing={1}
+            />
+          </main>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.add(root);
+    await act(async () => root.render(<AdjacentRanges />));
+    const footer = container.querySelector('[data-static="footer"]')!;
+
+    await act(async () => {
+      update({
+        primary: [{ id: "a", label: "Alpha" }],
+        secondary: [{ id: "x", label: "Xray" }],
+      });
+      await flushCompilerUpdates();
+    });
+    expect(rangeSnapshot(container)).toEqual(["a:0:0:Alpha", "x:0:0:Xray"]);
+    expect(container.querySelector('[data-static="footer"]')).toBe(footer);
+
+    await act(async () => {
+      update({ primary: [], secondary: [] });
+      await flushCompilerUpdates();
+    });
+    expect(rangeSnapshot(container)).toEqual([]);
+    expect(container.querySelector('[data-static="footer"]')).toBe(footer);
+  });
+
+  it("switches the complete container to React when runtime keys collide", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const metrics = { executions: 0, rangeRenders: 0 };
+    const board = defineRangeBoard(metrics);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.add(root);
+    await act(async () => root.render(<board.RangeBoard />));
+    const originalList = container.querySelector("ul")!;
+
+    await act(async () => {
+      board.updateModel((current) => {
+        const model = current as RangeModel;
+        return {
+          ...model,
+          primary: [
+            { id: "duplicate", label: "One" },
+            { id: "duplicate", label: "Two" },
+          ],
+        };
+      });
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector("ul")).not.toBe(originalList);
+    expect(metrics.rangeRenders).toBe(2);
+    expect(container.querySelectorAll('[data-key="duplicate"]')).toHaveLength(2);
+
+    await act(async () => {
+      board.updateModel((current) => ({
+        ...(current as RangeModel),
+        primary: [{ id: "safe", label: "Safe" }],
+      }));
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector('[data-key="safe"]')?.textContent).toBe("0:Safe");
+    expect(metrics.rangeRenders).toBe(3);
+  });
+
+  it("recovers hydration mismatches in StrictMode and drops queued work after unmount", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const metrics = { executions: 0, rangeRenders: 0 };
+    const board = defineRangeBoard(metrics);
+    const serverHtml = renderToString(
+      <StrictMode>
+        <board.RangeBoard />
+      </StrictMode>,
+    );
+    const container = document.createElement("div");
+    container.innerHTML = serverHtml.replace("Primary", "Server mismatch");
+    document.body.append(container);
+    const recoverable = vi.fn();
+    const root = hydrateRoot(
+      container,
+      <StrictMode>
+        <board.RangeBoard />
+      </StrictMode>,
+      { onRecoverableError: recoverable },
+    );
+    roots.add(root);
+    await act(async () => flushCompilerUpdates());
+    expect(recoverable).toHaveBeenCalled();
+
+    await act(async () => {
+      board.updateModel((current) => ({
+        ...(current as RangeModel),
+        primary: [{ id: "hydrated", label: "Hydrated" }],
+      }));
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector('[data-key="hydrated"]')?.textContent).toBe("0:Hydrated");
+
+    await act(async () => {
+      board.updateModel({ primary: [], secondary: [] });
+      root.unmount();
+      await flushCompilerUpdates();
+    });
+    roots.delete(root);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("falls back safely when parent props change static sibling output", async () => {
+    const metrics = { executions: 0, rangeRenders: 0 };
+    const board = defineRangeBoard(metrics);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.add(root);
+    await act(async () => root.render(<board.RangeBoard title="First" />));
+    const originalList = container.querySelector("ul")!;
+
+    await act(async () => {
+      root.render(<board.RangeBoard title="Second" />);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector("h1")?.textContent).toBe("Second");
+    expect(container.querySelector('[data-static="header"]')?.textContent).toBe("Second");
+    expect(container.querySelector("ul")).not.toBe(originalList);
+    expect(metrics.rangeRenders).toBe(2);
+  });
+
+  it("matches normal React through 2,000 deterministic multi-range transitions", async () => {
+    const metrics = { executions: 0, rangeRenders: 0 };
+    const compiled = defineRangeBoard(metrics);
+    let normalModel = compiled.initial;
+    let setNormal: React.Dispatch<React.SetStateAction<RangeModel>> = () => undefined;
+
+    function NormalBoard() {
+      const [model, setModel] = useState(compiled.initial);
+      normalModel = model;
+      setNormal = setModel;
+      return (
+        <ul>
+          <li data-static="header">Primary</li>
+          {model.primary.map((item, index) => (
+            <li data-index={index} data-key={item.id} key={item.id}>
+              {index}:{item.label}
+            </li>
+          ))}
+          <li data-static="divider">Secondary</li>
+          {model.secondary.map((item, index) => (
+            <li data-index={index} data-key={item.id} key={item.id}>
+              {index}:{item.label}
+            </li>
+          ))}
+          <li data-static="footer">{model.primary.length + model.secondary.length} total</li>
+        </ul>
+      );
+    }
+
+    const compiledContainer = document.createElement("div");
+    const normalContainer = document.createElement("div");
+    document.body.append(compiledContainer, normalContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const normalRoot = createRoot(normalContainer);
+    roots.add(compiledRoot);
+    roots.add(normalRoot);
+    await act(async () => {
+      compiledRoot.render(<compiled.RangeBoard />);
+      normalRoot.render(<NormalBoard />);
+    });
+
+    let seed = 0x9e3779b9;
+    const random = () => {
+      seed = (seed * 1664525 + 1013904223) >>> 0;
+      return seed;
+    };
+    const operations = Array.from({ length: 2000 }, (_, step) => ({
+      operation: random() % 7,
+      selector: random(),
+      step,
+    }));
+    const update = (model: RangeModel, step: number): RangeModel => {
+      const { operation, selector } = operations[step];
+      const side = selector % 2 === 0 ? "primary" : "secondary";
+      const other = side === "primary" ? "secondary" : "primary";
+      const rows = model[side];
+      if (operation === 0 && rows.length > 0) {
+        const target = selector % rows.length;
+        return {
+          ...model,
+          [side]: rows.map((row, index) =>
+            index === target ? { ...row, label: `${row.label}.${step}` } : row,
+          ),
+        };
+      }
+      if (operation === 1 && rows.length < 24) {
+        const id = `${side[0]}${step}`;
+        return { ...model, [side]: [...rows, { id, label: `Item ${step}` }] };
+      }
+      if (operation === 2 && rows.length > 0) {
+        return { ...model, [side]: rows.slice(1) };
+      }
+      if (operation === 3) return { ...model, [side]: [...rows].reverse() };
+      if (operation === 4 && rows.length > 1) {
+        return { ...model, [side]: [...rows.slice(1), rows[0]] };
+      }
+      if (operation === 5 && rows.length > 0) {
+        const target = selector % rows.length;
+        const moved = rows[target];
+        return {
+          ...model,
+          [side]: rows.filter((_, index) => index !== target),
+          [other]: [...model[other], moved],
+        };
+      }
+      return model;
+    };
+    const snapshot = (container: Element) => ({
+      rows: rangeSnapshot(container),
+      footer: container.querySelector('[data-static="footer"]')?.textContent,
+    });
+    const initialExecutions = metrics.executions;
+    const initialRangeRenders = metrics.rangeRenders;
+
+    for (let offset = 0; offset < operations.length; offset += 20) {
+      await act(async () => {
+        for (let step = offset; step < offset + 20; step += 1) {
+          const updater = (current: RangeModel) => update(current, step);
+          compiled.updateModel((current) => updater(current as RangeModel));
+          setNormal(updater);
+        }
+        await flushCompilerUpdates();
+      });
+      expect(compiled.readModel(), `model after batch ${offset}`).toEqual(normalModel);
+      expect(snapshot(compiledContainer), `DOM after batch ${offset}`).toEqual(
+        snapshot(normalContainer),
+      );
+    }
+
+    expect(metrics.executions).toBe(initialExecutions);
+    expect(metrics.rangeRenders).toBe(initialRangeRenders);
+  }, 30_000);
+});

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -149,6 +149,24 @@ export interface CompilerKeyedRowsBlockProps {
   conditionals?: readonly CompilerKeyedRowConditional[];
 }
 
+export interface CompilerKeyedRange {
+  /** Number of static direct host siblings between this range and the previous range. */
+  before: number;
+  items(): Iterable<unknown> | null | undefined;
+  rowKey(item: unknown, index: number): React.Key;
+  create(item: unknown, index: number): CompilerKeyedRowElement;
+  bindings: readonly CompilerKeyedRowBinding[];
+}
+
+export interface CompilerKeyedRangesBlockProps {
+  id: number;
+  render(): React.ReactElement;
+  rootRef?: React.RefCallback<Element>;
+  ranges: readonly CompilerKeyedRange[];
+  /** Number of static direct host siblings after the final keyed range. */
+  trailing: number;
+}
+
 export interface CompilerComponentBlockProps {
   id: number;
   render(): React.ReactNode;
@@ -159,6 +177,7 @@ export interface CompilerBlockRuntime {
   HostConditional: React.ComponentType<CompilerHostConditionalBlockProps>;
   KeyedList: React.ComponentType<CompilerKeyedListBlockProps>;
   KeyedRows: React.ComponentType<CompilerKeyedRowsBlockProps>;
+  KeyedRanges: React.ComponentType<CompilerKeyedRangesBlockProps>;
   Component: React.ComponentType<CompilerComponentBlockProps>;
   target(id: number): React.RefCallback<Element>;
 }
@@ -580,8 +599,10 @@ function normalizedKeyedRowBindingValue(binding: CompilerKeyedRowBinding, value:
   return binding.kind === "text" ? renderTextValue(value) : value;
 }
 
+type CompilerKeyedRowBindingSource = Pick<CompilerKeyedRowsBlockProps, "bindings">;
+
 function readKeyedRowBindingValues(
-  props: CompilerKeyedRowsBlockProps,
+  props: CompilerKeyedRowBindingSource,
   item: unknown,
   index: number,
 ): unknown[] {
@@ -591,7 +612,7 @@ function readKeyedRowBindingValues(
 }
 
 function applyKeyedRowBindings(
-  props: CompilerKeyedRowsBlockProps,
+  props: CompilerKeyedRowBindingSource,
   instance: CompilerKeyedRowInstance,
   item: unknown,
   index: number,
@@ -1408,6 +1429,259 @@ function createKeyedRowsBlockComponent(
   return FarmKeyedRowsBlock;
 }
 
+function createKeyedRangesBlockComponent(
+  owner: Pick<ConditionalBlockOwner, "subscribe">,
+): React.ComponentType<CompilerKeyedRangesBlockProps> {
+  interface State {
+    fallback: boolean;
+  }
+
+  interface ReadRange {
+    items: unknown[];
+    keys: string[];
+  }
+
+  class FarmKeyedRangesBlock extends React.Component<CompilerKeyedRangesBlockProps, State> {
+    static displayName = "FarmCompiledKeyedRanges";
+
+    state: State = { fallback: false };
+    private root: Element | null = null;
+    private mounted = false;
+    private fallbackRequested = false;
+    private fallbackVersion = 0;
+    private propFallbackQueued = false;
+    private currentProps = this.props;
+    private unsubscribe: (() => void) | undefined;
+    private rangeInstances: Array<Map<string, CompilerKeyedRowInstance>> = [];
+    private staticSegments: Element[][] = [];
+
+    private captureRoot = (root: Element | null) => {
+      this.root = root;
+      this.currentProps.rootRef?.(root);
+    };
+
+    private readRange(range: CompilerKeyedRange): ReadRange | null {
+      const source = range.items();
+      const items = source ? Array.from(source) : [];
+      const keys = items.map((item, index) => keyedRowIdentity(range.rowKey(item, index)));
+      if (new Set(keys).size !== keys.length) return null;
+      return { items, keys };
+    }
+
+    private readRanges(props: CompilerKeyedRangesBlockProps): ReadRange[] | null {
+      const ranges: ReadRange[] = [];
+      for (const range of props.ranges) {
+        const rows = this.readRange(range);
+        if (!rows) return null;
+        ranges.push(rows);
+      }
+      return ranges;
+    }
+
+    private adopt(props: CompilerKeyedRangesBlockProps = this.currentProps): boolean {
+      if (!this.root || !Number.isSafeInteger(props.trailing) || props.trailing < 0) return false;
+      const rowsByRange = this.readRanges(props);
+      if (!rowsByRange) return false;
+      const elements = [...this.root.children];
+      const staticSegments: Element[][] = [];
+      const instancesByRange: Array<Map<string, CompilerKeyedRowInstance>> = [];
+      let cursor = 0;
+
+      for (let rangeIndex = 0; rangeIndex < props.ranges.length; rangeIndex += 1) {
+        const range = props.ranges[rangeIndex];
+        const rows = rowsByRange[rangeIndex];
+        if (!Number.isSafeInteger(range.before) || range.before < 0) return false;
+        const staticEnd = cursor + range.before;
+        if (staticEnd > elements.length) return false;
+        staticSegments.push(elements.slice(cursor, staticEnd));
+        cursor = staticEnd;
+
+        const rowEnd = cursor + rows.items.length;
+        if (rowEnd > elements.length) return false;
+        const instances = new Map<string, CompilerKeyedRowInstance>();
+        for (let index = 0; index < rows.items.length; index += 1) {
+          const element = elements[cursor + index];
+          if (!matchesCompilerHostElement(element, range.create(rows.items[index], index))) {
+            return false;
+          }
+          instances.set(rows.keys[index], {
+            key: rows.keys[index],
+            element,
+            values: readKeyedRowBindingValues(range, rows.items[index], index),
+            item: rows.items[index],
+            index,
+            conditionalValues: new Map(),
+          });
+        }
+        instancesByRange.push(instances);
+        cursor = rowEnd;
+      }
+
+      if (cursor + props.trailing !== elements.length) return false;
+      staticSegments.push(elements.slice(cursor));
+      this.staticSegments = staticSegments;
+      this.rangeInstances = instancesByRange;
+      return true;
+    }
+
+    private anchorAfter(rangeIndex: number): ChildNode | null {
+      for (let next = rangeIndex + 1; next < this.rangeInstances.length; next += 1) {
+        const staticAnchor = this.staticSegments[next]?.[0];
+        if (staticAnchor) return staticAnchor;
+        const rowAnchor = this.rangeInstances[next].values().next().value?.element;
+        if (rowAnchor) return rowAnchor;
+      }
+      return this.staticSegments[this.rangeInstances.length]?.[0] || null;
+    }
+
+    private reconcileRange(rangeIndex: number, rows: ReadRange): void {
+      if (!this.root) return;
+      const range = this.currentProps.ranges[rangeIndex];
+      const previous = this.rangeInstances[rangeIndex];
+      const oldIndices = new Map<string, number>();
+      [...previous.keys()].forEach((key, index) => oldIndices.set(key, index));
+      const nextKeys = new Set(rows.keys);
+      for (const [key, instance] of previous) {
+        if (!nextKeys.has(key)) instance.element.remove();
+      }
+
+      const sequence = rows.keys.map((key) => oldIndices.get(key) ?? -1);
+      const stablePositions = longestIncreasingSubsequencePositions(sequence);
+      const nextInstances: CompilerKeyedRowInstance[] = [];
+      for (let index = 0; index < rows.items.length; index += 1) {
+        const key = rows.keys[index];
+        const existing = previous.get(key);
+        if (existing) {
+          applyKeyedRowBindings(range, existing, rows.items[index], index);
+          existing.item = rows.items[index];
+          existing.index = index;
+          nextInstances.push(existing);
+          continue;
+        }
+        const element = createCompilerHostElement(
+          this.root.ownerDocument,
+          range.create(rows.items[index], index),
+        );
+        nextInstances.push({
+          key,
+          element,
+          values: readKeyedRowBindingValues(range, rows.items[index], index),
+          item: rows.items[index],
+          index,
+          conditionalValues: new Map(),
+        });
+      }
+
+      let anchor = this.anchorAfter(rangeIndex);
+      for (let index = nextInstances.length - 1; index >= 0; index -= 1) {
+        const instance = nextInstances[index];
+        if (sequence[index] < 0) {
+          this.root.insertBefore(instance.element, anchor);
+        } else if (!stablePositions.has(index) && instance.element.nextSibling !== anchor) {
+          this.root.insertBefore(instance.element, anchor);
+        }
+        anchor = instance.element;
+      }
+      this.rangeInstances[rangeIndex] = new Map(
+        nextInstances.map((instance) => [instance.key, instance]),
+      );
+    }
+
+    private reconcile(afterCommit?: () => void): void {
+      if (!this.mounted || !this.root) {
+        afterCommit?.();
+        return;
+      }
+      if (this.state.fallback) {
+        this.fallbackVersion += 1;
+        this.forceUpdate(afterCommit);
+        return;
+      }
+      const rowsByRange = this.readRanges(this.currentProps);
+      if (!rowsByRange || rowsByRange.length !== this.rangeInstances.length) {
+        this.activateFallback(afterCommit);
+        return;
+      }
+
+      const activeElement = this.root.ownerDocument.activeElement;
+      const restoreFocus = Boolean(activeElement && this.root.contains(activeElement));
+      for (let rangeIndex = rowsByRange.length - 1; rangeIndex >= 0; rangeIndex -= 1) {
+        this.reconcileRange(rangeIndex, rowsByRange[rangeIndex]);
+      }
+      if (
+        restoreFocus &&
+        activeElement?.isConnected &&
+        activeElement.ownerDocument.activeElement !== activeElement &&
+        "focus" in activeElement
+      ) {
+        (activeElement as HTMLElement).focus({ preventScroll: true });
+      }
+      afterCommit?.();
+    }
+
+    private refresh = (afterCommit?: () => void) => {
+      this.reconcile(afterCommit);
+    };
+
+    private activateFallback(afterCommit?: () => void): void {
+      if (!this.mounted || this.state.fallback || this.fallbackRequested) {
+        afterCommit?.();
+        return;
+      }
+      this.fallbackRequested = true;
+      this.setState({ fallback: true }, afterCommit);
+    }
+
+    private schedulePropFallback(): void {
+      if (this.propFallbackQueued) return;
+      this.propFallbackQueued = true;
+      queueMicrotask(() => {
+        this.propFallbackQueued = false;
+        if (this.mounted && !this.state.fallback) this.activateFallback();
+      });
+    }
+
+    shouldComponentUpdate(nextProps: CompilerKeyedRangesBlockProps, nextState: State): boolean {
+      this.currentProps = nextProps;
+      if (nextState.fallback || this.state.fallback) return true;
+      // Parent props and compatible Fast Refresh definitions can change static
+      // siblings that are deliberately outside the range descriptors. Remount
+      // this one container through React instead of retaining stale markup.
+      this.schedulePropFallback();
+      return false;
+    }
+
+    componentDidMount(): void {
+      this.mounted = true;
+      this.unsubscribe = owner.subscribe(this.props.id, this.refresh);
+      if (!this.adopt()) this.activateFallback();
+    }
+
+    componentWillUnmount(): void {
+      this.mounted = false;
+      this.unsubscribe?.();
+      this.root = null;
+      this.rangeInstances = [];
+      this.staticSegments = [];
+    }
+
+    render(): React.ReactNode {
+      const container = this.currentProps.render();
+      if (!React.isValidElement(container) || typeof container.type !== "string") {
+        throw new TypeError(
+          `Compiled keyed ranges ${this.currentProps.id} must own one host container.`,
+        );
+      }
+      return React.cloneElement(container, {
+        key: this.state.fallback ? `react-${this.fallbackVersion}` : "compiled",
+        ref: this.captureRoot,
+      } as React.Attributes);
+    }
+  }
+
+  return FarmKeyedRangesBlock;
+}
+
 function createComponentBlockComponent(
   owner: Pick<ConditionalBlockOwner, "subscribe">,
 ): React.ComponentType<CompilerComponentBlockProps> {
@@ -1520,6 +1794,9 @@ export function createCompiledComponent<Props>(
           subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
         }),
         KeyedRows: createKeyedRowsBlockComponent({
+          subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
+        }),
+        KeyedRanges: createKeyedRangesBlockComponent({
           subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
         }),
         Component: createComponentBlockComponent({

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -128,6 +128,27 @@ interface KeyedRowsPlan {
   syntax: "map" | "list";
 }
 
+interface KeyedRangePlan {
+  before: number;
+  source: t.Expression | t.JSXElement;
+  collection: t.Expression;
+  keyCallback: t.ArrowFunctionExpression | t.FunctionExpression;
+  renderCallback: t.ArrowFunctionExpression | t.FunctionExpression;
+  row: t.JSXElement;
+  bindings: PendingKeyedRowBinding[];
+  syntax: "map" | "list";
+}
+
+interface KeyedRangesPlan {
+  kind: "keyed-ranges";
+  id: number;
+  parent?: number;
+  dependencies: number[];
+  source: t.JSXElement;
+  ranges: KeyedRangePlan[];
+  trailing: number;
+}
+
 interface ComponentIslandPlan {
   kind: "component";
   id: number;
@@ -141,6 +162,7 @@ type ComposableBlockPlan =
   | HostConditionalPlan
   | KeyedListPlan
   | KeyedRowsPlan
+  | KeyedRangesPlan
   | ComponentIslandPlan;
 
 interface Candidate {
@@ -1241,6 +1263,98 @@ function analyzeKeyedRowTree(
   return reason ? { reason } : { bindings, events, conditionals };
 }
 
+interface KeyedRowChildShape extends KeyedRowsShape {
+  source: t.Expression | t.JSXElement;
+}
+
+function analyzeKeyedRowChild(
+  child: t.JSXElement["children"][number],
+  statesByValue: ReadonlyMap<string, StateBinding>,
+  safeGlobals: ReadonlySet<string>,
+  listNames: ReadonlySet<string>,
+): KeyedRowChildShape | undefined {
+  let collection: t.Expression;
+  let keyCallback: t.ArrowFunctionExpression | t.FunctionExpression;
+  let renderCallback: t.ArrowFunctionExpression | t.FunctionExpression;
+  let row: t.JSXElement;
+  let dependencies: number[];
+  let syntax: "map" | "list";
+  let source: t.Expression | t.JSXElement;
+
+  if (
+    t.isJSXExpressionContainer(child) &&
+    !t.isJSXEmptyExpression(child.expression) &&
+    isMapCall(child.expression)
+  ) {
+    const result = analyzeMapList(child.expression, statesByValue, safeGlobals);
+    if (result.reason) return undefined;
+    const callback = child.expression.arguments[0];
+    if (!t.isArrowFunctionExpression(callback) && !t.isFunctionExpression(callback))
+      return undefined;
+    const returned = returnedExpression(callback);
+    if (!returned || !t.isJSXElement(returned)) return undefined;
+    const key = jsxKeyExpression(returned);
+    if (!key) return undefined;
+    collection = (child.expression.callee as t.MemberExpression).object as t.Expression;
+    keyCallback = t.arrowFunctionExpression(
+      callback.params.map((parameter) => t.cloneNode(parameter, true)) as t.Identifier[],
+      cloneExpression(key),
+    );
+    renderCallback = callback;
+    row = returned;
+    dependencies = result.dependencies || [];
+    syntax = "map";
+    source = child.expression;
+  } else if (t.isJSXElement(child) && isPublicListElement(child, listNames)) {
+    const result = analyzePublicList(child, statesByValue, safeGlobals);
+    if (result.reason) return undefined;
+    const each = listAttributeExpression(child, "each");
+    const by = listAttributeExpression(child, "by");
+    const renderChild = meaningfulJsxChildren(child)[0];
+    if (
+      !each ||
+      (!t.isArrowFunctionExpression(by) && !t.isFunctionExpression(by)) ||
+      !t.isJSXExpressionContainer(renderChild) ||
+      t.isJSXEmptyExpression(renderChild.expression) ||
+      (!t.isArrowFunctionExpression(renderChild.expression) &&
+        !t.isFunctionExpression(renderChild.expression))
+    ) {
+      return undefined;
+    }
+    const returned = returnedExpression(renderChild.expression);
+    if (!returned || !t.isJSXElement(returned)) return undefined;
+    collection = each;
+    keyCallback = by;
+    renderCallback = renderChild.expression;
+    row = returned;
+    dependencies = result.dependencies || [];
+    syntax = "list";
+    source = child;
+  } else {
+    return undefined;
+  }
+
+  const rowAnalysis = analyzeKeyedRowTree(
+    row,
+    renderCallback,
+    safeGlobals,
+    new Set([...statesByValue.values()].map((state) => state.setterName)),
+  );
+  if (rowAnalysis.reason) return undefined;
+  return {
+    source,
+    collection,
+    keyCallback,
+    renderCallback,
+    row,
+    dependencies,
+    bindings: rowAnalysis.bindings || [],
+    events: rowAnalysis.events || [],
+    conditionals: rowAnalysis.conditionals || [],
+    syntax,
+  };
+}
+
 function analyzeKeyedRowsContainer(
   container: t.JSXElement,
   statesByValue: ReadonlyMap<string, StateBinding>,
@@ -1273,83 +1387,68 @@ function analyzeKeyedRowsContainer(
 
   const children = meaningfulJsxChildren(container);
   if (children.length !== 1) return undefined;
+  return analyzeKeyedRowChild(children[0], statesByValue, safeGlobals, listNames);
+}
 
-  let collection: t.Expression;
-  let keyCallback: t.ArrowFunctionExpression | t.FunctionExpression;
-  let renderCallback: t.ArrowFunctionExpression | t.FunctionExpression;
-  let row: t.JSXElement;
-  let dependencies: number[];
-  let syntax: "map" | "list";
-
-  const child = children[0];
+function analyzeKeyedRangesContainer(
+  container: t.JSXElement,
+  statesByValue: ReadonlyMap<string, StateBinding>,
+  safeGlobals: ReadonlySet<string>,
+  listNames: ReadonlySet<string>,
+): { ranges: KeyedRangePlan[]; trailing: number; dependencies: number[] } | undefined {
   if (
-    t.isJSXExpressionContainer(child) &&
-    !t.isJSXEmptyExpression(child.expression) &&
-    isMapCall(child.expression)
+    container.openingElement.attributes.some(
+      (attribute) =>
+        t.isJSXSpreadAttribute(attribute) ||
+        (t.isJSXAttribute(attribute) &&
+          t.isJSXIdentifier(attribute.name) &&
+          (attribute.name.name === "ref" || attribute.name.name === "dangerouslySetInnerHTML")),
+    )
   ) {
-    const result = analyzeMapList(child.expression, statesByValue, safeGlobals);
-    if (result.reason) return undefined;
-    const callback = child.expression.arguments[0];
-    if (!t.isArrowFunctionExpression(callback) && !t.isFunctionExpression(callback))
-      return undefined;
-    const returned = returnedExpression(callback);
-    if (!returned || !t.isJSXElement(returned)) return undefined;
-    const key = jsxKeyExpression(returned);
-    if (!key) return undefined;
-    collection = (child.expression.callee as t.MemberExpression).object as t.Expression;
-    keyCallback = t.arrowFunctionExpression(
-      callback.params.map((parameter) => t.cloneNode(parameter, true)) as t.Identifier[],
-      cloneExpression(key),
-    );
-    renderCallback = callback;
-    row = returned;
-    dependencies = result.dependencies || [];
-    syntax = "map";
-  } else if (t.isJSXElement(child) && isPublicListElement(child, listNames)) {
-    const result = analyzePublicList(child, statesByValue, safeGlobals);
-    if (result.reason) return undefined;
-    const each = listAttributeExpression(child, "each");
-    const by = listAttributeExpression(child, "by");
-    const renderChild = meaningfulJsxChildren(child)[0];
-    if (
-      !each ||
-      (!t.isArrowFunctionExpression(by) && !t.isFunctionExpression(by)) ||
-      !t.isJSXExpressionContainer(renderChild) ||
-      t.isJSXEmptyExpression(renderChild.expression) ||
-      (!t.isArrowFunctionExpression(renderChild.expression) &&
-        !t.isFunctionExpression(renderChild.expression))
-    ) {
-      return undefined;
-    }
-    const returned = returnedExpression(renderChild.expression);
-    if (!returned || !t.isJSXElement(returned)) return undefined;
-    collection = each;
-    keyCallback = by;
-    renderCallback = renderChild.expression;
-    row = returned;
-    dependencies = result.dependencies || [];
-    syntax = "list";
-  } else {
     return undefined;
   }
 
-  const rowAnalysis = analyzeKeyedRowTree(
-    row,
-    renderCallback,
-    safeGlobals,
-    new Set([...statesByValue.values()].map((state) => state.setterName)),
-  );
-  if (rowAnalysis.reason) return undefined;
+  const children = meaningfulJsxChildren(container);
+  if (children.length < 2) return undefined;
+  const ranges: KeyedRangePlan[] = [];
+  const dependencies = new Set<number>();
+  let staticBefore = 0;
+  for (const child of children) {
+    const range = analyzeKeyedRowChild(child, statesByValue, safeGlobals, listNames);
+    if (range) {
+      if (range.events.length > 0 || range.conditionals.length > 0) return undefined;
+      ranges.push({
+        before: staticBefore,
+        source: range.source,
+        collection: range.collection,
+        keyCallback: range.keyCallback,
+        renderCallback: range.renderCallback,
+        row: range.row,
+        bindings: range.bindings,
+        syntax: range.syntax,
+      });
+      for (const dependency of range.dependencies) dependencies.add(dependency);
+      staticBefore = 0;
+      continue;
+    }
+    if (!t.isJSXElement(child) || !isHostElement(child)) return undefined;
+    let hostOnly = true;
+    t.traverseFast(child, (node) => {
+      if (
+        t.isJSXFragment(node) ||
+        (t.isJSXElement(node) && node !== child && !isHostElement(node))
+      ) {
+        hostOnly = false;
+      }
+    });
+    if (!hostOnly) return undefined;
+    staticBefore += 1;
+  }
+  if (ranges.length === 0) return undefined;
   return {
-    collection,
-    keyCallback,
-    renderCallback,
-    row,
-    dependencies,
-    bindings: rowAnalysis.bindings || [],
-    events: rowAnalysis.events || [],
-    conditionals: rowAnalysis.conditionals || [],
-    syntax,
+    ranges,
+    trailing: staticBefore,
+    dependencies: [...dependencies].sort((left, right) => left - right),
   };
 }
 
@@ -1982,6 +2081,83 @@ function keyedRowsBoundary(blockRuntime: t.Identifier, plan: KeyedRowsPlan): t.J
   );
 }
 
+function keyedRangeObject(range: KeyedRangePlan): t.ObjectExpression {
+  const parameters = range.renderCallback.params.map((parameter) =>
+    t.cloneNode(parameter, true),
+  ) as t.Identifier[];
+  return t.objectExpression([
+    t.objectProperty(t.identifier("before"), t.numericLiteral(range.before)),
+    t.objectProperty(
+      t.identifier("items"),
+      t.arrowFunctionExpression([], cloneExpression(range.collection)),
+    ),
+    t.objectProperty(t.identifier("rowKey"), t.cloneNode(range.keyCallback, true)),
+    t.objectProperty(
+      t.identifier("create"),
+      t.arrowFunctionExpression(
+        parameters.map((parameter) => t.cloneNode(parameter, true)),
+        hostElementDescriptor(range.row),
+      ),
+    ),
+    t.objectProperty(
+      t.identifier("bindings"),
+      t.arrayExpression(
+        range.bindings.map((binding) => keyedRowBindingObject(binding, parameters)),
+      ),
+    ),
+  ]);
+}
+
+function keyedRangesBoundary(blockRuntime: t.Identifier, plan: KeyedRangesPlan): t.JSXElement {
+  const name = t.jsxMemberExpression(
+    t.jsxIdentifier(blockRuntime.name),
+    t.jsxIdentifier("KeyedRanges"),
+  );
+  const source = t.cloneNode(plan.source, true);
+  let rootRef: t.Expression | undefined;
+  source.openingElement.attributes = source.openingElement.attributes.filter((attribute) => {
+    if (
+      !t.isJSXAttribute(attribute) ||
+      jsxAttributeName(attribute) !== "ref" ||
+      !t.isJSXExpressionContainer(attribute.value) ||
+      t.isJSXEmptyExpression(attribute.value.expression)
+    ) {
+      return true;
+    }
+    rootRef = cloneExpression(attribute.value.expression);
+    return false;
+  });
+  return t.jsxElement(
+    t.jsxOpeningElement(
+      name,
+      [
+        t.jsxAttribute(t.jsxIdentifier("id"), t.jsxExpressionContainer(t.numericLiteral(plan.id))),
+        t.jsxAttribute(
+          t.jsxIdentifier("render"),
+          t.jsxExpressionContainer(t.arrowFunctionExpression([], source)),
+        ),
+        ...(rootRef
+          ? [t.jsxAttribute(t.jsxIdentifier("rootRef"), t.jsxExpressionContainer(rootRef))]
+          : []),
+        t.jsxAttribute(
+          t.jsxIdentifier("ranges"),
+          t.jsxExpressionContainer(
+            t.arrayExpression(plan.ranges.map((range) => keyedRangeObject(range))),
+          ),
+        ),
+        t.jsxAttribute(
+          t.jsxIdentifier("trailing"),
+          t.jsxExpressionContainer(t.numericLiteral(plan.trailing)),
+        ),
+      ],
+      true,
+    ),
+    null,
+    [],
+    true,
+  );
+}
+
 function hostConditionalBranchObject(
   branch: t.JSXElement,
   bindings: readonly PendingKeyedRowBinding[],
@@ -2254,6 +2430,25 @@ function analyzeComposableBlocks(
 
       if (t.isJSXElement(child)) {
         if (isHostElement(child)) {
+          const keyedRanges = insideConditional
+            ? undefined
+            : analyzeKeyedRangesContainer(child, statesByValue, safeGlobals, listNames);
+          if (keyedRanges) {
+            plans.push({
+              kind: "keyed-ranges",
+              id: nextId++,
+              parent,
+              dependencies: keyedRanges.dependencies,
+              source: child,
+              ranges: keyedRanges.ranges,
+              trailing: keyedRanges.trailing,
+            });
+            for (const range of keyedRanges.ranges) {
+              if (t.isJSXElement(range.source)) ownedElements.add(range.source);
+              else keyedExpressions.add(range.source);
+            }
+            continue;
+          }
           const hostConditional = analyzeHostConditionalContainer(
             child,
             statesByValue,
@@ -2451,6 +2646,9 @@ function lowerComposableBlocks(
         }
         if (plan?.kind === "keyed-rows") {
           return keyedRowsBoundary(blockRuntime, plan);
+        }
+        if (plan?.kind === "keyed-ranges") {
+          return keyedRangesBoundary(blockRuntime, plan);
         }
         if (plan?.kind === "component") {
           return componentIslandBoundary(blockRuntime, plan, child);


### PR DESCRIPTION
## Summary

- compile eligible keyed maps that appear between static siblings into keyed DOM ranges
- reconcile multiple marker-bounded ranges independently while preserving surrounding DOM identity
- reuse keyed-row bindings and LIS move planning for inserts, removals, updates, and reorders
- fall back to React for unsafe runtime keys or unsupported structures
- document the keyed-range ownership and safety boundaries and extend the compiler experiment

## Context

PR #489 landed on `feat/react-keyed-row-forms-main`. This follow-up applies that feature cleanly on the latest `main` so it can ship without bringing the stacked branch's divergent history into the pull request.

## Validation

- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test` — 231 tests passed
- focused keyed-range/compiler suite — 13 tests passed
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and React 19.2.8 passed
- `pnpm --filter farm-react-compiler-example type-check`
- `pnpm --filter farm-react-compiler-example experiment` — production browser experiment passed
- docs navigation, targeted formatting, and targeted lint checks passed

The production experiment verifies two keyed ranges, 1,024 stress rows, preserved static-sibling and keyed DOM identity, zero owner update executions, and LIS-based reordering.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compiles non-interactive keyed maps between static host siblings into keyed DOM ranges in `@farm.js/react`, so lists reconcile independently without wrappers and static siblings keep their DOM identity. Previously these shapes used the React-owned keyed list; now Farm owns the ranges and applies per-range LIS, while unsafe keys or unsupported shapes still fall back to React.

- Compiler: adds keyed-range analysis and emits a `KeyedRanges` block with per-range descriptors and before/trailing static counts; keeps `KeyedList` for root lists, interactive rows, or component/fragment siblings.
- Runtime: implements `KeyedRanges` adoption and reconciliation with per-range key tables and LIS; preserves focus and static siblings; remounts the container through React on duplicate keys, adoption mismatches, or parent-driven static changes.
- Tests and examples: adds unit and runtime suites for keyed ranges, React 18/19 compatibility test coverage, and a new example experiment (“04G”) that verifies two ranges, 1,024 rows, preserved identity, and three LIS moves; updates the verification script accordingly.
- Docs: documents the keyed-range contract, ownership and safety boundaries, and clarifies when lists remain on the React-owned path.

<sup>Written for commit 94e1d02705f046c532d2286a47ea50b12b1e3504. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

