### PR TITLE
feat(react): compile host conditionals inside keyed rows

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -323,21 +323,21 @@ policy.
 The current compiler deliberately supports a smaller subset than general React. A component must
 satisfy all of these rules:
 
-| Area                | Current supported shape                                                                                                                                 |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Component discovery | A top-level, capitalized function declaration, function expression, or arrow component in application `.tsx` or `.jsx`.                                 |
-| Function shape      | Synchronous, non-generator, non-generic block body with zero parameters, one props identifier, or flat object props destructuring.                      |
-| Props               | Flat object destructuring supports shorthand names, aliases, and defaults. Nested, computed, and rest patterns fall back.                               |
-| Body                | Top-level `useState` declarations, optional compiler-safe derived values and synchronous named handlers, then one unconditional JSX return.             |
-| State               | `const [value, setValue] = useState(initial)`, including lazy initializers, multiple cells, and queued functional updates.                              |
-| Root                | Exactly one lowercase host JSX element such as `button`, `section`, `input`, or `div`.                                                                  |
-| Tree                | A statically known host tree around eligible conditional, keyed-list, compiled keyed-row, and component-island boundaries.                              |
-| Text bindings       | State-driven text in a leaf host element.                                                                                                               |
-| Attribute bindings  | Basic attributes, controlled form properties, and individual properties in one inline `style` object.                                                   |
-| Events              | Inline handlers and synchronous `const` or function-declaration handlers, including inline synchronous events in eligible host-only keyed rows.         |
-| Conditional blocks  | Logical/ternary host branches in dedicated containers or direct ranges among static host siblings, including the component root.                        |
-| Keyed lists         | Item-keyed maps and imported `List`, including safe collection pipelines; eligible rows use direct bindings and keyed row-local conditional boundaries. |
-| Component islands   | Stable imported or module-level component identifiers with explicit compiler-safe props and no JSX children, spread, `ref`, or `key`.                   |
+| Area                | Current supported shape                                                                                                                         |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Component discovery | A top-level, capitalized function declaration, function expression, or arrow component in application `.tsx` or `.jsx`.                         |
+| Function shape      | Synchronous, non-generator, non-generic block body with zero parameters, one props identifier, or flat object props destructuring.              |
+| Props               | Flat object destructuring supports shorthand names, aliases, and defaults. Nested, computed, and rest patterns fall back.                       |
+| Body                | Top-level `useState` declarations, optional compiler-safe derived values and synchronous named handlers, then one unconditional JSX return.     |
+| State               | `const [value, setValue] = useState(initial)`, including lazy initializers, multiple cells, and queued functional updates.                      |
+| Root                | Exactly one lowercase host JSX element such as `button`, `section`, `input`, or `div`.                                                          |
+| Tree                | A statically known host tree around eligible conditional, keyed-list, compiled keyed-row, and component-island boundaries.                      |
+| Text bindings       | State-driven text in a leaf host element.                                                                                                       |
+| Attribute bindings  | Basic attributes, controlled form properties, and individual properties in one inline `style` object.                                           |
+| Events              | Inline handlers and synchronous `const` or function-declaration handlers, including inline synchronous events in eligible host-only keyed rows. |
+| Conditional blocks  | Logical/ternary host branches in dedicated containers or direct ranges among static host siblings, including the component root.                |
+| Keyed lists         | Item-keyed maps and imported `List`, including safe collection pipelines; eligible rows use direct bindings and recursive host-only conditions. |
+| Component islands   | Stable imported or module-level component identifiers with explicit compiler-safe props and no JSX children, spread, `ref`, or `key`.           |
 
 This component is eligible:
 
@@ -670,10 +670,10 @@ custom controls, async or non-inline handlers, and a controlled textarea that al
 the React fallback. Duplicate keys discovered at runtime also switch that mounted list to React.
 These limits apply equally to automatically detected maps and inline host rows inside `List`.
 
-#### Row-local host conditionals
+#### Compiler-owned host conditionals inside keyed rows
 
-A keyed host row may contain logical or ternary branches without sending every same-key update
-through the complete list boundary:
+A non-interactive keyed host row may contain logical or ternary host branches. The branches may
+sit beside static host siblings and may contain deeper safe host-only conditions:
 
 ```tsx
 <ul>
@@ -682,7 +682,16 @@ through the complete list boundary:
       <span>{item.label}</span>
 
       <div className="status-slot">
-        {item.done ? <strong>{item.label} complete</strong> : <span>In progress</span>}
+        <i>State</i>
+        {item.done ? (
+          <article>
+            <strong>{item.label} complete</strong>
+            <div>{item.details && <small>{item.description}</small>}</div>
+          </article>
+        ) : (
+          <span>In progress</span>
+        )}
+        <b>Prepared</b>
       </div>
 
       <section className="details-slot">{item.expanded && <p>{item.description}</p>}</section>
@@ -691,28 +700,30 @@ through the complete list boundary:
 </ul>
 ```
 
-The `div` and `section` remain stable host containers. Each conditional is their only meaningful
-child. At build time, the compiler assigns row-local slot IDs and records the test plus the dynamic
-text, attribute, and style values in each host-only branch. At runtime, those IDs are scoped by the
-row key: slot `0` in row `"a"` cannot share data or a subscription with slot `0` in row `"b"`.
+At build time, the compiler prepares the complete lowercase host descriptor for one row, including
+the tests, static sibling counts, branch factories, text/attribute/style bindings, and recursively
+nested conditionals. React still renders or hydrates the initial list. After mount, each key owns one
+row instance and its nested host scopes. A same-key update creates the next lightweight descriptor,
+patches a surviving branch in place, mounts or removes only a changed branch, and leaves the row and
+static siblings untouched. The user component and map callback do not rerun.
 
-When the collection cell changes but its key order does not, Farm computes the prepared snapshots
-for each keyed row. It asks React to refresh only a conditional whose selected branch or active
-branch values changed. Ordinary row bindings are still patched directly, the map callback is not
-executed, and unchanged conditional boundaries do not render. Inline row events may update these
-slots through the same latest-item proxy described above.
+Insertions and removals create or clean only the affected row scopes. Reorders use the same LIS pass
+as ordinary compiler-owned keyed rows, so a condition change and a reorder queued in one event are
+committed from the same latest collection. Block IDs remain unique in the component graph, while
+the runtime scopes repeated row descriptors by their stable key. No marker nodes or extra wrappers
+are added to SSR output.
 
-React deliberately owns the conditional Fiber and every structural list commit. An insertion,
-removal, or reorder asks React to reconcile the keyed rows, after which Farm validates the static
-host skeleton, re-adopts it, and resumes targeted snapshots. This design preserves empty branches,
-SSR markup, hydration and recoverable hydration errors, error boundaries, Strict Mode, and Fast
-Refresh without adding marker elements to the server HTML.
+This compiler-owned tier requires a lowercase host row with no events. Branches may use logical or
+ternary expressions, multiple known locations, static siblings, nested lowercase host conditions,
+and safe text, attribute, or inline-style expressions. It applies to automatic keyed `.map(...)`
+syntax and inline host rows rendered by `List`.
 
-The first contract accepts `condition && <host />` and host-or-empty ternaries. A conditional must
-sit alone inside a persistent lowercase HTML container. Its branches must be statically known host
-trees without events, components, fragments, refs, SVG, spreads, dangerous HTML, or another dynamic
-block. A branch event, a conditional mixed with another child in the same slot, or any unsupported
-shape keeps the existing React-owned keyed-list boundary.
+Hooks, custom components, events inside a compiler-owned branch, refs, SVG, fragments, JSX spreads,
+dangerous HTML, controlled inputs inside a conditional, nested keyed lists, and any unproven shape
+stay on React. Existing interactive keyed rows keep their React-owned conditional-slot behavior:
+Farm compares row snapshots and asks React to refresh a changed slot, while React retains event,
+Fiber, hydration, and structural-list ownership. Duplicate runtime keys or an invalid adopted shape
+also switch the complete mounted list to React.
 
 #### Derived collection pipelines
 
@@ -802,7 +813,7 @@ The compiler uses four keyed-list tiers:
 2. A nested or component-root host container with one or more non-interactive keyed host ranges
    becomes one compiler-owned range block. Farm preserves any static segments and applies the same
    row descriptors and LIS reconciliation independently inside each range.
-3. The dedicated single-list shape with eligible inline events or row-local conditional slots
+3. The dedicated single-list shape with eligible inline events or other React-owned row-local slots
    keeps React event and structural ownership, while Farm patches same-key row bindings and refreshes
    only changed conditional boundaries.
 4. A safe keyed map or `List` that cannot use an optimized row shape becomes a small React-owned keyed
@@ -863,9 +874,11 @@ The optimized host-row contract is deliberately narrow:
   host siblings, either in a nested container or the component's returned host root.
 - The row is a statically known HTML host tree. Dynamic leaf text, attributes, controlled host
   properties, and individual inline style properties are supported.
-- Inline synchronous row events and dedicated logical or ternary host slots are supported by the
-  hybrid path. Branch events, nested dynamic blocks, conditionals mixed with siblings in one slot,
-  non-inline or async handlers, file inputs, dynamic form control types or options, custom
+- A dedicated non-interactive map/`List` may contain multiple logical or ternary host branches,
+  including recursively nested branches and branches beside static host siblings. The compiler
+  mounts, replaces, or removes only those host blocks within each keyed row instance.
+- Inline synchronous row events use the hybrid React-owned row path. Branch events, nested keyed
+  lists, non-inline or async handlers, file inputs, dynamic form control types or options, custom
   components, fragments, refs, SVG, attribute spreads, dangerous HTML, and dynamic text mixed
   beside nested elements stay React-owned.
 - Unsupported or mutating collection methods, spread children, Hooks in callbacks, and other
@@ -943,20 +956,21 @@ React then unmounts or replaces the branch normally. Inner boundaries unsubscrib
 unmount, so later updates while the branch is hidden do not target stale components. If the branch
 appears again, each boundary subscribes again and renders from the latest compiler-cell values.
 
-The compiler deliberately does not assign ordinary component-wide block IDs to syntax inside a
-keyed row callback. A host-only optimized row instead receives a separate runtime instance per key
-and a build-time binding list relative to that row root. Dedicated row-local conditional IDs are
-scoped by that key and retain React-owned Fibers. Eligible inline events use the hybrid React-event
-path described above. Component islands, Hooks, custom components, nested row blocks, and other
-dynamic structure remain on the complete React-owned row path; put Hooks inside a keyed row
-component.
+Safe host-only conditions inside a non-interactive keyed row receive globally unique build-time
+block IDs, while the runtime creates a separate scope for each stable row key. The outer keyed
+block drives those scopes, so a row can update a nested branch without a component rerun or a
+separate global subscription for every row. The scope moves with the row through LIS reordering and
+is cleaned when its key disappears. Eligible inline events use the hybrid React-event path and
+retain React-owned row-local conditional Fibers. Component islands, Hooks, custom components,
+nested keyed lists, and other unproven dynamic structure remain on the complete React-owned row
+path; put Hooks inside a keyed row component.
 
 ### What falls back to React
 
 | Unsupported shape                                                                                                                     | Why React keeps ownership                                                          |
 | ------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
 | Unkeyed/index-keyed maps, unsupported or mutating collection pipelines, or element arrays                                             | Their structure, purity, or item identity is outside the keyed-list contract.      |
-| Unsupported row events/forms, components, fragments, refs, SVG, nested blocks, or mixed conditional slots                             | Their event, lifecycle, or structure contract requires the React-owned row path.   |
+| Unsupported row events/forms, components, fragments, refs, SVG, nested keyed lists, or unsafe conditional branches                    | Their event, lifecycle, or structure contract requires the React-owned row path.   |
 | Interactive ranges beside siblings or non-host range siblings                                                                         | The range owner requires a host container and non-interactive host rows.           |
 | Branch events, keys, components, fragments, refs, SVG, interactive rows, or unsupported nested blocks in a compiled conditional range | They require the React-owned conditional path rather than compiler-created hosts.  |
 | Dynamic/member component types, component spreads, refs, keys, or children                                                            | Their identity or ownership is outside the first component-island contract.        |
@@ -1072,9 +1086,11 @@ callback refs keep direct DOM targets stable even when a React component island 
 fragment, or multiple nodes. React-owned conditional, keyed-list, and component boundaries give
 complex dynamic structure back to React. Compiler-owned branches and non-interactive rows are
 limited to complete host-only containers because manually inserted DOM has no React Fiber for
