### PR TITLE
fix(cache): treat revalidate: 0 as always stale on the adapter path too

### DIFF
--- a/packages/farm/src/__tests__/cache.test.ts
+++ b/packages/farm/src/__tests__/cache.test.ts
@@ -313,6 +313,24 @@ describe("server cache primitives", () => {
     expect(calls).toBe(2);
   });
 
+  it("treats revalidate: 0 as always stale through a distributed adapter", async () => {
+    const adapter = new TestSharedCacheAdapter();
+    const cache = new FarmDataCache({ adapter, namespace: "catalog" });
+    let calls = 0;
+    const produce = async () => ({ calls: ++calls });
+
+    // With an adapter configured, revalidate: 0 must still re-produce on every
+    // read (same semantics as the local cache), not serve a stored entry
+    // indefinitely.
+    await expect(cache.getOrSet("prices", produce, { revalidate: 0 })).resolves.toEqual({
+      calls: 1,
+    });
+    await expect(cache.getOrSet("prices", produce, { revalidate: 0 })).resolves.toEqual({
+      calls: 2,
+    });
+    expect(calls).toBe(2);
+  });
+
   it("dedupes concurrent cache fills", async () => {
     let calls = 0;
     const getProfile = unstable_cache(async () => {

--- a/packages/farm/src/cache.ts
+++ b/packages/farm/src/cache.ts
@@ -716,7 +716,7 @@ export class FarmDataCache {
   private async isAdapterEntryStale(entry: FarmCacheEntry, now = Date.now()): Promise<boolean> {
     if (
       typeof entry.revalidate === "number" &&
-      entry.revalidate > 0 &&
+      entry.revalidate >= 0 &&
       now - entry.createdAt >= entry.revalidate * 1000
     ) {
       return true;


### PR DESCRIPTION
`isAdapterEntryStale` (the distributed-adapter read path) gated its time-based staleness check on `entry.revalidate > 0`, while the local-cache `isStale` uses `entry.revalidate >= 0`:

```ts
// local (correct)         // adapter (this bug)
entry.revalidate >= 0      entry.revalidate > 0
```

with any cache adapter configured (`configureFarmCache({ adapter })`), an entry created via `unstable_cache(producer, ["k"], { revalidate: 0 })` stores `revalidate: 0`. every subsequent read goes through `isAdapterEntryStale`, where `0 > 0` is false, so the time check is skipped and — absent a tag bump — the entry is reported fresh. the producer never re-runs and stale data is served indefinitely, the exact opposite of `revalidate: 0`'s "always re-produce" semantics.

the local path was fixed earlier (the `>= 0` at line 475); the adapter path kept the old comparison and had no test, so it stayed broken. this aligns the adapter path to `>= 0`.

## testing

new test drives `getOrSet(..., { revalidate: 0 })` through a shared adapter twice and asserts the producer runs both times. it fails on the pre-fix code (verified by revert); the existing local-path `revalidate: 0` test still passes. cache suite 23 passed.

found in a round-4 scan of core subsystems.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats `revalidate: 0` as always stale on the distributed adapter read path, matching local cache behavior. Previously, with an adapter configured, `revalidate: 0` skipped the time check and entries were reported fresh indefinitely; now the producer re-runs on every read.

- Aligns `isAdapterEntryStale` to use `>= 0` (was `> 0`).
- Adds an adapter-backed test that verifies two reads with `revalidate: 0` trigger two producer runs.
- No migration; behavior for other `revalidate` values is unchanged.

<sup>Written for commit 8c26e426b3898557d77d56bd058fff98827ac503. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

