### PR TITLE
fix(rsc): preserve repeated params in the dev fallback

### DIFF
--- a/packages/farmjs-plugin/src/rsc/__tests__/rsc-entry-searchparams.test.ts
+++ b/packages/farmjs-plugin/src/rsc/__tests__/rsc-entry-searchparams.test.ts
@@ -7,6 +7,10 @@ const entrySource = readFileSync(
   path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../entries/rsc.ts"),
   "utf8",
 );
+const fallbackSource = readFileSync(
+  path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../index.ts"),
+  "utf8",
+);
 
 describe("RSC entry search params", () => {
   it("builds searchParams with the shared array-aware helper", () => {
@@ -21,5 +25,14 @@ describe("RSC entry search params", () => {
       "const errSearchParams = searchParamsToObject(url.searchParams);",
     );
     expect(entrySource).not.toContain("Object.fromEntries(url.searchParams)");
+  });
+
+  it("keeps repeated values in the legacy development fallback", () => {
+    expect(fallbackSource).toContain("const { searchParamsToObject } = require_(");
+    expect(fallbackSource).toContain('"@farm.js/core/internal/production-runtime"');
+    expect(fallbackSource).toContain("const searchParams = searchParamsToObject(");
+    expect(fallbackSource).not.toContain(
+      'Object.fromEntries(new URLSearchParams(url.split("?")[1] || ""))',
+    );
   });
 });

--- a/packages/farmjs-plugin/src/rsc/index.ts
+++ b/packages/farmjs-plugin/src/rsc/index.ts
@@ -55,6 +55,9 @@ const { normalizeFarmDeploymentId } = require_(
 const { getFarmLayerAliases, getFarmSourceRoots, resolveFarmLayers } = require_(
   "@farm.js/core/server",
 ) as typeof import("@farm.js/core/server");
+const { searchParamsToObject } = require_(
+  "@farm.js/core/internal/production-runtime",
+) as typeof import("@farm.js/core/internal/production-runtime");
 
 export type { FarmRscPluginOptions, EntryContext };
 export { buildRscNitro, waitForRscManifest, waitForRscOutputs } from "./nitro-build.js";
@@ -1386,7 +1389,9 @@ if (document.readyState === 'loading') {
 
               // Parse URL params (basic dynamic route support)
               const params: Record<string, string> = {};
-              const searchParams = Object.fromEntries(new URLSearchParams(url.split("?")[1] || ""));
+              const searchParams = searchParamsToObject(
+                new URL(url, `http://${req.headers.host || "localhost:3000"}`).searchParams,
+              );
 
               // Render the page with middleware data
               const pageProps = {


### PR DESCRIPTION
## Summary

- use the shared array-aware query parser in the legacy RSC development fallback
- keep repeated query parameters consistent with the primary RSC path
- guard the fallback against last-value-only conversion regressions

## Testing

- pnpm --dir packages/farmjs-plugin typecheck
- pnpm --dir packages/farmjs-plugin test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the legacy RSC development fallback so repeated query parameters keep all values instead of collapsing to the last one.

- Uses the shared array-aware `searchParamsToObject` helper in the fallback, matching the primary RSC path.
- Adds a regression test to prevent reverting to `Object.fromEntries(new URLSearchParams(...))` conversion.

<sup>Written for commit 2ef91bf60c24ab74282fcdb080bb413603184e97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

