### PR TITLE
fix(core): re-export readFarmRequestBody for the emitted workflow handler

### DIFF
--- a/packages/farm/src/__tests__/workflows.test.ts
+++ b/packages/farm/src/__tests__/workflows.test.ts
@@ -242,6 +242,42 @@ describe("Farm workflows", () => {
     expect(handlerSource).not.toContain("decodeURIComponent(event.context.params");
   });
 
+  it("emits only internal imports the production runtime actually exports", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-workflow-imports-"));
+    await fs.mkdir(path.join(root, "src", "jobs"), { recursive: true });
+    await fs.writeFile(
+      path.join(root, "src", "jobs", "sync.mjs"),
+      "export default { async run() { return { ok: true }; } };",
+    );
+
+    const prepared = await prepareFarmWorkflowsForNitro({ root, workflows: {}, server: {} });
+    const handlerSource = await fs.readFile(prepared.handlerPath!, "utf8");
+    const productionRuntime = await import("../nitro/production-runtime");
+
+    // Only a real build resolves these specifiers, so a name missing from the
+    // internal entry fails `farm build` and nothing before it.
+    const importBlock = handlerSource.match(
+      /import\s*\{([^}]*)\}\s*from\s*"@farm\.js\/core\/internal\/production-runtime"/,
+    );
+    expect(importBlock).not.toBeNull();
+
+    const imported = importBlock![1]
+      .split(",")
+      .map((entry) =>
+        entry
+          .trim()
+          .replace(/^type\s+/, "")
+          .split(/\s+as\s+/)[0]!
+          .trim(),
+      )
+      .filter(Boolean);
+
+    expect(imported.length).toBeGreaterThan(0);
+    for (const name of imported) {
+      expect(productionRuntime).toHaveProperty(name);
+    }
+  });
+
   it("404s on a malformed percent-encoded workflow id instead of throwing", async () => {
     const workflow = {
       id: "sync-users",

--- a/packages/farm/src/nitro/production-runtime.ts
+++ b/packages/farm/src/nitro/production-runtime.ts
@@ -2,6 +2,7 @@ export { _runWithAfterRequest } from "../after";
 export {
   bufferFarmRequestBody,
   createFarmRequestBodyErrorResponse,
+  readFarmRequestBody,
   resolveFarmServerConfig,
 } from "../server-http";
 export { createFarmProductionLifecycle } from "../production-lifecycle";


### PR DESCRIPTION
Closes #534.

The emitted Nitro workflow handler imports `readFarmRequestBody` from
`@farm.js/core/internal/production-runtime`, which re-exported `bufferFarmRequestBody` and
`createFarmRequestBodyErrorResponse` from the same module but never that one. Any app with a
workflows directory failed `farm build` with `MISSING_EXPORT`.

Dev was unaffected, since the dev handler is real TypeScript importing from `./server-http`
directly. Only the emitted handler goes through the internal entry, so this surfaced at build
time and failed the whole build.

## Verification

A minimal app with one workflow, before and after:

```
              before   after
farm dev      works    works
farm build    fails    passes
```

`farm start` on the built output then serves the workflow routes end to end:

```
200   /api/_farm/workflows
200   /api/_farm/workflows/hello
404   /api/_farm/workflows/nope
404   /api/_farm/workflows/caf%E9
      ?tag=a&tag=b -> {"payload":{"tag":["a","b"]}}
```

The last two also confirm #515 and #525 behave the same in production as in dev, which had
only ever been checked against `farm dev`.

Core suite green, 1260 passed and 6 skipped. Type check and lint clean.

## The test

It resolves every named import in the emitted handler against the internal entry's actual
exports, rather than asserting this one name. Only a real build resolves those specifiers, so
the unit suite could not see the breakage before. Reverting the one line fails it with
`expected ... to have property "readFarmRequestBody"`.

## Sweep

Since an emitted import can break this way anywhere, I checked every value import of a
`@farm.js/core/*` entry across all packages against the built `dist` namespace: 32 specifiers,
121 named imports. `readFarmRequestBody` was the only break, and reverting the fix makes the
sweep report exactly it and nothing else, so the check is not passing vacuously.

Type-only imports are excluded, they do not exist at runtime. The other emitted entries,
`internal/client-runtime` and `internal/build-runtime`, resolve cleanly.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `farm build` failing with `MISSING_EXPORT` for any app with a workflows directory. The emitted Nitro workflow handler imports `readFarmRequestBody` from `@farm.js/core/internal/production-runtime`, which never re-exported it; dev was unaffected because the dev handler imports from `./server-http` directly.

- Adds `readFarmRequestBody` to the internal production runtime's re-exports.
- Adds a test that resolves every named import in the emitted handler against the actual exports of the internal entry, since only a real build resolves those specifiers.

Closes #534.

<sup>Written for commit 92a02df2e87f9323dccd1c48598134ff12074910. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