-events, components, or Hooks. Interactive rows and rows with local conditional Fibers therefore
-never use the manual insertion/removal/LIS path: React reconciles their structure, and Farm only
-adopts committed host elements for binding patches and row-local snapshot refreshes.
+events, components, or Hooks. Interactive rows and other rows that require local conditional
+Fibers therefore never use the manual insertion/removal/LIS path: React reconciles their structure,
+and Farm only adopts committed host elements for binding patches and row-local snapshot refreshes.
+Proven non-interactive host conditions are part of the keyed descriptor instead, so their scopes
+can move safely with the existing LIS path.
 Unsupported dynamic component types, refs, effects, and other unproven shapes keep React ownership;
 fallback is the optimization's correctness mechanism.
 
@@ -1136,6 +1152,12 @@ The package and example test suites verify more than generated code:
 - row-local host conditionals refresh only changed keyed slots, remain coherent with inline events
   and parent updates, preserve row identity through React reorders, switch duplicate keys to React,
   route failures through error boundaries, and clean subscriptions on unmount;
+- non-interactive keyed rows own multiple and recursively nested host conditionals, patch a
+  surviving branch without a React commit, combine condition changes with LIS reorders, preserve
+  row, branch, and static-sibling identity, and clean every nested scope when a row disappears;
+- 2,000 deterministic compiler-owned row/branch/order transitions match normal React while the
+  compiled owner remains at one execution, with additional Strict Mode, parent/local, error-boundary,
+  duplicate-key, queued-unmount, SSR, and recoverable-hydration coverage;
 - component islands update only dependent children, preserve child-local state and context, route
   failures through React error boundaries, hydrate in Strict Mode, and safely drop queued updates
   after unmount;
@@ -1160,6 +1182,9 @@ The package and example test suites verify more than generated code:
 - the production browser experiment also replaces and reorders interactive items, verifies current
   keyed DOM identity and capture/stop-propagation behavior, and observes zero owner update
   executions;
+- the production browser experiment rotates 1,000 compiler-owned host rows with one LIS move,
+  updates outer and nested row conditions, preserves surviving row and branch identity, removes and
+  inserts a row, and observes zero owner update executions;
 - the public `List` renders iterable and nullish collections correctly with the compiler off;
 - the packaged runtime, including a keyed-range component root, editable and interactive keyed-row
   events, row-local conditions, reorders, identity, selection, and hydration, is exercised

