### PR TITLE
feat(react): compose recursive compiler-owned host blocks

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -456,8 +456,8 @@ The compiler-owned path is deliberately narrow:
 - Every non-empty branch has one lowercase HTML root and a statically known host-only descendant
   tree. Text, attributes, and individual inline style properties may use supported expressions.
 - Branch events, `key`, custom components, fragments, refs, SVG, `dangerouslySetInnerHTML`, JSX
-  spreads, nested dynamic blocks, and dynamic text mixed beside nested elements require React
-  ownership.
+  spreads, interactive keyed rows, mixed dynamic block kinds in one direct-child range, and dynamic
+  text mixed beside nested elements require React ownership.
 - A ternary may use `null` or `false` for an empty branch. For logical `&&`, a numeric falsy value
   such as `0` can be visible React output, so the runtime remounts that container through React
   instead of incorrectly treating it as empty.
@@ -470,6 +470,48 @@ descriptor and update behavior. It remains useful when a branch needs one fixed 
 ```tsx
 <div>{loading && <p>Loading…</p>}</div>
 ```
+
+### Recursive compiler-owned host blocks
+
+An eligible compiler-owned branch may contain more eligible host-only blocks:
+
+```tsx
+<div className="panel-slot">
+  {open ? (
+    <section>
+      <header>Inbox</header>
+      <div>{loading && <p>Loading…</p>}</div>
+      <ul>
+        <li>Fixed row</li>
+        {messages.map((message) => (
+          <li key={message.id}>{message.title}</li>
+        ))}
+      </ul>
+    </section>
+  ) : (
+    <aside>Closed</aside>
+  )}
+</div>
+```
+
+The outer `open` condition, nested `loading` range, and keyed `messages` range receive globally
+unique block IDs and separate dependency lists. Updating `loading` touches only its host range.
+Updating `messages` reuses matching rows, patches their prepared bindings, and applies LIS moves.
+Neither update reruns the component or replaces the outer `section`.
+
+If an outer condition and a descendant change in the same microtask, the scheduler commits the
+outer block first and suppresses the now-redundant child refresh. Removing an outer branch cleans
+every descendant subscription before removing its DOM. Reopening it creates the selected host tree
+from current compiler cells, so updates made while closed cannot become stale work.
+
+This recursive path is intentionally host-only. Nested conditional ranges may recurse again, and a
+nested container may own one or more non-interactive keyed ranges separated by static host
+siblings. Hooks, custom components, branch events, refs, SVG, fragments, dangerous HTML,
+interactive rows, nested structures inside a keyed row, or conditionals and lists mixed as direct
+siblings in the same range keep React ownership. React still renders the initial client/SSR tree,
+hydrates it, reports recoverable mismatches, and handles every fallback. Duplicate runtime keys or
+invalid adopted DOM remount the affected outer container through React; descendant dependencies
+remain live after that handoff.
 
 The existing React-owned conditional boundary remains the fallback for supported complex shapes.
 It can contain event handlers, nested host conditionals, keyed lists, and component islands while
@@ -911,24 +953,24 @@ component.
 
 ### What falls back to React
 
-| Unsupported shape                                                                                         | Why React keeps ownership                                                          |
-| --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| Unkeyed/index-keyed maps, unsupported or mutating collection pipelines, or element arrays                 | Their structure, purity, or item identity is outside the keyed-list contract.      |
-| Unsupported row events/forms, components, fragments, refs, SVG, nested blocks, or mixed conditional slots | Their event, lifecycle, or structure contract requires the React-owned row path.   |
-| Interactive ranges beside siblings or non-host range siblings                                             | The range owner requires a host container and non-interactive host rows.           |
-| Branch events, keys, components, fragments, refs, SVG, or nested blocks in a compiled conditional range   | They require the React-owned conditional path rather than compiler-created hosts.  |
-| Dynamic/member component types, component spreads, refs, keys, or children                                | Their identity or ownership is outside the first component-island contract.        |
-| Effects or hooks other than the supported `useState` shape                                                | Their lifecycle and ordering must remain under React's hook dispatcher.            |
-| `ref` or `dangerouslySetInnerHTML`                                                                        | They directly participate in DOM ownership.                                        |
-| Stateful `children` or `key` bindings outside an eligible boundary                                        | These need structure or identity semantics.                                        |
-| Conditional style objects, style spreads, methods, or computed names                                      | The final property set or precedence cannot be prepared statically.                |
-| JSX attribute spreads or namespaced attributes                                                            | The compiler cannot currently enumerate a stable binding contract.                 |
-| Multiple/conditional returns or impure/control-flow statements                                            | The compiler only lowers a single, statically analyzable render path.              |
-| Derived calls, assignments, identity-bearing values, functions, or JSX                                    | Their evaluation timing, side effects, or identity cannot yet be preserved safely. |
-| Nested, computed, or rest props destructuring                                                             | These patterns need additional parameter-shape and identity analysis.              |
-| Async/generator/generic handlers or named handlers outside JSX events                                     | Their scheduling, identity, or closure semantics are outside the current lowering. |
-| Async/generator or generic components                                                                     | These function shapes are outside the current lowering.                            |
-| Setters called outside JSX event handlers                                                                 | The compiler only controls and batches event-driven local updates.                 |
+| Unsupported shape                                                                                                                     | Why React keeps ownership                                                          |
+| ------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Unkeyed/index-keyed maps, unsupported or mutating collection pipelines, or element arrays                                             | Their structure, purity, or item identity is outside the keyed-list contract.      |
+| Unsupported row events/forms, components, fragments, refs, SVG, nested blocks, or mixed conditional slots                             | Their event, lifecycle, or structure contract requires the React-owned row path.   |
+| Interactive ranges beside siblings or non-host range siblings                                                                         | The range owner requires a host container and non-interactive host rows.           |
+| Branch events, keys, components, fragments, refs, SVG, interactive rows, or unsupported nested blocks in a compiled conditional range | They require the React-owned conditional path rather than compiler-created hosts.  |
+| Dynamic/member component types, component spreads, refs, keys, or children                                                            | Their identity or ownership is outside the first component-island contract.        |
+| Effects or hooks other than the supported `useState` shape                                                                            | Their lifecycle and ordering must remain under React's hook dispatcher.            |
+| `ref` or `dangerouslySetInnerHTML`                                                                                                    | They directly participate in DOM ownership.                                        |
+| Stateful `children` or `key` bindings outside an eligible boundary                                                                    | These need structure or identity semantics.                                        |
+| Conditional style objects, style spreads, methods, or computed names                                                                  | The final property set or precedence cannot be prepared statically.                |
+| JSX attribute spreads or namespaced attributes                                                                                        | The compiler cannot currently enumerate a stable binding contract.                 |
+| Multiple/conditional returns or impure/control-flow statements                                                                        | The compiler only lowers a single, statically analyzable render path.              |
+| Derived calls, assignments, identity-bearing values, functions, or JSX                                                                | Their evaluation timing, side effects, or identity cannot yet be preserved safely. |
+| Nested, computed, or rest props destructuring                                                                                         | These patterns need additional parameter-shape and identity analysis.              |
+| Async/generator/generic handlers or named handlers outside JSX events                                                                 | Their scheduling, identity, or closure semantics are outside the current lowering. |
+| Async/generator or generic components                                                                                                 | These function shapes are outside the current lowering.                            |
+| Setters called outside JSX event handlers                                                                                             | The compiler only controls and batches event-driven local updates.                 |
 
 Keys do not make list work disappear. A key identifies the row that survives an insert, removal,
 or move. On the non-interactive compiler-owned host path, Farm compares those keys, reuses matching
@@ -1066,6 +1108,14 @@ The package and example test suites verify more than generated code:
   state snapshot;
 - 3,000 deterministic nested-range updates and 3,000 component-root-range updates match normal
   React while unchanged branches, static siblings, and the compiled owner keep their identity;
+- recursive host scopes preserve an outer branch and static siblings while independently updating
+  nested conditions, deeper conditions, and LIS-keyed ranges;
+- 3,000 deterministic recursive updates match normal React across outer toggles, nested branch
+  changes, inserts, removals, binding edits, reversals, and rotations without rerunning the owner;
+- recursive scopes clean queued work on unmount and outer removal, rebind on combined parent-prop
+  and local updates, adopt exact SSR output, recover after hydration mismatches, and keep React
+  fallback live after duplicate runtime keys, while nested binding failures reach React error
+  boundaries;
 - object, array, and nullish state transitions match normal React across 3,000 deterministic
   randomized updates;
 - automatic keyed maps and explicit `List` boundaries preserve keyed DOM nodes and stateful row

--- a/examples/react-compiler/README.md
+++ b/examples/react-compiler/README.md
@@ -158,7 +158,7 @@ root and every static sibling are still the original DOM nodes, no marker nodes 
 component recorded zero update executions.
 
 This does not pre-mount both branches or bypass React's event system. Branch events, custom
-components, fragments, refs, SVG, keys, spreads, nested dynamic blocks, and dangerous HTML keep a
+components, fragments, refs, SVG, keys, spreads, unsupported nested structures, and dangerous HTML keep a
 React-owned conditional boundary or fall back to the original component. A numeric logical value
 such as `0 && <p />`, a parent-driven prop change, Fast Refresh, or invalid adopted DOM remounts the
 affected range container through React so visible output and React ownership remain exact.
@@ -167,6 +167,14 @@ The `08` card combines those boundary types under one outer conditional. It also
 hidden outer block removes its inner subscriptions: updates made while hidden do no render work,
 and remounting reads the newest compiler-cell values. Child-local React state resets after the
 outer branch unmounts, matching ordinary React semantics.
+
+The `09` card transfers the outer branch and its recursively nested host-only conditions and keyed
+ranges to compiler ownership. One action changes a nested condition, a deeper condition, and a
+keyed order while preserving the outer branch, static heading, and every surviving keyed row. The
+hide/update/show sequence verifies that removed scopes receive no stale work and remount from the
+latest cells. The production assertion records zero owner update executions. Interactive rows,
+Hooks, custom components, refs, SVG, branch events, and mixed conditional/list slots remain React
+fallbacks.
 
 ## Heavy compiler-on/off benchmark
 

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -1001,6 +1001,74 @@ try {
   );
   assert.equal(composableOwnerFinalExecutions - composableOwnerInitialExecutions, 0);
 
+  const recursive = '[data-experiment="recursive-host-blocks"]';
+  const recursiveOwnerInitialExecutions = await readNumber(
+    page,
+    `${recursive} [data-metric="recursive-owner-executions"]`,
+  );
+  await assertText(page, `${recursive} [data-metric="recursive-open"]`, "open");
+  await page.evaluate(() => {
+    window.__farmRecursiveOuter = document.querySelector("[data-recursive-outer]");
+    window.__farmRecursiveStatic = document.querySelector("[data-recursive-static]");
+    window.__farmRecursiveRows = Object.fromEntries(
+      [...document.querySelectorAll("[data-recursive-row]")].map((row) => [
+        row.getAttribute("data-recursive-row"),
+        row,
+      ]),
+    );
+  });
+
+  await page.locator(`${recursive} [data-action="recursive-update"]`).click();
+  await assertText(page, `${recursive} [data-metric="recursive-updates"]`, "1");
+  await assertText(page, `${recursive} [data-recursive-details]`, "Details 1");
+  assert.deepEqual(
+    await page.locator(`${recursive} [data-recursive-row]`).allTextContents(),
+    ["Gamma · updated", "Beta", "Alpha"],
+  );
+  assert.equal(
+    await page.evaluate(() =>
+      Object.entries(window.__farmRecursiveRows).every(
+        ([key, row]) => row === document.querySelector(`[data-recursive-row="${key}"]`),
+      ),
+    ),
+    true,
+    "recursive keyed ranges replaced a surviving row",
+  );
+  assert.equal(
+    await page.evaluate(
+      () => window.__farmRecursiveOuter === document.querySelector("[data-recursive-outer]"),
+    ),
+    true,
+    "a nested update replaced the outer compiler-owned branch",
+  );
+  assert.equal(
+    await page.evaluate(
+      () => window.__farmRecursiveStatic === document.querySelector("[data-recursive-static]"),
+    ),
+    true,
+    "a nested update replaced the recursive static sibling",
+  );
+
+  await page.locator(`${recursive} [data-action="recursive-hide-update"]`).click();
+  await assertText(page, `${recursive} [data-metric="recursive-open"]`, "closed");
+  assert.equal(await page.locator(`${recursive} [data-recursive-outer]`).count(), 0);
+  await page.locator(`${recursive} [data-action="recursive-hidden-update"]`).click();
+  await assertText(page, `${recursive} [data-metric="recursive-updates"]`, "3");
+  assert.equal(await page.locator(`${recursive} [data-recursive-outer]`).count(), 0);
+
+  await page.locator(`${recursive} [data-action="recursive-show"]`).click();
+  await assertText(page, `${recursive} [data-metric="recursive-open"]`, "open");
+  await assertText(page, `${recursive} [data-recursive-details]`, "Details 3");
+  assert.deepEqual(
+    await page.locator(`${recursive} [data-recursive-row]`).allTextContents(),
+    ["Gamma · updated · updated", "Beta", "Alpha · updated"],
+  );
+  const recursiveOwnerFinalExecutions = await readNumber(
+    page,
+    `${recursive} [data-metric="recursive-owner-executions"]`,
+  );
+  assert.equal(recursiveOwnerFinalExecutions - recursiveOwnerInitialExecutions, 0);
+
   await page.screenshot({ path: screenshotPath, fullPage: true });
 
   const mobilePage = await browser.newPage({
@@ -1199,6 +1267,15 @@ try {
             childStateResetAfterOuterUnmount: true,
             ownerUpdateExecutions:
               composableOwnerFinalExecutions - composableOwnerInitialExecutions,
+          },
+          recursiveHostBlocks: {
+            updates: 3,
+            keyedOrder: ["c", "b", "a"],
+            deepestConditional: "Details 3",
+            keyedDomIdentityPreserved: true,
+            staleSubscriptionsAfterHide: 0,
+            ownerUpdateExecutions:
+              recursiveOwnerFinalExecutions - recursiveOwnerInitialExecutions,
           },
         },
       },

