### PR TITLE
perf(react): target keyed identity updates

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -302,6 +302,7 @@ After a successful build, Farm writes `.farm/react-compiler.json`:
     "componentsConsidered": 4,
     "compiled": 2,
     "fallback": 2,
+    "keyedIdentityTargets": 2,
     "keyedMapUpdateHints": 1
   },
   "fallbackReasons": [
@@ -315,6 +316,7 @@ After a successful build, Farm writes `.farm/react-compiler.json`:
       "id": "src/Products.tsx",
       "compiled": ["ProductRow"],
       "optimizations": {
+        "keyedIdentityTargets": 2,
         "keyedMapUpdateHints": 1
       },
       "fallbacks": [
@@ -331,12 +333,13 @@ After a successful build, Farm writes `.farm/react-compiler.json`:
 ```
 
 `componentsConsidered` counts candidates selected by the active mode. `compiled` counts components
-using the AOT runtime, and `fallback` counts candidates left on React. `keyedMapUpdateHints` counts
-setter sites where the compiler proved that a direct keyed collection can report its changed row
-indexes while an immutable `map()` runs. The same count appears per module. `selected` is `true`
-when an annotation explicitly requested compilation. Module paths are relative to the project root,
-and the output is sorted and contains no timestamp, so CI can compare reports without
-machine-specific noise.
+using the AOT runtime, and `fallback` counts candidates left on React. `keyedIdentityTargets` counts
+row bindings that can update by looking up the previous and next key directly.
+`keyedMapUpdateHints` counts setter sites where the compiler proved that a direct keyed collection
+can report its changed row indexes while an immutable `map()` runs. The same counts appear per
+module. `selected` is `true` when an annotation explicitly requested compilation. Module paths are
+relative to the project root, and the output is sorted and contains no timestamp, so CI can compare
+reports without machine-specific noise.
 
 Use a different project-relative output path when CI collects artifacts elsewhere:
 
@@ -682,6 +685,42 @@ row, and new keys create only their prepared host tree. During a reorder, Farm c
 longest increasing subsequence (LIS) of the old row positions. Rows in that subsequence stay in
 place; only the other surviving rows move. LIS is a runtime move planner over compiler-prepared
 rows, not a claim that the future contents of an array are known at build time.
+
+#### Key-directed selection updates
+
+A separate state or primitive prop often identifies one active row while the collection itself
+does not change:
+
+```tsx
+const [selectedId, setSelectedId] = useState<string | null>(null);
+
+<tbody>
+  {rows.map((row) => (
+    <tr
+      aria-selected={row.id === selectedId}
+      className={row.id === selectedId ? "selected" : ""}
+      key={row.id}
+    >
+      <td>{row.label}</td>
+    </tr>
+  ))}
+</tbody>;
+```
+
+For an exact `===` or `!==` comparison against the same expression used by `key`, the compiler
+records which state or primitive-prop cell supplies the target. After mount, changing `selectedId`
+looks up the previously selected key and the next selected key in the existing row-instance map.
+Only those rows evaluate the affected class, attribute, style, or leaf-text binding. A 20,000-row
+selection therefore performs at most two row-binding evaluations instead of scanning all 20,000
+rows. The component and its `map()` callback still do not rerun.
+
+This proof is intentionally narrow. The target must be read only as an operand of strict key
+comparisons, the binding must have no second reactive dependency, and the target must not also
+change the collection or its key projection. The runtime accepts only string, number, bigint, or
+nullish targets. Object, array, boolean, ambiguous, mixed structural, React-owned, nested-block, and
+unsupported expressions use the existing complete evaluation or React fallback. Missing keys are
+safe and simply patch no next row. No option or component primitive is required. The compiler
+report exposes the number of emitted row-binding proofs as `keyedIdentityTargets`.
 
 #### Mutation-aware same-order updates
 
@@ -1493,9 +1532,10 @@ The package and example test suites verify more than generated code:
 - the production browser experiment rotates 1,000 compiler-owned host rows with one LIS move,
   updates outer and nested row conditions, preserves surviving row and branch identity, removes and
   inserts a row, and observes zero owner update executions;
-- the production 10,000/20,000-row benchmark requires a nonzero `keyedMapUpdateHints` report count,
-  at least an 8x keyed-update speedup in both compiler modes, and passes DOM correctness,
-  React-relative regression, and normalized scalability gates;
+- the production 10,000/20,000-row benchmark requires nonzero `keyedIdentityTargets` and
+  `keyedMapUpdateHints` report counts, preserves the keyed-update speedup floor, checks that
+  selection remains key-directed at scale, and passes DOM correctness, React-relative regression,
+  and normalized scalability gates;
 - the public `List` renders iterable and nullish collections correctly with the compiler off;
 - the packaged runtime, including a keyed-range component root, editable and interactive keyed-row
   events, row-local conditions, reorders, identity, selection, and hydration, is exercised

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,15 +2,15 @@
 
 Date: 2026-08-28
 
-Result: **PASS.** Correctness, the React-relative performance gate, the keyed-update optimization
-persistence gate, and the normalized scalability gate all pass. The production run compares two
-bracketing React baselines with static and hybrid compiler builds from the exact same component
-source.
+Result: **PASS.** Correctness, the React-relative performance gate, the keyed-update and
+key-directed selection persistence gates, and the normalized scalability gate all pass. The
+production run compares two bracketing React baselines with static and hybrid compiler builds from
+the exact same component source.
 
 ## Environment and method
 
 - Apple M1, 8 logical CPUs, macOS arm64
-- Google Chrome 151.0.7922.174, Node.js 23.11.0
+- Google Chrome 151.0.7922.175, Node.js 23.11.0
 - Four production builds: React baseline A, static compiler, hybrid compiler, React baseline B
 - Dashboard: 60 measured samples x 10 updates, after 5 warmup samples
 - Standard table: 10 measured samples per operation, after 5 warmup samples
@@ -19,12 +19,15 @@ source.
 - Baseline values average the medians from the two bracketing React trials
 - Performance gate: more than 10% and 0.25 ms slower than the bracketed baseline
 - Keyed-update persistence gate: at least 8x faster than React at both 10,000 and 20,000 rows
+- Key-directed selection gate: at least 10x faster than React at 20,000 rows and no more than 2x
+  normalized growth
 - No CPU throttling
 
 Every trial passed DOM assertions and browser-error checks. The compiler report proved that both
-workloads compiled, delegated keyed rows were present only in compiler builds, exactly one
-mutation-aware keyed-map update site was emitted, and hybrid/static added zero owner executions.
-The two React baselines added 1,430 dashboard and 261 table owner executions each.
+workloads compiled, delegated keyed rows were present only in compiler builds, exactly two
+key-directed row bindings and one mutation-aware keyed-map update site were emitted, and
+hybrid/static added zero owner executions. The two React baselines added 1,430 dashboard and 261
+table owner executions each.
 
 ## Complex dashboard
 
@@ -41,23 +44,28 @@ bindings.
 
 | Operation         |            Rows | React median | Hybrid median | Hybrid vs React |
 | ----------------- | --------------: | -----------: | ------------: | --------------: |
-| Create            |           1,000 |     12.45 ms |      10.50 ms |    1.19x faster |
-| Replace all       |           1,000 |     16.85 ms |      11.50 ms |    1.47x faster |
-| Create many       |          10,000 |    297.40 ms |     116.10 ms |    2.56x faster |
-| Append            | 10,000 -> 11,000 |     70.30 ms |      27.30 ms |    2.58x faster |
-| Update every 10th |          10,000 |     44.05 ms |       2.50 ms |   17.62x faster |
-| Select            |           1,000 |      4.10 ms |       0.20 ms |   20.50x faster |
-| Swap rows 2 / 999 |           1,000 |     10.20 ms |       1.10 ms |    9.27x faster |
-| Remove one row    |           1,000 |      4.65 ms |       2.40 ms |    1.94x faster |
-| Clear             |          10,000 |     53.60 ms |       9.70 ms |    5.53x faster |
+| Create            |           1,000 |     11.55 ms |      10.40 ms |    1.11x faster |
+| Replace all       |           1,000 |     15.85 ms |      11.30 ms |    1.40x faster |
+| Create many       |          10,000 |    265.65 ms |     112.90 ms |    2.35x faster |
+| Append            | 10,000 -> 11,000 |     71.90 ms |      25.30 ms |    2.84x faster |
+| Update every 10th |          10,000 |     40.35 ms |       2.40 ms |   16.81x faster |
+| Select            |           1,000 |      3.70 ms |       0.10 ms |   37.00x faster |
+| Swap rows 2 / 999 |           1,000 |      7.80 ms |       1.10 ms |    7.09x faster |
+| Remove one row    |           1,000 |      4.20 ms |       2.00 ms |    2.10x faster |
+| Clear             |          10,000 |     50.40 ms |       9.30 ms |    5.42x faster |
 
 `Update every 10th` is the targeted mutation-aware path. The application still executes its native
 immutable `map()` over 10,000 items and creates 1,000 replacement objects. The generated hint lets
 the keyed runtime validate and patch those 1,000 rows without a second scan of all 10,000 keys and
-bindings. That reduced the measured median from the previous compiler result of 9.90 ms to 2.50 ms
-on the same benchmark shape; cross-run timings remain machine- and load-sensitive.
-The 8x persistence floor leaves substantial headroom below this run's 16.39x-17.62x result while
-still rejecting a silent return to the older roughly 5x full-reconciliation path.
+bindings. The 8x persistence floor leaves substantial headroom below this run's 15.76x-16.81x
+result across compiler modes and row counts while still rejecting a silent return to the older
+roughly 5x full-reconciliation path.
+
+`Select` is the key-directed path added by this result. When a primitive state value is compared
+strictly with the exact row key, the compiler records that identity proof. The runtime then reads
+and patches only the previous and next keyed instances instead of evaluating that binding for every
+row. Package tests deterministically require no more than two row-binding reads per transition; the
+browser boundary still includes event dispatch, style invalidation, and DOM observation.
 
 ## Repeated 20,000-row scale profile
 
@@ -67,13 +75,13 @@ time is better.
 
 | Operation at scale        | React median | React p95 | Hybrid median | Hybrid p95 | Speedup |
 | ------------------------- | -----------: | --------: | ------------: | ---------: | ------: |
-| Create initial 10,000     |    293.65 ms | 347.20 ms |     107.50 ms |  130.90 ms |   2.73x |
-| Append a 1,000-row batch  |     90.65 ms | 119.60 ms |      28.60 ms |   34.30 ms |   3.17x |
-| Update every 10th at 20k |     98.35 ms | 106.95 ms |       6.00 ms |    9.70 ms |  16.39x |
-| Select at 20k             |     94.75 ms | 106.40 ms |       5.00 ms |    8.80 ms |  18.95x |
-| Swap at 20k               |    119.15 ms | 132.50 ms |      24.50 ms |   26.40 ms |   4.86x |
-| Remove middle row at 20k |    117.85 ms | 151.05 ms |      40.10 ms |   43.00 ms |   2.94x |
-| Clear 20k                 |    121.35 ms | 206.70 ms |      21.00 ms |   22.30 ms |   5.78x |
+| Create initial 10,000     |    337.70 ms | 399.90 ms |     121.90 ms |  130.20 ms |   2.77x |
+| Append a 1,000-row batch  |     84.85 ms | 114.20 ms |      27.40 ms |   36.50 ms |   3.10x |
+| Update every 10th at 20k |     96.15 ms | 103.35 ms |       6.10 ms |    6.30 ms |  15.76x |
+| Select at 20k             |     90.55 ms | 114.70 ms |       2.70 ms |    4.80 ms |  33.54x |
+| Swap at 20k               |    112.80 ms | 138.10 ms |      26.00 ms |   26.80 ms |   4.34x |
+| Remove middle row at 20k |    103.50 ms | 117.80 ms |      36.40 ms |   37.80 ms |   2.84x |
+| Clear 20k                 |    206.10 ms | 240.65 ms |      19.90 ms |   21.30 ms |  10.36x |
 
 ## Scalability gate
 
@@ -82,37 +90,38 @@ The gate divides observed timing growth by row-count growth. A value near 1 mean
 
 | Path                    | Row growth | Timing growth | Normalized growth |
 | ----------------------- | ---------: | ------------: | ----------------: |
-| Create 10k repeat       |      1.00x |         0.93x |             0.93x |
-| Update 10k -> 20k       |      2.00x |         2.40x |             1.20x |
-| Select 1k -> 20k        |     20.00x |        20.00x |             1.00x |
-| Swap 1k -> 20k          |     20.00x |        22.27x |             1.11x |
-| Remove 1k -> 20k        |     20.00x |        16.71x |             0.84x |
-| Clear 10k -> 20k        |      2.00x |         2.16x |             1.08x |
+| Create 10k repeat       |      1.00x |         1.08x |             1.08x |
+| Update 10k -> 20k       |      2.00x |         2.54x |             1.27x |
+| Select 1k -> 20k        |     20.00x |        10.80x |             0.54x |
+| Swap 1k -> 20k          |     20.00x |        23.64x |             1.18x |
+| Remove 1k -> 20k        |     20.00x |        18.20x |             0.91x |
+| Clear 10k -> 20k        |      2.00x |         2.14x |             1.07x |
 
-This demonstrates approximately linear rather than quadratic growth. Selection still scans the
-rows to evaluate the affected binding, so it is not O(1); it performs only the required DOM writes
-and remains 18.95x faster than React at 20,000 rows. Structural swap/removal paths are also O(n),
-as expected for validating keys and maintaining row indices.
+This demonstrates approximately linear rather than quadratic end-to-end growth. Key-directed
+selection performs constant row-binding work—at most the previous and next keyed instances—while
+its complete event-to-DOM timing remains 33.54x faster than React at 20,000 rows. Structural
+swap/removal paths remain O(n), as expected for validating keys and maintaining row indices.
 
 ## Bundle cost
 
 | Build                   | Page chunk raw | Page chunk gzip |
 | ----------------------- | -------------: | --------------: |
 | React baseline          |       18,567 B |         4,307 B |
-| Static compiler         |       74,029 B |        15,521 B |
-| Hybrid compiler         |       74,029 B |        15,522 B |
+| Static compiler         |       75,139 B |        15,854 B |
+| Hybrid compiler         |       75,139 B |        15,854 B |
 
-This deliberately broad page now pays an 11,215-byte gzip premium for the compiler runtime,
-including the mutation-aware keyed path. Smaller direct-only applications retain less of the
-runtime; the package-level fixtures and persisted size gate are documented in
+This deliberately broad page now pays an 11,547-byte gzip premium for the compiler runtime,
+including the mutation-aware and key-directed keyed paths. Smaller direct-only applications retain
+less of the runtime; the package-level fixtures and persisted size gate are documented in
 `packages/farm-react/RUNTIME_SIZE_RESULTS.md`.
 
 ## Conclusion
 
 The compiled path scales successfully through the tested 20,000-row mixed workload: all DOM and
 event assertions pass, there are no browser errors or owner rerenders, every scale operation beats
-the bracketed React baseline, and normalized growth stays at or below 1.20x. The evidence supports
-approximately linear scaling within this range, not unlimited or constant-time scaling.
+the bracketed React baseline, and normalized growth stays at or below 1.27x. Selection performs at
+most two row-binding reads, but the evidence claims only measured end-to-end behavior within this
+range—not unlimited constant-time browser work.
 
 The machine-readable output is `/tmp/farm-react-dashboard-benchmark.json`. Re-run
 `pnpm --filter farm-react-compiler-dashboard-example benchmark` to reproduce it.

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -58,8 +58,12 @@ noise from failing the run while retaining the relative gate for meaningful oper
 The targeted keyed-update optimization has an additional persistence gate. Both compiler modes must
 remain at least 8x faster than bracketed React for update-every-10th at 10,000 and 20,000 rows. This
 is intentionally below the measured 16x-17x result for machine headroom, but above the older roughly
-5x full-reconciliation path. A failed performance, scalability, or persistence gate writes the JSON
-report and exits with a nonzero status.
+5x full-reconciliation path. Key-directed selection has its own browser gate: selection at 20,000
+rows must remain at least 10x faster than React, and its normalized growth may not exceed 2x the 20x
+row-count increase from 1,000 to 20,000 rows. The package unit suite separately requires at most two
+row-binding reads, which is the deterministic guard against returning to a full row scan. A failed
+performance, scalability, or persistence gate writes the JSON report and exits with a nonzero
+status.
 
 Set `FARM_EXPERIMENT_BROWSER_PATH` to an installed Chrome/Chromium executable when Playwright's
 bundled browser is unavailable. Sample counts are configurable:

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -115,6 +115,10 @@ async function inspectBuild(compilerMode) {
     assert(compiled.has("OperationsDashboard"));
     assert(compiled.has("StandardTableBenchmark"));
     assert(
+      compilerReport.summary.keyedIdentityTargets > 0,
+      "The compiler build did not emit a key-directed row-binding target.",
+    );
+    assert(
       compilerReport.summary.keyedMapUpdateHints > 0,
       "The compiler build did not emit a mutation-aware keyed-map update hint.",
     );
@@ -843,10 +847,38 @@ const keyedUpdateSpeedups = keyedUpdateCases.flatMap(([group, metric]) =>
 const keyedUpdateRegressions = keyedUpdateSpeedups.filter(
   ({ speedup }) => !Number.isFinite(speedup) || speedup < keyedUpdateMinimumSpeedup,
 );
+// Selection is a separate-state update whose value is compared with the exact row key. The unit
+// suite deterministically requires at most two row-binding reads. This browser gate protects a
+// substantial end-to-end win and rejects growth beyond the same normalized 2x scalability ceiling
+// used by the complete workload. Style invalidation, event dispatch, and DOM observation remain in
+// the measured boundary even though row-binding work is key-directed.
+const keyedIdentityMinimumSpeedup = 10;
+const keyedIdentityMaximumNormalizedGrowth = 2;
+const keyedIdentityResults = ["static", "hybrid"].map((mode) => {
+  const tableMedianMs = comparisons.table.select[mode].medianMs;
+  const scaleMedianMs = comparisons.scale.select20k[mode].medianMs;
+  const growth = scaleMedianMs / Math.max(tableMedianMs, timingResolutionFloorMs);
+  return {
+    growth,
+    mode,
+    normalizedGrowth: growth / 20,
+    scaleMedianMs,
+    speedup: comparisons.scale.select20k[`${mode}VsBaseline`].speedup,
+    tableMedianMs,
+  };
+});
+const keyedIdentityRegressions = keyedIdentityResults.filter(
+  ({ normalizedGrowth, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedIdentityMinimumSpeedup ||
+    !Number.isFinite(normalizedGrowth) ||
+    normalizedGrowth > keyedIdentityMaximumNormalizedGrowth,
+);
 const passed =
   performanceRegressions.length === 0 &&
   scalabilityRegressions.length === 0 &&
-  keyedUpdateRegressions.length === 0;
+  keyedUpdateRegressions.length === 0 &&
+  keyedIdentityRegressions.length === 0;
 
 const report = {
   result: passed ? "PASS" : "CORRECTNESS_PASS_PERFORMANCE_REGRESSION",
@@ -862,6 +894,13 @@ const report = {
     regressions: keyedUpdateRegressions,
     speedups: keyedUpdateSpeedups,
     status: keyedUpdateRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedIdentityTargetGate: {
+    maximumNormalizedGrowth: keyedIdentityMaximumNormalizedGrowth,
+    minimumSpeedup: keyedIdentityMinimumSpeedup,
+    regressions: keyedIdentityRegressions,
+    results: keyedIdentityResults,
+    status: keyedIdentityRegressions.length === 0 ? "PASS" : "FAIL",
   },
   scalabilityGate: {
     metrics: scalability,

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -162,6 +162,15 @@ Later list updates patch surviving rows by key, create or remove only the change
 longest increasing subsequence (LIS) to minimize DOM moves during a reorder. The outer user
 component and the list callback do not rerun for those compiler-cell updates.
 
+When a separate state cell or primitive prop is compared with the exact row-key expression using
+`===` or `!==`, the compiler emits a key-directed binding proof. A selection change such as
+`item.id === selectedId` then looks up only the previously selected and newly selected row
+instances. Class, attribute, style, and leaf-text bindings on those rows update without evaluating
+the other keyed instances. The proof requires one reactive target used only in strict comparisons;
+mixed structural dependencies, ambiguous expressions, non-primitive runtime targets, React-owned
+rows, and unsupported shapes keep the complete scan or React fallback. No option is required, and
+the compiler report exposes the emitted binding count as `keyedIdentityTargets`.
+
 For a direct keyed `useState` collection, the compiler also recognizes conservative same-order
 updates such as:
 
@@ -458,8 +467,9 @@ compiler: {
 The default path is `.farm/react-compiler.json`. The report covers the production browser graph and
 contains project-relative module paths, compiled component names, fallback details, and fallback
 reasons aggregated by count. Its summary and per-module `optimizations` also report
-`keyedMapUpdateHints`, the number of compiler-proven direct keyed `map()` update sites. A custom
-project-relative `reportFile` also enables reporting.
+`keyedIdentityTargets`, the number of key-directed row bindings, and `keyedMapUpdateHints`, the
+number of compiler-proven direct keyed `map()` update sites. A custom project-relative `reportFile`
+also enables reporting.
 
 The runtime test compares the same counter interaction on both paths: ordinary React performs a
 second component render and commit, while the compiled component remains at one render and one

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -26,14 +26,14 @@
         "brotli": 51830
       },
       "compilerOn": {
-        "raw": 220985,
-        "gzip": 68700,
-        "brotli": 58929
+        "raw": 222676,
+        "gzip": 69230,
+        "brotli": 59321
       },
       "compilerPremium": {
-        "raw": 28051,
-        "gzip": 8593,
-        "brotli": 7099
+        "raw": 29742,
+        "gzip": 9123,
+        "brotli": 7491
       }
     },
     "isolatedRuntime": {
@@ -43,18 +43,18 @@
         "brotli": 51666
       },
       "full": {
-        "raw": 258777,
-        "gzip": 74199,
-        "brotli": 63977
+        "raw": 261907,
+        "gzip": 75076,
+        "brotli": 64785
       },
       "coreOnly": {
         "raw": 204922,
         "gzip": 63685,
         "brotli": 54902
       },
-      "fullRuntimePremiumGzip": 14280,
+      "fullRuntimePremiumGzip": 15157,
       "coreRuntimePremiumGzip": 3766,
-      "gzipReductionPercent": 73.6
+      "gzipReductionPercent": 75.2
     }
   }
 }

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.md
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.md
@@ -24,14 +24,17 @@ is enforced on every pull request instead of serving only as a manually recorded
 | Fixture                                           | Compiler off gzip | Compiler on gzip | Compiler premium |
 | ------------------------------------------------- | ----------------: | ---------------: | ---------------: |
 | Direct text, attribute, style, and event bindings |          60,043 B |         63,721 B |          3,678 B |
-| Delegated keyed rows and LIS                      |          60,107 B |         68,700 B |          8,593 B |
+| Delegated keyed rows, LIS, and targeted selection |          60,107 B |         69,230 B |          9,123 B |
 
-The isolated compatibility runtime contributes 14,280 B gzip over the React control. The
-compiler-selected core contributes 3,766 B, a **73.6% reduction**. This comparison uses the same
+The isolated compatibility runtime contributes 15,157 B gzip over the React control. The
+compiler-selected core contributes 3,766 B, a **75.2% reduction**. This comparison uses the same
 hand-authored compiled definition and changes only the runtime entry used to create it.
 
-The keyed fixture retains `FarmCompiledKeyedRows` but rejects the optional row-conditional runtime.
-The direct fixture rejects every structural runtime marker. The checked machine-readable result is
+The keyed fixture retains `FarmCompiledKeyedRows` and a compiler-emitted `identityTarget`, but
+rejects the optional row-conditional and keyed-map-hint runtimes. Key-directed validation adds
+530 B gzip to this deliberately targeted keyed fixture. The direct compiler premium and isolated
+core runtime remain byte-for-byte unchanged. The direct fixture rejects every structural runtime
+marker. The checked machine-readable result is
 [`RUNTIME_SIZE_RESULTS.json`](./RUNTIME_SIZE_RESULTS.json).
 
 ## Existing production benchmark audit

--- a/packages/farm-react/scripts/benchmark-runtime-size.mjs
+++ b/packages/farm-react/scripts/benchmark-runtime-size.mjs
@@ -82,6 +82,9 @@ if (keyedOn.code.includes("FarmCompiledKeyedRowConditional")) {
 if (keyedOn.code.includes("keyed-rows:hinted")) {
   throw new Error("Plain keyed fixture retained the optional keyed-update hint runtime.");
 }
+if (!keyedOn.code.includes("identityTarget")) {
+  throw new Error("Keyed selection fixture did not retain its key-directed binding target.");
+}
 
 const fullRuntimePremium = runtimeFull.gzip - runtimeControl.gzip;
 const coreRuntimePremium = runtimeCore.gzip - runtimeControl.gzip;

--- a/packages/farm-react/src/__tests__/compiler-keyed-identity-targets.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-identity-targets.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true);
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/KeyedIdentityTargets.tsx", infer);
+}
+
+describe("React AOT keyed identity targets", () => {
+  it("emits target metadata for strict comparisons against the exact row key", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function SelectableRows() {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        const [selectedId, setSelectedId] = useState(null);
+        return (
+          <section><ul>
+            {rows.map((row) => (
+              <li
+                aria-selected={selectedId === row.id}
+                className={row.id !== selectedId ? "idle" : "selected"}
+                key={row.id}
+                onClick={() => setSelectedId(row.id)}
+                style={{ opacity: selectedId === row.id ? 1 : 0.5 }}
+              >
+                <span>{selectedId === row.id ? row.label : "Hidden"}</span>
+              </li>
+            ))}
+          </ul></section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["SelectableRows"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedIdentityTargets).toBe(4);
+    expect(result.code.match(/identityTarget:/g)).toHaveLength(4);
+    expect(result.code).toContain("dependency: 1");
+    expect(result.code).toContain("read: () => _farmState[1].get()");
+  });
+
+  it("normalizes public List key parameter names and supports primitive prop targets", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List } from "@farm.js/react/list";
+      export function SelectedRows({ activeId }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return (
+          <section><ul>
+            <List each={rows} by={(entry) => entry.id}>
+              {(row) => <li data-active={row.id === activeId}>{row.label}</li>}
+            </List>
+          </ul></section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["SelectedRows"]);
+    expect(result.optimizations.keyedIdentityTargets).toBe(1);
+    expect(result.code).toContain("identityTarget:");
+    expect(result.code).toMatch(/read: \(\) => _farmState\[1\]\.get\(\)/);
+  });
+
+  it.each([
+    {
+      name: "loose equality",
+      binding: 'row.id == selectedId ? "selected" : ""',
+    },
+    {
+      name: "a different row field",
+      binding: 'row.slug === selectedId ? "selected" : ""',
+    },
+    {
+      name: "a target read outside the key comparison",
+      binding: 'row.id === selectedId ? "selected" : selectedId',
+    },
+    {
+      name: "another reactive dependency",
+      binding: 'row.id === selectedId && enabled ? "selected" : ""',
+    },
+  ])("keeps $name on complete binding evaluation", async ({ binding }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function ConservativeRows() {
+        const [rows, setRows] = useState([{ id: "a", slug: "alpha" }]);
+        const [selectedId, setSelectedId] = useState("a");
+        const [enabled, setEnabled] = useState(true);
+        return (
+          <section>
+            <button onClick={() => setSelectedId("b")}>Select</button>
+            <ul>{rows.map((row) => <li className={${binding}} key={row.id}>{row.id}</li>)}</ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.compiled).toEqual(["ConservativeRows"]);
+    expect(result.optimizations.keyedIdentityTargets).toBe(0);
+    expect(result.code).not.toContain("identityTarget:");
+  });
+
+  it("does not target a dependency that also changes key structure", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function StructuralTarget() {
+        const [rows, setRows] = useState([{ id: "a" }]);
+        const [selectedId, setSelectedId] = useState("a");
+        return (
+          <ul onClick={() => setSelectedId("b")}>
+            {rows.map((row) => (
+              <li data-selected={row.id === selectedId} key={selectedId + row.id}>{row.id}</li>
+            ))}
+          </ul>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["StructuralTarget"]);
+    expect(result.optimizations.keyedIdentityTargets).toBe(0);
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
@@ -39,7 +39,7 @@ describe("React AOT keyed update hints", () => {
 
     expect(result.compiled).toEqual(["Inventory"]);
     expect(result.diagnostics).toEqual([]);
-    expect(result.optimizations).toEqual({ keyedMapUpdateHints: 1 });
+    expect(result.optimizations).toEqual({ keyedIdentityTargets: 0, keyedMapUpdateHints: 1 });
     expect(result.code).toContain("createCompilerKeyedMapUpdate");
     expect(result.code).toContain("keyedRowsHintedRuntimeFeature");
     expect(result.code).toContain("collectionDependency={0}");

--- a/packages/farm-react/src/__tests__/compiler-report.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-report.test.ts
@@ -27,7 +27,7 @@ function observations(projectRoot: string): ReactCompilerModuleObservation[] {
       result: {
         compiled: ["Counter"],
         diagnostics: [],
-        optimizations: { keyedMapUpdateHints: 0 },
+        optimizations: { keyedIdentityTargets: 0, keyedMapUpdateHints: 0 },
       },
     },
     {
@@ -46,7 +46,7 @@ function observations(projectRoot: string): ReactCompilerModuleObservation[] {
             selected: true,
           },
         ],
-        optimizations: { keyedMapUpdateHints: 3 },
+        optimizations: { keyedIdentityTargets: 4, keyedMapUpdateHints: 3 },
       },
     },
   ];
@@ -62,6 +62,7 @@ describe("React compiler coverage report", () => {
       componentsConsidered: 4,
       compiled: 2,
       fallback: 2,
+      keyedIdentityTargets: 4,
       keyedMapUpdateHints: 3,
     });
     expect(report.fallbackReasons).toEqual([
@@ -77,7 +78,10 @@ describe("React compiler coverage report", () => {
       reason: "dynamic child structures require React reconciliation",
       selected: true,
     });
-    expect(report.modules[1]?.optimizations).toEqual({ keyedMapUpdateHints: 3 });
+    expect(report.modules[1]?.optimizations).toEqual({
+      keyedIdentityTargets: 4,
+      keyedMapUpdateHints: 3,
+    });
   });
 
   it("writes formatted JSON to the configured project-relative file", async () => {

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-identity-targets.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-identity-targets.test.tsx
@@ -1,0 +1,616 @@
+import React, { StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createCompiledComponent, type CompilerStateUpdater } from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Item {
+  id: string;
+  label: string;
+}
+
+const roots: Array<{ unmount(): void }> = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function items(count: number): Item[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `row-${index}`,
+    label: `Row ${index}`,
+  }));
+}
+
+describe("compiled keyed identity targets", () => {
+  it("evaluates only the previous and next keyed instances", async () => {
+    const initial = items(2_000);
+    let executions = 0;
+    let bindingReads = 0;
+    let setSelected: (next: CompilerStateUpdater) => void = () => undefined;
+    const Rows = createCompiledComponent({
+      displayName: "IdentityTargetRows",
+      initialize: () => [initial, null],
+      render(_props: Record<string, never>, state, blocks) {
+        executions += 1;
+        const readItems = () => state[0].get() as Item[];
+        const selected = () => state[1].get() as string | null;
+        setSelected = (next) => state[1].set(next);
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <KeyedRows
+              bindings={[
+                {
+                  dependencies: [1],
+                  identityTarget: { dependency: 1, read: selected },
+                  kind: "attribute",
+                  name: "data-selected",
+                  path: [],
+                  read: (item) => {
+                    bindingReads += 1;
+                    return (item as Item).id === selected();
+                  },
+                },
+              ]}
+              create={(item) => ({
+                kind: "element",
+                tag: "li",
+                attributes: [
+                  { name: "data-key", value: (item as Item).id },
+                  { name: "data-selected", value: (item as Item).id === selected() },
+                ],
+                styles: [],
+                children: [(item as Item).label],
+              })}
+              id={0}
+              items={readItems}
+              render={() => (
+                <ul>
+                  {readItems().map((item) => (
+                    <li data-key={item.id} data-selected={item.id === selected()} key={item.id}>
+                      {item.label}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+              structureDependencies={[0]}
+            />
+          </main>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0, 1] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Rows />));
+
+    bindingReads = 0;
+    await act(async () => {
+      setSelected("row-1500");
+      await flushCompilerUpdates();
+    });
+    expect(bindingReads).toBe(1);
+    expect(container.querySelector('[data-key="row-1500"]')?.getAttribute("data-selected")).toBe(
+      "true",
+    );
+
+    bindingReads = 0;
+    await act(async () => {
+      setSelected("row-12");
+      await flushCompilerUpdates();
+    });
+    expect(bindingReads).toBe(2);
+    expect(container.querySelector('[data-key="row-1500"]')?.getAttribute("data-selected")).toBe(
+      "false",
+    );
+    expect(container.querySelector('[data-key="row-12"]')?.getAttribute("data-selected")).toBe(
+      "true",
+    );
+
+    bindingReads = 0;
+    await act(async () => {
+      setSelected(null);
+      await flushCompilerUpdates();
+    });
+    expect(bindingReads).toBe(1);
+    expect(executions).toBe(1);
+  });
+
+  it("targets nullish runtime keys after the keyed runtime coerces them", async () => {
+    const initial = [
+      { id: null, label: "Null row" },
+      { id: undefined, label: "Undefined row" },
+    ];
+    let bindingReads = 0;
+    let setSelected: (next: CompilerStateUpdater) => void = () => undefined;
+    const Rows = createCompiledComponent({
+      displayName: "NullishIdentityTargetRows",
+      initialize: () => [initial, "missing"],
+      render(_props: Record<string, never>, state, blocks) {
+        const readItems = () => state[0].get() as typeof initial;
+        const selected = () => state[1].get() as string | null | undefined;
+        setSelected = (next) => state[1].set(next);
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <KeyedRows
+              bindings={[
+                {
+                  dependencies: [1],
+                  identityTarget: { dependency: 1, read: selected },
+                  kind: "attribute",
+                  name: "data-selected",
+                  path: [],
+                  read: (item) => {
+                    bindingReads += 1;
+                    return (item as (typeof initial)[number]).id === selected();
+                  },
+                },
+              ]}
+              create={(item) => ({
+                kind: "element",
+                tag: "li",
+                attributes: [
+                  { name: "data-key", value: String((item as (typeof initial)[number]).id) },
+                ],
+                styles: [],
+                children: [(item as (typeof initial)[number]).label],
+              })}
+              id={0}
+              items={readItems}
+              render={() => (
+                <ul>
+                  {readItems().map((item) => (
+                    <li
+                      data-key={String(item.id)}
+                      data-selected={item.id === selected()}
+                      key={String(item.id)}
+                    >
+                      {item.label}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as (typeof initial)[number]).id as unknown as React.Key}
+              structureDependencies={[0]}
+            />
+          </main>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0, 1] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Rows />));
+
+    bindingReads = 0;
+    await act(async () => {
+      setSelected(null);
+      await flushCompilerUpdates();
+    });
+    expect(bindingReads).toBe(1);
+    expect(
+      [...container.querySelectorAll("li")].map((element) => [
+        element.getAttribute("data-key"),
+        element.getAttribute("data-selected"),
+      ]),
+    ).toEqual([
+      ["null", "true"],
+      ["undefined", "false"],
+    ]);
+
+    bindingReads = 0;
+    await act(async () => {
+      setSelected(undefined);
+      await flushCompilerUpdates();
+    });
+    expect(bindingReads).toBe(2);
+    expect(
+      [...container.querySelectorAll("li")].map((element) => [
+        element.getAttribute("data-key"),
+        element.getAttribute("data-selected"),
+      ]),
+    ).toEqual([
+      ["null", "false"],
+      ["undefined", "true"],
+    ]);
+  });
+
+  it("falls back to a complete scan for untrusted targets, then resumes targeting", async () => {
+    const initial = items(64);
+    let bindingReads = 0;
+    let setSelected: (next: CompilerStateUpdater) => void = () => undefined;
+    const Rows = createCompiledComponent({
+      displayName: "GuardedIdentityTargets",
+      initialize: () => [initial, { id: "row-0" }],
+      render(_props: Record<string, never>, state, blocks) {
+        const readItems = () => state[0].get() as Item[];
+        const selected = () => state[1].get();
+        setSelected = (next) => state[1].set(next);
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <KeyedRows
+              bindings={[
+                {
+                  dependencies: [1],
+                  identityTarget: { dependency: 1, read: selected },
+                  kind: "attribute",
+                  name: "data-selected",
+                  path: [],
+                  read: (item) => {
+                    bindingReads += 1;
+                    return (item as Item).id === selected();
+                  },
+                },
+              ]}
+              create={(item) => ({
+                kind: "element",
+                tag: "li",
+                attributes: [],
+                styles: [],
+                children: [(item as Item).label],
+              })}
+              id={0}
+              items={readItems}
+              render={() => (
+                <ul>
+                  {readItems().map((item) => (
+                    <li data-selected={item.id === selected()} key={item.id}>
+                      {item.label}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+              structureDependencies={[0]}
+            />
+          </main>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0, 1] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Rows />));
+
+    bindingReads = 0;
+    await act(async () => {
+      setSelected("row-4");
+      await flushCompilerUpdates();
+    });
+    expect(bindingReads).toBe(initial.length);
+
+    bindingReads = 0;
+    await act(async () => {
+      setSelected("row-5");
+      await flushCompilerUpdates();
+    });
+    expect(bindingReads).toBe(2);
+  });
+
+  it("uses complete reconciliation for mixed structural work and refreshes its target cache", async () => {
+    const initial = items(100);
+    let bindingReads = 0;
+    let targetReads = 0;
+    let setRows: (next: CompilerStateUpdater) => void = () => undefined;
+    let setSelected: (next: CompilerStateUpdater) => void = () => undefined;
+    const Rows = createCompiledComponent({
+      displayName: "MixedIdentityTargetUpdate",
+      initialize: () => [initial, "row-1"],
+      render(_props: Record<string, never>, state, blocks) {
+        const readItems = () => state[0].get() as Item[];
+        const selected = () => state[1].get() as string | null;
+        const identityTarget = () => {
+          targetReads += 1;
+          return selected();
+        };
+        setRows = (next) => state[0].set(next);
+        setSelected = (next) => state[1].set(next);
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <KeyedRows
+              bindings={[
+                {
+                  dependencies: [1],
+                  identityTarget: { dependency: 1, read: identityTarget },
+                  kind: "attribute",
+                  name: "data-selected",
+                  path: [],
+                  read: (item) => {
+                    bindingReads += 1;
+                    return (item as Item).id === selected();
+                  },
+                },
+                {
+                  dependencies: [0],
+                  kind: "text",
+                  path: [],
+                  read: (item) => [(item as Item).label],
+                },
+              ]}
+              create={(item) => ({
+                kind: "element",
+                tag: "li",
+                attributes: [{ name: "data-key", value: (item as Item).id }],
+                styles: [],
+                children: [(item as Item).label],
+              })}
+              id={0}
+              items={readItems}
+              render={() => (
+                <ul>
+                  {readItems().map((item) => (
+                    <li data-key={item.id} data-selected={item.id === selected()} key={item.id}>
+                      {item.label}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+              structureDependencies={[0]}
+            />
+          </main>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0, 1] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Rows />));
+
+    bindingReads = 0;
+    targetReads = 0;
+    await act(async () => {
+      setRows((current) =>
+        (current as Item[]).map((item) =>
+          item.id === "row-10" ? { ...item, label: "Structural update" } : item,
+        ),
+      );
+      await flushCompilerUpdates();
+    });
+    expect(bindingReads).toBe(initial.length);
+    expect(targetReads).toBe(0);
+
+    bindingReads = 0;
+    targetReads = 0;
+    await act(async () => {
+      setSelected("row-80");
+      setRows((current) =>
+        (current as Item[]).map((item) =>
+          item.id === "row-80" ? { ...item, label: "Updated row" } : item,
+        ),
+      );
+      await flushCompilerUpdates();
+    });
+    expect(bindingReads).toBe(initial.length);
+    expect(targetReads).toBe(1);
+    expect(container.querySelector('[data-key="row-80"]')?.textContent).toBe("Updated row");
+
+    bindingReads = 0;
+    targetReads = 0;
+    await act(async () => {
+      setSelected("row-81");
+      await flushCompilerUpdates();
+    });
+    expect(bindingReads).toBe(2);
+    expect(targetReads).toBe(1);
+  });
+
+  it("matches React across queued randomized selections", async () => {
+    const initial = items(128);
+    let reads = 0;
+    let compiledSet: (next: CompilerStateUpdater) => void = () => undefined;
+    let reactSet: React.Dispatch<React.SetStateAction<string | null>> = () => undefined;
+    const Compiled = createCompiledComponent({
+      displayName: "RandomIdentityTargets",
+      initialize: () => [initial, null],
+      render(_props: Record<string, never>, state, blocks) {
+        const readItems = () => state[0].get() as Item[];
+        const selected = () => state[1].get() as string | null;
+        compiledSet = (next) => state[1].set(next);
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <KeyedRows
+              bindings={[
+                {
+                  dependencies: [1],
+                  identityTarget: { dependency: 1, read: selected },
+                  kind: "attribute",
+                  name: "data-selected",
+                  path: [],
+                  read: (item) => {
+                    reads += 1;
+                    return (item as Item).id === selected();
+                  },
+                },
+              ]}
+              create={(item) => ({
+                kind: "element",
+                tag: "li",
+                attributes: [{ name: "data-key", value: (item as Item).id }],
+                styles: [],
+                children: [(item as Item).label],
+              })}
+              id={0}
+              items={readItems}
+              render={() => (
+                <ul>
+                  {readItems().map((item) => (
+                    <li data-key={item.id} data-selected={item.id === selected()} key={item.id}>
+                      {item.label}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+              structureDependencies={[0]}
+            />
+          </main>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0, 1] }],
+    });
+
+    function Normal() {
+      const [selected, setSelected] = useState<string | null>(null);
+      reactSet = setSelected;
+      return (
+        <ul>
+          {initial.map((item) => (
+            <li data-key={item.id} data-selected={item.id === selected} key={item.id}>
+              {item.label}
+            </li>
+          ))}
+        </ul>
+      );
+    }
+
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<Compiled />);
+      reactRoot.render(<Normal />);
+    });
+
+    let random = 0x51ec7ed;
+    const nextTarget = () => {
+      random = (Math.imul(random, 1_664_525) + 1_013_904_223) >>> 0;
+      if (random % 11 === 0) return null;
+      if (random % 13 === 0) return `missing-${random}`;
+      return `row-${random % initial.length}`;
+    };
+    const snapshot = (container: Element) =>
+      [...container.querySelectorAll("li")].map((row) => row.getAttribute("data-selected"));
+
+    for (let batch = 0; batch < 100; batch += 1) {
+      reads = 0;
+      await act(async () => {
+        for (let update = 0; update < 20; update += 1) {
+          const target = nextTarget();
+          compiledSet(target);
+          reactSet(target);
+        }
+        await flushCompilerUpdates();
+      });
+      expect(reads, `targeted reads in batch ${batch}`).toBeLessThanOrEqual(2);
+      expect(snapshot(compiledContainer), `DOM after batch ${batch}`).toEqual(
+        snapshot(reactContainer),
+      );
+    }
+  });
+
+  it("is StrictMode-safe and drops a queued target update after unmount", async () => {
+    const initial = items(16);
+    let reads = 0;
+    let setSelected: (next: CompilerStateUpdater) => void = () => undefined;
+    const Rows = createCompiledComponent({
+      displayName: "UnmountedIdentityTarget",
+      initialize: () => [initial, null],
+      render(_props: Record<string, never>, state, blocks) {
+        const readItems = () => state[0].get() as Item[];
+        const selected = () => state[1].get() as string | null;
+        setSelected = (next) => state[1].set(next);
+        const KeyedRows = blocks.KeyedRows;
+        return (
+          <main>
+            <KeyedRows
+              bindings={[
+                {
+                  dependencies: [1],
+                  identityTarget: { dependency: 1, read: selected },
+                  kind: "attribute",
+                  name: "data-selected",
+                  path: [],
+                  read: (item) => {
+                    reads += 1;
+                    return (item as Item).id === selected();
+                  },
+                },
+              ]}
+              create={(item) => ({
+                kind: "element",
+                tag: "li",
+                attributes: [],
+                styles: [],
+                children: [(item as Item).label],
+              })}
+              id={0}
+              items={readItems}
+              render={() => (
+                <ul>
+                  {readItems().map((item) => (
+                    <li data-selected={item.id === selected()} key={item.id}>
+                      {item.label}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+              structureDependencies={[0]}
+            />
+          </main>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0, 1] }],
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <StrictMode>
+          <Rows />
+        </StrictMode>,
+      ),
+    );
+
+    reads = 0;
+    await act(async () => {
+      setSelected("row-8");
+      root.unmount();
+      roots.splice(roots.indexOf(root), 1);
+      await flushCompilerUpdates();
+    });
+    expect(reads).toBe(0);
+    expect(container.childElementCount).toBe(0);
+  });
+});

--- a/packages/farm-react/src/__tests__/vite.test.ts
+++ b/packages/farm-react/src/__tests__/vite.test.ts
@@ -85,6 +85,7 @@ describe("React renderer Vite integration", () => {
       componentsConsidered: 2,
       compiled: 2,
       fallback: 0,
+      keyedIdentityTargets: 0,
       keyedMapUpdateHints: 1,
     });
     expect(report.modules[0].compiled).toEqual(["Counter", "List"]);

--- a/packages/farm-react/src/compiler-report.ts
+++ b/packages/farm-react/src/compiler-report.ts
@@ -18,6 +18,7 @@ export interface ReactCompilerReport {
     componentsConsidered: number;
     compiled: number;
     fallback: number;
+    keyedIdentityTargets: number;
     keyedMapUpdateHints: number;
   };
   fallbackReasons: Array<{
@@ -28,6 +29,7 @@ export interface ReactCompilerReport {
     id: string;
     compiled: readonly string[];
     optimizations: {
+      keyedIdentityTargets: number;
       keyedMapUpdateHints: number;
     };
     fallbacks: ReactCompilerReportFallback[];
@@ -46,6 +48,7 @@ export function createReactCompilerReport(
   let componentsConsidered = 0;
   let compiled = 0;
   let fallback = 0;
+  let keyedIdentityTargets = 0;
   let keyedMapUpdateHints = 0;
 
   const modules = [...observations]
@@ -53,6 +56,7 @@ export function createReactCompilerReport(
       componentsConsidered += result.compiled.length + result.diagnostics.length;
       compiled += result.compiled.length;
       fallback += result.diagnostics.length;
+      keyedIdentityTargets += result.optimizations.keyedIdentityTargets || 0;
       keyedMapUpdateHints += result.optimizations.keyedMapUpdateHints;
       const moduleId = projectRelativeId(projectRoot, id);
       const fallbacks = result.diagnostics.map((diagnostic) => {
@@ -79,6 +83,7 @@ export function createReactCompilerReport(
       componentsConsidered,
       compiled,
       fallback,
+      keyedIdentityTargets,
       keyedMapUpdateHints,
     },
     fallbackReasons,

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -284,6 +284,11 @@ export interface CompilerKeyedRowBinding {
   name?: string;
   /** Component state cells read by this binding, when emitted by the compiler. */
   dependencies?: readonly number[];
+  /** A compiler-proven primitive value compared strictly with this row's key. */
+  identityTarget?: {
+    dependency: number;
+    read(): unknown;
+  };
   read(item: unknown, index: number): unknown;
 }
 
@@ -924,10 +929,26 @@ interface CompilerKeyedRowInstance extends CompilerHostInstance {
   conditionalValues: ReadonlyMap<number, readonly unknown[]>;
 }
 
+interface CompilerKeyedIdentityTargetSnapshot {
+  eligible: boolean;
+  key?: string;
+}
+
 const UNSET_KEYED_ROW_BINDING = Symbol("unset interactive keyed-row binding");
 
 function keyedRowIdentity(key: React.Key): string {
   return String(key);
+}
+
+function keyedIdentityTargetSnapshot(value: unknown): CompilerKeyedIdentityTargetSnapshot {
+  const kind = typeof value;
+  return value === null ||
+    value === undefined ||
+    kind === "string" ||
+    kind === "number" ||
+    kind === "bigint"
+    ? { eligible: true, key: String(value) }
+    : { eligible: false };
 }
 
 function normalizedKeyedRowBindingValue(binding: CompilerKeyedRowBinding, value: unknown): unknown {
@@ -2972,6 +2993,7 @@ function createKeyedRowsBlockComponent(
     private currentProps = this.props;
     private unsubscribe: (() => void) | undefined;
     private instances = new Map<string, CompilerKeyedRowInstance>();
+    private identityTargets = new Map<number, CompilerKeyedIdentityTargetSnapshot>();
     private collectionToken: object | undefined;
     private renderVersion = 0;
     private readonly eventHandlers = new Map<
@@ -3207,8 +3229,26 @@ function createKeyedRowsBlockComponent(
       }
     }
 
-    private commitCurrentCollection(): void {
+    private commitCurrentCollection(dirtyState?: ReadonlySet<number>): void {
       this.collectionToken = options.keyedMapUpdates?.commit(this.currentProps.items());
+      this.commitIdentityTargets(dirtyState);
+    }
+
+    private commitIdentityTargets(dirtyState?: ReadonlySet<number>): void {
+      if (!dirtyState) this.identityTargets.clear();
+      for (
+        let bindingIndex = 0;
+        bindingIndex < this.currentProps.bindings.length;
+        bindingIndex += 1
+      ) {
+        const target = this.currentProps.bindings[bindingIndex].identityTarget;
+        if (!target) {
+          this.identityTargets.delete(bindingIndex);
+          continue;
+        }
+        if (dirtyState && !dirtyState.has(target.dependency)) continue;
+        this.identityTargets.set(bindingIndex, keyedIdentityTargetSnapshot(target.read()));
+      }
     }
 
     private adopt(): boolean {
@@ -3362,16 +3402,50 @@ function createKeyedRowsBlockComponent(
         }
       }
 
-      for (const instance of this.instances.values()) {
-        for (const bindingIndex of affectedBindingIndices) {
-          applyKeyedRowBinding(
-            this.currentProps,
-            instance,
-            instance.item,
-            instance.index,
-            bindingIndex,
-          );
+      for (const bindingIndex of affectedBindingIndices) {
+        const binding = this.currentProps.bindings[bindingIndex];
+        const target = binding.identityTarget;
+        const previousTarget = this.identityTargets.get(bindingIndex);
+        const nextTarget = target ? keyedIdentityTargetSnapshot(target.read()) : undefined;
+        const canTarget = Boolean(
+          target &&
+          binding.dependencies?.length === 1 &&
+          binding.dependencies[0] === target.dependency &&
+          dirtyState.has(target.dependency) &&
+          previousTarget?.eligible &&
+          nextTarget?.eligible,
+        );
+
+        if (canTarget && previousTarget && nextTarget) {
+          const keys = new Set<string>();
+          if (previousTarget.key !== undefined) keys.add(previousTarget.key);
+          if (nextTarget.key !== undefined) keys.add(nextTarget.key);
+          for (const key of keys) {
+            const instance = this.instances.get(key);
+            if (instance) {
+              applyKeyedRowBinding(
+                this.currentProps,
+                instance,
+                instance.item,
+                instance.index,
+                bindingIndex,
+              );
+            }
+          }
+        } else {
+          for (const instance of this.instances.values()) {
+            applyKeyedRowBinding(
+              this.currentProps,
+              instance,
+              instance.item,
+              instance.index,
+              bindingIndex,
+            );
+          }
         }
+
+        if (nextTarget) this.identityTargets.set(bindingIndex, nextTarget);
+        else this.identityTargets.delete(bindingIndex);
       }
       afterCommit?.();
       return true;
@@ -3380,6 +3454,7 @@ function createKeyedRowsBlockComponent(
     private reconcileStableRows(
       rows: { items: unknown[]; keys: string[] },
       afterCommit?: () => void,
+      dirtyState?: ReadonlySet<number>,
     ): boolean {
       if (rows.keys.length !== this.instances.size) return false;
       let index = 0;
@@ -3420,7 +3495,7 @@ function createKeyedRowsBlockComponent(
         existing.item = rows.items[index];
         existing.index = index;
       }
-      this.commitCurrentCollection();
+      this.commitCurrentCollection(dirtyState);
       this.notifyConditionalChanges(conditionalChanges, afterCommit);
       return true;
     }
@@ -3428,6 +3503,7 @@ function createKeyedRowsBlockComponent(
     private reconcileSingleRemoval(
       rows: { items: unknown[]; keys: string[] },
       afterCommit?: () => void,
+      dirtyState?: ReadonlySet<number>,
     ): boolean {
       if (this.hasReactOwnedRows() || rows.keys.length + 1 !== this.instances.size) return false;
       const previousKeys = [...this.instances.keys()];
@@ -3483,12 +3559,12 @@ function createKeyedRowsBlockComponent(
       this.instances.delete(removedKey);
       this.eventHandlers.delete(removedKey);
       this.conditionalListeners.delete(removedKey);
-      this.commitCurrentCollection();
+      this.commitCurrentCollection(dirtyState);
       this.notifyConditionalChanges(conditionalChanges, afterCommit);
       return true;
     }
 
-    private reconcile(afterCommit?: () => void): void {
+    private reconcile(afterCommit?: () => void, dirtyState?: ReadonlySet<number>): void {
       if (!this.mounted || !this.root) {
         afterCommit?.();
         return;
@@ -3533,13 +3609,13 @@ function createKeyedRowsBlockComponent(
         this.instancesByElement = new WeakMap();
         this.eventHandlers.clear();
         this.conditionalListeners.clear();
-        this.commitCurrentCollection();
+        this.commitCurrentCollection(dirtyState);
         afterCommit?.();
         return;
       }
 
-      if (this.reconcileStableRows(rows, afterCommit)) return;
-      if (this.reconcileSingleRemoval(rows, afterCommit)) return;
+      if (this.reconcileStableRows(rows, afterCommit, dirtyState)) return;
+      if (this.reconcileSingleRemoval(rows, afterCommit, dirtyState)) return;
 
       const activeElement = this.root.ownerDocument.activeElement;
       const restoreFocus = Boolean(activeElement && this.root.contains(activeElement));
@@ -3660,7 +3736,7 @@ function createKeyedRowsBlockComponent(
       ) {
         (activeElement as HTMLElement).focus({ preventScroll: true });
       }
-      this.commitCurrentCollection();
+      this.commitCurrentCollection(dirtyState);
       this.notifyConditionalChanges(conditionalChanges, afterCommit);
     }
 
@@ -3689,7 +3765,7 @@ function createKeyedRowsBlockComponent(
         }
       }
       if (dirtyState && this.refreshDirtyBindings(dirtyState, afterCommit)) return;
-      this.reconcile(afterCommit);
+      this.reconcile(afterCommit, dirtyState);
     };
 
     private schedulePropSync(): void {
@@ -3741,6 +3817,7 @@ function createKeyedRowsBlockComponent(
       this.root = null;
       this.cleanupHostScopes();
       this.instances.clear();
+      this.identityTargets.clear();
       this.instancesByElement = new WeakMap();
       this.eventHandlers.clear();
       this.conditionalListeners.clear();

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -13,6 +13,7 @@ export interface CompileReactModuleResult {
   compiled: readonly string[];
   diagnostics: readonly CompilerDiagnostic[];
   optimizations: {
+    keyedIdentityTargets: number;
     keyedMapUpdateHints: number;
   };
 }
@@ -88,6 +89,10 @@ interface PendingKeyedRowBinding {
   path: number[];
   name?: string;
   dependencies?: number[];
+  identityTarget?: {
+    dependency: number;
+    value: t.Expression;
+  };
   value: t.Expression;
 }
 
@@ -220,7 +225,9 @@ const DELEGATABLE_KEYED_ROW_EVENTS = new Set([
   "onWheel",
 ]);
 
-function canDelegateKeyedRowEvents(plan: KeyedRowsPlan): boolean {
+function canDelegateKeyedRowEvents(
+  plan: Pick<KeyedRowsPlan, "events" | "conditionals" | "source">,
+): boolean {
   if (plan.events.length === 0 || plan.conditionals.length > 0) return false;
   if (
     plan.source.openingElement.attributes.some(
@@ -475,6 +482,83 @@ function referencesIdentifier(expression: t.Expression, name: string): boolean {
     },
   });
   return referenced;
+}
+
+function rewriteFreeIdentifierNames<T extends t.Expression>(
+  expression: T,
+  replacements: ReadonlyMap<string, t.Identifier>,
+): T {
+  if (replacements.size === 0) return cloneExpression(expression);
+  const file = expressionFile(cloneExpression(expression));
+  traverse(file, {
+    ReferencedIdentifier(path) {
+      if (path.scope.hasBinding(path.node.name)) return;
+      const replacement = replacements.get(path.node.name);
+      if (!replacement) return;
+      path.replaceWith(t.cloneNode(replacement));
+      path.skip();
+    },
+  });
+  return (file.program.body[0] as t.ExpressionStatement).expression as T;
+}
+
+function keyedIdentityTarget(
+  binding: PendingKeyedRowBinding,
+  keyCallback: t.ArrowFunctionExpression | t.FunctionExpression,
+  renderCallback: t.ArrowFunctionExpression | t.FunctionExpression,
+  reactiveByValue: ReadonlyMap<string, StateBinding>,
+  structureDependencies: ReadonlySet<number>,
+): PendingKeyedRowBinding["identityTarget"] {
+  const dependencies = binding.dependencies || [];
+  if (dependencies.length !== 1 || structureDependencies.has(dependencies[0])) return undefined;
+  const keyExpression = returnedExpression(keyCallback);
+  const keyItem = keyCallback.params[0];
+  const rowItem = renderCallback.params[0];
+  if (!keyExpression || !t.isIdentifier(keyItem) || !t.isIdentifier(rowItem)) return undefined;
+
+  const replacements = new Map<string, t.Identifier>([[keyItem.name, rowItem]]);
+  const keyIndex = keyCallback.params[1];
+  const rowIndex = renderCallback.params[1];
+  if (t.isIdentifier(keyIndex) && t.isIdentifier(rowIndex)) {
+    replacements.set(keyIndex.name, rowIndex);
+  }
+  const rowKeyExpression = rewriteFreeIdentifierNames(keyExpression, replacements);
+  const file = expressionFile(cloneExpression(binding.value));
+  let target: StateBinding | undefined;
+  let valid = true;
+  let comparisons = 0;
+  traverse(file, {
+    ReferencedIdentifier(path) {
+      if (!valid || path.scope.hasBinding(path.node.name)) return;
+      const reactive = reactiveByValue.get(path.node.name);
+      if (!reactive) return;
+      if (reactive.index !== dependencies[0] || (target && target !== reactive)) {
+        valid = false;
+        path.stop();
+        return;
+      }
+      const parent = path.parentPath;
+      if (
+        !parent.isBinaryExpression() ||
+        (parent.node.operator !== "===" && parent.node.operator !== "!==")
+      ) {
+        valid = false;
+        path.stop();
+        return;
+      }
+      const other = parent.node.left === path.node ? parent.node.right : parent.node.left;
+      if (!t.isExpression(other) || !t.isNodesEquivalent(other, rowKeyExpression)) {
+        valid = false;
+        path.stop();
+        return;
+      }
+      target = reactive;
+      comparisons += 1;
+    },
+  });
+  return valid && target && comparisons > 0
+    ? { dependency: target.index, value: t.identifier(target.valueName) }
+    : undefined;
 }
 
 function collectReferencedLocals(expression: t.Expression, names: ReadonlySet<string>): string[] {
@@ -1836,7 +1920,33 @@ function analyzeKeyedRowsContainer(
 
   const children = meaningfulJsxChildren(container);
   if (children.length !== 1) return undefined;
-  return analyzeKeyedRowChild(children[0], statesByValue, safeGlobals, listNames, true);
+  const shape = analyzeKeyedRowChild(children[0], statesByValue, safeGlobals, listNames, true);
+  if (!shape || shape.rowReason) return shape;
+  if (
+    shape.conditionals.length > 0 ||
+    (shape.events.length > 0 &&
+      !canDelegateKeyedRowEvents({
+        conditionals: shape.conditionals,
+        events: shape.events,
+        source: container,
+      }))
+  ) {
+    return shape;
+  }
+  const structureDependencies = new Set(shape.structureDependencies);
+  return {
+    ...shape,
+    bindings: shape.bindings.map((binding) => ({
+      ...binding,
+      identityTarget: keyedIdentityTarget(
+        binding,
+        shape.keyCallback,
+        shape.renderCallback,
+        statesByValue,
+        structureDependencies,
+      ),
+    })),
+  };
 }
 
 function analyzeKeyedRangesContainer(
@@ -3071,6 +3181,23 @@ function keyedRowBindingObject(
   ];
   if (binding.name) {
     properties.push(t.objectProperty(t.identifier("name"), t.stringLiteral(binding.name)));
+  }
+  if (binding.identityTarget) {
+    properties.push(
+      t.objectProperty(
+        t.identifier("identityTarget"),
+        t.objectExpression([
+          t.objectProperty(
+            t.identifier("dependency"),
+            t.numericLiteral(binding.identityTarget.dependency),
+          ),
+          t.objectProperty(
+            t.identifier("read"),
+            t.arrowFunctionExpression([], cloneExpression(binding.identityTarget.value)),
+          ),
+        ]),
+      ),
+    );
   }
   properties.push(
     t.objectProperty(
@@ -4863,7 +4990,7 @@ function compileCandidate(
   keyedMapUpdateIdentifier: t.Identifier,
   runtimeFeatureIdentifiers: ReadonlyMap<CompilerRuntimeFeatureName, t.Identifier>,
   usedRuntimeFeatures: Set<CompilerRuntimeFeatureName>,
-  optimizationCounts: { keyedMapUpdateHints: number },
+  optimizationCounts: { keyedIdentityTargets: number; keyedMapUpdateHints: number },
   useStateNames: ReadonlySet<string>,
   reactNames: ReadonlySet<string>,
   listNames: ReadonlySet<string>,
@@ -5145,6 +5272,14 @@ function compileCandidate(
     }
   }
   const blockPlans = blockAnalysis.plans || [];
+  optimizationCounts.keyedIdentityTargets += blockPlans.reduce(
+    (count, plan) =>
+      count +
+      (plan.kind === "keyed-rows"
+        ? plan.bindings.filter((binding) => binding.identityTarget !== undefined).length
+        : 0),
+    0,
+  );
   const runtimeFeatures = runtimeFeaturesForPlans(blockPlans, appliedKeyedMapUpdateHints > 0);
   markShortCircuitBindings(analysis.bindings || []);
   assignStableBindingTargets(analysis.bindings || []);
@@ -5329,7 +5464,7 @@ export async function compileReactModule(
 ): Promise<CompileReactModuleResult> {
   const compiled: string[] = [];
   const diagnostics: CompilerDiagnostic[] = [];
-  const optimizationCounts = { keyedMapUpdateHints: 0 };
+  const optimizationCounts = { keyedIdentityTargets: 0, keyedMapUpdateHints: 0 };
   const plugin = (): PluginObj => ({
     name: "farm-react-aot",
     visitor: {


### PR DESCRIPTION
## Summary

- prove strict exact-key comparisons at build time for keyed map rows and the public List primitive
- update only the previously selected and newly selected keyed rows instead of scanning every row
- preserve the existing full-scan, reconcile, and React fallback paths whenever the expression, event, key, value, or lifecycle state is not proven safe
- expose keyedIdentityTargets in compiler reports and document its behavior and limits

This is an internal optimization under the existing experimental React compiler. It adds no syntax or configuration.

## Safety and compatibility

- unsupported object, array, boolean, nullish-transition metadata, structural-key changes, conditionals, and React-owned event shapes retain the established paths
- prop commits, HMR/adoption, StrictMode, unmount-before-flush, mixed structural updates, and runtime nullish row keys are covered
- randomized differential tests compare 2,000 queued state transitions with normal React
- React 18.3.1 and React 19.2.8 compatibility suites pass

## Benchmark

The browser benchmark measures event dispatch through the observed DOM update.

- 20,000-row static selection: 3.00 ms compiled vs 90.55 ms React, 30.18x faster
- 20,000-row hybrid selection: 2.70 ms compiled vs 90.55 ms React, 33.54x faster
- deterministic runtime coverage proves target-only updates touch no more than two row bindings
- the existing 20,000-row keyed update path remains 15.76x-16.81x faster than React
- every existing dashboard performance and correctness gate passes

Runtime-size gates also pass. The targeted keyed fixture adds 530 B gzip; the direct compiler and isolated core premiums are unchanged.

## Verification

- corepack pnpm --filter @farm.js/react test — 45 files, 373 tests
- corepack pnpm --filter @farm.js/react type-check
- corepack pnpm --filter @farm.js/react test:compat — React 18.3.1 and 19.2.8
- corepack pnpm --filter @farm.js/react test:runtime-size
- React compiler dashboard browser benchmark — PASS
- corepack pnpm --filter farmjs-docs build
- corepack pnpm docs:check-navigation — 73 visible pages
- oxfmt, oxlint, and git diff checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up selection updates in keyed rows by patching only the previously and newly selected rows instead of scanning every row. The compiler now proves strict key comparisons at build time for keyed map rows and the `List` primitive; anything it cannot prove safe keeps the existing full-scan, reconcile, or React fallback path.

- Selection on 20,000 rows is now 33.54x faster than React (2.70 ms vs 90.55 ms); keyed updates stay 15.76x-16.81x faster.
- Adds `keyedIdentityTargets` to compiler reports and documents the proof's narrow limits.
- Unsupported object, array, boolean, structural-key, conditional, and React-owned event shapes retain established paths.
- Randomized differential tests match normal React across 2,000 queued transitions; React 18.3.1 and 19.2.8 compat suites pass.
- The targeted keyed fixture adds 530 B gzip; direct compiler and isolated core premiums are unchanged.

<sup>Written for commit f2e4b5756e1a7e36b9ae73635cd856feadc0afe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