--- a/examples/react-compiler/README.md
+++ b/examples/react-compiler/README.md
@@ -23,6 +23,8 @@ pnpm --filter farm-react-compiler-example experiment
 ```
 
 The Playwright install is needed once per machine (or whenever its browser cache is cleared).
+Set `FARM_EXPERIMENT_BROWSER_PATH` to an existing Chrome or Chromium executable when the machine
+uses a managed browser installation instead of Playwright's downloaded browser.
 
 The command creates a production build, starts it on a local port, runs desktop and mobile Chromium
 assertions, checks for console/runtime errors and horizontal overflow, saves screenshots under
@@ -48,6 +50,7 @@ assertions, checks for console/runtime errors and horizontal overflow, saves scr
 | Ternary conditional block  | `strong` and `span` replace each other; executions `0`     | —                                           | Only the compiler-owned branch is replaced.                            |
 | Root conditional ranges    | exact card root, two ranges, stable static siblings; executions `0` | —                                  | Direct branches reconcile without wrappers or marker nodes.            |
 | Composable nested blocks   | two lists, nested conditions, and one component island  | —                                              | One block graph mounts, updates, and cleans up nested subscriptions.    |
+| Keyed row host blocks      | 1,000 rows, one LIS move, nested branch patches, executions `0` | —                                      | Each key owns its safe recursive host conditions without React commits. |
 
 The package runtime test also measures one equivalent update under a React `Profiler`:
 
@@ -109,16 +112,14 @@ the rows while checking DOM and selection identity, loads 256 rows, and observes
 executions. File inputs, dynamic control types or option attributes, content-editable trees, refs,
 custom controls, and async or non-inline handlers remain React fallbacks.
 
-The `04E` card adds two branch slots to every keyed row. Each logical or ternary expression is the
-only child of a persistent host container. Farm scopes the prepared test and branch-value snapshot
-to the row key, then asks React to refresh only a slot whose selected branch or active values
-changed. The card toggles status and details independently, rotates the rows, checks that their DOM
-identity survives, and verifies zero outer component executions for same-key updates.
+The `04E` card covers the interactive tier: Farm scopes a prepared branch snapshot to each row key,
+then asks React to refresh only a slot whose selected branch or active values changed. The card
+toggles status and details independently, rotates the rows, checks that their DOM identity survives,
+and verifies zero outer component executions for same-key updates.
 
 React still owns the branch Fiber, initial render, hydration, errors, and every structural list
-commit. This is why row conditionals do not use the manual insertion or LIS path. Branch events,
-components, fragments, refs, SVG, nested blocks, or a conditional mixed with another child in the
-same slot use the existing React-owned list fallback.
+commit for this interactive tier. Branch events, components, fragments, refs, SVG, and unsupported
+nested blocks use the existing React-owned list fallback.
 
 The `04G` card is itself the returned host root. It places two non-interactive maps between its
 header, metrics, labels, and footer. React renders that original `article`; Farm adopts its direct
@@ -175,6 +176,17 @@ hide/update/show sequence verifies that removed scopes receive no stale work and
 latest cells. The production assertion records zero owner update executions. Interactive rows,
 Hooks, custom components, refs, SVG, branch events, and mixed conditional/list slots remain React
 fallbacks.
+
+The `10` card transfers that recursive host ownership into each non-interactive keyed row. Its 1,000
+rows contain a ternary beside static siblings, a deeper logical branch, and a second row-local
+condition. One action rotates the list with one LIS move while replacing one branch and patching a
+surviving nested branch. The production assertion preserves the row, active branch, and both static
+siblings, then removes and inserts one row and verifies zero owner update executions. The same path
+is automatic for an eligible `.map(...)` or inline host row in `List`; it needs no new option.
+
+Hooks, custom components, row or branch events, refs, SVG, fragments, dangerous HTML, controlled
+inputs inside a condition, nested keyed lists, and unproven expressions stay on React. Duplicate
+runtime keys also switch the mounted list to React.
 
 ## Heavy compiler-on/off benchmark
 

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -11,6 +11,7 @@ const compilerReportPath = path.resolve(".farm/react-compiler.json");
 const screenshotPath =
   process.env.FARM_EXPERIMENT_SCREENSHOT || "/tmp/farm-react-aot-edge-lab.png";
 const mobileScreenshotPath = screenshotPath.replace(/(\.[^.]+)?$/, "-mobile$1");
+const browserExecutablePath = process.env.FARM_EXPERIMENT_BROWSER_PATH;
 
 await access(serverEntry);
 const compilerReport = JSON.parse(await readFile(compilerReportPath, "utf8"));
@@ -38,6 +39,7 @@ for (const component of [
   "StatefulListRow",
   "ComponentIslandExperiment",
   "ComposableBlockExperiment",
+  "KeyedRowHostBlockExperiment",
 ]) {
   assert.ok(compiledComponents.has(component), `${component} was not compiled`);
 }
@@ -93,7 +95,10 @@ async function readNumber(page, selector) {
 let browser;
 try {
   await waitForServer();
-  browser = await chromium.launch({ headless: true });
+  browser = await chromium.launch({
+    headless: true,
+    ...(browserExecutablePath ? { executablePath: browserExecutablePath } : {}),
+  });
   const page = await browser.newPage({
     viewport: { width: 1440, height: 1100 },
   });
@@ -1069,6 +1074,102 @@ try {
   );
   assert.equal(recursiveOwnerFinalExecutions - recursiveOwnerInitialExecutions, 0);
 
+  const keyedHostRows = '[data-experiment="keyed-row-host-blocks"]';
+  const keyedHostOwnerInitialExecutions = await readNumber(
+    page,
+    `${keyedHostRows} [data-metric="keyed-host-owner-executions"]`,
+  );
+  await assertText(page, `${keyedHostRows} [data-metric="keyed-host-rows"]`, "1000");
+  await assertText(page, `${keyedHostRows} [data-metric="keyed-host-first"]`, "row-0");
+  assert.equal(await page.locator(`${keyedHostRows} [data-keyed-host-row]`).count(), 1000);
+  await page.evaluate(() => {
+    const list = document.querySelector("[data-keyed-host-list]");
+    window.__farmKeyedHostRow0 = document.querySelector('[data-keyed-host-row="row-0"]');
+    window.__farmKeyedHostRow12 = document.querySelector('[data-keyed-host-row="row-12"]');
+    window.__farmKeyedHostRow12Article = window.__farmKeyedHostRow12.querySelector("article");
+    window.__farmKeyedHostRow12Before = window.__farmKeyedHostRow12.querySelector(
+      "[data-keyed-host-status] > i",
+    );
+    window.__farmKeyedHostRow12After = window.__farmKeyedHostRow12.querySelector(
+      "[data-keyed-host-status] > b",
+    );
+    window.__farmKeyedHostMoves = 0;
+    const insertBefore = list.insertBefore.bind(list);
+    list.insertBefore = (node, anchor) => {
+      if (node.parentNode === list && node.matches?.("[data-keyed-host-row]")) {
+        window.__farmKeyedHostMoves += 1;
+      }
+      return insertBefore(node, anchor);
+    };
+  });
+
+  await page.locator(`${keyedHostRows} [data-action="keyed-host-rotate"]`).click();
+  await assertText(page, `${keyedHostRows} [data-metric="keyed-host-updates"]`, "1");
+  await assertText(page, `${keyedHostRows} [data-metric="keyed-host-first"]`, "row-1");
+  await assertText(
+    page,
+    `${keyedHostRows} [data-keyed-host-row="row-0"] [data-keyed-host-branch]`,
+    "Task 0 · branch replaced open",
+  );
+  await assertText(
+    page,
+    `${keyedHostRows} [data-keyed-host-row="row-12"] strong`,
+    "Task 12 · nested patched complete",
+  );
+  await assertText(
+    page,
+    `${keyedHostRows} [data-keyed-host-row="row-12"] [data-keyed-host-extra]`,
+    "Task 12 · nested patched expanded",
+  );
+  assert.equal(
+    await page.locator(
+      `${keyedHostRows} [data-keyed-host-row="row-12"] [data-keyed-host-detail]`,
+    ).count(),
+    0,
+  );
+  assert.equal(
+    await page.locator(
+      `${keyedHostRows} [data-keyed-host-row="row-12"] article`,
+    ).evaluate((article) => article.style.opacity),
+    "0.72",
+  );
+  assert.equal(await page.evaluate(() => window.__farmKeyedHostMoves), 1);
+  assert.equal(
+    await page.evaluate(
+      () =>
+        window.__farmKeyedHostRow0 ===
+          document.querySelector('[data-keyed-host-row="row-0"]') &&
+        window.__farmKeyedHostRow12 ===
+          document.querySelector('[data-keyed-host-row="row-12"]') &&
+        window.__farmKeyedHostRow12Article ===
+          document.querySelector('[data-keyed-host-row="row-12"] article') &&
+        window.__farmKeyedHostRow12Before ===
+          document.querySelector('[data-keyed-host-row="row-12"] [data-keyed-host-status] > i') &&
+        window.__farmKeyedHostRow12After ===
+          document.querySelector('[data-keyed-host-row="row-12"] [data-keyed-host-status] > b'),
+    ),
+    true,
+    "the keyed row host update replaced a surviving row, branch, or static sibling",
+  );
+
+  await page.locator(`${keyedHostRows} [data-action="keyed-host-replace"]`).click();
+  await assertText(page, `${keyedHostRows} [data-metric="keyed-host-updates"]`, "2");
+  await assertText(page, `${keyedHostRows} [data-metric="keyed-host-rows"]`, "1000");
+  assert.equal(
+    await page.locator(`${keyedHostRows} [data-keyed-host-row="row-10"]`).count(),
+    0,
+  );
+  await assertText(
+    page,
+    `${keyedHostRows} [data-keyed-host-row="inserted-1"] [data-keyed-host-detail]`,
+    "Inserted after update 1 detail",
+  );
+  const keyedHostOwnerFinalExecutions = await readNumber(
+    page,
+    `${keyedHostRows} [data-metric="keyed-host-owner-executions"]`,
+  );
+  assert.equal(keyedHostOwnerFinalExecutions - keyedHostOwnerInitialExecutions, 0);
+
   await page.screenshot({ path: screenshotPath, fullPage: true });
 
   const mobilePage = await browser.newPage({
@@ -1276,6 +1377,16 @@ try {
             staleSubscriptionsAfterHide: 0,
             ownerUpdateExecutions:
               recursiveOwnerFinalExecutions - recursiveOwnerInitialExecutions,
+          },
+          keyedRowHostBlocks: {
+            rows: 1000,
+            firstKey: "row-1",
+            lisMoves: 1,
+            sameBranchIdentityPreserved: true,
+            nestedConditionPatched: true,
+            removedAndInserted: true,
+            ownerUpdateExecutions:
+              keyedHostOwnerFinalExecutions - keyedHostOwnerInitialExecutions,
           },
         },
       },

--- a/examples/react-compiler/src/app/globals.css
+++ b/examples/react-compiler/src/app/globals.css
@@ -1197,6 +1197,67 @@ h1 span {
   list-style: none;
 }
 
+.keyed-host-row-list {
+  display: grid;
+  max-height: 24rem;
+  gap: 0.5rem;
+  overflow: auto;
+  margin: 1rem 0 0;
+  padding: 0.75rem;
+  border: 1px solid #33332f;
+  background: #0d0d0c;
+  list-style: none;
+}
+
+.keyed-host-row-list > li {
+  display: grid;
+  grid-template-columns: minmax(8rem, 0.65fr) minmax(14rem, 1.35fr) minmax(7rem, 0.6fr);
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 42rem;
+  border: 1px solid #30302c;
+  padding: 0.65rem 0.75rem;
+  color: #c8c8c1;
+  font: 0.64rem "Geist Mono Variable", ui-monospace, monospace;
+}
+
+.keyed-host-status {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.keyed-host-status > :is(i, b) {
+  color: #666660;
+  font-size: 0.55rem;
+  font-style: normal;
+  font-weight: 500;
+}
+
+.keyed-host-status article,
+.keyed-host-status aside,
+[data-keyed-host-extra] {
+  min-width: 0;
+  color: #9d9d96;
+  font-style: normal;
+}
+
+.keyed-host-status article strong,
+.keyed-host-status article small,
+[data-keyed-host-extra] em {
+  display: block;
+  overflow: hidden;
+  color: #d8ff9f;
+  font-style: normal;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.keyed-host-status article small {
+  color: #84847d;
+}
+
 .heavy-metrics > div {
   min-width: 0;
   padding: 1.25rem 0;

--- a/examples/react-compiler/src/app/page.tsx
+++ b/examples/react-compiler/src/app/page.tsx
@@ -5,6 +5,7 @@ import { ComposableBlockExperiment } from "../components/composable-block-experi
 import { ComponentIslandExperiment } from "../components/component-island-experiment";
 import { ConditionalBlockExperiment } from "../components/conditional-block-experiment";
 import { HeavyInteractionBenchmark } from "../components/heavy-interaction-benchmark";
+import { KeyedRowHostBlockExperiment } from "../components/keyed-row-host-block-experiment";
 import { RecursiveHostBlockExperiment } from "../components/recursive-host-block-experiment";
 import { StaticBindingExperiment } from "../components/static-binding-experiment";
 
@@ -77,6 +78,8 @@ export default function HomePage() {
       <ComposableBlockExperiment />
 
       <RecursiveHostBlockExperiment />
+
+      <KeyedRowHostBlockExperiment />
 
       <section
         className="benchmark-report"

--- a/examples/react-compiler/src/components/keyed-row-host-block-experiment.tsx
+++ b/examples/react-compiler/src/components/keyed-row-host-block-experiment.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState } from "react";
+
+interface HostRow {
+  id: string;
+  label: string;
+  done: boolean;
+  detail: boolean;
+  expanded: boolean;
+}
+
+const initialRows: HostRow[] = Array.from({ length: 1_000 }, (_, index) => ({
+  id: `row-${index}`,
+  label: `Task ${index}`,
+  done: index % 2 === 0,
+  detail: index % 3 === 0,
+  expanded: index % 5 === 0,
+}));
+
+let keyedRowHostOwnerExecutions = 0;
+
+export function KeyedRowHostBlockExperiment() {
+  const [items, setItems] = useState(initialRows);
+  const [updates, setUpdates] = useState(0);
+
+  function rotateAndUpdateBranches() {
+    setItems((rows) => {
+      const rotated = [...rows.slice(1), rows[0]];
+      return rotated.map((item) => {
+        if (item.id === "row-0") {
+          return {
+            ...item,
+            label: `${item.label} · branch replaced`,
+            done: !item.done,
+            expanded: !item.expanded,
+          };
+        }
+        if (item.id === "row-12") {
+          return {
+            ...item,
+            label: `${item.label} · nested patched`,
+            detail: !item.detail,
+            expanded: !item.expanded,
+          };
+        }
+        return item;
+      });
+    });
+    setUpdates((value) => value + 1);
+  }
+
+  function removeAndInsert() {
+    setItems((rows) => [
+      ...rows.filter((item) => item.id !== "row-10"),
+      {
+        id: `inserted-${updates}`,
+        label: `Inserted after update ${updates}`,
+        done: true,
+        detail: true,
+        expanded: true,
+      },
+    ]);
+    setUpdates((value) => value + 1);
+  }
+
+  return (
+    <section className="heavy-benchmark" data-experiment="keyed-row-host-blocks">
+      <header className="heavy-heading">
+        <div>
+          <span className="experiment-number">10</span>
+          <div>
+            <p className="heavy-kicker">KEYED ROW HOST BLOCKS</p>
+            <h2>Each keyed row owns its safe nested conditions</h2>
+          </div>
+        </div>
+        <span className="node-badge">1,000 ROWS / LIS + HOST BRANCHES</span>
+      </header>
+
+      <p className="heavy-copy">
+        React creates or hydrates the list once. The compiler then keeps each safe host-only row,
+        its logical and ternary branches, and its deeper condition in one keyed instance. A single
+        update can move rows and patch those branches without rerunning this component.
+      </p>
+
+      <dl className="heavy-metrics" aria-live="polite">
+        <div>
+          <dt>Owner executions</dt>
+          <dd data-metric="keyed-host-owner-executions">
+            {typeof window === "undefined" ? 1 : ++keyedRowHostOwnerExecutions}
+          </dd>
+        </div>
+        <div>
+          <dt>Rows</dt>
+          <dd data-metric="keyed-host-rows">{items.length}</dd>
+        </div>
+        <div>
+          <dt>Updates</dt>
+          <dd data-metric="keyed-host-updates">{updates}</dd>
+        </div>
+        <div>
+          <dt>First key</dt>
+          <dd data-metric="keyed-host-first">{items[0]?.id || "empty"}</dd>
+        </div>
+      </dl>
+
+      <div className="heavy-controls composable-controls">
+        <button data-action="keyed-host-rotate" type="button" onClick={rotateAndUpdateBranches}>
+          Rotate + update conditions <span aria-hidden="true">↗</span>
+        </button>
+        <button data-action="keyed-host-replace" type="button" onClick={removeAndInsert}>
+          Remove + insert row
+        </button>
+      </div>
+
+      <ul className="keyed-host-row-list" data-keyed-host-list>
+        {items.map((item, index) => (
+          <li data-index={index} data-keyed-host-row={item.id} key={item.id}>
+            <span>{item.label}</span>
+            <div className="keyed-host-status" data-keyed-host-status>
+              <i>STATE</i>
+              {item.done ? (
+                <article
+                  className={item.detail ? "keyed-host-branch--detail" : ""}
+                  data-keyed-host-branch="done"
+                  style={{ opacity: item.detail ? 1 : 0.72 }}
+                >
+                  <strong>{item.label} complete</strong>
+                  <div>
+                    {item.detail && (
+                      <small title={item.label} data-keyed-host-detail>
+                        {item.label} detail
+                      </small>
+                    )}
+                  </div>
+                </article>
+              ) : (
+                <aside data-keyed-host-branch="open">{item.label} open</aside>
+              )}
+              <b>PREPARED</b>
+            </div>
+            <section data-keyed-host-extra>
+              {item.expanded && <em>{item.label} expanded</em>}
+            </section>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -67,7 +67,8 @@ The current compiler handles components that it can prove have:
 - item-keyed `collection.map(...)` children and explicit `List` boundaries at statically known
   container locations, including supported non-mutating collection pipelines;
 - inline synchronous events inside otherwise eligible host-only keyed rows;
-- row-local logical and ternary host branches inside stable keyed-row containers;
+- multiple and recursively nested logical or ternary host branches inside non-interactive keyed
+  rows, including branches beside static host siblings;
 - stable module-level child components with compiler-safe props;
 - React-managed event handlers; and
 - no refs, effects, or unsupported dynamic child structures.
@@ -75,11 +76,12 @@ The current compiler handles components that it can prove have:
 The generated component preserves React ownership of initial placement, props, events, SSR, and
 hydration. Local state cells batch updates into a microtask and patch only compiler-known DOM
 targets. Proven host containers can transfer child ownership after mount for host-only conditional
-branches and ranges, plus non-interactive host-only keyed rows. An interactive row or a row with
-local conditional slots uses a hybrid boundary instead: React retains its events, conditional
-Fibers, and structural reconciliation, while Farm patches same-key bindings and refreshes only
-changed row-local branches. React still creates or hydrates all initial DOM. Anything outside those
-narrow contracts uses a small React-owned boundary or the complete original component.
+branches and ranges, plus non-interactive host-only keyed rows and their recursively nested host
+conditions. An interactive row uses a hybrid boundary instead: React retains its events,
+conditional Fibers, and structural reconciliation, while Farm patches same-key bindings and
+refreshes only changed React-owned row-local branches. React still creates or hydrates all initial
+DOM. Anything outside those narrow contracts uses a small React-owned boundary or the complete
+original component.
 
 For a common dedicated conditional, no new component or annotation is required:
 
@@ -155,7 +157,7 @@ insert, removal, or reorder asks React to reconcile the rows, adopts the committ
 reapplies current bindings, and then resumes direct same-key patches. This avoids creating eventful
 DOM outside React's Fiber tree.
 
-A keyed row may also contain dedicated conditional slots:
+A non-interactive keyed row may also transfer its safe host conditions to the same keyed instance:
 
 ```tsx
 <ul>
@@ -163,7 +165,16 @@ A keyed row may also contain dedicated conditional slots:
     <li key={item.id}>
       <span>{item.label}</span>
       <div className="status-slot">
-        {item.done ? <strong>{item.label} complete</strong> : <span>In progress</span>}
+        <i>State</i>
+        {item.done ? (
+          <article>
+            <strong>{item.label} complete</strong>
+            <div>{item.details && <small>{item.description}</small>}</div>
+          </article>
+        ) : (
+          <span>In progress</span>
+        )}
+        <b>Prepared</b>
       </div>
       <section className="details-slot">{item.expanded && <p>{item.description}</p>}</section>
     </li>
