### PR TITLE
perf(react): compile same-key map update hints

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1493,8 +1493,9 @@ The package and example test suites verify more than generated code:
 - the production browser experiment rotates 1,000 compiler-owned host rows with one LIS move,
   updates outer and nested row conditions, preserves surviving row and branch identity, removes and
   inserts a row, and observes zero owner update executions;
-- the production 10,000/20,000-row benchmark requires a nonzero `keyedMapUpdateHints` report count
-  and passes DOM correctness, React-relative regression, and normalized scalability gates;
+- the production 10,000/20,000-row benchmark requires a nonzero `keyedMapUpdateHints` report count,
+  at least an 8x keyed-update speedup in both compiler modes, and passes DOM correctness,
+  React-relative regression, and normalized scalability gates;
 - the public `List` renders iterable and nullish collections correctly with the compiler off;
 - the packaged runtime, including a keyed-range component root, editable and interactive keyed-row
   events, row-local conditions, reorders, identity, selection, and hydration, is exercised

--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -301,7 +301,8 @@ After a successful build, Farm writes `.farm/react-compiler.json`:
     "modules": 2,
     "componentsConsidered": 4,
     "compiled": 2,
-    "fallback": 2
+    "fallback": 2,
+    "keyedMapUpdateHints": 1
   },
   "fallbackReasons": [
     {
@@ -313,6 +314,9 @@ After a successful build, Farm writes `.farm/react-compiler.json`:
     {
       "id": "src/Products.tsx",
       "compiled": ["ProductRow"],
+      "optimizations": {
+        "keyedMapUpdateHints": 1
+      },
       "fallbacks": [
         {
           "module": "src/Products.tsx",
@@ -327,10 +331,12 @@ After a successful build, Farm writes `.farm/react-compiler.json`:
 ```
 
 `componentsConsidered` counts candidates selected by the active mode. `compiled` counts components
-using the AOT runtime, and `fallback` counts candidates left on React. `selected` is `true` when an
-annotation explicitly requested compilation. Module paths are relative to the project root, and
-the output is sorted and contains no timestamp, so CI can compare reports without machine-specific
-noise.
+using the AOT runtime, and `fallback` counts candidates left on React. `keyedMapUpdateHints` counts
+setter sites where the compiler proved that a direct keyed collection can report its changed row
+indexes while an immutable `map()` runs. The same count appears per module. `selected` is `true`
+when an annotation explicitly requested compilation. Module paths are relative to the project root,
+and the output is sorted and contains no timestamp, so CI can compare reports without
+machine-specific noise.
 
 Use a different project-relative output path when CI collects artifacts elsewhere:
 
@@ -670,12 +676,42 @@ prepare the row's host descriptor, key reader, and exact text, attribute, and st
 build time. React still creates the initial elements during client render or hydration. After the
 component mounts, Farm adopts those elements as keyed row instances.
 
-Updating `items` then does not execute `Inventory` or its map callback. Surviving rows are found by
-key and their prepared bindings are patched directly. Missing keys remove only their row, and new
-keys create only their prepared host tree. During a reorder, Farm calculates the longest increasing
-subsequence (LIS) of the old row positions. Rows in that subsequence stay in place; only the other
-surviving rows move. LIS is a runtime move planner over compiler-prepared rows, not a claim that the
-future contents of an array are known at build time.
+Updating `items` then does not execute `Inventory` or its JSX row-render callback. Surviving rows
+are found by key and their prepared bindings are patched directly. Missing keys remove only their
+row, and new keys create only their prepared host tree. During a reorder, Farm calculates the
+longest increasing subsequence (LIS) of the old row positions. Rows in that subsequence stay in
+place; only the other surviving rows move. LIS is a runtime move planner over compiler-prepared
+rows, not a claim that the future contents of an array are known at build time.
+
+#### Mutation-aware same-order updates
+
+The compiler can remove the runtime's second full-row scan for a common immutable update:
+
+```tsx
+setItems((current) =>
+  current.map((item) => (item.id === targetId ? { ...item, selected: !item.selected } : item)),
+);
+```
+
+This needs no option or component primitive. At build time, Farm recognizes a functional setter on
+the direct `useState` collection used by a compiled keyed map or `List`. The mapper must be a concise
+arrow expression with a conditional result: one branch returns the original item and the other
+returns a new object that spreads that item. The condition and replacement values must use the
+compiler's safe expression subset. The hint runtime is retained only in modules where at least one
+such site is emitted; direct-only and ordinary keyed builds do not import that capability.
+
+The generated mapper records an index only when the returned item has a different identity. The
+user's `map()` still runs and is still O(n); the optimization avoids reading every key and every row
+binding again after it finishes. Farm validates that the array length and each reported row's key
+and index are unchanged, then patches only those row instances. Multiple hinted functional updates
+queued in one compiler flush are combined.
+
+If a key changes, an insert, removal, or reorder occurs, a relevant second dependency changes, or a
+runtime check fails, Farm discards the hint and runs the existing complete keyed reconciliation and
+LIS path. Derived collections, non-functional setters, block-bodied mappers, mutating replacements,
+and other unproven shapes also keep that existing path. This is an optimization hint, not a new
+correctness contract or a way to bypass React fallback behavior. The compiler report exposes the
+number of emitted sites as `keyedMapUpdateHints`.
 
 #### Interactive host rows
 
@@ -1385,6 +1421,11 @@ The package and example test suites verify more than generated code:
 - compiler-owned host rows patch text, attributes, and styles in place, preserve focus and text
   selection, use the LIS minimum for measured rotations and reversals, and remount through React
   when runtime keys are duplicated;
+- mutation-aware keyed `map()` updates patch only compiler-reported same-key row indexes, compose
+  queued hints across multiple keyed boundaries, ignore unrelated state in the same flush, and
+  reject key changes or mixed unhinted collection updates into the complete reconciliation path;
+- a 2,048-row instrumentation test changes one item with one key read and one binding read, while
+  2,000 deterministic queued updates match normal React with one compiled owner execution;
 - keyed DOM ranges preserve static siblings around multiple lists, support adjacent empty ranges
   and exact component roots, apply LIS independently per range, and remount the complete container
   through React when keys or parent-driven static markup invalidate adoption;
@@ -1452,6 +1493,8 @@ The package and example test suites verify more than generated code:
 - the production browser experiment rotates 1,000 compiler-owned host rows with one LIS move,
   updates outer and nested row conditions, preserves surviving row and branch identity, removes and
   inserts a row, and observes zero owner update executions;
+- the production 10,000/20,000-row benchmark requires a nonzero `keyedMapUpdateHints` report count
+  and passes DOM correctness, React-relative regression, and normalized scalability gates;
 - the public `List` renders iterable and nullish collections correctly with the compiler off;
 - the packaged runtime, including a keyed-range component root, editable and interactive keyed-row
   events, row-local conditions, reorders, identity, selection, and hydration, is exercised

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -1,6 +1,6 @@
 # Complex dashboard and 20,000-row scale result
 
-Date: 2026-08-27
+Date: 2026-08-28
 
 Result: **PASS.** Correctness, the React-relative performance gate, and the normalized scalability
 gate all pass. The production run compares two bracketing React baselines with static and hybrid
@@ -20,9 +20,9 @@ compiler builds from the exact same component source.
 - No CPU throttling
 
 Every trial passed DOM assertions and browser-error checks. The compiler report proved that both
-workloads compiled, delegated keyed rows were present only in compiler builds, and hybrid/static
-added zero owner executions. The two React baselines added 1,430 dashboard and 261 table owner
-executions each.
+workloads compiled, delegated keyed rows were present only in compiler builds, exactly one
+mutation-aware keyed-map update site was emitted, and hybrid/static added zero owner executions.
+The two React baselines added 1,430 dashboard and 261 table owner executions each.
 
 ## Complex dashboard
 
@@ -31,23 +31,29 @@ bindings.
 
 | Interaction                 | React median | Hybrid median | Hybrid vs React |
 | --------------------------- | -----------: | ------------: | --------------: |
-| Active live pulse           |     0.100 ms |      0.080 ms |    1.25x faster |
-| Inactive branch update      |     0.070 ms |      0.020 ms |    3.50x faster |
+| Active live pulse           |     0.100 ms |      0.100 ms |          parity |
+| Inactive branch update      |     0.060 ms |      0.020 ms |    3.00x faster |
 | Switch live/snapshot branch |     0.100 ms |      0.100 ms |          parity |
 
 ## Standard table operations
 
 | Operation         |            Rows | React median | Hybrid median | Hybrid vs React |
 | ----------------- | --------------: | -----------: | ------------: | --------------: |
-| Create            |           1,000 |     12.60 ms |      11.20 ms |    1.13x faster |
-| Replace all       |           1,000 |     18.65 ms |      11.80 ms |    1.58x faster |
-| Create many       |          10,000 |    287.35 ms |     124.20 ms |    2.31x faster |
-| Append            | 10,000 -> 11,000 |     74.40 ms |      29.30 ms |    2.54x faster |
-| Update every 10th |          10,000 |     47.05 ms |       9.90 ms |    4.75x faster |
+| Create            |           1,000 |     12.45 ms |      10.50 ms |    1.19x faster |
+| Replace all       |           1,000 |     16.85 ms |      11.50 ms |    1.47x faster |
+| Create many       |          10,000 |    297.40 ms |     116.10 ms |    2.56x faster |
+| Append            | 10,000 -> 11,000 |     70.30 ms |      27.30 ms |    2.58x faster |
+| Update every 10th |          10,000 |     44.05 ms |       2.50 ms |   17.62x faster |
 | Select            |           1,000 |      4.10 ms |       0.20 ms |   20.50x faster |
-| Swap rows 2 / 999 |           1,000 |      9.20 ms |       1.20 ms |    7.67x faster |
-| Remove one row    |           1,000 |      4.60 ms |       2.00 ms |    2.30x faster |
-| Clear             |          10,000 |     49.05 ms |       9.70 ms |    5.06x faster |
+| Swap rows 2 / 999 |           1,000 |     10.20 ms |       1.10 ms |    9.27x faster |
+| Remove one row    |           1,000 |      4.65 ms |       2.40 ms |    1.94x faster |
+| Clear             |          10,000 |     53.60 ms |       9.70 ms |    5.53x faster |
+
+`Update every 10th` is the targeted mutation-aware path. The application still executes its native
+immutable `map()` over 10,000 items and creates 1,000 replacement objects. The generated hint lets
+the keyed runtime validate and patch those 1,000 rows without a second scan of all 10,000 keys and
+bindings. That reduced the measured median from the previous compiler result of 9.90 ms to 2.50 ms
+on the same benchmark shape; cross-run timings remain machine- and load-sensitive.
 
 ## Repeated 20,000-row scale profile
 
@@ -57,16 +63,13 @@ time is better.
 
 | Operation at scale        | React median | React p95 | Hybrid median | Hybrid p95 | Speedup |
 | ------------------------- | -----------: | --------: | ------------: | ---------: | ------: |
-| Create initial 10,000     |    306.60 ms | 370.30 ms |     128.90 ms |  133.70 ms |   2.38x |
-| Append a 1,000-row batch  |     88.80 ms | 117.95 ms |      29.80 ms |   34.50 ms |   2.98x |
-| Update every 10th at 20k |    104.65 ms | 133.35 ms |      20.50 ms |   22.20 ms |   5.10x |
-| Select at 20k             |     96.20 ms | 143.50 ms |       4.60 ms |    6.90 ms |  20.91x |
-| Swap at 20k               |    113.00 ms | 123.25 ms |      24.40 ms |   26.40 ms |   4.63x |
-| Remove middle row at 20k |    111.10 ms | 116.65 ms |      40.00 ms |   52.30 ms |   2.78x |
-| Clear 20k                 |    167.25 ms | 255.60 ms |      20.70 ms |   23.50 ms |   8.08x |
-
-The earlier one-off removal tail was not reproduced in the scale cycles: hybrid removal ranged
-from 39.9 to 52.3 ms, versus React's 101.2 to 122.7 ms.
+| Create initial 10,000     |    293.65 ms | 347.20 ms |     107.50 ms |  130.90 ms |   2.73x |
+| Append a 1,000-row batch  |     90.65 ms | 119.60 ms |      28.60 ms |   34.30 ms |   3.17x |
+| Update every 10th at 20k |     98.35 ms | 106.95 ms |       6.00 ms |    9.70 ms |  16.39x |
+| Select at 20k             |     94.75 ms | 106.40 ms |       5.00 ms |    8.80 ms |  18.95x |
+| Swap at 20k               |    119.15 ms | 132.50 ms |      24.50 ms |   26.40 ms |   4.86x |
+| Remove middle row at 20k |    117.85 ms | 151.05 ms |      40.10 ms |   43.00 ms |   2.94x |
+| Clear 20k                 |    121.35 ms | 206.70 ms |      21.00 ms |   22.30 ms |   5.78x |
 
 ## Scalability gate
 
@@ -75,38 +78,37 @@ The gate divides observed timing growth by row-count growth. A value near 1 mean
 
 | Path                    | Row growth | Timing growth | Normalized growth |
 | ----------------------- | ---------: | ------------: | ----------------: |
-| Create 10k repeat       |      1.00x |         1.04x |             1.04x |
-| Update 10k -> 20k       |      2.00x |         2.07x |             1.04x |
-| Select 1k -> 20k        |     20.00x |        18.40x |             0.92x |
-| Swap 1k -> 20k          |     20.00x |        20.33x |             1.02x |
-| Remove 1k -> 20k        |     20.00x |        20.00x |             1.00x |
-| Clear 10k -> 20k        |      2.00x |         2.13x |             1.07x |
+| Create 10k repeat       |      1.00x |         0.93x |             0.93x |
+| Update 10k -> 20k       |      2.00x |         2.40x |             1.20x |
+| Select 1k -> 20k        |     20.00x |        20.00x |             1.00x |
+| Swap 1k -> 20k          |     20.00x |        22.27x |             1.11x |
+| Remove 1k -> 20k        |     20.00x |        16.71x |             0.84x |
+| Clear 10k -> 20k        |      2.00x |         2.16x |             1.08x |
 
 This demonstrates approximately linear rather than quadratic growth. Selection still scans the
 rows to evaluate the affected binding, so it is not O(1); it performs only the required DOM writes
-and remains 20.91x faster than React at 20,000 rows. Structural swap/removal paths are also O(n),
+and remains 18.95x faster than React at 20,000 rows. Structural swap/removal paths are also O(n),
 as expected for validating keys and maintaining row indices.
 
 ## Bundle cost
 
 | Build                   | Page chunk raw | Page chunk gzip |
 | ----------------------- | -------------: | --------------: |
-| React baseline          |       18,567 B |         4,306 B |
-| Static compiler         |       71,688 B |        14,783 B |
-| Hybrid compiler         |       71,688 B |        14,785 B |
+| React baseline          |       18,567 B |         4,307 B |
+| Static compiler         |       74,029 B |        15,521 B |
+| Hybrid compiler         |       74,029 B |        15,522 B |
 
-This deliberately broad page now pays a 10,479-byte gzip premium for the compiler runtime. Static
-capability selection removes 22,915 raw bytes and 3,150 gzip bytes from the previous hybrid page
-chunk while preserving every benchmark scenario. Smaller direct-only applications retain less of
-the runtime; the package-level fixtures and persisted size gate are documented in
+This deliberately broad page now pays an 11,215-byte gzip premium for the compiler runtime,
+including the mutation-aware keyed path. Smaller direct-only applications retain less of the
+runtime; the package-level fixtures and persisted size gate are documented in
 `packages/farm-react/RUNTIME_SIZE_RESULTS.md`.
 
 ## Conclusion
 
 The compiled path scales successfully through the tested 20,000-row mixed workload: all DOM and
 event assertions pass, there are no browser errors or owner rerenders, every scale operation beats
-the bracketed React baseline, and normalized growth stays below 1.07x. The evidence supports
+the bracketed React baseline, and normalized growth stays at or below 1.20x. The evidence supports
 approximately linear scaling within this range, not unlimited or constant-time scaling.
 
-The machine-readable output is `/tmp/farm-react-dashboard-scale-final.json`. Re-run
+The machine-readable output is `/tmp/farm-react-dashboard-benchmark.json`. Re-run
 `pnpm --filter farm-react-compiler-dashboard-example benchmark` to reproduce it.

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,9 +2,10 @@
 
 Date: 2026-08-28
 
-Result: **PASS.** Correctness, the React-relative performance gate, and the normalized scalability
-gate all pass. The production run compares two bracketing React baselines with static and hybrid
-compiler builds from the exact same component source.
+Result: **PASS.** Correctness, the React-relative performance gate, the keyed-update optimization
+persistence gate, and the normalized scalability gate all pass. The production run compares two
+bracketing React baselines with static and hybrid compiler builds from the exact same component
+source.
 
 ## Environment and method
 
@@ -17,6 +18,7 @@ compiler builds from the exact same component source.
 - Timing boundary: event dispatch through an asserted DOM mutation
 - Baseline values average the medians from the two bracketing React trials
 - Performance gate: more than 10% and 0.25 ms slower than the bracketed baseline
+- Keyed-update persistence gate: at least 8x faster than React at both 10,000 and 20,000 rows
 - No CPU throttling
 
 Every trial passed DOM assertions and browser-error checks. The compiler report proved that both
@@ -54,6 +56,8 @@ immutable `map()` over 10,000 items and creates 1,000 replacement objects. The g
 the keyed runtime validate and patch those 1,000 rows without a second scan of all 10,000 keys and
 bindings. That reduced the measured median from the previous compiler result of 9.90 ms to 2.50 ms
 on the same benchmark shape; cross-run timings remain machine- and load-sensitive.
+The 8x persistence floor leaves substantial headroom below this run's 16.39x-17.62x result while
+still rejecting a silent return to the older roughly 5x full-reconciliation path.
 
 ## Repeated 20,000-row scale profile
 

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -55,6 +55,12 @@ still failing the performance gate when its median is both more than 10% and mor
 slower than the bracketed React baseline. The absolute tolerance keeps sub-millisecond browser timer
 noise from failing the run while retaining the relative gate for meaningful operations.
 
+The targeted keyed-update optimization has an additional persistence gate. Both compiler modes must
+remain at least 8x faster than bracketed React for update-every-10th at 10,000 and 20,000 rows. This
+is intentionally below the measured 16x-17x result for machine headroom, but above the older roughly
+5x full-reconciliation path. A failed performance, scalability, or persistence gate writes the JSON
+report and exits with a nonzero status.
+
 Set `FARM_EXPERIMENT_BROWSER_PATH` to an installed Chrome/Chromium executable when Playwright's
 bundled browser is unavailable. Sample counts are configurable:
 

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -823,7 +823,30 @@ const performanceRegressions = Object.entries(comparisons).flatMap(([group, metr
       speedup: comparison.hybridVsBaseline.speedup,
     })),
 );
-const passed = performanceRegressions.length === 0 && scalabilityRegressions.length === 0;
+// The general regression gate above only proves that compiled output is not slower than React.
+// Keep a separate floor for the mutation-aware keyed update this benchmark is designed to protect:
+// without the hint, the older compiled reconciliation path is still faster than React and would
+// otherwise pass despite losing most of the optimization.
+const keyedUpdateMinimumSpeedup = 8;
+const keyedUpdateCases = [
+  ["table", "updateEvery10th"],
+  ["scale", "updateEvery10th20k"],
+];
+const keyedUpdateSpeedups = keyedUpdateCases.flatMap(([group, metric]) =>
+  ["static", "hybrid"].map((mode) => ({
+    group,
+    metric,
+    mode,
+    speedup: comparisons[group][metric][`${mode}VsBaseline`].speedup,
+  })),
+);
+const keyedUpdateRegressions = keyedUpdateSpeedups.filter(
+  ({ speedup }) => !Number.isFinite(speedup) || speedup < keyedUpdateMinimumSpeedup,
+);
+const passed =
+  performanceRegressions.length === 0 &&
+  scalabilityRegressions.length === 0 &&
+  keyedUpdateRegressions.length === 0;
 
 const report = {
   result: passed ? "PASS" : "CORRECTNESS_PASS_PERFORMANCE_REGRESSION",
@@ -833,6 +856,12 @@ const report = {
     status: performanceRegressions.length === 0 ? "PASS" : "FAIL",
     toleranceMs: performanceToleranceMs,
     thresholdPercent: performanceThresholdPercent,
+  },
+  optimizationPersistenceGate: {
+    minimumSpeedup: keyedUpdateMinimumSpeedup,
+    regressions: keyedUpdateRegressions,
+    speedups: keyedUpdateSpeedups,
+    status: keyedUpdateRegressions.length === 0 ? "PASS" : "FAIL",
   },
   scalabilityGate: {
     metrics: scalability,
@@ -876,3 +905,4 @@ const report = {
 
 await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`);
 console.log(JSON.stringify({ ...report, reportPath }, null, 2));
+if (!passed) process.exitCode = 1;

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -114,6 +114,10 @@ async function inspectBuild(compilerMode) {
     const compiled = new Set(compilerReport.modules.flatMap((module) => module.compiled));
     assert(compiled.has("OperationsDashboard"));
     assert(compiled.has("StandardTableBenchmark"));
+    assert(
+      compilerReport.summary.keyedMapUpdateHints > 0,
+      "The compiler build did not emit a mutation-aware keyed-map update hint.",
+    );
   }
 
   return {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -162,6 +162,25 @@ Later list updates patch surviving rows by key, create or remove only the change
 longest increasing subsequence (LIS) to minimize DOM moves during a reorder. The outer user
 component and the list callback do not rerun for those compiler-cell updates.
 
+For a direct keyed `useState` collection, the compiler also recognizes conservative same-order
+updates such as:
+
+```tsx
+setItems((current) =>
+  current.map((item) => (item.id === targetId ? { ...item, selected: !item.selected } : item)),
+);
+```
+
+The generated native `map()` records which indexes returned new item identities. Farm then
+validates that length, keys, and positions are unchanged and patches only those row instances. The
+user's `map()` remains O(n); this removes the keyed runtime's second full key-and-binding scan.
+Queued hints compose. Key changes, structural edits, relevant mixed dependencies, and failed runtime
+checks use the existing complete reconciliation and LIS path. Non-functional setters, derived
+collections, block-bodied or mutating mappers, and other unproven forms are simply not hinted. No
+new option is required. A compiler report exposes the emitted-site count as
+`keyedMapUpdateHints`. The separate hint runtime capability is imported only when that count is
+nonzero, so direct-only and ordinary keyed builds do not retain it.
+
 An otherwise eligible host row may also contain an inline synchronous React event:
 
 ```tsx
@@ -438,7 +457,9 @@ compiler: {
 
 The default path is `.farm/react-compiler.json`. The report covers the production browser graph and
 contains project-relative module paths, compiled component names, fallback details, and fallback
-reasons aggregated by count. A custom project-relative `reportFile` also enables reporting.
+reasons aggregated by count. Its summary and per-module `optimizations` also report
+`keyedMapUpdateHints`, the number of compiler-proven direct keyed `map()` update sites. A custom
+project-relative `reportFile` also enables reporting.
 
 The runtime test compares the same counter interaction on both paths: ordinary React performs a
 second component render and commit, while the compiled component remains at one render and one

--- a/packages/farm-react/scripts/benchmark-runtime-size.mjs
+++ b/packages/farm-react/scripts/benchmark-runtime-size.mjs
@@ -79,6 +79,9 @@ if (!keyedOn.code.includes("FarmCompiledKeyedRows")) {
 if (keyedOn.code.includes("FarmCompiledKeyedRowConditional")) {
   throw new Error("Plain keyed fixture retained the optional row-conditional runtime.");
 }
+if (keyedOn.code.includes("keyed-rows:hinted")) {
+  throw new Error("Plain keyed fixture retained the optional keyed-update hint runtime.");
+}
 
 const fullRuntimePremium = runtimeFull.gzip - runtimeControl.gzip;
 const coreRuntimePremium = runtimeCore.gzip - runtimeControl.gzip;

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -39,7 +39,11 @@ const testSource = String.raw`
   const { flushSync } = await import("react-dom");
   const { createRoot, hydrateRoot } = await import("react-dom/client");
   const { renderToString } = await import("react-dom/server");
-  const { createCompiledComponent, createCompiledComponentWithFeatures } = await import(
+  const {
+    createCompiledComponent,
+    createCompiledComponentWithFeatures,
+    createCompilerKeyedMapUpdate,
+  } = await import(
     "@farm.js/react/compiler-runtime"
   );
   const { List } = await import("@farm.js/react/list");
@@ -744,6 +748,9 @@ const testSource = String.raw`
         ),
         React.createElement(blocks.KeyedRows, {
           id: 0,
+          collectionDependency: 0,
+          dependencies: [0],
+          structureDependencies: [0],
           render: () =>
             React.createElement(
               "ol",
@@ -1254,6 +1261,9 @@ const testSource = String.raw`
         null,
         React.createElement(blocks.KeyedRows, {
           id: 0,
+          collectionDependency: 0,
+          dependencies: [0],
+          structureDependencies: [0],
           render: (rowEvent, rowConditional) => {
             interactiveListRenders += 1;
             return React.createElement(
@@ -1343,13 +1353,17 @@ const testSource = String.raw`
               name: "onClick",
               invoke: (item, index, event) => {
                 interactiveCalls.push(item.label + ":" + index + ":" + event.currentTarget.dataset.index);
-                state[0].set((current) =>
-                  current.map((row) =>
-                    row.id === item.id
+                state[0].set((current) => {
+                  const changedIndices = [];
+                  const next = current.map((row, rowIndex) => {
+                    const mapped = row.id === item.id
                       ? { ...row, label: item.label + "!", done: !item.done }
-                      : row,
-                  ),
-                );
+                      : row;
+                    if (mapped !== row) changedIndices.push(rowIndex);
+                    return mapped;
+                  });
+                  return createCompilerKeyedMapUpdate(current, next, changedIndices);
+                });
               },
             },
           ],

--- a/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true);
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/KeyedUpdateHints.tsx", infer);
+}
+
+describe("React AOT keyed update hints", () => {
+  it("records changed indexes while a proven same-order map executes", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inventory() {
+        const [items, setItems] = useState([
+          { id: "a", label: "Alpha", selected: false },
+          { id: "b", label: "Beta", selected: false },
+        ]);
+        return (
+          <section>
+            <button
+              onClick={() => setItems((current) =>
+                current.map((row, index) =>
+                  index === 1 ? { ...row, label: row.label + "!", selected: true } : row,
+                )
+              )}
+            >
+              Update
+            </button>
+            <ul>{items.map((item) => <li key={item.id}>{item.label}</li>)}</ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations).toEqual({ keyedMapUpdateHints: 1 });
+    expect(result.code).toContain("createCompilerKeyedMapUpdate");
+    expect(result.code).toContain("keyedRowsHintedRuntimeFeature");
+    expect(result.code).toContain("collectionDependency={0}");
+    expect(result.code).toContain("dependencies={[0]}");
+    expect(result.code).toMatch(/const _farmChangedIndices\d* = \[\]/);
+    expect(result.code).toMatch(/_farmChangedIndices\d*\.push\(index\)/);
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedUpdateHints.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("createCompilerKeyedMapUpdate"),
+    });
+  });
+
+  it("supports direct-state public List rows without adding a public option", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List } from "@farm.js/react/list";
+      export function Inventory() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha" }]);
+        return (
+          <section>
+            <button onClick={() => setItems((current) => current.map((row) => row.id === "a" ? { ...row, label: "Updated" } : row))}>Update</button>
+            <ul>
+              <List each={items} by={(item) => item.id}>
+                {(item) => <li>{item.label}</li>}
+              </List>
+            </ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(1);
+    expect(result.code).toContain("collectionDependency={0}");
+  });
+
+  it.each([
+    {
+      name: "a derived collection",
+      declaration: "const visible = items.filter((item) => item.visible);",
+      collection: "visible",
+      update:
+        'setItems((current) => current.map((row) => row.id === "a" ? { ...row, label: "Updated" } : row))',
+    },
+    {
+      name: "a block-bodied mapper",
+      declaration: "",
+      collection: "items",
+      update:
+        'setItems((current) => current.map((row) => { return row.id === "a" ? { ...row, label: "Updated" } : row; }))',
+    },
+    {
+      name: "a potentially mutating mapper",
+      declaration: "",
+      collection: "items",
+      update:
+        'setItems((current) => current.map((row) => row.id === "a" ? Object.assign(row, { label: "Updated" }) : row))',
+    },
+    {
+      name: "a captured non-functional update",
+      declaration: "",
+      collection: "items",
+      update: 'setItems(items.map((row) => ({ ...row, label: "Updated" })))',
+    },
+  ])(
+    "keeps $name on the existing complete reconciliation path",
+    async ({ declaration, collection, update }) => {
+      const result = await compile(`
+      import { useState } from "react";
+      export function Inventory() {
+        const [items, setItems] = useState([{ id: "a", label: "Alpha", visible: true }]);
+        ${declaration}
+        return (
+          <section>
+            <button onClick={() => ${update}}>Update</button>
+            <ul>{${collection}.map((item) => <li key={item.id}>{item.label}</li>)}</ul>
+          </section>
+        );
+      }
+    `);
+
+      expect(result.compiled).toEqual(["Inventory"]);
+      expect(result.optimizations.keyedMapUpdateHints).toBe(0);
+      expect(result.code).not.toContain("createCompilerKeyedMapUpdate");
+      expect(result.code).not.toContain("keyedRowsHintedRuntimeFeature");
+    },
+  );
+});

--- a/packages/farm-react/src/__tests__/compiler-report.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-report.test.ts
@@ -27,6 +27,7 @@ function observations(projectRoot: string): ReactCompilerModuleObservation[] {
       result: {
         compiled: ["Counter"],
         diagnostics: [],
+        optimizations: { keyedMapUpdateHints: 0 },
       },
     },
     {
@@ -45,6 +46,7 @@ function observations(projectRoot: string): ReactCompilerModuleObservation[] {
             selected: true,
           },
         ],
+        optimizations: { keyedMapUpdateHints: 3 },
       },
     },
   ];
@@ -60,6 +62,7 @@ describe("React compiler coverage report", () => {
       componentsConsidered: 4,
       compiled: 2,
       fallback: 2,
+      keyedMapUpdateHints: 3,
     });
     expect(report.fallbackReasons).toEqual([
       {
@@ -74,6 +77,7 @@ describe("React compiler coverage report", () => {
       reason: "dynamic child structures require React reconciliation",
       selected: true,
     });
+    expect(report.modules[1]?.optimizations).toEqual({ keyedMapUpdateHints: 3 });
   });
 
   it("writes formatted JSON to the configured project-relative file", async () => {

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-update-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-update-hints.test.tsx
@@ -1,0 +1,488 @@
+import React, { useState } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createCompiledComponent,
+  createCompilerKeyedMapUpdate,
+  type CompilerKeyedRowElement,
+} from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Item {
+  id: string;
+  label: string;
+  selected: boolean;
+}
+
+const roots: Array<{ unmount(): void }> = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function descriptor(item: Item): CompilerKeyedRowElement {
+  return {
+    kind: "element",
+    tag: "li",
+    attributes: [{ name: "data-key", value: item.id }],
+    styles: [],
+    children: [item.label],
+  };
+}
+
+function hintedMap(previous: Item[], update: (item: Item, index: number) => Item): unknown {
+  const changedIndices: number[] = [];
+  const value = previous.map((item, index) => {
+    const next = update(item, index);
+    if (next !== item) changedIndices.push(index);
+    return next;
+  });
+  return createCompilerKeyedMapUpdate(previous, value, changedIndices);
+}
+
+describe("compiled keyed update hints", () => {
+  it("patches only proven changed rows while unrelated state updates share the flush", async () => {
+    const initialItems = Array.from(
+      { length: 2_048 },
+      (_, index): Item => ({
+        id: `row-${index}`,
+        label: `Row ${index}`,
+        selected: false,
+      }),
+    );
+    let executions = 0;
+    let listRenders = 0;
+    let keyReads = 0;
+    let descriptorReads = 0;
+    let bindingReads = 0;
+    const Inventory = createCompiledComponent({
+      displayName: "HintedInventory",
+      initialize: () => [initialItems, 0],
+      render(_props: Record<string, never>, state, blocks) {
+        executions += 1;
+        const items = () => state[0].get() as Item[];
+        return (
+          <section>
+            <button
+              onClick={() => {
+                state[0].set((previous) =>
+                  hintedMap(previous as Item[], (item, index) =>
+                    index === 1_337 ? { ...item, label: "Updated 1337", selected: true } : item,
+                  ),
+                );
+                state[1].set((value) => Number(value) + 1);
+              }}
+            >
+              Update
+            </button>
+            <blocks.KeyedRows
+              collectionDependency={0}
+              dependencies={[0]}
+              id={0}
+              items={items}
+              structureDependencies={[0]}
+              render={() => {
+                listRenders += 1;
+                return (
+                  <ul>
+                    {items().map((item) => (
+                      <li data-key={item.id} key={item.id}>
+                        {item.label}
+                      </li>
+                    ))}
+                  </ul>
+                );
+              }}
+              rowKey={(item) => {
+                keyReads += 1;
+                return (item as Item).id;
+              }}
+              create={(item) => {
+                descriptorReads += 1;
+                return descriptor(item as Item);
+              }}
+              bindings={[
+                {
+                  kind: "text",
+                  path: [],
+                  read: (item) => {
+                    bindingReads += 1;
+                    return [(item as Item).label];
+                  },
+                },
+              ]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Inventory />));
+    const before = container.querySelector<HTMLElement>('[data-key="row-1337"]');
+    keyReads = 0;
+    descriptorReads = 0;
+    bindingReads = 0;
+
+    await act(async () => {
+      container.querySelector("button")!.click();
+      await flushCompilerUpdates();
+    });
+
+    const after = container.querySelector<HTMLElement>('[data-key="row-1337"]');
+    expect(after).toBe(before);
+    expect(after?.textContent).toBe("Updated 1337");
+    expect(executions).toBe(1);
+    expect(listRenders).toBe(1);
+    expect(keyReads).toBe(1);
+    expect(descriptorReads).toBe(0);
+    expect(bindingReads).toBe(1);
+  });
+
+  it("falls back to complete keyed reconciliation when a hinted row changes its key", async () => {
+    let setItems: (next: unknown) => void = () => undefined;
+    const Inventory = createCompiledComponent({
+      displayName: "KeyChangingInventory",
+      initialize: () => [
+        [
+          { id: "a", label: "Alpha", selected: false },
+          { id: "b", label: "Beta", selected: false },
+          { id: "c", label: "Gamma", selected: false },
+        ],
+      ],
+      render(_props: Record<string, never>, state, blocks) {
+        const items = () => state[0].get() as Item[];
+        setItems = (next) => state[0].set(next);
+        return (
+          <section>
+            <blocks.KeyedRows
+              collectionDependency={0}
+              dependencies={[0]}
+              id={0}
+              items={items}
+              structureDependencies={[0]}
+              render={() => (
+                <ul>
+                  {items().map((item) => (
+                    <li data-key={item.id} key={item.id}>
+                      {item.label}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+              create={(item) => descriptor(item as Item)}
+              bindings={[{ kind: "text", path: [], read: (item) => [(item as Item).label] }]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Inventory />));
+    const alpha = container.querySelector('[data-key="a"]');
+    const gamma = container.querySelector('[data-key="c"]');
+
+    await act(async () => {
+      setItems((previous: Item[]) =>
+        hintedMap(previous, (item) =>
+          item.id === "b" ? { ...item, id: "z", label: "Zeta" } : item,
+        ),
+      );
+      await flushCompilerUpdates();
+    });
+
+    expect(
+      [...container.querySelectorAll<HTMLElement>("li")].map((row) => [
+        row.dataset.key,
+        row.textContent,
+      ]),
+    ).toEqual([
+      ["a", "Alpha"],
+      ["z", "Zeta"],
+      ["c", "Gamma"],
+    ]);
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+  });
+
+  it("rejects a hint whose source follows an unhinted update in the same flush", async () => {
+    let setItems: (next: unknown) => void = () => undefined;
+    let keyReads = 0;
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha", selected: false },
+      { id: "b", label: "Beta", selected: false },
+      { id: "c", label: "Gamma", selected: false },
+    ];
+    const Inventory = createCompiledComponent({
+      displayName: "MixedHintInventory",
+      initialize: () => [initialItems],
+      render(_props: Record<string, never>, state, blocks) {
+        const items = () => state[0].get() as Item[];
+        setItems = (next) => state[0].set(next);
+        return (
+          <section>
+            <blocks.KeyedRows
+              collectionDependency={0}
+              dependencies={[0]}
+              id={0}
+              items={items}
+              structureDependencies={[0]}
+              render={() => (
+                <ul>
+                  {items().map((item) => (
+                    <li data-key={item.id} key={item.id}>
+                      {item.label}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => {
+                keyReads += 1;
+                return (item as Item).id;
+              }}
+              create={(item) => descriptor(item as Item)}
+              bindings={[{ kind: "text", path: [], read: (item) => [(item as Item).label] }]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Inventory />));
+    keyReads = 0;
+
+    await act(async () => {
+      setItems((previous: Item[]) =>
+        previous.map((item) => (item.id === "a" ? { ...item, label: "Alpha plain" } : item)),
+      );
+      setItems((previous: Item[]) =>
+        hintedMap(previous, (item) =>
+          item.id === "c" ? { ...item, label: "Gamma hinted" } : item,
+        ),
+      );
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Alpha plain",
+      "Beta",
+      "Gamma hinted",
+    ]);
+    expect(keyReads).toBe(initialItems.length);
+  });
+
+  it("shares one hinted collection update across multiple keyed boundaries", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha", selected: false },
+      { id: "b", label: "Beta", selected: false },
+    ];
+    let update: () => void = () => undefined;
+    let keyReads = 0;
+    const Inventory = createCompiledComponent({
+      displayName: "SharedHintInventory",
+      initialize: () => [initialItems],
+      render(_props: Record<string, never>, state, blocks) {
+        const items = () => state[0].get() as Item[];
+        update = () =>
+          state[0].set((previous) =>
+            hintedMap(previous as Item[], (item) =>
+              item.id === "b" ? { ...item, label: "Beta updated" } : item,
+            ),
+          );
+        const list = (id: number, owner: string) => (
+          <blocks.KeyedRows
+            collectionDependency={0}
+            dependencies={[0]}
+            id={id}
+            items={items}
+            structureDependencies={[0]}
+            render={() => (
+              <ul data-owner={owner}>
+                {items().map((item) => (
+                  <li data-key={item.id} key={item.id}>
+                    {item.label}
+                  </li>
+                ))}
+              </ul>
+            )}
+            rowKey={(item) => {
+              keyReads += 1;
+              return (item as Item).id;
+            }}
+            create={(item) => descriptor(item as Item)}
+            bindings={[{ kind: "text", path: [], read: (item) => [(item as Item).label] }]}
+          />
+        );
+        return (
+          <section>
+            {list(0, "first")}
+            {list(1, "second")}
+          </section>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        { kind: "block", id: 1, dependencies: [0] },
+      ],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Inventory />));
+    keyReads = 0;
+
+    await act(async () => {
+      update();
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector('[data-owner="first"]')?.textContent).toBe("AlphaBeta updated");
+    expect(container.querySelector('[data-owner="second"]')?.textContent).toBe("AlphaBeta updated");
+    expect(keyReads).toBe(2);
+  });
+
+  it("matches React across 2,000 deterministic queued same-key updates", async () => {
+    const initialItems = Array.from(
+      { length: 128 },
+      (_, index): Item => ({
+        id: `row-${index}`,
+        label: `Row ${index}`,
+        selected: false,
+      }),
+    );
+    let compiledExecutions = 0;
+    let updateCompiled: (index: number) => void = () => undefined;
+    let updateReact: (index: number) => void = () => undefined;
+    const Compiled = createCompiledComponent({
+      displayName: "RandomHintedInventory",
+      initialize: () => [initialItems],
+      render(_props: Record<string, never>, state, blocks) {
+        compiledExecutions += 1;
+        const items = () => state[0].get() as Item[];
+        updateCompiled = (target) =>
+          state[0].set((previous) =>
+            hintedMap(previous as Item[], (item, index) =>
+              index === target
+                ? { ...item, label: `${item.label}!`, selected: !item.selected }
+                : item,
+            ),
+          );
+        return (
+          <section>
+            <blocks.KeyedRows
+              collectionDependency={0}
+              dependencies={[0]}
+              id={0}
+              items={items}
+              structureDependencies={[0]}
+              render={() => (
+                <ol data-owner="compiled">
+                  {items().map((item) => (
+                    <li data-key={item.id} data-selected={item.selected} key={item.id}>
+                      {item.label}
+                    </li>
+                  ))}
+                </ol>
+              )}
+              rowKey={(item) => (item as Item).id}
+              create={(item) => descriptor(item as Item)}
+              bindings={[
+                {
+                  kind: "attribute",
+                  path: [],
+                  name: "data-selected",
+                  read: (item) => (item as Item).selected,
+                },
+                { kind: "text", path: [], read: (item) => [(item as Item).label] },
+              ]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    function Normal() {
+      const [items, setItems] = useState(initialItems);
+      updateReact = (target) =>
+        setItems((previous) =>
+          previous.map((item, index) =>
+            index === target
+              ? { ...item, label: `${item.label}!`, selected: !item.selected }
+              : item,
+          ),
+        );
+      return (
+        <ol data-owner="react">
+          {items.map((item) => (
+            <li data-key={item.id} data-selected={item.selected} key={item.id}>
+              {item.label}
+            </li>
+          ))}
+        </ol>
+      );
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <>
+          <Compiled />
+          <Normal />
+        </>,
+      ),
+    );
+
+    let random = 0x12345678;
+    for (let batch = 0; batch < 100; batch += 1) {
+      await act(async () => {
+        for (let update = 0; update < 20; update += 1) {
+          random = (Math.imul(random, 1_664_525) + 1_013_904_223) >>> 0;
+          const index = random % initialItems.length;
+          updateCompiled(index);
+          updateReact(index);
+        }
+        await flushCompilerUpdates();
+      });
+      expect(container.querySelector('[data-owner="compiled"]')?.innerHTML).toBe(
+        container.querySelector('[data-owner="react"]')?.innerHTML,
+      );
+    }
+    expect(compiledExecutions).toBe(1);
+  });
+});

--- a/packages/farm-react/src/__tests__/vite.test.ts
+++ b/packages/farm-react/src/__tests__/vite.test.ts
@@ -47,8 +47,11 @@ describe("React renderer Vite integration", () => {
           return <button onClick={() => setCount(count + 1)}>{count}</button>;
         }
         export function List() {
-          const [items, setItems] = useState(["A"]);
-          return <ul onClick={() => setItems([...items, "B"])}>{items.map((item) => <li key={item}>{item}</li>)}</ul>;
+          const [items, setItems] = useState([{ id: "a", label: "A" }]);
+          return <section>
+            <button onClick={() => setItems((current) => current.map((item) => item.id === "a" ? { ...item, label: "B" } : item))}>Update</button>
+            <ul>{items.map((item) => <li key={item.id}>{item.label}</li>)}</ul>
+          </section>;
         }
       `,
       "utf8",
@@ -82,6 +85,7 @@ describe("React renderer Vite integration", () => {
       componentsConsidered: 2,
       compiled: 2,
       fallback: 0,
+      keyedMapUpdateHints: 1,
     });
     expect(report.modules[0].compiled).toEqual(["Counter", "List"]);
     expect(report.modules[0].fallbacks).toEqual([]);

--- a/packages/farm-react/src/compiler-report.ts
+++ b/packages/farm-react/src/compiler-report.ts
@@ -4,7 +4,7 @@ import type { CompileReactModuleResult, CompilerDiagnostic } from "./compiler";
 
 export interface ReactCompilerModuleObservation {
   id: string;
-  result: Pick<CompileReactModuleResult, "compiled" | "diagnostics">;
+  result: Pick<CompileReactModuleResult, "compiled" | "diagnostics" | "optimizations">;
 }
 
 export interface ReactCompilerReportFallback extends CompilerDiagnostic {
@@ -18,6 +18,7 @@ export interface ReactCompilerReport {
     componentsConsidered: number;
     compiled: number;
     fallback: number;
+    keyedMapUpdateHints: number;
   };
   fallbackReasons: Array<{
     count: number;
@@ -26,6 +27,9 @@ export interface ReactCompilerReport {
   modules: Array<{
     id: string;
     compiled: readonly string[];
+    optimizations: {
+      keyedMapUpdateHints: number;
+    };
     fallbacks: ReactCompilerReportFallback[];
   }>;
 }
@@ -42,12 +46,14 @@ export function createReactCompilerReport(
   let componentsConsidered = 0;
   let compiled = 0;
   let fallback = 0;
+  let keyedMapUpdateHints = 0;
 
   const modules = [...observations]
     .map(({ id, result }) => {
       componentsConsidered += result.compiled.length + result.diagnostics.length;
       compiled += result.compiled.length;
       fallback += result.diagnostics.length;
+      keyedMapUpdateHints += result.optimizations.keyedMapUpdateHints;
       const moduleId = projectRelativeId(projectRoot, id);
       const fallbacks = result.diagnostics.map((diagnostic) => {
         reasonCounts.set(diagnostic.reason, (reasonCounts.get(diagnostic.reason) || 0) + 1);
@@ -56,6 +62,7 @@ export function createReactCompilerReport(
       return {
         id: moduleId,
         compiled: [...result.compiled].sort(),
+        optimizations: result.optimizations,
         fallbacks,
       };
     })
@@ -72,6 +79,7 @@ export function createReactCompilerReport(
       componentsConsidered,
       compiled,
       fallback,
+      keyedMapUpdateHints,
     },
     fallbackReasons,
     modules,

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -5,6 +5,85 @@ import { materializeIterable } from "./iterable";
 export type CompilerStateUpdater = unknown | ((previous: unknown) => unknown);
 export type CompilerRuntimeReactivity = "static" | "hybrid";
 
+interface CompilerKeyedMapUpdateHint {
+  readonly sourceToken: object;
+  readonly changedIndices: readonly number[];
+  readonly previous?: CompilerKeyedMapUpdateHint;
+}
+
+const COMPILER_KEYED_COLLECTION_TOKENS = /* @__PURE__ */ new WeakMap<object, object>();
+const COMPILER_KEYED_MAP_UPDATES = /* @__PURE__ */ new WeakMap<
+  object,
+  CompilerKeyedMapUpdateHint
+>();
+const COMPILER_KEYED_COMMITTED_COLLECTIONS = /* @__PURE__ */ new WeakSet<object>();
+
+function compilerObject(value: unknown): object | undefined {
+  return (typeof value === "object" && value !== null) || typeof value === "function"
+    ? (value as object)
+    : undefined;
+}
+
+function compilerKeyedCollectionToken(value: unknown): object | undefined {
+  const target = compilerObject(value);
+  if (!target) return undefined;
+  let token = COMPILER_KEYED_COLLECTION_TOKENS.get(target);
+  if (!token) {
+    token = {};
+    COMPILER_KEYED_COLLECTION_TOKENS.set(target, token);
+  }
+  return token;
+}
+
+function commitCompilerKeyedCollection(value: unknown): object | undefined {
+  const target = compilerObject(value);
+  if (!target) return undefined;
+  COMPILER_KEYED_COMMITTED_COLLECTIONS.add(target);
+  return compilerKeyedCollectionToken(target);
+}
+
+function compilerKeyedMapChangedIndices(
+  value: unknown,
+  sourceToken: object | undefined,
+): readonly number[] | undefined {
+  const target = compilerObject(value);
+  if (!target || !sourceToken) return undefined;
+  const update = COMPILER_KEYED_MAP_UPDATES.get(target);
+  if (!update || update.sourceToken !== sourceToken) return undefined;
+  const changedIndices: number[] = [];
+  for (
+    let current: CompilerKeyedMapUpdateHint | undefined = update;
+    current;
+    current = current.previous
+  ) {
+    changedIndices.push(...current.changedIndices);
+  }
+  return changedIndices;
+}
+
+/** @internal Records compiler-proven same-order Array.map metadata and returns the Array. */
+export function createCompilerKeyedMapUpdate(
+  previous: unknown,
+  value: unknown,
+  changedIndices: readonly number[],
+): unknown {
+  const previousTarget = compilerObject(previous);
+  const valueTarget = compilerObject(value);
+  const sourceToken = compilerKeyedCollectionToken(previousTarget);
+  if (valueTarget && sourceToken) {
+    const previousUpdate =
+      previousTarget && !COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget)
+        ? COMPILER_KEYED_MAP_UPDATES.get(previousTarget)
+        : undefined;
+    COMPILER_KEYED_MAP_UPDATES.set(valueTarget, {
+      sourceToken: previousUpdate?.sourceToken || sourceToken,
+      changedIndices,
+      ...(previousUpdate ? { previous: previousUpdate } : {}),
+    });
+  }
+  return value;
+}
+
 export interface CompilerCell {
   get(): unknown;
   set(next: CompilerStateUpdater): void;
@@ -224,8 +303,12 @@ export interface CompilerKeyedRowsBlockProps {
     ) => React.ReactNode,
   ): React.ReactElement;
   items(): Iterable<unknown> | null | undefined;
+  /** Complete component-state dependencies used anywhere inside this boundary. */
+  dependencies?: readonly number[];
   /** State cells that can change the row collection or its key projection. */
   structureDependencies?: readonly number[];
+  /** Direct state cell supplying items, eligible for compiler-emitted update hints. */
+  collectionDependency?: number;
   rowKey(item: unknown, index: number): React.Key;
   create(item: unknown, index: number): CompilerKeyedRowElement;
   bindings: readonly CompilerKeyedRowBinding[];
@@ -2697,9 +2780,102 @@ interface KeyedRowHostRuntime {
   ): CompilerHostTreeScope | null;
 }
 
+interface KeyedMapUpdateRuntime {
+  commit(value: unknown): object | undefined;
+  reconcile(
+    props: CompilerKeyedRowsBlockProps,
+    dirtyState: ReadonlySet<number>,
+    collectionToken: object | undefined,
+    instances: ReadonlyMap<string, CompilerKeyedRowInstance>,
+    conditionals: KeyedRowConditionalRuntime | undefined,
+  ):
+    | {
+        collectionToken: object | undefined;
+        conditionalChanges: readonly {
+          key: string;
+          id: number;
+          item: unknown;
+          index: number;
+        }[];
+        fallback: boolean;
+      }
+    | undefined;
+}
+
+const keyedMapUpdateRuntime: KeyedMapUpdateRuntime = {
+  commit: commitCompilerKeyedCollection,
+  reconcile: reconcileCompilerKeyedMapUpdate,
+};
+
 interface KeyedRowsRuntimeOptions {
   conditionals?: KeyedRowConditionalRuntime;
   hostBlocks?: KeyedRowHostRuntime;
+  keyedMapUpdates?: KeyedMapUpdateRuntime;
+}
+
+function reconcileCompilerKeyedMapUpdate(
+  props: CompilerKeyedRowsBlockProps,
+  dirtyState: ReadonlySet<number>,
+  collectionToken: object | undefined,
+  instances: ReadonlyMap<string, CompilerKeyedRowInstance>,
+  conditionals: KeyedRowConditionalRuntime | undefined,
+): ReturnType<KeyedMapUpdateRuntime["reconcile"]> {
+  const dependency = props.collectionDependency;
+  if (dependency === undefined) return undefined;
+  const dependencies = props.dependencies || props.structureDependencies || [];
+  const relevantDirty = [...dirtyState].filter((index) => dependencies.includes(index));
+  if (relevantDirty.length !== 1 || relevantDirty[0] !== dependency) return undefined;
+
+  const finalValue = props.items();
+  const hintedIndices = compilerKeyedMapChangedIndices(finalValue, collectionToken);
+  if (!hintedIndices || !Array.isArray(finalValue) || finalValue.length !== instances.size) {
+    return undefined;
+  }
+
+  const changedIndices = [...new Set(hintedIndices)].sort((left, right) => left - right);
+  const updates: Array<{
+    key: string;
+    item: unknown;
+    index: number;
+    instance: CompilerKeyedRowInstance;
+  }> = [];
+  try {
+    for (const index of changedIndices) {
+      if (!Number.isSafeInteger(index) || index < 0 || index >= finalValue.length) return undefined;
+      const item = finalValue[index];
+      const key = keyedRowIdentity(props.rowKey(item, index));
+      const instance = instances.get(key);
+      if (!instance || instance.index !== index) return undefined;
+      updates.push({ key, item, index, instance });
+    }
+  } catch {
+    return undefined;
+  }
+
+  const conditionalChanges: Array<{ key: string; id: number; item: unknown; index: number }> = [];
+  for (const { key, item, index, instance } of updates) {
+    if (props.hostBlocks) {
+      const descriptor = props.create(item, index);
+      if (!instance.scope?.update(descriptor)) {
+        return { collectionToken, conditionalChanges: [], fallback: true };
+      }
+    }
+    applyKeyedRowBindings(props, instance, item, index);
+    const conditionalValues =
+      conditionals?.readValues(props, item, index) || EMPTY_KEYED_ROW_CONDITIONAL_VALUES;
+    for (const [id, values] of conditionalValues) {
+      if (conditionals?.changed(instance.conditionalValues.get(id), values)) {
+        conditionalChanges.push({ key, id, item, index });
+      }
+    }
+    instance.conditionalValues = conditionalValues;
+    instance.item = item;
+  }
+  return {
+    collectionToken: commitCompilerKeyedCollection(finalValue),
+    conditionalChanges,
+    fallback: false,
+  };
 }
 
 function createKeyedRowConditionalRuntime(): KeyedRowConditionalRuntime {
@@ -2796,6 +2972,7 @@ function createKeyedRowsBlockComponent(
     private currentProps = this.props;
     private unsubscribe: (() => void) | undefined;
     private instances = new Map<string, CompilerKeyedRowInstance>();
+    private collectionToken: object | undefined;
     private renderVersion = 0;
     private readonly eventHandlers = new Map<
       string,
@@ -3030,6 +3207,10 @@ function createKeyedRowsBlockComponent(
       }
     }
 
+    private commitCurrentCollection(): void {
+      this.collectionToken = options.keyedMapUpdates?.commit(this.currentProps.items());
+    }
+
     private adopt(): boolean {
       if (!this.root) return false;
       const rows = this.readRows(this.currentProps);
@@ -3082,6 +3263,7 @@ function createKeyedRowsBlockComponent(
       this.rebuildElementIndex(instances);
       this.pruneEventHandlers(rows.keys);
       this.pruneConditionalListeners(rows.keys);
+      this.commitCurrentCollection();
       return true;
     }
 
@@ -3238,6 +3420,7 @@ function createKeyedRowsBlockComponent(
         existing.item = rows.items[index];
         existing.index = index;
       }
+      this.commitCurrentCollection();
       this.notifyConditionalChanges(conditionalChanges, afterCommit);
       return true;
     }
@@ -3300,6 +3483,7 @@ function createKeyedRowsBlockComponent(
       this.instances.delete(removedKey);
       this.eventHandlers.delete(removedKey);
       this.conditionalListeners.delete(removedKey);
+      this.commitCurrentCollection();
       this.notifyConditionalChanges(conditionalChanges, afterCommit);
       return true;
     }
@@ -3349,6 +3533,7 @@ function createKeyedRowsBlockComponent(
         this.instancesByElement = new WeakMap();
         this.eventHandlers.clear();
         this.conditionalListeners.clear();
+        this.commitCurrentCollection();
         afterCommit?.();
         return;
       }
@@ -3475,10 +3660,34 @@ function createKeyedRowsBlockComponent(
       ) {
         (activeElement as HTMLElement).focus({ preventScroll: true });
       }
+      this.commitCurrentCollection();
       this.notifyConditionalChanges(conditionalChanges, afterCommit);
     }
 
     private refresh: CompilerBlockRefresh = (afterCommit, dirtyState) => {
+      if (
+        dirtyState &&
+        options.keyedMapUpdates &&
+        this.mounted &&
+        this.root &&
+        !this.state.fallback
+      ) {
+        const result = options.keyedMapUpdates.reconcile(
+          this.currentProps,
+          dirtyState,
+          this.collectionToken,
+          this.instances,
+          options.conditionals,
+        );
+        if (result) {
+          if (result.fallback) this.activateFallback(afterCommit);
+          else {
+            this.collectionToken = result.collectionToken;
+            this.notifyConditionalChanges(result.conditionalChanges, afterCommit);
+          }
+          return;
+        }
+      }
       if (dirtyState && this.refreshDirtyBindings(dirtyState, afterCommit)) return;
       this.reconcile(afterCommit);
     };
@@ -4037,11 +4246,28 @@ export const keyedRowsRuntimeFeature: CompilerRuntimeFeature = {
   }),
 };
 
+export const keyedRowsHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, { keyedMapUpdates: keyedMapUpdateRuntime }),
+  }),
+};
+
 export const keyedRowsConditionalRuntimeFeature: CompilerRuntimeFeature = {
   name: "keyed-rows:conditional",
   create: (owner) => ({
     KeyedRows: createKeyedRowsBlockComponent(owner, {
       conditionals: createKeyedRowConditionalRuntime(),
+    }),
+  }),
+};
+
+export const keyedRowsConditionalHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:conditional:hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      keyedMapUpdates: keyedMapUpdateRuntime,
     }),
   }),
 };
@@ -4055,12 +4281,33 @@ export const keyedRowsHostRuntimeFeature: CompilerRuntimeFeature = {
   }),
 };
 
+export const keyedRowsHostHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:host:hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedMapUpdates: keyedMapUpdateRuntime,
+    }),
+  }),
+};
+
 export const keyedRowsCompleteRuntimeFeature: CompilerRuntimeFeature = {
   name: "keyed-rows:complete",
   create: (owner) => ({
     KeyedRows: createKeyedRowsBlockComponent(owner, {
       conditionals: createKeyedRowConditionalRuntime(),
       hostBlocks: createKeyedRowHostRuntime(),
+    }),
+  }),
+};
+
+export const keyedRowsCompleteHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:complete:hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedMapUpdates: keyedMapUpdateRuntime,
     }),
   }),
 };
