### PR TITLE
feat(react): compile stateful range siblings

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -337,6 +337,7 @@ satisfy all of these rules:
 | Events              | Inline handlers and synchronous `const` or function-declaration handlers, including inline synchronous events in eligible host-only keyed rows. |
 | Conditional blocks  | Logical/ternary host branches in dedicated containers or direct ranges among static host siblings, including the component root.                |
 | Keyed lists         | Item-keyed maps and imported `List`, including safe collection pipelines; eligible rows use direct bindings and recursive host-only conditions. |
+| Range siblings      | Stable host siblings beside ranges may patch leaf text, attributes, `className`, and individual inline style properties.                        |
 | Component islands   | Stable imported or module-level component identifiers with explicit compiler-safe props and no JSX children, spread, `ref`, or `key`.           |
 
 This component is eligible:
@@ -537,11 +538,35 @@ independently. Reconciliation proceeds from right to left, preserving the exact 
 ranges become empty, grow, or change together. Static header, divider, and footer nodes are never
 used as synthetic markers and retain their DOM identity.
 
+Those structurally stable siblings may still contain stateful values:
+
+```tsx
+<section>
+  <header className={loading ? "busy" : "ready"}>{title}</header>
+  {loading && <p>Loading…</p>}
+  <i data-count={items.length}>Rows: {items.length}</i>
+  {items.map((item) => (
+    <article key={item.id}>{item.label}</article>
+  ))}
+  <footer style={{ opacity: enabled ? 1 : 0.5 }}>{summary}</footer>
+</section>
+```
+
+The build records each sibling binding by static segment, sibling position inside that segment,
+and nested host path. Unlike a live `children[index]` address, that coordinate does not shift when
+an earlier condition mounts or when an earlier keyed range inserts, removes, or reorders rows. One
+compiler flush can therefore patch the header, divider, and footer while also reconciling every
+dynamic range, without rerunning the owner or replacing those siblings. Supported bindings are
+safe leaf text, ordinary attributes, `className`, and individual properties in one inline style
+object.
+
 Safe host-only conditionals and keyed ranges may recurse inside a mixed branch or row. Every syntax
 site still receives one globally unique block ID and a parent link, so an affected outer mixed block
 suppresses redundant descendant refreshes. Removing a branch or keyed row cleans its nested mixed
 subscriptions before removing DOM. Recreating it reads current state, preventing hidden or removed
-work from becoming stale.
+work from becoming stale. Stateful static-sibling bindings use the same mechanism inside recursively
+compiled branches and keyed rows; row-local bindings close over the current row descriptor and are
+rebound when a surviving keyed row receives a new item value.
 
 This path requires at least one conditional and one keyed `.map(...)` or `List` range in the same
 lowercase host container. Every dynamic branch and row must have a statically known host tree and a
@@ -549,7 +574,9 @@ stable item-derived key. Hooks, custom components, events inside branches or row
 refs, SVG, fragments, spreads, dangerous HTML, duplicate runtime keys, numeric logical output, or an
 invalid hydration/adoption shape keep or transfer that complete container to React. Parent prop and
 Fast Refresh changes also remount the container through React so the compiler never retains stale
-closures or static markup.
+closures or static markup. Static siblings remain plain lowercase host trees; lifecycle-sensitive
+components, Hooks, refs, controlled forms, events requiring compiler DOM ownership, or unproven
+expressions retain the existing React fallback.
 
 The existing React-owned conditional boundary remains the fallback for supported complex shapes.
 It can contain event handlers, nested host conditionals, keyed lists, and component islands while
@@ -969,8 +996,9 @@ the range block partitions its direct element children into static segments and 
 the build-time shape and current collection lengths. Static header, divider, and footer elements
 retain their DOM identity. Each range keeps its own key-to-row table and LIS calculation, so an
 update in one range cannot reorder another range or its surrounding static elements. Stateful text,
-attributes, and styles inside the static host siblings continue to use the outer component's direct
-bindings.
+attributes, `className`, and individual inline styles inside the static host siblings are attached
+to the range controller through stable segment addresses, so they patch in the same flush as the
+keyed rows without replacing the sibling.
 
 The `ul` above may be the component's returned root. The generated root range block forwards that
 physical `ul` to the outer binding runtime, so stateful root attributes and styles still patch the
@@ -1250,6 +1278,9 @@ The package and example test suites verify more than generated code:
 - conditional DOM ranges preserve an exact component root and every static sibling, mount adjacent
   empty slots in source order without marker nodes, and commit simultaneous range changes from one
   state snapshot;
+- stateful static siblings patch text, classes, attributes, and individual styles through stable
+  segment/sibling/path addresses while conditional mounts and keyed LIS moves change nearby child
+  indexes; their DOM identity survives every update;
 - 3,000 deterministic nested-range updates and 3,000 component-root-range updates match normal
   React while unchanged branches, static siblings, and the compiled owner keep their identity;
 - recursive host scopes preserve an outer branch and static siblings while independently updating

--- a/examples/react-compiler/README.md
+++ b/examples/react-compiler/README.md
@@ -53,6 +53,7 @@ assertions, checks for console/runtime errors and horizontal overflow, saves scr
 | Keyed row host blocks      | 1,000 rows, one LIS move, nested branch patches, executions `0` | —                                      | Each key owns its safe recursive host conditions without React commits. |
 | Nested keyed rows          | 256 projects, 2,048 tasks, one LIS move per level, executions `0` | —                                    | Every outer key owns an isolated inner key table and LIS scope.         |
 | Recursive keyed scopes     | 48 boards, 288 columns, 2,304 cards, one LIS move per level, executions `0` | —                         | Keyed scope analysis continues through every safe host-row depth.       |
+| Stateful range siblings    | header/divider/footer text, class, data and style patch; executions `0` | —                              | Stable segment addresses survive conditional mounts and LIS moves.     |
 
 The package runtime test also measures one equivalent update under a React `Profiler`:
 
@@ -205,8 +206,10 @@ levels recurse; duplicate keys at any level switch the mounted outer list to Rea
 The `13` card interleaves logical and ternary branches with a keyed row range in one host container.
 Each row recursively owns another condition and keyed tag range. One action changes both outer
 branches, rotates all 32 rows with one LIS move, changes a row-local condition, and rotates its tags
