### PR TITLE
perf(react): target keyed Map lookups

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -303,6 +303,7 @@ After a successful build, Farm writes `.farm/react-compiler.json`:
     "compiled": 2,
     "fallback": 2,
     "keyedIdentityTargets": 2,
+    "keyedMapLookupTargets": 1,
     "keyedMembershipTargets": 1,
     "keyedMapUpdateHints": 1
   },
@@ -318,6 +319,7 @@ After a successful build, Farm writes `.farm/react-compiler.json`:
       "compiled": ["ProductRow"],
       "optimizations": {
         "keyedIdentityTargets": 2,
+        "keyedMapLookupTargets": 1,
         "keyedMembershipTargets": 1,
         "keyedMapUpdateHints": 1
       },
@@ -337,6 +339,8 @@ After a successful build, Farm writes `.farm/react-compiler.json`:
 `componentsConsidered` counts candidates selected by the active mode. `compiled` counts components
 using the AOT runtime, and `fallback` counts candidates left on React. `keyedIdentityTargets` counts
 row bindings that can update by looking up the previous and next key directly.
+`keyedMapLookupTargets` counts row bindings that can update from changed primitive values in a
+local native `Map`.
 `keyedMembershipTargets` counts row bindings that can update from the changed members of a local
 native `Set`.
 `keyedMapUpdateHints` counts setter sites where the compiler proved that a direct keyed collection
@@ -756,6 +760,39 @@ key dependencies do not use this path. If a runtime value fails the native-Set g
 boundary returns to React before compiled bindings are evaluated. This keeps custom collection
 semantics and error handling under React ownership. No option or component primitive is required.
 The report exposes the emitted binding count as `keyedMembershipTargets`.
+
+#### Key-directed Map lookup updates
+
+Per-row status and metadata often live in a local Map rather than on the row objects:
+
+```tsx
+const [statusById, setStatusById] = useState(() => new Map<number, string>());
+
+<tbody>
+  {rows.map((row) => (
+    <tr data-status={statusById.get(row.id) ?? "none"} key={row.id}>
+      <td>{row.label}</td>
+    </tr>
+  ))}
+</tbody>;
+```
+
+For an exact `localMap.get(rowKey)` binding, the compiler records the local state cell and row-key
+expression. The runtime snapshots the previous and next entries and compares mapped values with
+`Object.is`. Only keys whose visible lookup result changed evaluate the row binding. Status text,
+validation messages, progress attributes, classes, and styles can therefore update without
+evaluating the same lookup for every row. The component and its `map()` callback do not rerun.
+Snapshot comparison still visits Map entries; this optimization removes the full row-binding and
+DOM-target scan, not the application's Map construction or the runtime's entry comparison.
+
+The proof accepts one local `useState` dependency and a direct `get()` call with the exact
+expression used by `key`. At runtime, targeting requires an ordinary native `Map` with string,
+number, bigint, or nullish keys and string, number, bigint, boolean, or nullish values. Map
+subclasses, proxies, own `get` overrides, object values, different row fields, extra reactive
+dependencies, React-owned rows, nested blocks, and structural key dependencies do not use this
+path. A failed runtime guard returns that keyed boundary to React before compiled bindings run.
+No option or component primitive is required. The report exposes the emitted binding count as
+`keyedMapLookupTargets`.
 
 #### Mutation-aware same-order updates
 
@@ -1568,9 +1605,10 @@ The package and example test suites verify more than generated code:
   updates outer and nested row conditions, preserves surviving row and branch identity, removes and
   inserts a row, and observes zero owner update executions;
 - the production 10,000/20,000-row benchmark requires nonzero `keyedIdentityTargets`,
-  `keyedMembershipTargets`, and `keyedMapUpdateHints` report counts, preserves the keyed-update
-  speedup floor, checks that scalar selection and Set membership remain key-directed at scale, and
-  passes DOM correctness, React-relative regression, and normalized scalability gates;
+  `keyedMapLookupTargets`, `keyedMembershipTargets`, and `keyedMapUpdateHints` report counts,
+  preserves the keyed-update speedup floor, checks that scalar selection, Set membership, and Map
+  lookups remain key-directed at scale, and passes DOM correctness, React-relative regression, and
+  normalized scalability gates;
 - the public `List` renders iterable and nullish collections correctly with the compiler off;
 - the packaged runtime, including a keyed-range component root, editable and interactive keyed-row
   events, row-local conditions, reorders, identity, selection, and hydration, is exercised

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -3,7 +3,7 @@
 Date: 2026-08-28
 
 Result: **PASS.** Correctness, the React-relative performance gate, the keyed-update, scalar
-selection, and Set-membership persistence gates, and the normalized scalability gate all pass. The
+selection, Set-membership, Map-lookup persistence, and normalized scalability gates all pass. The
 production run compares two bracketing React baselines with static and hybrid compiler builds from
 the exact same component source.
 
@@ -23,13 +23,15 @@ the exact same component source.
   normalized growth
 - Key-directed Set-membership gate: at least 10x faster than React at 20,000 rows and no more than
   2x normalized growth
+- Key-directed Map-lookup gate: at least 10x faster than React at 20,000 rows and no more than 2x
+  normalized growth
 - No CPU throttling
 
 Every trial passed DOM assertions and browser-error checks. The compiler report proved that both
 workloads compiled, delegated keyed rows were present only in compiler builds, exactly two scalar
-key-directed bindings, one Set-membership binding, and one mutation-aware keyed-map update site were
-emitted, and hybrid/static added zero owner executions. The two React baselines added 1,430
-dashboard and 279 table owner executions each.
+key-directed bindings, one Set-membership binding, one Map-lookup binding, and one mutation-aware
+keyed-map update site were emitted, and hybrid/static added zero owner executions. The two React
+baselines added 1,430 dashboard and 297 table owner executions each.
 
 ## Complex dashboard
 
@@ -38,7 +40,7 @@ bindings.
 
 | Interaction                 | React median | Hybrid median | Hybrid vs React |
 | --------------------------- | -----------: | ------------: | --------------: |
-| Active live pulse           |      0.10 ms |       0.08 ms |    1.25x faster |
+| Active live pulse           |      0.11 ms |       0.09 ms |    1.22x faster |
 | Inactive branch update      |      0.06 ms |       0.02 ms |    3.00x faster |
 | Switch live/snapshot branch |     0.100 ms |      0.100 ms |          parity |
 
@@ -46,21 +48,22 @@ bindings.
 
 | Operation         |             Rows | React median | Hybrid median | Hybrid vs React |
 | ----------------- | ---------------: | -----------: | ------------: | --------------: |
-| Create            |            1,000 |     12.55 ms |      11.20 ms |    1.12x faster |
-| Replace all       |            1,000 |     18.15 ms |      12.10 ms |    1.50x faster |
-| Create many       |           10,000 |    291.30 ms |     120.50 ms |    2.42x faster |
-| Append            | 10,000 -> 11,000 |     71.10 ms |      26.00 ms |    2.73x faster |
-| Update every 10th |           10,000 |     43.70 ms |       2.90 ms |   15.07x faster |
-| Select            |            1,000 |      3.85 ms |       0.10 ms |   38.50x faster |
-| Mark two rows     |            1,000 |      3.75 ms |       0.10 ms |   37.50x faster |
-| Swap rows 2 / 999 |            1,000 |      7.90 ms |       1.50 ms |    5.27x faster |
-| Remove one row    |            1,000 |      4.45 ms |       2.70 ms |    1.65x faster |
-| Clear             |           10,000 |     63.95 ms |      11.00 ms |    5.81x faster |
+| Create            |            1,000 |     12.60 ms |      11.60 ms |    1.09x faster |
+| Replace all       |            1,000 |     17.20 ms |      11.80 ms |    1.46x faster |
+| Create many       |           10,000 |    310.10 ms |     117.20 ms |    2.65x faster |
+| Append            | 10,000 -> 11,000 |     73.80 ms |      25.50 ms |    2.89x faster |
+| Update every 10th |           10,000 |     40.45 ms |       2.60 ms |   15.56x faster |
+| Select            |            1,000 |      3.55 ms |       0.10 ms |   35.50x faster |
+| Mark two rows     |            1,000 |      4.00 ms |       0.10 ms |   40.00x faster |
+| Queue two rows    |            1,000 |      4.05 ms |       0.10 ms |   40.50x faster |
+| Swap rows 2 / 999 |            1,000 |      8.60 ms |       1.20 ms |    7.17x faster |
+| Remove one row    |            1,000 |      4.45 ms |       2.00 ms |    2.22x faster |
+| Clear             |           10,000 |     56.65 ms |       9.40 ms |    6.03x faster |
 
 `Update every 10th` is the targeted mutation-aware path. The application still executes its native
 immutable `map()` over 10,000 items and creates 1,000 replacement objects. The generated hint lets
 the keyed runtime validate and patch those 1,000 rows without a second scan of all 10,000 keys and
-bindings. The 8x persistence floor leaves substantial headroom below this run's 14.57x-16.58x
+bindings. The 8x persistence floor leaves substantial headroom below this run's 14.45x-16.18x
 result across compiler modes and row counts while still rejecting a silent return to the older
 roughly 5x full-reconciliation path.
 
@@ -76,22 +79,28 @@ Package tests require the binding-read count to equal the changed primitive keys
 table. The browser result includes event dispatch and the asserted DOM mutation; sub-millisecond
 values are timer-quantized, so the exact read-count test is the stronger proof of bounded row work.
 
