### PR TITLE
feat(react): compile keyed collections at component roots

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -735,9 +735,9 @@ The compiler uses four keyed-list tiers:
 
 1. A dedicated nested host container with one direct map or one `List`, returning a non-interactive
    host-only row, becomes compiler-owned keyed row instances. Farm patches bindings and uses LIS.
-2. A nested host container with static host siblings and one or more non-interactive keyed host
-   ranges becomes one compiler-owned range block. Farm preserves the static segments and applies
-   the same row descriptors and LIS reconciliation independently inside each range.
+2. A nested or component-root host container with one or more non-interactive keyed host ranges
+   becomes one compiler-owned range block. Farm preserves any static segments and applies the same
+   row descriptors and LIS reconciliation independently inside each range.
 3. The dedicated single-list shape with eligible inline events or row-local conditional slots
    keeps React event and structural ownership, while Farm patches same-key row bindings and refreshes
    only changed conditional boundaries.
@@ -772,14 +772,19 @@ update in one range cannot reorder another range or its surrounding static eleme
 attributes, and styles inside the static host siblings continue to use the outer component's direct
 bindings.
 
+The `ul` above may be the component's returned root. The generated root range block forwards that
+physical `ul` to the outer binding runtime, so stateful root attributes and styles still patch the
+same element. A root containing only one eligible map or `List` is supported as a range with no
+static segments. The compiler does not insert an extra parent merely to host the block.
+
 The first range-owned contract is deliberately non-interactive. Every meaningful direct child of
 the container must be either a lowercase host element or an eligible keyed map/`List`; every range
-must return a statically known host tree without events or row-local conditional slots. The
-component's outermost return container, fragments, components between ranges, interactive or
-controlled rows, and nested dynamic structures use the existing React-owned boundaries. Parent
-prop or compatible Fast Refresh changes remount this one range container through React so static
-markup cannot become stale. Duplicate keys or a mount/hydration shape that cannot be adopted also
-switch the complete container to React before later updates.
+must return a statically known host tree without events or row-local conditional slots. Fragments,
+components between ranges, interactive or controlled rows, and nested dynamic structures use the
+existing React-owned boundaries. Parent prop or compatible Fast Refresh changes remount this one
+range container through React so static markup cannot become stale. Duplicate keys or a
+mount/hydration shape that cannot be adopted also switch the complete container to React before
+later updates.
 
 The optimized host-row contract is deliberately narrow:
 
@@ -791,7 +796,7 @@ The optimized host-row contract is deliberately narrow:
   expression, and an item-derived key.
 - A single interactive list must be the only meaningful child of its nested lowercase host
   container. Non-interactive host rows may instead occupy one or more ranges separated by direct
-  host siblings. The component's outermost return container remains React-owned for now.
+  host siblings, either in a nested container or the component's returned host root.
 - The row is a statically known HTML host tree. Dynamic leaf text, attributes, controlled host
   properties, and individual inline style properties are supported.
 - Inline synchronous row events and dedicated logical or ternary host slots are supported by the
@@ -888,7 +893,7 @@ component.
 | ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
 | Unkeyed/index-keyed maps, unsupported or mutating collection pipelines, or element arrays                    | Their structure, purity, or item identity is outside the keyed-list contract.      |
 | Unsupported row events/forms, components, fragments, refs, SVG, nested blocks, or mixed conditional slots    | Their event, lifecycle, or structure contract requires the React-owned row path.   |
-| Interactive ranges beside siblings, non-host range siblings, or a range in the component root                | The first range owner requires one nested host container and non-interactive rows. |
+| Interactive ranges beside siblings or non-host range siblings                                                | The range owner requires a host container and non-interactive host rows.           |
 | Branch events, keys, components, fragments, refs, SVG, or nested blocks in a dedicated conditional container | They require the React-owned conditional path rather than compiler-created hosts.  |
 | Dynamic/member component types, component spreads, refs, keys, or children                                   | Their identity or ownership is outside the first component-island contract.        |
 | Effects or hooks other than the supported `useState` shape                                                   | Their lifecycle and ordering must remain under React's hook dispatcher.            |
@@ -1041,9 +1046,9 @@ The package and example test suites verify more than generated code:
 - compiler-owned host rows patch text, attributes, and styles in place, preserve focus and text
   selection, use the LIS minimum for measured rotations and reversals, and remount through React
   when runtime keys are duplicated;
-- keyed DOM ranges preserve static siblings around multiple lists, support adjacent empty ranges,
-  apply LIS independently per range, and remount the complete container through React when keys or
-  parent-driven static markup invalidate adoption;
+- keyed DOM ranges preserve static siblings around multiple lists, support adjacent empty ranges
+  and exact component roots, apply LIS independently per range, and remount the complete container
+  through React when keys or parent-driven static markup invalidate adoption;
 - interactive host rows keep React event propagation and `currentTarget`, resolve the latest item
   and index after same-key replacements and reorders, let React own structural commits, and resume
   direct binding patches without stale virtual-prop output;
@@ -1062,8 +1067,9 @@ The package and example test suites verify more than generated code:
 - 1,000 deterministic object, array, and nullish component-prop transitions match normal React;
 - 1,000 deterministic randomized compiler-owned list operations produce the same ordered output as
   normal React while the list owner stays at one execution;
-- 2,000 deterministic updates across two keyed ranges match normal React while every static sibling
-  and surviving row keeps its DOM identity and the owner stays at one execution;
+- 2,000 deterministic updates each for nested and component-root keyed ranges match normal React
+  while every static sibling and surviving row keeps its DOM identity and the owner stays at one
+  execution;
 - 5,000 deterministic filter, sort, slice, reverse, insertion, removal, and row-update transitions
   produce the same keyed output as normal React while preserving surviving DOM rows;
 - 4,000 deterministic interactive data, structure, and event transitions match normal React while
@@ -1078,9 +1084,9 @@ The package and example test suites verify more than generated code:
   keyed DOM identity and capture/stop-propagation behavior, and observes zero owner update
   executions;
 - the public `List` renders iterable and nullish collections correctly with the compiler off;
-- the packaged runtime, including keyed ranges, editable and interactive keyed-row events,
-  row-local conditions, reorders, identity, selection, and hydration, is exercised separately with
-  React 18.3 and React 19;
+- the packaged runtime, including a keyed-range component root, editable and interactive keyed-row
+  events, row-local conditions, reorders, identity, selection, and hydration, is exercised
+  separately with React 18.3 and React 19;
 - boolean `data-*` and `aria-*` attributes keep React-compatible string values; and
 - unsupported list shapes, effects, refs, and unsupported dynamic component-island shapes remain
   on React without corrupting output.

--- a/examples/react-compiler/README.md
+++ b/examples/react-compiler/README.md
@@ -41,7 +41,7 @@ assertions, checks for console/runtime errors and horizontal overflow, saves scr
 | Editable keyed rows         | caret, fields, identity, and a 256-row load; executions `0` | —                                           | Controlled form properties update by key without rerunning the owner.  |
 | Conditional row blocks      | only changed keyed branches refresh; owner executions `0`  | —                                           | Per-key snapshots isolate logical and ternary row content.              |
 | Explicit `List`             | stateful rows reorder, update executions `0`            | —                                              | React preserves custom-row state by key inside the isolated boundary.  |
-| Keyed DOM ranges            | two ranges, static-shell identity, three LIS moves, 1,024-row load | —                                    | Multiple host lists reconcile independently inside one container.      |
+| Root keyed ranges           | exact card root, two ranges, three LIS moves, 1,024-row load | —                                          | Multiple host lists reconcile without an artificial outer wrapper.     |
 | Calculated style bindings   | value `6`, progress `50%`, update executions `0`        | —                                              | Safe calls and individual CSS properties use prepared dependencies.    |
 | Controlled form bindings   | textarea/select/checkbox update, executions `0`         | —                                              | Form properties and textarea selection stay coherent.                  |
 | Logical conditional block  | stable branch patches, mounts, and unmounts; executions `0` | —                                           | A proven host branch updates without React reconciliation.             |
