### PR TITLE
feat(react): compile conditional DOM ranges

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -335,7 +335,7 @@ satisfy all of these rules:
 | Text bindings       | State-driven text in a leaf host element.                                                                                                               |
 | Attribute bindings  | Basic attributes, controlled form properties, and individual properties in one inline `style` object.                                                   |
 | Events              | Inline handlers and synchronous `const` or function-declaration handlers, including inline synchronous events in eligible host-only keyed rows.         |
-| Conditional blocks  | Logical/ternary host branches; dedicated host-only containers may use compiler-owned branch instances and bindings.                                     |
+| Conditional blocks  | Logical/ternary host branches in dedicated containers or direct ranges among static host siblings, including the component root.                        |
 | Keyed lists         | Item-keyed maps and imported `List`, including safe collection pipelines; eligible rows use direct bindings and keyed row-local conditional boundaries. |
 | Component islands   | Stable imported or module-level component identifiers with explicit compiler-safe props and no JSX children, spread, `ref`, or `key`.                   |
 
@@ -407,39 +407,52 @@ on React because their final property set or precedence can change.
 
 This optimization is automatic for components selected by the existing experimental compiler
 configuration. It does not require a conditional component, a new annotation, or another option.
-The compiler can isolate two common child structures when their position is known at build time:
+The compiler can isolate logical and ternary child structures when their positions are known at
+build time:
 
 ```tsx
 export function StatusPanel() {
   const [loading, setLoading] = useState(false);
   const [enabled, setEnabled] = useState(true);
+  const [updates, setUpdates] = useState(0);
 
   return (
-    <section>
-      <button onClick={() => setLoading(!loading)}>Toggle loading</button>
-      <div>{loading && <p>Loading…</p>}</div>
-
-      <button onClick={() => setEnabled(!enabled)}>Toggle status</button>
-      <div>{enabled ? <strong>Enabled</strong> : <span>Disabled</span>}</div>
-    </section>
+    <article data-update={updates}>
+      <header>Status</header>
+      {loading && <p>Loading update {updates}…</p>}
+      <section>Stable content · update {updates}</section>
+      {enabled ? <strong>Enabled at {updates}</strong> : <span>Disabled at {updates}</span>}
+      <footer>
+        <button onClick={() => setUpdates((value) => value + 1)}>Update values</button>
+        <button onClick={() => setLoading((value) => !value)}>Toggle loading</button>
+        <button onClick={() => setEnabled((value) => !value)}>Toggle status</button>
+      </footer>
+    </article>
   );
 }
 ```
 
-At build time, Farm records the condition's state cells and prepares a descriptor plus exact
-text/attribute/style bindings for each host branch. React still creates the initial branch during
-client rendering, SSR, or hydration. After mount, Farm adopts that existing element. A later update
-to the same branch patches only its changed bindings and preserves its DOM identity; a condition
-change creates, removes, or replaces only that branch. The outer user component does not execute
-again, and the compiler does not add a marker node to server HTML.
+At build time, Farm records each condition's state cells and prepares a descriptor plus exact
+text/attribute/style bindings for every host branch. It also counts the static host elements before
+each range and after the final range. React still creates the complete initial tree during client
+rendering, SSR, or hydration. After mount, Farm adopts the original container, its static siblings,
+and any active branches. It does not add a wrapper, comment marker, or hydration attribute.
+
+When a state update keeps the same branch, Farm patches only that branch's changed bindings and
+preserves its DOM identity. When the condition changes, Farm inserts, removes, or replaces only that
+range. Multiple ranges are evaluated from one state snapshot and committed from right to left, so
+adjacent empty ranges and simultaneous changes keep their original order. Root attributes and
+ordinary bindings such as `data-update` above continue to patch the same physical root. The user
+component and unchanged static siblings do not execute or remount.
 
 The compiler-owned path is deliberately narrow:
 
-- The conditional is the only meaningful child of a nested lowercase host container. A conditional
-  beside static siblings, or directly inside the component's outermost return element, keeps the
-  React-owned path.
-- The dedicated container itself has static attributes and no event handler. Dynamic properties and
-  events belong outside that ownership boundary or use the React-owned path.
+- A nested or component-root lowercase host container may contain one or more eligible direct
+  conditionals separated by statically known host siblings. A nested container needs at least two
+  meaningful children; the existing dedicated one-child optimization handles the smaller shape.
+- Every other direct child is a lowercase host subtree. Its text and ordinary attributes may use
+  supported bindings, and its event handlers remain React events. Fragments, custom components, or
+  another dynamic structure beside a range keep that container on the React-owned path.
 - Every non-empty branch has one lowercase HTML root and a statically known host-only descendant
   tree. Text, attributes, and individual inline style properties may use supported expressions.
 - Branch events, `key`, custom components, fragments, refs, SVG, `dangerouslySetInnerHTML`, JSX
@@ -451,11 +464,20 @@ The compiler-owned path is deliberately narrow:
 - The test and every prepared binding must use the same deterministic expression subset as other
   compiler bindings.
 
+A dedicated host container whose conditional is its only meaningful child uses the same branch
+descriptor and update behavior. It remains useful when a branch needs one fixed mounting location:
+
+```tsx
+<div>{loading && <p>Loading…</p>}</div>
+```
+
 The existing React-owned conditional boundary remains the fallback for supported complex shapes.
 It can contain event handlers, nested host conditionals, keyed lists, and component islands while
 still skipping the surrounding compiled component. Unsupported roots or unprovable behavior keep
-the complete original React component. In all three cases, React remains responsible for delegated
-events, error boundaries, Strict Mode, SSR, and hydration semantics.
+the complete original React component. A parent-prop update, Fast Refresh, invalid adopted DOM, or
+numeric logical output remounts the affected range container through React before direct updates
+resume. In every tier, React remains responsible for delegated events, error boundaries, Strict
+Mode, SSR, and hydration semantics.
 
 ### Compiled keyed rows and React list boundaries
 
@@ -889,24 +911,24 @@ component.
 
 ### What falls back to React
 
-| Unsupported shape                                                                                            | Why React keeps ownership                                                          |
-| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
-| Unkeyed/index-keyed maps, unsupported or mutating collection pipelines, or element arrays                    | Their structure, purity, or item identity is outside the keyed-list contract.      |
-| Unsupported row events/forms, components, fragments, refs, SVG, nested blocks, or mixed conditional slots    | Their event, lifecycle, or structure contract requires the React-owned row path.   |
-| Interactive ranges beside siblings or non-host range siblings                                                | The range owner requires a host container and non-interactive host rows.           |
-| Branch events, keys, components, fragments, refs, SVG, or nested blocks in a dedicated conditional container | They require the React-owned conditional path rather than compiler-created hosts.  |
-| Dynamic/member component types, component spreads, refs, keys, or children                                   | Their identity or ownership is outside the first component-island contract.        |
-| Effects or hooks other than the supported `useState` shape                                                   | Their lifecycle and ordering must remain under React's hook dispatcher.            |
-| `ref` or `dangerouslySetInnerHTML`                                                                           | They directly participate in DOM ownership.                                        |
-| Stateful `children` or `key` bindings outside an eligible boundary                                           | These need structure or identity semantics.                                        |
-| Conditional style objects, style spreads, methods, or computed names                                         | The final property set or precedence cannot be prepared statically.                |
-| JSX attribute spreads or namespaced attributes                                                               | The compiler cannot currently enumerate a stable binding contract.                 |
-| Multiple/conditional returns or impure/control-flow statements                                               | The compiler only lowers a single, statically analyzable render path.              |
-| Derived calls, assignments, identity-bearing values, functions, or JSX                                       | Their evaluation timing, side effects, or identity cannot yet be preserved safely. |
-| Nested, computed, or rest props destructuring                                                                | These patterns need additional parameter-shape and identity analysis.              |
-| Async/generator/generic handlers or named handlers outside JSX events                                        | Their scheduling, identity, or closure semantics are outside the current lowering. |
-| Async/generator or generic components                                                                        | These function shapes are outside the current lowering.                            |
-| Setters called outside JSX event handlers                                                                    | The compiler only controls and batches event-driven local updates.                 |
+| Unsupported shape                                                                                         | Why React keeps ownership                                                          |
+| --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Unkeyed/index-keyed maps, unsupported or mutating collection pipelines, or element arrays                 | Their structure, purity, or item identity is outside the keyed-list contract.      |
+| Unsupported row events/forms, components, fragments, refs, SVG, nested blocks, or mixed conditional slots | Their event, lifecycle, or structure contract requires the React-owned row path.   |
+| Interactive ranges beside siblings or non-host range siblings                                             | The range owner requires a host container and non-interactive host rows.           |
+| Branch events, keys, components, fragments, refs, SVG, or nested blocks in a compiled conditional range   | They require the React-owned conditional path rather than compiler-created hosts.  |
+| Dynamic/member component types, component spreads, refs, keys, or children                                | Their identity or ownership is outside the first component-island contract.        |
+| Effects or hooks other than the supported `useState` shape                                                | Their lifecycle and ordering must remain under React's hook dispatcher.            |
+| `ref` or `dangerouslySetInnerHTML`                                                                        | They directly participate in DOM ownership.                                        |
+| Stateful `children` or `key` bindings outside an eligible boundary                                        | These need structure or identity semantics.                                        |
+| Conditional style objects, style spreads, methods, or computed names                                      | The final property set or precedence cannot be prepared statically.                |
+| JSX attribute spreads or namespaced attributes                                                            | The compiler cannot currently enumerate a stable binding contract.                 |
+| Multiple/conditional returns or impure/control-flow statements                                            | The compiler only lowers a single, statically analyzable render path.              |
+| Derived calls, assignments, identity-bearing values, functions, or JSX                                    | Their evaluation timing, side effects, or identity cannot yet be preserved safely. |
+| Nested, computed, or rest props destructuring                                                             | These patterns need additional parameter-shape and identity analysis.              |
+| Async/generator/generic handlers or named handlers outside JSX events                                     | Their scheduling, identity, or closure semantics are outside the current lowering. |
+| Async/generator or generic components                                                                     | These function shapes are outside the current lowering.                            |
+| Setters called outside JSX event handlers                                                                 | The compiler only controls and batches event-driven local updates.                 |
 
 Keys do not make list work disappear. A key identifies the row that survives an insert, removal,
 or move. On the non-interactive compiler-owned host path, Farm compares those keys, reuses matching
@@ -957,7 +979,7 @@ follows:
 | JSX event registration and dispatch, including row events | Queuing local setter calls into one microtask                                |
 | Parent-driven prop updates                                | Comparing flushed values and selecting dependent bindings                    |
 | Unsupported trees, hooks, refs, handlers, and lifecycles  | Patching stable ref-owned text, attribute, and style targets                 |
