### PR TITLE
feat(react): compile nested keyed row lists

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -507,11 +507,11 @@ from current compiler cells, so updates made while closed cannot become stale wo
 This recursive path is intentionally host-only. Nested conditional ranges may recurse again, and a
 nested container may own one or more non-interactive keyed ranges separated by static host
 siblings. Hooks, custom components, branch events, refs, SVG, fragments, dangerous HTML,
-interactive rows, nested structures inside a keyed row, or conditionals and lists mixed as direct
-siblings in the same range keep React ownership. React still renders the initial client/SSR tree,
-hydrates it, reports recoverable mismatches, and handles every fallback. Duplicate runtime keys or
-invalid adopted DOM remount the affected outer container through React; descendant dependencies
-remain live after that handoff.
+interactive rows, unsupported structure inside an inner keyed row, or conditionals and lists mixed
+as direct siblings in the same range keep React ownership. React still renders the initial
+client/SSR tree, hydrates it, reports recoverable mismatches, and handles every fallback. Duplicate
+runtime keys or invalid adopted DOM remount the affected outer container through React; descendant
+dependencies remain live after that handoff.
 
 The existing React-owned conditional boundary remains the fallback for supported complex shapes.
 It can contain event handlers, nested host conditionals, keyed lists, and component islands while
@@ -719,11 +719,53 @@ and safe text, attribute, or inline-style expressions. It applies to automatic k
 syntax and inline host rows rendered by `List`.
 
 Hooks, custom components, events inside a compiler-owned branch, refs, SVG, fragments, JSX spreads,
-dangerous HTML, controlled inputs inside a conditional, nested keyed lists, and any unproven shape
-stay on React. Existing interactive keyed rows keep their React-owned conditional-slot behavior:
-Farm compares row snapshots and asks React to refresh a changed slot, while React retains event,
-Fiber, hydration, and structural-list ownership. Duplicate runtime keys or an invalid adopted shape
-also switch the complete mounted list to React.
+dangerous HTML, controlled inputs inside a conditional, and any unproven shape stay on React.
+Existing interactive keyed rows keep their React-owned conditional-slot behavior: Farm compares row
+snapshots and asks React to refresh a changed slot, while React retains event, Fiber, hydration, and
+structural-list ownership. Duplicate runtime keys or an invalid adopted shape also switch the
+complete mounted list to React.
+
+#### Nested keyed lists inside keyed rows
+
+A non-interactive outer row may own one or more inner keyed ranges in known host containers:
+
+```tsx
+<div>
+  {projects.map((project) => (
+    <section key={project.id}>
+      <h2>{project.name}</h2>
+      <ul>
+        <li className="heading">Tasks</li>
+        {project.tasks.map((task, taskIndex) => (
+          <li key={task.id} data-index={taskIndex}>
+            {task.title}
+          </li>
+        ))}
+        <li className="footer">End</li>
+      </ul>
+    </section>
+  ))}
+</div>
+```
+
+The build emits one outer keyed-row descriptor and embeds an inner keyed-range descriptor in that
+row. At runtime every stable `project.id` owns a separate inner key table for its tasks. Reordering
+projects applies LIS to the outer list. Reordering one project's tasks applies a second LIS pass
+only inside that project. A surviving project, task, and every static sibling keep their DOM
+identity; updating the inner task does not rerun the component or either map callback.
+
+The inner scope moves with its outer key and is cleaned when that project is removed. React still
+renders or hydrates the original nested lists, after which the compiler adopts the existing DOM.
+An outer and inner update queued together are read from the same latest collection. Duplicate keys
+at either level, or DOM that cannot be adopted safely, transfer the complete mounted outer list to
+its original React render.
+
+The initial nested contract accepts automatic `.map(...)` and inline `List` ranges, multiple inner
+ranges separated by static host siblings, item-derived keys, and safe text, attribute, and inline
+style bindings. The outer row may also contain eligible host-only conditional blocks in other known
+locations. Inner rows remain lowercase, non-interactive host trees. Events, controlled fields,
+Hooks, custom components, fragments, refs, SVG, JSX spreads, dangerous HTML, index keys, and another
+keyed level inside an inner row keep the outer row on React's safe fallback.
 
 #### Derived collection pipelines
 
@@ -809,7 +851,8 @@ row component such as `InventoryRow`, never directly inside the `List` child fun
 The compiler uses four keyed-list tiers:
 
 1. A dedicated nested host container with one direct map or one `List`, returning a non-interactive
-   host-only row, becomes compiler-owned keyed row instances. Farm patches bindings and uses LIS.
+   host-only row, becomes compiler-owned keyed row instances. Farm patches bindings and uses LIS;
+   eligible outer rows may carry separately scoped nested keyed ranges.
 2. A nested or component-root host container with one or more non-interactive keyed host ranges
    becomes one compiler-owned range block. Farm preserves any static segments and applies the same
    row descriptors and LIS reconciliation independently inside each range.
@@ -877,10 +920,12 @@ The optimized host-row contract is deliberately narrow:
 - A dedicated non-interactive map/`List` may contain multiple logical or ternary host branches,
   including recursively nested branches and branches beside static host siblings. The compiler
   mounts, replaces, or removes only those host blocks within each keyed row instance.
-- Inline synchronous row events use the hybrid React-owned row path. Branch events, nested keyed
-  lists, non-inline or async handlers, file inputs, dynamic form control types or options, custom
-  components, fragments, refs, SVG, attribute spreads, dangerous HTML, and dynamic text mixed
-  beside nested elements stay React-owned.
+- A dedicated non-interactive outer row may contain one or more nested keyed map/`List` ranges in
+  known host containers. Each outer key receives an isolated inner key table and LIS pass.
+- Inline synchronous row events use the hybrid React-owned row path. Branch or inner-row events,
+  deeper keyed levels, non-inline or async handlers, file inputs, dynamic form control types or
+  options, custom components, fragments, refs, SVG, attribute spreads, dangerous HTML, and dynamic
+  text mixed beside nested elements stay React-owned.
 - Unsupported or mutating collection methods, spread children, Hooks in callbacks, and other
   unproven shapes fall back to normal React.
 
@@ -956,21 +1001,22 @@ React then unmounts or replaces the branch normally. Inner boundaries unsubscrib
 unmount, so later updates while the branch is hidden do not target stale components. If the branch
 appears again, each boundary subscribes again and renders from the latest compiler-cell values.
 
-Safe host-only conditions inside a non-interactive keyed row receive globally unique build-time
-block IDs, while the runtime creates a separate scope for each stable row key. The outer keyed
-block drives those scopes, so a row can update a nested branch without a component rerun or a
-separate global subscription for every row. The scope moves with the row through LIS reordering and
-is cleaned when its key disappears. Eligible inline events use the hybrid React-event path and
-retain React-owned row-local conditional Fibers. Component islands, Hooks, custom components,
-nested keyed lists, and other unproven dynamic structure remain on the complete React-owned row
-path; put Hooks inside a keyed row component.
+Safe host-only conditions and keyed ranges inside a non-interactive keyed row receive globally
+unique build-time block IDs, while the runtime creates a separate scope for each stable outer row
+key. The outer keyed block drives those scopes, so a row can update a nested branch or inner list
+without a component rerun or a separate global subscription for every row. Each inner list keeps
+its own key table and LIS pass. The scope moves with the outer row and is cleaned when its key
+disappears. Eligible inline events use the hybrid React-event path and retain React-owned row-local
+conditional Fibers. Component islands, Hooks, custom components, interactive or deeper nested
+lists, and other unproven dynamic structure remain on the complete React-owned row path; put Hooks
+inside a keyed row component.
 
 ### What falls back to React
 
 | Unsupported shape                                                                                                                     | Why React keeps ownership                                                          |
 | ------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
 | Unkeyed/index-keyed maps, unsupported or mutating collection pipelines, or element arrays                                             | Their structure, purity, or item identity is outside the keyed-list contract.      |
