### PR TITLE
fix(cf-agent): rewrite environment-level main to the combined worker

### DIFF
--- a/packages/farm-cf-agent/src/__tests__/cf-agent.test.ts
+++ b/packages/farm-cf-agent/src/__tests__/cf-agent.test.ts
@@ -134,6 +134,52 @@ export default { fetch() { return new Response("agent"); } };
     await expect(access(join(root, "wrangler.jsonc"))).resolves.toBeUndefined();
   });
 
+  it("rewrites an environment-level main to the combined worker", async () => {
+    const root = await mkdtemp(join(tmpdir(), "farm-cf-agent-env-"));
+    const outputDir = join(root, ".output");
+    const configPath = join(root, "wrangler.jsonc");
+    await mkdir(join(root, "src"), { recursive: true });
+    await mkdir(join(outputDir, "server"), { recursive: true });
+    await mkdir(join(outputDir, "public"), { recursive: true });
+    await writeFile(
+      configPath,
+      `{
+        "name": "farm-agent",
+        "main": "src/agent.mjs",
+        "compatibility_date": "2026-07-16",
+        "env": {
+          "staging": { "main": "src/agent.staging.mjs" }
+        }
+      }\n`,
+    );
+    await writeFile(
+      join(root, "src", "agent.mjs"),
+      `export default { fetch() { return new Response("agent"); } };\n`,
+    );
+    await writeFile(
+      join(root, "src", "agent.staging.mjs"),
+      `export default { fetch() { return new Response("staging-agent"); } };\n`,
+    );
+    await writeFile(
+      join(outputDir, "server", "index.mjs"),
+      `export default { fetch() { return new Response("farm"); } };\n`,
+    );
+
+    const result = await writeCloudflareAgentOutput({
+      root,
+      outputDir,
+      config: "wrangler.jsonc",
+      routePrefix: "/agents",
+      environment: "staging",
+    });
+
+    const generated = parse(await readFile(result.configPath, "utf8"));
+    // Both the top-level and the selected env main must point at the wrapper,
+    // otherwise `wrangler deploy --env staging` serves only the agent Worker.
+    expect(generated.main).toBe("./.farm/cf-agent/worker.mjs");
+    expect(generated.env.staging.main).toBe("./.farm/cf-agent/worker.mjs");
+  });
+
   it("rejects unbundled Workers because they cannot compose Farm", async () => {
     const root = await mkdtemp(join(tmpdir(), "farm-cf-agent-unbundled-"));
     await writeFile(join(root, "wrangler.jsonc"), '{"main":"agent.mjs","no_bundle":true}\n');

--- a/packages/farm-cf-agent/src/output.ts
+++ b/packages/farm-cf-agent/src/output.ts
@@ -164,6 +164,10 @@ function createGeneratedWranglerConfig(input: {
       ...environments,
       [input.environment]: {
         ...selected,
+        // `main` is inheritable per environment: if the selected env overrides
+        // it, the raw agent entry survives and the deploy serves only the agent
+        // Worker. Rewrite it to the combined wrapper like the top-level main.
+        main: toConfigRelativePath(input.configDirectory, input.wrapperPath),
         compatibility_flags: withNodeCompatibility(
           selected.compatibility_flags ?? config.compatibility_flags,
         ),


### PR DESCRIPTION
`createGeneratedWranglerConfig` rewrites the top-level `main` to the generated combined-worker wrapper, but inside a selected environment block it spread the user's env config as-is and only re-normalized `compatibility_flags` and `assets`:

```ts
[input.environment]: {
  ...selected,
  compatibility_flags: withNodeCompatibility(...),
  assets: { ... },
},
```

`main` is inheritable per environment in Wrangler, so a config like:

```jsonc
{
  "main": "src/agent.ts",
  "env": { "staging": { "main": "src/agent.staging.ts" } }
}
```

deployed with `--env staging` kept `env.staging.main` pointing at the raw agent entry. The agent Worker gets served on its own and every Farm route is dead in that deployment — while the (correctly rewritten) top-level `main` makes a plain `wrangler deploy` look fine, so the breakage only shows up per-environment.

fix: rewrite the env-level `main` to the wrapper path, exactly as the top-level `main` is rewritten.

## testing

new test generates output for a config with `env.staging.main` and `environment: "staging"`, asserts both the top-level and `env.staging` main resolve to `./.farm/cf-agent/worker.mjs`. it fails on the pre-fix code (verified by revert). full cf-agent suite 6 passed.

from the round-3 scan backlog (infra findings).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures `cf-agent` rewrites an environment-level `main` to the combined worker wrapper. Previously, if an env overrode `main`, `wrangler deploy --env <env>` served only the raw agent Worker and Farm routes were dead; now both top-level and selected env `main` point to the wrapper.

- Behavior change: env configs that set `main` now deploy the combined wrapper instead of the raw agent.
- Test coverage: adds an assertion that both top-level `main` and `env.staging.main` resolve to `./.farm/cf-agent/worker.mjs`.

<sup>Written for commit 7d0943df13c335e2d236ed6d494f1caabd53f974. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

