### PR TITLE
fix(auth): close open redirect and cookie decode crash in shared auth utils

### DIFF
--- a/packages/farm-integration-utils/src/cookies.ts
+++ b/packages/farm-integration-utils/src/cookies.ts
@@ -13,6 +13,21 @@ export interface RequestCookieOptions {
   expires?: Date;
 }
 
+/**
+ * Decode a cookie value, tolerating malformed percent-encoding. A request can
+ * carry a cookie whose value is not valid UTF-8 percent-encoding (a latin-1
+ * value from an old link, a crawler, or an attacker-planted sibling-domain
+ * cookie); `decodeURIComponent` throws `URIError` on those. Falling back to the
+ * raw value keeps a single bad cookie from turning every auth route into a 500.
+ */
+function decodeCookieValue(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
 export function parseCookieHeaderMap(header: string | null): Record<string, string> {
   if (!header) {
     return {};
@@ -25,7 +40,7 @@ export function parseCookieHeaderMap(header: string | null): Record<string, stri
       .filter(Boolean)
       .map((part) => {
         const [key, ...rest] = part.split("=");
-        return [key, decodeURIComponent(rest.join("="))];
+        return [key, decodeCookieValue(rest.join("="))];
       }),
   );
 }

--- a/packages/farm-integration-utils/src/url.ts
+++ b/packages/farm-integration-utils/src/url.ts
@@ -10,7 +10,17 @@ export function getOrigin(request: Request, configuredBaseUrl?: string): string 
 }
 
 export function getReturnTo(rawValue: string | null | undefined, fallback = "/"): string {
+  // Must be a same-origin, root-relative path. A bare startsWith("/") check is
+  // not enough: "//evil.com" (protocol-relative) and "/\evil.com" (browsers
+  // and the URL parser treat "\" as "/") both begin with "/" yet resolve to a
+  // foreign origin when passed to `new URL(returnTo, origin)`, giving an open
+  // redirect after a legitimate login.
   if (!rawValue || !rawValue.startsWith("/")) {
+    return fallback;
+  }
+
+  const second = rawValue[1];
+  if (second === "/" || second === "\\") {
     return fallback;
   }
 

--- a/packages/farm/src/__tests__/integration-utils-auth-safety.test.ts
+++ b/packages/farm/src/__tests__/integration-utils-auth-safety.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { getCookieValue, parseCookieHeaderMap } from "../../../farm-integration-utils/src/cookies";
+import { getReturnTo } from "../../../farm-integration-utils/src/url";
+
+describe("getReturnTo open-redirect hardening", () => {
+  it("keeps ordinary root-relative paths", () => {
+    expect(getReturnTo("/dashboard", "/")).toBe("/dashboard");
+    expect(getReturnTo("/a/b?c=1#d", "/")).toBe("/a/b?c=1#d");
+    expect(getReturnTo("/", "/fallback")).toBe("/");
+  });
+
+  it("rejects protocol-relative and backslash targets that resolve off-origin", () => {
+    for (const evil of ["//evil.com", "/\\evil.com", "/\\/evil.com", "//evil.com/path"]) {
+      expect(getReturnTo(evil, "/dashboard")).toBe("/dashboard");
+      // The whole point: the rejected value must not resolve to a foreign origin.
+      const resolved = new URL(getReturnTo(evil, "/dashboard"), "https://app.example.com");
+      expect(resolved.origin).toBe("https://app.example.com");
+    }
+  });
+
+  it("rejects absolute URLs and empty values", () => {
+    expect(getReturnTo("https://evil.com", "/dashboard")).toBe("/dashboard");
+    expect(getReturnTo("javascript:alert(1)", "/dashboard")).toBe("/dashboard");
+    expect(getReturnTo("", "/dashboard")).toBe("/dashboard");
+    expect(getReturnTo(null, "/dashboard")).toBe("/dashboard");
+    expect(getReturnTo(undefined)).toBe("/");
+  });
+});
+
+describe("cookie parsing tolerates malformed percent-encoding", () => {
+  it("decodes valid values and falls back to raw for invalid ones", () => {
+    const map = parseCookieHeaderMap("good=%41; bad=%zz; partial=%; sid=abc123");
+    expect(map.good).toBe("A");
+    expect(map.bad).toBe("%zz");
+    expect(map.partial).toBe("%");
+    expect(map.sid).toBe("abc123");
+  });
+
+  it("does not throw when a single cookie is malformed", () => {
+    expect(() => parseCookieHeaderMap("session=%E9%; other=ok")).not.toThrow();
+    const headers = new Headers({ cookie: "auth=%C3%28; keep=value" });
+    expect(getCookieValue(headers, "auth")).toBe("%C3%28");
+    expect(getCookieValue(headers, "keep")).toBe("value");
+  });
+});


### PR DESCRIPTION
two hardening fixes in `@farm.js/integration-utils`, the shared helpers behind the auth0, workos, and supabase integrations. both surfaced in a scan of the auth packages and were confirmed by tracing the exact consumer call sites.

## 1. open redirect in `getReturnTo` (the more serious one)

`getReturnTo` gated the post-login return path on a bare `rawValue.startsWith("/")`. that check passes for two families of values that are not same-origin:

- `//evil.com` (protocol-relative)
- `/\evil.com` (the url parser and browsers treat `\` as `/`)

every consumer then builds the redirect with `new URL(returnTo, origin)`, and `new URL("//evil.com", "https://app.example.com")` resolves to `https://evil.com/` (verified in node). so `…/auth/login?returnTo=//evil.com` sends a user who logs in legitimately to an attacker origin. reached from `farm-workos` (`index.ts:140,252` → redirect at `:263`), `farm-supabase` (multiple `getReturnTo` sites → `new URL` at `:1244` etc.), and `farm-auth0` (`:346`).

fix: reject a second character of `/` or `\`, falling back to the caller's own default (`/dashboard`, `/`, …). ordinary paths like `/dashboard` and `/a/b?c=1#d` are unaffected.

## 2. cookie decode crash → 500 on auth routes

`parseCookieHeaderMap` decoded each value with an unguarded `decodeURIComponent`. a single request cookie with malformed percent-encoding (`caf%E9` from an old latin-1 link or a crawler, `%zz`, a bare `%`) throws `URIError` for the whole header map, before the handler runs. supabase calls it on every route via `getAll`, auth0 in `getSession` for profile and protected-route middleware, so one bad cookie an attacker can plant from a sibling subdomain turns those routes into a persistent 500 for the victim. same class as the core-middleware decode guard (#487) and the middleware-matcher issue in #502, just in the auth util copy.

fix: decode per entry inside try/catch, falling back to the raw value so a malformed cookie simply doesn't decode instead of taking down the request.

## testing

new suite in the core package (cross-package import, same pattern as the jobs-payload tests): root-relative paths preserved; `//evil.com`, `/\evil.com`, `/\/evil.com`, absolute and `javascript:` urls all rejected and verified to resolve back to the app origin; cookie map decodes valid values, falls back to raw for `%zz`/`%`, and never throws on a mixed valid+malformed header. the three behavior-change assertions fail on the old code (verified by revert). full farm suite: 1241 passed.

note: found by two independent scan agents converging on the same two call sites. a third finding in the same scan (workos callback lacks signed-state/CSRF binding, unlike auth0) is a larger change and will be a separate PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens `@farm.js/integration-utils` by closing an open redirect in `getReturnTo` and making cookie parsing tolerant of malformed values. Previously, `getReturnTo` accepted protocol-relative or backslash paths and could redirect off-origin, and `parseCookieHeaderMap` threw on bad percent-encoding causing 500s; now `getReturnTo` rejects those and falls back to a safe default, and cookie decoding falls back to the raw value.

- Affected functions: `getReturnTo` and `parseCookieHeaderMap` in `@farm.js/integration-utils`; consumers `farm-workos`, `farm-supabase`, and `farm-auth0` pick up the fixes with no code changes.
- `getReturnTo` now only accepts root-relative paths like "/dashboard"; values starting with `//` or `\` are ignored and the caller’s fallback is used.
- No migration required; ensure callers provide same-origin, root-relative `returnTo` values.
- Adds tests in `packages/farm/src/__tests__/integration-utils-auth-safety.test.ts` to verify same-origin resolution and non-throw cookie parsing.

<sup>Written for commit bb488e1647804a7abc5b31294597df4a1f843d17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

