### PR TITLE
feat(react): compile recursive keyed scopes

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -760,12 +760,56 @@ An outer and inner update queued together are read from the same latest collecti
 at either level, or DOM that cannot be adopted safely, transfer the complete mounted outer list to
 its original React render.
 
-The initial nested contract accepts automatic `.map(...)` and inline `List` ranges, multiple inner
-ranges separated by static host siblings, item-derived keys, and safe text, attribute, and inline
-style bindings. The outer row may also contain eligible host-only conditional blocks in other known
+The nested contract accepts automatic `.map(...)` and inline `List` ranges, multiple ranges
+separated by static host siblings, item-derived keys, and safe text, attribute, and inline style
+bindings. The outer row may also contain eligible host-only conditional blocks in other known
 locations. Inner rows remain lowercase, non-interactive host trees. Events, controlled fields,
-Hooks, custom components, fragments, refs, SVG, JSX spreads, dangerous HTML, index keys, and another
-keyed level inside an inner row keep the outer row on React's safe fallback.
+Hooks, custom components, fragments, refs, SVG, JSX spreads, dangerous HTML, and index keys keep the
+outer row on React's safe fallback.
+
+#### Recursive keyed scopes
+
+The same analysis continues through every safe keyed host row; there is no special two-level
+syntax:
+
+```tsx
+<div>
+  {boards.map((board) => (
+    <section key={board.id}>
+      <h2>{board.name}</h2>
+      <div>
+        {board.columns.map((column) => (
+          <article key={column.id}>
+            <h3>{column.name}</h3>
+            <ul>
+              {column.cards.map((card) => (
+                <li key={card.id}>{card.title}</li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+    </section>
+  ))}
+</div>
+```
+
+Build-time recursion assigns a globally unique block ID and parent relationship to every keyed
+container. At runtime the hierarchy is scoped by stable keys: a board instance owns its column
+controller, and each column instance owns its card controller. Every controller keeps an isolated
+key table and performs LIS only inside its own container. A simultaneous board, column, and card
+rotation therefore preserves all surviving DOM identities and runs one independent move plan at
+each affected depth without rerunning the component or map callbacks.
+
+Removing a parent recursively unsubscribes and removes all descendant scopes. Parent and local
+updates use the latest complete descriptor tree, and SSR or hydrated DOM is adopted from the
+outside inward. Duplicate keys or an invalid adopted shape at any level transfer the complete
+mounted outer keyed boundary to React, where subsequent updates remain live.
+
+Recursion does not widen the safety contract. Every optimized row must still be a non-interactive
+lowercase host tree with an explicit item-derived key. An event, controlled field, Hook, custom
+component, fragment, ref, SVG, spread, dangerous HTML, index key, or other unproven structure at
+the deepest level keeps the outer row on React rather than partially compiling an unsafe tree.
 
 #### Derived collection pipelines
 
@@ -920,12 +964,12 @@ The optimized host-row contract is deliberately narrow:
 - A dedicated non-interactive map/`List` may contain multiple logical or ternary host branches,
   including recursively nested branches and branches beside static host siblings. The compiler
   mounts, replaces, or removes only those host blocks within each keyed row instance.
-- A dedicated non-interactive outer row may contain one or more nested keyed map/`List` ranges in
-  known host containers. Each outer key receives an isolated inner key table and LIS pass.
+- A dedicated non-interactive row may recursively contain keyed map/`List` ranges in known host
+  containers. Each stable parent key receives an isolated child key table and LIS pass.
 - Inline synchronous row events use the hybrid React-owned row path. Branch or inner-row events,
-  deeper keyed levels, non-inline or async handlers, file inputs, dynamic form control types or
-  options, custom components, fragments, refs, SVG, attribute spreads, dangerous HTML, and dynamic
-  text mixed beside nested elements stay React-owned.
+  non-inline or async handlers, file inputs, dynamic form control types or options, custom
+  components, fragments, refs, SVG, attribute spreads, dangerous HTML, and dynamic text mixed
+  beside nested elements stay React-owned.
 - Unsupported or mutating collection methods, spread children, Hooks in callbacks, and other
   unproven shapes fall back to normal React.
 
@@ -1007,16 +1051,16 @@ key. The outer keyed block drives those scopes, so a row can update a nested bra
 without a component rerun or a separate global subscription for every row. Each inner list keeps
 its own key table and LIS pass. The scope moves with the outer row and is cleaned when its key
 disappears. Eligible inline events use the hybrid React-event path and retain React-owned row-local
-conditional Fibers. Component islands, Hooks, custom components, interactive or deeper nested
-lists, and other unproven dynamic structure remain on the complete React-owned row path; put Hooks
-inside a keyed row component.
+conditional Fibers. Component islands, Hooks, custom components, interactive or otherwise
+unsupported nested lists, and other unproven dynamic structure remain on the complete React-owned
+row path; put Hooks inside a keyed row component.
 
 ### What falls back to React
 
 | Unsupported shape                                                                                                                     | Why React keeps ownership                                                          |
 | ------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
 | Unkeyed/index-keyed maps, unsupported or mutating collection pipelines, or element arrays                                             | Their structure, purity, or item identity is outside the keyed-list contract.      |
-| Unsupported row events/forms, components, fragments, refs, SVG, interactive or deeper nested lists, or unsafe conditional branches    | Their event, lifecycle, or structure contract requires the React-owned row path.   |
+| Unsupported row events/forms, components, fragments, refs, SVG, interactive nested lists, or unsafe conditional branches              | Their event, lifecycle, or structure contract requires the React-owned row path.   |
 | Interactive ranges beside siblings or non-host range siblings                                                                         | The range owner requires a host container and non-interactive host rows.           |
 | Branch events, keys, components, fragments, refs, SVG, interactive rows, or unsupported nested blocks in a compiled conditional range | They require the React-owned conditional path rather than compiler-created hosts.  |
 | Dynamic/member component types, component spreads, refs, keys, or children                                                            | Their identity or ownership is outside the first component-island contract.        |
@@ -1209,6 +1253,12 @@ The package and example test suites verify more than generated code:
 - 2,500 deterministic two-level reorder, insert, remove, binding, and boolean transitions match
   normal React while the compiled owner remains at one execution, with additional Strict Mode,
   parent/local, duplicate-inner-key, Fast Refresh, queued-unmount, SSR, and hydration coverage;
+- recursive keyed scopes apply independent LIS passes at board, column, and card depth while
+  preserving every surviving row and static sibling;
+- 3,000 deterministic three-level reorder, insert, remove, binding, and boolean transitions match
+  normal React while the compiled owner remains at one execution, with additional Strict Mode,
+  parent/local, deepest-duplicate-key, error-boundary, Fast Refresh, queued-unmount, SSR, and
+  hydration coverage;
 - component islands update only dependent children, preserve child-local state and context, route
   failures through React error boundaries, hydrate in Strict Mode, and safely drop queued updates
   after unmount;

--- a/examples/react-compiler/README.md
+++ b/examples/react-compiler/README.md
@@ -52,6 +52,7 @@ assertions, checks for console/runtime errors and horizontal overflow, saves scr
 | Composable nested blocks   | two lists, nested conditions, and one component island  | —                                              | One block graph mounts, updates, and cleans up nested subscriptions.    |
 | Keyed row host blocks      | 1,000 rows, one LIS move, nested branch patches, executions `0` | —                                      | Each key owns its safe recursive host conditions without React commits. |
 | Nested keyed rows          | 256 projects, 2,048 tasks, one LIS move per level, executions `0` | —                                    | Every outer key owns an isolated inner key table and LIS scope.         |
+| Recursive keyed scopes     | 48 boards, 288 columns, 2,304 cards, one LIS move per level, executions `0` | —                         | Keyed scope analysis continues through every safe host-row depth.       |
 
 The package runtime test also measures one equivalent update under a React `Profiler`:
 
@@ -191,9 +192,15 @@ preserving the project, surviving task, and static heading/footer nodes. A secon
 inserts only one inner task. The production assertion covers 2,048 task rows and records zero owner
 update executions.
 
+The `12` card continues the same ownership model through boards, columns, and cards. One action
+rotates all 48 boards, the six columns inside one board, and the eight cards inside one column. The
+browser assertion observes exactly one LIS move at every level, preserves the selected board,
+column, cards, and static siblings, then removes and inserts one deepest card. It covers 2,304 card
+rows and records zero owner update executions.
+
 Hooks, custom components, row, branch, or inner-row events, refs, SVG, fragments, dangerous HTML,
-controlled inputs inside a condition, deeper keyed levels, and unproven expressions stay on React.
-Duplicate keys at either level also switch the mounted outer list to React.
+controlled inputs inside a condition, and unproven expressions stay on React. Safe host-only keyed
+levels recurse; duplicate keys at any level switch the mounted outer list to React.
 
 ## Heavy compiler-on/off benchmark
 

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -41,6 +41,7 @@ for (const component of [
   "ComposableBlockExperiment",
   "KeyedRowHostBlockExperiment",
   "NestedKeyedRowExperiment",
+  "RecursiveKeyedScopeExperiment",
 ]) {
   assert.ok(compiledComponents.has(component), `${component} was not compiled`);
 }
@@ -1277,6 +1278,201 @@ try {
   );
   assert.equal(nestedKeyedOwnerFinalExecutions - nestedKeyedOwnerInitialExecutions, 0);
 