-| Unsupported row events/forms, components, fragments, refs, SVG, nested keyed lists, or unsafe conditional branches                    | Their event, lifecycle, or structure contract requires the React-owned row path.   |
+| Unsupported row events/forms, components, fragments, refs, SVG, interactive or deeper nested lists, or unsafe conditional branches    | Their event, lifecycle, or structure contract requires the React-owned row path.   |
 | Interactive ranges beside siblings or non-host range siblings                                                                         | The range owner requires a host container and non-interactive host rows.           |
 | Branch events, keys, components, fragments, refs, SVG, interactive rows, or unsupported nested blocks in a compiled conditional range | They require the React-owned conditional path rather than compiler-created hosts.  |
 | Dynamic/member component types, component spreads, refs, keys, or children                                                            | Their identity or ownership is outside the first component-island contract.        |
@@ -1158,6 +1204,11 @@ The package and example test suites verify more than generated code:
 - 2,000 deterministic compiler-owned row/branch/order transitions match normal React while the
   compiled owner remains at one execution, with additional Strict Mode, parent/local, error-boundary,
   duplicate-key, queued-unmount, SSR, and recoverable-hydration coverage;
+- nested keyed rows apply independent outer and inner LIS passes while preserving project, task,
+  and static-sibling DOM identity, including simultaneous updates at both levels;
+- 2,500 deterministic two-level reorder, insert, remove, binding, and boolean transitions match
+  normal React while the compiled owner remains at one execution, with additional Strict Mode,
+  parent/local, duplicate-inner-key, Fast Refresh, queued-unmount, SSR, and hydration coverage;
 - component islands update only dependent children, preserve child-local state and context, route
   failures through React error boundaries, hydrate in Strict Mode, and safely drop queued updates
   after unmount;

--- a/examples/react-compiler/README.md
+++ b/examples/react-compiler/README.md
@@ -51,6 +51,7 @@ assertions, checks for console/runtime errors and horizontal overflow, saves scr
 | Root conditional ranges    | exact card root, two ranges, stable static siblings; executions `0` | —                                  | Direct branches reconcile without wrappers or marker nodes.            |
 | Composable nested blocks   | two lists, nested conditions, and one component island  | —                                              | One block graph mounts, updates, and cleans up nested subscriptions.    |
 | Keyed row host blocks      | 1,000 rows, one LIS move, nested branch patches, executions `0` | —                                      | Each key owns its safe recursive host conditions without React commits. |
+| Nested keyed rows          | 256 projects, 2,048 tasks, one LIS move per level, executions `0` | —                                    | Every outer key owns an isolated inner key table and LIS scope.         |
 
 The package runtime test also measures one equivalent update under a React `Profiler`:
 
@@ -184,9 +185,15 @@ surviving nested branch. The production assertion preserves the row, active bran
 siblings, then removes and inserts one row and verifies zero owner update executions. The same path
 is automatic for an eligible `.map(...)` or inline host row in `List`; it needs no new option.
 
-Hooks, custom components, row or branch events, refs, SVG, fragments, dangerous HTML, controlled
-inputs inside a condition, nested keyed lists, and unproven expressions stay on React. Duplicate
-runtime keys also switch the mounted list to React.
+The `11` card adds a separately keyed task list to every project row. One action rotates 256 outer
+projects and one project's eight tasks, producing exactly one measured LIS move at each level while
+preserving the project, surviving task, and static heading/footer nodes. A second action removes and
+inserts only one inner task. The production assertion covers 2,048 task rows and records zero owner
+update executions.
+
+Hooks, custom components, row, branch, or inner-row events, refs, SVG, fragments, dangerous HTML,
+controlled inputs inside a condition, deeper keyed levels, and unproven expressions stay on React.
+Duplicate keys at either level also switch the mounted outer list to React.
 
 ## Heavy compiler-on/off benchmark
 

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -40,6 +40,7 @@ for (const component of [
   "ComponentIslandExperiment",
   "ComposableBlockExperiment",
   "KeyedRowHostBlockExperiment",
+  "NestedKeyedRowExperiment",
 ]) {
   assert.ok(compiledComponents.has(component), `${component} was not compiled`);
 }
@@ -1170,6 +1171,112 @@ try {
   );
   assert.equal(keyedHostOwnerFinalExecutions - keyedHostOwnerInitialExecutions, 0);
 
+  const nestedKeyedRows = '[data-experiment="nested-keyed-rows"]';
+  const nestedKeyedOwnerInitialExecutions = await readNumber(
+    page,
+    `${nestedKeyedRows} [data-metric="nested-keyed-owner-executions"]`,
+  );
+  await assertText(page, `${nestedKeyedRows} [data-metric="nested-keyed-projects"]`, "256");
+  await assertText(page, `${nestedKeyedRows} [data-metric="nested-keyed-tasks"]`, "2048");
+  assert.equal(await page.locator(`${nestedKeyedRows} [data-nested-project]`).count(), 256);
+  assert.equal(await page.locator(`${nestedKeyedRows} [data-nested-task]`).count(), 2048);
+  await page.evaluate(() => {
+    const projectList = document.querySelector("[data-nested-project-list]");
+    const project = document.querySelector('[data-nested-project="project-12"]');
+    const taskList = project.querySelector('[data-nested-task-list="project-12"]');
+    window.__farmNestedProject12 = project;
+    window.__farmNestedTask120 = project.querySelector('[data-nested-task="task-12-0"]');
+    window.__farmNestedTask127 = project.querySelector('[data-nested-task="task-12-7"]');
+    window.__farmNestedStaticBefore = project.querySelector('[data-nested-static="before"]');
+    window.__farmNestedStaticAfter = project.querySelector('[data-nested-static="after"]');
+    window.__farmNestedOuterMoves = 0;
+    window.__farmNestedInnerMoves = 0;
+    const outerInsertBefore = projectList.insertBefore.bind(projectList);
+    projectList.insertBefore = (node, anchor) => {
+      if (node.parentNode === projectList && node.matches?.("[data-nested-project]")) {
+        window.__farmNestedOuterMoves += 1;
+      }
+      return outerInsertBefore(node, anchor);
+    };
+    const innerInsertBefore = taskList.insertBefore.bind(taskList);
+    taskList.insertBefore = (node, anchor) => {
+      if (node.parentNode === taskList && node.matches?.("[data-nested-task]")) {
+        window.__farmNestedInnerMoves += 1;
+      }
+      return innerInsertBefore(node, anchor);
+    };
+  });
+
+  await page.locator(`${nestedKeyedRows} [data-action="nested-keyed-reorder"]`).click();
+  await assertText(page, `${nestedKeyedRows} [data-metric="nested-keyed-updates"]`, "1");
+  assert.equal(
+    await page.locator(`${nestedKeyedRows} [data-nested-project]`).first().getAttribute(
+      "data-nested-project",
+    ),
+    "project-1",
+  );
+  assert.deepEqual(
+    await page
+      .locator(`${nestedKeyedRows} [data-nested-project="project-12"] [data-nested-task]`)
+      .evaluateAll((tasks) => tasks.map((task) => task.getAttribute("data-nested-task"))),
+    [
+      "task-12-7",
+      "task-12-0",
+      "task-12-1",
+      "task-12-2",
+      "task-12-3",
+      "task-12-4",
+      "task-12-5",
+      "task-12-6",
+    ],
+  );
+  await assertText(
+    page,
+    `${nestedKeyedRows} [data-nested-task="task-12-7"]`,
+    "Task 12.7 · moved",
+  );
+  assert.equal(await page.evaluate(() => window.__farmNestedOuterMoves), 1);
+  assert.equal(await page.evaluate(() => window.__farmNestedInnerMoves), 1);
+  assert.equal(
+    await page.evaluate(
+      () =>
+        window.__farmNestedProject12 ===
+          document.querySelector('[data-nested-project="project-12"]') &&
+        window.__farmNestedTask120 ===
+          document.querySelector('[data-nested-task="task-12-0"]') &&
+        window.__farmNestedTask127 ===
+          document.querySelector('[data-nested-task="task-12-7"]') &&
+        window.__farmNestedStaticBefore ===
+          document.querySelector(
+            '[data-nested-project="project-12"] [data-nested-static="before"]',
+          ) &&
+        window.__farmNestedStaticAfter ===
+          document.querySelector(
+            '[data-nested-project="project-12"] [data-nested-static="after"]',
+          ),
+    ),
+    true,
+    "nested keyed reconciliation replaced a surviving project, task, or static sibling",
+  );
+
+  await page.locator(`${nestedKeyedRows} [data-action="nested-keyed-replace"]`).click();
+  await assertText(page, `${nestedKeyedRows} [data-metric="nested-keyed-updates"]`, "2");
+  await assertText(page, `${nestedKeyedRows} [data-metric="nested-keyed-tasks"]`, "2048");
+  assert.equal(
+    await page.locator(`${nestedKeyedRows} [data-nested-task="task-12-1"]`).count(),
+    0,
+  );
+  await assertText(
+    page,
+    `${nestedKeyedRows} [data-nested-task="inserted-task-1"]`,
+    "Inserted after update 1",
+  );
+  const nestedKeyedOwnerFinalExecutions = await readNumber(
+    page,
+    `${nestedKeyedRows} [data-metric="nested-keyed-owner-executions"]`,
+  );
+  assert.equal(nestedKeyedOwnerFinalExecutions - nestedKeyedOwnerInitialExecutions, 0);
+
   await page.screenshot({ path: screenshotPath, fullPage: true });
 
   const mobilePage = await browser.newPage({
@@ -1387,6 +1494,17 @@ try {
             removedAndInserted: true,
             ownerUpdateExecutions:
               keyedHostOwnerFinalExecutions - keyedHostOwnerInitialExecutions,
+          },
+          nestedKeyedRows: {
+            projects: 256,
+            tasks: 2048,
+            outerLisMoves: 1,
+            innerLisMoves: 1,
+            outerIdentityPreserved: true,
+            innerIdentityPreserved: true,
+            staticSiblingIdentityPreserved: true,
+            ownerUpdateExecutions:
+              nestedKeyedOwnerFinalExecutions - nestedKeyedOwnerInitialExecutions,
           },
         },
       },

