### PR TITLE
fix(react): preserve one-shot iterable lists

### DIFF
--- a/packages/farm-react/src/__tests__/compiler-runtime-one-shot-iterables.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-one-shot-iterables.test.tsx
@@ -1,0 +1,179 @@
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { compileReactModule } from "../compiler";
+import { createCompiledComponent } from "../compiler-runtime";
+import { normalizeReactCompilerOptions } from "../index";
+import { List } from "../list";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Item {
+  id: string;
+  label: string;
+}
+
+const roots: Array<{ unmount(): void }> = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+});
+
+function oneShotItems(
+  items: readonly Item[] = [
+    { id: "a", label: "Alpha" },
+    { id: "b", label: "Beta" },
+  ],
+): IterableIterator<Item> {
+  return (function* () {
+    yield* items;
+  })();
+}
+
+describe("one-shot iterable lists", () => {
+  it("keeps rows when React renders the public List without compiler adoption", async () => {
+    const items = oneShotItems();
+
+    function Baseline() {
+      return (
+        <section>
+          <List each={items} by={(item) => item.id}>
+            {(item) => <li>{item.label}</li>}
+          </List>
+        </section>
+      );
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+
+    await act(async () => root.render(<Baseline />));
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Alpha",
+      "Beta",
+    ]);
+
+    await act(async () => root.render(<Baseline />));
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Alpha",
+      "Beta",
+    ]);
+  });
+
+  it("selects the host-owned keyed-row path for a public List backed by a generator", async () => {
+    const result = await compileReactModule(
+      `
+        import { useState } from "react";
+        import { List } from "@farm.js/react/list";
+
+        const items = (function* () {
+          yield { id: "a", label: "Alpha" };
+          yield { id: "b", label: "Beta" };
+        })();
+
+        export function Inventory() {
+          const [count, setCount] = useState(0);
+          return (
+            <section>
+              <button onClick={() => setCount(count + 1)}>{count}</button>
+              <List each={items} by={(item) => item.id}>
+                {(item) => <li>{item.label}</li>}
+              </List>
+            </section>
+          );
+        }
+      `,
+      "/app/Inventory.tsx",
+      normalizeReactCompilerOptions(true),
+    );
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.code).toContain("farmBlocks.KeyedRanges");
+  });
+
+  it("keeps rows rendered from a one-shot iterable after adoption", async () => {
+    const items = oneShotItems();
+    let replaceItems: ((next: Iterable<Item>) => void) | undefined;
+    const Panel = createCompiledComponent({
+      displayName: "OneShotList",
+      initialize: () => [items],
+      render(_props: Record<string, never>, state, blocks) {
+        const KeyedRanges = blocks.KeyedRanges;
+        const source = state[0].get() as Iterable<Item>;
+        replaceItems = (next) => state[0].set(next);
+        return (
+          <KeyedRanges
+            id={0}
+            render={() => (
+              <section>
+                <button>0</button>
+                <List each={source} by={(item) => item.id}>
+                  {(item) => <li>{item.label}</li>}
+                </List>
+              </section>
+            )}
+            ranges={[
+              {
+                before: 1,
+                items: () => state[0].get() as Iterable<Item>,
+                rowKey: (item) => (item as Item).id,
+                create: (item) => ({
+                  kind: "element",
+                  tag: "li",
+                  attributes: [],
+                  styles: [],
+                  children: [(item as Item).label],
+                }),
+                bindings: [],
+              },
+            ]}
+            trailing={0}
+          />
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+
+    await act(async () => root.render(<Panel />));
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Alpha",
+      "Beta",
+    ]);
+
+    await act(async () => {
+      replaceItems?.(
+        oneShotItems([
+          { id: "c", label: "Charlie" },
+          { id: "d", label: "Delta" },
+        ]),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Charlie",
+      "Delta",
+    ]);
+  });
+});

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { flushSync } from "react-dom";
+import { materializeIterable } from "./iterable";
 
 export type CompilerStateUpdater = unknown | ((previous: unknown) => unknown);
 
@@ -670,8 +671,7 @@ function materializeCompilerHostChildren(descriptor: CompilerHostElement): reado
   for (const range of block.ranges) {
     children.push(...staticChildren.slice(cursor, cursor + range.before));
     cursor += range.before;
-    const source = range.items();
-    const items = source ? Array.from(source) : [];
+    const items = materializeIterable(range.items());
     children.push(...items.map((item, index) => range.create(item, index)));
   }
   children.push(...staticChildren.slice(cursor, cursor + block.trailing));
@@ -692,8 +692,7 @@ function collectCompilerHostBlockIds(descriptor: CompilerHostElement, ids: Set<n
     }
   } else if (block.kind === "keyed-ranges") {
     for (const range of block.ranges) {
-      const source = range.items();
-      const first = source ? Array.from(source)[0] : undefined;
+      const first = materializeIterable(range.items())[0];
       if (first !== undefined) collectCompilerHostBlockIds(range.create(first, 0), ids);
     }
   } else {
@@ -702,8 +701,7 @@ function collectCompilerHostBlockIds(descriptor: CompilerHostElement, ids: Set<n
         if (range.truthy) collectCompilerHostBlockIds(range.truthy.create(), ids);
         if (range.falsy) collectCompilerHostBlockIds(range.falsy.create(), ids);
       } else {
-        const source = range.items();
-        const first = source ? Array.from(source)[0] : undefined;
+        const first = materializeIterable(range.items())[0];
         if (first !== undefined) collectCompilerHostBlockIds(range.create(first, 0), ids);
       }
     }