+  const recursiveKeyedScopes = '[data-experiment="recursive-keyed-scopes"]';
+  const recursiveKeyedOwnerInitialExecutions = await readNumber(
+    page,
+    `${recursiveKeyedScopes} [data-metric="recursive-keyed-owner-executions"]`,
+  );
+  await assertText(page, `${recursiveKeyedScopes} [data-metric="recursive-keyed-boards"]`, "48");
+  await assertText(
+    page,
+    `${recursiveKeyedScopes} [data-metric="recursive-keyed-columns"]`,
+    "288",
+  );
+  await assertText(
+    page,
+    `${recursiveKeyedScopes} [data-metric="recursive-keyed-cards"]`,
+    "2304",
+  );
+  assert.equal(await page.locator(`${recursiveKeyedScopes} [data-recursive-board]`).count(), 48);
+  assert.equal(
+    await page.locator(`${recursiveKeyedScopes} [data-recursive-column]`).count(),
+    288,
+  );
+  assert.equal(await page.locator(`${recursiveKeyedScopes} [data-recursive-card]`).count(), 2304);
+  await page.evaluate(() => {
+    const boardList = document.querySelector("[data-recursive-board-list]");
+    const board = document.querySelector('[data-recursive-board="recursive-board-12"]');
+    const columnList = board.querySelector(
+      '[data-recursive-column-list="recursive-board-12"]',
+    );
+    const column = board.querySelector(
+      '[data-recursive-column="recursive-column-12-3"]',
+    );
+    const cardList = column.querySelector(
+      '[data-recursive-card-list="recursive-column-12-3"]',
+    );
+    window.__farmRecursiveBoard12 = board;
+    window.__farmRecursiveColumn123 = column;
+    window.__farmRecursiveCard1230 = column.querySelector(
+      '[data-recursive-card="recursive-card-12-3-0"]',
+    );
+    window.__farmRecursiveCard1237 = column.querySelector(
+      '[data-recursive-card="recursive-card-12-3-7"]',
+    );
+    window.__farmRecursiveColumnsBefore = board.querySelector(
+      '[data-recursive-static="columns-before"]',
+    );
+    window.__farmRecursiveColumnsAfter = board.querySelector(
+      '[data-recursive-static="columns-after"]',
+    );
+    window.__farmRecursiveCardsBefore = column.querySelector(
+      '[data-recursive-static="cards-before"]',
+    );
+    window.__farmRecursiveCardsAfter = column.querySelector(
+      '[data-recursive-static="cards-after"]',
+    );
+    window.__farmRecursiveBoardMoves = 0;
+    window.__farmRecursiveColumnMoves = 0;
+    window.__farmRecursiveCardMoves = 0;
+    const boardInsertBefore = boardList.insertBefore.bind(boardList);
+    boardList.insertBefore = (node, anchor) => {
+      if (node.parentNode === boardList && node.matches?.("[data-recursive-board]")) {
+        window.__farmRecursiveBoardMoves += 1;
+      }
+      return boardInsertBefore(node, anchor);
+    };
+    const columnInsertBefore = columnList.insertBefore.bind(columnList);
+    columnList.insertBefore = (node, anchor) => {
+      if (node.parentNode === columnList && node.matches?.("[data-recursive-column]")) {
+        window.__farmRecursiveColumnMoves += 1;
+      }
+      return columnInsertBefore(node, anchor);
+    };
+    const cardInsertBefore = cardList.insertBefore.bind(cardList);
+    cardList.insertBefore = (node, anchor) => {
+      if (node.parentNode === cardList && node.matches?.("[data-recursive-card]")) {
+        window.__farmRecursiveCardMoves += 1;
+      }
+      return cardInsertBefore(node, anchor);
+    };
+  });
+
+  await page.locator(`${recursiveKeyedScopes} [data-action="recursive-keyed-reorder"]`).click();
+  await assertText(
+    page,
+    `${recursiveKeyedScopes} [data-metric="recursive-keyed-updates"]`,
+    "1",
+  );
+  assert.equal(
+    await page
+      .locator(`${recursiveKeyedScopes} [data-recursive-board]`)
+      .first()
+      .getAttribute("data-recursive-board"),
+    "recursive-board-1",
+  );
+  assert.deepEqual(
+    await page
+      .locator(
+        `${recursiveKeyedScopes} [data-recursive-board="recursive-board-12"] [data-recursive-column]`,
+      )
+      .evaluateAll((columns) => columns.map((column) => column.getAttribute("data-recursive-column"))),
+    [
+      "recursive-column-12-5",
+      "recursive-column-12-0",
+      "recursive-column-12-1",
+      "recursive-column-12-2",
+      "recursive-column-12-3",
+      "recursive-column-12-4",
+    ],
+  );
+  assert.deepEqual(
+    await page
+      .locator(
+        `${recursiveKeyedScopes} [data-recursive-column="recursive-column-12-3"] [data-recursive-card]`,
+      )
+      .evaluateAll((cards) => cards.map((card) => card.getAttribute("data-recursive-card"))),
+    [
+      "recursive-card-12-3-7",
+      "recursive-card-12-3-0",
+      "recursive-card-12-3-1",
+      "recursive-card-12-3-2",
+      "recursive-card-12-3-3",
+      "recursive-card-12-3-4",
+      "recursive-card-12-3-5",
+      "recursive-card-12-3-6",
+    ],
+  );
+  await assertText(
+    page,
+    `${recursiveKeyedScopes} [data-recursive-card="recursive-card-12-3-7"]`,
+    "Card 12.3.7 · moved",
+  );
+  assert.equal(await page.evaluate(() => window.__farmRecursiveBoardMoves), 1);
+  assert.equal(await page.evaluate(() => window.__farmRecursiveColumnMoves), 1);
+  assert.equal(await page.evaluate(() => window.__farmRecursiveCardMoves), 1);
+  assert.equal(
+    await page.evaluate(
+      () =>
+        window.__farmRecursiveBoard12 ===
+          document.querySelector('[data-recursive-board="recursive-board-12"]') &&
+        window.__farmRecursiveColumn123 ===
+          document.querySelector('[data-recursive-column="recursive-column-12-3"]') &&
+        window.__farmRecursiveCard1230 ===
+          document.querySelector('[data-recursive-card="recursive-card-12-3-0"]') &&
+        window.__farmRecursiveCard1237 ===
+          document.querySelector('[data-recursive-card="recursive-card-12-3-7"]') &&
+        window.__farmRecursiveColumnsBefore ===
+          document.querySelector(
+            '[data-recursive-board="recursive-board-12"] [data-recursive-static="columns-before"]',
+          ) &&
+        window.__farmRecursiveColumnsAfter ===
+          document.querySelector(
+            '[data-recursive-board="recursive-board-12"] [data-recursive-static="columns-after"]',
+          ) &&
+        window.__farmRecursiveCardsBefore ===
+          document.querySelector(
+            '[data-recursive-column="recursive-column-12-3"] [data-recursive-static="cards-before"]',
+          ) &&
+        window.__farmRecursiveCardsAfter ===
+          document.querySelector(
+            '[data-recursive-column="recursive-column-12-3"] [data-recursive-static="cards-after"]',
+          ),
+    ),
+    true,
+    "recursive keyed reconciliation replaced a surviving board, column, card, or static sibling",
+  );
+
+  await page.locator(`${recursiveKeyedScopes} [data-action="recursive-keyed-replace"]`).click();
+  await assertText(
+    page,
+    `${recursiveKeyedScopes} [data-metric="recursive-keyed-updates"]`,
+    "2",
+  );
+  await assertText(
+    page,
+    `${recursiveKeyedScopes} [data-metric="recursive-keyed-cards"]`,
+    "2304",
+  );
+  assert.equal(
+    await page
+      .locator(
+        `${recursiveKeyedScopes} [data-recursive-card="recursive-card-12-3-1"]`,
+      )
+      .count(),
+    0,
+  );
+  await assertText(
+    page,
+    `${recursiveKeyedScopes} [data-recursive-card="recursive-inserted-card-1"]`,
+    "Inserted after update 1",
+  );
+  const recursiveKeyedOwnerFinalExecutions = await readNumber(
+    page,
+    `${recursiveKeyedScopes} [data-metric="recursive-keyed-owner-executions"]`,
+  );
+  assert.equal(recursiveKeyedOwnerFinalExecutions - recursiveKeyedOwnerInitialExecutions, 0);
+
   await page.screenshot({ path: screenshotPath, fullPage: true });
 
   const mobilePage = await browser.newPage({
@@ -1505,6 +1701,18 @@ try {
             staticSiblingIdentityPreserved: true,
             ownerUpdateExecutions:
               nestedKeyedOwnerFinalExecutions - nestedKeyedOwnerInitialExecutions,
+          },
+          recursiveKeyedScopes: {
+            boards: 48,
+            columns: 288,
+            cards: 2304,
+            boardLisMoves: 1,
+            columnLisMoves: 1,
+            cardLisMoves: 1,
+            identityPreservedAtEveryLevel: true,
+            staticSiblingIdentityPreserved: true,
+            ownerUpdateExecutions:
+              recursiveKeyedOwnerFinalExecutions - recursiveKeyedOwnerInitialExecutions,
           },
         },
       },

--- a/examples/react-compiler/src/app/globals.css
+++ b/examples/react-compiler/src/app/globals.css
@@ -1258,6 +1258,68 @@ h1 span {
   font-size: 0.55rem;
 }
 
