### PR TITLE
fix(plugin): keep repeated query parameters in RSC page props

### DIFF
--- a/packages/farmjs-plugin/src/rsc/__tests__/rsc-entry-searchparams.test.ts
+++ b/packages/farmjs-plugin/src/rsc/__tests__/rsc-entry-searchparams.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const entrySource = readFileSync(
+  path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../entries/rsc.ts"),
+  "utf8",
+);
+
+describe("RSC entry search params", () => {
+  it("builds searchParams with the shared array-aware helper", () => {
+    // Object.fromEntries keeps only the last value of a repeated key, so
+    // ?tag=a&tag=b reached RSC pages as { tag: "b" } while every other
+    // environment delivers { tag: ["a", "b"] }.
+    expect(entrySource).toContain(
+      "import { _runWithCurrentRequest, searchParamsToObject } from '@farm.js/core/internal/production-runtime';",
+    );
+    expect(entrySource).toContain("const searchParams = searchParamsToObject(url.searchParams);");
+    expect(entrySource).toContain(
+      "const errSearchParams = searchParamsToObject(url.searchParams);",
+    );
+    expect(entrySource).not.toContain("Object.fromEntries(url.searchParams)");
+  });
+});

--- a/packages/farmjs-plugin/src/rsc/entries/rsc.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/rsc.ts
@@ -55,7 +55,7 @@ import {
 } from '@farm.js/core/middleware';
 import { invokeAPIRouteEndpoint, matchAPIRoute } from '@farm.js/core/api/runtime';
 import { _runWithAfterRequest } from '@farm.js/core/after';
-import { _runWithCurrentRequest } from '@farm.js/core/internal/production-runtime';
+import { _runWithCurrentRequest, searchParamsToObject } from '@farm.js/core/internal/production-runtime';
 
 const farmDeploymentId = ${JSON.stringify(ctx.deploymentId)};
 `;
@@ -741,7 +741,9 @@ async function handleFarmRequest(request) {
   const globalsCssPath = '/${ctx.srcDir}' + routesPath + '/globals.css';
   
   // Parse search params
-  const searchParams = Object.fromEntries(url.searchParams);
+  // Collect repeated keys into arrays, matching the searchParams prop shape
+  // every non-RSC environment produces (see core's search-params.ts).
+  const searchParams = searchParamsToObject(url.searchParams);
   
   // Page props passed to components (includes middleware shared data)
   const pageProps = { params, searchParams, middlewareData };
@@ -908,7 +910,7 @@ async function handleFarmRequest(request) {
         const Layout = LayoutModules[LayoutModules.length - 1]?.default;
         const LayoutComp = Layout || (function PassThrough({ children }) { return children; });
         const errParams = matched ? matched.params : {};
-        const errSearchParams = Object.fromEntries(url.searchParams);
+        const errSearchParams = searchParamsToObject(url.searchParams);
         const errorElement = h(ErrorComponent, {
           error: err,
           reset: () => {},


### PR DESCRIPTION
The two sites kira flagged in #524 and scoped out of #525.

## Summary

The RSC entry template built page `searchParams` (line ~744) and error-boundary `searchParams` (line ~911) with `Object.fromEntries(url.searchParams)` — last value wins — so `?tag=a&tag=b` reached RSC pages as `{ tag: "b" }` while every non-RSC environment has delivered `{ tag: ["a", "b"] }` since #365. Last known tenant of the repeated-params family (#457/#465 API routes, #492/#498 loadSearchParams, #524/#525 workflows).

## Changes

Both sites now use the shared `searchParamsToObject`, imported from `@farm.js/core/internal/production-runtime` — the same emitted-import path the entry already uses for `_runWithCurrentRequest` (and the same pattern #525 used for the workflow handler), so the import is proven to resolve in the emitted module's context. With #526 alongside, the helper also filters prototype-poisoning keys.

## Testing

- New source-invariant test in the plugin (mirroring core's `searchparams.test.ts` style): the entry imports the helper via the existing production-runtime import, uses it at both sites, and contains no `Object.fromEntries(url.searchParams)`.
- Full `@farm.js/plugin` suite passes (55/55); `tsc --noEmit`, `oxfmt`, `oxlint` clean.

Honest scope note, same as kira's: this is verified at template/source level plus the plugin suite; the behavioural claim rides on `searchParamsToObject`'s own tests in core plus the proven import path, since standing up a full RSC e2e app is beyond this fix's size. If we want belt-and-braces, an RSC e2e fixture asserting the prop shape would be a good separate addition.