-| Complex conditional branches, events, and nested blocks   | Host-only conditional identity, bindings, creation, removal, and replacement |
+| Complex conditional branches, events, and nested blocks   | Host-only conditional identity, range placement, bindings, and replacement   |
 | Interactive or conditional-row structure and reorders     | Same-key row bindings, latest-item events, and changed conditional snapshots |
 | React-owned custom or structurally complex keyed rows     | Non-interactive host-row identity, bindings, insertion, removal, and LIS     |
 | Component render, Hooks, context, and lifecycle           | Refreshing only a dependent React component-island boundary                  |
@@ -1039,6 +1061,11 @@ The package and example test suites verify more than generated code:
   logical output or any unproven structure;
 - 3,000 deterministic compiler-owned conditional transitions produce the same host output as
   normal React while the compiled owner stays at one execution;
+- conditional DOM ranges preserve an exact component root and every static sibling, mount adjacent
+  empty slots in source order without marker nodes, and commit simultaneous range changes from one
+  state snapshot;
+- 3,000 deterministic nested-range updates and 3,000 component-root-range updates match normal
+  React while unchanged branches, static siblings, and the compiled owner keep their identity;
 - object, array, and nullish state transitions match normal React across 3,000 deterministic
   randomized updates;
 - automatic keyed maps and explicit `List` boundaries preserve keyed DOM nodes and stateful row

--- a/examples/react-compiler/README.md
+++ b/examples/react-compiler/README.md
@@ -46,6 +46,7 @@ assertions, checks for console/runtime errors and horizontal overflow, saves scr
 | Controlled form bindings   | textarea/select/checkbox update, executions `0`         | —                                              | Form properties and textarea selection stay coherent.                  |
 | Logical conditional block  | stable branch patches, mounts, and unmounts; executions `0` | —                                           | A proven host branch updates without React reconciliation.             |
 | Ternary conditional block  | `strong` and `span` replace each other; executions `0`     | —                                           | Only the compiler-owned branch is replaced.                            |
+| Root conditional ranges    | exact card root, two ranges, stable static siblings; executions `0` | —                                  | Direct branches reconcile without wrappers or marker nodes.            |
 | Composable nested blocks   | two lists, nested conditions, and one component island  | —                                              | One block graph mounts, updates, and cleans up nested subscriptions.    |
 
 The package runtime test also measures one equivalent update under a React `Profiler`:
@@ -148,10 +149,19 @@ branches. React creates or hydrates the initial branch. After mount, a same-bran
 that existing element, while a condition change mounts, removes, or replaces only the branch. The
 production assertion checks that updating `07A` keeps the exact same branch DOM node.
 
+The `07C` card covers the wider range form. Its returned `article` contains a logical branch and a
+ternary branch separated by static header, content, metrics, and footer elements. Farm adopts that
+exact component root after React renders or hydrates it. Updating values preserves a same-branch
+node; changing both conditions in one event mounts one range and replaces the other from the same
+state snapshot. The browser assertion then removes the logical range again and verifies that the
+root and every static sibling are still the original DOM nodes, no marker nodes were added, and the
+component recorded zero update executions.
+
 This does not pre-mount both branches or bypass React's event system. Branch events, custom
 components, fragments, refs, SVG, keys, spreads, nested dynamic blocks, and dangerous HTML keep a
 React-owned conditional boundary or fall back to the original component. A numeric logical value
