### PR TITLE
feat(react): compile mixed recursive ranges

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -456,8 +456,8 @@ The compiler-owned path is deliberately narrow:
 - Every non-empty branch has one lowercase HTML root and a statically known host-only descendant
   tree. Text, attributes, and individual inline style properties may use supported expressions.
 - Branch events, `key`, custom components, fragments, refs, SVG, `dangerouslySetInnerHTML`, JSX
-  spreads, interactive keyed rows, mixed dynamic block kinds in one direct-child range, and dynamic
-  text mixed beside nested elements require React ownership.
+  spreads, interactive keyed rows, unsupported direct-child structures, and dynamic text mixed
+  beside nested elements require React ownership.
 - A ternary may use `null` or `false` for an empty branch. For logical `&&`, a numeric falsy value
   such as `0` can be visible React output, so the runtime remounts that container through React
   instead of incorrectly treating it as empty.
@@ -507,11 +507,49 @@ from current compiler cells, so updates made while closed cannot become stale wo
 This recursive path is intentionally host-only. Nested conditional ranges may recurse again, and a
 nested container may own one or more non-interactive keyed ranges separated by static host
 siblings. Hooks, custom components, branch events, refs, SVG, fragments, dangerous HTML,
-interactive rows, unsupported structure inside an inner keyed row, or conditionals and lists mixed
-as direct siblings in the same range keep React ownership. React still renders the initial
+interactive rows, or unsupported structure inside an inner keyed row keep React ownership. React still renders the initial
 client/SSR tree, hydrates it, reports recoverable mismatches, and handles every fallback. Duplicate
 runtime keys or invalid adopted DOM remount the affected outer container through React; descendant
 dependencies remain live after that handoff.
+
+### Mixed conditional and keyed ranges
+
+A safe host container may interleave both range kinds in their original order:
+
+```tsx
+<section>
+  <header>Inventory</header>
+  {loading && <p>Loading…</p>}
+  <i>Rows</i>
+  {items.map((item) => (
+    <article key={item.id}>{item.label}</article>
+  ))}
+  {error ? <strong>Error</strong> : <span>Ready</span>}
+  <footer>End</footer>
+</section>
+```
+
+The compiler emits one mixed-range descriptor rather than competing conditional and list
+controllers. Each slot records its kind and the number of static host siblings before it. On an
+update, every condition and collection is read from one compiler-cell snapshot. Conditional slots
+mount, replace, or remove one host branch; keyed slots reuse their per-key instances and run LIS
+independently. Reconciliation proceeds from right to left, preserving the exact order when adjacent
+ranges become empty, grow, or change together. Static header, divider, and footer nodes are never
+used as synthetic markers and retain their DOM identity.
+
+Safe host-only conditionals and keyed ranges may recurse inside a mixed branch or row. Every syntax
+site still receives one globally unique block ID and a parent link, so an affected outer mixed block
+suppresses redundant descendant refreshes. Removing a branch or keyed row cleans its nested mixed
+subscriptions before removing DOM. Recreating it reads current state, preventing hidden or removed
+work from becoming stale.
+
+This path requires at least one conditional and one keyed `.map(...)` or `List` range in the same
+lowercase host container. Every dynamic branch and row must have a statically known host tree and a
+stable item-derived key. Hooks, custom components, events inside branches or rows, controlled forms,
+refs, SVG, fragments, spreads, dangerous HTML, duplicate runtime keys, numeric logical output, or an
+invalid hydration/adoption shape keep or transfer that complete container to React. Parent prop and
+Fast Refresh changes also remount the container through React so the compiler never retains stale
+closures or static markup.
 
 The existing React-owned conditional boundary remains the fallback for supported complex shapes.
 It can contain event handlers, nested host conditionals, keyed lists, and component islands while
@@ -1259,6 +1297,10 @@ The package and example test suites verify more than generated code:
   normal React while the compiled owner remains at one execution, with additional Strict Mode,
   parent/local, deepest-duplicate-key, error-boundary, Fast Refresh, queued-unmount, SSR, and
   hydration coverage;
+- mixed conditional/keyed containers match normal React across 3,000 deterministic branch, reorder,
+  insertion, removal, binding, and recursively nested list transitions, with additional Strict Mode,
+  simultaneous parent/local, duplicate-key fallback, error-boundary, queued-unmount, SSR, and
+  recoverable-hydration coverage;
 - component islands update only dependent children, preserve child-local state and context, route
   failures through React error boundaries, hydrate in Strict Mode, and safely drop queued updates
   after unmount;

--- a/examples/react-compiler/README.md
+++ b/examples/react-compiler/README.md
@@ -202,6 +202,16 @@ Hooks, custom components, row, branch, or inner-row events, refs, SVG, fragments
 controlled inputs inside a condition, and unproven expressions stay on React. Safe host-only keyed
 levels recurse; duplicate keys at any level switch the mounted outer list to React.
 
+The `13` card interleaves logical and ternary branches with a keyed row range in one host container.
+Each row recursively owns another condition and keyed tag range. One action changes both outer
+branches, rotates all 32 rows with one LIS move, changes a row-local condition, and rotates its tags
+with one nested LIS move. The browser assertion preserves the selected row, tag, header, divider,
+and footer, then removes and inserts one row while recording zero owner update executions.
+
+Mixed ownership remains host-only. Branch or row events, Hooks, custom components, controlled
+forms, refs, SVG, fragments, spreads, dangerous HTML, duplicate keys, or an invalid adopted shape
+use the complete React-owned container.
+
 ## Heavy compiler-on/off benchmark
 
 The page contains two measured workloads:

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -42,6 +42,7 @@ for (const component of [
   "KeyedRowHostBlockExperiment",
   "NestedKeyedRowExperiment",
   "RecursiveKeyedScopeExperiment",
+  "MixedRangeExperiment",
 ]) {
   assert.ok(compiledComponents.has(component), `${component} was not compiled`);
 }
@@ -1473,6 +1474,91 @@ try {
   );
   assert.equal(recursiveKeyedOwnerFinalExecutions - recursiveKeyedOwnerInitialExecutions, 0);
 
+  const mixedRanges = '[data-experiment="mixed-ranges"]';
+  const mixedRangeOwnerInitialExecutions = await readNumber(
+    page,
+    `${mixedRanges} [data-metric="mixed-range-owner-executions"]`,
+  );
+  await page.evaluate(() => {
+    window.__farmMixedItem0 = document.querySelector('[data-mixed-item="mixed-item-0"]');
+    window.__farmMixedTag00 = document.querySelector('[data-mixed-tag="mixed-tag-0-0"]');
+    window.__farmMixedHeader = document.querySelector('[data-mixed-static="header"]');
+    window.__farmMixedRowsBefore = document.querySelector('[data-mixed-static="rows-before"]');
+    window.__farmMixedFooter = document.querySelector('[data-mixed-static="footer"]');
+    window.__farmMixedRowMoves = 0;
+    window.__farmMixedTagMoves = 0;
+    const rows = document.querySelector("[data-mixed-range-list]");
+    const tags = document.querySelector('[data-mixed-tag-list="mixed-item-0"]');
+    const rowInsertBefore = rows.insertBefore.bind(rows);
+    rows.insertBefore = (node, anchor) => {
+      if (node.parentNode === rows && node.matches?.("[data-mixed-item]")) {
+        window.__farmMixedRowMoves += 1;
+      }
+      return rowInsertBefore(node, anchor);
+    };
+    const tagInsertBefore = tags.insertBefore.bind(tags);
+    tags.insertBefore = (node, anchor) => {
+      if (node.parentNode === tags && node.matches?.("[data-mixed-tag]")) {
+        window.__farmMixedTagMoves += 1;
+      }
+      return tagInsertBefore(node, anchor);
+    };
+  });
+
+  await page.locator(`${mixedRanges} [data-action="mixed-range-reconcile"]`).click();
+  await assertText(page, `${mixedRanges} [data-metric="mixed-range-updates"]`, "1");
+  await assertText(page, `${mixedRanges} [data-metric="mixed-range-loading"]`, "shown");
+  await assertText(page, `${mixedRanges} [data-metric="mixed-range-status"]`, "error");
+  assert.equal(await page.locator(`${mixedRanges} [data-mixed-loading]`).count(), 1);
+  assert.equal(
+    await page.locator(`${mixedRanges} [data-mixed-item]`).first().getAttribute("data-mixed-item"),
+    "mixed-item-31",
+  );
+  await assertText(page, `${mixedRanges} [data-mixed-item="mixed-item-0"] h3`, "Item 0 · updated");
+  assert.equal(
+    await page.locator(`${mixedRanges} [data-mixed-visible="mixed-item-0"]`).count(),
+    0,
+  );
+  assert.deepEqual(
+    await page
+      .locator(`${mixedRanges} [data-mixed-item="mixed-item-0"] [data-mixed-tag]`)
+      .evaluateAll((tags) => tags.map((tag) => tag.getAttribute("data-mixed-tag"))),
+    ["mixed-tag-0-2", "mixed-tag-0-0", "mixed-tag-0-1"],
+  );
+  assert.equal(await page.evaluate(() => window.__farmMixedRowMoves), 1);
+  assert.equal(await page.evaluate(() => window.__farmMixedTagMoves), 1);
+  assert.equal(
+    await page.evaluate(
+      () =>
+        window.__farmMixedItem0 === document.querySelector('[data-mixed-item="mixed-item-0"]') &&
+        window.__farmMixedTag00 === document.querySelector('[data-mixed-tag="mixed-tag-0-0"]') &&
+        window.__farmMixedHeader === document.querySelector('[data-mixed-static="header"]') &&
+        window.__farmMixedRowsBefore ===
+          document.querySelector('[data-mixed-static="rows-before"]') &&
+        window.__farmMixedFooter === document.querySelector('[data-mixed-static="footer"]'),
+    ),
+    true,
+    "mixed range reconciliation replaced a surviving row, nested tag, or static sibling",
+  );
+
+  await page.locator(`${mixedRanges} [data-action="mixed-range-replace"]`).click();
+  await assertText(page, `${mixedRanges} [data-metric="mixed-range-updates"]`, "2");
+  await assertText(page, `${mixedRanges} [data-metric="mixed-range-rows"]`, "32");
+  assert.equal(
+    await page.locator(`${mixedRanges} [data-mixed-item="mixed-item-1"]`).count(),
+    0,
+  );
+  await assertText(
+    page,
+    `${mixedRanges} [data-mixed-item="mixed-inserted-1"] h3`,
+    "Inserted after update 1",
+  );
+  const mixedRangeOwnerFinalExecutions = await readNumber(
+    page,
+    `${mixedRanges} [data-metric="mixed-range-owner-executions"]`,
+  );
+  assert.equal(mixedRangeOwnerFinalExecutions - mixedRangeOwnerInitialExecutions, 0);
+
   await page.screenshot({ path: screenshotPath, fullPage: true });
 
   const mobilePage = await browser.newPage({
@@ -1713,6 +1799,17 @@ try {
             staticSiblingIdentityPreserved: true,
             ownerUpdateExecutions:
               recursiveKeyedOwnerFinalExecutions - recursiveKeyedOwnerInitialExecutions,
+          },
+          mixedRanges: {
+            rows: 32,
+            outerLisMoves: 1,
+            nestedLisMoves: 1,
+            simultaneousConditionalUpdates: 2,
+            recursivelyNestedRanges: true,
+            staticSiblingIdentityPreserved: true,
+            removedAndInserted: true,
+            ownerUpdateExecutions:
+              mixedRangeOwnerFinalExecutions - mixedRangeOwnerInitialExecutions,
           },
         },
       },