-with one nested LIS move. The browser assertion preserves the selected row, tag, header, divider,
-and footer, then removes and inserts one row while recording zero owner update executions.
+with one nested LIS move. The same update patches stateful text, class, data attributes, and inline
+styles on the stable header, divider, footer, and a row-local tag divider. The browser assertion
+preserves all of those nodes, then removes and inserts one row while recording zero owner update
+executions.
 
 Mixed ownership remains host-only. Branch or row events, Hooks, custom components, controlled
 forms, refs, SVG, fragments, spreads, dangerous HTML, duplicate keys, or an invalid adopted shape

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -1485,6 +1485,9 @@ try {
     window.__farmMixedHeader = document.querySelector('[data-mixed-static="header"]');
     window.__farmMixedRowsBefore = document.querySelector('[data-mixed-static="rows-before"]');
     window.__farmMixedFooter = document.querySelector('[data-mixed-static="footer"]');
+    window.__farmMixedTagsBefore = document.querySelector(
+      '[data-mixed-item="mixed-item-0"] [data-mixed-static="tags-before"]',
+    );
     window.__farmMixedRowMoves = 0;
     window.__farmMixedTagMoves = 0;
     const rows = document.querySelector("[data-mixed-range-list]");
@@ -1509,6 +1512,47 @@ try {
   await assertText(page, `${mixedRanges} [data-metric="mixed-range-updates"]`, "1");
   await assertText(page, `${mixedRanges} [data-metric="mixed-range-loading"]`, "shown");
   await assertText(page, `${mixedRanges} [data-metric="mixed-range-status"]`, "error");
+  await assertText(
+    page,
+    `${mixedRanges} [data-mixed-static="header"]`,
+    "MIXED INVENTORY · UPDATED",
+  );
+  assert.equal(
+    await page.locator(`${mixedRanges} [data-mixed-static="header"]`).getAttribute("class"),
+    "mixed-static-accent",
+  );
+  assert.equal(
+    await page.locator(`${mixedRanges} [data-mixed-static="header"]`).getAttribute(
+      "data-mixed-title",
+    ),
+    "MIXED INVENTORY · UPDATED",
+  );
+  assert.equal(
+    await page.locator(`${mixedRanges} [data-mixed-static="header"]`).evaluate(
+      (element) => element.style.opacity,
+    ),
+    "1",
+  );
+  await assertText(page, `${mixedRanges} [data-mixed-static="rows-before"]`, "ROWS · 32");
+  assert.equal(
+    await page.locator(`${mixedRanges} [data-mixed-static="rows-before"]`).getAttribute(
+      "data-count",
+    ),
+    "32",
+  );
+  await assertText(page, `${mixedRanges} [data-mixed-static="footer"]`, "BLOCKED");
+  assert.equal(
+    await page.locator(`${mixedRanges} [data-mixed-static="footer"]`).getAttribute(
+      "data-summary",
+    ),
+    "MIXED INVENTORY · UPDATED:32",
+  );
+  assert.equal(
+    await page.locator(`${mixedRanges} [data-mixed-static="footer"]`).evaluate(
+      (element) => element.style.width,
+    ),
+    "240px",
+  );
   assert.equal(await page.locator(`${mixedRanges} [data-mixed-loading]`).count(), 1);
   assert.equal(
     await page.locator(`${mixedRanges} [data-mixed-item]`).first().getAttribute("data-mixed-item"),
@@ -1525,6 +1569,19 @@ try {
       .evaluateAll((tags) => tags.map((tag) => tag.getAttribute("data-mixed-tag"))),
     ["mixed-tag-0-2", "mixed-tag-0-0", "mixed-tag-0-1"],
   );
+  await assertText(
+    page,
+    `${mixedRanges} [data-mixed-item="mixed-item-0"] [data-mixed-static="tags-before"]`,
+    "TAGS · 3",
+  );
+  assert.equal(
+    await page
+      .locator(
+        `${mixedRanges} [data-mixed-item="mixed-item-0"] [data-mixed-static="tags-before"]`,
+      )
+      .getAttribute("class"),
+    "mixed-tags-hidden",
+  );
   assert.equal(await page.evaluate(() => window.__farmMixedRowMoves), 1);
   assert.equal(await page.evaluate(() => window.__farmMixedTagMoves), 1);
   assert.equal(
@@ -1535,7 +1592,11 @@ try {
         window.__farmMixedHeader === document.querySelector('[data-mixed-static="header"]') &&
         window.__farmMixedRowsBefore ===
           document.querySelector('[data-mixed-static="rows-before"]') &&
-        window.__farmMixedFooter === document.querySelector('[data-mixed-static="footer"]'),
+        window.__farmMixedFooter === document.querySelector('[data-mixed-static="footer"]') &&
+        window.__farmMixedTagsBefore ===
+          document.querySelector(
+            '[data-mixed-item="mixed-item-0"] [data-mixed-static="tags-before"]',
+          ),
     ),
     true,
     "mixed range reconciliation replaced a surviving row, nested tag, or static sibling",
@@ -1544,6 +1605,23 @@ try {
   await page.locator(`${mixedRanges} [data-action="mixed-range-replace"]`).click();
   await assertText(page, `${mixedRanges} [data-metric="mixed-range-updates"]`, "2");
   await assertText(page, `${mixedRanges} [data-metric="mixed-range-rows"]`, "32");
+  await assertText(
+    page,
+    `${mixedRanges} [data-mixed-static="header"]`,
+    "MIXED INVENTORY · REPLACED",
+  );
+  assert.equal(
+    await page.locator(`${mixedRanges} [data-mixed-static="header"]`).evaluate(
+      (element) => element.style.opacity,
+    ),
+    "0.72",
+  );
+  assert.equal(
+    await page.locator(`${mixedRanges} [data-mixed-static="footer"]`).evaluate(
+      (element) => element.style.width,
+    ),
+    "180px",
+  );
   assert.equal(
     await page.locator(`${mixedRanges} [data-mixed-item="mixed-item-1"]`).count(),
     0,
@@ -1807,6 +1885,8 @@ try {
             simultaneousConditionalUpdates: 2,
             recursivelyNestedRanges: true,
             staticSiblingIdentityPreserved: true,
+            staticSiblingBindingsPatched: true,
+            recursiveRowStaticBindingsPatched: true,
             removedAndInserted: true,
             ownerUpdateExecutions:
               mixedRangeOwnerFinalExecutions - mixedRangeOwnerInitialExecutions,

--- a/examples/react-compiler/src/components/mixed-range-experiment.tsx
+++ b/examples/react-compiler/src/components/mixed-range-experiment.tsx
@@ -27,12 +27,16 @@ const initialItems: MixedItem[] = Array.from({ length: 32 }, (_, itemIndex) => (
 let mixedRangeOwnerExecutions = 0;
 
 export function MixedRangeExperiment() {
+  const [title, setTitle] = useState("MIXED INVENTORY");
+  const [accent, setAccent] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
   const [items, setItems] = useState(initialItems);
   const [updates, setUpdates] = useState(0);
 
   function reconcileMixedRanges() {
+    setTitle("MIXED INVENTORY · UPDATED");
+    setAccent(true);
     setLoading(true);
     setError((value) => !value);
     setItems((current) => {
@@ -56,6 +60,8 @@ export function MixedRangeExperiment() {
   }
 
   function replaceOneRow() {
+    setTitle("MIXED INVENTORY · REPLACED");
+    setAccent(false);
     setLoading(false);
     setItems((current) => [
       ...current.filter((item) => item.id !== "mixed-item-1"),
@@ -84,7 +90,7 @@ export function MixedRangeExperiment() {
 
       <p className="heavy-copy">
         One compiler controller owns interleaved conditional and keyed ranges. It patches branches,
-        applies LIS moves, and recursively updates each safe row while preserving static siblings.
+        applies LIS moves, and patches stateful static siblings without replacing their DOM nodes.
       </p>
 
       <dl className="heavy-metrics" aria-live="polite">
@@ -122,15 +128,30 @@ export function MixedRangeExperiment() {
       </div>
 
       <div className="keyed-host-row-list" data-mixed-range-list>
-        <header data-mixed-static="header">MIXED INVENTORY</header>
+        <header
+          className={accent ? "mixed-static-accent" : ""}
+          data-mixed-static="header"
+          data-mixed-title={title}
+          style={{ opacity: accent ? 1 : 0.72 }}
+        >
+          {title}
+        </header>
         {loading && <p data-mixed-loading>Loading inventory…</p>}
-        <i data-mixed-static="rows-before">ROWS</i>
+        <i data-count={items.length} data-mixed-static="rows-before">
+          ROWS · {items.length}
+        </i>
         {items.map((item, itemIndex) => (
           <article data-mixed-item={item.id} data-item-index={itemIndex} key={item.id}>
             <h3>{item.label}</h3>
             <div data-mixed-tag-list={item.id}>
               {item.visible && <strong data-mixed-visible={item.id}>Visible</strong>}
-              <i data-mixed-static="tags-before">TAGS</i>
+              <i
+                className={item.visible ? "mixed-tags-visible" : "mixed-tags-hidden"}
+                data-mixed-static="tags-before"
+                data-tag-count={item.tags.length}
+              >
+                TAGS · {item.tags.length}
+              </i>
               {item.tags.map((tag, tagIndex) => (
                 <em data-mixed-tag={tag.id} data-tag-index={tagIndex} key={tag.id}>
                   {tag.label}
@@ -140,7 +161,13 @@ export function MixedRangeExperiment() {
           </article>
         ))}
         {error ? <strong data-mixed-status="error">Error</strong> : <span data-mixed-status="ready">Ready</span>}
-        <footer data-mixed-static="footer">END MIXED INVENTORY</footer>
+        <footer
+          data-mixed-static="footer"
+          data-summary={`${title}:${items.length}`}
+          style={{ width: accent ? 240 : 180 }}
+        >
+          {error ? "BLOCKED" : "READY"}
+        </footer>
       </div>
     </section>
   );

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -371,7 +371,11 @@ containers. Each nested range receives its own dependency entry and updates with
 replacing the outer branch. When conditionals and keyed maps/`List` ranges are direct siblings in
 one safe host container, the compiler emits one ordered mixed-range controller. It mounts or removes
 conditional branches, applies independent LIS reconciliation to each keyed range, and preserves
-static siblings in place. The same mixed layout may recurse inside safe branches and keyed rows.
+static siblings in place. Stateful leaf text, attributes, `className`, and individual inline style
+properties on those siblings are compiled into stable segment/sibling/path bindings. Their address
+does not shift when a nearby condition mounts or a keyed range inserts, removes, or reorders rows,
+so the same controller patches them from the current state snapshot without replacing the sibling
+or rerunning the owner. The same mixed layout may recurse inside safe branches and keyed rows.
 Keys on branches, custom components, fragments, refs, SVG, attribute spreads,
 `dangerouslySetInnerHTML`, branch events, interactive rows, and unsupported mixed children keep
 React ownership. An empty ternary branch may be `null` or `false`. The
@@ -421,8 +425,10 @@ unsupported conditional roots, effects, and more advanced hook support intention
 in this release. Compiler-owned keyed rows support either one dedicated host-only map/`List` or
 one or more non-interactive ranges in a nested or component-root host container. A dedicated
 non-interactive row may also contain multiple recursive logical or ternary host branches beside
-static host siblings, plus recursively nested non-interactive keyed ranges scoped by every stable
-parent key. Inline synchronous row events continue to use the hybrid React-owned row path. Branch
+stateful static host siblings, plus recursively nested non-interactive keyed ranges scoped by every
+stable parent key. Static sibling bindings support safe leaf text, attributes, `className`, and
+individual style properties; lifecycle-sensitive shapes continue to fall back. Inline synchronous
+row events continue to use the hybrid React-owned row path. Branch
 or nested-row events, interactive ranges beside siblings, non-inline or async row handlers,
 unsupported form shapes, custom components, fragments, refs, SVG, and duplicate runtime keys keep
 or switch to React ownership.

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -426,7 +426,7 @@ const testSource = String.raw`
   let mixedRangeExecutions = 0;
   const MixedRanges = createCompiledComponent({
     displayName: "CompatibilityMixedRanges",
-    initialize: () => [{ loading: false, error: false, items: [{ id: "a", label: "Alpha" }, { id: "b", label: "Beta" }] }],
+    initialize: () => [{ title: "Header", accent: false, loading: false, error: false, items: [{ id: "a", label: "Alpha" }, { id: "b", label: "Beta" }] }],
     render(_props, state, blocks) {
       mixedRangeExecutions += 1;
       const model = () => state[0].get();
@@ -468,6 +468,14 @@ const testSource = String.raw`
           { kind: "conditional", before: 0, test: () => model().error, truthy: errorBranch, falsy: readyBranch },
         ],
         trailing: 1,
+        bindings: [
+          { kind: "text", segment: 0, sibling: 0, path: [], read: () => model().title },
+          { kind: "attribute", segment: 0, sibling: 0, path: [], name: "className", read: () => model().accent ? "accent" : "plain" },
+          { kind: "text", segment: 1, sibling: 0, path: [], read: () => ["Rows ", model().items.length] },
+          { kind: "attribute", segment: 1, sibling: 0, path: [], name: "data-count", read: () => model().items.length },
+          { kind: "text", segment: 3, sibling: 0, path: [], read: () => model().error ? "Blocked" : "Ready" },
+          { kind: "style", segment: 3, sibling: 0, path: [], name: "width", read: () => model().accent ? 24 : 12 },
+        ],
       });
       const create = () => ({
         kind: "element",
@@ -475,12 +483,12 @@ const testSource = String.raw`
         attributes: [{ name: "data-mixed-ranges", value: true }],
         styles: [],
         children: [
-          { kind: "element", tag: "header", attributes: [], styles: [], children: ["Header"] },
+          { kind: "element", tag: "header", attributes: [{ name: "className", value: model().accent ? "accent" : "plain" }], styles: [], children: [model().title] },
           ...(model().loading ? [loadingBranch.create()] : []),
-          { kind: "element", tag: "i", attributes: [], styles: [], children: ["Rows"] },
+          { kind: "element", tag: "i", attributes: [{ name: "data-count", value: model().items.length }], styles: [], children: ["Rows ", model().items.length] },
           ...model().items.map(rowDescriptor),
           model().error ? errorBranch.create() : readyBranch.create(),
-          { kind: "element", tag: "footer", attributes: [], styles: [], children: ["Footer"] },
+          { kind: "element", tag: "footer", attributes: [], styles: [{ name: "width", value: model().accent ? 24 : 12 }], children: [model().error ? "Blocked" : "Ready"] },
         ],
         block: mixedBlock(),
       });
@@ -490,6 +498,8 @@ const testSource = String.raw`
         React.createElement("button", {
           "data-mixed-update": true,
           onClick: () => state[0].set((current) => ({
+            title: "Updated header",
+            accent: true,
             loading: true,
             error: true,
             items: [{ ...current.items[1], label: "Beta updated" }, current.items[0]],
@@ -501,14 +511,14 @@ const testSource = String.raw`
           render: () => React.createElement(
             "div",
             { "data-mixed-ranges": true },
-            React.createElement("header", null, "Header"),
+            React.createElement("header", { className: model().accent ? "accent" : "plain" }, model().title),
             model().loading ? React.createElement("p", { "data-loading": true }, "Loading") : null,
-            React.createElement("i", null, "Rows"),
+            React.createElement("i", { "data-count": model().items.length }, "Rows ", model().items.length),
             ...model().items.map((item, index) => React.createElement("article", { key: item.id, "data-mixed-key": item.id, "data-index": index }, item.label)),
             model().error
               ? React.createElement("strong", { "data-status": "error" }, "Error")
               : React.createElement("span", { "data-status": "ready" }, "Ready"),
-            React.createElement("footer", null, "Footer"),
+            React.createElement("footer", { style: { width: model().accent ? 24 : 12 } }, model().error ? "Blocked" : "Ready"),
           ),
         }),
       );
@@ -531,6 +541,12 @@ const testSource = String.raw`
   );
   assert.equal(mixedRangeContainer.querySelector('[data-mixed-key="a"]'), originalMixedA);
   assert.equal(mixedRangeContainer.querySelector("header"), originalMixedHeader);
+  assert.equal(originalMixedHeader.textContent, "Updated header");
+  assert.equal(originalMixedHeader.getAttribute("class"), "accent");
+  assert.equal(mixedRangeContainer.querySelector("i").textContent, "Rows 2");
+  assert.equal(mixedRangeContainer.querySelector("i").getAttribute("data-count"), "2");
+  assert.equal(mixedRangeContainer.querySelector("footer").textContent, "Blocked");
+  assert.equal(mixedRangeContainer.querySelector("footer").style.width, "24px");
   assert.equal(mixedRangeContainer.querySelector('[data-mixed-key="b"]').textContent, "Beta updated");
   assert.equal(mixedRangeContainer.querySelector("[data-loading]").textContent, "Loading");
   assert.equal(mixedRangeContainer.querySelector('[data-status="error"]').textContent, "Error");

--- a/packages/farm-react/src/__tests__/compiler-conditional-ranges.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-conditional-ranges.test.ts
@@ -20,11 +20,13 @@ describe("React AOT conditional-range compiler", () => {
         const [enabled, setEnabled] = useState(true);
         return (
           <main data-active={loading || enabled}>
-            <header>Dashboard</header>
+            <header className={enabled ? "enabled" : "disabled"}>
+              Dashboard: {enabled ? "on" : "off"}
+            </header>
             {loading && <p data-state={loading ? "loading" : "idle"}>Loading…</p>}
             <section>Content</section>
             {enabled ? <strong>Enabled</strong> : <span>Disabled</span>}
-            <footer>Footer</footer>
+            <footer style={{ opacity: loading ? 0.5 : 1 }}>Footer</footer>
           </main>
         );
       }
@@ -37,6 +39,10 @@ describe("React AOT conditional-range compiler", () => {
     expect(result.code.match(/before: 1/g)).toHaveLength(2);
     expect(result.code).toContain("trailing={1}");
     expect(result.code).toContain("dependencies: [0, 1]");
+    expect(result.code).toContain("segment: 0");
+    expect(result.code).toContain("segment: 2");
+    expect(result.code).toContain('name: "className"');
+    expect(result.code).toContain('name: "opacity"');
     expect(result.code).toContain('name: "data-state"');
     expect(result.code).toContain('name: "data-active"');
     await expect(

--- a/packages/farm-react/src/__tests__/compiler-keyed-ranges.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-ranges.test.ts
@@ -24,7 +24,9 @@ describe("React AOT keyed-range compiler", () => {
         return (
           <main>
             <ul data-count={primary.length + secondary.length}>
-              <li data-static="header">Primary</li>
+              <li className={primary.length > 1 ? "many" : "few"} data-static="header">
+                Primary: {primary.length}
+              </li>
               {primary.map((item, index) => (
                 <li data-index={index} key={item.id}>{item.label}</li>
               ))}
@@ -32,7 +34,12 @@ describe("React AOT keyed-range compiler", () => {
               {secondary.map((item, index) => (
                 <li data-index={index} key={item.id}>{item.label}</li>
               ))}
-              <li data-static="footer">{primary.length + secondary.length} total</li>
+              <li
+                data-static="footer"
+                style={{ opacity: secondary.length > 0 ? 1 : 0.5 }}
+              >
+                {primary.length + secondary.length} total
+              </li>
             </ul>
             <button onClick={() => setPrimary((items) => [...items].reverse())}>Primary</button>
             <button onClick={() => setSecondary((items) => [...items].reverse())}>Secondary</button>
@@ -47,6 +54,10 @@ describe("React AOT keyed-range compiler", () => {
     expect(result.code).toContain("ranges={[");
     expect(result.code.match(/before: 1/g)).toHaveLength(2);
     expect(result.code).toContain("trailing={1}");
+    expect(result.code).toContain("segment: 0");
+    expect(result.code).toContain("segment: 2");
+    expect(result.code).toContain('name: "className"');
+    expect(result.code).toContain('name: "opacity"');
     expect(result.code).toContain("farmBlocks.target");
     expect(result.code).toMatch(/rootRef=\{_?farmBlocks\.target\(/);
     expect(result.code).not.toContain("farmBlocks.KeyedList");
@@ -56,6 +67,36 @@ describe("React AOT keyed-range compiler", () => {
         jsx: "automatic",
       }),
     ).resolves.toMatchObject({ code: expect.stringContaining("farmBlocks.KeyedRanges") });
+  });
+
+  it("keeps state-independent render instrumentation on React's initial static path", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      let executions = 0;
+      export function Board() {
+        const [primary, setPrimary] = useState([{ id: "a", label: "Alpha" }]);
+        const [secondary, setSecondary] = useState([{ id: "b", label: "Beta" }]);
+        const total = primary.length + secondary.length;
+        return (
+          <article>
+            <dl>
+              <div><dt>Rows</dt><dd>{total}</dd></div>
+              <div><dt>Executions</dt><dd>{typeof window === "undefined" ? 1 : ++executions}</dd></div>
+            </dl>
+            {primary.map((item) => <p key={item.id}>{item.label}</p>)}
+            <i>SECONDARY</i>
+            {secondary.map((item) => <p key={item.id}>{item.label}</p>)}
+            <button onClick={() => setPrimary((items) => [...items].reverse())}>Reverse</button>
+          </article>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Board"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("farmBlocks.KeyedRanges");
+    expect(result.code).not.toContain("farmBlocks.KeyedList");
+    expect(result.code).toContain("++executions");
   });
 
   it("supports an explicit List as one range beside host siblings", async () => {

--- a/packages/farm-react/src/__tests__/compiler-mixed-ranges.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-mixed-ranges.test.ts
@@ -19,16 +19,17 @@ describe("React AOT mixed conditional and keyed ranges", () => {
         const [loading, setLoading] = useState(false);
         const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
         const [error, setError] = useState(false);
+        const [title, setTitle] = useState("Inventory");
         return (
           <main>
             <button onClick={() => setLoading((value) => !value)}>Loading</button>
             <section data-dashboard>
-              <header>Inventory</header>
+              <header className={loading ? "busy" : "ready"}>{title}</header>
               {loading && <p data-loading>Loading…</p>}
-              <i>Rows</i>
+              <i data-count={items.length}>Rows: {items.length}</i>
               {items.map((item, index) => <article key={item.id} data-index={index}>{item.label}</article>)}
               {error ? <strong>Error</strong> : <span>Ready</span>}
-              <footer>End</footer>
+              <footer style={{ opacity: error ? 0.5 : 1 }}>{title}: {items.length}</footer>
             </section>
           </main>
         );
@@ -41,7 +42,13 @@ describe("React AOT mixed conditional and keyed ranges", () => {
     expect(result.code).toContain('kind: "mixed-ranges"');
     expect(result.code.match(/kind: "conditional"/g)).toHaveLength(2);
     expect(result.code.match(/kind: "keyed"/g)).toHaveLength(1);
-    expect(result.code).toContain("dependencies: [0, 1, 2]");
+    expect(result.code).toContain("dependencies: [0, 1, 2, 3]");
+    expect(result.code).toContain("segment: 0");
+    expect(result.code).toContain("segment: 1");
+    expect(result.code).toContain("segment: 3");
+    expect(result.code).toContain('name: "className"');
+    expect(result.code).toContain('name: "data-count"');
+    expect(result.code).toContain('name: "opacity"');
     expect(result.code).not.toContain("farmBlocks.ConditionalRanges");
     expect(result.code).not.toContain("farmBlocks.KeyedRanges");
     await expect(

--- a/packages/farm-react/src/__tests__/compiler-recursive-host-blocks.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-recursive-host-blocks.test.ts
@@ -52,8 +52,16 @@ describe("React AOT recursive host-block compiler", () => {
               {open ? (
                 <section>
                   <header>Inbox</header>
-                  <div>{loading && <p>Loading…</p>}</div>
+                  <div>
+                    <header className={loading ? "busy" : "idle"}>
+                      Messages: {messages.length}
+                    </header>
+                    {loading && <p>Loading…</p>}
+                  </div>
                   <ul>
+                    <li data-summary style={{ opacity: loading ? 0.5 : 1 }}>
+                      Total: {messages.length}
+                    </li>
                     {messages.map((message) => <li key={message.id}>{message.title}</li>)}
                   </ul>
                 </section>
@@ -71,8 +79,11 @@ describe("React AOT recursive host-block compiler", () => {
     expect(result.code).toContain('kind: "keyed-ranges"');
     expect(result.code).toContain("parent: 0");
     expect(result.code).toContain("dependencies: [0]");
-    expect(result.code).toContain("dependencies: [1]");
-    expect(result.code).toContain("dependencies: [2]");
+    expect(result.code.match(/dependencies: \[1, 2\]/g)).toHaveLength(2);
+    expect(result.code).toContain("segment: 0");
+    expect(result.code).toContain('name: "className"');
+    expect(result.code).toContain('name: "data-summary"');
+    expect(result.code).toContain('name: "opacity"');
     await expect(
       transformWithEsbuild(result.code, "/app/RecursiveHostBlocks.tsx", {
         loader: "tsx",

--- a/packages/farm-react/src/__tests__/compiler-runtime-conditional-ranges.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-conditional-ranges.test.tsx
@@ -126,21 +126,60 @@ function defineConditionalBoard(
       const rangeRoot = (
         <ConditionalRanges
           id={0}
+          bindings={[
+            {
+              kind: "text",
+              segment: 0,
+              sibling: 0,
+              path: [],
+              read: () => [props.title || "Dashboard", " ", model().count],
+            },
+            {
+              kind: "attribute",
+              segment: 0,
+              sibling: 0,
+              path: [],
+              name: "className",
+              read: () => (model().enabled ? "enabled" : "disabled"),
+            },
+            {
+              kind: "text",
+              segment: 1,
+              sibling: 0,
+              path: [],
+              read: () => ["Stable ", model().count],
+            },
+            {
+              kind: "text",
+              segment: 2,
+              sibling: 0,
+              path: [],
+              read: () => ["Footer ", model().count],
+            },
+            {
+              kind: "style",
+              segment: 2,
+              sibling: 0,
+              path: [],
+              name: "opacity",
+              read: () => (model().loading ? 0.5 : 1),
+            },
+          ]}
           ranges={ranges}
           rootRef={rootOwned ? undefined : blocks.target(1)}
           render={() => {
             metrics.rangeRenders += 1;
             return (
               <article data-board="conditions" data-count={model().count}>
-                <header data-static="header">{props.title || "Dashboard"}</header>
+                <header className={model().enabled ? "enabled" : "disabled"} data-static="header">
+                  {props.title || "Dashboard"} {model().count}
+                </header>
                 {model().loading && (
                   <p data-count={model().count} data-slot="loading">
                     Loading {model().count}
                   </p>
                 )}
-                <section data-static="content" ref={blocks.target(0)}>
-                  Stable {model().count}
-                </section>
+                <section data-static="content">Stable {model().count}</section>
                 {model().enabled ? (
                   <strong data-count={model().count} data-slot="status">
                     Enabled {model().count}
@@ -150,7 +189,9 @@ function defineConditionalBoard(
                     Disabled {model().count}
                   </span>
                 )}
-                <footer data-static="footer">Footer</footer>
+                <footer data-static="footer" style={{ opacity: model().loading ? 0.5 : 1 }}>
+                  Footer {model().count}
+                </footer>
               </article>
             );
           }}
@@ -167,13 +208,6 @@ function defineConditionalBoard(
       );
     },
     bindings: [
-      {
-        kind: "text",
-        path: [1, 1],
-        target: 0,
-        dependencies: [0],
-        read: (_props, state) => ["Stable ", (state[0].get() as ConditionalModel).count],
-      },
       {
         kind: "attribute" as const,
         path: rootOwned ? [] : [1],
@@ -237,6 +271,9 @@ describe("compiled conditional DOM ranges", () => {
     expect(article.querySelector('[data-slot="status"]')).toBe(enabled);
     expect(enabled.textContent).toBe("Enabled 2");
     expect(content.textContent).toBe("Stable 2");
+    expect(header.textContent).toBe("Dashboard 2");
+    expect(header.getAttribute("class")).toBe("enabled");
+    expect(footer.textContent).toBe("Footer 2");
 
     await act(async () => {
       board.updateModel({ count: 3, enabled: false, loading: true });
@@ -252,6 +289,9 @@ describe("compiled conditional DOM ranges", () => {
     ]);
     expect(article.querySelector('[data-slot="loading"]')?.textContent).toBe("Loading 3");
     expect(article.querySelector('[data-slot="status"]')?.textContent).toBe("Disabled 3");
+    expect(header.getAttribute("class")).toBe("disabled");
+    expect(footer.textContent).toBe("Footer 3");
+    expect((footer as HTMLElement).style.opacity).toBe("0.5");
     expect(enabled.isConnected).toBe(false);
     expect(metrics.executions).toBe(initialExecutions);
     expect(metrics.rangeRenders).toBe(initialRangeRenders);
@@ -651,7 +691,7 @@ describe("compiled conditional DOM ranges", () => {
       });
 
       expect(container.querySelector<HTMLElement>("[data-board='conditions']")).not.toBe(original);
-      expect(container.querySelector('[data-static="header"]')?.textContent).toBe("Second");
+      expect(container.querySelector('[data-static="header"]')?.textContent).toBe("Second 7");
       expect(container.querySelector('[data-slot="loading"]')?.textContent).toBe("Loading 7");
     },
   );
@@ -673,7 +713,9 @@ describe("compiled conditional DOM ranges", () => {
         setNormal = setModel;
         return (
           <article data-board="conditions" data-count={model.count}>
-            <header data-static="header">Dashboard</header>
+            <header className={model.enabled ? "enabled" : "disabled"} data-static="header">
+              Dashboard {model.count}
+            </header>
             {model.loading && (
               <p data-count={model.count} data-slot="loading">
                 Loading {model.count}
@@ -689,7 +731,9 @@ describe("compiled conditional DOM ranges", () => {
                 Disabled {model.count}
               </span>
             )}
-            <footer data-static="footer">Footer</footer>
+            <footer data-static="footer" style={{ opacity: model.loading ? 0.5 : 1 }}>
+              Footer {model.count}
+            </footer>
           </article>
         );
       }

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-ranges.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-ranges.test.tsx
@@ -124,6 +124,45 @@ function defineRangeBoard(
       const ranges = (
         <KeyedRanges
           id={0}
+          bindings={[
+            {
+              kind: "text",
+              segment: 0,
+              sibling: 0,
+              path: [],
+              read: () => [props.title || "Primary", " ", model().primary.length],
+            },
+            {
+              kind: "attribute",
+              segment: 0,
+              sibling: 0,
+              path: [],
+              name: "className",
+              read: () => (model().primary.length > 2 ? "many" : "few"),
+            },
+            {
+              kind: "text",
+              segment: 1,
+              sibling: 0,
+              path: [],
+              read: () => ["Secondary ", model().secondary.length],
+            },
+            {
+              kind: "text",
+              segment: 2,
+              sibling: 0,
+              path: [],
+              read: () => [model().primary.length + model().secondary.length, " total"],
+            },
+            {
+              kind: "style",
+              segment: 2,
+              sibling: 0,
+              path: [],
+              name: "width",
+              read: () => model().primary.length + model().secondary.length,
+            },
+          ]}
           ranges={[
             rangeDescriptor(1, () => model().primary),
             rangeDescriptor(1, () => model().secondary),
@@ -135,19 +174,24 @@ function defineRangeBoard(
                 data-board="ranges"
                 data-count={model().primary.length + model().secondary.length}
               >
-                <li data-static="header">{props.title || "Primary"}</li>
+                <li className={model().primary.length > 2 ? "many" : "few"} data-static="header">
+                  {props.title || "Primary"} {model().primary.length}
+                </li>
                 {model().primary.map((item, index) => (
                   <li data-index={index} data-key={item.id} key={item.id}>
                     {index}:{item.label}
                   </li>
                 ))}
-                <li data-static="divider">Secondary</li>
+                <li data-static="divider">Secondary {model().secondary.length}</li>
                 {model().secondary.map((item, index) => (
                   <li data-index={index} data-key={item.id} key={item.id}>
                     {index}:{item.label}
                   </li>
                 ))}
-                <li data-static="footer" ref={blocks.target(0)}>
+                <li
+                  data-static="footer"
+                  style={{ width: model().primary.length + model().secondary.length }}
+                >
                   {model().primary.length + model().secondary.length} total
                 </li>
               </ul>
@@ -166,16 +210,6 @@ function defineRangeBoard(
       );
     },
     bindings: [
-      {
-        kind: "text",
-        path: [1, 2],
-        target: 0,
-        dependencies: [0],
-        read: (_props, state) => {
-          const model = state[0].get() as RangeModel;
-          return [model.primary.length + model.secondary.length, " total"];
-        },
-      },
       ...(rootOwned
         ? [
             {
@@ -244,7 +278,11 @@ describe("compiled keyed DOM ranges", () => {
 
     expect(container.firstElementChild).toBe(list);
     expect(list.dataset.count).toBe("7");
+    expect(header.textContent).toBe("Primary 4");
+    expect(header.getAttribute("class")).toBe("many");
+    expect(divider.textContent).toBe("Secondary 3");
     expect(footer.textContent).toBe("7 total");
+    expect((footer as HTMLElement).style.width).toBe("7px");
     expect(list.querySelector('[data-static="header"]')).toBe(header);
     expect(list.querySelector('[data-static="divider"]')).toBe(divider);
     expect(list.querySelector('[data-static="footer"]')).toBe(footer);
@@ -541,7 +579,7 @@ describe("compiled keyed DOM ranges", () => {
       });
 
       if (!rootOwned) expect(container.querySelector("h1")?.textContent).toBe("Second");
-      expect(container.querySelector('[data-static="header"]')?.textContent).toBe("Second");
+      expect(container.querySelector('[data-static="header"]')?.textContent).toBe("Second 4");
       expect(container.querySelector("ul")).not.toBe(originalList);
       expect(metrics.rangeRenders).toBe(2);
     },
@@ -564,19 +602,26 @@ describe("compiled keyed DOM ranges", () => {
         setNormal = setModel;
         return (
           <ul>
-            <li data-static="header">Primary</li>
+            <li className={model.primary.length > 2 ? "many" : "few"} data-static="header">
+              Primary {model.primary.length}
+            </li>
             {model.primary.map((item, index) => (
               <li data-index={index} data-key={item.id} key={item.id}>
                 {index}:{item.label}
               </li>
             ))}
-            <li data-static="divider">Secondary</li>
+            <li data-static="divider">Secondary {model.secondary.length}</li>
             {model.secondary.map((item, index) => (
               <li data-index={index} data-key={item.id} key={item.id}>
                 {index}:{item.label}
               </li>
             ))}
-            <li data-static="footer">{model.primary.length + model.secondary.length} total</li>
+            <li
+              data-static="footer"
+              style={{ width: model.primary.length + model.secondary.length }}
+            >
+              {model.primary.length + model.secondary.length} total
+            </li>
           </ul>
         );
       }

--- a/packages/farm-react/src/__tests__/compiler-runtime-mixed-ranges.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-mixed-ranges.test.tsx
@@ -30,12 +30,17 @@ interface Item {
 }
 
 interface Model {
+  title: string;
+  accent: boolean;
+  staticFail?: boolean;
   loading: boolean;
   error: boolean;
   items: Item[];
 }
 
 const initialModel: Model = {
+  title: "Inventory",
+  accent: false,
   loading: false,
   error: false,
   items: [
@@ -148,6 +153,39 @@ function itemDescriptor(item: Item, index: number): CompilerHostElement {
   );
 }
 
+function headerDescriptor(model: Model): CompilerHostElement {
+  return {
+    ...host(
+      "header",
+      [model.title],
+      [
+        { name: "className", value: model.accent ? "accent" : "plain" },
+        { name: "data-title", value: model.title.toLowerCase() },
+      ],
+    ),
+    styles: [{ name: "opacity", value: model.accent ? 1 : 0.6 }],
+  };
+}
+
+function dividerDescriptor(model: Model): CompilerHostElement {
+  return host(
+    "i",
+    [`Rows: ${model.items.length}`],
+    [{ name: "data-count", value: model.items.length }],
+  );
+}
+
+function footerDescriptor(model: Model): CompilerHostElement {
+  return {
+    ...host(
+      "footer",
+      [model.error ? "Blocked" : "Ready"],
+      [{ name: "data-summary", value: `${model.title}:${model.items.length}` }],
+    ),
+    styles: [{ name: "width", value: model.accent ? 24 : 12 }],
+  };
+}
+
 const itemBindings: CompilerKeyedRowBinding[] = [
   { kind: "attribute", path: [], name: "data-item-index", read: (_item, index) => index },
   {
@@ -166,16 +204,16 @@ function mixedDescriptor(readModel: () => Model, prefix = ""): CompilerHostEleme
     ...host(
       "section",
       [
-        host("header", ["Inventory"]),
+        headerDescriptor(model),
         ...(model.loading
           ? [host("p", ["Loading…"], [{ name: "data-loading", value: true }])]
           : []),
-        host("i", ["Rows"]),
+        dividerDescriptor(model),
         ...model.items.map(itemDescriptor),
         model.error
           ? host("strong", ["Error"], [{ name: "data-status", value: "error" }])
           : host("span", ["Ready"], [{ name: "data-status", value: "ready" }]),
-        host("footer", ["End"]),
+        footerDescriptor(model),
       ],
       [
         { name: "data-mixed", value: true },
@@ -212,6 +250,80 @@ function mixedDescriptor(readModel: () => Model, prefix = ""): CompilerHostEleme
         },
       ],
       trailing: 1,
+      bindings: [
+        {
+          kind: "text",
+          segment: 0,
+          sibling: 0,
+          path: [],
+          read: () => {
+            if (readModel().staticFail) throw new Error("static sibling binding failed");
+            return readModel().title;
+          },
+        },
+        {
+          kind: "attribute",
+          segment: 0,
+          sibling: 0,
+          path: [],
+          name: "className",
+          read: () => (readModel().accent ? "accent" : "plain"),
+        },
+        {
+          kind: "attribute",
+          segment: 0,
+          sibling: 0,
+          path: [],
+          name: "data-title",
+          read: () => readModel().title.toLowerCase(),
+        },
+        {
+          kind: "style",
+          segment: 0,
+          sibling: 0,
+          path: [],
+          name: "opacity",
+          read: () => (readModel().accent ? 1 : 0.6),
+        },
+        {
+          kind: "text",
+          segment: 1,
+          sibling: 0,
+          path: [],
+          read: () => ["Rows: ", readModel().items.length],
+        },
+        {
+          kind: "attribute",
+          segment: 1,
+          sibling: 0,
+          path: [],
+          name: "data-count",
+          read: () => readModel().items.length,
+        },
+        {
+          kind: "text",
+          segment: 3,
+          sibling: 0,
+          path: [],
+          read: () => (readModel().error ? "Blocked" : "Ready"),
+        },
+        {
+          kind: "attribute",
+          segment: 3,
+          sibling: 0,
+          path: [],
+          name: "data-summary",
+          read: () => `${readModel().title}:${readModel().items.length}`,
+        },
+        {
+          kind: "style",
+          segment: 3,
+          sibling: 0,
+          path: [],
+          name: "width",
+          read: () => (readModel().accent ? 24 : 12),
+        },
+      ],
     },
   };
 }
@@ -219,9 +331,15 @@ function mixedDescriptor(readModel: () => Model, prefix = ""): CompilerHostEleme
 function mixedMarkup(model: Model, prefix = "") {
   return (
     <section data-mixed data-prefix={prefix || undefined}>
-      <header>Inventory</header>
+      <header
+        className={model.accent ? "accent" : "plain"}
+        data-title={model.title.toLowerCase()}
+        style={{ opacity: model.accent ? 1 : 0.6 }}
+      >
+        {model.title}
+      </header>
       {model.loading && <p data-loading>Loading…</p>}
-      <i>Rows</i>
+      <i data-count={model.items.length}>Rows: {model.items.length}</i>
       {model.items.map((item, index) => (
         <article key={item.id} data-item={item.id} data-item-index={index}>
           <span>{item.label}</span>
@@ -241,7 +359,12 @@ function mixedMarkup(model: Model, prefix = "") {
       ) : (
         <span data-status="ready">Ready</span>
       )}
-      <footer>End</footer>
+      <footer
+        data-summary={`${model.title}:${model.items.length}`}
+        style={{ width: model.accent ? 24 : 12 }}
+      >
+        {model.error ? "Blocked" : "Ready"}
+      </footer>
     </section>
   );
 }
@@ -323,6 +446,8 @@ describe("compiler-owned mixed conditional and keyed ranges runtime", () => {
         const model = value as Model;
         const [a, b] = model.items;
         return {
+          title: "Inventory updated",
+          accent: true,
           loading: true,
           error: true,
           items: [
@@ -358,8 +483,17 @@ describe("compiler-owned mixed conditional and keyed ranges runtime", () => {
       ),
     ).toEqual(["a2", "a1", "a3"]);
     expect(container.querySelector("header")).toBe(header);
+    expect(header?.textContent).toBe("Inventory updated");
+    expect(header?.getAttribute("class")).toBe("accent");
+    expect(header?.getAttribute("data-title")).toBe("inventory updated");
+    expect((header as HTMLElement | null)?.style.opacity).toBe("1");
     expect(container.querySelector("section > i")).toBe(divider);
+    expect(divider?.textContent).toBe("Rows: 2");
+    expect(divider?.getAttribute("data-count")).toBe("2");
     expect(container.querySelector("footer")).toBe(footer);
+    expect(footer?.textContent).toBe("Blocked");
+    expect(footer?.getAttribute("data-summary")).toBe("Inventory updated:2");
+    expect((footer as HTMLElement | null)?.style.width).toBe("24px");
     expect(fixture.executions()).toBe(executionsAfterMount);
     expect(commits).toBe(commitsAfterMount);
   });
@@ -470,6 +604,8 @@ describe("compiler-owned mixed conditional and keyed ranges runtime", () => {
 
     await act(async () => {
       fixture.setModel(() => ({
+        title: "Recovered",
+        accent: true,
         loading: true,
         error: true,
         items: [{ id: "safe", label: "Safe", visible: true, tags: [] }],
@@ -508,6 +644,30 @@ describe("compiler-owned mixed conditional and keyed ranges runtime", () => {
     expect(container.querySelector("[data-error]")?.textContent).toBe("mixed range binding failed");
   });
 
+  it("routes static-sibling binding failures through React error boundaries", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const fixture = createMixedFixture();
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <Boundary>
+          <fixture.View />
+        </Boundary>,
+      ),
+    );
+
+    await act(async () => {
+      fixture.setModel((value) => ({ ...(value as Model), staticFail: true }));
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("[data-error]")?.textContent).toBe(
+      "static sibling binding failed",
+    );
+  });
+
   it("matches normal React through 3,000 deterministic mixed updates", async () => {
     const fixture = createMixedFixture();
     let updateNormal: React.Dispatch<React.SetStateAction<Model>> = () => undefined;
@@ -529,7 +689,7 @@ describe("compiler-owned mixed conditional and keyed ranges runtime", () => {
     });
 
     const transition = (model: Model, step: number): Model => {
-      const action = step % 8;
+      const action = step % 10;
       if (action === 0) return { ...model, loading: !model.loading };
       if (action === 1) return { ...model, error: !model.error };
       if (action === 2) return { ...model, items: [...model.items].reverse() };
@@ -553,6 +713,8 @@ describe("compiler-owned mixed conditional and keyed ranges runtime", () => {
       if (action === 5 && model.items.length > 1) {
         return { ...model, items: model.items.slice(1) };
       }
+      if (action === 8) return { ...model, title: `Inventory ${step}` };
+      if (action === 9) return { ...model, accent: !model.accent };
       if (model.items.length === 0) return model;
       const index = step % model.items.length;
       return {

--- a/packages/farm-react/src/__tests__/compiler-runtime-recursive-host-blocks.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-recursive-host-blocks.test.tsx
@@ -171,19 +171,31 @@ describe("compiled recursive host-block runtime", () => {
           create: () => ({
             ...host("section", [
               {
-                ...host("div", [state[1].get() ? nested.create() : null]),
+                ...host("div", [
+                  host("header", [state[1].get() ? "On" : "Off"]),
+                  state[1].get() ? nested.create() : null,
+                ]),
                 block: {
                   kind: "conditional-ranges",
                   id: 1,
                   ranges: [
                     {
-                      before: 0,
+                      before: 1,
                       test: () => state[1].get(),
                       logical: true,
                       truthy: nested,
                     },
                   ],
                   trailing: 0,
+                  bindings: [
+                    {
+                      kind: "text",
+                      segment: 0,
+                      sibling: 0,
+                      path: [],
+                      read: () => (state[1].get() ? "On" : "Off"),
+                    },
+                  ],
                 },
               },
             ]),
@@ -199,7 +211,10 @@ describe("compiled recursive host-block runtime", () => {
                 <button data-action="inner" onClick={() => state[1].set((value) => !value)} />
                 {state[0].get() ? (
                   <section>
-                    <div>{state[1].get() ? <strong>Ready</strong> : null}</div>
+                    <div>
+                      <header>{state[1].get() ? "On" : "Off"}</header>
+                      {state[1].get() ? <strong>Ready</strong> : null}
+                    </div>
                   </section>
                 ) : (
                   <aside>Closed</aside>
@@ -231,11 +246,14 @@ describe("compiled recursive host-block runtime", () => {
     await act(async () => root.render(<Panel />));
     const rendersAfterMount = ownerRenders;
     const section = container.querySelector("section");
+    const staticHeader = container.querySelector("header");
     await act(async () => {
       click(container, "inner");
       await flushCompilerUpdates();
     });
     expect(container.querySelector("strong")?.textContent).toBe("Ready");
+    expect(container.querySelector("header")).toBe(staticHeader);
+    expect(staticHeader?.textContent).toBe("On");
     expect(container.querySelector("section")).toBe(section);
     expect(ownerRenders).toBe(rendersAfterMount);
   });

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -106,6 +106,18 @@ export interface CompilerHostConditionalBinding {
   read(): unknown;
 }
 
+export interface CompilerStaticRangeBinding {
+  kind: "text" | "attribute" | "style";
+  /** Static segment before range N, or the trailing segment at ranges.length. */
+  segment: number;
+  /** Direct host sibling inside that static segment. */
+  sibling: number;
+  /** Host-element path relative to the selected static sibling. */
+  path: readonly number[];
+  name?: string;
+  read(): unknown;
+}
+
 export interface CompilerHostConditionalBranch {
   create(): CompilerHostElement;
   bindings: readonly CompilerHostConditionalBinding[];
@@ -116,6 +128,7 @@ export interface CompilerHostConditionalRanges {
   id: number;
   ranges: readonly CompilerConditionalRange[];
   trailing: number;
+  bindings?: readonly CompilerStaticRangeBinding[];
 }
 
 export interface CompilerHostKeyedRanges {
@@ -123,6 +136,7 @@ export interface CompilerHostKeyedRanges {
   id: number;
   ranges: readonly CompilerKeyedRange[];
   trailing: number;
+  bindings?: readonly CompilerStaticRangeBinding[];
   /** Compiler output may store only static direct children and materialize rows from the ranges. */
   staticChildrenOnly?: boolean;
 }
@@ -132,6 +146,7 @@ export interface CompilerHostMixedRanges {
   id: number;
   ranges: readonly CompilerMixedRange[];
   trailing: number;
+  bindings?: readonly CompilerStaticRangeBinding[];
 }
 
 export type CompilerHostBlock =
@@ -166,6 +181,7 @@ export interface CompilerConditionalRangesBlockProps {
   ranges: readonly CompilerConditionalRange[];
   /** Number of static direct host siblings after the final conditional slot. */
   trailing: number;
+  bindings?: readonly CompilerStaticRangeBinding[];
 }
 
 export interface CompilerKeyedRowBinding {
@@ -227,6 +243,7 @@ export interface CompilerKeyedRangesBlockProps {
   ranges: readonly CompilerKeyedRange[];
   /** Number of static direct host siblings after the final keyed range. */
   trailing: number;
+  bindings?: readonly CompilerStaticRangeBinding[];
 }
 
 export interface CompilerComponentBlockProps {
@@ -716,6 +733,56 @@ function findCompilerHostTarget(root: Element, path: readonly number[]): Element
   return current;
 }
 
+const UNSET_STATIC_RANGE_BINDING = Symbol("unset static range binding");
+
+function normalizedStaticRangeBindingValue(
+  binding: CompilerStaticRangeBinding,
+  value: unknown,
+): unknown {
+  return binding.kind === "text" ? renderTextValue(value) : value;
+}
+
+function applyStaticRangeBindings(
+  bindings: readonly CompilerStaticRangeBinding[] | undefined,
+  segments: readonly (readonly Element[])[],
+  values: unknown[],
+): boolean {
+  const activeBindings = bindings || [];
+  if (values.length === 0 && activeBindings.length > 0) {
+    values.push(...activeBindings.map(() => UNSET_STATIC_RANGE_BINDING));
+  }
+  if (values.length !== activeBindings.length) return false;
+
+  for (let index = 0; index < activeBindings.length; index += 1) {
+    const binding = activeBindings[index];
+    if (
+      !Number.isSafeInteger(binding.segment) ||
+      binding.segment < 0 ||
+      !Number.isSafeInteger(binding.sibling) ||
+      binding.sibling < 0
+    ) {
+      return false;
+    }
+    const sibling = segments[binding.segment]?.[binding.sibling];
+    const target = sibling && findCompilerHostTarget(sibling, binding.path);
+    if (!target) return false;
+    const rawValue = binding.read();
+    const value = normalizedStaticRangeBindingValue(binding, rawValue);
+    if (Object.is(values[index], value)) continue;
+    values[index] = value;
+    if (binding.kind === "text") {
+      target.textContent = value as string;
+    } else if (binding.kind === "style" && binding.name) {
+      updateStyle(target, binding.name, rawValue);
+    } else if (binding.kind === "attribute" && binding.name) {
+      updateAttribute(target, binding.name, rawValue);
+    } else {
+      return false;
+    }
+  }
+  return true;
+}
+
 interface CompilerKeyedRowInstance extends CompilerHostInstance {
   key: string;
   item: unknown;
@@ -999,6 +1066,7 @@ class CompilerNestedConditionalRanges implements CompilerHostTreeScope {
   private readonly instances: Array<NestedConditionalRangeInstance | null> = [];
   private readonly staticSegments: Element[][] = [];
   private readonly staticScopes: CompilerHostTreeScope[] = [];
+  private readonly staticValues: unknown[] = [];
   private unsubscribe: (() => void) | undefined;
   private active = true;
 
@@ -1099,6 +1167,10 @@ class CompilerNestedConditionalRanges implements CompilerHostTreeScope {
       return false;
     }
     this.staticSegments.push(elements.slice(cursor));
+    if (!applyStaticRangeBindings(this.block.bindings, this.staticSegments, this.staticValues)) {
+      this.cleanup();
+      return false;
+    }
     this.unsubscribe = this.owner.subscribe(this.block.id, this.refresh);
     return true;
   }
@@ -1159,6 +1231,11 @@ class CompilerNestedConditionalRanges implements CompilerHostTreeScope {
       afterCommit?.();
       return;
     }
+    if (!applyStaticRangeBindings(this.block.bindings, this.staticSegments, this.staticValues)) {
+      this.onFallback();
+      afterCommit?.();
+      return;
+    }
     for (let index = this.instances.length - 1; index >= 0; index -= 1) {
       if (!this.reconcileRange(index, selections[index])) {
         this.onFallback();
@@ -1208,7 +1285,13 @@ class CompilerNestedConditionalRanges implements CompilerHostTreeScope {
     this.host = descriptor;
     this.block = block;
     const selections = this.readSelections();
-    if (!selections || !this.updateStaticScopes(descriptor, selections)) return false;
+    if (
+      !selections ||
+      !this.updateStaticScopes(descriptor, selections) ||
+      !applyStaticRangeBindings(this.block.bindings, this.staticSegments, this.staticValues)
+    ) {
+      return false;
+    }
     for (let index = this.instances.length - 1; index >= 0; index -= 1) {
       if (!this.reconcileRange(index, selections[index])) return false;
     }
@@ -1224,6 +1307,7 @@ class CompilerNestedConditionalRanges implements CompilerHostTreeScope {
     this.instances.length = 0;
     this.staticSegments.length = 0;
     this.staticScopes.length = 0;
+    this.staticValues.length = 0;
   }
 }
 
@@ -1236,6 +1320,7 @@ class CompilerNestedKeyedRanges implements CompilerHostTreeScope {
   private readonly instances: Array<Map<string, CompilerKeyedRowInstance>> = [];
   private readonly staticSegments: Element[][] = [];
   private readonly staticScopes: CompilerHostTreeScope[] = [];
+  private readonly staticValues: unknown[] = [];
   private unsubscribe: (() => void) | undefined;
   private active = true;
 
@@ -1346,6 +1431,10 @@ class CompilerNestedKeyedRanges implements CompilerHostTreeScope {
       return false;
     }
     this.staticSegments.push(elements.slice(cursor));
+    if (!applyStaticRangeBindings(this.block.bindings, this.staticSegments, this.staticValues)) {
+      this.cleanup();
+      return false;
+    }
     this.unsubscribe = this.owner.subscribe(this.block.id, this.refresh);
     return true;
   }
@@ -1428,6 +1517,11 @@ class CompilerNestedKeyedRanges implements CompilerHostTreeScope {
       afterCommit?.();
       return;
     }
+    if (!applyStaticRangeBindings(this.block.bindings, this.staticSegments, this.staticValues)) {
+      this.onFallback();
+      afterCommit?.();
+      return;
+    }
     const activeElement = this.root.ownerDocument.activeElement;
     const restoreFocus = Boolean(activeElement && this.root.contains(activeElement));
     for (let index = rowsByRange.length - 1; index >= 0; index -= 1) {
@@ -1490,7 +1584,8 @@ class CompilerNestedKeyedRanges implements CompilerHostTreeScope {
     if (
       !rowsByRange ||
       rowsByRange.length !== this.instances.length ||
-      !this.updateStaticScopes(descriptor, rowsByRange)
+      !this.updateStaticScopes(descriptor, rowsByRange) ||
+      !applyStaticRangeBindings(this.block.bindings, this.staticSegments, this.staticValues)
     ) {
       return false;
     }
@@ -1511,6 +1606,7 @@ class CompilerNestedKeyedRanges implements CompilerHostTreeScope {
     this.instances.length = 0;
     this.staticSegments.length = 0;
     this.staticScopes.length = 0;
+    this.staticValues.length = 0;
   }
 }
 
@@ -1526,6 +1622,7 @@ class CompilerNestedMixedRanges implements CompilerHostTreeScope {
   private readonly instances: NestedMixedRangeInstance[] = [];
   private readonly staticSegments: Element[][] = [];
   private readonly staticScopes: CompilerHostTreeScope[] = [];
+  private readonly staticValues: unknown[] = [];
   private unsubscribe: (() => void) | undefined;
   private active = true;
 
@@ -1677,6 +1774,10 @@ class CompilerNestedMixedRanges implements CompilerHostTreeScope {
       return false;
     }
     this.staticSegments.push(elements.slice(cursor));
+    if (!applyStaticRangeBindings(this.block.bindings, this.staticSegments, this.staticValues)) {
+      this.cleanup();
+      return false;
+    }
     this.unsubscribe = this.owner.subscribe(this.block.id, this.refresh);
     return true;
   }
@@ -1823,6 +1924,11 @@ class CompilerNestedMixedRanges implements CompilerHostTreeScope {
       afterCommit?.();
       return;
     }
+    if (!applyStaticRangeBindings(this.block.bindings, this.staticSegments, this.staticValues)) {
+      this.onFallback();
+      afterCommit?.();
+      return;
+    }
     const activeElement = this.root.ownerDocument.activeElement;
     const restoreFocus = Boolean(activeElement && this.root.contains(activeElement));
     for (let index = snapshots.length - 1; index >= 0; index -= 1) {
@@ -1894,7 +2000,8 @@ class CompilerNestedMixedRanges implements CompilerHostTreeScope {
     if (
       !snapshots ||
       snapshots.length !== this.instances.length ||
-      !this.updateStaticScopes(descriptor, snapshots)
+      !this.updateStaticScopes(descriptor, snapshots) ||
+      !applyStaticRangeBindings(this.block.bindings, this.staticSegments, this.staticValues)
     ) {
       return false;
     }
@@ -1919,6 +2026,7 @@ class CompilerNestedMixedRanges implements CompilerHostTreeScope {
     this.instances.length = 0;
     this.staticSegments.length = 0;
     this.staticScopes.length = 0;
+    this.staticValues.length = 0;
   }
 }
 
@@ -2171,6 +2279,7 @@ function createConditionalRangesBlockComponent(
     private fallbackUnsubscribers: Array<() => void> = [];
     private rangeInstances: Array<ConditionalRangeInstance | null> = [];
     private staticSegments: Element[][] = [];
+    private readonly staticValues: unknown[] = [];
 
     private requestNestedFallback = () => {
       for (const instance of this.rangeInstances) instance?.host.scope?.cleanup();
@@ -2279,6 +2388,12 @@ function createConditionalRangesBlockComponent(
       staticSegments.push(elements.slice(cursor));
       this.staticSegments = staticSegments;
       this.rangeInstances = instances;
+      if (!applyStaticRangeBindings(props.bindings, this.staticSegments, this.staticValues)) {
+        cleanupInstances();
+        this.rangeInstances = [];
+        this.staticSegments = [];
+        return false;
+      }
       return true;
     }
 
@@ -2364,6 +2479,16 @@ function createConditionalRangesBlockComponent(
         this.activateFallback(afterCommit);
         return;
       }
+      if (
+        !applyStaticRangeBindings(
+          this.currentProps.bindings,
+          this.staticSegments,
+          this.staticValues,
+        )
+      ) {
+        this.activateFallback(afterCommit);
+        return;
+      }
 
       for (let rangeIndex = this.rangeInstances.length - 1; rangeIndex >= 0; rangeIndex -= 1) {
         if (!this.reconcileRange(rangeIndex, selections[rangeIndex])) {
@@ -2423,6 +2548,7 @@ function createConditionalRangesBlockComponent(
       this.root = null;
       this.rangeInstances = [];
       this.staticSegments = [];
+      this.staticValues.length = 0;
     }
 
     render(): React.ReactNode {
@@ -3056,6 +3182,7 @@ function createKeyedRangesBlockComponent(
     private unsubscribe: (() => void) | undefined;
     private rangeInstances: Array<Map<string, CompilerKeyedRowInstance>> = [];
     private staticSegments: Element[][] = [];
+    private readonly staticValues: unknown[] = [];
 
     private captureRoot = (root: Element | null) => {
       this.root = root;
@@ -3123,6 +3250,11 @@ function createKeyedRangesBlockComponent(
       staticSegments.push(elements.slice(cursor));
       this.staticSegments = staticSegments;
       this.rangeInstances = instancesByRange;
+      if (!applyStaticRangeBindings(props.bindings, this.staticSegments, this.staticValues)) {
+        this.rangeInstances = [];
+        this.staticSegments = [];
+        return false;
+      }
       return true;
     }
 
@@ -3204,6 +3336,16 @@ function createKeyedRangesBlockComponent(
         this.activateFallback(afterCommit);
         return;
       }
+      if (
+        !applyStaticRangeBindings(
+          this.currentProps.bindings,
+          this.staticSegments,
+          this.staticValues,
+        )
+      ) {
+        this.activateFallback(afterCommit);
+        return;
+      }
 
       const activeElement = this.root.ownerDocument.activeElement;
       const restoreFocus = Boolean(activeElement && this.root.contains(activeElement));
@@ -3265,6 +3407,7 @@ function createKeyedRangesBlockComponent(
       this.root = null;
       this.rangeInstances = [];
       this.staticSegments = [];
+      this.staticValues.length = 0;
     }
 
     render(): React.ReactNode {

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -80,6 +80,13 @@ interface PendingKeyedRowBinding {
   value: t.Expression;
 }
 
+interface PendingStaticRangeBinding extends PendingKeyedRowBinding {
+  /** Static segment before range N, or the trailing segment at ranges.length. */
+  segment: number;
+  /** Direct host sibling inside the static segment. */
+  sibling: number;
+}
+
 interface PendingKeyedRowEvent {
   id: number;
   path: number[];
@@ -133,6 +140,7 @@ interface ConditionalRangesPlan {
   source: t.JSXElement;
   ranges: ConditionalRangePlan[];
   trailing: number;
+  staticBindings: PendingStaticRangeBinding[];
   descriptorBlocks?: ReadonlyMap<t.JSXElement, HostDescriptorBlockPlan>;
 }
 
@@ -172,6 +180,7 @@ interface KeyedRangesPlan {
   source: t.JSXElement;
   ranges: KeyedRangePlan[];
   trailing: number;
+  staticBindings: PendingStaticRangeBinding[];
 }
 
 type MixedRangePlan =
@@ -186,6 +195,7 @@ interface MixedRangesPlan {
   source: t.JSXElement;
   ranges: MixedRangePlan[];
   trailing: number;
+  staticBindings: PendingStaticRangeBinding[];
   descriptorBlocks: ReadonlyMap<t.JSXElement, HostDescriptorBlockPlan>;
 }
 
@@ -197,6 +207,7 @@ interface NestedHostConditionalRangesPlan {
   source: t.JSXElement;
   ranges: ConditionalRangePlan[];
   trailing: number;
+  staticBindings: PendingStaticRangeBinding[];
 }
 
 interface NestedHostKeyedRangesPlan {
@@ -207,6 +218,7 @@ interface NestedHostKeyedRangesPlan {
   source: t.JSXElement;
   ranges: KeyedRangePlan[];
   trailing: number;
+  staticBindings: PendingStaticRangeBinding[];
 }
 
 interface NestedHostMixedRangesPlan {
@@ -217,6 +229,7 @@ interface NestedHostMixedRangesPlan {
   source: t.JSXElement;
   ranges: MixedRangePlan[];
   trailing: number;
+  staticBindings: PendingStaticRangeBinding[];
 }
 
 type HostDescriptorBlockPlan =
@@ -1473,37 +1486,20 @@ function analyzeKeyedRowsContainer(
   return analyzeKeyedRowChild(children[0], statesByValue, safeGlobals, listNames, true);
 }
 
-function isStaticRangeSibling(
-  element: t.JSXElement,
-  statesByValue: ReadonlyMap<string, StateBinding>,
-  safeGlobals: ReadonlySet<string>,
-): boolean {
-  for (const child of meaningfulJsxChildren(element)) {
-    if (t.isJSXFragment(child)) return false;
-    if (t.isJSXElement(child)) {
-      if (!isHostElement(child) || !isStaticRangeSibling(child, statesByValue, safeGlobals)) {
-        return false;
-      }
-      continue;
-    }
-    if (
-      t.isJSXExpressionContainer(child) &&
-      !t.isJSXEmptyExpression(child.expression) &&
-      !isTextExpression(child.expression, statesByValue, safeGlobals)
-    ) {
-      return false;
-    }
-  }
-  return true;
-}
-
 function analyzeKeyedRangesContainer(
   container: t.JSXElement,
   statesByValue: ReadonlyMap<string, StateBinding>,
   safeGlobals: ReadonlySet<string>,
   listNames: ReadonlySet<string>,
   allowSingleRange = false,
-): { ranges: KeyedRangePlan[]; trailing: number; dependencies: number[] } | undefined {
+):
+  | {
+      ranges: KeyedRangePlan[];
+      trailing: number;
+      dependencies: number[];
+      staticBindings: PendingStaticRangeBinding[];
+    }
+  | undefined {
   if (
     container.openingElement.attributes.some(
       (attribute) =>
@@ -1520,6 +1516,7 @@ function analyzeKeyedRangesContainer(
   if (children.length < (allowSingleRange ? 1 : 2)) return undefined;
   const ranges: KeyedRangePlan[] = [];
   const dependencies = new Set<number>();
+  const staticBindings: PendingStaticRangeBinding[] = [];
   let staticBefore = 0;
   for (const child of children) {
     const range = analyzeKeyedRowChild(child, statesByValue, safeGlobals, listNames);
@@ -1540,7 +1537,18 @@ function analyzeKeyedRangesContainer(
       continue;
     }
     if (!t.isJSXElement(child) || !isHostElement(child)) return undefined;
-    if (!isStaticRangeSibling(child, statesByValue, safeGlobals)) return undefined;
+    const analysis = analyzeHostConditionalTree(child, safeGlobals, true, statesByValue);
+    if (analysis.reason) return undefined;
+    for (const binding of analysis.bindings || []) {
+      staticBindings.push({
+        ...binding,
+        segment: ranges.length,
+        sibling: staticBefore,
+      });
+      for (const dependency of collectStateDependencies(binding.value, statesByValue)) {
+        dependencies.add(dependency);
+      }
+    }
     staticBefore += 1;
   }
   if (ranges.length === 0) return undefined;
@@ -1548,14 +1556,19 @@ function analyzeKeyedRangesContainer(
     ranges,
     trailing: staticBefore,
     dependencies: [...dependencies].sort((left, right) => left - right),
+    staticBindings,
   };
 }
 
 function analyzeHostConditionalTree(
   branch: t.JSXElement,
   safeGlobals: ReadonlySet<string>,
+  allowStaticEvents = false,
+  statefulOnly?: ReadonlyMap<string, StateBinding>,
 ): { bindings?: PendingKeyedRowBinding[]; reason?: string } {
   const bindings: PendingKeyedRowBinding[] = [];
+  const needsStaticBinding = (expression: t.Expression): boolean =>
+    !statefulOnly || collectStateDependencies(expression, statefulOnly).length > 0;
   const visit = (element: t.JSXElement, path: number[]): string | undefined => {
     const tag = element.openingElement.name;
     if (!t.isJSXIdentifier(tag) || !/^[a-z]/.test(tag.name)) {
@@ -1565,14 +1578,24 @@ function analyzeHostConditionalTree(
 
     for (const attribute of element.openingElement.attributes) {
       if (t.isJSXSpreadAttribute(attribute)) {
+        if (statefulOnly && !needsStaticBinding(attribute.argument)) continue;
         return "compiler-owned conditionals do not support JSX attribute spreads";
       }
       const name = jsxAttributeName(attribute);
       if (!name) return "compiler-owned conditionals do not support namespaced JSX attributes";
       if (name === "ref" || name === "dangerouslySetInnerHTML" || name === "key") {
+        if (
+          statefulOnly &&
+          (!t.isJSXExpressionContainer(attribute.value) ||
+            t.isJSXEmptyExpression(attribute.value.expression) ||
+            !needsStaticBinding(attribute.value.expression))
+        ) {
+          continue;
+        }
         return `compiler-owned conditional ${name} requires React ownership`;
       }
       if (/^on[A-Z]/.test(name)) {
+        if (allowStaticEvents) continue;
         return "compiler-owned conditional events require React ownership";
       }
       if (
@@ -1583,6 +1606,7 @@ function analyzeHostConditionalTree(
       }
 
       const expression = attribute.value.expression;
+      if (!needsStaticBinding(expression)) continue;
       if (name === "style") {
         if (!t.isObjectExpression(expression)) {
           return "compiler-owned conditional styles must use one inline object literal";
@@ -1603,6 +1627,7 @@ function analyzeHostConditionalTree(
           if (!propertyName || (propertyName.includes("-") && !propertyName.startsWith("--"))) {
             return "compiler-owned conditional style names must use camelCase or a CSS custom property";
           }
+          if (!needsStaticBinding(property.value)) continue;
           const unsupported = validateDerivedExpression(property.value, safeGlobals);
           if (unsupported) {
             return `compiler-owned conditional style ${propertyName} cannot use ${unsupported}`;
@@ -1640,14 +1665,22 @@ function analyzeHostConditionalTree(
       (child): child is t.JSXExpressionContainer =>
         t.isJSXExpressionContainer(child) && !t.isJSXEmptyExpression(child.expression),
     );
-    for (const child of expressions) {
-      const unsupported = validateDerivedExpression(child.expression as t.Expression, safeGlobals);
-      if (unsupported) return `compiler-owned conditional text cannot use ${unsupported}`;
+    const boundExpressions = statefulOnly
+      ? expressions.filter((child) => needsStaticBinding(child.expression as t.Expression))
+      : expressions;
+    if (boundExpressions.length > 0) {
+      for (const child of expressions) {
+        const unsupported = validateDerivedExpression(
+          child.expression as t.Expression,
+          safeGlobals,
+        );
+        if (unsupported) return `compiler-owned conditional text cannot use ${unsupported}`;
+      }
     }
-    if (nestedElements.length > 0 && expressions.length > 0) {
+    if (nestedElements.length > 0 && boundExpressions.length > 0) {
       return "compiler-owned conditionals do not support dynamic text beside nested elements yet";
     }
-    if (nestedElements.length === 0 && expressions.length > 0) {
+    if (nestedElements.length === 0 && boundExpressions.length > 0) {
       const parts: t.Expression[] = [];
       for (const child of element.children) {
         if (t.isJSXText(child)) {
@@ -1692,14 +1725,6 @@ function analyzeRecursiveHostTree(
   const bindings: PendingKeyedRowBinding[] = [];
   const plans: HostDescriptorBlockPlan[] = [];
   const blocks = new Map<t.JSXElement, HostDescriptorBlockPlan>();
-
-  const merge = (analysis: RecursiveHostTreeAnalysis): string | undefined => {
-    if (analysis.reason) return analysis.reason;
-    bindings.push(...analysis.bindings);
-    plans.push(...analysis.plans);
-    for (const [element, plan] of analysis.blocks) blocks.set(element, plan);
-    return undefined;
-  };
 
   const visit = (element: t.JSXElement, path: number[], owner: number): string | undefined => {
     const tag = element.openingElement.name;
@@ -1809,6 +1834,7 @@ function analyzeRecursiveHostTree(
           source: element,
           ranges: mixed.ranges,
           trailing: mixed.trailing,
+          staticBindings: mixed.staticBindings,
         };
         plans.push(plan);
         blocks.set(element, plan);
@@ -1837,11 +1863,11 @@ function analyzeRecursiveHostTree(
     if (conditionalContainer && conditionalChildren.size > 0) {
       const id = allocateId();
       const ranges: ConditionalRangePlan[] = [];
+      const staticBindings: PendingStaticRangeBinding[] = [];
       const dependencies = new Set<number>();
       let staticBefore = 0;
       for (const child of children) {
         if (t.isJSXElement(child)) {
-          const beforeBindings = bindings.length;
           const nested = analyzeRecursiveHostTree(
             child,
             statesByValue,
@@ -1850,10 +1876,18 @@ function analyzeRecursiveHostTree(
             owner,
             allocateId,
           );
-          const reason = merge(nested);
-          if (reason) return reason;
-          if (bindings.length !== beforeBindings) {
-            return "stateful static siblings beside recursive conditionals require React ownership";
+          if (nested.reason) return nested.reason;
+          plans.push(...nested.plans);
+          for (const [nestedElement, plan] of nested.blocks) blocks.set(nestedElement, plan);
+          for (const binding of nested.bindings) {
+            staticBindings.push({
+              ...binding,
+              segment: ranges.length,
+              sibling: staticBefore,
+            });
+            for (const dependency of collectStateDependencies(binding.value, statesByValue)) {
+              dependencies.add(dependency);
+            }
           }
           staticBefore += 1;
           continue;
@@ -1918,6 +1952,7 @@ function analyzeRecursiveHostTree(
         source: element,
         ranges,
         trailing: staticBefore,
+        staticBindings,
       };
       plans.push(plan);
       blocks.set(element, plan);
@@ -1927,14 +1962,22 @@ function analyzeRecursiveHostTree(
     const keyedRows: Array<{ before: number; range: KeyedRowChildShape }> = [];
     let keyedContainer = children.length > 0;
     let staticBefore = 0;
-    const staticChildren: t.JSXElement[] = [];
+    const staticChildren: Array<{
+      element: t.JSXElement;
+      segment: number;
+      sibling: number;
+    }> = [];
     for (const child of children) {
       const range = analyzeKeyedRowChild(child, statesByValue, safeGlobals, listNames, true);
       if (range) {
         keyedRows.push({ before: staticBefore, range });
         staticBefore = 0;
       } else if (t.isJSXElement(child) && isHostElement(child)) {
-        staticChildren.push(child);
+        staticChildren.push({
+          element: child,
+          segment: keyedRows.length,
+          sibling: staticBefore,
+        });
         staticBefore += 1;
       } else {
         keyedContainer = false;
@@ -1945,6 +1988,7 @@ function analyzeRecursiveHostTree(
     if (keyedContainer && keyedRows.length > 0) {
       const id = allocateId();
       const keyedRanges: KeyedRangePlan[] = [];
+      const staticBindings: PendingStaticRangeBinding[] = [];
       const keyedDependencies = new Set<number>();
       for (const { before, range } of keyedRows) {
         if (range.events.length > 0) {
@@ -1979,8 +2023,7 @@ function analyzeRecursiveHostTree(
         });
         for (const dependency of range.dependencies) keyedDependencies.add(dependency);
       }
-      for (const child of staticChildren) {
-        const beforeBindings = bindings.length;
+      for (const { element: child, segment, sibling } of staticChildren) {
         const nested = analyzeRecursiveHostTree(
           child,
           statesByValue,
@@ -1989,10 +2032,14 @@ function analyzeRecursiveHostTree(
           owner,
           allocateId,
         );
-        const reason = merge(nested);
-        if (reason) return reason;
-        if (bindings.length !== beforeBindings) {
-          return "stateful static siblings beside recursive keyed ranges require React ownership";
+        if (nested.reason) return nested.reason;
+        plans.push(...nested.plans);
+        for (const [nestedElement, plan] of nested.blocks) blocks.set(nestedElement, plan);
+        for (const binding of nested.bindings) {
+          staticBindings.push({ ...binding, segment, sibling });
+          for (const dependency of collectStateDependencies(binding.value, statesByValue)) {
+            keyedDependencies.add(dependency);
+          }
         }
       }
       const plan: NestedHostKeyedRangesPlan = {
@@ -2003,6 +2050,7 @@ function analyzeRecursiveHostTree(
         source: element,
         ranges: keyedRanges,
         trailing: staticBefore,
+        staticBindings,
       };
       plans.push(plan);
       blocks.set(element, plan);
@@ -2197,6 +2245,7 @@ function analyzeConditionalRangesContainer(
       ranges: ConditionalRangePlan[];
       trailing: number;
       dependencies: number[];
+      staticBindings: PendingStaticRangeBinding[];
       descriptorBlocks: ReadonlyMap<t.JSXElement, HostDescriptorBlockPlan>;
       nestedPlans: HostDescriptorBlockPlan[];
     }
@@ -2223,6 +2272,7 @@ function analyzeConditionalRangesContainer(
   const dependencies = new Set<number>();
   const descriptorBlocks = new Map<t.JSXElement, HostDescriptorBlockPlan>();
   const nestedPlans: HostDescriptorBlockPlan[] = [];
+  const staticBindings: PendingStaticRangeBinding[] = [];
   let staticBefore = 0;
 
   for (const child of children) {
@@ -2280,7 +2330,18 @@ function analyzeConditionalRangesContainer(
     }
 
     if (!t.isJSXElement(child) || !isHostElement(child)) return undefined;
-    if (!isStaticRangeSibling(child, statesByValue, safeGlobals)) return undefined;
+    const staticAnalysis = analyzeHostConditionalTree(child, safeGlobals, true, statesByValue);
+    if (staticAnalysis.reason) return undefined;
+    for (const binding of staticAnalysis.bindings || []) {
+      staticBindings.push({
+        ...binding,
+        segment: ranges.length,
+        sibling: staticBefore,
+      });
+      for (const dependency of collectStateDependencies(binding.value, statesByValue)) {
+        dependencies.add(dependency);
+      }
+    }
     staticBefore += 1;
   }
 
@@ -2289,6 +2350,7 @@ function analyzeConditionalRangesContainer(
     ranges,
     trailing: staticBefore,
     dependencies: [...dependencies].sort((left, right) => left - right),
+    staticBindings,
     descriptorBlocks,
     nestedPlans,
   };
@@ -2306,6 +2368,7 @@ function analyzeMixedRangesContainer(
       ranges: MixedRangePlan[];
       trailing: number;
       dependencies: number[];
+      staticBindings: PendingStaticRangeBinding[];
       descriptorBlocks: ReadonlyMap<t.JSXElement, HostDescriptorBlockPlan>;
       nestedPlans: HostDescriptorBlockPlan[];
     }
@@ -2332,6 +2395,7 @@ function analyzeMixedRangesContainer(
   const dependencies = new Set<number>();
   const descriptorBlocks = new Map<t.JSXElement, HostDescriptorBlockPlan>();
   const nestedPlans: HostDescriptorBlockPlan[] = [];
+  const staticBindings: PendingStaticRangeBinding[] = [];
   let conditionalCount = 0;
   let keyedCount = 0;
   let staticBefore = 0;
@@ -2435,7 +2499,14 @@ function analyzeMixedRangesContainer(
       parent,
       allocateId,
     );
-    if (staticAnalysis.reason || staticAnalysis.bindings.length > 0) return undefined;
+    if (staticAnalysis.reason) return undefined;
+    for (const binding of staticAnalysis.bindings) {
+      staticBindings.push({
+        ...binding,
+        segment: ranges.length,
+        sibling: staticBefore,
+      });
+    }
     if (!mergeAnalysis(staticAnalysis)) return undefined;
     staticBefore += 1;
   }
@@ -2445,6 +2516,7 @@ function analyzeMixedRangesContainer(
     ranges,
     trailing: staticBefore,
     dependencies: [...dependencies].sort((left, right) => left - right),
+    staticBindings,
     descriptorBlocks,
     nestedPlans,
   };
@@ -2651,6 +2723,17 @@ function keyedRowBindingObject(
     ),
   );
   return t.objectExpression(properties);
+}
+
+function staticRangeBindingObject(binding: PendingStaticRangeBinding): t.ObjectExpression {
+  const value = keyedRowBindingObject(binding, []);
+  value.properties.splice(
+    1,
+    0,
+    t.objectProperty(t.identifier("segment"), t.numericLiteral(binding.segment)),
+    t.objectProperty(t.identifier("sibling"), t.numericLiteral(binding.sibling)),
+  );
+  return value;
 }
 
 function uniqueLocalIdentifier(base: string, nodes: readonly t.Node[]): t.Identifier {
@@ -3046,6 +3129,12 @@ function keyedRangesBoundary(blockRuntime: t.Identifier, plan: KeyedRangesPlan):
           t.jsxIdentifier("trailing"),
           t.jsxExpressionContainer(t.numericLiteral(plan.trailing)),
         ),
+        t.jsxAttribute(
+          t.jsxIdentifier("bindings"),
+          t.jsxExpressionContainer(
+            t.arrayExpression(plan.staticBindings.map(staticRangeBindingObject)),
+          ),
+        ),
       ],
       true,
     ),
@@ -3172,6 +3261,10 @@ function nestedHostBlockObject(
       ),
     ),
     t.objectProperty(t.identifier("trailing"), t.numericLiteral(plan.trailing)),
+    t.objectProperty(
+      t.identifier("bindings"),
+      t.arrayExpression(plan.staticBindings.map(staticRangeBindingObject)),
+    ),
     ...(plan.kind === "nested-host-keyed-ranges"
       ? [t.objectProperty(t.identifier("staticChildrenOnly"), t.booleanLiteral(true))]
       : []),
@@ -3213,6 +3306,7 @@ function mixedRangesBoundary(blockRuntime: t.Identifier, plan: MixedRangesPlan):
     source: plan.source,
     ranges: plan.ranges,
     trailing: plan.trailing,
+    staticBindings: plan.staticBindings,
   };
   const descriptorBlocks = new Map(plan.descriptorBlocks);
   descriptorBlocks.set(plan.source, nestedPlan);
@@ -3271,6 +3365,12 @@ function conditionalRangesBoundary(
     t.jsxAttribute(
       t.jsxIdentifier("trailing"),
       t.jsxExpressionContainer(t.numericLiteral(plan.trailing)),
+    ),
+    t.jsxAttribute(
+      t.jsxIdentifier("bindings"),
+      t.jsxExpressionContainer(
+        t.arrayExpression(plan.staticBindings.map(staticRangeBindingObject)),
+      ),
     ),
   ];
   if (rootRef?.value) {
@@ -3517,6 +3617,7 @@ function analyzeComposableBlocks(
               source: child,
               ranges: mixedRanges.ranges,
               trailing: mixedRanges.trailing,
+              staticBindings: mixedRanges.staticBindings,
               descriptorBlocks: mixedRanges.descriptorBlocks,
             });
             plans.push(...mixedRanges.nestedPlans);
@@ -3544,6 +3645,7 @@ function analyzeComposableBlocks(
               source: child,
               ranges: keyedRanges.ranges,
               trailing: keyedRanges.trailing,
+              staticBindings: keyedRanges.staticBindings,
             });
             for (const range of keyedRanges.ranges) {
               if (t.isJSXElement(range.source)) ownedElements.add(range.source);
@@ -3573,6 +3675,7 @@ function analyzeComposableBlocks(
               source: child,
               ranges: conditionalRanges.ranges,
               trailing: conditionalRanges.trailing,
+              staticBindings: conditionalRanges.staticBindings,
               descriptorBlocks: conditionalRanges.descriptorBlocks,
             });
             plans.push(...(conditionalRanges.nestedPlans || []));
@@ -3769,6 +3872,7 @@ function analyzeComposableBlocks(
       source: root,
       ranges: rootMixedRanges.ranges,
       trailing: rootMixedRanges.trailing,
+      staticBindings: rootMixedRanges.staticBindings,
       descriptorBlocks: rootMixedRanges.descriptorBlocks,
     });
     plans.push(...rootMixedRanges.nestedPlans);
@@ -3800,6 +3904,7 @@ function analyzeComposableBlocks(
       source: root,
       ranges: rootRanges.ranges,
       trailing: rootRanges.trailing,
+      staticBindings: rootRanges.staticBindings,
     });
     for (const range of rootRanges.ranges) {
       if (t.isJSXElement(range.source)) ownedElements.add(range.source);
@@ -3833,6 +3938,7 @@ function analyzeComposableBlocks(
       source: root,
       ranges: rootConditionalRanges.ranges,
       trailing: rootConditionalRanges.trailing,
+      staticBindings: rootConditionalRanges.staticBindings,
       descriptorBlocks: rootConditionalRanges.descriptorBlocks,
     });
     plans.push(...(rootConditionalRanges.nestedPlans || []));


### PR DESCRIPTION
## Summary

- compile safe text, attribute, className, and individual style bindings on stable host siblings beside conditional, keyed, and mixed ranges
- address those targets by static segment, sibling, and nested host path so nearby mounts and LIS moves cannot shift the target
- support the same bindings in recursive conditional branches and keyed-row scopes, with defensive React fallback and subscription cleanup
- preserve state-independent render instrumentation on the initial React path instead of degrading keyed ranges to React reconciliation
- extend the production experiment and experimental compiler docs

## Safety and behavior

- unsupported or invalid coordinates fall back to React
- parent prop and Fast Refresh definition changes retain the existing React remount path
- surviving static siblings keep DOM identity
- recursive row bindings are rebound to the current keyed item
- React 18 and React 19 remain supported

## Battle testing

- `pnpm --filter @farm.js/react test` — 39 files, 326 tests
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8
- `pnpm --filter @farm.js/react build`
- `pnpm --filter farm-react-compiler-example exec tsc --noEmit`
- `pnpm --filter farm-react-compiler-example experiment` — production desktop/mobile browser PASS
- `NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter farmjs-docs build`
- targeted `oxlint`, `oxfmt --check`, and `git diff --check`

The randomized differential coverage compares compiled output with normal React across 3,000 mixed updates. The browser experiment verifies zero owner update executions, preserved static and keyed DOM identity, one outer LIS move, one nested LIS move, controlled input composition/selection behavior, hydration recovery, and no console or overflow failures. It also caught and now guards a regression where state-independent instrumentation caused the keyed-range example to take Reacts 5-move path instead of the compiler LIS 3-move path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compiles stateful text, attribute, `className`, and individual inline style bindings on stable host siblings beside conditional, keyed, and mixed ranges. Previously those siblings had to stay fully static or the container fell back to React; now the compiler patches them through stable segment, sibling, and nested host path coordinates, so adjacent conditional mounts and keyed LIS moves cannot shift the target and sibling DOM nodes keep their identity without rerunning the owner.

**New Features**
- Supports the same bindings in recursive conditional branches and keyed-row scopes, rebinding row-local bindings to the current keyed item and cleaning up subscriptions when a branch or row is removed.
- Unsupported coordinates or failed reads fall back to React; parent prop and Fast Refresh definition changes keep the existing React remount path.

**Bug Fixes**
- Preserves state-independent render instrumentation on the initial React path so keyed ranges no longer degrade to React reconciliation.

<sup>Written for commit ef61ccb110a7eefee3935063c2b62aa530df2030. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

