### PR TITLE
fix(middleware): stop reflecting request headers in dev

### DIFF
--- a/packages/farm/src/__tests__/middleware.test.ts
+++ b/packages/farm/src/__tests__/middleware.test.ts
@@ -1352,14 +1352,15 @@ describe("Header Management Advanced", () => {
     expect(ctx.headers.get("X-Custom")).toBe("value2");
   });
 
-  it("should preserve existing headers", () => {
+  it("keeps request headers separate from response headers", () => {
     const req = createMockRequest("/test");
     req.headers["existing-header"] = "existing-value";
 
     const res = createMockResponse();
     const ctx = createContext(req, res);
 
-    expect(ctx.headers.get("existing-header")).toBe("existing-value");
+    expect(ctx.request.headers["existing-header"]).toBe("existing-value");
+    expect(ctx.headers.has("existing-header")).toBe(false);
   });
 });
 
@@ -1807,6 +1808,30 @@ describe("Middleware Data Access (getMiddlewareData)", () => {
 });
 
 describe("Middleware Manager Data Flow", () => {
+  it("does not reflect private request headers into the response", async () => {
+    const manager = new MiddlewareManager("/tmp", undefined, [
+      {
+        matcher: "/**",
+        async handler(ctx, next) {
+          ctx.headers.set("x-farm-response", "yes");
+          await next();
+        },
+      },
+    ]);
+
+    const req = createMockRequest("/dashboard");
+    req.headers.authorization = "Bearer secret";
+    req.headers.cookie = "session=secret";
+    const res = createMockResponse();
+
+    await manager.execute(req, res);
+
+    expect(res.setHeader).toHaveBeenCalledWith("x-farm-response", "yes");
+    expect(res.setHeader).not.toHaveBeenCalledWith("authorization", expect.anything());
+    expect(res.setHeader).not.toHaveBeenCalledWith("cookie", expect.anything());
+    expect(res.setHeader).not.toHaveBeenCalledWith("host", expect.anything());
+  });
+
   it("executes farm.config middleware entries when their matcher matches", async () => {
     const seen: string[] = [];
     const manager = new MiddlewareManager("/tmp", undefined, [

--- a/packages/farm/src/middleware/context.ts
+++ b/packages/farm/src/middleware/context.ts
@@ -131,15 +131,6 @@ export function createContext(
   const locals = parent?.locals ? new Map(parent.locals) : new Map<string, any>();
   const cookies = new CookieJarImpl(req, res);
 
-  // Copy existing headers
-  Object.entries(req.headers).forEach(([key, value]) => {
-    if (typeof value === "string") {
-      headers.set(key, value);
-    } else if (Array.isArray(value)) {
-      headers.set(key, value.join(", "));
-    }
-  });
-
   if (parent?.headers) {
     for (const [key, value] of Object.entries(parent.headers)) {
       headers.set(key, value);


### PR DESCRIPTION
## Summary

- keep incoming headers available through ctx.request.headers
- initialize middleware response headers separately
- prevent host, authorization, and cookie request headers from being copied onto the response

## Testing

- pnpm --dir packages/farm exec vitest run src/__tests__/middleware.test.ts
- pnpm --dir packages/farm type-check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops middleware from copying request headers onto the response in development, so private headers like `authorization`, `cookie`, and `host` no longer leak into responses.

- Keeps incoming headers accessible through `ctx.request.headers` while `ctx.headers` now only tracks response headers.
- Initializes response headers separately instead of seeding them from the request.

<sup>Written for commit dd9d5e96b835aee89ff780564f593320de78b000. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