@@ -86,8 +86,8 @@ use the same compiler-owned row path. A custom stateful row such as `<Row item={
 React-owned keyed boundary so React preserves its Hooks, events, lifecycle, and Fiber state. The
 outer compiled component can still avoid rerunning.
 
-The compiler-owned path supports one dedicated keyed map/`List`, or multiple non-interactive host
-ranges separated by direct host siblings in one nested container. A collection may chain
+The compiler-owned path supports one dedicated keyed map/`List`, or one or more non-interactive host
+ranges in a nested or component-root container. A collection may chain
 synchronous inline `filter`, `slice`, `toSorted`, and `toReversed` operations. The compiler records
 the state dependencies used by those operations and reruns the pipeline only when one changes; it
 still performs the necessary filtering or sorting. Mutating methods, external or async callbacks,
@@ -119,11 +119,11 @@ commit. This is why row conditionals do not use the manual insertion or LIS path
 components, fragments, refs, SVG, nested blocks, or a conditional mixed with another child in the
 same slot use the existing React-owned list fallback.
 
-The `04G` card places two non-interactive maps between a shared header, divider, and footer. React
-renders the original `ul`; Farm adopts the direct element ranges after mount without inserting a
-wrapper or hydration marker. The production test rotates both ranges, observes three total LIS
-moves, preserves both surviving rows and all static siblings, crosses empty ranges, loads 1,024
-rows, and records zero owner update executions.
+The `04G` card is itself the returned host root. It places two non-interactive maps between its
+header, metrics, labels, and footer. React renders that original `article`; Farm adopts its direct
+element ranges after mount without inserting a wrapper or hydration marker. The production test
+rotates both ranges, observes three total LIS moves, preserves the root, surviving rows, and all
+static siblings, crosses empty ranges, loads 1,024 rows, and records zero owner update executions.
 
 Non-inline or async row handlers, unsupported form shapes, custom components, fragments, refs, SVG,
 interactive ranges beside siblings, and index or missing keys use the React-owned list path.

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -655,14 +655,14 @@ try {
   assert.equal(editableListFinalExecutions - editableListInitialExecutions, 0);
 
   const keyedRanges = '[data-experiment="keyed-ranges"]';
+  const keyedRangesList = `${keyedRanges}[data-list="ranges"]`;
   const keyedRangesInitialExecutions = await readNumber(
     page,
     `${keyedRanges} [data-metric="executions"]`,
   );
   await page.evaluate(() => {
-    const list = document.querySelector(
-      '[data-experiment="keyed-ranges"] [data-list="ranges"]',
-    );
+    const list = document.querySelector('[data-experiment="keyed-ranges"][data-list="ranges"]');
+    window.__farmRangeRoot = list;
     window.__farmRangeHeader = list.querySelector('[data-static="range-header"]');
     window.__farmRangeDivider = list.querySelector('[data-static="range-divider"]');
     window.__farmRangeFooter = list.querySelector('[data-static="range-footer"]');
@@ -686,14 +686,16 @@ try {
     .evaluateAll((rows) => rows.map((row) => row.getAttribute("data-key")));
   assert.deepEqual(primaryRangeOrder, ["d", "a", "b", "c"]);
   assert.deepEqual(secondaryRangeOrder, ["z", "y", "x"]);
-  assert.equal(
-    await page.locator(`${keyedRanges} [data-list="ranges"]`).getAttribute("data-rows"),
-    "7",
-  );
+  assert.equal(await page.locator(keyedRangesList).getAttribute("data-rows"), "7");
+  assert.equal(await page.locator(keyedRangesList).evaluate((root) => root.tagName), "ARTICLE");
   assert.equal(await page.evaluate(() => window.__farmRangeMoves), 3);
   assert.equal(
     await page.evaluate(
       () =>
+        window.__farmRangeRoot ===
+          document.querySelector(
+            '[data-experiment="keyed-ranges"][data-list="ranges"]',
+          ) &&
         window.__farmRangeHeader ===
           document.querySelector(
             '[data-experiment="keyed-ranges"] [data-static="range-header"]',
@@ -716,22 +718,12 @@ try {
   );
   await page.locator(`${keyedRanges} [data-action="clear-ranges"]`).click();
   await assertText(page, `${keyedRanges} [data-metric="rows"]`, "0");
-  assert.equal(
-    await page.locator(`${keyedRanges} [data-list="ranges"]`).getAttribute("data-rows"),
-    "0",
-  );
+  assert.equal(await page.locator(keyedRangesList).getAttribute("data-rows"), "0");
   assert.equal(await page.locator(`${keyedRanges} [data-key]`).count(), 0);
-  await assertText(
-    page,
-    `${keyedRanges} [data-static="range-footer"]`,
-    "0 ROWS / STATIC SHELL",
-  );
+  await assertText(page, `${keyedRanges} [data-range-summary]`, "0 ROWS / ROOT SHELL");
   await page.locator(`${keyedRanges} [data-action="stress-ranges"]`).click();
   await assertText(page, `${keyedRanges} [data-metric="rows"]`, "1024");
-  assert.equal(
-    await page.locator(`${keyedRanges} [data-list="ranges"]`).getAttribute("data-rows"),
-    "1024",
-  );
+  assert.equal(await page.locator(keyedRangesList).getAttribute("data-rows"), "1024");
   assert.equal(await page.locator(`${keyedRanges} [data-key]`).count(), 1024);
   const keyedRangesFinalExecutions = await readNumber(
     page,
@@ -1061,7 +1053,8 @@ try {
               keyedRangesFinalExecutions - keyedRangesInitialExecutions,
             staticSiblingIdentityPreserved: true,
             keyedDomIdentityPreserved: true,
-            owner: "Farm keyed ranges",
+            rootHostIdentityPreserved: true,
+            owner: "Farm root keyed ranges",
           },
           derivedCollection: {
             order: derivedCollectionOrder,

--- a/examples/react-compiler/src/app/globals.css
+++ b/examples/react-compiler/src/app/globals.css
@@ -649,41 +649,79 @@ h1 span {
     monospace;
 }
 
-.edge-card .keyed-range-list {
-  max-height: 19rem;
+.keyed-range-root {
+  display: grid;
+  max-height: 32rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   align-content: flex-start;
+  gap: 0.5rem;
   overflow-y: auto;
-  padding: 0.55rem;
-  border: 1px solid #33332f;
-  background: #0d0d0c;
 }
 
-.keyed-range-list [data-range] {
+.keyed-range-root > :is(header, .compact-metrics, .keyed-range-static, .keyed-range-footer) {
+  grid-column: 1 / -1;
+}
+
+.keyed-range-root > header {
+  margin-bottom: 0.4rem;
+}
+
+.keyed-range-root > .compact-metrics {
+  margin: 0.8rem 0;
+}
+
+.keyed-range-root > [data-range] {
   min-width: 6.5rem;
+  border: 1px solid #484842;
+  padding: 0.4rem 0.55rem;
+  color: #c8c8c1;
   background: #111110;
+  font:
+    0.66rem "Geist Mono Variable",
+    ui-monospace,
+    monospace;
 }
 
-.keyed-range-list [data-range="secondary"] {
+.keyed-range-root > [data-range="secondary"] {
   border-color: #5a5a52;
   color: #aaa9a1;
 }
 
-.keyed-range-list .keyed-range-static {
-  flex: 1 0 100%;
-  border-color: rgb(184 255 91 / 0.28);
+.keyed-range-root > .keyed-range-static {
+  border: 1px solid rgb(184 255 91 / 0.28);
+  padding: 0.45rem 0.55rem;
   color: #91b864;
   background: rgb(184 255 91 / 0.035);
-  font-size: 0.56rem;
+  font:
+    0.56rem "Geist Mono Variable",
+    ui-monospace,
+    monospace;
   letter-spacing: 0.075em;
 }
 
-.keyed-range-list [data-static="range-divider"] {
+.keyed-range-root > [data-static="range-divider"] {
   margin-top: 0.15rem;
 }
 
-.keyed-range-list [data-static="range-footer"] {
+.keyed-range-footer {
+  display: grid;
+  gap: 0.7rem;
+  padding-top: 0.65rem;
+  border-top: 1px solid #33332f;
+}
+
+.keyed-range-footer [data-range-summary] {
   color: #d8ff9f;
+  font:
+    0.6rem "Geist Mono Variable",
+    ui-monospace,
+    monospace;
+  letter-spacing: 0.075em;
   text-align: right;
+}
+
+.keyed-range-footer .button-row {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .interactive-keyed-list .interactive-row {
@@ -1370,6 +1408,10 @@ code {
 
   .reason-grid article + article {
     padding-left: 0;
+  }
+
+  .keyed-range-footer .button-row {
+    grid-template-columns: 1fr;
   }
 
   .heavy-heading {

--- a/examples/react-compiler/src/components/compiler-edge-lab.tsx
+++ b/examples/react-compiler/src/components/compiler-edge-lab.tsx
@@ -733,15 +733,20 @@ export function KeyedRangeExperiment() {
   const total = primary.length + secondary.length;
 
   return (
-    <article className="edge-card" data-experiment="keyed-ranges">
-      <header>
+    <article
+      className="edge-card keyed-range-root"
+      data-experiment="keyed-ranges"
+      data-list="ranges"
+      data-rows={total}
+    >
+      <header data-static="range-header">
         <span className="experiment-number">04G</span>
         <div>
-          <h3>Keyed DOM ranges</h3>
-          <p>Two lists move independently while their shared header, divider, and footer stay put.</p>
+          <h3>Root keyed ranges</h3>
+          <p>The card itself owns two lists without an extra wrapper, marker, or React rerender.</p>
         </div>
       </header>
-      <dl className="compact-metrics" aria-live="polite">
+      <dl className="compact-metrics" data-static="range-metrics" aria-live="polite">
         <div>
           <dt>Ranges</dt>
           <dd data-metric="ranges">2</dd>
@@ -757,73 +762,71 @@ export function KeyedRangeExperiment() {
           </dd>
         </div>
       </dl>
-      <ul className="keyed-range-list" data-list="ranges" data-rows={total}>
-        <li className="keyed-range-static" data-static="range-header">
-          PRIMARY RANGE
-        </li>
-        {primary.map((item, index) => (
-          <li data-index={index} data-key={item.id} data-range="primary" key={item.id}>
-            {index + 1}. {item.label}
-          </li>
-        ))}
-        <li className="keyed-range-static" data-static="range-divider">
-          SECONDARY RANGE
-        </li>
-        {secondary.map((item, index) => (
-          <li data-index={index} data-key={item.id} data-range="secondary" key={item.id}>
-            {index + 1}. {item.label}
-          </li>
-        ))}
-        <li className="keyed-range-static" data-static="range-footer">
-          {total} ROWS / STATIC SHELL
-        </li>
-      </ul>
-      <div className="button-row">
-        <button
-          data-action="rotate-ranges"
-          onClick={() => {
-            setPrimary((items) =>
-              items.length > 1
-                ? [items[items.length - 1], ...items.slice(0, items.length - 1)]
-                : items,
-            );
-            setSecondary((items) => [...items].reverse());
-          }}
-          type="button"
-        >
-          Rotate both ranges
-        </button>
-        <button
-          data-action="clear-ranges"
-          onClick={() => {
-            setPrimary([]);
-            setSecondary([]);
-          }}
-          type="button"
-        >
-          Empty ranges
-        </button>
-        <button
-          data-action="stress-ranges"
-          onClick={() => {
-            setPrimary(
-              Array.from({ length: 512 }, (_, index) => ({
-                id: `primary-${index}`,
-                label: `Primary ${index}`,
-              })),
-            );
-            setSecondary(
-              Array.from({ length: 512 }, (_, index) => ({
-                id: `secondary-${index}`,
-                label: `Secondary ${index}`,
-              })),
-            );
-          }}
-          type="button"
-        >
-          Load 1,024 rows
-        </button>
+      <div className="keyed-range-static" data-static="range-primary-label">
+        PRIMARY RANGE
       </div>
+      {primary.map((item, index) => (
+        <div data-index={index} data-key={item.id} data-range="primary" key={item.id}>
+          {index + 1}. {item.label}
+        </div>
+      ))}
+      <div className="keyed-range-static" data-static="range-divider">
+        SECONDARY RANGE
+      </div>
+      {secondary.map((item, index) => (
+        <div data-index={index} data-key={item.id} data-range="secondary" key={item.id}>
+          {index + 1}. {item.label}
+        </div>
+      ))}
+      <footer className="keyed-range-footer" data-static="range-footer">
+        <span data-range-summary>{total} ROWS / ROOT SHELL</span>
+        <div className="button-row">
+          <button
+            data-action="rotate-ranges"
+            onClick={() => {
+              setPrimary((items) =>
+                items.length > 1
+                  ? [items[items.length - 1], ...items.slice(0, items.length - 1)]
+                  : items,
+              );
+              setSecondary((items) => [...items].reverse());
+            }}
+            type="button"
+          >
+            Rotate both ranges
+          </button>
+          <button
+            data-action="clear-ranges"
+            onClick={() => {
+              setPrimary([]);
+              setSecondary([]);
+            }}
+            type="button"
+          >
+            Empty ranges
+          </button>
+          <button
+            data-action="stress-ranges"
+            onClick={() => {
+              setPrimary(
+                Array.from({ length: 512 }, (_, index) => ({
+                  id: `primary-${index}`,
+                  label: `Primary ${index}`,
+                })),
+              );
+              setSecondary(
+                Array.from({ length: 512 }, (_, index) => ({
+                  id: `secondary-${index}`,
+                  label: `Secondary ${index}`,
+                })),
+              );
+            }}
+            type="button"
+          >
+            Load 1,024 rows
+          </button>
+        </div>
+      </footer>
     </article>
   );
 }

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -195,7 +195,7 @@ other children in the same host slot uses the existing React-owned keyed boundar
 compiled component can still be skipped, but React reconciles that list's rows and owns their
 events, lifecycle, and state.
 
-Non-interactive host maps can share one nested container with static host siblings:
+Non-interactive host maps can share a nested or component-root container with static host siblings:
 
 ```tsx
 <ul>
