### PR TITLE
fix(core): keep repeated query parameters in workflow GET triggers

### DIFF
--- a/packages/farm/src/__tests__/searchparams.test.ts
+++ b/packages/farm/src/__tests__/searchparams.test.ts
@@ -224,6 +224,19 @@ describe("SearchParams in the production runtime", () => {
     expect(source).not.toContain("const searchParams: Record<string, string> = {};");
   });
 
+  it("triggers workflows with array-aware search params", () => {
+    const source = readSource("workflows.ts");
+
+    expect(source).toContain('import { searchParamsToObject } from "./search-params";');
+    expect(source).toContain("return searchParamsToObject(url.searchParams);");
+    // the emitted Nitro handler pulls it from the same re-export
+    expect(source).toContain(`  searchParamsToObject
+} from "@farm.js/core/internal/production-runtime";`);
+    expect(source).toContain("return searchParamsToObject(event.url.searchParams);");
+    expect(source).not.toContain("Object.fromEntries(url.searchParams.entries())");
+    expect(source).not.toContain("Object.fromEntries(event.url.searchParams.entries())");
+  });
+
   it("shares the dev renderer's helper", () => {
     const source = readSource("server", "renderer.ts");
 

--- a/packages/farm/src/__tests__/workflows.test.ts
+++ b/packages/farm/src/__tests__/workflows.test.ts
@@ -266,6 +266,32 @@ describe("Farm workflows", () => {
     }
   });
 
+  it("keeps every value of a repeated query parameter in a GET trigger payload", async () => {
+    const workflow = {
+      id: "sync-users",
+      filePath: "/virtual/sync-users.ts",
+      description: "Sync users.",
+      schedule: [],
+      routePath: "/api/_farm/workflows/sync-users",
+    };
+    const run = vi.fn(async (ctx: any) => ({ received: ctx.payload }));
+    const handler = createFarmWorkflowRequestHandler({
+      workflows: [workflow],
+      config: resolveWorkflowsConfig({ secret: "test-secret" }),
+      loadModule: async () => ({ default: { run } }),
+    });
+
+    const response = await handler(
+      new Request("https://example.com/api/_farm/workflows/sync-users?tag=a&tag=b&one=x", {
+        method: "GET",
+        headers: { authorization: "Bearer test-secret" },
+      }),
+    );
+
+    expect(response?.status).toBe(200);
+    expect(run.mock.calls[0]?.[0].payload).toEqual({ tag: ["a", "b"], one: "x" });
+  });
+
   it("adds scheduled workflows to Vercel crons without duplicating existing entries", () => {
     const config = applyFarmWorkflowVercelCrons(
       {

--- a/packages/farm/src/workflows.ts
+++ b/packages/farm/src/workflows.ts
@@ -5,6 +5,7 @@ import {
   type FarmServerConfig,
   type ResolvedFarmServerConfig,
 } from "./server-http";
+import { searchParamsToObject } from "./search-params";
 import { decodeRouteSegment } from "./utils/decode";
 import { toPosixPath } from "./utils";
 
@@ -593,7 +594,8 @@ import { H3 } from "h3";
 import { runTask } from "nitro/runtime";
 import {
   createFarmRequestBodyErrorResponse,
-  readFarmRequestBody
+  readFarmRequestBody,
+  searchParamsToObject
 } from "@farm.js/core/internal/production-runtime";
 
 const route = ${JSON.stringify(config.route)};
@@ -638,7 +640,7 @@ function verifySecret(event) {
 
 async function readPayload(event) {
   if (event.req.method === "GET" || event.req.method === "HEAD") {
-    return Object.fromEntries(event.url.searchParams.entries());
+    return searchParamsToObject(event.url.searchParams);
   }
   const bytes = await readFarmRequestBody(event.req, bodySizeLimit);
   const text = new TextDecoder().decode(bytes);
@@ -702,7 +704,7 @@ function toWorkflowMetadata(workflow: FarmDiscoveredWorkflow) {
 async function readWorkflowPayload(request: Request, bodySizeLimit: number): Promise<unknown> {
   const url = new URL(request.url);
   if (request.method === "GET" || request.method === "HEAD") {
-    return Object.fromEntries(url.searchParams.entries());
+    return searchParamsToObject(url.searchParams);
   }
 
   const bytes = await readFarmRequestBody(request, bodySizeLimit);


### PR DESCRIPTION
Closes #524.

The GET trigger payload was built with `Object.fromEntries(searchParams.entries())`, which
keeps only the last value of a repeated key, so `?tag=a&tag=b` reached the workflow as
`{ tag: "b" }` with the first value dropped silently.

Both handlers now use `searchParamsToObject`, the representation `search-params.ts` already
documents as shared by the dev renderer, the production SSR entry, the SPA page-data endpoint
and the generated client runtime. The emitted Nitro handler pulls it from
`@farm.js/core/internal/production-runtime`, which it was already importing from, so no inlined
copy was needed.

Same class as #492 and #498.

## Verification

`farm dev` against an app whose workflow echoes its payload:

```
                            before                  after
?tag=a&tag=b                {"tag":"b"}             {"tag":["a","b"]}
?tag=a                      {"tag":"a"}             {"tag":"a"}
?tag=a&tag=b&one=x          {"tag":"b","one":"x"}   {"tag":["a","b"],"one":"x"}
no params                   {}                      {}
```

The single value and empty cases are unchanged, only the repeated case differs.

Two tests, both failing on `main` first: a behavioural one on the request handler, and an
emitted-source assertion added to `searchparams.test.ts` alongside the existing per-environment
checks, so the workflow trigger is now covered by the same invariant as everything else.

Core suite green, 1257 passed and 6 skipped, no failures. Type check and lint clean.

## Note

`packages/farmjs-plugin/src/rsc/entries/rsc.ts:744` and `:911` build the page `searchParams`
prop the same way. I flagged it in #524 but left it out here, since I have only read that code
and not exercised the RSC path. Happy to look at it separately.

`middleware/production-runtime.ts:841` looked like the related #507 shape but is correct, it
uses `getSetCookie` and only falls back to `.get()` on runtimes without it.