--- a/examples/react-compiler/src/app/page.tsx
+++ b/examples/react-compiler/src/app/page.tsx
@@ -6,6 +6,7 @@ import { ComponentIslandExperiment } from "../components/component-island-experi
 import { ConditionalBlockExperiment } from "../components/conditional-block-experiment";
 import { HeavyInteractionBenchmark } from "../components/heavy-interaction-benchmark";
 import { KeyedRowHostBlockExperiment } from "../components/keyed-row-host-block-experiment";
+import { MixedRangeExperiment } from "../components/mixed-range-experiment";
 import { NestedKeyedRowExperiment } from "../components/nested-keyed-row-experiment";
 import { RecursiveHostBlockExperiment } from "../components/recursive-host-block-experiment";
 import { RecursiveKeyedScopeExperiment } from "../components/recursive-keyed-scope-experiment";
@@ -86,6 +87,8 @@ export default function HomePage() {
       <NestedKeyedRowExperiment />
 
       <RecursiveKeyedScopeExperiment />
+
+      <MixedRangeExperiment />
 
       <section
         className="benchmark-report"

--- a/examples/react-compiler/src/components/mixed-range-experiment.tsx
+++ b/examples/react-compiler/src/components/mixed-range-experiment.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState } from "react";
+
+interface MixedTag {
+  id: string;
+  label: string;
+}
+
+interface MixedItem {
+  id: string;
+  label: string;
+  visible: boolean;
+  tags: MixedTag[];
+}
+
+const initialItems: MixedItem[] = Array.from({ length: 32 }, (_, itemIndex) => ({
+  id: `mixed-item-${itemIndex}`,
+  label: `Item ${itemIndex}`,
+  visible: itemIndex % 2 === 0,
+  tags: Array.from({ length: 3 }, (_, tagIndex) => ({
+    id: `mixed-tag-${itemIndex}-${tagIndex}`,
+    label: `Tag ${itemIndex}.${tagIndex}`,
+  })),
+}));
+
+let mixedRangeOwnerExecutions = 0;
+
+export function MixedRangeExperiment() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+  const [items, setItems] = useState(initialItems);
+  const [updates, setUpdates] = useState(0);
+
+  function reconcileMixedRanges() {
+    setLoading(true);
+    setError((value) => !value);
+    setItems((current) => {
+      const rotated = [current[current.length - 1], ...current.slice(0, -1)];
+      return rotated.map((item) =>
+        item.id === "mixed-item-0"
+          ? {
+              ...item,
+              label: "Item 0 · updated",
+              visible: !item.visible,
+              tags: [
+                { ...item.tags[2], label: "Tag 0.2 · moved" },
+                item.tags[0],
+                item.tags[1],
+              ],
+            }
+          : item,
+      );
+    });
+    setUpdates((value) => value + 1);
+  }
+
+  function replaceOneRow() {
+    setLoading(false);
+    setItems((current) => [
+      ...current.filter((item) => item.id !== "mixed-item-1"),
+      {
+        id: `mixed-inserted-${updates}`,
+        label: `Inserted after update ${updates}`,
+        visible: true,
+        tags: [],
+      },
+    ]);
+    setUpdates((value) => value + 1);
+  }
+
+  return (
+    <section className="heavy-benchmark" data-experiment="mixed-ranges">
+      <header className="heavy-heading">
+        <div>
+          <span className="experiment-number">13</span>
+          <div>
+            <p className="heavy-kicker">MIXED RECURSIVE RANGES</p>
+            <h2>Conditions and keyed lists share one ordered container</h2>
+          </div>
+        </div>
+        <span className="node-badge">32 ROWS / 96 NESTED TAGS</span>
+      </header>
+
+      <p className="heavy-copy">
+        One compiler controller owns interleaved conditional and keyed ranges. It patches branches,
+        applies LIS moves, and recursively updates each safe row while preserving static siblings.
+      </p>
+
+      <dl className="heavy-metrics" aria-live="polite">
+        <div>
+          <dt>Owner executions</dt>
+          <dd data-metric="mixed-range-owner-executions">
+            {typeof window === "undefined" ? 1 : ++mixedRangeOwnerExecutions}
+          </dd>
+        </div>
+        <div>
+          <dt>Rows</dt>
+          <dd data-metric="mixed-range-rows">{items.length}</dd>
+        </div>
+        <div>
+          <dt>Loading</dt>
+          <dd data-metric="mixed-range-loading">{loading ? "shown" : "hidden"}</dd>
+        </div>
+        <div>
+          <dt>Status</dt>
+          <dd data-metric="mixed-range-status">{error ? "error" : "ready"}</dd>
+        </div>
+        <div>
+          <dt>Updates</dt>
+          <dd data-metric="mixed-range-updates">{updates}</dd>
+        </div>
+      </dl>
+
+      <div className="heavy-controls composable-controls">
+        <button data-action="mixed-range-reconcile" type="button" onClick={reconcileMixedRanges}>
+          Reconcile every range <span aria-hidden="true">↗</span>
+        </button>
+        <button data-action="mixed-range-replace" type="button" onClick={replaceOneRow}>
+          Replace one row
+        </button>
+      </div>
+
+      <div className="keyed-host-row-list" data-mixed-range-list>
+        <header data-mixed-static="header">MIXED INVENTORY</header>
+        {loading && <p data-mixed-loading>Loading inventory…</p>}
+        <i data-mixed-static="rows-before">ROWS</i>
+        {items.map((item, itemIndex) => (
+          <article data-mixed-item={item.id} data-item-index={itemIndex} key={item.id}>
+            <h3>{item.label}</h3>
+            <div data-mixed-tag-list={item.id}>
+              {item.visible && <strong data-mixed-visible={item.id}>Visible</strong>}
+              <i data-mixed-static="tags-before">TAGS</i>
+              {item.tags.map((tag, tagIndex) => (
+                <em data-mixed-tag={tag.id} data-tag-index={tagIndex} key={tag.id}>
+                  {tag.label}
+                </em>
+              ))}
+            </div>
+          </article>
+        ))}
+        {error ? <strong data-mixed-status="error">Error</strong> : <span data-mixed-status="ready">Ready</span>}
+        <footer data-mixed-static="footer">END MIXED INVENTORY</footer>
+      </div>
+    </section>
+  );
+}

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -368,9 +368,13 @@ boundary. The more general React-owned conditional path accepts supported events
 conditionals, keyed lists, and component islands. A compiler-owned host branch may now recursively
 contain eligible host-only conditional ranges and non-interactive keyed ranges in nested host
 containers. Each nested range receives its own dependency entry and updates without rerunning or
