### PR TITLE
fix(query): honor subsecond server-query stale times

### DIFF
--- a/packages/farm/src/__tests__/server-query.test.ts
+++ b/packages/farm/src/__tests__/server-query.test.ts
@@ -15,6 +15,7 @@ import { _runWithCurrentRequest } from "../server/request";
 describe("createServerQuery", () => {
   afterEach(() => {
     getFarmDataCache().clear();
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -94,6 +95,25 @@ describe("createServerQuery", () => {
     invalidate(key);
     await expect(product({ id: "123" })).resolves.toEqual({ id: "123", source: "query-1" });
     expect(calls).toBe(1);
+  });
+
+  it("honors subsecond stale times without rounding them to one second", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    let calls = 0;
+    const query = createServerQuery({
+      key: () => ["subsecond"],
+      staleTime: "250ms",
+      async handler() {
+        return ++calls;
+      },
+    });
+
+    await expect(query()).resolves.toBe(1);
+    vi.setSystemTime(249);
+    await expect(query()).resolves.toBe(1);
+    vi.setSystemTime(250);
+    await expect(query()).resolves.toBe(2);
   });
 
   it("returns transport metadata only during a server action call", async () => {

--- a/packages/farm/src/server-query.ts
+++ b/packages/farm/src/server-query.ts
@@ -157,7 +157,7 @@ export function createServerQuery(options: AnyServerQueryOptions): ServerQuery<u
         const cache = getFarmDataCache();
         data = await cache.getOrSet(cacheKey, producer, {
           tags: [createRouteDataCacheTag(routeKey)],
-          revalidate: staleTime === false ? false : Math.max(1, Math.ceil(staleTime / 1000)),
+          revalidate: staleTime === false ? false : staleTime / 1000,
         });
         updatedAt =
           (await cache.getEntryAsync(cacheKey, { allowStale: true }))?.createdAt ?? Date.now();


### PR DESCRIPTION
## Summary

- pass exact stale-time seconds into the data cache
- stop rounding millisecond durations up to one second
- cover cache behavior immediately before and at a 250 ms expiry boundary

## Testing

- pnpm --dir packages/farm exec vitest run src/__tests__/server-query.test.ts src/__tests__/cache.test.ts
- pnpm --dir packages/farm type-check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes server-query stale times so subsecond values like 250ms are honored instead of being rounded up to 1 second, preventing queries from serving stale data longer than configured.

- Passes the exact stale time in seconds to the data cache instead of rounding with `Math.max(1, Math.ceil(staleTime / 1000))`.
- Adds a fake-timer test that verifies cache refresh behavior at 249ms and 250ms, with `vi.useRealTimers()` restored after each test.

<sup>Written for commit b563902e3b4b530fe52ea6864378e161264daee3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