@@ -4645,7 +4892,7 @@ const COMPLETE_RUNTIME_FEATURES: readonly CompilerRuntimeFeature[] = [
   hostConditionalRuntimeFeature,
   conditionalRangesRuntimeFeature,
   keyedListRuntimeFeature,
-  keyedRowsCompleteRuntimeFeature,
+  keyedRowsCompleteHintedRuntimeFeature,
   keyedRangesRuntimeFeature,
   mixedRangesRuntimeFeature,
   componentRuntimeFeature,

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -12,6 +12,9 @@ export interface CompileReactModuleResult {
   map: unknown;
   compiled: readonly string[];
   diagnostics: readonly CompilerDiagnostic[];
+  optimizations: {
+    keyedMapUpdateHints: number;
+  };
 }
 
 interface StateBinding {
@@ -159,6 +162,7 @@ interface KeyedRowsPlan {
   dependencies: number[];
   source: t.JSXElement;
   collection: t.Expression;
+  collectionDependency?: number;
   structureDependencies: number[];
   keyCallback: t.ArrowFunctionExpression | t.FunctionExpression;
   renderCallback: t.ArrowFunctionExpression | t.FunctionExpression;
@@ -336,9 +340,13 @@ type CompilerRuntimeFeatureName =
   | "conditional-ranges"
   | "keyed-list"
   | "keyed-rows"
+  | "keyed-rows-hinted"
   | "keyed-rows-conditional"
+  | "keyed-rows-conditional-hinted"
   | "keyed-rows-host"
+  | "keyed-rows-host-hinted"
   | "keyed-rows-complete"
+  | "keyed-rows-complete-hinted"
   | "keyed-ranges"
   | "mixed-ranges"
   | "component";
@@ -349,9 +357,13 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
   "conditional-ranges": "conditionalRangesRuntimeFeature",
   "keyed-list": "keyedListRuntimeFeature",
   "keyed-rows": "keyedRowsRuntimeFeature",
+  "keyed-rows-hinted": "keyedRowsHintedRuntimeFeature",
   "keyed-rows-conditional": "keyedRowsConditionalRuntimeFeature",
+  "keyed-rows-conditional-hinted": "keyedRowsConditionalHintedRuntimeFeature",
   "keyed-rows-host": "keyedRowsHostRuntimeFeature",
+  "keyed-rows-host-hinted": "keyedRowsHostHintedRuntimeFeature",
   "keyed-rows-complete": "keyedRowsCompleteRuntimeFeature",
+  "keyed-rows-complete-hinted": "keyedRowsCompleteHintedRuntimeFeature",
   "keyed-ranges": "keyedRangesRuntimeFeature",
   "mixed-ranges": "mixedRangesRuntimeFeature",
   component: "componentRuntimeFeature",
@@ -359,6 +371,7 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
 
 function runtimeFeaturesForPlans(
   plans: readonly ComposableBlockPlan[],
+  keyedMapUpdateHints: boolean,
 ): CompilerRuntimeFeatureName[] {
   const features = new Set<CompilerRuntimeFeatureName>();
   let keyedRowsHaveConditionals = false;
@@ -374,14 +387,18 @@ function runtimeFeaturesForPlans(
     }
   }
   if (plans.some((plan) => plan.kind === "keyed-rows")) {
-    features.add(
+    const keyedRowsFeature =
       keyedRowsHaveConditionals && keyedRowsHaveHostBlocks
         ? "keyed-rows-complete"
         : keyedRowsHaveConditionals
           ? "keyed-rows-conditional"
           : keyedRowsHaveHostBlocks
             ? "keyed-rows-host"
-            : "keyed-rows",
+            : "keyed-rows";
+    features.add(
+      keyedMapUpdateHints
+        ? (`${keyedRowsFeature}-hinted` as CompilerRuntimeFeatureName)
+        : keyedRowsFeature,
     );
   }
   return [...features].sort();
@@ -691,6 +708,147 @@ function validateSetterUsage(
     },
   });
   return reason;
+}
+
+function isUnchangedMapItem(expression: t.Expression, item: t.Identifier): boolean {
+  return t.isIdentifier(expression, { name: item.name });
+}
+
+function isSafeKeyedMapReplacement(
+  expression: t.Expression,
+  item: t.Identifier,
+  safeGlobals: ReadonlySet<string>,
+): boolean {
+  if (!t.isObjectExpression(expression)) return false;
+  let spreadsItem = false;
+  for (const property of expression.properties) {
+    if (t.isSpreadElement(property)) {
+      if (!t.isIdentifier(property.argument, { name: item.name })) return false;
+      spreadsItem = true;
+      continue;
+    }
+    if (!t.isObjectProperty(property) || property.computed || !t.isExpression(property.value)) {
+      return false;
+    }
+    if (validateDerivedExpression(property.value, safeGlobals)) return false;
+  }
+  return spreadsItem;
+}
+
+function isSafeKeyedMapResult(
+  expression: t.Expression,
+  item: t.Identifier,
+  safeGlobals: ReadonlySet<string>,
+): boolean {
+  if (!t.isConditionalExpression(expression)) return false;
+  if (validateDerivedExpression(expression.test, safeGlobals)) return false;
+  return (
+    (isUnchangedMapItem(expression.consequent, item) &&
+      isSafeKeyedMapReplacement(expression.alternate, item, safeGlobals)) ||
+    (isUnchangedMapItem(expression.alternate, item) &&
+      isSafeKeyedMapReplacement(expression.consequent, item, safeGlobals))
+  );
+}
+
+function rewriteKeyedMapUpdateHints(
+  root: t.JSXElement,
+  hintedStateIndices: ReadonlySet<number>,
+  statesBySetter: ReadonlyMap<string, StateBinding>,
+  helperIdentifier: t.Identifier,
+  safeGlobals: ReadonlySet<string>,
+): { root: t.JSXElement; count: number } {
+  if (hintedStateIndices.size === 0) return { root: t.cloneNode(root, true), count: 0 };
+  const file = expressionFile(t.cloneNode(root, true));
+  let count = 0;
+  traverse(file, {
+    CallExpression(path) {
+      const callee = path.get("callee");
+      if (!callee.isIdentifier() || callee.scope.hasBinding(callee.node.name)) return;
+      const state = statesBySetter.get(callee.node.name);
+      if (!state || !hintedStateIndices.has(state.index) || path.node.arguments.length !== 1) {
+        return;
+      }
+      const updater = path.node.arguments[0];
+      if (
+        !t.isArrowFunctionExpression(updater) ||
+        updater.async ||
+        updater.generator ||
+        updater.params.length !== 1 ||
+        !t.isIdentifier(updater.params[0]) ||
+        !t.isCallExpression(updater.body) ||
+        !t.isMemberExpression(updater.body.callee) ||
+        updater.body.callee.computed ||
+        !t.isIdentifier(updater.body.callee.object, { name: updater.params[0].name }) ||
+        !t.isIdentifier(updater.body.callee.property, { name: "map" })
+      ) {
+        return;
+      }
+      const callback = updater.body.arguments[0];
+      if (
+        !t.isArrowFunctionExpression(callback) ||
+        callback.async ||
+        callback.generator ||
+        callback.params.length === 0 ||
+        callback.params.length > 3 ||
+        callback.params.some((parameter) => !t.isIdentifier(parameter)) ||
+        !t.isExpression(callback.body)
+      ) {
+        return;
+      }
+      const item = callback.params[0] as t.Identifier;
+      if (!isSafeKeyedMapResult(callback.body, item, safeGlobals)) return;
+
+      const changedIndices = path.scope.generateUidIdentifier("farmChangedIndices");
+      const mappedItem = path.scope.generateUidIdentifier("farmMappedItem");
+      const nextValue = path.scope.generateUidIdentifier("farmNextItems");
+      const index = t.isIdentifier(callback.params[1])
+        ? t.cloneNode(callback.params[1])
+        : path.scope.generateUidIdentifier("farmMapIndex");
+      const wrappedCallback = t.cloneNode(callback, true);
+      if (wrappedCallback.params.length === 1) wrappedCallback.params.push(t.cloneNode(index));
+      wrappedCallback.body = t.blockStatement([
+        t.variableDeclaration("const", [
+          t.variableDeclarator(t.cloneNode(mappedItem), t.cloneNode(callback.body, true)),
+        ]),
+        t.ifStatement(
+          t.binaryExpression("!==", t.cloneNode(mappedItem), t.cloneNode(item)),
+          t.expressionStatement(
+            t.callExpression(
+              t.memberExpression(t.cloneNode(changedIndices), t.identifier("push")),
+              [t.cloneNode(index)],
+            ),
+          ),
+        ),
+        t.returnStatement(t.cloneNode(mappedItem)),
+      ]);
+
+      const mapCall = t.cloneNode(updater.body, true);
+      mapCall.arguments[0] = wrappedCallback;
+      const previous = t.cloneNode(updater.params[0]);
+      path.node.arguments[0] = t.arrowFunctionExpression(
+        [t.cloneNode(previous)],
+        t.blockStatement([
+          t.variableDeclaration("const", [
+            t.variableDeclarator(t.cloneNode(changedIndices), t.arrayExpression([])),
+          ]),
+          t.variableDeclaration("const", [t.variableDeclarator(t.cloneNode(nextValue), mapCall)]),
+          t.returnStatement(
+            t.callExpression(t.cloneNode(helperIdentifier), [
+              t.cloneNode(previous),
+              t.cloneNode(nextValue),
+              t.cloneNode(changedIndices),
+            ]),
+          ),
+        ]),
+      );
+      count += 1;
+      path.skip();
+    },
+  });
+  return {
+    root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement,
+    count,
+  };
 }
 
 function rewriteStateAccess(
@@ -1148,6 +1306,7 @@ function analyzePublicList(
 
 interface KeyedRowsShape {
   collection: t.Expression;
+  collectionDependency?: number;
   structureDependencies: number[];
   keyCallback: t.ArrowFunctionExpression | t.FunctionExpression;
   renderCallback: t.ArrowFunctionExpression | t.FunctionExpression;
@@ -1626,6 +1785,9 @@ function analyzeKeyedRowChild(
   return {
     source,
     collection,
+    collectionDependency: t.isIdentifier(collection)
+      ? statesByValue.get(collection.name)?.index
+      : undefined,
     structureDependencies: [...structureDependencies].sort((left, right) => left - right),
     keyCallback,
     renderCallback,
@@ -3157,7 +3319,11 @@ function keyedRowConditionalObject(
   return t.objectExpression(properties);
 }
 
-function keyedRowsBoundary(blockRuntime: t.Identifier, plan: KeyedRowsPlan): t.JSXElement {
+function keyedRowsBoundary(
+  blockRuntime: t.Identifier,
+  plan: KeyedRowsPlan,
+  keyedMapUpdateHints: boolean,
+): t.JSXElement {
   const name = t.jsxMemberExpression(
     t.jsxIdentifier(blockRuntime.name),
     t.jsxIdentifier("KeyedRows"),
@@ -3196,6 +3362,18 @@ function keyedRowsBoundary(blockRuntime: t.Identifier, plan: KeyedRowsPlan): t.J
           t.jsxIdentifier("items"),
           t.jsxExpressionContainer(t.arrowFunctionExpression([], cloneExpression(plan.collection))),
         ),
+        ...(keyedMapUpdateHints
+          ? [
+              t.jsxAttribute(
+                t.jsxIdentifier("dependencies"),
+                t.jsxExpressionContainer(
+                  t.arrayExpression(
+                    plan.dependencies.map((dependency) => t.numericLiteral(dependency)),
+                  ),
+                ),
+              ),
+            ]
+          : []),
         t.jsxAttribute(
           t.jsxIdentifier("structureDependencies"),
           t.jsxExpressionContainer(
@@ -3204,6 +3382,14 @@ function keyedRowsBoundary(blockRuntime: t.Identifier, plan: KeyedRowsPlan): t.J
             ),
           ),
         ),
+        ...(!keyedMapUpdateHints || plan.collectionDependency === undefined
+          ? []
+          : [
+              t.jsxAttribute(
+                t.jsxIdentifier("collectionDependency"),
+                t.jsxExpressionContainer(t.numericLiteral(plan.collectionDependency)),
+              ),
+            ]),
         t.jsxAttribute(
           t.jsxIdentifier("rowKey"),
           t.jsxExpressionContainer(t.cloneNode(plan.keyCallback, true)),
@@ -3954,6 +4140,7 @@ function analyzeComposableBlocks(
               dependencies: keyedRows.dependencies,
               source: child,
               collection: keyedRows.collection,
+              collectionDependency: keyedRows.collectionDependency,
               structureDependencies: keyedRows.structureDependencies,
               keyCallback: keyedRows.keyCallback,
               renderCallback: keyedRows.renderCallback,
@@ -4217,6 +4404,7 @@ function lowerComposableBlocks(
   plans: readonly ComposableBlockPlan[],
   blockRuntime: t.Identifier,
   listNames: ReadonlySet<string>,
+  keyedMapUpdateHints: boolean,
 ): t.JSXElement {
   const planBySource = new Map<t.Node, ComposableBlockPlan>(
     plans.map((plan) => [plan.source, plan]),
@@ -4243,7 +4431,7 @@ function lowerComposableBlocks(
           return mixedRangesBoundary(blockRuntime, plan);
         }
         if (plan?.kind === "keyed-rows") {
-          return keyedRowsBoundary(blockRuntime, plan);
+          return keyedRowsBoundary(blockRuntime, plan, keyedMapUpdateHints);
         }
         if (plan?.kind === "keyed-ranges") {
           return keyedRangesBoundary(blockRuntime, plan);
@@ -4672,8 +4860,10 @@ function wrapperElement(definitionIdentifier: t.Identifier, props?: t.Expression
 function compileCandidate(
   candidate: Candidate,
   createComponentIdentifier: t.Identifier,
+  keyedMapUpdateIdentifier: t.Identifier,
   runtimeFeatureIdentifiers: ReadonlyMap<CompilerRuntimeFeatureName, t.Identifier>,
   usedRuntimeFeatures: Set<CompilerRuntimeFeatureName>,
+  optimizationCounts: { keyedMapUpdateHints: number },
   useStateNames: ReadonlySet<string>,
   reactNames: ReadonlySet<string>,
   listNames: ReadonlySet<string>,
@@ -4913,8 +5103,49 @@ function compileCandidate(
   }
   if (blockAnalysis.reason) return blockAnalysis.reason;
   if (analysis.reason) return analysis.reason;
+  const hintedStateIndices = new Set(
+    (blockAnalysis.plans || [])
+      .filter(
+        (plan): plan is KeyedRowsPlan =>
+          plan.kind === "keyed-rows" && plan.collectionDependency !== undefined,
+      )
+      .map((plan) => plan.collectionDependency as number),
+  );
+  const hintedRoot = rewriteKeyedMapUpdateHints(
+    expandedReactiveRoot,
+    hintedStateIndices,
+    statesBySetter,
+    keyedMapUpdateIdentifier,
+    safeGlobals,
+  );
+  let appliedKeyedMapUpdateHints = 0;
+  if (hintedRoot.count > 0) {
+    const hintedBlockAnalysis = analyzeComposableBlocks(
+      hintedRoot.root,
+      reactiveByValue,
+      safeGlobals,
+      listNames,
+      allowedComponentNames,
+    );
+    const hintedAnalysis = analyzeHostTree(
+      hintedRoot.root,
+      reactiveByValue,
+      safeGlobals,
+      hintedBlockAnalysis.conditionalExpressions || new Set<t.Expression>(),
+      hintedBlockAnalysis.keyedExpressions || new Set<t.Expression>(),
+      hintedBlockAnalysis.ownedElements || new Set<t.JSXElement>(),
+      hintedBlockAnalysis.componentElements || new Set<t.JSXElement>(),
+    );
+    if (!hintedBlockAnalysis.reason && !hintedAnalysis.reason) {
+      expandedReactiveRoot = hintedRoot.root;
+      blockAnalysis = hintedBlockAnalysis;
+      analysis = hintedAnalysis;
+      appliedKeyedMapUpdateHints = hintedRoot.count;
+      optimizationCounts.keyedMapUpdateHints += hintedRoot.count;
+    }
+  }
   const blockPlans = blockAnalysis.plans || [];
-  const runtimeFeatures = runtimeFeaturesForPlans(blockPlans);
+  const runtimeFeatures = runtimeFeaturesForPlans(blockPlans, appliedKeyedMapUpdateHints > 0);
   markShortCircuitBindings(analysis.bindings || []);
   assignStableBindingTargets(analysis.bindings || []);
 
@@ -4933,6 +5164,7 @@ function compileCandidate(
     blockPlans,
     blockParameter,
     listNames,
+    appliedKeyedMapUpdateHints > 0,
   );
   const rewrittenRoot = rewriteStateAccess(
     rootWithBlocks,
@@ -5097,6 +5329,7 @@ export async function compileReactModule(
 ): Promise<CompileReactModuleResult> {
   const compiled: string[] = [];
   const diagnostics: CompilerDiagnostic[] = [];
+  const optimizationCounts = { keyedMapUpdateHints: 0 };
   const plugin = (): PluginObj => ({
     name: "farm-react-aot",
     visitor: {
@@ -5134,6 +5367,9 @@ export async function compileReactModule(
         const candidates = collectCandidates(programPath);
         const createComponentIdentifier =
           programPath.scope.generateUidIdentifier("createCompiledComponent");
+        const keyedMapUpdateIdentifier = programPath.scope.generateUidIdentifier(
+          "createCompilerKeyedMapUpdate",
+        );
         const runtimeFeatureIdentifiers = new Map<CompilerRuntimeFeatureName, t.Identifier>(
           Object.entries(COMPILER_RUNTIME_FEATURE_EXPORTS).map(([feature, exportName]) => [
             feature as CompilerRuntimeFeatureName,
@@ -5155,8 +5391,10 @@ export async function compileReactModule(
           const reason = compileCandidate(
             candidate,
             createComponentIdentifier,
+            keyedMapUpdateIdentifier,
             runtimeFeatureIdentifiers,
             usedRuntimeFeatures,
+            optimizationCounts,
             useStateNames,
             reactNames,
             listNames,
@@ -5183,6 +5421,14 @@ export async function compileReactModule(
                   createComponentIdentifier,
                   t.identifier("createCompiledComponentWithFeatures"),
                 ),
+                ...(optimizationCounts.keyedMapUpdateHints > 0
+                  ? [
+                      t.importSpecifier(
+                        keyedMapUpdateIdentifier,
+                        t.identifier("createCompilerKeyedMapUpdate"),
+                      ),
+                    ]
+                  : []),
                 ...[...usedRuntimeFeatures]
                   .sort()
                   .map((feature) =>
@@ -5224,5 +5470,6 @@ export async function compileReactModule(
     map: result?.map || null,
     compiled,
     diagnostics,
+    optimizations: optimizationCounts,
   };
 }


### PR DESCRIPTION
## Summary

- recognize conservative functional `setState(current => current.map(...))` updates for direct compiler-owned keyed collections and record only indexes that return new item identities
- validate the collection source, length, row key, and index before patching only reported row instances; mixed or structural updates keep the existing full reconciliation and LIS path
- compose queued hints, support multiple keyed boundaries, and retain the hint runtime only when a module actually emits an eligible site
- expose `keyedMapUpdateHints` in compiler reports and document the syntax, limits, fallback behavior, size cost, and production results

## Verification

- `pnpm --filter @farm.js/react test` — 43 files, 360 tests passed
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and React 19.2.8
- `pnpm docs:build`
- `pnpm --filter farm-react-compiler-dashboard-example benchmark` — correctness, regression, and scalability gates passed

## Measured result

The production benchmark still executes the application immutable `map()`; the new path removes the keyed runtime second full key-and-binding scan.

- update every 10th row at 10k: React 44.05 ms, hybrid 2.50 ms — 17.62x faster
- update every 10th row at 20k: React 98.35 ms, hybrid 6.00 ms — 16.39x faster
- compiler report: one emitted hint site; compiled owner update executions: zero
- direct-only runtime premium remains exactly 3,678 B gzip; ordinary non-hinted keyed output is 8,717 B, within the existing 8,849 B gate

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds compiler support for keyed collections that can report changed row indexes during an immutable `map()` update, letting the runtime patch only those rows instead of scanning all keys and bindings again.

- Recognizes functional setters on direct `useState` collections where the mapper is a concise arrow returning either the unchanged item or a spread replacement.
- Validates the collection source, length, row key, and index before applying a hint; any structural change, key change, mixed unhinted update, or unproven shape uses the existing full reconciliation and LIS path.
- Composes queued hints, supports multiple keyed boundaries, and includes the hint runtime only when a module emits at least one eligible site.
- Exposes `keyedMapUpdateHints` in compiler reports and documents syntax, limits, fallback behavior, and size cost.
- Production benchmark: update-every-10th is 17.62x faster than React at 10k rows and 16.39x at 20k, with the direct-only runtime premium unchanged at 3,678 B gzip.
- The benchmark now fails unless both compiler modes stay at least 8x faster than React for update-every-10th at both row counts and the report shows a nonzero `keyedMapUpdateHints`, then exits nonzero.

<sup>Written for commit d5f351c99e336b2c8b40187e10208aff4ad320d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

