### PR TITLE
fix(preview-gateway): preserve multiple Set-Cookie headers end to end

### DIFF
--- a/packages/farm-cli/src/preview-gateway.ts
+++ b/packages/farm-cli/src/preview-gateway.ts
@@ -31,7 +31,7 @@ export interface PreviewGatewayRequest {
 
 export interface PreviewGatewayResponse {
   status: number;
-  headers?: Record<string, string>;
+  headers?: Record<string, string | string[]>;
   body?: string | null;
   encoding?: "base64";
 }
@@ -242,6 +242,11 @@ export async function createGatewaySession(
   return session;
 }
 
+function getSetCookies(headers: Headers): string[] {
+  const getSetCookie = (headers as Headers & { getSetCookie?: () => string[] }).getSetCookie;
+  return getSetCookie?.call(headers) || [];
+}
+
 export async function forwardGatewayRequest(
   target: PreviewTarget,
   request: PreviewGatewayRequest,
@@ -267,13 +272,19 @@ export async function forwardGatewayRequest(
       : undefined,
   });
 
-  const responseHeaders: Record<string, string> = {};
+  const responseHeaders: Record<string, string | string[]> = {};
   response.headers.forEach((value, key) => {
     const normalized = key.toLowerCase();
-    if (!HOP_BY_HOP_HEADERS.has(normalized)) {
+    // Set-Cookie is collected separately: Headers.forEach folds repeated
+    // headers into one comma-joined value, which corrupts multiple cookies.
+    if (!HOP_BY_HOP_HEADERS.has(normalized) && normalized !== "set-cookie") {
       responseHeaders[key] = value;
     }
   });
+  const setCookies = getSetCookies(response.headers);
+  if (setCookies.length > 0) {
+    responseHeaders["set-cookie"] = setCookies;
+  }
 
   return {
     status: response.status,

--- a/packages/farm-preview-gateway/src/index.ts
+++ b/packages/farm-preview-gateway/src/index.ts
@@ -37,7 +37,10 @@ export interface PreviewGatewayRequest {
 
 export interface PreviewGatewayResponse {
   status: number;
-  headers?: Record<string, string>;
+  // A header may carry multiple values (notably Set-Cookie: a login response
+  // commonly sets a session cookie and a CSRF cookie). Those must survive as
+  // an array through the store and back onto the public response.
+  headers?: Record<string, string | string[]>;
   body?: string | null;
   encoding?: "base64";
 }
@@ -159,9 +162,17 @@ export function createNodePreviewGatewayHandler(options: PreviewGatewayOptions =
   return async function nodePreviewGatewayHandler(req: IncomingMessage, res: ServerResponse) {
     const response = await handler(nodeRequestToWebRequest(req));
     res.statusCode = response.status;
+    // Headers.forEach folds repeated headers into one comma-joined value, which
+    // corrupts multiple Set-Cookie. Emit those separately as an array so each
+    // cookie becomes its own header line.
+    const setCookies = response.headers.getSetCookie?.() ?? [];
     response.headers.forEach((value, key) => {
+      if (key.toLowerCase() === "set-cookie") return;
       res.setHeader(key, value);
     });
+    if (setCookies.length > 0) {
+      res.setHeader("set-cookie", setCookies);
+    }
     res.end(Buffer.from(await response.arrayBuffer()));
   };
 }
@@ -547,8 +558,13 @@ async function proxyPublicRequest(
   const headers = new Headers();
   for (const [key, value] of Object.entries(response.headers || {})) {
     const normalized = key.toLowerCase();
-    if (!HOP_BY_HOP_HEADERS.has(normalized)) {
-      headers.set(key, value);
+    if (HOP_BY_HOP_HEADERS.has(normalized)) {
+      continue;
+    }
+    // Append multi-valued headers (Set-Cookie) so every value reaches the
+    // visitor; Headers.set would keep only the last.
+    for (const single of Array.isArray(value) ? value : [value]) {
+      headers.append(key, single);
     }
   }
   headers.set("cache-control", "no-store");

--- a/packages/farm-preview-gateway/test/gateway.test.mjs
+++ b/packages/farm-preview-gateway/test/gateway.test.mjs
@@ -59,6 +59,53 @@ test("proxies a public preview request through the gateway queue", async () => {
   }
 });
 
+test("replays every Set-Cookie header to the public visitor", async () => {
+  const store = new MemoryPreviewGatewayStore();
+  const gateway = await createGatewayServer(store);
+
+  try {
+    const sessionResponse = await fetch(`${gateway.url}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "cookie-check", localUrl: "http://localhost:4321" }),
+    });
+    const session = await sessionResponse.json();
+
+    const publicRequest = fetch(`${gateway.url}/__preview/cookie-check/login`, { method: "POST" });
+    const pollResponse = await fetch(
+      `${gateway.url}/api/sessions/${session.id}/requests?token=${session.token}&wait=1000`,
+    );
+    const poll = await pollResponse.json();
+
+    // A login response commonly sets both a session and a CSRF cookie.
+    await fetch(
+      `${gateway.url}/api/sessions/${session.id}/responses/${poll.requests[0].id}?token=${session.token}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          status: 200,
+          headers: {
+            "content-type": "text/plain",
+            "set-cookie": ["session=abc; Path=/; HttpOnly", "csrf=xyz; Path=/"],
+          },
+          body: Buffer.from("ok").toString("base64"),
+          encoding: "base64",
+        }),
+      },
+    );
+
+    const response = await publicRequest;
+    assert.equal(response.status, 200);
+    const setCookie = response.headers.getSetCookie();
+    assert.equal(setCookie.length, 2);
+    assert.ok(setCookie.some((cookie) => cookie.startsWith("session=abc")));
+    assert.ok(setCookie.some((cookie) => cookie.startsWith("csrf=xyz")));
+  } finally {
+    await gateway.close();
+  }
+});
+
 test("expires stale preview clients before queueing public requests", async () => {
   const store = new MemoryPreviewGatewayStore();
   const gateway = await createGatewayServer(store, {


### PR DESCRIPTION
a local preview response that sets more than one cookie — a login route commonly sets both a session cookie and a CSRF cookie — reached the public visitor through the preview URL with only one of them, so auth/CSRF flows silently broke when tested through a shared preview.

`Set-Cookie` was collapsed at **three** points along the path, each fixed to carry the values as an array the way the sibling `farm-preview-tunnel` protocol already does:

1. `PreviewGatewayResponse.headers` was typed `Record<string, string>`, which cannot represent two cookies. now `Record<string, string | string[]>` (in both the gateway package and the CLI's copy of the type).
2. the CLI client `forwardGatewayRequest` built the response headers with `Headers.forEach`, which folds repeated headers into one comma-joined value (and comma is valid inside a cookie's Expires date, so it is unrecoverable). it now skips `set-cookie` in that loop and captures it via `getSetCookie()` as an array.
3. on replay, `proxyPublicRequest` used `Headers.set` (last-wins) — changed to append each value — and the Node handler adapter re-flattened them a second time through `Headers.forEach`, so it now emits `set-cookie` as an array via `res.setHeader`.

point 3's second leak (the Node adapter) was caught by the end-to-end test rather than by reading, which is why the test drives the real gateway handler.

## testing

new gateway test posts a response with two `Set-Cookie` values and asserts both arrive on the public response via `getSetCookie()`. it fails on the pre-fix code (verified by revert). gateway suite 5 passed, CLI suite 86 passed.

from the round-3 scan (same batch as #504/#505/#506).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves multiple Set-Cookie headers end to end in the preview gateway so shared previews mirror local auth/CSRF flows. Previously, only one cookie reached the public visitor because repeated headers were collapsed; now all Set-Cookie values propagate intact.

**Review notes**
- Represent repeated headers: `PreviewGatewayResponse.headers` is now `Record<string, string | string[]>` in `farm-preview-gateway` and the `farm-cli` type copy.
- Capture cookies correctly in the CLI: `forwardGatewayRequest` skips `Headers.forEach` for `set-cookie` and uses `getSetCookie()` to collect an array.
- Replay correctly: `proxyPublicRequest` appends each value; the Node handler emits `set-cookie` via `res.setHeader([...])` instead of relying on `Headers.forEach`.
- Adds an end-to-end test that posts two `set-cookie` values and asserts both reach the public response via `getSetCookie()`.

**Migration**
- If you construct or consume `PreviewGatewayResponse.headers`, handle `set-cookie` as `string | string[]`. Provide an array when returning multiple cookies; reading code must accept either shape.

<sup>Written for commit d5139e17cdd06c0d6b33baf98b4afadcfac75f01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

