### PR TITLE
fix(create-app): derive package name from the final path segment

### DIFF
--- a/packages/create-farm-app/src/index.ts
+++ b/packages/create-farm-app/src/index.ts
@@ -815,7 +815,10 @@ async function updatePackageJson(
     const content = await fs.readFile(packageJsonPath, "utf-8");
     const packageJson = JSON.parse(content);
 
-    packageJson.name = projectName;
+    // projectName may be a nested path (e.g. "apps/my-app"): the directory is
+    // created at that path, but an unscoped package name cannot contain a
+    // slash, so the manifest name is the final path segment only.
+    packageJson.name = path.basename(projectName.replace(/[\\/]+$/, "")) || projectName;
     if (packageManager.version) {
       packageJson.packageManager = `${packageManager.name}@${packageManager.version}`;
     }

--- a/packages/create-farm-app/test/create-app.test.mjs
+++ b/packages/create-farm-app/test/create-app.test.mjs
@@ -32,6 +32,40 @@ test("spaces the CLI banner and matches the website hero copy", async () => {
   assert.doesNotMatch(lines.join("\n"), /React (?:meta-)?framework/i);
 });
 
+test("writes a valid package name when the target is a nested path", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "create-farm-app-nested-"));
+
+  try {
+    const projectName = "apps/my-nested-app";
+    execFileSync(
+      process.execPath,
+      [
+        path.join(packageDir, "bin/create-farm-app.js"),
+        projectName,
+        "--template",
+        "basic",
+        "--typescript",
+        "--skip-install",
+      ],
+      {
+        cwd: tempDir,
+        encoding: "utf8",
+        env: { ...process.env, npm_config_user_agent: "pnpm/11.18.0 npm/? node/v22.0.0" },
+      },
+    );
+
+    // The directory is created at the nested path...
+    const generatedDir = path.join(tempDir, "apps", "my-nested-app");
+    const packageJson = JSON.parse(await readFile(path.join(generatedDir, "package.json"), "utf8"));
+
+    // ...but the manifest name is the final segment, which is a valid npm name.
+    assert.equal(packageJson.name, "my-nested-app");
+    assert.doesNotMatch(packageJson.name, /[\\/]/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("uses concise labels for CLI template choices", async () => {
   const source = await readFile(path.join(packageDir, "src/index.ts"), "utf8");
 


### PR DESCRIPTION
`validateProjectPathArg` validates only the *basename* of the target path (`validateProjectName(path.basename(normalized))`), so a nested target like `create-farm-app apps/my-app` passes validation. the directory is then created correctly at `apps/my-app`, but `updatePackageJson` wrote the full `projectName` as the manifest name:

```ts
packageJson.name = projectName;   // "apps/my-app"
```

an unscoped npm name cannot contain a slash, so the generated `package.json` is invalid and `npm`/`pnpm` reject it on the first install.

fix: set the manifest name to the final path segment (`my-app`), matching the name validation already checked. flat project names are unaffected (`path.basename("my-app") === "my-app"`), and the `cd`/next-step messages keep using the full path, which is correct for navigation.

## testing

new test drives the real CLI binary with `apps/my-nested-app`, asserts the directory lands at the nested path and `package.json` name is `my-nested-app` with no slash. reverting the fix regresses it (verified). lint/format clean.

from the same round-3 scan as #504 and #505.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `package.json` name to the final path segment when `create-farm-app` targets a nested path. Previously it wrote the full path (e.g., "apps/my-app"), which is an invalid unscoped name and caused `npm`/`pnpm` installs to fail.

- Derives the manifest name from the basename of `projectName` (after trimming trailing slashes). Flat names are unchanged; directory creation and "cd" hints still use the full path.
- Adds an integration test that runs the CLI with `apps/my-nested-app` and asserts the generated `package.json` name is `my-nested-app` (no slashes).

<sup>Written for commit 771846762c91be2a414f8341980ae2e84c6ca72e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

