### PR TITLE
fix(dev): emit API errors through observability

### DIFF
--- a/packages/farm/src/__tests__/api-route-manager.test.ts
+++ b/packages/farm/src/__tests__/api-route-manager.test.ts
@@ -64,6 +64,30 @@ describe("APIRouteManager", () => {
     await expect(response.text()).resolves.toBe("part-one\npart-two\n");
   });
 
+  it("can propagate endpoint errors to a framework lifecycle boundary", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-api-route-"));
+    tempDirs.push(root);
+
+    const routeDir = path.join(root, "api", "failure");
+    fs.mkdirSync(routeDir, { recursive: true });
+    const routeFile = path.join(routeDir, "route.js");
+    fs.writeFileSync(routeFile, "export {};\n");
+    const failure = new Error("API failure");
+
+    const manager = new APIRouteManager(root, {
+      ssrLoadModule: async () => ({
+        GET: async () => {
+          throw failure;
+        },
+      }),
+    } as any);
+
+    await manager.discoverRoutes();
+    const handler = manager.getHandler({ throwOnError: true });
+
+    await expect(handler!(new Request("http://example.com/api/failure"))).rejects.toBe(failure);
+  });
+
   it("passes raw request bodies to Next-style route handlers", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-api-route-"));
     tempDirs.push(root);

--- a/packages/farm/src/__tests__/development-observability.test.ts
+++ b/packages/farm/src/__tests__/development-observability.test.ts
@@ -66,7 +66,7 @@ describe("development OpenTelemetry tracing", () => {
         path.join(root, "node_modules", "react-dom"),
         "junction",
       );
-      await fs.mkdir(path.join(root, "src", "app"), { recursive: true });
+      await fs.mkdir(path.join(root, "src", "app", "api", "failure"), { recursive: true });
       await fs.writeFile(
         path.join(root, "package.json"),
         JSON.stringify({ private: true, type: "module" }, null, 2),
@@ -79,6 +79,10 @@ describe("development OpenTelemetry tracing", () => {
       await fs.writeFile(
         path.join(root, "src", "app", "page.tsx"),
         `import React from "react"; export default function Page() { return <main data-instrumentation={globalThis.__farmDevelopmentInstrumentation}>development tracing</main>; }`,
+      );
+      await fs.writeFile(
+        path.join(root, "src", "app", "api", "failure", "route.ts"),
+        `export async function GET() { throw new Error("development API failure"); }`,
       );
       await fs.writeFile(
         path.join(root, "src", "instrumentation.ts"),
@@ -156,6 +160,10 @@ await server.listen(Number(process.env.PORT));
       }
       expect(body).toContain('data-instrumentation="development:nodejs"');
 
+      const apiResponse = await fetch(`http://localhost:${port}/api/failure`);
+      expect(apiResponse.status).toBe(500);
+      await expect(apiResponse.json()).resolves.toEqual({ error: "Internal server error" });
+
       developmentServer.kill("SIGTERM");
       await new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(
@@ -188,6 +196,16 @@ await server.listen(Number(process.env.PORT));
       expect(requestSpan.events).toEqual(
         expect.arrayContaining(["request.start", "route.matched", "request.complete"]),
       );
+      const failedApiRequestSpan = spans.find((span) => span.name === "GET /api/failure");
+      expect(failedApiRequestSpan).toMatchObject({
+        attributes: {
+          "http.request.method": "GET",
+          "http.response.status_code": 500,
+          "http.route": "/api/failure",
+        },
+      });
+      expect(failedApiRequestSpan.events).toContain("api.error");
+      expect(failedApiRequestSpan.events).not.toContain("api.request.complete");
     } finally {
       if (developmentServer && developmentServer.exitCode === null) {
         developmentServer.kill("SIGKILL");

--- a/packages/farm/src/api/route-manager.ts
+++ b/packages/farm/src/api/route-manager.ts
@@ -26,6 +26,11 @@ export interface APIRouteManagerOptions {
   bodySizeLimit?: number;
 }
 
+export interface APIRouteHandlerOptions {
+  /** Let a framework request boundary report the original endpoint error. */
+  throwOnError?: boolean;
+}
+
 export const API_ROUTE_METHODS = [
   "GET",
   "HEAD",
@@ -287,7 +292,7 @@ export class APIRouteManager {
   /**
    * Get the handler that directly invokes endpoint handlers
    */
-  getHandler(): ((req: Request) => Promise<Response>) | null {
+  getHandler(options: APIRouteHandlerOptions = {}): ((req: Request) => Promise<Response>) | null {
     if (this.routes.size === 0) {
       return null;
     }
@@ -323,6 +328,7 @@ export class APIRouteManager {
         try {
           return await invokeAPIRouteEndpoint(endpoint, request, params, this.bodySizeLimit);
         } catch (error: any) {
+          if (options.throwOnError) throw error;
           console.error(`[API Error] ${pathname}:`, error);
           return new Response(JSON.stringify({ error: "Internal Server Error" }), {
             status: 500,

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -1562,7 +1562,9 @@ window.__FARM_MANIFEST__ = ${inlineValue({
               return;
             }
 
-            const apiHandler = apiRouteManager.getHandler();
+            // Let this request boundary observe endpoint failures before it
+            // converts them into the development 500 response below.
+            const apiHandler = apiRouteManager.getHandler({ throwOnError: true });
             const hasExplicitAPIRoute =
               hasMatchedApiRoute || Boolean(apiRouteManager.matchRoute(pathname));
             if (apiHandler && hasExplicitAPIRoute) {


### PR DESCRIPTION
## Summary

- let the Vite development request boundary receive original API endpoint exceptions
- run runtime plugin error hooks and emit `api.error` before returning the existing safe 500 response
- preserve the current standalone `APIRouteManager` behavior by making propagation opt-in
- add unit and spawned development-server regression coverage

## Why

`APIRouteManager.getHandler()` previously caught endpoint exceptions and returned a 500 response before the development lifecycle could observe them. Production emitted `api.error`, but development only logged the exception, so observability integrations such as Sentry could not capture it.

## Verification

- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/api-route-manager.test.ts src/__tests__/development-observability.test.ts`
- `pnpm exec oxfmt --check` on changed files
- `pnpm exec oxlint` on changed files

Closes #547


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes development API errors not reaching observability, so tools like Sentry can capture them in dev the same way they do in production.

`APIRouteManager.getHandler()` previously caught endpoint exceptions and returned a 500 response before the development lifecycle could observe them. The Vite request boundary now receives the original endpoint error, runs plugin error hooks, and emits `api.error` before returning the existing safe 500 response. Propagation is opt-in via a `throwOnError` option, so standalone `APIRouteManager` usage keeps its current behavior.

Closes #547.

<sup>Written for commit 176c3184d9acc53546488e2d5d4a599290343609. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

