### PR TITLE
feat(pwa): add automatic caching and custom workers

### DIFF
--- a/docs/src/app/docs/plugins/pwa/page.md
+++ b/docs/src/app/docs/plugins/pwa/page.md
@@ -8,7 +8,8 @@ section: "Plugin Ecosystem"
 
 `@farm.js/pwa` turns a production Farm build into an installable, offline-aware Progressive Web App.
 It generates a service worker from the final client output, maps emitted static routes to their HTML
-files, and registers the worker through Farm's browser lifecycle.
+files, and registers the worker through Farm's browser lifecycle. Advanced applications can replace
+the generated worker with a prebuilt JavaScript file while retaining that registration lifecycle.
 
 ## Install
 
@@ -32,7 +33,7 @@ export default defineConfig({
 });
 ```
 
-The worker always precaches immutable build assets. `cache: "auto"` additionally means:
+The generated worker always precaches immutable build assets. `cache: "auto"` additionally means:
 
 - Precache every HTML page Farm emitted as a static route.
 - Cache public same-origin images with SWR.
@@ -42,8 +43,8 @@ The worker always precaches immutable build assets. `cache: "auto"` additionally
 value remains available as a compatibility alias. Service worker updates separately default to
 `update: "prompt"`.
 
-The worker only intercepts `GET` requests and same-origin URLs. Dynamic pages, APIs, actions,
-integrations, and workflows remain network-owned.
+The generated worker only intercepts `GET` requests and same-origin URLs. Dynamic pages, APIs,
+actions, integrations, and workflows remain network-owned.
 
 ## Add the offline page
 
@@ -131,6 +132,42 @@ pwa({
 `limit` is the maximum image count. `ttl` accepts milliseconds or `s`, `m`, `h`, `d`, and `w`
 durations such as `30s`, `5m`, `6h`, `30d`, or `2w`.
 
+## Bring your own service worker
+
+Use a custom worker when you need complete control over fetch routing, background sync, push
+notifications, or a caching strategy outside the generated worker's scope:
+
+```ts title="farm.config.ts"
+pwa({
+  serviceWorker: {
+    source: "src/service-worker.js",
+    type: "module",
+  },
+  update: "prompt",
+});
+```
+
+`source` is relative to the Farm project root. Farm copies it verbatim to the final `sw.js` path
+under `basePath`; it does not bundle or transform the file. Module imports must therefore resolve
+to files available in the production public output.
+
+The custom worker owns install, fetch, offline, and cache behavior, so `serviceWorker` cannot be
+combined with `offline` or `cache`. Farm still registers the worker and exposes its update events.
+To support `applyUpdate`, handle the message used by Farm's update lifecycle:
+
+```js title="src/service-worker.js"
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("message", (event) => {
+  if (event.data?.type === "FARM_PWA_SKIP_WAITING") void self.skipWaiting();
+});
+```
+
+If you need to control registration and scope as well, leave out the PWA plugin and register the
+worker directly in application client code.
+
 ## Update behavior
 
 The default is `update: "prompt"`. When a new service worker finishes installing, the plugin
@@ -154,12 +191,13 @@ worker and reloads once the new worker controls the page.
 
 ## Options
 
-| Option    | Default    | Description                                                           |
-| --------- | ---------- | --------------------------------------------------------------------- |
-| `enabled` | `true`     | Generate and register the worker.                                     |
-| `offline` | `false`    | Static route served after an offline navigation misses the cache.     |
-| `update`  | `"prompt"` | Prompt or automatically activate and reload for a waiting worker.     |
-| `cache`   | `"auto"`   | Automatic caching, a custom object, or `false` for build assets only. |
+| Option          | Default    | Description                                                         |
+| --------------- | ---------- | ------------------------------------------------------------------- |
+| `enabled`       | `true`     | Generate or copy and then register the worker.                      |
+| `offline`       | `false`    | Static fallback route for the generated worker.                     |
+| `update`        | `"prompt"` | Prompt or automatically activate and reload for a waiting worker.   |
+| `cache`         | `"auto"`   | Generated-worker caching, a custom object, or build assets only.    |
+| `serviceWorker` | `false`    | Prebuilt worker source and optional `"classic"` or `"module"` type. |
 
 | Cache option   | Default under `auto` | Description                                          |
 | -------------- | -------------------- | ---------------------------------------------------- |
@@ -168,13 +206,16 @@ worker and reloads once the new worker controls the page.
 
 ## Production lifecycle
 
-During `farm build`, the plugin:
+During `farm build`, generated-worker mode:
 
 1. Finds the preset's final public output.
 2. Hashes precached files and caching options into a deployment-specific cache ID.
 3. Writes `sw.js` under Farm's configured `basePath`.
 4. Maps clean static route URLs to emitted HTML files.
 5. Fails if the configured offline page is missing.
+
+Custom-worker mode copies the configured source to the same deployment-aware `sw.js` location and
+leaves its contents untouched.
 
 In the browser, the plugin registers only for production builds. Service workers require HTTPS in
 production; browsers also permit localhost for development and local production testing.

--- a/docs/src/app/docs/plugins/pwa/page.md
+++ b/docs/src/app/docs/plugins/pwa/page.md
@@ -26,19 +26,21 @@ export default defineConfig({
   plugins: [
     pwa({
       offline: "/offline",
-      cache: "recommended",
+      cache: "auto",
     }),
   ],
 });
 ```
 
