### PR TITLE
fix(middleware): guard cookie decode, match by path segment, keep Max-Age=0

### DIFF
--- a/packages/farmjs-plugin/src/middleware/index.ts
+++ b/packages/farmjs-plugin/src/middleware/index.ts
@@ -19,6 +19,7 @@ import type { IncomingMessage, ServerResponse } from "http";
 import { createRequire } from "node:module";
 import { _withAfterNodeMiddleware } from "@farm.js/core/after";
 import { devServableFileExists } from "../dev-static.js";
+import { middlewareMatchesPath, parseCookies, serializeCookie } from "./matching.js";
 
 // Create require for ESM compatibility
 const require_ = createRequire(import.meta.url);
@@ -138,64 +139,6 @@ export interface DiscoveredMiddleware {
     | MiddlewareHandler
     | { build: () => { handlers: MiddlewareHandler[] }; setBasePath?: (path: string) => void };
   config?: { matcher?: string[] };
-}
-
-/**
- * Parse cookies from Cookie header
- */
-function parseCookies(cookieHeader?: string): Record<string, string> {
-  if (!cookieHeader) return {};
-
-  return cookieHeader.split(";").reduce(
-    (cookies, cookie) => {
-      const [name, ...rest] = cookie.split("=");
-      const value = rest.join("=").trim();
-      if (name && value) {
-        cookies[name.trim()] = decodeURIComponent(value);
-      }
-      return cookies;
-    },
-    {} as Record<string, string>,
-  );
-}
-
-/**
- * Serialize a cookie
- */
-function serializeCookie(name: string, value: string, options: CookieOptions = {}): string {
-  let cookie = `${encodeURIComponent(name)}=${encodeURIComponent(value)}`;
-
-  if (options.maxAge) {
-    cookie += `; Max-Age=${options.maxAge}`;
-  }
-
-  if (options.expires) {
-    cookie += `; Expires=${options.expires.toUTCString()}`;
-  }
-
-  if (options.path) {
-    cookie += `; Path=${options.path}`;
-  } else {
-    cookie += "; Path=/";
-  }
-
-  if (options.domain) {
-    cookie += `; Domain=${options.domain}`;
-  }
-
-  if (options.secure) {
-    cookie += "; Secure";
-  }
-
-  if (options.httpOnly) {
-    cookie += "; HttpOnly";
-  }
-
-  if (options.sameSite) {
-    cookie += `; SameSite=${options.sameSite.charAt(0).toUpperCase() + options.sameSite.slice(1)}`;
-  }
-
-  return cookie;
 }
 
 /**
@@ -444,10 +387,7 @@ export default function farmMiddleware(options: FarmMiddlewareOptions = {}): Plu
 
         // Find applicable middleware (cascading from root to specific)
         const applicable = Array.from(middlewareCache.values())
-          .filter((mw) => {
-            if (mw.path === "/") return true;
-            return pathname.startsWith(mw.path) || pathname === mw.path;
-          })
+          .filter((mw) => middlewareMatchesPath(pathname, mw.path))
           .sort((a, b) => a.path.split("/").length - b.path.split("/").length);
 
         if (applicable.length === 0) return false;

--- a/packages/farmjs-plugin/src/middleware/matching.test.ts
+++ b/packages/farmjs-plugin/src/middleware/matching.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { middlewareMatchesPath, parseCookies, serializeCookie } from "./matching.js";
+
+describe("parseCookies", () => {
+  it("parses and decodes ordinary cookies", () => {
+    expect(parseCookies("session=abc123; theme=dark")).toEqual({
+      session: "abc123",
+      theme: "dark",
+    });
+    expect(parseCookies("name=%41%42")).toEqual({ name: "AB" });
+  });
+
+  it("falls back to the raw value for malformed percent-encoding without throwing", () => {
+    // A latin-1 value, a bare %, and %zz would each make decodeURIComponent
+    // throw. The middleware runner swallows throws and calls next(), so a
+    // throw here silently skips every middleware — an auth bypass.
+    expect(() => parseCookies("session=ok; promo=100%off")).not.toThrow();
+    const cookies = parseCookies("good=%41; bad=%zz; latin=caf%E9; session=keep");
+    expect(cookies.good).toBe("A");
+    expect(cookies.bad).toBe("%zz");
+    expect(cookies.latin).toBe("caf%E9");
+    // The valid session cookie is still readable despite the sibling bad ones.
+    expect(cookies.session).toBe("keep");
+  });
+
+  it("returns an empty map for an absent header", () => {
+    expect(parseCookies(undefined)).toEqual({});
+    expect(parseCookies("")).toEqual({});
+  });
+});
+
+describe("middlewareMatchesPath", () => {
+  it("root middleware matches everything", () => {
+    expect(middlewareMatchesPath("/anything/here", "/")).toBe(true);
+  });
+
+  it("matches the exact path and true sub-segments", () => {
+    expect(middlewareMatchesPath("/admin", "/admin")).toBe(true);
+    expect(middlewareMatchesPath("/admin/users", "/admin")).toBe(true);
+    expect(middlewareMatchesPath("/admin/users/42", "/admin")).toBe(true);
+  });
+
+  it("does not match sibling routes that only share a string prefix", () => {
+    expect(middlewareMatchesPath("/administrator", "/admin")).toBe(false);
+    expect(middlewareMatchesPath("/admin-public", "/admin")).toBe(false);
+    expect(middlewareMatchesPath("/adminery/x", "/admin")).toBe(false);
+  });
+});
+
+describe("serializeCookie", () => {
+  it("emits Max-Age=0 for immediate expiry instead of dropping it", () => {
+    const cookie = serializeCookie("session", "", { maxAge: 0 });
+    expect(cookie).toContain("Max-Age=0");
+  });
+
+  it("omits Max-Age when not provided", () => {
+    expect(serializeCookie("a", "b")).not.toContain("Max-Age");
+  });
+
+  it("serializes standard attributes", () => {
+    const cookie = serializeCookie("a", "b", {
+      maxAge: 3600,
+      path: "/app",
+      secure: true,
+      httpOnly: true,
+      sameSite: "lax",
+    });
+    expect(cookie).toBe("a=b; Max-Age=3600; Path=/app; Secure; HttpOnly; SameSite=Lax");
+  });
+
+  it("defaults Path to / when unspecified", () => {
+    expect(serializeCookie("a", "b")).toContain("Path=/");
+  });
+});

--- a/packages/farmjs-plugin/src/middleware/matching.ts
+++ b/packages/farmjs-plugin/src/middleware/matching.ts
@@ -1,0 +1,91 @@
+import type { CookieOptions } from "./index.js";
+
+/**
+ * Parse cookies from a Cookie header.
+ *
+ * A single request cookie whose value is not valid UTF-8 percent-encoding
+ * (a latin-1 value from an old link, a crawler, or a bare `%`) must not take
+ * the whole map down: an unguarded `decodeURIComponent` throws `URIError`,
+ * which — because the middleware runner swallows the throw and calls `next()` —
+ * would silently skip every middleware for that request (a dev-time auth
+ * bypass). Decoding falls back to the raw value per entry instead.
+ */
+export function parseCookies(cookieHeader?: string): Record<string, string> {
+  if (!cookieHeader) return {};
+
+  return cookieHeader.split(";").reduce(
+    (cookies, cookie) => {
+      const [name, ...rest] = cookie.split("=");
+      const value = rest.join("=").trim();
+      if (name && value) {
+        cookies[name.trim()] = decodeCookieValue(value);
+      }
+      return cookies;
+    },
+    {} as Record<string, string>,
+  );
+}
+
+function decodeCookieValue(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Whether a middleware registered at `middlewarePath` applies to `pathname`.
+ *
+ * Matching is by path segment, not raw string prefix: middleware at `/admin`
+ * covers `/admin` and everything under `/admin/`, but not sibling routes like
+ * `/administrator` or `/admin-public` that merely share a textual prefix.
+ */
+export function middlewareMatchesPath(pathname: string, middlewarePath: string): boolean {
+  if (middlewarePath === "/") return true;
+  if (pathname === middlewarePath) return true;
+  return pathname.startsWith(`${middlewarePath}/`);
+}
+
+/**
+ * Serialize a cookie.
+ *
+ * `Max-Age=0` is the canonical immediate-expiry directive, so the attribute is
+ * emitted whenever `maxAge` is provided — a `0` must not be dropped the way a
+ * plain truthiness check would drop it.
+ */
+export function serializeCookie(name: string, value: string, options: CookieOptions = {}): string {
+  let cookie = `${encodeURIComponent(name)}=${encodeURIComponent(value)}`;
+
+  if (options.maxAge != null) {
+    cookie += `; Max-Age=${options.maxAge}`;
+  }
+
+  if (options.expires) {
+    cookie += `; Expires=${options.expires.toUTCString()}`;
+  }
+
+  if (options.path) {
+    cookie += `; Path=${options.path}`;
+  } else {
+    cookie += "; Path=/";
+  }
+
+  if (options.domain) {
+    cookie += `; Domain=${options.domain}`;
+  }
+
+  if (options.secure) {
+    cookie += "; Secure";
+  }
+
+  if (options.httpOnly) {
+    cookie += "; HttpOnly";
+  }
+
+  if (options.sameSite) {
+    cookie += `; SameSite=${options.sameSite.charAt(0).toUpperCase() + options.sameSite.slice(1)}`;
+  }
+
+  return cookie;
+}


### PR DESCRIPTION
three defects in the dev-middleware plugin (`@farm.js/plugin/middleware`), extracted into `middleware/matching.ts` with direct unit tests (mirroring the `dev-static.ts` split).

## 1. malformed cookie silently bypasses all middleware (the notable one)

`parseCookies` decoded each value with a bare `decodeURIComponent`. a request cookie with malformed percent-encoding (`promo=100%off`, a bare `%`, a latin-1 `caf%E9`) throws `URIError`. that throw propagates out of `executeMiddleware`, and the caller catches it and calls `next()`:

```ts
try {
  const handled = await executeMiddleware(...);
  if (handled) return;
} catch (e) {
  console.error("[FARM] Middleware error:", e);
}
next();
```

so a single bad cookie means the request runs with **no middleware applied** — auth guards, redirects, protected-route checks all skipped in dev. decoding now falls back to the raw value per entry, so a malformed cookie simply doesn't decode.

## 2. middleware over-applies to sibling routes

applicability used `pathname.startsWith(mw.path)`, a raw string prefix. middleware registered at `/admin` therefore also ran on `/administrator` and `/admin-public`. now matched by path segment: exact match or a `/`-delimited sub-path (`middlewareMatchesPath`).

## 3. Max-Age=0 dropped

`serializeCookie` gated the attribute on `if (options.maxAge)`, so `maxAge: 0` — the canonical immediate-expiry directive — was omitted. now emitted whenever `maxAge` is provided.

## testing

10 new unit tests over the extracted helpers. each of the three fixes regresses a dedicated test when the original code is restored (verified). typecheck clean, full plugin suite 54 passed.

found in the same round-3 scan as #504; this is the dev-plugin analogue of that PR's core-util cookie fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard cookie decoding, match middleware by path segment, and emit `Max-Age=0` in the dev middleware for `@farm.js/plugin/middleware`. Prevents malformed cookies from skipping middleware and stops `/admin` middleware from running on sibling routes.

- Behavior changes:
  - Cookie parsing: previously decoded each value and threw on malformed percent-encoding, causing the runner to catch and call next(), skipping all middleware. Now decodes per entry and falls back to the raw value on error; middleware continues to run. Side effect: invalid cookie values remain as provided.
  - Path matching: previously used string prefix matching, so `/admin` middleware applied to `/administrator` and `/admin-public`. Now matches exact path or slash-delimited subpaths only.
  - Cookie serialization: previously dropped `Max-Age=0` due to a truthy check. Now emits `Max-Age` whenever provided, including 0 for immediate expiry.

- Review notes:
  - Helpers extracted to `middleware/matching.ts` (`parseCookies`, `middlewareMatchesPath`, `serializeCookie`) with focused tests in `middleware/matching.test.ts`; `index.ts` now imports these. 10 new unit tests; plugin suite passes.

<sup>Written for commit 8e359fbf2314a931fa4f6c1c01b6d39beca1e5f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

