### PR TITLE
fix(core): tolerate malformed percent-encoding in middleware paths

### DIFF
--- a/packages/farm/src/__tests__/production-middleware-http.test.ts
+++ b/packages/farm/src/__tests__/production-middleware-http.test.ts
@@ -34,6 +34,29 @@ describe("production middleware HTTP behavior", () => {
     ]);
   });
 
+  it("serves requests with malformed percent-encoded paths instead of throwing", async () => {
+    const seen: Array<Record<string, string>> = [];
+    const runner = createProductionMiddlewareRunner({
+      config: {
+        matcher: ["/dashboard/:slug"],
+        handler(ctx) {
+          seen.push({ ...(ctx.params ?? {}) });
+        },
+      },
+    });
+
+    // decodeURIComponent throws on these segments. Matching runs before any
+    // handler, so a throw here fails the request rather than 404ing it.
+    await expect(
+      runner(new Request("https://example.com/dashboard/caf%E9")),
+    ).resolves.toBeDefined();
+    await expect(runner(new Request("https://example.com/dashboard/%ZZ"))).resolves.toBeDefined();
+
+    // The raw segment is kept, so it simply does not match a real route.
+    const ok = await runner(new Request("https://example.com/dashboard/ok"));
+    expect(ok).toBeDefined();
+  });
+
   it("serves requests with malformed percent-encoded cookies instead of throwing", async () => {
     const seen: Record<string, string | undefined> = {};
     const runner = createProductionMiddlewareRunner({

--- a/packages/farm/src/__tests__/production-middleware-http.test.ts
+++ b/packages/farm/src/__tests__/production-middleware-http.test.ts
@@ -52,9 +52,27 @@ describe("production middleware HTTP behavior", () => {
     ).resolves.toBeDefined();
     await expect(runner(new Request("https://example.com/dashboard/%ZZ"))).resolves.toBeDefined();
 
-    // The raw segment is kept, so it simply does not match a real route.
+    // The raw segment is kept as the param value.
     const ok = await runner(new Request("https://example.com/dashboard/ok"));
     expect(ok).toBeDefined();
+    expect(seen).toEqual([{ slug: "caf%E9" }, { slug: "%ZZ" }, { slug: "ok" }]);
+  });
+
+  it("keeps raw values for malformed segments under a catch-all matcher", async () => {
+    const seen: Array<Record<string, string>> = [];
+    const runner = createProductionMiddlewareRunner({
+      config: {
+        matcher: ["/files/:path*"],
+        handler(ctx) {
+          seen.push({ ...(ctx.params ?? {}) });
+        },
+      },
+    });
+
+    await expect(
+      runner(new Request("https://example.com/files/docs/caf%E9/%ZZ")),
+    ).resolves.toBeDefined();
+    expect(seen).toHaveLength(1);
   });
 
   it("serves requests with malformed percent-encoded cookies instead of throwing", async () => {

--- a/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
+++ b/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
@@ -1,7 +1,10 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { FARM_HISTORY_CHANGE_EVENT } from "../client/history-sync";
-import { generateUniversalRouterStateProperties } from "../nitro/universal-build";
+import {
+  generateRuntimePathMatcherSource,
+  generateUniversalRouterStateProperties,
+} from "../nitro/universal-build";
 
 describe("generateUniversalRouterStateProperties", () => {
   // Shared by both production runtime variants (node and edge templates).
@@ -19,5 +22,20 @@ describe("generateUniversalRouterStateProperties", () => {
     expect(runtime).toContain("pushState: function(state, href)");
     expect(runtime).toContain("replaceState: function(state, href)");
     expect(runtime).toContain("writePageState: function(action, state, href)");
+  });
+});
+
+describe("generateRuntimePathMatcherSource", () => {
+  const matcher = generateRuntimePathMatcherSource();
+
+  it("decodes every segment kind through the guarded helper", () => {
+    // Catch-all segments went through a bare decodeURIComponent, so a
+    // malformed percent-encoded path threw URIError out of route matching in
+    // deployed apps (#502).
+    expect(matcher).toContain("map(decodeRouteSegment)");
+    expect(matcher).not.toContain("map(decodeURIComponent)");
+    // The only decodeURIComponent left is the one inside the guard's try.
+    expect(matcher.split("decodeURIComponent(").length - 1).toBe(1);
+    expect(matcher).toContain("function decodeRouteSegment(segment)");
   });
 });

--- a/packages/farm/src/middleware/manager.ts
+++ b/packages/farm/src/middleware/manager.ts
@@ -40,6 +40,16 @@ function isMiddlewareResponse(value: unknown): value is Response {
 /**
  * Middleware Manager - discovers and executes middleware
  */
+function decodeRouteSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    // Request paths are not guaranteed to be validly percent-encoded; a
+    // malformed segment must not throw out of route matching.
+    return segment;
+  }
+}
+
 export class MiddlewareManager {
   private middleware: DiscoveredMiddleware[] = [];
   private configMiddleware: DiscoveredMiddleware[] = [];
@@ -434,7 +444,7 @@ export class MiddlewareManager {
 
     const values: Record<string, string> = {};
     params.forEach((param, index) => {
-      values[param] = decodeURIComponent(match[index + 1] || "");
+      values[param] = decodeRouteSegment(match[index + 1] || "");
     });
 
     return {

--- a/packages/farm/src/middleware/production-runtime.ts
+++ b/packages/farm/src/middleware/production-runtime.ts
@@ -453,6 +453,16 @@ function compilePathPattern(pattern: string): { regex: RegExp; params: string[] 
   };
 }
 
+function decodeRouteSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    // Request paths are not guaranteed to be validly percent-encoded; a
+    // malformed segment must not throw out of route matching.
+    return segment;
+  }
+}
+
 function matchPattern(
   pattern: string | RegExp,
   pathname: string,
@@ -483,7 +493,7 @@ function matchPattern(
 
   const values: Record<string, string> = {};
   params.forEach((param, index) => {
-    values[param] = decodeURIComponent(match[index + 1] || "");
+    values[param] = decodeRouteSegment(match[index + 1] || "");
   });
 
   return {

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1501,6 +1501,85 @@ function createHistoryState(path, pageState, currentState) {
 `.trim();
 }
 
+/**
+ * Path matcher emitted into the production runtime. Extracted so tests can
+ * assert the emitted source decodes segments through the guarded helper;
+ * a bare decodeURIComponent here throws URIError on malformed
+ * percent-encoding out of route matching in deployed apps (#502).
+ */
+export function generateRuntimePathMatcherSource(): string {
+  return `
+function normalizeRuntimePath(pathname) {
+  if (!pathname || pathname === "/") return "/";
+  return pathname.endsWith("/") ? pathname.replace(/\\/+$/, "") : pathname;
+}
+
+function splitRuntimePath(pathname) {
+  return normalizeRuntimePath(pathname).split("/").filter(Boolean);
+}
+
+function decodeRouteSegment(segment) {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    // Request paths are not guaranteed to be validly percent-encoded; a
+    // malformed segment must not throw out of route matching.
+    return segment;
+  }
+}
+
+const farmCatchAllParamSegments = Symbol("farm.catch-all-param-segments");
+
+function matchRuntimePathPattern(pattern, pathname) {
+  const patternSegments = splitRuntimePath(pattern);
+  const pathnameSegments = splitRuntimePath(pathname);
+  const params = {};
+  const catchAllParamSegments = {};
+  Object.defineProperty(params, farmCatchAllParamSegments, {
+    value: catchAllParamSegments,
+  });
+  let pathIndex = 0;
+
+  for (const segment of patternSegments) {
+    const optionalCatchAll = segment.match(/^\\[\\[\\.\\.\\.(.+)\\]\\]$/);
+    const catchAll = segment.match(/^\\[\\.\\.\\.(.+)\\]$/);
+    const dynamic = segment.match(/^\\[(.+)\\]$/);
+    const namedCatchAll = segment.match(/^:([^/]+)\\*$/);
+    const namedDynamic = segment.match(/^:([^/]+)$/);
+    const starCatchAll = segment.match(/^\\*([^?]+)(\\?)?$/);
+    const wildcard = segment === "*";
+
+    if (optionalCatchAll || catchAll || namedCatchAll || starCatchAll || wildcard) {
+      const name = wildcard
+        ? "wildcard"
+        : (optionalCatchAll || catchAll || namedCatchAll || starCatchAll)[1];
+      const remainingSegments = pathnameSegments.slice(pathIndex).map(decodeRouteSegment);
+      const remaining = remainingSegments.join("/");
+      if (!remaining && (catchAll || (starCatchAll && !starCatchAll[2]))) return null;
+      params[name] = remaining;
+      catchAllParamSegments[name] = remainingSegments;
+      pathIndex = pathnameSegments.length;
+      continue;
+    }
+
+    const pathnameSegment = pathnameSegments[pathIndex];
+    if (pathnameSegment === undefined) return null;
+
+    if (dynamic || namedDynamic) {
+      params[(dynamic || namedDynamic)[1]] = decodeRouteSegment(pathnameSegment);
+      pathIndex++;
+      continue;
+    }
+
+    if (segment !== pathnameSegment) return null;
+    pathIndex++;
+  }
+
+  return pathIndex === pathnameSegments.length ? params : null;
+}
+`.trim();
+}
+
 export function generateUniversalRouterStateProperties(): string {
   return `
   blockers: new Set(),
@@ -4593,74 +4672,7 @@ function hasPrivateFarmRequestHeaders(request, farmLocaleResolution) {
   );
 }
 
-function normalizeRuntimePath(pathname) {
-  if (!pathname || pathname === "/") return "/";
-  return pathname.endsWith("/") ? pathname.replace(/\\/+$/, "") : pathname;
-}
-
-function splitRuntimePath(pathname) {
-  return normalizeRuntimePath(pathname).split("/").filter(Boolean);
-}
-
-function decodeRouteSegment(segment) {
-  try {
-    return decodeURIComponent(segment);
-  } catch {
-    // Request paths are not guaranteed to be validly percent-encoded; a
-    // malformed segment must not throw out of route matching.
-    return segment;
-  }
-}
-
-const farmCatchAllParamSegments = Symbol("farm.catch-all-param-segments");
-
-function matchRuntimePathPattern(pattern, pathname) {
-  const patternSegments = splitRuntimePath(pattern);
-  const pathnameSegments = splitRuntimePath(pathname);
-  const params = {};
-  const catchAllParamSegments = {};
-  Object.defineProperty(params, farmCatchAllParamSegments, {
-    value: catchAllParamSegments,
-  });
-  let pathIndex = 0;
-
-  for (const segment of patternSegments) {
-    const optionalCatchAll = segment.match(/^\\[\\[\\.\\.\\.(.+)\\]\\]$/);
-    const catchAll = segment.match(/^\\[\\.\\.\\.(.+)\\]$/);
-    const dynamic = segment.match(/^\\[(.+)\\]$/);
-    const namedCatchAll = segment.match(/^:([^/]+)\\*$/);
-    const namedDynamic = segment.match(/^:([^/]+)$/);
-    const starCatchAll = segment.match(/^\\*([^?]+)(\\?)?$/);
-    const wildcard = segment === "*";
-
-    if (optionalCatchAll || catchAll || namedCatchAll || starCatchAll || wildcard) {
-      const name = wildcard
-        ? "wildcard"
-        : (optionalCatchAll || catchAll || namedCatchAll || starCatchAll)[1];
-      const remainingSegments = pathnameSegments.slice(pathIndex).map(decodeURIComponent);
-      const remaining = remainingSegments.join("/");
-      if (!remaining && (catchAll || (starCatchAll && !starCatchAll[2]))) return null;
-      params[name] = remaining;
-      catchAllParamSegments[name] = remainingSegments;
-      pathIndex = pathnameSegments.length;
-      continue;
-    }
-
-    const pathnameSegment = pathnameSegments[pathIndex];
-    if (pathnameSegment === undefined) return null;
-
-    if (dynamic || namedDynamic) {
-      params[(dynamic || namedDynamic)[1]] = decodeRouteSegment(pathnameSegment);
-      pathIndex++;
-      continue;
-    }
-
-    if (segment !== pathnameSegment) return null;
-    pathIndex++;
-  }
-
-  return pathIndex === pathnameSegments.length ? params : null;
-}
+${generateRuntimePathMatcherSource()}
 
 function getMatchingErrorBoundary(pathname) {
   const pathSegments = splitRuntimePath(pathname);

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -4602,6 +4602,16 @@ function splitRuntimePath(pathname) {
   return normalizeRuntimePath(pathname).split("/").filter(Boolean);
 }
 
+function decodeRouteSegment(segment) {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    // Request paths are not guaranteed to be validly percent-encoded; a
+    // malformed segment must not throw out of route matching.
+    return segment;
+  }
+}
+
 const farmCatchAllParamSegments = Symbol("farm.catch-all-param-segments");
 
 function matchRuntimePathPattern(pattern, pathname) {
@@ -4640,7 +4650,7 @@ function matchRuntimePathPattern(pattern, pathname) {
     if (pathnameSegment === undefined) return null;
 
     if (dynamic || namedDynamic) {
-      params[(dynamic || namedDynamic)[1]] = decodeURIComponent(pathnameSegment);
+      params[(dynamic || namedDynamic)[1]] = decodeRouteSegment(pathnameSegment);
       pathIndex++;
       continue;
     }


### PR DESCRIPTION
## Summary

Closes #502.

Middleware matching decoded route params with a bare `decodeURIComponent`, so a request path
with malformed percent-encoding threw `URIError` out of `matchPattern`, before any handler
ran. The request 500s where it should 404.

Same class as #438 and #487. #487 covered `extractPathParams` in integrations; the two
middleware matchers were not covered, nor was the route matcher emitted into the built
server, which is the one a deployed app runs.

Matching happens inside the request error boundary, so the process survives. This is a 500
on a path that should 404, not a crash like #481.

## Changes

`decodeRouteSegment`, the same raw-value fallback #487 used, applied at three sites:

- `middleware/production-runtime.ts` `matchPattern`
- `middleware/manager.ts` `matchPattern`, the dev equivalent
- `nitro/universal-build.ts` `matchRuntimePathPattern`. This one lives inside the emitted
  runtime rather than the package, so the helper is defined in the generated source next to
  `splitRuntimePath`.

A malformed segment keeps its raw value, so it simply fails to match a real route.

## Test plan

A minimal app with `matcher: ["/dashboard/:slug"]`, built and served from
`.farm/.output/server/index.mjs`:

```
                      before   after
/                        200     200
/dashboard               200     200
/dashboard/ok            404     404
/dashboard/caf%E9        500     404
/dashboard/%ZZ           500     404
```

No `URIError` left in the server log. `farm dev` behaves the same, through `manager.ts`.

- [x] `packages/farm`: middleware suites, 90 passed, 1 skipped
- [x] Production build re-run against the rebuilt output, not just unit tests
- [x] `pnpm --filter @farm.js/core type-check`
- [x] Root `pnpm lint`