@@ -171,13 +182,19 @@ A keyed row may also contain dedicated conditional slots:
 </ul>
 ```
 
-Each conditional must be the only meaningful child of its persistent lowercase host container.
-The compiler records its test and branch bindings per row key. A same-key collection update compares
-those prepared snapshots and asks React to render only the conditional boundaries whose selected
-branch or branch values changed. Other conditional rows and the outer map stay untouched. Inserts,
-removals, and reorders remain React structural commits for these rows, after which Farm re-adopts
-the host skeleton and resumes row-local updates. This keeps empty branches, SSR, hydration,
-recoverable hydration errors, error boundaries, and Fast Refresh inside React's ownership.
+The compiler prepares the row descriptor, static sibling positions, branch factories, and
+text/attribute/style bindings at build time. React creates or hydrates the initial list. After
+mount, a same-key update patches the active branch in place or mounts, replaces, or removes only the
+changed branch. Multiple and deeper host-only conditions share that row scope. Insertions and
+removals create or clean one row scope, while reorders use the normal LIS pass. The component body
+and map callback do not rerun, and no wrapper or hydration marker is added.
+
+This compiler-owned tier requires a lowercase non-interactive host row. Hooks, custom components,
+branch events, refs, SVG, fragments, spreads, dangerous HTML, controlled inputs inside a condition,
+nested keyed lists, and unproven expressions stay on React. An otherwise eligible row with inline
+events continues to use the hybrid boundary: React owns its conditional Fibers and structural
+commits, while Farm compares per-key snapshots and refreshes only changed slots. Duplicate runtime
+keys or invalid adopted DOM switch the complete list to React.
 
 A keyed collection may use derived locals or an inline chain of `filter`, `slice`, `toSorted`, and
 `toReversed`:
@@ -211,10 +228,9 @@ the TypeScript `lib` with ES2023 and target a runtime that supports them when us
 
 React remains the fallback and compatibility boundary. An interactive map beside static children,
 a non-host sibling between ranges, a row with a non-inline or async handler, a file input or dynamic
-form control shape, a fragment, a ref, a custom component, or a conditional mixed directly beside
-other children in the same host slot uses the existing React-owned keyed boundary. The outer
-compiled component can still be skipped, but React reconciles that list's rows and owns their
-events, lifecycle, and state.
+form control shape, a fragment, a ref, a custom component, or any unsupported nested dynamic
+structure uses the existing React-owned keyed boundary. The outer compiled component can still be
+skipped, but React reconciles that list's rows and owns their events, lifecycle, and state.
 
 Non-interactive host maps can share a nested or component-root container with static host siblings:
 
@@ -365,8 +381,9 @@ Application and prototype calls, dynamic style objects, handlers outside JSX eve
 computed, and rest props patterns, async handlers, unkeyed or index-keyed lists, chained maps,
 unsupported conditional roots, effects, and more advanced hook support intentionally stay on React
 in this release. Compiler-owned keyed rows support either one dedicated host-only map/`List` or
-one or more non-interactive ranges in a nested or component-root host container. Inline synchronous
-events and dedicated row-local host conditional slots can use the single-list hybrid path, but
-branch events, interactive ranges beside siblings, nested dynamic blocks, conditionals mixed with
-siblings in one slot, non-inline or async row handlers, unsupported form shapes, custom components,
-fragments, refs, SVG, and duplicate runtime keys keep or switch to React ownership.
+one or more non-interactive ranges in a nested or component-root host container. A dedicated
+non-interactive row may also contain multiple recursive logical or ternary host branches beside
+static host siblings. Inline synchronous row events continue to use the hybrid React-owned row
+path. Branch events, nested keyed lists, interactive ranges beside siblings, non-inline or async
+row handlers, unsupported form shapes, custom components, fragments, refs, SVG, and duplicate
+runtime keys keep or switch to React ownership.

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -660,6 +660,151 @@ const testSource = String.raw`
   assert.equal(keyedRowExecutions, initialKeyedRowExecutions);
   flushSync(() => keyedRowsRoot.unmount());
 
