### PR TITLE
perf(react): tree-shake compiler runtime features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,10 @@ jobs:
       - name: Build React renderer
         run: pnpm --filter @farm.js/react build
 
+      - name: Verify compiler runtime size budget
+        if: matrix.react-version == '19.2.8'
+        run: pnpm --filter @farm.js/react test:runtime-size
+
       - name: Verify packaged renderer
         run: node packages/farm-react/scripts/test-react-version.mjs ${{ matrix.react-version }}
 

--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1223,25 +1223,37 @@ source maps with the transformed module.
 For each eligible component, the transform conceptually emits a definition like this:
 
 ```ts
-createCompiledComponent({
-  initialize: (props) => [props.initial],
-  readProps: (props) => [props.label],
-  render: (_props, state) => <button>{state[1].get()}: {state[0].get()}</button>,
-  bindings: [
-    {
-      kind: "text",
-      path: [],
-      target: 0,
-      dependencies: [0, 1],
-      read: (_props, state) => [state[1].get(), ": ", state[0].get()],
-    },
-  ],
-});
+createCompiledComponentWithFeatures(
+  {
+    initialize: (props) => [props.initial],
+    readProps: (props) => [props.label],
+    render: (_props, state) => <button>{state[1].get()}: {state[0].get()}</button>,
+    bindings: [
+      {
+        kind: "text",
+        path: [],
+        target: 0,
+        dependencies: [0, 1],
+        read: (_props, state) => [state[1].get(), ": ", state[0].get()],
+      },
+    ],
+  },
+  [],
+);
 ```
 
-The actual output imports `createCompiledComponent` from `@farm.js/react/compiler-runtime` only in
-modules where at least one component compiled. Unsupported modules keep their original source and
-do not receive the runtime import.
+The empty capability array means this component needs only direct bindings. A component with a
+conditional, keyed list, keyed row, range, or component island receives the matching statically
+imported feature. Plain keyed rows select a smaller implementation than rows with React-owned
+conditional slots or recursively compiler-owned host blocks. The selection uses ordinary build-time
+imports rather than loading code after an interaction, so SSR and hydration remain synchronous.
+
+The actual output imports `createCompiledComponentWithFeatures` and only its required feature
+exports from `@farm.js/react/compiler-runtime` in modules where at least one component compiled.
+Unused feature exports are tree-shaken from the production browser bundle. Unsupported modules keep
+their original source and do not receive the runtime import. Runtime features are also part of the
+Fast Refresh compatibility signature; changing a component into a new structural kind cannot reuse
+an instance that lacks the new runtime.
 
 ### Runtime behavior
 
@@ -1430,6 +1442,10 @@ The package and example test suites verify more than generated code:
   rerunning the owner component or corrupting the existing compiler experiments;
 - the package reactivity benchmark updates one prop across 2,048 bindings, requires identical
   first/last DOM output, and verifies one compiled render plan against 251 control render plans;
+- production-size fixtures verify that direct components omit every structural runtime, plain keyed
+  rows omit conditional-row support, and the core-only gzip premium remains at least 50% below the
+  complete compatibility runtime; the checked result is persisted in
+  `packages/farm-react/RUNTIME_SIZE_RESULTS.json`;
 - the production browser experiment also replaces and reorders interactive items, verifies current
   keyed DOM identity and capture/stop-propagation behavior, and observes zero owner update
   executions;

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -91,12 +91,15 @@ as expected for validating keys and maintaining row indices.
 
 | Build                   | Page chunk raw | Page chunk gzip |
 | ----------------------- | -------------: | --------------: |
-| React baseline          |       18,567 B |         4,307 B |
-| Static compiler         |       94,603 B |        17,934 B |
-| Hybrid compiler         |       94,603 B |        17,935 B |
+| React baseline          |       18,567 B |         4,306 B |
+| Static compiler         |       71,688 B |        14,783 B |
+| Hybrid compiler         |       71,688 B |        14,785 B |
 
-This deliberately broad page pays a 13,628-byte gzip premium for the compiler runtime. Runtime
-splitting remains the main unresolved optimization opportunity.
+This deliberately broad page now pays a 10,479-byte gzip premium for the compiler runtime. Static
+capability selection removes 22,915 raw bytes and 3,150 gzip bytes from the previous hybrid page
+chunk while preserving every benchmark scenario. Smaller direct-only applications retain less of
+the runtime; the package-level fixtures and persisted size gate are documented in
+`packages/farm-react/RUNTIME_SIZE_RESULTS.md`.
 
 ## Conclusion
 

