### PR TITLE
fix(preview-gateway): stop touchSession from resurrecting a deleted session

### DIFF
--- a/packages/farm-preview-gateway/src/index.ts
+++ b/packages/farm-preview-gateway/src/index.ts
@@ -219,6 +219,10 @@ export class MemoryPreviewGatewayStore implements PreviewGatewayStore {
   }
 
   async touchSession(session: PreviewGatewaySession, ttlMs: number): Promise<void> {
+    // A concurrent delete (the preview was stopped) must win: a poll handler
+    // that outlives the DELETE must never resurrect a session that is no
+    // longer stored, or its name would look "online" and block a restart.
+    if (!this.sessions.has(session.id)) return;
     session.expiresAt = Date.now() + ttlMs;
     this.sessions.set(session.id, session);
     const nameOwner = this.names.get(session.name);
@@ -292,13 +296,18 @@ export class RedisRestPreviewGatewayStore implements PreviewGatewayStore {
       ...session,
       expiresAt: Date.now() + ttlMs,
     };
-    await this.command(
+    // XX only refreshes a session key that still exists. A poll handler that
+    // outlives a DELETE must not recreate the session (nor its name mapping),
+    // which would otherwise block reclaiming the name on restart.
+    const result = await this.command<string | null>(
       "SET",
       this.sessionKey(session.id),
       JSON.stringify(nextSession),
       "PX",
       ttlMs,
+      "XX",
     );
+    if (result === null) return;
     const nameOwner = await this.command<string | null>("GET", this.nameKey(session.name));
     if (!nameOwner || nameOwner === session.id) {
       await this.command("SET", this.nameKey(session.name), session.id, "PX", ttlMs);

--- a/packages/farm-preview-gateway/test/gateway.test.mjs
+++ b/packages/farm-preview-gateway/test/gateway.test.mjs
@@ -59,6 +59,28 @@ test("proxies a public preview request through the gateway queue", async () => {
   }
 });
 
+test("does not resurrect a deleted session when a stale touch lands late", async () => {
+  const store = new MemoryPreviewGatewayStore();
+  const session = {
+    id: "sess-1",
+    name: "late-touch",
+    localUrl: "http://localhost:4321",
+    token: "tok",
+    expiresAt: Date.now() + 60_000,
+    lastHeartbeatAt: Date.now(),
+  };
+  await store.createSession(session, 60_000);
+
+  // The preview is stopped: the session is deleted while a poll handler still
+  // holds the old snapshot.
+  await store.deleteSession(session);
+  await store.touchSession(session, 60_000);
+
+  // A late touch must not bring the session (or its name mapping) back.
+  assert.equal(await store.getSessionById("sess-1"), undefined);
+  assert.equal(await store.getSessionByName("late-touch"), undefined);
+});
+
 test("replays every Set-Cookie header to the public visitor", async () => {
   const store = new MemoryPreviewGatewayStore();
   const gateway = await createGatewayServer(store);


### PR DESCRIPTION
`touchSession` refreshed a session's TTL by writing the whole snapshot back with no check that the session still exists:

- memory store: `this.sessions.set(session.id, session)` unconditionally
- Redis store: `SET sessionKey ... PX ttlMs` (no `XX`)

and both then re-added the name mapping whenever its current owner was missing.

the race: the CLI stops a preview, which aborts the poll client-side and `DELETE`s the session. but the gateway's `pollSessionRequests` loop doesn't observe that abort and keeps running up to its wait window; its final `markSessionOnline` -> `touchSession` writes the session back with a fresh 30-minute expiry and re-claims the name mapping. the user restarts the preview with the same name and gets a false `A Farm preview named "x" is already active` 409 even though nothing is running.

fix: `touchSession` only refreshes a session that still exists.
- memory: early-return when the id is no longer in the map.
- Redis: `SET ... PX ttlMs XX` (refresh-only) and bail when the result is nil, so the name mapping isn't recreated either.

## testing

new store-level test creates a session, deletes it, then applies a late `touchSession` with the stale snapshot and asserts both `getSessionById` and `getSessionByName` stay `undefined`. it fails on the pre-fix code (verified by revert). gateway suite 6 passed.

from the round-3 scan backlog (infra findings); complements the multi-Set-Cookie fix in #507.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `touchSession` in `farm-preview-gateway` from resurrecting a deleted session, avoiding false “already active” 409s on preview restart. Previously, a late poll handler rewrote the session and re-claimed its name after DELETE; now `touchSession` only refreshes sessions that still exist and leaves the name mapping untouched when absent.

**Review notes**
- Memory store: return early when `session.id` is missing; skip TTL refresh and name mapping changes.
- Redis store: use `SET ... PX ttlMs XX`; bail on null so neither the session nor its name mapping is recreated.
- New store-level test asserts no resurrection after delete; gateway suite passed.

<sup>Written for commit d5974b5f09cc9baae48a1965d0ec24a9387c2581. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