+  let keyedHostRowExecutions = 0;
+  const KeyedHostRows = createCompiledComponent({
+    displayName: "CompatibilityKeyedHostRows",
+    initialize: () => [[
+      { id: "a", label: "Alpha", done: false, detail: false },
+      { id: "b", label: "Beta", done: true, detail: true },
+      { id: "c", label: "Gamma", done: false, detail: true },
+    ]],
+    render(_props, state, blocks) {
+      keyedHostRowExecutions += 1;
+      const items = () => state[0].get();
+      const descriptor = (item, index) => {
+        const detailBranch = {
+          create: () => ({ kind: "element", tag: "small", attributes: [], styles: [], children: [item.label, " detail"] }),
+          bindings: [{ kind: "text", path: [], read: () => [item.label, " detail"] }],
+        };
+        const doneBranch = {
+          create: () => ({
+            kind: "element",
+            tag: "article",
+            attributes: [],
+            styles: [],
+            children: [
+              { kind: "element", tag: "strong", attributes: [], styles: [], children: [item.label, " done"] },
+              {
+                kind: "element",
+                tag: "div",
+                attributes: [],
+                styles: [],
+                children: [item.detail ? detailBranch.create() : null],
+                block: {
+                  kind: "conditional-ranges",
+                  id: 2,
+                  ranges: [{ before: 0, test: () => item.detail, logical: true, truthy: detailBranch }],
+                  trailing: 0,
+                },
+              },
+            ],
+          }),
+          bindings: [{ kind: "text", path: [0], read: () => [item.label, " done"] }],
+        };
+        const openBranch = {
+          create: () => ({ kind: "element", tag: "aside", attributes: [], styles: [], children: [item.label, " open"] }),
+          bindings: [{ kind: "text", path: [], read: () => [item.label, " open"] }],
+        };
+        return {
+          kind: "element",
+          tag: "li",
+          attributes: [{ name: "data-key", value: item.id }, { name: "data-index", value: index }],
+          styles: [],
+          children: [
+            { kind: "element", tag: "span", attributes: [], styles: [], children: [item.label] },
+            {
+              kind: "element",
+              tag: "div",
+              attributes: [{ name: "data-status", value: "" }],
+              styles: [],
+              children: [
+                { kind: "element", tag: "i", attributes: [], styles: [], children: ["State"] },
+                item.done ? doneBranch.create() : openBranch.create(),
+                { kind: "element", tag: "b", attributes: [], styles: [], children: ["Prepared"] },
+              ],
+              block: {
+                kind: "conditional-ranges",
+                id: 1,
+                ranges: [{ before: 1, test: () => item.done, truthy: doneBranch, falsy: openBranch }],
+                trailing: 1,
+              },
+            },
+          ],
+        };
+      };
+      const row = (item, index) => React.createElement(
+        "li",
+        { key: item.id, "data-key": item.id, "data-index": index },
+        React.createElement("span", null, item.label),
+        React.createElement(
+          "div",
+          { "data-status": true },
+          React.createElement("i", null, "State"),
+          item.done
+            ? React.createElement(
+                "article",
+                null,
+                React.createElement("strong", null, item.label, " done"),
+                React.createElement("div", null, item.detail ? React.createElement("small", null, item.label, " detail") : null),
+              )
+            : React.createElement("aside", null, item.label, " open"),
+          React.createElement("b", null, "Prepared"),
+        ),
+      );
+      return React.createElement(
+        "section",
+        null,
+        React.createElement("button", {
+          "data-keyed-host-update": true,
+          onClick: () => state[0].set((current) => {
+            const [a, b, c] = current;
+            return [{ ...c, done: true }, a, { ...b, label: "Beta newest", detail: false }];
+          }),
+        }, "Update keyed host rows"),
+        React.createElement(blocks.KeyedRows, {
+          id: 0,
+          hostBlocks: true,
+          items,
+          rowKey: (item) => item.id,
+          create: descriptor,
+          bindings: [
+            { kind: "attribute", path: [], name: "data-index", read: (_item, index) => index },
+            { kind: "text", path: [0], read: (item) => [item.label] },
+          ],
+          render: () => React.createElement("ul", null, ...items().map(row)),
+        }),
+      );
+    },
+    bindings: [
+      { kind: "block", id: 0, dependencies: [0] },
+      { kind: "block", id: 1, parent: 0, dependencies: [] },
+      { kind: "block", id: 2, parent: 1, dependencies: [] },
+    ],
+  });
+  const keyedHostContainer = document.createElement("div");
+  document.body.append(keyedHostContainer);
+  const keyedHostRoot = createRoot(keyedHostContainer);
+  flushSync(() => keyedHostRoot.render(React.createElement(KeyedHostRows)));
+  const initialKeyedHostExecutions = keyedHostRowExecutions;
+  const originalKeyedHostB = keyedHostContainer.querySelector('[data-key="b"]');
+  const originalKeyedHostBArticle = originalKeyedHostB.querySelector("article");
+  const originalKeyedHostBStatic = originalKeyedHostB.querySelector("i");
+  keyedHostContainer.querySelector("[data-keyed-host-update]").click();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.deepEqual(
+    [...keyedHostContainer.querySelectorAll("li")].map((row) => row.getAttribute("data-key")),
+    ["c", "a", "b"],
+  );
+  assert.equal(keyedHostContainer.querySelector('[data-key="b"]'), originalKeyedHostB);
+  assert.equal(keyedHostContainer.querySelector('[data-key="b"] article'), originalKeyedHostBArticle);
+  assert.equal(keyedHostContainer.querySelector('[data-key="b"] i'), originalKeyedHostBStatic);
+  assert.equal(keyedHostContainer.querySelector('[data-key="b"] strong').textContent, "Beta newest done");
+  assert.equal(keyedHostContainer.querySelector('[data-key="b"] small'), null);
+  assert.equal(keyedHostContainer.querySelector('[data-key="c"] article').textContent, "Gamma doneGamma detail");
+  assert.equal(keyedHostRowExecutions, initialKeyedHostExecutions);
+  flushSync(() => keyedHostRoot.unmount());
+
   let keyedRangeExecutions = 0;
   const KeyedRanges = createCompiledComponent({
     displayName: "CompatibilityKeyedRanges",

--- a/packages/farm-react/src/__tests__/compiler-keyed-row-conditionals.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-row-conditionals.test.ts
@@ -45,11 +45,13 @@ describe("React AOT keyed-row conditional compiler", () => {
     expect(result.compiled).toEqual(["Tasks"]);
     expect(result.diagnostics).toEqual([]);
     expect(result.code).toContain("farmBlocks.KeyedRows");
-    expect(result.code).toContain("conditionals={[");
-    expect(result.code).toContain("_farmRowConditional(item, index, 0");
-    expect(result.code).toContain("_farmRowConditional(item, index, 1");
+    expect(result.code).toContain("hostBlocks={true}");
+    expect(result.code).toContain('kind: "conditional-ranges"');
+    expect(result.code).toContain("parent: 0");
+    expect(result.code).not.toContain("conditionals={[");
+    expect(result.code).not.toContain("_farmRowConditional");
     expect(result.code).toContain("logical: true");
-    expect(result.code).toContain("logical: false");
+    expect(result.code).toContain("falsy: {");
     expect(result.code).not.toContain("farmBlocks.KeyedList");
     await expect(
       transformWithEsbuild(result.code, "/app/RowConditionals.tsx", {
@@ -92,10 +94,6 @@ describe("React AOT keyed-row conditional compiler", () => {
   });
 
   it.each([
-    {
-      name: "a conditional beside another child in the same host",
-      content: "<span>Always</span>{item.done && <strong>Done</strong>}",
-    },
     {
       name: "an event inside the conditional branch",
       content: "{item.done && <button onClick={() => setItems([])}>Done</button>}",

--- a/packages/farm-react/src/__tests__/compiler-keyed-row-host-blocks.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-row-host-blocks.test.ts
@@ -1,0 +1,237 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true);
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/KeyedRowHostBlocks.tsx", infer);
+}
+
+describe("React AOT compiler-owned keyed-row host blocks", () => {
+  it("prepares multiple and recursively nested host conditionals for automatic map syntax", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inbox({ emphasized }) {
+        const [items, setItems] = useState([
+          { id: "a", label: "Alpha", done: false, expanded: true, detail: true },
+        ]);
+        return (
+          <main>
+            <button onClick={() => setItems((rows) => [...rows].reverse())}>Reverse</button>
+            <ul data-list>
+              {items.map((item, index) => (
+                <li key={item.id} data-index={index}>
+                  <span>{item.label}</span>
+                  <div>
+                    <i>State</i>
+                    {item.done && <strong className={emphasized ? "hot" : "calm"}>Done</strong>}
+                    <b>After</b>
+                  </div>
+                  <section>
+                    {item.expanded ? (
+                      <article>
+                        <p>{item.label} details</p>
+                        <div>{item.detail && <small title={item.label}>More</small>}</div>
+                      </article>
+                    ) : (
+                      <aside>Closed</aside>
+                    )}
+                  </section>
+                </li>
+              ))}
+            </ul>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inbox"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedRows");
+    expect(result.code).toContain("hostBlocks={true}");
+    expect(result.code.match(/kind: "conditional-ranges"/g)).toHaveLength(4);
+    expect(result.code).toContain("parent: 0");
+    expect(result.code).toContain("parent: 2");
+    expect(result.code).not.toContain("_farmRowConditional");
+    expect(result.code).not.toContain('name: "key"');
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedRowHostBlocks.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({ code: expect.stringContaining("hostBlocks") });
+  });
+
+  it("supports the public List primitive without requiring another option", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List } from "@farm.js/react/list";
+      export function Inbox() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha", visible: true }]);
+        return (
+          <main>
+            <button onClick={() => setItems((rows) => [...rows])}>Refresh</button>
+            <ul>
+              <List each={items} by={(item) => item.id}>
+                {(item, index) => (
+                  <li data-index={index}>
+                    <span>{item.label}</span>
+                    <div>{item.visible ? <strong>{item.label}</strong> : <small>Hidden</small>}</div>
+                  </li>
+                )}
+              </List>
+            </ul>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inbox"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedRows");
+    expect(result.code).toContain("hostBlocks={true}");
+    expect(result.code).toContain('kind: "conditional-ranges"');
+    expect(result.code).not.toContain("_farmRowConditional");
+  });
+
+  it("keeps component state and prop reads on the parent keyed dependency", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inbox({ suffix }) {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha", visible: true }]);
+        const [tone, setTone] = useState("warm");
+        return (
+          <main>
+            <button onClick={() => setItems((rows) => [...rows])}>Refresh</button>
+            <button onClick={() => setTone((value) => value === "warm" ? "cool" : "warm")}>Tone</button>
+            <ul>
+              {items.map((item) => (
+                <li key={item.id}>
+                  <span>{item.label}{suffix}</span>
+                  <div>{item.visible && <strong className={tone}>{item.label}{suffix}</strong>}</div>
+                </li>
+              ))}
+            </ul>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inbox"]);
+    expect(result.code).toContain("hostBlocks={true}");
+    expect(result.code).toMatch(/dependencies: \[0, 1\]/);
+    expect(result.code).toContain("_props.suffix");
+  });
+
+  it.each([
+    {
+      name: "an event in a compiler-owned branch",
+      branch: "<button onClick={() => setItems([])}>Done</button>",
+    },
+    {
+      name: "a custom component branch",
+      branch: "<Status value={item.label} />",
+      declaration: "function Status({ value }) { return <strong>{value}</strong>; }",
+    },
+    {
+      name: "a ref in a branch",
+      branch: "<strong ref={() => undefined}>Done</strong>",
+    },
+    {
+      name: "an SVG branch",
+      branch: '<svg><circle cx="2" cy="2" r="2" /></svg>',
+    },
+    {
+      name: "a fragment branch",
+      branch: "<><strong>Done</strong><small>Now</small></>",
+    },
+    {
+      name: "dangerous HTML in a branch",
+      branch: "<strong dangerouslySetInnerHTML={{ __html: item.label }} />",
+    },
+    {
+      name: "a controlled input in a branch",
+      branch: "<input value={item.label} onChange={() => undefined} />",
+    },
+  ])("leaves $name on React's safe fallback", async ({ branch, declaration = "" }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      ${declaration}
+      export function Inbox() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha", done: true }]);
+        return (
+          <main>
+            <ul>
+              {items.map((item) => (
+                <li key={item.id}><div>{item.done ? ${branch} : <small>Open</small>}</div></li>
+              ))}
+            </ul>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inbox"]);
+    expect(result.code).not.toContain("hostBlocks={true}");
+  });
+
+  it("defers nested keyed lists inside a row while preserving normal React output", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inbox() {
+        const [items, setItems] = useState([{ id: "a", visible: true, children: [{ id: "x", label: "X" }] }]);
+        return (
+          <main>
+            <button onClick={() => setItems((rows) => [...rows])}>Refresh</button>
+            <ul>
+              {items.map((item) => (
+                <li key={item.id}>
+                  <div>{item.visible && <strong>Visible</strong>}</div>
+                  <ol>{item.children.map((child) => <li key={child.id}>{child.label}</li>)}</ol>
+                </li>
+              ))}
+            </ul>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inbox"]);
+    expect(result.code).not.toContain("hostBlocks={true}");
+    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.code).toContain("item.children.map");
+  });
+
+  it("keeps block ids unique across sibling lists and component-level blocks", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Dashboard() {
+        const [left, setLeft] = useState([{ id: "a", show: true }]);
+        const [right, setRight] = useState([{ id: "b", open: false }]);
+        const [ready, setReady] = useState(true);
+        return (
+          <main>
+            <button onClick={() => setLeft((rows) => [...rows])}>Left</button>
+            <button onClick={() => setRight((rows) => [...rows])}>Right</button>
+            <button onClick={() => setReady((value) => !value)}>Ready</button>
+            <div>{ready && <p>Ready</p>}</div>
+            <ul>{left.map((item) => <li key={item.id}><span>{item.show && <b>Left</b>}</span></li>)}</ul>
+            <ol>{right.map((item) => <li key={item.id}><span>{item.open ? <b>Open</b> : <i>Closed</i>}</span></li>)}</ol>
+          </main>
+        );
+      }
+    `);
+
+    const ids = [
+      ...result.code.matchAll(/kind: "block",\s+dependencies: \[[^\]]*\],\s+id: (\d+)/g),
+    ].map((match) => Number(match[1]));
+    expect(result.compiled).toEqual(["Dashboard"]);
+    expect(result.code.match(/hostBlocks=\{true\}/g)).toHaveLength(2);
+    expect(ids.length).toBeGreaterThanOrEqual(5);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-row-host-blocks.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-row-host-blocks.test.tsx
@@ -1,0 +1,799 @@
+import React, { Profiler, StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createCompiledComponent,
+  type CompiledComponentDefinition,
+  type CompilerHostConditionalBranch,
+  type CompilerHostElement,
+  type CompilerStateUpdater,
+} from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Item {
+  id: string;
+  label: string;
+  done: boolean;
+  detail: boolean;
+  expanded: boolean;
+  fail?: boolean;
+}
+
+const initialItems: Item[] = [
+  { id: "a", label: "Alpha", done: false, detail: false, expanded: true },
+  { id: "b", label: "Beta", done: true, detail: true, expanded: false },
+  { id: "c", label: "Gamma", done: false, detail: true, expanded: true },
+];
+
+const roots: Array<{ unmount(): void }> = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function host(
+  tag: string,
+  children: readonly unknown[] = [],
+  attributes: readonly { name: string; value: unknown }[] = [],
+  styles: readonly { name: string; value: unknown }[] = [],
+): CompilerHostElement {
+  return { kind: "element", tag, attributes, styles, children };
+}
+
+function rowDescriptor(item: Item, index: number, prefix: string): CompilerHostElement {
+  const detailBranch: CompilerHostConditionalBranch = {
+    create: () => host("small", [prefix, item.label], [{ name: "title", value: item.label }]),
+    bindings: [
+      { kind: "attribute", path: [], name: "title", read: () => item.label },
+      { kind: "text", path: [], read: () => [prefix, item.label] },
+    ],
+  };
+  const doneBranch: CompilerHostConditionalBranch = {
+    create: () => ({
+      ...host(
+        "article",
+        [
+          host("p", [prefix, item.label, " done"]),
+          {
+            ...host("div", [item.detail ? detailBranch.create() : null]),
+            block: {
+              kind: "conditional-ranges",
+              id: 2,
+              ranges: [
+                {
+                  before: 0,
+                  test: () => item.detail,
+                  logical: true,
+                  truthy: detailBranch,
+                },
+              ],
+              trailing: 0,
+            },
+          },
+        ],
+        [{ name: "data-tone", value: prefix }],
+        [{ name: "opacity", value: item.detail ? 1 : 0.7 }],
+      ),
+    }),
+    bindings: [
+      { kind: "attribute", path: [], name: "data-tone", read: () => prefix },
+      { kind: "style", path: [], name: "opacity", read: () => (item.detail ? 1 : 0.7) },
+      { kind: "text", path: [0], read: () => [prefix, item.label, " done"] },
+    ],
+  };
+  const openBranch: CompilerHostConditionalBranch = {
+    create: () => host("aside", [prefix, "Open"]),
+    bindings: [{ kind: "text", path: [], read: () => [prefix, "Open"] }],
+  };
+  const expandedBranch: CompilerHostConditionalBranch = {
+    create: () => host("em", [prefix, item.label]),
+    bindings: [{ kind: "text", path: [], read: () => [prefix, item.label] }],
+  };
+
+  return host(
+    "li",
+    [
+      host("span", [prefix, item.label]),
+      {
+        ...host(
+          "div",
+          [
+            host("i", ["State"]),
+            item.done ? doneBranch.create() : openBranch.create(),
+            host("b", ["After"]),
+          ],
+          [{ name: "data-status", value: "" }],
+        ),
+        block: {
+          kind: "conditional-ranges",
+          id: 1,
+          ranges: [
+            {
+              before: 1,
+              test: () => item.done,
+              truthy: doneBranch,
+              falsy: openBranch,
+            },
+          ],
+          trailing: 1,
+        },
+      },
+      {
+        ...host(
+          "section",
+          [item.expanded ? expandedBranch.create() : null],
+          [{ name: "data-extra", value: "" }],
+        ),
+        block: {
+          kind: "conditional-ranges",
+          id: 3,
+          ranges: [
+            {
+              before: 0,
+              test: () => item.expanded,
+              logical: true,
+              truthy: expandedBranch,
+            },
+          ],
+          trailing: 0,
+        },
+      },
+    ],
+    [
+      { name: "data-key", value: item.id },
+      { name: "data-index", value: index },
+    ],
+  );
+}
+
+function rowBindings(prefix: () => string) {
+  return [
+    {
+      kind: "attribute" as const,
+      path: [] as const,
+      name: "data-index",
+      read: (_item: unknown, index: number) => index,
+    },
+    {
+      kind: "text" as const,
+      path: [0] as const,
+      read: (item: unknown) => [prefix(), (item as Item).label],
+    },
+  ];
+}
+
+function RowMarkup({ item, index, prefix }: { item: Item; index: number; prefix: string }) {
+  return (
+    <li data-index={index} data-key={item.id}>
+      <span>
+        {prefix}
+        {item.label}
+      </span>
+      <div data-status>
+        <i>State</i>
+        {item.done ? (
+          <article data-tone={prefix} style={{ opacity: item.detail ? 1 : 0.7 }}>
+            <p>
+              {prefix}
+              {item.label} done
+            </p>
+            <div>
+              {item.detail ? (
+                <small title={item.label}>
+                  {prefix}
+                  {item.label}
+                </small>
+              ) : null}
+            </div>
+          </article>
+        ) : (
+          <aside>{prefix}Open</aside>
+        )}
+        <b>After</b>
+      </div>
+      <section data-extra>
+        {item.expanded ? (
+          <em>
+            {prefix}
+            {item.label}
+          </em>
+        ) : null}
+      </section>
+    </li>
+  );
+}
+
+function createHostRowsFixture(onRender?: () => void) {
+  let executions = 0;
+  let setItems: (next: CompilerStateUpdater) => void = () => undefined;
+  let setPrefix: (next: CompilerStateUpdater) => void = () => undefined;
+  const Rows = createCompiledComponent({
+    displayName: "CompilerOwnedKeyedRowHostBlocks",
+    initialize: (props: { prefix: string }) => [initialItems, props.prefix],
+    render(props: { prefix: string }, state, blocks) {
+      executions += 1;
+      onRender?.();
+      setItems = state[0].set;
+      setPrefix = state[1].set;
+      const items = () => state[0].get() as Item[];
+      const prefix = () => state[1].get() as string;
+      const KeyedRows = blocks.KeyedRows;
+      return (
+        <main data-owner-prefix={props.prefix}>
+          <KeyedRows
+            bindings={rowBindings(prefix)}
+            create={(item, index) => rowDescriptor(item as Item, index, prefix())}
+            hostBlocks
+            id={0}
+            items={items}
+            render={() => (
+              <ul data-rows>
+                {items().map((item, index) => (
+                  <RowMarkup item={item} index={index} key={item.id} prefix={prefix()} />
+                ))}
+              </ul>
+            )}
+            rowKey={(item) => (item as Item).id}
+          />
+        </main>
+      );
+    },
+    bindings: [
+      { kind: "block", id: 0, dependencies: [0, 1] },
+      { kind: "block", id: 1, parent: 0, dependencies: [] },
+      { kind: "block", id: 2, parent: 1, dependencies: [] },
+      { kind: "block", id: 3, parent: 0, dependencies: [] },
+    ],
+  });
+  return {
+    Rows,
+    executions: () => executions,
+    setItems: (next: CompilerStateUpdater) => setItems(next),
+    setPrefix: (next: CompilerStateUpdater) => setPrefix(next),
+  };
+}
+
+function semanticRows(container: Element, selector: string) {
+  return [...container.querySelectorAll<HTMLElement>(`${selector} > li`)].map((row) => {
+    const status = row.querySelector<HTMLElement>("[data-status] > article, [data-status] > aside");
+    const detail = row.querySelector<HTMLElement>("[data-status] small");
+    return {
+      key: row.dataset.key,
+      index: row.dataset.index,
+      label: row.querySelector("span")?.textContent,
+      statusTag: status?.tagName,
+      statusText: status?.textContent,
+      tone: status?.dataset.tone,
+      opacity: status?.style.opacity,
+      detail: detail?.textContent,
+      detailTitle: detail?.getAttribute("title"),
+      extra: row.querySelector("[data-extra]")?.textContent,
+    };
+  });
+}
+
+class Boundary extends React.Component<{ children: React.ReactNode }, { message: string | null }> {
+  state = { message: null as string | null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { message: error.message };
+  }
+
+  render() {
+    return this.state.message ? <p data-error>{this.state.message}</p> : this.props.children;
+  }
+}
+
+describe("compiler-owned keyed-row host blocks runtime", () => {
+  it("patches recursive branches during an LIS reorder without React commits or lost identity", async () => {
+    let profilerCommits = 0;
+    const fixture = createHostRowsFixture();
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <StrictMode>
+          <Profiler id="rows" onRender={() => (profilerCommits += 1)}>
+            <fixture.Rows prefix="Initial: " />
+          </Profiler>
+        </StrictMode>,
+      ),
+    );
+
+    const executionsAfterMount = fixture.executions();
+    const commitsAfterMount = profilerCommits;
+    const rows = new Map(
+      [...container.querySelectorAll<HTMLElement>("[data-key]")].map((row) => [
+        row.dataset.key,
+        row,
+      ]),
+    );
+    const betaArticle = rows.get("b")?.querySelector("article");
+    const betaStaticBefore = rows.get("b")?.querySelector("i");
+    const betaStaticAfter = rows.get("b")?.querySelector("b");
+
+    await act(async () => {
+      fixture.setItems((current) => {
+        const [a, b, c] = current as Item[];
+        return [
+          { ...c, label: "Gamma newest", done: true, detail: false },
+          { ...a, expanded: false },
+          { ...b, label: "Beta newest", detail: true, expanded: true },
+        ];
+      });
+      fixture.setPrefix("Live: ");
+      await flushCompilerUpdates();
+    });
+
+    const reordered = [...container.querySelectorAll<HTMLElement>("[data-key]")];
+    expect(reordered.map((row) => row.dataset.key)).toEqual(["c", "a", "b"]);
+    expect(reordered[0]).toBe(rows.get("c"));
+    expect(reordered[1]).toBe(rows.get("a"));
+    expect(reordered[2]).toBe(rows.get("b"));
+    expect(rows.get("b")?.querySelector("article")).toBe(betaArticle);
+    expect(rows.get("b")?.querySelector("i")).toBe(betaStaticBefore);
+    expect(rows.get("b")?.querySelector("b")).toBe(betaStaticAfter);
+    expect(rows.get("b")?.querySelector("p")?.textContent).toBe("Live: Beta newest done");
+    expect(rows.get("b")?.querySelector("small")?.textContent).toBe("Live: Beta newest");
+    expect(rows.get("b")?.querySelector("em")?.textContent).toBe("Live: Beta newest");
+    expect(rows.get("c")?.querySelector("article")?.style.opacity).toBe("0.7");
+    expect(rows.get("a")?.querySelector("aside")?.textContent).toBe("Live: Open");
+    expect(fixture.executions()).toBe(executionsAfterMount);
+    expect(profilerCommits).toBe(commitsAfterMount);
+  });
+
+  it("combines parent props and local updates, then drops queued work on unmount", async () => {
+    const fixture = createHostRowsFixture();
+    function Parent() {
+      const [prefix, setPrefix] = useState("Prop A");
+      return (
+        <>
+          <button data-parent onClick={() => setPrefix("Prop B")} />
+          <fixture.Rows prefix={prefix} />
+        </>
+      );
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Parent />));
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("[data-parent]")?.click();
+      fixture.setPrefix("Local: ");
+      fixture.setItems((current) =>
+        (current as Item[]).map((item) =>
+          item.id === "a" ? { ...item, label: "Alpha updated", done: true } : item,
+        ),
+      );
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("main")?.getAttribute("data-owner-prefix")).toBe("Prop B");
+    expect(container.querySelector('[data-key="a"] article p')?.textContent).toBe(
+      "Local: Alpha updated done",
+    );
+
+    fixture.setItems((current) => [...(current as Item[])].reverse());
+    await act(async () => root.unmount());
+    roots.splice(roots.indexOf(root), 1);
+    await flushCompilerUpdates();
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("preserves keyed state and replaces recursive descriptors through Fast Refresh", async () => {
+    const hmrId = `keyed-row-host-blocks-refresh-${Math.random()}`;
+    const definition = (prefix: string): CompiledComponentDefinition<Record<string, never>> => ({
+      displayName: "RefreshKeyedRowHostBlocks",
+      hmrId,
+      stateSignature: "items",
+      initialize: () => [[initialItems[1]]],
+      render(_props, state, blocks) {
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <button
+              onClick={() =>
+                state[0].set((current) => [{ ...(current as Item[])[0], label: "Updated" }])
+              }
+              type="button"
+            >
+              Update
+            </button>
+            <KeyedRows
+              bindings={rowBindings(() => prefix)}
+              create={(item, index) => rowDescriptor(item as Item, index, prefix)}
+              hostBlocks
+              id={0}
+              items={items}
+              render={() => (
+                <ul>
+                  {items().map((item, index) => (
+                    <RowMarkup item={item} index={index} key={item.id} prefix={prefix} />
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+            />
+          </main>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        { kind: "block", id: 1, parent: 0, dependencies: [] },
+        { kind: "block", id: 2, parent: 1, dependencies: [] },
+        { kind: "block", id: 3, parent: 0, dependencies: [] },
+      ],
+    });
+
+    const Initial = createCompiledComponent(definition("Before: "));
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Initial />));
+    const row = container.querySelector("li");
+    const branch = container.querySelector("article");
+
+    let Refreshed = Initial;
+    await act(async () => {
+      Refreshed = createCompiledComponent(definition("After: "));
+      root.render(<Refreshed />);
+      await flushCompilerUpdates();
+    });
+    expect(Refreshed).toBe(Initial);
+    expect(container.querySelector("li")).toBe(row);
+    expect(container.querySelector("article")).toBe(branch);
+    expect(container.querySelector("article p")?.textContent).toBe("After: Beta done");
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("button")?.click();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("article")).toBe(branch);
+    expect(container.querySelector("article p")?.textContent).toBe("After: Updated done");
+  });
+
+  it("falls back safely and stays live when runtime keys are duplicated", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    let setItems: (next: CompilerStateUpdater) => void = () => undefined;
+    const BrokenRows = createCompiledComponent({
+      displayName: "BrokenHostRows",
+      initialize: () => [initialItems],
+      render(_props: Record<string, never>, state, blocks) {
+        setItems = state[0].set;
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <KeyedRows
+              bindings={rowBindings(() => "")}
+              create={(value, index) => rowDescriptor(value as Item, index, "")}
+              hostBlocks
+              id={0}
+              items={items}
+              render={() => (
+                <ul>
+                  {items().map((item, index) => (
+                    <RowMarkup item={item} index={index} key={`${item.id}:${index}`} prefix="" />
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+            />
+          </main>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        { kind: "block", id: 1, parent: 0, dependencies: [] },
+        { kind: "block", id: 2, parent: 1, dependencies: [] },
+        { kind: "block", id: 3, parent: 0, dependencies: [] },
+      ],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <Boundary>
+          <BrokenRows />
+        </Boundary>,
+      ),
+    );
+
+    await act(async () => {
+      setItems([
+        { ...initialItems[0], label: "First" },
+        { ...initialItems[0], label: "Duplicate" },
+      ]);
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelectorAll("[data-key]")).toHaveLength(2);
+    expect(container.textContent).toContain("Duplicate");
+
+    await act(async () => {
+      setItems([{ ...initialItems[2], id: "safe", label: "Safe again" }]);
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector('[data-key="safe"] span')?.textContent).toBe("Safe again");
+  });
+
+  it("routes recursive row binding errors through the nearest React boundary", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    let setItems: (next: CompilerStateUpdater) => void = () => undefined;
+    const ErrorRows = createCompiledComponent({
+      displayName: "ErrorHostRows",
+      initialize: () => [[initialItems[0]]],
+      render(_props: Record<string, never>, state, blocks) {
+        setItems = state[0].set;
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <KeyedRows
+              bindings={rowBindings(() => "")}
+              create={(value, index) => {
+                const item = value as Item;
+                const descriptor = rowDescriptor(item, index, "");
+                const status = descriptor.children[1] as CompilerHostElement;
+                const range =
+                  status.block?.kind === "conditional-ranges" ? status.block.ranges[0] : null;
+                if (range?.truthy && item.fail) {
+                  range.truthy = {
+                    ...range.truthy,
+                    bindings: [
+                      {
+                        kind: "text",
+                        path: [0],
+                        read: () => {
+                          throw new Error("keyed row host binding failed");
+                        },
+                      },
+                    ],
+                  };
+                }
+                return descriptor;
+              }}
+              hostBlocks
+              id={0}
+              items={items}
+              render={() => (
+                <ul>
+                  {items().map((item, index) => (
+                    <RowMarkup item={item} index={index} key={item.id} prefix="" />
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+            />
+          </main>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        { kind: "block", id: 1, parent: 0, dependencies: [] },
+        { kind: "block", id: 2, parent: 1, dependencies: [] },
+        { kind: "block", id: 3, parent: 0, dependencies: [] },
+      ],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <Boundary>
+          <ErrorRows />
+        </Boundary>,
+      ),
+    );
+    await act(async () => {
+      setItems([{ ...initialItems[0], done: true, detail: true, fail: true }]);
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("[data-error]")?.textContent).toBe(
+      "keyed row host binding failed",
+    );
+  });
+
+  it("adopts server rows and remains live after recoverable hydration mismatches", async () => {
+    for (const mismatch of [false, true]) {
+      const fixture = createHostRowsFixture();
+      const container = document.createElement("div");
+      const serverHtml = renderToString(<fixture.Rows prefix="SSR: " />);
+      container.innerHTML = mismatch ? serverHtml.replace("Alpha", "Server mismatch") : serverHtml;
+      document.body.append(container);
+      const recoverable = vi.fn();
+      let root!: ReturnType<typeof hydrateRoot>;
+      await act(async () => {
+        root = hydrateRoot(container, <fixture.Rows prefix="SSR: " />, {
+          onRecoverableError: recoverable,
+        });
+        await flushCompilerUpdates();
+      });
+      roots.push(root);
+
+      expect(container.querySelector('[data-key="a"] span')?.textContent).toBe("SSR: Alpha");
+      if (mismatch) expect(recoverable).toHaveBeenCalled();
+      else expect(recoverable).not.toHaveBeenCalled();
+      await act(async () => {
+        fixture.setItems((current) =>
+          (current as Item[]).map((item) =>
+            item.id === "a" ? { ...item, label: "Hydrated", done: true, detail: true } : item,
+          ),
+        );
+        await flushCompilerUpdates();
+      });
+      expect(container.querySelector('[data-key="a"] article p')?.textContent).toBe(
+        "SSR: Hydrated done",
+      );
+
+      await act(async () => root.unmount());
+      roots.splice(roots.indexOf(root), 1);
+      container.remove();
+    }
+  });
+
+  it("matches normal React through 2,000 deterministic row, branch, and order transitions", async () => {
+    type Action = "reverse" | "rotate" | "toggle" | "detail" | "expand" | "edit" | "add" | "remove";
+    let compiledSet: (next: CompilerStateUpdater) => void = () => undefined;
+    let normalSet: React.Dispatch<React.SetStateAction<Item[]>> = () => undefined;
+    let compiledExecutions = 0;
+
+    const transition = (items: Item[], action: Action, step: number): Item[] => {
+      if (action === "reverse") return [...items].reverse();
+      if (action === "rotate" && items.length > 1) return [...items.slice(1), items[0]];
+      if (action === "toggle" && items.length > 0) {
+        return items.map((item, index) =>
+          index === step % items.length ? { ...item, done: !item.done } : item,
+        );
+      }
+      if (action === "detail" && items.length > 0) {
+        return items.map((item, index) =>
+          index === step % items.length ? { ...item, detail: !item.detail } : item,
+        );
+      }
+      if (action === "expand" && items.length > 0) {
+        return items.map((item, index) =>
+          index === step % items.length ? { ...item, expanded: !item.expanded } : item,
+        );
+      }
+      if (action === "edit" && items.length > 0) {
+        return items.map((item, index) =>
+          index === step % items.length ? { ...item, label: `${item.label}!` } : item,
+        );
+      }
+      if (action === "add" && items.length < 12) {
+        let candidate = step;
+        const ids = new Set(items.map((item) => item.id));
+        while (ids.has(`n${candidate}`)) candidate += 1;
+        return [
+          ...items,
+          {
+            id: `n${candidate}`,
+            label: `New ${candidate}`,
+            done: step % 2 === 0,
+            detail: true,
+            expanded: false,
+          },
+        ];
+      }
+      if (action === "remove" && items.length > 1) return items.slice(1);
+      return items;
+    };
+
+    const Compiled = createCompiledComponent({
+      displayName: "KeyedRowHostDifferential",
+      initialize: () => [initialItems],
+      render(_props: Record<string, never>, state, blocks) {
+        compiledExecutions += 1;
+        compiledSet = state[0].set;
+        const items = () => state[0].get() as Item[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <div data-compiled>
+            <KeyedRows
+              bindings={rowBindings(() => "Test: ")}
+              create={(item, index) => rowDescriptor(item as Item, index, "Test: ")}
+              hostBlocks
+              id={0}
+              items={items}
+              render={() => (
+                <ul>
+                  {items().map((item, index) => (
+                    <RowMarkup item={item} index={index} key={item.id} prefix="Test: " />
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+            />
+          </div>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        { kind: "block", id: 1, parent: 0, dependencies: [] },
+        { kind: "block", id: 2, parent: 1, dependencies: [] },
+        { kind: "block", id: 3, parent: 0, dependencies: [] },
+      ],
+    });
+
+    function Normal() {
+      const [items, setItems] = useState(initialItems);
+      normalSet = setItems;
+      return (
+        <div data-normal>
+          <ul>
+            {items.map((item, index) => (
+              <RowMarkup item={item} index={index} key={item.id} prefix="Test: " />
+            ))}
+          </ul>
+        </div>
+      );
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <>
+          <Compiled />
+          <Normal />
+        </>,
+      ),
+    );
+    const executionsAfterMount = compiledExecutions;
+    const actions: Action[] = [
+      "reverse",
+      "rotate",
+      "toggle",
+      "detail",
+      "expand",
+      "edit",
+      "add",
+      "remove",
+    ];
+    let random = 0x5eed1234;
+    for (let step = 0; step < 2000; step += 1) {
+      random = (random * 1664525 + 1013904223) >>> 0;
+      const action = actions[random % actions.length];
+      await act(async () => {
+        compiledSet((current) => transition(current as Item[], action, step));
+        normalSet((current) => transition(current, action, step));
+        await flushCompilerUpdates();
+      });
+      expect(semanticRows(container, "[data-compiled] ul")).toEqual(
+        semanticRows(container, "[data-normal] ul"),
+      );
+    }
+    expect(compiledExecutions).toBe(executionsAfterMount);
+  }, 15_000);
+});

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -184,6 +184,8 @@ export interface CompilerKeyedRowsBlockProps {
   bindings: readonly CompilerKeyedRowBinding[];
   events?: readonly CompilerKeyedRowEvent[];
   conditionals?: readonly CompilerKeyedRowConditional[];
+  /** Row descriptors contain compiler-owned nested host scopes. */
+  hostBlocks?: boolean;
 }
 
 export interface CompilerKeyedRange {
@@ -807,6 +809,7 @@ function applyHostConditionalBindings(
 
 interface CompilerHostTreeScope {
   cleanup(): void;
+  update(descriptor: CompilerHostElement): boolean;
 }
 
 const UNSET_HOST_CONDITIONAL_BINDING = Symbol("unset host conditional binding");
@@ -871,6 +874,14 @@ function mountCompilerHostTree(
   }
   let active = true;
   return {
+    update(nextDescriptor) {
+      if (!active || nextDescriptor.block || !matchesCompilerHostElement(element, nextDescriptor)) {
+        return false;
+      }
+      const nextChildren = flattenCompilerHostElements(nextDescriptor.children);
+      if (nextChildren.length !== scopes.length) return false;
+      return scopes.every((scope, index) => scope.update(nextChildren[index]));
+    },
     cleanup() {
       if (!active) return;
       active = false;
@@ -917,8 +928,8 @@ class CompilerNestedConditionalRanges implements CompilerHostTreeScope {
   constructor(
     private readonly owner: Pick<ConditionalBlockOwner, "subscribe">,
     private readonly root: Element,
-    private readonly host: CompilerHostElement,
-    private readonly block: CompilerHostConditionalRanges,
+    private host: CompilerHostElement,
+    private block: CompilerHostConditionalRanges,
     private readonly onFallback: () => void,
   ) {}
 
@@ -1038,15 +1049,7 @@ class CompilerNestedConditionalRanges implements CompilerHostTreeScope {
     }
     if (previous?.key === selection.key) {
       const descriptor = selection.branch.create();
-      previous.host.scope?.cleanup();
-      const scope = mountCompilerHostTree(
-        this.owner,
-        previous.host.element,
-        descriptor,
-        this.onFallback,
-      );
-      if (!scope) return false;
-      previous.host.scope = scope;
+      if (!previous.host.scope?.update(descriptor)) return false;
       applyHostConditionalBindings(selection.branch, previous.host);
       return true;
     }
@@ -1089,6 +1092,52 @@ class CompilerNestedConditionalRanges implements CompilerHostTreeScope {
     afterCommit?.();
   };
 
+  private updateStaticScopes(
+    descriptor: CompilerHostElement,
+    selections: readonly CompilerHostConditionalPreparedSelection[],
+  ): boolean {
+    const descriptors = flattenCompilerHostElements(descriptor.children);
+    let descriptorIndex = 0;
+    let scopeIndex = 0;
+    for (let rangeIndex = 0; rangeIndex < this.block.ranges.length; rangeIndex += 1) {
+      const range = this.block.ranges[rangeIndex];
+      for (let index = 0; index < range.before; index += 1) {
+        const scope = this.staticScopes[scopeIndex++];
+        const child = descriptors[descriptorIndex++];
+        if (!scope || !child || !scope.update(child)) return false;
+      }
+      if (selections[rangeIndex].kind === "branch") descriptorIndex += 1;
+    }
+    for (let index = 0; index < this.block.trailing; index += 1) {
+      const scope = this.staticScopes[scopeIndex++];
+      const child = descriptors[descriptorIndex++];
+      if (!scope || !child || !scope.update(child)) return false;
+    }
+    return scopeIndex === this.staticScopes.length && descriptorIndex === descriptors.length;
+  }
+
+  update(descriptor: CompilerHostElement): boolean {
+    const block = descriptor.block;
+    if (
+      !this.active ||
+      block?.kind !== "conditional-ranges" ||
+      block.id !== this.block.id ||
+      block.ranges.length !== this.block.ranges.length ||
+      block.trailing !== this.block.trailing ||
+      block.ranges.some((range, index) => range.before !== this.block.ranges[index].before)
+    ) {
+      return false;
+    }
+    this.host = descriptor;
+    this.block = block;
+    const selections = this.readSelections();
+    if (!selections || !this.updateStaticScopes(descriptor, selections)) return false;
+    for (let index = this.instances.length - 1; index >= 0; index -= 1) {
+      if (!this.reconcileRange(index, selections[index])) return false;
+    }
+    return true;
+  }
+
   cleanup(): void {
     if (!this.active) return;
     this.active = false;
@@ -1116,8 +1165,8 @@ class CompilerNestedKeyedRanges implements CompilerHostTreeScope {
   constructor(
     private readonly owner: Pick<ConditionalBlockOwner, "subscribe">,
     private readonly root: Element,
-    private readonly host: CompilerHostElement,
-    private readonly block: CompilerHostKeyedRanges,
+    private host: CompilerHostElement,
+    private block: CompilerHostKeyedRanges,
     private readonly onFallback: () => void,
   ) {}
 
@@ -1253,6 +1302,8 @@ class CompilerNestedKeyedRanges implements CompilerHostTreeScope {
       const key = rows.keys[index];
       const existing = previous.get(key);
       if (existing) {
+        const descriptor = range.create(rows.items[index], index);
+        if (!existing.scope?.update(descriptor)) return false;
         applyKeyedRowBindings(range, existing, rows.items[index], index);
         existing.item = rows.items[index];
         existing.index = index;
@@ -1319,6 +1370,58 @@ class CompilerNestedKeyedRanges implements CompilerHostTreeScope {
     }
     afterCommit?.();
   };
+
+  private updateStaticScopes(
+    descriptor: CompilerHostElement,
+    rowsByRange: readonly NestedReadKeyedRange[],
+  ): boolean {
+    const descriptors = flattenCompilerHostElements(descriptor.children);
+    let descriptorIndex = 0;
+    let scopeIndex = 0;
+    for (let rangeIndex = 0; rangeIndex < this.block.ranges.length; rangeIndex += 1) {
+      const range = this.block.ranges[rangeIndex];
+      for (let index = 0; index < range.before; index += 1) {
+        const scope = this.staticScopes[scopeIndex++];
+        const child = descriptors[descriptorIndex++];
+        if (!scope || !child || !scope.update(child)) return false;
+      }
+      descriptorIndex += rowsByRange[rangeIndex].items.length;
+    }
+    for (let index = 0; index < this.block.trailing; index += 1) {
+      const scope = this.staticScopes[scopeIndex++];
+      const child = descriptors[descriptorIndex++];
+      if (!scope || !child || !scope.update(child)) return false;
+    }
+    return scopeIndex === this.staticScopes.length && descriptorIndex === descriptors.length;
+  }
+
+  update(descriptor: CompilerHostElement): boolean {
+    const block = descriptor.block;
+    if (
+      !this.active ||
+      block?.kind !== "keyed-ranges" ||
+      block.id !== this.block.id ||
+      block.ranges.length !== this.block.ranges.length ||
+      block.trailing !== this.block.trailing ||
+      block.ranges.some((range, index) => range.before !== this.block.ranges[index].before)
+    ) {
+      return false;
+    }
+    this.host = descriptor;
+    this.block = block;
+    const rowsByRange = this.readRanges();
+    if (
+      !rowsByRange ||
+      rowsByRange.length !== this.instances.length ||
+      !this.updateStaticScopes(descriptor, rowsByRange)
+    ) {
+      return false;
+    }
+    for (let index = rowsByRange.length - 1; index >= 0; index -= 1) {
+      if (!this.reconcileRange(index, rowsByRange[index])) return false;
+    }
+    return true;
+  }
 
   cleanup(): void {
     if (!this.active) return;
@@ -1888,6 +1991,10 @@ function createKeyedRowsBlockComponent(
     fallback: boolean;
   }
 
+  const rowHostScopeOwner: Pick<ConditionalBlockOwner, "subscribe"> = {
+    subscribe: () => () => {},
+  };
+
   type RowConditionalRefresh = (item: unknown, index: number, afterCommit?: () => void) => void;
 
   interface RowConditionalOwner {
@@ -1992,6 +2099,10 @@ function createKeyedRowsBlockComponent(
       this.root = root;
     };
 
+    private requestHostScopeFallback = () => {
+      this.activateFallback();
+    };
+
     private readRows(
       props: CompilerKeyedRowsBlockProps,
     ): { items: unknown[]; keys: string[] } | null {
@@ -2071,6 +2182,26 @@ function createKeyedRowsBlockComponent(
       return Boolean(props.events?.length || props.conditionals?.length);
     }
 
+    private cleanupHostScopes(
+      instances: ReadonlyMap<string, CompilerKeyedRowInstance> = this.instances,
+    ): void {
+      for (const instance of instances.values()) instance.scope?.cleanup();
+    }
+
+    private mountRowHostScope(
+      element: Element,
+      descriptor: CompilerHostElement,
+      props: CompilerKeyedRowsBlockProps = this.currentProps,
+    ): CompilerHostTreeScope | null | undefined {
+      if (!props.hostBlocks) return undefined;
+      return mountCompilerHostTree(
+        rowHostScopeOwner,
+        element,
+        descriptor,
+        this.requestHostScopeFallback,
+      );
+    }
+
     private pruneEventHandlers(keys: readonly string[]): void {
       const active = new Set(keys);
       for (const key of this.eventHandlers.keys()) {
@@ -2095,19 +2226,23 @@ function createKeyedRowsBlockComponent(
       );
       const instances = new Map<string, CompilerKeyedRowInstance>();
       for (let index = 0; index < rows.items.length; index += 1) {
+        const descriptor = this.currentProps.create(rows.items[index], index);
         if (
           this.hasReactOwnedRows() &&
-          !matchesCompilerHostElement(
-            elements[index],
-            this.currentProps.create(rows.items[index], index),
-            opaqueConditionalPaths,
-          )
+          !matchesCompilerHostElement(elements[index], descriptor, opaqueConditionalPaths)
         ) {
+          this.cleanupHostScopes(instances);
+          return false;
+        }
+        const scope = this.mountRowHostScope(elements[index], descriptor);
+        if (this.currentProps.hostBlocks && !scope) {
+          this.cleanupHostScopes(instances);
           return false;
         }
         const instance: CompilerKeyedRowInstance = {
           key: rows.keys[index],
           element: elements[index],
+          scope: scope || undefined,
           values: this.hasReactOwnedRows()
             ? this.currentProps.bindings.map(() => UNSET_KEYED_ROW_BINDING)
             : readKeyedRowBindingValues(this.currentProps, rows.items[index], index),
@@ -2128,6 +2263,7 @@ function createKeyedRowsBlockComponent(
         }
         instances.set(rows.keys[index], instance);
       }
+      this.cleanupHostScopes();
       this.instances = instances;
       this.pruneEventHandlers(rows.keys);
       this.pruneConditionalListeners(rows.keys);
@@ -2151,6 +2287,7 @@ function createKeyedRowsBlockComponent(
       this.fallbackKeysWereUnsafe = this.hasUnsafeFallbackKeys();
       // One key change on entry: the compiled path mutated the DOM behind
       // React's back, so the first fallback render must rebuild the subtree.
+      this.cleanupHostScopes();
       this.fallbackVersion += 1;
       this.setState({ fallback: true }, afterCommit);
     }
@@ -2242,7 +2379,10 @@ function createKeyedRowsBlockComponent(
       [...this.instances].forEach(([key], index) => oldIndices.set(key, index));
       const nextKeys = new Set(rows.keys);
       for (const [key, instance] of this.instances) {
-        if (!nextKeys.has(key)) instance.element.remove();
+        if (!nextKeys.has(key)) {
+          instance.scope?.cleanup();
+          instance.element.remove();
+        }
       }
 
       const sequence = rows.keys.map((key) => oldIndices.get(key) ?? -1);
@@ -2258,6 +2398,13 @@ function createKeyedRowsBlockComponent(
         const key = rows.keys[index];
         const existing = this.instances.get(key);
         if (existing) {
+          if (this.currentProps.hostBlocks) {
+            const descriptor = this.currentProps.create(rows.items[index], index);
+            if (!existing.scope?.update(descriptor)) {
+              this.activateFallback(afterCommit);
+              return;
+            }
+          }
           applyKeyedRowBindings(this.currentProps, existing, rows.items[index], index);
           const conditionalValues = readKeyedRowConditionalValues(
             this.currentProps,
@@ -2275,13 +2422,20 @@ function createKeyedRowsBlockComponent(
           nextInstances.push(existing);
           continue;
         }
-        const element = createCompilerHostElement(
-          this.root.ownerDocument,
-          this.currentProps.create(rows.items[index], index),
-        );
+        const descriptor = this.currentProps.create(rows.items[index], index);
+        const element = createCompilerHostElement(this.root.ownerDocument, descriptor);
+        const scope = this.mountRowHostScope(element, descriptor);
+        if (this.currentProps.hostBlocks && !scope) {
+          for (const instance of nextInstances) {
+            if (!this.instances.has(instance.key)) instance.scope?.cleanup();
+          }
+          this.activateFallback(afterCommit);
+          return;
+        }
         nextInstances.push({
           key,
           element,
+          scope: scope || undefined,
           values: readKeyedRowBindingValues(this.currentProps, rows.items[index], index),
           item: rows.items[index],
           index,
@@ -2368,6 +2522,7 @@ function createKeyedRowsBlockComponent(
       this.mounted = false;
       this.unsubscribe?.();
       this.root = null;
+      this.cleanupHostScopes();
       this.instances.clear();
       this.eventHandlers.clear();
       this.conditionalListeners.clear();

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -149,6 +149,7 @@ interface KeyedRowsPlan {
   bindings: PendingKeyedRowBinding[];
   events: PendingKeyedRowEvent[];
   conditionals: PendingKeyedRowConditional[];
+  descriptorBlocks?: ReadonlyMap<t.JSXElement, HostDescriptorBlockPlan>;
   syntax: "map" | "list";
 }
 
@@ -932,6 +933,7 @@ interface KeyedRowsShape {
   bindings: PendingKeyedRowBinding[];
   events: PendingKeyedRowEvent[];
   conditionals: PendingKeyedRowConditional[];
+  rowReason?: string;
   syntax: "map" | "list";
 }
 
@@ -1321,6 +1323,7 @@ function analyzeKeyedRowChild(
   statesByValue: ReadonlyMap<string, StateBinding>,
   safeGlobals: ReadonlySet<string>,
   listNames: ReadonlySet<string>,
+  acceptUnsupportedRow = false,
 ): KeyedRowChildShape | undefined {
   let collection: t.Expression;
   let keyCallback: t.ArrowFunctionExpression | t.FunctionExpression;
@@ -1389,7 +1392,7 @@ function analyzeKeyedRowChild(
     safeGlobals,
     new Set([...statesByValue.values()].map((state) => state.setterName)),
   );
-  if (rowAnalysis.reason) return undefined;
+  if (rowAnalysis.reason && !acceptUnsupportedRow) return undefined;
   return {
     source,
     collection,
@@ -1400,6 +1403,7 @@ function analyzeKeyedRowChild(
     bindings: rowAnalysis.bindings || [],
     events: rowAnalysis.events || [],
     conditionals: rowAnalysis.conditionals || [],
+    rowReason: rowAnalysis.reason,
     syntax,
   };
 }
@@ -1436,7 +1440,7 @@ function analyzeKeyedRowsContainer(
 
   const children = meaningfulJsxChildren(container);
   if (children.length !== 1) return undefined;
-  return analyzeKeyedRowChild(children[0], statesByValue, safeGlobals, listNames);
+  return analyzeKeyedRowChild(children[0], statesByValue, safeGlobals, listNames, true);
 }
 
 function isStaticRangeSibling(
@@ -1953,6 +1957,50 @@ function analyzeRecursiveHostTree(
 
   const reason = visit(branch, [], parent);
   return { bindings, plans, blocks, reason };
+}
+
+function analyzeCompilerOwnedKeyedRowHostBlocks(
+  shape: KeyedRowsShape,
+  statesByValue: ReadonlyMap<string, StateBinding>,
+  safeGlobals: ReadonlySet<string>,
+  listNames: ReadonlySet<string>,
+  parent: number,
+  allocateId: () => number,
+):
+  | {
+      row: t.JSXElement;
+      bindings: PendingKeyedRowBinding[];
+      descriptorBlocks: ReadonlyMap<t.JSXElement, HostDescriptorBlockPlan>;
+      nestedPlans: HostDescriptorBlockPlan[];
+    }
+  | undefined {
+  if (shape.events.length > 0) return undefined;
+
+  const row = t.cloneNode(shape.row, true);
+  row.openingElement.attributes = row.openingElement.attributes.filter(
+    (attribute) => !t.isJSXAttribute(attribute) || jsxAttributeName(attribute) !== "key",
+  );
+  const analysis = analyzeRecursiveHostTree(
+    row,
+    statesByValue,
+    safeGlobals,
+    listNames,
+    parent,
+    allocateId,
+  );
+  if (
+    analysis.reason ||
+    analysis.plans.length === 0 ||
+    analysis.plans.some((plan) => plan.kind !== "nested-host-conditional-ranges")
+  ) {
+    return undefined;
+  }
+  return {
+    row,
+    bindings: analysis.bindings,
+    descriptorBlocks: analysis.blocks,
+    nestedPlans: analysis.plans,
+  };
 }
 
 function analyzeHostConditionalContainer(
@@ -2617,7 +2665,7 @@ function keyedRowsBoundary(blockRuntime: t.Identifier, plan: KeyedRowsPlan): t.J
           t.jsxExpressionContainer(
             t.arrowFunctionExpression(
               parameters.map((parameter) => t.cloneNode(parameter, true)),
-              hostElementDescriptor(plan.row),
+              hostElementDescriptor(plan.row, plan.descriptorBlocks),
             ),
           ),
         ),
@@ -2652,6 +2700,14 @@ function keyedRowsBoundary(blockRuntime: t.Identifier, plan: KeyedRowsPlan): t.J
                     ),
                   ),
                 ),
+              ),
+            ]
+          : []),
+        ...(plan.descriptorBlocks?.size
+          ? [
+              t.jsxAttribute(
+                t.jsxIdentifier("hostBlocks"),
+                t.jsxExpressionContainer(t.booleanLiteral(true)),
               ),
             ]
           : []),
@@ -3195,26 +3251,48 @@ function analyzeComposableBlocks(
             continue;
           }
           nextId = hostConditionalStart;
+          const keyedRowsStart = nextId;
+          const keyedRowsId = nextId++;
           const keyedRows = analyzeKeyedRowsContainer(child, statesByValue, safeGlobals, listNames);
           if (keyedRows) {
+            const nestedStart = nextId;
+            const hostBlocks = analyzeCompilerOwnedKeyedRowHostBlocks(
+              keyedRows,
+              statesByValue,
+              safeGlobals,
+              listNames,
+              keyedRowsId,
+              () => nextId++,
+            );
+            if (!hostBlocks) nextId = nestedStart;
+            if (keyedRows.rowReason && !hostBlocks) {
+              nextId = keyedRowsStart;
+              const nested = visitHost(child, parent, insideConditional);
+              if (nested.reason) return { dependencies, reason: nested.reason };
+              mergeDependencies(dependencies, nested.dependencies);
+              continue;
+            }
             plans.push({
               kind: "keyed-rows",
-              id: nextId++,
+              id: keyedRowsId,
               parent,
               dependencies: keyedRows.dependencies,
               source: child,
               collection: keyedRows.collection,
               keyCallback: keyedRows.keyCallback,
               renderCallback: keyedRows.renderCallback,
-              row: keyedRows.row,
-              bindings: keyedRows.bindings,
+              row: hostBlocks?.row || keyedRows.row,
+              bindings: hostBlocks?.bindings || keyedRows.bindings,
               events: keyedRows.events,
-              conditionals: keyedRows.conditionals,
+              conditionals: hostBlocks ? [] : keyedRows.conditionals,
+              descriptorBlocks: hostBlocks?.descriptorBlocks,
               syntax: keyedRows.syntax,
             });
+            plans.push(...(hostBlocks?.nestedPlans || []));
             ownedElements.add(child);
             continue;
           }
+          nextId = keyedRowsStart;
           const nested = visitHost(child, parent, insideConditional);
           if (nested.reason) return { dependencies, reason: nested.reason };
           mergeDependencies(dependencies, nested.dependencies);


### PR DESCRIPTION
## Summary

- prepare multiple and recursively nested host-only logical or ternary branches inside eligible non-interactive keyed map and List rows at build time
- create one compiler-owned host scope per stable key, update surviving branches in place, reuse the existing LIS reorder path, and clean subscriptions and scopes when rows disappear
- preserve React ownership for initial render, SSR, hydration, events, Hooks, components, and every unsupported structure through explicit fallback
- document the supported contract and add a 1,000-row production browser experiment

## Safety boundaries

Rows with branch events, custom components, Hooks, refs, SVG, fragments, controlled inputs inside conditions, nested keyed lists, unsafe descriptors, or duplicate runtime keys remain on or switch to React. The generated server HTML has no extra wrappers or markers.

## Validation

- pnpm --filter @farm.js/react test — 35 files and 288 tests passed
- pnpm --filter @farm.js/react type-check
- focused compiler/runtime suite — 24 tests passed
- oxlint — 0 warnings and 0 errors
- React compatibility script — React 18.3.1 and React 19.2.8 passed
- production example build and browser verification — 1,000 rows, one LIS move, preserved row/branch/static-sibling identity, nested condition updates, remove/insert cleanup, zero owner update executions, and no browser console errors
- 2,000 deterministic randomized collection/branch transitions matched normal React output