@@ -213,11 +213,13 @@ Non-interactive host maps can share one nested container with static host siblin
 
 The compiler emits one range block for that host container. React renders and hydrates the original
 markup. After mount, Farm records the static element segments and reconciles each keyed range with
-its own row table and LIS pass. It does not add wrappers or hydration markers. Stateful bindings in
-the static siblings still patch normally. Direct children must be host elements or eligible maps
-or `List` ranges; events, controlled rows, row conditionals, components, fragments, root-container
-ranges, and nested dynamic structures keep the React boundary. Duplicate keys, an adoption shape
-mismatch, or a parent-driven static markup change remounts the complete container through React.
+its own row table and LIS pass. It does not add wrappers or hydration markers. When the container is
+the component root, the block forwards that exact host element to the outer binding runtime, so
+root attributes and styles keep updating normally. A root with one eligible map or `List` also
+works without static siblings. Direct children must be host elements or eligible ranges; events,
+controlled rows, row conditionals, components, fragments, and nested dynamic structures keep the
+React boundary. Duplicate keys, an adoption shape mismatch, or a parent-driven static markup change
+remounts the complete container through React.
 
 Controlled host fields can use the hybrid keyed-row path:
 
@@ -332,8 +334,8 @@ Application and prototype calls, dynamic style objects, handlers outside JSX eve
 computed, and rest props patterns, async handlers, unkeyed or index-keyed lists, chained maps,
 unsupported conditional roots, effects, and more advanced hook support intentionally stay on React
 in this release. Compiler-owned keyed rows support either one dedicated host-only map/`List` or
