### PR TITLE
refactor: share decodeRouteSegment across route matching

### DIFF
--- a/packages/farm/src/__tests__/workflows.test.ts
+++ b/packages/farm/src/__tests__/workflows.test.ts
@@ -238,6 +238,32 @@ describe("Farm workflows", () => {
     expect(handlerSource).toContain('getHeader(event, "x-farm-workflow-secret")');
     expect(handlerSource).toContain("authorization.match(/^Bearer");
     expect(handlerSource).not.toContain('searchParams.get("secret")');
+    expect(handlerSource).toContain("function decodeRouteSegment(segment)");
+    expect(handlerSource).not.toContain("decodeURIComponent(event.context.params");
+  });
+
+  it("404s on a malformed percent-encoded workflow id instead of throwing", async () => {
+    const workflow = {
+      id: "sync-users",
+      filePath: "/virtual/sync-users.ts",
+      description: "Sync users.",
+      schedule: [],
+      routePath: "/api/_farm/workflows/sync-users",
+    };
+    const handler = createFarmWorkflowRequestHandler({
+      workflows: [workflow],
+      config: resolveWorkflowsConfig({ secret: "test-secret" }),
+      loadModule: async () => ({ default: { run: async () => ({}) } }),
+    });
+
+    // The id is decoded before the secret is checked, so these are reachable
+    // without credentials and must not throw out of the handler.
+    for (const id of ["caf%E9", "%ZZ", "a%"]) {
+      const response = await handler(
+        new Request(`https://example.com/api/_farm/workflows/${id}`, { method: "POST" }),
+      );
+      expect(response?.status).toBe(404);
+    }
   });
 
   it("adds scheduled workflows to Vercel crons without duplicating existing entries", () => {

--- a/packages/farm/src/integrations.ts
+++ b/packages/farm/src/integrations.ts
@@ -11,6 +11,7 @@ import type {
 } from "./integration-api";
 import type { InferFarmIntegrationOrmClient } from "./integration-orm";
 import { setFarmPluginIntegrationContext } from "./plugin-integration-context";
+import { decodeRouteSegment } from "./utils/decode";
 import type {
   FarmPlugin,
   FarmPluginContext,
@@ -3173,16 +3174,6 @@ function resolveMatcherParams(
 
 function matchesPath(pattern: string, pathname: string): boolean {
   return extractPathParams(pattern, pathname) !== null;
-}
-
-function decodeRouteSegment(segment: string): string {
-  try {
-    return decodeURIComponent(segment);
-  } catch {
-    // Request paths are not guaranteed to be validly percent-encoded; a
-    // malformed segment must not throw out of route matching.
-    return segment;
-  }
 }
 
 function extractPathParams(pattern: string, pathname: string): FarmIntegrationRouteParams | null {

--- a/packages/farm/src/middleware/manager.ts
+++ b/packages/farm/src/middleware/manager.ts
@@ -7,6 +7,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import type { ViteDevServer } from "vite";
+import { decodeRouteSegment } from "../utils/decode";
 import type { IncomingMessage, ServerResponse } from "http";
 import type {
   FarmMiddlewareConfig,
@@ -40,16 +41,6 @@ function isMiddlewareResponse(value: unknown): value is Response {
 /**
  * Middleware Manager - discovers and executes middleware
  */
-function decodeRouteSegment(segment: string): string {
-  try {
-    return decodeURIComponent(segment);
-  } catch {
-    // Request paths are not guaranteed to be validly percent-encoded; a
-    // malformed segment must not throw out of route matching.
-    return segment;
-  }
-}
-
 export class MiddlewareManager {
   private middleware: DiscoveredMiddleware[] = [];
   private configMiddleware: DiscoveredMiddleware[] = [];

--- a/packages/farm/src/middleware/production-runtime.ts
+++ b/packages/farm/src/middleware/production-runtime.ts
@@ -10,6 +10,7 @@ import type {
   MiddlewareResult,
 } from "./types";
 import { emitFarmEvent } from "../observability";
+import { decodeRouteSegment } from "../utils/decode";
 import { normalizeMiddlewareModule } from "./module";
 import { stripFarmLocaleFromPathname } from "../i18n/routing";
 import type { ResolvedFarmI18nConfig } from "../i18n/types";
@@ -451,16 +452,6 @@ function compilePathPattern(pattern: string): { regex: RegExp; params: string[] 
     regex: new RegExp(`^${parts.join("")}$`),
     params,
   };
-}
-
-function decodeRouteSegment(segment: string): string {
-  try {
-    return decodeURIComponent(segment);
-  } catch {
-    // Request paths are not guaranteed to be validly percent-encoded; a
-    // malformed segment must not throw out of route matching.
-    return segment;
-  }
 }
 
 function matchPattern(

--- a/packages/farm/src/utils/decode.ts
+++ b/packages/farm/src/utils/decode.ts
@@ -1,0 +1,16 @@
+/**
+ * Decode a percent-encoded path segment, falling back to the raw value.
+ *
+ * Request paths are not guaranteed to be validly percent-encoded, so
+ * `decodeURIComponent` can throw on input that is still a legal URL: a
+ * latin-1 escape such as `caf%E9` from an old link, or a truncated `%ZZ`
+ * from a crawler. A malformed segment simply will not match a known route,
+ * which is a 404, so it must not throw out of route matching.
+ */
+export function decodeRouteSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}

--- a/packages/farm/src/workflows.ts
+++ b/packages/farm/src/workflows.ts
@@ -5,6 +5,7 @@ import {
   type FarmServerConfig,
   type ResolvedFarmServerConfig,
 } from "./server-http";
+import { decodeRouteSegment } from "./utils/decode";
 import { toPosixPath } from "./utils";
 
 export type FarmWorkflowSchedule = string | string[];
@@ -212,7 +213,7 @@ export function createFarmWorkflowRequestHandler(options: FarmWorkflowHTTPHandle
       });
     }
 
-    const id = decodeURIComponent(url.pathname.slice(route.length + 1));
+    const id = decodeRouteSegment(url.pathname.slice(route.length + 1));
     const workflow = workflowsById.get(id);
     if (!workflow) {
       return Response.json({ error: `Workflow "${id}" was not found.` }, { status: 404 });
@@ -609,6 +610,14 @@ function json(value, status = 200) {
   });
 }
 
+function decodeRouteSegment(segment) {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
 function getHeader(event, name) {
   return event.req.headers.get(name);
 }
@@ -644,7 +653,7 @@ export default new H3()
     return { workflows };
   })
   .all(route + "/:id", async (event) => {
-    const id = decodeURIComponent(event.context.params?.id || "");
+    const id = decodeRouteSegment(event.context.params?.id || "");
     if (!workflowIds.has(id)) {
       return json({ error: "Workflow " + id + " was not found." }, 404);
     }


### PR DESCRIPTION
Follow-up to #515, as offered there.

`decodeRouteSegment` had been copied into four places, each by the fix that needed it and
before a shared home existed: `integrations.ts` in #487, then the two middleware runtimes and
the emitted matcher in #508. #515 added `utils/decode` rather than a fifth copy.

This imports the shared helper in the three that can. The bodies were byte identical, so
there is no behaviour change.

The copies in `nitro/universal-build.ts` and `workflows.ts` stay inlined. Both are emitted
into generated runtime source that runs in its own bundle and cannot import from core.

## Verification

Core suite green, 1248 passed and 6 skipped, the same counts as before the change. The suites
covering the touched paths pass in isolation too, 212 tests across middleware, integrations,
router and workflows. Type check and lint clean.

## Note

Stacked on #515, so it shows that commit until #515 lands.

While checking I swept every `decodeURIComponent` in `packages/*/src`, 37 sites. Aside from
these, they are inline `try`/`catch` at the call site with their own fallback semantics, so I
left them alone. The one bare decode left is `farm-cli/src/explain.ts:615`, which reads a CLI
argument rather than a request path, so a malformed value there fails the command rather than
a response. Happy to file it separately if you think it is worth tidying.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates route-segment decoding and fixes workflow ID decoding errors. Previously, malformed percent-encodings in workflow IDs (e.g., caf%E9, %ZZ) threw and returned 500; they now fall back to the raw segment and return 404.

- Introduces a shared `decodeRouteSegment` in `packages/farm/src/utils/decode.ts` and replaces duplicated implementations in `integrations.ts`, `middleware/manager.ts`, and `middleware/production-runtime.ts` (no behavior change).
- Updates the workflows request handler to use the shared helper; adds an inlined copy in the emitted Nitro handler because generated runtime code cannot import from core.
- Adds tests verifying 404 on malformed workflow IDs; no config or API changes.

<sup>Written for commit c57102245c21b21cf84a526fd40d754d016407ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