--- a/examples/react-compiler-js-framework-benchmark/scripts/prepare-official.mjs
+++ b/examples/react-compiler-js-framework-benchmark/scripts/prepare-official.mjs
@@ -34,14 +34,14 @@ const variants = [
   {
     directory: "farm-react-static",
     script: "build:static",
-    version: "0.1.0-beta.3-static-react-19.2.0",
+    version: "0.1.0-beta.4-static-react-19.2.0",
     compiled: true,
     reactivity: "static",
   },
   {
     directory: "farm-react-hybrid",
     script: "build:hybrid",
-    version: "0.1.0-beta.3-hybrid-react-19.2.0",
+    version: "0.1.0-beta.4-hybrid-react-19.2.0",
     compiled: true,
     reactivity: "hybrid",
   },

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -32,6 +32,19 @@ binding. The runtime uses direct subscription indexes rather than proxies or a c
 scan. Use `compiler: { reactivity: "static" }` to retain only the complete build-time dependency
 lists for comparison or diagnosis.
 
+Compiler output also selects its runtime capabilities at build time. A direct counter imports only
+the cell scheduler and direct-binding core; conditionals, keyed rows and LIS, nested host ranges,
+and component islands are retained only when a compiled component in that module needs them. Plain
+keyed rows omit the larger recursive-host and row-conditional extensions. This selection is
+automatic and does not add a configuration option or asynchronous runtime loading. The legacy
+`createCompiledComponent` export remains a complete compatibility entry for hand-authored
+definitions, while generated code uses the tree-shakable feature entry.
+
+The persisted production-size fixtures and regression gate live in
+[`RUNTIME_SIZE_RESULTS.md`](./RUNTIME_SIZE_RESULTS.md). The recorded direct-only runtime premium is
+73.6% smaller than the complete compatibility runtime premium; the feature-heavy keyed benchmark
+application removes 6,185 gzip bytes from its previous compiler-on build.
+
 For selective adoption, use annotation mode:
 
 ```ts

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -1,0 +1,60 @@
+{
+  "version": 1,
+  "compression": "gzip level 9 and Node Brotli defaults",
+  "fixtures": {
+    "direct": {
+      "compilerOff": {
+        "raw": 192789,
+        "gzip": 60043,
+        "brotli": 51805
+      },
+      "compilerOn": {
+        "raw": 205422,
+        "gzip": 63721,
+        "brotli": 55001
+      },
+      "compilerPremium": {
+        "raw": 12633,
+        "gzip": 3678,
+        "brotli": 3196
+      }
+    },
+    "keyed": {
+      "compilerOff": {
+        "raw": 192934,
+        "gzip": 60107,
+        "brotli": 51830
+      },
+      "compilerOn": {
+        "raw": 220985,
+        "gzip": 68700,
+        "brotli": 58929
+      },
+      "compilerPremium": {
+        "raw": 28051,
+        "gzip": 8593,
+        "brotli": 7099
+      }
+    },
+    "isolatedRuntime": {
+      "control": {
+        "raw": 192643,
+        "gzip": 59919,
+        "brotli": 51666
+      },
+      "full": {
+        "raw": 258777,
+        "gzip": 74199,
+        "brotli": 63977
+      },
+      "coreOnly": {
+        "raw": 204922,
+        "gzip": 63685,
+        "brotli": 54902
+      },
+      "fullRuntimePremiumGzip": 14280,
+      "coreRuntimePremiumGzip": 3766,
+      "gzipReductionPercent": 73.6
+    }
+  }
+}

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.md
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.md
@@ -1,0 +1,56 @@
+# Compiler runtime size results
+
+The runtime-size benchmark builds fixed React fixtures with Vite's production minifier and reports
+raw, gzip level 9, and Brotli byte counts. It also inspects the generated bundles so a direct-only
+component cannot silently retain conditional, keyed, range, or component-island runtimes.
+
+Run and update the recorded result:
+
+```bash
+pnpm --filter @farm.js/react benchmark:runtime-size
+```
+
+Run the persisted regression gate without rewriting the result:
+
+```bash
+pnpm --filter @farm.js/react test:runtime-size
+```
+
+The React compiler compatibility CI runs this command for the React 19 lane, so the checked budget
+is enforced on every pull request instead of serving only as a manually recorded benchmark.
+
+## Recorded fixture result
+
+| Fixture                                           | Compiler off gzip | Compiler on gzip | Compiler premium |
+| ------------------------------------------------- | ----------------: | ---------------: | ---------------: |
+| Direct text, attribute, style, and event bindings |          60,043 B |         63,721 B |          3,678 B |
+| Delegated keyed rows and LIS                      |          60,107 B |         68,700 B |          8,593 B |
+
+The isolated compatibility runtime contributes 14,280 B gzip over the React control. The
+compiler-selected core contributes 3,766 B, a **73.6% reduction**. This comparison uses the same
+hand-authored compiled definition and changes only the runtime entry used to create it.
+
+The keyed fixture retains `FarmCompiledKeyedRows` but rejects the optional row-conditional runtime.
+The direct fixture rejects every structural runtime marker. The checked machine-readable result is
+[`RUNTIME_SIZE_RESULTS.json`](./RUNTIME_SIZE_RESULTS.json).
+
+## Existing production benchmark audit
+
+The existing js-framework-benchmark application was also rebuilt before and after runtime
+specialization with the same workspace, source, Vite configuration, and compression command:
+
+| Build                                   |       Raw |     Gzip |   Brotli |
+| --------------------------------------- | --------: | -------: | -------: |
+| Compiler off                            | 196,335 B | 61,194 B | 52,750 B |
+| Compiler on, previous full runtime      | 274,635 B | 79,297 B | 65,547 B |
+| Compiler on, selected keyed-row runtime | 236,899 B | 73,112 B | 60,499 B |
+
+Runtime selection removes **37,736 raw bytes, 6,185 gzip bytes, and 5,048 Brotli bytes** from the
+compiler-on build. The measured gzip premium over compiler-off falls from 18,103 B to 11,918 B,
+which is a **34.2% reduction** for this feature-heavy keyed application. These build-size numbers
+are separate from the official browser CPU result; the official harness must still be rerun before
+changing its checked headline.
+
+The regression gate allows only small compression variance and fails if the direct or keyed
+premium grows materially, if core runtime reduction falls by more than one percentage point, or if
+an unused capability marker returns.

--- a/packages/farm-react/fixtures/runtime-size/direct.tsx
+++ b/packages/farm-react/fixtures/runtime-size/direct.tsx
@@ -1,0 +1,19 @@
+import React, { useState } from "react";
+import { createRoot } from "react-dom/client";
+
+export function DirectCounter() {
+  const [count, setCount] = useState(0);
+  const doubled = count * 2;
+  return (
+    <button
+      className={count > 0 ? "active" : "idle"}
+      data-count={doubled}
+      onClick={() => setCount((value) => value + 1)}
+      style={{ opacity: count > 0 ? 1 : 0.5 }}
+    >
+      Count: {count} · doubled: {doubled}
+    </button>
+  );
+}
+
+createRoot(document.body).render(<DirectCounter />);

--- a/packages/farm-react/fixtures/runtime-size/keyed.tsx
+++ b/packages/farm-react/fixtures/runtime-size/keyed.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from "react";
+import { createRoot } from "react-dom/client";
+
+interface Row {
+  id: number;
+  label: string;
+}
+
+export function KeyedTable() {
+  const [rows, setRows] = useState<Row[]>(
+    Array.from({ length: 1_000 }, (_, id) => ({ id, label: `Row ${id}` })),
+  );
+  const [selected, setSelected] = useState(-1);
+  return (
+    <main>
+      <button onClick={() => setRows((value) => [...value].reverse())}>Reverse</button>
+      <ul>
+        {rows.map((row) => (
+          <li
+            className={selected === row.id ? "selected" : ""}
+            key={row.id}
+            onClick={() => setSelected(row.id)}
+          >
+            {row.label}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+
+createRoot(document.body).render(<KeyedTable />);

--- a/packages/farm-react/fixtures/runtime-size/runtime-control.tsx
+++ b/packages/farm-react/fixtures/runtime-size/runtime-control.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+
+function Counter() {
+  return <button>Count: 0</button>;
+}
+
+createRoot(document.body).render(<Counter />);

--- a/packages/farm-react/fixtures/runtime-size/runtime-core.tsx
+++ b/packages/farm-react/fixtures/runtime-size/runtime-core.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { createCompiledComponentWithFeatures } from "@farm.js/react/compiler-runtime";
+
+const Counter = createCompiledComponentWithFeatures(
+  {
+    displayName: "RuntimeCoreCounter",
+    initialize: () => [0],
+    render(_props, state) {
+      return (
+        <button onClick={() => state[0].set((value) => Number(value) + 1)}>
+          Count: {Number(state[0].get())}
+        </button>
+      );
+    },
+    bindings: [
+      {
+        kind: "text",
+        path: [],
+        dependencies: [0],
+        read: (_props, state) => ["Count: ", state[0].get()],
+      },
+    ],
+  },
+  [],
+);
+
+createRoot(document.body).render(<Counter />);

--- a/packages/farm-react/fixtures/runtime-size/runtime-full.tsx
+++ b/packages/farm-react/fixtures/runtime-size/runtime-full.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { createCompiledComponent } from "@farm.js/react/compiler-runtime";
+
+const Counter = createCompiledComponent({
+  displayName: "RuntimeFullCounter",
+  initialize: () => [0],
+  render(_props, state) {
+    return (
+      <button onClick={() => state[0].set((value) => Number(value) + 1)}>
+        Count: {Number(state[0].get())}
+      </button>
+    );
+  },
+  bindings: [
+    {
+      kind: "text",
+      path: [],
+      dependencies: [0],
+      read: (_props, state) => ["Count: ", state[0].get()],
+    },
+  ],
+});
+
+createRoot(document.body).render(<Counter />);

--- a/packages/farm-react/package.json
+++ b/packages/farm-react/package.json
@@ -62,6 +62,8 @@
     "type-check": "tsc --noEmit",
     "test": "vitest run",
     "benchmark:reactivity": "node scripts/benchmark-reactivity.mjs",
+    "benchmark:runtime-size": "pnpm build && node scripts/benchmark-runtime-size.mjs",
+    "test:runtime-size": "pnpm build && node scripts/benchmark-runtime-size.mjs --check",
     "test:compat": "pnpm build && node scripts/test-react-version.mjs 18.3.1 && node scripts/test-react-version.mjs 19.2.8",
     "clean": "rm -rf dist"
   },

--- a/packages/farm-react/scripts/benchmark-runtime-size.mjs
+++ b/packages/farm-react/scripts/benchmark-runtime-size.mjs
@@ -1,0 +1,165 @@
+import { brotliCompressSync, gzipSync } from "node:zlib";
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "vite";
+import { createFarmRendererPlugin } from "../dist/vite.mjs";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const fixtureRoot = join(packageRoot, "fixtures/runtime-size");
+const resultFile = join(packageRoot, "RUNTIME_SIZE_RESULTS.json");
+const checkOnly = process.argv.includes("--check");
+
+async function bundle(entry, compiler) {
+  const result = await build({
+    configFile: false,
+    root: fixtureRoot,
+    logLevel: "silent",
+    css: {
+      postcss: { plugins: [] },
+    },
+    plugins: createFarmRendererPlugin({
+      rendererOptions: {
+        experimental: {
+          compiler: compiler ? { onUnsupported: "error" } : false,
+        },
+      },
+    }),
+    build: {
+      write: false,
+      minify: "esbuild",
+      rollupOptions: {
+        input: join(fixtureRoot, entry),
+      },
+    },
+  });
+  const outputs = Array.isArray(result) ? result : [result];
+  const code = outputs
+    .flatMap((output) => output.output)
+    .filter((output) => output.type === "chunk")
+    .map((output) => output.code)
+    .join("\n");
+  const bytes = Buffer.from(code);
+  return {
+    code,
+    raw: bytes.length,
+    gzip: gzipSync(bytes, { level: 9 }).length,
+    brotli: brotliCompressSync(bytes).length,
+  };
+}
+
+const [directOff, directOn, keyedOff, keyedOn, runtimeControl, runtimeCore, runtimeFull] =
+  await Promise.all([
+    bundle("direct.tsx", false),
+    bundle("direct.tsx", true),
+    bundle("keyed.tsx", false),
+    bundle("keyed.tsx", true),
+    bundle("runtime-control.tsx", false),
+    bundle("runtime-core.tsx", false),
+    bundle("runtime-full.tsx", false),
+  ]);
+
+const forbiddenDirectMarkers = [
+  "FarmCompiledConditionalBlock",
+  "FarmCompiledHostConditionalBlock",
+  "FarmCompiledKeyedListBlock",
+  "FarmCompiledKeyedRows",
+  "FarmCompiledKeyedRangesBlock",
+  "FarmCompiledMixedRangesBlock",
+  "FarmCompiledComponentBlock",
+];
+for (const marker of forbiddenDirectMarkers) {
+  if (directOn.code.includes(marker) || runtimeCore.code.includes(marker)) {
+    throw new Error(`Direct-only runtime unexpectedly retained ${marker}.`);
+  }
+}
+if (!keyedOn.code.includes("FarmCompiledKeyedRows")) {
+  throw new Error("Keyed fixture did not retain its keyed-row runtime.");
+}
+if (keyedOn.code.includes("FarmCompiledKeyedRowConditional")) {
+  throw new Error("Plain keyed fixture retained the optional row-conditional runtime.");
+}
+
+const fullRuntimePremium = runtimeFull.gzip - runtimeControl.gzip;
+const coreRuntimePremium = runtimeCore.gzip - runtimeControl.gzip;
+const runtimeReduction = 1 - coreRuntimePremium / fullRuntimePremium;
+if (runtimeReduction < 0.5) {
+  throw new Error(
+    `Core runtime gzip reduction was ${(runtimeReduction * 100).toFixed(1)}%; expected at least 50%.`,
+  );
+}
+
+const results = {
+  version: 1,
+  compression: "gzip level 9 and Node Brotli defaults",
+  fixtures: {
+    direct: {
+      compilerOff: { raw: directOff.raw, gzip: directOff.gzip, brotli: directOff.brotli },
+      compilerOn: { raw: directOn.raw, gzip: directOn.gzip, brotli: directOn.brotli },
+      compilerPremium: {
+        raw: directOn.raw - directOff.raw,
+        gzip: directOn.gzip - directOff.gzip,
+        brotli: directOn.brotli - directOff.brotli,
+      },
+    },
+    keyed: {
+      compilerOff: { raw: keyedOff.raw, gzip: keyedOff.gzip, brotli: keyedOff.brotli },
+      compilerOn: { raw: keyedOn.raw, gzip: keyedOn.gzip, brotli: keyedOn.brotli },
+      compilerPremium: {
+        raw: keyedOn.raw - keyedOff.raw,
+        gzip: keyedOn.gzip - keyedOff.gzip,
+        brotli: keyedOn.brotli - keyedOff.brotli,
+      },
+    },
+    isolatedRuntime: {
+      control: {
+        raw: runtimeControl.raw,
+        gzip: runtimeControl.gzip,
+        brotli: runtimeControl.brotli,
+      },
+      full: { raw: runtimeFull.raw, gzip: runtimeFull.gzip, brotli: runtimeFull.brotli },
+      coreOnly: { raw: runtimeCore.raw, gzip: runtimeCore.gzip, brotli: runtimeCore.brotli },
+      fullRuntimePremiumGzip: fullRuntimePremium,
+      coreRuntimePremiumGzip: coreRuntimePremium,
+      gzipReductionPercent: Number((runtimeReduction * 100).toFixed(1)),
+    },
+  },
+};
+
+if (checkOnly) {
+  const reference = JSON.parse(await readFile(resultFile, "utf8"));
+  const checks = [
+    {
+      name: "direct compiler premium",
+      current: results.fixtures.direct.compilerPremium.gzip,
+      maximum: reference.fixtures.direct.compilerPremium.gzip + 128,
+    },
+    {
+      name: "keyed compiler premium",
+      current: results.fixtures.keyed.compilerPremium.gzip,
+      maximum: reference.fixtures.keyed.compilerPremium.gzip + 256,
+    },
+    {
+      name: "core runtime premium",
+      current: results.fixtures.isolatedRuntime.coreRuntimePremiumGzip,
+      maximum: reference.fixtures.isolatedRuntime.coreRuntimePremiumGzip + 128,
+    },
+  ];
+  for (const check of checks) {
+    if (check.current > check.maximum) {
+      throw new Error(
+        `${check.name} grew to ${check.current} B gzip; persisted maximum is ${check.maximum} B.`,
+      );
+    }
+  }
+  if (
+    results.fixtures.isolatedRuntime.gzipReductionPercent <
+    reference.fixtures.isolatedRuntime.gzipReductionPercent - 1
+  ) {
+    throw new Error("Core-only runtime reduction regressed against the persisted result.");
+  }
+} else {
+  await writeFile(resultFile, `${JSON.stringify(results, null, 2)}\n`, "utf8");
+}
+
+console.log(JSON.stringify(results, null, 2));

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -39,10 +39,12 @@ const testSource = String.raw`
   const { flushSync } = await import("react-dom");
   const { createRoot, hydrateRoot } = await import("react-dom/client");
   const { renderToString } = await import("react-dom/server");
-  const { createCompiledComponent } = await import("@farm.js/react/compiler-runtime");
+  const { createCompiledComponent, createCompiledComponentWithFeatures } = await import(
+    "@farm.js/react/compiler-runtime"
+  );
   const { List } = await import("@farm.js/react/list");
 
-  const Counter = createCompiledComponent({
+  const Counter = createCompiledComponentWithFeatures({
     displayName: "CompatibilityCounter",
     reactivity: "hybrid",
     initialize: () => [0],
@@ -63,7 +65,7 @@ const testSource = String.raw`
         read: (_props, state) => ["Count: ", state[0].get()],
       },
     ],
-  });
+  }, []);
 
   const container = document.createElement("div");
   document.body.append(container);
@@ -75,7 +77,7 @@ const testSource = String.raw`
   assert.equal(container.textContent, "Count: 1");
   flushSync(() => root.unmount());
 
-  const StaticBindings = createCompiledComponent({
+  const StaticBindings = createCompiledComponentWithFeatures({
     displayName: "CompatibilityStaticBindings",
     initialize: () => [8, "draft", "safe", true],
     render(_props, state) {
@@ -144,7 +146,7 @@ const testSource = String.raw`
         read: (_props, state) => state[3].get(),
       },
     ],
-  });
+  }, []);
 
   const staticContainer = document.createElement("div");
   document.body.append(staticContainer);

--- a/packages/farm-react/src/__tests__/compiler-component-islands.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-component-islands.test.ts
@@ -32,6 +32,8 @@ describe("React AOT component island compiler", () => {
 
     expect(result.compiled).toEqual(["Dashboard"]);
     expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("componentRuntimeFeature");
+    expect(result.code).not.toContain("keyedRowsRuntimeFeature");
     expect(result.code).toContain("farmBlocks.Component");
     expect(result.code).toContain("farmBlocks.target(");
     expect(result.code).toContain('kind: "block"');

--- a/packages/farm-react/src/__tests__/compiler-conditional-blocks.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-conditional-blocks.test.ts
@@ -31,6 +31,8 @@ describe("React AOT conditional block compiler", () => {
 
     expect(result.diagnostics).toEqual([]);
     expect(result.compiled).toEqual(["ConditionalPanel"]);
+    expect(result.code).toContain("conditionalRangesRuntimeFeature");
+    expect(result.code).not.toContain("mixedRangesRuntimeFeature");
     expect(result.code.match(/farmBlocks\.ConditionalRanges/g)).toHaveLength(1);
     expect(result.code.match(/farmBlocks\.Conditional(?!Ranges)/g)).toBeNull();
     expect(result.code).toContain('kind: "block"');
@@ -71,6 +73,8 @@ describe("React AOT conditional block compiler", () => {
 
     expect(result.diagnostics).toEqual([]);
     expect(result.compiled).toEqual(["InteractiveBranch"]);
+    expect(result.code).toContain("conditionalRuntimeFeature");
+    expect(result.code).not.toContain("hostConditionalRuntimeFeature");
     expect(result.code).toContain('kind: "block"');
     expect(result.code).toContain("dependencies: [0, 1]");
     expect(result.code).toMatch(/farmState\[1\]\.set/);
@@ -123,6 +127,8 @@ describe("React AOT conditional block compiler", () => {
 
     expect(result.diagnostics).toEqual([]);
     expect(result.compiled).toEqual(["PreparedStatus"]);
+    expect(result.code).toContain("hostConditionalRuntimeFeature");
+    expect(result.code).not.toContain("conditionalRuntimeFeature");
     expect(result.code.match(/farmBlocks\.HostConditional/g)).toHaveLength(1);
     expect(result.code).not.toContain("farmBlocks.Conditional");
     expect(result.code).toContain("truthy={{");

--- a/packages/farm-react/src/__tests__/compiler-conditional-ranges.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-conditional-ranges.test.ts
@@ -34,6 +34,8 @@ describe("React AOT conditional-range compiler", () => {
 
     expect(result.diagnostics).toEqual([]);
     expect(result.compiled).toEqual(["Dashboard"]);
+    expect(result.code).toContain("conditionalRangesRuntimeFeature");
+    expect(result.code).not.toContain("keyedRangesRuntimeFeature");
     expect(result.code.match(/farmBlocks\.ConditionalRanges/g)).toHaveLength(1);
     expect(result.code.match(/farmBlocks\.Conditional(?!Ranges)/g)).toBeNull();
     expect(result.code.match(/before: 1/g)).toHaveLength(2);

--- a/packages/farm-react/src/__tests__/compiler-interactive-keyed-rows.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-interactive-keyed-rows.test.ts
@@ -55,6 +55,9 @@ describe("React AOT interactive keyed-row compiler", () => {
 
     expect(result.compiled).toEqual(["Tasks"]);
     expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("keyedRowsRuntimeFeature");
+    expect(result.code).not.toContain("keyedRowsConditionalRuntimeFeature");
+    expect(result.code).not.toContain("keyedRowsHostRuntimeFeature");
     expect(result.code).toContain("farmBlocks.KeyedRows");
     expect(result.code).toContain("structureDependencies={[0]}");
     expect(result.code).toMatch(

--- a/packages/farm-react/src/__tests__/compiler-keyed-lists.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-lists.test.ts
@@ -32,6 +32,9 @@ describe("React AOT keyed list compiler", () => {
 
     expect(result.compiled).toEqual(["Inventory"]);
     expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("keyedRowsRuntimeFeature");
+    expect(result.code).not.toContain("keyedRowsConditionalRuntimeFeature");
+    expect(result.code).not.toContain("keyedRowsHostRuntimeFeature");
     expect(result.code).toContain("farmBlocks.KeyedRows");
     expect(result.code).toContain("rowKey={item => item.id}");
     expect(result.code).toContain('kind: "element"');
@@ -70,6 +73,8 @@ describe("React AOT keyed list compiler", () => {
 
     expect(result.compiled).toEqual(["Inventory"]);
     expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("keyedListRuntimeFeature");
+    expect(result.code).not.toContain("keyedRowsRuntimeFeature");
     expect(result.code).toContain("farmBlocks.KeyedList");
     expect(result.code).toContain("<Keyed each=");
     expect(result.code).toContain("dependencies: [0]");

--- a/packages/farm-react/src/__tests__/compiler-keyed-ranges.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-ranges.test.ts
@@ -50,6 +50,8 @@ describe("React AOT keyed-range compiler", () => {
 
     expect(result.compiled).toEqual(["Board"]);
     expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("keyedRangesRuntimeFeature");
+    expect(result.code).not.toContain("mixedRangesRuntimeFeature");
     expect(result.code).toContain("farmBlocks.KeyedRanges");
     expect(result.code).toContain("ranges={[");
     expect(result.code.match(/before: 1/g)).toHaveLength(2);

--- a/packages/farm-react/src/__tests__/compiler-keyed-row-conditionals.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-row-conditionals.test.ts
@@ -45,6 +45,9 @@ describe("React AOT keyed-row conditional compiler", () => {
     expect(result.compiled).toEqual(["Tasks"]);
     expect(result.diagnostics).toEqual([]);
     expect(result.code).toContain("farmBlocks.KeyedRows");
+    expect(result.code).toContain("keyedRowsHostRuntimeFeature");
+    expect(result.code).not.toContain("keyedRowsConditionalRuntimeFeature");
+    expect(result.code).not.toContain("keyedRowsCompleteRuntimeFeature");
     expect(result.code).toContain("hostBlocks={true}");
     expect(result.code).toContain('kind: "conditional-ranges"');
     expect(result.code).toContain("parent: 0");
@@ -87,6 +90,9 @@ describe("React AOT keyed-row conditional compiler", () => {
     expect(result.compiled).toEqual(["Tasks"]);
     expect(result.diagnostics).toEqual([]);
     expect(result.code).toContain("farmBlocks.KeyedRows");
+    expect(result.code).toContain("keyedRowsConditionalRuntimeFeature");
+    expect(result.code).not.toContain("keyedRowsHostRuntimeFeature");
+    expect(result.code).not.toContain("keyedRowsCompleteRuntimeFeature");
     expect(result.code).toContain("_farmRowEvent(item, 0, 0)");
     expect(result.code).toContain("_farmRowConditional(item, 0, 0");
     expect(result.code).toContain('name: "onClick"');

--- a/packages/farm-react/src/__tests__/compiler-keyed-row-host-blocks.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-row-host-blocks.test.ts
@@ -12,6 +12,44 @@ async function compile(source: string) {
 }
 
 describe("React AOT compiler-owned keyed-row host blocks", () => {
+  it("selects the complete keyed-row runtime when sibling lists need both extensions", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function MixedRows() {
+        const [items, setItems] = useState([
+          { id: "a", label: "Alpha", visible: true },
+        ]);
+        return (
+          <main>
+            <ul>
+              {items.map((item) => (
+                <li key={item.id}>
+                  <div>{item.visible && <strong>{item.label}</strong>}</div>
+                </li>
+              ))}
+            </ul>
+            <ol>
+              {items.map((item) => (
+                <li key={item.id}>
+                  <button onClick={() => setItems((rows) => [...rows])}>Refresh</button>
+                  <div>
+                    {item.visible && <strong>{item.label}</strong>}
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </main>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["MixedRows"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("keyedRowsCompleteRuntimeFeature");
+    expect(result.code).not.toContain("keyedRowsHostRuntimeFeature");
+    expect(result.code).not.toContain("keyedRowsConditionalRuntimeFeature");
+  });
+
   it("prepares multiple and recursively nested host conditionals for automatic map syntax", async () => {
     const result = await compile(`
       import { useState } from "react";
@@ -52,6 +90,8 @@ describe("React AOT compiler-owned keyed-row host blocks", () => {
     expect(result.compiled).toEqual(["Inbox"]);
     expect(result.diagnostics).toEqual([]);
     expect(result.code).toContain("farmBlocks.KeyedRows");
+    expect(result.code).toContain("keyedRowsHostRuntimeFeature");
+    expect(result.code).not.toContain("keyedRowsCompleteRuntimeFeature");
     expect(result.code).toContain("hostBlocks={true}");
     expect(result.code.match(/kind: "conditional-ranges"/g)).toHaveLength(4);
     expect(result.code).toContain("parent: 0");

--- a/packages/farm-react/src/__tests__/compiler-mixed-ranges.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-mixed-ranges.test.ts
@@ -38,6 +38,9 @@ describe("React AOT mixed conditional and keyed ranges", () => {
 
     expect(result.compiled).toEqual(["Dashboard"]);
     expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("mixedRangesRuntimeFeature");
+    expect(result.code).not.toContain("conditionalRangesRuntimeFeature");
+    expect(result.code).not.toContain("keyedRangesRuntimeFeature");
     expect(result.code.match(/farmBlocks\.MixedRanges/g)).toHaveLength(1);
     expect(result.code).toContain('kind: "mixed-ranges"');
     expect(result.code.match(/kind: "conditional"/g)).toHaveLength(2);

--- a/packages/farm-react/src/__tests__/compiler-runtime-hardening.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-hardening.test.tsx
@@ -3,7 +3,12 @@ import { act } from "react";
 import { createRoot, hydrateRoot, type Root } from "react-dom/client";
 import { renderToString } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createCompiledComponent, type CompiledComponentDefinition } from "../compiler-runtime";
+import {
+  conditionalRuntimeFeature,
+  createCompiledComponent,
+  createCompiledComponentWithFeatures,
+  type CompiledComponentDefinition,
+} from "../compiler-runtime";
 
 declare global {
   var IS_REACT_ACT_ENVIRONMENT: boolean;
@@ -61,6 +66,49 @@ function counterDefinition(
 }
 
 describe("compiled React runtime hardening", () => {
+  it("runs direct bindings with the structural runtime completely omitted", async () => {
+    let renders = 0;
+    const definition = counterDefinition("CoreOnlyCounter");
+    const Counter = createCompiledComponentWithFeatures(
+      {
+        ...definition,
+        render(props, state) {
+          renders += 1;
+          return definition.render(props, state);
+        },
+      },
+      [],
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = trackRoot(createRoot(container));
+
+    await act(async () => root.render(<Counter />));
+    await act(async () => {
+      container.querySelector("button")!.click();
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("Count: 1");
+    expect(renders).toBe(1);
+  });
+
+  it("uses runtime capabilities as part of Fast Refresh compatibility", () => {
+    const hmrId = `runtime-feature-refresh-${Math.random()}`;
+    const definition = {
+      ...counterDefinition("RuntimeFeatureRefresh"),
+      hmrId,
+      stateSignature: "1",
+    };
+
+    const Initial = createCompiledComponentWithFeatures(definition, []);
+    const Compatible = createCompiledComponentWithFeatures(definition, []);
+    const Structural = createCompiledComponentWithFeatures(definition, [conditionalRuntimeFeature]);
+
+    expect(Compatible).toBe(Initial);
+    expect(Structural).not.toBe(Initial);
+  });
+
   it("survives the StrictMode development mount cycle without rerendering on a local update", async () => {
     let renders = 0;
     const definition = counterDefinition("StrictCounter");

--- a/packages/farm-react/src/__tests__/compiler.test.ts
+++ b/packages/farm-react/src/__tests__/compiler.test.ts
@@ -29,7 +29,11 @@ describe("React AOT compiler", () => {
     expect(result.diagnostics).toEqual([]);
     expect(result.compiled).toEqual(["Counter"]);
     expect(result.code).toContain("@farm.js/react/compiler-runtime");
-    expect(result.code).toContain("createCompiledComponent");
+    expect(result.code).toContain("createCompiledComponentWithFeatures");
+    expect(result.code).toMatch(/_createCompiledComponent\([\s\S]+, \[\]\)/);
+    expect(result.code).not.toContain("conditionalRuntimeFeature");
+    expect(result.code).not.toContain("keyedRowsRuntimeFeature");
+    expect(result.code).not.toContain("componentRuntimeFeature");
     expect(result.code).toContain('reactivity: "hybrid"');
     expect(result.code).not.toContain('tracking: "dynamic"');
     expect(result.code).toContain('kind: "text"');

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -321,6 +321,7 @@ interface CompilerHmrRegistryEntry {
   definition: CompiledDefinitionReference<unknown>;
   refreshListeners: Set<() => void>;
   stateSignature: string;
+  runtimeSignature: string;
 }
 
 type CompilerHmrRegistry = Map<string, CompilerHmrRegistryEntry>;
@@ -537,6 +538,17 @@ function updateAttribute(element: Element, name: string, value: unknown): void {
 }
 
 type CompilerBlockRefresh = (afterCommit?: () => void, dirtyState?: ReadonlySet<number>) => void;
+
+export interface CompilerRuntimeFeatureOwner {
+  setRoot(id: number, root: Element | null): void;
+  subscribe(id: number, refresh: CompilerBlockRefresh): () => void;
+}
+
+export interface CompilerRuntimeFeature {
+  /** Stable identity used by Fast Refresh compatibility checks. */
+  name: string;
+  create(owner: CompilerRuntimeFeatureOwner): Partial<CompilerBlockRuntime>;
+}
 
 interface ConditionalBlockOwner {
   setRoot(id: number, root: Element | null): void;
@@ -2645,39 +2657,52 @@ function longestIncreasingSubsequencePositions(sequence: readonly number[]): Set
   return positions;
 }
 
-function createKeyedRowsBlockComponent(
-  owner: Pick<ConditionalBlockOwner, "subscribe">,
-): React.ComponentType<CompilerKeyedRowsBlockProps> {
-  interface State {
-    fallback: boolean;
-  }
+type RowConditionalRefresh = (item: unknown, index: number, afterCommit?: () => void) => void;
 
-  const rowHostScopeOwner: Pick<ConditionalBlockOwner, "subscribe"> = {
-    subscribe: () => () => {},
-  };
+interface RowConditionalOwner {
+  subscribe(key: string, id: number, refresh: RowConditionalRefresh): () => void;
+}
 
-  type RowConditionalRefresh = (item: unknown, index: number, afterCommit?: () => void) => void;
+interface RowConditionalProps {
+  owner: RowConditionalOwner;
+  rowKey: string;
+  id: number;
+  renderVersion: number;
+  item: unknown;
+  index: number;
+  render(item: unknown, index: number): React.ReactNode;
+}
 
-  interface RowConditionalOwner {
-    subscribe(key: string, id: number, refresh: RowConditionalRefresh): () => void;
-  }
+interface RowConditionalState {
+  renderVersion: number;
+  item: unknown;
+  index: number;
+}
 
-  interface RowConditionalProps {
-    owner: RowConditionalOwner;
-    rowKey: string;
-    id: number;
-    renderVersion: number;
-    item: unknown;
-    index: number;
-    render(item: unknown, index: number): React.ReactNode;
-  }
+interface KeyedRowConditionalRuntime {
+  Component: React.ComponentType<RowConditionalProps>;
+  readValues(
+    props: Pick<CompilerKeyedRowsBlockProps, "conditionals">,
+    item: unknown,
+    index: number,
+  ): ReadonlyMap<number, readonly unknown[]>;
+  changed(previous: readonly unknown[] | undefined, next: readonly unknown[]): boolean;
+}
 
-  interface RowConditionalState {
-    renderVersion: number;
-    item: unknown;
-    index: number;
-  }
+interface KeyedRowHostRuntime {
+  mount(
+    element: Element,
+    descriptor: CompilerHostElement,
+    requestFallback: () => void,
+  ): CompilerHostTreeScope | null;
+}
 
+interface KeyedRowsRuntimeOptions {
+  conditionals?: KeyedRowConditionalRuntime;
+  hostBlocks?: KeyedRowHostRuntime;
+}
+
+function createKeyedRowConditionalRuntime(): KeyedRowConditionalRuntime {
   class FarmKeyedRowConditional extends React.Component<RowConditionalProps, RowConditionalState> {
     static displayName = "FarmCompiledKeyedRowConditional";
 
@@ -2731,6 +2756,31 @@ function createKeyedRowsBlockComponent(
     render(): React.ReactNode {
       return this.props.render(this.state.item, this.state.index);
     }
+  }
+
+  return {
+    Component: FarmKeyedRowConditional,
+    readValues: readKeyedRowConditionalValues,
+    changed: keyedRowConditionalChanged,
+  };
+}
+
+function createKeyedRowHostRuntime(): KeyedRowHostRuntime {
+  const owner: Pick<ConditionalBlockOwner, "subscribe"> = {
+    subscribe: () => () => {},
+  };
+  return {
+    mount: (element, descriptor, requestFallback) =>
+      mountCompilerHostTree(owner, element, descriptor, requestFallback),
+  };
+}
+
+function createKeyedRowsBlockComponent(
+  owner: Pick<ConditionalBlockOwner, "subscribe">,
+  options: KeyedRowsRuntimeOptions = {},
+): React.ComponentType<CompilerKeyedRowsBlockProps> {
+  interface State {
+    fallback: boolean;
   }
 
   class FarmKeyedRowsBlock extends React.Component<CompilerKeyedRowsBlockProps, State> {
@@ -2902,7 +2952,9 @@ function createKeyedRowsBlockComponent(
     ): React.ReactNode => {
       if (this.state.fallback) return render(item, index);
       const key = keyedRowIdentity(this.currentProps.rowKey(item, index));
-      return React.createElement(FarmKeyedRowConditional, {
+      const Conditional = options.conditionals?.Component;
+      if (!Conditional) return render(item, index);
+      return React.createElement(Conditional, {
         key: `${key}:${conditionalId}`,
         owner: this.conditionalOwner,
         rowKey: key,
@@ -2951,11 +3003,16 @@ function createKeyedRowsBlockComponent(
       props: CompilerKeyedRowsBlockProps = this.currentProps,
     ): CompilerHostTreeScope | null | undefined {
       if (!props.hostBlocks) return undefined;
-      return mountCompilerHostTree(
-        rowHostScopeOwner,
-        element,
-        descriptor,
-        this.requestHostScopeFallback,
+      return options.hostBlocks?.mount(element, descriptor, this.requestHostScopeFallback) || null;
+    }
+
+    private readConditionalValues(
+      props: CompilerKeyedRowsBlockProps,
+      item: unknown,
+      index: number,
+    ): ReadonlyMap<number, readonly unknown[]> {
+      return (
+        options.conditionals?.readValues(props, item, index) || EMPTY_KEYED_ROW_CONDITIONAL_VALUES
       );
     }
 
@@ -3005,7 +3062,7 @@ function createKeyedRowsBlockComponent(
             : readKeyedRowBindingValues(this.currentProps, rows.items[index], index),
           item: rows.items[index],
           index,
-          conditionalValues: readKeyedRowConditionalValues(
+          conditionalValues: this.readConditionalValues(
             this.currentProps,
             rows.items[index],
             index,
@@ -3167,13 +3224,13 @@ function createKeyedRowsBlockComponent(
           }
         }
         applyKeyedRowBindings(this.currentProps, existing, rows.items[index], index);
-        const conditionalValues = readKeyedRowConditionalValues(
+        const conditionalValues = this.readConditionalValues(
           this.currentProps,
           rows.items[index],
           index,
         );
         for (const [id, values] of conditionalValues) {
-          if (keyedRowConditionalChanged(existing.conditionalValues.get(id), values)) {
+          if (options.conditionals?.changed(existing.conditionalValues.get(id), values)) {
             conditionalChanges.push({ key, id, item: rows.items[index], index });
           }
         }
@@ -3223,13 +3280,13 @@ function createKeyedRowsBlockComponent(
           }
         }
         applyKeyedRowBindings(this.currentProps, existing, rows.items[index], index);
-        const conditionalValues = readKeyedRowConditionalValues(
+        const conditionalValues = this.readConditionalValues(
           this.currentProps,
           rows.items[index],
           index,
         );
         for (const [id, values] of conditionalValues) {
-          if (keyedRowConditionalChanged(existing.conditionalValues.get(id), values)) {
+          if (options.conditionals?.changed(existing.conditionalValues.get(id), values)) {
             conditionalChanges.push({ key, id, item: rows.items[index], index });
           }
         }
@@ -3339,13 +3396,13 @@ function createKeyedRowsBlockComponent(
             }
           }
           applyKeyedRowBindings(this.currentProps, existing, rows.items[index], index);
-          const conditionalValues = readKeyedRowConditionalValues(
+          const conditionalValues = this.readConditionalValues(
             this.currentProps,
             rows.items[index],
             index,
           );
           for (const [id, values] of conditionalValues) {
-            if (keyedRowConditionalChanged(existing.conditionalValues.get(id), values)) {
+            if (options.conditionals?.changed(existing.conditionalValues.get(id), values)) {
               conditionalChanges.push({ key, id, item: rows.items[index], index });
             }
           }
@@ -3372,7 +3429,7 @@ function createKeyedRowsBlockComponent(
           values: readKeyedRowBindingValues(this.currentProps, rows.items[index], index),
           item: rows.items[index],
           index,
-          conditionalValues: readKeyedRowConditionalValues(
+          conditionalValues: this.readConditionalValues(
             this.currentProps,
             rows.items[index],
             index,
@@ -3945,21 +4002,112 @@ function createComponentBlockComponent(
   return FarmComponentBlock;
 }
 
+export const conditionalRuntimeFeature: CompilerRuntimeFeature = {
+  name: "conditional",
+  create: (owner) => ({
+    Conditional: createConditionalBlockComponent(owner),
+  }),
+};
+
+export const hostConditionalRuntimeFeature: CompilerRuntimeFeature = {
+  name: "host-conditional",
+  create: (owner) => ({
+    HostConditional: createHostConditionalBlockComponent(owner),
+  }),
+};
+
+export const conditionalRangesRuntimeFeature: CompilerRuntimeFeature = {
+  name: "conditional-ranges",
+  create: (owner) => ({
+    ConditionalRanges: createConditionalRangesBlockComponent(owner),
+  }),
+};
+
+export const keyedListRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-list",
+  create: (owner) => ({
+    KeyedList: createKeyedListBlockComponent(owner),
+  }),
+};
+
+export const keyedRowsRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner),
+  }),
+};
+
+export const keyedRowsConditionalRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:conditional",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+    }),
+  }),
+};
+
+export const keyedRowsHostRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:host",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      hostBlocks: createKeyedRowHostRuntime(),
+    }),
+  }),
+};
+
+export const keyedRowsCompleteRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:complete",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      hostBlocks: createKeyedRowHostRuntime(),
+    }),
+  }),
+};
+
+export const keyedRangesRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-ranges",
+  create: (owner) => ({
+    KeyedRanges: createKeyedRangesBlockComponent(owner),
+  }),
+};
+
+export const mixedRangesRuntimeFeature: CompilerRuntimeFeature = {
+  name: "mixed-ranges",
+  create: (owner) => ({
+    MixedRanges: createMixedRangesBlockComponent(owner),
+  }),
+};
+
+export const componentRuntimeFeature: CompilerRuntimeFeature = {
+  name: "component",
+  create: (owner) => ({
+    Component: createComponentBlockComponent(owner),
+  }),
+};
+
 /**
- * Runtime target emitted by the AOT transform.
+ * Tree-shakable runtime target emitted by the AOT transform.
  *
  * React owns initial placement, SSR, hydration, props, and event semantics.
- * Compiler cells own local updates and precomputed DOM paths. A proven host-only
- * keyed container may transfer its child-row ownership after mount.
+ * Compiler cells own local updates and precomputed DOM paths. Structural
+ * helpers are installed only when the compiler emitted that boundary kind.
  */
-export function createCompiledComponent<Props>(
+export function createCompiledComponentWithFeatures<Props>(
   definition: CompiledComponentDefinition<Props>,
+  runtimeFeatures: readonly CompilerRuntimeFeature[],
 ): React.ComponentType<Props> {
   const stateSignature = definition.stateSignature || String(definition.initialize.length);
+  const runtimeSignature = [...new Set(runtimeFeatures.map((feature) => feature.name))]
+    .sort()
+    .join(",");
   if (definition.hmrId) {
     const registry = getCompilerHmrRegistry();
     const existing = registry.get(definition.hmrId);
-    if (existing?.stateSignature === stateSignature) {
+    if (
+      existing?.stateSignature === stateSignature &&
+      existing.runtimeSignature === runtimeSignature
+    ) {
       existing.definition.current = definition as CompiledComponentDefinition<unknown>;
       existing.component.displayName = `FarmCompiled(${definition.displayName})`;
       for (const refresh of existing.refreshListeners) refresh();
@@ -4034,34 +4182,17 @@ export function createCompiledComponent<Props>(
           },
         };
       });
-      this.blockRuntime = {
-        Conditional: createConditionalBlockComponent({
-          setRoot: (id, root) => this.setBlockRoot(id, root),
-          subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
-        }),
-        HostConditional: createHostConditionalBlockComponent({
-          subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
-        }),
-        ConditionalRanges: createConditionalRangesBlockComponent({
-          subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
-        }),
-        KeyedList: createKeyedListBlockComponent({
-          subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
-        }),
-        KeyedRows: createKeyedRowsBlockComponent({
-          subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
-        }),
-        KeyedRanges: createKeyedRangesBlockComponent({
-          subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
-        }),
-        MixedRanges: createMixedRangesBlockComponent({
-          subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
-        }),
-        Component: createComponentBlockComponent({
-          subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
-        }),
+      const featureOwner: CompilerRuntimeFeatureOwner = {
+        setRoot: (id, root) => this.setBlockRoot(id, root),
+        subscribe: (id, refresh) => this.subscribeToBlock(id, refresh),
+      };
+      const blockRuntime: Partial<CompilerBlockRuntime> = {
         target: (id) => this.bindingTarget(id),
       };
+      for (const feature of runtimeFeatures) {
+        Object.assign(blockRuntime, feature.create(featureOwner));
+      }
+      this.blockRuntime = blockRuntime as CompilerBlockRuntime;
     }
 
     private usesHybridReactivity(): boolean {
@@ -4502,8 +4633,31 @@ export function createCompiledComponent<Props>(
       definition: definitionReference as CompiledDefinitionReference<unknown>,
       refreshListeners,
       stateSignature,
+      runtimeSignature,
     });
   }
 
   return component;
+}
+
+const COMPLETE_RUNTIME_FEATURES: readonly CompilerRuntimeFeature[] = [
+  conditionalRuntimeFeature,
+  hostConditionalRuntimeFeature,
+  conditionalRangesRuntimeFeature,
+  keyedListRuntimeFeature,
+  keyedRowsCompleteRuntimeFeature,
+  keyedRangesRuntimeFeature,
+  mixedRangesRuntimeFeature,
+  componentRuntimeFeature,
+];
+
+/**
+ * Compatibility entry for hand-authored runtime definitions.
+ * Compiler output uses createCompiledComponentWithFeatures so unused structural
+ * runtimes can be removed from production bundles.
+ */
+export function createCompiledComponent<Props>(
+  definition: CompiledComponentDefinition<Props>,
+): React.ComponentType<Props> {
+  return createCompiledComponentWithFeatures(definition, COMPLETE_RUNTIME_FEATURES);
 }

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -330,6 +330,63 @@ type ComposableBlockPlan =
   | NestedHostMixedRangesPlan
   | ComponentIslandPlan;
 
+type CompilerRuntimeFeatureName =
+  | "conditional"
+  | "host-conditional"
+  | "conditional-ranges"
+  | "keyed-list"
+  | "keyed-rows"
+  | "keyed-rows-conditional"
+  | "keyed-rows-host"
+  | "keyed-rows-complete"
+  | "keyed-ranges"
+  | "mixed-ranges"
+  | "component";
+
+const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, string> = {
+  conditional: "conditionalRuntimeFeature",
+  "host-conditional": "hostConditionalRuntimeFeature",
+  "conditional-ranges": "conditionalRangesRuntimeFeature",
+  "keyed-list": "keyedListRuntimeFeature",
+  "keyed-rows": "keyedRowsRuntimeFeature",
+  "keyed-rows-conditional": "keyedRowsConditionalRuntimeFeature",
+  "keyed-rows-host": "keyedRowsHostRuntimeFeature",
+  "keyed-rows-complete": "keyedRowsCompleteRuntimeFeature",
+  "keyed-ranges": "keyedRangesRuntimeFeature",
+  "mixed-ranges": "mixedRangesRuntimeFeature",
+  component: "componentRuntimeFeature",
+};
+
+function runtimeFeaturesForPlans(
+  plans: readonly ComposableBlockPlan[],
+): CompilerRuntimeFeatureName[] {
+  const features = new Set<CompilerRuntimeFeatureName>();
+  let keyedRowsHaveConditionals = false;
+  let keyedRowsHaveHostBlocks = false;
+  for (const plan of plans) {
+    if (plan.kind === "keyed-rows") {
+      keyedRowsHaveConditionals ||= plan.conditionals.length > 0;
+      keyedRowsHaveHostBlocks ||= Boolean(plan.descriptorBlocks?.size);
+      continue;
+    }
+    if (plan.kind in COMPILER_RUNTIME_FEATURE_EXPORTS) {
+      features.add(plan.kind as CompilerRuntimeFeatureName);
+    }
+  }
+  if (plans.some((plan) => plan.kind === "keyed-rows")) {
+    features.add(
+      keyedRowsHaveConditionals && keyedRowsHaveHostBlocks
+        ? "keyed-rows-complete"
+        : keyedRowsHaveConditionals
+          ? "keyed-rows-conditional"
+          : keyedRowsHaveHostBlocks
+            ? "keyed-rows-host"
+            : "keyed-rows",
+    );
+  }
+  return [...features].sort();
+}
+
 interface Candidate {
   name: string;
   path: NodePath<t.FunctionDeclaration | t.FunctionExpression | t.ArrowFunctionExpression>;
@@ -4615,6 +4672,8 @@ function wrapperElement(definitionIdentifier: t.Identifier, props?: t.Expression
 function compileCandidate(
   candidate: Candidate,
   createComponentIdentifier: t.Identifier,
+  runtimeFeatureIdentifiers: ReadonlyMap<CompilerRuntimeFeatureName, t.Identifier>,
+  usedRuntimeFeatures: Set<CompilerRuntimeFeatureName>,
   useStateNames: ReadonlySet<string>,
   reactNames: ReadonlySet<string>,
   listNames: ReadonlySet<string>,
@@ -4855,6 +4914,7 @@ function compileCandidate(
   if (blockAnalysis.reason) return blockAnalysis.reason;
   if (analysis.reason) return analysis.reason;
   const blockPlans = blockAnalysis.plans || [];
+  const runtimeFeatures = runtimeFeaturesForPlans(blockPlans);
   markShortCircuitBindings(analysis.bindings || []);
   assignStableBindingTargets(analysis.bindings || []);
 
@@ -4965,6 +5025,9 @@ function compileCandidate(
         ),
       ),
     ]),
+    t.arrayExpression(
+      runtimeFeatures.map((feature) => t.cloneNode(runtimeFeatureIdentifiers.get(feature)!)),
+    ),
   ]);
 
   path
@@ -4977,6 +5040,7 @@ function compileCandidate(
   statementPath.insertAfter(
     t.variableDeclaration("const", [t.variableDeclarator(definitionIdentifier, definition)]),
   );
+  for (const feature of runtimeFeatures) usedRuntimeFeatures.add(feature);
   return undefined;
 }
 
@@ -5070,6 +5134,13 @@ export async function compileReactModule(
         const candidates = collectCandidates(programPath);
         const createComponentIdentifier =
           programPath.scope.generateUidIdentifier("createCompiledComponent");
+        const runtimeFeatureIdentifiers = new Map<CompilerRuntimeFeatureName, t.Identifier>(
+          Object.entries(COMPILER_RUNTIME_FEATURE_EXPORTS).map(([feature, exportName]) => [
+            feature as CompilerRuntimeFeatureName,
+            programPath.scope.generateUidIdentifier(exportName),
+          ]),
+        );
+        const usedRuntimeFeatures = new Set<CompilerRuntimeFeatureName>();
         for (const candidate of candidates) {
           const functionDirectives = new Set(
             t.isBlockStatement(candidate.path.node.body)
@@ -5084,6 +5155,8 @@ export async function compileReactModule(
           const reason = compileCandidate(
             candidate,
             createComponentIdentifier,
+            runtimeFeatureIdentifiers,
+            usedRuntimeFeatures,
             useStateNames,
             reactNames,
             listNames,
@@ -5108,8 +5181,16 @@ export async function compileReactModule(
               [
                 t.importSpecifier(
                   createComponentIdentifier,
-                  t.identifier("createCompiledComponent"),
+                  t.identifier("createCompiledComponentWithFeatures"),
                 ),
+                ...[...usedRuntimeFeatures]
+                  .sort()
+                  .map((feature) =>
+                    t.importSpecifier(
+                      t.cloneNode(runtimeFeatureIdentifiers.get(feature)!),
+                      t.identifier(COMPILER_RUNTIME_FEATURE_EXPORTS[feature]),
+                    ),
+                  ),
               ],
               t.stringLiteral("@farm.js/react/compiler-runtime"),
             ),


### PR DESCRIPTION
## Summary

- make compiler output import only the runtime capabilities used by each compiled component
- split keyed-row support into plain, conditional, nested-host, and complete variants
- retain the complete compatibility entry for hand-authored definitions and include runtime capabilities in Fast Refresh compatibility
- add persisted production-size fixtures, emitted-code assertions, byte budgets, and CI enforcement
- document the generated output and refresh the measured dashboard and benchmark bundle costs

## Measured bundle impact

- direct-only core runtime premium: 14,280 B to 3,766 B gzip, a 73.6% reduction
- feature-heavy keyed benchmark compiler premium: 18,103 B to 11,918 B gzip, a 34.2% reduction
- dashboard hybrid page chunk: 17,935 B to 14,785 B gzip

The upstream official browser CPU headline is intentionally unchanged because this change reran the production bundle audit separately from the official webdriver harness.

## Verification

- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test` — 41 files, 349 tests
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and React 19.2.8
- production compiler browser verification
- heavy interactive benchmark — 12x median update speedup, zero owner update executions
- 20,000-row dashboard correctness, performance, and scalability gates
- `pnpm docs:build`
- targeted oxlint and oxfmt checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits the compiler runtime into statically imported feature exports so each compiled component pulls only the runtime capabilities it uses, cutting the direct-only core runtime premium from 14,280 B to 3,766 B gzip (73.6%) and the keyed benchmark premium from 18,103 B to 11,918 B gzip (34.2%).

- Generated code now calls `createCompiledComponentWithFeatures` with a capability array; plain keyed rows omit conditional and host-row support, and mixed structural kinds select a complete variant automatically.
- The legacy `createCompiledComponent` stays as the full compatibility entry for hand-authored definitions, and runtime capabilities are now part of the Fast Refresh compatibility signature.
- Adds production-size bundle fixtures with byte budgets, persisted results, and a `test:runtime-size` gate enforced in the React 19 CI lane.

**Migration**

- Hand-authored definitions using `createCompiledComponent` keep working unchanged; only compiler-emitted output switches to the feature entry.

<sup>Written for commit 8932deae700b9ff55aab300519261afd2aac9464. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