-`recommended` means:
+The worker always precaches immutable build assets. `cache: "auto"` additionally means:
 
-- Precache hashed JavaScript, CSS, fonts, WebAssembly, and emitted web manifest files.
 - Precache every HTML page Farm emitted as a static route.
 - Cache public same-origin images with SWR.
 - Keep up to 100 image responses fresh for 30 days.
-- Prompt before activating a new deployment.
+
+`auto` is the default, so you can omit `cache` for the same behavior. The previous `recommended`
+value remains available as a compatibility alias. Service worker updates separately default to
+`update: "prompt"`.
 
 The worker only intercepts `GET` requests and same-origin URLs. Dynamic pages, APIs, actions,
 integrations, and workflows remain network-owned.
@@ -89,7 +91,7 @@ export default function manifest(): MetadataRoute.Manifest {
 
 ## SWR in one line
 
-Use the explicit form when you do not want every recommended behavior:
+Use the explicit form when you want individual cache controls instead of the automatic preset:
 
 ```ts
 pwa({
@@ -152,17 +154,17 @@ worker and reloads once the new worker controls the page.
 
 ## Options
 
-| Option    | Default         | Description                                                             |
-| --------- | --------------- | ----------------------------------------------------------------------- |
-| `enabled` | `true`          | Generate and register the worker.                                       |
-| `offline` | `false`         | Static route served after an offline navigation misses the cache.       |
-| `update`  | `"prompt"`      | Prompt or automatically activate and reload for a waiting worker.       |
-| `cache`   | `"recommended"` | Recommended caching, a custom object, or `false` for build assets only. |
+| Option    | Default    | Description                                                           |
+| --------- | ---------- | --------------------------------------------------------------------- |
+| `enabled` | `true`     | Generate and register the worker.                                     |
+| `offline` | `false`    | Static route served after an offline navigation misses the cache.     |
+| `update`  | `"prompt"` | Prompt or automatically activate and reload for a waiting worker.     |
+| `cache`   | `"auto"`   | Automatic caching, a custom object, or `false` for build assets only. |
 
-| Cache option   | Default under `recommended` | Description                                          |
-| -------------- | --------------------------- | ---------------------------------------------------- |
-| `staticRoutes` | `true`                      | Every emitted static page, a route list, or `false`. |
-| `images`       | `"swr"`                     | SWR options, `true`, `"swr"`, or `false`.            |
+| Cache option   | Default under `auto` | Description                                          |
+| -------------- | -------------------- | ---------------------------------------------------- |
+| `staticRoutes` | `true`               | Every emitted static page, a route list, or `false`. |
+| `images`       | `"swr"`              | SWR options, `true`, `"swr"`, or `false`.            |
 
 ## Production lifecycle
 

--- a/packages/farm-pwa/README.md
+++ b/packages/farm-pwa/README.md
@@ -1,7 +1,8 @@
 # @farm.js/pwa
 
 Installable, offline-aware Progressive Web Apps for Farm.js. The plugin generates a route-aware
-service worker during the production build and registers it through Farm's browser plugin lifecycle.
+service worker or copies a custom one during the production build, then registers it through Farm's
+browser plugin lifecycle.
 
 Farm.js is currently in beta.
 
@@ -73,6 +74,25 @@ pwa({
   },
 });
 ```
+
+## Bring your own service worker
+
+Advanced applications can replace the generated worker with a prebuilt JavaScript file:
+
+```ts
+pwa({
+  serviceWorker: {
+    source: "src/service-worker.js",
+    type: "module",
+  },
+});
+```
+
+The source path is relative to the Farm project root. Farm copies the file verbatim to the final
+`sw.js` location and keeps its production registration and update lifecycle. A custom worker owns
+all fetch, offline, and cache behavior, so `serviceWorker` cannot be combined with `offline` or
+`cache`. It must handle the `FARM_PWA_SKIP_WAITING` message for Farm's update action to activate a
+waiting worker.
 
 ## Updates
 

--- a/packages/farm-pwa/README.md
+++ b/packages/farm-pwa/README.md
@@ -21,7 +21,7 @@ export default defineConfig({
   plugins: [
     pwa({
       offline: "/offline",
-      cache: "recommended",
+      cache: "auto",
     }),
   ],
 });
@@ -33,14 +33,17 @@ does not duplicate it.
 
 ## Short cache configuration
 
-`recommended` precaches emitted static pages and uses SWR for public same-origin images:
+`auto` precaches emitted static pages and uses SWR for public same-origin images. It is the default,
+so you can omit `cache` when you want this behavior:
 
 ```ts
 pwa({
   offline: "/offline",
-  cache: "recommended",
+  cache: "auto",
 });
 ```
+
+The previous `recommended` value remains available as a compatibility alias for `auto`.
 
 The explicit short form is:
 

--- a/packages/farm-pwa/src/build.test.ts
+++ b/packages/farm-pwa/src/build.test.ts
@@ -84,6 +84,27 @@ describe("writePwaBuildArtifacts", () => {
     expect(result.staticRoutes).toEqual({ "/app/offline": "offline/index.html" });
   });
 
+  it("copies a custom service worker verbatim under basePath", async () => {
+    const { root, publicDir } = await createOutput("node-server");
+    const customWorker = 'self.addEventListener("fetch", () => undefined);\n';
+    await writeFile(path.join(root, "custom-worker.js"), customWorker);
+
+    const result = await writePwaBuildArtifacts({
+      root,
+      outputDir: root,
+      preset: "node-server",
+      basePath: "/app",
+      options: resolvePwaOptions({
+        serviceWorker: { source: "custom-worker.js", type: "module" },
+      }),
+    });
+
+    expect(result.mode).toBe("custom");
+    expect(result.workerUrl).toBe("/app/sw.js");
+    expect(result.precacheUrls).toEqual([]);
+    expect(await readFile(path.join(publicDir, "app", "sw.js"), "utf8")).toBe(customWorker);
+  });
+
   it("prefixes every logical static route without requiring basePath folders on disk", async () => {
     const { root } = await createOutput("node-server");
     const result = await writePwaBuildArtifacts({

--- a/packages/farm-pwa/src/build.test.ts
+++ b/packages/farm-pwa/src/build.test.ts
@@ -40,7 +40,7 @@ describe("writePwaBuildArtifacts", () => {
       outputDir: root,
       preset: "node-server",
       basePath: "/",
-      options: resolvePwaOptions({ offline: "/offline", cache: "recommended" }),
+      options: resolvePwaOptions({ offline: "/offline", cache: "auto" }),
     });
 
     expect(result.workerPath).toBe(path.join(publicDir, "sw.js"));

--- a/packages/farm-pwa/src/build.ts
+++ b/packages/farm-pwa/src/build.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { ResolvedPwaOptions } from "./config.js";
 
 export interface PwaBuildInput {
+  root?: string;
   outputDir: string;
   publicDir?: string;
   preset: string;
@@ -12,6 +13,7 @@ export interface PwaBuildInput {
 }
 
 export interface PwaBuildResult {
+  mode: "generated" | "custom";
   workerPath: string;
   workerUrl: string;
   precacheUrls: string[];
@@ -33,10 +35,38 @@ const PRECACHE_EXTENSIONS = new Set([
 
 export async function writePwaBuildArtifacts(input: PwaBuildInput): Promise<PwaBuildResult> {
   const publicDir = input.publicDir ?? resolvePwaPublicDir(input.outputDir, input.preset);
-  const files = await walkFiles(publicDir);
-  const staticRouteFiles = resolveStaticRouteFiles(files);
   const basePath = normalizeBasePath(input.basePath);
   const workerRelativePath = path.posix.join(basePath.replace(/^\//, ""), "sw.js");
+  const workerPath = path.join(publicDir, ...workerRelativePath.split("/"));
+
+  if (input.options.serviceWorker) {
+    const sourcePath = path.resolve(
+      input.root ?? process.cwd(),
+      input.options.serviceWorker.source,
+    );
+    let source: Buffer;
+    try {
+      source = await readFile(sourcePath);
+    } catch (cause) {
+      throw new Error(
+        `[farm:pwa] Custom service worker ${JSON.stringify(input.options.serviceWorker.source)} could not be read.`,
+        { cause },
+      );
+    }
+    await mkdir(path.dirname(workerPath), { recursive: true });
+    await writeFile(workerPath, source);
+    return {
+      mode: "custom",
+      workerPath,
+      workerUrl: withBasePath("/sw.js", basePath),
+      precacheUrls: [],
+      staticRoutes: {},
+      cacheId: createHash("sha256").update(source).digest("hex").slice(0, 16),
+    };
+  }
+
+  const files = await walkFiles(publicDir);
+  const staticRouteFiles = resolveStaticRouteFiles(files);
   const selectedRoutes = selectStaticRoutes(
     staticRouteFiles,
     input.options.cache.staticRoutes,
@@ -84,7 +114,6 @@ export async function writePwaBuildArtifacts(input: PwaBuildInput): Promise<PwaB
     .digest("hex")
     .slice(0, 16);
 
-  const workerPath = path.join(publicDir, ...workerRelativePath.split("/"));
   await mkdir(path.dirname(workerPath), { recursive: true });
   await writeFile(
     workerPath,
@@ -99,6 +128,7 @@ export async function writePwaBuildArtifacts(input: PwaBuildInput): Promise<PwaB
   );
 
   return {
+    mode: "generated",
     workerPath,
     workerUrl: withBasePath("/sw.js", basePath),
     precacheUrls,

--- a/packages/farm-pwa/src/config.test.ts
+++ b/packages/farm-pwa/src/config.test.ts
@@ -7,6 +7,7 @@ describe("resolvePwaOptions", () => {
       enabled: true,
       offline: "/offline",
       update: "prompt",
+      serviceWorker: false,
       cache: {
         staticRoutes: true,
         images: {
@@ -25,6 +26,26 @@ describe("resolvePwaOptions", () => {
     expect(resolvePwaOptions({ cache: "recommended" })).toEqual(
       resolvePwaOptions({ cache: "auto" }),
     );
+  });
+
+  it("gives a custom service worker full ownership of offline and cache behavior", () => {
+    expect(
+      resolvePwaOptions({
+        serviceWorker: { source: "src/service-worker.js", type: "module" },
+      }),
+    ).toMatchObject({
+      offline: false,
+      serviceWorker: { source: "src/service-worker.js", type: "module" },
+      cache: { staticRoutes: false, images: false },
+    });
+
+    expect(() =>
+      resolvePwaOptions({
+        serviceWorker: { source: "src/service-worker.js" },
+        cache: "auto",
+      }),
+    ).toThrow("cannot be combined");
+    expect(() => resolvePwaOptions({ serviceWorker: { source: " " } })).toThrow("non-empty path");
   });
 
   it("accepts images: swr and a compact advanced form", () => {

--- a/packages/farm-pwa/src/config.test.ts
+++ b/packages/farm-pwa/src/config.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { parsePwaDuration, resolvePwaOptions } from "./config";
 
 describe("resolvePwaOptions", () => {
-  it("uses the short recommended configuration by default", () => {
-    expect(resolvePwaOptions({ offline: "/offline" })).toEqual({
+  it("uses the automatic cache preset by default", () => {
+    const expected = {
       enabled: true,
       offline: "/offline",
       update: "prompt",
@@ -15,7 +15,16 @@ describe("resolvePwaOptions", () => {
           ttlMs: 30 * 24 * 60 * 60 * 1_000,
         },
       },
-    });
+    };
+
+    expect(resolvePwaOptions({ offline: "/offline" })).toEqual(expected);
+    expect(resolvePwaOptions({ offline: "/offline", cache: "auto" })).toEqual(expected);
+  });
+
+  it("keeps recommended as a compatibility alias for auto", () => {
+    expect(resolvePwaOptions({ cache: "recommended" })).toEqual(
+      resolvePwaOptions({ cache: "auto" }),
+    );
   });
 
   it("accepts images: swr and a compact advanced form", () => {

--- a/packages/farm-pwa/src/config.ts
+++ b/packages/farm-pwa/src/config.ts
@@ -18,6 +18,13 @@ export interface PwaCacheOptions {
   images?: PwaImageCache;
 }
 
+export interface PwaServiceWorkerOptions {
+  /** JavaScript file copied verbatim into the production output as sw.js. */
+  source: string;
+  /** Registration type for the custom worker. */
+  type?: "classic" | "module";
+}
+
 export interface PwaPluginOptions {
   /** Set false to keep the plugin registered without emitting or registering a worker. */
   enabled?: boolean;
@@ -25,8 +32,10 @@ export interface PwaPluginOptions {
   offline?: string | false;
   /** How a waiting service worker becomes active. */
   update?: "prompt" | "auto";
-  /** Automatic caching, a custom cache policy, or build assets only. */
+  /** Generated-worker caching, a custom cache policy, or build assets only. */
   cache?: "auto" | "recommended" | PwaCacheOptions | false;
+  /** Copy and register a prebuilt service worker instead of generating one. */
+  serviceWorker?: PwaServiceWorkerOptions;
 }
 
 export interface ResolvedPwaImageCacheOptions {
@@ -39,6 +48,7 @@ export interface ResolvedPwaOptions {
   enabled: boolean;
   offline: string | false;
   update: "prompt" | "auto";
+  serviceWorker: Required<PwaServiceWorkerOptions> | false;
   cache: {
     staticRoutes: boolean | string[];
     images: ResolvedPwaImageCacheOptions | false;
@@ -49,27 +59,51 @@ const DEFAULT_IMAGE_LIMIT = 100;
 const DEFAULT_IMAGE_TTL = "30d";
 
 export function resolvePwaOptions(options: PwaPluginOptions = {}): ResolvedPwaOptions {
+  const serviceWorker = resolveServiceWorker(options.serviceWorker);
+  if (serviceWorker && (options.offline !== undefined || options.cache !== undefined)) {
+    throw new TypeError(
+      "PWA serviceWorker cannot be combined with offline or cache because the custom worker owns those behaviors",
+    );
+  }
+
   const cache = options.cache ?? "auto";
   const usesAutomaticCache = cache === "auto" || cache === "recommended";
   const customCache = typeof cache === "object" ? cache : undefined;
 
   return {
     enabled: options.enabled !== false,
-    offline: normalizeRoute(options.offline ?? false, "offline"),
+    offline: serviceWorker ? false : normalizeRoute(options.offline ?? false, "offline"),
     update: options.update ?? "prompt",
+    serviceWorker,
     cache: {
-      staticRoutes: usesAutomaticCache
-        ? true
-        : cache === false
-          ? false
-          : normalizeStaticRoutes(customCache?.staticRoutes ?? false),
-      images: usesAutomaticCache
-        ? resolveImageCache("swr")
-        : cache === false
-          ? false
-          : resolveImageCache(customCache?.images ?? false),
+      staticRoutes: serviceWorker
+        ? false
+        : usesAutomaticCache
+          ? true
+          : cache === false
+            ? false
+            : normalizeStaticRoutes(customCache?.staticRoutes ?? false),
+      images: serviceWorker
+        ? false
+        : usesAutomaticCache
+          ? resolveImageCache("swr")
+          : cache === false
+            ? false
+            : resolveImageCache(customCache?.images ?? false),
     },
   };
+}
+
+function resolveServiceWorker(
+  value: PwaServiceWorkerOptions | undefined,
+): Required<PwaServiceWorkerOptions> | false {
+  if (!value) return false;
+  const source = value.source.trim();
+  if (!source) throw new TypeError("PWA serviceWorker source must be a non-empty path");
+  if (value.type !== undefined && value.type !== "classic" && value.type !== "module") {
+    throw new TypeError('PWA serviceWorker type must be "classic" or "module"');
+  }
+  return { source, type: value.type ?? "classic" };
 }
 
 export function parsePwaDuration(value: PwaDuration): number {

--- a/packages/farm-pwa/src/config.ts
+++ b/packages/farm-pwa/src/config.ts
@@ -25,8 +25,8 @@ export interface PwaPluginOptions {
   offline?: string | false;
   /** How a waiting service worker becomes active. */
   update?: "prompt" | "auto";
-  /** Recommended caching, custom caching, or build assets only. */
-  cache?: "recommended" | PwaCacheOptions | false;
+  /** Automatic caching, a custom cache policy, or build assets only. */
+  cache?: "auto" | "recommended" | PwaCacheOptions | false;
 }
 
 export interface ResolvedPwaImageCacheOptions {
@@ -49,7 +49,8 @@ const DEFAULT_IMAGE_LIMIT = 100;
 const DEFAULT_IMAGE_TTL = "30d";
 
 export function resolvePwaOptions(options: PwaPluginOptions = {}): ResolvedPwaOptions {
-  const cache = options.cache ?? "recommended";
+  const cache = options.cache ?? "auto";
+  const usesAutomaticCache = cache === "auto" || cache === "recommended";
   const customCache = typeof cache === "object" ? cache : undefined;
 
   return {
@@ -57,18 +58,16 @@ export function resolvePwaOptions(options: PwaPluginOptions = {}): ResolvedPwaOp
     offline: normalizeRoute(options.offline ?? false, "offline"),
     update: options.update ?? "prompt",
     cache: {
-      staticRoutes:
-        cache === "recommended"
-          ? true
-          : cache === false
-            ? false
-            : normalizeStaticRoutes(customCache?.staticRoutes ?? false),
-      images:
-        cache === "recommended"
-          ? resolveImageCache("swr")
-          : cache === false
-            ? false
-            : resolveImageCache(customCache?.images ?? false),
+      staticRoutes: usesAutomaticCache
+        ? true
+        : cache === false
+          ? false
+          : normalizeStaticRoutes(customCache?.staticRoutes ?? false),
+      images: usesAutomaticCache
+        ? resolveImageCache("swr")
+        : cache === false
+          ? false
+          : resolveImageCache(customCache?.images ?? false),
     },
   };
 }

--- a/packages/farm-pwa/src/index.test.ts
+++ b/packages/farm-pwa/src/index.test.ts
@@ -87,6 +87,30 @@ describe("pwa browser lifecycle", () => {
 
     expect(serviceWorker.register).not.toHaveBeenCalled();
   });
+
+  it("registers a custom module worker through the same browser lifecycle", async () => {
+    const serviceWorker = new ServiceWorkerContainerMock();
+    serviceWorker.controller = null as never;
+    serviceWorker.registration.waiting = null;
+    vi.stubGlobal("navigator", { serviceWorker });
+    vi.stubGlobal("window", Object.assign(new EventTarget(), { location: { reload: vi.fn() } }));
+
+    const plugin = pwa({
+      serviceWorker: { source: "src/service-worker.js", type: "module" },
+    });
+    await plugin.client?.setup?.({
+      plugin: { name: plugin.name },
+      public: plugin.client.public,
+      router: {} as never,
+      isDev: false,
+      isProd: true,
+    } as never);
+
+    expect(serviceWorker.register).toHaveBeenCalledWith("/sw.js", {
+      scope: "/",
+      type: "module",
+    });
+  });
 });
 
 describe("pwa production build lifecycle", () => {

--- a/packages/farm-pwa/src/index.ts
+++ b/packages/farm-pwa/src/index.ts
@@ -7,9 +7,17 @@ import {
   type PwaImageCache,
   type PwaImageCacheOptions,
   type PwaPluginOptions,
+  type PwaServiceWorkerOptions,
 } from "./config.js";
 
-export type { PwaCacheOptions, PwaDuration, PwaImageCache, PwaImageCacheOptions, PwaPluginOptions };
+export type {
+  PwaCacheOptions,
+  PwaDuration,
+  PwaImageCache,
+  PwaImageCacheOptions,
+  PwaPluginOptions,
+  PwaServiceWorkerOptions,
+};
 
 export interface FarmPwaBrowserRuntime {
   registration: ServiceWorkerRegistration;
@@ -29,12 +37,13 @@ declare global {
 }
 
 /**
- * Generate and register a route-aware service worker for a Farm application.
- * Build assets are always precached. Optional page and image caching stays
- * constrained to safe GET navigation and same-origin image requests.
+ * Generate or copy and then register a service worker for a Farm application.
+ * In generated mode, build assets are always precached while optional page and
+ * image caching stays constrained to safe GET navigation and same-origin images.
  */
 export function pwa(options: PwaPluginOptions = {}) {
   const resolved = resolvePwaOptions(options);
+  let configuredRoot = ".";
   let configuredBasePath = "/";
   let configuredOutputDir = ".farm/.output";
   const publicConfig = {
@@ -42,12 +51,14 @@ export function pwa(options: PwaPluginOptions = {}) {
     workerUrl: "/sw.js",
     scope: "/",
     update: resolved.update,
+    workerType: resolved.serviceWorker ? resolved.serviceWorker.type : "classic",
   };
 
   return definePlugin({
     name: "farm:pwa",
 
     configure(config) {
+      configuredRoot = config.root ?? ".";
       const basePath = normalizeBasePath(config.basePath);
       configuredBasePath = basePath;
       configuredOutputDir = `${config.root ?? "."}/.farm/.output`;
@@ -66,6 +77,7 @@ export function pwa(options: PwaPluginOptions = {}) {
         const generate = async () => {
           if (generated) return;
           const built = await writePwaBuildArtifacts({
+            root: configuredRoot,
             outputDir: nitroConfig.output?.dir ?? configuredOutputDir,
             publicDir: nitroConfig.output?.publicDir,
             preset: nitroConfig.preset ?? "node-server",
@@ -74,7 +86,9 @@ export function pwa(options: PwaPluginOptions = {}) {
           });
           generated = true;
           console.info(
-            `[farm:pwa] Generated ${built.workerUrl} with ${built.precacheUrls.length} precached files`,
+            built.mode === "custom"
+              ? `[farm:pwa] Copied custom service worker to ${built.workerUrl}`
+              : `[farm:pwa] Generated ${built.workerUrl} with ${built.precacheUrls.length} precached files`,
           );
         };
 
@@ -102,9 +116,12 @@ export function pwa(options: PwaPluginOptions = {}) {
       async setup({ public: config, isProd }) {
         if (!config.enabled || !isProd || !("serviceWorker" in navigator)) return undefined;
 
-        const registration = await navigator.serviceWorker.register(config.workerUrl, {
-          scope: config.scope,
-        });
+        const registration = await navigator.serviceWorker.register(
+          config.workerUrl,
+          config.workerType === "module"
+            ? { scope: config.scope, type: "module" }
+            : { scope: config.scope },
+        );
         const hadControllerAtSetup = Boolean(navigator.serviceWorker.controller);
         let applyingUpdate = false;
         let reloading = false;


### PR DESCRIPTION
## Summary

- make `cache: "auto"` the canonical and default safe cache preset
- keep `cache: "recommended"` as a compatibility alias
- add a bring-your-own-worker mode for prebuilt classic or module service workers
- copy custom workers verbatim to the deployment-aware `sw.js` path while retaining Farm registration and update events
- reject custom-worker configurations that also set generated-worker `offline` or `cache` options
- document safe defaults, advanced cache controls, custom-worker ownership, and the update message contract

## Validation

- `pnpm --filter @farm.js/pwa test` (18 tests)
- `pnpm --filter @farm.js/pwa type-check`
- `pnpm --filter @farm.js/pwa build`
- `pnpm docs:check-navigation`
- `pnpm format:check`
- `pnpm lint`