### PR TITLE
fix(theme): fall back to the default theme without a request context

### DIFF
--- a/examples/stackblitz/farm.config.ts
+++ b/examples/stackblitz/farm.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "@farm.js/core";
+import { react } from "@farm.js/react";
 
 export default defineConfig({
   theme: {
@@ -7,6 +8,17 @@ export default defineConfig({
   deploy: {
     target: "vercel",
   },
+  // Components that opt in with a "use compiler" directive are compiled ahead
+  // of time into direct DOM updates; everything else keeps the normal React
+  // path. See src/components/counter.tsx for the opt-in.
+  renderer: react({
+    experimental: {
+      compiler: {
+        mode: "annotation",
+        onUnsupported: "warn",
+      },
+    },
+  }),
   experimental: {
     serverComponents: true,
     serverActions: true,

--- a/examples/stackblitz/package.json
+++ b/examples/stackblitz/package.json
@@ -9,7 +9,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "^0.1.0-beta.57",
+    "@farm.js/core": "0.1.0-beta.60",
+    "@farm.js/react": "0.1.0-beta.2",
     "@fontsource-variable/geist": "5.3.0",
     "@fontsource-variable/geist-mono": "5.3.0",
     "react": "^19.0.0",
@@ -17,7 +18,7 @@
     "zod": "^4.1.12"
   },
   "devDependencies": {
-    "@farm.js/cli": "^0.1.0-beta.57",
+    "@farm.js/cli": "0.1.0-beta.60",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "tailwindcss": "^4.0.0",

--- a/examples/stackblitz/src/app/globals.css
+++ b/examples/stackblitz/src/app/globals.css
@@ -240,3 +240,66 @@ code {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* Playground-specific extensions of the starter design system. */
+
+.playground-hero {
+  align-items: flex-start;
+  padding-top: clamp(3rem, 10vh, 6rem);
+}
+
+.playground-copy {
+  width: min(100%, 720px);
+}
+
+.playground-lede {
+  max-width: 620px;
+  margin: 1.4rem 0 0;
+  color: var(--ink-soft);
+  font-size: 0.9rem;
+  line-height: 1.65;
+}
+
+.playground-lede code,
+.demo-note code {
+  border: 1px solid var(--line);
+  background: rgb(255 255 255 / 0.07);
+  padding: 0.05em 0.25em;
+  color: var(--ink);
+  font-size: 0.85em;
+}
+
+.demo-list {
+  max-width: 620px;
+  margin-top: 1.75rem;
+  border-block: 1px solid var(--line);
+}
+
+.demo-block {
+  padding: 1.15rem 0;
+}
+
+.demo-block + .demo-block {
+  border-top: 1px solid var(--line);
+}
+
+.demo-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  color: var(--ink-faint);
+  font-family: var(--font-mono);
+  font-size: 0.67rem;
+  text-transform: uppercase;
+}
+
+.demo-heading span:first-child {
+  color: var(--ink);
+}
+
+.demo-note {
+  margin: 0.7rem 0 0.95rem;
+  color: var(--ink-soft);
+  font-size: 0.82rem;
+  line-height: 1.6;
+}

--- a/examples/stackblitz/src/app/page.tsx
+++ b/examples/stackblitz/src/app/page.tsx
@@ -39,11 +39,15 @@ export default function HomePage() {
 
       <section className="flex flex-col gap-3 rounded-lg border border-white/10 p-5">
         <h2 className="text-sm font-medium uppercase tracking-wide text-neutral-500">
-          Client island
+          Compiled client island
         </h2>
         <p className="text-sm text-neutral-400">
-          Only this counter's JavaScript is sent to the browser. The rest of
-          the page stays server-only.
+          This counter opts into the experimental AOT compiler with a{" "}
+          <code className="text-neutral-200">"use compiler"</code> directive
+          (see <code className="text-neutral-200">src/components/counter.tsx</code>):
+          its state updates patch the DOM directly, skipping the reconciler.
+          The guestbook below stays on the normal React path. Only the
+          islands' JavaScript is sent to the browser.
         </p>
         <Counter />
       </section>

--- a/examples/stackblitz/src/app/page.tsx
+++ b/examples/stackblitz/src/app/page.tsx
@@ -1,66 +1,74 @@
 import { Counter } from "../components/counter";
 import { Guestbook } from "../components/guestbook";
+import { ResourceLinks } from "../components/resource-links";
 
-// This page renders on the server. The two "use client" components below are
+// This page renders on the server. The "use client" components below are
 // hydrated as islands, and the rest of the page ships no JavaScript.
 export default function HomePage() {
   const renderedAt = new Date().toLocaleTimeString("en-US", { hour12: false });
 
   return (
-    <main className="mx-auto flex min-h-screen max-w-2xl flex-col gap-10 px-6 py-16">
-      <header className="flex flex-col gap-3">
-        <h1 className="text-3xl font-semibold tracking-tight">
-          Farm.js Playground
-        </h1>
-        <p className="text-[15px] leading-relaxed text-neutral-400">
-          A product-integrated full-stack framework on Vite: typesafe APIs
-          and server functions, integrations as typed modules, and an
-          experimental compiler that turns component updates into direct DOM
-          patches. This page rendered on the server at{" "}
-          <code className="text-neutral-200">{renderedAt}</code>. Edit{" "}
-          <code className="text-neutral-200">src/app/page.tsx</code> and watch
-          it hot-reload.
-        </p>
-        <div className="flex gap-4 text-sm text-neutral-400">
-          <a
-            href="https://farmjs.dev"
-            className="underline underline-offset-4 hover:text-white"
-          >
-            Docs
-          </a>
-          <a
-            href="https://github.com/farming-labs/farm.js"
-            className="underline underline-offset-4 hover:text-white"
-          >
-            GitHub ★
-          </a>
+    <main className="landing-main">
+      <section className="hero-section playground-hero">
+        <div className="hero-copy playground-copy">
+          <div className="eyebrow-row">
+            <span>00</span>
+            <span>FARMJS / Playground</span>
+          </div>
+
+          <h1>
+            The framework, running in <code>your browser</code>.
+          </h1>
+
+          <p className="playground-lede">
+            A product-integrated full-stack framework on Vite: typesafe APIs
+            and server functions, integrations as typed modules, and an
+            experimental compiler that turns component updates into direct DOM
+            patches. This page rendered on the server at{" "}
+            <code>{renderedAt}</code>. Edit <code>src/app/page.tsx</code> and
+            watch it hot-reload.
+          </p>
+
+          <div className="demo-list">
+            <section className="demo-block" aria-label="Compiled client island">
+              <div className="demo-heading">
+                <span>01</span>
+                <span>Compiled client island</span>
+              </div>
+              <p className="demo-note">
+                This counter opts into the experimental AOT compiler with a{" "}
+                <code>"use compiler"</code> directive (see{" "}
+                <code>src/components/counter.tsx</code>): its state updates
+                patch the DOM directly, skipping the reconciler. The guestbook
+                below stays on the normal React path.
+              </p>
+              <Counter />
+            </section>
+
+            <section
+              className="demo-block"
+              aria-label="Server function guestbook"
+            >
+              <div className="demo-heading">
+                <span>02</span>
+                <span>Server function guestbook</span>
+              </div>
+              <p className="demo-note">
+                The form calls a <code>createServerFn</code> mutation through a
+                typed API client, validated with Zod on the server.
+              </p>
+              <Guestbook />
+            </section>
+          </div>
+
+          <ResourceLinks
+            className="resource-links"
+            primary={{
+              href: "https://github.com/farming-labs/farm.js",
+              label: "Star on GitHub",
+            }}
+          />
         </div>
-      </header>
-
-      <section className="flex flex-col gap-3 rounded-lg border border-white/10 p-5">
-        <h2 className="text-sm font-medium uppercase tracking-wide text-neutral-500">
-          Compiled client island
-        </h2>
-        <p className="text-sm text-neutral-400">
-          This counter opts into the experimental AOT compiler with a{" "}
-          <code className="text-neutral-200">"use compiler"</code> directive
-          (see <code className="text-neutral-200">src/components/counter.tsx</code>):
-          its state updates patch the DOM directly, skipping the reconciler.
-          The guestbook below stays on the normal React path. Only the
-          islands' JavaScript is sent to the browser.
-        </p>
-        <Counter />
-      </section>
-
-      <section className="flex flex-col gap-4 rounded-lg border border-white/10 p-5">
-        <h2 className="text-sm font-medium uppercase tracking-wide text-neutral-500">
-          Server Function guestbook
-        </h2>
-        <p className="text-sm text-neutral-400">
-          The form calls a <code>createServerFn</code> mutation through a
-          typed API client, validated with Zod on the server.
-        </p>
-        <Guestbook />
       </section>
     </main>
   );

--- a/examples/stackblitz/src/components/counter.tsx
+++ b/examples/stackblitz/src/components/counter.tsx
@@ -3,6 +3,10 @@
 import { useState } from "react";
 
 export function Counter() {
+  // The directive opts this component into the experimental AOT compiler:
+  // its state updates patch the DOM directly instead of re-rendering through
+  // the reconciler. Remove the directive and it's a normal React component.
+  "use compiler";
   const [count, setCount] = useState(0);
 
   return (

--- a/examples/stackblitz/src/components/resource-links.tsx
+++ b/examples/stackblitz/src/components/resource-links.tsx
@@ -1,0 +1,78 @@
+interface ResourceLinkAction {
+  href: string;
+  label: string;
+}
+
+interface ResourceLinksProps {
+  className: string;
+  primary?: ResourceLinkAction;
+}
+
+function DocsIcon() {
+  return (
+    <svg
+      className="resource-icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z" />
+      <path d="M14 2v6h6M8 13h8M8 17h6" />
+    </svg>
+  );
+}
+
+function GitHubIcon() {
+  return (
+    <svg
+      className="resource-icon"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M12 .7a11.5 11.5 0 0 0-3.64 22.41c.58.1.79-.25.79-.56v-2.23c-3.22.7-3.9-1.37-3.9-1.37-.52-1.34-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.57-.29-5.27-1.29-5.27-5.68 0-1.26.45-2.28 1.18-3.09-.12-.29-.51-1.47.11-3.05 0 0 .96-.31 3.16 1.18A10.95 10.95 0 0 1 12 6.1c.98 0 1.95.13 2.87.39 2.2-1.49 3.16-1.18 3.16-1.18.62 1.58.23 2.76.11 3.05.74.81 1.18 1.83 1.18 3.09 0 4.4-2.71 5.38-5.29 5.67.42.36.79 1.07.79 2.16v3.27c0 .31.21.67.8.56A11.5 11.5 0 0 0 12 .7Z" />
+    </svg>
+  );
+}
+
+function ResourceSeparator() {
+  return (
+    <span className="resource-separator" aria-hidden="true">
+      /
+    </span>
+  );
+}
+
+export function ResourceLinks({ className, primary }: ResourceLinksProps) {
+  return (
+    <nav className={className} aria-label="Starter resources">
+      {primary ? (
+        <span className="resource-link-item">
+          <a className="resource-link-primary" href={primary.href}>
+            {primary.label}
+          </a>
+        </span>
+      ) : null}
+      <span className="resource-link-item">
+        {primary ? <ResourceSeparator /> : null}
+        <a href="https://farmjs.dev">
+          <DocsIcon />
+          <span>Docs</span>
+        </a>
+      </span>
+      <span className="resource-link-item">
+        <ResourceSeparator />
+        <a href="https://github.com/farming-labs/farm.js">
+          <GitHubIcon />
+          <span>GitHub</span>
+        </a>
+      </span>
+    </nav>
+  );
+}

--- a/packages/farm/src/__tests__/theme.test.tsx
+++ b/packages/farm/src/__tests__/theme.test.tsx
@@ -62,6 +62,14 @@ describe("FARMJS theme configuration", () => {
     await expect(_runWithCurrentRequest(request, () => getTheme())).resolves.toBe("dark");
   });
 
+  it("falls back to the configured default when no request context exists", () => {
+    // Runtimes with partial AsyncLocalStorage support can lose the request
+    // store mid-render; the theme read must degrade instead of throwing.
+    _setDefaultFarmThemeConfig({ default: "dark", storageKey: "site-theme" });
+
+    expect(getTheme()).toBe("dark");
+  });
+
   it("shares the request snapshot across isolated dev SSR module graphs", async () => {
     _setDefaultFarmThemeConfig({ default: "dark", storageKey: "site-theme" });
     const request = new Request("https://farmjs.dev/dashboard", {

--- a/packages/farm/src/server/request.ts
+++ b/packages/farm/src/server/request.ts
@@ -68,3 +68,11 @@ export function getCurrentRequest(): Request {
 
   return request;
 }
+
+// Some runtimes (StackBlitz WebContainers among them) lose AsyncLocalStorage
+// context across async boundaries mid-render. Callers whose feature can
+// degrade gracefully should use this instead of getCurrentRequest() so a
+// missing store never turns into a 500.
+export function getCurrentRequestOrNull(): Request | null {
+  return requestStore.getStore() ?? null;
+}

--- a/packages/farm/src/theme/server.ts
+++ b/packages/farm/src/theme/server.ts
@@ -1,4 +1,4 @@
-import { getCurrentRequest } from "../server/request";
+import { getCurrentRequestOrNull } from "../server/request";
 import { _setFarmThemeServerSnapshotResolver } from "./bridge";
 import { resolveFarmThemeConfig } from "./config";
 import type {
@@ -17,12 +17,22 @@ export function _setDefaultFarmThemeConfig(
   defaultThemeConfig = resolveFarmThemeConfig(config, basePath);
 }
 
-export function getTheme(request: Request = getCurrentRequest()): FarmThemePreference {
+// The theme preference is cosmetic, so a missing request context must never
+// crash a render: without a request to read the cookie from, the configured
+// default applies. Runtimes with partial AsyncLocalStorage support (for
+// example StackBlitz WebContainers) can lose the store mid-render, and a
+// thrown error here would also take down the error page itself.
+export function getTheme(request: Request | null = getCurrentRequestOrNull()): FarmThemePreference {
+  if (!request) return defaultThemeConfig.default;
   return readFarmThemePreference(request, defaultThemeConfig);
 }
 
-export function getThemeSnapshot(request: Request = getCurrentRequest()): FarmThemeSnapshot {
-  const theme = readFarmThemePreference(request, defaultThemeConfig);
+export function getThemeSnapshot(
+  request: Request | null = getCurrentRequestOrNull(),
+): FarmThemeSnapshot {
+  const theme = request
+    ? readFarmThemePreference(request, defaultThemeConfig)
+    : defaultThemeConfig.default;
   return {
     theme,
     resolvedTheme: theme === "system" ? undefined : theme,


### PR DESCRIPTION
getTheme() and getThemeSnapshot() evaluated getCurrentRequest() as a default parameter, so any runtime that loses the AsyncLocalStorage store mid-render turned a cosmetic cookie read into a 500. stackblitz webcontainers does exactly that, which made the dev server crash on every page render there, and since renderError goes through the same createFullHTML path the error page crashed too.

the theme read now degrades to the configured default when no request context exists instead of throwing. the production nitro path already passes the request explicitly so it never relied on this, meaning this only changes behavior for runtimes where the store is already gone (which previously crashed).

repro was the playground on stackblitz: https://stackblitz.com/github/farming-labs/farm.js/tree/main/examples/stackblitz which 500s on beta.60. added a regression test for the no-context fallback, full theme suite passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Theme reads no longer crash when the request context is missing; they now fall back to the configured default. Previously `getTheme`/`getThemeSnapshot` pulled `getCurrentRequest` via a default parameter and 500’d on runtimes that lose AsyncLocalStorage (e.g., StackBlitz), including the error page; production paths that pass the request explicitly are unchanged.

**Bug Fixes**
- `getTheme` and `getThemeSnapshot` accept a null request and default the theme.
- Introduces `getCurrentRequestOrNull` for graceful degradation.
- Adds a regression test covering the no-context fallback.

<sup>Written for commit 5b86bf464009c094a12e96f0ca639a6b72459404. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