-replacing the outer branch. Keys on branches, custom components, fragments, refs, SVG, attribute
-spreads, `dangerouslySetInnerHTML`, branch events, interactive rows, and mixed dynamic kinds in one
-direct-child range keep React ownership. An empty ternary branch may be `null` or `false`. The
+replacing the outer branch. When conditionals and keyed maps/`List` ranges are direct siblings in
+one safe host container, the compiler emits one ordered mixed-range controller. It mounts or removes
+conditional branches, applies independent LIS reconciliation to each keyed range, and preserves
+static siblings in place. The same mixed layout may recurse inside safe branches and keyed rows.
+Keys on branches, custom components, fragments, refs, SVG, attribute spreads,
+`dangerouslySetInnerHTML`, branch events, interactive rows, and unsupported mixed children keep
+React ownership. An empty ternary branch may be `null` or `false`. The
 inactive branch is described at build time but is never pre-mounted or cached. If a logical `&&`
 evaluates to a number such as `0`,
 or adopted DOM no longer matches its descriptor, the affected container remounts through React so

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -423,6 +423,120 @@ const testSource = String.raw`
   assert.equal(recursiveHostExecutions, initialRecursiveHostExecutions);
   flushSync(() => recursiveHostRoot.unmount());
 
+  let mixedRangeExecutions = 0;
+  const MixedRanges = createCompiledComponent({
+    displayName: "CompatibilityMixedRanges",
+    initialize: () => [{ loading: false, error: false, items: [{ id: "a", label: "Alpha" }, { id: "b", label: "Beta" }] }],
+    render(_props, state, blocks) {
+      mixedRangeExecutions += 1;
+      const model = () => state[0].get();
+      const loadingBranch = {
+        create: () => ({ kind: "element", tag: "p", attributes: [{ name: "data-loading", value: true }], styles: [], children: ["Loading"] }),
+        bindings: [],
+      };
+      const errorBranch = {
+        create: () => ({ kind: "element", tag: "strong", attributes: [{ name: "data-status", value: "error" }], styles: [], children: ["Error"] }),
+        bindings: [],
+      };
+      const readyBranch = {
+        create: () => ({ kind: "element", tag: "span", attributes: [{ name: "data-status", value: "ready" }], styles: [], children: ["Ready"] }),
+        bindings: [],
+      };
+      const rowDescriptor = (item, index) => ({
+        kind: "element",
+        tag: "article",
+        attributes: [{ name: "data-mixed-key", value: item.id }, { name: "data-index", value: index }],
+        styles: [],
+        children: [item.label],
+      });
+      const mixedBlock = () => ({
+        kind: "mixed-ranges",
+        id: 0,
+        ranges: [
+          { kind: "conditional", before: 1, test: () => model().loading, logical: true, truthy: loadingBranch },
+          {
+            kind: "keyed",
+            before: 1,
+            items: () => model().items,
+            rowKey: (item) => item.id,
+            create: rowDescriptor,
+            bindings: [
+              { kind: "attribute", path: [], name: "data-index", read: (_item, index) => index },
+              { kind: "text", path: [], read: (item) => item.label },
+            ],
+          },
+          { kind: "conditional", before: 0, test: () => model().error, truthy: errorBranch, falsy: readyBranch },
+        ],
+        trailing: 1,
+      });
+      const create = () => ({
+        kind: "element",
+        tag: "div",
+        attributes: [{ name: "data-mixed-ranges", value: true }],
+        styles: [],
+        children: [
+          { kind: "element", tag: "header", attributes: [], styles: [], children: ["Header"] },
+          ...(model().loading ? [loadingBranch.create()] : []),
+          { kind: "element", tag: "i", attributes: [], styles: [], children: ["Rows"] },
+          ...model().items.map(rowDescriptor),
+          model().error ? errorBranch.create() : readyBranch.create(),
+          { kind: "element", tag: "footer", attributes: [], styles: [], children: ["Footer"] },
+        ],
+        block: mixedBlock(),
+      });
+      return React.createElement(
+        "section",
+        null,
+        React.createElement("button", {
+          "data-mixed-update": true,
+          onClick: () => state[0].set((current) => ({
+            loading: true,
+            error: true,
+            items: [{ ...current.items[1], label: "Beta updated" }, current.items[0]],
+          })),
+        }, "Update mixed ranges"),
+        React.createElement(blocks.MixedRanges, {
+          id: 0,
+          create,
+          render: () => React.createElement(
+            "div",
+            { "data-mixed-ranges": true },
+            React.createElement("header", null, "Header"),
+            model().loading ? React.createElement("p", { "data-loading": true }, "Loading") : null,
+            React.createElement("i", null, "Rows"),
+            ...model().items.map((item, index) => React.createElement("article", { key: item.id, "data-mixed-key": item.id, "data-index": index }, item.label)),
+            model().error
+              ? React.createElement("strong", { "data-status": "error" }, "Error")
+              : React.createElement("span", { "data-status": "ready" }, "Ready"),
+            React.createElement("footer", null, "Footer"),
+          ),
+        }),
+      );
+    },
+    bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+  });
+  const mixedRangeContainer = document.createElement("div");
+  document.body.append(mixedRangeContainer);
+  const mixedRangeRoot = createRoot(mixedRangeContainer);
+  flushSync(() => mixedRangeRoot.render(React.createElement(MixedRanges)));
+  const initialMixedRangeExecutions = mixedRangeExecutions;
+  const originalMixedA = mixedRangeContainer.querySelector('[data-mixed-key="a"]');
+  const originalMixedHeader = mixedRangeContainer.querySelector("header");
+  mixedRangeContainer.querySelector("[data-mixed-update]").click();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.deepEqual(
+    [...mixedRangeContainer.querySelectorAll("[data-mixed-key]")].map((row) => row.getAttribute("data-mixed-key")),
+    ["b", "a"],
+  );
+  assert.equal(mixedRangeContainer.querySelector('[data-mixed-key="a"]'), originalMixedA);
+  assert.equal(mixedRangeContainer.querySelector("header"), originalMixedHeader);
+  assert.equal(mixedRangeContainer.querySelector('[data-mixed-key="b"]').textContent, "Beta updated");
+  assert.equal(mixedRangeContainer.querySelector("[data-loading]").textContent, "Loading");
+  assert.equal(mixedRangeContainer.querySelector('[data-status="error"]').textContent, "Error");
+  assert.equal(mixedRangeExecutions, initialMixedRangeExecutions);
+  flushSync(() => mixedRangeRoot.unmount());
+
   let conditionalRangeExecutions = 0;
   const ConditionalRanges = createCompiledComponent({
     displayName: "CompatibilityConditionalRanges",

--- a/packages/farm-react/src/__tests__/compiler-mixed-ranges.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-mixed-ranges.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true);
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/MixedRanges.tsx", infer);
+}
+
+describe("React AOT mixed conditional and keyed ranges", () => {
+  it("prepares interleaved conditionals, maps, and static host siblings as one block", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Dashboard() {
+        const [loading, setLoading] = useState(false);
+        const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
+        const [error, setError] = useState(false);
+        return (
+          <main>
+            <button onClick={() => setLoading((value) => !value)}>Loading</button>
+            <section data-dashboard>
+              <header>Inventory</header>
+              {loading && <p data-loading>Loading…</p>}
+              <i>Rows</i>
+              {items.map((item, index) => <article key={item.id} data-index={index}>{item.label}</article>)}
+              {error ? <strong>Error</strong> : <span>Ready</span>}
+              <footer>End</footer>
+            </section>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Dashboard"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code.match(/farmBlocks\.MixedRanges/g)).toHaveLength(1);
+    expect(result.code).toContain('kind: "mixed-ranges"');
+    expect(result.code.match(/kind: "conditional"/g)).toHaveLength(2);
+    expect(result.code.match(/kind: "keyed"/g)).toHaveLength(1);
+    expect(result.code).toContain("dependencies: [0, 1, 2]");
+    expect(result.code).not.toContain("farmBlocks.ConditionalRanges");
+    expect(result.code).not.toContain("farmBlocks.KeyedRanges");
+    await expect(
+      transformWithEsbuild(result.code, "/app/MixedRanges.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({ code: expect.stringContaining("MixedRanges") });
+  });
+
+  it("supports the public List primitive and recursive mixed descendants", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List } from "@farm.js/react/list";
+      export function Workspace() {
+        const [open, setOpen] = useState(true);
+        const [boards, setBoards] = useState([{ id: "b", title: "Board", ready: true, cards: [{ id: "c", title: "Card" }] }]);
+        return (
+          <main>
+            <button onClick={() => setOpen((value) => !value)}>Open</button>
+            <div>
+              {open && <h1>Workspace</h1>}
+              <List each={boards} by={(board) => board.id}>
+                {(board) => (
+                  <section>
+                    {board.ready && <strong>Ready</strong>}
+                    <i>Cards</i>
+                    {board.cards.map((card) => <article key={card.id}>{card.title}</article>)}
+                  </section>
+                )}
+              </List>
+            </div>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Workspace"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.MixedRanges");
+    expect(result.code.match(/kind: "mixed-ranges"/g)?.length).toBeGreaterThanOrEqual(2);
+    expect(result.code).toContain("parent: 0");
+    expect(result.code).not.toContain("farmBlocks.KeyedList");
+  });
+
+  it.each([
+    {
+      name: "an interactive conditional branch",
+      conditional: "<button onClick={() => setOpen(false)}>Close</button>",
+      row: "<article key={item.id}>{item.label}</article>",
+    },
+    {
+      name: "an interactive keyed row",
+      conditional: "<strong>Open</strong>",
+      row: "<button key={item.id} onClick={() => setItems([])}>{item.label}</button>",
+    },
+    {
+      name: "a custom component branch",
+      declaration: "function Status() { return <strong>Open</strong>; }",
+      conditional: "<Status />",
+      row: "<article key={item.id}>{item.label}</article>",
+    },
+  ])("keeps $name on React's existing fallback", async ({ declaration = "", conditional, row }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      ${declaration}
+      export function Fallback() {
+        const [open, setOpen] = useState(true);
+        const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
+        return (
+          <main>
+            <section>
+              {open && ${conditional}}
+              {items.map((item) => ${row})}
+            </section>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.code).not.toContain("farmBlocks.MixedRanges");
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-runtime-mixed-ranges.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-mixed-ranges.test.tsx
@@ -1,0 +1,586 @@
+import React, { Profiler, StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createCompiledComponent,
+  type CompiledComponentDefinition,
+  type CompilerHostConditionalBranch,
+  type CompilerHostElement,
+  type CompilerKeyedRowBinding,
+  type CompilerStateUpdater,
+} from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Tag {
+  id: string;
+  label: string;
+}
+
+interface Item {
+  id: string;
+  label: string;
+  visible: boolean;
+  tags: Tag[];
+  fail?: boolean;
+}
+
+interface Model {
+  loading: boolean;
+  error: boolean;
+  items: Item[];
+}
+
+const initialModel: Model = {
+  loading: false,
+  error: false,
+  items: [
+    {
+      id: "a",
+      label: "Alpha",
+      visible: true,
+      tags: [
+        { id: "a1", label: "A one" },
+        { id: "a2", label: "A two" },
+      ],
+    },
+    {
+      id: "b",
+      label: "Beta",
+      visible: false,
+      tags: [{ id: "b1", label: "B one" }],
+    },
+  ],
+};
+
+const roots: Array<{ unmount(): void }> = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function host(
+  tag: string,
+  children: readonly unknown[] = [],
+  attributes: readonly { name: string; value: unknown }[] = [],
+): CompilerHostElement {
+  return { kind: "element", tag, attributes, styles: [], children };
+}
+
+function branch(create: () => CompilerHostElement): CompilerHostConditionalBranch {
+  return { create, bindings: [] };
+}
+
+function tagDescriptor(tag: Tag, index: number): CompilerHostElement {
+  return host(
+    "em",
+    [tag.label],
+    [
+      { name: "data-tag", value: tag.id },
+      { name: "data-tag-index", value: index },
+    ],
+  );
+}
+
+const tagBindings: CompilerKeyedRowBinding[] = [
+  { kind: "attribute", path: [], name: "data-tag-index", read: (_tag, index) => index },
+  { kind: "text", path: [], read: (tag) => (tag as Tag).label },
+];
+
+function itemDescriptor(item: Item, index: number): CompilerHostElement {
+  const detail = {
+    ...host("div", [
+      ...(item.visible
+        ? [host("strong", [item.label], [{ name: "data-visible", value: item.id }])]
+        : []),
+      host("i", ["Tags"]),
+      ...item.tags.map(tagDescriptor),
+    ]),
+    block: {
+      kind: "mixed-ranges" as const,
+      id: 1,
+      ranges: [
+        {
+          kind: "conditional" as const,
+          before: 0,
+          test: () => item.visible,
+          logical: true,
+          truthy: branch(() =>
+            host("strong", [item.label], [{ name: "data-visible", value: item.id }]),
+          ),
+        },
+        {
+          kind: "keyed" as const,
+          before: 1,
+          items: () => item.tags,
+          rowKey: (tag: unknown) => (tag as Tag).id,
+          create: (tag: unknown, tagIndex: number) => tagDescriptor(tag as Tag, tagIndex),
+          bindings: tagBindings,
+        },
+      ],
+      trailing: 0,
+    },
+  };
+  return host(
+    "article",
+    [host("span", [item.label]), detail],
+    [
+      { name: "data-item", value: item.id },
+      { name: "data-item-index", value: index },
+    ],
+  );
+}
+
+const itemBindings: CompilerKeyedRowBinding[] = [
+  { kind: "attribute", path: [], name: "data-item-index", read: (_item, index) => index },
+  {
+    kind: "text",
+    path: [0],
+    read: (item) => {
+      if ((item as Item).fail) throw new Error("mixed range binding failed");
+      return (item as Item).label;
+    },
+  },
+];
+
+function mixedDescriptor(readModel: () => Model, prefix = ""): CompilerHostElement {
+  const model = readModel();
+  return {
+    ...host(
+      "section",
+      [
+        host("header", ["Inventory"]),
+        ...(model.loading
+          ? [host("p", ["Loading…"], [{ name: "data-loading", value: true }])]
+          : []),
+        host("i", ["Rows"]),
+        ...model.items.map(itemDescriptor),
+        model.error
+          ? host("strong", ["Error"], [{ name: "data-status", value: "error" }])
+          : host("span", ["Ready"], [{ name: "data-status", value: "ready" }]),
+        host("footer", ["End"]),
+      ],
+      [
+        { name: "data-mixed", value: true },
+        { name: "data-prefix", value: prefix || undefined },
+      ],
+    ),
+    block: {
+      kind: "mixed-ranges",
+      id: 0,
+      ranges: [
+        {
+          kind: "conditional",
+          before: 1,
+          test: () => readModel().loading,
+          logical: true,
+          truthy: branch(() => host("p", ["Loading…"], [{ name: "data-loading", value: true }])),
+        },
+        {
+          kind: "keyed",
+          before: 1,
+          items: () => readModel().items,
+          rowKey: (item: unknown) => (item as Item).id,
+          create: (item: unknown, index: number) => itemDescriptor(item as Item, index),
+          bindings: itemBindings,
+        },
+        {
+          kind: "conditional",
+          before: 0,
+          test: () => readModel().error,
+          truthy: branch(() =>
+            host("strong", ["Error"], [{ name: "data-status", value: "error" }]),
+          ),
+          falsy: branch(() => host("span", ["Ready"], [{ name: "data-status", value: "ready" }])),
+        },
+      ],
+      trailing: 1,
+    },
+  };
+}
+
+function mixedMarkup(model: Model, prefix = "") {
+  return (
+    <section data-mixed data-prefix={prefix || undefined}>
+      <header>Inventory</header>
+      {model.loading && <p data-loading>Loading…</p>}
+      <i>Rows</i>
+      {model.items.map((item, index) => (
+        <article key={item.id} data-item={item.id} data-item-index={index}>
+          <span>{item.label}</span>
+          <div>
+            {item.visible && <strong data-visible={item.id}>{item.label}</strong>}
+            <i>Tags</i>
+            {item.tags.map((tag, tagIndex) => (
+              <em key={tag.id} data-tag={tag.id} data-tag-index={tagIndex}>
+                {tag.label}
+              </em>
+            ))}
+          </div>
+        </article>
+      ))}
+      {model.error ? (
+        <strong data-status="error">Error</strong>
+      ) : (
+        <span data-status="ready">Ready</span>
+      )}
+      <footer>End</footer>
+    </section>
+  );
+}
+
+function cloneInitialModel(): Model {
+  return structuredClone(initialModel);
+}
+
+function createMixedFixture(initial = cloneInitialModel()) {
+  let setModel: (next: CompilerStateUpdater) => void = () => undefined;
+  let executions = 0;
+  const definition: CompiledComponentDefinition<{ prefix?: string }> = {
+    displayName: "MixedFixture",
+    initialize: () => [initial],
+    render: (props, state, blocks) => {
+      executions += 1;
+      setModel = (next) => state[0].set(next);
+      const readModel = () => state[0].get() as Model;
+      return (
+        <blocks.MixedRanges
+          id={0}
+          render={() => mixedMarkup(readModel(), props.prefix)}
+          create={() => mixedDescriptor(readModel, props.prefix)}
+        />
+      );
+    },
+    bindings: [
+      { kind: "block", id: 0, dependencies: [0] },
+      { kind: "block", id: 1, parent: 0, dependencies: [0] },
+    ],
+  };
+  return {
+    View: createCompiledComponent(definition),
+    setModel: (next: CompilerStateUpdater) => setModel(next),
+    executions: () => executions,
+  };
+}
+
+class Boundary extends React.Component<React.PropsWithChildren, { message: string }> {
+  state = { message: "" };
+
+  static getDerivedStateFromError(error: Error) {
+    return { message: error.message };
+  }
+
+  render() {
+    return this.state.message ? <p data-error>{this.state.message}</p> : this.props.children;
+  }
+}
+
+describe("compiler-owned mixed conditional and keyed ranges runtime", () => {
+  it("commits simultaneous branches and LIS list moves without a React render", async () => {
+    const fixture = createMixedFixture();
+    let commits = 0;
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <StrictMode>
+          <Profiler id="mixed" onRender={() => (commits += 1)}>
+            <fixture.View />
+          </Profiler>
+        </StrictMode>,
+      ),
+    );
+
+    const executionsAfterMount = fixture.executions();
+    const commitsAfterMount = commits;
+    const alpha = container.querySelector('[data-item="a"]');
+    const alphaTag = container.querySelector('[data-tag="a1"]');
+    const header = container.querySelector("header");
+    const divider = container.querySelector("section > i");
+    const footer = container.querySelector("footer");
+
+    await act(async () => {
+      fixture.setModel((value) => {
+        const model = value as Model;
+        const [a, b] = model.items;
+        return {
+          loading: true,
+          error: true,
+          items: [
+            { ...b, visible: true },
+            {
+              ...a,
+              label: "Alpha updated",
+              visible: false,
+              tags: [
+                { ...a.tags[1], label: "A two updated" },
+                a.tags[0],
+                { id: "a3", label: "A three" },
+              ],
+            },
+          ],
+        };
+      });
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector("[data-loading]")?.textContent).toBe("Loading…");
+    expect(container.querySelector('[data-status="error"]')?.textContent).toBe("Error");
+    expect(
+      [...container.querySelectorAll<HTMLElement>("[data-item]")].map((item) => item.dataset.item),
+    ).toEqual(["b", "a"]);
+    expect(container.querySelector('[data-item="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-tag="a1"]')).toBe(alphaTag);
+    expect(container.querySelector('[data-item="a"] span')?.textContent).toBe("Alpha updated");
+    expect(container.querySelector('[data-item="a"] [data-visible]')).toBeNull();
+    expect(
+      [...container.querySelectorAll<HTMLElement>('[data-item="a"] [data-tag]')].map(
+        (tag) => tag.dataset.tag,
+      ),
+    ).toEqual(["a2", "a1", "a3"]);
+    expect(container.querySelector("header")).toBe(header);
+    expect(container.querySelector("section > i")).toBe(divider);
+    expect(container.querySelector("footer")).toBe(footer);
+    expect(fixture.executions()).toBe(executionsAfterMount);
+    expect(commits).toBe(commitsAfterMount);
+  });
+
+  it("drops a queued mixed refresh when the component unmounts", async () => {
+    const fixture = createMixedFixture();
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<fixture.View />));
+
+    fixture.setModel((value) => ({ ...(value as Model), loading: true, items: [] }));
+    await act(async () => root.unmount());
+    roots.splice(roots.indexOf(root), 1);
+    await flushCompilerUpdates();
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("converges a parent prop commit with local conditional and keyed updates", async () => {
+    const fixture = createMixedFixture();
+    function Parent() {
+      const [prefix, setPrefix] = useState("before");
+      return (
+        <>
+          <button data-parent onClick={() => setPrefix("after")} type="button" />
+          <fixture.View prefix={prefix} />
+        </>
+      );
+    }
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Parent />));
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("[data-parent]")?.click();
+      fixture.setModel((value) => ({
+        ...(value as Model),
+        loading: true,
+        items: [...(value as Model).items].reverse(),
+      }));
+      await flushCompilerUpdates();
+    });
+    await flushCompilerUpdates();
+
+    expect(container.querySelector("[data-mixed]")?.getAttribute("data-prefix")).toBe("after");
+    expect(container.querySelector("[data-loading]")).not.toBeNull();
+    expect(
+      [...container.querySelectorAll<HTMLElement>("[data-item]")].map((item) => item.dataset.item),
+    ).toEqual(["b", "a"]);
+  });
+
+  it("adopts server markup and preserves recovery for hydration mismatches", async () => {
+    for (const mismatch of [false, true]) {
+      const fixture = createMixedFixture();
+      const container = document.createElement("div");
+      const html = renderToString(<fixture.View />);
+      container.innerHTML = mismatch ? html.replace("Alpha</span>", "Server</span>") : html;
+      document.body.append(container);
+      const recoverable = vi.fn();
+      let root!: ReturnType<typeof hydrateRoot>;
+      await act(async () => {
+        root = hydrateRoot(container, <fixture.View />, { onRecoverableError: recoverable });
+        await flushCompilerUpdates();
+      });
+      roots.push(root);
+      const alpha = container.querySelector('[data-item="a"]');
+      if (mismatch) expect(recoverable).toHaveBeenCalled();
+      else expect(recoverable).not.toHaveBeenCalled();
+
+      await act(async () => {
+        fixture.setModel((value) => ({
+          ...(value as Model),
+          loading: true,
+          items: [...(value as Model).items].reverse(),
+        }));
+        await flushCompilerUpdates();
+      });
+      expect(container.querySelector('[data-item="a"]')).toBe(alpha);
+      expect(container.querySelector("[data-loading]")).not.toBeNull();
+
+      await act(async () => root.unmount());
+      roots.splice(roots.indexOf(root), 1);
+      container.remove();
+    }
+  });
+
+  it("falls back on duplicate keys and keeps every mixed dependency live", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const fixture = createMixedFixture();
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<fixture.View />));
+
+    await act(async () => {
+      fixture.setModel((value) => {
+        const model = value as Model;
+        return { ...model, items: [model.items[0], { ...model.items[0], label: "Duplicate" }] };
+      });
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelectorAll('[data-item="a"]')).toHaveLength(2);
+    expect(container.textContent).toContain("Duplicate");
+
+    await act(async () => {
+      fixture.setModel(() => ({
+        loading: true,
+        error: true,
+        items: [{ id: "safe", label: "Safe", visible: true, tags: [] }],
+      }));
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector('[data-item="safe"] span')?.textContent).toBe("Safe");
+    expect(container.querySelector("[data-loading]")).not.toBeNull();
+    expect(container.querySelector('[data-status="error"]')).not.toBeNull();
+  });
+
+  it("routes mixed keyed binding failures through React error boundaries", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const fixture = createMixedFixture();
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <Boundary>
+          <fixture.View />
+        </Boundary>,
+      ),
+    );
+
+    await act(async () => {
+      fixture.setModel((value) => ({
+        ...(value as Model),
+        items: (value as Model).items.map((item) =>
+          item.id === "a" ? { ...item, fail: true } : item,
+        ),
+      }));
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("[data-error]")?.textContent).toBe("mixed range binding failed");
+  });
+
+  it("matches normal React through 3,000 deterministic mixed updates", async () => {
+    const fixture = createMixedFixture();
+    let updateNormal: React.Dispatch<React.SetStateAction<Model>> = () => undefined;
+    function Normal() {
+      const [model, setModel] = useState(cloneInitialModel);
+      updateNormal = setModel;
+      return mixedMarkup(model);
+    }
+
+    const compiledContainer = document.createElement("div");
+    const normalContainer = document.createElement("div");
+    document.body.append(compiledContainer, normalContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const normalRoot = createRoot(normalContainer);
+    roots.push(compiledRoot, normalRoot);
+    await act(async () => {
+      compiledRoot.render(<fixture.View />);
+      normalRoot.render(<Normal />);
+    });
+
+    const transition = (model: Model, step: number): Model => {
+      const action = step % 8;
+      if (action === 0) return { ...model, loading: !model.loading };
+      if (action === 1) return { ...model, error: !model.error };
+      if (action === 2) return { ...model, items: [...model.items].reverse() };
+      if (action === 3 && model.items.length > 1) {
+        return { ...model, items: [...model.items.slice(1), model.items[0]] };
+      }
+      if (action === 4 && model.items.length < 7) {
+        return {
+          ...model,
+          items: [
+            ...model.items,
+            {
+              id: `item-${step}`,
+              label: `Item ${step}`,
+              visible: step % 2 === 0,
+              tags: [{ id: `tag-${step}`, label: `Tag ${step}` }],
+            },
+          ],
+        };
+      }
+      if (action === 5 && model.items.length > 1) {
+        return { ...model, items: model.items.slice(1) };
+      }
+      if (model.items.length === 0) return model;
+      const index = step % model.items.length;
+      return {
+        ...model,
+        items: model.items.map((item, itemIndex) => {
+          if (itemIndex !== index) return item;
+          if (action === 6) {
+            return { ...item, label: `${item.label}!`, visible: !item.visible };
+          }
+          const tags =
+            item.tags.length > 1
+              ? [...item.tags.slice(1), item.tags[0]]
+              : [...item.tags, { id: `${item.id}-tag-${step}`, label: `Nested ${step}` }];
+          return { ...item, tags };
+        }),
+      };
+    };
+
+    for (let step = 0; step < 3_000; step += 1) {
+      await act(async () => {
+        fixture.setModel((value) => transition(value as Model, step));
+        updateNormal((value) => transition(value, step));
+        await flushCompilerUpdates();
+      });
+      if (step % 100 === 0) {
+        expect(compiledContainer.innerHTML).toBe(normalContainer.innerHTML);
+      }
+    }
+    expect(compiledContainer.innerHTML).toBe(normalContainer.innerHTML);
+  }, 60_000);
+});

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -127,7 +127,17 @@ export interface CompilerHostKeyedRanges {
   staticChildrenOnly?: boolean;
 }
 
-export type CompilerHostBlock = CompilerHostConditionalRanges | CompilerHostKeyedRanges;
+export interface CompilerHostMixedRanges {
+  kind: "mixed-ranges";
+  id: number;
+  ranges: readonly CompilerMixedRange[];
+  trailing: number;
+}
+
+export type CompilerHostBlock =
+  | CompilerHostConditionalRanges
+  | CompilerHostKeyedRanges
+  | CompilerHostMixedRanges;
 
 export interface CompilerHostConditionalBlockProps {
   id: number;
@@ -199,6 +209,17 @@ export interface CompilerKeyedRange {
   bindings: readonly CompilerKeyedRowBinding[];
 }
 
+export type CompilerMixedRange =
+  | ({ kind: "conditional" } & CompilerConditionalRange)
+  | ({ kind: "keyed" } & CompilerKeyedRange);
+
+export interface CompilerMixedRangesBlockProps {
+  id: number;
+  render(): React.ReactElement;
+  create(): CompilerHostElement;
+  rootRef?: React.RefCallback<Element>;
+}
+
 export interface CompilerKeyedRangesBlockProps {
   id: number;
   render(): React.ReactElement;
@@ -220,6 +241,7 @@ export interface CompilerBlockRuntime {
   KeyedList: React.ComponentType<CompilerKeyedListBlockProps>;
   KeyedRows: React.ComponentType<CompilerKeyedRowsBlockProps>;
   KeyedRanges: React.ComponentType<CompilerKeyedRangesBlockProps>;
+  MixedRanges: React.ComponentType<CompilerMixedRangesBlockProps>;
   Component: React.ComponentType<CompilerComponentBlockProps>;
   target(id: number): React.RefCallback<Element>;
 }
@@ -668,11 +690,22 @@ function collectCompilerHostBlockIds(descriptor: CompilerHostElement, ids: Set<n
       if (range.truthy) collectCompilerHostBlockIds(range.truthy.create(), ids);
       if (range.falsy) collectCompilerHostBlockIds(range.falsy.create(), ids);
     }
-  } else {
+  } else if (block.kind === "keyed-ranges") {
     for (const range of block.ranges) {
       const source = range.items();
       const first = source ? Array.from(source)[0] : undefined;
       if (first !== undefined) collectCompilerHostBlockIds(range.create(first, 0), ids);
+    }
+  } else {
+    for (const range of block.ranges) {
+      if (range.kind === "conditional") {
+        if (range.truthy) collectCompilerHostBlockIds(range.truthy.create(), ids);
+        if (range.falsy) collectCompilerHostBlockIds(range.falsy.create(), ids);
+      } else {
+        const source = range.items();
+        const first = source ? Array.from(source)[0] : undefined;
+        if (first !== undefined) collectCompilerHostBlockIds(range.create(first, 0), ids);
+      }
     }
   }
 }
@@ -867,6 +900,23 @@ function mountCompilerHostTree(
   }
   if (descriptor.block?.kind === "keyed-ranges") {
     const controller = new CompilerNestedKeyedRanges(
+      owner,
+      element,
+      descriptor,
+      descriptor.block,
+      onFallback,
+    );
+    try {
+      if (controller.adopt()) return controller;
+      controller.cleanup();
+      return null;
+    } catch (error) {
+      controller.cleanup();
+      throw error;
+    }
+  }
+  if (descriptor.block?.kind === "mixed-ranges") {
+    const controller = new CompilerNestedMixedRanges(
       owner,
       element,
       descriptor,
@@ -1456,6 +1506,414 @@ class CompilerNestedKeyedRanges implements CompilerHostTreeScope {
     this.unsubscribe?.();
     for (const instances of this.instances) {
       for (const instance of instances.values()) instance.scope?.cleanup();
+    }
+    for (const scope of this.staticScopes) scope.cleanup();
+    this.instances.length = 0;
+    this.staticSegments.length = 0;
+    this.staticScopes.length = 0;
+  }
+}
+
+type NestedMixedRangeSnapshot =
+  | { kind: "conditional"; selection: CompilerHostConditionalPreparedSelection }
+  | { kind: "keyed"; rows: NestedReadKeyedRange };
+
+type NestedMixedRangeInstance =
+  | { kind: "conditional"; value: NestedConditionalRangeInstance | null }
+  | { kind: "keyed"; value: Map<string, CompilerKeyedRowInstance> };
+
+class CompilerNestedMixedRanges implements CompilerHostTreeScope {
+  private readonly instances: NestedMixedRangeInstance[] = [];
+  private readonly staticSegments: Element[][] = [];
+  private readonly staticScopes: CompilerHostTreeScope[] = [];
+  private unsubscribe: (() => void) | undefined;
+  private active = true;
+
+  constructor(
+    private readonly owner: Pick<ConditionalBlockOwner, "subscribe">,
+    private readonly root: Element,
+    private host: CompilerHostElement,
+    private block: CompilerHostMixedRanges,
+    private readonly onFallback: () => void,
+  ) {}
+
+  private readSnapshots(): NestedMixedRangeSnapshot[] | null {
+    const snapshots: NestedMixedRangeSnapshot[] = [];
+    for (const range of this.block.ranges) {
+      if (range.kind === "conditional") {
+        const selection = hostConditionalSelection(range);
+        if (selection.kind === "fallback") return null;
+        snapshots.push({ kind: "conditional", selection });
+        continue;
+      }
+      const source = range.items();
+      const items = source ? Array.from(source) : [];
+      const keys = items.map((item, index) => keyedRowIdentity(range.rowKey(item, index)));
+      if (new Set(keys).size !== keys.length) return null;
+      snapshots.push({ kind: "keyed", rows: { items, keys } });
+    }
+    return snapshots;
+  }
+
+  private mountStatic(
+    elements: readonly Element[],
+    descriptors: readonly CompilerHostElement[],
+  ): boolean {
+    if (elements.length !== descriptors.length) return false;
+    for (let index = 0; index < elements.length; index += 1) {
+      const scope = mountCompilerHostTree(
+        this.owner,
+        elements[index],
+        descriptors[index],
+        this.onFallback,
+      );
+      if (!scope) return false;
+      this.staticScopes.push(scope);
+    }
+    return true;
+  }
+
+  adopt(): boolean {
+    if (!Number.isSafeInteger(this.block.trailing) || this.block.trailing < 0) return false;
+    const snapshots = this.readSnapshots();
+    if (!snapshots) return false;
+    const elements = [...this.root.children];
+    const descriptors = flattenCompilerHostElements(this.host.children);
+    if (elements.length !== descriptors.length) return false;
+    let cursor = 0;
+
+    for (let rangeIndex = 0; rangeIndex < this.block.ranges.length; rangeIndex += 1) {
+      const range = this.block.ranges[rangeIndex];
+      const snapshot = snapshots[rangeIndex];
+      if (!Number.isSafeInteger(range.before) || range.before < 0 || range.kind !== snapshot.kind) {
+        this.cleanup();
+        return false;
+      }
+      const staticEnd = cursor + range.before;
+      if (
+        staticEnd > elements.length ||
+        !this.mountStatic(elements.slice(cursor, staticEnd), descriptors.slice(cursor, staticEnd))
+      ) {
+        this.cleanup();
+        return false;
+      }
+      this.staticSegments.push(elements.slice(cursor, staticEnd));
+      cursor = staticEnd;
+
+      if (range.kind === "conditional" && snapshot.kind === "conditional") {
+        if (snapshot.selection.kind === "empty") {
+          this.instances.push({ kind: "conditional", value: null });
+          continue;
+        }
+        const element = elements[cursor];
+        if (!element) {
+          this.cleanup();
+          return false;
+        }
+        const descriptor = snapshot.selection.branch.create();
+        const host = mountCompilerHostInstance(
+          this.owner,
+          element,
+          descriptor,
+          snapshot.selection.branch,
+          this.onFallback,
+        );
+        if (!host) {
+          this.cleanup();
+          return false;
+        }
+        this.instances.push({
+          kind: "conditional",
+          value: { key: snapshot.selection.key, host },
+        });
+        cursor += 1;
+        continue;
+      }
+
+      if (range.kind !== "keyed" || snapshot.kind !== "keyed") {
+        this.cleanup();
+        return false;
+      }
+      const keyedInstances = new Map<string, CompilerKeyedRowInstance>();
+      for (let index = 0; index < snapshot.rows.items.length; index += 1) {
+        const element = elements[cursor + index];
+        if (!element) {
+          this.cleanup();
+          return false;
+        }
+        const descriptor = range.create(snapshot.rows.items[index], index);
+        const scope = mountCompilerHostTree(this.owner, element, descriptor, this.onFallback);
+        if (!scope) {
+          this.cleanup();
+          return false;
+        }
+        const instance: CompilerKeyedRowInstance = {
+          key: snapshot.rows.keys[index],
+          element,
+          scope,
+          values: range.bindings.map(() => UNSET_KEYED_ROW_BINDING),
+          item: snapshot.rows.items[index],
+          index,
+          conditionalValues: new Map(),
+        };
+        try {
+          applyKeyedRowBindings(range, instance, snapshot.rows.items[index], index);
+        } catch (error) {
+          scope.cleanup();
+          throw error;
+        }
+        keyedInstances.set(snapshot.rows.keys[index], instance);
+      }
+      this.instances.push({ kind: "keyed", value: keyedInstances });
+      cursor += snapshot.rows.items.length;
+    }
+
+    const trailingEnd = cursor + this.block.trailing;
+    if (
+      trailingEnd !== elements.length ||
+      !this.mountStatic(elements.slice(cursor), descriptors.slice(cursor))
+    ) {
+      this.cleanup();
+      return false;
+    }
+    this.staticSegments.push(elements.slice(cursor));
+    this.unsubscribe = this.owner.subscribe(this.block.id, this.refresh);
+    return true;
+  }
+
+  private firstInstanceElement(instance: NestedMixedRangeInstance): Element | null {
+    if (instance.kind === "conditional") return instance.value?.host.element || null;
+    return instance.value.values().next().value?.element || null;
+  }
+
+  private anchorAfter(rangeIndex: number): ChildNode | null {
+    for (let next = rangeIndex + 1; next < this.instances.length; next += 1) {
+      const staticAnchor = this.staticSegments[next]?.[0];
+      if (staticAnchor) return staticAnchor;
+      const rangeAnchor = this.firstInstanceElement(this.instances[next]);
+      if (rangeAnchor) return rangeAnchor;
+    }
+    return this.staticSegments[this.instances.length]?.[0] || null;
+  }
+
+  private reconcileConditional(
+    rangeIndex: number,
+    range: CompilerMixedRange & { kind: "conditional" },
+    selection: CompilerHostConditionalPreparedSelection,
+  ): boolean {
+    const instance = this.instances[rangeIndex];
+    if (instance.kind !== "conditional") return false;
+    const previous = instance.value;
+    if (selection.kind === "empty") {
+      previous?.host.scope?.cleanup();
+      previous?.host.element.remove();
+      instance.value = null;
+      return true;
+    }
+    if (previous?.key === selection.key) {
+      const descriptor = selection.branch.create();
+      if (!previous.host.scope?.update(descriptor)) return false;
+      applyHostConditionalBindings(selection.branch, previous.host);
+      return true;
+    }
+    const descriptor = selection.branch.create();
+    const element = createCompilerHostElement(this.root.ownerDocument, descriptor);
+    const host = mountCompilerHostInstance(
+      this.owner,
+      element,
+      descriptor,
+      selection.branch,
+      this.onFallback,
+    );
+    if (!host) return false;
+    previous?.host.scope?.cleanup();
+    if (previous) previous.host.element.replaceWith(element);
+    else this.root.insertBefore(element, this.anchorAfter(rangeIndex));
+    instance.value = { key: selection.key, host };
+    return true;
+  }
+
+  private reconcileKeyed(
+    rangeIndex: number,
+    range: CompilerMixedRange & { kind: "keyed" },
+    rows: NestedReadKeyedRange,
+  ): boolean {
+    const instance = this.instances[rangeIndex];
+    if (instance.kind !== "keyed") return false;
+    const previous = instance.value;
+    const oldIndices = new Map<string, number>();
+    [...previous.keys()].forEach((key, index) => oldIndices.set(key, index));
+    const nextKeys = new Set(rows.keys);
+    for (const [key, row] of previous) {
+      if (nextKeys.has(key)) continue;
+      row.scope?.cleanup();
+      row.element.remove();
+    }
+
+    const sequence = rows.keys.map((key) => oldIndices.get(key) ?? -1);
+    const stablePositions = longestIncreasingSubsequencePositions(sequence);
+    const nextInstances: CompilerKeyedRowInstance[] = [];
+    for (let index = 0; index < rows.items.length; index += 1) {
+      const key = rows.keys[index];
+      const existing = previous.get(key);
+      if (existing) {
+        const descriptor = range.create(rows.items[index], index);
+        if (!existing.scope?.update(descriptor)) return false;
+        applyKeyedRowBindings(range, existing, rows.items[index], index);
+        existing.item = rows.items[index];
+        existing.index = index;
+        nextInstances.push(existing);
+        continue;
+      }
+      const descriptor = range.create(rows.items[index], index);
+      const element = createCompilerHostElement(this.root.ownerDocument, descriptor);
+      const scope = mountCompilerHostTree(this.owner, element, descriptor, this.onFallback);
+      if (!scope) return false;
+      let values: unknown[];
+      try {
+        values = readKeyedRowBindingValues(range, rows.items[index], index);
+      } catch (error) {
+        scope.cleanup();
+        throw error;
+      }
+      nextInstances.push({
+        key,
+        element,
+        scope,
+        values,
+        item: rows.items[index],
+        index,
+        conditionalValues: new Map(),
+      });
+    }
+
+    let anchor = this.anchorAfter(rangeIndex);
+    for (let index = nextInstances.length - 1; index >= 0; index -= 1) {
+      const row = nextInstances[index];
+      if (
+        sequence[index] < 0 ||
+        (!stablePositions.has(index) && row.element.nextSibling !== anchor)
+      ) {
+        this.root.insertBefore(row.element, anchor);
+      }
+      anchor = row.element;
+    }
+    instance.value = new Map(nextInstances.map((row) => [row.key, row]));
+    return true;
+  }
+
+  private reconcileRange(rangeIndex: number, snapshot: NestedMixedRangeSnapshot): boolean {
+    const range = this.block.ranges[rangeIndex];
+    if (range.kind !== snapshot.kind) return false;
+    return range.kind === "conditional" && snapshot.kind === "conditional"
+      ? this.reconcileConditional(rangeIndex, range, snapshot.selection)
+      : range.kind === "keyed" && snapshot.kind === "keyed"
+        ? this.reconcileKeyed(rangeIndex, range, snapshot.rows)
+        : false;
+  }
+
+  private refresh = (afterCommit?: () => void) => {
+    if (!this.active) {
+      afterCommit?.();
+      return;
+    }
+    const snapshots = this.readSnapshots();
+    if (!snapshots || snapshots.length !== this.instances.length) {
+      this.onFallback();
+      afterCommit?.();
+      return;
+    }
+    const activeElement = this.root.ownerDocument.activeElement;
+    const restoreFocus = Boolean(activeElement && this.root.contains(activeElement));
+    for (let index = snapshots.length - 1; index >= 0; index -= 1) {
+      if (!this.reconcileRange(index, snapshots[index])) {
+        this.onFallback();
+        afterCommit?.();
+        return;
+      }
+    }
+    if (
+      restoreFocus &&
+      activeElement?.isConnected &&
+      activeElement.ownerDocument.activeElement !== activeElement &&
+      "focus" in activeElement
+    ) {
+      (activeElement as HTMLElement).focus({ preventScroll: true });
+    }
+    afterCommit?.();
+  };
+
+  private updateStaticScopes(
+    descriptor: CompilerHostElement,
+    snapshots: readonly NestedMixedRangeSnapshot[],
+  ): boolean {
+    const descriptors = flattenCompilerHostElements(descriptor.children);
+    let descriptorIndex = 0;
+    let scopeIndex = 0;
+    for (let rangeIndex = 0; rangeIndex < this.block.ranges.length; rangeIndex += 1) {
+      const range = this.block.ranges[rangeIndex];
+      for (let index = 0; index < range.before; index += 1) {
+        const scope = this.staticScopes[scopeIndex++];
+        const child = descriptors[descriptorIndex++];
+        if (!scope || !child || !scope.update(child)) return false;
+      }
+      const snapshot = snapshots[rangeIndex];
+      if (snapshot.kind === "conditional") {
+        if (snapshot.selection.kind === "branch") descriptorIndex += 1;
+      } else {
+        descriptorIndex += snapshot.rows.items.length;
+      }
+    }
+    for (let index = 0; index < this.block.trailing; index += 1) {
+      const scope = this.staticScopes[scopeIndex++];
+      const child = descriptors[descriptorIndex++];
+      if (!scope || !child || !scope.update(child)) return false;
+    }
+    return scopeIndex === this.staticScopes.length && descriptorIndex === descriptors.length;
+  }
+
+  update(descriptor: CompilerHostElement): boolean {
+    const block = descriptor.block;
+    if (
+      !this.active ||
+      block?.kind !== "mixed-ranges" ||
+      block.id !== this.block.id ||
+      block.ranges.length !== this.block.ranges.length ||
+      block.trailing !== this.block.trailing ||
+      block.ranges.some(
+        (range, index) =>
+          range.kind !== this.block.ranges[index].kind ||
+          range.before !== this.block.ranges[index].before,
+      )
+    ) {
+      return false;
+    }
+    this.host = descriptor;
+    this.block = block;
+    const snapshots = this.readSnapshots();
+    if (
+      !snapshots ||
+      snapshots.length !== this.instances.length ||
+      !this.updateStaticScopes(descriptor, snapshots)
+    ) {
+      return false;
+    }
+    for (let index = snapshots.length - 1; index >= 0; index -= 1) {
+      if (!this.reconcileRange(index, snapshots[index])) return false;
+    }
+    return true;
+  }
+
+  cleanup(): void {
+    if (!this.active) return;
+    this.active = false;
+    this.unsubscribe?.();
+    for (const instance of this.instances) {
+      if (instance.kind === "conditional") {
+        instance.value?.host.scope?.cleanup();
+      } else {
+        for (const row of instance.value.values()) row.scope?.cleanup();
+      }
     }
     for (const scope of this.staticScopes) scope.cleanup();
     this.instances.length = 0;
@@ -2826,6 +3284,145 @@ function createKeyedRangesBlockComponent(
   return FarmKeyedRangesBlock;
 }
 
+function createMixedRangesBlockComponent(
+  owner: Pick<ConditionalBlockOwner, "subscribe">,
+): React.ComponentType<CompilerMixedRangesBlockProps> {
+  interface State {
+    fallback: boolean;
+  }
+
+  class FarmMixedRangesBlock extends React.Component<CompilerMixedRangesBlockProps, State> {
+    static displayName = "FarmCompiledMixedRanges";
+
+    state: State = { fallback: false };
+    private root: Element | null = null;
+    private mounted = false;
+    private fallbackRequested = false;
+    private fallbackVersion = 0;
+    private propFallbackQueued = false;
+    private currentProps = this.props;
+    private controller: CompilerNestedMixedRanges | null = null;
+    private fallbackUnsubscribers: Array<() => void> = [];
+
+    private captureRoot = (root: Element | null) => {
+      this.root = root;
+      this.currentProps.rootRef?.(root);
+    };
+
+    private clearFallbackSubscriptions(): void {
+      for (const unsubscribe of this.fallbackUnsubscribers) unsubscribe();
+      this.fallbackUnsubscribers = [];
+    }
+
+    private subscribeFallbackBlocks(): void {
+      this.clearFallbackSubscriptions();
+      const descriptor = this.currentProps.create();
+      const ids = new Set<number>();
+      collectCompilerHostBlockIds(descriptor, ids);
+      for (const id of ids) {
+        this.fallbackUnsubscribers.push(
+          owner.subscribe(id, (afterCommit) => {
+            if (!this.mounted || !this.state.fallback) {
+              afterCommit?.();
+              return;
+            }
+            this.fallbackVersion += 1;
+            this.forceUpdate(afterCommit);
+          }),
+        );
+      }
+    }
+
+    private adopt(): boolean {
+      if (!this.root) return false;
+      const descriptor = this.currentProps.create();
+      const block = descriptor.block;
+      if (block?.kind !== "mixed-ranges" || block.id !== this.currentProps.id) return false;
+      const controller = new CompilerNestedMixedRanges(
+        owner,
+        this.root,
+        descriptor,
+        block,
+        this.activateFallback,
+      );
+      try {
+        if (!controller.adopt()) {
+          controller.cleanup();
+          return false;
+        }
+      } catch (error) {
+        controller.cleanup();
+        throw error;
+      }
+      this.controller = controller;
+      return true;
+    }
+
+    private activateFallback = (afterCommit?: () => void): void => {
+      if (!this.mounted || this.state.fallback || this.fallbackRequested) {
+        afterCommit?.();
+        return;
+      }
+      this.fallbackRequested = true;
+      this.controller?.cleanup();
+      this.controller = null;
+      this.fallbackVersion += 1;
+      this.setState({ fallback: true }, () => {
+        this.subscribeFallbackBlocks();
+        afterCommit?.();
+      });
+    };
+
+    private schedulePropFallback(): void {
+      if (this.propFallbackQueued) return;
+      this.propFallbackQueued = true;
+      queueMicrotask(() => {
+        this.propFallbackQueued = false;
+        if (this.mounted && !this.state.fallback) this.activateFallback();
+      });
+    }
+
+    shouldComponentUpdate(nextProps: CompilerMixedRangesBlockProps, nextState: State): boolean {
+      this.currentProps = nextProps;
+      if (nextState.fallback || this.state.fallback) return true;
+      this.schedulePropFallback();
+      return false;
+    }
+
+    componentDidMount(): void {
+      this.mounted = true;
+      if (!this.adopt()) this.activateFallback();
+    }
+
+    componentDidUpdate(): void {
+      if (this.state.fallback) this.subscribeFallbackBlocks();
+    }
+
+    componentWillUnmount(): void {
+      this.mounted = false;
+      this.controller?.cleanup();
+      this.controller = null;
+      this.clearFallbackSubscriptions();
+      this.root = null;
+    }
+
+    render(): React.ReactNode {
+      const container = this.currentProps.render();
+      if (!React.isValidElement(container) || typeof container.type !== "string") {
+        throw new TypeError(
+          `Compiled mixed ranges ${this.currentProps.id} must own one host container.`,
+        );
+      }
+      return React.cloneElement(container, {
+        key: this.state.fallback ? `react-${this.fallbackVersion}` : "compiled",
+        ref: this.captureRoot,
+      } as React.Attributes);
+    }
+  }
+
+  return FarmMixedRangesBlock;
+}
+
 function createComponentBlockComponent(
   owner: Pick<ConditionalBlockOwner, "subscribe">,
 ): React.ComponentType<CompilerComponentBlockProps> {
@@ -2944,6 +3541,9 @@ export function createCompiledComponent<Props>(
           subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
         }),
         KeyedRanges: createKeyedRangesBlockComponent({
+          subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
+        }),
+        MixedRanges: createMixedRangesBlockComponent({
           subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
         }),
         Component: createComponentBlockComponent({
@@ -3168,6 +3768,11 @@ export function createCompiledComponent<Props>(
           element as React.ReactElement<CompilerConditionalRangesBlockProps>,
           { rootRef: this.captureRoot },
         );
+      }
+      if (element.type === this.blockRuntime.MixedRanges) {
+        return React.cloneElement(element as React.ReactElement<CompilerMixedRangesBlockProps>, {
+          rootRef: this.captureRoot,
+        });
       }
       if (typeof element.type !== "string") {
         throw new TypeError(

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -174,6 +174,21 @@ interface KeyedRangesPlan {
   trailing: number;
 }
 
+type MixedRangePlan =
+  | ({ rangeKind: "conditional" } & ConditionalRangePlan)
+  | ({ rangeKind: "keyed" } & KeyedRangePlan);
+
+interface MixedRangesPlan {
+  kind: "mixed-ranges";
+  id: number;
+  parent?: number;
+  dependencies: number[];
+  source: t.JSXElement;
+  ranges: MixedRangePlan[];
+  trailing: number;
+  descriptorBlocks: ReadonlyMap<t.JSXElement, HostDescriptorBlockPlan>;
+}
+
 interface NestedHostConditionalRangesPlan {
   kind: "nested-host-conditional-ranges";
   id: number;
@@ -194,7 +209,20 @@ interface NestedHostKeyedRangesPlan {
   trailing: number;
 }
 
-type HostDescriptorBlockPlan = NestedHostConditionalRangesPlan | NestedHostKeyedRangesPlan;
+interface NestedHostMixedRangesPlan {
+  kind: "nested-host-mixed-ranges";
+  id: number;
+  parent?: number;
+  dependencies: number[];
+  source: t.JSXElement;
+  ranges: MixedRangePlan[];
+  trailing: number;
+}
+
+type HostDescriptorBlockPlan =
+  | NestedHostConditionalRangesPlan
+  | NestedHostKeyedRangesPlan
+  | NestedHostMixedRangesPlan;
 
 interface ComponentIslandPlan {
   kind: "component";
@@ -211,8 +239,10 @@ type ComposableBlockPlan =
   | KeyedListPlan
   | KeyedRowsPlan
   | KeyedRangesPlan
+  | MixedRangesPlan
   | NestedHostConditionalRangesPlan
   | NestedHostKeyedRangesPlan
+  | NestedHostMixedRangesPlan
   | ComponentIslandPlan;
 
 interface Candidate {
@@ -1746,6 +1776,46 @@ function analyzeRecursiveHostTree(
     }
 
     const children = meaningfulJsxChildren(element);
+    const hasConditionalRange = children.some(
+      (child) =>
+        t.isJSXExpressionContainer(child) &&
+        !t.isJSXEmptyExpression(child.expression) &&
+        conditionalBlockShape(child.expression) !== null,
+    );
+    const hasKeyedRange = children.some(
+      (child) =>
+        analyzeKeyedRowChild(child, statesByValue, safeGlobals, listNames, true) !== undefined,
+    );
+    if (hasConditionalRange && hasKeyedRange) {
+      const id = allocateId();
+      const mixed = analyzeMixedRangesContainer(
+        element,
+        statesByValue,
+        safeGlobals,
+        listNames,
+        id,
+        allocateId,
+      );
+      if (mixed) {
+        plans.push(...mixed.nestedPlans);
+        for (const [nestedElement, plan] of mixed.descriptorBlocks) {
+          blocks.set(nestedElement, plan);
+        }
+        const plan: NestedHostMixedRangesPlan = {
+          kind: "nested-host-mixed-ranges",
+          id,
+          parent: owner,
+          dependencies: mixed.dependencies,
+          source: element,
+          ranges: mixed.ranges,
+          trailing: mixed.trailing,
+        };
+        plans.push(plan);
+        blocks.set(element, plan);
+        return undefined;
+      }
+    }
+
     const conditionalChildren = new Map<
       t.Expression,
       NonNullable<ReturnType<typeof conditionalBlockShape>>
@@ -2224,6 +2294,162 @@ function analyzeConditionalRangesContainer(
   };
 }
 
+function analyzeMixedRangesContainer(
+  container: t.JSXElement,
+  statesByValue: ReadonlyMap<string, StateBinding>,
+  safeGlobals: ReadonlySet<string>,
+  listNames: ReadonlySet<string>,
+  parent: number,
+  allocateId: () => number,
+):
+  | {
+      ranges: MixedRangePlan[];
+      trailing: number;
+      dependencies: number[];
+      descriptorBlocks: ReadonlyMap<t.JSXElement, HostDescriptorBlockPlan>;
+      nestedPlans: HostDescriptorBlockPlan[];
+    }
+  | undefined {
+  const containerName = container.openingElement.name;
+  if (
+    !t.isJSXIdentifier(containerName) ||
+    !/^[a-z]/.test(containerName.name) ||
+    containerName.name === "svg" ||
+    container.openingElement.attributes.some(
+      (attribute) =>
+        t.isJSXSpreadAttribute(attribute) ||
+        (t.isJSXAttribute(attribute) &&
+          t.isJSXIdentifier(attribute.name) &&
+          (attribute.name.name === "ref" || attribute.name.name === "dangerouslySetInnerHTML")),
+    )
+  ) {
+    return undefined;
+  }
+
+  const children = meaningfulJsxChildren(container);
+  if (children.length < 2) return undefined;
+  const ranges: MixedRangePlan[] = [];
+  const dependencies = new Set<number>();
+  const descriptorBlocks = new Map<t.JSXElement, HostDescriptorBlockPlan>();
+  const nestedPlans: HostDescriptorBlockPlan[] = [];
+  let conditionalCount = 0;
+  let keyedCount = 0;
+  let staticBefore = 0;
+
+  const mergeAnalysis = (analysis: RecursiveHostTreeAnalysis): boolean => {
+    if (analysis.reason) return false;
+    nestedPlans.push(...analysis.plans);
+    for (const [element, plan] of analysis.blocks) descriptorBlocks.set(element, plan);
+    for (const binding of analysis.bindings) {
+      for (const dependency of collectStateDependencies(binding.value, statesByValue)) {
+        dependencies.add(dependency);
+      }
+    }
+    return true;
+  };
+
+  for (const child of children) {
+    if (t.isJSXExpressionContainer(child) && !t.isJSXEmptyExpression(child.expression)) {
+      const shape = conditionalBlockShape(child.expression);
+      if (shape && !validateDerivedExpression(shape.test, safeGlobals)) {
+        const truthyAnalysis = shape.truthy
+          ? analyzeRecursiveHostTree(
+              shape.truthy,
+              statesByValue,
+              safeGlobals,
+              listNames,
+              parent,
+              allocateId,
+            )
+          : { bindings: [], plans: [], blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>() };
+        const falsyAnalysis = shape.falsy
+          ? analyzeRecursiveHostTree(
+              shape.falsy,
+              statesByValue,
+              safeGlobals,
+              listNames,
+              parent,
+              allocateId,
+            )
+          : { bindings: [], plans: [], blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>() };
+        if (!mergeAnalysis(truthyAnalysis) || !mergeAnalysis(falsyAnalysis)) return undefined;
+        for (const dependency of collectStateDependencies(shape.test, statesByValue)) {
+          dependencies.add(dependency);
+        }
+        ranges.push({
+          rangeKind: "conditional",
+          before: staticBefore,
+          source: child.expression,
+          test: cloneExpression(shape.test),
+          logical: shape.logical,
+          truthy: shape.truthy,
+          falsy: shape.falsy,
+          truthyBindings: truthyAnalysis.bindings,
+          falsyBindings: falsyAnalysis.bindings,
+        });
+        conditionalCount += 1;
+        staticBefore = 0;
+        continue;
+      }
+    }
+
+    const keyed = analyzeKeyedRowChild(child, statesByValue, safeGlobals, listNames, true);
+    if (keyed) {
+      if (keyed.events.length > 0) return undefined;
+      const row = t.cloneNode(keyed.row, true);
+      row.openingElement.attributes = row.openingElement.attributes.filter(
+        (attribute) => !t.isJSXAttribute(attribute) || jsxAttributeName(attribute) !== "key",
+      );
+      const rowAnalysis = analyzeRecursiveHostTree(
+        row,
+        statesByValue,
+        safeGlobals,
+        listNames,
+        parent,
+        allocateId,
+      );
+      if (!mergeAnalysis(rowAnalysis)) return undefined;
+      for (const dependency of keyed.dependencies) dependencies.add(dependency);
+      ranges.push({
+        rangeKind: "keyed",
+        before: staticBefore,
+        source: keyed.source,
+        collection: keyed.collection,
+        keyCallback: keyed.keyCallback,
+        renderCallback: keyed.renderCallback,
+        row,
+        bindings: rowAnalysis.bindings,
+        syntax: keyed.syntax,
+      });
+      keyedCount += 1;
+      staticBefore = 0;
+      continue;
+    }
+
+    if (!t.isJSXElement(child) || !isHostElement(child)) return undefined;
+    const staticAnalysis = analyzeRecursiveHostTree(
+      child,
+      statesByValue,
+      safeGlobals,
+      listNames,
+      parent,
+      allocateId,
+    );
+    if (staticAnalysis.reason || staticAnalysis.bindings.length > 0) return undefined;
+    if (!mergeAnalysis(staticAnalysis)) return undefined;
+    staticBefore += 1;
+  }
+
+  if (conditionalCount === 0 || keyedCount === 0) return undefined;
+  return {
+    ranges,
+    trailing: staticBefore,
+    dependencies: [...dependencies].sort((left, right) => left - right),
+    descriptorBlocks,
+    nestedPlans,
+  };
+}
+
 function keyedListBoundary(
   blockRuntime: t.Identifier,
   plan: KeyedListPlan,
@@ -2262,7 +2488,7 @@ function hostElementDescriptor(
   for (const attribute of element.openingElement.attributes) {
     if (!t.isJSXAttribute(attribute)) continue;
     const name = jsxAttributeName(attribute);
-    if (!name || name === "key" || /^on[A-Z]/.test(name)) continue;
+    if (!name || name === "key" || name === "ref" || /^on[A-Z]/.test(name)) continue;
     if (name === "style") {
       if (
         t.isJSXExpressionContainer(attribute.value) &&
@@ -2307,6 +2533,11 @@ function hostElementDescriptor(
     for (const range of block.ranges) conditionalBySource.set(range.source, range);
   } else if (block?.kind === "nested-host-keyed-ranges") {
     for (const range of block.ranges) keyedBySource.set(range.source, range);
+  } else if (block?.kind === "nested-host-mixed-ranges") {
+    for (const range of block.ranges) {
+      if (range.rangeKind === "conditional") conditionalBySource.set(range.source, range);
+      else keyedBySource.set(range.source, range);
+    }
   }
 
   const children: t.Expression[] = [];
@@ -2921,20 +3152,23 @@ function nestedHostBlockObject(
   plan: HostDescriptorBlockPlan,
   descriptorBlocks: ReadonlyMap<t.JSXElement, HostDescriptorBlockPlan>,
 ): t.ObjectExpression {
+  const kind =
+    plan.kind === "nested-host-conditional-ranges"
+      ? "conditional-ranges"
+      : plan.kind === "nested-host-keyed-ranges"
+        ? "keyed-ranges"
+        : "mixed-ranges";
   return t.objectExpression([
-    t.objectProperty(
-      t.identifier("kind"),
-      t.stringLiteral(
-        plan.kind === "nested-host-conditional-ranges" ? "conditional-ranges" : "keyed-ranges",
-      ),
-    ),
+    t.objectProperty(t.identifier("kind"), t.stringLiteral(kind)),
     t.objectProperty(t.identifier("id"), t.numericLiteral(plan.id)),
     t.objectProperty(
       t.identifier("ranges"),
       t.arrayExpression(
         plan.kind === "nested-host-conditional-ranges"
           ? plan.ranges.map((range) => conditionalRangeObject(range, descriptorBlocks))
-          : plan.ranges.map((range) => keyedRangeObject(range, descriptorBlocks)),
+          : plan.kind === "nested-host-keyed-ranges"
+            ? plan.ranges.map((range) => keyedRangeObject(range, descriptorBlocks))
+            : plan.ranges.map((range) => mixedRangeObject(range, descriptorBlocks)),
       ),
     ),
     t.objectProperty(t.identifier("trailing"), t.numericLiteral(plan.trailing)),
@@ -2942,6 +3176,63 @@ function nestedHostBlockObject(
       ? [t.objectProperty(t.identifier("staticChildrenOnly"), t.booleanLiteral(true))]
       : []),
   ]);
+}
+
+function mixedRangeObject(
+  range: MixedRangePlan,
+  descriptorBlocks: ReadonlyMap<t.JSXElement, HostDescriptorBlockPlan>,
+): t.ObjectExpression {
+  const value =
+    range.rangeKind === "conditional"
+      ? conditionalRangeObject(range, descriptorBlocks)
+      : keyedRangeObject(range, descriptorBlocks);
+  value.properties.unshift(
+    t.objectProperty(t.identifier("kind"), t.stringLiteral(range.rangeKind)),
+  );
+  return value;
+}
+
+function mixedRangesBoundary(blockRuntime: t.Identifier, plan: MixedRangesPlan): t.JSXElement {
+  const name = t.jsxMemberExpression(
+    t.jsxIdentifier(blockRuntime.name),
+    t.jsxIdentifier("MixedRanges"),
+  );
+  const source = t.cloneNode(plan.source, true);
+  const rootRefIndex = source.openingElement.attributes.findIndex(
+    (attribute) => t.isJSXAttribute(attribute) && jsxAttributeName(attribute) === "ref",
+  );
+  const rootRef =
+    rootRefIndex >= 0
+      ? (source.openingElement.attributes.splice(rootRefIndex, 1)[0] as t.JSXAttribute)
+      : undefined;
+  const nestedPlan: NestedHostMixedRangesPlan = {
+    kind: "nested-host-mixed-ranges",
+    id: plan.id,
+    parent: plan.parent,
+    dependencies: plan.dependencies,
+    source: plan.source,
+    ranges: plan.ranges,
+    trailing: plan.trailing,
+  };
+  const descriptorBlocks = new Map(plan.descriptorBlocks);
+  descriptorBlocks.set(plan.source, nestedPlan);
+  const attributes: t.JSXAttribute[] = [
+    t.jsxAttribute(t.jsxIdentifier("id"), t.jsxExpressionContainer(t.numericLiteral(plan.id))),
+    t.jsxAttribute(
+      t.jsxIdentifier("render"),
+      t.jsxExpressionContainer(t.arrowFunctionExpression([], source)),
+    ),
+    t.jsxAttribute(
+      t.jsxIdentifier("create"),
+      t.jsxExpressionContainer(
+        t.arrowFunctionExpression([], hostElementDescriptor(plan.source, descriptorBlocks)),
+      ),
+    ),
+  ];
+  if (rootRef?.value) {
+    attributes.push(t.jsxAttribute(t.jsxIdentifier("rootRef"), t.cloneNode(rootRef.value, true)));
+  }
+  return t.jsxElement(t.jsxOpeningElement(name, attributes, true), null, [], true);
 }
 
 function conditionalRangesBoundary(
@@ -3205,6 +3496,42 @@ function analyzeComposableBlocks(
 
       if (t.isJSXElement(child)) {
         if (isHostElement(child)) {
+          const mixedRangeStart = nextId;
+          const mixedRangeId = nextId++;
+          const mixedRanges = insideConditional
+            ? undefined
+            : analyzeMixedRangesContainer(
+                child,
+                statesByValue,
+                safeGlobals,
+                listNames,
+                mixedRangeId,
+                () => nextId++,
+              );
+          if (mixedRanges) {
+            plans.push({
+              kind: "mixed-ranges",
+              id: mixedRangeId,
+              parent,
+              dependencies: mixedRanges.dependencies,
+              source: child,
+              ranges: mixedRanges.ranges,
+              trailing: mixedRanges.trailing,
+              descriptorBlocks: mixedRanges.descriptorBlocks,
+            });
+            plans.push(...mixedRanges.nestedPlans);
+            for (const range of mixedRanges.ranges) {
+              if (range.rangeKind === "conditional") {
+                conditionalExpressions.add(range.source);
+              } else if (t.isJSXElement(range.source)) {
+                ownedElements.add(range.source);
+              } else {
+                keyedExpressions.add(range.source);
+              }
+            }
+            continue;
+          }
+          nextId = mixedRangeStart;
           const keyedRanges = insideConditional
             ? undefined
             : analyzeKeyedRangesContainer(child, statesByValue, safeGlobals, listNames);
@@ -3424,6 +3751,46 @@ function analyzeComposableBlocks(
     return { dependencies };
   };
 
+  const rootMixedRangeStart = nextId;
+  const rootMixedRangeId = nextId++;
+  const rootMixedRanges = analyzeMixedRangesContainer(
+    root,
+    statesByValue,
+    safeGlobals,
+    listNames,
+    rootMixedRangeId,
+    () => nextId++,
+  );
+  if (rootMixedRanges) {
+    plans.push({
+      kind: "mixed-ranges",
+      id: rootMixedRangeId,
+      dependencies: rootMixedRanges.dependencies,
+      source: root,
+      ranges: rootMixedRanges.ranges,
+      trailing: rootMixedRanges.trailing,
+      descriptorBlocks: rootMixedRanges.descriptorBlocks,
+    });
+    plans.push(...rootMixedRanges.nestedPlans);
+    for (const range of rootMixedRanges.ranges) {
+      if (range.rangeKind === "conditional") {
+        conditionalExpressions.add(range.source);
+      } else if (t.isJSXElement(range.source)) {
+        ownedElements.add(range.source);
+      } else {
+        keyedExpressions.add(range.source);
+      }
+    }
+    return {
+      plans,
+      componentElements,
+      conditionalExpressions,
+      ownedElements,
+      keyedExpressions,
+    };
+  }
+  nextId = rootMixedRangeStart;
+
   const rootRanges = analyzeKeyedRangesContainer(root, statesByValue, safeGlobals, listNames, true);
   if (rootRanges) {
     plans.push({
@@ -3530,6 +3897,9 @@ function lowerComposableBlocks(
     plans.map((plan) => [plan.source, plan]),
   );
   const rootPlan = planBySource.get(root);
+  if (rootPlan?.kind === "mixed-ranges") {
+    return mixedRangesBoundary(blockRuntime, rootPlan);
+  }
   if (rootPlan?.kind === "keyed-ranges") {
     return keyedRangesBoundary(blockRuntime, rootPlan);
   }
@@ -3543,6 +3913,9 @@ function lowerComposableBlocks(
         const plan = planBySource.get(child);
         if (plan?.kind === "host-conditional") {
           return hostConditionalBoundary(blockRuntime, plan);
+        }
+        if (plan?.kind === "mixed-ranges") {
+          return mixedRangesBoundary(blockRuntime, plan);
         }
         if (plan?.kind === "keyed-rows") {
           return keyedRowsBoundary(blockRuntime, plan);


### PR DESCRIPTION
## Summary

- compile safe host containers that interleave conditional and keyed `.map`/`List` ranges into one ordered mixed-range descriptor
- reconcile conditional slots and per-range keyed instances together while preserving static siblings, keyed identity, nested scopes, and independent LIS passes
- recurse through safe host-only branches and rows with globally unique block IDs, parent suppression, subscription cleanup, and conservative React fallback
- document the ownership contract and add a production example with outer and nested mixed ranges

## Safety

React keeps ownership for Hooks, custom components, branch or row events, controlled forms, refs, SVG, fragments, spreads, dangerous HTML, unsafe logical values, duplicate keys, and invalid adopted DOM. Parent-prop and compatible Fast Refresh changes remount the affected container through React.

## Verification

- `pnpm --filter @farm.js/react test` — 324 tests passed
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8 passed
- `pnpm --filter farm-react-compiler-example type-check`
- `pnpm --filter farm-react-compiler-example build`
- production browser verifier — desktop/mobile PASS, one outer LIS move, one nested LIS move, two simultaneous conditional updates, preserved row/tag/static identity, zero owner update executions
- 3,000 deterministic mixed updates matched normal React
- StrictMode, parent/local races, queued unmount, SSR, recoverable hydration mismatches, duplicate-key fallback, and error boundaries covered