+[data-recursive-board-list] > li {
+  grid-template-columns: minmax(9rem, 0.25fr) minmax(80rem, 1.75fr);
+  min-width: 92rem;
+}
+
+[data-recursive-board-list] h3,
+[data-recursive-column-list] h4 {
+  overflow: hidden;
+  margin: 0;
+  color: #d8ff9f;
+  font-size: 0.7rem;
+  font-weight: 550;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-recursive-column-list] {
+  display: grid;
+  grid-template-columns: auto repeat(6, minmax(12rem, 1fr)) auto;
+  gap: 0.4rem;
+  align-items: stretch;
+}
+
+[data-recursive-column] {
+  min-width: 0;
+  border: 1px solid #30302c;
+  padding: 0.45rem;
+}
+
+[data-recursive-column-list] h4 {
+  margin-bottom: 0.35rem;
+  font-size: 0.58rem;
+}
+
+[data-recursive-card-list] {
+  display: grid;
+  grid-template-columns: auto repeat(8, minmax(0, 1fr)) auto;
+  gap: 0.18rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+[data-recursive-card-list] > li {
+  overflow: hidden;
+  border: 1px solid #292925;
+  padding: 0.3rem;
+  font-size: 0.5rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-recursive-column-list] > [data-recursive-static],
+[data-recursive-card-list] > [data-recursive-static] {
+  align-self: center;
+  border-color: transparent;
+  color: #666660;
+  font-size: 0.48rem;
+  font-style: normal;
+  font-weight: 500;
+}
+
 .keyed-host-status {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;

--- a/examples/react-compiler/src/app/page.tsx
+++ b/examples/react-compiler/src/app/page.tsx
@@ -8,6 +8,7 @@ import { HeavyInteractionBenchmark } from "../components/heavy-interaction-bench
 import { KeyedRowHostBlockExperiment } from "../components/keyed-row-host-block-experiment";
 import { NestedKeyedRowExperiment } from "../components/nested-keyed-row-experiment";
 import { RecursiveHostBlockExperiment } from "../components/recursive-host-block-experiment";
+import { RecursiveKeyedScopeExperiment } from "../components/recursive-keyed-scope-experiment";
 import { StaticBindingExperiment } from "../components/static-binding-experiment";
 
 export default function HomePage() {
@@ -83,6 +84,8 @@ export default function HomePage() {
       <KeyedRowHostBlockExperiment />
 
       <NestedKeyedRowExperiment />
+
+      <RecursiveKeyedScopeExperiment />
 
       <section
         className="benchmark-report"

--- a/examples/react-compiler/src/components/recursive-keyed-scope-experiment.tsx
+++ b/examples/react-compiler/src/components/recursive-keyed-scope-experiment.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState } from "react";
+
+interface RecursiveCard {
+  id: string;
+  label: string;
+  done: boolean;
+}
+
+interface RecursiveColumn {
+  id: string;
+  label: string;
+  cards: RecursiveCard[];
+}
+
+interface RecursiveBoard {
+  id: string;
+  label: string;
+  columns: RecursiveColumn[];
+}
+
+const initialBoards: RecursiveBoard[] = Array.from({ length: 48 }, (_, boardIndex) => ({
+  id: `recursive-board-${boardIndex}`,
+  label: `Board ${boardIndex}`,
+  columns: Array.from({ length: 6 }, (_, columnIndex) => ({
+    id: `recursive-column-${boardIndex}-${columnIndex}`,
+    label: `Column ${boardIndex}.${columnIndex}`,
+    cards: Array.from({ length: 8 }, (_, cardIndex) => ({
+      id: `recursive-card-${boardIndex}-${columnIndex}-${cardIndex}`,
+      label: `Card ${boardIndex}.${columnIndex}.${cardIndex}`,
+      done: cardIndex % 2 === 0,
+    })),
+  })),
+}));
+
+let recursiveKeyedOwnerExecutions = 0;
+
+export function RecursiveKeyedScopeExperiment() {
+  const [boards, setBoards] = useState(initialBoards);
+  const [updates, setUpdates] = useState(0);
+
+  function reorderEveryLevel() {
+    setBoards((current) => {
+      const rotatedBoards = [...current.slice(1), current[0]];
+      return rotatedBoards.map((board) => {
+        if (board.id !== "recursive-board-12") return board;
+        const rotatedColumns = [board.columns[5], ...board.columns.slice(0, 5)];
+        return {
+          ...board,
+          label: "Board 12 · updated",
+          columns: rotatedColumns.map((column) => {
+            if (column.id !== "recursive-column-12-3") return column;
+            const lastCard = column.cards[column.cards.length - 1];
+            return {
+              ...column,
+              label: "Column 12.3 · updated",
+              cards: [
+                { ...lastCard, label: `${lastCard.label} · moved`, done: true },
+                ...column.cards.slice(0, -1),
+              ],
+            };
+          }),
+        };
+      });
+    });
+    setUpdates((value) => value + 1);
+  }
+
+  function replaceDeepestRow() {
+    setBoards((current) =>
+      current.map((board) =>
+        board.id === "recursive-board-12"
+          ? {
+              ...board,
+              columns: board.columns.map((column) =>
+                column.id === "recursive-column-12-3"
+                  ? {
+                      ...column,
+                      cards: [
+                        ...column.cards.filter(
+                          (card) => card.id !== "recursive-card-12-3-1",
+                        ),
+                        {
+                          id: `recursive-inserted-card-${updates}`,
+                          label: `Inserted after update ${updates}`,
+                          done: false,
+                        },
+                      ],
+                    }
+                  : column,
+              ),
+            }
+          : board,
+      ),
+    );
+    setUpdates((value) => value + 1);
+  }
+
+  return (
+    <section className="heavy-benchmark" data-experiment="recursive-keyed-scopes">
+      <header className="heavy-heading">
+        <div>
+          <span className="experiment-number">12</span>
+          <div>
+            <p className="heavy-kicker">RECURSIVE KEYED SCOPES</p>
+            <h2>Every stable parent key owns the next keyed level</h2>
+          </div>
+        </div>
+        <span className="node-badge">48 BOARDS / 288 COLUMNS / 2,304 CARDS</span>
+      </header>
+
+      <p className="heavy-copy">
+        The compiler recursively prepares boards, columns, and cards. Each level gets its own key
+        table and LIS pass, so one deep update preserves every surviving DOM node without rerunning
+        this component.
+      </p>
+
+      <dl className="heavy-metrics" aria-live="polite">
+        <div>
+          <dt>Owner executions</dt>
+          <dd data-metric="recursive-keyed-owner-executions">
+            {typeof window === "undefined" ? 1 : ++recursiveKeyedOwnerExecutions}
+          </dd>
+        </div>
+        <div>
+          <dt>Boards</dt>
+          <dd data-metric="recursive-keyed-boards">{boards.length}</dd>
+        </div>
+        <div>
+          <dt>Columns</dt>
+          <dd data-metric="recursive-keyed-columns">{boards.length * 6}</dd>
+        </div>
+        <div>
+          <dt>Cards</dt>
+          <dd data-metric="recursive-keyed-cards">{boards.length * 6 * 8}</dd>
+        </div>
+        <div>
+          <dt>Updates</dt>
+          <dd data-metric="recursive-keyed-updates">{updates}</dd>
+        </div>
+      </dl>
+
+      <div className="heavy-controls composable-controls">
+        <button data-action="recursive-keyed-reorder" type="button" onClick={reorderEveryLevel}>
+          Reorder every level <span aria-hidden="true">↗</span>
+        </button>
+        <button data-action="recursive-keyed-replace" type="button" onClick={replaceDeepestRow}>
+          Replace one card
+        </button>
+      </div>
+
+      <ol className="keyed-host-row-list" data-recursive-board-list>
+        {boards.map((board, boardIndex) => (
+          <li data-recursive-board={board.id} data-board-index={boardIndex} key={board.id}>
+            <h3>{board.label}</h3>
+            <div data-recursive-column-list={board.id}>
+              <i data-recursive-static="columns-before">COLUMNS</i>
+              {board.columns.map((column, columnIndex) => (
+                <article
+                  data-recursive-column={column.id}
+                  data-column-index={columnIndex}
+                  key={column.id}
+                >
+                  <h4>{column.label}</h4>
+                  <ul data-recursive-card-list={column.id}>
+                    <li data-recursive-static="cards-before">CARDS</li>
+                    {column.cards.map((card, cardIndex) => (
+                      <li
+                        data-recursive-card={card.id}
+                        data-card-index={cardIndex}
+                        key={card.id}
+                        style={{ opacity: card.done ? 1 : 0.72 }}
+                        title={card.label}
+                      >
+                        {card.label}
+                      </li>
+                    ))}
+                    <li data-recursive-static="cards-after">END</li>
+                  </ul>
+                </article>
+              ))}
+              <b data-recursive-static="columns-after">END COLUMNS</b>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -220,8 +220,15 @@ task scope; reordering one task list touches only that project. Surviving projec
 sibling elements keep their DOM identity, and removing an outer row cleans its inner scope. The
 initial contract accepts non-interactive lowercase inner rows from `.map(...)` or inline `List`,
 including multiple ranges separated by static host siblings. Inner events or forms, Hooks, custom
-components, fragments, refs, SVG, spreads, dangerous HTML, index keys, and a deeper keyed level keep
-the complete outer row on React's fallback.
+components, fragments, refs, SVG, spreads, dangerous HTML, and index keys keep the complete outer
+row on React's fallback. Additional keyed levels that satisfy the same host-only contract are
+analyzed recursively instead of using a fixed nesting limit.
+
+For example, `boards → columns → cards → tags` becomes a tree of keyed scopes. Each stable parent
+key owns its child key table and LIS pass. Moving a board carries its column, card, and tag scopes;
+reordering cards reconciles only the selected column. Block IDs stay globally unique while runtime
+instances are isolated by their complete parent-key path. Removing any parent cleans every
+descendant subscription before its DOM leaves the document.
 
 A keyed collection may use derived locals or an inline chain of `filter`, `slice`, `toSorted`, and
 `toReversed`:
@@ -410,8 +417,8 @@ unsupported conditional roots, effects, and more advanced hook support intention
 in this release. Compiler-owned keyed rows support either one dedicated host-only map/`List` or
 one or more non-interactive ranges in a nested or component-root host container. A dedicated
 non-interactive row may also contain multiple recursive logical or ternary host branches beside
-static host siblings, plus one or more nested non-interactive keyed ranges scoped by the outer row
-key. Inline synchronous row events continue to use the hybrid React-owned row path. Branch or
-inner-row events, deeper keyed levels, interactive ranges beside siblings, non-inline or async row
-handlers, unsupported form shapes, custom components, fragments, refs, SVG, and duplicate runtime
-keys keep or switch to React ownership.
+static host siblings, plus recursively nested non-interactive keyed ranges scoped by every stable
+parent key. Inline synchronous row events continue to use the hybrid React-owned row path. Branch
+or nested-row events, interactive ranges beside siblings, non-inline or async row handlers,
+unsupported form shapes, custom components, fragments, refs, SVG, and duplicate runtime keys keep
+or switch to React ownership.

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -809,18 +809,53 @@ const testSource = String.raw`
   const NestedKeyedRows = createCompiledComponent({
     displayName: "CompatibilityNestedKeyedRows",
     initialize: () => [[
-      { id: "a", name: "Alpha", tasks: [{ id: "a1", title: "Design" }, { id: "a2", title: "Build" }] },
-      { id: "b", name: "Beta", tasks: [{ id: "b1", title: "Test" }, { id: "b2", title: "Ship" }] },
+      { id: "a", name: "Alpha", tasks: [{ id: "a1", title: "Design", tags: [{ id: "a1x", label: "Idea" }] }, { id: "a2", title: "Build", tags: [{ id: "a2x", label: "Ready" }] }] },
+      { id: "b", name: "Beta", tasks: [{ id: "b1", title: "Test", tags: [{ id: "b1x", label: "Check" }] }, { id: "b2", title: "Ship", tags: [{ id: "b2x", label: "Next" }, { id: "b2y", label: "Now" }] }] },
     ]],
     render(_props, state, blocks) {
       nestedKeyedExecutions += 1;
       const projects = () => state[0].get();
+      const tagDescriptor = (tag, index) => ({
+        kind: "element",
+        tag: "li",
+        attributes: [{ name: "data-tag", value: tag.id }, { name: "data-index", value: index }],
+        styles: [],
+        children: [tag.label],
+      });
       const taskDescriptor = (task, index) => ({
         kind: "element",
         tag: "li",
         attributes: [{ name: "data-task", value: task.id }, { name: "data-index", value: index }],
         styles: [],
-        children: [task.title],
+        children: [
+          { kind: "element", tag: "span", attributes: [], styles: [], children: [task.title] },
+          {
+            kind: "element",
+            tag: "ul",
+            attributes: [],
+            styles: [],
+            children: [
+              { kind: "element", tag: "i", attributes: [], styles: [], children: ["Tags"] },
+              ...task.tags.map(tagDescriptor),
+              { kind: "element", tag: "b", attributes: [], styles: [], children: ["End tags"] },
+            ],
+            block: {
+              kind: "keyed-ranges",
+              id: 2,
+              ranges: [{
+                before: 1,
+                items: () => task.tags,
+                rowKey: (tag) => tag.id,
+                create: tagDescriptor,
+                bindings: [
+                  { kind: "attribute", path: [], name: "data-index", read: (_tag, tagIndex) => tagIndex },
+                  { kind: "text", path: [], read: (tag) => [tag.label] },
+                ],
+              }],
+              trailing: 1,
+            },
+          },
+        ],
       });
       const projectDescriptor = (project, index) => ({
         kind: "element",
@@ -849,7 +884,7 @@ const testSource = String.raw`
                 create: taskDescriptor,
                 bindings: [
                   { kind: "attribute", path: [], name: "data-index", read: (_task, taskIndex) => taskIndex },
-                  { kind: "text", path: [], read: (task) => [task.title] },
+                  { kind: "text", path: [0], read: (task) => [task.title] },
                 ],
               }],
               trailing: 1,
@@ -866,7 +901,20 @@ const testSource = String.raw`
           null,
           React.createElement("i", null, "Tasks"),
           ...project.tasks.map((task, taskIndex) =>
-            React.createElement("li", { key: task.id, "data-task": task.id, "data-index": taskIndex }, task.title),
+            React.createElement(
+              "li",
+              { key: task.id, "data-task": task.id, "data-index": taskIndex },
+              React.createElement("span", null, task.title),
+              React.createElement(
+                "ul",
+                null,
+                React.createElement("i", null, "Tags"),
+                ...task.tags.map((tag, tagIndex) =>
+                  React.createElement("li", { key: tag.id, "data-tag": tag.id, "data-index": tagIndex }, tag.label),
+                ),
+                React.createElement("b", null, "End tags"),
+              ),
+            ),
           ),
           React.createElement("b", null, "End"),
         ),
@@ -879,7 +927,7 @@ const testSource = String.raw`
           onClick: () => state[0].set((current) => {
             const [a, b] = current;
             return [
-              { ...b, name: "Beta newest", tasks: [{ ...b.tasks[1], title: "Ship now" }, b.tasks[0]] },
+              { ...b, name: "Beta newest", tasks: [{ ...b.tasks[1], title: "Ship now", tags: [{ ...b.tasks[1].tags[1], label: "Now updated" }, b.tasks[1].tags[0]] }, b.tasks[0]] },
               a,
             ];
           }),
@@ -901,6 +949,7 @@ const testSource = String.raw`
     bindings: [
       { kind: "block", id: 0, dependencies: [0] },
       { kind: "block", id: 1, parent: 0, dependencies: [] },
+      { kind: "block", id: 2, parent: 1, dependencies: [] },
     ],
   });
   const nestedKeyedContainer = document.createElement("div");
@@ -911,6 +960,8 @@ const testSource = String.raw`
   const originalProjectB = nestedKeyedContainer.querySelector('[data-project="b"]');
   const originalTaskB1 = nestedKeyedContainer.querySelector('[data-task="b1"]');
   const originalTaskB2 = nestedKeyedContainer.querySelector('[data-task="b2"]');
+  const originalTagB2X = nestedKeyedContainer.querySelector('[data-tag="b2x"]');
+  const originalTagB2Y = nestedKeyedContainer.querySelector('[data-tag="b2y"]');
   const originalNestedStatic = originalProjectB.querySelector("ul > i");
   nestedKeyedContainer.querySelector("[data-nested-keyed-update]").click();
   await Promise.resolve();
@@ -926,8 +977,15 @@ const testSource = String.raw`
   assert.equal(nestedKeyedContainer.querySelector('[data-project="b"]'), originalProjectB);
   assert.equal(nestedKeyedContainer.querySelector('[data-task="b1"]'), originalTaskB1);
   assert.equal(nestedKeyedContainer.querySelector('[data-task="b2"]'), originalTaskB2);
+  assert.equal(nestedKeyedContainer.querySelector('[data-tag="b2x"]'), originalTagB2X);
+  assert.equal(nestedKeyedContainer.querySelector('[data-tag="b2y"]'), originalTagB2Y);
+  assert.deepEqual(
+    [...originalTaskB2.querySelectorAll("[data-tag]")].map((row) => row.dataset.tag),
+    ["b2y", "b2x"],
+  );
   assert.equal(originalProjectB.querySelector("ul > i"), originalNestedStatic);
-  assert.equal(originalTaskB2.textContent, "Ship now");
+  assert.equal(originalTaskB2.querySelector(":scope > span").textContent, "Ship now");
+  assert.equal(originalTagB2Y.textContent, "Now updated");
   assert.equal(nestedKeyedExecutions, initialNestedKeyedExecutions);
   flushSync(() => nestedKeyedRoot.unmount());
 

--- a/packages/farm-react/src/__tests__/compiler-keyed-row-host-blocks.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-row-host-blocks.test.ts
@@ -255,6 +255,159 @@ describe("React AOT compiler-owned keyed-row host blocks", () => {
     expect(result.code).not.toContain("farmBlocks.KeyedList");
   });
 
+  it("recursively prepares map and List keyed scopes at every safe host level", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List } from "@farm.js/react/list";
+      export function Workspace() {
+        const [boards, setBoards] = useState([{ id: "b", name: "Board", columns: [{ id: "c", name: "Column", cards: [{ id: "r", title: "Card", tags: [{ id: "t", label: "Ready" }] }] }] }]);
+        return (
+          <main>
+            <button onClick={() => setBoards((rows) => [...rows])}>Refresh</button>
+            <div>
+              {boards.map((board, boardIndex) => (
+                <section key={board.id} data-board-index={boardIndex}>
+                  <h2>{board.name}</h2>
+                  <div>
+                    <i>Columns</i>
+                    <List each={board.columns} by={(column) => column.id}>
+                      {(column, columnIndex) => (
+                        <article data-column-index={columnIndex}>
+                          <h3>{column.name}</h3>
+                          <ul>
+                            {column.cards.map((card, cardIndex) => (
+                              <li key={card.id} data-card-index={cardIndex}>
+                                <span>{card.title}</span>
+                                <ol>
+                                  <List each={card.tags} by={(tag) => tag.id}>
+                                    {(tag, tagIndex) => <li data-tag-index={tagIndex}>{tag.label}</li>}
+                                  </List>
+                                </ol>
+                              </li>
+                            ))}
+                          </ul>
+                        </article>
+                      )}
+                    </List>
+                    <b>End</b>
+                  </div>
+                </section>
+              ))}
+            </div>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Workspace"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("hostBlocks={true}");
+    expect(result.code.match(/kind: "keyed-ranges"/g)).toHaveLength(3);
+    expect(result.code.match(/staticChildrenOnly: true/g)).toHaveLength(3);
+    expect(result.code).toContain("parent: 0");
+    expect(result.code).toContain("parent: 1");
+    expect(result.code).toContain("parent: 2");
+    expect(result.code).not.toContain("farmBlocks.KeyedList");
+    expect(result.code).toContain("card.tags");
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedRowHostBlocks.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({ code: expect.stringContaining("hostBlocks") });
+  });
+
+  it("keeps descriptor output linear without a fixed keyed nesting limit", async () => {
+    const depth = 10;
+    let row = `<li key={node${depth - 1}.id}>{node${depth - 1}.label}</li>`;
+    for (let level = depth - 2; level >= 0; level -= 1) {
+      row = `
+        <section key={node${level}.id}>
+          <h2>{node${level}.label}</h2>
+          <div>
+            {node${level}.children.map((node${level + 1}) => (${row}))}
+          </div>
+        </section>
+      `;
+    }
+
+    const result = await compile(`
+      import { useState } from "react";
+      export function DeepTree() {
+        const [tree, setTree] = useState([]);
+        return (
+          <main>
+            <button onClick={() => setTree((value) => [...value])}>Refresh</button>
+            <div>{tree.map((node0) => (${row}))}</div>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["DeepTree"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("hostBlocks={true}");
+    expect(result.code.match(/kind: "keyed-ranges"/g)).toHaveLength(depth - 1);
+    expect(result.code.match(/staticChildrenOnly: true/g)).toHaveLength(depth - 1);
+    expect(result.code).toContain(`parent: ${depth - 2}`);
+    await expect(
+      transformWithEsbuild(result.code, "/app/DeepRecursiveKeyedTree.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({ code: expect.stringContaining("hostBlocks") });
+  });
+
+  it.each([
+    {
+      name: "an event",
+      row: "<li key={card.id}><button onClick={() => setBoards([])}>{card.title}</button></li>",
+    },
+    {
+      name: "a custom component",
+      row: "<CardRow key={card.id} card={card} />",
+      declaration: "function CardRow({ card }) { return <li>{card.title}</li>; }",
+    },
+    {
+      name: "a fragment",
+      row: "<><li key={card.id}>{card.title}</li></>",
+    },
+    {
+      name: "an index key",
+      row: "<li key={cardIndex}>{card.title}</li>",
+    },
+  ])("keeps a deepest keyed row with $name on React", async ({ row, declaration = "" }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      ${declaration}
+      export function Workspace() {
+        const [boards, setBoards] = useState([{ id: "b", columns: [{ id: "c", cards: [{ id: "r", title: "Card" }] }] }]);
+        return (
+          <main>
+            <button onClick={() => setBoards((rows) => [...rows])}>Refresh</button>
+            <div>
+              {boards.map((board) => (
+                <section key={board.id}>
+                  <div>
+                    {board.columns.map((column) => (
+                      <article key={column.id}>
+                        <ul>{column.cards.map((card, cardIndex) => ${row})}</ul>
+                      </article>
+                    ))}
+                  </div>
+                </section>
+              ))}
+            </div>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Workspace"]);
+    expect(result.code).not.toContain("hostBlocks={true}");
+    expect(result.code).toContain("column.cards.map");
+  });
+
   it.each([
     {
       name: "an interactive inner row",

--- a/packages/farm-react/src/__tests__/compiler-recursive-host-blocks.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-recursive-host-blocks.test.ts
@@ -146,7 +146,8 @@ describe("React AOT recursive host-block compiler", () => {
 
     expect(result.diagnostics).toEqual([]);
     expect(result.code).toContain('kind: "keyed-ranges"');
-    expect(result.code).toContain("Array.from");
+    expect(result.code).toContain("staticChildrenOnly: true");
+    expect(result.code).not.toContain("Array.from");
   });
 
   it("retains React ownership for lifecycle-sensitive nested structures", async () => {

--- a/packages/farm-react/src/__tests__/compiler-runtime-recursive-keyed-scopes.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-recursive-keyed-scopes.test.tsx
@@ -874,7 +874,7 @@ describe("compiler-owned recursive keyed scopes runtime", () => {
       );
     }
     expect(fixture.executions()).toBe(executionsAfterMount);
-  }, 30_000);
+  }, 60_000);
 
   it("preserves every keyed depth through compatible Fast Refresh", async () => {
     const hmrId = `recursive-keyed-refresh-${Math.random()}`;

--- a/packages/farm-react/src/__tests__/compiler-runtime-recursive-keyed-scopes.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-recursive-keyed-scopes.test.tsx
@@ -1,0 +1,934 @@
+import React, { Profiler, StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createCompiledComponent,
+  type CompiledComponentDefinition,
+  type CompilerHostElement,
+  type CompilerKeyedRowBinding,
+  type CompilerStateUpdater,
+} from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Card {
+  id: string;
+  title: string;
+  done: boolean;
+  fail?: boolean;
+}
+
+interface Column {
+  id: string;
+  name: string;
+  cards: Card[];
+}
+
+interface Board {
+  id: string;
+  name: string;
+  columns: Column[];
+}
+
+const initialBoards: Board[] = [
+  {
+    id: "a",
+    name: "Alpha",
+    columns: [
+      {
+        id: "a1",
+        name: "Ideas",
+        cards: [
+          { id: "a1c1", title: "Explore", done: false },
+          { id: "a1c2", title: "Draft", done: true },
+        ],
+      },
+      {
+        id: "a2",
+        name: "Ready",
+        cards: [
+          { id: "a2c1", title: "Review", done: false },
+          { id: "a2c2", title: "Approve", done: true },
+        ],
+      },
+    ],
+  },
+  {
+    id: "b",
+    name: "Beta",
+    columns: [
+      {
+        id: "b1",
+        name: "Plan",
+        cards: [
+          { id: "b1c1", title: "Scope", done: false },
+          { id: "b1c2", title: "Estimate", done: true },
+        ],
+      },
+      {
+        id: "b2",
+        name: "Build",
+        cards: [
+          { id: "b2c1", title: "Compile", done: false },
+          { id: "b2c2", title: "Test", done: true },
+          { id: "b2c3", title: "Ship", done: false },
+        ],
+      },
+      {
+        id: "b3",
+        name: "Observe",
+        cards: [
+          { id: "b3c1", title: "Measure", done: false },
+          { id: "b3c2", title: "Report", done: true },
+        ],
+      },
+    ],
+  },
+  {
+    id: "c",
+    name: "Gamma",
+    columns: [
+      {
+        id: "c1",
+        name: "Queue",
+        cards: [
+          { id: "c1c1", title: "One", done: false },
+          { id: "c1c2", title: "Two", done: true },
+        ],
+      },
+    ],
+  },
+];
+
+const roots: Array<{ unmount(): void }> = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function host(
+  tag: string,
+  children: readonly unknown[] = [],
+  attributes: readonly { name: string; value: unknown }[] = [],
+  styles: readonly { name: string; value: unknown }[] = [],
+): CompilerHostElement {
+  return { kind: "element", tag, attributes, styles, children };
+}
+
+function cardDescriptor(card: Card, index: number, prefix: string): CompilerHostElement {
+  return host(
+    "li",
+    [host("span", [prefix, card.title]), host("small", [card.done ? "done" : "open"])],
+    [
+      { name: "data-card", value: card.id },
+      { name: "data-card-index", value: index },
+      { name: "title", value: card.title },
+    ],
+    [{ name: "opacity", value: card.done ? 1 : 0.7 }],
+  );
+}
+
+function cardBindings(prefix: string): CompilerKeyedRowBinding[] {
+  return [
+    {
+      kind: "attribute",
+      path: [],
+      name: "data-card-index",
+      read: (_card, index) => index,
+    },
+    {
+      kind: "attribute",
+      path: [],
+      name: "title",
+      read: (card) => (card as Card).title,
+    },
+    {
+      kind: "style",
+      path: [],
+      name: "opacity",
+      read: (card) => ((card as Card).done ? 1 : 0.7),
+    },
+    {
+      kind: "text",
+      path: [0],
+      read: (card) => {
+        if ((card as Card).fail) throw new Error("recursive keyed binding failed");
+        return [prefix, (card as Card).title];
+      },
+    },
+    {
+      kind: "text",
+      path: [1],
+      read: (card) => ((card as Card).done ? "done" : "open"),
+    },
+  ];
+}
+
+function columnDescriptor(column: Column, index: number, prefix: string): CompilerHostElement {
+  return host(
+    "article",
+    [
+      host("h3", [prefix, column.name]),
+      {
+        ...host("ul", [
+          host("i", ["CARDS"]),
+          ...column.cards.map((card, cardIndex) => cardDescriptor(card, cardIndex, prefix)),
+          host("b", ["END CARDS"]),
+        ]),
+        block: {
+          kind: "keyed-ranges",
+          id: 2,
+          ranges: [
+            {
+              before: 1,
+              items: () => column.cards,
+              rowKey: (card: unknown) => (card as Card).id,
+              create: (card: unknown, cardIndex: number) =>
+                cardDescriptor(card as Card, cardIndex, prefix),
+              bindings: cardBindings(prefix),
+            },
+          ],
+          trailing: 1,
+        },
+      },
+    ],
+    [
+      { name: "data-column", value: column.id },
+      { name: "data-column-index", value: index },
+    ],
+  );
+}
+
+function columnBindings(prefix: string): CompilerKeyedRowBinding[] {
+  return [
+    {
+      kind: "attribute",
+      path: [],
+      name: "data-column-index",
+      read: (_column, index) => index,
+    },
+    {
+      kind: "text",
+      path: [0],
+      read: (column) => [prefix, (column as Column).name],
+    },
+  ];
+}
+
+function boardDescriptor(board: Board, index: number, prefix: string): CompilerHostElement {
+  return host(
+    "section",
+    [
+      host("h2", [prefix, board.name]),
+      {
+        ...host("div", [
+          host("i", ["COLUMNS"]),
+          ...board.columns.map((column, columnIndex) =>
+            columnDescriptor(column, columnIndex, prefix),
+          ),
+          host("b", ["END COLUMNS"]),
+        ]),
+        block: {
+          kind: "keyed-ranges",
+          id: 1,
+          ranges: [
+            {
+              before: 1,
+              items: () => board.columns,
+              rowKey: (column: unknown) => (column as Column).id,
+              create: (column: unknown, columnIndex: number) =>
+                columnDescriptor(column as Column, columnIndex, prefix),
+              bindings: columnBindings(prefix),
+            },
+          ],
+          trailing: 1,
+        },
+      },
+    ],
+    [
+      { name: "data-board", value: board.id },
+      { name: "data-board-index", value: index },
+    ],
+  );
+}
+
+function boardBindings(prefix: string): CompilerKeyedRowBinding[] {
+  return [
+    {
+      kind: "attribute",
+      path: [],
+      name: "data-board-index",
+      read: (_board, index) => index,
+    },
+    {
+      kind: "text",
+      path: [0],
+      read: (board) => [prefix, (board as Board).name],
+    },
+  ];
+}
+
+function cardMarkup(card: Card, index: number, prefix: string): React.ReactElement {
+  return (
+    <li
+      data-card={card.id}
+      data-card-index={index}
+      key={card.id}
+      style={{ opacity: card.done ? 1 : 0.7 }}
+      title={card.title}
+    >
+      <span>
+        {prefix}
+        {card.title}
+      </span>
+      <small>{card.done ? "done" : "open"}</small>
+    </li>
+  );
+}
+
+function columnMarkup(column: Column, index: number, prefix: string): React.ReactElement {
+  return (
+    <article data-column={column.id} data-column-index={index} key={column.id}>
+      <h3>
+        {prefix}
+        {column.name}
+      </h3>
+      <ul>
+        <i>CARDS</i>
+        {column.cards.map((card, cardIndex) => cardMarkup(card, cardIndex, prefix))}
+        <b>END CARDS</b>
+      </ul>
+    </article>
+  );
+}
+
+function boardMarkup(board: Board, index: number, prefix: string): React.ReactElement {
+  return (
+    <section data-board={board.id} data-board-index={index} key={board.id}>
+      <h2>
+        {prefix}
+        {board.name}
+      </h2>
+      <div>
+        <i>COLUMNS</i>
+        {board.columns.map((column, columnIndex) => columnMarkup(column, columnIndex, prefix))}
+        <b>END COLUMNS</b>
+      </div>
+    </section>
+  );
+}
+
+function createRecursiveFixture() {
+  let executions = 0;
+  let setBoards: (next: CompilerStateUpdater) => void = () => undefined;
+  const Workspace = createCompiledComponent({
+    displayName: "RecursiveKeyedWorkspace",
+    initialize: () => [initialBoards],
+    render(props: { prefix: string }, state, blocks) {
+      executions += 1;
+      setBoards = state[0].set;
+      const boards = () => state[0].get() as Board[];
+      const KeyedRows = blocks.KeyedRows;
+      return (
+        <main>
+          <KeyedRows
+            bindings={boardBindings(props.prefix)}
+            create={(board, index) => boardDescriptor(board as Board, index, props.prefix)}
+            hostBlocks
+            id={0}
+            items={boards}
+            render={() => (
+              <div data-boards>
+                {boards().map((board, index) => boardMarkup(board, index, props.prefix))}
+              </div>
+            )}
+            rowKey={(board) => (board as Board).id}
+          />
+        </main>
+      );
+    },
+    bindings: [
+      { kind: "block", id: 0, dependencies: [0] },
+      { kind: "block", id: 1, parent: 0, dependencies: [] },
+      { kind: "block", id: 2, parent: 1, dependencies: [] },
+    ],
+  });
+  return {
+    Workspace,
+    executions: () => executions,
+    setBoards: (next: CompilerStateUpdater) => setBoards(next),
+  };
+}
+
+function semanticBoards(container: Element, owner: string) {
+  return [...container.querySelectorAll<HTMLElement>(`${owner} [data-board]`)].map((board) => ({
+    id: board.dataset.board,
+    index: board.dataset.boardIndex,
+    name: board.querySelector(":scope > h2")?.textContent,
+    columns: [...board.querySelectorAll<HTMLElement>(":scope > div > [data-column]")].map(
+      (column) => ({
+        id: column.dataset.column,
+        index: column.dataset.columnIndex,
+        name: column.querySelector(":scope > h3")?.textContent,
+        cards: [...column.querySelectorAll<HTMLElement>(":scope > ul > [data-card]")].map(
+          (card) => ({
+            id: card.dataset.card,
+            index: card.dataset.cardIndex,
+            title: card.getAttribute("title"),
+            label: card.querySelector("span")?.textContent,
+            status: card.querySelector("small")?.textContent,
+            opacity: card.style.opacity,
+          }),
+        ),
+      }),
+    ),
+  }));
+}
+
+class Boundary extends React.Component<React.PropsWithChildren, { message: string }> {
+  state = { message: "" };
+
+  static getDerivedStateFromError(error: Error) {
+    return { message: error.message };
+  }
+
+  render() {
+    return this.state.message ? <p data-error>{this.state.message}</p> : this.props.children;
+  }
+}
+
+describe("compiler-owned recursive keyed scopes runtime", () => {
+  it("runs one independent LIS move at every keyed depth without React commits", async () => {
+    let profilerCommits = 0;
+    const fixture = createRecursiveFixture();
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <StrictMode>
+          <Profiler id="recursive-keyed" onRender={() => (profilerCommits += 1)}>
+            <fixture.Workspace prefix="Live: " />
+          </Profiler>
+        </StrictMode>,
+      ),
+    );
+
+    const executionsAfterMount = fixture.executions();
+    const commitsAfterMount = profilerCommits;
+    const boardB = container.querySelector<HTMLElement>('[data-board="b"]')!;
+    const columnB2 = boardB.querySelector<HTMLElement>('[data-column="b2"]')!;
+    const cardB2C1 = columnB2.querySelector<HTMLElement>('[data-card="b2c1"]')!;
+    const cardB2C2 = columnB2.querySelector<HTMLElement>('[data-card="b2c2"]')!;
+    const boardStatic = boardB.querySelector(":scope > div > i");
+    const columnStatic = columnB2.querySelector(":scope > ul > i");
+    const boardsRoot = container.querySelector<HTMLElement>("[data-boards]")!;
+    const columnsRoot = boardB.querySelector<HTMLElement>(":scope > div")!;
+    const cardsRoot = columnB2.querySelector<HTMLElement>(":scope > ul")!;
+    let boardMoves = 0;
+    let columnMoves = 0;
+    let cardMoves = 0;
+    const boardInsertBefore = boardsRoot.insertBefore.bind(boardsRoot);
+    boardsRoot.insertBefore = (node, anchor) => {
+      if (node.parentNode === boardsRoot) boardMoves += 1;
+      return boardInsertBefore(node, anchor);
+    };
+    const columnInsertBefore = columnsRoot.insertBefore.bind(columnsRoot);
+    columnsRoot.insertBefore = (node, anchor) => {
+      if (node.parentNode === columnsRoot && (node as Element).matches?.("[data-column]")) {
+        columnMoves += 1;
+      }
+      return columnInsertBefore(node, anchor);
+    };
+    const cardInsertBefore = cardsRoot.insertBefore.bind(cardsRoot);
+    cardsRoot.insertBefore = (node, anchor) => {
+      if (node.parentNode === cardsRoot && (node as Element).matches?.("[data-card]")) {
+        cardMoves += 1;
+      }
+      return cardInsertBefore(node, anchor);
+    };
+
+    await act(async () => {
+      fixture.setBoards((current) => {
+        const [a, b, c] = current as Board[];
+        const [b1, b2, b3] = b.columns;
+        const [first, second, third] = b2.cards;
+        return [b, c, a].map((board) =>
+          board.id === "b"
+            ? {
+                ...board,
+                name: "Beta updated",
+                columns: [
+                  {
+                    ...b2,
+                    name: "Build updated",
+                    cards: [{ ...third, title: "Ship now", done: true }, first, second],
+                  },
+                  b3,
+                  b1,
+                ],
+              }
+            : board,
+        );
+      });
+      await flushCompilerUpdates();
+    });
+
+    expect(
+      [...container.querySelectorAll<HTMLElement>("[data-board]")].map(
+        (board) => board.dataset.board,
+      ),
+    ).toEqual(["b", "c", "a"]);
+    expect(
+      [...boardB.querySelectorAll<HTMLElement>(":scope > div > [data-column]")].map(
+        (column) => column.dataset.column,
+      ),
+    ).toEqual(["b2", "b3", "b1"]);
+    expect(
+      [...columnB2.querySelectorAll<HTMLElement>(":scope > ul > [data-card]")].map(
+        (card) => card.dataset.card,
+      ),
+    ).toEqual(["b2c3", "b2c1", "b2c2"]);
+    expect(container.querySelector('[data-board="b"]')).toBe(boardB);
+    expect(boardB.querySelector('[data-column="b2"]')).toBe(columnB2);
+    expect(columnB2.querySelector('[data-card="b2c1"]')).toBe(cardB2C1);
+    expect(columnB2.querySelector('[data-card="b2c2"]')).toBe(cardB2C2);
+    expect(boardB.querySelector(":scope > div > i")).toBe(boardStatic);
+    expect(columnB2.querySelector(":scope > ul > i")).toBe(columnStatic);
+    expect(columnB2.querySelector('[data-card="b2c3"] span')?.textContent).toBe("Live: Ship now");
+    expect(boardMoves).toBe(1);
+    expect(columnMoves).toBe(1);
+    expect(cardMoves).toBe(1);
+    expect(fixture.executions()).toBe(executionsAfterMount);
+    expect(profilerCommits).toBe(commitsAfterMount);
+  });
+
+  it("combines parent props with deepest updates and drops queued work after unmount", async () => {
+    const fixture = createRecursiveFixture();
+    function Parent() {
+      const [prefix, setPrefix] = useState("Before: ");
+      return (
+        <>
+          <button data-parent onClick={() => setPrefix("After: ")} type="button" />
+          <fixture.Workspace prefix={prefix} />
+        </>
+      );
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Parent />));
+    const card = container.querySelector('[data-card="b2c2"]');
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("[data-parent]")?.click();
+      fixture.setBoards((current) =>
+        (current as Board[]).map((board) =>
+          board.id === "b"
+            ? {
+                ...board,
+                columns: board.columns.map((column) =>
+                  column.id === "b2"
+                    ? {
+                        ...column,
+                        cards: column.cards.map((currentCard) =>
+                          currentCard.id === "b2c2"
+                            ? { ...currentCard, title: "Together", done: false }
+                            : currentCard,
+                        ),
+                      }
+                    : column,
+                ),
+              }
+            : board,
+        ),
+      );
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector('[data-card="b2c2"]')).toBe(card);
+    expect(container.querySelector('[data-card="b2c2"] span')?.textContent).toBe("After: Together");
+
+    fixture.setBoards((current) => [...(current as Board[])].reverse());
+    await act(async () => root.unmount());
+    roots.splice(roots.indexOf(root), 1);
+    await flushCompilerUpdates();
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("adopts recursive server rows and recovers from hydration mismatches", async () => {
+    for (const mismatch of [false, true]) {
+      const fixture = createRecursiveFixture();
+      const container = document.createElement("div");
+      const serverHtml = renderToString(<fixture.Workspace prefix="SSR: " />);
+      container.innerHTML = mismatch
+        ? serverHtml.replace("Compile</span>", "Server mismatch</span>")
+        : serverHtml;
+      document.body.append(container);
+      const recoverable = vi.fn();
+      let root!: ReturnType<typeof hydrateRoot>;
+      await act(async () => {
+        root = hydrateRoot(container, <fixture.Workspace prefix="SSR: " />, {
+          onRecoverableError: recoverable,
+        });
+        await flushCompilerUpdates();
+      });
+      roots.push(root);
+      const card = container.querySelector('[data-card="b2c1"]');
+      if (mismatch) expect(recoverable).toHaveBeenCalled();
+      else expect(recoverable).not.toHaveBeenCalled();
+
+      await act(async () => {
+        fixture.setBoards((current) =>
+          (current as Board[]).map((board) =>
+            board.id === "b"
+              ? {
+                  ...board,
+                  columns: board.columns.map((column) =>
+                    column.id === "b2"
+                      ? {
+                          ...column,
+                          cards: [
+                            column.cards[2],
+                            { ...column.cards[0], title: "Hydrated", done: true },
+                            column.cards[1],
+                          ],
+                        }
+                      : column,
+                  ),
+                }
+              : board,
+          ),
+        );
+        await flushCompilerUpdates();
+      });
+      expect(container.querySelector('[data-card="b2c1"]')).toBe(card);
+      expect(container.querySelector('[data-card="b2c1"] span')?.textContent).toBe("SSR: Hydrated");
+
+      await act(async () => root.unmount());
+      roots.splice(roots.indexOf(root), 1);
+      container.remove();
+    }
+  });
+
+  it("falls back to React for duplicate deepest keys and remains live", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const fixture = createRecursiveFixture();
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<fixture.Workspace prefix="Safe: " />));
+
+    await act(async () => {
+      fixture.setBoards((current) =>
+        (current as Board[]).map((board) =>
+          board.id === "b"
+            ? {
+                ...board,
+                columns: board.columns.map((column) =>
+                  column.id === "b2"
+                    ? {
+                        ...column,
+                        cards: [
+                          { ...column.cards[0], title: "First" },
+                          { ...column.cards[0], title: "Duplicate" },
+                        ],
+                      }
+                    : column,
+                ),
+              }
+            : board,
+        ),
+      );
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelectorAll('[data-column="b2"] [data-card="b2c1"]')).toHaveLength(2);
+    expect(container.textContent).toContain("Duplicate");
+
+    await act(async () => {
+      fixture.setBoards((current) =>
+        (current as Board[]).map((board) =>
+          board.id === "b"
+            ? {
+                ...board,
+                columns: board.columns.map((column) =>
+                  column.id === "b2"
+                    ? {
+                        ...column,
+                        cards: [{ id: "safe", title: "Safe again", done: true }],
+                      }
+                    : column,
+                ),
+              }
+            : board,
+        ),
+      );
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector('[data-card="safe"] span')?.textContent).toBe(
+      "Safe: Safe again",
+    );
+  });
+
+  it("routes deepest binding failures through React error boundaries", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const fixture = createRecursiveFixture();
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <Boundary>
+          <fixture.Workspace prefix="Error: " />
+        </Boundary>,
+      ),
+    );
+    await act(async () => {
+      fixture.setBoards((current) =>
+        (current as Board[]).map((board) =>
+          board.id === "b"
+            ? {
+                ...board,
+                columns: board.columns.map((column) =>
+                  column.id === "b2"
+                    ? {
+                        ...column,
+                        cards: column.cards.map((card) =>
+                          card.id === "b2c1" ? { ...card, fail: true } : card,
+                        ),
+                      }
+                    : column,
+                ),
+              }
+            : board,
+        ),
+      );
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("[data-error]")?.textContent).toBe(
+      "recursive keyed binding failed",
+    );
+  });
+
+  it("matches normal React across 3,000 deterministic three-level mutations", async () => {
+    type Action =
+      | "board-reverse"
+      | "board-rotate"
+      | "column-reverse"
+      | "column-rotate"
+      | "column-add"
+      | "column-remove"
+      | "card-reverse"
+      | "card-rotate"
+      | "card-edit"
+      | "card-toggle"
+      | "card-add"
+      | "card-remove";
+    let normalSet: React.Dispatch<React.SetStateAction<Board[]>> = () => undefined;
+    const fixture = createRecursiveFixture();
+
+    function Normal() {
+      const [boards, setBoards] = useState(initialBoards);
+      normalSet = setBoards;
+      return (
+        <div data-normal>{boards.map((board, index) => boardMarkup(board, index, "Test: "))}</div>
+      );
+    }
+
+    const transition = (boards: Board[], action: Action, step: number): Board[] => {
+      if (action === "board-reverse") return [...boards].reverse();
+      if (action === "board-rotate" && boards.length > 1) {
+        return [...boards.slice(1), boards[0]];
+      }
+      if (boards.length === 0) return boards;
+      const boardIndex = step % boards.length;
+      return boards.map((board, currentBoardIndex) => {
+        if (currentBoardIndex !== boardIndex) return board;
+        const columns = board.columns;
+        if (action === "column-reverse") return { ...board, columns: [...columns].reverse() };
+        if (action === "column-rotate" && columns.length > 1) {
+          return { ...board, columns: [...columns.slice(1), columns[0]] };
+        }
+        if (action === "column-add" && columns.length < 6) {
+          return {
+            ...board,
+            columns: [
+              ...columns,
+              {
+                id: `${board.id}-column-${step}`,
+                name: `Column ${step}`,
+                cards: [{ id: `${board.id}-card-${step}`, title: `Card ${step}`, done: false }],
+              },
+            ],
+          };
+        }
+        if (action === "column-remove" && columns.length > 1) {
+          return { ...board, columns: columns.slice(1) };
+        }
+        if (columns.length === 0) return board;
+        const columnIndex = (step * 7) % columns.length;
+        return {
+          ...board,
+          columns: columns.map((column, currentColumnIndex) => {
+            if (currentColumnIndex !== columnIndex) return column;
+            const cards = column.cards;
+            if (action === "card-reverse") return { ...column, cards: [...cards].reverse() };
+            if (action === "card-rotate" && cards.length > 1) {
+              return { ...column, cards: [...cards.slice(1), cards[0]] };
+            }
+            if (action === "card-edit" && cards.length > 0) {
+              return {
+                ...column,
+                cards: cards.map((card, cardIndex) =>
+                  cardIndex === step % cards.length ? { ...card, title: `${card.title}!` } : card,
+                ),
+              };
+            }
+            if (action === "card-toggle" && cards.length > 0) {
+              return {
+                ...column,
+                cards: cards.map((card, cardIndex) =>
+                  cardIndex === step % cards.length ? { ...card, done: !card.done } : card,
+                ),
+              };
+            }
+            if (action === "card-add" && cards.length < 8) {
+              return {
+                ...column,
+                cards: [
+                  ...cards,
+                  { id: `${column.id}-card-${step}`, title: `New ${step}`, done: step % 2 === 0 },
+                ],
+              };
+            }
+            if (action === "card-remove" && cards.length > 1) {
+              return { ...column, cards: cards.slice(1) };
+            }
+            return column;
+          }),
+        };
+      });
+    };
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <>
+          <div data-compiled>
+            <fixture.Workspace prefix="Test: " />
+          </div>
+          <Normal />
+        </>,
+      ),
+    );
+    const executionsAfterMount = fixture.executions();
+    const actions: Action[] = [
+      "board-reverse",
+      "board-rotate",
+      "column-reverse",
+      "column-rotate",
+      "column-add",
+      "column-remove",
+      "card-reverse",
+      "card-rotate",
+      "card-edit",
+      "card-toggle",
+      "card-add",
+      "card-remove",
+    ];
+    let random = 0x4f1bbcdc;
+    for (let step = 0; step < 3000; step += 1) {
+      random = (random * 1664525 + 1013904223) >>> 0;
+      const action = actions[random % actions.length];
+      await act(async () => {
+        fixture.setBoards((current) => transition(current as Board[], action, step));
+        normalSet((current) => transition(current, action, step));
+        await flushCompilerUpdates();
+      });
+      expect(semanticBoards(container, "[data-compiled]")).toEqual(
+        semanticBoards(container, "[data-normal]"),
+      );
+    }
+    expect(fixture.executions()).toBe(executionsAfterMount);
+  }, 30_000);
+
+  it("preserves every keyed depth through compatible Fast Refresh", async () => {
+    const hmrId = `recursive-keyed-refresh-${Math.random()}`;
+    const definition = (prefix: string): CompiledComponentDefinition<Record<string, never>> => ({
+      displayName: "RefreshRecursiveKeyed",
+      hmrId,
+      stateSignature: "boards",
+      initialize: () => [initialBoards],
+      render(_props, state, blocks) {
+        const boards = () => state[0].get() as Board[];
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <KeyedRows
+              bindings={boardBindings(prefix)}
+              create={(board, index) => boardDescriptor(board as Board, index, prefix)}
+              hostBlocks
+              id={0}
+              items={boards}
+              render={() => (
+                <div>{boards().map((board, index) => boardMarkup(board, index, prefix))}</div>
+              )}
+              rowKey={(board) => (board as Board).id}
+            />
+          </main>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        { kind: "block", id: 1, parent: 0, dependencies: [] },
+        { kind: "block", id: 2, parent: 1, dependencies: [] },
+      ],
+    });
+
+    const Initial = createCompiledComponent(definition("Before: "));
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Initial />));
+    const board = container.querySelector('[data-board="b"]');
+    const column = container.querySelector('[data-column="b2"]');
+    const card = container.querySelector('[data-card="b2c1"]');
+
+    let Refreshed = Initial;
+    await act(async () => {
+      Refreshed = createCompiledComponent(definition("After: "));
+      root.render(<Refreshed />);
+      await flushCompilerUpdates();
+    });
+    expect(Refreshed).toBe(Initial);
+    expect(container.querySelector('[data-board="b"]')).toBe(board);
+    expect(container.querySelector('[data-column="b2"]')).toBe(column);
+    expect(container.querySelector('[data-card="b2c1"]')).toBe(card);
+    expect(container.querySelector('[data-card="b2c1"] span')?.textContent).toBe("After: Compile");
+  });
+});

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -123,6 +123,8 @@ export interface CompilerHostKeyedRanges {
   id: number;
   ranges: readonly CompilerKeyedRange[];
   trailing: number;
+  /** Compiler output may store only static direct children and materialize rows from the ranges. */
+  staticChildrenOnly?: boolean;
 }
 
 export type CompilerHostBlock = CompilerHostConditionalRanges | CompilerHostKeyedRanges;
@@ -595,7 +597,7 @@ function createCompilerHostElement(document: Document, descriptor: CompilerHostE
     const text = renderTextValue(child);
     if (text) element.append(document.createTextNode(text));
   };
-  for (const child of descriptor.children) appendChild(child);
+  for (const child of materializeCompilerHostChildren(descriptor)) appendChild(child);
   // Select options and textarea text must exist before their controlled value
   // is finalized. Reapplying is harmless for other attributes and avoids a
   // transient/default selection becoming the compiled branch's final state.
@@ -635,6 +637,25 @@ function flattenCompilerHostElements(children: readonly unknown[]): CompilerHost
   return elements;
 }
 
+function materializeCompilerHostChildren(descriptor: CompilerHostElement): readonly unknown[] {
+  const block = descriptor.block;
+  if (block?.kind !== "keyed-ranges" || !block.staticChildrenOnly) {
+    return descriptor.children;
+  }
+  const staticChildren = flattenCompilerHostElements(descriptor.children);
+  const children: CompilerHostElement[] = [];
+  let cursor = 0;
+  for (const range of block.ranges) {
+    children.push(...staticChildren.slice(cursor, cursor + range.before));
+    cursor += range.before;
+    const source = range.items();
+    const items = source ? Array.from(source) : [];
+    children.push(...items.map((item, index) => range.create(item, index)));
+  }
+  children.push(...staticChildren.slice(cursor, cursor + block.trailing));
+  return children;
+}
+
 function collectCompilerHostBlockIds(descriptor: CompilerHostElement, ids: Set<number>): void {
   for (const child of flattenCompilerHostElements(descriptor.children)) {
     collectCompilerHostBlockIds(child, ids);
@@ -646,6 +667,12 @@ function collectCompilerHostBlockIds(descriptor: CompilerHostElement, ids: Set<n
     for (const range of block.ranges) {
       if (range.truthy) collectCompilerHostBlockIds(range.truthy.create(), ids);
       if (range.falsy) collectCompilerHostBlockIds(range.falsy.create(), ids);
+    }
+  } else {
+    for (const range of block.ranges) {
+      const source = range.items();
+      const first = source ? Array.from(source)[0] : undefined;
+      if (first !== undefined) collectCompilerHostBlockIds(range.create(first, 0), ids);
     }
   }
 }
@@ -1210,7 +1237,7 @@ class CompilerNestedKeyedRanges implements CompilerHostTreeScope {
     const rowsByRange = this.readRanges();
     if (!rowsByRange) return false;
     const elements = [...this.root.children];
-    const descriptors = flattenCompilerHostElements(this.host.children);
+    const descriptors = flattenCompilerHostElements(materializeCompilerHostChildren(this.host));
     if (elements.length !== descriptors.length) return false;
     let cursor = 0;
 
@@ -1375,7 +1402,7 @@ class CompilerNestedKeyedRanges implements CompilerHostTreeScope {
     descriptor: CompilerHostElement,
     rowsByRange: readonly NestedReadKeyedRange[],
   ): boolean {
-    const descriptors = flattenCompilerHostElements(descriptor.children);
+    const descriptors = flattenCompilerHostElements(materializeCompilerHostChildren(descriptor));
     let descriptorIndex = 0;
     let scopeIndex = 0;
     for (let rangeIndex = 0; rangeIndex < this.block.ranges.length; rangeIndex += 1) {

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -1854,25 +1854,14 @@ function analyzeRecursiveHostTree(
       return undefined;
     }
 
-    const keyedRanges: KeyedRangePlan[] = [];
+    const keyedRows: Array<{ before: number; range: KeyedRowChildShape }> = [];
     let keyedContainer = children.length > 0;
     let staticBefore = 0;
-    const keyedDependencies = new Set<number>();
     const staticChildren: t.JSXElement[] = [];
     for (const child of children) {
-      const range = analyzeKeyedRowChild(child, statesByValue, safeGlobals, listNames);
-      if (range && range.events.length === 0 && range.conditionals.length === 0) {
-        keyedRanges.push({
-          before: staticBefore,
-          source: range.source,
-          collection: range.collection,
-          keyCallback: range.keyCallback,
-          renderCallback: range.renderCallback,
-          row: range.row,
-          bindings: range.bindings,
-          syntax: range.syntax,
-        });
-        for (const dependency of range.dependencies) keyedDependencies.add(dependency);
+      const range = analyzeKeyedRowChild(child, statesByValue, safeGlobals, listNames, true);
+      if (range) {
+        keyedRows.push({ before: staticBefore, range });
         staticBefore = 0;
       } else if (t.isJSXElement(child) && isHostElement(child)) {
         staticChildren.push(child);
@@ -1883,8 +1872,43 @@ function analyzeRecursiveHostTree(
       }
     }
 
-    if (keyedContainer && keyedRanges.length > 0) {
+    if (keyedContainer && keyedRows.length > 0) {
       const id = allocateId();
+      const keyedRanges: KeyedRangePlan[] = [];
+      const keyedDependencies = new Set<number>();
+      for (const { before, range } of keyedRows) {
+        if (range.events.length > 0) {
+          return "recursive compiler-owned keyed rows cannot contain events";
+        }
+        const row = t.cloneNode(range.row, true);
+        row.openingElement.attributes = row.openingElement.attributes.filter(
+          (attribute) => !t.isJSXAttribute(attribute) || jsxAttributeName(attribute) !== "key",
+        );
+        const rowAnalysis = analyzeRecursiveHostTree(
+          row,
+          statesByValue,
+          safeGlobals,
+          listNames,
+          id,
+          allocateId,
+        );
+        if (rowAnalysis.reason) return rowAnalysis.reason;
+        plans.push(...rowAnalysis.plans);
+        for (const [nestedElement, nestedPlan] of rowAnalysis.blocks) {
+          blocks.set(nestedElement, nestedPlan);
+        }
+        keyedRanges.push({
+          before,
+          source: range.source,
+          collection: range.collection,
+          keyCallback: range.keyCallback,
+          renderCallback: range.renderCallback,
+          row,
+          bindings: rowAnalysis.bindings,
+          syntax: range.syntax,
+        });
+        for (const dependency of range.dependencies) keyedDependencies.add(dependency);
+      }
       for (const child of staticChildren) {
         const beforeBindings = bindings.length;
         const nested = analyzeRecursiveHostTree(
@@ -2293,7 +2317,9 @@ function hostElementDescriptor(
     } else if (t.isJSXElement(child)) {
       const keyedRange = keyedBySource.get(child);
       if (keyedRange) {
-        children.push(keyedRangeDescriptorChildren(keyedRange, descriptorBlocks));
+        if (block?.kind !== "nested-host-keyed-ranges") {
+          children.push(keyedRangeDescriptorChildren(keyedRange, descriptorBlocks));
+        }
       } else {
         children.push(hostElementDescriptor(child, descriptorBlocks));
       }
@@ -2303,7 +2329,9 @@ function hostElementDescriptor(
       if (conditionalRange) {
         children.push(conditionalRangeDescriptorChild(conditionalRange, descriptorBlocks));
       } else if (keyedRange) {
-        children.push(keyedRangeDescriptorChildren(keyedRange, descriptorBlocks));
+        if (block?.kind !== "nested-host-keyed-ranges") {
+          children.push(keyedRangeDescriptorChildren(keyedRange, descriptorBlocks));
+        }
       } else {
         children.push(cloneExpression(child.expression));
       }
@@ -2910,6 +2938,9 @@ function nestedHostBlockObject(
       ),
     ),
     t.objectProperty(t.identifier("trailing"), t.numericLiteral(plan.trailing)),
+    ...(plan.kind === "nested-host-keyed-ranges"
+      ? [t.objectProperty(t.identifier("staticChildrenOnly"), t.booleanLiteral(true))]
+      : []),
   ]);
 }
 


### PR DESCRIPTION
## Summary

- recursively analyze safe host-only keyed rows with no fixed nesting limit
- give each keyed depth a globally unique block ID, parent relationship, isolated key table, and LIS reconciliation scope
- keep generated descriptors linear by storing static direct children once and materializing keyed rows from their range descriptors
- preserve the existing React fallback for events, controlled fields, Hooks, custom components, fragments, refs, SVG, spreads, dangerous HTML, index keys, duplicate keys, and invalid hydration shapes
- document the public behavior and add a production example with 48 boards, 288 columns, and 2,304 cards

## Safety and correctness

- preserves surviving DOM identity and static siblings through simultaneous outer, middle, and deepest reorders
- cleans descendant subscriptions when a parent keyed row disappears
- handles Strict Mode, parent and local updates in the same turn, queued updates after unmount, SSR adoption, recoverable hydration errors, error boundaries, duplicate deepest keys, and compatible Fast Refresh
- compares compiled output with normal React across 3,000 deterministic three-level mutations
- verifies ten keyed levels compile to one descriptor per nested level rather than duplicated descendant trees
- verifies packaged compatibility on React 18.3.1 and React 19.2.8

## Validation

- `pnpm --filter @farm.js/react test` — 37 files, 312 tests passed
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8 passed
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter farm-react-compiler-example type-check`
- `pnpm --filter farm-react-compiler-example build`
- production Chrome experiment — 48 boards, 288 columns, 2,304 cards; one LIS move at each depth; zero owner update executions; no app console/runtime errors or mobile overflow
- `pnpm lint` — zero errors
- `pnpm format:check`
- `pnpm docs:build`