-multiple non-interactive ranges separated by host siblings. Inline synchronous events and dedicated
-row-local host conditional slots can use the single-list hybrid path, but branch events, interactive
-ranges beside siblings, nested dynamic blocks, conditionals mixed with siblings in one slot,
-non-inline or async row handlers, unsupported form shapes, custom components, fragments, refs, SVG,
-and duplicate runtime keys keep or switch to React ownership.
+one or more non-interactive ranges in a nested or component-root host container. Inline synchronous
+events and dedicated row-local host conditional slots can use the single-list hybrid path, but
+branch events, interactive ranges beside siblings, nested dynamic blocks, conditionals mixed with
+siblings in one slot, non-inline or async row handlers, unsupported form shapes, custom components,
+fragments, refs, SVG, and duplicate runtime keys keep or switch to React ownership.

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -472,27 +472,28 @@ const testSource = String.raw`
           { kind: "text", path: [], read: (item, index) => [index, ":", item.toUpperCase()] },
         ],
       });
-      return React.createElement(
-        "section",
-        null,
-        React.createElement(
-          "button",
-          {
-            onClick: () =>
-              state[0].set((current) => ({
-                primary: [...current.primary].reverse(),
-                secondary: [current.secondary[1], "z", current.secondary[0]],
-              })),
-          },
-          "Update ranges",
-        ),
-        React.createElement(blocks.KeyedRanges, {
-          id: 0,
-          render: () =>
+      return React.createElement(blocks.KeyedRanges, {
+        id: 0,
+        render: () =>
+          React.createElement(
+            "ul",
+            { "data-count": model().primary.length + model().secondary.length },
             React.createElement(
-              "ul",
-              null,
-              React.createElement("li", { "data-static": "header" }, "Primary"),
+              "li",
+              { "data-static": "header" },
+              "Primary ",
+              React.createElement(
+                "button",
+                {
+                  onClick: () =>
+                    state[0].set((current) => ({
+                      primary: [...current.primary].reverse(),
+                      secondary: [current.secondary[1], "z", current.secondary[0]],
+                    })),
+                },
+                "Update ranges",
+              ),
+            ),
               model().primary.map((item, index) =>
                 React.createElement(
                   "li",
@@ -509,16 +510,28 @@ const testSource = String.raw`
                 ),
               ),
               React.createElement("li", { "data-static": "footer" }, "End"),
-            ),
-          ranges: [
-            descriptor(1, () => model().primary),
-            descriptor(1, () => model().secondary),
-          ],
-          trailing: 1,
-        }),
-      );
+          ),
+        ranges: [
+          descriptor(1, () => model().primary),
+          descriptor(1, () => model().secondary),
+        ],
+        trailing: 1,
+      });
     },
-    bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    bindings: [
+      {
+        kind: "attribute",
+        path: [],
+        target: 0,
+        dependencies: [0],
+        name: "data-count",
+        read: (_props, state) => {
+          const model = state[0].get();
+          return model.primary.length + model.secondary.length;
+        },
+      },
+      { kind: "block", id: 0, dependencies: [0] },
+    ],
   });
   const keyedRangesContainer = document.createElement("div");
   document.body.append(keyedRangesContainer);
@@ -540,6 +553,8 @@ const testSource = String.raw`
   assert.equal(keyedRangesContainer.querySelector("[data-static='divider']"), rangeDivider);
   assert.equal(keyedRangesContainer.querySelector("[data-static='footer']"), rangeFooter);
   assert.equal(keyedRangesContainer.querySelector("[data-key='a']"), rangeA);
+  assert.equal(keyedRangesContainer.firstElementChild.tagName, "UL");
+  assert.equal(keyedRangesContainer.firstElementChild.dataset.count, "6");
   assert.equal(keyedRangeExecutions, initialKeyedRangeExecutions);
   flushSync(() => keyedRangesRoot.unmount());
 

--- a/packages/farm-react/src/__tests__/compiler-derived-collections.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-derived-collections.test.ts
@@ -169,7 +169,8 @@ describe("React AOT derived collection compiler", () => {
 
     expect(result.compiled).toEqual(["IndexedFilter"]);
     expect(result.diagnostics).toEqual([]);
-    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).toContain("farmBlocks.KeyedRanges");
+    expect(result.code).not.toContain("farmBlocks.KeyedList");
     expect(result.code).toContain("dependencies: [0, 1]");
   });
 

--- a/packages/farm-react/src/__tests__/compiler-keyed-lists.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-lists.test.ts
@@ -109,7 +109,7 @@ describe("React AOT keyed list compiler", () => {
     expect(result.diagnostics[0]?.reason).toMatch(reason);
   });
 
-  it("isolates a keyed list alongside static siblings", async () => {
+  it("compiles a component-root keyed range alongside static siblings", async () => {
     const result = await compile(`
       import { useState } from "react";
       export function MixedList() {
@@ -126,7 +126,8 @@ describe("React AOT keyed list compiler", () => {
     expect(result.compiled).toEqual(["MixedList"]);
     expect(result.diagnostics).toEqual([]);
     expect(result.code).toContain("<li>Static row</li>");
-    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).toContain("farmBlocks.KeyedRanges");
+    expect(result.code).not.toContain("farmBlocks.KeyedList");
     expect(result.code).toContain("id={0}");
   });
 

--- a/packages/farm-react/src/__tests__/compiler-keyed-ranges.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-ranges.test.ts
@@ -85,33 +85,7 @@ describe("React AOT keyed-range compiler", () => {
     expect(result.code).not.toContain("farmBlocks.KeyedList");
   });
 
