### PR TITLE
perf(react): target keyed Set membership

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -303,6 +303,7 @@ After a successful build, Farm writes `.farm/react-compiler.json`:
     "compiled": 2,
     "fallback": 2,
     "keyedIdentityTargets": 2,
+    "keyedMembershipTargets": 1,
     "keyedMapUpdateHints": 1
   },
   "fallbackReasons": [
@@ -317,6 +318,7 @@ After a successful build, Farm writes `.farm/react-compiler.json`:
       "compiled": ["ProductRow"],
       "optimizations": {
         "keyedIdentityTargets": 2,
+        "keyedMembershipTargets": 1,
         "keyedMapUpdateHints": 1
       },
       "fallbacks": [
@@ -335,6 +337,8 @@ After a successful build, Farm writes `.farm/react-compiler.json`:
 `componentsConsidered` counts candidates selected by the active mode. `compiled` counts components
 using the AOT runtime, and `fallback` counts candidates left on React. `keyedIdentityTargets` counts
 row bindings that can update by looking up the previous and next key directly.
+`keyedMembershipTargets` counts row bindings that can update from the changed members of a local
+native `Set`.
 `keyedMapUpdateHints` counts setter sites where the compiler proved that a direct keyed collection
 can report its changed row indexes while an immutable `map()` runs. The same counts appear per
 module. `selected` is `true` when an annotation explicitly requested compilation. Module paths are
@@ -721,6 +725,37 @@ nullish targets. Object, array, boolean, ambiguous, mixed structural, React-owne
 unsupported expressions use the existing complete evaluation or React fallback. Missing keys are
 safe and simply patch no next row. No option or component primitive is required. The compiler
 report exposes the number of emitted row-binding proofs as `keyedIdentityTargets`.
+
+#### Key-directed Set membership updates
+
+Multi-selection usually keeps several row keys in local state:
+
+```tsx
+const [markedIds, setMarkedIds] = useState(() => new Set<number>());
+
+<tbody>
+  {rows.map((row) => (
+    <tr data-marked={markedIds.has(row.id)} key={row.id}>
+      <td>{row.label}</td>
+    </tr>
+  ))}
+</tbody>;
+```
+
+For an exact `localSet.has(rowKey)` binding, the compiler records the local state cell and the row
+key expression. The runtime snapshots the previous and next members and computes their symmetric
+difference. Only rows whose membership changed evaluate that binding. Replacing two marked keys in
+a 20,000-row table therefore touches at most four matching row instances instead of scanning every
+row. The component and its `map()` callback do not rerun.
+
+The proof accepts only a direct `has()` call on one local `useState` value with the exact expression
+used by `key`. At runtime, targeting requires an ordinary native `Set` containing only string,
+number, bigint, or nullish members. Set subclasses, proxies, own `has` overrides, object members,
+different row fields, extra reactive dependencies, React-owned rows, nested blocks, and structural
+key dependencies do not use this path. If a runtime value fails the native-Set guard, that keyed
+boundary returns to React before compiled bindings are evaluated. This keeps custom collection
+semantics and error handling under React ownership. No option or component primitive is required.
+The report exposes the emitted binding count as `keyedMembershipTargets`.
 
 #### Mutation-aware same-order updates
 
@@ -1532,10 +1567,10 @@ The package and example test suites verify more than generated code:
 - the production browser experiment rotates 1,000 compiler-owned host rows with one LIS move,
   updates outer and nested row conditions, preserves surviving row and branch identity, removes and
   inserts a row, and observes zero owner update executions;
-- the production 10,000/20,000-row benchmark requires nonzero `keyedIdentityTargets` and
-  `keyedMapUpdateHints` report counts, preserves the keyed-update speedup floor, checks that
-  selection remains key-directed at scale, and passes DOM correctness, React-relative regression,
-  and normalized scalability gates;
+- the production 10,000/20,000-row benchmark requires nonzero `keyedIdentityTargets`,
+  `keyedMembershipTargets`, and `keyedMapUpdateHints` report counts, preserves the keyed-update
+  speedup floor, checks that scalar selection and Set membership remain key-directed at scale, and
+  passes DOM correctness, React-relative regression, and normalized scalability gates;
 - the public `List` renders iterable and nullish collections correctly with the compiler off;
 - the packaged runtime, including a keyed-range component root, editable and interactive keyed-row
   events, row-local conditions, reorders, identity, selection, and hydration, is exercised

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,8 +2,8 @@
 
 Date: 2026-08-28
 
-Result: **PASS.** Correctness, the React-relative performance gate, the keyed-update and
-key-directed selection persistence gates, and the normalized scalability gate all pass. The
+Result: **PASS.** Correctness, the React-relative performance gate, the keyed-update, scalar
+selection, and Set-membership persistence gates, and the normalized scalability gate all pass. The
 production run compares two bracketing React baselines with static and hybrid compiler builds from
 the exact same component source.
 
@@ -21,13 +21,15 @@ the exact same component source.
 - Keyed-update persistence gate: at least 8x faster than React at both 10,000 and 20,000 rows
 - Key-directed selection gate: at least 10x faster than React at 20,000 rows and no more than 2x
   normalized growth
+- Key-directed Set-membership gate: at least 10x faster than React at 20,000 rows and no more than
+  2x normalized growth
 - No CPU throttling
 
 Every trial passed DOM assertions and browser-error checks. The compiler report proved that both
-workloads compiled, delegated keyed rows were present only in compiler builds, exactly two
-key-directed row bindings and one mutation-aware keyed-map update site were emitted, and
-hybrid/static added zero owner executions. The two React baselines added 1,430 dashboard and 261
-table owner executions each.
+workloads compiled, delegated keyed rows were present only in compiler builds, exactly two scalar
+key-directed bindings, one Set-membership binding, and one mutation-aware keyed-map update site were
+emitted, and hybrid/static added zero owner executions. The two React baselines added 1,430
+dashboard and 279 table owner executions each.
 
 ## Complex dashboard
 
@@ -36,28 +38,29 @@ bindings.
 
 | Interaction                 | React median | Hybrid median | Hybrid vs React |
 | --------------------------- | -----------: | ------------: | --------------: |
-| Active live pulse           |     0.100 ms |      0.100 ms |          parity |
-| Inactive branch update      |     0.060 ms |      0.020 ms |    3.00x faster |
+| Active live pulse           |      0.10 ms |       0.08 ms |    1.25x faster |
+| Inactive branch update      |      0.06 ms |       0.02 ms |    3.00x faster |
 | Switch live/snapshot branch |     0.100 ms |      0.100 ms |          parity |
 
 ## Standard table operations
 
-| Operation         |            Rows | React median | Hybrid median | Hybrid vs React |
-| ----------------- | --------------: | -----------: | ------------: | --------------: |
-| Create            |           1,000 |     11.55 ms |      10.40 ms |    1.11x faster |
-| Replace all       |           1,000 |     15.85 ms |      11.30 ms |    1.40x faster |
-| Create many       |          10,000 |    265.65 ms |     112.90 ms |    2.35x faster |
-| Append            | 10,000 -> 11,000 |     71.90 ms |      25.30 ms |    2.84x faster |
-| Update every 10th |          10,000 |     40.35 ms |       2.40 ms |   16.81x faster |
-| Select            |           1,000 |      3.70 ms |       0.10 ms |   37.00x faster |
-| Swap rows 2 / 999 |           1,000 |      7.80 ms |       1.10 ms |    7.09x faster |
-| Remove one row    |           1,000 |      4.20 ms |       2.00 ms |    2.10x faster |
-| Clear             |          10,000 |     50.40 ms |       9.30 ms |    5.42x faster |
+| Operation         |             Rows | React median | Hybrid median | Hybrid vs React |
+| ----------------- | ---------------: | -----------: | ------------: | --------------: |
+| Create            |            1,000 |     12.55 ms |      11.20 ms |    1.12x faster |
+| Replace all       |            1,000 |     18.15 ms |      12.10 ms |    1.50x faster |
+| Create many       |           10,000 |    291.30 ms |     120.50 ms |    2.42x faster |
+| Append            | 10,000 -> 11,000 |     71.10 ms |      26.00 ms |    2.73x faster |
+| Update every 10th |           10,000 |     43.70 ms |       2.90 ms |   15.07x faster |
+| Select            |            1,000 |      3.85 ms |       0.10 ms |   38.50x faster |
+| Mark two rows     |            1,000 |      3.75 ms |       0.10 ms |   37.50x faster |
+| Swap rows 2 / 999 |            1,000 |      7.90 ms |       1.50 ms |    5.27x faster |
+| Remove one row    |            1,000 |      4.45 ms |       2.70 ms |    1.65x faster |
+| Clear             |           10,000 |     63.95 ms |      11.00 ms |    5.81x faster |
 
 `Update every 10th` is the targeted mutation-aware path. The application still executes its native
 immutable `map()` over 10,000 items and creates 1,000 replacement objects. The generated hint lets
 the keyed runtime validate and patch those 1,000 rows without a second scan of all 10,000 keys and
-bindings. The 8x persistence floor leaves substantial headroom below this run's 15.76x-16.81x
+bindings. The 8x persistence floor leaves substantial headroom below this run's 14.57x-16.58x
 result across compiler modes and row counts while still rejecting a silent return to the older
 roughly 5x full-reconciliation path.
 
@@ -67,61 +70,73 @@ and patches only the previous and next keyed instances instead of evaluating tha
 row. Package tests deterministically require no more than two row-binding reads per transition; the
 browser boundary still includes event dispatch, style invalidation, and DOM observation.
 
+`Mark two rows` is the Set-membership path. For `markedIds.has(row.id)`, the runtime compares the
+previous and next native Set snapshots and evaluates only row keys in their symmetric difference.
+Package tests require the binding-read count to equal the changed primitive keys that exist in the
+table. The browser result includes event dispatch and the asserted DOM mutation; sub-millisecond
+values are timer-quantized, so the exact read-count test is the stronger proof of bounded row work.
+
 ## Repeated 20,000-row scale profile
 
 Each of the three cycles creates 10,000 rows, appends ten 1,000-row batches to 20,000, updates
-2,000 rows, performs two distant selections, swaps rows, removes a middle row, and clears. Lower
-time is better.
+2,000 rows, performs two distant selections, replaces two marked Set members, swaps rows, removes a
+middle row, and clears. Lower time is better.
 
-| Operation at scale        | React median | React p95 | Hybrid median | Hybrid p95 | Speedup |
-| ------------------------- | -----------: | --------: | ------------: | ---------: | ------: |
-| Create initial 10,000     |    337.70 ms | 399.90 ms |     121.90 ms |  130.20 ms |   2.77x |
-| Append a 1,000-row batch  |     84.85 ms | 114.20 ms |      27.40 ms |   36.50 ms |   3.10x |
-| Update every 10th at 20k |     96.15 ms | 103.35 ms |       6.10 ms |    6.30 ms |  15.76x |
-| Select at 20k             |     90.55 ms | 114.70 ms |       2.70 ms |    4.80 ms |  33.54x |
-| Swap at 20k               |    112.80 ms | 138.10 ms |      26.00 ms |   26.80 ms |   4.34x |
-| Remove middle row at 20k |    103.50 ms | 117.80 ms |      36.40 ms |   37.80 ms |   2.84x |
-| Clear 20k                 |    206.10 ms | 240.65 ms |      19.90 ms |   21.30 ms |  10.36x |
+| Operation at scale       | React median | React p95 | Hybrid median | Hybrid p95 | Speedup |
+| ------------------------ | -----------: | --------: | ------------: | ---------: | ------: |
+| Create initial 10,000    |    315.20 ms | 412.55 ms |     124.70 ms |  127.80 ms |   2.53x |
+| Append a 1,000-row batch |     85.35 ms | 121.90 ms |      29.10 ms |   35.10 ms |   2.93x |
+| Update every 10th at 20k |    104.45 ms | 109.40 ms |       6.30 ms |   19.00 ms |  16.58x |
+| Select at 20k            |     93.90 ms | 106.00 ms |       3.70 ms |    4.40 ms |  25.38x |
+| Mark two rows at 20k     |     96.15 ms | 104.20 ms |       0.20 ms |    4.40 ms | 480.75x |
+| Swap at 20k              |    113.50 ms | 135.10 ms |      26.70 ms |   27.20 ms |   4.25x |
+| Remove middle row at 20k |    111.85 ms | 117.20 ms |      38.00 ms |   42.30 ms |   2.94x |
+| Clear 20k                |    215.75 ms | 312.60 ms |      21.70 ms |   22.60 ms |   9.94x |
 
 ## Scalability gate
 
 The gate divides observed timing growth by row-count growth. A value near 1 means linear scaling;
 2 is the failure threshold. All measured paths pass.
 
-| Path                    | Row growth | Timing growth | Normalized growth |
-| ----------------------- | ---------: | ------------: | ----------------: |
-| Create 10k repeat       |      1.00x |         1.08x |             1.08x |
-| Update 10k -> 20k       |      2.00x |         2.54x |             1.27x |
-| Select 1k -> 20k        |     20.00x |        10.80x |             0.54x |
-| Swap 1k -> 20k          |     20.00x |        23.64x |             1.18x |
-| Remove 1k -> 20k        |     20.00x |        18.20x |             0.91x |
-| Clear 10k -> 20k        |      2.00x |         2.14x |             1.07x |
+| Path               | Row growth | Timing growth | Normalized growth |
+| ------------------ | ---------: | ------------: | ----------------: |
+| Create 10k repeat  |      1.00x |         1.03x |             1.03x |
+| Update 10k -> 20k  |      2.00x |         2.17x |             1.09x |
+| Select 1k -> 20k   |     20.00x |        14.80x |             0.74x |
+| Mark Set 1k -> 20k |     20.00x |         0.80x |             0.04x |
+| Swap 1k -> 20k     |     20.00x |        17.80x |             0.89x |
+| Remove 1k -> 20k   |     20.00x |        14.07x |             0.70x |
+| Clear 10k -> 20k   |      2.00x |         1.97x |             0.99x |
 
 This demonstrates approximately linear rather than quadratic end-to-end growth. Key-directed
-selection performs constant row-binding work—at most the previous and next keyed instances—while
-its complete event-to-DOM timing remains 33.54x faster than React at 20,000 rows. Structural
-swap/removal paths remain O(n), as expected for validating keys and maintaining row indices.
+scalar selection performs constant row-binding work—at most the previous and next keyed
+instances—while its complete event-to-DOM timing remains 25.38x faster than React at 20,000 rows.
+Set membership performs work proportional to the changed members rather than total rows. Its
+0.20 ms median is near browser timer resolution, so the deterministic unit gate remains the primary
+complexity evidence. Structural swap/removal paths remain O(n), as expected for validating keys
+and maintaining row indices.
 
 ## Bundle cost
 
-| Build                   | Page chunk raw | Page chunk gzip |
-| ----------------------- | -------------: | --------------: |
-| React baseline          |       18,567 B |         4,307 B |
-| Static compiler         |       75,139 B |        15,854 B |
-| Hybrid compiler         |       75,139 B |        15,854 B |
+| Build           | Page chunk raw | Page chunk gzip |
+| --------------- | -------------: | --------------: |
+| React baseline  |       19,073 B |         4,494 B |
+| Static compiler |       77,870 B |        16,525 B |
+| Hybrid compiler |       77,870 B |        16,526 B |
 
-This deliberately broad page now pays an 11,547-byte gzip premium for the compiler runtime,
-including the mutation-aware and key-directed keyed paths. Smaller direct-only applications retain
-less of the runtime; the package-level fixtures and persisted size gate are documented in
+This deliberately broad page now pays a 12,032-byte hybrid gzip premium for the compiler runtime,
+including the mutation-aware, scalar key-directed, and Set-membership paths. Smaller direct-only
+applications retain less of the runtime; the package-level fixtures and persisted size gate are documented in
 `packages/farm-react/RUNTIME_SIZE_RESULTS.md`.
 
 ## Conclusion
 
 The compiled path scales successfully through the tested 20,000-row mixed workload: all DOM and
 event assertions pass, there are no browser errors or owner rerenders, every scale operation beats
-the bracketed React baseline, and normalized growth stays at or below 1.27x. Selection performs at
-most two row-binding reads, but the evidence claims only measured end-to-end behavior within this
-range—not unlimited constant-time browser work.
+the bracketed React baseline, and normalized growth stays at or below 1.09x. Scalar selection
+performs at most two row-binding reads, while Set membership evaluates only changed members that map
+to rows. The evidence claims only measured end-to-end behavior within this range—not unlimited
+constant-time browser work.
 
 The machine-readable output is `/tmp/farm-react-dashboard-benchmark.json`. Re-run
 `pnpm --filter farm-react-compiler-dashboard-example benchmark` to reproduce it.

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -65,6 +65,12 @@ row-binding reads, which is the deterministic guard against returning to a full 
 performance, scalability, or persistence gate writes the JSON report and exits with a nonzero
 status.
 
+Set membership has a separate operation and persistence gate. The table alternates two marked row
+keys with `markedIds.has(row.id)` at 1,000 and 20,000 rows. Both compiler modes must remain at least
+10x faster than React at 20,000 rows, normalized growth may not exceed 2x, and the compiler report
+must contain a nonzero `keyedMembershipTargets` count. Differential unit tests separately require
+the exact number of binding reads to equal the primitive-key symmetric difference.
+
 Set `FARM_EXPERIMENT_BROWSER_PATH` to an installed Chrome/Chromium executable when Playwright's
 bundled browser is unavailable. Sample counts are configurable:
 

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -119,6 +119,10 @@ async function inspectBuild(compilerMode) {
       "The compiler build did not emit a key-directed row-binding target.",
     );
     assert(
+      compilerReport.summary.keyedMembershipTargets > 0,
+      "The compiler build did not emit a keyed Set-membership target.",
+    );
+    assert(
       compilerReport.summary.keyedMapUpdateHints > 0,
       "The compiler build did not emit a mutation-aware keyed-map update hint.",
     );
@@ -477,6 +481,19 @@ async function measureTrial(browser, trial, compilerMode, port) {
           },
         );
 
+        const tableMembership = await measureTable(
+          async () => ensure1000(),
+          async () => {
+            const row = table.querySelectorAll("tbody tr")[500];
+            const previous = row?.getAttribute("data-marked");
+            if (!row) throw new Error("Membership target row is missing.");
+            await runTableAction(
+              () => tableButton("table-mark").click(),
+              () => row.getAttribute("data-marked") !== previous,
+            );
+          },
+        );
+
         const tableRemove = await measureTable(
           async () => {
             if (rowCount() !== 1_000) await create1000();
@@ -504,6 +521,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
           appendTo20k: [],
           clear20k: [],
           create10k: [],
+          membership20k: [],
           remove20k: [],
           select20k: [],
           swap20k: [],
@@ -551,6 +569,16 @@ async function measureTrial(browser, trial, compilerMode, port) {
             scale.select20k.push(performance.now() - selectStartedAt);
           }
 
+          const membershipRow = table.querySelectorAll("tbody tr")[10_000];
+          const previousMembership = membershipRow?.getAttribute("data-marked");
+          if (!membershipRow) throw new Error("20,000-row membership target is missing.");
+          const membershipStartedAt = performance.now();
+          await runTableAction(
+            () => tableButton("table-mark").click(),
+            () => membershipRow.getAttribute("data-marked") !== previousMembership,
+          );
+          scale.membership20k.push(performance.now() - membershipStartedAt);
+
           const rowsBeforeSwap = table.querySelectorAll("tbody tr");
           const second = rowsBeforeSwap[1]?.getAttribute("data-row-id");
           const penultimate = rowsBeforeSwap[998]?.getAttribute("data-row-id");
@@ -590,6 +618,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
             activeBarStayedStableDuringInactiveUpdates: activeBarBefore === activeBarAfter,
             dashboardLive: dashboard.dataset.live,
             dashboardRevision: Number(dashboard.dataset.revision),
+            finalMarkedCount: Number(table.dataset.markedCount),
             finalTableRows: rowCount(),
             scalePeakRows: peakRows,
           },
@@ -605,6 +634,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
             create: tableCreate,
             createMany: tableCreateMany,
             executionsAdded: Number(tableExecutions.textContent) - initialTableExecutions,
+            membership: tableMembership,
             remove: tableRemove,
             replace: tableReplace,
             select: tableSelect,
@@ -625,6 +655,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
 
     assert.equal(result.correctness.activeBarStayedStableDuringInactiveUpdates, true);
     assert.equal(result.correctness.dashboardLive, "true");
+    assert.equal(result.correctness.finalMarkedCount, 0);
     assert.equal(result.correctness.finalTableRows, 0);
     assert.equal(result.correctness.scalePeakRows, 20_000);
     assert.equal(browserErrors.length, 0, browserErrors.join("\n"));
@@ -656,6 +687,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
         appendTo20k: timingSummary(result.scale.appendTo20k),
         clear20k: timingSummary(result.scale.clear20k),
         create10k: timingSummary(result.scale.create10k),
+        membership20k: timingSummary(result.scale.membership20k),
         remove20k: timingSummary(result.scale.remove20k),
         select20k: timingSummary(result.scale.select20k),
         swap20k: timingSummary(result.scale.swap20k),
@@ -667,6 +699,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
         create: timingSummary(result.table.create),
         createMany: timingSummary(result.table.createMany),
         executionsAdded: result.table.executionsAdded,
+        membership: timingSummary(result.table.membership),
         remove: timingSummary(result.table.remove),
         replace: timingSummary(result.table.replace),
         select: timingSummary(result.table.select),
@@ -741,6 +774,7 @@ const tableMetrics = [
   "append",
   "updateEvery10th",
   "select",
+  "membership",
   "swap",
   "remove",
   "clear",
@@ -750,6 +784,7 @@ const scaleMetrics = [
   "appendTo20k",
   "updateEvery10th20k",
   "select20k",
+  "membership20k",
   "swap20k",
   "remove20k",
   "clear20k",
@@ -781,6 +816,7 @@ const scalabilityCases = [
   ["create10k", "createMany", 1],
   ["updateEvery10th20k", "updateEvery10th", 2],
   ["select20k", "select", 20],
+  ["membership20k", "membership", 20],
   ["swap20k", "swap", 20],
   ["remove20k", "remove", 20],
   ["clear20k", "clear", 2],
@@ -874,11 +910,37 @@ const keyedIdentityRegressions = keyedIdentityResults.filter(
     !Number.isFinite(normalizedGrowth) ||
     normalizedGrowth > keyedIdentityMaximumNormalizedGrowth,
 );
+// A native Set membership update can change several keyed rows at once. The compiler snapshots the
+// previous and next primitive members and touches only their symmetric difference. The unit suite
+// verifies the exact read count; this browser gate protects the corresponding 20,000-row win.
+const keyedMembershipMinimumSpeedup = 10;
+const keyedMembershipMaximumNormalizedGrowth = 2;
+const keyedMembershipResults = ["static", "hybrid"].map((mode) => {
+  const tableMedianMs = comparisons.table.membership[mode].medianMs;
+  const scaleMedianMs = comparisons.scale.membership20k[mode].medianMs;
+  const growth = scaleMedianMs / Math.max(tableMedianMs, timingResolutionFloorMs);
+  return {
+    growth,
+    mode,
+    normalizedGrowth: growth / 20,
+    scaleMedianMs,
+    speedup: comparisons.scale.membership20k[`${mode}VsBaseline`].speedup,
+    tableMedianMs,
+  };
+});
+const keyedMembershipRegressions = keyedMembershipResults.filter(
+  ({ normalizedGrowth, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedMembershipMinimumSpeedup ||
+    !Number.isFinite(normalizedGrowth) ||
+    normalizedGrowth > keyedMembershipMaximumNormalizedGrowth,
+);
 const passed =
   performanceRegressions.length === 0 &&
   scalabilityRegressions.length === 0 &&
   keyedUpdateRegressions.length === 0 &&
-  keyedIdentityRegressions.length === 0;
+  keyedIdentityRegressions.length === 0 &&
+  keyedMembershipRegressions.length === 0;
 
 const report = {
   result: passed ? "PASS" : "CORRECTNESS_PASS_PERFORMANCE_REGRESSION",
@@ -901,6 +963,13 @@ const report = {
     regressions: keyedIdentityRegressions,
     results: keyedIdentityResults,
     status: keyedIdentityRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedMembershipTargetGate: {
+    maximumNormalizedGrowth: keyedMembershipMaximumNormalizedGrowth,
+    minimumSpeedup: keyedMembershipMinimumSpeedup,
+    regressions: keyedMembershipRegressions,
+    results: keyedMembershipResults,
+    status: keyedMembershipRegressions.length === 0 ? "PASS" : "FAIL",
   },
   scalabilityGate: {
     metrics: scalability,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -43,6 +43,7 @@ export function StandardTableBenchmark() {
   const [rows, setRows] = useState(() => buildRows(100, 0));
   const [seed, setSeed] = useState(0);
   const [selected, setSelected] = useState(0);
+  const [markedIds, setMarkedIds] = useState(() => new Set<number>());
   const [operation, setOperation] = useState("initial 100 rows");
   const [revision, setRevision] = useState(0);
 
@@ -52,6 +53,7 @@ export function StandardTableBenchmark() {
       data-benchmark="table"
       data-revision={revision}
       data-selected={selected}
+      data-marked-count={markedIds.size}
       id="table-benchmark"
     >
       <header className="benchmark-heading">
@@ -91,6 +93,7 @@ export function StandardTableBenchmark() {
             setSeed(nextSeed);
             setRows(buildRows(1_000, nextSeed));
             setSelected(0);
+            setMarkedIds(new Set());
             setOperation("create 1,000");
             setRevision((value) => value + 1);
           }}
@@ -106,6 +109,7 @@ export function StandardTableBenchmark() {
             setSeed(nextSeed);
             setRows(buildRows(10_000, nextSeed));
             setSelected(0);
+            setMarkedIds(new Set());
             setOperation("create 10,000");
             setRevision((value) => value + 1);
           }}
@@ -134,6 +138,7 @@ export function StandardTableBenchmark() {
             setSeed(nextSeed);
             setRows(buildRows(1_000, nextSeed));
             setSelected(0);
+            setMarkedIds(new Set());
             setOperation("replace 1,000");
             setRevision((value) => value + 1);
           }}
@@ -155,6 +160,25 @@ export function StandardTableBenchmark() {
           }}
         >
           Update every 10th
+        </button>
+        <button
+          data-action="table-mark"
+          type="button"
+          onClick={() => {
+            setMarkedIds((current) => {
+              const middle = Math.floor(rows.length / 2);
+              const first = rows[middle]?.id;
+              const second = rows[middle + 1]?.id;
+              if (first === undefined || second === undefined) return current;
+              return current.has(first)
+                ? new Set([rows[middle + 2]?.id ?? first, rows[middle + 3]?.id ?? second])
+                : new Set([first, second]);
+            });
+            setOperation("mark two rows");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Mark two rows
         </button>
         <button
           data-action="table-swap"
@@ -186,6 +210,7 @@ export function StandardTableBenchmark() {
           onClick={() => {
             setRows([]);
             setSelected(0);
+            setMarkedIds(new Set());
             setOperation("clear");
             setRevision((value) => value + 1);
           }}
@@ -212,6 +237,7 @@ export function StandardTableBenchmark() {
             {rows.map((row, index) => (
               <tr
                 className={selected === row.id ? "table-row--selected" : ""}
+                data-marked={markedIds.has(row.id)}
                 data-row-id={row.id}
                 data-selected={selected === row.id}
                 key={row.id}

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -171,6 +171,14 @@ mixed structural dependencies, ambiguous expressions, non-primitive runtime targ
 rows, and unsupported shapes keep the complete scan or React fallback. No option is required, and
 the compiler report exposes the emitted binding count as `keyedIdentityTargets`.
 
+For multi-selection, an exact local-state expression such as `markedIds.has(item.id)` receives a
+separate Set-membership proof. The runtime compares the previous and next native `Set` snapshots and
+patches only row keys in their symmetric difference. It accepts ordinary native sets containing
+primitive keys. Different fields, extra reactive dependencies, Set subclasses or proxies, object
+members, customized `has` behavior, React-owned rows, nested blocks, and structural dependencies
+stay on the existing complete or React-owned paths. The compiler report exposes this count as
+`keyedMembershipTargets`.
+
 For a direct keyed `useState` collection, the compiler also recognizes conservative same-order
 updates such as:
 
@@ -467,9 +475,10 @@ compiler: {
 The default path is `.farm/react-compiler.json`. The report covers the production browser graph and
 contains project-relative module paths, compiled component names, fallback details, and fallback
 reasons aggregated by count. Its summary and per-module `optimizations` also report
-`keyedIdentityTargets`, the number of key-directed row bindings, and `keyedMapUpdateHints`, the
-number of compiler-proven direct keyed `map()` update sites. A custom project-relative `reportFile`
-also enables reporting.
+`keyedIdentityTargets`, the number of scalar key-directed row bindings;
+`keyedMembershipTargets`, the number of native-Set membership bindings; and
+`keyedMapUpdateHints`, the number of compiler-proven direct keyed `map()` update sites. A custom
+project-relative `reportFile` also enables reporting.
 
 The runtime test compares the same counter interaction on both paths: ordinary React performs a
 second component render and commit, while the compiled component remains at one render and one

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -21,19 +21,19 @@
     },
     "keyed": {
       "compilerOff": {
-        "raw": 192934,
-        "gzip": 60107,
-        "brotli": 51830
+        "raw": 193012,
+        "gzip": 60135,
+        "brotli": 51847
       },
       "compilerOn": {
-        "raw": 222676,
-        "gzip": 69230,
-        "brotli": 59321
+        "raw": 224836,
+        "gzip": 69756,
+        "brotli": 59775
       },
       "compilerPremium": {
-        "raw": 29742,
-        "gzip": 9123,
-        "brotli": 7491
+        "raw": 31824,
+        "gzip": 9621,
+        "brotli": 7928
       }
     },
     "isolatedRuntime": {
@@ -43,18 +43,18 @@
         "brotli": 51666
       },
       "full": {
-        "raw": 261907,
-        "gzip": 75076,
-        "brotli": 64785
+        "raw": 263738,
+        "gzip": 75549,
+        "brotli": 65096
       },
       "coreOnly": {
         "raw": 204922,
         "gzip": 63685,
         "brotli": 54902
       },
-      "fullRuntimePremiumGzip": 15157,
+      "fullRuntimePremiumGzip": 15630,
       "coreRuntimePremiumGzip": 3766,
-      "gzipReductionPercent": 75.2
+      "gzipReductionPercent": 75.9
     }
   }
 }

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.md
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.md
@@ -24,17 +24,17 @@ is enforced on every pull request instead of serving only as a manually recorded
 | Fixture                                           | Compiler off gzip | Compiler on gzip | Compiler premium |
 | ------------------------------------------------- | ----------------: | ---------------: | ---------------: |
 | Direct text, attribute, style, and event bindings |          60,043 B |         63,721 B |          3,678 B |
-| Delegated keyed rows, LIS, and targeted selection |          60,107 B |         69,230 B |          9,123 B |
+| Keyed rows, LIS, scalar and Set targeting         |          60,135 B |         69,756 B |          9,621 B |
 
-The isolated compatibility runtime contributes 15,157 B gzip over the React control. The
-compiler-selected core contributes 3,766 B, a **75.2% reduction**. This comparison uses the same
+The isolated compatibility runtime contributes 15,630 B gzip over the React control. The
+compiler-selected core contributes 3,766 B, a **75.9% reduction**. This comparison uses the same
 hand-authored compiled definition and changes only the runtime entry used to create it.
 
-The keyed fixture retains `FarmCompiledKeyedRows` and a compiler-emitted `identityTarget`, but
-rejects the optional row-conditional and keyed-map-hint runtimes. Key-directed validation adds
-530 B gzip to this deliberately targeted keyed fixture. The direct compiler premium and isolated
-core runtime remain byte-for-byte unchanged. The direct fixture rejects every structural runtime
-marker. The checked machine-readable result is
+The keyed fixture retains `FarmCompiledKeyedRows` plus compiler-emitted `identityTarget` and
+`membershipTarget` metadata, but rejects the optional row-conditional and keyed-map-hint runtimes.
+Set membership adds 498 B gzip to the keyed fixture's compiler premium. The direct compiler premium
+and isolated core runtime remain byte-for-byte unchanged. The direct fixture rejects every
+structural runtime marker. The checked machine-readable result is
 [`RUNTIME_SIZE_RESULTS.json`](./RUNTIME_SIZE_RESULTS.json).
 
 ## Existing production benchmark audit

--- a/packages/farm-react/fixtures/runtime-size/keyed.tsx
+++ b/packages/farm-react/fixtures/runtime-size/keyed.tsx
@@ -11,6 +11,7 @@ export function KeyedTable() {
     Array.from({ length: 1_000 }, (_, id) => ({ id, label: `Row ${id}` })),
   );
   const [selected, setSelected] = useState(-1);
+  const [marked, setMarked] = useState(() => new Set<number>());
   return (
     <main>
       <button onClick={() => setRows((value) => [...value].reverse())}>Reverse</button>
@@ -18,8 +19,12 @@ export function KeyedTable() {
         {rows.map((row) => (
           <li
             className={selected === row.id ? "selected" : ""}
+            data-marked={marked.has(row.id)}
             key={row.id}
-            onClick={() => setSelected(row.id)}
+            onClick={() => {
+              setSelected(row.id);
+              setMarked(new Set([row.id]));
+            }}
           >
             {row.label}
           </li>

--- a/packages/farm-react/scripts/benchmark-runtime-size.mjs
+++ b/packages/farm-react/scripts/benchmark-runtime-size.mjs
@@ -85,6 +85,9 @@ if (keyedOn.code.includes("keyed-rows:hinted")) {
 if (!keyedOn.code.includes("identityTarget")) {
   throw new Error("Keyed selection fixture did not retain its key-directed binding target.");
 }
+if (!keyedOn.code.includes("membershipTarget")) {
+  throw new Error("Keyed selection fixture did not retain its Set-membership binding target.");
+}
 
 const fullRuntimePremium = runtimeFull.gzip - runtimeControl.gzip;
 const coreRuntimePremium = runtimeCore.gzip - runtimeControl.gzip;

--- a/packages/farm-react/src/__tests__/compiler-keyed-membership-targets.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-membership-targets.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true);
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/KeyedMembershipTargets.tsx", infer);
+}
+
+describe("React AOT keyed membership targets", () => {
+  it("emits target metadata for local Set membership against the exact row key", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function MarkedRows() {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        const [markedIds, setMarkedIds] = useState(new Set(["a"]));
+        return (
+          <section><ul>
+            {rows.map((row) => (
+              <li
+                aria-checked={markedIds.has(row.id)}
+                className={markedIds.has(row.id) ? "marked" : ""}
+                key={row.id}
+                onClick={() => setMarkedIds(new Set([row.id]))}
+                style={{ opacity: markedIds.has(row.id) ? 1 : 0.5 }}
+              >
+                {markedIds.has(row.id) ? row.label : "Hidden"}
+              </li>
+            ))}
+          </ul></section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["MarkedRows"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMembershipTargets).toBe(4);
+    expect(result.code.match(/membershipTarget:/g)).toHaveLength(4);
+    expect(result.code).toContain("dependency: 1");
+    expect(result.code).toContain("read: () => _farmState[1].get()");
+  });
+
+  it("normalizes public List key parameter names", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List } from "@farm.js/react/list";
+      export function MarkedRows() {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        const [markedIds, setMarkedIds] = useState(new Set(["a"]));
+        return (
+          <section><ul>
+            <List each={rows} by={(entry) => entry.id}>
+              {(row) => <li data-marked={markedIds.has(row.id)}>{row.label}</li>}
+            </List>
+          </ul></section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["MarkedRows"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMembershipTargets).toBe(1);
+    expect(result.code).toContain("membershipTarget:");
+  });
+
+  it.each([
+    {
+      name: "a different row field",
+      binding: "markedIds.has(row.slug)",
+    },
+    {
+      name: "another reactive dependency",
+      binding: "markedIds.has(row.id) && enabled",
+    },
+    {
+      name: "another read from the target",
+      binding: "markedIds.has(row.id) ? markedIds.size : 0",
+    },
+  ])("keeps $name on React's existing path", async ({ binding }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function ConservativeRows() {
+        const [rows, setRows] = useState([{ id: "a", slug: "alpha" }]);
+        const [markedIds, setMarkedIds] = useState(new Set(["a"]));
+        const [enabled, setEnabled] = useState(true);
+        return (
+          <section>
+            <button onClick={() => setMarkedIds(new Set(["a"]))}>Mark</button>
+            <ul>{rows.map((row) => <li data-marked={${binding}} key={row.id}>{row.id}</li>)}</ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.optimizations.keyedMembershipTargets).toBe(0);
+    expect(result.code).not.toContain("membershipTarget:");
+  });
+
+  it("does not treat Set-like props as locally owned membership state", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function PropMembership({ markedIds }) {
+        const [rows, setRows] = useState([{ id: "a" }]);
+        return <ul>{rows.map((row) => <li data-marked={markedIds.has(row.id)} key={row.id}>{row.id}</li>)}</ul>;
+      }
+    `);
+
+    expect(result.optimizations.keyedMembershipTargets).toBe(0);
+    expect(result.code).not.toContain("membershipTarget:");
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
@@ -39,7 +39,11 @@ describe("React AOT keyed update hints", () => {
 
     expect(result.compiled).toEqual(["Inventory"]);
     expect(result.diagnostics).toEqual([]);
-    expect(result.optimizations).toEqual({ keyedIdentityTargets: 0, keyedMapUpdateHints: 1 });
+    expect(result.optimizations).toEqual({
+      keyedIdentityTargets: 0,
+      keyedMembershipTargets: 0,
+      keyedMapUpdateHints: 1,
+    });
     expect(result.code).toContain("createCompilerKeyedMapUpdate");
     expect(result.code).toContain("keyedRowsHintedRuntimeFeature");
     expect(result.code).toContain("collectionDependency={0}");

--- a/packages/farm-react/src/__tests__/compiler-report.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-report.test.ts
@@ -27,7 +27,11 @@ function observations(projectRoot: string): ReactCompilerModuleObservation[] {
       result: {
         compiled: ["Counter"],
         diagnostics: [],
-        optimizations: { keyedIdentityTargets: 0, keyedMapUpdateHints: 0 },
+        optimizations: {
+          keyedIdentityTargets: 0,
+          keyedMembershipTargets: 0,
+          keyedMapUpdateHints: 0,
+        },
       },
     },
     {
@@ -46,7 +50,11 @@ function observations(projectRoot: string): ReactCompilerModuleObservation[] {
             selected: true,
           },
         ],
-        optimizations: { keyedIdentityTargets: 4, keyedMapUpdateHints: 3 },
+        optimizations: {
+          keyedIdentityTargets: 4,
+          keyedMembershipTargets: 2,
+          keyedMapUpdateHints: 3,
+        },
       },
     },
   ];
@@ -63,6 +71,7 @@ describe("React compiler coverage report", () => {
       compiled: 2,
       fallback: 2,
       keyedIdentityTargets: 4,
+      keyedMembershipTargets: 2,
       keyedMapUpdateHints: 3,
     });
     expect(report.fallbackReasons).toEqual([
@@ -80,6 +89,7 @@ describe("React compiler coverage report", () => {
     });
     expect(report.modules[1]?.optimizations).toEqual({
       keyedIdentityTargets: 4,
+      keyedMembershipTargets: 2,
       keyedMapUpdateHints: 3,
     });
   });

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-membership-targets.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-membership-targets.test.tsx
@@ -1,0 +1,371 @@
+import React, { StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createCompiledComponent, type CompilerStateUpdater } from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Item {
+  id: unknown;
+  label: string;
+}
+
+interface Counters {
+  bindingReads: number;
+  executions: number;
+  targetReads: number;
+}
+
+const roots: Array<{ unmount(): void }> = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function items(count: number): Item[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `row-${index}`,
+    label: `Row ${index}`,
+  }));
+}
+
+function createMembershipHarness(initialItems: Item[], initialMembership: Set<unknown>) {
+  const counters: Counters = { bindingReads: 0, executions: 0, targetReads: 0 };
+  let updateItems: (next: CompilerStateUpdater) => void = () => undefined;
+  let updateMembership: (next: CompilerStateUpdater) => void = () => undefined;
+  const Rows = createCompiledComponent({
+    displayName: "MembershipTargetRows",
+    initialize: () => [initialItems, initialMembership],
+    render(_props: Record<string, never>, state, blocks) {
+      counters.executions += 1;
+      const readItems = () => state[0].get() as Item[];
+      const membership = () => state[1].get() as Set<unknown>;
+      const membershipTarget = () => {
+        counters.targetReads += 1;
+        return membership();
+      };
+      updateItems = (next) => state[0].set(next);
+      updateMembership = (next) => state[1].set(next);
+      const KeyedRows = blocks.KeyedRows;
+      return (
+        <main>
+          <KeyedRows
+            bindings={[
+              {
+                dependencies: [1],
+                membershipTarget: { dependency: 1, read: membershipTarget },
+                kind: "attribute",
+                name: "data-marked",
+                path: [],
+                read: (item) => {
+                  counters.bindingReads += 1;
+                  return membership().has((item as Item).id);
+                },
+              },
+              {
+                dependencies: [0],
+                kind: "text",
+                path: [],
+                read: (item) => [(item as Item).label],
+              },
+            ]}
+            create={(item) => ({
+              kind: "element",
+              tag: "li",
+              attributes: [
+                { name: "data-key", value: String((item as Item).id) },
+                { name: "data-marked", value: membership().has((item as Item).id) },
+              ],
+              styles: [],
+              children: [(item as Item).label],
+            })}
+            id={0}
+            items={readItems}
+            render={() => (
+              <ul>
+                {readItems().map((item) => (
+                  <li
+                    data-key={String(item.id)}
+                    data-marked={membership().has(item.id)}
+                    key={String(item.id)}
+                  >
+                    {item.label}
+                  </li>
+                ))}
+              </ul>
+            )}
+            rowKey={(item) => (item as Item).id as React.Key}
+            structureDependencies={[0]}
+          />
+        </main>
+      );
+    },
+    bindings: [{ kind: "block", id: 0, dependencies: [0, 1] }],
+  });
+  return {
+    Rows,
+    counters,
+    setItems: (next: CompilerStateUpdater) => updateItems(next),
+    setMembership: (next: CompilerStateUpdater) => updateMembership(next),
+  };
+}
+
+function membershipSnapshot(container: Element): Array<[string | null, string | null]> {
+  return [...container.querySelectorAll("li")].map((row) => [
+    row.getAttribute("data-key"),
+    row.getAttribute("data-marked"),
+  ]);
+}
+
+describe("compiled keyed membership targets", () => {
+  it("evaluates only keys in the Set symmetric difference", async () => {
+    const initial = items(2_000);
+    const harness = createMembershipHarness(initial, new Set(["row-10"]));
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Rows />));
+
+    harness.counters.bindingReads = 0;
+    harness.counters.targetReads = 0;
+    await act(async () => {
+      harness.setMembership(new Set(["row-10", "row-1500"]));
+      await flushCompilerUpdates();
+    });
+    expect(harness.counters.bindingReads).toBe(1);
+    expect(harness.counters.targetReads).toBe(1);
+
+    harness.counters.bindingReads = 0;
+    await act(async () => {
+      harness.setMembership(new Set(["row-12", "row-1501"]));
+      await flushCompilerUpdates();
+    });
+    expect(harness.counters.bindingReads).toBe(4);
+    expect(
+      [...container.querySelectorAll('[data-marked="true"]')].map((row) =>
+        row.getAttribute("data-key"),
+      ),
+    ).toEqual(["row-12", "row-1501"]);
+
+    harness.counters.bindingReads = 0;
+    await act(async () => {
+      harness.setMembership(new Set(["row-12", "row-1501"]));
+      await flushCompilerUpdates();
+    });
+    expect(harness.counters.bindingReads).toBe(0);
+    expect(harness.counters.executions).toBe(1);
+  });
+
+  it("preserves Set equality when different primitive values share one React key string", async () => {
+    const initial: Item[] = [
+      { id: null, label: "Null" },
+      { id: undefined, label: "Undefined" },
+      { id: 1, label: "Number" },
+    ];
+    const harness = createMembershipHarness(initial, new Set([null, 1]));
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Rows />));
+
+    harness.counters.bindingReads = 0;
+    await act(async () => {
+      harness.setMembership(new Set([undefined, "1"]));
+      await flushCompilerUpdates();
+    });
+
+    expect(harness.counters.bindingReads).toBe(3);
+    expect(membershipSnapshot(container)).toEqual([
+      ["null", "false"],
+      ["undefined", "true"],
+      ["1", "false"],
+    ]);
+  });
+
+  it("uses complete reconciliation for mixed structural work and refreshes its cache", async () => {
+    const initial = items(100);
+    const harness = createMembershipHarness(initial, new Set(["row-1"]));
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Rows />));
+
+    harness.counters.bindingReads = 0;
+    harness.counters.targetReads = 0;
+    await act(async () => {
+      harness.setMembership(new Set(["row-80"]));
+      harness.setItems((current) =>
+        (current as Item[]).map((item) =>
+          item.id === "row-80" ? { ...item, label: "Updated row" } : item,
+        ),
+      );
+      await flushCompilerUpdates();
+    });
+    expect(harness.counters.bindingReads).toBe(initial.length);
+    expect(harness.counters.targetReads).toBe(2);
+    expect(container.querySelector('[data-key="row-80"]')?.textContent).toBe("Updated row");
+
+    harness.counters.bindingReads = 0;
+    await act(async () => {
+      harness.setMembership(new Set(["row-81"]));
+      await flushCompilerUpdates();
+    });
+    expect(harness.counters.bindingReads).toBe(2);
+  });
+
+  it("hands customized Set values back to React before evaluating compiled bindings", async () => {
+    class CustomizedSet extends Set<unknown> {}
+    const initial = items(32);
+    const harness = createMembershipHarness(initial, new CustomizedSet(["row-1"]));
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Rows />));
+
+    expect(harness.counters.bindingReads).toBe(0);
+    await act(async () => {
+      harness.setMembership(new CustomizedSet(["row-20"]));
+      await flushCompilerUpdates();
+    });
+
+    expect(harness.counters.bindingReads).toBe(0);
+    expect(container.querySelector('[data-key="row-20"]')?.getAttribute("data-marked")).toBe(
+      "true",
+    );
+    expect(harness.counters.executions).toBe(1);
+  });
+
+  it("keeps an own Set has override under React ownership", async () => {
+    const customized = new Set<unknown>(["row-1"]);
+    Object.defineProperty(customized, "has", {
+      configurable: true,
+      value: (value: unknown) => value === "row-1",
+    });
+    const harness = createMembershipHarness(items(8), customized);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Rows />));
+
+    expect(harness.counters.bindingReads).toBe(0);
+    expect(container.querySelector('[data-key="row-1"]')?.getAttribute("data-marked")).toBe("true");
+    expect(container.querySelector('[data-key="row-2"]')?.getAttribute("data-marked")).toBe(
+      "false",
+    );
+  });
+
+  it("matches React across 2,000 randomized queued updates", async () => {
+    const initial = items(128);
+    const harness = createMembershipHarness(initial, new Set());
+    let reactSet: React.Dispatch<React.SetStateAction<Set<unknown>>> = () => undefined;
+    function Normal() {
+      const [membership, setMembership] = useState<Set<unknown>>(new Set());
+      reactSet = setMembership;
+      return (
+        <ul>
+          {initial.map((item) => (
+            <li
+              data-key={String(item.id)}
+              data-marked={membership.has(item.id)}
+              key={String(item.id)}
+            >
+              {item.label}
+            </li>
+          ))}
+        </ul>
+      );
+    }
+
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<harness.Rows />);
+      reactRoot.render(<Normal />);
+    });
+
+    harness.counters.bindingReads = 0;
+    let random = 0x5e7a11;
+    const nextRandom = () => (random = (Math.imul(random, 1_664_525) + 1_013_904_223) >>> 0);
+    let committed = new Set<unknown>();
+    for (let batch = 0; batch < 100; batch += 1) {
+      let final = committed;
+      await act(async () => {
+        for (let update = 0; update < 20; update += 1) {
+          const size = nextRandom() % 9;
+          const next = new Set<unknown>();
+          for (let index = 0; index < size; index += 1) {
+            const value = nextRandom();
+            next.add(value % 13 === 0 ? `missing-${value}` : `row-${value % initial.length}`);
+          }
+          final = next;
+          harness.setMembership(next);
+          reactSet(next);
+        }
+        await flushCompilerUpdates();
+      });
+      const changed = new Set(
+        [...committed, ...final].filter((value) => committed.has(value) !== final.has(value)),
+      );
+      const presentChanged = [...changed].filter((value) =>
+        initial.some((item) => Object.is(item.id, value)),
+      ).length;
+      expect(harness.counters.bindingReads, `targeted reads in batch ${batch}`).toBe(
+        presentChanged,
+      );
+      expect(membershipSnapshot(compiledContainer), `DOM after batch ${batch}`).toEqual(
+        membershipSnapshot(reactContainer),
+      );
+      committed = final;
+      harness.counters.bindingReads = 0;
+    }
+  });
+
+  it("is StrictMode-safe and drops a queued membership update after unmount", async () => {
+    const harness = createMembershipHarness(items(16), new Set());
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <StrictMode>
+          <harness.Rows />
+        </StrictMode>,
+      ),
+    );
+
+    harness.counters.bindingReads = 0;
+    await act(async () => {
+      harness.setMembership(new Set(["row-8"]));
+      root.unmount();
+      roots.splice(roots.indexOf(root), 1);
+      await flushCompilerUpdates();
+    });
+    expect(harness.counters.bindingReads).toBe(0);
+    expect(container.childElementCount).toBe(0);
+  });
+});

--- a/packages/farm-react/src/__tests__/vite.test.ts
+++ b/packages/farm-react/src/__tests__/vite.test.ts
@@ -86,6 +86,7 @@ describe("React renderer Vite integration", () => {
       compiled: 2,
       fallback: 0,
       keyedIdentityTargets: 0,
+      keyedMembershipTargets: 0,
       keyedMapUpdateHints: 1,
     });
     expect(report.modules[0].compiled).toEqual(["Counter", "List"]);

--- a/packages/farm-react/src/compiler-report.ts
+++ b/packages/farm-react/src/compiler-report.ts
@@ -19,6 +19,7 @@ export interface ReactCompilerReport {
     compiled: number;
     fallback: number;
     keyedIdentityTargets: number;
+    keyedMembershipTargets: number;
     keyedMapUpdateHints: number;
   };
   fallbackReasons: Array<{
@@ -30,6 +31,7 @@ export interface ReactCompilerReport {
     compiled: readonly string[];
     optimizations: {
       keyedIdentityTargets: number;
+      keyedMembershipTargets: number;
       keyedMapUpdateHints: number;
     };
     fallbacks: ReactCompilerReportFallback[];
@@ -49,6 +51,7 @@ export function createReactCompilerReport(
   let compiled = 0;
   let fallback = 0;
   let keyedIdentityTargets = 0;
+  let keyedMembershipTargets = 0;
   let keyedMapUpdateHints = 0;
 
   const modules = [...observations]
@@ -57,6 +60,7 @@ export function createReactCompilerReport(
       compiled += result.compiled.length;
       fallback += result.diagnostics.length;
       keyedIdentityTargets += result.optimizations.keyedIdentityTargets || 0;
+      keyedMembershipTargets += result.optimizations.keyedMembershipTargets || 0;
       keyedMapUpdateHints += result.optimizations.keyedMapUpdateHints;
       const moduleId = projectRelativeId(projectRoot, id);
       const fallbacks = result.diagnostics.map((diagnostic) => {
@@ -84,6 +88,7 @@ export function createReactCompilerReport(
       compiled,
       fallback,
       keyedIdentityTargets,
+      keyedMembershipTargets,
       keyedMapUpdateHints,
     },
     fallbackReasons,

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -289,6 +289,11 @@ export interface CompilerKeyedRowBinding {
     dependency: number;
     read(): unknown;
   };
+  /** A compiler-proven native Set whose members are compared with this row's key. */
+  membershipTarget?: {
+    dependency: number;
+    read(): unknown;
+  };
   read(item: unknown, index: number): unknown;
 }
 
@@ -934,6 +939,11 @@ interface CompilerKeyedIdentityTargetSnapshot {
   key?: string;
 }
 
+interface CompilerKeyedMembershipTargetSnapshot {
+  eligible: boolean;
+  values?: ReadonlySet<unknown>;
+}
+
 const UNSET_KEYED_ROW_BINDING = Symbol("unset interactive keyed-row binding");
 
 function keyedRowIdentity(key: React.Key): string {
@@ -949,6 +959,52 @@ function keyedIdentityTargetSnapshot(value: unknown): CompilerKeyedIdentityTarge
     kind === "bigint"
     ? { eligible: true, key: String(value) }
     : { eligible: false };
+}
+
+const NATIVE_SET_PROTOTYPE = Set.prototype;
+const NATIVE_SET_ADD = Set.prototype.add;
+const NATIVE_SET_HAS = Set.prototype.has;
+const NATIVE_SET_VALUES = Set.prototype.values;
+
+function keyedMembershipTargetSnapshot(value: unknown): CompilerKeyedMembershipTargetSnapshot {
+  if (typeof value !== "object" || value === null) return { eligible: false };
+  let iterator: SetIterator<unknown>;
+  try {
+    iterator = NATIVE_SET_VALUES.call(value as Set<unknown>);
+  } catch {
+    return { eligible: false };
+  }
+  if (
+    Object.getPrototypeOf(value) !== NATIVE_SET_PROTOTYPE ||
+    Object.prototype.hasOwnProperty.call(value, "has") ||
+    (value as Set<unknown>).has !== NATIVE_SET_HAS
+  ) {
+    return { eligible: false };
+  }
+  const values = new Set<unknown>();
+  try {
+    for (const entry of iterator) {
+      if (!keyedIdentityTargetSnapshot(entry).eligible) return { eligible: false };
+      NATIVE_SET_ADD.call(values, entry);
+    }
+  } catch {
+    return { eligible: false };
+  }
+  return { eligible: true, values };
+}
+
+function keyedMembershipChangedKeys(
+  previous: ReadonlySet<unknown>,
+  next: ReadonlySet<unknown>,
+): Set<string> {
+  const keys = new Set<string>();
+  for (const value of previous) {
+    if (!NATIVE_SET_HAS.call(next, value)) NATIVE_SET_ADD.call(keys, String(value));
+  }
+  for (const value of next) {
+    if (!NATIVE_SET_HAS.call(previous, value)) NATIVE_SET_ADD.call(keys, String(value));
+  }
+  return keys;
 }
 
 function normalizedKeyedRowBindingValue(binding: CompilerKeyedRowBinding, value: unknown): unknown {
@@ -2994,6 +3050,7 @@ function createKeyedRowsBlockComponent(
     private unsubscribe: (() => void) | undefined;
     private instances = new Map<string, CompilerKeyedRowInstance>();
     private identityTargets = new Map<number, CompilerKeyedIdentityTargetSnapshot>();
+    private membershipTargets = new Map<number, CompilerKeyedMembershipTargetSnapshot>();
     private collectionToken: object | undefined;
     private renderVersion = 0;
     private readonly eventHandlers = new Map<
@@ -3231,28 +3288,54 @@ function createKeyedRowsBlockComponent(
 
     private commitCurrentCollection(dirtyState?: ReadonlySet<number>): void {
       this.collectionToken = options.keyedMapUpdates?.commit(this.currentProps.items());
-      this.commitIdentityTargets(dirtyState);
+      this.commitKeyedTargets(dirtyState);
     }
 
-    private commitIdentityTargets(dirtyState?: ReadonlySet<number>): void {
-      if (!dirtyState) this.identityTargets.clear();
+    private hasSafeMembershipTargets(dirtyState?: ReadonlySet<number>): boolean {
+      for (const binding of this.currentProps.bindings) {
+        const target = binding.membershipTarget;
+        if (!target || (dirtyState && !dirtyState.has(target.dependency))) continue;
+        if (!keyedMembershipTargetSnapshot(target.read()).eligible) return false;
+      }
+      return true;
+    }
+
+    private commitKeyedTargets(dirtyState?: ReadonlySet<number>): void {
+      if (!dirtyState) {
+        this.identityTargets.clear();
+        this.membershipTargets.clear();
+      }
       for (
         let bindingIndex = 0;
         bindingIndex < this.currentProps.bindings.length;
         bindingIndex += 1
       ) {
-        const target = this.currentProps.bindings[bindingIndex].identityTarget;
-        if (!target) {
+        const binding = this.currentProps.bindings[bindingIndex];
+        const identityTarget = binding.identityTarget;
+        if (!identityTarget) {
           this.identityTargets.delete(bindingIndex);
-          continue;
+        } else if (!dirtyState || dirtyState.has(identityTarget.dependency)) {
+          this.identityTargets.set(
+            bindingIndex,
+            keyedIdentityTargetSnapshot(identityTarget.read()),
+          );
         }
-        if (dirtyState && !dirtyState.has(target.dependency)) continue;
-        this.identityTargets.set(bindingIndex, keyedIdentityTargetSnapshot(target.read()));
+
+        const membershipTarget = binding.membershipTarget;
+        if (!membershipTarget) {
+          this.membershipTargets.delete(bindingIndex);
+        } else if (!dirtyState || dirtyState.has(membershipTarget.dependency)) {
+          this.membershipTargets.set(
+            bindingIndex,
+            keyedMembershipTargetSnapshot(membershipTarget.read()),
+          );
+        }
       }
     }
 
     private adopt(): boolean {
       if (!this.root) return false;
+      if (!this.hasSafeMembershipTargets()) return false;
       const rows = this.readRows(this.currentProps);
       const elements = [...this.root.children];
       if (!rows || rows.items.length !== elements.length) return false;
@@ -3402,24 +3485,78 @@ function createKeyedRowsBlockComponent(
         }
       }
 
+      const nextIdentityTargets = new Map<number, CompilerKeyedIdentityTargetSnapshot>();
+      const nextMembershipTargets = new Map<number, CompilerKeyedMembershipTargetSnapshot>();
       for (const bindingIndex of affectedBindingIndices) {
         const binding = this.currentProps.bindings[bindingIndex];
-        const target = binding.identityTarget;
-        const previousTarget = this.identityTargets.get(bindingIndex);
-        const nextTarget = target ? keyedIdentityTargetSnapshot(target.read()) : undefined;
-        const canTarget = Boolean(
-          target &&
+        if (binding.identityTarget) {
+          nextIdentityTargets.set(
+            bindingIndex,
+            keyedIdentityTargetSnapshot(binding.identityTarget.read()),
+          );
+        }
+        if (binding.membershipTarget) {
+          const snapshot = keyedMembershipTargetSnapshot(binding.membershipTarget.read());
+          if (!snapshot.eligible) {
+            this.activateFallback(afterCommit);
+            return true;
+          }
+          nextMembershipTargets.set(bindingIndex, snapshot);
+        }
+      }
+
+      for (const bindingIndex of affectedBindingIndices) {
+        const binding = this.currentProps.bindings[bindingIndex];
+        const identityTarget = binding.identityTarget;
+        const previousIdentityTarget = this.identityTargets.get(bindingIndex);
+        const nextIdentityTarget = nextIdentityTargets.get(bindingIndex);
+        const canTargetIdentity = Boolean(
+          identityTarget &&
           binding.dependencies?.length === 1 &&
-          binding.dependencies[0] === target.dependency &&
-          dirtyState.has(target.dependency) &&
-          previousTarget?.eligible &&
-          nextTarget?.eligible,
+          binding.dependencies[0] === identityTarget.dependency &&
+          dirtyState.has(identityTarget.dependency) &&
+          previousIdentityTarget?.eligible &&
+          nextIdentityTarget?.eligible,
+        );
+        const membershipTarget = binding.membershipTarget;
+        const previousMembershipTarget = this.membershipTargets.get(bindingIndex);
+        const nextMembershipTarget = nextMembershipTargets.get(bindingIndex);
+        const canTargetMembership = Boolean(
+          membershipTarget &&
+          binding.dependencies?.length === 1 &&
+          binding.dependencies[0] === membershipTarget.dependency &&
+          dirtyState.has(membershipTarget.dependency) &&
+          previousMembershipTarget?.eligible &&
+          previousMembershipTarget.values &&
+          nextMembershipTarget?.eligible &&
+          nextMembershipTarget.values,
         );
 
-        if (canTarget && previousTarget && nextTarget) {
+        if (
+          canTargetMembership &&
+          previousMembershipTarget?.values &&
+          nextMembershipTarget?.values
+        ) {
+          const keys = keyedMembershipChangedKeys(
+            previousMembershipTarget.values,
+            nextMembershipTarget.values,
+          );
+          for (const key of keys) {
+            const instance = this.instances.get(key);
+            if (instance) {
+              applyKeyedRowBinding(
+                this.currentProps,
+                instance,
+                instance.item,
+                instance.index,
+                bindingIndex,
+              );
+            }
+          }
+        } else if (canTargetIdentity && previousIdentityTarget && nextIdentityTarget) {
           const keys = new Set<string>();
-          if (previousTarget.key !== undefined) keys.add(previousTarget.key);
-          if (nextTarget.key !== undefined) keys.add(nextTarget.key);
+          if (previousIdentityTarget.key !== undefined) keys.add(previousIdentityTarget.key);
+          if (nextIdentityTarget.key !== undefined) keys.add(nextIdentityTarget.key);
           for (const key of keys) {
             const instance = this.instances.get(key);
             if (instance) {
@@ -3444,8 +3581,13 @@ function createKeyedRowsBlockComponent(
           }
         }
 
-        if (nextTarget) this.identityTargets.set(bindingIndex, nextTarget);
+        if (nextIdentityTarget) this.identityTargets.set(bindingIndex, nextIdentityTarget);
         else this.identityTargets.delete(bindingIndex);
+        if (nextMembershipTarget) {
+          this.membershipTargets.set(bindingIndex, nextMembershipTarget);
+        } else {
+          this.membershipTargets.delete(bindingIndex);
+        }
       }
       afterCommit?.();
       return true;
@@ -3582,6 +3724,11 @@ function createKeyedRowsBlockComponent(
         }
         this.fallbackKeysWereUnsafe = unsafeKeys;
         this.forceUpdate(afterCommit);
+        return;
+      }
+
+      if (!this.hasSafeMembershipTargets(dirtyState)) {
+        this.activateFallback(afterCommit);
         return;
       }
 
@@ -3818,6 +3965,7 @@ function createKeyedRowsBlockComponent(
       this.cleanupHostScopes();
       this.instances.clear();
       this.identityTargets.clear();
+      this.membershipTargets.clear();
       this.instancesByElement = new WeakMap();
       this.eventHandlers.clear();
       this.conditionalListeners.clear();

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -14,6 +14,7 @@ export interface CompileReactModuleResult {
   diagnostics: readonly CompilerDiagnostic[];
   optimizations: {
     keyedIdentityTargets: number;
+    keyedMembershipTargets: number;
     keyedMapUpdateHints: number;
   };
 }
@@ -90,6 +91,10 @@ interface PendingKeyedRowBinding {
   name?: string;
   dependencies?: number[];
   identityTarget?: {
+    dependency: number;
+    value: t.Expression;
+  };
+  membershipTarget?: {
     dependency: number;
     value: t.Expression;
   };
@@ -561,6 +566,99 @@ function keyedIdentityTarget(
     : undefined;
 }
 
+function isPotentialKeyedMembershipCall(
+  expression: t.CallExpression,
+  reactiveByValue: ReadonlyMap<string, StateBinding>,
+): boolean {
+  if (
+    expression.arguments.length !== 1 ||
+    !t.isExpression(expression.arguments[0]) ||
+    !t.isMemberExpression(expression.callee) ||
+    expression.callee.computed ||
+    !t.isIdentifier(expression.callee.object) ||
+    !t.isIdentifier(expression.callee.property, { name: "has" })
+  ) {
+    return false;
+  }
+  const reactive = reactiveByValue.get(expression.callee.object.name);
+  return Boolean(reactive?.setterName);
+}
+
+function containsPotentialKeyedMembershipCall(
+  expression: t.Expression,
+  reactiveByValue: ReadonlyMap<string, StateBinding>,
+): boolean {
+  let found = false;
+  traverse(expressionFile(cloneExpression(expression)), {
+    CallExpression(path) {
+      if (!isPotentialKeyedMembershipCall(path.node, reactiveByValue)) return;
+      found = true;
+      path.stop();
+    },
+  });
+  return found;
+}
+
+function keyedMembershipTarget(
+  binding: PendingKeyedRowBinding,
+  keyCallback: t.ArrowFunctionExpression | t.FunctionExpression,
+  renderCallback: t.ArrowFunctionExpression | t.FunctionExpression,
+  reactiveByValue: ReadonlyMap<string, StateBinding>,
+  structureDependencies: ReadonlySet<number>,
+): PendingKeyedRowBinding["membershipTarget"] {
+  const dependencies = binding.dependencies || [];
+  if (dependencies.length !== 1 || structureDependencies.has(dependencies[0])) return undefined;
+  const keyExpression = returnedExpression(keyCallback);
+  const keyItem = keyCallback.params[0];
+  const rowItem = renderCallback.params[0];
+  if (!keyExpression || !t.isIdentifier(keyItem) || !t.isIdentifier(rowItem)) return undefined;
+
+  const replacements = new Map<string, t.Identifier>([[keyItem.name, rowItem]]);
+  const keyIndex = keyCallback.params[1];
+  const rowIndex = renderCallback.params[1];
+  if (t.isIdentifier(keyIndex) && t.isIdentifier(rowIndex)) {
+    replacements.set(keyIndex.name, rowIndex);
+  }
+  const rowKeyExpression = rewriteFreeIdentifierNames(keyExpression, replacements);
+  const file = expressionFile(cloneExpression(binding.value));
+  let target: StateBinding | undefined;
+  let valid = true;
+  let calls = 0;
+  traverse(file, {
+    ReferencedIdentifier(path) {
+      if (!valid || path.scope.hasBinding(path.node.name)) return;
+      const reactive = reactiveByValue.get(path.node.name);
+      if (!reactive) return;
+      const member = path.parentPath;
+      const call = member.parentPath;
+      if (
+        !reactive.setterName ||
+        reactive.index !== dependencies[0] ||
+        (target && target !== reactive) ||
+        !member.isMemberExpression() ||
+        member.node.object !== path.node ||
+        member.node.computed ||
+        !t.isIdentifier(member.node.property, { name: "has" }) ||
+        !call ||
+        !call.isCallExpression() ||
+        call.node.callee !== member.node ||
+        call.node.arguments.length !== 1 ||
+        !t.isExpression(call.node.arguments[0]) ||
+        !t.isNodesEquivalent(call.node.arguments[0], rowKeyExpression)
+      ) {
+        valid = false;
+        path.stop();
+        return;
+      }
+      target = reactive;
+      calls += 1;
+    },
+  });
+  return valid && target && calls > 0
+    ? { dependency: target.index, value: t.identifier(target.valueName) }
+    : undefined;
+}
+
 function collectReferencedLocals(expression: t.Expression, names: ReadonlySet<string>): string[] {
   const references = new Set<string>();
   traverse(expressionFile(cloneExpression(expression)), {
@@ -731,6 +829,7 @@ function isSafeCompilerCall(
 function validateDerivedExpression(
   expression: t.Expression,
   safeGlobals: ReadonlySet<string>,
+  additionalSafeCall?: (expression: t.CallExpression) => boolean,
 ): string | undefined {
   let unsupported: string | undefined;
   const reject = (reason: string, path: NodePath) => {
@@ -743,7 +842,9 @@ function validateDerivedExpression(
     AssignmentExpression: (path) => reject("assignments", path),
     AwaitExpression: (path) => reject("await expressions", path),
     CallExpression(path) {
-      if (!isSafeCompilerCall(path.node, safeGlobals)) reject("function calls", path);
+      if (!isSafeCompilerCall(path.node, safeGlobals) && !additionalSafeCall?.(path.node)) {
+        reject("function calls", path);
+      }
     },
     ClassExpression: (path) => reject("class expressions", path),
     Function: (path) => reject("function expressions", path),
@@ -1550,6 +1651,7 @@ function analyzeKeyedRowTree(
   renderCallback: t.ArrowFunctionExpression | t.FunctionExpression,
   safeGlobals: ReadonlySet<string>,
   compilerSetters: ReadonlySet<string>,
+  membershipReactiveByValue?: ReadonlyMap<string, StateBinding>,
 ): {
   bindings?: PendingKeyedRowBinding[];
   events?: PendingKeyedRowEvent[];
@@ -1570,6 +1672,14 @@ function analyzeKeyedRowTree(
   const bindings: PendingKeyedRowBinding[] = [];
   const events: PendingKeyedRowEvent[] = [];
   const conditionals: PendingKeyedRowConditional[] = [];
+  const validateBindingExpression = (expression: t.Expression) =>
+    validateDerivedExpression(
+      expression,
+      safeGlobals,
+      membershipReactiveByValue
+        ? (call) => isPotentialKeyedMembershipCall(call, membershipReactiveByValue)
+        : undefined,
+    );
   const visit = (element: t.JSXElement, path: number[]): string | undefined => {
     const tag = element.openingElement.name;
     if (!t.isJSXIdentifier(tag) || !/^[a-z]/.test(tag.name)) {
@@ -1668,7 +1778,7 @@ function analyzeKeyedRowTree(
           if (!propertyName || (propertyName.includes("-") && !propertyName.startsWith("--"))) {
             return "compiled keyed row style names must use camelCase or a CSS custom property";
           }
-          const unsupported = validateDerivedExpression(property.value, safeGlobals);
+          const unsupported = validateBindingExpression(property.value);
           if (unsupported) {
             return `compiled keyed row style ${propertyName} cannot use ${unsupported}`;
           }
@@ -1683,7 +1793,7 @@ function analyzeKeyedRowTree(
       }
 
       if (name === "children") return "compiled keyed row children props are not supported yet";
-      const unsupported = validateDerivedExpression(expression, safeGlobals);
+      const unsupported = validateBindingExpression(expression);
       if (unsupported) return `compiled keyed row ${name} cannot use ${unsupported}`;
       bindings.push({
         kind: "attribute",
@@ -1747,7 +1857,7 @@ function analyzeKeyedRowTree(
         t.isJSXExpressionContainer(child) && !t.isJSXEmptyExpression(child.expression),
     );
     for (const child of expressions) {
-      const unsupported = validateDerivedExpression(child.expression as t.Expression, safeGlobals);
+      const unsupported = validateBindingExpression(child.expression as t.Expression);
       if (unsupported) return `compiled keyed row text cannot use ${unsupported}`;
     }
     if (nestedElements.length > 0 && expressions.length > 0) {
@@ -1790,6 +1900,7 @@ function analyzeKeyedRowChild(
   safeGlobals: ReadonlySet<string>,
   listNames: ReadonlySet<string>,
   acceptUnsupportedRow = false,
+  allowMembershipTargets = false,
 ): KeyedRowChildShape | undefined {
   let collection: t.Expression;
   let keyCallback: t.ArrowFunctionExpression | t.FunctionExpression;
@@ -1857,6 +1968,7 @@ function analyzeKeyedRowChild(
     renderCallback,
     safeGlobals,
     new Set([...statesByValue.values()].map((state) => state.setterName)),
+    allowMembershipTargets ? statesByValue : undefined,
   );
   if (rowAnalysis.reason && !acceptUnsupportedRow) return undefined;
   const keyExpression = returnedExpression(keyCallback);
@@ -1920,8 +2032,17 @@ function analyzeKeyedRowsContainer(
 
   const children = meaningfulJsxChildren(container);
   if (children.length !== 1) return undefined;
-  const shape = analyzeKeyedRowChild(children[0], statesByValue, safeGlobals, listNames, true);
+  const shape = analyzeKeyedRowChild(
+    children[0],
+    statesByValue,
+    safeGlobals,
+    listNames,
+    true,
+    true,
+  );
   if (!shape || shape.rowReason) return shape;
+  const needsMembershipProof = (binding: PendingKeyedRowBinding) =>
+    containsPotentialKeyedMembershipCall(binding.value, statesByValue);
   if (
     shape.conditionals.length > 0 ||
     (shape.events.length > 0 &&
@@ -1931,21 +2052,45 @@ function analyzeKeyedRowsContainer(
         source: container,
       }))
   ) {
-    return shape;
+    return shape.bindings.some(needsMembershipProof)
+      ? {
+          ...shape,
+          rowReason:
+            "keyed membership targets require compiler-owned rows without React-owned branches or events",
+        }
+      : shape;
   }
   const structureDependencies = new Set(shape.structureDependencies);
+  const bindings = shape.bindings.map((binding) => ({
+    ...binding,
+    identityTarget: keyedIdentityTarget(
+      binding,
+      shape.keyCallback,
+      shape.renderCallback,
+      statesByValue,
+      structureDependencies,
+    ),
+    membershipTarget: keyedMembershipTarget(
+      binding,
+      shape.keyCallback,
+      shape.renderCallback,
+      statesByValue,
+      structureDependencies,
+    ),
+  }));
+  if (
+    bindings.some(
+      (binding, index) => needsMembershipProof(shape.bindings[index]) && !binding.membershipTarget,
+    )
+  ) {
+    return {
+      ...shape,
+      rowReason: "keyed membership targets must call one local Set state with the exact row key",
+    };
+  }
   return {
     ...shape,
-    bindings: shape.bindings.map((binding) => ({
-      ...binding,
-      identityTarget: keyedIdentityTarget(
-        binding,
-        shape.keyCallback,
-        shape.renderCallback,
-        statesByValue,
-        structureDependencies,
-      ),
-    })),
+    bindings,
   };
 }
 
@@ -3194,6 +3339,23 @@ function keyedRowBindingObject(
           t.objectProperty(
             t.identifier("read"),
             t.arrowFunctionExpression([], cloneExpression(binding.identityTarget.value)),
+          ),
+        ]),
+      ),
+    );
+  }
+  if (binding.membershipTarget) {
+    properties.push(
+      t.objectProperty(
+        t.identifier("membershipTarget"),
+        t.objectExpression([
+          t.objectProperty(
+            t.identifier("dependency"),
+            t.numericLiteral(binding.membershipTarget.dependency),
+          ),
+          t.objectProperty(
+            t.identifier("read"),
+            t.arrowFunctionExpression([], cloneExpression(binding.membershipTarget.value)),
           ),
         ]),
       ),
@@ -4990,7 +5152,11 @@ function compileCandidate(
   keyedMapUpdateIdentifier: t.Identifier,
   runtimeFeatureIdentifiers: ReadonlyMap<CompilerRuntimeFeatureName, t.Identifier>,
   usedRuntimeFeatures: Set<CompilerRuntimeFeatureName>,
-  optimizationCounts: { keyedIdentityTargets: number; keyedMapUpdateHints: number },
+  optimizationCounts: {
+    keyedIdentityTargets: number;
+    keyedMembershipTargets: number;
+    keyedMapUpdateHints: number;
+  },
   useStateNames: ReadonlySet<string>,
   reactNames: ReadonlySet<string>,
   listNames: ReadonlySet<string>,
@@ -5280,6 +5446,14 @@ function compileCandidate(
         : 0),
     0,
   );
+  optimizationCounts.keyedMembershipTargets += blockPlans.reduce(
+    (count, plan) =>
+      count +
+      (plan.kind === "keyed-rows"
+        ? plan.bindings.filter((binding) => binding.membershipTarget !== undefined).length
+        : 0),
+    0,
+  );
   const runtimeFeatures = runtimeFeaturesForPlans(blockPlans, appliedKeyedMapUpdateHints > 0);
   markShortCircuitBindings(analysis.bindings || []);
   assignStableBindingTargets(analysis.bindings || []);
@@ -5464,7 +5638,11 @@ export async function compileReactModule(
 ): Promise<CompileReactModuleResult> {
   const compiled: string[] = [];
   const diagnostics: CompilerDiagnostic[] = [];
-  const optimizationCounts = { keyedIdentityTargets: 0, keyedMapUpdateHints: 0 };
+  const optimizationCounts = {
+    keyedIdentityTargets: 0,
+    keyedMembershipTargets: 0,
+    keyedMapUpdateHints: 0,
+  };
   const plugin = (): PluginObj => ({
     name: "farm-react-aot",
     visitor: {


### PR DESCRIPTION
## Summary

- prove exact local Set.has(rowKey) bindings at build time and emit a keyed membership target
- snapshot safe native primitive Sets and patch only keys in the symmetric difference
- fall back to React before compiled reads for subclasses, proxies, custom has behavior, object members, structural dependencies, or unsupported expressions
- expose keyedMembershipTargets in compiler reports and document the behavior, safety boundary, and benchmark

## Correctness and safety

- preserves existing full reconciliation and React fallback paths
- covers attributes, classes, styles, text, public List normalization, primitive key collisions, mixed structural updates, StrictMode, and unmount-before-flush
- includes 2,000 randomized queued differential updates against normal React
- verifies Set subclasses and own has overrides fall back before binding reads

## Verification

- @farm.js/react: 47 files / 386 tests passed
- React compatibility: 18.3.1 and 19.2.8 passed
- React package type-check passed
- oxlint, oxfmt, Prettier, git diff check, and docs navigation passed
- docs production build passed
- production Chrome benchmark: all correctness, performance, persistence, and scalability gates passed
- existing 20,000-row keyed update: 16.58x faster in hybrid mode
- existing 20,000-row scalar selection: 25.38x faster in hybrid mode
- new 20,000-row Set membership update: 480.75x faster in hybrid mode; deterministic tests provide the exact bounded-work proof because the browser measurement is near timer resolution
- compiled owner executions remained zero
- runtime-size gate passed: keyed fixture +498 B gzip; direct/core-only fixture unchanged; core-only runtime remains 75.9% smaller than the full runtime

## Benchmark scope

The browser benchmark measures event dispatch through an asserted DOM mutation. It does not claim constant total browser time. The compiler optimization makes row-binding work proportional to changed Set members; structural list work continues to use the existing reconciliation path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds build-time proof for local `Set.has(rowKey)` bindings and emits keyed membership targets, so membership updates patch only rows whose Set membership changed instead of evaluating the binding across every row.

Previously these bindings went through full keyed reconciliation. Now the runtime snapshots the previous and next native primitive Set and patches only the symmetric difference. Unsafe cases—Set subclasses, proxies, own `has` overrides, object members, extra reactive dependencies, structural key dependencies, or unsupported expressions—fall back to React before compiled reads. The compiler report and docs now expose `keyedMembershipTargets`.

**Correctness and safety**
- Preserves existing full reconciliation and React fallback paths.
- Covers attributes, classes, styles, text, public `List` normalization, primitive key collisions, mixed structural updates, StrictMode, and unmount-before-flush.
- Adds 2,000 randomized queued differential updates against normal React.

**Verification**
- Passes `@farm.js/react` 386 tests, React 18.3.1 and 19.2.8, type-check, lint/format, docs build, and production Chrome gates.
- 20,000-row Set membership update is 480.75x faster in hybrid mode; scalar selection is 25.38x and keyed update is 16.58x faster.
- Keyed fixture grows 498 B gzip; direct/core-only runtime unchanged and core remains 75.9% smaller than full runtime.

<sup>Written for commit c23b348520ba0ecea9247f041ffa5e9aa918da33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

