### PR TITLE
chore(examples): bump the playground to beta.61

### DIFF
--- a/examples/stackblitz/package.json
+++ b/examples/stackblitz/package.json
@@ -9,8 +9,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@farm.js/core": "0.1.0-beta.60",
-    "@farm.js/react": "0.1.0-beta.2",
+    "@farm.js/core": "0.1.0-beta.61",
+    "@farm.js/react": "0.1.0-beta.3",
     "@fontsource-variable/geist": "5.3.0",
     "@fontsource-variable/geist-mono": "5.3.0",
     "react": "^19.0.0",
@@ -18,7 +18,7 @@
     "zod": "^4.1.12"
   },
   "devDependencies": {
-    "@farm.js/cli": "0.1.0-beta.60",
+    "@farm.js/cli": "0.1.0-beta.61",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "tailwindcss": "^4.0.0",


### PR DESCRIPTION
moves the stackblitz playground to the beta.61 trio (core/cli 0.1.0-beta.61, react 0.1.0-beta.3) so it picks up the theme fix from #521. the stackblitz dev server was 500ing on webcontainers because the theme read crashed without a request context; beta.61 falls back to the configured default instead.