--- a/examples/react-compiler/src/app/globals.css
+++ b/examples/react-compiler/src/app/globals.css
@@ -1160,7 +1160,8 @@ h1 span {
 
 .composable-row-set > span,
 .composable-row-set > strong,
-.composable-row-set > em {
+.composable-row-set > em,
+.composable-row-set > li {
   border: 1px solid #3b3b37;
   padding: 0.45rem 0.6rem;
   font: 0.65rem "Geist Mono Variable", ui-monospace, monospace;
@@ -1175,6 +1176,25 @@ h1 span {
 
 .composable-fixed {
   color: #8d8d86;
+}
+
+.recursive-host-slot {
+  min-height: 12rem;
+}
+
+.recursive-status {
+  min-height: 4rem;
+}
+
+.recursive-status > p,
+.recursive-status > div {
+  margin: 0;
+}
+
+[data-recursive-list] {
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 .heavy-metrics > div {

--- a/examples/react-compiler/src/app/page.tsx
+++ b/examples/react-compiler/src/app/page.tsx
@@ -5,6 +5,7 @@ import { ComposableBlockExperiment } from "../components/composable-block-experi
 import { ComponentIslandExperiment } from "../components/component-island-experiment";
 import { ConditionalBlockExperiment } from "../components/conditional-block-experiment";
 import { HeavyInteractionBenchmark } from "../components/heavy-interaction-benchmark";
+import { RecursiveHostBlockExperiment } from "../components/recursive-host-block-experiment";
 import { StaticBindingExperiment } from "../components/static-binding-experiment";
 
 export default function HomePage() {
@@ -74,6 +75,8 @@ export default function HomePage() {
       <ComponentIslandExperiment />
 
       <ComposableBlockExperiment />
+
+      <RecursiveHostBlockExperiment />
 
       <section
         className="benchmark-report"

--- a/examples/react-compiler/src/components/recursive-host-block-experiment.tsx
+++ b/examples/react-compiler/src/components/recursive-host-block-experiment.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from "react";
+
+interface Item {
+  id: string;
+  label: string;
+}
+
+const initialItems: Item[] = [
+  { id: "a", label: "Alpha" },
+  { id: "b", label: "Beta" },
+  { id: "c", label: "Gamma" },
+];
+
+let recursiveOwnerExecutions = 0;
+
+export function RecursiveHostBlockExperiment() {
+  const [open, setOpen] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [details, setDetails] = useState(false);
+  const [items, setItems] = useState(initialItems);
+  const [updates, setUpdates] = useState(0);
+
+  function updateInnerBlocks() {
+    setLoading((value) => !value);
+    setDetails((value) => !value);
+    setItems((rows) => {
+      const reversed = [...rows].reverse();
+      return reversed.map((row, index) =>
+        index === 0 ? { ...row, label: `${row.label} · updated` } : row,
+      );
+    });
+    setUpdates((value) => value + 1);
+  }
+
+  return (
+    <section className="heavy-benchmark" data-experiment="recursive-host-blocks">
+      <header className="heavy-heading">
+        <div>
+          <span className="experiment-number">09</span>
+          <div>
+            <p className="heavy-kicker">RECURSIVE HOST BLOCKS</p>
+            <h2>Nested conditions and lists update their own DOM ranges</h2>
+          </div>
+        </div>
+        <span className="node-badge">HOST ONLY / REACT FALLBACK</span>
+      </header>
+
+      <p className="heavy-copy">
+        The outer branch, its nested condition, a deeper condition, and the keyed rows share one
+        build-time dependency graph. Each state change reaches the smallest safe block without
+        rerunning this component.
+      </p>
+
+      <dl className="heavy-metrics" aria-live="polite">
+        <div>
+          <dt>Owner executions</dt>
+          <dd data-metric="recursive-owner-executions">
+            {typeof window === "undefined" ? 1 : ++recursiveOwnerExecutions}
+          </dd>
+        </div>
+        <div>
+          <dt>Outer branch</dt>
+          <dd data-metric="recursive-open">{open ? "open" : "closed"}</dd>
+        </div>
+        <div>
+          <dt>Rows</dt>
+          <dd data-metric="recursive-rows">{items.length}</dd>
+        </div>
+        <div>
+          <dt>Updates</dt>
+          <dd data-metric="recursive-updates">{updates}</dd>
+        </div>
+      </dl>
+
+      <div className="heavy-controls composable-controls">
+        <button data-action="recursive-update" type="button" onClick={updateInnerBlocks}>
+          Update nested blocks <span aria-hidden="true">↗</span>
+        </button>
+        <button
+          data-action="recursive-hide-update"
+          type="button"
+          onClick={() => {
+            setOpen(false);
+            updateInnerBlocks();
+          }}
+        >
+          Hide and update
+        </button>
+        <button data-action="recursive-hidden-update" type="button" onClick={updateInnerBlocks}>
+          Update while hidden
+        </button>
+        <button data-action="recursive-show" type="button" onClick={() => setOpen(true)}>
+          Show latest state
+        </button>
+      </div>
+
+      <div className="recursive-host-slot">
+        {open ? (
+          <article className="composable-stage" data-recursive-outer>
+            <h3 data-recursive-static>Compiler-owned host tree</h3>
+            <div className="recursive-status">
+              {loading ? (
+                <div data-recursive-loading="loading">
+                  <p>Loading update {updates}</p>
+                  <div>{details && <strong data-recursive-details>Details {updates}</strong>}</div>
+                </div>
+              ) : (
+                <p data-recursive-loading="ready">Ready after {updates} updates</p>
+              )}
+            </div>
+            <ul className="composable-row-set" data-recursive-list>
+              <li data-recursive-fixed>Fixed row</li>
+              {items.map((item) => (
+                <li data-recursive-row={item.id} key={item.id}>
+                  {item.label}
+                </li>
+              ))}
+            </ul>
+          </article>
+        ) : (
+          <aside className="composable-stage" data-recursive-closed>
+            Outer host block is closed. Inner subscriptions are cleaned up.
+          </aside>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -315,20 +315,28 @@ Conditional blocks have three safe ownership levels. One or more proven host-onl
 may become compiler-owned ranges among static host siblings, including at the exact component root.
 A dedicated container with exactly one conditional child uses the smaller compiler-owned branch
 boundary. The more general React-owned conditional path accepts supported events, nested host
-conditionals, keyed lists, and component islands. Keys, custom components, fragments, refs, SVG,
-attribute spreads, `dangerouslySetInnerHTML`, nested dynamic blocks, and branch events keep React
-ownership. An empty ternary branch may be `null` or `false`. The inactive branch is described at
-build time but is never pre-mounted or cached. If a logical `&&` evaluates to a number such as `0`,
+conditionals, keyed lists, and component islands. A compiler-owned host branch may now recursively
+contain eligible host-only conditional ranges and non-interactive keyed ranges in nested host
+containers. Each nested range receives its own dependency entry and updates without rerunning or
+replacing the outer branch. Keys on branches, custom components, fragments, refs, SVG, attribute
+spreads, `dangerouslySetInnerHTML`, branch events, interactive rows, and mixed dynamic kinds in one
+direct-child range keep React ownership. An empty ternary branch may be `null` or `false`. The
+inactive branch is described at build time but is never pre-mounted or cached. If a logical `&&`
+evaluates to a number such as `0`,
 or adopted DOM no longer matches its descriptor, the affected container remounts through React so
 JavaScript, hydration, and React rendering semantics remain exact.
 
 All component-level boundary types share one block graph and one ID sequence. A nested
 binding records its nearest conditional parent. If one state flush affects both an outer
 conditional and its descendants, the runtime refreshes the mounted outer boundary once and skips
-the redundant descendant refreshes. React unmounts inner boundaries normally, their subscriptions
-are removed, and a later remount reads the latest compiler-cell values. Host-only keyed rows have
-separate runtime instances per key. Row-local conditional IDs are scoped to that instance and
-paired with its stable key, so two rows can use the same build-time slot ID without sharing data or
+the redundant descendant refreshes. React-owned inner boundaries unmount normally. Compiler-owned
+host scopes explicitly remove every nested subscription before their outer DOM is removed, and a
+later mount reads the latest compiler-cell values. Surviving keyed rows move with the existing LIS
+algorithm. Duplicate runtime keys, invalid adoption, or an unsafe logical value transfer the outer
+container back to React; descendant dependencies remain subscribed so that fallback stays live.
+Host-only keyed rows have separate runtime instances per key. Row-local conditional IDs are scoped
+to that instance and paired with its stable key, so two rows can use the same build-time slot ID
+without sharing data or
 subscriptions. Unsupported row subtrees stay complete React-owned keyed boundaries.
 
 Unsupported components fall back to React by default. Use `onUnsupported: "warn"` for diagnostics

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -313,6 +313,116 @@ const testSource = String.raw`
   assert.equal(hostConditionalExecutions, initialHostConditionalExecutions);
   flushSync(() => hostConditionalRoot.unmount());
 
+  let recursiveHostExecutions = 0;
+  const RecursiveHostBlocks = createCompiledComponent({
+    displayName: "CompatibilityRecursiveHostBlocks",
+    initialize: () => [true, false, [{ id: "a", label: "Alpha" }, { id: "b", label: "Beta" }]],
+    render(_props, state, blocks) {
+      recursiveHostExecutions += 1;
+      const readyBranch = {
+        create: () => ({ kind: "element", tag: "strong", attributes: [], styles: [], children: ["Ready"] }),
+        bindings: [],
+      };
+      const items = () => state[2].get();
+      const outerBranch = {
+        create: () => ({
+          kind: "element",
+          tag: "article",
+          attributes: [],
+          styles: [],
+          children: [
+            {
+              kind: "element",
+              tag: "div",
+              attributes: [],
+              styles: [],
+              children: [state[1].get() ? readyBranch.create() : null],
+              block: {
+                kind: "conditional-ranges",
+                id: 1,
+                ranges: [{ before: 0, test: () => state[1].get(), logical: true, truthy: readyBranch }],
+                trailing: 0,
+              },
+            },
+            {
+              kind: "element",
+              tag: "ul",
+              attributes: [],
+              styles: [],
+              children: [items().map((item) => ({ kind: "element", tag: "li", attributes: [{ name: "data-key", value: item.id }], styles: [], children: [item.label] }))],
+              block: {
+                kind: "keyed-ranges",
+                id: 2,
+                ranges: [{
+                  before: 0,
+                  items,
+                  rowKey: (item) => item.id,
+                  create: (item) => ({ kind: "element", tag: "li", attributes: [{ name: "data-key", value: item.id }], styles: [], children: [item.label] }),
+                  bindings: [{ kind: "text", path: [], read: (item) => item.label }],
+                }],
+                trailing: 0,
+              },
+            },
+          ],
+        }),
+        bindings: [],
+      };
+      return React.createElement(
+        "section",
+        null,
+        React.createElement("button", {
+          "data-recursive-update": true,
+          onClick: () => {
+            state[1].set((value) => !value);
+            state[2].set((value) => [...value].reverse());
+          },
+        }, "Update recursive blocks"),
+        React.createElement(blocks.HostConditional, {
+          id: 0,
+          render: () => React.createElement(
+            "div",
+            null,
+            React.createElement(
+              "article",
+              null,
+              React.createElement("div", null, state[1].get() ? React.createElement("strong", null, "Ready") : null),
+              React.createElement("ul", null, ...items().map((item) => React.createElement("li", { key: item.id, "data-key": item.id }, item.label))),
+            ),
+          ),
+          test: () => state[0].get(),
+          truthy: outerBranch,
+        }),
+      );
+    },
+    bindings: [
+      { kind: "block", id: 0, dependencies: [0] },
+      { kind: "block", id: 1, parent: 0, dependencies: [1] },
+      { kind: "block", id: 2, parent: 0, dependencies: [2] },
+    ],
+  });
+  const recursiveHostContainer = document.createElement("div");
+  document.body.append(recursiveHostContainer);
+  const recursiveHostRoot = createRoot(recursiveHostContainer);
+  flushSync(() => recursiveHostRoot.render(React.createElement(RecursiveHostBlocks)));
+  const initialRecursiveHostExecutions = recursiveHostExecutions;
+  const initialRecursiveArticle = recursiveHostContainer.querySelector("article");
+  const initialRecursiveRows = Object.fromEntries(
+    [...recursiveHostContainer.querySelectorAll("[data-key]")].map((row) => [row.getAttribute("data-key"), row]),
+  );
+  recursiveHostContainer.querySelector("[data-recursive-update]").click();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(recursiveHostContainer.querySelector("strong").textContent, "Ready");
+  assert.deepEqual(
+    [...recursiveHostContainer.querySelectorAll("[data-key]")].map((row) => row.getAttribute("data-key")),
+    ["b", "a"],
+  );
+  assert.equal(recursiveHostContainer.querySelector("article"), initialRecursiveArticle);
+  assert.equal(recursiveHostContainer.querySelector('[data-key="a"]'), initialRecursiveRows.a);
+  assert.equal(recursiveHostContainer.querySelector('[data-key="b"]'), initialRecursiveRows.b);
+  assert.equal(recursiveHostExecutions, initialRecursiveHostExecutions);
+  flushSync(() => recursiveHostRoot.unmount());
+
   let conditionalRangeExecutions = 0;
   const ConditionalRanges = createCompiledComponent({
     displayName: "CompatibilityConditionalRanges",

--- a/packages/farm-react/src/__tests__/compiler-conditional-blocks.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-conditional-blocks.test.ts
@@ -254,11 +254,13 @@ describe("React AOT conditional block compiler", () => {
 
     expect(result.compiled).toEqual(["NestedBlocks"]);
     expect(result.diagnostics).toEqual([]);
-    expect(result.code.match(/farmBlocks\.Conditional/g)).toHaveLength(2);
-    expect(result.code.match(/farmBlocks\.KeyedRows/g)).toHaveLength(1);
+    expect(result.code.match(/farmBlocks\.ConditionalRanges/g)).toHaveLength(1);
+    expect(result.code).not.toContain("farmBlocks.KeyedRows");
+    expect(result.code).toContain('kind: "conditional-ranges"');
+    expect(result.code).toContain('kind: "keyed-ranges"');
     expect(result.code).toContain("id={0}");
-    expect(result.code).toContain("id={1}");
-    expect(result.code).toContain("id={2}");
+    expect(result.code).toContain("id: 1");
+    expect(result.code).toContain("id: 2");
     expect(result.code.match(/parent: 0/g)).toHaveLength(2);
   });
 });

--- a/packages/farm-react/src/__tests__/compiler-recursive-host-blocks.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-recursive-host-blocks.test.ts
@@ -1,0 +1,182 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true);
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/RecursiveHostBlocks.tsx", infer);
+}
+
+describe("React AOT recursive host-block compiler", () => {
+  it("composes recursive descriptors from a component-root conditional range", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function RootComposition() {
+        const [open, setOpen] = useState(true);
+        const [ready, setReady] = useState(false);
+        return (
+          <main>
+            <header>Static</header>
+            {open ? (
+              <section><div>{ready && <strong>Ready</strong>}</div></section>
+            ) : <aside>Closed</aside>}
+            <footer>Stable</footer>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code.match(/farmBlocks\.ConditionalRanges/g)).toHaveLength(1);
+    expect(result.code).toContain('kind: "conditional-ranges"');
+    expect(result.code).toContain("parent: 0");
+    expect(result.code).toContain("dependencies: [0]");
+    expect(result.code).toContain("dependencies: [1]");
+  });
+
+  it("embeds independent conditional and keyed descriptors in one compiler-owned branch", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inbox() {
+        const [open, setOpen] = useState(true);
+        const [loading, setLoading] = useState(false);
+        const [messages, setMessages] = useState([{ id: "a", title: "Alpha" }]);
+        return (
+          <main>
+            <button onClick={() => setOpen((value) => !value)}>Open</button>
+            <div className="slot">
+              {open ? (
+                <section>
+                  <header>Inbox</header>
+                  <div>{loading && <p>Loading…</p>}</div>
+                  <ul>
+                    {messages.map((message) => <li key={message.id}>{message.title}</li>)}
+                  </ul>
+                </section>
+              ) : <aside>Closed</aside>}
+            </div>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.compiled).toEqual(["Inbox"]);
+    expect(result.code.match(/farmBlocks\.HostConditional/g)).toHaveLength(1);
+    expect(result.code).toContain('kind: "conditional-ranges"');
+    expect(result.code).toContain('kind: "keyed-ranges"');
+    expect(result.code).toContain("parent: 0");
+    expect(result.code).toContain("dependencies: [0]");
+    expect(result.code).toContain("dependencies: [1]");
+    expect(result.code).toContain("dependencies: [2]");
+    await expect(
+      transformWithEsbuild(result.code, "/app/RecursiveHostBlocks.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining('kind: "keyed-ranges"'),
+    });
+  });
+
+  it("assigns recursive conditional descendants to their replacing parent block", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function RecursiveStatus() {
+        const [open, setOpen] = useState(true);
+        const [ready, setReady] = useState(true);
+        const [detailed, setDetailed] = useState(false);
+        return (
+          <main>
+            <div>
+              {open ? (
+                <section>
+                  <div>
+                    {ready ? (
+                      <article>
+                        <div>{detailed && <strong>Details</strong>}</div>
+                      </article>
+                    ) : <i>Waiting</i>}
+                  </div>
+                </section>
+              ) : <aside>Closed</aside>}
+            </div>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code.match(/kind: "conditional-ranges"/g)?.length).toBeGreaterThanOrEqual(2);
+    expect(result.code).toContain("id: 0");
+    expect(result.code).toContain("id: 1");
+    expect(result.code).toContain("id: 2");
+    expect(result.code).toContain("parent: 0");
+    expect(result.code).toContain("parent: 1");
+  });
+
+  it("supports the public List primitive inside a recursive host branch", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List } from "@farm.js/react/list";
+      export function Tasks() {
+        const [open, setOpen] = useState(true);
+        const [tasks, setTasks] = useState([{ id: 1, label: "Ship" }]);
+        return (
+          <main>
+            <div>
+              {open ? (
+                <section>
+                  <ol>
+                    <List each={tasks} by={(task) => task.id}>
+                      {(task) => <li>{task.label}</li>}
+                    </List>
+                  </ol>
+                </section>
+              ) : <aside>Closed</aside>}
+            </div>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain('kind: "keyed-ranges"');
+    expect(result.code).toContain("Array.from");
+  });
+
+  it("retains React ownership for lifecycle-sensitive nested structures", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      function Child() { return <strong>Child</strong>; }
+      export function SafeFallback() {
+        const [open, setOpen] = useState(true);
+        const [ready, setReady] = useState(false);
+        return (
+          <main>
+            <div>
+              {open ? (
+                <section>
+                  <div>{ready && <button onClick={() => setReady(false)}>Ready</button>}</div>
+                  <Child />
+                </section>
+              ) : <aside>Closed</aside>}
+            </div>
+            <button onClick={() => setOpen(false)}>Close</button>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({ component: "Child", selected: false }),
+    ]);
+    expect(result.code).not.toContain("farmBlocks.HostConditional");
+    expect(result.code).toContain("farmBlocks.Conditional");
+    expect(result.code).not.toContain('kind: "conditional-ranges"');
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-runtime-recursive-host-blocks.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-recursive-host-blocks.test.tsx
@@ -1,0 +1,1009 @@
+import React, { StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createCompiledComponent,
+  type CompilerCell,
+  type CompilerHostConditionalBranch,
+  type CompilerHostElement,
+} from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Item {
+  id: string;
+  label: string;
+}
+
+const roots: Array<{ unmount(): void }> = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function host(
+  tag: string,
+  children: readonly unknown[] = [],
+  attributes: readonly { name: string; value: unknown }[] = [],
+): CompilerHostElement {
+  return { kind: "element", tag, attributes, styles: [], children };
+}
+
+function click(container: Element, action: string): void {
+  const button = container.querySelector<HTMLButtonElement>(`[data-action="${action}"]`);
+  if (!button) throw new Error(`Missing action: ${action}`);
+  button.click();
+}
+
+class RuntimeErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { error: Error | null }
+> {
+  state = { error: null as Error | null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  render() {
+    return this.state.error ? (
+      <p data-recursive-error>{this.state.error.message}</p>
+    ) : (
+      this.props.children
+    );
+  }
+}
+
+function recursiveBranch(state: readonly CompilerCell[]): CompilerHostConditionalBranch {
+  const detailBranch: CompilerHostConditionalBranch = {
+    create: () => host("strong", ["Details"]),
+    bindings: [],
+  };
+  const loadingBranch: CompilerHostConditionalBranch = {
+    create: () => ({
+      ...host("article", [
+        host("p", ["Loading…"]),
+        {
+          ...host("div", [state[2].get() ? detailBranch.create() : null]),
+          block: {
+            kind: "conditional-ranges",
+            id: 2,
+            ranges: [
+              {
+                before: 0,
+                test: () => state[2].get(),
+                logical: true,
+                truthy: detailBranch,
+              },
+            ],
+            trailing: 0,
+          },
+        },
+      ]),
+    }),
+    bindings: [],
+  };
+  const items = () => state[3].get() as Item[];
+  return {
+    create: () => ({
+      ...host("section", [
+        host("header", ["Inbox"]),
+        {
+          ...host("div", [state[1].get() ? loadingBranch.create() : null]),
+          block: {
+            kind: "conditional-ranges",
+            id: 1,
+            ranges: [
+              {
+                before: 0,
+                test: () => state[1].get(),
+                logical: true,
+                truthy: loadingBranch,
+              },
+            ],
+            trailing: 0,
+          },
+        },
+        {
+          ...host(
+            "ul",
+            items().map((item) => host("li", [item.label], [{ name: "data-key", value: item.id }])),
+          ),
+          block: {
+            kind: "keyed-ranges",
+            id: 3,
+            ranges: [
+              {
+                before: 0,
+                items,
+                rowKey: (item) => (item as Item).id,
+                create: (item) => {
+                  const row = item as Item;
+                  return host("li", [row.label], [{ name: "data-key", value: row.id }]);
+                },
+                bindings: [
+                  {
+                    kind: "text",
+                    path: [],
+                    read: (item) => (item as Item).label,
+                  },
+                ],
+              },
+            ],
+            trailing: 0,
+          },
+        },
+      ]),
+    }),
+    bindings: [],
+  };
+}
+
+describe("compiled recursive host-block runtime", () => {
+  it("composes a nested host block inside a component-root conditional range", async () => {
+    let ownerRenders = 0;
+    const Panel = createCompiledComponent({
+      displayName: "RootRecursiveRange",
+      initialize: () => [true, false],
+      render(_props: Record<string, never>, state, blocks) {
+        ownerRenders += 1;
+        const nested: CompilerHostConditionalBranch = {
+          create: () => host("strong", ["Ready"]),
+          bindings: [],
+        };
+        const branch: CompilerHostConditionalBranch = {
+          create: () => ({
+            ...host("section", [
+              {
+                ...host("div", [state[1].get() ? nested.create() : null]),
+                block: {
+                  kind: "conditional-ranges",
+                  id: 1,
+                  ranges: [
+                    {
+                      before: 0,
+                      test: () => state[1].get(),
+                      logical: true,
+                      truthy: nested,
+                    },
+                  ],
+                  trailing: 0,
+                },
+              },
+            ]),
+          }),
+          bindings: [],
+        };
+        const ConditionalRanges = blocks.ConditionalRanges;
+        return (
+          <ConditionalRanges
+            id={0}
+            render={() => (
+              <main>
+                <button data-action="inner" onClick={() => state[1].set((value) => !value)} />
+                {state[0].get() ? (
+                  <section>
+                    <div>{state[1].get() ? <strong>Ready</strong> : null}</div>
+                  </section>
+                ) : (
+                  <aside>Closed</aside>
+                )}
+              </main>
+            )}
+            ranges={[
+              {
+                before: 1,
+                test: () => state[0].get(),
+                truthy: branch,
+                falsy: { create: () => host("aside", ["Closed"]), bindings: [] },
+              },
+            ]}
+            trailing={0}
+          />
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        { kind: "block", id: 1, parent: 0, dependencies: [1] },
+      ],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Panel />));
+    const rendersAfterMount = ownerRenders;
+    const section = container.querySelector("section");
+    await act(async () => {
+      click(container, "inner");
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("strong")?.textContent).toBe("Ready");
+    expect(container.querySelector("section")).toBe(section);
+    expect(ownerRenders).toBe(rendersAfterMount);
+  });
+
+  it("updates nested conditions and LIS-keyed rows without rerunning the component", async () => {
+    let ownerRenders = 0;
+    const Panel = createCompiledComponent({
+      displayName: "RecursiveHostPanel",
+      initialize: () => [
+        true,
+        false,
+        false,
+        [
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Beta" },
+          { id: "c", label: "Gamma" },
+        ],
+      ],
+      render(_props: Record<string, never>, state, blocks) {
+        ownerRenders += 1;
+        const HostConditional = blocks.HostConditional;
+        const branch = recursiveBranch(state);
+        const items = state[3].get() as Item[];
+        return (
+          <main>
+            <button data-action="loading" onClick={() => state[1].set((value) => !value)} />
+            <button data-action="details" onClick={() => state[2].set((value) => !value)} />
+            <button
+              data-action="reorder"
+              onClick={() =>
+                state[3].set((value) => {
+                  const [a, b, c] = value as Item[];
+                  return [{ ...c, label: "Gamma updated" }, a, b];
+                })
+              }
+            />
+            <button
+              data-action="hide-update"
+              onClick={() => {
+                state[0].set(false);
+                state[1].set(true);
+                state[2].set(true);
+                state[3].set((value) => [...(value as Item[])].reverse());
+              }}
+            />
+            <button data-action="hidden-update" onClick={() => state[1].set(false)} />
+            <button data-action="show" onClick={() => state[0].set(true)} />
+            <HostConditional
+              id={0}
+              render={() => (
+                <div data-slot>
+                  {state[0].get() ? (
+                    <section>
+                      <header>Inbox</header>
+                      <div>
+                        {state[1].get() ? (
+                          <article>
+                            <p>Loading…</p>
+                            <div>{state[2].get() ? <strong>Details</strong> : null}</div>
+                          </article>
+                        ) : null}
+                      </div>
+                      <ul>
+                        {items.map((item) => (
+                          <li data-key={item.id} key={item.id}>
+                            {item.label}
+                          </li>
+                        ))}
+                      </ul>
+                    </section>
+                  ) : (
+                    <aside>Closed</aside>
+                  )}
+                </div>
+              )}
+              test={() => state[0].get()}
+              truthy={branch}
+              falsy={{ create: () => host("aside", ["Closed"]), bindings: [] }}
+            />
+          </main>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        { kind: "block", id: 1, parent: 0, dependencies: [1] },
+        { kind: "block", id: 2, parent: 1, dependencies: [2] },
+        { kind: "block", id: 3, parent: 0, dependencies: [3] },
+      ],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <StrictMode>
+          <Panel />
+        </StrictMode>,
+      ),
+    );
+
+    const rendersAfterMount = ownerRenders;
+    const section = container.querySelector("section");
+    const rows = new Map(
+      [...container.querySelectorAll<HTMLElement>("[data-key]")].map((row) => [
+        row.dataset.key,
+        row,
+      ]),
+    );
+
+    await act(async () => {
+      click(container, "loading");
+      click(container, "details");
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("article strong")?.textContent).toBe("Details");
+    expect(container.querySelector("section")).toBe(section);
+
+    await act(async () => {
+      click(container, "reorder");
+      await flushCompilerUpdates();
+    });
+    const reordered = [...container.querySelectorAll<HTMLElement>("[data-key]")];
+    expect(reordered.map((row) => row.dataset.key)).toEqual(["c", "a", "b"]);
+    expect(reordered[0]).toBe(rows.get("c"));
+    expect(reordered[1]).toBe(rows.get("a"));
+    expect(reordered[2]).toBe(rows.get("b"));
+    expect(reordered[0].textContent).toBe("Gamma updated");
+    expect(ownerRenders).toBe(rendersAfterMount);
+
+    await act(async () => {
+      click(container, "hide-update");
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("aside")?.textContent).toBe("Closed");
+    expect(container.querySelector("section")).toBeNull();
+
+    await act(async () => {
+      click(container, "hidden-update");
+      click(container, "show");
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("section")).not.toBeNull();
+    expect(container.querySelector("article")).toBeNull();
+    expect(
+      [...container.querySelectorAll<HTMLElement>("[data-key]")].map((row) => row.dataset.key),
+    ).toEqual(["b", "a", "c"]);
+    expect(ownerRenders).toBe(rendersAfterMount);
+  });
+
+  it("drops queued nested work when the compiled owner unmounts", async () => {
+    let nestedSetter: ((next: unknown) => void) | undefined;
+    const Panel = createCompiledComponent({
+      displayName: "RecursiveUnmount",
+      initialize: () => [true, false],
+      render(_props: Record<string, never>, state, blocks) {
+        nestedSetter = state[1].set;
+        const branch: CompilerHostConditionalBranch = {
+          create: () => ({
+            ...host("section", [
+              {
+                ...host("div", [state[1].get() ? host("strong", ["Ready"]) : null]),
+                block: {
+                  kind: "conditional-ranges",
+                  id: 1,
+                  ranges: [
+                    {
+                      before: 0,
+                      test: () => state[1].get(),
+                      logical: true,
+                      truthy: { create: () => host("strong", ["Ready"]), bindings: [] },
+                    },
+                  ],
+                  trailing: 0,
+                },
+              },
+            ]),
+          }),
+          bindings: [],
+        };
+        const HostConditional = blocks.HostConditional;
+        return (
+          <main>
+            <HostConditional
+              id={0}
+              render={() => (
+                <div>
+                  {state[0].get() ? (
+                    <section>
+                      <div>{state[1].get() ? <strong>Ready</strong> : null}</div>
+                    </section>
+                  ) : null}
+                </div>
+              )}
+              test={() => state[0].get()}
+              truthy={branch}
+            />
+          </main>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        { kind: "block", id: 1, parent: 0, dependencies: [1] },
+      ],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Panel />));
+    nestedSetter?.(true);
+    await act(async () => root.unmount());
+    roots.splice(roots.indexOf(root), 1);
+    await flushCompilerUpdates();
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("matches normal React through 3,000 deterministic recursive updates", async () => {
+    type Action =
+      | "outer"
+      | "loading"
+      | "details"
+      | "reverse"
+      | "rotate"
+      | "edit"
+      | "append"
+      | "remove";
+    let compiledDispatch: ((action: Action) => void) | undefined;
+    let reactDispatch: ((action: Action) => void) | undefined;
+    let compiledRenders = 0;
+    let normalRenders = 0;
+
+    const applyListAction = (items: Item[], action: Action): Item[] => {
+      if (action === "reverse") return [...items].reverse();
+      if (action === "rotate" && items.length > 1) return [...items.slice(1), items[0]];
+      if (action === "edit" && items.length > 0) {
+        return [{ ...items[0], label: `${items[0].label}!` }, ...items.slice(1)];
+      }
+      if (action === "append" && items.length < 10) {
+        const keys = new Set(items.map((item) => item.id));
+        let candidate = 0;
+        while (keys.has(String(candidate))) candidate += 1;
+        const id = String(candidate);
+        return [...items, { id, label: `Item ${id}` }];
+      }
+      if (action === "remove" && items.length > 1) return items.slice(0, -1);
+      return items;
+    };
+
+    const initialItems: Item[] = [
+      { id: "0", label: "Zero" },
+      { id: "1", label: "One" },
+      { id: "2", label: "Two" },
+    ];
+
+    const Compiled = createCompiledComponent({
+      displayName: "RecursiveDifferential",
+      initialize: () => [true, false, false, initialItems],
+      render(_props: Record<string, never>, state, blocks) {
+        compiledRenders += 1;
+        compiledDispatch = (action) => {
+          if (action === "outer") state[0].set((value) => !value);
+          else if (action === "loading") state[1].set((value) => !value);
+          else if (action === "details") state[2].set((value) => !value);
+          else state[3].set((value) => applyListAction(value as Item[], action));
+        };
+        const branch = recursiveBranch(state);
+        const HostConditional = blocks.HostConditional;
+        const items = state[3].get() as Item[];
+        return (
+          <div data-compiled>
+            <HostConditional
+              id={0}
+              render={() => (
+                <div data-view>
+                  {state[0].get() ? (
+                    <section>
+                      <header>Inbox</header>
+                      <div>
+                        {state[1].get() ? (
+                          <article>
+                            <p>Loading…</p>
+                            <div>{state[2].get() ? <strong>Details</strong> : null}</div>
+                          </article>
+                        ) : null}
+                      </div>
+                      <ul>
+                        {items.map((item) => (
+                          <li data-key={item.id} key={item.id}>
+                            {item.label}
+                          </li>
+                        ))}
+                      </ul>
+                    </section>
+                  ) : (
+                    <aside>Closed</aside>
+                  )}
+                </div>
+              )}
+              test={() => state[0].get()}
+              truthy={branch}
+              falsy={{ create: () => host("aside", ["Closed"]), bindings: [] }}
+            />
+          </div>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        { kind: "block", id: 1, parent: 0, dependencies: [1] },
+        { kind: "block", id: 2, parent: 1, dependencies: [2] },
+        { kind: "block", id: 3, parent: 0, dependencies: [3] },
+      ],
+    });
+
+    function Normal() {
+      normalRenders += 1;
+      const [open, setOpen] = useState(true);
+      const [loading, setLoading] = useState(false);
+      const [details, setDetails] = useState(false);
+      const [items, setItems] = useState(initialItems);
+      reactDispatch = (action) => {
+        if (action === "outer") setOpen((value) => !value);
+        else if (action === "loading") setLoading((value) => !value);
+        else if (action === "details") setDetails((value) => !value);
+        else setItems((value) => applyListAction(value, action));
+      };
+      return (
+        <div data-react>
+          <div data-view>
+            {open ? (
+              <section>
+                <header>Inbox</header>
+                <div>
+                  {loading ? (
+                    <article>
+                      <p>Loading…</p>
+                      <div>{details ? <strong>Details</strong> : null}</div>
+                    </article>
+                  ) : null}
+                </div>
+                <ul>
+                  {items.map((item) => (
+                    <li data-key={item.id} key={item.id}>
+                      {item.label}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ) : (
+              <aside>Closed</aside>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <>
+          <Compiled />
+          <Normal />
+        </>,
+      ),
+    );
+    const rendersAfterMount = compiledRenders;
+    const actions: Action[] = [
+      "outer",
+      "loading",
+      "details",
+      "reverse",
+      "rotate",
+      "edit",
+      "append",
+      "remove",
+    ];
+    let random = 0x51f15e;
+    for (let step = 0; step < 3000; step += 1) {
+      random = (random * 1664525 + 1013904223) >>> 0;
+      const action = actions[random % actions.length];
+      await act(async () => {
+        compiledDispatch?.(action);
+        reactDispatch?.(action);
+        await flushCompilerUpdates();
+      });
+      expect(container.querySelector("[data-compiled] [data-view]")?.innerHTML).toBe(
+        container.querySelector("[data-react] [data-view]")?.innerHTML,
+      );
+    }
+    expect(compiledRenders).toBe(rendersAfterMount);
+    expect(normalRenders).toBeGreaterThan(compiledRenders);
+  });
+
+  it("adopts nested server markup and remains correct after a recoverable mismatch", async () => {
+    let setLoading: ((next: unknown) => void) | undefined;
+    let setItems: ((next: unknown) => void) | undefined;
+    const Panel = createCompiledComponent({
+      displayName: "RecursiveHydration",
+      initialize: () => [true, false, false, [{ id: "a", label: "Alpha" }]],
+      render(_props: Record<string, never>, state, blocks) {
+        setLoading = state[1].set;
+        setItems = state[3].set;
+        const branch = recursiveBranch(state);
+        const items = state[3].get() as Item[];
+        const HostConditional = blocks.HostConditional;
+        return (
+          <main>
+            <HostConditional
+              id={0}
+              render={() => (
+                <div>
+                  <section>
+                    <header>Inbox</header>
+                    <div>
+                      {state[1].get() ? (
+                        <article>
+                          <p>Loading…</p>
+                          <div />
+                        </article>
+                      ) : null}
+                    </div>
+                    <ul>
+                      {items.map((item) => (
+                        <li data-key={item.id} key={item.id}>
+                          {item.label}
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+                </div>
+              )}
+              test={() => state[0].get()}
+              truthy={branch}
+            />
+          </main>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        { kind: "block", id: 1, parent: 0, dependencies: [1] },
+        { kind: "block", id: 2, parent: 1, dependencies: [2] },
+        { kind: "block", id: 3, parent: 0, dependencies: [3] },
+      ],
+    });
+
+    for (const mismatch of [false, true]) {
+      const container = document.createElement("div");
+      document.body.append(container);
+      const serverHtml = renderToString(<Panel />);
+      container.innerHTML = mismatch
+        ? serverHtml.replace('<li data-key="a">Alpha</li>', "<div>Wrong</div>")
+        : serverHtml;
+      const errors: unknown[] = [];
+      let root!: ReturnType<typeof hydrateRoot>;
+      await act(async () => {
+        root = hydrateRoot(container, <Panel />, {
+          onRecoverableError: (error) => errors.push(error),
+        });
+      });
+      roots.push(root);
+      if (mismatch) expect(errors.length).toBeGreaterThan(0);
+      else expect(errors).toEqual([]);
+
+      const section = container.querySelector("section");
+      await act(async () => {
+        setLoading?.(true);
+        setItems?.([
+          { id: "b", label: "Beta" },
+          { id: "a", label: "Alpha 2" },
+        ]);
+        await flushCompilerUpdates();
+      });
+      expect(container.querySelector("section")).toBe(section);
+      expect(container.querySelector("article")?.textContent).toContain("Loading");
+      expect(
+        [...container.querySelectorAll<HTMLElement>("[data-key]")].map((row) => [
+          row.dataset.key,
+          row.textContent,
+        ]),
+      ).toEqual([
+        ["b", "Beta"],
+        ["a", "Alpha 2"],
+      ]);
+
+      await act(async () => root.unmount());
+      roots.splice(roots.indexOf(root), 1);
+      container.remove();
+    }
+  });
+
+  it("keeps React fallback live after duplicate nested keys", async () => {
+    let setItems: ((next: unknown) => void) | undefined;
+    let ownerRenders = 0;
+    const Panel = createCompiledComponent({
+      displayName: "RecursiveDuplicateKeys",
+      initialize: () => [
+        true,
+        [
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Beta" },
+        ],
+      ],
+      render(_props: Record<string, never>, state, blocks) {
+        ownerRenders += 1;
+        setItems = state[1].set;
+        const items = () => state[1].get() as Item[];
+        const branch: CompilerHostConditionalBranch = {
+          create: () => ({
+            ...host("section", [
+              {
+                ...host(
+                  "ul",
+                  items().map((item) => host("li", [item.label])),
+                ),
+                block: {
+                  kind: "keyed-ranges",
+                  id: 1,
+                  ranges: [
+                    {
+                      before: 0,
+                      items,
+                      rowKey: (item) => (item as Item).id,
+                      create: (item) => host("li", [(item as Item).label]),
+                      bindings: [{ kind: "text", path: [], read: (item) => (item as Item).label }],
+                    },
+                  ],
+                  trailing: 0,
+                },
+              },
+            ]),
+          }),
+          bindings: [],
+        };
+        const HostConditional = blocks.HostConditional;
+        return (
+          <main>
+            <HostConditional
+              id={0}
+              render={() => (
+                <div>
+                  <section>
+                    <ul>
+                      {items().map((item) => (
+                        <li key={item.id}>{item.label}</li>
+                      ))}
+                    </ul>
+                  </section>
+                </div>
+              )}
+              test={() => state[0].get()}
+              truthy={branch}
+            />
+          </main>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        { kind: "block", id: 1, parent: 0, dependencies: [1] },
+      ],
+    });
+
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Panel />));
+    const rendersAfterMount = ownerRenders;
+    await act(async () => {
+      setItems?.([
+        { id: "a", label: "First" },
+        { id: "a", label: "Second" },
+      ]);
+      await flushCompilerUpdates();
+    });
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "First",
+      "Second",
+    ]);
+
+    await act(async () => {
+      setItems?.([{ id: "c", label: "Recovered" }]);
+      await flushCompilerUpdates();
+    });
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Recovered",
+    ]);
+    expect(ownerRenders).toBe(rendersAfterMount);
+    consoleError.mockRestore();
+  });
+
+  it("rebinds nested descriptors when parent props and local state change together", async () => {
+    let setItems: ((next: unknown) => void) | undefined;
+    const Panel = createCompiledComponent<{ prefix: string }>({
+      displayName: "RecursiveProps",
+      initialize: () => [true, [{ id: "a", label: "Alpha" }]],
+      render(props, state, blocks) {
+        setItems = state[1].set;
+        const items = () => state[1].get() as Item[];
+        const row = (item: Item) => `${props.prefix}${item.label}`;
+        const branch: CompilerHostConditionalBranch = {
+          create: () => ({
+            ...host("section", [
+              {
+                ...host(
+                  "ul",
+                  items().map((item) => host("li", [row(item)])),
+                ),
+                block: {
+                  kind: "keyed-ranges",
+                  id: 1,
+                  ranges: [
+                    {
+                      before: 0,
+                      items,
+                      rowKey: (item) => (item as Item).id,
+                      create: (item) => host("li", [row(item as Item)]),
+                      bindings: [{ kind: "text", path: [], read: (item) => row(item as Item) }],
+                    },
+                  ],
+                  trailing: 0,
+                },
+              },
+            ]),
+          }),
+          bindings: [],
+        };
+        const HostConditional = blocks.HostConditional;
+        return (
+          <main>
+            <HostConditional
+              id={0}
+              render={() => (
+                <div>
+                  <section>
+                    <ul>
+                      {items().map((item) => (
+                        <li key={item.id}>{row(item)}</li>
+                      ))}
+                    </ul>
+                  </section>
+                </div>
+              )}
+              test={() => state[0].get()}
+              truthy={branch}
+            />
+          </main>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        { kind: "block", id: 1, parent: 0, dependencies: [1] },
+      ],
+    });
+
+    function Parent() {
+      const [prefix, setPrefix] = useState("Old: ");
+      return (
+        <>
+          <button data-props onClick={() => setPrefix("New: ")} />
+          <Panel prefix={prefix} />
+        </>
+      );
+    }
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Parent />));
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("[data-props]")?.click();
+      setItems?.([{ id: "a", label: "Updated" }]);
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("li")?.textContent).toBe("New: Updated");
+  });
+
+  it("routes nested binding failures through the nearest React error boundary", async () => {
+    let fail: (() => void) | undefined;
+    const Panel = createCompiledComponent({
+      displayName: "RecursiveBindingError",
+      initialize: () => [true, false],
+      render(_props: Record<string, never>, state, blocks) {
+        fail = () => state[1].set(true);
+        const brokenBranch: CompilerHostConditionalBranch = {
+          create: () => host("strong", ["Broken"]),
+          bindings: [
+            {
+              kind: "text",
+              path: [],
+              read: () => {
+                if (state[1].get()) throw new Error("recursive binding failed");
+                return "Ready";
+              },
+            },
+          ],
+        };
+        const outerBranch: CompilerHostConditionalBranch = {
+          create: () => ({
+            ...host("section", [
+              {
+                ...host("div", [state[1].get() ? brokenBranch.create() : null]),
+                block: {
+                  kind: "conditional-ranges",
+                  id: 1,
+                  ranges: [
+                    {
+                      before: 0,
+                      test: () => state[1].get(),
+                      logical: true,
+                      truthy: brokenBranch,
+                    },
+                  ],
+                  trailing: 0,
+                },
+              },
+            ]),
+          }),
+          bindings: [],
+        };
+        const HostConditional = blocks.HostConditional;
+        return (
+          <main>
+            <HostConditional
+              id={0}
+              render={() => (
+                <div>
+                  <section>
+                    <div>{state[1].get() ? <strong>Broken</strong> : null}</div>
+                  </section>
+                </div>
+              )}
+              test={() => state[0].get()}
+              truthy={outerBranch}
+            />
+          </main>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        { kind: "block", id: 1, parent: 0, dependencies: [1] },
+      ],
+    });
+
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <RuntimeErrorBoundary>
+          <Panel />
+        </RuntimeErrorBoundary>,
+      ),
+    );
+    await act(async () => {
+      fail?.();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("[data-recursive-error]")?.textContent).toBe(
+      "recursive binding failed",
+    );
+    consoleError.mockRestore();
+  });
+});

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -74,6 +74,8 @@ export interface CompilerHostElement {
   attributes: readonly { name: string; value: unknown }[];
   styles: readonly { name: string; value: unknown }[];
   children: readonly (CompilerHostElement | unknown)[];
+  /** Direct-child structure owned without creating another React fiber. */
+  block?: CompilerHostBlock;
 }
 
 export type CompilerKeyedRowElement = CompilerHostElement;
@@ -108,6 +110,22 @@ export interface CompilerHostConditionalBranch {
   create(): CompilerHostElement;
   bindings: readonly CompilerHostConditionalBinding[];
 }
+
+export interface CompilerHostConditionalRanges {
+  kind: "conditional-ranges";
+  id: number;
+  ranges: readonly CompilerConditionalRange[];
+  trailing: number;
+}
+
+export interface CompilerHostKeyedRanges {
+  kind: "keyed-ranges";
+  id: number;
+  ranges: readonly CompilerKeyedRange[];
+  trailing: number;
+}
+
+export type CompilerHostBlock = CompilerHostConditionalRanges | CompilerHostKeyedRanges;
 
 export interface CompilerHostConditionalBlockProps {
   id: number;
@@ -548,6 +566,7 @@ function createKeyedListBlockComponent(
 interface CompilerHostInstance {
   element: Element;
   values: unknown[];
+  scope?: CompilerHostTreeScope;
 }
 
 function isCompilerHostElement(value: unknown): value is CompilerHostElement {
@@ -562,14 +581,19 @@ function createCompilerHostElement(document: Document, descriptor: CompilerHostE
     updateAttribute(element, attribute.name, attribute.value);
   }
   for (const style of descriptor.styles) updateStyle(element, style.name, style.value);
-  for (const child of descriptor.children) {
+  const appendChild = (child: unknown): void => {
+    if (Array.isArray(child)) {
+      for (const nested of child) appendChild(nested);
+      return;
+    }
     if (isCompilerHostElement(child)) {
       element.append(createCompilerHostElement(document, child));
-      continue;
+      return;
     }
     const text = renderTextValue(child);
     if (text) element.append(document.createTextNode(text));
-  }
+  };
+  for (const child of descriptor.children) appendChild(child);
   // Select options and textarea text must exist before their controlled value
   // is finalized. Reapplying is harmless for other attributes and avoids a
   // transient/default selection becoming the compiled branch's final state.
@@ -588,12 +612,40 @@ function matchesCompilerHostElement(
   path: readonly number[] = [],
 ): boolean {
   if (element.tagName.toLowerCase() !== descriptor.tag.toLowerCase()) return false;
-  if (opaquePaths.has(path.join("."))) return true;
-  const expectedChildren = descriptor.children.filter(isCompilerHostElement);
+  if (opaquePaths.has(path.join(".")) || descriptor.block) return true;
+  const expectedChildren = flattenCompilerHostElements(descriptor.children);
   if (element.children.length !== expectedChildren.length) return false;
   return expectedChildren.every((child, index) =>
     matchesCompilerHostElement(element.children[index], child, opaquePaths, [...path, index]),
   );
+}
+
+function flattenCompilerHostElements(children: readonly unknown[]): CompilerHostElement[] {
+  const elements: CompilerHostElement[] = [];
+  const visit = (child: unknown): void => {
+    if (Array.isArray(child)) {
+      for (const nested of child) visit(nested);
+    } else if (isCompilerHostElement(child)) {
+      elements.push(child);
+    }
+  };
+  for (const child of children) visit(child);
+  return elements;
+}
+
+function collectCompilerHostBlockIds(descriptor: CompilerHostElement, ids: Set<number>): void {
+  for (const child of flattenCompilerHostElements(descriptor.children)) {
+    collectCompilerHostBlockIds(child, ids);
+  }
+  const block = descriptor.block;
+  if (!block || ids.has(block.id)) return;
+  ids.add(block.id);
+  if (block.kind === "conditional-ranges") {
+    for (const range of block.ranges) {
+      if (range.truthy) collectCompilerHostBlockIds(range.truthy.create(), ids);
+      if (range.falsy) collectCompilerHostBlockIds(range.falsy.create(), ids);
+    }
+  }
 }
 
 function findCompilerHostTarget(root: Element, path: readonly number[]): Element | null {
@@ -731,12 +783,6 @@ function normalizedHostConditionalBindingValue(
   return binding.kind === "text" ? renderTextValue(value) : value;
 }
 
-function readHostConditionalBindingValues(branch: CompilerHostConditionalBranch): unknown[] {
-  return branch.bindings.map((binding) =>
-    normalizedHostConditionalBindingValue(binding, binding.read()),
-  );
-}
-
 function applyHostConditionalBindings(
   branch: CompilerHostConditionalBranch,
   instance: CompilerHostInstance,
@@ -759,6 +805,535 @@ function applyHostConditionalBindings(
   }
 }
 
+interface CompilerHostTreeScope {
+  cleanup(): void;
+}
+
+const UNSET_HOST_CONDITIONAL_BINDING = Symbol("unset host conditional binding");
+
+function mountCompilerHostTree(
+  owner: Pick<ConditionalBlockOwner, "subscribe">,
+  element: Element,
+  descriptor: CompilerHostElement,
+  onFallback: () => void,
+): CompilerHostTreeScope | null {
+  if (!matchesCompilerHostElement(element, descriptor)) return null;
+  if (descriptor.block?.kind === "conditional-ranges") {
+    const controller = new CompilerNestedConditionalRanges(
+      owner,
+      element,
+      descriptor,
+      descriptor.block,
+      onFallback,
+    );
+    try {
+      if (controller.adopt()) return controller;
+      controller.cleanup();
+      return null;
+    } catch (error) {
+      controller.cleanup();
+      throw error;
+    }
+  }
+  if (descriptor.block?.kind === "keyed-ranges") {
+    const controller = new CompilerNestedKeyedRanges(
+      owner,
+      element,
+      descriptor,
+      descriptor.block,
+      onFallback,
+    );
+    try {
+      if (controller.adopt()) return controller;
+      controller.cleanup();
+      return null;
+    } catch (error) {
+      controller.cleanup();
+      throw error;
+    }
+  }
+
+  const descriptors = flattenCompilerHostElements(descriptor.children);
+  if (descriptors.length !== element.children.length) return null;
+  const scopes: CompilerHostTreeScope[] = [];
+  for (let index = 0; index < descriptors.length; index += 1) {
+    const scope = mountCompilerHostTree(
+      owner,
+      element.children[index],
+      descriptors[index],
+      onFallback,
+    );
+    if (!scope) {
+      for (const mounted of scopes) mounted.cleanup();
+      return null;
+    }
+    scopes.push(scope);
+  }
+  let active = true;
+  return {
+    cleanup() {
+      if (!active) return;
+      active = false;
+      for (const scope of scopes) scope.cleanup();
+    },
+  };
+}
+
+function mountCompilerHostInstance(
+  owner: Pick<ConditionalBlockOwner, "subscribe">,
+  element: Element,
+  descriptor: CompilerHostElement,
+  branch: Pick<CompilerHostConditionalBranch, "bindings">,
+  onFallback: () => void,
+): CompilerHostInstance | null {
+  const scope = mountCompilerHostTree(owner, element, descriptor, onFallback);
+  if (!scope) return null;
+  const instance: CompilerHostInstance = {
+    element,
+    scope,
+    values: branch.bindings.map(() => UNSET_HOST_CONDITIONAL_BINDING),
+  };
+  try {
+    applyHostConditionalBindings(branch as CompilerHostConditionalBranch, instance);
+  } catch (error) {
+    scope.cleanup();
+    throw error;
+  }
+  return instance;
+}
+
+interface NestedConditionalRangeInstance {
+  key: "truthy" | "falsy";
+  host: CompilerHostInstance;
+}
+
+class CompilerNestedConditionalRanges implements CompilerHostTreeScope {
+  private readonly instances: Array<NestedConditionalRangeInstance | null> = [];
+  private readonly staticSegments: Element[][] = [];
+  private readonly staticScopes: CompilerHostTreeScope[] = [];
+  private unsubscribe: (() => void) | undefined;
+  private active = true;
+
+  constructor(
+    private readonly owner: Pick<ConditionalBlockOwner, "subscribe">,
+    private readonly root: Element,
+    private readonly host: CompilerHostElement,
+    private readonly block: CompilerHostConditionalRanges,
+    private readonly onFallback: () => void,
+  ) {}
+
+  private readSelections(): CompilerHostConditionalPreparedSelection[] | null {
+    const selections: CompilerHostConditionalPreparedSelection[] = [];
+    for (const range of this.block.ranges) {
+      const selection = hostConditionalSelection(range);
+      if (selection.kind === "fallback") return null;
+      selections.push(selection);
+    }
+    return selections;
+  }
+
+  private mountStatic(
+    elements: readonly Element[],
+    descriptors: readonly CompilerHostElement[],
+  ): boolean {
+    if (elements.length !== descriptors.length) return false;
+    for (let index = 0; index < elements.length; index += 1) {
+      const scope = mountCompilerHostTree(
+        this.owner,
+        elements[index],
+        descriptors[index],
+        this.onFallback,
+      );
+      if (!scope) return false;
+      this.staticScopes.push(scope);
+    }
+    return true;
+  }
+
+  adopt(): boolean {
+    if (!Number.isSafeInteger(this.block.trailing) || this.block.trailing < 0) return false;
+    const selections = this.readSelections();
+    if (!selections) return false;
+    const elements = [...this.root.children];
+    const descriptors = flattenCompilerHostElements(this.host.children);
+    if (elements.length !== descriptors.length) return false;
+    let cursor = 0;
+
+    for (let index = 0; index < this.block.ranges.length; index += 1) {
+      const range = this.block.ranges[index];
+      if (!Number.isSafeInteger(range.before) || range.before < 0) {
+        this.cleanup();
+        return false;
+      }
+      const staticEnd = cursor + range.before;
+      if (
+        staticEnd > elements.length ||
+        !this.mountStatic(elements.slice(cursor, staticEnd), descriptors.slice(cursor, staticEnd))
+      ) {
+        this.cleanup();
+        return false;
+      }
+      this.staticSegments.push(elements.slice(cursor, staticEnd));
+      cursor = staticEnd;
+
+      const selection = selections[index];
+      if (selection.kind === "empty") {
+        this.instances.push(null);
+        continue;
+      }
+      const element = elements[cursor];
+      if (!element) {
+        this.cleanup();
+        return false;
+      }
+      const descriptor = selection.branch.create();
+      const host = mountCompilerHostInstance(
+        this.owner,
+        element,
+        descriptor,
+        selection.branch,
+        this.onFallback,
+      );
+      if (!host) {
+        this.cleanup();
+        return false;
+      }
+      this.instances.push({ key: selection.key, host });
+      cursor += 1;
+    }
+
+    const trailingEnd = cursor + this.block.trailing;
+    if (
+      trailingEnd !== elements.length ||
+      !this.mountStatic(elements.slice(cursor), descriptors.slice(cursor))
+    ) {
+      this.cleanup();
+      return false;
+    }
+    this.staticSegments.push(elements.slice(cursor));
+    this.unsubscribe = this.owner.subscribe(this.block.id, this.refresh);
+    return true;
+  }
+
+  private anchorAfter(rangeIndex: number): ChildNode | null {
+    for (let next = rangeIndex + 1; next < this.instances.length; next += 1) {
+      const staticAnchor = this.staticSegments[next]?.[0];
+      if (staticAnchor) return staticAnchor;
+      const rangeAnchor = this.instances[next]?.host.element;
+      if (rangeAnchor) return rangeAnchor;
+    }
+    return this.staticSegments[this.instances.length]?.[0] || null;
+  }
+
+  private reconcileRange(
+    rangeIndex: number,
+    selection: CompilerHostConditionalPreparedSelection,
+  ): boolean {
+    const previous = this.instances[rangeIndex];
+    if (selection.kind === "empty") {
+      previous?.host.scope?.cleanup();
+      previous?.host.element.remove();
+      this.instances[rangeIndex] = null;
+      return true;
+    }
+    if (previous?.key === selection.key) {
+      const descriptor = selection.branch.create();
+      previous.host.scope?.cleanup();
+      const scope = mountCompilerHostTree(
+        this.owner,
+        previous.host.element,
+        descriptor,
+        this.onFallback,
+      );
+      if (!scope) return false;
+      previous.host.scope = scope;
+      applyHostConditionalBindings(selection.branch, previous.host);
+      return true;
+    }
+
+    const descriptor = selection.branch.create();
+    const element = createCompilerHostElement(this.root.ownerDocument, descriptor);
+    const host = mountCompilerHostInstance(
+      this.owner,
+      element,
+      descriptor,
+      selection.branch,
+      this.onFallback,
+    );
+    if (!host) return false;
+    previous?.host.scope?.cleanup();
+    if (previous) previous.host.element.replaceWith(element);
+    else this.root.insertBefore(element, this.anchorAfter(rangeIndex));
+    this.instances[rangeIndex] = { key: selection.key, host };
+    return true;
+  }
+
+  private refresh = (afterCommit?: () => void) => {
+    if (!this.active) {
+      afterCommit?.();
+      return;
+    }
+    const selections = this.readSelections();
+    if (!selections || selections.length !== this.instances.length) {
+      this.onFallback();
+      afterCommit?.();
+      return;
+    }
+    for (let index = this.instances.length - 1; index >= 0; index -= 1) {
+      if (!this.reconcileRange(index, selections[index])) {
+        this.onFallback();
+        afterCommit?.();
+        return;
+      }
+    }
+    afterCommit?.();
+  };
+
+  cleanup(): void {
+    if (!this.active) return;
+    this.active = false;
+    this.unsubscribe?.();
+    for (const instance of this.instances) instance?.host.scope?.cleanup();
+    for (const scope of this.staticScopes) scope.cleanup();
+    this.instances.length = 0;
+    this.staticSegments.length = 0;
+    this.staticScopes.length = 0;
+  }
+}
+
+interface NestedReadKeyedRange {
+  items: unknown[];
+  keys: string[];
+}
+
+class CompilerNestedKeyedRanges implements CompilerHostTreeScope {
+  private readonly instances: Array<Map<string, CompilerKeyedRowInstance>> = [];
+  private readonly staticSegments: Element[][] = [];
+  private readonly staticScopes: CompilerHostTreeScope[] = [];
+  private unsubscribe: (() => void) | undefined;
+  private active = true;
+
+  constructor(
+    private readonly owner: Pick<ConditionalBlockOwner, "subscribe">,
+    private readonly root: Element,
+    private readonly host: CompilerHostElement,
+    private readonly block: CompilerHostKeyedRanges,
+    private readonly onFallback: () => void,
+  ) {}
+
+  private readRange(range: CompilerKeyedRange): NestedReadKeyedRange | null {
+    const source = range.items();
+    const items = source ? Array.from(source) : [];
+    const keys = items.map((item, index) => keyedRowIdentity(range.rowKey(item, index)));
+    return new Set(keys).size === keys.length ? { items, keys } : null;
+  }
+
+  private readRanges(): NestedReadKeyedRange[] | null {
+    const ranges: NestedReadKeyedRange[] = [];
+    for (const range of this.block.ranges) {
+      const rows = this.readRange(range);
+      if (!rows) return null;
+      ranges.push(rows);
+    }
+    return ranges;
+  }
+
+  private mountStatic(
+    elements: readonly Element[],
+    descriptors: readonly CompilerHostElement[],
+  ): boolean {
+    if (elements.length !== descriptors.length) return false;
+    for (let index = 0; index < elements.length; index += 1) {
+      const scope = mountCompilerHostTree(
+        this.owner,
+        elements[index],
+        descriptors[index],
+        this.onFallback,
+      );
+      if (!scope) return false;
+      this.staticScopes.push(scope);
+    }
+    return true;
+  }
+
+  adopt(): boolean {
+    if (!Number.isSafeInteger(this.block.trailing) || this.block.trailing < 0) return false;
+    const rowsByRange = this.readRanges();
+    if (!rowsByRange) return false;
+    const elements = [...this.root.children];
+    const descriptors = flattenCompilerHostElements(this.host.children);
+    if (elements.length !== descriptors.length) return false;
+    let cursor = 0;
+
+    for (let rangeIndex = 0; rangeIndex < this.block.ranges.length; rangeIndex += 1) {
+      const range = this.block.ranges[rangeIndex];
+      const rows = rowsByRange[rangeIndex];
+      if (!Number.isSafeInteger(range.before) || range.before < 0) {
+        this.cleanup();
+        return false;
+      }
+      const staticEnd = cursor + range.before;
+      if (
+        staticEnd > elements.length ||
+        !this.mountStatic(elements.slice(cursor, staticEnd), descriptors.slice(cursor, staticEnd))
+      ) {
+        this.cleanup();
+        return false;
+      }
+      this.staticSegments.push(elements.slice(cursor, staticEnd));
+      cursor = staticEnd;
+
+      const instances = new Map<string, CompilerKeyedRowInstance>();
+      for (let index = 0; index < rows.items.length; index += 1) {
+        const element = elements[cursor + index];
+        if (!element) {
+          this.cleanup();
+          return false;
+        }
+        const descriptor = range.create(rows.items[index], index);
+        const scope = mountCompilerHostTree(this.owner, element, descriptor, this.onFallback);
+        if (!scope) {
+          this.cleanup();
+          return false;
+        }
+        instances.set(rows.keys[index], {
+          key: rows.keys[index],
+          element,
+          scope,
+          values: range.bindings.map(() => UNSET_KEYED_ROW_BINDING),
+          item: rows.items[index],
+          index,
+          conditionalValues: new Map(),
+        });
+        applyKeyedRowBindings(range, instances.get(rows.keys[index])!, rows.items[index], index);
+      }
+      this.instances.push(instances);
+      cursor += rows.items.length;
+    }
+
+    const trailingEnd = cursor + this.block.trailing;
+    if (
+      trailingEnd !== elements.length ||
+      !this.mountStatic(elements.slice(cursor), descriptors.slice(cursor))
+    ) {
+      this.cleanup();
+      return false;
+    }
+    this.staticSegments.push(elements.slice(cursor));
+    this.unsubscribe = this.owner.subscribe(this.block.id, this.refresh);
+    return true;
+  }
+
+  private anchorAfter(rangeIndex: number): ChildNode | null {
+    for (let next = rangeIndex + 1; next < this.instances.length; next += 1) {
+      const staticAnchor = this.staticSegments[next]?.[0];
+      if (staticAnchor) return staticAnchor;
+      const rowAnchor = this.instances[next].values().next().value?.element;
+      if (rowAnchor) return rowAnchor;
+    }
+    return this.staticSegments[this.instances.length]?.[0] || null;
+  }
+
+  private reconcileRange(rangeIndex: number, rows: NestedReadKeyedRange): boolean {
+    const range = this.block.ranges[rangeIndex];
+    const previous = this.instances[rangeIndex];
+    const oldIndices = new Map<string, number>();
+    [...previous.keys()].forEach((key, index) => oldIndices.set(key, index));
+    const nextKeys = new Set(rows.keys);
+    for (const [key, instance] of previous) {
+      if (nextKeys.has(key)) continue;
+      instance.scope?.cleanup();
+      instance.element.remove();
+    }
+
+    const sequence = rows.keys.map((key) => oldIndices.get(key) ?? -1);
+    const stablePositions = longestIncreasingSubsequencePositions(sequence);
+    const nextInstances: CompilerKeyedRowInstance[] = [];
+    for (let index = 0; index < rows.items.length; index += 1) {
+      const key = rows.keys[index];
+      const existing = previous.get(key);
+      if (existing) {
+        applyKeyedRowBindings(range, existing, rows.items[index], index);
+        existing.item = rows.items[index];
+        existing.index = index;
+        nextInstances.push(existing);
+        continue;
+      }
+      const descriptor = range.create(rows.items[index], index);
+      const element = createCompilerHostElement(this.root.ownerDocument, descriptor);
+      const scope = mountCompilerHostTree(this.owner, element, descriptor, this.onFallback);
+      if (!scope) return false;
+      nextInstances.push({
+        key,
+        element,
+        scope,
+        values: readKeyedRowBindingValues(range, rows.items[index], index),
+        item: rows.items[index],
+        index,
+        conditionalValues: new Map(),
+      });
+    }
+
+    let anchor = this.anchorAfter(rangeIndex);
+    for (let index = nextInstances.length - 1; index >= 0; index -= 1) {
+      const instance = nextInstances[index];
+      if (
+        sequence[index] < 0 ||
+        (!stablePositions.has(index) && instance.element.nextSibling !== anchor)
+      ) {
+        this.root.insertBefore(instance.element, anchor);
+      }
+      anchor = instance.element;
+    }
+    this.instances[rangeIndex] = new Map(nextInstances.map((instance) => [instance.key, instance]));
+    return true;
+  }
+
+  private refresh = (afterCommit?: () => void) => {
+    if (!this.active) {
+      afterCommit?.();
+      return;
+    }
+    const rowsByRange = this.readRanges();
+    if (!rowsByRange || rowsByRange.length !== this.instances.length) {
+      this.onFallback();
+      afterCommit?.();
+      return;
+    }
+    const activeElement = this.root.ownerDocument.activeElement;
+    const restoreFocus = Boolean(activeElement && this.root.contains(activeElement));
+    for (let index = rowsByRange.length - 1; index >= 0; index -= 1) {
+      if (!this.reconcileRange(index, rowsByRange[index])) {
+        this.onFallback();
+        afterCommit?.();
+        return;
+      }
+    }
+    if (
+      restoreFocus &&
+      activeElement?.isConnected &&
+      activeElement.ownerDocument.activeElement !== activeElement &&
+      "focus" in activeElement
+    ) {
+      (activeElement as HTMLElement).focus({ preventScroll: true });
+    }
+    afterCommit?.();
+  };
+
+  cleanup(): void {
+    if (!this.active) return;
+    this.active = false;
+    this.unsubscribe?.();
+    for (const instances of this.instances) {
+      for (const instance of instances.values()) instance.scope?.cleanup();
+    }
+    for (const scope of this.staticScopes) scope.cleanup();
+    this.instances.length = 0;
+    this.staticSegments.length = 0;
+    this.staticScopes.length = 0;
+  }
+}
+
 function createHostConditionalBlockComponent(
   owner: Pick<ConditionalBlockOwner, "subscribe">,
 ): React.ComponentType<CompilerHostConditionalBlockProps> {
@@ -777,8 +1352,35 @@ function createHostConditionalBlockComponent(
     private propSyncQueued = false;
     private currentProps = this.props;
     private unsubscribe: (() => void) | undefined;
+    private fallbackUnsubscribers: Array<() => void> = [];
     private activeBranch: "truthy" | "falsy" | null = null;
     private instance: CompilerHostInstance | null = null;
+
+    private requestNestedFallback = () => {
+      this.instance?.scope?.cleanup();
+      this.activateFallback();
+    };
+
+    private subscribeFallbackDescendants(): void {
+      for (const unsubscribe of this.fallbackUnsubscribers) unsubscribe();
+      this.fallbackUnsubscribers = [];
+      const ids = new Set<number>();
+      if (this.currentProps.truthy) {
+        collectCompilerHostBlockIds(this.currentProps.truthy.create(), ids);
+      }
+      if (this.currentProps.falsy) {
+        collectCompilerHostBlockIds(this.currentProps.falsy.create(), ids);
+      }
+      ids.delete(this.currentProps.id);
+      for (const id of ids) {
+        this.fallbackUnsubscribers.push(
+          owner.subscribe(id, (afterCommit) => {
+            this.fallbackVersion += 1;
+            this.forceUpdate(afterCommit);
+          }),
+        );
+      }
+    }
 
     private captureRoot = (root: Element | null) => {
       this.root = root;
@@ -804,11 +1406,16 @@ function createHostConditionalBlockComponent(
       const descriptor = selection.branch.create();
       const element = this.root.firstElementChild;
       if (!matchesCompilerHostElement(element, descriptor)) return false;
-      this.activeBranch = selection.key;
-      this.instance = {
+      const instance = mountCompilerHostInstance(
+        owner,
         element,
-        values: readHostConditionalBindingValues(selection.branch),
-      };
+        descriptor,
+        selection.branch,
+        this.requestNestedFallback,
+      );
+      if (!instance) return false;
+      this.activeBranch = selection.key;
+      this.instance = instance;
       return true;
     }
 
@@ -818,6 +1425,10 @@ function createHostConditionalBlockComponent(
         return;
       }
       this.fallbackRequested = true;
+      this.instance?.scope?.cleanup();
+      this.instance = null;
+      this.activeBranch = null;
+      this.subscribeFallbackDescendants();
       // One key change on entry: the compiled path mutated the DOM behind
       // React's back, so the first fallback render must rebuild the subtree.
       this.fallbackVersion += 1;
@@ -843,6 +1454,7 @@ function createHostConditionalBlockComponent(
         return;
       }
       if (selection.kind === "empty") {
+        this.instance?.scope?.cleanup();
         if (this.instance) this.instance.element.remove();
         this.activeBranch = null;
         this.instance = null;
@@ -850,18 +1462,41 @@ function createHostConditionalBlockComponent(
         return;
       }
       if (this.activeBranch === selection.key && this.instance) {
+        const descriptor = selection.branch.create();
+        const scope = mountCompilerHostTree(
+          owner,
+          this.instance.element,
+          descriptor,
+          this.requestNestedFallback,
+        );
+        if (!scope) {
+          this.activateFallback(afterCommit);
+          return;
+        }
+        this.instance.scope?.cleanup();
+        this.instance.scope = scope;
         applyHostConditionalBindings(selection.branch, this.instance);
         afterCommit?.();
         return;
       }
 
-      const element = createCompilerHostElement(this.root.ownerDocument, selection.branch.create());
+      const descriptor = selection.branch.create();
+      const element = createCompilerHostElement(this.root.ownerDocument, descriptor);
+      const instance = mountCompilerHostInstance(
+        owner,
+        element,
+        descriptor,
+        selection.branch,
+        this.requestNestedFallback,
+      );
+      if (!instance) {
+        this.activateFallback(afterCommit);
+        return;
+      }
+      this.instance?.scope?.cleanup();
       this.root.replaceChildren(element);
       this.activeBranch = selection.key;
-      this.instance = {
-        element,
-        values: readHostConditionalBindingValues(selection.branch),
-      };
+      this.instance = instance;
       afterCommit?.();
     }
 
@@ -894,6 +1529,9 @@ function createHostConditionalBlockComponent(
     componentWillUnmount(): void {
       this.mounted = false;
       this.unsubscribe?.();
+      for (const unsubscribe of this.fallbackUnsubscribers) unsubscribe();
+      this.fallbackUnsubscribers = [];
+      this.instance?.scope?.cleanup();
       this.root = null;
       this.activeBranch = null;
       this.instance = null;
@@ -942,8 +1580,33 @@ function createConditionalRangesBlockComponent(
     private propFallbackQueued = false;
     private currentProps = this.props;
     private unsubscribe: (() => void) | undefined;
+    private fallbackUnsubscribers: Array<() => void> = [];
     private rangeInstances: Array<ConditionalRangeInstance | null> = [];
     private staticSegments: Element[][] = [];
+
+    private requestNestedFallback = () => {
+      for (const instance of this.rangeInstances) instance?.host.scope?.cleanup();
+      this.activateFallback();
+    };
+
+    private subscribeFallbackDescendants(): void {
+      for (const unsubscribe of this.fallbackUnsubscribers) unsubscribe();
+      this.fallbackUnsubscribers = [];
+      const ids = new Set<number>();
+      for (const range of this.currentProps.ranges) {
+        if (range.truthy) collectCompilerHostBlockIds(range.truthy.create(), ids);
+        if (range.falsy) collectCompilerHostBlockIds(range.falsy.create(), ids);
+      }
+      ids.delete(this.currentProps.id);
+      for (const id of ids) {
+        this.fallbackUnsubscribers.push(
+          owner.subscribe(id, (afterCommit) => {
+            this.fallbackVersion += 1;
+            this.forceUpdate(afterCommit);
+          }),
+        );
+      }
+    }
 
     private captureRoot = (root: Element | null) => {
       this.root = root;
@@ -969,13 +1632,22 @@ function createConditionalRangesBlockComponent(
       const elements = [...this.root.children];
       const staticSegments: Element[][] = [];
       const instances: Array<ConditionalRangeInstance | null> = [];
+      const cleanupInstances = () => {
+        for (const instance of instances) instance?.host.scope?.cleanup();
+      };
       let cursor = 0;
 
       for (let rangeIndex = 0; rangeIndex < props.ranges.length; rangeIndex += 1) {
         const range = props.ranges[rangeIndex];
-        if (!Number.isSafeInteger(range.before) || range.before < 0) return false;
+        if (!Number.isSafeInteger(range.before) || range.before < 0) {
+          cleanupInstances();
+          return false;
+        }
         const staticEnd = cursor + range.before;
-        if (staticEnd > elements.length) return false;
+        if (staticEnd > elements.length) {
+          cleanupInstances();
+          return false;
+        }
         staticSegments.push(elements.slice(cursor, staticEnd));
         cursor = staticEnd;
 
@@ -985,20 +1657,37 @@ function createConditionalRangesBlockComponent(
           continue;
         }
         const element = elements[cursor];
-        if (!element) return false;
+        if (!element) {
+          cleanupInstances();
+          return false;
+        }
         const descriptor = selection.branch.create();
-        if (!matchesCompilerHostElement(element, descriptor)) return false;
+        if (!matchesCompilerHostElement(element, descriptor)) {
+          cleanupInstances();
+          return false;
+        }
+        const host = mountCompilerHostInstance(
+          owner,
+          element,
+          descriptor,
+          selection.branch,
+          this.requestNestedFallback,
+        );
+        if (!host) {
+          cleanupInstances();
+          return false;
+        }
         instances.push({
           key: selection.key,
-          host: {
-            element,
-            values: readHostConditionalBindingValues(selection.branch),
-          },
+          host,
         });
         cursor += 1;
       }
 
-      if (cursor + props.trailing !== elements.length) return false;
+      if (cursor + props.trailing !== elements.length) {
+        cleanupInstances();
+        return false;
+      }
       staticSegments.push(elements.slice(cursor));
       this.staticSegments = staticSegments;
       this.rangeInstances = instances;
@@ -1018,29 +1707,54 @@ function createConditionalRangesBlockComponent(
     private reconcileRange(
       rangeIndex: number,
       selection: CompilerHostConditionalPreparedSelection,
-    ): void {
-      if (!this.root) return;
+    ): boolean {
+      if (!this.root) return false;
       const previous = this.rangeInstances[rangeIndex];
       if (selection.kind === "empty") {
+        previous?.host.scope?.cleanup();
         previous?.host.element.remove();
         this.rangeInstances[rangeIndex] = null;
-        return;
+        return true;
       }
       if (previous?.key === selection.key) {
+        const descriptor = selection.branch.create();
+        const scope = mountCompilerHostTree(
+          owner,
+          previous.host.element,
+          descriptor,
+          this.requestNestedFallback,
+        );
+        if (!scope) {
+          this.requestNestedFallback();
+          return false;
+        }
+        previous.host.scope?.cleanup();
+        previous.host.scope = scope;
         applyHostConditionalBindings(selection.branch, previous.host);
-        return;
+        return true;
       }
 
-      const element = createCompilerHostElement(this.root.ownerDocument, selection.branch.create());
+      const descriptor = selection.branch.create();
+      const element = createCompilerHostElement(this.root.ownerDocument, descriptor);
+      const host = mountCompilerHostInstance(
+        owner,
+        element,
+        descriptor,
+        selection.branch,
+        this.requestNestedFallback,
+      );
+      if (!host) {
+        this.requestNestedFallback();
+        return false;
+      }
+      previous?.host.scope?.cleanup();
       if (previous) previous.host.element.replaceWith(element);
       else this.root.insertBefore(element, this.anchorAfter(rangeIndex));
       this.rangeInstances[rangeIndex] = {
         key: selection.key,
-        host: {
-          element,
-          values: readHostConditionalBindingValues(selection.branch),
-        },
+        host,
       };
+      return true;
     }
 
     private reconcile(afterCommit?: () => void): void {
@@ -1064,7 +1778,10 @@ function createConditionalRangesBlockComponent(
       }
 
       for (let rangeIndex = this.rangeInstances.length - 1; rangeIndex >= 0; rangeIndex -= 1) {
-        this.reconcileRange(rangeIndex, selections[rangeIndex]);
+        if (!this.reconcileRange(rangeIndex, selections[rangeIndex])) {
+          afterCommit?.();
+          return;
+        }
       }
       afterCommit?.();
     }
@@ -1079,6 +1796,8 @@ function createConditionalRangesBlockComponent(
         return;
       }
       this.fallbackRequested = true;
+      for (const instance of this.rangeInstances) instance?.host.scope?.cleanup();
+      this.subscribeFallbackDescendants();
       this.setState({ fallback: true }, afterCommit);
     }
 
@@ -1110,6 +1829,9 @@ function createConditionalRangesBlockComponent(
     componentWillUnmount(): void {
       this.mounted = false;
       this.unsubscribe?.();
+      for (const unsubscribe of this.fallbackUnsubscribers) unsubscribe();
+      this.fallbackUnsubscribers = [];
+      for (const instance of this.rangeInstances) instance?.host.scope?.cleanup();
       this.root = null;
       this.rangeInstances = [];
       this.staticSegments = [];

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -110,6 +110,8 @@ interface HostConditionalPlan {
   falsy?: t.JSXElement;
   truthyBindings: PendingKeyedRowBinding[];
   falsyBindings: PendingKeyedRowBinding[];
+  descriptorBlocks?: ReadonlyMap<t.JSXElement, HostDescriptorBlockPlan>;
+  nestedPlans?: HostDescriptorBlockPlan[];
 }
 
 interface ConditionalRangePlan {
@@ -131,6 +133,7 @@ interface ConditionalRangesPlan {
   source: t.JSXElement;
   ranges: ConditionalRangePlan[];
   trailing: number;
+  descriptorBlocks?: ReadonlyMap<t.JSXElement, HostDescriptorBlockPlan>;
 }
 
 interface KeyedRowsPlan {
@@ -170,6 +173,28 @@ interface KeyedRangesPlan {
   trailing: number;
 }
 
+interface NestedHostConditionalRangesPlan {
+  kind: "nested-host-conditional-ranges";
+  id: number;
+  parent?: number;
+  dependencies: number[];
+  source: t.JSXElement;
+  ranges: ConditionalRangePlan[];
+  trailing: number;
+}
+
+interface NestedHostKeyedRangesPlan {
+  kind: "nested-host-keyed-ranges";
+  id: number;
+  parent?: number;
+  dependencies: number[];
+  source: t.JSXElement;
+  ranges: KeyedRangePlan[];
+  trailing: number;
+}
+
+type HostDescriptorBlockPlan = NestedHostConditionalRangesPlan | NestedHostKeyedRangesPlan;
+
 interface ComponentIslandPlan {
   kind: "component";
   id: number;
@@ -185,6 +210,8 @@ type ComposableBlockPlan =
   | KeyedListPlan
   | KeyedRowsPlan
   | KeyedRangesPlan
+  | NestedHostConditionalRangesPlan
+  | NestedHostKeyedRangesPlan
   | ComponentIslandPlan;
 
 interface Candidate {
@@ -1613,10 +1640,328 @@ function analyzeHostConditionalTree(
   return reason ? { reason } : { bindings };
 }
 
+interface RecursiveHostTreeAnalysis {
+  bindings: PendingKeyedRowBinding[];
+  plans: HostDescriptorBlockPlan[];
+  blocks: Map<t.JSXElement, HostDescriptorBlockPlan>;
+  reason?: string;
+}
+
+function analyzeRecursiveHostTree(
+  branch: t.JSXElement,
+  statesByValue: ReadonlyMap<string, StateBinding>,
+  safeGlobals: ReadonlySet<string>,
+  listNames: ReadonlySet<string>,
+  parent: number,
+  allocateId: () => number,
+): RecursiveHostTreeAnalysis {
+  const bindings: PendingKeyedRowBinding[] = [];
+  const plans: HostDescriptorBlockPlan[] = [];
+  const blocks = new Map<t.JSXElement, HostDescriptorBlockPlan>();
+
+  const merge = (analysis: RecursiveHostTreeAnalysis): string | undefined => {
+    if (analysis.reason) return analysis.reason;
+    bindings.push(...analysis.bindings);
+    plans.push(...analysis.plans);
+    for (const [element, plan] of analysis.blocks) blocks.set(element, plan);
+    return undefined;
+  };
+
+  const visit = (element: t.JSXElement, path: number[], owner: number): string | undefined => {
+    const tag = element.openingElement.name;
+    if (!t.isJSXIdentifier(tag) || !/^[a-z]/.test(tag.name)) {
+      return "recursive compiler-owned blocks support host elements only";
+    }
+    if (tag.name === "svg") return "recursive compiler-owned blocks do not support SVG yet";
+
+    for (const attribute of element.openingElement.attributes) {
+      if (t.isJSXSpreadAttribute(attribute)) {
+        return "recursive compiler-owned blocks do not support JSX attribute spreads";
+      }
+      const name = jsxAttributeName(attribute);
+      if (!name) return "recursive compiler-owned blocks do not support namespaced attributes";
+      if (name === "ref" || name === "dangerouslySetInnerHTML" || name === "key") {
+        return `recursive compiler-owned block ${name} requires React ownership`;
+      }
+      if (/^on[A-Z]/.test(name)) {
+        return "recursive compiler-owned block events require React ownership";
+      }
+      if (
+        !t.isJSXExpressionContainer(attribute.value) ||
+        t.isJSXEmptyExpression(attribute.value.expression)
+      ) {
+        continue;
+      }
+
+      const expression = attribute.value.expression;
+      if (name === "style") {
+        if (!t.isObjectExpression(expression)) {
+          return "recursive compiler-owned styles must use one inline object literal";
+        }
+        for (const property of expression.properties) {
+          if (
+            !t.isObjectProperty(property) ||
+            property.computed ||
+            !t.isExpression(property.value)
+          ) {
+            return "recursive compiler-owned styles do not support spreads, methods, or computed properties";
+          }
+          const propertyName = t.isIdentifier(property.key)
+            ? property.key.name
+            : t.isStringLiteral(property.key)
+              ? property.key.value
+              : undefined;
+          if (!propertyName || (propertyName.includes("-") && !propertyName.startsWith("--"))) {
+            return "recursive compiler-owned style names must use camelCase or a CSS custom property";
+          }
+          const unsupported = validateDerivedExpression(property.value, safeGlobals);
+          if (unsupported) {
+            return `recursive compiler-owned style ${propertyName} cannot use ${unsupported}`;
+          }
+          bindings.push({
+            kind: "style",
+            path: [...path],
+            name: propertyName,
+            value: cloneExpression(property.value),
+          });
+        }
+        continue;
+      }
+
+      if (name === "children") {
+        return "recursive compiler-owned children props are not supported yet";
+      }
+      const unsupported = validateDerivedExpression(expression, safeGlobals);
+      if (unsupported) return `recursive compiler-owned ${name} cannot use ${unsupported}`;
+      bindings.push({
+        kind: "attribute",
+        path: [...path],
+        name,
+        value: cloneExpression(expression),
+      });
+    }
+
+    const children = meaningfulJsxChildren(element);
+    const conditionalChildren = new Map<
+      t.Expression,
+      NonNullable<ReturnType<typeof conditionalBlockShape>>
+    >();
+    let conditionalContainer = children.length > 0;
+    for (const child of children) {
+      if (t.isJSXElement(child) && isHostElement(child)) continue;
+      if (t.isJSXExpressionContainer(child) && !t.isJSXEmptyExpression(child.expression)) {
+        const shape = conditionalBlockShape(child.expression);
+        if (shape && !validateDerivedExpression(shape.test, safeGlobals)) {
+          conditionalChildren.set(child.expression, shape);
+          continue;
+        }
+      }
+      conditionalContainer = false;
+      break;
+    }
+
+    if (conditionalContainer && conditionalChildren.size > 0) {
+      const id = allocateId();
+      const ranges: ConditionalRangePlan[] = [];
+      const dependencies = new Set<number>();
+      let staticBefore = 0;
+      for (const child of children) {
+        if (t.isJSXElement(child)) {
+          const beforeBindings = bindings.length;
+          const nested = analyzeRecursiveHostTree(
+            child,
+            statesByValue,
+            safeGlobals,
+            listNames,
+            owner,
+            allocateId,
+          );
+          const reason = merge(nested);
+          if (reason) return reason;
+          if (bindings.length !== beforeBindings) {
+            return "stateful static siblings beside recursive conditionals require React ownership";
+          }
+          staticBefore += 1;
+          continue;
+        }
+
+        if (!t.isJSXExpressionContainer(child) || t.isJSXEmptyExpression(child.expression)) {
+          return "recursive conditional ranges contain an unsupported child";
+        }
+        const expression = child.expression;
+        const shape = conditionalChildren.get(expression)!;
+        const truthy = shape.truthy
+          ? analyzeRecursiveHostTree(
+              shape.truthy,
+              statesByValue,
+              safeGlobals,
+              listNames,
+              id,
+              allocateId,
+            )
+          : { bindings: [], plans: [], blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>() };
+        const falsy = shape.falsy
+          ? analyzeRecursiveHostTree(
+              shape.falsy,
+              statesByValue,
+              safeGlobals,
+              listNames,
+              id,
+              allocateId,
+            )
+          : { bindings: [], plans: [], blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>() };
+        if (truthy.reason) return truthy.reason;
+        if (falsy.reason) return falsy.reason;
+        plans.push(...truthy.plans, ...falsy.plans);
+        for (const [nestedElement, plan] of truthy.blocks) blocks.set(nestedElement, plan);
+        for (const [nestedElement, plan] of falsy.blocks) blocks.set(nestedElement, plan);
+
+        for (const dependency of collectStateDependencies(shape.test, statesByValue)) {
+          dependencies.add(dependency);
+        }
+        for (const binding of [...truthy.bindings, ...falsy.bindings]) {
+          for (const dependency of collectStateDependencies(binding.value, statesByValue)) {
+            dependencies.add(dependency);
+          }
+        }
+        ranges.push({
+          before: staticBefore,
+          source: expression,
+          test: cloneExpression(shape.test),
+          logical: shape.logical,
+          truthy: shape.truthy,
+          falsy: shape.falsy,
+          truthyBindings: truthy.bindings,
+          falsyBindings: falsy.bindings,
+        });
+        staticBefore = 0;
+      }
+      const plan: NestedHostConditionalRangesPlan = {
+        kind: "nested-host-conditional-ranges",
+        id,
+        parent: owner,
+        dependencies: [...dependencies].sort((left, right) => left - right),
+        source: element,
+        ranges,
+        trailing: staticBefore,
+      };
+      plans.push(plan);
+      blocks.set(element, plan);
+      return undefined;
+    }
+
+    const keyedRanges: KeyedRangePlan[] = [];
+    let keyedContainer = children.length > 0;
+    let staticBefore = 0;
+    const keyedDependencies = new Set<number>();
+    const staticChildren: t.JSXElement[] = [];
+    for (const child of children) {
+      const range = analyzeKeyedRowChild(child, statesByValue, safeGlobals, listNames);
+      if (range && range.events.length === 0 && range.conditionals.length === 0) {
+        keyedRanges.push({
+          before: staticBefore,
+          source: range.source,
+          collection: range.collection,
+          keyCallback: range.keyCallback,
+          renderCallback: range.renderCallback,
+          row: range.row,
+          bindings: range.bindings,
+          syntax: range.syntax,
+        });
+        for (const dependency of range.dependencies) keyedDependencies.add(dependency);
+        staticBefore = 0;
+      } else if (t.isJSXElement(child) && isHostElement(child)) {
+        staticChildren.push(child);
+        staticBefore += 1;
+      } else {
+        keyedContainer = false;
+        break;
+      }
+    }
+
+    if (keyedContainer && keyedRanges.length > 0) {
+      const id = allocateId();
+      for (const child of staticChildren) {
+        const beforeBindings = bindings.length;
+        const nested = analyzeRecursiveHostTree(
+          child,
+          statesByValue,
+          safeGlobals,
+          listNames,
+          owner,
+          allocateId,
+        );
+        const reason = merge(nested);
+        if (reason) return reason;
+        if (bindings.length !== beforeBindings) {
+          return "stateful static siblings beside recursive keyed ranges require React ownership";
+        }
+      }
+      const plan: NestedHostKeyedRangesPlan = {
+        kind: "nested-host-keyed-ranges",
+        id,
+        parent: owner,
+        dependencies: [...keyedDependencies].sort((left, right) => left - right),
+        source: element,
+        ranges: keyedRanges,
+        trailing: staticBefore,
+      };
+      plans.push(plan);
+      blocks.set(element, plan);
+      return undefined;
+    }
+
+    if (element.children.some((child) => t.isJSXFragment(child))) {
+      return "recursive compiler-owned blocks do not support fragments yet";
+    }
+    const nestedElements = element.children.filter((child): child is t.JSXElement =>
+      t.isJSXElement(child),
+    );
+    const expressions = element.children.filter(
+      (child): child is t.JSXExpressionContainer =>
+        t.isJSXExpressionContainer(child) && !t.isJSXEmptyExpression(child.expression),
+    );
+    for (const child of expressions) {
+      const unsupported = validateDerivedExpression(child.expression as t.Expression, safeGlobals);
+      if (unsupported) return `recursive compiler-owned text cannot use ${unsupported}`;
+    }
+    if (nestedElements.length > 0 && expressions.length > 0) {
+      return "recursive compiler-owned blocks do not support dynamic text beside nested elements";
+    }
+    if (nestedElements.length === 0 && expressions.length > 0) {
+      const parts: t.Expression[] = [];
+      for (const child of element.children) {
+        if (t.isJSXText(child)) {
+          const text = cleanJsxText(child.value);
+          if (text) parts.push(t.stringLiteral(text));
+        } else if (t.isJSXExpressionContainer(child) && !t.isJSXEmptyExpression(child.expression)) {
+          parts.push(cloneExpression(child.expression));
+        }
+      }
+      bindings.push({ kind: "text", path: [...path], value: t.arrayExpression(parts) });
+    }
+
+    let elementIndex = 0;
+    for (const child of element.children) {
+      if (!t.isJSXElement(child)) continue;
+      const reason = visit(child, [...path, elementIndex], owner);
+      if (reason) return reason;
+      elementIndex += 1;
+    }
+    return undefined;
+  };
+
+  const reason = visit(branch, [], parent);
+  return { bindings, plans, blocks, reason };
+}
+
 function analyzeHostConditionalContainer(
   container: t.JSXElement,
   statesByValue: ReadonlyMap<string, StateBinding>,
   safeGlobals: ReadonlySet<string>,
+  listNames: ReadonlySet<string>,
+  parent: number,
+  allocateId: () => number,
 ): Omit<HostConditionalPlan, "kind" | "id" | "parent" | "source"> | undefined {
   const containerName = container.openingElement.name;
   if (
@@ -1661,11 +2006,25 @@ function analyzeHostConditionalContainer(
   if (!shape || validateDerivedExpression(shape.test, safeGlobals)) return undefined;
 
   const truthyAnalysis = shape.truthy
-    ? analyzeHostConditionalTree(shape.truthy, safeGlobals)
-    : { bindings: [] as PendingKeyedRowBinding[] };
+    ? analyzeRecursiveHostTree(
+        shape.truthy,
+        statesByValue,
+        safeGlobals,
+        listNames,
+        parent,
+        allocateId,
+      )
+    : { bindings: [], plans: [], blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>() };
   const falsyAnalysis = shape.falsy
-    ? analyzeHostConditionalTree(shape.falsy, safeGlobals)
-    : { bindings: [] as PendingKeyedRowBinding[] };
+    ? analyzeRecursiveHostTree(
+        shape.falsy,
+        statesByValue,
+        safeGlobals,
+        listNames,
+        parent,
+        allocateId,
+      )
+    : { bindings: [], plans: [], blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>() };
   if (truthyAnalysis.reason || falsyAnalysis.reason) return undefined;
 
   const dependencies = new Set(collectStateDependencies(shape.test, statesByValue));
@@ -1682,6 +2041,8 @@ function analyzeHostConditionalContainer(
     falsy: shape.falsy,
     truthyBindings: truthyAnalysis.bindings || [],
     falsyBindings: falsyAnalysis.bindings || [],
+    descriptorBlocks: new Map([...truthyAnalysis.blocks, ...falsyAnalysis.blocks]),
+    nestedPlans: [...truthyAnalysis.plans, ...falsyAnalysis.plans],
   };
 }
 
@@ -1689,8 +2050,19 @@ function analyzeConditionalRangesContainer(
   container: t.JSXElement,
   statesByValue: ReadonlyMap<string, StateBinding>,
   safeGlobals: ReadonlySet<string>,
-  allowSingleRange = false,
-): { ranges: ConditionalRangePlan[]; trailing: number; dependencies: number[] } | undefined {
+  allowSingleRange: boolean,
+  listNames: ReadonlySet<string>,
+  parent: number,
+  allocateId: () => number,
+):
+  | {
+      ranges: ConditionalRangePlan[];
+      trailing: number;
+      dependencies: number[];
+      descriptorBlocks: ReadonlyMap<t.JSXElement, HostDescriptorBlockPlan>;
+      nestedPlans: HostDescriptorBlockPlan[];
+    }
+  | undefined {
   const containerName = container.openingElement.name;
   if (
     !t.isJSXIdentifier(containerName) ||
@@ -1711,6 +2083,8 @@ function analyzeConditionalRangesContainer(
   if (children.length < (allowSingleRange ? 1 : 2)) return undefined;
   const ranges: ConditionalRangePlan[] = [];
   const dependencies = new Set<number>();
+  const descriptorBlocks = new Map<t.JSXElement, HostDescriptorBlockPlan>();
+  const nestedPlans: HostDescriptorBlockPlan[] = [];
   let staticBefore = 0;
 
   for (const child of children) {
@@ -1718,12 +2092,29 @@ function analyzeConditionalRangesContainer(
       const shape = conditionalBlockShape(child.expression);
       if (shape && !validateDerivedExpression(shape.test, safeGlobals)) {
         const truthyAnalysis = shape.truthy
-          ? analyzeHostConditionalTree(shape.truthy, safeGlobals)
-          : { bindings: [] as PendingKeyedRowBinding[] };
+          ? analyzeRecursiveHostTree(
+              shape.truthy,
+              statesByValue,
+              safeGlobals,
+              listNames,
+              parent,
+              allocateId,
+            )
+          : { bindings: [], plans: [], blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>() };
         const falsyAnalysis = shape.falsy
-          ? analyzeHostConditionalTree(shape.falsy, safeGlobals)
-          : { bindings: [] as PendingKeyedRowBinding[] };
+          ? analyzeRecursiveHostTree(
+              shape.falsy,
+              statesByValue,
+              safeGlobals,
+              listNames,
+              parent,
+              allocateId,
+            )
+          : { bindings: [], plans: [], blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>() };
         if (truthyAnalysis.reason || falsyAnalysis.reason) return undefined;
+        nestedPlans.push(...truthyAnalysis.plans, ...falsyAnalysis.plans);
+        for (const [element, plan] of truthyAnalysis.blocks) descriptorBlocks.set(element, plan);
+        for (const [element, plan] of falsyAnalysis.blocks) descriptorBlocks.set(element, plan);
 
         const rangeDependencies = new Set(collectStateDependencies(shape.test, statesByValue));
         for (const binding of [
@@ -1760,6 +2151,8 @@ function analyzeConditionalRangesContainer(
     ranges,
     trailing: staticBefore,
     dependencies: [...dependencies].sort((left, right) => left - right),
+    descriptorBlocks,
+    nestedPlans,
   };
 }
 
@@ -1790,7 +2183,10 @@ function keyedListBoundary(
   );
 }
 
-function hostElementDescriptor(element: t.JSXElement): t.ObjectExpression {
+function hostElementDescriptor(
+  element: t.JSXElement,
+  descriptorBlocks: ReadonlyMap<t.JSXElement, HostDescriptorBlockPlan> = new Map(),
+): t.ObjectExpression {
   const tag = element.openingElement.name as t.JSXIdentifier;
   const attributes: t.ObjectExpression[] = [];
   const styles: t.ObjectExpression[] = [];
@@ -1836,25 +2232,96 @@ function hostElementDescriptor(element: t.JSXElement): t.ObjectExpression {
     );
   }
 
+  const block = descriptorBlocks.get(element);
+  const conditionalBySource = new Map<t.Node, ConditionalRangePlan>();
+  const keyedBySource = new Map<t.Node, KeyedRangePlan>();
+  if (block?.kind === "nested-host-conditional-ranges") {
+    for (const range of block.ranges) conditionalBySource.set(range.source, range);
+  } else if (block?.kind === "nested-host-keyed-ranges") {
+    for (const range of block.ranges) keyedBySource.set(range.source, range);
+  }
+
   const children: t.Expression[] = [];
   for (const child of element.children) {
     if (t.isJSXText(child)) {
       const text = cleanJsxText(child.value);
       if (text) children.push(t.stringLiteral(text));
     } else if (t.isJSXElement(child)) {
-      children.push(hostElementDescriptor(child));
+      const keyedRange = keyedBySource.get(child);
+      if (keyedRange) {
+        children.push(keyedRangeDescriptorChildren(keyedRange, descriptorBlocks));
+      } else {
+        children.push(hostElementDescriptor(child, descriptorBlocks));
+      }
     } else if (t.isJSXExpressionContainer(child) && !t.isJSXEmptyExpression(child.expression)) {
-      children.push(cloneExpression(child.expression));
+      const conditionalRange = conditionalBySource.get(child.expression);
+      const keyedRange = keyedBySource.get(child.expression);
+      if (conditionalRange) {
+        children.push(conditionalRangeDescriptorChild(conditionalRange, descriptorBlocks));
+      } else if (keyedRange) {
+        children.push(keyedRangeDescriptorChildren(keyedRange, descriptorBlocks));
+      } else {
+        children.push(cloneExpression(child.expression));
+      }
     }
   }
 
-  return t.objectExpression([
+  const properties: Array<t.ObjectProperty> = [
     t.objectProperty(t.identifier("kind"), t.stringLiteral("element")),
     t.objectProperty(t.identifier("tag"), t.stringLiteral(tag.name)),
     t.objectProperty(t.identifier("attributes"), t.arrayExpression(attributes)),
     t.objectProperty(t.identifier("styles"), t.arrayExpression(styles)),
     t.objectProperty(t.identifier("children"), t.arrayExpression(children)),
-  ]);
+  ];
+  if (block) {
+    properties.push(
+      t.objectProperty(t.identifier("block"), nestedHostBlockObject(block, descriptorBlocks)),
+    );
+  }
+  return t.objectExpression(properties);
+}
+
+function conditionalRangeDescriptorChild(
+  range: ConditionalRangePlan,
+  descriptorBlocks: ReadonlyMap<t.JSXElement, HostDescriptorBlockPlan>,
+): t.Expression {
+  const truthy = range.truthy
+    ? hostElementDescriptor(range.truthy, descriptorBlocks)
+    : t.nullLiteral();
+  if (range.logical) {
+    return t.logicalExpression("&&", cloneExpression(range.test), truthy);
+  }
+  return t.conditionalExpression(
+    cloneExpression(range.test),
+    truthy,
+    range.falsy ? hostElementDescriptor(range.falsy, descriptorBlocks) : t.nullLiteral(),
+  );
+}
+
+function keyedRangeDescriptorChildren(
+  range: KeyedRangePlan,
+  descriptorBlocks: ReadonlyMap<t.JSXElement, HostDescriptorBlockPlan>,
+): t.Expression {
+  const parameters = range.renderCallback.params.map((parameter) =>
+    t.cloneNode(parameter, true),
+  ) as t.Identifier[];
+  const callback = t.arrowFunctionExpression(
+    parameters,
+    hostElementDescriptor(range.row, descriptorBlocks),
+  );
+  const collection = cloneExpression(range.collection);
+  if (range.syntax === "map") {
+    return t.callExpression(t.memberExpression(collection, t.identifier("map")), [callback]);
+  }
+  return t.callExpression(
+    t.memberExpression(
+      t.callExpression(t.memberExpression(t.identifier("Array"), t.identifier("from")), [
+        t.logicalExpression("||", collection, t.arrayExpression([])),
+      ]),
+      t.identifier("map"),
+    ),
+    [callback],
+  );
 }
 
 function keyedRowBindingObject(
@@ -2197,7 +2664,10 @@ function keyedRowsBoundary(blockRuntime: t.Identifier, plan: KeyedRowsPlan): t.J
   );
 }
 
-function keyedRangeObject(range: KeyedRangePlan): t.ObjectExpression {
+function keyedRangeObject(
+  range: KeyedRangePlan,
+  descriptorBlocks: ReadonlyMap<t.JSXElement, HostDescriptorBlockPlan> = new Map(),
+): t.ObjectExpression {
   const parameters = range.renderCallback.params.map((parameter) =>
     t.cloneNode(parameter, true),
   ) as t.Identifier[];
@@ -2212,7 +2682,7 @@ function keyedRangeObject(range: KeyedRangePlan): t.ObjectExpression {
       t.identifier("create"),
       t.arrowFunctionExpression(
         parameters.map((parameter) => t.cloneNode(parameter, true)),
-        hostElementDescriptor(range.row),
+        hostElementDescriptor(range.row, descriptorBlocks),
       ),
     ),
     t.objectProperty(
@@ -2277,11 +2747,12 @@ function keyedRangesBoundary(blockRuntime: t.Identifier, plan: KeyedRangesPlan):
 function hostConditionalBranchObject(
   branch: t.JSXElement,
   bindings: readonly PendingKeyedRowBinding[],
+  descriptorBlocks: ReadonlyMap<t.JSXElement, HostDescriptorBlockPlan> = new Map(),
 ): t.ObjectExpression {
   return t.objectExpression([
     t.objectProperty(
       t.identifier("create"),
-      t.arrowFunctionExpression([], hostElementDescriptor(branch)),
+      t.arrowFunctionExpression([], hostElementDescriptor(branch, descriptorBlocks)),
     ),
     t.objectProperty(
       t.identifier("bindings"),
@@ -2314,7 +2785,9 @@ function hostConditionalBoundary(
     attributes.push(
       t.jsxAttribute(
         t.jsxIdentifier("truthy"),
-        t.jsxExpressionContainer(hostConditionalBranchObject(plan.truthy, plan.truthyBindings)),
+        t.jsxExpressionContainer(
+          hostConditionalBranchObject(plan.truthy, plan.truthyBindings, plan.descriptorBlocks),
+        ),
       ),
     );
   }
@@ -2322,14 +2795,19 @@ function hostConditionalBoundary(
     attributes.push(
       t.jsxAttribute(
         t.jsxIdentifier("falsy"),
-        t.jsxExpressionContainer(hostConditionalBranchObject(plan.falsy, plan.falsyBindings)),
+        t.jsxExpressionContainer(
+          hostConditionalBranchObject(plan.falsy, plan.falsyBindings, plan.descriptorBlocks),
+        ),
       ),
     );
   }
   return t.jsxElement(t.jsxOpeningElement(name, attributes, true), null, [], true);
 }
 
-function conditionalRangeObject(range: ConditionalRangePlan): t.ObjectExpression {
+function conditionalRangeObject(
+  range: ConditionalRangePlan,
+  descriptorBlocks: ReadonlyMap<t.JSXElement, HostDescriptorBlockPlan> = new Map(),
+): t.ObjectExpression {
   const properties: t.ObjectProperty[] = [
     t.objectProperty(t.identifier("before"), t.numericLiteral(range.before)),
     t.objectProperty(
@@ -2344,7 +2822,7 @@ function conditionalRangeObject(range: ConditionalRangePlan): t.ObjectExpression
     properties.push(
       t.objectProperty(
         t.identifier("truthy"),
-        hostConditionalBranchObject(range.truthy, range.truthyBindings),
+        hostConditionalBranchObject(range.truthy, range.truthyBindings, descriptorBlocks),
       ),
     );
   }
@@ -2352,11 +2830,35 @@ function conditionalRangeObject(range: ConditionalRangePlan): t.ObjectExpression
     properties.push(
       t.objectProperty(
         t.identifier("falsy"),
-        hostConditionalBranchObject(range.falsy, range.falsyBindings),
+        hostConditionalBranchObject(range.falsy, range.falsyBindings, descriptorBlocks),
       ),
     );
   }
   return t.objectExpression(properties);
+}
+
+function nestedHostBlockObject(
+  plan: HostDescriptorBlockPlan,
+  descriptorBlocks: ReadonlyMap<t.JSXElement, HostDescriptorBlockPlan>,
+): t.ObjectExpression {
+  return t.objectExpression([
+    t.objectProperty(
+      t.identifier("kind"),
+      t.stringLiteral(
+        plan.kind === "nested-host-conditional-ranges" ? "conditional-ranges" : "keyed-ranges",
+      ),
+    ),
+    t.objectProperty(t.identifier("id"), t.numericLiteral(plan.id)),
+    t.objectProperty(
+      t.identifier("ranges"),
+      t.arrayExpression(
+        plan.kind === "nested-host-conditional-ranges"
+          ? plan.ranges.map((range) => conditionalRangeObject(range, descriptorBlocks))
+          : plan.ranges.map((range) => keyedRangeObject(range, descriptorBlocks)),
+      ),
+    ),
+    t.objectProperty(t.identifier("trailing"), t.numericLiteral(plan.trailing)),
+  ]);
 }
 
 function conditionalRangesBoundary(
@@ -2387,7 +2889,9 @@ function conditionalRangesBoundary(
     t.jsxAttribute(
       t.jsxIdentifier("ranges"),
       t.jsxExpressionContainer(
-        t.arrayExpression(plan.ranges.map((range) => conditionalRangeObject(range))),
+        t.arrayExpression(
+          plan.ranges.map((range) => conditionalRangeObject(range, plan.descriptorBlocks)),
+        ),
       ),
     ),
     t.jsxAttribute(
@@ -2637,40 +3141,60 @@ function analyzeComposableBlocks(
             }
             continue;
           }
+          const conditionalRangeStart = nextId;
+          const conditionalRangeId = nextId++;
           const conditionalRanges = insideConditional
             ? undefined
-            : analyzeConditionalRangesContainer(child, statesByValue, safeGlobals);
+            : analyzeConditionalRangesContainer(
+                child,
+                statesByValue,
+                safeGlobals,
+                false,
+                listNames,
+                conditionalRangeId,
+                () => nextId++,
+              );
           if (conditionalRanges) {
             plans.push({
               kind: "conditional-ranges",
-              id: nextId++,
+              id: conditionalRangeId,
               parent,
               dependencies: conditionalRanges.dependencies,
               source: child,
               ranges: conditionalRanges.ranges,
               trailing: conditionalRanges.trailing,
+              descriptorBlocks: conditionalRanges.descriptorBlocks,
             });
+            plans.push(...(conditionalRanges.nestedPlans || []));
             for (const range of conditionalRanges.ranges) {
               conditionalExpressions.add(range.source);
             }
             continue;
           }
+          nextId = conditionalRangeStart;
+          const hostConditionalStart = nextId;
+          const hostConditionalId = nextId++;
           const hostConditional = analyzeHostConditionalContainer(
             child,
             statesByValue,
             safeGlobals,
+            listNames,
+            hostConditionalId,
+            () => nextId++,
           );
           if (hostConditional) {
             plans.push({
               kind: "host-conditional",
-              id: nextId++,
+              id: hostConditionalId,
               parent,
               source: child,
               ...hostConditional,
             });
+            plans.push(...(hostConditional.nestedPlans || []));
             ownedElements.add(child);
             continue;
           }
+          nextId = hostConditionalStart;
           const keyedRows = analyzeKeyedRowsContainer(child, statesByValue, safeGlobals, listNames);
           if (keyedRows) {
             plans.push({
@@ -2818,21 +3342,28 @@ function analyzeComposableBlocks(
     };
   }
 
+  const rootConditionalRangeStart = nextId;
+  const rootConditionalRangeId = nextId++;
   const rootConditionalRanges = analyzeConditionalRangesContainer(
     root,
     statesByValue,
     safeGlobals,
     true,
+    listNames,
+    rootConditionalRangeId,
+    () => nextId++,
   );
   if (rootConditionalRanges) {
     plans.push({
       kind: "conditional-ranges",
-      id: nextId++,
+      id: rootConditionalRangeId,
       dependencies: rootConditionalRanges.dependencies,
       source: root,
       ranges: rootConditionalRanges.ranges,
       trailing: rootConditionalRanges.trailing,
+      descriptorBlocks: rootConditionalRanges.descriptorBlocks,
     });
+    plans.push(...(rootConditionalRanges.nestedPlans || []));
     for (const range of rootConditionalRanges.ranges) {
       conditionalExpressions.add(range.source);
     }
@@ -2844,6 +3375,7 @@ function analyzeComposableBlocks(
       keyedExpressions,
     };
   }
+  nextId = rootConditionalRangeStart;
 
   const result = visitHost(root, undefined, false);
   if (result.reason) return { reason: result.reason };


### PR DESCRIPTION
## Summary

- recursively lower eligible host-only conditional and keyed ranges inside compiler-owned branches using one globally identified dependency graph
- mount nested runtime scopes with parent-first scheduling, subscription cleanup, keyed-row reuse, LIS moves, and live React fallback
- add a production example, browser assertions, compatibility coverage, and public experimental-compiler documentation

## Safety boundaries

React still owns initial rendering, SSR, hydration, events, error boundaries, and unsupported structures. Hooks, custom components, refs, SVG, fragments, dangerous HTML, branch events, interactive rows, and unproven shapes retain React ownership.

## Verification

- `pnpm --filter @farm.js/react run type-check`
- `pnpm --filter @farm.js/react test -- --reporter=dot` — 270 tests passed
- `pnpm --filter @farm.js/react build`
- React 18.3.1 and React 19.2.8 compatibility runs
- production compiler example build and Playwright verifier
- docs production Vercel build
- `oxfmt --check`, `oxlint`, and `git diff --check`

The recursive production case preserves keyed DOM identity, performs zero owner-component update executions, and reports zero stale subscriptions after hide/update/show.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The experimental React compiler in `@farm.js/react` now composes recursive compiler-owned host blocks. Previously only the immediate host branch could be compiler-owned; nested conditionals and keyed rows stayed React-owned. Now eligible nested host-only conditionals and non-interactive keyed ranges run inside the same compiler-owned block, preserving keyed DOM identity and avoiding owner re-executions, while still falling back to React when structures are unsupported.

**New Features**
- Mounts nested runtime scopes parent-first and cleans subscriptions on hide/show.
- Reuses keyed rows and performs LIS moves without re-running owner components.
- Adds a production example and Playwright verification of recursive behavior.
- Extends compatibility runs to React 18.3.1 and 19.2.8.
- Updates docs to clarify ownership limits, interactive keyed-row exclusions, and mixing rules.

<sup>Written for commit cf1d0ecf404fdb114413d1e49858d0a2c7397fed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