+`Queue two rows` is the Map-lookup path. For `queueById.get(row.id)`, the runtime compares native
+Map snapshots and evaluates only row keys whose mapped primitive value changed. Package tests
+require the exact present-key read count across 2,000 randomized queued updates and verify that
+custom Maps or identity-bearing values return to React before compiled binding reads.
+
 ## Repeated 20,000-row scale profile
 
 Each of the three cycles creates 10,000 rows, appends ten 1,000-row batches to 20,000, updates
-2,000 rows, performs two distant selections, replaces two marked Set members, swaps rows, removes a
-middle row, and clears. Lower time is better.
+2,000 rows, performs two distant selections, replaces two marked Set members and two mapped queue
+values, swaps rows, removes a middle row, and clears. Lower time is better.
 
 | Operation at scale       | React median | React p95 | Hybrid median | Hybrid p95 | Speedup |
 | ------------------------ | -----------: | --------: | ------------: | ---------: | ------: |
-| Create initial 10,000    |    315.20 ms | 412.55 ms |     124.70 ms |  127.80 ms |   2.53x |
-| Append a 1,000-row batch |     85.35 ms | 121.90 ms |      29.10 ms |   35.10 ms |   2.93x |
-| Update every 10th at 20k |    104.45 ms | 109.40 ms |       6.30 ms |   19.00 ms |  16.58x |
-| Select at 20k            |     93.90 ms | 106.00 ms |       3.70 ms |    4.40 ms |  25.38x |
-| Mark two rows at 20k     |     96.15 ms | 104.20 ms |       0.20 ms |    4.40 ms | 480.75x |
-| Swap at 20k              |    113.50 ms | 135.10 ms |      26.70 ms |   27.20 ms |   4.25x |
-| Remove middle row at 20k |    111.85 ms | 117.20 ms |      38.00 ms |   42.30 ms |   2.94x |
-| Clear 20k                |    215.75 ms | 312.60 ms |      21.70 ms |   22.60 ms |   9.94x |
+| Create initial 10,000    |    386.70 ms | 489.70 ms |     120.00 ms |  133.40 ms |   3.22x |
+| Append a 1,000-row batch |     91.95 ms | 144.85 ms |      32.70 ms |   49.70 ms |   2.81x |
+| Update every 10th at 20k |    105.20 ms | 110.50 ms |       6.50 ms |    7.00 ms |  16.18x |
+| Select at 20k            |     96.75 ms | 120.05 ms |       3.90 ms |    4.80 ms |  24.81x |
+| Mark two rows at 20k     |     95.50 ms | 101.50 ms |       0.20 ms |    0.20 ms | 477.50x |
+| Queue two rows at 20k    |     99.65 ms | 108.80 ms |       0.20 ms |    0.20 ms | 498.25x |
+| Swap at 20k              |    112.85 ms | 142.70 ms |      26.20 ms |   28.10 ms |   4.31x |
+| Remove middle row at 20k |    123.80 ms | 157.50 ms |      41.20 ms |   42.00 ms |   3.00x |
+| Clear 20k                |    227.45 ms | 275.75 ms |      23.80 ms |   24.40 ms |   9.56x |
 
 ## Scalability gate
 
@@ -101,42 +110,43 @@ The gate divides observed timing growth by row-count growth. A value near 1 mean
 | Path               | Row growth | Timing growth | Normalized growth |
 | ------------------ | ---------: | ------------: | ----------------: |
 | Create 10k repeat  |      1.00x |         1.03x |             1.03x |
-| Update 10k -> 20k  |      2.00x |         2.17x |             1.09x |
-| Select 1k -> 20k   |     20.00x |        14.80x |             0.74x |
+| Update 10k -> 20k  |      2.00x |         2.50x |             1.25x |
+| Select 1k -> 20k   |     20.00x |        15.60x |             0.78x |
 | Mark Set 1k -> 20k |     20.00x |         0.80x |             0.04x |
-| Swap 1k -> 20k     |     20.00x |        17.80x |             0.89x |
-| Remove 1k -> 20k   |     20.00x |        14.07x |             0.70x |
-| Clear 10k -> 20k   |      2.00x |         1.97x |             0.99x |
+| Read Map 1k -> 20k |     20.00x |         0.80x |             0.04x |
+| Swap 1k -> 20k     |     20.00x |        21.83x |             1.09x |
+| Remove 1k -> 20k   |     20.00x |        20.60x |             1.03x |
+| Clear 10k -> 20k   |      2.00x |         2.53x |             1.27x |
 
 This demonstrates approximately linear rather than quadratic end-to-end growth. Key-directed
 scalar selection performs constant row-binding work—at most the previous and next keyed
-instances—while its complete event-to-DOM timing remains 25.38x faster than React at 20,000 rows.
-Set membership performs work proportional to the changed members rather than total rows. Its
-0.20 ms median is near browser timer resolution, so the deterministic unit gate remains the primary
-complexity evidence. Structural swap/removal paths remain O(n), as expected for validating keys
-and maintaining row indices.
+instances—while its complete event-to-DOM timing remains 24.81x faster than React at 20,000 rows.
+Set membership and Map lookup evaluate bindings only for changed keys. Their 0.20 ms medians are
+near browser timer resolution, so deterministic exact-read gates remain the primary complexity
+evidence. Structural swap/removal paths remain O(n), as expected for validating keys and
+maintaining row indices.
 
 ## Bundle cost
 
 | Build           | Page chunk raw | Page chunk gzip |
 | --------------- | -------------: | --------------: |
-| React baseline  |       19,073 B |         4,494 B |
-| Static compiler |       77,870 B |        16,525 B |
-| Hybrid compiler |       77,870 B |        16,526 B |
+| React baseline  |       19,632 B |         4,592 B |
+| Static compiler |       80,707 B |        16,987 B |
+| Hybrid compiler |       80,707 B |        16,987 B |
 
-This deliberately broad page now pays a 12,032-byte hybrid gzip premium for the compiler runtime,
-including the mutation-aware, scalar key-directed, and Set-membership paths. Smaller direct-only
-applications retain less of the runtime; the package-level fixtures and persisted size gate are documented in
-`packages/farm-react/RUNTIME_SIZE_RESULTS.md`.
+This deliberately broad page now pays a 12,395-byte hybrid gzip premium for the compiler runtime,
+including the mutation-aware, scalar key-directed, Set-membership, and Map-lookup paths. Smaller
+direct-only applications retain less of the runtime; the package-level fixtures and persisted size
+gate are documented in `packages/farm-react/RUNTIME_SIZE_RESULTS.md`.
 
 ## Conclusion
 
 The compiled path scales successfully through the tested 20,000-row mixed workload: all DOM and
 event assertions pass, there are no browser errors or owner rerenders, every scale operation beats
-the bracketed React baseline, and normalized growth stays at or below 1.09x. Scalar selection
-performs at most two row-binding reads, while Set membership evaluates only changed members that map
-to rows. The evidence claims only measured end-to-end behavior within this range—not unlimited
-constant-time browser work.
+the bracketed React baseline, and normalized growth stays at or below 1.27x. Scalar selection
+performs at most two row-binding reads, while Set membership and Map lookup evaluate only changed
+keys that map to rows. The evidence claims only measured end-to-end behavior within this range—not
+unlimited constant-time browser work.
 
 The machine-readable output is `/tmp/farm-react-dashboard-benchmark.json`. Re-run
 `pnpm --filter farm-react-compiler-dashboard-example benchmark` to reproduce it.

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -71,6 +71,12 @@ keys with `markedIds.has(row.id)` at 1,000 and 20,000 rows. Both compiler modes 
 must contain a nonzero `keyedMembershipTargets` count. Differential unit tests separately require
 the exact number of binding reads to equal the primitive-key symmetric difference.
 
+Map lookup targeting has the same independent gate. The table replaces two queue values through
+`queueById.get(row.id)` at 1,000 and 20,000 rows. Both compiler modes must remain at least 10x faster
+than React at 20,000 rows, normalized growth may not exceed 2x, and the compiler report must contain
+a nonzero `keyedMapLookupTargets` count. Differential unit tests require binding reads to equal the
+present row keys whose mapped primitive values changed.
+
 Set `FARM_EXPERIMENT_BROWSER_PATH` to an installed Chrome/Chromium executable when Playwright's
 bundled browser is unavailable. Sample counts are configurable:
 

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -123,6 +123,10 @@ async function inspectBuild(compilerMode) {
       "The compiler build did not emit a keyed Set-membership target.",
     );
     assert(
+      compilerReport.summary.keyedMapLookupTargets > 0,
+      "The compiler build did not emit a keyed Map-lookup target.",
+    );
+    assert(
       compilerReport.summary.keyedMapUpdateHints > 0,
       "The compiler build did not emit a mutation-aware keyed-map update hint.",
     );
@@ -494,6 +498,19 @@ async function measureTrial(browser, trial, compilerMode, port) {
           },
         );
 