--- a/examples/react-compiler/src/app/globals.css
+++ b/examples/react-compiler/src/app/globals.css
@@ -1221,6 +1221,43 @@ h1 span {
   font: 0.64rem "Geist Mono Variable", ui-monospace, monospace;
 }
 
+[data-nested-project-list] > li {
+  grid-template-columns: minmax(9rem, 0.35fr) minmax(30rem, 1.65fr);
+}
+
+[data-nested-project-list] h3 {
+  overflow: hidden;
+  margin: 0;
+  color: #d8ff9f;
+  font-size: 0.7rem;
+  font-weight: 550;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-nested-task-list] {
+  display: grid;
+  grid-template-columns: auto repeat(8, minmax(7rem, 1fr)) auto;
+  gap: 0.35rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+[data-nested-task-list] > li {
+  overflow: hidden;
+  border: 1px solid #30302c;
+  padding: 0.45rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-nested-task-list] > [data-nested-static] {
+  border-color: transparent;
+  color: #666660;
+  font-size: 0.55rem;
+}
+
 .keyed-host-status {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;

--- a/examples/react-compiler/src/app/page.tsx
+++ b/examples/react-compiler/src/app/page.tsx
@@ -6,6 +6,7 @@ import { ComponentIslandExperiment } from "../components/component-island-experi
 import { ConditionalBlockExperiment } from "../components/conditional-block-experiment";
 import { HeavyInteractionBenchmark } from "../components/heavy-interaction-benchmark";
 import { KeyedRowHostBlockExperiment } from "../components/keyed-row-host-block-experiment";
+import { NestedKeyedRowExperiment } from "../components/nested-keyed-row-experiment";
 import { RecursiveHostBlockExperiment } from "../components/recursive-host-block-experiment";
 import { StaticBindingExperiment } from "../components/static-binding-experiment";
 
@@ -80,6 +81,8 @@ export default function HomePage() {
       <RecursiveHostBlockExperiment />
 
       <KeyedRowHostBlockExperiment />
+
+      <NestedKeyedRowExperiment />
 
       <section
         className="benchmark-report"

--- a/examples/react-compiler/src/components/nested-keyed-row-experiment.tsx
+++ b/examples/react-compiler/src/components/nested-keyed-row-experiment.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState } from "react";
+
+interface NestedTask {
+  id: string;
+  label: string;
+  done: boolean;
+}
+
+interface NestedProject {
+  id: string;
+  label: string;
+  tasks: NestedTask[];
+}
+
+const initialProjects: NestedProject[] = Array.from({ length: 256 }, (_, projectIndex) => ({
+  id: `project-${projectIndex}`,
+  label: `Project ${projectIndex}`,
+  tasks: Array.from({ length: 8 }, (_, taskIndex) => ({
+    id: `task-${projectIndex}-${taskIndex}`,
+    label: `Task ${projectIndex}.${taskIndex}`,
+    done: taskIndex % 2 === 0,
+  })),
+}));
+
+let nestedKeyedOwnerExecutions = 0;
+
+export function NestedKeyedRowExperiment() {
+  const [projects, setProjects] = useState(initialProjects);
+  const [updates, setUpdates] = useState(0);
+
+  function reorderBothLevels() {
+    setProjects((current) => {
+      const rotated = [...current.slice(1), current[0]];
+      return rotated.map((project) => {
+        if (project.id !== "project-12") return project;
+        const lastTask = project.tasks[project.tasks.length - 1];
+        return {
+          ...project,
+          label: "Project 12 · updated",
+          tasks: [
+            { ...lastTask, label: `${lastTask.label} · moved`, done: true },
+            ...project.tasks.slice(0, -1),
+          ],
+        };
+      });
+    });
+    setUpdates((value) => value + 1);
+  }
+
+  function replaceOneInnerRow() {
+    setProjects((current) =>
+      current.map((project) =>
+        project.id === "project-12"
+          ? {
+              ...project,
+              tasks: [
+                ...project.tasks.filter((task) => task.id !== "task-12-1"),
+                {
+                  id: `inserted-task-${updates}`,
+                  label: `Inserted after update ${updates}`,
+                  done: false,
+                },
+              ],
+            }
+          : project,
+      ),
+    );
+    setUpdates((value) => value + 1);
+  }
+
+  return (
+    <section className="heavy-benchmark" data-experiment="nested-keyed-rows">
+      <header className="heavy-heading">
+        <div>
+          <span className="experiment-number">11</span>
+          <div>
+            <p className="heavy-kicker">NESTED KEYED ROWS</p>
+            <h2>Each outer key owns an independent inner LIS scope</h2>
+          </div>
+        </div>
+        <span className="node-badge">256 PROJECTS / 2,048 TASKS</span>
+      </header>
+
+      <p className="heavy-copy">
+        The compiler scopes every task list to its stable project key. One update can move a project
+        and reorder its tasks while preserving both levels of DOM identity, without rerunning this
+        component.
+      </p>
+
+      <dl className="heavy-metrics" aria-live="polite">
+        <div>
+          <dt>Owner executions</dt>
+          <dd data-metric="nested-keyed-owner-executions">
+            {typeof window === "undefined" ? 1 : ++nestedKeyedOwnerExecutions}
+          </dd>
+        </div>
+        <div>
+          <dt>Projects</dt>
+          <dd data-metric="nested-keyed-projects">{projects.length}</dd>
+        </div>
+        <div>
+          <dt>Tasks</dt>
+          <dd data-metric="nested-keyed-tasks">{projects.length * 8}</dd>
+        </div>
+        <div>
+          <dt>Updates</dt>
+          <dd data-metric="nested-keyed-updates">{updates}</dd>
+        </div>
+      </dl>
+
+      <div className="heavy-controls composable-controls">
+        <button data-action="nested-keyed-reorder" type="button" onClick={reorderBothLevels}>
+          Reorder both levels <span aria-hidden="true">↗</span>
+        </button>
+        <button data-action="nested-keyed-replace" type="button" onClick={replaceOneInnerRow}>
+          Replace one task
+        </button>
+      </div>
+
+      <ol className="keyed-host-row-list" data-nested-project-list>
+        {projects.map((project, projectIndex) => (
+          <li
+            data-nested-project={project.id}
+            data-project-index={projectIndex}
+            key={project.id}
+          >
+            <h3>{project.label}</h3>
+            <ul data-nested-task-list={project.id}>
+              <li data-nested-static="before">TASKS</li>
+              {project.tasks.map((task, taskIndex) => (
+                <li
+                  data-nested-task={task.id}
+                  data-task-index={taskIndex}
+                  key={task.id}
+                  style={{ opacity: task.done ? 1 : 0.72 }}
+                  title={task.label}
+                >
+                  {task.label}
+                </li>
+              ))}
+              <li data-nested-static="after">END</li>
+            </ul>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -191,10 +191,37 @@ and map callback do not rerun, and no wrapper or hydration marker is added.
 
 This compiler-owned tier requires a lowercase non-interactive host row. Hooks, custom components,
 branch events, refs, SVG, fragments, spreads, dangerous HTML, controlled inputs inside a condition,
-nested keyed lists, and unproven expressions stay on React. An otherwise eligible row with inline
-events continues to use the hybrid boundary: React owns its conditional Fibers and structural
-commits, while Farm compares per-key snapshots and refreshes only changed slots. Duplicate runtime
-keys or invalid adopted DOM switch the complete list to React.
+and unproven expressions stay on React. An otherwise eligible row with inline events continues to
+use the hybrid boundary: React owns its conditional Fibers and structural commits, while Farm
+compares per-key snapshots and refreshes only changed slots. Duplicate runtime keys or invalid
+adopted DOM switch the complete list to React.
+
+An eligible outer keyed row may also own nested keyed ranges:
+
+```tsx
+<div>
+  {projects.map((project) => (
+    <section key={project.id}>
+      <h2>{project.name}</h2>
+      <ul>
+        <li>Tasks</li>
+        {project.tasks.map((task) => (
+          <li key={task.id}>{task.title}</li>
+        ))}
+        <li>End</li>
+      </ul>
+    </section>
+  ))}
+</div>
+```
+
+Every outer key receives an isolated inner key table and LIS pass. Moving a project preserves its
+task scope; reordering one task list touches only that project. Surviving project, task, and static
+sibling elements keep their DOM identity, and removing an outer row cleans its inner scope. The
+initial contract accepts non-interactive lowercase inner rows from `.map(...)` or inline `List`,
+including multiple ranges separated by static host siblings. Inner events or forms, Hooks, custom
+components, fragments, refs, SVG, spreads, dangerous HTML, index keys, and a deeper keyed level keep
+the complete outer row on React's fallback.
 
 A keyed collection may use derived locals or an inline chain of `filter`, `slice`, `toSorted`, and
 `toReversed`:
@@ -350,10 +377,10 @@ host scopes explicitly remove every nested subscription before their outer DOM i
 later mount reads the latest compiler-cell values. Surviving keyed rows move with the existing LIS
 algorithm. Duplicate runtime keys, invalid adoption, or an unsafe logical value transfer the outer
 container back to React; descendant dependencies remain subscribed so that fallback stays live.
-Host-only keyed rows have separate runtime instances per key. Row-local conditional IDs are scoped
-to that instance and paired with its stable key, so two rows can use the same build-time slot ID
-without sharing data or
-subscriptions. Unsupported row subtrees stay complete React-owned keyed boundaries.
+Host-only keyed rows have separate runtime instances per key. Row-local conditional and keyed-range
+IDs are scoped to that instance and paired with its stable key, so two rows can use the same
+build-time slot ID without sharing data or subscriptions. Unsupported row subtrees stay complete
+React-owned keyed boundaries.
 
 Unsupported components fall back to React by default. Use `onUnsupported: "warn"` for diagnostics
 or `onUnsupported: "error"` while tightening an annotated migration.
@@ -383,7 +410,8 @@ unsupported conditional roots, effects, and more advanced hook support intention
 in this release. Compiler-owned keyed rows support either one dedicated host-only map/`List` or
 one or more non-interactive ranges in a nested or component-root host container. A dedicated
 non-interactive row may also contain multiple recursive logical or ternary host branches beside
-static host siblings. Inline synchronous row events continue to use the hybrid React-owned row
-path. Branch events, nested keyed lists, interactive ranges beside siblings, non-inline or async
-row handlers, unsupported form shapes, custom components, fragments, refs, SVG, and duplicate
-runtime keys keep or switch to React ownership.
+static host siblings, plus one or more nested non-interactive keyed ranges scoped by the outer row
+key. Inline synchronous row events continue to use the hybrid React-owned row path. Branch or
+inner-row events, deeper keyed levels, interactive ranges beside siblings, non-inline or async row
+handlers, unsupported form shapes, custom components, fragments, refs, SVG, and duplicate runtime
+keys keep or switch to React ownership.

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -805,6 +805,132 @@ const testSource = String.raw`
   assert.equal(keyedHostRowExecutions, initialKeyedHostExecutions);
   flushSync(() => keyedHostRoot.unmount());
 
+  let nestedKeyedExecutions = 0;
+  const NestedKeyedRows = createCompiledComponent({
+    displayName: "CompatibilityNestedKeyedRows",
+    initialize: () => [[
+      { id: "a", name: "Alpha", tasks: [{ id: "a1", title: "Design" }, { id: "a2", title: "Build" }] },
+      { id: "b", name: "Beta", tasks: [{ id: "b1", title: "Test" }, { id: "b2", title: "Ship" }] },
+    ]],
+    render(_props, state, blocks) {
+      nestedKeyedExecutions += 1;
+      const projects = () => state[0].get();
+      const taskDescriptor = (task, index) => ({
+        kind: "element",
+        tag: "li",
+        attributes: [{ name: "data-task", value: task.id }, { name: "data-index", value: index }],
+        styles: [],
+        children: [task.title],
+      });
+      const projectDescriptor = (project, index) => ({
+        kind: "element",
+        tag: "section",
+        attributes: [{ name: "data-project", value: project.id }, { name: "data-index", value: index }],
+        styles: [],
+        children: [
+          { kind: "element", tag: "h3", attributes: [], styles: [], children: [project.name] },
+          {
+            kind: "element",
+            tag: "ul",
+            attributes: [],
+            styles: [],
+            children: [
+              { kind: "element", tag: "i", attributes: [], styles: [], children: ["Tasks"] },
+              ...project.tasks.map(taskDescriptor),
+              { kind: "element", tag: "b", attributes: [], styles: [], children: ["End"] },
+            ],
+            block: {
+              kind: "keyed-ranges",
+              id: 1,
+              ranges: [{
+                before: 1,
+                items: () => project.tasks,
+                rowKey: (task) => task.id,
+                create: taskDescriptor,
+                bindings: [
+                  { kind: "attribute", path: [], name: "data-index", read: (_task, taskIndex) => taskIndex },
+                  { kind: "text", path: [], read: (task) => [task.title] },
+                ],
+              }],
+              trailing: 1,
+            },
+          },
+        ],
+      });
+      const projectMarkup = (project, index) => React.createElement(
+        "section",
+        { key: project.id, "data-project": project.id, "data-index": index },
+        React.createElement("h3", null, project.name),
+        React.createElement(
+          "ul",
+          null,
+          React.createElement("i", null, "Tasks"),
+          ...project.tasks.map((task, taskIndex) =>
+            React.createElement("li", { key: task.id, "data-task": task.id, "data-index": taskIndex }, task.title),
+          ),
+          React.createElement("b", null, "End"),
+        ),
+      );
+      return React.createElement(
+        "main",
+        null,
+        React.createElement("button", {
+          "data-nested-keyed-update": true,
+          onClick: () => state[0].set((current) => {
+            const [a, b] = current;
+            return [
+              { ...b, name: "Beta newest", tasks: [{ ...b.tasks[1], title: "Ship now" }, b.tasks[0]] },
+              a,
+            ];
+          }),
+        }, "Update nested keyed rows"),
+        React.createElement(blocks.KeyedRows, {
+          id: 0,
+          hostBlocks: true,
+          items: projects,
+          rowKey: (project) => project.id,
+          create: projectDescriptor,
+          bindings: [
+            { kind: "attribute", path: [], name: "data-index", read: (_project, index) => index },
+            { kind: "text", path: [0], read: (project) => [project.name] },
+          ],
+          render: () => React.createElement("div", null, ...projects().map(projectMarkup)),
+        }),
+      );
+    },
+    bindings: [
+      { kind: "block", id: 0, dependencies: [0] },
+      { kind: "block", id: 1, parent: 0, dependencies: [] },
+    ],
+  });
+  const nestedKeyedContainer = document.createElement("div");
+  document.body.append(nestedKeyedContainer);
+  const nestedKeyedRoot = createRoot(nestedKeyedContainer);
+  flushSync(() => nestedKeyedRoot.render(React.createElement(NestedKeyedRows)));
+  const initialNestedKeyedExecutions = nestedKeyedExecutions;
+  const originalProjectB = nestedKeyedContainer.querySelector('[data-project="b"]');
+  const originalTaskB1 = nestedKeyedContainer.querySelector('[data-task="b1"]');
+  const originalTaskB2 = nestedKeyedContainer.querySelector('[data-task="b2"]');
+  const originalNestedStatic = originalProjectB.querySelector("ul > i");
+  nestedKeyedContainer.querySelector("[data-nested-keyed-update]").click();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.deepEqual(
+    [...nestedKeyedContainer.querySelectorAll("[data-project]")].map((row) => row.dataset.project),
+    ["b", "a"],
+  );
+  assert.deepEqual(
+    [...originalProjectB.querySelectorAll("[data-task]")].map((row) => row.dataset.task),
+    ["b2", "b1"],
+  );
+  assert.equal(nestedKeyedContainer.querySelector('[data-project="b"]'), originalProjectB);
+  assert.equal(nestedKeyedContainer.querySelector('[data-task="b1"]'), originalTaskB1);
+  assert.equal(nestedKeyedContainer.querySelector('[data-task="b2"]'), originalTaskB2);
+  assert.equal(originalProjectB.querySelector("ul > i"), originalNestedStatic);
+  assert.equal(originalTaskB2.textContent, "Ship now");
+  assert.equal(nestedKeyedExecutions, initialNestedKeyedExecutions);
+  flushSync(() => nestedKeyedRoot.unmount());
+
   let keyedRangeExecutions = 0;
   const KeyedRanges = createCompiledComponent({
     displayName: "CompatibilityKeyedRanges",

--- a/packages/farm-react/src/__tests__/compiler-keyed-row-host-blocks.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-row-host-blocks.test.ts
@@ -179,7 +179,7 @@ describe("React AOT compiler-owned keyed-row host blocks", () => {
     expect(result.code).not.toContain("hostBlocks={true}");
   });
 
-  it("defers nested keyed lists inside a row while preserving normal React output", async () => {
+  it("prepares nested keyed lists inside an outer keyed row", async () => {
     const result = await compile(`
       import { useState } from "react";
       export function Inbox() {
@@ -201,9 +201,102 @@ describe("React AOT compiler-owned keyed-row host blocks", () => {
     `);
 
     expect(result.compiled).toEqual(["Inbox"]);
-    expect(result.code).not.toContain("hostBlocks={true}");
-    expect(result.code).toContain("farmBlocks.KeyedList");
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("hostBlocks={true}");
+    expect(result.code).toContain('kind: "keyed-ranges"');
+    expect(result.code).toContain("parent: 0");
+    expect(result.code).not.toContain("farmBlocks.KeyedList");
     expect(result.code).toContain("item.children.map");
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedRowHostBlocks.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({ code: expect.stringContaining("hostBlocks") });
+  });
+
+  it("supports multiple nested map and List ranges beside static siblings", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List } from "@farm.js/react/list";
+      export function Projects() {
+        const [projects, setProjects] = useState([{ id: "p", name: "Farm", ready: true, tasks: [{ id: "t", title: "Test" }], notes: [{ id: "n", text: "Ship" }] }]);
+        return (
+          <main>
+            <button onClick={() => setProjects((rows) => [...rows])}>Refresh</button>
+            <div>
+              {projects.map((project) => (
+                <section key={project.id}>
+                  <h2>{project.name}</h2>
+                  <div>{project.ready && <strong>Ready</strong>}</div>
+                  <ul>
+                    <i>Tasks</i>
+                    {project.tasks.map((task, index) => <li key={task.id} data-index={index}>{task.title}</li>)}
+                    <b>Notes</b>
+                    <List each={project.notes} by={(note) => note.id}>
+                      {(note) => <li title={note.text}>{note.text}</li>}
+                    </List>
+                    <em>End</em>
+                  </ul>
+                </section>
+              ))}
+            </div>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Projects"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("hostBlocks={true}");
+    expect(result.code.match(/kind: "keyed-ranges"/g)).toHaveLength(1);
+    expect(result.code.match(/before: /g)?.length).toBeGreaterThanOrEqual(2);
+    expect(result.code).toContain('kind: "conditional-ranges"');
+    expect(result.code).not.toContain("farmBlocks.KeyedList");
+  });
+
+  it.each([
+    {
+      name: "an interactive inner row",
+      row: "<li key={task.id}><button onClick={() => setItems([])}>{task.title}</button></li>",
+    },
+    {
+      name: "a custom component inner row",
+      row: "<TaskRow key={task.id} task={task} />",
+      declaration: "function TaskRow({ task }) { return <li>{task.title}</li>; }",
+    },
+    {
+      name: "an inner fragment row",
+      row: "<><li key={task.id}>{task.title}</li></>",
+    },
+    {
+      name: "an index-keyed inner row",
+      row: "<li key={index}>{task.title}</li>",
+    },
+  ])("keeps $name on React's safe row fallback", async ({ row, declaration = "" }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      ${declaration}
+      export function Projects() {
+        const [items, setItems] = useState([{ id: "p", tasks: [{ id: "t", title: "Test" }] }]);
+        return (
+          <main>
+            <button onClick={() => setItems((rows) => [...rows])}>Refresh</button>
+            <div>
+              {items.map((item) => (
+                <section key={item.id}>
+                  <ol>{item.tasks.map((task, index) => ${row})}</ol>
+                </section>
+              ))}
+            </div>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Projects"]);
+    expect(result.code).not.toContain("hostBlocks={true}");
+    expect(result.code).toContain("item.tasks.map");
   });
 
   it("keeps block ids unique across sibling lists and component-level blocks", async () => {

--- a/packages/farm-react/src/__tests__/compiler-runtime-nested-keyed-rows.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-nested-keyed-rows.test.tsx
@@ -1,0 +1,666 @@
+import React, { Profiler, StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createCompiledComponent,
+  type CompiledComponentDefinition,
+  type CompilerHostElement,
+  type CompilerKeyedRowBinding,
+  type CompilerStateUpdater,
+} from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Task {
+  id: string;
+  title: string;
+  done: boolean;
+}
+
+interface Project {
+  id: string;
+  name: string;
+  tasks: Task[];
+}
+
+const initialProjects: Project[] = [
+  {
+    id: "a",
+    name: "Alpha",
+    tasks: [
+      { id: "a1", title: "Design", done: false },
+      { id: "a2", title: "Build", done: true },
+      { id: "a3", title: "Ship", done: false },
+    ],
+  },
+  {
+    id: "b",
+    name: "Beta",
+    tasks: [
+      { id: "b1", title: "Plan", done: false },
+      { id: "b2", title: "Test", done: true },
+      { id: "b3", title: "Release", done: false },
+    ],
+  },
+  {
+    id: "c",
+    name: "Gamma",
+    tasks: [
+      { id: "c1", title: "Review", done: false },
+      { id: "c2", title: "Merge", done: true },
+    ],
+  },
+];
+
+const roots: Array<{ unmount(): void }> = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function host(
+  tag: string,
+  children: readonly unknown[] = [],
+  attributes: readonly { name: string; value: unknown }[] = [],
+  styles: readonly { name: string; value: unknown }[] = [],
+): CompilerHostElement {
+  return { kind: "element", tag, attributes, styles, children };
+}
+
+function taskDescriptor(task: Task, index: number, prefix: string): CompilerHostElement {
+  return host(
+    "li",
+    [host("span", [prefix, task.title]), host("small", [task.done ? "done" : "open"])],
+    [
+      { name: "data-task", value: task.id },
+      { name: "data-task-index", value: index },
+      { name: "title", value: task.title },
+    ],
+    [{ name: "opacity", value: task.done ? 1 : 0.7 }],
+  );
+}
+
+function taskBindings(prefix: string): CompilerKeyedRowBinding[] {
+  return [
+    {
+      kind: "attribute",
+      path: [],
+      name: "data-task-index",
+      read: (_task, index) => index,
+    },
+    {
+      kind: "attribute",
+      path: [],
+      name: "title",
+      read: (task) => (task as Task).title,
+    },
+    {
+      kind: "style",
+      path: [],
+      name: "opacity",
+      read: (task) => ((task as Task).done ? 1 : 0.7),
+    },
+    {
+      kind: "text",
+      path: [0],
+      read: (task) => [prefix, (task as Task).title],
+    },
+    {
+      kind: "text",
+      path: [1],
+      read: (task) => ((task as Task).done ? "done" : "open"),
+    },
+  ];
+}
+
+function projectDescriptor(project: Project, index: number, prefix: string): CompilerHostElement {
+  const taskRange = {
+    before: 1,
+    items: () => project.tasks,
+    rowKey: (task: unknown) => (task as Task).id,
+    create: (task: unknown, taskIndex: number) => taskDescriptor(task as Task, taskIndex, prefix),
+    bindings: taskBindings(prefix),
+  };
+  return host(
+    "section",
+    [
+      host("h3", [prefix, project.name]),
+      {
+        ...host("ul", [
+          host("i", ["TASKS"]),
+          ...project.tasks.map((task, taskIndex) => taskDescriptor(task, taskIndex, prefix)),
+          host("b", ["END"]),
+        ]),
+        block: {
+          kind: "keyed-ranges",
+          id: 1,
+          ranges: [taskRange],
+          trailing: 1,
+        },
+      },
+    ],
+    [
+      { name: "data-project", value: project.id },
+      { name: "data-project-index", value: index },
+    ],
+  );
+}
+
+function projectBindings(prefix: string): CompilerKeyedRowBinding[] {
+  return [
+    {
+      kind: "attribute",
+      path: [],
+      name: "data-project-index",
+      read: (_project, index) => index,
+    },
+    {
+      kind: "text",
+      path: [0],
+      read: (project) => [prefix, (project as Project).name],
+    },
+  ];
+}
+
+function projectMarkup(project: Project, index: number, prefix: string): React.ReactElement {
+  return (
+    <section data-project={project.id} data-project-index={index} key={project.id}>
+      <h3>
+        {prefix}
+        {project.name}
+      </h3>
+      <ul>
+        <i>TASKS</i>
+        {project.tasks.map((task, taskIndex) => (
+          <li
+            data-task={task.id}
+            data-task-index={taskIndex}
+            key={task.id}
+            style={{ opacity: task.done ? 1 : 0.7 }}
+            title={task.title}
+          >
+            <span>
+              {prefix}
+              {task.title}
+            </span>
+            <small>{task.done ? "done" : "open"}</small>
+          </li>
+        ))}
+        <b>END</b>
+      </ul>
+    </section>
+  );
+}
+
+function createNestedRowsFixture() {
+  let executions = 0;
+  let setProjects: (next: CompilerStateUpdater) => void = () => undefined;
+  const Rows = createCompiledComponent({
+    displayName: "NestedKeyedRows",
+    initialize: () => [initialProjects],
+    render(props: { prefix: string }, state, blocks) {
+      executions += 1;
+      setProjects = state[0].set;
+      const projects = () => state[0].get() as Project[];
+      const KeyedRows = blocks.KeyedRows;
+      return (
+        <main>
+          <KeyedRows
+            bindings={projectBindings(props.prefix)}
+            create={(project, index) => projectDescriptor(project as Project, index, props.prefix)}
+            hostBlocks
+            id={0}
+            items={projects}
+            render={() => (
+              <div data-projects>
+                {projects().map((project, index) => projectMarkup(project, index, props.prefix))}
+              </div>
+            )}
+            rowKey={(project) => (project as Project).id}
+          />
+        </main>
+      );
+    },
+    bindings: [
+      { kind: "block", id: 0, dependencies: [0] },
+      { kind: "block", id: 1, parent: 0, dependencies: [] },
+    ],
+  });
+  return {
+    Rows,
+    executions: () => executions,
+    setProjects: (next: CompilerStateUpdater) => setProjects(next),
+  };
+}
+
+function semanticProjects(container: Element, owner: string) {
+  return [...container.querySelectorAll<HTMLElement>(`${owner} [data-project]`)].map((project) => ({
+    id: project.dataset.project,
+    index: project.dataset.projectIndex,
+    name: project.querySelector("h3")?.textContent,
+    tasks: [...project.querySelectorAll<HTMLElement>("[data-task]")].map((task) => ({
+      id: task.dataset.task,
+      index: task.dataset.taskIndex,
+      title: task.getAttribute("title"),
+      label: task.querySelector("span")?.textContent,
+      status: task.querySelector("small")?.textContent,
+      opacity: task.style.opacity,
+    })),
+  }));
+}
+
+describe("compiler-owned nested keyed rows runtime", () => {
+  it("runs independent outer and inner LIS passes without React commits or lost identity", async () => {
+    let profilerCommits = 0;
+    const fixture = createNestedRowsFixture();
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <StrictMode>
+          <Profiler id="nested-rows" onRender={() => (profilerCommits += 1)}>
+            <fixture.Rows prefix="Live: " />
+          </Profiler>
+        </StrictMode>,
+      ),
+    );
+
+    const executionsAfterMount = fixture.executions();
+    const commitsAfterMount = profilerCommits;
+    const projectB = container.querySelector<HTMLElement>('[data-project="b"]')!;
+    const taskB1 = projectB.querySelector<HTMLElement>('[data-task="b1"]')!;
+    const taskB2 = projectB.querySelector<HTMLElement>('[data-task="b2"]')!;
+    const taskB3 = projectB.querySelector<HTMLElement>('[data-task="b3"]')!;
+    const staticBefore = projectB.querySelector("ul > i");
+    const staticAfter = projectB.querySelector("ul > b");
+    let outerMoves = 0;
+    let innerMoves = 0;
+    const projectsRoot = container.querySelector<HTMLElement>("[data-projects]")!;
+    const tasksRoot = projectB.querySelector<HTMLElement>("ul")!;
+    const outerInsertBefore = projectsRoot.insertBefore.bind(projectsRoot);
+    projectsRoot.insertBefore = (node, anchor) => {
+      if (node.parentNode === projectsRoot) outerMoves += 1;
+      return outerInsertBefore(node, anchor);
+    };
+    const innerInsertBefore = tasksRoot.insertBefore.bind(tasksRoot);
+    tasksRoot.insertBefore = (node, anchor) => {
+      if (node.parentNode === tasksRoot && (node as Element).matches?.("[data-task]")) {
+        innerMoves += 1;
+      }
+      return innerInsertBefore(node, anchor);
+    };
+
+    await act(async () => {
+      fixture.setProjects((current) => {
+        const [a, b, c] = current as Project[];
+        return [
+          c,
+          a,
+          {
+            ...b,
+            name: "Beta updated",
+            tasks: [
+              { ...b.tasks[2], title: "Release now", done: true },
+              b.tasks[0],
+              { ...b.tasks[1], done: false },
+              { id: "b4", title: "Observe", done: false },
+            ],
+          },
+        ];
+      });
+      await flushCompilerUpdates();
+    });
+
+    expect(
+      [...container.querySelectorAll<HTMLElement>("[data-project]")].map(
+        (project) => project.dataset.project,
+      ),
+    ).toEqual(["c", "a", "b"]);
+    expect(container.querySelector('[data-project="b"]')).toBe(projectB);
+    expect(projectB.querySelector('[data-task="b1"]')).toBe(taskB1);
+    expect(projectB.querySelector('[data-task="b2"]')).toBe(taskB2);
+    expect(projectB.querySelector('[data-task="b3"]')).toBe(taskB3);
+    expect(projectB.querySelector("ul > i")).toBe(staticBefore);
+    expect(projectB.querySelector("ul > b")).toBe(staticAfter);
+    expect(
+      [...projectB.querySelectorAll<HTMLElement>("[data-task]")].map((task) => task.dataset.task),
+    ).toEqual(["b3", "b1", "b2", "b4"]);
+    expect(projectB.querySelector('[data-task="b3"] span')?.textContent).toBe("Live: Release now");
+    expect(projectB.querySelector('[data-task="b2"] small')?.textContent).toBe("open");
+    expect(outerMoves).toBe(1);
+    expect(innerMoves).toBe(1);
+    expect(fixture.executions()).toBe(executionsAfterMount);
+    expect(profilerCommits).toBe(commitsAfterMount);
+  });
+
+  it("combines parent props with inner updates and drops a queued update after unmount", async () => {
+    const fixture = createNestedRowsFixture();
+    function Parent() {
+      const [prefix, setPrefix] = useState("Before: ");
+      return (
+        <>
+          <button data-parent onClick={() => setPrefix("After: ")} type="button" />
+          <fixture.Rows prefix={prefix} />
+        </>
+      );
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Parent />));
+    const task = container.querySelector('[data-task="a2"]');
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("[data-parent]")?.click();
+      fixture.setProjects((current) =>
+        (current as Project[]).map((project) =>
+          project.id === "a"
+            ? {
+                ...project,
+                tasks: project.tasks.map((currentTask) =>
+                  currentTask.id === "a2"
+                    ? { ...currentTask, title: "Built together", done: false }
+                    : currentTask,
+                ),
+              }
+            : project,
+        ),
+      );
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector('[data-task="a2"]')).toBe(task);
+    expect(container.querySelector('[data-task="a2"] span')?.textContent).toBe(
+      "After: Built together",
+    );
+
+    fixture.setProjects((current) => [...(current as Project[])].reverse());
+    await act(async () => root.unmount());
+    roots.splice(roots.indexOf(root), 1);
+    await flushCompilerUpdates();
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("adopts hydrated nested rows and recovers from server mismatches", async () => {
+    for (const mismatch of [false, true]) {
+      const fixture = createNestedRowsFixture();
+      const container = document.createElement("div");
+      const serverHtml = renderToString(<fixture.Rows prefix="SSR: " />);
+      container.innerHTML = mismatch
+        ? serverHtml.replace("Design</span>", "Server mismatch</span>")
+        : serverHtml;
+      document.body.append(container);
+      const recoverable = vi.fn();
+      let root!: ReturnType<typeof hydrateRoot>;
+      await act(async () => {
+        root = hydrateRoot(container, <fixture.Rows prefix="SSR: " />, {
+          onRecoverableError: recoverable,
+        });
+        await flushCompilerUpdates();
+      });
+      roots.push(root);
+      const task = container.querySelector('[data-task="a1"]');
+      if (mismatch) expect(recoverable).toHaveBeenCalled();
+      else expect(recoverable).not.toHaveBeenCalled();
+
+      await act(async () => {
+        fixture.setProjects((current) =>
+          (current as Project[]).map((project) =>
+            project.id === "a"
+              ? {
+                  ...project,
+                  tasks: [
+                    project.tasks[2],
+                    { ...project.tasks[0], title: "Hydrated", done: true },
+                    project.tasks[1],
+                  ],
+                }
+              : project,
+          ),
+        );
+        await flushCompilerUpdates();
+      });
+      expect(container.querySelector('[data-task="a1"]')).toBe(task);
+      expect(container.querySelector('[data-task="a1"] span')?.textContent).toBe("SSR: Hydrated");
+
+      await act(async () => root.unmount());
+      roots.splice(roots.indexOf(root), 1);
+      container.remove();
+    }
+  });
+
+  it("falls back to React for duplicate inner keys and remains live", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const fixture = createNestedRowsFixture();
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<fixture.Rows prefix="Safe: " />));
+
+    await act(async () => {
+      fixture.setProjects((current) =>
+        (current as Project[]).map((project) =>
+          project.id === "a"
+            ? {
+                ...project,
+                tasks: [
+                  { ...project.tasks[0], title: "First" },
+                  { ...project.tasks[0], title: "Duplicate" },
+                ],
+              }
+            : project,
+        ),
+      );
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelectorAll('[data-project="a"] [data-task="a1"]')).toHaveLength(2);
+    expect(container.textContent).toContain("Duplicate");
+
+    await act(async () => {
+      fixture.setProjects((current) =>
+        (current as Project[]).map((project) =>
+          project.id === "a"
+            ? { ...project, tasks: [{ id: "safe", title: "Safe again", done: true }] }
+            : project,
+        ),
+      );
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector('[data-task="safe"] span')?.textContent).toBe(
+      "Safe: Safe again",
+    );
+  });
+
+  it("matches normal React across 2,500 deterministic two-level mutations", async () => {
+    type Action =
+      | "outer-reverse"
+      | "outer-rotate"
+      | "inner-reverse"
+      | "inner-rotate"
+      | "inner-edit"
+      | "inner-toggle"
+      | "inner-add"
+      | "inner-remove";
+    let normalSet: React.Dispatch<React.SetStateAction<Project[]>> = () => undefined;
+    const fixture = createNestedRowsFixture();
+
+    function Normal() {
+      const [projects, setProjects] = useState(initialProjects);
+      normalSet = setProjects;
+      return (
+        <div data-normal>
+          {projects.map((project, index) => projectMarkup(project, index, "Test: "))}
+        </div>
+      );
+    }
+
+    const transition = (projects: Project[], action: Action, step: number): Project[] => {
+      if (action === "outer-reverse") return [...projects].reverse();
+      if (action === "outer-rotate" && projects.length > 1) {
+        return [...projects.slice(1), projects[0]];
+      }
+      if (projects.length === 0) return projects;
+      const projectIndex = step % projects.length;
+      return projects.map((project, index) => {
+        if (index !== projectIndex) return project;
+        const tasks = project.tasks;
+        if (action === "inner-reverse") return { ...project, tasks: [...tasks].reverse() };
+        if (action === "inner-rotate" && tasks.length > 1) {
+          return { ...project, tasks: [...tasks.slice(1), tasks[0]] };
+        }
+        if (action === "inner-edit" && tasks.length > 0) {
+          return {
+            ...project,
+            tasks: tasks.map((task, taskIndex) =>
+              taskIndex === step % tasks.length ? { ...task, title: `${task.title}!` } : task,
+            ),
+          };
+        }
+        if (action === "inner-toggle" && tasks.length > 0) {
+          return {
+            ...project,
+            tasks: tasks.map((task, taskIndex) =>
+              taskIndex === step % tasks.length ? { ...task, done: !task.done } : task,
+            ),
+          };
+        }
+        if (action === "inner-add" && tasks.length < 8) {
+          let candidate = step;
+          const ids = new Set(tasks.map((task) => task.id));
+          while (ids.has(`${project.id}-n${candidate}`)) candidate += 1;
+          return {
+            ...project,
+            tasks: [
+              ...tasks,
+              {
+                id: `${project.id}-n${candidate}`,
+                title: `New ${candidate}`,
+                done: candidate % 2 === 0,
+              },
+            ],
+          };
+        }
+        if (action === "inner-remove" && tasks.length > 1) {
+          return { ...project, tasks: tasks.slice(1) };
+        }
+        return project;
+      });
+    };
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <>
+          <div data-compiled>
+            <fixture.Rows prefix="Test: " />
+          </div>
+          <Normal />
+        </>,
+      ),
+    );
+    const executionsAfterMount = fixture.executions();
+    const actions: Action[] = [
+      "outer-reverse",
+      "outer-rotate",
+      "inner-reverse",
+      "inner-rotate",
+      "inner-edit",
+      "inner-toggle",
+      "inner-add",
+      "inner-remove",
+    ];
+    let random = 0x81a5b7c3;
+    for (let step = 0; step < 2500; step += 1) {
+      random = (random * 1664525 + 1013904223) >>> 0;
+      const action = actions[random % actions.length];
+      await act(async () => {
+        fixture.setProjects((current) => transition(current as Project[], action, step));
+        normalSet((current) => transition(current, action, step));
+        await flushCompilerUpdates();
+      });
+      expect(semanticProjects(container, "[data-compiled]")).toEqual(
+        semanticProjects(container, "[data-normal]"),
+      );
+    }
+    expect(fixture.executions()).toBe(executionsAfterMount);
+  }, 20_000);
+
+  it("preserves nested identities and state through compatible Fast Refresh", async () => {
+    const hmrId = `nested-keyed-rows-refresh-${Math.random()}`;
+    const definition = (prefix: string): CompiledComponentDefinition<Record<string, never>> => ({
+      displayName: "RefreshNestedKeyedRows",
+      hmrId,
+      stateSignature: "projects",
+      initialize: () => [initialProjects],
+      render(_props, state, blocks) {
+        const projects = () => state[0].get() as Project[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <KeyedRows
+              bindings={projectBindings(prefix)}
+              create={(project, index) => projectDescriptor(project as Project, index, prefix)}
+              hostBlocks
+              id={0}
+              items={projects}
+              render={() => (
+                <div>
+                  {projects().map((project, index) => projectMarkup(project, index, prefix))}
+                </div>
+              )}
+              rowKey={(project) => (project as Project).id}
+            />
+          </main>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        { kind: "block", id: 1, parent: 0, dependencies: [] },
+      ],
+    });
+
+    const Initial = createCompiledComponent(definition("Before: "));
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Initial />));
+    const project = container.querySelector('[data-project="a"]');
+    const task = container.querySelector('[data-task="a1"]');
+
+    let Refreshed = Initial;
+    await act(async () => {
+      Refreshed = createCompiledComponent(definition("After: "));
+      root.render(<Refreshed />);
+      await flushCompilerUpdates();
+    });
+    expect(Refreshed).toBe(Initial);
+    expect(container.querySelector('[data-project="a"]')).toBe(project);
+    expect(container.querySelector('[data-task="a1"]')).toBe(task);
+    expect(container.querySelector('[data-task="a1"] span')?.textContent).toBe("After: Design");
+  });
+});

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -1988,11 +1988,7 @@ function analyzeCompilerOwnedKeyedRowHostBlocks(
     parent,
     allocateId,
   );
-  if (
-    analysis.reason ||
-    analysis.plans.length === 0 ||
-    analysis.plans.some((plan) => plan.kind !== "nested-host-conditional-ranges")
-  ) {
+  if (analysis.reason || analysis.plans.length === 0) {
     return undefined;
   }
   return {


### PR DESCRIPTION
## Summary

- compile eligible keyed `.map(...)` and inline `List` ranges inside compiler-owned outer keyed host rows
- give every stable outer key an isolated inner key table, keyed-range controller, and LIS reconciliation pass
- preserve outer rows, inner rows, and static siblings while cleaning inner subscriptions when an outer row disappears
- retain React ownership for unsupported interactive rows, Hooks, custom components, fragments, refs, SVG, spreads, dangerous HTML, index keys, and deeper keyed levels
- document the contract and add a production example with 256 projects and 2,048 nested task rows

## Runtime safety

React still creates the initial client or SSR tree and handles hydration. The compiler adopts only a proven host-only shape. Duplicate keys or invalid adopted DOM transfer the complete mounted outer list back to its original React render, where updates remain live.

## Verification

- `pnpm --filter @farm.js/react test` — 36 files, 299 tests passed
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and React 19.2.8 passed
- 2,500 deterministic two-level mutations matched normal React with zero compiled-owner update executions
- production browser verification passed with 256 outer rows, 2,048 inner rows, exactly one measured LIS move at each level, preserved DOM identity, and no browser errors
- StrictMode, parent/local updates, queued unmounts, SSR adoption, recoverable hydration mismatches, duplicate-key fallback, and Fast Refresh are covered
- renderer and example type checks, renderer/CLI/core builds, lint/format checks, and the complete docs/Vercel production build passed
