### PR TITLE
fix(integrations): reject prototype-poisoning input keys

### DIFF
--- a/packages/farm/src/__tests__/integrations.test.ts
+++ b/packages/farm/src/__tests__/integrations.test.ts
@@ -682,6 +682,74 @@ describe("integrations runtime", () => {
     expect(routeMiddleware).toHaveBeenCalledTimes(1);
   });
 
+  it("drops prototype keys from query and form inputs", async () => {
+    const describeInput = (value: unknown) => {
+      const input = value as Record<string, unknown>;
+      return {
+        input,
+        usesPlainPrototype: Object.getPrototypeOf(input) === Object.prototype,
+        ownsPrototypeKey: Object.hasOwn(input, "__proto__"),
+      };
+    };
+    const manager = createManager();
+    manager.addPlugins(
+      resolveIntegrationPlugins({
+        safeInput: defineIntegration({
+          category: "custom",
+          type: "safe-input",
+          instance: {},
+          routes: [
+            integrationRoute.get("/api/safe-input/query", {
+              query: z.any(),
+              handler(_request, context) {
+                return Response.json(describeInput(context.input.query));
+              },
+            }),
+            integrationRoute.post("/api/safe-input/form", {
+              bodyFormat: "form",
+              body: z.any(),
+              handler(_request, context) {
+                return Response.json(describeInput(context.input.body));
+              },
+            }),
+          ],
+        }),
+      }),
+    );
+
+    await manager.runHookParallel("init");
+    const runtime = getRegisteredIntegrationRuntime("safeInput");
+    expect(runtime).toBeDefined();
+
+    const queryResponse = await dispatchIntegrationRequest(
+      runtime!,
+      new Request(
+        "http://localhost/api/safe-input/query?safe=yes&__proto__=first&__proto__=second&constructor=blocked&prototype=blocked",
+      ),
+    );
+    expect(await queryResponse?.json()).toEqual({
+      input: { safe: "yes" },
+      usesPlainPrototype: true,
+      ownsPrototypeKey: false,
+    });
+
+    const formResponse = await dispatchIntegrationRequest(
+      runtime!,
+      new Request("http://localhost/api/safe-input/form", {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+        },
+        body: "safe=yes&__proto__=first&__proto__=second&constructor=blocked&prototype=blocked",
+      }),
+    );
+    expect(await formResponse?.json()).toEqual({
+      input: { safe: "yes" },
+      usesPlainPrototype: true,
+      ownsPrototypeKey: false,
+    });
+  });
+
   it("supports Better Call-style Zod body and query schemas on integration routes", async () => {
     const beforeHook = vi.fn();
     const manager = createManager();

--- a/packages/farm/src/integrations.ts
+++ b/packages/farm/src/integrations.ts
@@ -2645,6 +2645,8 @@ async function runIntegrationRouteAfterHooks(
 function createQueryInput(searchParams: URLSearchParams): Record<string, string | string[]> {
   const input: Record<string, string | string[]> = {};
   searchParams.forEach((value, key) => {
+    if (key === "__proto__" || key === "constructor" || key === "prototype") return;
+
     const existing = input[key];
     if (existing === undefined) {
       input[key] = value;
@@ -2661,6 +2663,8 @@ function createFormInput(
 ): Record<string, FormDataEntryValue | FormDataEntryValue[]> {
   const input: Record<string, FormDataEntryValue | FormDataEntryValue[]> = {};
   formData.forEach((value, key) => {
+    if (key === "__proto__" || key === "constructor" || key === "prototype") return;
+
     const existing = input[key];
     if (existing === undefined) {
       input[key] = value;


### PR DESCRIPTION
## Summary

- discard __proto__, constructor, and prototype keys while parsing integration inputs
- apply the same protection to query strings and form bodies
- preserve repeated safe values and plain-object input semantics

## Testing

- pnpm --dir packages/farm exec vitest run src/__tests__/integrations.test.ts
- pnpm --dir packages/farm type-check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops `__proto__`, `constructor`, and `prototype` keys when parsing integration route query strings and form bodies, so they can no longer pollute object prototypes. Repeated safe keys still collect into arrays, and the resulting input objects keep a normal plain prototype.

<sup>Written for commit 579602f5b5eab35384f721d8f9c0331f930c35bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