+        const tableMapLookup = await measureTable(
+          async () => ensure1000(),
+          async () => {
+            const row = table.querySelectorAll("tbody tr")[500];
+            const previous = row?.getAttribute("data-queue");
+            if (!row) throw new Error("Map lookup target row is missing.");
+            await runTableAction(
+              () => tableButton("table-queue").click(),
+              () => row.getAttribute("data-queue") !== previous,
+            );
+          },
+        );
+
         const tableRemove = await measureTable(
           async () => {
             if (rowCount() !== 1_000) await create1000();
@@ -521,6 +538,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
           appendTo20k: [],
           clear20k: [],
           create10k: [],
+          mapLookup20k: [],
           membership20k: [],
           remove20k: [],
           select20k: [],
@@ -579,6 +597,16 @@ async function measureTrial(browser, trial, compilerMode, port) {
           );
           scale.membership20k.push(performance.now() - membershipStartedAt);
 
+          const mapLookupRow = table.querySelectorAll("tbody tr")[10_000];
+          const previousMapLookup = mapLookupRow?.getAttribute("data-queue");
+          if (!mapLookupRow) throw new Error("20,000-row Map lookup target is missing.");
+          const mapLookupStartedAt = performance.now();
+          await runTableAction(
+            () => tableButton("table-queue").click(),
+            () => mapLookupRow.getAttribute("data-queue") !== previousMapLookup,
+          );
+          scale.mapLookup20k.push(performance.now() - mapLookupStartedAt);
+
           const rowsBeforeSwap = table.querySelectorAll("tbody tr");
           const second = rowsBeforeSwap[1]?.getAttribute("data-row-id");
           const penultimate = rowsBeforeSwap[998]?.getAttribute("data-row-id");
@@ -619,6 +647,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
             dashboardLive: dashboard.dataset.live,
             dashboardRevision: Number(dashboard.dataset.revision),
             finalMarkedCount: Number(table.dataset.markedCount),
+            finalQueueCount: Number(table.dataset.queueCount),
             finalTableRows: rowCount(),
             scalePeakRows: peakRows,
           },
@@ -634,6 +663,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
             create: tableCreate,
             createMany: tableCreateMany,
             executionsAdded: Number(tableExecutions.textContent) - initialTableExecutions,
+            mapLookup: tableMapLookup,
             membership: tableMembership,
             remove: tableRemove,
             replace: tableReplace,
@@ -656,6 +686,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
     assert.equal(result.correctness.activeBarStayedStableDuringInactiveUpdates, true);
     assert.equal(result.correctness.dashboardLive, "true");
     assert.equal(result.correctness.finalMarkedCount, 0);
+    assert.equal(result.correctness.finalQueueCount, 0);
     assert.equal(result.correctness.finalTableRows, 0);
     assert.equal(result.correctness.scalePeakRows, 20_000);
     assert.equal(browserErrors.length, 0, browserErrors.join("\n"));
@@ -687,6 +718,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
         appendTo20k: timingSummary(result.scale.appendTo20k),
         clear20k: timingSummary(result.scale.clear20k),
         create10k: timingSummary(result.scale.create10k),
+        mapLookup20k: timingSummary(result.scale.mapLookup20k),
         membership20k: timingSummary(result.scale.membership20k),
         remove20k: timingSummary(result.scale.remove20k),
         select20k: timingSummary(result.scale.select20k),
@@ -699,6 +731,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
         create: timingSummary(result.table.create),
         createMany: timingSummary(result.table.createMany),
         executionsAdded: result.table.executionsAdded,
+        mapLookup: timingSummary(result.table.mapLookup),
         membership: timingSummary(result.table.membership),
         remove: timingSummary(result.table.remove),
         replace: timingSummary(result.table.replace),
@@ -775,6 +808,7 @@ const tableMetrics = [
   "updateEvery10th",
   "select",
   "membership",
+  "mapLookup",
   "swap",
   "remove",
   "clear",
@@ -785,6 +819,7 @@ const scaleMetrics = [
   "updateEvery10th20k",
   "select20k",
   "membership20k",
+  "mapLookup20k",
   "swap20k",
   "remove20k",
   "clear20k",
@@ -817,6 +852,7 @@ const scalabilityCases = [
   ["updateEvery10th20k", "updateEvery10th", 2],
   ["select20k", "select", 20],
   ["membership20k", "membership", 20],
+  ["mapLookup20k", "mapLookup", 20],
   ["swap20k", "swap", 20],
   ["remove20k", "remove", 20],
   ["clear20k", "clear", 2],
@@ -935,12 +971,38 @@ const keyedMembershipRegressions = keyedMembershipResults.filter(
     !Number.isFinite(normalizedGrowth) ||
     normalizedGrowth > keyedMembershipMaximumNormalizedGrowth,
 );
+// A native Map lookup binding is similarly key-directed, but its mapped primitive value can feed
+// text, attributes, classes, or styles. Deterministic tests prove that only keys whose mapped value
+// changed evaluate the binding; this gate protects the corresponding end-to-end win at scale.
+const keyedMapLookupMinimumSpeedup = 10;
+const keyedMapLookupMaximumNormalizedGrowth = 2;
+const keyedMapLookupResults = ["static", "hybrid"].map((mode) => {
+  const tableMedianMs = comparisons.table.mapLookup[mode].medianMs;
+  const scaleMedianMs = comparisons.scale.mapLookup20k[mode].medianMs;
+  const growth = scaleMedianMs / Math.max(tableMedianMs, timingResolutionFloorMs);
+  return {
+    growth,
+    mode,
+    normalizedGrowth: growth / 20,
+    scaleMedianMs,
+    speedup: comparisons.scale.mapLookup20k[`${mode}VsBaseline`].speedup,
+    tableMedianMs,
+  };
+});
+const keyedMapLookupRegressions = keyedMapLookupResults.filter(
+  ({ normalizedGrowth, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedMapLookupMinimumSpeedup ||
+    !Number.isFinite(normalizedGrowth) ||
+    normalizedGrowth > keyedMapLookupMaximumNormalizedGrowth,
+);
 const passed =
   performanceRegressions.length === 0 &&
   scalabilityRegressions.length === 0 &&
   keyedUpdateRegressions.length === 0 &&
   keyedIdentityRegressions.length === 0 &&
-  keyedMembershipRegressions.length === 0;
+  keyedMembershipRegressions.length === 0 &&
+  keyedMapLookupRegressions.length === 0;
 
 const report = {
   result: passed ? "PASS" : "CORRECTNESS_PASS_PERFORMANCE_REGRESSION",
@@ -970,6 +1032,13 @@ const report = {
     regressions: keyedMembershipRegressions,
     results: keyedMembershipResults,
     status: keyedMembershipRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedMapLookupTargetGate: {
+    maximumNormalizedGrowth: keyedMapLookupMaximumNormalizedGrowth,
+    minimumSpeedup: keyedMapLookupMinimumSpeedup,
+    regressions: keyedMapLookupRegressions,
+    results: keyedMapLookupResults,
+    status: keyedMapLookupRegressions.length === 0 ? "PASS" : "FAIL",
   },
   scalabilityGate: {
     metrics: scalability,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -44,6 +44,7 @@ export function StandardTableBenchmark() {
   const [seed, setSeed] = useState(0);
   const [selected, setSelected] = useState(0);
   const [markedIds, setMarkedIds] = useState(() => new Set<number>());
+  const [queueById, setQueueById] = useState(() => new Map<number, string>());
   const [operation, setOperation] = useState("initial 100 rows");
   const [revision, setRevision] = useState(0);
 
@@ -54,6 +55,7 @@ export function StandardTableBenchmark() {
       data-revision={revision}
       data-selected={selected}
       data-marked-count={markedIds.size}
+      data-queue-count={queueById.size}
       id="table-benchmark"
     >
       <header className="benchmark-heading">
@@ -94,6 +96,7 @@ export function StandardTableBenchmark() {
             setRows(buildRows(1_000, nextSeed));
             setSelected(0);
             setMarkedIds(new Set());
+            setQueueById(new Map());
             setOperation("create 1,000");
             setRevision((value) => value + 1);
           }}
@@ -110,6 +113,7 @@ export function StandardTableBenchmark() {
             setRows(buildRows(10_000, nextSeed));
             setSelected(0);
             setMarkedIds(new Set());
+            setQueueById(new Map());
             setOperation("create 10,000");
             setRevision((value) => value + 1);
           }}
@@ -139,6 +143,7 @@ export function StandardTableBenchmark() {
             setRows(buildRows(1_000, nextSeed));
             setSelected(0);
             setMarkedIds(new Set());
+            setQueueById(new Map());
             setOperation("replace 1,000");
             setRevision((value) => value + 1);
           }}
@@ -181,6 +186,31 @@ export function StandardTableBenchmark() {
           Mark two rows
         </button>
         <button
+          data-action="table-queue"
+          type="button"
+          onClick={() => {
+            setQueueById((current) => {
+              const middle = Math.floor(rows.length / 2);
+              const first = rows[middle]?.id;
+              const second = rows[middle + 1]?.id;
+              if (first === undefined || second === undefined) return current;
+              return current.has(first)
+                ? new Map([
+                    [rows[middle + 2]?.id ?? first, "expedite"],
+                    [rows[middle + 3]?.id ?? second, "hold"],
+                  ])
+                : new Map([
+                    [first, "expedite"],
+                    [second, "hold"],
+                  ]);
+            });
+            setOperation("queue two rows");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Queue two rows
+        </button>
+        <button
           data-action="table-swap"
           id="swaprows"
           type="button"
@@ -211,6 +241,7 @@ export function StandardTableBenchmark() {
             setRows([]);
             setSelected(0);
             setMarkedIds(new Set());
+            setQueueById(new Map());
             setOperation("clear");
             setRevision((value) => value + 1);
           }}
@@ -238,6 +269,7 @@ export function StandardTableBenchmark() {
               <tr
                 className={selected === row.id ? "table-row--selected" : ""}
                 data-marked={markedIds.has(row.id)}
+                data-queue={queueById.get(row.id) ?? "none"}
                 data-row-id={row.id}
                 data-selected={selected === row.id}
                 key={row.id}

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -179,6 +179,14 @@ members, customized `has` behavior, React-owned rows, nested blocks, and structu
 stay on the existing complete or React-owned paths. The compiler report exposes this count as
 `keyedMembershipTargets`.
 
+For per-row data, an exact local-state expression such as `statusById.get(item.id)` receives a
+separate Map-lookup proof. The runtime compares the previous and next native `Map` snapshots and
+patches only row keys whose mapped primitive value changed. It accepts ordinary native maps with
+primitive keys and primitive or nullish values. Different fields, extra dependencies, Map
+subclasses or proxies, object values, customized `get` behavior, React-owned rows, nested blocks,
+and structural dependencies keep the existing complete or React-owned paths. The compiler report
+exposes this count as `keyedMapLookupTargets`.
+
 For a direct keyed `useState` collection, the compiler also recognizes conservative same-order
 updates such as:
 
@@ -476,6 +484,7 @@ The default path is `.farm/react-compiler.json`. The report covers the productio
 contains project-relative module paths, compiled component names, fallback details, and fallback
 reasons aggregated by count. Its summary and per-module `optimizations` also report
 `keyedIdentityTargets`, the number of scalar key-directed row bindings;
+`keyedMapLookupTargets`, the number of native-Map keyed lookup bindings;
 `keyedMembershipTargets`, the number of native-Set membership bindings; and
 `keyedMapUpdateHints`, the number of compiler-proven direct keyed `map()` update sites. A custom
 project-relative `reportFile` also enables reporting.

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -21,19 +21,19 @@
     },
     "keyed": {
       "compilerOff": {
-        "raw": 193012,
-        "gzip": 60135,
-        "brotli": 51847
+        "raw": 193105,
+        "gzip": 60176,
+        "brotli": 51978
       },
       "compilerOn": {
-        "raw": 224836,
-        "gzip": 69756,
-        "brotli": 59775
+        "raw": 227076,
+        "gzip": 70211,
+        "brotli": 60029
       },
       "compilerPremium": {
-        "raw": 31824,
-        "gzip": 9621,
-        "brotli": 7928
+        "raw": 33971,
+        "gzip": 10035,
+        "brotli": 8051
       }
     },
     "isolatedRuntime": {
@@ -43,18 +43,18 @@
         "brotli": 51666
       },
       "full": {
-        "raw": 263738,
-        "gzip": 75549,
-        "brotli": 65096
+        "raw": 265630,
+        "gzip": 75907,
+        "brotli": 65428
       },
       "coreOnly": {
         "raw": 204922,
         "gzip": 63685,
         "brotli": 54902
       },
-      "fullRuntimePremiumGzip": 15630,
+      "fullRuntimePremiumGzip": 15988,
       "coreRuntimePremiumGzip": 3766,
-      "gzipReductionPercent": 75.9
+      "gzipReductionPercent": 76.4
     }
   }
 }

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.md
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.md
@@ -24,17 +24,17 @@ is enforced on every pull request instead of serving only as a manually recorded
 | Fixture                                           | Compiler off gzip | Compiler on gzip | Compiler premium |
 | ------------------------------------------------- | ----------------: | ---------------: | ---------------: |
 | Direct text, attribute, style, and event bindings |          60,043 B |         63,721 B |          3,678 B |
-| Keyed rows, LIS, scalar and Set targeting         |          60,135 B |         69,756 B |          9,621 B |
+| Keyed rows, LIS, scalar, Set, and Map targeting   |          60,176 B |         70,211 B |         10,035 B |
 
-The isolated compatibility runtime contributes 15,630 B gzip over the React control. The
-compiler-selected core contributes 3,766 B, a **75.9% reduction**. This comparison uses the same
+The isolated compatibility runtime contributes 15,988 B gzip over the React control. The
+compiler-selected core contributes 3,766 B, a **76.4% reduction**. This comparison uses the same
 hand-authored compiled definition and changes only the runtime entry used to create it.
 
-The keyed fixture retains `FarmCompiledKeyedRows` plus compiler-emitted `identityTarget` and
-`membershipTarget` metadata, but rejects the optional row-conditional and keyed-map-hint runtimes.
-Set membership adds 498 B gzip to the keyed fixture's compiler premium. The direct compiler premium
-and isolated core runtime remain byte-for-byte unchanged. The direct fixture rejects every
-structural runtime marker. The checked machine-readable result is
+The keyed fixture retains `FarmCompiledKeyedRows` plus compiler-emitted `identityTarget`,
+`membershipTarget`, and `mapLookupTarget` metadata, but rejects the optional row-conditional and
+keyed-map-hint runtimes. Map lookup targeting adds 414 B gzip to the keyed fixture's compiler
+premium. The direct compiler premium and isolated core runtime remain byte-for-byte unchanged. The
+direct fixture rejects every structural runtime marker. The checked machine-readable result is
 [`RUNTIME_SIZE_RESULTS.json`](./RUNTIME_SIZE_RESULTS.json).
 
 ## Existing production benchmark audit

--- a/packages/farm-react/fixtures/runtime-size/keyed.tsx
+++ b/packages/farm-react/fixtures/runtime-size/keyed.tsx
@@ -12,6 +12,7 @@ export function KeyedTable() {
   );
   const [selected, setSelected] = useState(-1);
   const [marked, setMarked] = useState(() => new Set<number>());
+  const [queueById, setQueueById] = useState(() => new Map<number, string>());
   return (
     <main>
       <button onClick={() => setRows((value) => [...value].reverse())}>Reverse</button>
@@ -20,10 +21,12 @@ export function KeyedTable() {
           <li
             className={selected === row.id ? "selected" : ""}
             data-marked={marked.has(row.id)}
+            data-queue={queueById.get(row.id) ?? "none"}
             key={row.id}
             onClick={() => {
               setSelected(row.id);
               setMarked(new Set([row.id]));
+              setQueueById(new Map([[row.id, "ready"]]));
             }}
           >
             {row.label}

--- a/packages/farm-react/scripts/benchmark-runtime-size.mjs
+++ b/packages/farm-react/scripts/benchmark-runtime-size.mjs
@@ -88,6 +88,9 @@ if (!keyedOn.code.includes("identityTarget")) {
 if (!keyedOn.code.includes("membershipTarget")) {
   throw new Error("Keyed selection fixture did not retain its Set-membership binding target.");
 }
+if (!keyedOn.code.includes("mapLookupTarget")) {
+  throw new Error("Keyed selection fixture did not retain its Map-lookup binding target.");
+}
 
 const fullRuntimePremium = runtimeFull.gzip - runtimeControl.gzip;
 const coreRuntimePremium = runtimeCore.gzip - runtimeControl.gzip;

--- a/packages/farm-react/src/__tests__/compiler-keyed-map-lookup-targets.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-map-lookup-targets.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true);
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/KeyedMapLookupTargets.tsx", infer);
+}
+
+describe("React AOT keyed Map lookup targets", () => {
+  it("emits target metadata for local Map lookups with the exact row key", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function StatusRows() {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        const [statusById, setStatusById] = useState(new Map([["a", "ready"]]));
+        return (
+          <section><ul>
+            {rows.map((row) => (
+              <li
+                aria-label={statusById.get(row.id) ?? "unknown"}
+                className={statusById.get(row.id) === "ready" ? "ready" : ""}
+                key={row.id}
+                onClick={() => setStatusById(new Map([[row.id, "done"]]))}
+                style={{ opacity: statusById.get(row.id) === "done" ? 1 : 0.5 }}
+              >
+                {statusById.get(row.id) ?? row.label}
+              </li>
+            ))}
+          </ul></section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["StatusRows"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapLookupTargets).toBe(4);
+    expect(result.code.match(/mapLookupTarget:/g)).toHaveLength(4);
+    expect(result.code).toContain("dependency: 1");
+    expect(result.code).toContain("read: () => _farmState[1].get()");
+  });
+
+  it("normalizes public List key parameter names", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List } from "@farm.js/react/list";
+      export function StatusRows() {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        const [statusById, setStatusById] = useState(new Map([["a", "ready"]]));
+        return (
+          <section><ul>
+            <List each={rows} by={(entry) => entry.id}>
+              {(row) => <li data-status={statusById.get(row.id)}>{row.label}</li>}
+            </List>
+          </ul></section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["StatusRows"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapLookupTargets).toBe(1);
+    expect(result.code).toContain("mapLookupTarget:");
+  });
+
+  it.each([
+    {
+      name: "a different row field",
+      binding: "statusById.get(row.slug)",
+    },
+    {
+      name: "another reactive dependency",
+      binding: "enabled ? statusById.get(row.id) : 'disabled'",
+    },
+    {
+      name: "another read from the target",
+      binding: "statusById.get(row.id) ? statusById.size : 0",
+    },
+  ])("keeps $name on React's existing path", async ({ binding }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function ConservativeRows() {
+        const [rows, setRows] = useState([{ id: "a", slug: "alpha" }]);
+        const [statusById, setStatusById] = useState(new Map([["a", "ready"]]));
+        const [enabled, setEnabled] = useState(true);
+        return (
+          <section>
+            <button onClick={() => setStatusById(new Map([["a", "done"]]))}>Update</button>
+            <ul>{rows.map((row) => <li data-status={${binding}} key={row.id}>{row.id}</li>)}</ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.optimizations.keyedMapLookupTargets).toBe(0);
+    expect(result.code).not.toContain("mapLookupTarget:");
+  });
+
+  it("does not treat Map-like props as locally owned lookup state", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function PropLookup({ statusById }) {
+        const [rows, setRows] = useState([{ id: "a" }]);
+        return <ul>{rows.map((row) => <li data-status={statusById.get(row.id)} key={row.id}>{row.id}</li>)}</ul>;
+      }
+    `);
+
+    expect(result.optimizations.keyedMapLookupTargets).toBe(0);
+    expect(result.code).not.toContain("mapLookupTarget:");
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
@@ -41,6 +41,7 @@ describe("React AOT keyed update hints", () => {
     expect(result.diagnostics).toEqual([]);
     expect(result.optimizations).toEqual({
       keyedIdentityTargets: 0,
+      keyedMapLookupTargets: 0,
       keyedMembershipTargets: 0,
       keyedMapUpdateHints: 1,
     });

--- a/packages/farm-react/src/__tests__/compiler-report.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-report.test.ts
@@ -29,6 +29,7 @@ function observations(projectRoot: string): ReactCompilerModuleObservation[] {
         diagnostics: [],
         optimizations: {
           keyedIdentityTargets: 0,
+          keyedMapLookupTargets: 0,
           keyedMembershipTargets: 0,
           keyedMapUpdateHints: 0,
         },
@@ -52,6 +53,7 @@ function observations(projectRoot: string): ReactCompilerModuleObservation[] {
         ],
         optimizations: {
           keyedIdentityTargets: 4,
+          keyedMapLookupTargets: 5,
           keyedMembershipTargets: 2,
           keyedMapUpdateHints: 3,
         },
@@ -71,6 +73,7 @@ describe("React compiler coverage report", () => {
       compiled: 2,
       fallback: 2,
       keyedIdentityTargets: 4,
+      keyedMapLookupTargets: 5,
       keyedMembershipTargets: 2,
       keyedMapUpdateHints: 3,
     });
@@ -89,6 +92,7 @@ describe("React compiler coverage report", () => {
     });
     expect(report.modules[1]?.optimizations).toEqual({
       keyedIdentityTargets: 4,
+      keyedMapLookupTargets: 5,
       keyedMembershipTargets: 2,
       keyedMapUpdateHints: 3,
     });

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-map-lookup-targets.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-map-lookup-targets.test.tsx
@@ -1,0 +1,466 @@
+import React, { StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createCompiledComponent, type CompilerStateUpdater } from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Item {
+  id: unknown;
+  label: string;
+}
+
+interface Counters {
+  bindingReads: number;
+  executions: number;
+  targetReads: number;
+}
+
+const roots: Array<{ unmount(): void }> = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function items(count: number): Item[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `row-${index}`,
+    label: `Row ${index}`,
+  }));
+}
+
+function displayLookupValue(value: unknown): unknown {
+  return value ?? "none";
+}
+
+function createMapLookupHarness(initialItems: Item[], initialLookup: Map<unknown, unknown>) {
+  const counters: Counters = { bindingReads: 0, executions: 0, targetReads: 0 };
+  let updateItems: (next: CompilerStateUpdater) => void = () => undefined;
+  let updateLookup: (next: CompilerStateUpdater) => void = () => undefined;
+  const Rows = createCompiledComponent({
+    displayName: "MapLookupTargetRows",
+    initialize: () => [initialItems, initialLookup],
+    render(_props: Record<string, never>, state, blocks) {
+      counters.executions += 1;
+      const readItems = () => state[0].get() as Item[];
+      const lookup = () => state[1].get() as Map<unknown, unknown>;
+      const mapLookupTarget = () => {
+        counters.targetReads += 1;
+        return lookup();
+      };
+      updateItems = (next) => state[0].set(next);
+      updateLookup = (next) => state[1].set(next);
+      const KeyedRows = blocks.KeyedRows;
+      return (
+        <main>
+          <KeyedRows
+            bindings={[
+              {
+                dependencies: [1],
+                mapLookupTarget: { dependency: 1, read: mapLookupTarget },
+                kind: "attribute",
+                name: "data-status",
+                path: [],
+                read: (item) => {
+                  counters.bindingReads += 1;
+                  return displayLookupValue(lookup().get((item as Item).id));
+                },
+              },
+              {
+                dependencies: [0],
+                kind: "text",
+                path: [],
+                read: (item) => [(item as Item).label],
+              },
+            ]}
+            create={(item) => ({
+              kind: "element",
+              tag: "li",
+              attributes: [
+                { name: "data-key", value: String((item as Item).id) },
+                {
+                  name: "data-status",
+                  value: displayLookupValue(lookup().get((item as Item).id)),
+                },
+              ],
+              styles: [],
+              children: [(item as Item).label],
+            })}
+            id={0}
+            items={readItems}
+            render={() => (
+              <ul>
+                {readItems().map((item) => (
+                  <li
+                    data-key={String(item.id)}
+                    data-status={displayLookupValue(lookup().get(item.id)) as string}
+                    key={String(item.id)}
+                  >
+                    {item.label}
+                  </li>
+                ))}
+              </ul>
+            )}
+            rowKey={(item) => (item as Item).id as React.Key}
+            structureDependencies={[0]}
+          />
+        </main>
+      );
+    },
+    bindings: [{ kind: "block", id: 0, dependencies: [0, 1] }],
+  });
+  return {
+    Rows,
+    counters,
+    setItems: (next: CompilerStateUpdater) => updateItems(next),
+    setLookup: (next: CompilerStateUpdater) => updateLookup(next),
+  };
+}
+
+function lookupSnapshot(container: Element): Array<[string | null, string | null]> {
+  return [...container.querySelectorAll("li")].map((row) => [
+    row.getAttribute("data-key"),
+    row.getAttribute("data-status"),
+  ]);
+}
+
+describe("compiled keyed Map lookup targets", () => {
+  it("evaluates only row keys whose mapped value changed", async () => {
+    const initial = items(2_000);
+    const harness = createMapLookupHarness(initial, new Map([["row-10", "ready"]]));
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Rows />));
+
+    harness.counters.bindingReads = 0;
+    harness.counters.targetReads = 0;
+    await act(async () => {
+      harness.setLookup(
+        new Map([
+          ["row-10", "ready"],
+          ["row-1500", "busy"],
+        ]),
+      );
+      await flushCompilerUpdates();
+    });
+    expect(harness.counters.bindingReads).toBe(1);
+    expect(harness.counters.targetReads).toBe(1);
+
+    harness.counters.bindingReads = 0;
+    await act(async () => {
+      harness.setLookup(
+        new Map([
+          ["row-12", "ready"],
+          ["row-1501", "busy"],
+        ]),
+      );
+      await flushCompilerUpdates();
+    });
+    expect(harness.counters.bindingReads).toBe(4);
+    expect(container.querySelector('[data-key="row-12"]')?.getAttribute("data-status")).toBe(
+      "ready",
+    );
+    expect(container.querySelector('[data-key="row-1501"]')?.getAttribute("data-status")).toBe(
+      "busy",
+    );
+
+    harness.counters.bindingReads = 0;
+    await act(async () => {
+      harness.setLookup(
+        new Map([
+          ["row-12", "ready"],
+          ["row-1501", "busy"],
+        ]),
+      );
+      await flushCompilerUpdates();
+    });
+    expect(harness.counters.bindingReads).toBe(0);
+    expect(harness.counters.executions).toBe(1);
+  });
+
+  it("preserves Map key equality when primitive values share a React key string", async () => {
+    const initial: Item[] = [
+      { id: null, label: "Null" },
+      { id: undefined, label: "Undefined" },
+      { id: 1, label: "Number" },
+    ];
+    const harness = createMapLookupHarness(
+      initial,
+      new Map<unknown, unknown>([
+        [null, "null-value"],
+        [1, "number-value"],
+      ]),
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Rows />));
+
+    harness.counters.bindingReads = 0;
+    await act(async () => {
+      harness.setLookup(
+        new Map<unknown, unknown>([
+          [undefined, "undefined-value"],
+          ["1", "string-value"],
+        ]),
+      );
+      await flushCompilerUpdates();
+    });
+
+    expect(harness.counters.bindingReads).toBe(3);
+    expect(lookupSnapshot(container)).toEqual([
+      ["null", "none"],
+      ["undefined", "undefined-value"],
+      ["1", "none"],
+    ]);
+  });
+
+  it("supports primitive and nullish mapped-value transitions", async () => {
+    const harness = createMapLookupHarness(items(4), new Map([["row-1", false]]));
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Rows />));
+
+    for (const value of [0, "", null, undefined, 4n, true]) {
+      harness.counters.bindingReads = 0;
+      await act(async () => {
+        harness.setLookup(new Map([["row-1", value]]));
+        await flushCompilerUpdates();
+      });
+      expect(harness.counters.bindingReads).toBe(1);
+      expect(container.querySelector('[data-key="row-1"]')?.getAttribute("data-status")).toBe(
+        String(displayLookupValue(value)),
+      );
+    }
+  });
+
+  it("uses complete reconciliation for mixed structural work and refreshes its cache", async () => {
+    const initial = items(100);
+    const harness = createMapLookupHarness(initial, new Map([["row-1", "ready"]]));
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Rows />));
+
+    harness.counters.bindingReads = 0;
+    harness.counters.targetReads = 0;
+    await act(async () => {
+      harness.setLookup(new Map([["row-80", "done"]]));
+      harness.setItems((current) =>
+        (current as Item[]).map((item) =>
+          item.id === "row-80" ? { ...item, label: "Updated row" } : item,
+        ),
+      );
+      await flushCompilerUpdates();
+    });
+    expect(harness.counters.bindingReads).toBe(initial.length);
+    expect(harness.counters.targetReads).toBe(2);
+    expect(container.querySelector('[data-key="row-80"]')?.textContent).toBe("Updated row");
+
+    harness.counters.bindingReads = 0;
+    await act(async () => {
+      harness.setLookup(new Map([["row-81", "done"]]));
+      await flushCompilerUpdates();
+    });
+    expect(harness.counters.bindingReads).toBe(2);
+  });
+
+  it("hands customized Map values back to React before compiled binding reads", async () => {
+    class CustomizedMap extends Map<unknown, unknown> {}
+    const harness = createMapLookupHarness(items(32), new CustomizedMap([["row-1", "ready"]]));
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Rows />));
+
+    expect(harness.counters.bindingReads).toBe(0);
+    await act(async () => {
+      harness.setLookup(new CustomizedMap([["row-20", "done"]]));
+      await flushCompilerUpdates();
+    });
+
+    expect(harness.counters.bindingReads).toBe(0);
+    expect(container.querySelector('[data-key="row-20"]')?.getAttribute("data-status")).toBe(
+      "done",
+    );
+    expect(harness.counters.executions).toBe(1);
+  });
+
+  it("keeps an own Map get override under React ownership", async () => {
+    const customized = new Map<unknown, unknown>([["row-1", "ignored"]]);
+    Object.defineProperty(customized, "get", {
+      configurable: true,
+      value: (value: unknown) => (value === "row-1" ? "custom" : undefined),
+    });
+    const harness = createMapLookupHarness(items(8), customized);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Rows />));
+
+    expect(harness.counters.bindingReads).toBe(0);
+    expect(container.querySelector('[data-key="row-1"]')?.getAttribute("data-status")).toBe(
+      "custom",
+    );
+    expect(container.querySelector('[data-key="row-2"]')?.getAttribute("data-status")).toBe("none");
+  });
+
+  it("falls back for identity-bearing mapped values", async () => {
+    const harness = createMapLookupHarness(items(8), new Map([["row-1", { status: "ready" }]]));
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Rows />));
+
+    expect(harness.counters.bindingReads).toBe(0);
+    expect(container.querySelector('[data-key="row-1"]')?.getAttribute("data-status")).toBe(
+      "[object Object]",
+    );
+  });
+
+  it("matches React across 2,000 randomized queued updates", async () => {
+    const initial = items(128);
+    const harness = createMapLookupHarness(initial, new Map());
+    let reactSet: React.Dispatch<React.SetStateAction<Map<unknown, unknown>>> = () => undefined;
+    function Normal() {
+      const [lookup, setLookup] = useState<Map<unknown, unknown>>(new Map());
+      reactSet = setLookup;
+      return (
+        <ul>
+          {initial.map((item) => (
+            <li
+              data-key={String(item.id)}
+              data-status={displayLookupValue(lookup.get(item.id)) as string}
+              key={String(item.id)}
+            >
+              {item.label}
+            </li>
+          ))}
+        </ul>
+      );
+    }
+
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<harness.Rows />);
+      reactRoot.render(<Normal />);
+    });
+
+    harness.counters.bindingReads = 0;
+    let random = 0x6d6170;
+    const nextRandom = () => (random = (Math.imul(random, 1_664_525) + 1_013_904_223) >>> 0);
+    let committed = new Map<unknown, unknown>();
+    for (let batch = 0; batch < 100; batch += 1) {
+      let final = committed;
+      await act(async () => {
+        for (let update = 0; update < 20; update += 1) {
+          const size = nextRandom() % 9;
+          const next = new Map<unknown, unknown>();
+          for (let index = 0; index < size; index += 1) {
+            const value = nextRandom();
+            const key = value % 13 === 0 ? `missing-${value}` : `row-${value % initial.length}`;
+            next.set(key, `status-${nextRandom() % 7}`);
+          }
+          final = next;
+          harness.setLookup(next);
+          reactSet(next);
+        }
+        await flushCompilerUpdates();
+      });
+      const keys = new Set([...committed.keys(), ...final.keys()]);
+      const presentChanged = [...keys].filter(
+        (key) =>
+          !Object.is(committed.get(key), final.get(key)) &&
+          initial.some((item) => Object.is(item.id, key)),
+      ).length;
+      expect(harness.counters.bindingReads, `targeted reads in batch ${batch}`).toBe(
+        presentChanged,
+      );
+      expect(lookupSnapshot(compiledContainer), `DOM after batch ${batch}`).toEqual(
+        lookupSnapshot(reactContainer),
+      );
+      committed = final;
+      harness.counters.bindingReads = 0;
+    }
+  });
+
+  it("is StrictMode-safe and drops a queued Map update after unmount", async () => {
+    const harness = createMapLookupHarness(items(16), new Map());
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <StrictMode>
+          <harness.Rows />
+        </StrictMode>,
+      ),
+    );
+
+    harness.counters.bindingReads = 0;
+    await act(async () => {
+      harness.setLookup(new Map([["row-8", "done"]]));
+      root.unmount();
+      roots.splice(roots.indexOf(root), 1);
+      await flushCompilerUpdates();
+    });
+    expect(harness.counters.bindingReads).toBe(0);
+    expect(container.childElementCount).toBe(0);
+  });
+
+  it("adopts server rows and keeps Map lookup targeting after hydration", async () => {
+    const harness = createMapLookupHarness(items(32), new Map([["row-1", "ready"]]));
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(<harness.Rows />);
+    document.body.append(container);
+    let root!: ReturnType<typeof hydrateRoot>;
+    await act(async () => {
+      root = hydrateRoot(container, <harness.Rows />);
+      await flushCompilerUpdates();
+    });
+    roots.push(root);
+
+    harness.counters.bindingReads = 0;
+    await act(async () => {
+      harness.setLookup(new Map([["row-20", "done"]]));
+      await flushCompilerUpdates();
+    });
+
+    expect(harness.counters.bindingReads).toBe(2);
+    expect(container.querySelector('[data-key="row-1"]')?.getAttribute("data-status")).toBe("none");
+    expect(container.querySelector('[data-key="row-20"]')?.getAttribute("data-status")).toBe(
+      "done",
+    );
+  });
+});

--- a/packages/farm-react/src/__tests__/vite.test.ts
+++ b/packages/farm-react/src/__tests__/vite.test.ts
@@ -86,6 +86,7 @@ describe("React renderer Vite integration", () => {
       compiled: 2,
       fallback: 0,
       keyedIdentityTargets: 0,
+      keyedMapLookupTargets: 0,
       keyedMembershipTargets: 0,
       keyedMapUpdateHints: 1,
     });

--- a/packages/farm-react/src/compiler-report.ts
+++ b/packages/farm-react/src/compiler-report.ts
@@ -19,6 +19,7 @@ export interface ReactCompilerReport {
     compiled: number;
     fallback: number;
     keyedIdentityTargets: number;
+    keyedMapLookupTargets: number;
     keyedMembershipTargets: number;
     keyedMapUpdateHints: number;
   };
@@ -31,6 +32,7 @@ export interface ReactCompilerReport {
     compiled: readonly string[];
     optimizations: {
       keyedIdentityTargets: number;
+      keyedMapLookupTargets: number;
       keyedMembershipTargets: number;
       keyedMapUpdateHints: number;
     };
@@ -51,6 +53,7 @@ export function createReactCompilerReport(
   let compiled = 0;
   let fallback = 0;
   let keyedIdentityTargets = 0;
+  let keyedMapLookupTargets = 0;
   let keyedMembershipTargets = 0;
   let keyedMapUpdateHints = 0;
 
@@ -60,6 +63,7 @@ export function createReactCompilerReport(
       compiled += result.compiled.length;
       fallback += result.diagnostics.length;
       keyedIdentityTargets += result.optimizations.keyedIdentityTargets || 0;
+      keyedMapLookupTargets += result.optimizations.keyedMapLookupTargets || 0;
       keyedMembershipTargets += result.optimizations.keyedMembershipTargets || 0;
       keyedMapUpdateHints += result.optimizations.keyedMapUpdateHints;
       const moduleId = projectRelativeId(projectRoot, id);
@@ -88,6 +92,7 @@ export function createReactCompilerReport(
       compiled,
       fallback,
       keyedIdentityTargets,
+      keyedMapLookupTargets,
       keyedMembershipTargets,
       keyedMapUpdateHints,
     },

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -294,6 +294,11 @@ export interface CompilerKeyedRowBinding {
     dependency: number;
     read(): unknown;
   };
+  /** A compiler-proven native Map whose values are read with this row's key. */
+  mapLookupTarget?: {
+    dependency: number;
+    read(): unknown;
+  };
   read(item: unknown, index: number): unknown;
 }
 
@@ -944,6 +949,11 @@ interface CompilerKeyedMembershipTargetSnapshot {
   values?: ReadonlySet<unknown>;
 }
 
+interface CompilerKeyedMapLookupTargetSnapshot {
+  eligible: boolean;
+  values?: ReadonlyMap<unknown, unknown>;
+}
+
 const UNSET_KEYED_ROW_BINDING = Symbol("unset interactive keyed-row binding");
 
 function keyedRowIdentity(key: React.Key): string {
@@ -1003,6 +1013,69 @@ function keyedMembershipChangedKeys(
   }
   for (const value of next) {
     if (!NATIVE_SET_HAS.call(previous, value)) NATIVE_SET_ADD.call(keys, String(value));
+  }
+  return keys;
+}
+
+const NATIVE_MAP_PROTOTYPE = Map.prototype;
+const NATIVE_MAP_GET = Map.prototype.get;
+const NATIVE_MAP_SET = Map.prototype.set;
+const NATIVE_MAP_ENTRIES = Map.prototype.entries;
+
+function isSafeKeyedMapLookupValue(value: unknown): boolean {
+  return (
+    value === null ||
+    value === undefined ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "bigint" ||
+    typeof value === "boolean"
+  );
+}
+
+function keyedMapLookupTargetSnapshot(value: unknown): CompilerKeyedMapLookupTargetSnapshot {
+  if (typeof value !== "object" || value === null) return { eligible: false };
+  let iterator: MapIterator<[unknown, unknown]>;
+  try {
+    iterator = NATIVE_MAP_ENTRIES.call(value as Map<unknown, unknown>);
+  } catch {
+    return { eligible: false };
+  }
+  if (
+    Object.getPrototypeOf(value) !== NATIVE_MAP_PROTOTYPE ||
+    Object.prototype.hasOwnProperty.call(value, "get") ||
+    (value as Map<unknown, unknown>).get !== NATIVE_MAP_GET
+  ) {
+    return { eligible: false };
+  }
+  const values = new Map<unknown, unknown>();
+  try {
+    for (const [key, entry] of iterator) {
+      if (!keyedIdentityTargetSnapshot(key).eligible || !isSafeKeyedMapLookupValue(entry)) {
+        return { eligible: false };
+      }
+      NATIVE_MAP_SET.call(values, key, entry);
+    }
+  } catch {
+    return { eligible: false };
+  }
+  return { eligible: true, values };
+}
+
+function keyedMapLookupChangedKeys(
+  previous: ReadonlyMap<unknown, unknown>,
+  next: ReadonlyMap<unknown, unknown>,
+): Set<string> {
+  const keys = new Set<string>();
+  for (const [key, value] of previous) {
+    if (!Object.is(value, NATIVE_MAP_GET.call(next, key))) {
+      NATIVE_SET_ADD.call(keys, String(key));
+    }
+  }
+  for (const [key, value] of next) {
+    if (!Object.is(value, NATIVE_MAP_GET.call(previous, key))) {
+      NATIVE_SET_ADD.call(keys, String(key));
+    }
   }
   return keys;
 }
@@ -3051,6 +3124,7 @@ function createKeyedRowsBlockComponent(
     private instances = new Map<string, CompilerKeyedRowInstance>();
     private identityTargets = new Map<number, CompilerKeyedIdentityTargetSnapshot>();
     private membershipTargets = new Map<number, CompilerKeyedMembershipTargetSnapshot>();
+    private mapLookupTargets = new Map<number, CompilerKeyedMapLookupTargetSnapshot>();
     private collectionToken: object | undefined;
     private renderVersion = 0;
     private readonly eventHandlers = new Map<
@@ -3300,10 +3374,20 @@ function createKeyedRowsBlockComponent(
       return true;
     }
 
+    private hasSafeMapLookupTargets(dirtyState?: ReadonlySet<number>): boolean {
+      for (const binding of this.currentProps.bindings) {
+        const target = binding.mapLookupTarget;
+        if (!target || (dirtyState && !dirtyState.has(target.dependency))) continue;
+        if (!keyedMapLookupTargetSnapshot(target.read()).eligible) return false;
+      }
+      return true;
+    }
+
     private commitKeyedTargets(dirtyState?: ReadonlySet<number>): void {
       if (!dirtyState) {
         this.identityTargets.clear();
         this.membershipTargets.clear();
+        this.mapLookupTargets.clear();
       }
       for (
         let bindingIndex = 0;
@@ -3330,12 +3414,22 @@ function createKeyedRowsBlockComponent(
             keyedMembershipTargetSnapshot(membershipTarget.read()),
           );
         }
+
+        const mapLookupTarget = binding.mapLookupTarget;
+        if (!mapLookupTarget) {
+          this.mapLookupTargets.delete(bindingIndex);
+        } else if (!dirtyState || dirtyState.has(mapLookupTarget.dependency)) {
+          this.mapLookupTargets.set(
+            bindingIndex,
+            keyedMapLookupTargetSnapshot(mapLookupTarget.read()),
+          );
+        }
       }
     }
 
     private adopt(): boolean {
       if (!this.root) return false;
-      if (!this.hasSafeMembershipTargets()) return false;
+      if (!this.hasSafeMembershipTargets() || !this.hasSafeMapLookupTargets()) return false;
       const rows = this.readRows(this.currentProps);
       const elements = [...this.root.children];
       if (!rows || rows.items.length !== elements.length) return false;
@@ -3487,6 +3581,7 @@ function createKeyedRowsBlockComponent(
 
       const nextIdentityTargets = new Map<number, CompilerKeyedIdentityTargetSnapshot>();
       const nextMembershipTargets = new Map<number, CompilerKeyedMembershipTargetSnapshot>();
+      const nextMapLookupTargets = new Map<number, CompilerKeyedMapLookupTargetSnapshot>();
       for (const bindingIndex of affectedBindingIndices) {
         const binding = this.currentProps.bindings[bindingIndex];
         if (binding.identityTarget) {
@@ -3502,6 +3597,14 @@ function createKeyedRowsBlockComponent(
             return true;
           }
           nextMembershipTargets.set(bindingIndex, snapshot);
+        }
+        if (binding.mapLookupTarget) {
+          const snapshot = keyedMapLookupTargetSnapshot(binding.mapLookupTarget.read());
+          if (!snapshot.eligible) {
+            this.activateFallback(afterCommit);
+            return true;
+          }
+          nextMapLookupTargets.set(bindingIndex, snapshot);
         }
       }
 
@@ -3531,8 +3634,38 @@ function createKeyedRowsBlockComponent(
           nextMembershipTarget?.eligible &&
           nextMembershipTarget.values,
         );
+        const mapLookupTarget = binding.mapLookupTarget;
+        const previousMapLookupTarget = this.mapLookupTargets.get(bindingIndex);
+        const nextMapLookupTarget = nextMapLookupTargets.get(bindingIndex);
+        const canTargetMapLookup = Boolean(
+          mapLookupTarget &&
+          binding.dependencies?.length === 1 &&
+          binding.dependencies[0] === mapLookupTarget.dependency &&
+          dirtyState.has(mapLookupTarget.dependency) &&
+          previousMapLookupTarget?.eligible &&
+          previousMapLookupTarget.values &&
+          nextMapLookupTarget?.eligible &&
+          nextMapLookupTarget.values,
+        );
 
-        if (
+        if (canTargetMapLookup && previousMapLookupTarget?.values && nextMapLookupTarget?.values) {
+          const keys = keyedMapLookupChangedKeys(
+            previousMapLookupTarget.values,
+            nextMapLookupTarget.values,
+          );
+          for (const key of keys) {
+            const instance = this.instances.get(key);
+            if (instance) {
+              applyKeyedRowBinding(
+                this.currentProps,
+                instance,
+                instance.item,
+                instance.index,
+                bindingIndex,
+              );
+            }
+          }
+        } else if (
           canTargetMembership &&
           previousMembershipTarget?.values &&
           nextMembershipTarget?.values
@@ -3587,6 +3720,11 @@ function createKeyedRowsBlockComponent(
           this.membershipTargets.set(bindingIndex, nextMembershipTarget);
         } else {
           this.membershipTargets.delete(bindingIndex);
+        }
+        if (nextMapLookupTarget) {
+          this.mapLookupTargets.set(bindingIndex, nextMapLookupTarget);
+        } else {
+          this.mapLookupTargets.delete(bindingIndex);
         }
       }
       afterCommit?.();
@@ -3728,6 +3866,11 @@ function createKeyedRowsBlockComponent(
       }
 
       if (!this.hasSafeMembershipTargets(dirtyState)) {
+        this.activateFallback(afterCommit);
+        return;
+      }
+
+      if (!this.hasSafeMapLookupTargets(dirtyState)) {
         this.activateFallback(afterCommit);
         return;
       }
@@ -3966,6 +4109,7 @@ function createKeyedRowsBlockComponent(
       this.instances.clear();
       this.identityTargets.clear();
       this.membershipTargets.clear();
+      this.mapLookupTargets.clear();
       this.instancesByElement = new WeakMap();
       this.eventHandlers.clear();
       this.conditionalListeners.clear();

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -14,6 +14,7 @@ export interface CompileReactModuleResult {
   diagnostics: readonly CompilerDiagnostic[];
   optimizations: {
     keyedIdentityTargets: number;
+    keyedMapLookupTargets: number;
     keyedMembershipTargets: number;
     keyedMapUpdateHints: number;
   };
@@ -95,6 +96,10 @@ interface PendingKeyedRowBinding {
     value: t.Expression;
   };
   membershipTarget?: {
+    dependency: number;
+    value: t.Expression;
+  };
+  mapLookupTarget?: {
     dependency: number;
     value: t.Expression;
   };
@@ -599,6 +604,39 @@ function containsPotentialKeyedMembershipCall(
   return found;
 }
 
+function isPotentialKeyedMapLookupCall(
+  expression: t.CallExpression,
+  reactiveByValue: ReadonlyMap<string, StateBinding>,
+): boolean {
+  if (
+    expression.arguments.length !== 1 ||
+    !t.isExpression(expression.arguments[0]) ||
+    !t.isMemberExpression(expression.callee) ||
+    expression.callee.computed ||
+    !t.isIdentifier(expression.callee.object) ||
+    !t.isIdentifier(expression.callee.property, { name: "get" })
+  ) {
+    return false;
+  }
+  const reactive = reactiveByValue.get(expression.callee.object.name);
+  return Boolean(reactive?.setterName);
+}
+
+function containsPotentialKeyedMapLookupCall(
+  expression: t.Expression,
+  reactiveByValue: ReadonlyMap<string, StateBinding>,
+): boolean {
+  let found = false;
+  traverse(expressionFile(cloneExpression(expression)), {
+    CallExpression(path) {
+      if (!isPotentialKeyedMapLookupCall(path.node, reactiveByValue)) return;
+      found = true;
+      path.stop();
+    },
+  });
+  return found;
+}
+
 function keyedMembershipTarget(
   binding: PendingKeyedRowBinding,
   keyCallback: t.ArrowFunctionExpression | t.FunctionExpression,
@@ -639,6 +677,66 @@ function keyedMembershipTarget(
         member.node.object !== path.node ||
         member.node.computed ||
         !t.isIdentifier(member.node.property, { name: "has" }) ||
+        !call ||
+        !call.isCallExpression() ||
+        call.node.callee !== member.node ||
+        call.node.arguments.length !== 1 ||
+        !t.isExpression(call.node.arguments[0]) ||
+        !t.isNodesEquivalent(call.node.arguments[0], rowKeyExpression)
+      ) {
+        valid = false;
+        path.stop();
+        return;
+      }
+      target = reactive;
+      calls += 1;
+    },
+  });
+  return valid && target && calls > 0
+    ? { dependency: target.index, value: t.identifier(target.valueName) }
+    : undefined;
+}
+
+function keyedMapLookupTarget(
+  binding: PendingKeyedRowBinding,
+  keyCallback: t.ArrowFunctionExpression | t.FunctionExpression,
+  renderCallback: t.ArrowFunctionExpression | t.FunctionExpression,
+  reactiveByValue: ReadonlyMap<string, StateBinding>,
+  structureDependencies: ReadonlySet<number>,
+): PendingKeyedRowBinding["mapLookupTarget"] {
+  const dependencies = binding.dependencies || [];
+  if (dependencies.length !== 1 || structureDependencies.has(dependencies[0])) return undefined;
+  const keyExpression = returnedExpression(keyCallback);
+  const keyItem = keyCallback.params[0];
+  const rowItem = renderCallback.params[0];
+  if (!keyExpression || !t.isIdentifier(keyItem) || !t.isIdentifier(rowItem)) return undefined;
+
+  const replacements = new Map<string, t.Identifier>([[keyItem.name, rowItem]]);
+  const keyIndex = keyCallback.params[1];
+  const rowIndex = renderCallback.params[1];
+  if (t.isIdentifier(keyIndex) && t.isIdentifier(rowIndex)) {
+    replacements.set(keyIndex.name, rowIndex);
+  }
+  const rowKeyExpression = rewriteFreeIdentifierNames(keyExpression, replacements);
+  const file = expressionFile(cloneExpression(binding.value));
+  let target: StateBinding | undefined;
+  let valid = true;
+  let calls = 0;
+  traverse(file, {
+    ReferencedIdentifier(path) {
+      if (!valid || path.scope.hasBinding(path.node.name)) return;
+      const reactive = reactiveByValue.get(path.node.name);
+      if (!reactive) return;
+      const member = path.parentPath;
+      const call = member.parentPath;
+      if (
+        !reactive.setterName ||
+        reactive.index !== dependencies[0] ||
+        (target && target !== reactive) ||
+        !member.isMemberExpression() ||
+        member.node.object !== path.node ||
+        member.node.computed ||
+        !t.isIdentifier(member.node.property, { name: "get" }) ||
         !call ||
         !call.isCallExpression() ||
         call.node.callee !== member.node ||
@@ -1651,7 +1749,7 @@ function analyzeKeyedRowTree(
   renderCallback: t.ArrowFunctionExpression | t.FunctionExpression,
   safeGlobals: ReadonlySet<string>,
   compilerSetters: ReadonlySet<string>,
-  membershipReactiveByValue?: ReadonlyMap<string, StateBinding>,
+  keyedTargetReactiveByValue?: ReadonlyMap<string, StateBinding>,
 ): {
   bindings?: PendingKeyedRowBinding[];
   events?: PendingKeyedRowEvent[];
@@ -1676,8 +1774,10 @@ function analyzeKeyedRowTree(
     validateDerivedExpression(
       expression,
       safeGlobals,
-      membershipReactiveByValue
-        ? (call) => isPotentialKeyedMembershipCall(call, membershipReactiveByValue)
+      keyedTargetReactiveByValue
+        ? (call) =>
+            isPotentialKeyedMembershipCall(call, keyedTargetReactiveByValue) ||
+            isPotentialKeyedMapLookupCall(call, keyedTargetReactiveByValue)
         : undefined,
     );
   const visit = (element: t.JSXElement, path: number[]): string | undefined => {
@@ -2043,6 +2143,8 @@ function analyzeKeyedRowsContainer(
   if (!shape || shape.rowReason) return shape;
   const needsMembershipProof = (binding: PendingKeyedRowBinding) =>
     containsPotentialKeyedMembershipCall(binding.value, statesByValue);
+  const needsMapLookupProof = (binding: PendingKeyedRowBinding) =>
+    containsPotentialKeyedMapLookupCall(binding.value, statesByValue);
   if (
     shape.conditionals.length > 0 ||
     (shape.events.length > 0 &&
@@ -2052,11 +2154,13 @@ function analyzeKeyedRowsContainer(
         source: container,
       }))
   ) {
-    return shape.bindings.some(needsMembershipProof)
+    return shape.bindings.some(
+      (binding) => needsMembershipProof(binding) || needsMapLookupProof(binding),
+    )
       ? {
           ...shape,
           rowReason:
-            "keyed membership targets require compiler-owned rows without React-owned branches or events",
+            "keyed collection targets require compiler-owned rows without React-owned branches or events",
         }
       : shape;
   }
@@ -2077,6 +2181,13 @@ function analyzeKeyedRowsContainer(
       statesByValue,
       structureDependencies,
     ),
+    mapLookupTarget: keyedMapLookupTarget(
+      binding,
+      shape.keyCallback,
+      shape.renderCallback,
+      statesByValue,
+      structureDependencies,
+    ),
   }));
   if (
     bindings.some(
@@ -2086,6 +2197,16 @@ function analyzeKeyedRowsContainer(
     return {
       ...shape,
       rowReason: "keyed membership targets must call one local Set state with the exact row key",
+    };
+  }
+  if (
+    bindings.some(
+      (binding, index) => needsMapLookupProof(shape.bindings[index]) && !binding.mapLookupTarget,
+    )
+  ) {
+    return {
+      ...shape,
+      rowReason: "keyed Map lookup targets must call one local Map state with the exact row key",
     };
   }
   return {
@@ -3356,6 +3477,23 @@ function keyedRowBindingObject(
           t.objectProperty(
             t.identifier("read"),
             t.arrowFunctionExpression([], cloneExpression(binding.membershipTarget.value)),
+          ),
+        ]),
+      ),
+    );
+  }
+  if (binding.mapLookupTarget) {
+    properties.push(
+      t.objectProperty(
+        t.identifier("mapLookupTarget"),
+        t.objectExpression([
+          t.objectProperty(
+            t.identifier("dependency"),
+            t.numericLiteral(binding.mapLookupTarget.dependency),
+          ),
+          t.objectProperty(
+            t.identifier("read"),
+            t.arrowFunctionExpression([], cloneExpression(binding.mapLookupTarget.value)),
           ),
         ]),
       ),
@@ -5154,6 +5292,7 @@ function compileCandidate(
   usedRuntimeFeatures: Set<CompilerRuntimeFeatureName>,
   optimizationCounts: {
     keyedIdentityTargets: number;
+    keyedMapLookupTargets: number;
     keyedMembershipTargets: number;
     keyedMapUpdateHints: number;
   },
@@ -5454,6 +5593,14 @@ function compileCandidate(
         : 0),
     0,
   );
+  optimizationCounts.keyedMapLookupTargets += blockPlans.reduce(
+    (count, plan) =>
+      count +
+      (plan.kind === "keyed-rows"
+        ? plan.bindings.filter((binding) => binding.mapLookupTarget !== undefined).length
+        : 0),
+    0,
+  );
   const runtimeFeatures = runtimeFeaturesForPlans(blockPlans, appliedKeyedMapUpdateHints > 0);
   markShortCircuitBindings(analysis.bindings || []);
   assignStableBindingTargets(analysis.bindings || []);
@@ -5640,6 +5787,7 @@ export async function compileReactModule(
   const diagnostics: CompilerDiagnostic[] = [];
   const optimizationCounts = {
     keyedIdentityTargets: 0,
+    keyedMapLookupTargets: 0,
     keyedMembershipTargets: 0,
     keyedMapUpdateHints: 0,
   };


### PR DESCRIPTION
## Summary\n\n- prove direct local Map.get(rowKey) bindings inside compiler-owned keyed host rows\n- snapshot native Map state and patch only row keys whose mapped primitive value changed\n- report keyedMapLookupTargets in compiler observability\n- document and benchmark the optimization without adding public syntax or configuration\n\n## Safety boundaries\n\n- requires one non-structural local useState dependency and the exact keyed-row expression\n- supports only exact native Maps, safe primitive keys, and primitive or nullish values\n- Map subclasses, proxies, own get overrides, object values, extra dependencies, and unsupported structures fall back to React before compiled binding reads\n- structural collection changes continue through the existing full reconciliation path\n\n## Verification\n\n- React compiler/runtime suite: 49 files, 402 tests\n- TypeScript type-check\n- React 18.3.1 and React 19.2.8 compatibility\n- persisted runtime-size gate\n- docs navigation and production build\n- dashboard production build and four-build browser benchmark\n- 2,000 randomized differential updates, StrictMode, pre-flush unmount, hydration, mixed structural updates, key collisions, and fallback cases\n\n## Performance\n\nAll existing benchmark gates remain green. At 20,000 rows, the Map lookup operation measured 99.65 ms in normal React and 0.20 ms in the compiled path (498.25x in this run), with zero compiled owner executions. The deterministic tests are the primary complexity proof because browser sub-millisecond timers are quantized.\n\nThe keyed fixture adds 414 B gzip over the previous targeted-membership runtime. Direct-component and core-only runtime measurements are unchanged.\n\nMap snapshots still visit entries; this optimization removes the full row-binding and DOM-target scan for exact mapped-value changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up keyed rows that read a local `Map.get(rowKey)` by comparing native Map snapshots and patching only row keys whose mapped primitive value changed, instead of evaluating the lookup for every row or running full reconciliation. The compiler records these targets as `keyedMapLookupTargets`, and unsupported Maps (subclasses, proxies, own `get` overrides, object values, extra reactive dependencies, structural key dependencies) fall back to React before any compiled binding read.

<sup>Written for commit 6ab1c23e90608c95759ee6958334ece495deade7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

