### PR TITLE
fix(middleware): preserve Max-Age=0 cookies

### DIFF
--- a/packages/farm/src/__tests__/middleware.test.ts
+++ b/packages/farm/src/__tests__/middleware.test.ts
@@ -1371,9 +1371,7 @@ describe("Cookie Management Advanced", () => {
 
     ctx.cookies.set("preview", "", { maxAge: 0 });
 
-    expect(res.setHeader).toHaveBeenCalledWith("Set-Cookie", [
-      "preview=; Max-Age=0; Path=/",
-    ]);
+    expect(res.setHeader).toHaveBeenCalledWith("Set-Cookie", ["preview=; Max-Age=0; Path=/"]);
   });
 
   it("should handle cookie expiration", () => {

--- a/packages/farm/src/__tests__/middleware.test.ts
+++ b/packages/farm/src/__tests__/middleware.test.ts
@@ -1364,6 +1364,18 @@ describe("Header Management Advanced", () => {
 });
 
 describe("Cookie Management Advanced", () => {
+  it("should preserve Max-Age=0 when expiring a cookie", () => {
+    const req = createMockRequest("/test");
+    const res = createMockResponse();
+    const ctx = createContext(req, res);
+
+    ctx.cookies.set("preview", "", { maxAge: 0 });
+
+    expect(res.setHeader).toHaveBeenCalledWith("Set-Cookie", [
+      "preview=; Max-Age=0; Path=/",
+    ]);
+  });
+
   it("should handle cookie expiration", () => {
     const req = createMockRequest("/test");
     const res = createMockResponse();

--- a/packages/farm/src/__tests__/production-middleware-http.test.ts
+++ b/packages/farm/src/__tests__/production-middleware-http.test.ts
@@ -7,6 +7,19 @@ import {
 } from "../middleware/production-runtime";
 
 describe("production middleware HTTP behavior", () => {
+  it("preserves Max-Age=0 when expiring a cookie", async () => {
+    const runner = createProductionMiddlewareRunner({
+      config: {
+        handler(ctx) {
+          ctx.cookies.set("preview", "", { maxAge: 0 });
+        },
+      },
+    });
+
+    const result = await runner(new Request("https://example.com/"));
+    expect(result.headers.getSetCookie()).toEqual(["preview=; Max-Age=0; Path=/"]);
+  });
+
   it("keeps multiple middleware cookies as separate Set-Cookie headers", async () => {
     const runner = createProductionMiddlewareRunner({
       config: {

--- a/packages/farm/src/middleware/context.ts
+++ b/packages/farm/src/middleware/context.ts
@@ -41,7 +41,7 @@ function parseCookies(cookieHeader?: string): Record<string, string> {
 function serializeCookie(name: string, value: string, options: CookieOptions = {}): string {
   let cookie = `${encodeURIComponent(name)}=${encodeURIComponent(value)}`;
 
-  if (options.maxAge) {
+  if (options.maxAge != null) {
     cookie += `; Max-Age=${options.maxAge}`;
   }
 

--- a/packages/farm/src/middleware/production-runtime.ts
+++ b/packages/farm/src/middleware/production-runtime.ts
@@ -132,7 +132,7 @@ function parseCookies(cookieHeader?: string | null): Record<string, string> {
 function serializeCookie(name: string, value: string, options: CookieOptions = {}): string {
   let cookie = `${encodeURIComponent(name)}=${encodeURIComponent(value)}`;
 
-  if (options.maxAge) cookie += `; Max-Age=${options.maxAge}`;
+  if (options.maxAge != null) cookie += `; Max-Age=${options.maxAge}`;
   if (options.expires) cookie += `; Expires=${options.expires.toUTCString()}`;
   cookie += `; Path=${options.path || "/"}`;
   if (options.domain) cookie += `; Domain=${options.domain}`;


### PR DESCRIPTION
## Summary

- serialize zero-valued Max-Age cookie options
- keep development and production middleware behavior aligned
- cover explicit cookie expiry in both middleware runtimes

## Testing

- pnpm --dir packages/farm exec vitest run src/__tests__/middleware.test.ts src/__tests__/production-middleware-http.test.ts
- pnpm --dir packages/farm type-check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cookie serialization so `Max-Age=0` cookies are now preserved, keeping dev and production middleware behavior aligned.

**Bug Fixes**
- Serializes zero-valued `Max-Age` options instead of dropping them.
- Adds tests for explicit cookie expiry in both middleware runtimes.

<sup>Written for commit da8b898b3f2f7c2b675c2c2e44b3ea4e5c7a2a5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

