### PR TITLE
feat(create-farm-app): power auth, better-auth, and react-compiler docs with the farmjs framework

### DIFF
--- a/packages/create-farm-app/templates/auth/docs.config.ts
+++ b/packages/create-farm-app/templates/auth/docs.config.ts
@@ -1,0 +1,33 @@
+import { defineDocs } from "@farming-labs/docs";
+
+// Site-wide docs configuration, powered by the @farming-labs/farmjs framework.
+// Farm auto-detects the installed adapter (because farm.config.ts sets
+// `docs: { enabled: true }`), loads this file, and serves Markdown from
+// src/app/docs.
+//
+// This typed config takes priority over docs.json. Keep docs.json in sync as
+// the language-agnostic manifest: it is the fallback for frameworkless / non
+// JS-TS setups and the source the docs cloud reads.
+export default defineDocs({
+  entry: "docs",
+  docsPath: "/docs",
+  metadata: {
+    description: "Documentation for your Farm.js app.",
+  },
+  nav: {
+    title: "Farm App",
+    url: "/",
+  },
+  search: {
+    provider: "simple",
+    enabled: true,
+    maxResults: 12,
+  },
+  llmsTxt: {
+    enabled: true,
+    siteTitle: "Farm App Docs",
+    siteDescription: "Documentation for your Farm.js app.",
+  },
+  sitemap: true,
+  robots: true,
+});

--- a/packages/create-farm-app/templates/auth/docs.json
+++ b/packages/create-farm-app/templates/auth/docs.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://docs.farming-labs.dev/schema/docs.json",
+  "version": 1,
+  "entry": "docs",
+  "docsPath": "/docs",
+  "docs": {
+    "mode": "framework",
+    "runtime": "farm",
+    "root": "."
+  },
+  "content": {
+    "docsRoot": "src/app/docs"
+  },
+  "site": {
+    "name": "Farm App Docs"
+  },
+  "metadata": {
+    "description": "Documentation for your Farm.js app."
+  },
+  "nav": {
+    "title": "Farm App",
+    "url": "/"
+  },
+  "search": {
+    "provider": "simple",
+    "enabled": true,
+    "maxResults": 12
+  },
+  "llmsTxt": {
+    "enabled": true,
+    "siteTitle": "Farm App Docs",
+    "siteDescription": "Documentation for your Farm.js app."
+  },
+  "sitemap": true,
+  "robots": true
+}