-  it("keeps interactive sibling ranges on the React-owned keyed boundary", async () => {
-    const result = await compile(`
-      import { useState } from "react";
-      export function Tasks() {
-        const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
-        return (
-          <section>
-            <ul>
-              <li data-static="header">Tasks</li>
-              {items.map((item) => (
-                <li key={item.id}>
-                  <button onClick={() => setItems([])}>{item.label}</button>
-                </li>
-              ))}
-              <li data-static="footer">End</li>
-            </ul>
-          </section>
-        );
-      }
-    `);
-
-    expect(result.compiled).toEqual(["Tasks"]);
-    expect(result.code).toContain("farmBlocks.KeyedList");
-    expect(result.code).not.toContain("farmBlocks.KeyedRanges");
-  });
-
-  it("keeps a keyed map in the component root on the existing React boundary", async () => {
+  it("keeps an interactive component-root range on the React-owned keyed boundary", async () => {
     const result = await compile(`
       import { useState } from "react";
       export function Tasks() {
@@ -119,7 +93,11 @@ describe("React AOT keyed-range compiler", () => {
         return (
           <ul>
             <li data-static="header">Tasks</li>
-            {items.map((item) => <li key={item.id}>{item.label}</li>)}
+            {items.map((item) => (
+              <li key={item.id}>
+                <button onClick={() => setItems([])}>{item.label}</button>
+              </li>
+            ))}
             <li data-static="footer">End</li>
           </ul>
         );
@@ -131,7 +109,79 @@ describe("React AOT keyed-range compiler", () => {
     expect(result.code).not.toContain("farmBlocks.KeyedRanges");
   });
 
-  it("keeps a component sibling outside the range-owned contract", async () => {
+  it("compiles a keyed range directly in the component root", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Tasks() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
+        return (
+          <ul data-count={items.length}>
+            <li data-static="header">Tasks</li>
+            {items.map((item) => <li key={item.id}>{item.label}</li>)}
+            <li data-static="footer">{items.length} total</li>
+          </ul>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Tasks"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedRanges");
+    expect(result.code).toContain("before: 1");
+    expect(result.code).toContain("trailing={1}");
+    expect(result.code).not.toContain("farmBlocks.KeyedList");
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedRanges.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({ code: expect.stringContaining("farmBlocks.KeyedRanges") });
+  });
+
+  it("compiles one keyed map as the only child of the component root", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Tasks() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
+        return (
+          <ul data-count={items.length}>
+            {items.map((item) => <li key={item.id}>{item.label}</li>)}
+          </ul>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Tasks"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedRanges");
+    expect(result.code).toContain("before: 0");
+    expect(result.code).toContain("trailing={0}");
+    expect(result.code).not.toContain("farmBlocks.KeyedList");
+  });
+
+  it("compiles an explicit List directly in the component root", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List } from "@farm.js/react/list";
+      export function Tasks() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
+        return (
+          <ul>
+            <List each={items} by={(item) => item.id}>
+              {(item) => <li>{item.label}</li>}
+            </List>
+          </ul>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Tasks"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedRanges");
+    expect(result.code).not.toContain("farmBlocks.KeyedList");
+  });
+
+  it("keeps a component sibling in the root outside the range-owned contract", async () => {
     const result = await compile(`
       import { useState } from "react";
       function Heading() {
@@ -140,18 +190,38 @@ describe("React AOT keyed-range compiler", () => {
       export function Tasks() {
         const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
         return (
-          <section>
-            <ul>
-              <Heading />
-              {items.map((item) => <li key={item.id}>{item.label}</li>)}
-              <li>End</li>
-            </ul>
-          </section>
+          <ul>
+            <Heading />
+            {items.map((item) => <li key={item.id}>{item.label}</li>)}
+            <li>End</li>
+          </ul>
         );
       }
     `);
 
     expect(result.compiled).toContain("Tasks");
+    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).not.toContain("farmBlocks.KeyedRanges");
+  });
+
+  it("preserves existing block composition when a root sibling contains dynamic structure", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Dashboard() {
+        const [open, setOpen] = useState(true);
+        const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
+        return (
+          <main>
+            <section>{open && <strong>{items.length} items</strong>}</section>
+            {items.map((item) => <article key={item.id}>{item.label}</article>)}
+          </main>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Dashboard"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.HostConditional");
     expect(result.code).toContain("farmBlocks.KeyedList");
     expect(result.code).not.toContain("farmBlocks.KeyedRanges");
   });

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-ranges.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-ranges.test.tsx
@@ -27,6 +27,21 @@ interface RangeBoardProps {
   title?: string;
 }
 
+class RootRangeErrorBoundary extends React.Component<
+  React.PropsWithChildren,
+  { message: string | null }
+> {
+  state = { message: null as string | null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { message: error.message };
+  }
+
+  render() {
+    return this.state.message ? <div role="alert">{this.state.message}</div> : this.props.children;
+  }
+}
+
 const roots = new Set<Root>();
 
 beforeEach(() => {
@@ -78,7 +93,10 @@ function rangeDescriptor(before: number, readItems: () => RangeItem[]): Compiler
   };
 }
 
-function defineRangeBoard(metrics: { executions: number; rangeRenders: number }) {
+function defineRangeBoard(
+  metrics: { executions: number; rangeRenders: number },
+  rootOwned = false,
+) {
   const initial: RangeModel = {
     primary: [
       { id: "a", label: "Alpha" },
@@ -103,39 +121,47 @@ function defineRangeBoard(metrics: { executions: number; rangeRenders: number })
       readModel = model;
       updateModel = (next) => state[0].set(next);
       const KeyedRanges = blocks.KeyedRanges;
-      return (
+      const ranges = (
+        <KeyedRanges
+          id={0}
+          ranges={[
+            rangeDescriptor(1, () => model().primary),
+            rangeDescriptor(1, () => model().secondary),
+          ]}
+          render={() => {
+            metrics.rangeRenders += 1;
+            return (
+              <ul
+                data-board="ranges"
+                data-count={model().primary.length + model().secondary.length}
+              >
+                <li data-static="header">{props.title || "Primary"}</li>
+                {model().primary.map((item, index) => (
+                  <li data-index={index} data-key={item.id} key={item.id}>
+                    {index}:{item.label}
+                  </li>
+                ))}
+                <li data-static="divider">Secondary</li>
+                {model().secondary.map((item, index) => (
+                  <li data-index={index} data-key={item.id} key={item.id}>
+                    {index}:{item.label}
+                  </li>
+                ))}
+                <li data-static="footer" ref={blocks.target(0)}>
+                  {model().primary.length + model().secondary.length} total
+                </li>
+              </ul>
+            );
+          }}
+          trailing={1}
+        />
+      );
+      return rootOwned ? (
+        ranges
+      ) : (
         <main>
           <h1>{props.title || "Ranges"}</h1>
-          <KeyedRanges
-            id={0}
-            ranges={[
-              rangeDescriptor(1, () => model().primary),
-              rangeDescriptor(1, () => model().secondary),
-            ]}
-            render={() => {
-              metrics.rangeRenders += 1;
-              return (
-                <ul data-board="ranges">
-                  <li data-static="header">{props.title || "Primary"}</li>
-                  {model().primary.map((item, index) => (
-                    <li data-index={index} data-key={item.id} key={item.id}>
-                      {index}:{item.label}
-                    </li>
-                  ))}
-                  <li data-static="divider">Secondary</li>
-                  {model().secondary.map((item, index) => (
-                    <li data-index={index} data-key={item.id} key={item.id}>
-                      {index}:{item.label}
-                    </li>
-                  ))}
-                  <li data-static="footer" ref={blocks.target(0)}>
-                    {model().primary.length + model().secondary.length} total
-                  </li>
-                </ul>
-              );
-            }}
-            trailing={1}
-          />
+          {ranges}
         </main>
       );
     },
@@ -150,6 +176,21 @@ function defineRangeBoard(metrics: { executions: number; rangeRenders: number })
           return [model.primary.length + model.secondary.length, " total"];
         },
       },
+      ...(rootOwned
+        ? [
+            {
+              kind: "attribute" as const,
+              path: [],
+              target: 1,
+              dependencies: [0],
+              name: "data-count",
+              read: (_props: RangeBoardProps, state: readonly { get(): unknown }[]) => {
+                const model = state[0].get() as RangeModel;
+                return model.primary.length + model.secondary.length;
+              },
+            },
+          ]
+        : []),
       { kind: "block", id: 0, dependencies: [0] },
     ],
   });
@@ -169,6 +210,50 @@ function rangeSnapshot(container: Element): string[] {
 }
 
 describe("compiled keyed DOM ranges", () => {
+  it("owns the exact component root and keeps root bindings coherent", async () => {
+    const metrics = { executions: 0, rangeRenders: 0 };
+    const board = defineRangeBoard(metrics, true);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.add(root);
+    await act(async () => root.render(<board.RangeBoard />));
+
+    const list = container.querySelector<HTMLUListElement>("[data-board='ranges']")!;
+    const header = list.querySelector('[data-static="header"]')!;
+    const divider = list.querySelector('[data-static="divider"]')!;
+    const footer = list.querySelector('[data-static="footer"]')!;
+    const alpha = list.querySelector('[data-key="a"]')!;
+    const xray = list.querySelector('[data-key="x"]')!;
+    const initialExecutions = metrics.executions;
+    const initialRangeRenders = metrics.rangeRenders;
+    expect(container.children).toHaveLength(1);
+    expect(container.firstElementChild).toBe(list);
+    expect(list.dataset.count).toBe("6");
+
+    await act(async () => {
+      board.updateModel((current) => {
+        const model = current as RangeModel;
+        return {
+          primary: [model.primary[3], ...model.primary.slice(0, 3)],
+          secondary: [...model.secondary, { id: "z", label: "Zulu" }],
+        };
+      });
+      await flushCompilerUpdates();
+    });
+
+    expect(container.firstElementChild).toBe(list);
+    expect(list.dataset.count).toBe("7");
+    expect(footer.textContent).toBe("7 total");
+    expect(list.querySelector('[data-static="header"]')).toBe(header);
+    expect(list.querySelector('[data-static="divider"]')).toBe(divider);
+    expect(list.querySelector('[data-static="footer"]')).toBe(footer);
+    expect(list.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(list.querySelector('[data-key="x"]')).toBe(xray);
+    expect(metrics.executions).toBe(initialExecutions);
+    expect(metrics.rangeRenders).toBe(initialRangeRenders);
+  });
+
   it("reconciles two ranges while preserving every static sibling", async () => {
     const metrics = { executions: 0, rangeRenders: 0 };
     const board = defineRangeBoard(metrics);
@@ -284,10 +369,13 @@ describe("compiled keyed DOM ranges", () => {
     expect(container.querySelector('[data-static="footer"]')).toBe(footer);
   });
 
-  it("switches the complete container to React when runtime keys collide", async () => {
+  it.each([
+    ["nested container", false],
+    ["component root", true],
+  ])("switches the complete %s to React when runtime keys collide", async (_label, rootOwned) => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     const metrics = { executions: 0, rangeRenders: 0 };
-    const board = defineRangeBoard(metrics);
+    const board = defineRangeBoard(metrics, rootOwned);
     const container = document.createElement("div");
     document.body.append(container);
     const root = createRoot(container);
@@ -324,179 +412,258 @@ describe("compiled keyed DOM ranges", () => {
     expect(metrics.rangeRenders).toBe(3);
   });
 
-  it("recovers hydration mismatches in StrictMode and drops queued work after unmount", async () => {
+  it("routes root-range update errors through the nearest error boundary", async () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
-    const metrics = { executions: 0, rangeRenders: 0 };
-    const board = defineRangeBoard(metrics);
-    const serverHtml = renderToString(
-      <StrictMode>
-        <board.RangeBoard />
-      </StrictMode>,
-    );
-    const container = document.createElement("div");
-    container.innerHTML = serverHtml.replace("Primary", "Server mismatch");
-    document.body.append(container);
-    const recoverable = vi.fn();
-    const root = hydrateRoot(
-      container,
-      <StrictMode>
-        <board.RangeBoard />
-      </StrictMode>,
-      { onRecoverableError: recoverable },
-    );
-    roots.add(root);
-    await act(async () => flushCompilerUpdates());
-    expect(recoverable).toHaveBeenCalled();
-
-    await act(async () => {
-      board.updateModel((current) => ({
-        ...(current as RangeModel),
-        primary: [{ id: "hydrated", label: "Hydrated" }],
-      }));
-      await flushCompilerUpdates();
+    let update: (next: CompilerStateUpdater) => void = () => undefined;
+    const ThrowingRoot = createCompiledComponent({
+      displayName: "ThrowingRootRange",
+      initialize: () => [[{ id: "a", label: "Alpha" }]],
+      render(_props: Record<string, never>, state, blocks) {
+        const items = () => state[0].get() as RangeItem[];
+        update = (next) => state[0].set(next);
+        const KeyedRanges = blocks.KeyedRanges;
+        const descriptor = rangeDescriptor(0, items);
+        return (
+          <KeyedRanges
+            id={0}
+            ranges={[
+              {
+                ...descriptor,
+                create: (item, index) => {
+                  if ((item as RangeItem).label === "Throw") {
+                    throw new Error("root keyed range failed");
+                  }
+                  return descriptor.create(item, index);
+                },
+              },
+            ]}
+            render={() => (
+              <ul>
+                {items().map((item, index) => (
+                  <li data-index={index} data-key={item.id} key={item.id}>
+                    {index}:{item.label}
+                  </li>
+                ))}
+              </ul>
+            )}
+            trailing={0}
+          />
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
     });
-    expect(container.querySelector('[data-key="hydrated"]')?.textContent).toBe("0:Hydrated");
-
-    await act(async () => {
-      board.updateModel({ primary: [], secondary: [] });
-      root.unmount();
-      await flushCompilerUpdates();
-    });
-    roots.delete(root);
-    expect(container.innerHTML).toBe("");
-  });
-
-  it("falls back safely when parent props change static sibling output", async () => {
-    const metrics = { executions: 0, rangeRenders: 0 };
-    const board = defineRangeBoard(metrics);
     const container = document.createElement("div");
     document.body.append(container);
     const root = createRoot(container);
     roots.add(root);
-    await act(async () => root.render(<board.RangeBoard title="First" />));
-    const originalList = container.querySelector("ul")!;
+    await act(async () =>
+      root.render(
+        <RootRangeErrorBoundary>
+          <ThrowingRoot />
+        </RootRangeErrorBoundary>,
+      ),
+    );
 
     await act(async () => {
-      root.render(<board.RangeBoard title="Second" />);
+      update([{ id: "broken", label: "Throw" }]);
       await flushCompilerUpdates();
     });
 
-    expect(container.querySelector("h1")?.textContent).toBe("Second");
-    expect(container.querySelector('[data-static="header"]')?.textContent).toBe("Second");
-    expect(container.querySelector("ul")).not.toBe(originalList);
-    expect(metrics.rangeRenders).toBe(2);
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe("root keyed range failed");
   });
 
-  it("matches normal React through 2,000 deterministic multi-range transitions", async () => {
-    const metrics = { executions: 0, rangeRenders: 0 };
-    const compiled = defineRangeBoard(metrics);
-    let normalModel = compiled.initial;
-    let setNormal: React.Dispatch<React.SetStateAction<RangeModel>> = () => undefined;
-
-    function NormalBoard() {
-      const [model, setModel] = useState(compiled.initial);
-      normalModel = model;
-      setNormal = setModel;
-      return (
-        <ul>
-          <li data-static="header">Primary</li>
-          {model.primary.map((item, index) => (
-            <li data-index={index} data-key={item.id} key={item.id}>
-              {index}:{item.label}
-            </li>
-          ))}
-          <li data-static="divider">Secondary</li>
-          {model.secondary.map((item, index) => (
-            <li data-index={index} data-key={item.id} key={item.id}>
-              {index}:{item.label}
-            </li>
-          ))}
-          <li data-static="footer">{model.primary.length + model.secondary.length} total</li>
-        </ul>
+  it.each([
+    ["nested container", false],
+    ["component root", true],
+  ])(
+    "recovers %s hydration mismatches in StrictMode and drops queued work after unmount",
+    async (_label, rootOwned) => {
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+      const metrics = { executions: 0, rangeRenders: 0 };
+      const board = defineRangeBoard(metrics, rootOwned);
+      const serverHtml = renderToString(
+        <StrictMode>
+          <board.RangeBoard />
+        </StrictMode>,
       );
-    }
+      const container = document.createElement("div");
+      container.innerHTML = serverHtml.replace("Primary", "Server mismatch");
+      document.body.append(container);
+      const recoverable = vi.fn();
+      const root = hydrateRoot(
+        container,
+        <StrictMode>
+          <board.RangeBoard />
+        </StrictMode>,
+        { onRecoverableError: recoverable },
+      );
+      roots.add(root);
+      await act(async () => flushCompilerUpdates());
+      expect(recoverable).toHaveBeenCalled();
 
-    const compiledContainer = document.createElement("div");
-    const normalContainer = document.createElement("div");
-    document.body.append(compiledContainer, normalContainer);
-    const compiledRoot = createRoot(compiledContainer);
-    const normalRoot = createRoot(normalContainer);
-    roots.add(compiledRoot);
-    roots.add(normalRoot);
-    await act(async () => {
-      compiledRoot.render(<compiled.RangeBoard />);
-      normalRoot.render(<NormalBoard />);
-    });
-
-    let seed = 0x9e3779b9;
-    const random = () => {
-      seed = (seed * 1664525 + 1013904223) >>> 0;
-      return seed;
-    };
-    const operations = Array.from({ length: 2000 }, (_, step) => ({
-      operation: random() % 7,
-      selector: random(),
-      step,
-    }));
-    const update = (model: RangeModel, step: number): RangeModel => {
-      const { operation, selector } = operations[step];
-      const side = selector % 2 === 0 ? "primary" : "secondary";
-      const other = side === "primary" ? "secondary" : "primary";
-      const rows = model[side];
-      if (operation === 0 && rows.length > 0) {
-        const target = selector % rows.length;
-        return {
-          ...model,
-          [side]: rows.map((row, index) =>
-            index === target ? { ...row, label: `${row.label}.${step}` } : row,
-          ),
-        };
-      }
-      if (operation === 1 && rows.length < 24) {
-        const id = `${side[0]}${step}`;
-        return { ...model, [side]: [...rows, { id, label: `Item ${step}` }] };
-      }
-      if (operation === 2 && rows.length > 0) {
-        return { ...model, [side]: rows.slice(1) };
-      }
-      if (operation === 3) return { ...model, [side]: [...rows].reverse() };
-      if (operation === 4 && rows.length > 1) {
-        return { ...model, [side]: [...rows.slice(1), rows[0]] };
-      }
-      if (operation === 5 && rows.length > 0) {
-        const target = selector % rows.length;
-        const moved = rows[target];
-        return {
-          ...model,
-          [side]: rows.filter((_, index) => index !== target),
-          [other]: [...model[other], moved],
-        };
-      }
-      return model;
-    };
-    const snapshot = (container: Element) => ({
-      rows: rangeSnapshot(container),
-      footer: container.querySelector('[data-static="footer"]')?.textContent,
-    });
-    const initialExecutions = metrics.executions;
-    const initialRangeRenders = metrics.rangeRenders;
-
-    for (let offset = 0; offset < operations.length; offset += 20) {
       await act(async () => {
-        for (let step = offset; step < offset + 20; step += 1) {
-          const updater = (current: RangeModel) => update(current, step);
-          compiled.updateModel((current) => updater(current as RangeModel));
-          setNormal(updater);
-        }
+        board.updateModel((current) => ({
+          ...(current as RangeModel),
+          primary: [{ id: "hydrated", label: "Hydrated" }],
+        }));
         await flushCompilerUpdates();
       });
-      expect(compiled.readModel(), `model after batch ${offset}`).toEqual(normalModel);
-      expect(snapshot(compiledContainer), `DOM after batch ${offset}`).toEqual(
-        snapshot(normalContainer),
-      );
-    }
+      expect(container.querySelector('[data-key="hydrated"]')?.textContent).toBe("0:Hydrated");
 
-    expect(metrics.executions).toBe(initialExecutions);
-    expect(metrics.rangeRenders).toBe(initialRangeRenders);
-  }, 30_000);
+      await act(async () => {
+        board.updateModel({ primary: [], secondary: [] });
+        root.unmount();
+        await flushCompilerUpdates();
+      });
+      roots.delete(root);
+      expect(container.innerHTML).toBe("");
+    },
+  );
+
+  it.each([
+    ["nested container", false],
+    ["component root", true],
+  ])(
+    "falls back safely for %s when parent props change static output",
+    async (_label, rootOwned) => {
+      const metrics = { executions: 0, rangeRenders: 0 };
+      const board = defineRangeBoard(metrics, rootOwned);
+      const container = document.createElement("div");
+      document.body.append(container);
+      const root = createRoot(container);
+      roots.add(root);
+      await act(async () => root.render(<board.RangeBoard title="First" />));
+      const originalList = container.querySelector("ul")!;
+
+      await act(async () => {
+        root.render(<board.RangeBoard title="Second" />);
+        await flushCompilerUpdates();
+      });
+
+      if (!rootOwned) expect(container.querySelector("h1")?.textContent).toBe("Second");
+      expect(container.querySelector('[data-static="header"]')?.textContent).toBe("Second");
+      expect(container.querySelector("ul")).not.toBe(originalList);
+      expect(metrics.rangeRenders).toBe(2);
+    },
+  );
+
+  it.each([
+    ["nested container", false],
+    ["component root", true],
+  ])(
+    "matches normal React through 2,000 deterministic %s transitions",
+    async (_label, rootOwned) => {
+      const metrics = { executions: 0, rangeRenders: 0 };
+      const compiled = defineRangeBoard(metrics, rootOwned);
+      let normalModel = compiled.initial;
+      let setNormal: React.Dispatch<React.SetStateAction<RangeModel>> = () => undefined;
+
+      function NormalBoard() {
+        const [model, setModel] = useState(compiled.initial);
+        normalModel = model;
+        setNormal = setModel;
+        return (
+          <ul>
+            <li data-static="header">Primary</li>
+            {model.primary.map((item, index) => (
+              <li data-index={index} data-key={item.id} key={item.id}>
+                {index}:{item.label}
+              </li>
+            ))}
+            <li data-static="divider">Secondary</li>
+            {model.secondary.map((item, index) => (
+              <li data-index={index} data-key={item.id} key={item.id}>
+                {index}:{item.label}
+              </li>
+            ))}
+            <li data-static="footer">{model.primary.length + model.secondary.length} total</li>
+          </ul>
+        );
+      }
+
+      const compiledContainer = document.createElement("div");
+      const normalContainer = document.createElement("div");
+      document.body.append(compiledContainer, normalContainer);
+      const compiledRoot = createRoot(compiledContainer);
+      const normalRoot = createRoot(normalContainer);
+      roots.add(compiledRoot);
+      roots.add(normalRoot);
+      await act(async () => {
+        compiledRoot.render(<compiled.RangeBoard />);
+        normalRoot.render(<NormalBoard />);
+      });
+
+      let seed = 0x9e3779b9;
+      const random = () => {
+        seed = (seed * 1664525 + 1013904223) >>> 0;
+        return seed;
+      };
+      const operations = Array.from({ length: 2000 }, (_, step) => ({
+        operation: random() % 7,
+        selector: random(),
+        step,
+      }));
+      const update = (model: RangeModel, step: number): RangeModel => {
+        const { operation, selector } = operations[step];
+        const side = selector % 2 === 0 ? "primary" : "secondary";
+        const other = side === "primary" ? "secondary" : "primary";
+        const rows = model[side];
+        if (operation === 0 && rows.length > 0) {
+          const target = selector % rows.length;
+          return {
+            ...model,
+            [side]: rows.map((row, index) =>
+              index === target ? { ...row, label: `${row.label}.${step}` } : row,
+            ),
+          };
+        }
+        if (operation === 1 && rows.length < 24) {
+          const id = `${side[0]}${step}`;
+          return { ...model, [side]: [...rows, { id, label: `Item ${step}` }] };
+        }
+        if (operation === 2 && rows.length > 0) {
+          return { ...model, [side]: rows.slice(1) };
+        }
+        if (operation === 3) return { ...model, [side]: [...rows].reverse() };
+        if (operation === 4 && rows.length > 1) {
+          return { ...model, [side]: [...rows.slice(1), rows[0]] };
+        }
+        if (operation === 5 && rows.length > 0) {
+          const target = selector % rows.length;
+          const moved = rows[target];
+          return {
+            ...model,
+            [side]: rows.filter((_, index) => index !== target),
+            [other]: [...model[other], moved],
+          };
+        }
+        return model;
+      };
+      const snapshot = (container: Element) => ({
+        rows: rangeSnapshot(container),
+        footer: container.querySelector('[data-static="footer"]')?.textContent,
+      });
+      const initialExecutions = metrics.executions;
+      const initialRangeRenders = metrics.rangeRenders;
+
+      for (let offset = 0; offset < operations.length; offset += 20) {
+        await act(async () => {
+          for (let step = offset; step < offset + 20; step += 1) {
+            const updater = (current: RangeModel) => update(current, step);
+            compiled.updateModel((current) => updater(current as RangeModel));
+            setNormal(updater);
+          }
+          await flushCompilerUpdates();
+        });
+        expect(compiled.readModel(), `model after batch ${offset}`).toEqual(normalModel);
+        expect(snapshot(compiledContainer), `DOM after batch ${offset}`).toEqual(
+          snapshot(normalContainer),
+        );
+      }
+
+      expect(metrics.executions).toBe(initialExecutions);
+      expect(metrics.rangeRenders).toBe(initialRangeRenders);
+    },
+    30_000,
+  );
 });

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -2006,7 +2006,17 @@ export function createCompiledComponent<Props>(
       if (this.hasBindingError) throw this.bindingError;
       const currentDefinition = definitionReference.current;
       const element = currentDefinition.render(this.props, this.cells, this.blockRuntime);
-      if (!React.isValidElement(element) || typeof element.type !== "string") {
+      if (!React.isValidElement(element)) {
+        throw new TypeError(
+          `Compiled component ${currentDefinition.displayName} must return one host element.`,
+        );
+      }
+      if (element.type === this.blockRuntime.KeyedRanges) {
+        return React.cloneElement(element as React.ReactElement<CompilerKeyedRangesBlockProps>, {
+          rootRef: this.captureRoot,
+        });
+      }
+      if (typeof element.type !== "string") {
         throw new TypeError(
           `Compiled component ${currentDefinition.displayName} must return one host element.`,
         );

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -1390,11 +1390,36 @@ function analyzeKeyedRowsContainer(
   return analyzeKeyedRowChild(children[0], statesByValue, safeGlobals, listNames);
 }
 
+function isStaticKeyedRangeSibling(
+  element: t.JSXElement,
+  statesByValue: ReadonlyMap<string, StateBinding>,
+  safeGlobals: ReadonlySet<string>,
+): boolean {
+  for (const child of meaningfulJsxChildren(element)) {
+    if (t.isJSXFragment(child)) return false;
+    if (t.isJSXElement(child)) {
+      if (!isHostElement(child) || !isStaticKeyedRangeSibling(child, statesByValue, safeGlobals)) {
+        return false;
+      }
+      continue;
+    }
+    if (
+      t.isJSXExpressionContainer(child) &&
+      !t.isJSXEmptyExpression(child.expression) &&
+      !isTextExpression(child.expression, statesByValue, safeGlobals)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function analyzeKeyedRangesContainer(
   container: t.JSXElement,
   statesByValue: ReadonlyMap<string, StateBinding>,
   safeGlobals: ReadonlySet<string>,
   listNames: ReadonlySet<string>,
+  allowSingleRange = false,
 ): { ranges: KeyedRangePlan[]; trailing: number; dependencies: number[] } | undefined {
   if (
     container.openingElement.attributes.some(
@@ -1409,7 +1434,7 @@ function analyzeKeyedRangesContainer(
   }
 
   const children = meaningfulJsxChildren(container);
-  if (children.length < 2) return undefined;
+  if (children.length < (allowSingleRange ? 1 : 2)) return undefined;
   const ranges: KeyedRangePlan[] = [];
   const dependencies = new Set<number>();
   let staticBefore = 0;
@@ -1432,16 +1457,7 @@ function analyzeKeyedRangesContainer(
       continue;
     }
     if (!t.isJSXElement(child) || !isHostElement(child)) return undefined;
-    let hostOnly = true;
-    t.traverseFast(child, (node) => {
-      if (
-        t.isJSXFragment(node) ||
-        (t.isJSXElement(node) && node !== child && !isHostElement(node))
-      ) {
-        hostOnly = false;
-      }
-    });
-    if (!hostOnly) return undefined;
+    if (!isStaticKeyedRangeSibling(child, statesByValue, safeGlobals)) return undefined;
     staticBefore += 1;
   }
   if (ranges.length === 0) return undefined;
@@ -2589,6 +2605,29 @@ function analyzeComposableBlocks(
     return { dependencies };
   };
 
+  const rootRanges = analyzeKeyedRangesContainer(root, statesByValue, safeGlobals, listNames, true);
+  if (rootRanges) {
+    plans.push({
+      kind: "keyed-ranges",
+      id: nextId++,
+      dependencies: rootRanges.dependencies,
+      source: root,
+      ranges: rootRanges.ranges,
+      trailing: rootRanges.trailing,
+    });
+    for (const range of rootRanges.ranges) {
+      if (t.isJSXElement(range.source)) ownedElements.add(range.source);
+      else keyedExpressions.add(range.source);
+    }
+    return {
+      plans,
+      componentElements,
+      conditionalExpressions,
+      ownedElements,
+      keyedExpressions,
+    };
+  }
+
   const result = visitHost(root, undefined, false);
   if (result.reason) return { reason: result.reason };
   return {
@@ -2636,6 +2675,10 @@ function lowerComposableBlocks(
   const planBySource = new Map<t.Node, ComposableBlockPlan>(
     plans.map((plan) => [plan.source, plan]),
   );
+  const rootPlan = planBySource.get(root);
+  if (rootPlan?.kind === "keyed-ranges") {
+    return keyedRangesBoundary(blockRuntime, rootPlan);
+  }
 
   const visit = (element: t.JSXElement): void => {
     element.children = element.children.map((child) => {


### PR DESCRIPTION
## Summary

- compile eligible non-interactive keyed host ranges when their container is the component's returned host root
- preserve the exact root DOM node and its compiled attributes/styles without adding wrappers or hydration markers
- keep unsupported siblings, interactive rows, custom components, duplicate keys, adoption mismatches, parent prop changes, and refresh changes on the existing React fallback paths
- add a production edge-lab card and document the supported and fallback contracts

## Battle testing

- `pnpm --filter @farm.js/react test` — 29 files, 240 tests
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and React 19.2.8
- `pnpm --filter farm-react-compiler-example experiment` — production Chromium verification, responsive/console checks, exact root/static/row identity, three measured LIS moves, empty ranges, and 1,024-row stress load
- `pnpm --filter farmjs-docs build` — Vercel/Nitro deployment output
- `pnpm exec oxfmt --check ...`
- `git diff --check`

The randomized differential coverage runs 2,000 transitions for the nested owner and another 2,000 for the component-root owner, comparing each result with normal React. It also covers StrictMode, hydration mismatches, early unmount, simultaneous parent/local updates, duplicate keys, error boundaries, and cleanup.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compiles eligible non-interactive keyed collections when their container is the component’s returned host root, not just a nested host container. The exact root DOM node and its attributes/styles are preserved with no wrappers or hydration markers; unsupported shapes continue on React.

- Compiler: detects `KeyedRanges` at the component root (including a single eligible map/`List` with no static siblings), validates host-only static siblings, and emits a root `KeyedRanges` block with correct before/trailing offsets. Root analysis is prioritized before nested lowering.
- Runtime: `createCompiledComponent` accepts a root `KeyedRanges` element and forwards a `rootRef` to capture the physical root so outer bindings remain coherent.
- Fallbacks/behavior: interactive rows/siblings, components/fragments inside the root container, duplicate keys, adoption shape mismatches, and parent-prop or Fast Refresh changes switch the entire container/root back to the React path. Root-range update errors route to the nearest error boundary. StrictMode hydration mismatches recover; queued work is dropped after unmount.
- Tests: expand coverage for root ranges (React 18/19), deterministic transitions for both nested and root owners, LIS moves, DOM identity (root and static siblings), hydration, duplicate keys, and error boundaries; update AOT tests to expect `KeyedRanges` at the root and allow single-range roots.
- Examples/docs: rename the card to “Root keyed ranges,” render ranges directly in the root (no wrapper/marker), adjust selectors/metrics, and update CSS layout; docs and READMEs describe root support and unchanged React fallbacks.
- No migration required; existing nested-range behavior and contracts remain the same.

<sup>Written for commit dad702b79bb56ae438e99949c52c7b347b236626. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

