### PR TITLE
feat(react): compile primitive prop updates

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -80,14 +80,16 @@ a few text or attribute values can change.
 
 For that safe subset, Farm prepares three things ahead of time:
 
-1. local state cells and their setters;
+1. local state cells plus read-only cells for eligible primitive props;
 2. the DOM path of every state-driven text or attribute binding; and
 3. the state-cell dependencies for each binding.
 
 After mount, an eligible local update flushes the changed cells and patches only the affected
-bindings. It does not schedule another React render or reconciliation pass for that update. React
-still owns initial rendering, component placement, parent-driven prop updates, events, SSR,
-hydration, and unmounting.
+bindings. A parent update still enters through React, but flat destructured `string`, `number`,
+`boolean`, `bigint`, `null`, or `undefined` props can reuse the mounted compiled render plan and
+patch the same dependency graph after commit. React still owns initial rendering, component
+placement, the parent update, events, SSR, hydration, and unmounting. Identity-bearing props and
+unsupported prop shapes keep the full React render path.
 
 ### Enable the compiler
 
@@ -351,7 +353,7 @@ satisfy all of these rules:
 | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | Component discovery | A top-level, capitalized function declaration, function expression, or arrow component in application `.tsx` or `.jsx`.                         |
 | Function shape      | Synchronous, non-generator, non-generic block body with zero parameters, one props identifier, or flat object props destructuring.              |
-| Props               | Flat object destructuring supports shorthand names, aliases, and defaults. Nested, computed, and rest patterns fall back.                       |
+| Props               | Flat object destructuring supports shorthand names, aliases, and defaults. Referenced primitive values join the dependency graph after mount.   |
 | Body                | Top-level `useState` declarations, optional compiler-safe derived values and synchronous named handlers, then one unconditional JSX return.     |
 | State               | `const [value, setValue] = useState(initial)`, including lazy initializers, multiple cells, and queued functional updates.                      |
 | Root                | Exactly one lowercase host JSX element such as `button`, `section`, `input`, or `div`.                                                          |
@@ -422,6 +424,41 @@ synchronous `const` function or function declaration. It is expanded when passed
 event or called from that event's inline function, including arguments such as
 `onClick={() => select(productId)}`. Calling it while producing the event prop, exposing it as a
 child, using it outside an event, or making it async/generic still falls back to React.
+
+#### Primitive prop cells
+
+Flat destructured props referenced by the compiled render are assigned read-only cells after the
+component's local state cells. The compiler includes those cell indexes in ordinary text,
+attribute, style, conditional, keyed-range, and component-island dependencies. For example:
+
+```tsx
+export function Total({ label, price, quantity, enabled }: TotalProps) {
+  const [discount, setDiscount] = useState(0);
+  const total = price * quantity - discount;
+
+  return (
+    <section data-enabled={enabled}>
+      <strong>
+        {label}: {total}
+      </strong>
+      {enabled && <span>Ready</span>}
+      <button onClick={() => setDiscount((value) => value + 1)}>Discount</button>
+    </section>
+  );
+}
+```
+
+When `label`, `price`, `quantity`, or `enabled` changes to another primitive, React commits the
+parent update, the compiled wrapper returns its already-mounted element, and the runtime commits
+the new prop cells. Only dependent targets or blocks refresh. `discount` and a prop change in the
+same turn share one coherent flush, so `total` observes both newest values.
+
+The optimization is deliberately runtime-guarded. If any tracked value is an object, array,
+function, symbol, React element, or `children`, the definition runs through normal React rendering
+and reconciliation for that update. Components using an identifier props parameter also retain
+the existing React prop path; flat destructuring is the current proof boundary. Props used only as
+`useState` initializers keep React's normal initialize-once semantics and are not turned into live
+state replacements. No extra option or annotation is required.
 
 Stateful styles use one inline object literal. The compiler creates a separate binding for each
 state-dependent camelCase property or CSS custom property, so changing `opacity` does not rewrite
@@ -1162,6 +1199,7 @@ row path; put Hooks inside a keyed row component.
 | Multiple/conditional returns or impure/control-flow statements                                                                        | The compiler only lowers a single, statically analyzable render path.              |
 | Derived calls, assignments, identity-bearing values, functions, or JSX                                                                | Their evaluation timing, side effects, or identity cannot yet be preserved safely. |
 | Nested, computed, or rest props destructuring                                                                                         | These patterns need additional parameter-shape and identity analysis.              |
+| Object, array, function, symbol, React-element, or `children` prop updates                                                            | Identity and child ownership stay on the full React render path.                   |
 | Async/generator/generic handlers or named handlers outside JSX events                                                                 | Their scheduling, identity, or closure semantics are outside the current lowering. |
 | Async/generator or generic components                                                                                                 | These function shapes are outside the current lowering.                            |
 | Setters called outside JSX event handlers                                                                                             | The compiler only controls and batches event-driven local updates.                 |
