### PR TITLE
fix(core): drop prototype-poisoning keys in searchParamsToObject

### DIFF
--- a/packages/farm/src/__tests__/searchparams.test.ts
+++ b/packages/farm/src/__tests__/searchparams.test.ts
@@ -185,6 +185,28 @@ describe("searchParamsToObject", () => {
   });
 });
 
+describe("searchParamsToObject hardening", () => {
+  it("drops prototype-poisoning keys and keeps the prototype intact", () => {
+    // Repeated __proto__ keys previously rewrote the returned object's
+    // prototype via the read-then-assign flow.
+    const output = searchParamsToObject(
+      new URLSearchParams("__proto__=a&__proto__=b&constructor=c&prototype=d&tag=x"),
+    );
+
+    expect(Object.getPrototypeOf(output)).toBe(Object.prototype);
+    expect(output).toEqual({ tag: "x" });
+    expect(Object.keys(output)).toEqual(["tag"]);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("still collects ordinary repeated keys into arrays", () => {
+    expect(searchParamsToObject(new URLSearchParams("tag=a&tag=b&one=x"))).toEqual({
+      tag: ["a", "b"],
+      one: "x",
+    });
+  });
+});
+
 describe("SearchParams in the production runtime", () => {
   const readSource = (...segments: string[]) =>
     fs.readFileSync(path.join(process.cwd(), "src", ...segments), "utf-8");

--- a/packages/farm/src/search-params.ts
+++ b/packages/farm/src/search-params.ts
@@ -11,6 +11,12 @@ export function searchParamsToObject(
   const output: Record<string, string | string[] | undefined> = {};
 
   searchParams.forEach((value, key) => {
+    // Keys come from the request URL. Writing "__proto__" onto a plain object
+    // replaces its prototype instead of adding an entry, so a crafted query
+    // string could reshape the object handed to pages and workflow handlers.
+    // The API route helper (entriesToObject in api/runtime.ts) already skips
+    // these names; keep both representations consistent.
+    if (key === "__proto__" || key === "constructor" || key === "prototype") return;
     const existing = output[key];
     if (existing !== undefined) {
       if (Array.isArray(existing)) {


### PR DESCRIPTION
Follow-up flagged in the #465 and #525 reviews.

## Summary

`searchParamsToObject` writes URL-controlled keys straight onto a plain object. Because assigning `__proto__` replaces an object's prototype rather than adding an entry, a crafted query string (`?__proto__=a&__proto__=b`) **rewrote the prototype of the returned object** via the read-then-assign flow — scoped to that object, not global pollution, but the object is what pages receive as `searchParams`, what the SPA page-data endpoint builds, and (since #525) what workflow GET handlers get as their payload.

Meanwhile the API-route helper (`entriesToObject` in `api/runtime.ts`) already skips `__proto__`/`constructor`/`prototype` — the two representations disagreed.

## Changes

Skip the three poisoning key names in `searchParamsToObject`, with a comment tying it to the API helper so the two stay consistent. Nothing else changes: ordinary repeated keys still collect into arrays.

## Testing

- New regression test proving the prototype stays `Object.prototype` under repeated `__proto__` keys (this failed before the fix — the prototype was genuinely replaced), poisoned keys are absent, ordinary keys survive, and the global `Object.prototype` was never touched.
- A companion test pinning normal repeated-key collection, so the filter can't be blamed for future regressions there.
- `searchparams`, `query-client-shallow`, and `workflows` suites pass (39/39); `tsc`, `oxfmt`, `oxlint` clean.

Truly unifying the two helpers into one module remains open (surafel58 offered in #465); this makes them behaviourally consistent in the meantime.