-such as `0 && <p />` also remounts through React so visible primitive output is preserved exactly.
+such as `0 && <p />`, a parent-driven prop change, Fast Refresh, or invalid adopted DOM remounts the
+affected range container through React so visible output and React ownership remain exact.
 
 The `08` card combines those boundary types under one outer conditional. It also proves that a
 hidden outer block removes its inner subscriptions: updates made while hidden do no render work,

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -27,6 +27,7 @@ for (const component of [
   "FormBindingPanel",
   "LogicalBlockPanel",
   "TernaryBlockPanel",
+  "ConditionalRangePanel",
   "AutomaticKeyedListExperiment",
   "DerivedCollectionExperiment",
   "InteractiveKeyedListExperiment",
@@ -396,6 +397,86 @@ try {
     `${ternary} [data-metric="executions"]`,
   );
   assert.equal(ternaryFinalExecutions - ternaryInitialExecutions, 0);
+
+  const conditionalRanges = '[data-experiment="conditional-ranges"]';
+  const conditionalRangesInitialExecutions = await readNumber(
+    page,
+    `${conditionalRanges} [data-metric="range-executions"]`,
+  );
+  await page.evaluate(() => {
+    const root = document.querySelector('[data-experiment="conditional-ranges"]');
+    window.__farmConditionalRangeRoot = root;
+    window.__farmConditionalRangeHeader = root.querySelector('[data-static="range-header"]');
+    window.__farmConditionalRangeContent = root.querySelector('[data-static="range-content"]');
+    window.__farmConditionalRangeMetrics = root.querySelector('[data-static="range-metrics"]');
+    window.__farmConditionalRangeFooter = root.querySelector('[data-static="range-footer"]');
+    window.__farmConditionalRangeStatus = root.querySelector('[data-slot="range-status"]');
+  });
+  await assertText(page, `${conditionalRanges} [data-slot="range-status"]`, "Enabled at 0");
+  assert.equal(await page.locator(`${conditionalRanges} [data-slot="range-loading"]`).count(), 0);
+
+  await page.locator(`${conditionalRanges} [data-action="increment-ranges"]`).click();
+  await assertText(page, `${conditionalRanges} [data-slot="range-status"]`, "Enabled at 1");
+  await assertText(page, `${conditionalRanges} [data-metric="range-updates"]`, "Update 1");
+  assert.equal(await page.locator(conditionalRanges).getAttribute("data-update"), "1");
+  assert.equal(
+    await page.evaluate(
+      () =>
+        window.__farmConditionalRangeStatus ===
+        document.querySelector('[data-experiment="conditional-ranges"] [data-slot="range-status"]'),
+    ),
+    true,
+    "a same-branch conditional range lost its DOM identity",
+  );
+
+  await page.locator(`${conditionalRanges} [data-action="toggle-ranges"]`).click();
+  await assertText(page, `${conditionalRanges} [data-slot="range-loading"]`, "Loading update 1");
+  await assertText(page, `${conditionalRanges} [data-slot="range-status"]`, "Disabled at 1");
+  assert.deepEqual(
+    await page.locator(conditionalRanges).evaluate((root) =>
+      [...root.children].map(
+        (child) => child.getAttribute("data-static") || child.getAttribute("data-slot"),
+      ),
+    ),
+    [
+      "range-header",
+      "range-loading",
+      "range-content",
+      "range-status",
+      "range-metrics",
+      "range-footer",
+    ],
+  );
+
+  await page.locator(`${conditionalRanges} [data-action="toggle-ranges"]`).click();
+  await assertText(page, `${conditionalRanges} [data-slot="range-status"]`, "Enabled at 1");
+  assert.equal(await page.locator(`${conditionalRanges} [data-slot="range-loading"]`).count(), 0);
+  const conditionalRangesIdentity = await page.evaluate(() => {
+    const root = document.querySelector('[data-experiment="conditional-ranges"]');
+    return {
+      root: window.__farmConditionalRangeRoot === root,
+      header:
+        window.__farmConditionalRangeHeader === root.querySelector('[data-static="range-header"]'),
+      content:
+        window.__farmConditionalRangeContent === root.querySelector('[data-static="range-content"]'),
+      metrics:
+        window.__farmConditionalRangeMetrics === root.querySelector('[data-static="range-metrics"]'),
+      footer:
+        window.__farmConditionalRangeFooter === root.querySelector('[data-static="range-footer"]'),
+    };
+  });
+  assert.deepEqual(conditionalRangesIdentity, {
+    root: true,
+    header: true,
+    content: true,
+    metrics: true,
+    footer: true,
+  });
+  const conditionalRangesFinalExecutions = await readNumber(
+    page,
+    `${conditionalRanges} [data-metric="range-executions"]`,
+  );
+  assert.equal(conditionalRangesFinalExecutions - conditionalRangesInitialExecutions, 0);
 
   const automaticList = '[data-experiment="keyed-automatic"]';
   const automaticListInitialExecutions = await readNumber(
@@ -1031,6 +1112,16 @@ try {
           conditionalTernaryBlock: {
             branch: "enabled",
             updateExecutions: ternaryFinalExecutions - ternaryInitialExecutions,
+          },
+          conditionalRanges: {
+            ranges: 2,
+            branch: "enabled",
+            updateExecutions:
+              conditionalRangesFinalExecutions - conditionalRangesInitialExecutions,
+            rootHostIdentityPreserved: conditionalRangesIdentity.root,
+            staticSiblingIdentityPreserved: Object.values(conditionalRangesIdentity).every(Boolean),
+            markerNodes: 0,
+            owner: "Farm root conditional ranges",
           },
           automaticKeyedList: {
             items: 4,

--- a/examples/react-compiler/src/app/globals.css
+++ b/examples/react-compiler/src/app/globals.css
@@ -619,6 +619,41 @@ h1 span {
   content: "";
 }
 
+.conditional-range-root {
+  grid-column: 1 / -1;
+  border-top: 1px solid #33332f;
+}
+
+.edge-card + .conditional-range-root {
+  border-left: 0;
+}
+
+.conditional-range-branch,
+.conditional-range-static {
+  display: flex;
+  min-height: 3.3rem;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 1rem;
+  border: 1px solid #33332f;
+  padding: 0.8rem 1rem;
+  background: #0d0d0c;
+}
+
+.conditional-range-static {
+  color: #8d8d86;
+  font:
+    0.7rem "Geist Mono Variable",
+    ui-monospace,
+    monospace;
+  letter-spacing: 0.035em;
+}
+
+.conditional-range-static strong {
+  color: #f3f3ed;
+  font-weight: 550;
+}
+
 .conditional-branch--paused {
   color: #999992;
 }

--- a/examples/react-compiler/src/components/conditional-block-experiment.tsx
+++ b/examples/react-compiler/src/components/conditional-block-experiment.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 
 let logicalBlockExecutions = 0;
 let ternaryBlockExecutions = 0;
+let conditionalRangeExecutions = 0;
 
 export function LogicalBlockPanel() {
   const [loading, setLoading] = useState(false);
@@ -111,6 +112,84 @@ export function TernaryBlockPanel() {
   );
 }
 
+export function ConditionalRangePanel() {
+  const [loading, setLoading] = useState(false);
+  const [enabled, setEnabled] = useState(true);
+  const [updates, setUpdates] = useState(0);
+
+  return (
+    <article
+      className="edge-card conditional-range-root"
+      data-experiment="conditional-ranges"
+      data-update={updates}
+    >
+      <header data-static="range-header">
+        <span className="experiment-number">07C</span>
+        <div>
+          <h3>Keep the root, change its ranges</h3>
+          <p>Two direct branches update between static siblings without a wrapper or marker.</p>
+        </div>
+      </header>
+      {loading && (
+        <p className="conditional-branch conditional-range-branch" data-slot="range-loading">
+          Loading update {updates}
+        </p>
+      )}
+      <div className="conditional-range-static" data-static="range-content">
+        <span>Stable content</span>
+        <strong data-metric="range-updates">Update {updates}</strong>
+      </div>
+      {enabled ? (
+        <strong className="conditional-branch conditional-range-branch" data-slot="range-status">
+          Enabled at {updates}
+        </strong>
+      ) : (
+        <span
+          className="conditional-branch conditional-branch--paused conditional-range-branch"
+          data-slot="range-status"
+        >
+          Disabled at {updates}
+        </span>
+      )}
+      <dl className="compact-metrics" data-static="range-metrics">
+        <div>
+          <dt>Slots</dt>
+          <dd>2</dd>
+        </div>
+        <div>
+          <dt>Root</dt>
+          <dd>Same</dd>
+        </div>
+        <div>
+          <dt>Executions</dt>
+          <dd data-metric="range-executions">
+            {typeof window === "undefined" ? 1 : ++conditionalRangeExecutions}
+          </dd>
+        </div>
+      </dl>
+      <footer className="button-row" data-static="range-footer">
+        <button
+          data-action="increment-ranges"
+          type="button"
+          onClick={() => setUpdates((value) => value + 1)}
+        >
+          Update bindings
+        </button>
+        <button
+          data-action="toggle-ranges"
+          type="button"
+          onClick={() => {
+            setLoading((value) => !value);
+            setEnabled((value) => !value);
+          }}
+        >
+          Change both ranges
+        </button>
+      </footer>
+    </article>
+  );
+}
+
 export function ConditionalBlockExperiment() {
   "use no compiler";
 
@@ -127,6 +206,7 @@ export function ConditionalBlockExperiment() {
       <div className="edge-grid edge-grid--paired">
         <LogicalBlockPanel />
         <TernaryBlockPanel />
+        <ConditionalRangePanel />
       </div>
     </section>
   );

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -62,7 +62,8 @@ The current compiler handles components that it can prove have:
 - optional synchronous `const` or function-declaration handlers used by JSX events;
 - state-driven text, attributes, per-property inline styles, and controlled form properties;
 - host-rooted `condition && <element>` and `condition ? <element> : <element>` child blocks at
-  statically known locations, including supported nested boundaries;
+  statically known locations, including direct ranges among static siblings and at the component
+  root;
 - item-keyed `collection.map(...)` children and explicit `List` boundaries at statically known
   container locations, including supported non-mutating collection pipelines;
 - inline synchronous events inside otherwise eligible host-only keyed rows;
@@ -73,8 +74,8 @@ The current compiler handles components that it can prove have:
 
 The generated component preserves React ownership of initial placement, props, events, SSR, and
 hydration. Local state cells batch updates into a microtask and patch only compiler-known DOM
-targets. Proven, dedicated host containers can transfer child ownership after mount for host-only
-conditional branches and non-interactive host-only keyed rows. An interactive row or a row with
+targets. Proven host containers can transfer child ownership after mount for host-only conditional
+branches and ranges, plus non-interactive host-only keyed rows. An interactive row or a row with
 local conditional slots uses a hybrid boundary instead: React retains its events, conditional
 Fibers, and structural reconciliation, while Farm patches same-key bindings and refreshes only
 changed row-local branches. React still creates or hydrates all initial DOM. Anything outside those
@@ -95,6 +96,26 @@ both host descriptors and their exact text/attribute/style bindings. After the i
 or hydration, a same-branch update patches those bindings without replacing the element. A condition
 change creates, removes, or replaces only the selected branch. No marker node is added to SSR output.
 More complex conditional shapes keep the existing React-owned conditional boundary.
+
+Eligible direct conditionals can also share a host container with static host siblings:
+
+```tsx
+<article data-update={updates}>
+  <header>Status</header>
+  {loading && <p>Loading {updates}</p>}
+  <section>Stable content</section>
+  {enabled ? <strong>Enabled</strong> : <span>Disabled</span>}
+  <footer>Actions</footer>
+</article>
+```
+
+That `article` may be the component's exact returned root. Farm adopts the original container and
+counts its direct static elements as anchors for the conditional ranges. Same-branch bindings patch
+in place; branch changes insert, remove, or replace only their range. Multiple changed ranges use
+one state snapshot and reconcile from right to left, including when adjacent ranges are empty. The
+root and every unchanged static sibling keep their DOM identity, and no wrapper or marker is added.
+Branch events, components, fragments, refs, SVG, spreads, nested dynamic blocks, or another
+unsupported direct child keep the container on the React-owned path.
 
 For a common keyed map, no new API is required:
 
@@ -290,14 +311,16 @@ Generated callback refs give directly patched host elements stable private targe
 React-owned component may therefore return `null`, a fragment, or multiple host nodes without
 shifting an unrelated compiler binding. These refs do not add attributes to SSR output.
 
-Conditional blocks have two safe ownership levels. A dedicated container with exactly one proven
-host-only conditional child can use compiler-owned branch instances. Events, keys, custom
-components, fragments, refs, SVG, attribute spreads, `dangerouslySetInnerHTML`, nested dynamic
-blocks, and static siblings in that container keep React ownership. The more general React-owned
-conditional path still accepts supported nested conditionals, keyed lists, and component islands.
-An empty ternary branch may be `null` or `false`. The inactive branch is described at build time but
-is never pre-mounted or cached. If a logical `&&` evaluates to a number such as `0`, the runtime also
-falls back to React so JavaScript and React rendering semantics remain exact.
+Conditional blocks have three safe ownership levels. One or more proven host-only direct branches
+may become compiler-owned ranges among static host siblings, including at the exact component root.
+A dedicated container with exactly one conditional child uses the smaller compiler-owned branch
+boundary. The more general React-owned conditional path accepts supported events, nested host
+conditionals, keyed lists, and component islands. Keys, custom components, fragments, refs, SVG,
+attribute spreads, `dangerouslySetInnerHTML`, nested dynamic blocks, and branch events keep React
+ownership. An empty ternary branch may be `null` or `false`. The inactive branch is described at
+build time but is never pre-mounted or cached. If a logical `&&` evaluates to a number such as `0`,
+or adopted DOM no longer matches its descriptor, the affected container remounts through React so
+JavaScript, hydration, and React rendering semantics remain exact.
 
 All component-level boundary types share one block graph and one ID sequence. A nested
 binding records its nearest conditional parent. If one state flush affects both an outer

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -313,6 +313,110 @@ const testSource = String.raw`
   assert.equal(hostConditionalExecutions, initialHostConditionalExecutions);
   flushSync(() => hostConditionalRoot.unmount());
 
+  let conditionalRangeExecutions = 0;
+  const ConditionalRanges = createCompiledComponent({
+    displayName: "CompatibilityConditionalRanges",
+    initialize: () => [false, true, 0],
+    render(_props, state, blocks) {
+      conditionalRangeExecutions += 1;
+      const branch = (tag, slot, label) => ({
+        create: () => ({
+          kind: "element",
+          tag,
+          attributes: [{ name: "data-slot", value: slot }],
+          styles: [],
+          children: [[label, " ", state[2].get()]],
+        }),
+        bindings: [
+          { kind: "text", path: [], read: () => [label, " ", state[2].get()] },
+        ],
+      });
+      return React.createElement(blocks.ConditionalRanges, {
+        id: 0,
+        ranges: [
+          {
+            before: 3,
+            logical: true,
+            test: () => state[0].get(),
+            truthy: branch("p", "loading", "Loading"),
+          },
+          {
+            before: 1,
+            test: () => state[1].get(),
+            truthy: branch("strong", "status", "Enabled"),
+            falsy: branch("span", "status", "Disabled"),
+          },
+        ],
+        trailing: 1,
+        render: () =>
+          React.createElement(
+            "section",
+            { "data-count": state[2].get(), "data-owner": "conditional-ranges" },
+            React.createElement("header", { "data-static": "header" }, "Header"),
+            React.createElement(
+              "button",
+              { "data-increment": true, onClick: () => state[2].set((value) => Number(value) + 1) },
+              "Increment",
+            ),
+            React.createElement(
+              "button",
+              { "data-toggle-loading": true, onClick: () => state[0].set((value) => !value) },
+              "Toggle loading",
+            ),
+            state[0].get()
+              ? React.createElement("p", { "data-slot": "loading" }, "Loading ", state[2].get())
+              : null,
+            React.createElement("div", { "data-static": "divider" }, "Divider"),
+            state[1].get()
+              ? React.createElement("strong", { "data-slot": "status" }, "Enabled ", state[2].get())
+              : React.createElement("span", { "data-slot": "status" }, "Disabled ", state[2].get()),
+            React.createElement("footer", { "data-static": "footer", ref: blocks.target(0) }, "Count ", state[2].get()),
+          ),
+      });
+    },
+    bindings: [
+      {
+        kind: "attribute",
+        path: [],
+        dependencies: [2],
+        name: "data-count",
+        read: (_props, state) => state[2].get(),
+      },
+      {
+        kind: "text",
+        path: [5],
+        target: 0,
+        dependencies: [2],
+        read: (_props, state) => ["Count ", state[2].get()],
+      },
+      { kind: "block", id: 0, dependencies: [0, 1, 2] },
+    ],
+  });
+  const conditionalRangesContainer = document.createElement("div");
+  document.body.append(conditionalRangesContainer);
+  const conditionalRangesRoot = createRoot(conditionalRangesContainer);
+  flushSync(() => conditionalRangesRoot.render(React.createElement(ConditionalRanges)));
+  const conditionalRangesHost = conditionalRangesContainer.firstElementChild;
+  const conditionalRangesHeader = conditionalRangesContainer.querySelector("[data-static='header']");
+  const conditionalRangesStatus = conditionalRangesContainer.querySelector("[data-slot='status']");
+  const initialConditionalRangeExecutions = conditionalRangeExecutions;
+  conditionalRangesContainer.querySelector("[data-increment]").click();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(conditionalRangesContainer.firstElementChild, conditionalRangesHost);
+  assert.equal(conditionalRangesContainer.firstElementChild.dataset.count, "1");
+  assert.equal(conditionalRangesContainer.querySelector("[data-static='header']"), conditionalRangesHeader);
+  assert.equal(conditionalRangesContainer.querySelector("[data-slot='status']"), conditionalRangesStatus);
+  assert.equal(conditionalRangesStatus.textContent, "Enabled 1");
+  assert.equal(conditionalRangesContainer.querySelector("[data-static='footer']").textContent, "Count 1");
+  conditionalRangesContainer.querySelector("[data-toggle-loading]").click();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(conditionalRangesContainer.querySelector("[data-slot='loading']").textContent, "Loading 1");
+  assert.equal(conditionalRangesContainer.firstElementChild, conditionalRangesHost);
+  assert.equal(conditionalRangeExecutions, initialConditionalRangeExecutions);
+  flushSync(() => conditionalRangesRoot.unmount());
+
   const explicitListContainer = document.createElement("div");
   document.body.append(explicitListContainer);
   const explicitListRoot = createRoot(explicitListContainer);

--- a/packages/farm-react/src/__tests__/compiler-conditional-blocks.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-conditional-blocks.test.ts
@@ -31,19 +31,18 @@ describe("React AOT conditional block compiler", () => {
 
     expect(result.diagnostics).toEqual([]);
     expect(result.compiled).toEqual(["ConditionalPanel"]);
-    expect(result.code.match(/farmBlocks\.Conditional/g)).toHaveLength(2);
+    expect(result.code.match(/farmBlocks\.ConditionalRanges/g)).toHaveLength(1);
+    expect(result.code.match(/farmBlocks\.Conditional(?!Ranges)/g)).toBeNull();
     expect(result.code).toContain('kind: "block"');
     expect(result.code).toContain("id: 0");
-    expect(result.code).toContain("id: 1");
-    expect(result.code).toContain("dependencies: [0]");
-    expect(result.code).toContain("dependencies: [1]");
+    expect(result.code).toContain("dependencies: [0, 1]");
     await expect(
       transformWithEsbuild(result.code, "/app/Conditional.tsx", {
         loader: "tsx",
         jsx: "automatic",
       }),
     ).resolves.toMatchObject({
-      code: expect.stringContaining("farmBlocks.Conditional"),
+      code: expect.stringContaining("farmBlocks.ConditionalRanges"),
     });
   });
 
@@ -94,7 +93,8 @@ describe("React AOT conditional block compiler", () => {
 
     expect(result.diagnostics).toEqual([]);
     expect(result.compiled).toEqual(["EmptyBranches"]);
-    expect(result.code.match(/farmBlocks\.Conditional/g)).toHaveLength(2);
+    expect(result.code.match(/farmBlocks\.ConditionalRanges/g)).toHaveLength(1);
+    expect(result.code.match(/farmBlocks\.Conditional(?!Ranges)/g)).toBeNull();
   });
 
   it("transfers a dedicated host-only container to the compiler runtime", async () => {

--- a/packages/farm-react/src/__tests__/compiler-conditional-ranges.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-conditional-ranges.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true);
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/ConditionalRanges.tsx", infer);
+}
+
+describe("React AOT conditional-range compiler", () => {
+  it("compiles multiple root conditions between static host siblings", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Dashboard() {
+        const [loading, setLoading] = useState(false);
+        const [enabled, setEnabled] = useState(true);
+        return (
+          <main data-active={loading || enabled}>
+            <header>Dashboard</header>
+            {loading && <p data-state={loading ? "loading" : "idle"}>Loading…</p>}
+            <section>Content</section>
+            {enabled ? <strong>Enabled</strong> : <span>Disabled</span>}
+            <footer>Footer</footer>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.compiled).toEqual(["Dashboard"]);
+    expect(result.code.match(/farmBlocks\.ConditionalRanges/g)).toHaveLength(1);
+    expect(result.code.match(/farmBlocks\.Conditional(?!Ranges)/g)).toBeNull();
+    expect(result.code.match(/before: 1/g)).toHaveLength(2);
+    expect(result.code).toContain("trailing={1}");
+    expect(result.code).toContain("dependencies: [0, 1]");
+    expect(result.code).toContain('name: "data-state"');
+    expect(result.code).toContain('name: "data-active"');
+    await expect(
+      transformWithEsbuild(result.code, "/app/ConditionalRanges.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("farmBlocks.ConditionalRanges"),
+    });
+  });
+
+  it("supports one conditional as the only child of the returned host root", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function RootSlot() {
+        const [visible, setVisible] = useState(false);
+        return <section>{visible && <p>Visible</p>}</section>;
+      }
+    `);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.ConditionalRanges");
+    expect(result.code).toContain("before: 0");
+    expect(result.code).toContain("trailing={0}");
+    expect(result.code).not.toContain("farmBlocks.HostConditional");
+  });
+
+  it("compiles a nested mixed container while retaining outer bindings", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function NestedStatus() {
+        const [visible, setVisible] = useState(false);
+        const [count, setCount] = useState(0);
+        return (
+          <main>
+            <div data-visible={visible}>
+              <h2>Count {count}</h2>
+              {visible ? <strong data-count={count}>Visible {count}</strong> : null}
+              <p>Stable {count}</p>
+            </div>
+            <output>{count}</output>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code.match(/farmBlocks\.ConditionalRanges/g)).toHaveLength(1);
+    expect(result.code).toContain('name: "data-visible"');
+    expect(result.code).toContain('name: "data-count"');
+    expect(result.code.match(/\.target\(/g)?.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("keeps interactive branches on the React-owned conditional path", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function InteractiveStatus() {
+        const [visible, setVisible] = useState(false);
+        return (
+          <main>
+            <header>Status</header>
+            {visible ? <button onClick={() => setVisible(false)}>Close</button> : null}
+            <footer>Footer</footer>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).not.toContain("farmBlocks.ConditionalRanges");
+    expect(result.code.match(/farmBlocks\.Conditional(?!Ranges)/g)).toHaveLength(1);
+  });
+
+  it("does not let a root range swallow a static sibling containing another block", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function NestedComposition() {
+        const [visible, setVisible] = useState(false);
+        const [enabled, setEnabled] = useState(false);
+        return (
+          <section>
+            <div>
+              <h2>Status</h2>
+              {visible && <i>Visible</i>}
+            </div>
+            {enabled && <p>Enabled</p>}
+          </section>
+        );
+      }
+    `);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code.match(/farmBlocks\.ConditionalRanges/g)).toHaveLength(1);
+    expect(result.code.match(/farmBlocks\.Conditional(?!Ranges)/g)).toHaveLength(1);
+    expect(result.code).toContain("dependencies: [0]");
+    expect(result.code).toContain("dependencies: [1]");
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-runtime-conditional-ranges.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-conditional-ranges.test.tsx
@@ -1,0 +1,759 @@
+import React, { StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createCompiledComponent,
+  type CompilerConditionalRange,
+  type CompilerHostConditionalBranch,
+  type CompilerStateUpdater,
+} from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface ConditionalModel {
+  count: number;
+  enabled: boolean;
+  loading: boolean | number;
+}
+
+interface ConditionalBoardProps {
+  title?: string;
+}
+
+class ConditionalRangeErrorBoundary extends React.Component<
+  React.PropsWithChildren,
+  { message: string | null }
+> {
+  state = { message: null as string | null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { message: error.message };
+  }
+
+  render() {
+    return this.state.message ? <div role="alert">{this.state.message}</div> : this.props.children;
+  }
+}
+
+const roots = new Set<Root>();
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots) root.unmount();
+  });
+  roots.clear();
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function statusBranch(
+  tag: string,
+  slot: string,
+  label: string,
+  readCount: () => number,
+): CompilerHostConditionalBranch {
+  return {
+    create: () => ({
+      kind: "element",
+      tag,
+      attributes: [
+        { name: "data-slot", value: slot },
+        { name: "data-count", value: readCount() },
+      ],
+      styles: [],
+      children: [[label, " ", readCount()]],
+    }),
+    bindings: [
+      {
+        kind: "attribute",
+        path: [],
+        name: "data-count",
+        read: readCount,
+      },
+      {
+        kind: "text",
+        path: [],
+        read: () => [label, " ", readCount()],
+      },
+    ],
+  };
+}
+
+function defineConditionalBoard(
+  metrics: { executions: number; rangeRenders: number },
+  rootOwned = false,
+) {
+  const initial: ConditionalModel = { count: 1, enabled: true, loading: false };
+  let updateModel: (next: CompilerStateUpdater) => void = () => undefined;
+  let readModel: () => ConditionalModel = () => initial;
+
+  const ConditionalBoard = createCompiledComponent<ConditionalBoardProps>({
+    displayName: "ConditionalBoard",
+    initialize: () => [initial],
+    render(props, state, blocks) {
+      metrics.executions += 1;
+      const model = () => state[0].get() as ConditionalModel;
+      readModel = model;
+      updateModel = (next) => state[0].set(next);
+      const ConditionalRanges = blocks.ConditionalRanges;
+      const ranges: CompilerConditionalRange[] = [
+        {
+          before: 1,
+          logical: true,
+          test: () => model().loading,
+          truthy: statusBranch("p", "loading", "Loading", () => model().count),
+        },
+        {
+          before: 1,
+          test: () => model().enabled,
+          truthy: statusBranch("strong", "status", "Enabled", () => model().count),
+          falsy: statusBranch("span", "status", "Disabled", () => model().count),
+        },
+      ];
+      const rangeRoot = (
+        <ConditionalRanges
+          id={0}
+          ranges={ranges}
+          rootRef={rootOwned ? undefined : blocks.target(1)}
+          render={() => {
+            metrics.rangeRenders += 1;
+            return (
+              <article data-board="conditions" data-count={model().count}>
+                <header data-static="header">{props.title || "Dashboard"}</header>
+                {model().loading && (
+                  <p data-count={model().count} data-slot="loading">
+                    Loading {model().count}
+                  </p>
+                )}
+                <section data-static="content" ref={blocks.target(0)}>
+                  Stable {model().count}
+                </section>
+                {model().enabled ? (
+                  <strong data-count={model().count} data-slot="status">
+                    Enabled {model().count}
+                  </strong>
+                ) : (
+                  <span data-count={model().count} data-slot="status">
+                    Disabled {model().count}
+                  </span>
+                )}
+                <footer data-static="footer">Footer</footer>
+              </article>
+            );
+          }}
+          trailing={1}
+        />
+      );
+      return rootOwned ? (
+        rangeRoot
+      ) : (
+        <main>
+          <h1>{props.title || "Conditions"}</h1>
+          {rangeRoot}
+        </main>
+      );
+    },
+    bindings: [
+      {
+        kind: "text",
+        path: [1, 1],
+        target: 0,
+        dependencies: [0],
+        read: (_props, state) => ["Stable ", (state[0].get() as ConditionalModel).count],
+      },
+      {
+        kind: "attribute" as const,
+        path: rootOwned ? [] : [1],
+        target: rootOwned ? undefined : 1,
+        dependencies: [0],
+        name: "data-count",
+        read: (_props: ConditionalBoardProps, state: readonly { get(): unknown }[]) =>
+          (state[0].get() as ConditionalModel).count,
+      },
+      { kind: "block", id: 0, dependencies: [0] },
+    ],
+  });
+
+  return {
+    ConditionalBoard,
+    initial,
+    readModel: () => readModel(),
+    updateModel: (next: CompilerStateUpdater) => updateModel(next),
+  };
+}
+
+function conditionalSnapshot(container: Element) {
+  const board = container.querySelector<HTMLElement>("[data-board='conditions']")!;
+  return {
+    count: board.dataset.count,
+    children: [...board.children].map(
+      (child) =>
+        `${child.tagName}:${child.getAttribute("data-static") || child.getAttribute("data-slot")}:${child.textContent}`,
+    ),
+  };
+}
+
+describe("compiled conditional DOM ranges", () => {
+  it("owns the exact component root and updates only the affected slots", async () => {
+    const metrics = { executions: 0, rangeRenders: 0 };
+    const board = defineConditionalBoard(metrics, true);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.add(root);
+    await act(async () => root.render(<board.ConditionalBoard />));
+
+    const article = container.querySelector<HTMLElement>("[data-board='conditions']")!;
+    const header = article.querySelector('[data-static="header"]')!;
+    const content = article.querySelector('[data-static="content"]')!;
+    const footer = article.querySelector('[data-static="footer"]')!;
+    const enabled = article.querySelector('[data-slot="status"]')!;
+    const initialExecutions = metrics.executions;
+    const initialRangeRenders = metrics.rangeRenders;
+
+    await act(async () => {
+      board.updateModel((current) => ({ ...(current as ConditionalModel), count: 2 }));
+      await flushCompilerUpdates();
+    });
+
+    expect(container.firstElementChild).toBe(article);
+    expect(article.dataset.count).toBe("2");
+    expect(article.querySelector('[data-static="header"]')).toBe(header);
+    expect(article.querySelector('[data-static="content"]')).toBe(content);
+    expect(article.querySelector('[data-static="footer"]')).toBe(footer);
+    expect(article.querySelector('[data-slot="status"]')).toBe(enabled);
+    expect(enabled.textContent).toBe("Enabled 2");
+    expect(content.textContent).toBe("Stable 2");
+
+    await act(async () => {
+      board.updateModel({ count: 3, enabled: false, loading: true });
+      await flushCompilerUpdates();
+    });
+
+    expect([...article.children].map((child) => child.getAttribute("data-slot"))).toEqual([
+      null,
+      "loading",
+      null,
+      "status",
+      null,
+    ]);
+    expect(article.querySelector('[data-slot="loading"]')?.textContent).toBe("Loading 3");
+    expect(article.querySelector('[data-slot="status"]')?.textContent).toBe("Disabled 3");
+    expect(enabled.isConnected).toBe(false);
+    expect(metrics.executions).toBe(initialExecutions);
+    expect(metrics.rangeRenders).toBe(initialRangeRenders);
+  });
+
+  it("mounts adjacent empty slots in deterministic order without marker nodes", async () => {
+    let update: (next: CompilerStateUpdater) => void = () => undefined;
+    const Adjacent = createCompiledComponent({
+      displayName: "AdjacentConditionalRanges",
+      initialize: () => [{ first: false, second: false }],
+      render(_props: Record<string, never>, state, blocks) {
+        update = (next) => state[0].set(next);
+        const model = () => state[0].get() as { first: boolean; second: boolean };
+        const branch = (slot: string): CompilerHostConditionalBranch => ({
+          create: () => ({
+            kind: "element",
+            tag: "p",
+            attributes: [{ name: "data-slot", value: slot }],
+            styles: [],
+            children: [slot],
+          }),
+          bindings: [],
+        });
+        const ConditionalRanges = blocks.ConditionalRanges;
+        return (
+          <ConditionalRanges
+            id={0}
+            ranges={[
+              {
+                before: 1,
+                logical: true,
+                test: () => model().first,
+                truthy: branch("first"),
+              },
+              {
+                before: 0,
+                logical: true,
+                test: () => model().second,
+                truthy: branch("second"),
+              },
+            ]}
+            render={() => (
+              <section>
+                <header>Header</header>
+                {model().first && <p data-slot="first">first</p>}
+                {model().second && <p data-slot="second">second</p>}
+                <footer>Footer</footer>
+              </section>
+            )}
+            trailing={1}
+          />
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.add(root);
+    await act(async () => root.render(<Adjacent />));
+    const section = container.querySelector("section")!;
+    expect(section.childNodes).toHaveLength(2);
+
+    await act(async () => {
+      update({ first: true, second: true });
+      await flushCompilerUpdates();
+    });
+    expect([...section.querySelectorAll("[data-slot]")].map((node) => node.textContent)).toEqual([
+      "first",
+      "second",
+    ]);
+
+    await act(async () => {
+      update({ first: false, second: true });
+      await flushCompilerUpdates();
+    });
+    expect([...section.querySelectorAll("[data-slot]")].map((node) => node.textContent)).toEqual([
+      "second",
+    ]);
+  });
+
+  it("keeps controlled selection coherent while patching a stable branch", async () => {
+    let update: (next: CompilerStateUpdater) => void = () => undefined;
+    const Editor = createCompiledComponent({
+      displayName: "ConditionalRangeEditor",
+      initialize: () => ["Compiler"],
+      render(_props: Record<string, never>, state, blocks) {
+        update = (next) => state[0].set(next);
+        const value = () => String(state[0].get());
+        const ConditionalRanges = blocks.ConditionalRanges;
+        return (
+          <ConditionalRanges
+            id={0}
+            ranges={[
+              {
+                before: 0,
+                test: () => true,
+                truthy: {
+                  create: () => ({
+                    kind: "element",
+                    tag: "input",
+                    attributes: [
+                      { name: "data-slot", value: "editor" },
+                      { name: "readOnly", value: true },
+                      { name: "value", value: value() },
+                    ],
+                    styles: [],
+                    children: [],
+                  }),
+                  bindings: [{ kind: "attribute", path: [], name: "value", read: value }],
+                },
+              },
+            ]}
+            render={() => (
+              <section>
+                <input data-slot="editor" readOnly value={value()} />
+              </section>
+            )}
+            trailing={0}
+          />
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.add(root);
+    await act(async () => root.render(<Editor />));
+    const input = container.querySelector("input")!;
+    input.focus();
+    input.setSelectionRange(2, 5);
+
+    await act(async () => {
+      update("ComXpiler");
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector("input")).toBe(input);
+    expect(input.value).toBe("ComXpiler");
+    expect(input.selectionStart).toBe(2);
+    expect(input.selectionEnd).toBe(5);
+  });
+
+  it("returns the complete container to React when adopted DOM does not match its descriptor", async () => {
+    let update: (next: CompilerStateUpdater) => void = () => undefined;
+    let rangeRenders = 0;
+    const InvalidAdoption = createCompiledComponent({
+      displayName: "InvalidConditionalRangeAdoption",
+      initialize: () => ["one"],
+      render(_props: Record<string, never>, state, blocks) {
+        update = (next) => state[0].set(next);
+        const value = () => String(state[0].get());
+        const ConditionalRanges = blocks.ConditionalRanges;
+        return (
+          <ConditionalRanges
+            id={0}
+            ranges={[
+              {
+                before: 0,
+                test: () => true,
+                truthy: {
+                  create: () => ({
+                    kind: "element",
+                    tag: "strong",
+                    attributes: [{ name: "data-slot", value: "value" }],
+                    styles: [],
+                    children: [value()],
+                  }),
+                  bindings: [{ kind: "text", path: [], read: value }],
+                },
+              },
+            ]}
+            render={() => {
+              rangeRenders += 1;
+              return (
+                <section>
+                  <p data-slot="value">{value()}</p>
+                </section>
+              );
+            }}
+            trailing={0}
+          />
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.add(root);
+    await act(async () => root.render(<InvalidAdoption />));
+
+    expect(container.querySelector("p")?.textContent).toBe("one");
+    expect(container.querySelector("strong")).toBeNull();
+    expect(rangeRenders).toBe(2);
+
+    await act(async () => {
+      update("two");
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector("p")?.textContent).toBe("two");
+    expect(container.querySelector("strong")).toBeNull();
+    expect(rangeRenders).toBe(3);
+  });
+
+  it("switches the complete range owner to React for visible numeric logical output", async () => {
+    let update: (next: CompilerStateUpdater) => void = () => undefined;
+    let renders = 0;
+    const Numeric = createCompiledComponent({
+      displayName: "NumericConditionalRange",
+      initialize: () => [false as boolean | number],
+      render(_props: Record<string, never>, state, blocks) {
+        update = (next) => state[0].set(next);
+        const value = () => state[0].get() as boolean | number;
+        const ConditionalRanges = blocks.ConditionalRanges;
+        return (
+          <ConditionalRanges
+            id={0}
+            ranges={[
+              {
+                before: 1,
+                logical: true,
+                test: value,
+                truthy: {
+                  create: () => ({
+                    kind: "element",
+                    tag: "p",
+                    attributes: [],
+                    styles: [],
+                    children: ["Visible"],
+                  }),
+                  bindings: [],
+                },
+              },
+            ]}
+            render={() => {
+              renders += 1;
+              return (
+                <section>
+                  <header>Header</header>
+                  {value() && <p>Visible</p>}
+                  <footer>Footer</footer>
+                </section>
+              );
+            }}
+            trailing={1}
+          />
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.add(root);
+    await act(async () => root.render(<Numeric />));
+    const original = container.querySelector("section")!;
+
+    await act(async () => {
+      update(0);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector("section")).not.toBe(original);
+    expect(container.querySelector("section")?.textContent).toBe("Header0Footer");
+    expect(renders).toBe(2);
+  });
+
+  it("routes descriptor errors through the nearest React error boundary", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    let update: (next: CompilerStateUpdater) => void = () => undefined;
+    const Throwing = createCompiledComponent({
+      displayName: "ThrowingConditionalRange",
+      initialize: () => [{ enabled: true, fail: false }],
+      render(_props: Record<string, never>, state, blocks) {
+        update = (next) => state[0].set(next);
+        const model = () => state[0].get() as { enabled: boolean; fail: boolean };
+        const branch = (label: string): CompilerHostConditionalBranch => ({
+          create: () => {
+            if (model().fail) throw new Error("conditional range failed");
+            return {
+              kind: "element",
+              tag: "p",
+              attributes: [],
+              styles: [],
+              children: [label],
+            };
+          },
+          bindings: [],
+        });
+        const ConditionalRanges = blocks.ConditionalRanges;
+        return (
+          <ConditionalRanges
+            id={0}
+            ranges={[
+              {
+                before: 0,
+                test: () => model().enabled,
+                truthy: branch("Enabled"),
+                falsy: branch("Disabled"),
+              },
+            ]}
+            render={() => <section>{model().enabled ? <p>Enabled</p> : <p>Disabled</p>}</section>}
+            trailing={0}
+          />
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.add(root);
+    await act(async () =>
+      root.render(
+        <ConditionalRangeErrorBoundary>
+          <Throwing />
+        </ConditionalRangeErrorBoundary>,
+      ),
+    );
+
+    await act(async () => {
+      update({ enabled: false, fail: true });
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe("conditional range failed");
+  });
+
+  it.each([
+    ["nested container", false],
+    ["component root", true],
+  ])(
+    "recovers %s hydration mismatches in StrictMode and ignores work after unmount",
+    async (_label, rootOwned) => {
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+      const metrics = { executions: 0, rangeRenders: 0 };
+      const board = defineConditionalBoard(metrics, rootOwned);
+      const serverHtml = renderToString(
+        <StrictMode>
+          <board.ConditionalBoard />
+        </StrictMode>,
+      );
+      const container = document.createElement("div");
+      container.innerHTML = serverHtml.replace("Stable", "Server mismatch");
+      document.body.append(container);
+      const recoverable = vi.fn();
+      const root = hydrateRoot(
+        container,
+        <StrictMode>
+          <board.ConditionalBoard />
+        </StrictMode>,
+        { onRecoverableError: recoverable },
+      );
+      roots.add(root);
+      await act(async () => flushCompilerUpdates());
+      expect(recoverable).toHaveBeenCalled();
+
+      await act(async () => {
+        board.updateModel({ count: 4, enabled: false, loading: true });
+        await flushCompilerUpdates();
+      });
+      expect(container.querySelector('[data-slot="loading"]')?.textContent).toBe("Loading 4");
+      expect(container.querySelector('[data-slot="status"]')?.textContent).toBe("Disabled 4");
+
+      await act(async () => {
+        board.updateModel({ count: 5, enabled: true, loading: false });
+        root.unmount();
+        await flushCompilerUpdates();
+      });
+      roots.delete(root);
+      expect(container.innerHTML).toBe("");
+    },
+  );
+
+  it.each([
+    ["nested container", false],
+    ["component root", true],
+  ])(
+    "falls back safely for %s when parent props change static output",
+    async (_label, rootOwned) => {
+      const metrics = { executions: 0, rangeRenders: 0 };
+      const board = defineConditionalBoard(metrics, rootOwned);
+      const container = document.createElement("div");
+      document.body.append(container);
+      const root = createRoot(container);
+      roots.add(root);
+      await act(async () => root.render(<board.ConditionalBoard title="First" />));
+      const original = container.querySelector<HTMLElement>("[data-board='conditions']")!;
+
+      await act(async () => {
+        root.render(<board.ConditionalBoard title="Second" />);
+        board.updateModel({ count: 7, enabled: false, loading: true });
+        await flushCompilerUpdates();
+      });
+
+      expect(container.querySelector<HTMLElement>("[data-board='conditions']")).not.toBe(original);
+      expect(container.querySelector('[data-static="header"]')?.textContent).toBe("Second");
+      expect(container.querySelector('[data-slot="loading"]')?.textContent).toBe("Loading 7");
+    },
+  );
+
+  it.each([
+    ["nested container", false],
+    ["component root", true],
+  ])(
+    "matches normal React through 3,000 deterministic %s transitions",
+    async (_label, rootOwned) => {
+      const metrics = { executions: 0, rangeRenders: 0 };
+      const compiled = defineConditionalBoard(metrics, rootOwned);
+      let normalModel = compiled.initial;
+      let setNormal: React.Dispatch<React.SetStateAction<ConditionalModel>> = () => undefined;
+
+      function NormalBoard() {
+        const [model, setModel] = useState(compiled.initial);
+        normalModel = model;
+        setNormal = setModel;
+        return (
+          <article data-board="conditions" data-count={model.count}>
+            <header data-static="header">Dashboard</header>
+            {model.loading && (
+              <p data-count={model.count} data-slot="loading">
+                Loading {model.count}
+              </p>
+            )}
+            <section data-static="content">Stable {model.count}</section>
+            {model.enabled ? (
+              <strong data-count={model.count} data-slot="status">
+                Enabled {model.count}
+              </strong>
+            ) : (
+              <span data-count={model.count} data-slot="status">
+                Disabled {model.count}
+              </span>
+            )}
+            <footer data-static="footer">Footer</footer>
+          </article>
+        );
+      }
+
+      const compiledContainer = document.createElement("div");
+      const normalContainer = document.createElement("div");
+      document.body.append(compiledContainer, normalContainer);
+      const compiledRoot = createRoot(compiledContainer);
+      const normalRoot = createRoot(normalContainer);
+      roots.add(compiledRoot);
+      roots.add(normalRoot);
+      await act(async () => {
+        compiledRoot.render(<compiled.ConditionalBoard />);
+        normalRoot.render(<NormalBoard />);
+      });
+
+      let seed = 0x6d2b79f5;
+      const random = () => {
+        seed = (seed * 1664525 + 1013904223) >>> 0;
+        return seed;
+      };
+      const operations = Array.from({ length: 3000 }, (_, step) => ({
+        operation: random() % 6,
+        value: random(),
+        step,
+      }));
+      const update = (model: ConditionalModel, step: number): ConditionalModel => {
+        const operation = operations[step];
+        if (operation.operation === 0) return { ...model, loading: !model.loading };
+        if (operation.operation === 1) return { ...model, enabled: !model.enabled };
+        if (operation.operation === 2) return { ...model, count: operation.value % 1000 };
+        if (operation.operation === 3) {
+          return { ...model, count: model.count + 1, loading: !model.loading };
+        }
+        if (operation.operation === 4) {
+          return { ...model, count: model.count - 1, enabled: !model.enabled };
+        }
+        return {
+          count: operation.step,
+          enabled: operation.value % 2 === 0,
+          loading: operation.value % 3 === 0,
+        };
+      };
+      const initialExecutions = metrics.executions;
+      const initialRangeRenders = metrics.rangeRenders;
+
+      for (let offset = 0; offset < operations.length; offset += 25) {
+        await act(async () => {
+          for (let step = offset; step < offset + 25; step += 1) {
+            const updater = (current: ConditionalModel) => update(current, step);
+            compiled.updateModel((current) => updater(current as ConditionalModel));
+            setNormal(updater);
+          }
+          await flushCompilerUpdates();
+        });
+        expect(compiled.readModel(), `model after batch ${offset}`).toEqual(normalModel);
+        expect(conditionalSnapshot(compiledContainer), `DOM after batch ${offset}`).toEqual(
+          conditionalSnapshot(normalContainer),
+        );
+      }
+
+      expect(metrics.executions).toBe(initialExecutions);
+      expect(metrics.rangeRenders).toBe(initialRangeRenders);
+    },
+    30_000,
+  );
+});

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -119,6 +119,25 @@ export interface CompilerHostConditionalBlockProps {
   falsy?: CompilerHostConditionalBranch;
 }
 
+export interface CompilerConditionalRange {
+  /** Number of static direct host siblings between this slot and the previous slot. */
+  before: number;
+  test(): unknown;
+  /** Logical && can produce a visible number instead of an empty branch. */
+  logical?: boolean;
+  truthy?: CompilerHostConditionalBranch;
+  falsy?: CompilerHostConditionalBranch;
+}
+
+export interface CompilerConditionalRangesBlockProps {
+  id: number;
+  render(): React.ReactElement;
+  rootRef?: React.RefCallback<Element>;
+  ranges: readonly CompilerConditionalRange[];
+  /** Number of static direct host siblings after the final conditional slot. */
+  trailing: number;
+}
+
 export interface CompilerKeyedRowBinding {
   kind: "text" | "attribute" | "style";
   path: readonly number[];
@@ -175,6 +194,7 @@ export interface CompilerComponentBlockProps {
 export interface CompilerBlockRuntime {
   Conditional: React.ComponentType<CompilerConditionalBlockProps>;
   HostConditional: React.ComponentType<CompilerHostConditionalBlockProps>;
+  ConditionalRanges: React.ComponentType<CompilerConditionalRangesBlockProps>;
   KeyedList: React.ComponentType<CompilerKeyedListBlockProps>;
   KeyedRows: React.ComponentType<CompilerKeyedRowsBlockProps>;
   KeyedRanges: React.ComponentType<CompilerKeyedRangesBlockProps>;
@@ -683,9 +703,13 @@ type CompilerHostConditionalSelection =
   | { kind: "branch"; key: "truthy" | "falsy"; branch: CompilerHostConditionalBranch }
   | { kind: "empty" }
   | { kind: "fallback" };
+type CompilerHostConditionalPreparedSelection = Exclude<
+  CompilerHostConditionalSelection,
+  { kind: "fallback" }
+>;
 
 function hostConditionalSelection(
-  props: CompilerHostConditionalBlockProps,
+  props: Pick<CompilerHostConditionalBlockProps, "test" | "logical" | "truthy" | "falsy">,
 ): CompilerHostConditionalSelection {
   const test = props.test();
   if (props.logical && !test) {
@@ -890,6 +914,222 @@ function createHostConditionalBlockComponent(
   }
 
   return FarmHostConditionalBlock;
+}
+
+function createConditionalRangesBlockComponent(
+  owner: Pick<ConditionalBlockOwner, "subscribe">,
+): React.ComponentType<CompilerConditionalRangesBlockProps> {
+  interface State {
+    fallback: boolean;
+  }
+
+  interface ConditionalRangeInstance {
+    key: "truthy" | "falsy";
+    host: CompilerHostInstance;
+  }
+
+  class FarmConditionalRangesBlock extends React.Component<
+    CompilerConditionalRangesBlockProps,
+    State
+  > {
+    static displayName = "FarmCompiledConditionalRanges";
+
+    state: State = { fallback: false };
+    private root: Element | null = null;
+    private mounted = false;
+    private fallbackRequested = false;
+    private fallbackVersion = 0;
+    private propFallbackQueued = false;
+    private currentProps = this.props;
+    private unsubscribe: (() => void) | undefined;
+    private rangeInstances: Array<ConditionalRangeInstance | null> = [];
+    private staticSegments: Element[][] = [];
+
+    private captureRoot = (root: Element | null) => {
+      this.root = root;
+      this.currentProps.rootRef?.(root);
+    };
+
+    private readSelections(
+      props: CompilerConditionalRangesBlockProps,
+    ): CompilerHostConditionalPreparedSelection[] | null {
+      const selections: CompilerHostConditionalPreparedSelection[] = [];
+      for (const range of props.ranges) {
+        const selection = hostConditionalSelection(range);
+        if (selection.kind === "fallback") return null;
+        selections.push(selection);
+      }
+      return selections;
+    }
+
+    private adopt(props: CompilerConditionalRangesBlockProps = this.currentProps): boolean {
+      if (!this.root || !Number.isSafeInteger(props.trailing) || props.trailing < 0) return false;
+      const selections = this.readSelections(props);
+      if (!selections) return false;
+      const elements = [...this.root.children];
+      const staticSegments: Element[][] = [];
+      const instances: Array<ConditionalRangeInstance | null> = [];
+      let cursor = 0;
+
+      for (let rangeIndex = 0; rangeIndex < props.ranges.length; rangeIndex += 1) {
+        const range = props.ranges[rangeIndex];
+        if (!Number.isSafeInteger(range.before) || range.before < 0) return false;
+        const staticEnd = cursor + range.before;
+        if (staticEnd > elements.length) return false;
+        staticSegments.push(elements.slice(cursor, staticEnd));
+        cursor = staticEnd;
+
+        const selection = selections[rangeIndex];
+        if (selection.kind === "empty") {
+          instances.push(null);
+          continue;
+        }
+        const element = elements[cursor];
+        if (!element) return false;
+        const descriptor = selection.branch.create();
+        if (!matchesCompilerHostElement(element, descriptor)) return false;
+        instances.push({
+          key: selection.key,
+          host: {
+            element,
+            values: readHostConditionalBindingValues(selection.branch),
+          },
+        });
+        cursor += 1;
+      }
+
+      if (cursor + props.trailing !== elements.length) return false;
+      staticSegments.push(elements.slice(cursor));
+      this.staticSegments = staticSegments;
+      this.rangeInstances = instances;
+      return true;
+    }
+
+    private anchorAfter(rangeIndex: number): ChildNode | null {
+      for (let next = rangeIndex + 1; next < this.rangeInstances.length; next += 1) {
+        const staticAnchor = this.staticSegments[next]?.[0];
+        if (staticAnchor) return staticAnchor;
+        const rangeAnchor = this.rangeInstances[next]?.host.element;
+        if (rangeAnchor) return rangeAnchor;
+      }
+      return this.staticSegments[this.rangeInstances.length]?.[0] || null;
+    }
+
+    private reconcileRange(
+      rangeIndex: number,
+      selection: CompilerHostConditionalPreparedSelection,
+    ): void {
+      if (!this.root) return;
+      const previous = this.rangeInstances[rangeIndex];
+      if (selection.kind === "empty") {
+        previous?.host.element.remove();
+        this.rangeInstances[rangeIndex] = null;
+        return;
+      }
+      if (previous?.key === selection.key) {
+        applyHostConditionalBindings(selection.branch, previous.host);
+        return;
+      }
+
+      const element = createCompilerHostElement(this.root.ownerDocument, selection.branch.create());
+      if (previous) previous.host.element.replaceWith(element);
+      else this.root.insertBefore(element, this.anchorAfter(rangeIndex));
+      this.rangeInstances[rangeIndex] = {
+        key: selection.key,
+        host: {
+          element,
+          values: readHostConditionalBindingValues(selection.branch),
+        },
+      };
+    }
+
+    private reconcile(afterCommit?: () => void): void {
+      if (!this.mounted || !this.root) {
+        afterCommit?.();
+        return;
+      }
+      if (this.state.fallback) {
+        this.fallbackVersion += 1;
+        this.forceUpdate(afterCommit);
+        return;
+      }
+      if (this.currentProps.ranges.length !== this.rangeInstances.length) {
+        this.activateFallback(afterCommit);
+        return;
+      }
+      const selections = this.readSelections(this.currentProps);
+      if (!selections) {
+        this.activateFallback(afterCommit);
+        return;
+      }
+
+      for (let rangeIndex = this.rangeInstances.length - 1; rangeIndex >= 0; rangeIndex -= 1) {
+        this.reconcileRange(rangeIndex, selections[rangeIndex]);
+      }
+      afterCommit?.();
+    }
+
+    private refresh = (afterCommit?: () => void) => {
+      this.reconcile(afterCommit);
+    };
+
+    private activateFallback(afterCommit?: () => void): void {
+      if (!this.mounted || this.state.fallback || this.fallbackRequested) {
+        afterCommit?.();
+        return;
+      }
+      this.fallbackRequested = true;
+      this.setState({ fallback: true }, afterCommit);
+    }
+
+    private schedulePropFallback(): void {
+      if (this.propFallbackQueued) return;
+      this.propFallbackQueued = true;
+      queueMicrotask(() => {
+        this.propFallbackQueued = false;
+        if (this.mounted && !this.state.fallback) this.activateFallback();
+      });
+    }
+
+    shouldComponentUpdate(
+      nextProps: CompilerConditionalRangesBlockProps,
+      nextState: State,
+    ): boolean {
+      this.currentProps = nextProps;
+      if (nextState.fallback || this.state.fallback) return true;
+      this.schedulePropFallback();
+      return false;
+    }
+
+    componentDidMount(): void {
+      this.mounted = true;
+      this.unsubscribe = owner.subscribe(this.props.id, this.refresh);
+      if (!this.adopt()) this.activateFallback();
+    }
+
+    componentWillUnmount(): void {
+      this.mounted = false;
+      this.unsubscribe?.();
+      this.root = null;
+      this.rangeInstances = [];
+      this.staticSegments = [];
+    }
+
+    render(): React.ReactNode {
+      const container = this.currentProps.render();
+      if (!React.isValidElement(container) || typeof container.type !== "string") {
+        throw new TypeError(
+          `Compiled conditional ranges ${this.currentProps.id} must own one host container.`,
+        );
+      }
+      return React.cloneElement(container, {
+        key: this.state.fallback ? `react-${this.fallbackVersion}` : "compiled",
+        ref: this.captureRoot,
+      } as React.Attributes);
+    }
+  }
+
+  return FarmConditionalRangesBlock;
 }
 
 /** Returns positions forming the LIS while ignoring newly inserted (-1) entries. */
@@ -1790,6 +2030,9 @@ export function createCompiledComponent<Props>(
         HostConditional: createHostConditionalBlockComponent({
           subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
         }),
+        ConditionalRanges: createConditionalRangesBlockComponent({
+          subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
+        }),
         KeyedList: createKeyedListBlockComponent({
           subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
         }),
@@ -2015,6 +2258,12 @@ export function createCompiledComponent<Props>(
         return React.cloneElement(element as React.ReactElement<CompilerKeyedRangesBlockProps>, {
           rootRef: this.captureRoot,
         });
+      }
+      if (element.type === this.blockRuntime.ConditionalRanges) {
+        return React.cloneElement(
+          element as React.ReactElement<CompilerConditionalRangesBlockProps>,
+          { rootRef: this.captureRoot },
+        );
       }
       if (typeof element.type !== "string") {
         throw new TypeError(

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -112,6 +112,27 @@ interface HostConditionalPlan {
   falsyBindings: PendingKeyedRowBinding[];
 }
 
+interface ConditionalRangePlan {
+  before: number;
+  source: t.Expression;
+  test: t.Expression;
+  logical: boolean;
+  truthy?: t.JSXElement;
+  falsy?: t.JSXElement;
+  truthyBindings: PendingKeyedRowBinding[];
+  falsyBindings: PendingKeyedRowBinding[];
+}
+
+interface ConditionalRangesPlan {
+  kind: "conditional-ranges";
+  id: number;
+  parent?: number;
+  dependencies: number[];
+  source: t.JSXElement;
+  ranges: ConditionalRangePlan[];
+  trailing: number;
+}
+
 interface KeyedRowsPlan {
   kind: "keyed-rows";
   id: number;
@@ -160,6 +181,7 @@ interface ComponentIslandPlan {
 type ComposableBlockPlan =
   | ConditionalBlockPlan
   | HostConditionalPlan
+  | ConditionalRangesPlan
   | KeyedListPlan
   | KeyedRowsPlan
   | KeyedRangesPlan
@@ -1390,7 +1412,7 @@ function analyzeKeyedRowsContainer(
   return analyzeKeyedRowChild(children[0], statesByValue, safeGlobals, listNames);
 }
 
-function isStaticKeyedRangeSibling(
+function isStaticRangeSibling(
   element: t.JSXElement,
   statesByValue: ReadonlyMap<string, StateBinding>,
   safeGlobals: ReadonlySet<string>,
@@ -1398,7 +1420,7 @@ function isStaticKeyedRangeSibling(
   for (const child of meaningfulJsxChildren(element)) {
     if (t.isJSXFragment(child)) return false;
     if (t.isJSXElement(child)) {
-      if (!isHostElement(child) || !isStaticKeyedRangeSibling(child, statesByValue, safeGlobals)) {
+      if (!isHostElement(child) || !isStaticRangeSibling(child, statesByValue, safeGlobals)) {
         return false;
       }
       continue;
@@ -1457,7 +1479,7 @@ function analyzeKeyedRangesContainer(
       continue;
     }
     if (!t.isJSXElement(child) || !isHostElement(child)) return undefined;
-    if (!isStaticKeyedRangeSibling(child, statesByValue, safeGlobals)) return undefined;
+    if (!isStaticRangeSibling(child, statesByValue, safeGlobals)) return undefined;
     staticBefore += 1;
   }
   if (ranges.length === 0) return undefined;
@@ -1660,6 +1682,84 @@ function analyzeHostConditionalContainer(
     falsy: shape.falsy,
     truthyBindings: truthyAnalysis.bindings || [],
     falsyBindings: falsyAnalysis.bindings || [],
+  };
+}
+
+function analyzeConditionalRangesContainer(
+  container: t.JSXElement,
+  statesByValue: ReadonlyMap<string, StateBinding>,
+  safeGlobals: ReadonlySet<string>,
+  allowSingleRange = false,
+): { ranges: ConditionalRangePlan[]; trailing: number; dependencies: number[] } | undefined {
+  const containerName = container.openingElement.name;
+  if (
+    !t.isJSXIdentifier(containerName) ||
+    !/^[a-z]/.test(containerName.name) ||
+    containerName.name === "svg" ||
+    container.openingElement.attributes.some(
+      (attribute) =>
+        t.isJSXSpreadAttribute(attribute) ||
+        (t.isJSXAttribute(attribute) &&
+          t.isJSXIdentifier(attribute.name) &&
+          (attribute.name.name === "ref" || attribute.name.name === "dangerouslySetInnerHTML")),
+    )
+  ) {
+    return undefined;
+  }
+
+  const children = meaningfulJsxChildren(container);
+  if (children.length < (allowSingleRange ? 1 : 2)) return undefined;
+  const ranges: ConditionalRangePlan[] = [];
+  const dependencies = new Set<number>();
+  let staticBefore = 0;
+
+  for (const child of children) {
+    if (t.isJSXExpressionContainer(child) && !t.isJSXEmptyExpression(child.expression)) {
+      const shape = conditionalBlockShape(child.expression);
+      if (shape && !validateDerivedExpression(shape.test, safeGlobals)) {
+        const truthyAnalysis = shape.truthy
+          ? analyzeHostConditionalTree(shape.truthy, safeGlobals)
+          : { bindings: [] as PendingKeyedRowBinding[] };
+        const falsyAnalysis = shape.falsy
+          ? analyzeHostConditionalTree(shape.falsy, safeGlobals)
+          : { bindings: [] as PendingKeyedRowBinding[] };
+        if (truthyAnalysis.reason || falsyAnalysis.reason) return undefined;
+
+        const rangeDependencies = new Set(collectStateDependencies(shape.test, statesByValue));
+        for (const binding of [
+          ...(truthyAnalysis.bindings || []),
+          ...(falsyAnalysis.bindings || []),
+        ]) {
+          for (const dependency of collectStateDependencies(binding.value, statesByValue)) {
+            rangeDependencies.add(dependency);
+          }
+        }
+        for (const dependency of rangeDependencies) dependencies.add(dependency);
+        ranges.push({
+          before: staticBefore,
+          source: child.expression,
+          test: cloneExpression(shape.test),
+          logical: shape.logical,
+          truthy: shape.truthy,
+          falsy: shape.falsy,
+          truthyBindings: truthyAnalysis.bindings || [],
+          falsyBindings: falsyAnalysis.bindings || [],
+        });
+        staticBefore = 0;
+        continue;
+      }
+    }
+
+    if (!t.isJSXElement(child) || !isHostElement(child)) return undefined;
+    if (!isStaticRangeSibling(child, statesByValue, safeGlobals)) return undefined;
+    staticBefore += 1;
+  }
+
+  if (ranges.length === 0) return undefined;
+  return {
+    ranges,
+    trailing: staticBefore,
+    dependencies: [...dependencies].sort((left, right) => left - right),
   };
 }
 
@@ -2229,6 +2329,78 @@ function hostConditionalBoundary(
   return t.jsxElement(t.jsxOpeningElement(name, attributes, true), null, [], true);
 }
 
+function conditionalRangeObject(range: ConditionalRangePlan): t.ObjectExpression {
+  const properties: t.ObjectProperty[] = [
+    t.objectProperty(t.identifier("before"), t.numericLiteral(range.before)),
+    t.objectProperty(
+      t.identifier("test"),
+      t.arrowFunctionExpression([], cloneExpression(range.test)),
+    ),
+  ];
+  if (range.logical) {
+    properties.push(t.objectProperty(t.identifier("logical"), t.booleanLiteral(true)));
+  }
+  if (range.truthy) {
+    properties.push(
+      t.objectProperty(
+        t.identifier("truthy"),
+        hostConditionalBranchObject(range.truthy, range.truthyBindings),
+      ),
+    );
+  }
+  if (range.falsy) {
+    properties.push(
+      t.objectProperty(
+        t.identifier("falsy"),
+        hostConditionalBranchObject(range.falsy, range.falsyBindings),
+      ),
+    );
+  }
+  return t.objectExpression(properties);
+}
+
+function conditionalRangesBoundary(
+  blockRuntime: t.Identifier,
+  plan: ConditionalRangesPlan,
+): t.JSXElement {
+  const name = t.jsxMemberExpression(
+    t.jsxIdentifier(blockRuntime.name),
+    t.jsxIdentifier("ConditionalRanges"),
+  );
+  const source = t.cloneNode(plan.source, true);
+  const rootRefIndex = source.openingElement.attributes.findIndex(
+    (attribute) =>
+      t.isJSXAttribute(attribute) &&
+      t.isJSXIdentifier(attribute.name) &&
+      attribute.name.name === "ref",
+  );
+  const rootRef =
+    rootRefIndex >= 0
+      ? (source.openingElement.attributes.splice(rootRefIndex, 1)[0] as t.JSXAttribute)
+      : undefined;
+  const attributes: t.JSXAttribute[] = [
+    t.jsxAttribute(t.jsxIdentifier("id"), t.jsxExpressionContainer(t.numericLiteral(plan.id))),
+    t.jsxAttribute(
+      t.jsxIdentifier("render"),
+      t.jsxExpressionContainer(t.arrowFunctionExpression([], source)),
+    ),
+    t.jsxAttribute(
+      t.jsxIdentifier("ranges"),
+      t.jsxExpressionContainer(
+        t.arrayExpression(plan.ranges.map((range) => conditionalRangeObject(range))),
+      ),
+    ),
+    t.jsxAttribute(
+      t.jsxIdentifier("trailing"),
+      t.jsxExpressionContainer(t.numericLiteral(plan.trailing)),
+    ),
+  ];
+  if (rootRef?.value) {
+    attributes.push(t.jsxAttribute(t.jsxIdentifier("rootRef"), t.cloneNode(rootRef.value, true)));
+  }
+  return t.jsxElement(t.jsxOpeningElement(name, attributes, true), null, [], true);
+}
+
 function analyzeComponentIslandElement(
   element: t.JSXElement,
   statesByValue: ReadonlyMap<string, StateBinding>,
@@ -2465,6 +2637,24 @@ function analyzeComposableBlocks(
             }
             continue;
           }
+          const conditionalRanges = insideConditional
+            ? undefined
+            : analyzeConditionalRangesContainer(child, statesByValue, safeGlobals);
+          if (conditionalRanges) {
+            plans.push({
+              kind: "conditional-ranges",
+              id: nextId++,
+              parent,
+              dependencies: conditionalRanges.dependencies,
+              source: child,
+              ranges: conditionalRanges.ranges,
+              trailing: conditionalRanges.trailing,
+            });
+            for (const range of conditionalRanges.ranges) {
+              conditionalExpressions.add(range.source);
+            }
+            continue;
+          }
           const hostConditional = analyzeHostConditionalContainer(
             child,
             statesByValue,
@@ -2628,6 +2818,33 @@ function analyzeComposableBlocks(
     };
   }
 
+  const rootConditionalRanges = analyzeConditionalRangesContainer(
+    root,
+    statesByValue,
+    safeGlobals,
+    true,
+  );
+  if (rootConditionalRanges) {
+    plans.push({
+      kind: "conditional-ranges",
+      id: nextId++,
+      dependencies: rootConditionalRanges.dependencies,
+      source: root,
+      ranges: rootConditionalRanges.ranges,
+      trailing: rootConditionalRanges.trailing,
+    });
+    for (const range of rootConditionalRanges.ranges) {
+      conditionalExpressions.add(range.source);
+    }
+    return {
+      plans,
+      componentElements,
+      conditionalExpressions,
+      ownedElements,
+      keyedExpressions,
+    };
+  }
+
   const result = visitHost(root, undefined, false);
   if (result.reason) return { reason: result.reason };
   return {
@@ -2679,6 +2896,9 @@ function lowerComposableBlocks(
   if (rootPlan?.kind === "keyed-ranges") {
     return keyedRangesBoundary(blockRuntime, rootPlan);
   }
+  if (rootPlan?.kind === "conditional-ranges") {
+    return conditionalRangesBoundary(blockRuntime, rootPlan);
+  }
 
   const visit = (element: t.JSXElement): void => {
     element.children = element.children.map((child) => {
@@ -2692,6 +2912,9 @@ function lowerComposableBlocks(
         }
         if (plan?.kind === "keyed-ranges") {
           return keyedRangesBoundary(blockRuntime, plan);
+        }
+        if (plan?.kind === "conditional-ranges") {
+          return conditionalRangesBoundary(blockRuntime, plan);
         }
         if (plan?.kind === "component") {
           return componentIslandBoundary(blockRuntime, plan, child);


### PR DESCRIPTION
## Summary

- detect eligible logical and ternary DOM ranges between static host siblings, including at the exact component root
- adopt the React-rendered container and reconcile only changed branches without wrappers, markers, or owner rerenders
- preserve root bindings and static sibling identity while falling back to React for props, refresh, invalid adoption, numeric logical output, and unsupported branch shapes
- add a production-browser example and document the supported contract, ownership model, and fallback rules

## Correctness coverage

- compiler lowering and fallback tests
- exact-root and nested runtime tests
- StrictMode, SSR hydration recovery, early unmount cleanup, parent/local update races, controlled selection, errors, and invalid descriptor adoption
- adjacent empty slots and simultaneous multi-range changes
- 3,000 nested plus 3,000 component-root differential transitions against normal React
- packaged consumer coverage on React 18.3.1 and React 19.2.8

## Validation

- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test` — 31 files, 257 tests passed
- `pnpm --filter @farm.js/react test:compat`
- React compiler example TypeScript check
- React compiler production build and Playwright verifier on desktop and mobile
- docs production build

The production proof reports zero owner update executions, preserves the exact root and every static sibling, and emits no marker nodes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compiles conditional DOM ranges for React so logical/ternary branches directly among static host siblings — including at the component root — are adopted and patched without wrappers or marker nodes. Previously these shapes stayed on the React-owned path; now the compiler preserves the exact root and static sibling identity and only reconciles changed branches, while safely falling back to React when needed.

- New Features
  - Detects eligible direct logical/ternary ranges and lowers them to `ConditionalRanges` (root or nested containers).
  - Adopts the React-rendered container and active branches; patches only changed bindings and commits multiple ranges from one snapshot right-to-left.
  - Keeps the root and all unchanged static siblings identical across updates and SSR; no wrapper or comment markers are added.

- Notes
  - Falls back to React for branch events, components/fragments/refs/SVG, spreads, nested dynamic structures, numeric logical output, parent-prop changes, Fast Refresh, or invalid adopted DOM.
  - Retains React ownership for events, Strict Mode, SSR, hydration, and error boundaries.
  - Adds a production-browser example card, updates docs to describe the contract and fallback rules, and includes extensive compiler/runtime tests (adjacent empty ranges, controlled selection, SSR hydration recovery, and 3,000 deterministic transitions).

<sup>Written for commit 62e6832ff5b4f92534444713d58d1d13399291cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