@@ -1248,8 +1246,7 @@ class CompilerNestedKeyedRanges implements CompilerHostTreeScope {
   ) {}
 
   private readRange(range: CompilerKeyedRange): NestedReadKeyedRange | null {
-    const source = range.items();
-    const items = source ? Array.from(source) : [];
+    const items = materializeIterable(range.items());
     const keys = items.map((item, index) => keyedRowIdentity(range.rowKey(item, index)));
     return new Set(keys).size === keys.length ? { items, keys } : null;
   }
@@ -1546,8 +1543,7 @@ class CompilerNestedMixedRanges implements CompilerHostTreeScope {
         snapshots.push({ kind: "conditional", selection });
         continue;
       }
-      const source = range.items();
-      const items = source ? Array.from(source) : [];
+      const items = materializeIterable(range.items());
       const keys = items.map((item, index) => keyedRowIdentity(range.rowKey(item, index)));
       if (new Set(keys).size !== keys.length) return null;
       snapshots.push({ kind: "keyed", rows: { items, keys } });
@@ -2591,8 +2587,7 @@ function createKeyedRowsBlockComponent(
     private readRows(
       props: CompilerKeyedRowsBlockProps,
     ): { items: unknown[]; keys: string[] } | null {
-      const source = props.items();
-      const items = source ? Array.from(source) : [];
+      const items = materializeIterable(props.items());
       const keys = items.map((item, index) => keyedRowIdentity(props.rowKey(item, index)));
       if (new Set(keys).size !== keys.length) return null;
       return { items, keys };
@@ -3063,8 +3058,7 @@ function createKeyedRangesBlockComponent(
     };
 
     private readRange(range: CompilerKeyedRange): ReadRange | null {
-      const source = range.items();
-      const items = source ? Array.from(source) : [];
+      const items = materializeIterable(range.items());
       const keys = items.map((item, index) => keyedRowIdentity(range.rowKey(item, index)));
       if (new Set(keys).size !== keys.length) return null;
       return { items, keys };

--- a/packages/farm-react/src/iterable.ts
+++ b/packages/farm-react/src/iterable.ts
@@ -1,0 +1,19 @@
+const oneShotSnapshots = new WeakMap<object, readonly unknown[]>();
+
+/** Materialize an iterable without consuming a one-shot iterator more than once. */
+export function materializeIterable<Item>(source: Iterable<Item> | null | undefined): Item[] {
+  if (source == null) return [];
+
+  const iterator = source[Symbol.iterator]();
+  const oneShot =
+    iterator === (source as unknown) &&
+    (typeof source === "object" || typeof source === "function");
+  if (oneShot) {
+    const cached = oneShotSnapshots.get(source as object);
+    if (cached) return cached as Item[];
+  }
+
+  const items = Array.from({ [Symbol.iterator]: () => iterator });
+  if (oneShot) oneShotSnapshots.set(source as object, items);
+  return items;
+}

--- a/packages/farm-react/src/list.tsx
+++ b/packages/farm-react/src/list.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { materializeIterable } from "./iterable";
 
 export interface ListProps<Item> {
   /** Items to render. Nullish collections are treated as empty. */
@@ -17,7 +18,7 @@ export interface ListProps<Item> {
  * updates do not execute the surrounding user component.
  */
 export function List<Item>({ each, by, children }: ListProps<Item>): React.ReactElement {
-  const rows = each ? Array.from(each) : [];
+  const rows = materializeIterable(each);
   return React.createElement(
     React.Fragment,
     null,


### PR DESCRIPTION
## Summary

- preserve generator-backed `List` rows during compiler DOM adoption
- share one-shot iterable snapshots across public list rendering and compiled keyed paths
- keep repeatable iterables materialized normally
- add regression coverage for React rerenders, compiler adoption, and replacement generators

## Why

`ListProps.each` accepts any iterable. The compiled keyed-list path rendered a generator through React and then consumed it again while adopting the DOM. Since generators are one-shot iterators, the second read was empty and the rendered rows disappeared.

## Validation

- `pnpm --dir packages/farm-react test` (327 tests)
- `pnpm --dir packages/farm-react build`
- focused one-shot iterable regression suite

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes generator-backed `List` rows disappearing after React rerenders or compiler DOM adoption.

Generators are one-shot iterators, so reading them twice (once during render, once during adoption) produced an empty second read. The fix snapshots one-shot iterable results once and reuses the snapshot across public `List` rendering and compiled keyed paths.

**Bug Fixes**
- Snapshot one-shot iterables in `materializeIterable` so they are only consumed once.
- Repeatable iterables are still materialized normally on each read.
- Adds regression tests for rerenders, compiler adoption, and replaced generators.

<sup>Written for commit 150c2431cf634bf6b0378c1688e1d0cade0ed973. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