@@ -1187,14 +1225,15 @@ For each eligible component, the transform conceptually emits a definition like 
 ```ts
 createCompiledComponent({
   initialize: (props) => [props.initial],
-  render: (props, state) => <button>Count: {state[0].get()}</button>,
+  readProps: (props) => [props.label],
+  render: (_props, state) => <button>{state[1].get()}: {state[0].get()}</button>,
   bindings: [
     {
       kind: "text",
       path: [],
       target: 0,
-      dependencies: [0],
-      read: (_props, state) => ["Count: ", state[0].get()],
+      dependencies: [0, 1],
+      read: (_props, state) => [state[1].get(), ": ", state[0].get()],
     },
   ],
 });
@@ -1213,13 +1252,14 @@ follows:
 | --------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | Initial element creation, SSR markup, and hydration       | Local compiler-cell values                                                   |
 | JSX event registration and dispatch, including row events | Queuing local setter calls into one microtask                                |
-| Parent-driven prop updates                                | Comparing flushed values and selecting dependent bindings                    |
+| Parent update scheduling and commit                       | Primitive prop cells and their dependency-indexed patches                    |
+| Identity-bearing and unsupported prop reconciliation      | Reusing the mounted render plan for compiler-safe primitive prop updates     |
 | Unsupported trees, hooks, refs, handlers, and lifecycles  | Patching stable ref-owned text, attribute, and style targets                 |
 | Complex conditional branches, events, and nested blocks   | Host-only conditional identity, range placement, bindings, and replacement   |
 | Interactive or conditional-row structure and reorders     | Same-key row bindings, latest-item events, and changed conditional snapshots |
 | React-owned custom or structurally complex keyed rows     | Non-interactive host-row identity, bindings, insertion, removal, and LIS     |
 | Component render, Hooks, context, and lifecycle           | Refreshing only a dependent React component-island boundary                  |
-| Unmounting and the surrounding component tree             | Reapplying bindings after a parent-driven React update                       |
+| Unmounting and the surrounding component tree             | Committing prop and local cells together after a parent-driven update        |
 
 Queued functional setters preserve the event's state snapshot. Two calls such as
 `setCount(value => value + 1)` are applied in order during the same microtask flush, while reads
@@ -1274,9 +1314,13 @@ can move safely with the existing LIS path.
 Unsupported dynamic component types, refs, effects, and other unproven shapes keep React ownership;
 fallback is the optimization's correctness mechanism.
 
-Parent-driven prop updates also remain React updates. After React reconciles the new props, the
-runtime reapplies compiler-owned bindings from the current local cells so prop changes and local
-state remain coherent.
+Parent-driven updates remain React updates, but not every update needs a new compiled element tree.
+For compiler-emitted flat primitive prop cells, render-phase reads use a pending snapshot without
+mutating committed cells. React can abandon that render safely. After a successful commit, the
+runtime publishes the cells and refreshes their indexed bindings and blocks. Identity-bearing
+values skip this reuse path and receive normal React reconciliation. This split keeps prop changes
+and local state coherent without moving an imperative DOM write into React's abortable render
+phase.
 
 ### Verification and benchmark scope
 
@@ -1292,6 +1336,13 @@ The package and example test suites verify more than generated code:
 - Strict Mode mounting, queued-unmount cleanup, bubbled events, controlled input selection, and
   composition events preserve their React behavior;
 - simultaneous parent-prop and compiled-local updates remain coherent;
+- flat primitive prop transitions patch direct bindings and host conditionals without rebuilding
+  the compiled render plan, preserve focused selection and DOM identity, and match React across
+  deterministic string, number, boolean, and nullish transitions;
+- object and function prop identities retain the full React render path, while SSR hydration and
+  Strict Mode preserve the primitive prop optimization afterward;
+- nested fallback blocks read one coherent render snapshot, and an abandoned concurrent render
+  cannot publish prop cells or replace the last committed compiled element;
 - compatible Fast Refresh preserves state, while binding errors reach React error boundaries;
 - hydration mismatches follow React's recoverable-error path and remain interactive;
 - compiler-owned conditionals preserve a same-branch DOM instance, patch nested text, attributes,
@@ -1377,6 +1428,8 @@ The package and example test suites verify more than generated code:
   compiled owner remains at one execution;
 - the production browser experiment derives a keyed window from 2,048 source rows without
   rerunning the owner component or corrupting the existing compiler experiments;
+- the package reactivity benchmark updates one prop across 2,048 bindings, requires identical
+  first/last DOM output, and verifies one compiled render plan against 251 control render plans;
 - the production browser experiment also replaces and reorders interactive items, verifies current
   keyed DOM identity and capture/stop-propagation behavior, and observes zero owner update
   executions;
@@ -1417,8 +1470,9 @@ React commit, while a dependent component island still performs its required chi
 
 The [`examples/react-compiler`](https://github.com/farming-labs/farm.js/tree/main/examples/react-compiler)
 app contains batching, multiple-binding, common-syntax, calculated-style, controlled-form,
-automatic and explicit keyed-list, component-island, compiler-on/off, and heavy-interaction
-experiments. The standalone starter intentionally keeps the first experience focused.
+primitive-prop, automatic and explicit keyed-list, component-island, compiler-on/off, and
+heavy-interaction experiments. The standalone starter intentionally keeps the first experience
+focused.
 
 ## React-specific FARMJS APIs
 

--- a/examples/react-compiler/scripts/verify-experiment.mjs
+++ b/examples/react-compiler/scripts/verify-experiment.mjs
@@ -43,6 +43,7 @@ for (const component of [
   "NestedKeyedRowExperiment",
   "RecursiveKeyedScopeExperiment",
   "MixedRangeExperiment",
+  "PrimitivePropPanel",
 ]) {
   assert.ok(compiledComponents.has(component), `${component} was not compiled`);
 }
@@ -159,6 +160,37 @@ try {
   }
   assert.equal(batchExecutions["batch-compiled"].added, 0);
   assert.equal(batchExecutions["batch-react"].added, 1);
+
+  const primitiveProps = '[data-experiment="primitive-props"]';
+  const primitivePropsRoot = await page.locator(primitiveProps).elementHandle();
+  assert(primitivePropsRoot);
+  const primitiveInitialExecutions = await readNumber(
+    page,
+    `${primitiveProps} [data-metric="executions"]`,
+  );
+  await assertText(page, `${primitiveProps} h3`, "Compiled props A");
+  await assertText(page, `${primitiveProps} [data-metric="step"]`, "1");
+  await page.locator('[data-action="update-primitive-props"]').click();
+  await assertText(page, `${primitiveProps} h3`, "Compiled props B");
+  await assertText(page, `${primitiveProps} [data-metric="step"]`, "5");
+  await assertText(page, `${primitiveProps} [data-slot="status"]`, "Compiled props B is active");
+  assert.equal(await page.locator(primitiveProps).getAttribute("data-active"), "true");
+  assert(
+    await primitivePropsRoot.evaluate((element) =>
+      element.isSameNode(document.querySelector('[data-experiment="primitive-props"]')),
+    ),
+  );
+  await page.locator(`${primitiveProps} [data-action="local-prop-step"]`).click();
+  await assertText(page, `${primitiveProps} [data-metric="count"]`, "5");
+  await page.locator('[data-action="update-primitive-props"]').click();
+  await assertText(page, `${primitiveProps} h3`, "Compiled props A");
+  await page.locator(`${primitiveProps} [data-action="local-prop-step"]`).click();
+  await assertText(page, `${primitiveProps} [data-metric="count"]`, "6");
+  const primitiveFinalExecutions = await readNumber(
+    page,
+    `${primitiveProps} [data-metric="executions"]`,
+  );
+  assert.equal(primitiveFinalExecutions - primitiveInitialExecutions, 0);
 
   const multiple = '[data-experiment="multiple-bindings"]';
   const multipleInitialExecutions = await readNumber(
@@ -1703,6 +1735,14 @@ try {
             input: "value-1",
             updateExecutions:
               multipleFinalExecutions - multipleInitialExecutions,
+          },
+          primitiveProps: {
+            label: "Compiled props A",
+            localCount: 6,
+            currentStep: 1,
+            ownerDomIdentityPreserved: true,
+            renderPlanExecutions:
+              primitiveFinalExecutions - primitiveInitialExecutions,
           },
           commonSyntax: {
             count: 4,

--- a/examples/react-compiler/src/app/globals.css
+++ b/examples/react-compiler/src/app/globals.css
@@ -482,6 +482,43 @@ h1 span {
   background: rgb(184 255 91 / 0.08);
 }
 
+.primitive-prop-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem clamp(1.25rem, 3vw, 2rem);
+  border-bottom: 1px solid #33332f;
+  background: #0d0d0c;
+}
+
+.primitive-prop-toolbar > span {
+  color: #777771;
+  font-family: "Geist Mono Variable", ui-monospace, monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.primitive-prop-toolbar button {
+  min-height: 2.5rem;
+  border: 1px solid #b8ff5b;
+  padding: 0.65rem 0.9rem;
+  background: #b8ff5b;
+  color: #0a0a09;
+  cursor: pointer;
+  font-family: "Geist Mono Variable", ui-monospace, monospace;
+  font-size: 0.68rem;
+  font-weight: 600;
+  transition:
+    background 160ms ease,
+    color 160ms ease;
+}
+
+.primitive-prop-toolbar button:hover {
+  background: #d8ff9f;
+}
+
 .button-row {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -1631,6 +1668,11 @@ code {
 
   .heavy-heading {
     align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .primitive-prop-toolbar {
+    align-items: stretch;
     flex-direction: column;
   }
 

--- a/examples/react-compiler/src/app/page.tsx
+++ b/examples/react-compiler/src/app/page.tsx
@@ -8,6 +8,7 @@ import { HeavyInteractionBenchmark } from "../components/heavy-interaction-bench
 import { KeyedRowHostBlockExperiment } from "../components/keyed-row-host-block-experiment";
 import { MixedRangeExperiment } from "../components/mixed-range-experiment";
 import { NestedKeyedRowExperiment } from "../components/nested-keyed-row-experiment";
+import { PrimitivePropExperiment } from "../components/primitive-prop-experiment";
 import { RecursiveHostBlockExperiment } from "../components/recursive-host-block-experiment";
 import { RecursiveKeyedScopeExperiment } from "../components/recursive-keyed-scope-experiment";
 import { StaticBindingExperiment } from "../components/static-binding-experiment";
@@ -59,14 +60,16 @@ export default function HomePage() {
             <span>03 / FALL BACK</span>
             <h3>Keep React semantics</h3>
             <p>
-              React still owns SSR, hydration, events, props, placement, and
-              every structure the compiler cannot prove safe.
+              React still owns SSR, hydration, events, placement, parent
+              commits, and every value or structure the compiler cannot prove safe.
             </p>
           </article>
         </div>
       </section>
 
       <CompilerEdgeLab />
+
+      <PrimitivePropExperiment />
 
       <CommonSyntaxExperiment />
 

--- a/examples/react-compiler/src/components/primitive-prop-experiment.tsx
+++ b/examples/react-compiler/src/components/primitive-prop-experiment.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+
+let primitivePropExecutions = 0;
+
+interface PrimitivePropPanelProps {
+  active: boolean;
+  label: string;
+  step: number;
+}
+
+export function PrimitivePropPanel({ active, label, step }: PrimitivePropPanelProps) {
+  const [count, setCount] = useState(0);
+
+  return (
+    <article
+      className={active ? "edge-card edge-card--active" : "edge-card"}
+      data-active={active}
+      data-experiment="primitive-props"
+    >
+      <header>
+        <span className="experiment-number">PROP</span>
+        <div>
+          <h3>{label}</h3>
+          <p>Flat primitive props share the prepared state dependency graph.</p>
+        </div>
+      </header>
+      <dl className="compact-metrics" aria-live="polite">
+        <div>
+          <dt>Local count</dt>
+          <dd data-metric="count">{count}</dd>
+        </div>
+        <div>
+          <dt>Current step</dt>
+          <dd data-metric="step">{step}</dd>
+        </div>
+        <div>
+          <dt>Render plans</dt>
+          <dd data-metric="executions">
+            {typeof window === "undefined" ? 1 : ++primitivePropExecutions}
+          </dd>
+        </div>
+      </dl>
+      <div className="binding-preview" data-slot="status">
+        {active ? <strong>{label} is active</strong> : <span>{label} is idle</span>}
+      </div>
+      <button
+        data-action="local-prop-step"
+        onClick={() => setCount((value) => value + step)}
+        type="button"
+      >
+        Apply current step
+      </button>
+    </article>
+  );
+}
+
+export function PrimitivePropExperiment() {
+  "use no compiler";
+
+  const [version, setVersion] = useState(0);
+  const active = version % 2 === 1;
+  const label = active ? "Compiled props B" : "Compiled props A";
+  const step = active ? 5 : 1;
+
+  return (
+    <section className="edge-lab" aria-labelledby="primitive-props-title">
+      <div className="section-heading">
+        <span>PRIMITIVE PROP REACTIVITY</span>
+        <h2 id="primitive-props-title">Parent data, without rebuilding the compiled plan.</h2>
+        <p>
+          Change the string, number, and boolean props together. The mounted host tree and local
+          state remain in place; objects, functions, symbols, and children still use React.
+        </p>
+      </div>
+      <div className="edge-grid edge-grid--paired edge-grid--single">
+        <div className="primitive-prop-shell">
+          <div className="primitive-prop-toolbar">
+            <span>Parent source / version {version}</span>
+            <button
+              data-action="update-primitive-props"
+              onClick={() => setVersion((value) => value + 1)}
+              type="button"
+            >
+              Update parent props
+            </button>
+          </div>
+          <PrimitivePropPanel active={active} label={label} step={step} />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -64,6 +64,7 @@ The current compiler handles components that it can prove have:
 - one host-element root and a statically known host-element tree around supported conditional,
   keyed-list, and React component-island boundaries;
 - an identifier props parameter or flat object destructuring with aliases and defaults;
+- build-time dependency cells for referenced flat primitive props, with runtime identity guards;
 - top-level `useState` declarations;
 - optional compiler-safe derived `const` values declared after state and in source order;
 - whitelisted `Boolean`, `Number`, `String`, and deterministic `Math` calculations;
@@ -81,9 +82,12 @@ The current compiler handles components that it can prove have:
 - React-managed event handlers; and
 - no refs, effects, or unsupported dynamic child structures.
 
-The generated component preserves React ownership of initial placement, props, events, SSR, and
-hydration. Local state cells batch updates into a microtask, use dependency-indexed subscriptions,
-skip unchanged binding output, and patch only compiler-known DOM targets. Proven host containers
+The generated component preserves React ownership of initial placement, parent update commits,
+identity-bearing props, events, SSR, and hydration. Local state cells batch updates into a
+microtask; eligible flat destructured primitive props join the same dependency index after React
+commits their parent update. The runtime skips unchanged binding output and patches only
+compiler-known DOM targets. Objects, arrays, functions, symbols, React elements, `children`, and
+identifier props retain the normal React prop-render path. Proven host containers
 can transfer child ownership after mount for host-only conditional
 branches and ranges, plus non-interactive host-only keyed rows and their recursively nested host
 conditions. An interactive row uses a hybrid boundary instead: React retains its events,

--- a/packages/farm-react/scripts/benchmark-reactivity.mjs
+++ b/packages/farm-react/scripts/benchmark-reactivity.mjs
@@ -181,12 +181,103 @@ async function measureIndexedScheduling(reactivity) {
   }
 }
 
+function mountPrimitivePropFanout(compiled) {
+  let renderPlans = 0;
+  let bindingReads = 0;
+  let value = 0;
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  let View;
+
+  if (compiled) {
+    const bindings = Array.from({ length: bindingCount }, (_, index) => ({
+      kind: "text",
+      path: [index],
+      target: index,
+      dependencies: [1],
+      read(_props, state) {
+        bindingReads += 1;
+        return state[1].get();
+      },
+    }));
+    View = createCompiledComponent({
+      displayName: "PrimitivePropFanout",
+      reactivity: "hybrid",
+      initialize: () => [0],
+      readProps: (props) => [props.value],
+      render(_props, state, blocks) {
+        renderPlans += 1;
+        return React.createElement(
+          "div",
+          null,
+          ...bindings.map((binding, index) =>
+            React.createElement(
+              "span",
+              { key: index, ref: blocks.target(binding.target) },
+              state[1].get(),
+            ),
+          ),
+        );
+      },
+      bindings,
+    });
+  } else {
+    View = function ReactPrimitivePropFanout(props) {
+      renderPlans += 1;
+      return React.createElement(
+        "div",
+        null,
+        ...Array.from({ length: bindingCount }, (_, index) =>
+          React.createElement("span", { key: index }, props.value),
+        ),
+      );
+    };
+  }
+
+  flushSync(() => root.render(React.createElement(View, { value })));
+  return {
+    bindingReads: () => bindingReads,
+    container,
+    renderPlans: () => renderPlans,
+    update() {
+      value += 1;
+      flushSync(() => root.render(React.createElement(View, { value })));
+    },
+    value: () => value,
+    unmount() {
+      flushSync(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+async function measurePrimitiveProps(compiled) {
+  const fixture = mountPrimitivePropFanout(compiled);
+  try {
+    const timing = await measure(async () => fixture.update());
+    const first = fixture.container.querySelector("span")?.textContent;
+    const last = fixture.container.querySelector("span:last-child")?.textContent;
+    return {
+      ...timing,
+      bindingReads: fixture.bindingReads(),
+      finalValue: fixture.value(),
+      outputCorrect: first === String(fixture.value()) && last === String(fixture.value()),
+      renderPlans: fixture.renderPlans(),
+    };
+  } finally {
+    fixture.unmount();
+  }
+}
+
 const staticCold = await measureBranchAction("static", 2);
 const hybridCold = await measureBranchAction("hybrid", 2);
 const staticActive = await measureBranchAction("static", 1);
 const hybridActive = await measureBranchAction("hybrid", 1);
 const staticIndexed = await measureIndexedScheduling("static");
 const hybridIndexed = await measureIndexedScheduling("hybrid");
+const reactPrimitiveProps = await measurePrimitiveProps(false);
+const compiledPrimitiveProps = await measurePrimitiveProps(true);
 
 const totalMeasuredUpdates = measuredSamples * updatesPerSample;
 const report = {
@@ -211,6 +302,11 @@ const report = {
     static: staticIndexed,
     hybrid: hybridIndexed,
   },
+  primitiveProps: {
+    react: reactPrimitiveProps,
+    compiled: compiledPrimitiveProps,
+    speedup: reactPrimitiveProps.medianMs / compiledPrimitiveProps.medianMs,
+  },
 };
 
 console.log(JSON.stringify(report, null, 2));
@@ -229,4 +325,21 @@ if (staticIndexed.bindingReads !== (warmupSamples + measuredSamples) * updatesPe
 }
 if (hybridIndexed.bindingReads !== (warmupSamples + measuredSamples) * updatesPerSample) {
   throw new Error("Hybrid dependency indexing evaluated unrelated bindings.");
+}
+if (!reactPrimitiveProps.outputCorrect || !compiledPrimitiveProps.outputCorrect) {
+  throw new Error("Primitive prop benchmark did not converge on the expected DOM output.");
+}
+if (compiledPrimitiveProps.renderPlans !== 1) {
+  throw new Error(
+    `Compiled primitive prop updates rebuilt ${compiledPrimitiveProps.renderPlans} render plans.`,
+  );
+}
+if (reactPrimitiveProps.renderPlans !== 1 + (warmupSamples + measuredSamples) * updatesPerSample) {
+  throw new Error("React primitive prop control did not rerender once per measured update.");
+}
+if (
+  compiledPrimitiveProps.bindingReads !==
+  bindingCount * (warmupSamples + measuredSamples) * updatesPerSample
+) {
+  throw new Error("Compiled primitive prop updates did not patch every declared binding.");
 }

--- a/packages/farm-react/src/__tests__/compiler-keyed-row-host-blocks.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-row-host-blocks.test.ts
@@ -123,8 +123,9 @@ describe("React AOT compiler-owned keyed-row host blocks", () => {
 
     expect(result.compiled).toEqual(["Inbox"]);
     expect(result.code).toContain("hostBlocks={true}");
-    expect(result.code).toMatch(/dependencies: \[0, 1\]/);
-    expect(result.code).toContain("_props.suffix");
+    expect(result.code).toMatch(/dependencies: \[0, 1, 2\]/);
+    expect(result.code).toContain("readProps: _props => [_props.suffix]");
+    expect(result.code).toContain("_farmState[2].get()");
   });
 
   it.each([

--- a/packages/farm-react/src/__tests__/compiler-runtime-prop-reactivity.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-prop-reactivity.test.tsx
@@ -1,0 +1,528 @@
+import React, { startTransition, StrictMode, Suspense, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createCompiledComponent } from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+const roots = new Set<Root>();
+
+function trackRoot(root: Root): Root {
+  roots.add(root);
+  return root;
+}
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots) root.unmount();
+  });
+  roots.clear();
+  document.body.replaceChildren();
+});
+
+describe("compiled primitive prop reactivity", () => {
+  it("patches text, attributes, styles, and controlled values without rerunning the render plan", async () => {
+    interface Props {
+      active: boolean;
+      label: string;
+      width: number;
+    }
+
+    let renderPlans = 0;
+    let updateParent: React.Dispatch<React.SetStateAction<Props>> = () => undefined;
+    const Counter = createCompiledComponent<Props>({
+      displayName: "PrimitivePropCounter",
+      initialize: () => [0],
+      readProps: (props) => [props.label, props.active, props.width],
+      render(_props, state) {
+        renderPlans += 1;
+        return (
+          <section data-active={state[2].get()} style={{ width: Number(state[3].get()) }}>
+            <button onClick={() => state[0].set((value) => Number(value) + 1)}>Local</button>
+            <output>
+              {String(state[1].get())}:{Number(state[0].get())}
+            </output>
+            <input value={String(state[1].get())} onChange={() => undefined} />
+          </section>
+        );
+      },
+      bindings: [
+        {
+          kind: "attribute",
+          path: [],
+          name: "data-active",
+          dependencies: [2],
+          read: (_p, state) => state[2].get(),
+        },
+        {
+          kind: "style",
+          path: [],
+          name: "width",
+          dependencies: [3],
+          read: (_p, state) => state[3].get(),
+        },
+        {
+          kind: "text",
+          path: [1],
+          dependencies: [0, 1],
+          read: (_p, state) => [state[1].get(), ":", state[0].get()],
+        },
+        {
+          kind: "attribute",
+          path: [2],
+          name: "value",
+          dependencies: [1],
+          read: (_p, state) => state[1].get(),
+        },
+      ],
+    });
+
+    function Parent() {
+      const [props, setProps] = useState<Props>({ active: false, label: "before", width: 120 });
+      updateParent = setProps;
+      return <Counter {...props} />;
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = trackRoot(createRoot(container));
+    await act(async () => root.render(<Parent />));
+    const initialRenderPlans = renderPlans;
+    const section = container.querySelector("section");
+    const input = container.querySelector("input")!;
+    input.focus();
+    input.setSelectionRange(2, 4);
+
+    await act(async () => {
+      updateParent({ active: true, label: "after", width: 240 });
+      await flushCompilerUpdates();
+    });
+
+    expect(renderPlans).toBe(initialRenderPlans);
+    expect(container.querySelector("section")).toBe(section);
+    expect(container.querySelector("input")).toBe(input);
+    expect(section?.getAttribute("data-active")).toBe("true");
+    expect((section as HTMLElement).style.width).toBe("240px");
+    expect(container.querySelector("output")?.textContent).toBe("after:0");
+    expect(input.value).toBe("after");
+    expect(input.selectionStart).toBe(2);
+    expect(input.selectionEnd).toBe(4);
+
+    await act(async () => {
+      container.querySelector("button")!.click();
+      updateParent((current) => ({ ...current, label: "together" }));
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector("output")?.textContent).toBe("together:1");
+    expect(renderPlans).toBe(initialRenderPlans);
+  });
+
+  it("updates a prop-driven host conditional without rerunning its owner plan", async () => {
+    interface Props {
+      enabled: boolean;
+      label: string;
+    }
+
+    let renderPlans = 0;
+    let updateParent: React.Dispatch<React.SetStateAction<Props>> = () => undefined;
+    const Conditional = createCompiledComponent<Props>({
+      displayName: "PropConditional",
+      initialize: () => [0],
+      readProps: (props) => [props.enabled, props.label],
+      render(_props, state, blocks) {
+        renderPlans += 1;
+        const HostConditional = blocks.HostConditional;
+        return (
+          <article>
+            <HostConditional
+              id={0}
+              render={() => (
+                <div>
+                  {state[1].get() ? <strong>{String(state[2].get())}</strong> : <span>Off</span>}
+                </div>
+              )}
+              test={() => state[1].get()}
+              truthy={{
+                create: () => ({
+                  kind: "element",
+                  tag: "strong",
+                  attributes: [],
+                  styles: [],
+                  children: [state[2].get()],
+                }),
+                bindings: [{ kind: "text", path: [], read: () => state[2].get() }],
+              }}
+              falsy={{
+                create: () => ({
+                  kind: "element",
+                  tag: "span",
+                  attributes: [],
+                  styles: [],
+                  children: ["Off"],
+                }),
+                bindings: [],
+              }}
+            />
+          </article>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [1, 2] }],
+    });
+
+    function Parent() {
+      const [props, setProps] = useState<Props>({ enabled: false, label: "Before" });
+      updateParent = setProps;
+      return <Conditional {...props} />;
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = trackRoot(createRoot(container));
+    await act(async () => root.render(<Parent />));
+    const initialRenderPlans = renderPlans;
+
+    await act(async () => {
+      updateParent({ enabled: true, label: "After" });
+      await flushCompilerUpdates();
+    });
+    await flushCompilerUpdates();
+
+    expect(container.querySelector("strong")?.textContent).toBe("After");
+    expect(renderPlans).toBe(initialRenderPlans);
+
+    await act(async () => {
+      updateParent({ enabled: false, label: "Hidden" });
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("span")?.textContent).toBe("Off");
+    expect(renderPlans).toBe(initialRenderPlans);
+  });
+
+  it("falls back to a full React render for object and function prop identities", async () => {
+    interface Props {
+      format(value: string): string;
+      item: { label: string };
+    }
+
+    let renderPlans = 0;
+    let updateParent: React.Dispatch<React.SetStateAction<Props>> = () => undefined;
+    const IdentityProps = createCompiledComponent<Props>({
+      displayName: "IdentityProps",
+      initialize: () => [0],
+      readProps: (props) => [props.item, props.format],
+      render(_props, state) {
+        renderPlans += 1;
+        const item = state[1].get() as Props["item"];
+        const format = state[2].get() as Props["format"];
+        return <output>{format(item.label)}</output>;
+      },
+      bindings: [
+        {
+          kind: "text",
+          path: [],
+          dependencies: [1, 2],
+          read: (_props, state) => {
+            const item = state[1].get() as Props["item"];
+            const format = state[2].get() as Props["format"];
+            return format(item.label);
+          },
+        },
+      ],
+    });
+
+    function Parent() {
+      const [props, setProps] = useState<Props>({
+        item: { label: "one" },
+        format: (value) => value.toUpperCase(),
+      });
+      updateParent = setProps;
+      return <IdentityProps {...props} />;
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = trackRoot(createRoot(container));
+    await act(async () => root.render(<Parent />));
+    const initialRenderPlans = renderPlans;
+
+    await act(async () => {
+      updateParent({ item: { label: "two" }, format: (value) => `[${value}]` });
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("[two]");
+    expect(renderPlans).toBe(initialRenderPlans + 1);
+  });
+
+  it("keeps identity-value snapshots coherent inside nested compiled blocks", async () => {
+    interface Model {
+      label: string;
+      visible: boolean;
+    }
+    interface Props {
+      model: Model;
+    }
+
+    let updateParent: React.Dispatch<React.SetStateAction<Model>> = () => undefined;
+    const NestedIdentity = createCompiledComponent<Props>({
+      displayName: "NestedIdentityProps",
+      initialize: () => [0],
+      readProps: (props) => [props.model],
+      render(_props, state, blocks) {
+        const HostConditional = blocks.HostConditional;
+        return (
+          <article>
+            <HostConditional
+              id={0}
+              render={() => {
+                const model = state[1].get() as Model;
+                return (
+                  <div>{model.visible ? <strong>{model.label}</strong> : <span>Hidden</span>}</div>
+                );
+              }}
+              test={() => (state[1].get() as Model).visible}
+              truthy={{
+                create: () => ({
+                  kind: "element",
+                  tag: "strong",
+                  attributes: [],
+                  styles: [],
+                  children: [(state[1].get() as Model).label],
+                }),
+                bindings: [
+                  {
+                    kind: "text",
+                    path: [],
+                    read: () => (state[1].get() as Model).label,
+                  },
+                ],
+              }}
+              falsy={{
+                create: () => ({
+                  kind: "element",
+                  tag: "span",
+                  attributes: [],
+                  styles: [],
+                  children: ["Hidden"],
+                }),
+                bindings: [],
+              }}
+            />
+          </article>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [1] }],
+    });
+
+    function Parent() {
+      const [model, setModel] = useState<Model>({ label: "Before", visible: false });
+      updateParent = setModel;
+      return <NestedIdentity model={model} />;
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = trackRoot(createRoot(container));
+    await act(async () => root.render(<Parent />));
+
+    await act(async () => {
+      updateParent({ label: "After", visible: true });
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector("strong")?.textContent).toBe("After");
+    expect(container.querySelector("span")).toBeNull();
+  });
+
+  it("does not cache an abandoned concurrent prop render", async () => {
+    type Value = string | { label: string };
+    interface Props {
+      value: Value;
+    }
+
+    let setValue: React.Dispatch<React.SetStateAction<Value>> = () => undefined;
+    let releaseSuspension = () => undefined;
+    const suspension = new Promise<void>((resolve) => {
+      releaseSuspension = resolve;
+    });
+
+    function Suspender({ active }: { active: boolean }) {
+      if (active) throw suspension;
+      return null;
+    }
+
+    const ConcurrentValue = createCompiledComponent<Props>({
+      displayName: "ConcurrentPrimitiveProp",
+      initialize: () => [0],
+      readProps: (props) => [props.value],
+      render(_props, state) {
+        const value = state[1].get() as Value;
+        return (
+          <section>
+            <output>{typeof value === "string" ? value : value.label}</output>
+            <Suspender active={typeof value === "object"} />
+          </section>
+        );
+      },
+      bindings: [
+        {
+          kind: "text",
+          path: [0],
+          dependencies: [1],
+          read: (_props, state) => {
+            const value = state[1].get() as Value;
+            return typeof value === "string" ? value : value.label;
+          },
+        },
+      ],
+    });
+
+    function Parent() {
+      const [value, updateValue] = useState<Value>("before");
+      setValue = updateValue;
+      return (
+        <Suspense fallback={<p>Loading</p>}>
+          <ConcurrentValue value={value} />
+        </Suspense>
+      );
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = trackRoot(createRoot(container));
+    await act(async () => root.render(<Parent />));
+
+    await act(async () => {
+      startTransition(() => setValue({ label: "abandoned" }));
+      await Promise.resolve();
+    });
+    expect(container.textContent).toBe("before");
+
+    await act(async () => {
+      setValue("after");
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("after");
+    expect(container.querySelector("p")).toBeNull();
+
+    await act(async () => releaseSuspension());
+  });
+
+  it("matches React through deterministic primitive and nullish prop transitions", async () => {
+    type Value = string | number | boolean | null | undefined;
+    interface Props {
+      value: Value;
+    }
+
+    let compiledPlans = 0;
+    let setCompiled: React.Dispatch<React.SetStateAction<Value>> = () => undefined;
+    let setBaseline: React.Dispatch<React.SetStateAction<Value>> = () => undefined;
+    const CompiledValue = createCompiledComponent<Props>({
+      displayName: "RandomPrimitiveProps",
+      initialize: () => [0],
+      readProps: (props) => [props.value],
+      render(_props, state) {
+        compiledPlans += 1;
+        return <output>{String(state[1].get())}</output>;
+      },
+      bindings: [
+        { kind: "text", path: [], dependencies: [1], read: (_p, state) => String(state[1].get()) },
+      ],
+    });
+    function CompiledParent() {
+      const [value, setValue] = useState<Value>(null);
+      setCompiled = setValue;
+      return <CompiledValue value={value} />;
+    }
+    function BaselineParent() {
+      const [value, setValue] = useState<Value>(null);
+      setBaseline = setValue;
+      return <output>{String(value)}</output>;
+    }
+
+    const compiledContainer = document.createElement("div");
+    const baselineContainer = document.createElement("div");
+    document.body.append(compiledContainer, baselineContainer);
+    const compiledRoot = trackRoot(createRoot(compiledContainer));
+    const baselineRoot = trackRoot(createRoot(baselineContainer));
+    await act(async () => {
+      compiledRoot.render(
+        <StrictMode>
+          <CompiledParent />
+        </StrictMode>,
+      );
+      baselineRoot.render(<BaselineParent />);
+    });
+    const initialPlans = compiledPlans;
+    const values: Value[] = [undefined, "", "farm", 0, -1, 42.5, false, true, null];
+
+    for (let index = 0; index < 256; index += 1) {
+      const next = values[(index * 17 + 5) % values.length];
+      await act(async () => {
+        setCompiled(next);
+        setBaseline(next);
+        await flushCompilerUpdates();
+      });
+      expect(compiledContainer.textContent).toBe(baselineContainer.textContent);
+    }
+
+    expect(compiledPlans).toBe(initialPlans);
+  });
+
+  it("hydrates first and preserves the primitive prop path afterward", async () => {
+    interface Props {
+      label: string;
+    }
+    let renderPlans = 0;
+    const Hydrated = createCompiledComponent<Props>({
+      displayName: "HydratedPrimitiveProp",
+      initialize: () => [0],
+      readProps: (props) => [props.label],
+      render(_props, state) {
+        renderPlans += 1;
+        return <output>{String(state[1].get())}</output>;
+      },
+      bindings: [
+        { kind: "text", path: [], dependencies: [1], read: (_p, state) => state[1].get() },
+      ],
+    });
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(<Hydrated label="server" />);
+    document.body.append(container);
+    let updateParent: React.Dispatch<React.SetStateAction<string>> = () => undefined;
+    function Parent() {
+      const [label, setLabel] = useState("server");
+      updateParent = setLabel;
+      return <Hydrated label={label} />;
+    }
+
+    let root!: Root;
+    await act(async () => {
+      root = hydrateRoot(container, <Parent />);
+      await flushCompilerUpdates();
+    });
+    trackRoot(root);
+    const hydratedPlans = renderPlans;
+    await act(async () => {
+      updateParent("client");
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("client");
+    expect(renderPlans).toBe(hydratedPlans);
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler.test.ts
+++ b/packages/farm-react/src/__tests__/compiler.test.ts
@@ -123,6 +123,106 @@ describe("React AOT compiler", () => {
     });
   });
 
+  it("adds flat render props to the compiled dependency graph", async () => {
+    const result = await compileReactModule(
+      `
+        import { useState } from "react";
+        export function PropCounter({
+          initial = 1,
+          label: title,
+          multiplier,
+          active,
+        }: {
+          initial?: number;
+          label: string;
+          multiplier: number;
+          active: boolean;
+        }) {
+          const [count, setCount] = useState(initial);
+          const total = count * multiplier;
+          return (
+            <button
+              className={active ? "active" : "idle"}
+              onClick={() => setCount((value) => value + 1)}
+            >{title}: {total}</button>
+          );
+        }
+      `,
+      "/app/PropCounter.tsx",
+      infer,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("readProps:");
+    expect(result.code).toContain('stateSignature: "1:title,multiplier,active"');
+    expect(result.code).toMatch(
+      /readProps: _props => \[_props\.title, _props\.multiplier, _props\.active\]/,
+    );
+    expect(result.code).toContain("dependencies: [0, 1, 2]");
+    expect(result.code).toContain("dependencies: [3]");
+    expect(result.code).toMatch(/farmState\[1\]\.get/);
+    expect(result.code).toMatch(/farmState\[2\]\.get/);
+    expect(result.code).toMatch(/farmState\[3\]\.get/);
+    expect(result.code).not.toMatch(/readProps: props => \[[^\]]*props\.initial/);
+  });
+
+  it("keeps children and identifier props on React's normal prop path", async () => {
+    const [childrenResult, identifierResult] = await Promise.all([
+      compileReactModule(
+        `
+          import { useState } from "react";
+          export function ChildBoundary({ children }: { children: React.ReactNode }) {
+            const [active, setActive] = useState(false);
+            return <button onClick={() => setActive(!active)}>{active ? children : "empty"}</button>;
+          }
+        `,
+        "/app/ChildBoundary.tsx",
+        infer,
+      ),
+      compileReactModule(
+        `
+          import { useState } from "react";
+          export function IdentifierProps(props: { label: string }) {
+            const [count, setCount] = useState(0);
+            return <button onClick={() => setCount(count + 1)}>{props.label}: {count}</button>;
+          }
+        `,
+        "/app/IdentifierProps.tsx",
+        infer,
+      ),
+    ]);
+
+    expect(childrenResult.diagnostics).toEqual([]);
+    expect(identifierResult.diagnostics).toEqual([]);
+    expect(childrenResult.code).not.toContain("readProps:");
+    expect(identifierResult.code).not.toContain("readProps:");
+  });
+
+  it("keeps the existing compiled component when a prop-cell shape is not yet supported", async () => {
+    const result = await compileReactModule(
+      `
+        import { useState } from "react";
+        export function ControlledLabel({ label = "Name" }: { label?: string }) {
+          const [value, setValue] = useState("");
+          return (
+            <label>
+              {label}
+              <input value={value} onInput={(event) => setValue(event.currentTarget.value)} />
+            </label>
+          );
+        }
+      `,
+      "/app/ControlledLabel.tsx",
+      infer,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.compiled).toEqual(["ControlledLabel"]);
+    expect(result.code).not.toContain("readProps:");
+    expect(result.code).toContain("_props.label");
+    expect(result.code).toMatch(/dependencies: \[0\]/);
+  });
+
   it("compiles destructured props and named synchronous event handlers", async () => {
     const result = await compileReactModule(
       `

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -12,7 +12,12 @@ export interface CompilerCell {
 
 interface RuntimeCell extends CompilerCell {
   flush(): boolean;
+  replace(next: unknown): void;
 }
+
+type PendingCellUpdate =
+  | { kind: "state"; update: CompilerStateUpdater }
+  | { kind: "value"; value: unknown };
 
 type SelectableTextControl = HTMLInputElement | HTMLTextAreaElement;
 
@@ -294,6 +299,11 @@ export interface CompiledComponentDefinition<Props> {
   /** Changes when the compiler-owned state layout is no longer refresh-compatible. */
   stateSignature?: string;
   initialize(props: Props): readonly unknown[];
+  /**
+   * Compiler-emitted flat prop reads. Primitive values can share the local
+   * dependency graph; identity-bearing values retain normal React rendering.
+   */
+  readProps?(props: Props): readonly unknown[];
   render(
     props: Props,
     state: readonly CompilerCell[],
@@ -330,6 +340,18 @@ function renderTextValue(value: unknown): string {
   if (Array.isArray(value)) return value.map(renderTextValue).join("");
   if (value === null || value === undefined || typeof value === "boolean") return "";
   return String(value);
+}
+
+function isCompilerPrimitive(value: unknown): boolean {
+  if (value === null) return true;
+  const kind = typeof value;
+  return (
+    kind === "string" ||
+    kind === "number" ||
+    kind === "boolean" ||
+    kind === "bigint" ||
+    kind === "undefined"
+  );
 }
 
 function findBindingTarget(
@@ -3948,7 +3970,7 @@ export function createCompiledComponent<Props>(
   const definitionReference: CompiledDefinitionReference<Props> = { current: definition };
   const refreshListeners = new Set<() => void>();
 
-  class FarmCompiledComponent extends React.Component<Props> {
+  class FarmCompiledComponent extends React.Component<Props, Record<string, never>, boolean> {
     private root: Element | null = null;
     private mounted = false;
     private flushQueued = false;
@@ -3966,6 +3988,9 @@ export function createCompiledComponent<Props>(
     private activeBinding: CompilerBinding<Props> | null = null;
     private activeDependencies: Set<number> | null = null;
     private readonly cells: RuntimeCell[];
+    private readonly propCellOffset: number;
+    private renderedDefinition: CompiledComponentDefinition<Props> | null = null;
+    private renderedElement: React.ReactElement | null = null;
     private readonly blockRefreshListeners = new Map<number, CompilerBlockRefresh>();
     private readonly blockRoots = new Map<number, Element>();
     private readonly blockRootElements = new Set<Element>();
@@ -3975,9 +4000,12 @@ export function createCompiledComponent<Props>(
 
     constructor(props: Props) {
       super(props);
-      this.cells = definitionReference.current.initialize(props).map((initialValue, index) => {
+      const initialState = definitionReference.current.initialize(props);
+      const initialProps = definitionReference.current.readProps?.(props) || [];
+      this.propCellOffset = initialState.length;
+      this.cells = [...initialState, ...initialProps].map((initialValue, index) => {
         let value = initialValue;
-        const pending: CompilerStateUpdater[] = [];
+        const pending: PendingCellUpdate[] = [];
         return {
           get: () => {
             if (this.activeBinding && this.activeDependencies) {
@@ -3986,14 +4014,21 @@ export function createCompiledComponent<Props>(
             return value;
           },
           set: (next) => {
-            pending.push(next);
+            pending.push({ kind: "state", update: next });
             this.scheduleBindingFlush(index);
+          },
+          replace: (next) => {
+            pending.push({ kind: "value", value: next });
           },
           flush: () => {
             if (pending.length === 0) return false;
             const previous = value;
             for (const next of pending.splice(0)) {
-              value = typeof next === "function" ? next(value) : next;
+              if (next.kind === "value") {
+                value = next.value;
+              } else {
+                value = typeof next.update === "function" ? next.update(value) : next.update;
+              }
             }
             return !Object.is(previous, value);
           },
@@ -4031,6 +4066,46 @@ export function createCompiledComponent<Props>(
 
     private usesHybridReactivity(): boolean {
       return definitionReference.current.reactivity === "hybrid";
+    }
+
+    private canReuseRenderedElement(
+      currentDefinition: CompiledComponentDefinition<Props>,
+      propValues: readonly unknown[] | null,
+    ): boolean {
+      return Boolean(
+        this.mounted &&
+        propValues &&
+        propValues.every(isCompilerPrimitive) &&
+        this.renderedDefinition === currentDefinition &&
+        this.renderedElement,
+      );
+    }
+
+    private renderCellsForProps(propValues: readonly unknown[] | null): {
+      cells: readonly CompilerCell[];
+      commit(): void;
+    } {
+      if (!propValues) return { cells: this.cells, commit: () => undefined };
+      // A full React render must see its own prop snapshot, including inside
+      // nested block render callbacks. The view switches to committed cells
+      // only when its root ref is attached, so an abandoned render cannot
+      // publish values or replace the reusable element.
+      let committed = false;
+      const cells: CompilerCell[] = this.cells.slice(0, this.propCellOffset);
+      for (let propIndex = 0; propIndex < propValues.length; propIndex += 1) {
+        const cell = this.cells[this.propCellOffset + propIndex];
+        if (!cell) continue;
+        cells.push({
+          get: () => (committed ? cell.get() : propValues[propIndex]),
+          set: (next) => cell.set(next),
+        });
+      }
+      return {
+        cells,
+        commit: () => {
+          committed = true;
+        },
+      };
     }
 
     private tracksBinding(
@@ -4199,75 +4274,75 @@ export function createCompiledComponent<Props>(
       this.flushQueued = true;
       queueMicrotask(() => {
         this.flushQueued = false;
-        const inputSelection = this.inputSelection;
-        this.inputSelection = null;
-        if (!this.mounted) return;
-        const dirty = new Set<number>();
-        for (const index of this.dirtyState) {
-          if (this.cells[index]?.flush()) dirty.add(index);
-        }
-        this.dirtyState.clear();
-        if (dirty.size === 0) return;
-        try {
-          this.ensureBindingIndex();
-          const affectedBlockIds = new Set<number>();
-          const affectedBindings = new Set<CompilerBinding<Props>>();
+        this.flushBindingUpdates();
+      });
+    }
 
-          for (const dependency of dirty) {
-            for (const binding of this.blockBindingsByDependency[dependency] || []) {
-              affectedBlockIds.add(binding.id);
-            }
-            for (const binding of this.staticBindingsByDependency[dependency] || []) {
+    private flushBindingUpdates(): void {
+      const inputSelection = this.inputSelection;
+      this.inputSelection = null;
+      if (!this.mounted) return;
+      const dirty = new Set<number>();
+      for (const index of this.dirtyState) {
+        if (this.cells[index]?.flush()) dirty.add(index);
+      }
+      this.dirtyState.clear();
+      if (dirty.size === 0) return;
+      try {
+        this.ensureBindingIndex();
+        const affectedBlockIds = new Set<number>();
+        const affectedBindings = new Set<CompilerBinding<Props>>();
+
+        for (const dependency of dirty) {
+          for (const binding of this.blockBindingsByDependency[dependency] || []) {
+            affectedBlockIds.add(binding.id);
+          }
+          for (const binding of this.staticBindingsByDependency[dependency] || []) {
+            affectedBindings.add(binding);
+          }
+          if (this.usesHybridReactivity()) {
+            for (const binding of this.trackedBindingsByDependency[dependency] || []) {
               affectedBindings.add(binding);
             }
-            if (this.usesHybridReactivity()) {
-              for (const binding of this.trackedBindingsByDependency[dependency] || []) {
-                affectedBindings.add(binding);
-              }
-            }
           }
-
-          const hasAffectedMountedAncestor = (
-            binding: CompilerConditionalBlockBinding,
-          ): boolean => {
-            let parent = binding.parent;
-            while (parent !== undefined) {
-              if (affectedBlockIds.has(parent) && this.blockRefreshListeners.has(parent)) {
-                return true;
-              }
-              parent = this.blockBindings.get(parent)?.parent;
-            }
-            return false;
-          };
-
-          const blockRefreshes = [...affectedBlockIds]
-            .map((id) => {
-              const binding = this.blockBindings.get(id);
-              const refresh = this.blockRefreshListeners.get(id);
-              return binding && refresh && !hasAffectedMountedAncestor(binding)
-                ? refresh
-                : undefined;
-            })
-            .filter((refresh): refresh is CompilerBlockRefresh => refresh !== undefined);
-
-          for (const binding of affectedBindings) {
-            if (binding.kind !== "block") this.applyBinding(binding);
-          }
-
-          let pendingBlockCommits = blockRefreshes.length;
-          for (const refresh of blockRefreshes) {
-            refresh(() => {
-              pendingBlockCommits -= 1;
-              if (pendingBlockCommits === 0) this.restoreInputSelection(inputSelection);
-            }, dirty);
-          }
-          if (blockRefreshes.length === 0) this.restoreInputSelection(inputSelection);
-        } catch (error) {
-          this.bindingError = error;
-          this.hasBindingError = true;
-          this.forceUpdate();
         }
-      });
+
+        const hasAffectedMountedAncestor = (binding: CompilerConditionalBlockBinding): boolean => {
+          let parent = binding.parent;
+          while (parent !== undefined) {
+            if (affectedBlockIds.has(parent) && this.blockRefreshListeners.has(parent)) {
+              return true;
+            }
+            parent = this.blockBindings.get(parent)?.parent;
+          }
+          return false;
+        };
+
+        const blockRefreshes = [...affectedBlockIds]
+          .map((id) => {
+            const binding = this.blockBindings.get(id);
+            const refresh = this.blockRefreshListeners.get(id);
+            return binding && refresh && !hasAffectedMountedAncestor(binding) ? refresh : undefined;
+          })
+          .filter((refresh): refresh is CompilerBlockRefresh => refresh !== undefined);
+
+        for (const binding of affectedBindings) {
+          if (binding.kind !== "block") this.applyBinding(binding);
+        }
+
+        let pendingBlockCommits = blockRefreshes.length;
+        for (const refresh of blockRefreshes) {
+          refresh(() => {
+            pendingBlockCommits -= 1;
+            if (pendingBlockCommits === 0) this.restoreInputSelection(inputSelection);
+          }, dirty);
+        }
+        if (blockRefreshes.length === 0) this.restoreInputSelection(inputSelection);
+      } catch (error) {
+        this.bindingError = error;
+        this.hasBindingError = true;
+        this.forceUpdate();
+      }
     }
 
     private applyBinding(binding: CompilerBinding<Props>, force = false): void {
@@ -4301,10 +4376,39 @@ export function createCompiledComponent<Props>(
       this.primeHybridBindings();
     }
 
-    componentDidUpdate(): void {
-      // React has reconciled a parent-driven prop update. Reapply compiled
-      // bindings from the current cells so React and the imperative state stay
-      // coherent even when both change in the same turn.
+    getSnapshotBeforeUpdate(): boolean {
+      const currentDefinition = definitionReference.current;
+      const propValues = currentDefinition.readProps?.(this.props) || null;
+      return this.canReuseRenderedElement(currentDefinition, propValues);
+    }
+
+    componentDidUpdate(
+      _previousProps: Readonly<Props>,
+      _previousState: Readonly<Record<string, never>>,
+      reusedRenderedElement = false,
+    ): void {
+      const propValues = definitionReference.current.readProps?.(this.props) || null;
+      if (propValues) {
+        if (reusedRenderedElement) this.captureInputSelection();
+        for (let propIndex = 0; propIndex < propValues.length; propIndex += 1) {
+          const cellIndex = this.propCellOffset + propIndex;
+          const cell = this.cells[cellIndex];
+          if (!cell) continue;
+          cell.replace(propValues[propIndex]);
+          if (reusedRenderedElement) {
+            this.dirtyState.add(cellIndex);
+          } else {
+            // React already reconciled a full render using the pending prop
+            // snapshot. Commit the cell without scheduling duplicate work.
+            cell.flush();
+          }
+        }
+        this.flushBindingUpdates();
+        return;
+      }
+
+      // Hand-authored definitions without prop cells retain the original
+      // React-owned prop reconciliation behavior.
       this.ensureBindingIndex();
       for (const binding of definitionReference.current.bindings) {
         if (binding.kind !== "block") this.applyBinding(binding, true);
@@ -4336,36 +4440,55 @@ export function createCompiledComponent<Props>(
     render(): React.ReactNode {
       if (this.hasBindingError) throw this.bindingError;
       const currentDefinition = definitionReference.current;
-      const element = currentDefinition.render(this.props, this.cells, this.blockRuntime);
+      const propValues = currentDefinition.readProps?.(this.props) || null;
+      if (this.canReuseRenderedElement(currentDefinition, propValues)) {
+        return this.renderedElement;
+      }
+
+      const renderCells = this.renderCellsForProps(propValues);
+      const element = currentDefinition.render(this.props, renderCells.cells, this.blockRuntime);
       if (!React.isValidElement(element)) {
         throw new TypeError(
           `Compiled component ${currentDefinition.displayName} must return one host element.`,
         );
       }
+      let renderedElement: React.ReactElement;
+      const captureCommittedRoot = (root: Element | null) => {
+        this.captureRoot(root);
+        if (!root) return;
+        renderCells.commit();
+        this.renderedDefinition = currentDefinition;
+        this.renderedElement = renderedElement;
+      };
       if (element.type === this.blockRuntime.KeyedRanges) {
-        return React.cloneElement(element as React.ReactElement<CompilerKeyedRangesBlockProps>, {
-          rootRef: this.captureRoot,
-        });
-      }
-      if (element.type === this.blockRuntime.ConditionalRanges) {
-        return React.cloneElement(
-          element as React.ReactElement<CompilerConditionalRangesBlockProps>,
-          { rootRef: this.captureRoot },
+        renderedElement = React.cloneElement(
+          element as React.ReactElement<CompilerKeyedRangesBlockProps>,
+          {
+            rootRef: captureCommittedRoot,
+          },
         );
-      }
-      if (element.type === this.blockRuntime.MixedRanges) {
-        return React.cloneElement(element as React.ReactElement<CompilerMixedRangesBlockProps>, {
-          rootRef: this.captureRoot,
-        });
-      }
-      if (typeof element.type !== "string") {
+      } else if (element.type === this.blockRuntime.ConditionalRanges) {
+        renderedElement = React.cloneElement(
+          element as React.ReactElement<CompilerConditionalRangesBlockProps>,
+          { rootRef: captureCommittedRoot },
+        );
+      } else if (element.type === this.blockRuntime.MixedRanges) {
+        renderedElement = React.cloneElement(
+          element as React.ReactElement<CompilerMixedRangesBlockProps>,
+          {
+            rootRef: captureCommittedRoot,
+          },
+        );
+      } else if (typeof element.type !== "string") {
         throw new TypeError(
           `Compiled component ${currentDefinition.displayName} must return one host element.`,
         );
+      } else {
+        renderedElement = React.cloneElement(element, {
+          ref: captureCommittedRoot,
+        } as React.Attributes);
       }
-      return React.cloneElement(element, {
-        ref: this.captureRoot,
-      } as React.Attributes);
+      return renderedElement;
     }
   }
 

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -38,6 +38,12 @@ interface PropsPlan {
   destructuredNames: ReadonlySet<string>;
 }
 
+interface PropBinding {
+  localName: string;
+  valueName: string;
+  index: number;
+}
+
 interface PendingDomBinding {
   kind: "text" | "attribute" | "style";
   tracking?: "dynamic";
@@ -440,6 +446,56 @@ function rewriteDestructuredPropAccess<T extends t.Expression>(
       path.replaceWith(
         t.memberExpression(t.cloneNode(propsParameter), t.identifier(path.node.name)),
       );
+      path.skip();
+    },
+  });
+  return (file.program.body[0] as t.ExpressionStatement).expression as T;
+}
+
+function collectDestructuredPropNames(
+  expression: t.Expression,
+  names: ReadonlySet<string>,
+  propsParameter: t.Identifier,
+): Set<string> {
+  const referenced = new Set<string>();
+  if (names.size === 0) return referenced;
+  traverse(expressionFile(cloneExpression(expression)), {
+    MemberExpression(path) {
+      const { object, property, computed } = path.node;
+      if (
+        computed ||
+        !t.isIdentifier(object, { name: propsParameter.name }) ||
+        !t.isIdentifier(property) ||
+        !names.has(property.name)
+      ) {
+        return;
+      }
+      referenced.add(property.name);
+    },
+  });
+  return referenced;
+}
+
+function rewriteTrackedPropAccess<T extends t.Expression>(
+  expression: T,
+  propsParameter: t.Identifier,
+  bindingsByName: ReadonlyMap<string, PropBinding>,
+): T {
+  if (bindingsByName.size === 0) return cloneExpression(expression);
+  const file = expressionFile(cloneExpression(expression));
+  traverse(file, {
+    MemberExpression(path) {
+      const { object, property, computed } = path.node;
+      if (
+        computed ||
+        !t.isIdentifier(object, { name: propsParameter.name }) ||
+        !t.isIdentifier(property)
+      ) {
+        return;
+      }
+      const binding = bindingsByName.get(property.name);
+      if (!binding) return;
+      path.replaceWith(t.identifier(binding.valueName));
       path.skip();
     },
   });
@@ -4702,8 +4758,41 @@ function compileCandidate(
   );
   const setterReason = validateSetterUsage(expandedRoot, statesBySetter);
   if (setterReason) return setterReason;
+  const referencedPropNames = collectDestructuredPropNames(
+    expandedRoot,
+    propsPlan.destructuredNames,
+    propsPlan.definitionParameter,
+  );
+  // React children and identity-bearing values remain on React's normal prop
+  // reconciliation path. Other flat destructured props get runtime-validated
+  // primitive cells so the compiled render plan can stay mounted.
+  let propBindings = referencedPropNames.has("children")
+    ? []
+    : [...propsPlan.destructuredNames]
+        .filter((propName) => referencedPropNames.has(propName))
+        .map(
+          (localName, propIndex): PropBinding => ({
+            localName,
+            valueName: path.scope.generateUidIdentifier(`farmProp${propIndex}`).name,
+            index: states.length + propIndex,
+          }),
+        );
+  const propBindingsByName = new Map(propBindings.map((binding) => [binding.localName, binding]));
+  let reactiveByValue = new Map(statesByValue);
+  for (const binding of propBindings) {
+    reactiveByValue.set(binding.valueName, {
+      valueName: binding.valueName,
+      setterName: "",
+      index: binding.index,
+    });
+  }
+  let expandedReactiveRoot = rewriteTrackedPropAccess(
+    expandedRoot,
+    propsPlan.definitionParameter,
+    propBindingsByName,
+  ) as t.JSXElement;
   const referencedComponentNames = new Set<string>();
-  traverse(expressionFile(t.cloneNode(expandedRoot, true)), {
+  traverse(expressionFile(t.cloneNode(expandedReactiveRoot, true)), {
     JSXOpeningElement(componentPath) {
       const componentName = componentPath.node.name;
       if (t.isJSXIdentifier(componentName) && isComponentName(componentName.name)) {
@@ -4723,25 +4812,49 @@ function compileCandidate(
       );
     }),
   );
-  const blockAnalysis = analyzeComposableBlocks(
-    expandedRoot,
-    statesByValue,
+  let blockAnalysis = analyzeComposableBlocks(
+    expandedReactiveRoot,
+    reactiveByValue,
     safeGlobals,
     listNames,
     allowedComponentNames,
   );
-  if (blockAnalysis.reason) return blockAnalysis.reason;
-  const blockPlans = blockAnalysis.plans || [];
-  const analysis = analyzeHostTree(
-    expandedRoot,
-    statesByValue,
+  let analysis = analyzeHostTree(
+    expandedReactiveRoot,
+    reactiveByValue,
     safeGlobals,
     blockAnalysis.conditionalExpressions || new Set<t.Expression>(),
     blockAnalysis.keyedExpressions || new Set<t.Expression>(),
     blockAnalysis.ownedElements || new Set<t.JSXElement>(),
     blockAnalysis.componentElements || new Set<t.JSXElement>(),
   );
+  if (propBindings.length > 0 && (blockAnalysis.reason || analysis.reason)) {
+    // Prop reactivity is optional inside an already eligible local-state
+    // component. Preserve the established React prop path when the added prop
+    // dependency makes a shape exceed the narrower prop-cell proof.
+    propBindings = [];
+    reactiveByValue = new Map(statesByValue);
+    expandedReactiveRoot = t.cloneNode(expandedRoot, true);
+    blockAnalysis = analyzeComposableBlocks(
+      expandedReactiveRoot,
+      reactiveByValue,
+      safeGlobals,
+      listNames,
+      allowedComponentNames,
+    );
+    analysis = analyzeHostTree(
+      expandedReactiveRoot,
+      reactiveByValue,
+      safeGlobals,
+      blockAnalysis.conditionalExpressions || new Set<t.Expression>(),
+      blockAnalysis.keyedExpressions || new Set<t.Expression>(),
+      blockAnalysis.ownedElements || new Set<t.JSXElement>(),
+      blockAnalysis.componentElements || new Set<t.JSXElement>(),
+    );
+  }
+  if (blockAnalysis.reason) return blockAnalysis.reason;
   if (analysis.reason) return analysis.reason;
+  const blockPlans = blockAnalysis.plans || [];
   markShortCircuitBindings(analysis.bindings || []);
   assignStableBindingTargets(analysis.bindings || []);
 
@@ -4750,7 +4863,7 @@ function compileCandidate(
   const definitionIdentifier = path.scope.generateUidIdentifier(`${name}Compiled`);
   const propsParameter = propsPlan.definitionParameter;
   const rootWithTargets = lowerStableBindingTargets(
-    expandedRoot,
+    expandedReactiveRoot,
     analysis.bindings || [],
     blockParameter,
     blockAnalysis.ownedElements || new Set<t.JSXElement>(),
@@ -4764,7 +4877,7 @@ function compileCandidate(
   const rewrittenRoot = rewriteStateAccess(
     rootWithBlocks,
     stateParameter,
-    statesByValue,
+    reactiveByValue,
     statesBySetter,
   ) as t.JSXElement;
   const definition = t.callExpression(t.cloneNode(createComponentIdentifier), [
@@ -4781,7 +4894,11 @@ function compileCandidate(
             t.objectProperty(t.identifier("hmrId"), t.stringLiteral(`${moduleId}#${name}`)),
             t.objectProperty(
               t.identifier("stateSignature"),
-              t.stringLiteral(String(states.length)),
+              t.stringLiteral(
+                propBindings.length === 0
+                  ? String(states.length)
+                  : `${states.length}:${propBindings.map((binding) => binding.localName).join(",")}`,
+              ),
             ),
           ]),
           t.objectExpression([]),
@@ -4806,6 +4923,24 @@ function compileCandidate(
           ),
         ),
       ),
+      ...(propBindings.length > 0
+        ? [
+            t.objectProperty(
+              t.identifier("readProps"),
+              t.arrowFunctionExpression(
+                [t.cloneNode(propsParameter)],
+                t.arrayExpression(
+                  propBindings.map((binding) =>
+                    t.memberExpression(
+                      t.cloneNode(propsParameter),
+                      t.identifier(binding.localName),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ]
+        : []),
       t.objectProperty(
         t.identifier("render"),
         t.arrowFunctionExpression(
@@ -4825,7 +4960,7 @@ function compileCandidate(
               dependencies: block.dependencies,
             })),
           ].map((binding) =>
-            bindingObject(binding, propsParameter, stateParameter, statesByValue, statesBySetter),
+            bindingObject(binding, propsParameter, stateParameter, reactiveByValue, statesBySetter),
           ),
         ),
       ),


### PR DESCRIPTION
## Summary

- detect referenced flat destructured props and add them to the existing compiler dependency graph after local state cells
- reuse the committed compiled element for string, number, boolean, bigint, null, and undefined prop updates
- patch only dependent text, attributes, styles, controlled values, conditionals, keyed ranges, and component-island boundaries after the React parent commit
- retain full React rendering for objects, arrays, functions, symbols, React elements, children, identifier props, and compiler shapes that exceed the prop-cell proof
- add a production example, expanded experimental documentation, browser verification, and a dedicated prop-fanout benchmark

## Runtime safety

- prop cells use direct value replacement, so function props are never mistaken for state updater functions
- render snapshots are published only from a committed root ref; suspended or abandoned concurrent renders cannot replace the reusable element
- nested block callbacks receive a coherent render snapshot and switch to committed cells only after commit
- parent props and local state changed in the same turn share one dependency flush
- SSR, hydration, StrictMode remounting, controlled-input selection, HMR signatures, React error handling, and the existing unsupported fallback remain intact

## Verification

- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter farm-react-compiler-example type-check`
- `pnpm --filter @farm.js/react test` — 41 files, 346 tests passed
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and React 19.2.8 passed
- production compiler example build and Playwright verifier — PASS, 27 compiled components and all existing experiments preserved
- docs Vercel/Nitro production build — PASS across 73 routes
- reduced dashboard benchmark — correctness PASS, performance gate PASS, 20k scalability gate PASS

## Benchmark

The isolated 2,048-binding prop-fanout benchmark ran 50 warmup updates and 200 measured updates. The React control rebuilt 251 render plans; the compiled path kept one render plan and produced the same first and last DOM values.

- React median: 11.479 ms/update
- compiled median: 8.138 ms/update
- median speedup: 1.41x

The existing inactive-branch, active-fanout, and indexed-binding cases still run and satisfy their original correctness/read-count gates. Checked-in official benchmark reports are unchanged; dashboard audit output was written to `/tmp`.

Stacked on #546.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flat destructured primitive props now reuse the compiled render plan on parent updates, so eligible prop changes patch only dependent bindings instead of re-rendering through React. Object, array, function, symbol, React element, `children`, and identifier props keep the full React render path, and unsupported shapes silently retain existing behavior.

**Runtime safety**
- Prop cells replace values directly, so function props are never mistaken for state updater functions.
- Render snapshots publish only from a committed root ref, so suspended or abandoned concurrent renders cannot replace the reusable element.
- Nested block callbacks receive one coherent snapshot and switch to committed cells only after commit.
- Parent props and local state changed in the same turn share one dependency flush.
- SSR, hydration, StrictMode remounting, controlled-input selection, HMR signatures, and React error handling remain intact.

**Benchmark**
- The 2,048-binding prop fanout matches React's DOM output at 1.41x median speedup (8.138 ms vs 11.479 ms per update).
- The compiled path builds one render plan; the React control builds 251.

<sup>Written for commit fe44ed0ccfd006c49bda50e96024dd65c94802fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

