### PR TITLE
fix(autumn): report scheduled cancel-at-period-end as active, not canceled

### DIFF
--- a/packages/farm-autumn/src/index.ts
+++ b/packages/farm-autumn/src/index.ts
@@ -875,7 +875,7 @@ function setProjectedUsage(input: {
   pendingAutumnMeterProjection.set(projectionKey(input), input.projectedUsage);
 }
 
-function normalizeAutumnStatus(
+export function normalizeAutumnStatus(
   customer: Customer | null,
   subscription: Customer["subscriptions"][number] | null,
 ): AutumnBillingStatus {
@@ -887,7 +887,14 @@ function normalizeAutumnStatus(
     return "past_due";
   }
 
-  if (subscription.canceledAt != null) {
+  // A subscription scheduled to cancel at period end has `canceledAt` set but
+  // remains usable until `expiresAt`. Only report the terminal "canceled"
+  // status once access has actually ended; until then it stays active/trialing
+  // and the cancellation is surfaced via `cancelAtPeriodEnd`.
+  if (
+    subscription.canceledAt != null &&
+    (subscription.expiresAt == null || subscription.expiresAt <= Date.now())
+  ) {
     return "canceled";
   }
 
@@ -900,6 +907,22 @@ function normalizeAutumnStatus(
   }
 
   return "active";
+}
+
+/**
+ * Whether the subscription is scheduled to cancel but has not yet ended: a
+ * cancellation exists (`canceledAt`) and access continues until a future
+ * `expiresAt`. This is the "cancels on <date>" state, distinct from a fully
+ * ended subscription.
+ */
+export function isAutumnCancelAtPeriodEnd(
+  subscription: Customer["subscriptions"][number] | null | undefined,
+): boolean {
+  return (
+    subscription?.canceledAt != null &&
+    subscription.expiresAt != null &&
+    subscription.expiresAt > Date.now()
+  );
 }
 
 function resolveActiveProduct(
@@ -1444,10 +1467,7 @@ export function autumn<TInput extends AutumnIntegrationInput>(
             subscriptionId: active.subscription?.id ?? null,
             currentPeriodStart: currentPeriodStart(active.subscription),
             currentPeriodEnd: currentPeriodEnd(active.subscription),
-            cancelAtPeriodEnd:
-              active.subscription?.expiresAt != null &&
-              (active.subscription.canceledAt == null ||
-                active.subscription.canceledAt > Date.now()),
+            cancelAtPeriodEnd: isAutumnCancelAtPeriodEnd(active.subscription),
             trialEndsAt: trialEndsAt(active.subscription),
             features: plan.features ?? {},
             limits: plan.limits ?? {},

--- a/packages/farm/src/__tests__/autumn-cancel-at-period-end.test.ts
+++ b/packages/farm/src/__tests__/autumn-cancel-at-period-end.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { isAutumnCancelAtPeriodEnd, normalizeAutumnStatus } from "../../../farm-autumn/src/index";
+
+const HOUR = 60 * 60 * 1000;
+
+// Minimal subscription shape; only the fields these helpers read matter.
+function subscription(overrides: Record<string, unknown> = {}): any {
+  return {
+    id: "sub_1",
+    planId: "pro",
+    pastDue: false,
+    canceledAt: null,
+    expiresAt: null,
+    trialEndsAt: null,
+    status: "active",
+    startedAt: Date.now() - HOUR,
+    ...overrides,
+  };
+}
+
+function customer(): any {
+  return { id: "cus_1", subscriptions: [], purchases: [] };
+}
+
+describe("normalizeAutumnStatus", () => {
+  it("keeps a scheduled cancel-at-period-end subscription active", () => {
+    // canceledAt in the past, still usable until a future expiresAt.
+    const sub = subscription({ canceledAt: Date.now() - HOUR, expiresAt: Date.now() + HOUR });
+    expect(normalizeAutumnStatus(customer(), sub)).toBe("active");
+  });
+
+  it("reports canceled once access has ended", () => {
+    expect(
+      normalizeAutumnStatus(
+        customer(),
+        subscription({ canceledAt: Date.now() - HOUR, expiresAt: Date.now() - 1 }),
+      ),
+    ).toBe("canceled");
+    // canceledAt with no remaining access window is an immediate cancel.
+    expect(
+      normalizeAutumnStatus(
+        customer(),
+        subscription({ canceledAt: Date.now() - HOUR, expiresAt: null }),
+      ),
+    ).toBe("canceled");
+  });
+
+  it("still reports active, trialing, and past_due correctly", () => {
+    expect(normalizeAutumnStatus(customer(), subscription())).toBe("active");
+    expect(
+      normalizeAutumnStatus(customer(), subscription({ trialEndsAt: Date.now() + HOUR })),
+    ).toBe("trialing");
+    expect(normalizeAutumnStatus(customer(), subscription({ pastDue: true }))).toBe("past_due");
+  });
+});
+
+describe("isAutumnCancelAtPeriodEnd", () => {
+  it("is true only for a scheduled-but-not-yet-ended cancellation", () => {
+    expect(
+      isAutumnCancelAtPeriodEnd(
+        subscription({ canceledAt: Date.now() - HOUR, expiresAt: Date.now() + HOUR }),
+      ),
+    ).toBe(true);
+  });
+
+  it("is false when nothing is scheduled, or the subscription already ended", () => {
+    expect(isAutumnCancelAtPeriodEnd(subscription())).toBe(false);
+    expect(isAutumnCancelAtPeriodEnd(subscription({ expiresAt: Date.now() + HOUR }))).toBe(false);
+    expect(
+      isAutumnCancelAtPeriodEnd(
+        subscription({ canceledAt: Date.now() - HOUR, expiresAt: Date.now() - 1 }),
+      ),
+    ).toBe(false);
+    expect(isAutumnCancelAtPeriodEnd(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
in `farm-autumn`, two functions disagreed about `canceledAt` and both mishandled a subscription that is scheduled to cancel at period end (still usable until a future `expiresAt`):

- `normalizeAutumnStatus` returned `"canceled"` the moment `canceledAt` was non-null. so `/billing/status` reports a terminal `canceled` status as soon as a user schedules a cancellation, and the app locks them out even though they keep paid access until period end.
- `cancelAtPeriodEnd` was `expiresAt != null && (canceledAt == null || canceledAt > now)`. for a real scheduled cancel, `canceledAt` is in the past, so this evaluates to `false` and the UI can never show a "cancels on <date>" banner.

the two are also mutually inconsistent (one treats `canceledAt` as "terminal now", the other reads `canceledAt > now`), so at least one was wrong under any interpretation.

fix keys access off `expiresAt` and treats `canceledAt` only as "a cancellation exists":
- `normalizeAutumnStatus` returns `"canceled"` only once `expiresAt == null || expiresAt <= now`; a scheduled-but-active sub falls through to active/trialing.
- the cancel-at-period-end signal is extracted into `isAutumnCancelAtPeriodEnd(sub)` = `canceledAt != null && expiresAt != null && expiresAt > now`.

`resolveActiveProduct` selects the latest subscription with no cancel filtering, so such a subscription really does reach these functions as the active one.

## assumption to confirm (semantics)

this relies on autumn-js's documented field meaning — `canceledAt` = "when the subscription was canceled" (set at schedule time for a period-end cancel), `expiresAt` = "when it will expire" (future, access continues until then) — matching Stripe, which Autumn wraps. i verified the SDK type docs (`autumn-js@1.2.7` sdk/index.d.mts ~3748-3755) but not against a live Autumn account. **if Autumn instead sets `canceledAt` to the future end time, `normalizeAutumnStatus` is still corrected, and `isAutumnCancelAtPeriodEnd` also stays correct** (it only checks `canceledAt != null` plus a future `expiresAt`), so the fix holds under both readings — worth a maintainer sanity check regardless.

## testing

`normalizeAutumnStatus` and `isAutumnCancelAtPeriodEnd` are exported and unit-tested (from the core suite, same cross-package pattern as the jobs tests) over scheduled-cancel, ended, immediate-cancel, active, trialing, and past_due inputs. the changed assertions regress on the old logic (verified by reverting the two conditions). typecheck + lint clean.

found in a round-4 scan of the billing/jobs packages (the only finding there beyond the already-fixed items).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report scheduled cancel-at-period-end subscriptions as active/trialing until access ends, and expose a correct cancel-at-period-end flag. Previously, we returned "canceled" as soon as `canceledAt` was set and the UI could not show "cancels on <date>"; now we key status off `expiresAt` and consistently detect scheduled cancels.

- `normalizeAutumnStatus` returns "canceled" only when `expiresAt` is null or in the past; otherwise it stays active/trialing. Exported for reuse and tests.
- Introduces `isAutumnCancelAtPeriodEnd(subscription)` (requires `canceledAt` set and future `expiresAt`) and uses it in `autumn()` to populate `cancelAtPeriodEnd`.
- Adds tests in `farm` covering scheduled-cancel, ended, immediate-cancel, active, trialing, and past_due cases.

**Migration**
- If any consumer treated status "canceled" as "scheduled to cancel," switch to `cancelAtPeriodEnd` (or `isAutumnCancelAtPeriodEnd`) for that UI state.

<sup>Written for commit 74c54a71dde9a8d20071b1265d0ce19f5d7aa652. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