--- a/packages/create-farm-app/templates/auth/farm.config.ts
+++ b/packages/create-farm-app/templates/auth/farm.config.ts
@@ -5,6 +5,12 @@ export default defineConfig({
   theme: {
     default: "dark",
   },
+  // Docs are powered by the @farming-labs/farmjs framework. Farm auto-detects
+  // the installed adapter and reads docs.config.ts (docs.json is kept as a
+  // language-agnostic fallback/manifest); content lives in src/app/docs.
+  docs: {
+    enabled: true,
+  },
   experimental: {
     serverComponents: true,
   },

--- a/packages/create-farm-app/templates/auth/package.json
+++ b/packages/create-farm-app/templates/auth/package.json
@@ -13,6 +13,9 @@
   "dependencies": {
     "@farm.js/auth": "0.1.0-beta.62",
     "@farm.js/core": "0.1.0-beta.62",
+    "@farming-labs/docs": "0.2.111",
+    "@farming-labs/farmjs": "0.2.111",
+    "@farming-labs/theme": "0.2.111",
     "@fontsource-variable/geist": "5.3.0",
     "@fontsource-variable/geist-mono": "5.3.0",
     "better-call": "1.3.2",

--- a/packages/create-farm-app/templates/auth/src/app/docs/page.md
+++ b/packages/create-farm-app/templates/auth/src/app/docs/page.md
@@ -1,0 +1,29 @@
+---
+title: "Getting Started"
+description: "Your Farm.js documentation, powered by the @farming-labs/farmjs docs framework."
+---
+
+# Getting Started
+
+These docs are served by the Farm docs runtime, powered by the
+[@farming-labs/farmjs](https://www.npmjs.com/package/@farming-labs/farmjs) docs
+framework. The same Markdown files power human pages, Markdown routes,
+`llms.txt`, the sitemap, search, and agent discovery through `/api/docs`.
+
+## Edit this page
+
+This page lives at `src/app/docs/page.md`. Add more pages as folders with their
+own `page.md` — for example `src/app/docs/configuration/page.md` is served at
+`/docs/configuration`.
+
+## Configure
+
+Site-wide docs settings live in `docs.config.ts` at the project root (title,
+navigation, search, `llms.txt`, sitemap, and robots). Farm auto-detects the
+installed adapter because `farm.config.ts` sets `docs: { enabled: true }` — no
+manual wiring required.
+
+## Learn more
+
+- [Farm.js documentation](https://farm.js.dev/docs)
+- [Configuration guide](https://farm.js.dev/docs/configuration)

--- a/packages/create-farm-app/templates/better-auth/docs.config.ts
+++ b/packages/create-farm-app/templates/better-auth/docs.config.ts
@@ -1,0 +1,33 @@
+import { defineDocs } from "@farming-labs/docs";
+
+// Site-wide docs configuration, powered by the @farming-labs/farmjs framework.
+// Farm auto-detects the installed adapter (because farm.config.ts sets
+// `docs: { enabled: true }`), loads this file, and serves Markdown from
+// src/app/docs.
+//
+// This typed config takes priority over docs.json. Keep docs.json in sync as
+// the language-agnostic manifest: it is the fallback for frameworkless / non
+// JS-TS setups and the source the docs cloud reads.
+export default defineDocs({
+  entry: "docs",
+  docsPath: "/docs",
+  metadata: {
+    description: "Documentation for your Farm.js app.",
+  },
+  nav: {
+    title: "Farm App",
+    url: "/",
+  },
+  search: {
+    provider: "simple",
+    enabled: true,
+    maxResults: 12,
+  },
+  llmsTxt: {
+    enabled: true,
+    siteTitle: "Farm App Docs",
+    siteDescription: "Documentation for your Farm.js app.",
+  },
+  sitemap: true,
+  robots: true,
+});

--- a/packages/create-farm-app/templates/better-auth/docs.json
+++ b/packages/create-farm-app/templates/better-auth/docs.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://docs.farming-labs.dev/schema/docs.json",
+  "version": 1,
+  "entry": "docs",
+  "docsPath": "/docs",
+  "docs": {
+    "mode": "framework",
+    "runtime": "farm",
+    "root": "."
+  },
+  "content": {
+    "docsRoot": "src/app/docs"
+  },
+  "site": {
+    "name": "Farm App Docs"
+  },
+  "metadata": {
+    "description": "Documentation for your Farm.js app."
+  },
+  "nav": {
+    "title": "Farm App",
+    "url": "/"
+  },
+  "search": {
+    "provider": "simple",
+    "enabled": true,
+    "maxResults": 12
+  },
+  "llmsTxt": {
+    "enabled": true,
+    "siteTitle": "Farm App Docs",
+    "siteDescription": "Documentation for your Farm.js app."
+  },
+  "sitemap": true,
+  "robots": true
+}

--- a/packages/create-farm-app/templates/better-auth/farm.config.ts
+++ b/packages/create-farm-app/templates/better-auth/farm.config.ts
@@ -7,6 +7,12 @@ export default defineConfig({
   theme: {
     default: "dark",
   },
+  // Docs are powered by the @farming-labs/farmjs framework. Farm auto-detects
+  // the installed adapter and reads docs.config.ts (docs.json is kept as a
+  // language-agnostic fallback/manifest); content lives in src/app/docs.
+  docs: {
+    enabled: true,
+  },
   experimental: {
     serverComponents: true,
   },

--- a/packages/create-farm-app/templates/better-auth/package.json
+++ b/packages/create-farm-app/templates/better-auth/package.json
@@ -12,6 +12,9 @@
   "dependencies": {
     "@farm.js/better-auth": "0.1.0-beta.62",
     "@farm.js/core": "0.1.0-beta.62",
+    "@farming-labs/docs": "0.2.111",
+    "@farming-labs/farmjs": "0.2.111",
+    "@farming-labs/theme": "0.2.111",
     "@fontsource-variable/geist": "5.3.0",
     "@fontsource-variable/geist-mono": "5.3.0",
     "better-auth": "1.6.25",

--- a/packages/create-farm-app/templates/better-auth/src/app/docs/page.md
+++ b/packages/create-farm-app/templates/better-auth/src/app/docs/page.md
@@ -1,0 +1,29 @@
+---
+title: "Getting Started"
+description: "Your Farm.js documentation, powered by the @farming-labs/farmjs docs framework."
+---
+
+# Getting Started
+
+These docs are served by the Farm docs runtime, powered by the
+[@farming-labs/farmjs](https://www.npmjs.com/package/@farming-labs/farmjs) docs
+framework. The same Markdown files power human pages, Markdown routes,
+`llms.txt`, the sitemap, search, and agent discovery through `/api/docs`.
+
+## Edit this page
+
+This page lives at `src/app/docs/page.md`. Add more pages as folders with their
+own `page.md` — for example `src/app/docs/configuration/page.md` is served at
+`/docs/configuration`.
+
+## Configure
+
+Site-wide docs settings live in `docs.config.ts` at the project root (title,
+navigation, search, `llms.txt`, sitemap, and robots). Farm auto-detects the
+installed adapter because `farm.config.ts` sets `docs: { enabled: true }` — no
+manual wiring required.
+
+## Learn more
+
+- [Farm.js documentation](https://farm.js.dev/docs)
+- [Configuration guide](https://farm.js.dev/docs/configuration)

--- a/packages/create-farm-app/templates/react-compiler/docs.config.ts
+++ b/packages/create-farm-app/templates/react-compiler/docs.config.ts
@@ -1,0 +1,33 @@
+import { defineDocs } from "@farming-labs/docs";
+
+// Site-wide docs configuration, powered by the @farming-labs/farmjs framework.
+// Farm auto-detects the installed adapter (because farm.config.ts sets
+// `docs: { enabled: true }`), loads this file, and serves Markdown from
+// src/app/docs.
+//
+// This typed config takes priority over docs.json. Keep docs.json in sync as
+// the language-agnostic manifest: it is the fallback for frameworkless / non
+// JS-TS setups and the source the docs cloud reads.
+export default defineDocs({
+  entry: "docs",
+  docsPath: "/docs",
+  metadata: {
+    description: "Documentation for your Farm.js app.",
+  },
+  nav: {
+    title: "Farm App",
+    url: "/",
+  },
+  search: {
+    provider: "simple",
+    enabled: true,
+    maxResults: 12,
+  },
+  llmsTxt: {
+    enabled: true,
+    siteTitle: "Farm App Docs",
+    siteDescription: "Documentation for your Farm.js app.",
+  },
+  sitemap: true,
+  robots: true,
+});

--- a/packages/create-farm-app/templates/react-compiler/docs.json
+++ b/packages/create-farm-app/templates/react-compiler/docs.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://docs.farming-labs.dev/schema/docs.json",
+  "version": 1,
+  "entry": "docs",
+  "docsPath": "/docs",
+  "docs": {
+    "mode": "framework",
+    "runtime": "farm",
+    "root": "."
+  },
+  "content": {
+    "docsRoot": "src/app/docs"
+  },
+  "site": {
+    "name": "Farm App Docs"
+  },
+  "metadata": {
+    "description": "Documentation for your Farm.js app."
+  },
+  "nav": {
+    "title": "Farm App",
+    "url": "/"
+  },
+  "search": {
+    "provider": "simple",
+    "enabled": true,
+    "maxResults": 12
+  },
+  "llmsTxt": {
+    "enabled": true,
+    "siteTitle": "Farm App Docs",
+    "siteDescription": "Documentation for your Farm.js app."
+  },
+  "sitemap": true,
+  "robots": true
+}

--- a/packages/create-farm-app/templates/react-compiler/farm.config.ts
+++ b/packages/create-farm-app/templates/react-compiler/farm.config.ts
@@ -17,6 +17,12 @@ export default defineConfig({
   theme: {
     default: "dark",
   },
+  // Docs are powered by the @farming-labs/farmjs framework. Farm auto-detects
+  // the installed adapter and reads docs.config.ts (docs.json is kept as a
+  // language-agnostic fallback/manifest); content lives in src/app/docs.
+  docs: {
+    enabled: true,
+  },
   deploy: {
     target: "node",
   },

--- a/packages/create-farm-app/templates/react-compiler/package.json
+++ b/packages/create-farm-app/templates/react-compiler/package.json
@@ -13,6 +13,9 @@
   "dependencies": {
     "@farm.js/core": "0.1.0-beta.62",
     "@farm.js/react": "0.1.0-beta.3",
+    "@farming-labs/docs": "0.2.111",
+    "@farming-labs/farmjs": "0.2.111",
+    "@farming-labs/theme": "0.2.111",
     "@fontsource-variable/geist": "5.3.0",
     "@fontsource-variable/geist-mono": "5.3.0",
     "react": "19.2.8",

--- a/packages/create-farm-app/templates/react-compiler/src/app/docs/page.md
+++ b/packages/create-farm-app/templates/react-compiler/src/app/docs/page.md
@@ -1,0 +1,29 @@
+---
+title: "Getting Started"
+description: "Your Farm.js documentation, powered by the @farming-labs/farmjs docs framework."
+---
+
+# Getting Started
+
+These docs are served by the Farm docs runtime, powered by the
+[@farming-labs/farmjs](https://www.npmjs.com/package/@farming-labs/farmjs) docs
+framework. The same Markdown files power human pages, Markdown routes,
+`llms.txt`, the sitemap, search, and agent discovery through `/api/docs`.
+
+## Edit this page
+
+This page lives at `src/app/docs/page.md`. Add more pages as folders with their
+own `page.md` — for example `src/app/docs/configuration/page.md` is served at
+`/docs/configuration`.
+
+## Configure
+
+Site-wide docs settings live in `docs.config.ts` at the project root (title,
+navigation, search, `llms.txt`, sitemap, and robots). Farm auto-detects the
+installed adapter because `farm.config.ts` sets `docs: { enabled: true }` — no
+manual wiring required.
+
+## Learn more
+
+- [Farm.js documentation](https://farm.js.dev/docs)
+- [Configuration guide](https://farm.js.dev/docs/configuration)


### PR DESCRIPTION
## What

Propagates the docs-framework setup from the basic template ([#522](https://github.com/farming-labs/farm.js/pull/522)) to the remaining React app templates: `auth`, `better-auth`, and `react-compiler`.

Each gets:
- `farm.config.ts`: `docs: { enabled: true }` (Farm auto-detects the adapter)
- `package.json`: `@farming-labs/farmjs`, `@farming-labs/docs`, `@farming-labs/theme`
- `docs.config.ts`: typed config via `defineDocs()` (takes priority)
- `docs.json`: language-agnostic fallback manifest (docs cloud + frameworkless setups)
- `src/app/docs/page.md`: starter page

## Verification

- **auth** (has the `minimumReleaseAge` policy): scaffold + install + build — @farming-labs deps clear the policy, docs delegated to @farming-labs/farmjs, `/docs` built.
- **react-compiler** (react renderer + compiler): scaffold + install + build — docs delegated, `/docs` built (node-server preset).
- **better-auth**: not separately built (structurally identical to auth: same release-age policy, same React base, same docs edit).

Non-React templates (`_renderers/*`, `_integrations/*` non-react) are intentionally left out — the docs adapter runtime is React-only today, so those keep the embedded renderer.