### PR TITLE
perf(react): carry keyed collection deltas

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -302,6 +302,7 @@ After a successful build, Farm writes `.farm/react-compiler.json`:
     "componentsConsidered": 4,
     "compiled": 2,
     "fallback": 2,
+    "keyedCollectionUpdateHints": 3,
     "keyedIdentityTargets": 2,
     "keyedMapLookupTargets": 1,
     "keyedMembershipTargets": 1,
@@ -318,6 +319,7 @@ After a successful build, Farm writes `.farm/react-compiler.json`:
       "id": "src/Products.tsx",
       "compiled": ["ProductRow"],
       "optimizations": {
+        "keyedCollectionUpdateHints": 3,
         "keyedIdentityTargets": 2,
         "keyedMapLookupTargets": 1,
         "keyedMembershipTargets": 1,
@@ -343,6 +345,8 @@ row bindings that can update by looking up the previous and next key directly.
 local native `Map`.
 `keyedMembershipTargets` counts row bindings that can update from the changed members of a local
 native `Set`.
+`keyedCollectionUpdateHints` counts proven native Set/Map mutation sites that can carry their
+executed keys to the runtime.
 `keyedMapUpdateHints` counts setter sites where the compiler proved that a direct keyed collection
 can report its changed row indexes while an immutable `map()` runs. The same counts appear per
 module. `selected` is `true` when an annotation explicitly requested compilation. Module paths are
@@ -793,6 +797,45 @@ dependencies, React-owned rows, nested blocks, and structural key dependencies d
 path. A failed runtime guard returns that keyed boundary to React before compiled bindings run.
 No option or component primitive is required. The report exposes the emitted binding count as
 `keyedMapLookupTargets`.
+
+#### Producer-side Set and Map deltas
+
+The Set-membership and Map-lookup paths above normally compare complete previous and next
+snapshots to discover which keys changed. Farm can remove that second collection scan when it can
+prove a compiler-owned immutable functional update:
+
+```tsx
+setMarkedIds((current) => {
+  const next = new Set(current);
+  if (next.has(id)) next.delete(id);
+  else next.add(id);
+  return next;
+});
+
+setStatusById((current) => new Map(current).set(id, "ready"));
+```
+
+The JavaScript written by the application still creates and mutates its fresh collection, so
+`new Set(current)` and `new Map(current)` retain their normal cost and semantics. At build time,
+the compiler wraps only proven native `Set.add`, `Set.delete`, `Map.set`, and `Map.delete` calls.
+The generated metadata contains the keys whose mutations actually executed. At commit, the
+runtime validates those keys against the previous collection and updates only matching keyed-row
+bindings instead of walking every old and new entry to rediscover the delta.
+
+Concise `new Set(current).add(key)` and `new Map(current).set(key, value)` updaters are supported.
+A block updater may clone `current` once into a `const`, read `has`, `get`, or `size`, perform native
+mutations, and return `current`, that clone, or a fresh same-kind collection. Queued functional
+updates compose. Runtime snapshots use persistent change overlays and compact after a bounded
+chain, so repeated updates do not build an unlimited lookup history.
+
+The proof requires a native collection created by the same local `useState` declaration. Every
+setter use for that state must be either a fresh same-kind replacement or a proven updater. Direct
+state mutation, unknown setter results, state or draft escape, draft aliases, shadowed
+constructors, collection subclasses/proxies, object keys, and object Map values disable the delta
+path. A failed proof keeps the existing full snapshot comparison; a failed runtime safety check
+returns the boundary to React before compiled binding reads. This is an internal optimization and
+adds no component, directive, or configuration. Reports expose the number of wrapped native
+mutation sites as `keyedCollectionUpdateHints`.
 
 #### Mutation-aware same-order updates
 
@@ -1535,6 +1578,11 @@ The package and example test suites verify more than generated code:
 - mutation-aware keyed `map()` updates patch only compiler-reported same-key row indexes, compose
   queued hints across multiple keyed boundaries, ignore unrelated state in the same flush, and
   reject key changes or mixed unhinted collection updates into the complete reconciliation path;
+- compiler-proven immutable Set/Map updaters carry exact native mutation keys across queued
+  updates, compact long persistent snapshot chains, and fall back before binding reads for unsafe
+  keys, values, collections, or ownership;
+- 2,000 deterministic hinted Set mutations and 2,000 deterministic hinted Map mutations match
+  normal React while evaluating only changed present-row keys;
 - a 2,048-row instrumentation test changes one item with one key read and one binding read, while
   2,000 deterministic queued updates match normal React with one compiled owner execution;
 - keyed DOM ranges preserve static siblings around multiple lists, support adjacent empty ranges
@@ -1605,10 +1653,12 @@ The package and example test suites verify more than generated code:
   updates outer and nested row conditions, preserves surviving row and branch identity, removes and
   inserts a row, and observes zero owner update executions;
 - the production 10,000/20,000-row benchmark requires nonzero `keyedIdentityTargets`,
-  `keyedMapLookupTargets`, `keyedMembershipTargets`, and `keyedMapUpdateHints` report counts,
+  `keyedMapLookupTargets`, `keyedMembershipTargets`, `keyedCollectionUpdateHints`, and
+  `keyedMapUpdateHints` report counts,
   preserves the keyed-update speedup floor, checks that scalar selection, Set membership, and Map
-  lookups remain key-directed at scale, and passes DOM correctness, React-relative regression, and
-  normalized scalability gates;
+  lookups remain key-directed at scale, compares dense hinted Set/Map updates with equivalent
+  compiled snapshot controls, and passes DOM correctness, React-relative regression, direct-delta,
+  and normalized scalability gates;
 - the public `List` renders iterable and nullish collections correctly with the compiler off;
 - the packaged runtime, including a keyed-range component root, editable and interactive keyed-row
   events, row-local conditions, reorders, identity, selection, and hydration, is exercised

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,10 +2,11 @@
 
 Date: 2026-08-28
 
-Result: **PASS.** Correctness, the React-relative performance gate, the keyed-update, scalar
-selection, Set-membership, Map-lookup persistence, and normalized scalability gates all pass. The
+Result: **PASS.** Correctness, the React-relative performance gate, keyed-update, scalar selection,
+Set-membership, Map-lookup, collection-delta, and normalized scalability gates all pass. The
 production run compares two bracketing React baselines with static and hybrid compiler builds from
-the exact same component source.
+the exact same component source. Dense Set/Map operations also compare the new delta handoff with
+an unhinted snapshot control inside each compiler build.
 
 ## Environment and method
 
@@ -25,13 +26,15 @@ the exact same component source.
   2x normalized growth
 - Key-directed Map-lookup gate: at least 10x faster than React at 20,000 rows and no more than 2x
   normalized growth
+- Keyed collection-delta gate: at least 2x faster than React, at least 1.5x faster than the
+  equivalent compiled snapshot path, and no more than 2x normalized growth at 20,000 entries
 - No CPU throttling
 
 Every trial passed DOM assertions and browser-error checks. The compiler report proved that both
 workloads compiled, delegated keyed rows were present only in compiler builds, exactly two scalar
-key-directed bindings, one Set-membership binding, one Map-lookup binding, and one mutation-aware
-keyed-map update site were emitted, and hybrid/static added zero owner executions. The two React
-baselines added 1,430 dashboard and 297 table owner executions each.
+key-directed bindings, two Set-membership bindings, two Map-lookup bindings, 19 Set/Map mutation
+sites, and one mutation-aware keyed-map update site were emitted. Hybrid/static added zero owner
+executions. The two React baselines added 1,430 dashboard and 432 table owner executions each.
 
 ## Complex dashboard
 
@@ -40,25 +43,27 @@ bindings.
 
 | Interaction                 | React median | Hybrid median | Hybrid vs React |
 | --------------------------- | -----------: | ------------: | --------------: |
-| Active live pulse           |      0.11 ms |       0.09 ms |    1.22x faster |
-| Inactive branch update      |      0.06 ms |       0.02 ms |    3.00x faster |
+| Active live pulse           |      0.10 ms |       0.08 ms |    1.25x faster |
+| Inactive branch update      |     0.065 ms |       0.02 ms |    3.25x faster |
 | Switch live/snapshot branch |     0.100 ms |      0.100 ms |          parity |
 
 ## Standard table operations
 
 | Operation         |             Rows | React median | Hybrid median | Hybrid vs React |
 | ----------------- | ---------------: | -----------: | ------------: | --------------: |
-| Create            |            1,000 |     12.60 ms |      11.60 ms |    1.09x faster |
-| Replace all       |            1,000 |     17.20 ms |      11.80 ms |    1.46x faster |
-| Create many       |           10,000 |    310.10 ms |     117.20 ms |    2.65x faster |
-| Append            | 10,000 -> 11,000 |     73.80 ms |      25.50 ms |    2.89x faster |
-| Update every 10th |           10,000 |     40.45 ms |       2.60 ms |   15.56x faster |
-| Select            |            1,000 |      3.55 ms |       0.10 ms |   35.50x faster |
-| Mark two rows     |            1,000 |      4.00 ms |       0.10 ms |   40.00x faster |
-| Queue two rows    |            1,000 |      4.05 ms |       0.10 ms |   40.50x faster |
-| Swap rows 2 / 999 |            1,000 |      8.60 ms |       1.20 ms |    7.17x faster |
-| Remove one row    |            1,000 |      4.45 ms |       2.00 ms |    2.22x faster |
-| Clear             |           10,000 |     56.65 ms |       9.40 ms |    6.03x faster |
+| Create            |            1,000 |     12.60 ms |      11.50 ms |    1.10x faster |
+| Replace all       |            1,000 |     16.60 ms |      12.30 ms |    1.35x faster |
+| Create many       |           10,000 |    270.60 ms |     123.60 ms |    2.19x faster |
+| Append            | 10,000 -> 11,000 |     71.15 ms |      27.40 ms |    2.60x faster |
+| Update every 10th |           10,000 |     43.65 ms |       2.60 ms |   16.79x faster |
+| Select            |            1,000 |      3.90 ms |       0.10 ms |   39.00x faster |
+| Mark two rows     |            1,000 |      3.75 ms |       0.10 ms |   37.50x faster |
+| Queue two rows    |            1,000 |      3.70 ms |       0.10 ms |   37.00x faster |
+| Dense Set delta   |            1,000 |      3.75 ms |       0.10 ms |   37.50x faster |
+| Dense Map delta   |            1,000 |      3.75 ms |       0.10 ms |   37.50x faster |
+| Swap rows 2 / 999 |            1,000 |      7.80 ms |       1.30 ms |    6.00x faster |
+| Remove one row    |            1,000 |      4.60 ms |       2.00 ms |    2.30x faster |
+| Clear             |           10,000 |     58.00 ms |       9.40 ms |    6.17x faster |
 
 `Update every 10th` is the targeted mutation-aware path. The application still executes its native
 immutable `map()` over 10,000 items and creates 1,000 replacement objects. The generated hint lets
@@ -84,6 +89,15 @@ Map snapshots and evaluates only row keys whose mapped primitive value changed. 
 require the exact present-key read count across 2,000 randomized queued updates and verify that
 custom Maps or identity-bearing values return to React before compiled binding reads.
 
+The dense operations isolate this result's producer-side delta metadata. Both start with 20,000
+primitive entries and immutably clone the collection, so the application's required `new Set()` or
+`new Map()` work remains in both paths. A proven updater records only the native mutation keys that
+actually execute. The runtime validates those keys and extends a bounded persistent snapshot,
+instead of iterating every previous and next entry again. At 20,000 entries, the Set delta measured
+`0.30 ms` versus `2.00 ms` for the equivalent compiled snapshot control (**6.67x faster**); the Map
+delta measured `0.90 ms` versus `4.90 ms` (**5.44x faster**) in hybrid mode. These direct
+compiler-to-compiler comparisons are the evidence for this PR's incremental win.
+
 ## Repeated 20,000-row scale profile
 
 Each of the three cycles creates 10,000 rows, appends ten 1,000-row batches to 20,000, updates
@@ -92,15 +106,19 @@ values, swaps rows, removes a middle row, and clears. Lower time is better.
 
 | Operation at scale       | React median | React p95 | Hybrid median | Hybrid p95 | Speedup |
 | ------------------------ | -----------: | --------: | ------------: | ---------: | ------: |
-| Create initial 10,000    |    386.70 ms | 489.70 ms |     120.00 ms |  133.40 ms |   3.22x |
-| Append a 1,000-row batch |     91.95 ms | 144.85 ms |      32.70 ms |   49.70 ms |   2.81x |
-| Update every 10th at 20k |    105.20 ms | 110.50 ms |       6.50 ms |    7.00 ms |  16.18x |
-| Select at 20k            |     96.75 ms | 120.05 ms |       3.90 ms |    4.80 ms |  24.81x |
-| Mark two rows at 20k     |     95.50 ms | 101.50 ms |       0.20 ms |    0.20 ms | 477.50x |
-| Queue two rows at 20k    |     99.65 ms | 108.80 ms |       0.20 ms |    0.20 ms | 498.25x |
-| Swap at 20k              |    112.85 ms | 142.70 ms |      26.20 ms |   28.10 ms |   4.31x |
-| Remove middle row at 20k |    123.80 ms | 157.50 ms |      41.20 ms |   42.00 ms |   3.00x |
-| Clear 20k                |    227.45 ms | 275.75 ms |      23.80 ms |   24.40 ms |   9.56x |
+| Create initial 10,000    |    331.25 ms | 352.75 ms |     124.50 ms |  124.90 ms |    2.66x |
+| Append a 1,000-row batch |     90.10 ms | 119.40 ms |      30.50 ms |   36.20 ms |    2.95x |
+| Update every 10th at 20k |    102.25 ms | 114.35 ms |       6.20 ms |    6.30 ms |   16.49x |
+| Select at 20k            |    100.20 ms | 116.00 ms |       3.00 ms |    4.30 ms |   33.40x |
+| Mark two rows at 20k     |    107.60 ms | 119.20 ms |       0.10 ms |    0.20 ms | 1076.00x |
+| Queue two rows at 20k    |    100.20 ms | 116.60 ms |       0.20 ms |    0.20 ms |  501.00x |
+| Dense Set delta at 20k   |    117.15 ms | 134.35 ms |       0.30 ms |    0.30 ms |  390.50x |
+| Dense Set snapshot       |    115.05 ms | 116.45 ms |       2.00 ms |    2.20 ms |   57.53x |
+| Dense Map delta at 20k   |    102.60 ms | 142.25 ms |       0.90 ms |    1.00 ms |  114.00x |
+| Dense Map snapshot       |    111.85 ms | 134.20 ms |       4.90 ms |    4.90 ms |   22.83x |
+| Swap at 20k              |    123.45 ms | 156.35 ms |      28.20 ms |   28.30 ms |    4.38x |
+| Remove middle row at 20k |    124.05 ms | 138.40 ms |      41.50 ms |   42.30 ms |    2.99x |
+| Clear 20k                |    171.85 ms | 281.50 ms |      20.40 ms |   20.80 ms |    8.42x |
 
 ## Scalability gate
 
@@ -109,33 +127,39 @@ The gate divides observed timing growth by row-count growth. A value near 1 mean
 
 | Path               | Row growth | Timing growth | Normalized growth |
 | ------------------ | ---------: | ------------: | ----------------: |
-| Create 10k repeat  |      1.00x |         1.03x |             1.03x |
-| Update 10k -> 20k  |      2.00x |         2.50x |             1.25x |
-| Select 1k -> 20k   |     20.00x |        15.60x |             0.78x |
-| Mark Set 1k -> 20k |     20.00x |         0.80x |             0.04x |
-| Read Map 1k -> 20k |     20.00x |         0.80x |             0.04x |
-| Swap 1k -> 20k     |     20.00x |        21.83x |             1.09x |
-| Remove 1k -> 20k   |     20.00x |        20.60x |             1.03x |
-| Clear 10k -> 20k   |      2.00x |         2.53x |             1.27x |
+| Create 10k repeat    |      1.00x |         1.01x |             1.01x |
+| Update 10k -> 20k    |      2.00x |         2.38x |             1.19x |
+| Select 1k -> 20k     |     20.00x |        12.00x |             0.60x |
+| Mark Set 1k -> 20k   |     20.00x |         0.40x |             0.02x |
+| Read Map 1k -> 20k   |     20.00x |         0.80x |             0.04x |
+| Dense Set delta      |     20.00x |         1.20x |             0.06x |
+| Dense Map delta      |     20.00x |         3.60x |             0.18x |
+| Dense Set snapshot   |     20.00x |         8.00x |             0.40x |
+| Dense Map snapshot   |     20.00x |        16.33x |             0.82x |
+| Swap 1k -> 20k       |     20.00x |        21.69x |             1.08x |
+| Remove 1k -> 20k     |     20.00x |        20.75x |             1.04x |
+| Clear 10k -> 20k     |      2.00x |         2.17x |             1.09x |
 
 This demonstrates approximately linear rather than quadratic end-to-end growth. Key-directed
 scalar selection performs constant row-binding work—at most the previous and next keyed
-instances—while its complete event-to-DOM timing remains 24.81x faster than React at 20,000 rows.
-Set membership and Map lookup evaluate bindings only for changed keys. Their 0.20 ms medians are
-near browser timer resolution, so deterministic exact-read gates remain the primary complexity
-evidence. Structural swap/removal paths remain O(n), as expected for validating keys and
-maintaining row indices.
+instances—while its complete event-to-DOM timing remains 33.40x faster than React at 20,000 rows.
+Set membership and Map lookup evaluate bindings only for changed keys. Their 0.10-0.20 ms medians
+are near browser timer resolution, so deterministic exact-read gates remain the primary complexity
+evidence. The dense delta-versus-snapshot controls remain above that floor and independently prove
+the removed collection scan. Structural swap/removal paths remain O(n), as expected for validating
+keys and maintaining row indices.
 
 ## Bundle cost
 
 | Build           | Page chunk raw | Page chunk gzip |
 | --------------- | -------------: | --------------: |
-| React baseline  |       19,632 B |         4,592 B |
-| Static compiler |       80,707 B |        16,987 B |
-| Hybrid compiler |       80,707 B |        16,987 B |
+| React baseline  |       21,650 B |         4,959 B |
+| Static compiler |       87,011 B |        18,259 B |
+| Hybrid compiler |       87,011 B |        18,257 B |
 
-This deliberately broad page now pays a 12,395-byte hybrid gzip premium for the compiler runtime,
-including the mutation-aware, scalar key-directed, Set-membership, and Map-lookup paths. Smaller
+This deliberately broad page now pays a 13,298-byte hybrid gzip premium for the compiler runtime,
+including the mutation-aware, scalar key-directed, Set-membership, Map-lookup, and collection-delta
+paths. Smaller
 direct-only applications retain less of the runtime; the package-level fixtures and persisted size
 gate are documented in `packages/farm-react/RUNTIME_SIZE_RESULTS.md`.
 
@@ -143,10 +167,12 @@ gate are documented in `packages/farm-react/RUNTIME_SIZE_RESULTS.md`.
 
 The compiled path scales successfully through the tested 20,000-row mixed workload: all DOM and
 event assertions pass, there are no browser errors or owner rerenders, every scale operation beats
-the bracketed React baseline, and normalized growth stays at or below 1.27x. Scalar selection
-performs at most two row-binding reads, while Set membership and Map lookup evaluate only changed
-keys that map to rows. The evidence claims only measured end-to-end behavior within this range—not
-unlimited constant-time browser work.
+the bracketed React baseline, and normalized growth stays at or below 1.19x for the primary
+workload. Scalar selection performs at most two row-binding reads, while Set membership and Map
+lookup evaluate only changed keys that map to rows. For dense collections, producer deltas were
+6.67x faster for Set and 5.44x faster for Map than equivalent compiled snapshot scans. The evidence
+claims only measured end-to-end behavior within this range—not unlimited constant-time browser
+work.
 
 The machine-readable output is `/tmp/farm-react-dashboard-benchmark.json`. Re-run
 `pnpm --filter farm-react-compiler-dashboard-example benchmark` to reproduce it.

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -77,6 +77,14 @@ than React at 20,000 rows, normalized growth may not exceed 2x, and the compiler
 a nonzero `keyedMapLookupTargets` count. Differential unit tests require binding reads to equal the
 present row keys whose mapped primitive values changed.
 
+Dense Set and Map operations isolate producer-side collection deltas from those binding
+optimizations. Each compiler build runs a proven immutable functional updater and an equivalent
+unhinted snapshot control over the same dense collection. The hinted path must be at least 2x
+faster than React, at least 1.5x faster than the compiled snapshot control, and stay within 2x
+normalized growth at 20,000 entries. The report must contain a nonzero
+`keyedCollectionUpdateHints` count. Deterministic unit tests separately compare 2,000 randomized
+hinted Set mutations and 2,000 randomized hinted Map mutations with normal React.
+
 Set `FARM_EXPERIMENT_BROWSER_PATH` to an installed Chrome/Chromium executable when Playwright's
 bundled browser is unavailable. Sample counts are configurable:
 
@@ -103,6 +111,9 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
   disappear.
 - The scale profile compares 20,000-row medians with their 1,000- or 10,000-row references and
   records both raw growth and growth normalized by the row-count increase.
+- The dense collection controls show only the incremental delta benefit: both compiler paths keep
+  the application's immutable collection copy, while the hinted path avoids the runtime's second
+  complete entry scan.
 - This is an operation-compatible local benchmark, not an official `js-framework-benchmark`
   submission or a score comparable to its published result table. This app has richer rows and
   measures event dispatch through an asserted DOM result without CPU throttling.

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -130,6 +130,10 @@ async function inspectBuild(compilerMode) {
       compilerReport.summary.keyedMapUpdateHints > 0,
       "The compiler build did not emit a mutation-aware keyed-map update hint.",
     );
+    assert(
+      compilerReport.summary.keyedCollectionUpdateHints > 0,
+      "The compiler build did not emit a keyed Set/Map collection-delta hint.",
+    );
   }
 
   return {
@@ -404,6 +408,21 @@ async function measureTrial(browser, trial, compilerMode, port) {
           }
           return timings;
         };
+        const seedDenseTargets = async () => {
+          const expected = rowCount();
+          const middle = table.querySelectorAll("tbody tr")[Math.floor(expected / 2)];
+          if (!middle) throw new Error("Dense-target row is missing.");
+          await runTableAction(
+            () => tableButton("table-seed-dense-targets").click(),
+            () =>
+              Number(table.dataset.markedCount) === expected &&
+              Number(table.dataset.queueCount) === expected &&
+              middle.getAttribute("data-marked") === "true" &&
+              middle.getAttribute("data-queue") === "dense" &&
+              middle.getAttribute("data-snapshot-marked") === "true" &&
+              middle.getAttribute("data-snapshot-queue") === "dense",
+          );
+        };
 
         const tableCreate = await measureTable(
           async () => {
@@ -511,6 +530,70 @@ async function measureTrial(browser, trial, compilerMode, port) {
           },
         );
 
+        const tableDenseMembership = await measureTable(
+          async () => {
+            await ensure1000();
+            await seedDenseTargets();
+          },
+          async () => {
+            const row = table.querySelectorAll("tbody tr")[500];
+            const previous = row?.getAttribute("data-marked");
+            if (!row) throw new Error("Dense membership target row is missing.");
+            await runTableAction(
+              () => tableButton("table-toggle-dense-mark").click(),
+              () => row.getAttribute("data-marked") !== previous,
+            );
+          },
+        );
+
+        const tableDenseMapLookup = await measureTable(
+          async () => {
+            await ensure1000();
+            await seedDenseTargets();
+          },
+          async () => {
+            const row = table.querySelectorAll("tbody tr")[500];
+            const previous = row?.getAttribute("data-queue");
+            if (!row) throw new Error("Dense Map target row is missing.");
+            await runTableAction(
+              () => tableButton("table-update-dense-queue").click(),
+              () => row.getAttribute("data-queue") !== previous,
+            );
+          },
+        );
+
+        const tableSnapshotMembership = await measureTable(
+          async () => {
+            await ensure1000();
+            await seedDenseTargets();
+          },
+          async () => {
+            const row = table.querySelectorAll("tbody tr")[500];
+            const previous = row?.getAttribute("data-snapshot-marked");
+            if (!row) throw new Error("Snapshot membership target row is missing.");
+            await runTableAction(
+              () => tableButton("table-toggle-snapshot-mark").click(),
+              () => row.getAttribute("data-snapshot-marked") !== previous,
+            );
+          },
+        );
+
+        const tableSnapshotMapLookup = await measureTable(
+          async () => {
+            await ensure1000();
+            await seedDenseTargets();
+          },
+          async () => {
+            const row = table.querySelectorAll("tbody tr")[500];
+            const previous = row?.getAttribute("data-snapshot-queue");
+            if (!row) throw new Error("Snapshot Map target row is missing.");
+            await runTableAction(
+              () => tableButton("table-update-snapshot-queue").click(),
+              () => row.getAttribute("data-snapshot-queue") !== previous,
+            );
+          },
+        );
+
         const tableRemove = await measureTable(
           async () => {
             if (rowCount() !== 1_000) await create1000();
@@ -538,10 +621,14 @@ async function measureTrial(browser, trial, compilerMode, port) {
           appendTo20k: [],
           clear20k: [],
           create10k: [],
+          denseMapLookup20k: [],
+          denseMembership20k: [],
           mapLookup20k: [],
           membership20k: [],
           remove20k: [],
           select20k: [],
+          snapshotMapLookup20k: [],
+          snapshotMembership20k: [],
           swap20k: [],
           updateEvery10th20k: [],
         };
@@ -607,6 +694,43 @@ async function measureTrial(browser, trial, compilerMode, port) {
           );
           scale.mapLookup20k.push(performance.now() - mapLookupStartedAt);
 
+          await seedDenseTargets();
+          const denseTarget = table.querySelectorAll("tbody tr")[10_000];
+          if (!denseTarget) throw new Error("20,000-row dense target is missing.");
+
+          const previousDenseMembership = denseTarget.getAttribute("data-marked");
+          const denseMembershipStartedAt = performance.now();
+          await runTableAction(
+            () => tableButton("table-toggle-dense-mark").click(),
+            () => denseTarget.getAttribute("data-marked") !== previousDenseMembership,
+          );
+          scale.denseMembership20k.push(performance.now() - denseMembershipStartedAt);
+
+          const previousDenseMapLookup = denseTarget.getAttribute("data-queue");
+          const denseMapLookupStartedAt = performance.now();
+          await runTableAction(
+            () => tableButton("table-update-dense-queue").click(),
+            () => denseTarget.getAttribute("data-queue") !== previousDenseMapLookup,
+          );
+          scale.denseMapLookup20k.push(performance.now() - denseMapLookupStartedAt);
+
+          const previousSnapshotMembership = denseTarget.getAttribute("data-snapshot-marked");
+          const snapshotMembershipStartedAt = performance.now();
+          await runTableAction(
+            () => tableButton("table-toggle-snapshot-mark").click(),
+            () =>
+              denseTarget.getAttribute("data-snapshot-marked") !== previousSnapshotMembership,
+          );
+          scale.snapshotMembership20k.push(performance.now() - snapshotMembershipStartedAt);
+
+          const previousSnapshotMapLookup = denseTarget.getAttribute("data-snapshot-queue");
+          const snapshotMapLookupStartedAt = performance.now();
+          await runTableAction(
+            () => tableButton("table-update-snapshot-queue").click(),
+            () => denseTarget.getAttribute("data-snapshot-queue") !== previousSnapshotMapLookup,
+          );
+          scale.snapshotMapLookup20k.push(performance.now() - snapshotMapLookupStartedAt);
+
           const rowsBeforeSwap = table.querySelectorAll("tbody tr");
           const second = rowsBeforeSwap[1]?.getAttribute("data-row-id");
           const penultimate = rowsBeforeSwap[998]?.getAttribute("data-row-id");
@@ -662,12 +786,16 @@ async function measureTrial(browser, trial, compilerMode, port) {
             clear: tableClear,
             create: tableCreate,
             createMany: tableCreateMany,
+            denseMapLookup: tableDenseMapLookup,
+            denseMembership: tableDenseMembership,
             executionsAdded: Number(tableExecutions.textContent) - initialTableExecutions,
             mapLookup: tableMapLookup,
             membership: tableMembership,
             remove: tableRemove,
             replace: tableReplace,
             select: tableSelect,
+            snapshotMapLookup: tableSnapshotMapLookup,
+            snapshotMembership: tableSnapshotMembership,
             swap: tableSwap,
             updateEvery10th: tableUpdate,
           },
@@ -718,10 +846,14 @@ async function measureTrial(browser, trial, compilerMode, port) {
         appendTo20k: timingSummary(result.scale.appendTo20k),
         clear20k: timingSummary(result.scale.clear20k),
         create10k: timingSummary(result.scale.create10k),
+        denseMapLookup20k: timingSummary(result.scale.denseMapLookup20k),
+        denseMembership20k: timingSummary(result.scale.denseMembership20k),
         mapLookup20k: timingSummary(result.scale.mapLookup20k),
         membership20k: timingSummary(result.scale.membership20k),
         remove20k: timingSummary(result.scale.remove20k),
         select20k: timingSummary(result.scale.select20k),
+        snapshotMapLookup20k: timingSummary(result.scale.snapshotMapLookup20k),
+        snapshotMembership20k: timingSummary(result.scale.snapshotMembership20k),
         swap20k: timingSummary(result.scale.swap20k),
         updateEvery10th20k: timingSummary(result.scale.updateEvery10th20k),
       },
@@ -730,12 +862,16 @@ async function measureTrial(browser, trial, compilerMode, port) {
         clear: timingSummary(result.table.clear),
         create: timingSummary(result.table.create),
         createMany: timingSummary(result.table.createMany),
+        denseMapLookup: timingSummary(result.table.denseMapLookup),
+        denseMembership: timingSummary(result.table.denseMembership),
         executionsAdded: result.table.executionsAdded,
         mapLookup: timingSummary(result.table.mapLookup),
         membership: timingSummary(result.table.membership),
         remove: timingSummary(result.table.remove),
         replace: timingSummary(result.table.replace),
         select: timingSummary(result.table.select),
+        snapshotMapLookup: timingSummary(result.table.snapshotMapLookup),
+        snapshotMembership: timingSummary(result.table.snapshotMembership),
         swap: timingSummary(result.table.swap),
         updateEvery10th: timingSummary(result.table.updateEvery10th),
       },
@@ -809,6 +945,10 @@ const tableMetrics = [
   "select",
   "membership",
   "mapLookup",
+  "denseMembership",
+  "denseMapLookup",
+  "snapshotMembership",
+  "snapshotMapLookup",
   "swap",
   "remove",
   "clear",
@@ -820,6 +960,10 @@ const scaleMetrics = [
   "select20k",
   "membership20k",
   "mapLookup20k",
+  "denseMembership20k",
+  "denseMapLookup20k",
+  "snapshotMembership20k",
+  "snapshotMapLookup20k",
   "swap20k",
   "remove20k",
   "clear20k",
@@ -853,6 +997,10 @@ const scalabilityCases = [
   ["select20k", "select", 20],
   ["membership20k", "membership", 20],
   ["mapLookup20k", "mapLookup", 20],
+  ["denseMembership20k", "denseMembership", 20],
+  ["denseMapLookup20k", "denseMapLookup", 20],
+  ["snapshotMembership20k", "snapshotMembership", 20],
+  ["snapshotMapLookup20k", "snapshotMapLookup", 20],
   ["swap20k", "swap", 20],
   ["remove20k", "remove", 20],
   ["clear20k", "clear", 2],
@@ -996,13 +1144,51 @@ const keyedMapLookupRegressions = keyedMapLookupResults.filter(
     !Number.isFinite(normalizedGrowth) ||
     normalizedGrowth > keyedMapLookupMaximumNormalizedGrowth,
 );
+// Dense Set/Map operations still pay the application's immutable collection clone, but a proven
+// updater carries its executed keys to the runtime. This gate ensures that a 20,000-entry
+// collection does not restore the removed second snapshot scan or the full keyed-row scan.
+const keyedCollectionDeltaMinimumSpeedup = 2;
+const keyedCollectionDeltaMinimumSnapshotSpeedup = 1.5;
+const keyedCollectionDeltaMaximumNormalizedGrowth = 2;
+const keyedCollectionDeltaResults = [
+  ["set", "denseMembership", "denseMembership20k", "snapshotMembership20k"],
+  ["map", "denseMapLookup", "denseMapLookup20k", "snapshotMapLookup20k"],
+].flatMap(([kind, tableMetric, scaleMetric, snapshotScaleMetric]) =>
+  ["static", "hybrid"].map((mode) => {
+    const tableMedianMs = comparisons.table[tableMetric][mode].medianMs;
+    const scaleMedianMs = comparisons.scale[scaleMetric][mode].medianMs;
+    const snapshotScaleMedianMs = comparisons.scale[snapshotScaleMetric][mode].medianMs;
+    const growth = scaleMedianMs / Math.max(tableMedianMs, timingResolutionFloorMs);
+    return {
+      growth,
+      kind,
+      mode,
+      normalizedGrowth: growth / 20,
+      scaleMedianMs,
+      snapshotScaleMedianMs,
+      snapshotSpeedup: snapshotScaleMedianMs / scaleMedianMs,
+      speedup: comparisons.scale[scaleMetric][`${mode}VsBaseline`].speedup,
+      tableMedianMs,
+    };
+  }),
+);
+const keyedCollectionDeltaRegressions = keyedCollectionDeltaResults.filter(
+  ({ normalizedGrowth, snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedCollectionDeltaMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedCollectionDeltaMinimumSnapshotSpeedup ||
+    !Number.isFinite(normalizedGrowth) ||
+    normalizedGrowth > keyedCollectionDeltaMaximumNormalizedGrowth,
+);
 const passed =
   performanceRegressions.length === 0 &&
   scalabilityRegressions.length === 0 &&
   keyedUpdateRegressions.length === 0 &&
   keyedIdentityRegressions.length === 0 &&
   keyedMembershipRegressions.length === 0 &&
-  keyedMapLookupRegressions.length === 0;
+  keyedMapLookupRegressions.length === 0 &&
+  keyedCollectionDeltaRegressions.length === 0;
 
 const report = {
   result: passed ? "PASS" : "CORRECTNESS_PASS_PERFORMANCE_REGRESSION",
@@ -1039,6 +1225,14 @@ const report = {
     regressions: keyedMapLookupRegressions,
     results: keyedMapLookupResults,
     status: keyedMapLookupRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedCollectionDeltaGate: {
+    maximumNormalizedGrowth: keyedCollectionDeltaMaximumNormalizedGrowth,
+    minimumSpeedup: keyedCollectionDeltaMinimumSpeedup,
+    minimumSnapshotSpeedup: keyedCollectionDeltaMinimumSnapshotSpeedup,
+    regressions: keyedCollectionDeltaRegressions,
+    results: keyedCollectionDeltaResults,
+    status: keyedCollectionDeltaRegressions.length === 0 ? "PASS" : "FAIL",
   },
   scalabilityGate: {
     metrics: scalability,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -45,6 +45,8 @@ export function StandardTableBenchmark() {
   const [selected, setSelected] = useState(0);
   const [markedIds, setMarkedIds] = useState(() => new Set<number>());
   const [queueById, setQueueById] = useState(() => new Map<number, string>());
+  const [snapshotMarkedIds, setSnapshotMarkedIds] = useState(() => new Set<number>());
+  const [snapshotQueueById, setSnapshotQueueById] = useState(() => new Map<number, string>());
   const [operation, setOperation] = useState("initial 100 rows");
   const [revision, setRevision] = useState(0);
 
@@ -97,6 +99,8 @@ export function StandardTableBenchmark() {
             setSelected(0);
             setMarkedIds(new Set());
             setQueueById(new Map());
+            setSnapshotMarkedIds(new Set());
+            setSnapshotQueueById(new Map());
             setOperation("create 1,000");
             setRevision((value) => value + 1);
           }}
@@ -114,6 +118,8 @@ export function StandardTableBenchmark() {
             setSelected(0);
             setMarkedIds(new Set());
             setQueueById(new Map());
+            setSnapshotMarkedIds(new Set());
+            setSnapshotQueueById(new Map());
             setOperation("create 10,000");
             setRevision((value) => value + 1);
           }}
@@ -144,6 +150,8 @@ export function StandardTableBenchmark() {
             setSelected(0);
             setMarkedIds(new Set());
             setQueueById(new Map());
+            setSnapshotMarkedIds(new Set());
+            setSnapshotQueueById(new Map());
             setOperation("replace 1,000");
             setRevision((value) => value + 1);
           }}
@@ -174,10 +182,29 @@ export function StandardTableBenchmark() {
               const middle = Math.floor(rows.length / 2);
               const first = rows[middle]?.id;
               const second = rows[middle + 1]?.id;
-              if (first === undefined || second === undefined) return current;
-              return current.has(first)
-                ? new Set([rows[middle + 2]?.id ?? first, rows[middle + 3]?.id ?? second])
-                : new Set([first, second]);
+              const third = rows[middle + 2]?.id;
+              const fourth = rows[middle + 3]?.id;
+              if (
+                first === undefined ||
+                second === undefined ||
+                third === undefined ||
+                fourth === undefined
+              ) {
+                return current;
+              }
+              const next = new Set(current);
+              if (next.has(first)) {
+                next.delete(first);
+                next.delete(second);
+                next.add(third);
+                next.add(fourth);
+              } else {
+                next.delete(third);
+                next.delete(fourth);
+                next.add(first);
+                next.add(second);
+              }
+              return next;
             });
             setOperation("mark two rows");
             setRevision((value) => value + 1);
@@ -193,22 +220,115 @@ export function StandardTableBenchmark() {
               const middle = Math.floor(rows.length / 2);
               const first = rows[middle]?.id;
               const second = rows[middle + 1]?.id;
-              if (first === undefined || second === undefined) return current;
-              return current.has(first)
-                ? new Map([
-                    [rows[middle + 2]?.id ?? first, "expedite"],
-                    [rows[middle + 3]?.id ?? second, "hold"],
-                  ])
-                : new Map([
-                    [first, "expedite"],
-                    [second, "hold"],
-                  ]);
+              const third = rows[middle + 2]?.id;
+              const fourth = rows[middle + 3]?.id;
+              if (
+                first === undefined ||
+                second === undefined ||
+                third === undefined ||
+                fourth === undefined
+              ) {
+                return current;
+              }
+              const next = new Map(current);
+              if (next.has(first)) {
+                next.delete(first);
+                next.delete(second);
+                next.set(third, "expedite");
+                next.set(fourth, "hold");
+              } else {
+                next.delete(third);
+                next.delete(fourth);
+                next.set(first, "expedite");
+                next.set(second, "hold");
+              }
+              return next;
             });
             setOperation("queue two rows");
             setRevision((value) => value + 1);
           }}
         >
           Queue two rows
+        </button>
+        <button
+          data-action="table-seed-dense-targets"
+          type="button"
+          onClick={() => {
+            setMarkedIds(new Set(rows.map((row) => row.id)));
+            setQueueById(new Map(rows.map((row) => [row.id, "dense"])));
+            setSnapshotMarkedIds(new Set(rows.map((row) => row.id)));
+            setSnapshotQueueById(new Map(rows.map((row) => [row.id, "dense"])));
+            setOperation("seed dense row targets");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Seed dense targets
+        </button>
+        <button
+          data-action="table-toggle-dense-mark"
+          type="button"
+          onClick={() => {
+            setMarkedIds((current) => {
+              const target = rows[Math.floor(rows.length / 2)]?.id;
+              if (target === undefined) return current;
+              const next = new Set(current);
+              if (next.has(target)) next.delete(target);
+              else next.add(target);
+              return next;
+            });
+            setOperation("toggle one dense mark");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Toggle one dense mark
+        </button>
+        <button
+          data-action="table-update-dense-queue"
+          type="button"
+          onClick={() => {
+            setQueueById((current) => {
+              const target = rows[Math.floor(rows.length / 2)]?.id;
+              if (target === undefined) return current;
+              const next = new Map(current);
+              next.set(target, next.get(target) === "priority" ? "dense" : "priority");
+              return next;
+            });
+            setOperation("update one dense queue value");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Update one dense queue value
+        </button>
+        <button
+          data-action="table-toggle-snapshot-mark"
+          type="button"
+          onClick={() => {
+            const target = rows[Math.floor(rows.length / 2)]?.id;
+            if (target === undefined) return;
+            const next = new Set(snapshotMarkedIds);
+            if (next.has(target)) next.delete(target);
+            else next.add(target);
+            setSnapshotMarkedIds(next);
+            setOperation("toggle one snapshot mark");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Toggle one snapshot mark
+        </button>
+        <button
+          data-action="table-update-snapshot-queue"
+          type="button"
+          onClick={() => {
+            const target = rows[Math.floor(rows.length / 2)]?.id;
+            if (target === undefined) return;
+            const next = new Map(snapshotQueueById);
+            next.set(target, next.get(target) === "priority" ? "dense" : "priority");
+            setSnapshotQueueById(next);
+            setOperation("update one snapshot queue value");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Update one snapshot queue value
         </button>
         <button
           data-action="table-swap"
@@ -242,6 +362,8 @@ export function StandardTableBenchmark() {
             setSelected(0);
             setMarkedIds(new Set());
             setQueueById(new Map());
+            setSnapshotMarkedIds(new Set());
+            setSnapshotQueueById(new Map());
             setOperation("clear");
             setRevision((value) => value + 1);
           }}
@@ -270,6 +392,8 @@ export function StandardTableBenchmark() {
                 className={selected === row.id ? "table-row--selected" : ""}
                 data-marked={markedIds.has(row.id)}
                 data-queue={queueById.get(row.id) ?? "none"}
+                data-snapshot-marked={snapshotMarkedIds.has(row.id)}
+                data-snapshot-queue={snapshotQueueById.get(row.id) ?? "none"}
                 data-row-id={row.id}
                 data-selected={selected === row.id}
                 key={row.id}

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -187,6 +187,34 @@ subclasses or proxies, object values, customized `get` behavior, React-owned row
 and structural dependencies keep the existing complete or React-owned paths. The compiler report
 exposes this count as `keyedMapLookupTargets`.
 
+When a targeted Set or Map is compiler-owned, Farm can also carry the exact mutated keys from a
+proven immutable functional update:
+
+```tsx
+setMarkedIds((current) => {
+  const next = new Set(current);
+  if (next.has(id)) next.delete(id);
+  else next.add(id);
+  return next;
+});
+
+setStatusById((current) => new Map(current).set(id, "ready"));
+```
+
+The application still creates its normal immutable collection. The generated update records only
+the native `add`, `delete`, or `set` calls that execute, and the runtime validates those keys
+against the previous committed collection. It can then update the relevant keyed rows without
+iterating every old and new Set member or Map entry first. Queued functional updates compose, and
+the runtime periodically compacts its persistent snapshot so a long update chain stays bounded.
+
+This proof is deliberately conservative. The state must start from a compiler-owned native
+`Set`/`Map`; every setter use must be a fresh same-kind replacement or a recognized immutable
+updater; and the collection, updater parameter, and cloned draft must not escape or be mutated
+through unknown code. Shadowed constructors, custom collections, object keys, object Map values,
+direct state mutation, aliased drafts, or a failed runtime check use the existing snapshot or
+React-owned path before compiled bindings run. No option or syntax is added. The compiler report
+counts emitted native mutation sites as `keyedCollectionUpdateHints`.
+
 For a direct keyed `useState` collection, the compiler also recognizes conservative same-order
 updates such as:
 
@@ -485,7 +513,8 @@ contains project-relative module paths, compiled component names, fallback detai
 reasons aggregated by count. Its summary and per-module `optimizations` also report
 `keyedIdentityTargets`, the number of scalar key-directed row bindings;
 `keyedMapLookupTargets`, the number of native-Map keyed lookup bindings;
-`keyedMembershipTargets`, the number of native-Set membership bindings; and
+`keyedMembershipTargets`, the number of native-Set membership bindings;
+`keyedCollectionUpdateHints`, the number of compiler-proven native Set/Map mutation sites; and
 `keyedMapUpdateHints`, the number of compiler-proven direct keyed `map()` update sites. A custom
 project-relative `reportFile` also enables reporting.
 

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -21,19 +21,19 @@
     },
     "keyed": {
       "compilerOff": {
-        "raw": 193105,
-        "gzip": 60176,
-        "brotli": 51978
+        "raw": 193119,
+        "gzip": 60179,
+        "brotli": 51897
       },
       "compilerOn": {
-        "raw": 227076,
-        "gzip": 70211,
-        "brotli": 60029
+        "raw": 230600,
+        "gzip": 71136,
+        "brotli": 60895
       },
       "compilerPremium": {
-        "raw": 33971,
-        "gzip": 10035,
-        "brotli": 8051
+        "raw": 37481,
+        "gzip": 10957,
+        "brotli": 8998
       }
     },
     "isolatedRuntime": {
@@ -43,18 +43,18 @@
         "brotli": 51666
       },
       "full": {
-        "raw": 265630,
-        "gzip": 75907,
-        "brotli": 65428
+        "raw": 268071,
+        "gzip": 76403,
+        "brotli": 65852
       },
       "coreOnly": {
         "raw": 204922,
         "gzip": 63685,
         "brotli": 54902
       },
-      "fullRuntimePremiumGzip": 15988,
+      "fullRuntimePremiumGzip": 16484,
       "coreRuntimePremiumGzip": 3766,
-      "gzipReductionPercent": 76.4
+      "gzipReductionPercent": 77.2
     }
   }
 }

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.md
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.md
@@ -24,18 +24,18 @@ is enforced on every pull request instead of serving only as a manually recorded
 | Fixture                                           | Compiler off gzip | Compiler on gzip | Compiler premium |
 | ------------------------------------------------- | ----------------: | ---------------: | ---------------: |
 | Direct text, attribute, style, and event bindings |          60,043 B |         63,721 B |          3,678 B |
-| Keyed rows, LIS, scalar, Set, and Map targeting   |          60,176 B |         70,211 B |         10,035 B |
+| Keyed rows, LIS, scalar, Set, and Map targeting   |          60,179 B |         71,136 B |         10,957 B |
 
-The isolated compatibility runtime contributes 15,988 B gzip over the React control. The
-compiler-selected core contributes 3,766 B, a **76.4% reduction**. This comparison uses the same
+The isolated compatibility runtime contributes 16,484 B gzip over the React control. The
+compiler-selected core contributes 3,766 B, a **77.2% reduction**. This comparison uses the same
 hand-authored compiled definition and changes only the runtime entry used to create it.
 
 The keyed fixture retains `FarmCompiledKeyedRows` plus compiler-emitted `identityTarget`,
-`membershipTarget`, and `mapLookupTarget` metadata, but rejects the optional row-conditional and
-keyed-map-hint runtimes. Map lookup targeting adds 414 B gzip to the keyed fixture's compiler
-premium. The direct compiler premium and isolated core runtime remain byte-for-byte unchanged. The
-direct fixture rejects every structural runtime marker. The checked machine-readable result is
-[`RUNTIME_SIZE_RESULTS.json`](./RUNTIME_SIZE_RESULTS.json).
+`membershipTarget`, and `mapLookupTarget` metadata, plus Set/Map producer-delta helpers. It rejects
+the optional row-conditional and keyed-map-hint runtimes. The collection-delta fixture raises the
+keyed compiler premium by 922 B gzip while keeping the direct compiler premium and isolated core
+runtime byte-for-byte unchanged. The direct fixture rejects every structural runtime marker. The
+checked machine-readable result is [`RUNTIME_SIZE_RESULTS.json`](./RUNTIME_SIZE_RESULTS.json).
 
 ## Existing production benchmark audit
 

--- a/packages/farm-react/fixtures/runtime-size/keyed.tsx
+++ b/packages/farm-react/fixtures/runtime-size/keyed.tsx
@@ -25,8 +25,8 @@ export function KeyedTable() {
             key={row.id}
             onClick={() => {
               setSelected(row.id);
-              setMarked(new Set([row.id]));
-              setQueueById(new Map([[row.id, "ready"]]));
+              setMarked((current) => new Set(current).add(row.id));
+              setQueueById((current) => new Map(current).set(row.id, "ready"));
             }}
           >
             {row.label}

--- a/packages/farm-react/scripts/benchmark-runtime-size.mjs
+++ b/packages/farm-react/scripts/benchmark-runtime-size.mjs
@@ -67,6 +67,8 @@ const forbiddenDirectMarkers = [
   "FarmCompiledKeyedRangesBlock",
   "FarmCompiledMixedRangesBlock",
   "FarmCompiledComponentBlock",
+  '"set-add"',
+  '"map-set"',
 ];
 for (const marker of forbiddenDirectMarkers) {
   if (directOn.code.includes(marker) || runtimeCore.code.includes(marker)) {
@@ -90,6 +92,9 @@ if (!keyedOn.code.includes("membershipTarget")) {
 }
 if (!keyedOn.code.includes("mapLookupTarget")) {
   throw new Error("Keyed selection fixture did not retain its Map-lookup binding target.");
+}
+if (!keyedOn.code.includes('"set-add"') || !keyedOn.code.includes('"map-set"')) {
+  throw new Error("Keyed selection fixture did not retain its Set/Map collection-delta helpers.");
 }
 
 const fullRuntimePremium = runtimeFull.gzip - runtimeControl.gzip;

--- a/packages/farm-react/src/__tests__/compiler-keyed-collection-update-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-collection-update-hints.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true);
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/KeyedCollectionUpdateHints.tsx", infer);
+}
+
+describe("React AOT keyed collection update hints", () => {
+  it("records executed keys for proven immutable Set and Map updaters", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inventory() {
+        const [rows, setRows] = useState([{ id: "a" }, { id: "b" }]);
+        const [marked, setMarked] = useState(() => new Set());
+        const [statusById, setStatusById] = useState(() => new Map());
+        return (
+          <section>
+            <button onClick={() => setMarked((current) => {
+              const next = new Set(current);
+              if (next.has("a")) next.delete("a");
+              else next.add("a");
+              return next;
+            })}>Toggle</button>
+            <button onClick={() => setStatusById((current) => new Map(current).set("b", "done"))}>
+              Update
+            </button>
+            <ul>
+              {rows.map((row) => (
+                <li data-marked={marked.has(row.id)} data-status={statusById.get(row.id)} key={row.id}>
+                  {row.id}
+                </li>
+              ))}
+            </ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations).toMatchObject({
+      keyedCollectionUpdateHints: 3,
+      keyedMapLookupTargets: 1,
+      keyedMembershipTargets: 1,
+    });
+    expect(result.code).toContain("createCompilerKeyedCollectionUpdate");
+    expect(result.code).toContain("applyCompilerKeyedCollectionMutation");
+    expect(result.code).toContain('"set-add"');
+    expect(result.code).toContain('"set-delete"');
+    expect(result.code).toContain('"map-set"');
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedCollectionUpdateHints.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("createCompilerKeyedCollectionUpdate"),
+    });
+  });
+
+  it("keeps fresh direct replacements compatible with later proven updates", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Queue() {
+        const [rows, setRows] = useState([{ id: "a" }]);
+        const [queue, setQueue] = useState(() => new Map());
+        return <main>
+          <button onClick={() => setQueue(new Map())}>Reset</button>
+          <button onClick={() => setQueue((current) => new Map(current).set("a", "ready"))}>Set</button>
+          <ul>{rows.map((row) => <li data-queue={queue.get(row.id)} key={row.id}>{row.id}</li>)}</ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Queue"]);
+    expect(result.optimizations.keyedCollectionUpdateHints).toBe(1);
+  });
+
+  it.each([
+    {
+      name: "an externally owned initializer",
+      initializer: "seed",
+      before: "const seed = new Map();",
+      update: 'setQueue((current) => new Map(current).set("a", "ready"))',
+      extra: "",
+    },
+    {
+      name: "an unknown setter result",
+      initializer: "() => new Map()",
+      before: "",
+      update: "setQueue(buildQueue())",
+      extra: "function buildQueue() { return new Map(); }",
+    },
+    {
+      name: "a directly mutated state collection",
+      initializer: "() => new Map()",
+      before: "",
+      update: 'queue.set("a", "unsafe"); setQueue((current) => new Map(current).set("b", "ready"))',
+      extra: "",
+    },
+    {
+      name: "a collection that escapes to another function",
+      initializer: "() => new Map()",
+      before: "",
+      update: 'inspect(queue); setQueue((current) => new Map(current).set("b", "ready"))',
+      extra: "function inspect(_value) {}",
+    },
+    {
+      name: "an updater that aliases its draft",
+      initializer: "() => new Map()",
+      before: "",
+      update:
+        'setQueue((current) => { const next = new Map(current); inspect(next); next.set("a", "ready"); return next; })',
+      extra: "function inspect(_value) {}",
+    },
+    {
+      name: "a shadowed collection constructor",
+      initializer: "() => new Map()",
+      before: "",
+      update:
+        'setQueue((current) => { const Map = class extends globalThis.Map {}; return new Map(current).set("a", "ready"); })',
+      extra: "",
+    },
+  ])("does not emit delta metadata for $name", async ({ initializer, before, update, extra }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      ${before}
+      ${extra}
+      export function Queue() {
+        const [rows, setRows] = useState([{ id: "a" }, { id: "b" }]);
+        const [queue, setQueue] = useState(${initializer});
+        return <main>
+          <button onClick={() => { ${update}; }}>Update</button>
+          <ul>{rows.map((row) => <li data-queue={queue.get(row.id)} key={row.id}>{row.id}</li>)}</ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Queue"]);
+    expect(result.optimizations.keyedMapLookupTargets).toBe(1);
+    expect(result.optimizations.keyedCollectionUpdateHints).toBe(0);
+    expect(result.code).not.toContain("createCompilerKeyedCollectionUpdate");
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
@@ -40,6 +40,7 @@ describe("React AOT keyed update hints", () => {
     expect(result.compiled).toEqual(["Inventory"]);
     expect(result.diagnostics).toEqual([]);
     expect(result.optimizations).toEqual({
+      keyedCollectionUpdateHints: 0,
       keyedIdentityTargets: 0,
       keyedMapLookupTargets: 0,
       keyedMembershipTargets: 0,

--- a/packages/farm-react/src/__tests__/compiler-report.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-report.test.ts
@@ -28,6 +28,7 @@ function observations(projectRoot: string): ReactCompilerModuleObservation[] {
         compiled: ["Counter"],
         diagnostics: [],
         optimizations: {
+          keyedCollectionUpdateHints: 0,
           keyedIdentityTargets: 0,
           keyedMapLookupTargets: 0,
           keyedMembershipTargets: 0,
@@ -52,6 +53,7 @@ function observations(projectRoot: string): ReactCompilerModuleObservation[] {
           },
         ],
         optimizations: {
+          keyedCollectionUpdateHints: 6,
           keyedIdentityTargets: 4,
           keyedMapLookupTargets: 5,
           keyedMembershipTargets: 2,
@@ -72,6 +74,7 @@ describe("React compiler coverage report", () => {
       componentsConsidered: 4,
       compiled: 2,
       fallback: 2,
+      keyedCollectionUpdateHints: 6,
       keyedIdentityTargets: 4,
       keyedMapLookupTargets: 5,
       keyedMembershipTargets: 2,
@@ -91,6 +94,7 @@ describe("React compiler coverage report", () => {
       selected: true,
     });
     expect(report.modules[1]?.optimizations).toEqual({
+      keyedCollectionUpdateHints: 6,
       keyedIdentityTargets: 4,
       keyedMapLookupTargets: 5,
       keyedMembershipTargets: 2,

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-map-lookup-targets.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-map-lookup-targets.test.tsx
@@ -3,7 +3,12 @@ import { act } from "react";
 import { createRoot, hydrateRoot } from "react-dom/client";
 import { renderToString } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createCompiledComponent, type CompilerStateUpdater } from "../compiler-runtime";
+import {
+  applyCompilerKeyedCollectionMutation,
+  createCompiledComponent,
+  createCompilerKeyedCollectionUpdate,
+  type CompilerStateUpdater,
+} from "../compiler-runtime";
 
 declare global {
   var IS_REACT_ACT_ENVIRONMENT: boolean;
@@ -47,6 +52,25 @@ function items(count: number): Item[] {
 
 function displayLookupValue(value: unknown): unknown {
   return value ?? "none";
+}
+
+function hintedMapSet(
+  previous: unknown,
+  key: unknown,
+  value: unknown,
+): ReturnType<typeof createCompilerKeyedCollectionUpdate> {
+  const next = new Map(previous as Map<unknown, unknown>);
+  applyCompilerKeyedCollectionMutation(next, next.set, "map-set", key, value);
+  return createCompilerKeyedCollectionUpdate(previous, next, "map");
+}
+
+function hintedMapDelete(
+  previous: unknown,
+  key: unknown,
+): ReturnType<typeof createCompilerKeyedCollectionUpdate> {
+  const next = new Map(previous as Map<unknown, unknown>);
+  applyCompilerKeyedCollectionMutation(next, next.delete, "map-delete", key);
+  return createCompilerKeyedCollectionUpdate(previous, next, "map");
 }
 
 function createMapLookupHarness(initialItems: Item[], initialLookup: Map<unknown, unknown>) {
@@ -141,6 +165,89 @@ function lookupSnapshot(container: Element): Array<[string | null, string | null
 }
 
 describe("compiled keyed Map lookup targets", () => {
+  it("consumes compiler-proven Map deltas across queued setters", async () => {
+    const initial = items(2_000);
+    const initialLookup = new Map<unknown, unknown>(
+      initial.map((item, index) => [item.id, `status-${index}`]),
+    );
+    const harness = createMapLookupHarness(initial, initialLookup);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Rows />));
+
+    harness.counters.bindingReads = 0;
+    harness.counters.targetReads = 0;
+    await act(async () => {
+      harness.setLookup((current) => hintedMapSet(current, "row-1500", "urgent"));
+      harness.setLookup((current) => hintedMapDelete(current, "row-10"));
+      harness.setLookup((current) => hintedMapSet(current, "missing", "ignored"));
+      await flushCompilerUpdates();
+    });
+
+    expect(harness.counters.bindingReads).toBe(2);
+    expect(harness.counters.targetReads).toBe(1);
+    expect(container.querySelector('[data-key="row-10"]')?.getAttribute("data-status")).toBe(
+      "none",
+    );
+    expect(container.querySelector('[data-key="row-1500"]')?.getAttribute("data-status")).toBe(
+      "urgent",
+    );
+    expect(harness.counters.executions).toBe(1);
+  });
+
+  it("keeps hinted Map snapshots correct across compaction and ordinary replacements", async () => {
+    const initial = items(96);
+    const harness = createMapLookupHarness(initial, new Map());
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Rows />));
+
+    for (let index = 0; index < 80; index += 1) {
+      await act(async () => {
+        harness.setLookup((current) =>
+          hintedMapSet(current, `row-${index % initial.length}`, `value-${index}`),
+        );
+        await flushCompilerUpdates();
+      });
+    }
+    await act(async () => {
+      harness.setLookup(new Map([["row-90", "replacement"]]));
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector('[data-key="row-79"]')?.getAttribute("data-status")).toBe(
+      "none",
+    );
+    expect(container.querySelector('[data-key="row-90"]')?.getAttribute("data-status")).toBe(
+      "replacement",
+    );
+    expect(harness.counters.executions).toBe(1);
+  });
+
+  it("rejects unsafe hinted Map values before compiled binding reads", async () => {
+    const harness = createMapLookupHarness(items(16), new Map());
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Rows />));
+
+    harness.counters.bindingReads = 0;
+    await act(async () => {
+      harness.setLookup((current) => hintedMapSet(current, "row-8", { unsafe: true }));
+      await flushCompilerUpdates();
+    });
+
+    expect(harness.counters.bindingReads).toBe(0);
+    expect(container.querySelector('[data-key="row-8"]')?.getAttribute("data-status")).toBe(
+      "[object Object]",
+    );
+  });
+
   it("evaluates only row keys whose mapped value changed", async () => {
     const initial = items(2_000);
     const harness = createMapLookupHarness(initial, new Map([["row-10", "ready"]]));
@@ -414,6 +521,82 @@ describe("compiled keyed Map lookup targets", () => {
     }
   });
 
+  it("matches React across 2,000 randomized compiler-hinted Map mutations", async () => {
+    const initial = items(128);
+    const harness = createMapLookupHarness(initial, new Map());
+    let reactSet: React.Dispatch<React.SetStateAction<Map<unknown, unknown>>> = () => undefined;
+    function Normal() {
+      const [lookup, setLookup] = useState<Map<unknown, unknown>>(new Map());
+      reactSet = setLookup;
+      return (
+        <ul>
+          {initial.map((item) => (
+            <li
+              data-key={String(item.id)}
+              data-status={displayLookupValue(lookup.get(item.id)) as string}
+              key={String(item.id)}
+            >
+              {item.label}
+            </li>
+          ))}
+        </ul>
+      );
+    }
+
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<harness.Rows />);
+      reactRoot.render(<Normal />);
+    });
+
+    let random = 0x6d617044;
+    const nextRandom = () => (random = (Math.imul(random, 1_664_525) + 1_013_904_223) >>> 0);
+    let committed = new Map<unknown, unknown>();
+    for (let batch = 0; batch < 100; batch += 1) {
+      const final = new Map(committed);
+      harness.counters.bindingReads = 0;
+      await act(async () => {
+        for (let update = 0; update < 20; update += 1) {
+          const value = nextRandom();
+          const key = value % 13 === 0 ? `missing-${value}` : `row-${value % initial.length}`;
+          if (value % 5 === 0) {
+            final.delete(key);
+            harness.setLookup((current) => hintedMapDelete(current, key));
+            reactSet((current) => {
+              const next = new Map(current);
+              next.delete(key);
+              return next;
+            });
+          } else {
+            const status = `status-${nextRandom() % 11}`;
+            final.set(key, status);
+            harness.setLookup((current) => hintedMapSet(current, key, status));
+            reactSet((current) => new Map(current).set(key, status));
+          }
+        }
+        await flushCompilerUpdates();
+      });
+      const keys = new Set([...committed.keys(), ...final.keys()]);
+      const changedRows = [...keys].filter(
+        (key) =>
+          (committed.has(key) !== final.has(key) ||
+            !Object.is(committed.get(key), final.get(key))) &&
+          initial.some((item) => Object.is(item.id, key)),
+      ).length;
+      expect(harness.counters.bindingReads, `hinted reads in batch ${batch}`).toBe(changedRows);
+      expect(lookupSnapshot(compiledContainer), `hinted DOM after batch ${batch}`).toEqual(
+        lookupSnapshot(reactContainer),
+      );
+      committed = final;
+    }
+    expect(harness.counters.executions).toBe(1);
+  });
+
   it("is StrictMode-safe and drops a queued Map update after unmount", async () => {
     const harness = createMapLookupHarness(items(16), new Map());
     const container = document.createElement("div");
@@ -430,7 +613,7 @@ describe("compiled keyed Map lookup targets", () => {
 
     harness.counters.bindingReads = 0;
     await act(async () => {
-      harness.setLookup(new Map([["row-8", "done"]]));
+      harness.setLookup((current) => hintedMapSet(current, "row-8", "done"));
       root.unmount();
       roots.splice(roots.indexOf(root), 1);
       await flushCompilerUpdates();
@@ -453,7 +636,8 @@ describe("compiled keyed Map lookup targets", () => {
 
     harness.counters.bindingReads = 0;
     await act(async () => {
-      harness.setLookup(new Map([["row-20", "done"]]));
+      harness.setLookup((current) => hintedMapDelete(current, "row-1"));
+      harness.setLookup((current) => hintedMapSet(current, "row-20", "done"));
       await flushCompilerUpdates();
     });
 

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-membership-targets.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-membership-targets.test.tsx
@@ -2,7 +2,12 @@ import React, { StrictMode, useState } from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createCompiledComponent, type CompilerStateUpdater } from "../compiler-runtime";
+import {
+  applyCompilerKeyedCollectionMutation,
+  createCompiledComponent,
+  createCompilerKeyedCollectionUpdate,
+  type CompilerStateUpdater,
+} from "../compiler-runtime";
 
 declare global {
   var IS_REACT_ACT_ENVIRONMENT: boolean;
@@ -42,6 +47,17 @@ function items(count: number): Item[] {
     id: `row-${index}`,
     label: `Row ${index}`,
   }));
+}
+
+function hintedSetMutation(
+  previous: unknown,
+  operation: "set-add" | "set-delete",
+  key: unknown,
+): ReturnType<typeof createCompilerKeyedCollectionUpdate> {
+  const next = new Set(previous as Set<unknown>);
+  const method = operation === "set-add" ? next.add : next.delete;
+  applyCompilerKeyedCollectionMutation(next, method, operation, key);
+  return createCompilerKeyedCollectionUpdate(previous, next, "set");
 }
 
 function createMembershipHarness(initialItems: Item[], initialMembership: Set<unknown>) {
@@ -133,6 +149,87 @@ function membershipSnapshot(container: Element): Array<[string | null, string | 
 }
 
 describe("compiled keyed membership targets", () => {
+  it("consumes compiler-proven Set deltas across queued setters", async () => {
+    const initial = items(2_000);
+    const harness = createMembershipHarness(
+      initial,
+      new Set(initial.slice(0, 1_000).map((item) => item.id)),
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Rows />));
+
+    harness.counters.bindingReads = 0;
+    harness.counters.targetReads = 0;
+    await act(async () => {
+      harness.setMembership((current) => hintedSetMutation(current, "set-delete", "row-10"));
+      harness.setMembership((current) => hintedSetMutation(current, "set-add", "row-1500"));
+      harness.setMembership((current) => hintedSetMutation(current, "set-add", "missing"));
+      await flushCompilerUpdates();
+    });
+
+    expect(harness.counters.bindingReads).toBe(2);
+    expect(harness.counters.targetReads).toBe(1);
+    expect(container.querySelector('[data-key="row-10"]')?.getAttribute("data-marked")).toBe(
+      "false",
+    );
+    expect(container.querySelector('[data-key="row-1500"]')?.getAttribute("data-marked")).toBe(
+      "true",
+    );
+    expect(harness.counters.executions).toBe(1);
+  });
+
+  it("keeps hinted Set snapshots correct across compaction and ordinary replacements", async () => {
+    const initial = items(96);
+    const harness = createMembershipHarness(initial, new Set());
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Rows />));
+
+    for (let index = 0; index < 80; index += 1) {
+      await act(async () => {
+        harness.setMembership((current) =>
+          hintedSetMutation(current, "set-add", `row-${index % initial.length}`),
+        );
+        await flushCompilerUpdates();
+      });
+    }
+    await act(async () => {
+      harness.setMembership(new Set(["row-90"]));
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector('[data-key="row-79"]')?.getAttribute("data-marked")).toBe(
+      "false",
+    );
+    expect(container.querySelector('[data-key="row-90"]')?.getAttribute("data-marked")).toBe(
+      "true",
+    );
+    expect(harness.counters.executions).toBe(1);
+  });
+
+  it("rejects unsafe hinted Set keys before compiled binding reads", async () => {
+    const harness = createMembershipHarness(items(16), new Set());
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Rows />));
+
+    harness.counters.bindingReads = 0;
+    await act(async () => {
+      harness.setMembership((current) => hintedSetMutation(current, "set-add", { unsafe: true }));
+      await flushCompilerUpdates();
+    });
+
+    expect(harness.counters.bindingReads).toBe(0);
+    expect(harness.counters.executions).toBe(1);
+  });
+
   it("evaluates only keys in the Set symmetric difference", async () => {
     const initial = items(2_000);
     const harness = createMembershipHarness(initial, new Set(["row-10"]));
@@ -344,6 +441,75 @@ describe("compiled keyed membership targets", () => {
     }
   });
 
+  it("matches React across 2,000 randomized compiler-hinted Set mutations", async () => {
+    const initial = items(128);
+    const harness = createMembershipHarness(initial, new Set());
+    let reactSet: React.Dispatch<React.SetStateAction<Set<unknown>>> = () => undefined;
+    function Normal() {
+      const [membership, setMembership] = useState<Set<unknown>>(new Set());
+      reactSet = setMembership;
+      return (
+        <ul>
+          {initial.map((item) => (
+            <li
+              data-key={String(item.id)}
+              data-marked={membership.has(item.id)}
+              key={String(item.id)}
+            >
+              {item.label}
+            </li>
+          ))}
+        </ul>
+      );
+    }
+
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<harness.Rows />);
+      reactRoot.render(<Normal />);
+    });
+
+    let random = 0x5e7a1144;
+    const nextRandom = () => (random = (Math.imul(random, 1_664_525) + 1_013_904_223) >>> 0);
+    let committed = new Set<unknown>();
+    for (let batch = 0; batch < 100; batch += 1) {
+      const final = new Set(committed);
+      harness.counters.bindingReads = 0;
+      await act(async () => {
+        for (let update = 0; update < 20; update += 1) {
+          const value = nextRandom();
+          const key = value % 13 === 0 ? `missing-${value}` : `row-${value % initial.length}`;
+          const operation = value % 3 === 0 ? "set-delete" : "set-add";
+          if (operation === "set-delete") final.delete(key);
+          else final.add(key);
+          harness.setMembership((current) => hintedSetMutation(current, operation, key));
+          reactSet((current) => {
+            const next = new Set(current);
+            if (operation === "set-delete") next.delete(key);
+            else next.add(key);
+            return next;
+          });
+        }
+        await flushCompilerUpdates();
+      });
+      const changedRows = [...new Set([...committed, ...final])].filter(
+        (key) =>
+          committed.has(key) !== final.has(key) && initial.some((item) => Object.is(item.id, key)),
+      ).length;
+      expect(harness.counters.bindingReads, `hinted reads in batch ${batch}`).toBe(changedRows);
+      expect(membershipSnapshot(compiledContainer), `hinted DOM after batch ${batch}`).toEqual(
+        membershipSnapshot(reactContainer),
+      );
+      committed = final;
+    }
+    expect(harness.counters.executions).toBe(1);
+  });
+
   it("is StrictMode-safe and drops a queued membership update after unmount", async () => {
     const harness = createMembershipHarness(items(16), new Set());
     const container = document.createElement("div");
@@ -360,7 +526,7 @@ describe("compiled keyed membership targets", () => {
 
     harness.counters.bindingReads = 0;
     await act(async () => {
-      harness.setMembership(new Set(["row-8"]));
+      harness.setMembership((current) => hintedSetMutation(current, "set-add", "row-8"));
       root.unmount();
       roots.splice(roots.indexOf(root), 1);
       await flushCompilerUpdates();

--- a/packages/farm-react/src/__tests__/vite.test.ts
+++ b/packages/farm-react/src/__tests__/vite.test.ts
@@ -85,6 +85,7 @@ describe("React renderer Vite integration", () => {
       componentsConsidered: 2,
       compiled: 2,
       fallback: 0,
+      keyedCollectionUpdateHints: 0,
       keyedIdentityTargets: 0,
       keyedMapLookupTargets: 0,
       keyedMembershipTargets: 0,

--- a/packages/farm-react/src/compiler-report.ts
+++ b/packages/farm-react/src/compiler-report.ts
@@ -18,6 +18,7 @@ export interface ReactCompilerReport {
     componentsConsidered: number;
     compiled: number;
     fallback: number;
+    keyedCollectionUpdateHints: number;
     keyedIdentityTargets: number;
     keyedMapLookupTargets: number;
     keyedMembershipTargets: number;
@@ -31,6 +32,7 @@ export interface ReactCompilerReport {
     id: string;
     compiled: readonly string[];
     optimizations: {
+      keyedCollectionUpdateHints: number;
       keyedIdentityTargets: number;
       keyedMapLookupTargets: number;
       keyedMembershipTargets: number;
@@ -52,6 +54,7 @@ export function createReactCompilerReport(
   let componentsConsidered = 0;
   let compiled = 0;
   let fallback = 0;
+  let keyedCollectionUpdateHints = 0;
   let keyedIdentityTargets = 0;
   let keyedMapLookupTargets = 0;
   let keyedMembershipTargets = 0;
@@ -62,6 +65,7 @@ export function createReactCompilerReport(
       componentsConsidered += result.compiled.length + result.diagnostics.length;
       compiled += result.compiled.length;
       fallback += result.diagnostics.length;
+      keyedCollectionUpdateHints += result.optimizations.keyedCollectionUpdateHints || 0;
       keyedIdentityTargets += result.optimizations.keyedIdentityTargets || 0;
       keyedMapLookupTargets += result.optimizations.keyedMapLookupTargets || 0;
       keyedMembershipTargets += result.optimizations.keyedMembershipTargets || 0;
@@ -91,6 +95,7 @@ export function createReactCompilerReport(
       componentsConsidered,
       compiled,
       fallback,
+      keyedCollectionUpdateHints,
       keyedIdentityTargets,
       keyedMapLookupTargets,
       keyedMembershipTargets,

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -11,12 +11,36 @@ interface CompilerKeyedMapUpdateHint {
   readonly previous?: CompilerKeyedMapUpdateHint;
 }
 
+type CompilerKeyedCollectionKind = "set" | "map";
+type CompilerKeyedCollectionMutation = "set-add" | "set-delete" | "map-set" | "map-delete";
+
+interface CompilerKeyedCollectionDraft {
+  readonly kind: CompilerKeyedCollectionKind;
+  readonly changedKeys: unknown[];
+}
+
+interface CompilerKeyedCollectionUpdateHint {
+  readonly kind: CompilerKeyedCollectionKind;
+  readonly sourceToken: object;
+  readonly changedKeys: readonly unknown[];
+  readonly previous?: CompilerKeyedCollectionUpdateHint;
+}
+
 const COMPILER_KEYED_COLLECTION_TOKENS = /* @__PURE__ */ new WeakMap<object, object>();
 const COMPILER_KEYED_MAP_UPDATES = /* @__PURE__ */ new WeakMap<
   object,
   CompilerKeyedMapUpdateHint
 >();
+const COMPILER_KEYED_COLLECTION_DRAFTS = /* @__PURE__ */ new WeakMap<
+  object,
+  CompilerKeyedCollectionDraft
+>();
+const COMPILER_KEYED_COLLECTION_UPDATES = /* @__PURE__ */ new WeakMap<
+  object,
+  CompilerKeyedCollectionUpdateHint
+>();
 const COMPILER_KEYED_COMMITTED_COLLECTIONS = /* @__PURE__ */ new WeakSet<object>();
+const NATIVE_REFLECT_APPLY = Reflect.apply;
 
 function compilerObject(value: unknown): object | undefined {
   return (typeof value === "object" && value !== null) || typeof value === "function"
@@ -61,6 +85,27 @@ function compilerKeyedMapChangedIndices(
   return changedIndices;
 }
 
+function compilerKeyedCollectionChangedKeys(
+  value: unknown,
+  sourceToken: object | undefined,
+  kind: CompilerKeyedCollectionKind,
+): readonly unknown[] | undefined {
+  const target = compilerObject(value);
+  if (!target || !sourceToken) return undefined;
+  const update = COMPILER_KEYED_COLLECTION_UPDATES.get(target);
+  if (!update || update.kind !== kind || update.sourceToken !== sourceToken) return undefined;
+  const changedKeys: unknown[] = [];
+  for (
+    let current: CompilerKeyedCollectionUpdateHint | undefined = update;
+    current;
+    current = current.previous
+  ) {
+    if (current.kind !== kind || current.sourceToken !== sourceToken) return undefined;
+    changedKeys.push(...current.changedKeys);
+  }
+  return changedKeys;
+}
+
 /** @internal Records compiler-proven same-order Array.map metadata and returns the Array. */
 export function createCompilerKeyedMapUpdate(
   previous: unknown,
@@ -81,6 +126,66 @@ export function createCompilerKeyedMapUpdate(
       ...(previousUpdate ? { previous: previousUpdate } : {}),
     });
   }
+  return value;
+}
+
+/** @internal Preserves a proven native collection mutation while recording its executed key. */
+export function applyCompilerKeyedCollectionMutation(
+  collection: unknown,
+  method: unknown,
+  operation: CompilerKeyedCollectionMutation,
+  key: unknown,
+  value?: unknown,
+): unknown {
+  const args = operation === "map-set" ? [key, value] : [key];
+  const result = NATIVE_REFLECT_APPLY(method as (...args: unknown[]) => unknown, collection, args);
+  const target = compilerObject(collection);
+  if (!target) return result;
+
+  const kind: CompilerKeyedCollectionKind = operation.startsWith("set-") ? "set" : "map";
+  const nativeMethod =
+    operation === "set-add"
+      ? NATIVE_SET_ADD
+      : operation === "set-delete"
+        ? NATIVE_SET_DELETE
+        : operation === "map-set"
+          ? NATIVE_MAP_SET
+          : NATIVE_MAP_DELETE;
+  const nativePrototype = kind === "set" ? NATIVE_SET_PROTOTYPE : NATIVE_MAP_PROTOTYPE;
+  if (method !== nativeMethod || Object.getPrototypeOf(collection) !== nativePrototype) {
+    return result;
+  }
+
+  const existing = COMPILER_KEYED_COLLECTION_DRAFTS.get(target);
+  if (existing && existing.kind !== kind) return result;
+  if (existing) existing.changedKeys.push(key);
+  else COMPILER_KEYED_COLLECTION_DRAFTS.set(target, { kind, changedKeys: [key] });
+  return result;
+}
+
+/** @internal Connects compiler-owned immutable Set/Map mutations to their committed source. */
+export function createCompilerKeyedCollectionUpdate(
+  previous: unknown,
+  value: unknown,
+  kind: CompilerKeyedCollectionKind,
+): unknown {
+  const previousTarget = compilerObject(previous);
+  const valueTarget = compilerObject(value);
+  if (!previousTarget || !valueTarget || previousTarget === valueTarget) return value;
+  const draft = COMPILER_KEYED_COLLECTION_DRAFTS.get(valueTarget);
+  if (!draft || draft.kind !== kind || draft.changedKeys.length === 0) return value;
+
+  const sourceToken = compilerKeyedCollectionToken(previousTarget);
+  if (!sourceToken) return value;
+  const previousUpdate = !COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget)
+    ? COMPILER_KEYED_COLLECTION_UPDATES.get(previousTarget)
+    : undefined;
+  COMPILER_KEYED_COLLECTION_UPDATES.set(valueTarget, {
+    kind,
+    sourceToken: previousUpdate?.sourceToken || sourceToken,
+    changedKeys: [...draft.changedKeys],
+    ...(previousUpdate ? { previous: previousUpdate } : {}),
+  });
   return value;
 }
 
@@ -947,11 +1052,26 @@ interface CompilerKeyedIdentityTargetSnapshot {
 interface CompilerKeyedMembershipTargetSnapshot {
   eligible: boolean;
   values?: ReadonlySet<unknown>;
+  previous?: CompilerKeyedMembershipTargetSnapshot;
+  changes?: ReadonlyMap<unknown, boolean>;
+  sourceToken?: object;
+  targetedKeys?: ReadonlySet<string>;
+  depth?: number;
 }
 
 interface CompilerKeyedMapLookupTargetSnapshot {
   eligible: boolean;
   values?: ReadonlyMap<unknown, unknown>;
+  previous?: CompilerKeyedMapLookupTargetSnapshot;
+  changes?: ReadonlyMap<unknown, CompilerKeyedMapLookupValue>;
+  sourceToken?: object;
+  targetedKeys?: ReadonlySet<string>;
+  depth?: number;
+}
+
+interface CompilerKeyedMapLookupValue {
+  present: boolean;
+  value?: unknown;
 }
 
 const UNSET_KEYED_ROW_BINDING = Symbol("unset interactive keyed-row binding");
@@ -973,10 +1093,93 @@ function keyedIdentityTargetSnapshot(value: unknown): CompilerKeyedIdentityTarge
 
 const NATIVE_SET_PROTOTYPE = Set.prototype;
 const NATIVE_SET_ADD = Set.prototype.add;
+const NATIVE_SET_DELETE = Set.prototype.delete;
 const NATIVE_SET_HAS = Set.prototype.has;
 const NATIVE_SET_VALUES = Set.prototype.values;
+const KEYED_COLLECTION_SNAPSHOT_MAX_DEPTH = 64;
 
-function keyedMembershipTargetSnapshot(value: unknown): CompilerKeyedMembershipTargetSnapshot {
+function materializeKeyedMembershipSnapshot(
+  snapshot: CompilerKeyedMembershipTargetSnapshot,
+): Set<unknown> | undefined {
+  if (!snapshot.eligible) return undefined;
+  if (snapshot.values) return new Set(snapshot.values);
+  if (!snapshot.previous || !snapshot.changes) return undefined;
+  const values = materializeKeyedMembershipSnapshot(snapshot.previous);
+  if (!values) return undefined;
+  for (const [key, present] of snapshot.changes) {
+    if (present) NATIVE_SET_ADD.call(values, key);
+    else NATIVE_SET_DELETE.call(values, key);
+  }
+  return values;
+}
+
+function keyedMembershipSnapshotHas(
+  snapshot: CompilerKeyedMembershipTargetSnapshot,
+  key: unknown,
+): boolean | undefined {
+  for (
+    let current: CompilerKeyedMembershipTargetSnapshot | undefined = snapshot;
+    current;
+    current = current.previous
+  ) {
+    if (!current.eligible) return undefined;
+    if (current.changes?.has(key)) return current.changes.get(key);
+    if (current.values) return NATIVE_SET_HAS.call(current.values, key);
+  }
+  return undefined;
+}
+
+function keyedMembershipDeltaSnapshot(
+  value: unknown,
+  previous: CompilerKeyedMembershipTargetSnapshot,
+): CompilerKeyedMembershipTargetSnapshot | undefined {
+  if (!previous.eligible || !previous.sourceToken) return undefined;
+  const target = compilerObject(value);
+  if (!target) return undefined;
+  const changedKeys = compilerKeyedCollectionChangedKeys(value, previous.sourceToken, "set");
+  if (!changedKeys) return undefined;
+  if (
+    Object.getPrototypeOf(value) !== NATIVE_SET_PROTOTYPE ||
+    Object.prototype.hasOwnProperty.call(value, "has") ||
+    (value as Set<unknown>).has !== NATIVE_SET_HAS
+  ) {
+    return undefined;
+  }
+
+  const changes = new Map<unknown, boolean>();
+  const targetedKeys = new Set<string>();
+  try {
+    for (const key of changedKeys) {
+      if (!keyedIdentityTargetSnapshot(key).eligible) return undefined;
+      const present = NATIVE_SET_HAS.call(value as Set<unknown>, key);
+      const before = keyedMembershipSnapshotHas(previous, key);
+      if (before === undefined) return undefined;
+      changes.set(key, present);
+      if (before !== present) NATIVE_SET_ADD.call(targetedKeys, String(key));
+    }
+  } catch {
+    return undefined;
+  }
+  const depth = (previous.depth || 0) + 1;
+  if (depth > KEYED_COLLECTION_SNAPSHOT_MAX_DEPTH) return undefined;
+  return {
+    eligible: true,
+    previous,
+    changes,
+    sourceToken: commitCompilerKeyedCollection(value),
+    targetedKeys,
+    depth,
+  };
+}
+
+function keyedMembershipTargetSnapshot(
+  value: unknown,
+  previous?: CompilerKeyedMembershipTargetSnapshot,
+): CompilerKeyedMembershipTargetSnapshot {
+  if (previous) {
+    const delta = keyedMembershipDeltaSnapshot(value, previous);
+    if (delta) return delta;
+  }
   if (typeof value !== "object" || value === null) return { eligible: false };
   let iterator: SetIterator<unknown>;
   try {
@@ -1000,14 +1203,23 @@ function keyedMembershipTargetSnapshot(value: unknown): CompilerKeyedMembershipT
   } catch {
     return { eligible: false };
   }
-  return { eligible: true, values };
+  return {
+    eligible: true,
+    values,
+    sourceToken: commitCompilerKeyedCollection(value),
+    depth: 0,
+  };
 }
 
 function keyedMembershipChangedKeys(
-  previous: ReadonlySet<unknown>,
-  next: ReadonlySet<unknown>,
+  previousSnapshot: CompilerKeyedMembershipTargetSnapshot,
+  nextSnapshot: CompilerKeyedMembershipTargetSnapshot,
 ): Set<string> {
+  if (nextSnapshot.targetedKeys) return new Set(nextSnapshot.targetedKeys);
+  const previous = materializeKeyedMembershipSnapshot(previousSnapshot);
+  const next = materializeKeyedMembershipSnapshot(nextSnapshot);
   const keys = new Set<string>();
+  if (!previous || !next) return keys;
   for (const value of previous) {
     if (!NATIVE_SET_HAS.call(next, value)) NATIVE_SET_ADD.call(keys, String(value));
   }
@@ -1019,7 +1231,9 @@ function keyedMembershipChangedKeys(
 
 const NATIVE_MAP_PROTOTYPE = Map.prototype;
 const NATIVE_MAP_GET = Map.prototype.get;
+const NATIVE_MAP_HAS = Map.prototype.has;
 const NATIVE_MAP_SET = Map.prototype.set;
+const NATIVE_MAP_DELETE = Map.prototype.delete;
 const NATIVE_MAP_ENTRIES = Map.prototype.entries;
 
 function isSafeKeyedMapLookupValue(value: unknown): boolean {
@@ -1033,7 +1247,96 @@ function isSafeKeyedMapLookupValue(value: unknown): boolean {
   );
 }
 
-function keyedMapLookupTargetSnapshot(value: unknown): CompilerKeyedMapLookupTargetSnapshot {
+function materializeKeyedMapLookupSnapshot(
+  snapshot: CompilerKeyedMapLookupTargetSnapshot,
+): Map<unknown, unknown> | undefined {
+  if (!snapshot.eligible) return undefined;
+  if (snapshot.values) return new Map(snapshot.values);
+  if (!snapshot.previous || !snapshot.changes) return undefined;
+  const values = materializeKeyedMapLookupSnapshot(snapshot.previous);
+  if (!values) return undefined;
+  for (const [key, entry] of snapshot.changes) {
+    if (entry.present) NATIVE_MAP_SET.call(values, key, entry.value);
+    else NATIVE_MAP_DELETE.call(values, key);
+  }
+  return values;
+}
+
+function keyedMapLookupSnapshotValue(
+  snapshot: CompilerKeyedMapLookupTargetSnapshot,
+  key: unknown,
+): CompilerKeyedMapLookupValue | undefined {
+  for (
+    let current: CompilerKeyedMapLookupTargetSnapshot | undefined = snapshot;
+    current;
+    current = current.previous
+  ) {
+    if (!current.eligible) return undefined;
+    const changed = current.changes?.get(key);
+    if (changed) return changed;
+    if (current.values) {
+      const present = NATIVE_MAP_HAS.call(current.values, key);
+      return { present, ...(present ? { value: NATIVE_MAP_GET.call(current.values, key) } : {}) };
+    }
+  }
+  return undefined;
+}
+
+function keyedMapLookupDeltaSnapshot(
+  value: unknown,
+  previous: CompilerKeyedMapLookupTargetSnapshot,
+): CompilerKeyedMapLookupTargetSnapshot | undefined {
+  if (!previous.eligible || !previous.sourceToken) return undefined;
+  const target = compilerObject(value);
+  if (!target) return undefined;
+  const changedKeys = compilerKeyedCollectionChangedKeys(value, previous.sourceToken, "map");
+  if (!changedKeys) return undefined;
+  if (
+    Object.getPrototypeOf(value) !== NATIVE_MAP_PROTOTYPE ||
+    Object.prototype.hasOwnProperty.call(value, "get") ||
+    (value as Map<unknown, unknown>).get !== NATIVE_MAP_GET
+  ) {
+    return undefined;
+  }
+
+  const changes = new Map<unknown, CompilerKeyedMapLookupValue>();
+  const targetedKeys = new Set<string>();
+  try {
+    for (const key of changedKeys) {
+      if (!keyedIdentityTargetSnapshot(key).eligible) return undefined;
+      const present = NATIVE_MAP_HAS.call(value as Map<unknown, unknown>, key);
+      const entry = present ? NATIVE_MAP_GET.call(value as Map<unknown, unknown>, key) : undefined;
+      if (present && !isSafeKeyedMapLookupValue(entry)) return undefined;
+      const before = keyedMapLookupSnapshotValue(previous, key);
+      if (!before) return undefined;
+      changes.set(key, { present, ...(present ? { value: entry } : {}) });
+      if (before.present !== present || !Object.is(before.value, entry)) {
+        NATIVE_SET_ADD.call(targetedKeys, String(key));
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  const depth = (previous.depth || 0) + 1;
+  if (depth > KEYED_COLLECTION_SNAPSHOT_MAX_DEPTH) return undefined;
+  return {
+    eligible: true,
+    previous,
+    changes,
+    sourceToken: commitCompilerKeyedCollection(value),
+    targetedKeys,
+    depth,
+  };
+}
+
+function keyedMapLookupTargetSnapshot(
+  value: unknown,
+  previous?: CompilerKeyedMapLookupTargetSnapshot,
+): CompilerKeyedMapLookupTargetSnapshot {
+  if (previous) {
+    const delta = keyedMapLookupDeltaSnapshot(value, previous);
+    if (delta) return delta;
+  }
   if (typeof value !== "object" || value === null) return { eligible: false };
   let iterator: MapIterator<[unknown, unknown]>;
   try {
@@ -1059,14 +1362,23 @@ function keyedMapLookupTargetSnapshot(value: unknown): CompilerKeyedMapLookupTar
   } catch {
     return { eligible: false };
   }
-  return { eligible: true, values };
+  return {
+    eligible: true,
+    values,
+    sourceToken: commitCompilerKeyedCollection(value),
+    depth: 0,
+  };
 }
 
 function keyedMapLookupChangedKeys(
-  previous: ReadonlyMap<unknown, unknown>,
-  next: ReadonlyMap<unknown, unknown>,
+  previousSnapshot: CompilerKeyedMapLookupTargetSnapshot,
+  nextSnapshot: CompilerKeyedMapLookupTargetSnapshot,
 ): Set<string> {
+  if (nextSnapshot.targetedKeys) return new Set(nextSnapshot.targetedKeys);
+  const previous = materializeKeyedMapLookupSnapshot(previousSnapshot);
+  const next = materializeKeyedMapLookupSnapshot(nextSnapshot);
   const keys = new Set<string>();
+  if (!previous || !next) return keys;
   for (const [key, value] of previous) {
     if (!Object.is(value, NATIVE_MAP_GET.call(next, key))) {
       NATIVE_SET_ADD.call(keys, String(key));
@@ -3591,7 +3903,10 @@ function createKeyedRowsBlockComponent(
           );
         }
         if (binding.membershipTarget) {
-          const snapshot = keyedMembershipTargetSnapshot(binding.membershipTarget.read());
+          const snapshot = keyedMembershipTargetSnapshot(
+            binding.membershipTarget.read(),
+            this.membershipTargets.get(bindingIndex),
+          );
           if (!snapshot.eligible) {
             this.activateFallback(afterCommit);
             return true;
@@ -3599,7 +3914,10 @@ function createKeyedRowsBlockComponent(
           nextMembershipTargets.set(bindingIndex, snapshot);
         }
         if (binding.mapLookupTarget) {
-          const snapshot = keyedMapLookupTargetSnapshot(binding.mapLookupTarget.read());
+          const snapshot = keyedMapLookupTargetSnapshot(
+            binding.mapLookupTarget.read(),
+            this.mapLookupTargets.get(bindingIndex),
+          );
           if (!snapshot.eligible) {
             this.activateFallback(afterCommit);
             return true;
@@ -3630,9 +3948,7 @@ function createKeyedRowsBlockComponent(
           binding.dependencies[0] === membershipTarget.dependency &&
           dirtyState.has(membershipTarget.dependency) &&
           previousMembershipTarget?.eligible &&
-          previousMembershipTarget.values &&
-          nextMembershipTarget?.eligible &&
-          nextMembershipTarget.values,
+          nextMembershipTarget?.eligible,
         );
         const mapLookupTarget = binding.mapLookupTarget;
         const previousMapLookupTarget = this.mapLookupTargets.get(bindingIndex);
@@ -3643,16 +3959,11 @@ function createKeyedRowsBlockComponent(
           binding.dependencies[0] === mapLookupTarget.dependency &&
           dirtyState.has(mapLookupTarget.dependency) &&
           previousMapLookupTarget?.eligible &&
-          previousMapLookupTarget.values &&
-          nextMapLookupTarget?.eligible &&
-          nextMapLookupTarget.values,
+          nextMapLookupTarget?.eligible,
         );
 
-        if (canTargetMapLookup && previousMapLookupTarget?.values && nextMapLookupTarget?.values) {
-          const keys = keyedMapLookupChangedKeys(
-            previousMapLookupTarget.values,
-            nextMapLookupTarget.values,
-          );
+        if (canTargetMapLookup && previousMapLookupTarget && nextMapLookupTarget) {
+          const keys = keyedMapLookupChangedKeys(previousMapLookupTarget, nextMapLookupTarget);
           for (const key of keys) {
             const instance = this.instances.get(key);
             if (instance) {
@@ -3665,15 +3976,8 @@ function createKeyedRowsBlockComponent(
               );
             }
           }
-        } else if (
-          canTargetMembership &&
-          previousMembershipTarget?.values &&
-          nextMembershipTarget?.values
-        ) {
-          const keys = keyedMembershipChangedKeys(
-            previousMembershipTarget.values,
-            nextMembershipTarget.values,
-          );
+        } else if (canTargetMembership && previousMembershipTarget && nextMembershipTarget) {
+          const keys = keyedMembershipChangedKeys(previousMembershipTarget, nextMembershipTarget);
           for (const key of keys) {
             const instance = this.instances.get(key);
             if (instance) {

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -13,6 +13,7 @@ export interface CompileReactModuleResult {
   compiled: readonly string[];
   diagnostics: readonly CompilerDiagnostic[];
   optimizations: {
+    keyedCollectionUpdateHints: number;
     keyedIdentityTargets: number;
     keyedMapLookupTargets: number;
     keyedMembershipTargets: number;
@@ -1128,6 +1129,450 @@ function rewriteKeyedMapUpdateHints(
       path.skip();
     },
   });
+  return {
+    root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement,
+    count,
+  };
+}
+
+type KeyedCollectionTargetKind = "set" | "map";
+
+interface PreparedKeyedCollectionUpdater {
+  updater: t.ArrowFunctionExpression | t.FunctionExpression;
+  mutations: number;
+}
+
+function collectionConstructorName(kind: KeyedCollectionTargetKind): "Set" | "Map" {
+  return kind === "set" ? "Set" : "Map";
+}
+
+function isCollectionConstruction(
+  expression: t.Expression | null | undefined,
+  kind: KeyedCollectionTargetKind,
+  previous?: t.Identifier,
+): expression is t.NewExpression {
+  if (
+    !t.isNewExpression(expression) ||
+    !t.isIdentifier(expression.callee, { name: collectionConstructorName(kind) })
+  ) {
+    return false;
+  }
+  if (!previous) return true;
+  return (
+    expression.arguments.length === 1 &&
+    t.isIdentifier(expression.arguments[0], { name: previous.name })
+  );
+}
+
+function collectionStateInitializerIsOwned(
+  initialValue: t.Expression | undefined,
+  kind: KeyedCollectionTargetKind,
+  constructorIsGlobal: boolean,
+): boolean {
+  if (!initialValue || !constructorIsGlobal) return false;
+  if (isCollectionConstruction(initialValue, kind)) return true;
+  if (!t.isArrowFunctionExpression(initialValue) && !t.isFunctionExpression(initialValue)) {
+    return false;
+  }
+  if (t.isBlockStatement(initialValue.body) && initialValue.body.body.length !== 1) return false;
+  const value = returnedExpression(initialValue);
+  return Boolean(value && isCollectionConstruction(value, kind));
+}
+
+function collectionStateHasOnlyOwnedReads(
+  root: t.JSXElement,
+  state: StateBinding,
+  kind: KeyedCollectionTargetKind,
+): boolean {
+  const file = expressionFile(t.cloneNode(root, true));
+  let valid = true;
+  const readMethods = kind === "set" ? new Set(["has"]) : new Set(["get", "has"]);
+  traverse(file, {
+    ReferencedIdentifier(path) {
+      if (
+        !valid ||
+        !t.isIdentifier(path.node) ||
+        path.node.name !== state.valueName ||
+        path.scope.hasBinding(path.node.name)
+      ) {
+        return;
+      }
+      const parent = path.parentPath;
+      if (
+        parent.isNewExpression() &&
+        t.isIdentifier(parent.node.callee, { name: collectionConstructorName(kind) }) &&
+        parent.node.arguments.length === 1 &&
+        parent.node.arguments[0] === path.node
+      ) {
+        return;
+      }
+      if (
+        !parent.isMemberExpression() ||
+        parent.node.object !== path.node ||
+        parent.node.computed ||
+        !t.isIdentifier(parent.node.property)
+      ) {
+        valid = false;
+        path.stop();
+        return;
+      }
+      const property = parent.node.property.name;
+      if (property === "size") return;
+      const call = parent.parentPath;
+      if (
+        !readMethods.has(property) ||
+        !call?.isCallExpression() ||
+        call.node.callee !== parent.node
+      ) {
+        valid = false;
+        path.stop();
+      }
+    },
+  });
+  return valid;
+}
+
+function collectionMutationOperation(
+  kind: KeyedCollectionTargetKind,
+  method: string,
+): "set-add" | "set-delete" | "map-set" | "map-delete" | undefined {
+  if (kind === "set" && method === "add") return "set-add";
+  if (kind === "set" && method === "delete") return "set-delete";
+  if (kind === "map" && method === "set") return "map-set";
+  if (kind === "map" && method === "delete") return "map-delete";
+  return undefined;
+}
+
+function collectionMutationArgumentsAreValid(
+  operation: ReturnType<typeof collectionMutationOperation>,
+  args: readonly (t.Expression | t.JSXNamespacedName | t.ArgumentPlaceholder | t.SpreadElement)[],
+): args is readonly t.Expression[] {
+  if (!operation || args.some((argument) => !t.isExpression(argument))) return false;
+  return operation === "map-set" ? args.length === 2 : args.length === 1;
+}
+
+function prepareKeyedCollectionUpdater(
+  updater: t.ArrowFunctionExpression | t.FunctionExpression,
+  kind: KeyedCollectionTargetKind,
+  updateHelper: t.Identifier,
+  mutationHelper: t.Identifier,
+): PreparedKeyedCollectionUpdater | undefined {
+  if (
+    updater.async ||
+    updater.generator ||
+    updater.params.length !== 1 ||
+    !t.isIdentifier(updater.params[0])
+  ) {
+    return undefined;
+  }
+  const previous = updater.params[0];
+
+  if (t.isExpression(updater.body)) {
+    if (
+      !t.isCallExpression(updater.body) ||
+      !t.isMemberExpression(updater.body.callee) ||
+      updater.body.callee.computed ||
+      !t.isIdentifier(updater.body.callee.property)
+    ) {
+      return undefined;
+    }
+    const operation = collectionMutationOperation(kind, updater.body.callee.property.name);
+    if (
+      (operation !== "set-add" && operation !== "map-set") ||
+      !collectionMutationArgumentsAreValid(operation, updater.body.arguments) ||
+      !isCollectionConstruction(updater.body.callee.object, kind, previous)
+    ) {
+      return undefined;
+    }
+    const collection = uniqueLocalIdentifier("_farmCollection", [updater]);
+    const body = t.blockStatement([
+      t.variableDeclaration("const", [
+        t.variableDeclarator(
+          t.cloneNode(collection),
+          t.cloneNode(updater.body.callee.object, true),
+        ),
+      ]),
+      t.returnStatement(
+        t.callExpression(t.cloneNode(updateHelper), [
+          t.cloneNode(previous),
+          t.callExpression(t.cloneNode(mutationHelper), [
+            t.cloneNode(collection),
+            t.memberExpression(t.cloneNode(collection), t.cloneNode(updater.body.callee.property)),
+            t.stringLiteral(operation),
+            ...updater.body.arguments.map(
+              (argument) => t.cloneNode(argument, true) as t.Expression,
+            ),
+          ]),
+          t.stringLiteral(kind),
+        ]),
+      ),
+    ]);
+    return {
+      updater: t.arrowFunctionExpression([t.cloneNode(previous)], body),
+      mutations: 1,
+    };
+  }
+
+  const cloned = t.cloneNode(updater, true);
+  const file = expressionFile(cloned);
+  let functionPath: NodePath<t.ArrowFunctionExpression | t.FunctionExpression> | undefined;
+  traverse(file, {
+    Function(path) {
+      if (functionPath) return;
+      if (path.isArrowFunctionExpression() || path.isFunctionExpression()) {
+        functionPath = path;
+      }
+    },
+  });
+  if (!functionPath || !t.isBlockStatement(functionPath.node.body)) return undefined;
+  const clonedPrevious = functionPath.node.params[0];
+  if (!t.isIdentifier(clonedPrevious)) return undefined;
+
+  let collectionDeclaration: NodePath<t.VariableDeclarator> | undefined;
+  const updaterBody = functionPath.get("body");
+  if (!updaterBody.isBlockStatement()) return undefined;
+  for (const statement of updaterBody.get("body")) {
+    if (!statement.isVariableDeclaration({ kind: "const" })) continue;
+    for (const declaration of statement.get("declarations")) {
+      if (
+        declaration.isVariableDeclarator() &&
+        t.isIdentifier(declaration.node.id) &&
+        t.isExpression(declaration.node.init) &&
+        isCollectionConstruction(declaration.node.init, kind, clonedPrevious)
+      ) {
+        if (collectionDeclaration) return undefined;
+        collectionDeclaration = declaration;
+      }
+    }
+  }
+  if (!collectionDeclaration || !t.isIdentifier(collectionDeclaration.node.id)) return undefined;
+  if (collectionDeclaration.scope.getBinding(collectionConstructorName(kind))) return undefined;
+  const collectionName = collectionDeclaration.node.id.name;
+  const collectionBinding = collectionDeclaration.scope.getBinding(collectionName);
+  const previousBinding = functionPath.scope.getBinding(clonedPrevious.name);
+  if (!collectionBinding || !previousBinding) return undefined;
+
+  let valid = true;
+  let mutations = 0;
+  traverse(file, {
+    ReferencedIdentifier(path) {
+      if (!valid) return;
+      const binding = path.scope.getBinding(path.node.name);
+      const belongsToUpdater = path.getFunctionParent()?.node === functionPath?.node;
+      if (binding === collectionBinding) {
+        if (!belongsToUpdater) {
+          valid = false;
+          path.stop();
+          return;
+        }
+        const parent = path.parentPath;
+        if (parent.isReturnStatement() && parent.node.argument === path.node) return;
+        if (
+          !parent.isMemberExpression() ||
+          parent.node.object !== path.node ||
+          parent.node.computed ||
+          !t.isIdentifier(parent.node.property)
+        ) {
+          valid = false;
+          path.stop();
+          return;
+        }
+        const method = parent.node.property.name;
+        if (method === "size") return;
+        const call = parent.parentPath;
+        if (!call?.isCallExpression() || call.node.callee !== parent.node) {
+          valid = false;
+          path.stop();
+          return;
+        }
+        const operation = collectionMutationOperation(kind, method);
+        const read = kind === "set" ? method === "has" : method === "get" || method === "has";
+        if (read) return;
+        if (
+          !collectionMutationArgumentsAreValid(operation, call.node.arguments) ||
+          (call.parentPath.isMemberExpression() && call.parentPath.node.object === call.node)
+        ) {
+          valid = false;
+          path.stop();
+          return;
+        }
+        mutations += 1;
+        return;
+      }
+      if (binding === previousBinding) {
+        if (!belongsToUpdater) {
+          valid = false;
+          path.stop();
+          return;
+        }
+        const parent = path.parentPath;
+        if (parent.isReturnStatement() && parent.node.argument === path.node) return;
+        if (
+          parent.isNewExpression() &&
+          parent.node.arguments.length === 1 &&
+          parent.node.arguments[0] === path.node &&
+          t.isIdentifier(parent.node.callee, { name: collectionConstructorName(kind) })
+        ) {
+          return;
+        }
+        if (
+          parent.isMemberExpression() &&
+          parent.node.object === path.node &&
+          !parent.node.computed &&
+          t.isIdentifier(parent.node.property)
+        ) {
+          const method = parent.node.property.name;
+          const call = parent.parentPath;
+          if (
+            method === "size" ||
+            ((kind === "set" ? method === "has" : method === "get" || method === "has") &&
+              call?.isCallExpression() &&
+              call.node.callee === parent.node)
+          ) {
+            return;
+          }
+        }
+        valid = false;
+        path.stop();
+      }
+    },
+    ReturnStatement(path) {
+      if (!valid || path.getFunctionParent()?.node !== functionPath?.node || !path.node.argument) {
+        return;
+      }
+      const value = path.node.argument;
+      const returnsOwnedCollection =
+        (t.isIdentifier(value) &&
+          (path.scope.getBinding(value.name) === collectionBinding ||
+            path.scope.getBinding(value.name) === previousBinding)) ||
+        isCollectionConstruction(value, kind);
+      if (!returnsOwnedCollection) {
+        valid = false;
+        path.stop();
+      }
+    },
+  });
+  if (!valid || mutations === 0) return undefined;
+
+  traverse(file, {
+    CallExpression(path) {
+      if (path.getFunctionParent()?.node !== functionPath?.node) return;
+      const callee = path.node.callee;
+      if (
+        !t.isMemberExpression(callee) ||
+        callee.computed ||
+        !t.isIdentifier(callee.object, { name: collectionName }) ||
+        path.scope.getBinding(collectionName) !== collectionBinding ||
+        !t.isIdentifier(callee.property)
+      ) {
+        return;
+      }
+      const operation = collectionMutationOperation(kind, callee.property.name);
+      if (!collectionMutationArgumentsAreValid(operation, path.node.arguments)) return;
+      path.replaceWith(
+        t.callExpression(t.cloneNode(mutationHelper), [
+          t.cloneNode(callee.object),
+          t.memberExpression(t.cloneNode(callee.object), t.cloneNode(callee.property)),
+          t.stringLiteral(operation!),
+          ...path.node.arguments.map((argument) => t.cloneNode(argument, true) as t.Expression),
+        ]),
+      );
+      path.skip();
+    },
+    ReturnStatement(path) {
+      if (path.getFunctionParent()?.node !== functionPath?.node || !path.node.argument) return;
+      path.node.argument = t.callExpression(t.cloneNode(updateHelper), [
+        t.cloneNode(clonedPrevious),
+        t.cloneNode(path.node.argument, true),
+        t.stringLiteral(kind),
+      ]);
+    },
+  });
+  const prepared = (file.program.body[0] as t.ExpressionStatement).expression;
+  return t.isArrowFunctionExpression(prepared) || t.isFunctionExpression(prepared)
+    ? { updater: prepared, mutations }
+    : undefined;
+}
+
+function rewriteKeyedCollectionUpdateHints(
+  root: t.JSXElement,
+  targetKinds: ReadonlyMap<number, KeyedCollectionTargetKind>,
+  states: readonly StateBinding[],
+  statesBySetter: ReadonlyMap<string, StateBinding>,
+  updateHelper: t.Identifier,
+  mutationHelper: t.Identifier,
+  globalCollections: ReadonlySet<string>,
+): { root: t.JSXElement; count: number } {
+  if (targetKinds.size === 0) return { root: t.cloneNode(root, true), count: 0 };
+  const file = expressionFile(t.cloneNode(root, true));
+  let count = 0;
+
+  for (const [stateIndex, kind] of targetKinds) {
+    const state = states[stateIndex];
+    if (
+      !state ||
+      !collectionStateInitializerIsOwned(
+        state.initialValue,
+        kind,
+        globalCollections.has(collectionConstructorName(kind)),
+      ) ||
+      !collectionStateHasOnlyOwnedReads(root, state, kind)
+    ) {
+      continue;
+    }
+
+    const replacements = new Map<t.CallExpression, PreparedKeyedCollectionUpdater>();
+    let valid = true;
+    traverse(file, {
+      CallExpression(path) {
+        if (!valid) return;
+        const callee = path.get("callee");
+        if (
+          !callee.isIdentifier({ name: state.setterName }) ||
+          callee.scope.hasBinding(callee.node.name) ||
+          statesBySetter.get(callee.node.name)?.index !== stateIndex
+        ) {
+          return;
+        }
+        if (path.node.arguments.length !== 1 || !t.isExpression(path.node.arguments[0])) {
+          valid = false;
+          path.stop();
+          return;
+        }
+        const update = path.node.arguments[0];
+        if (path.scope.getBinding(collectionConstructorName(kind))) {
+          valid = false;
+          path.stop();
+          return;
+        }
+        if (isCollectionConstruction(update, kind)) return;
+        if (!t.isArrowFunctionExpression(update) && !t.isFunctionExpression(update)) {
+          valid = false;
+          path.stop();
+          return;
+        }
+        const prepared = prepareKeyedCollectionUpdater(update, kind, updateHelper, mutationHelper);
+        if (!prepared) {
+          valid = false;
+          path.stop();
+          return;
+        }
+        replacements.set(path.node, prepared);
+      },
+    });
+    if (!valid || replacements.size === 0) continue;
+
+    traverse(file, {
+      CallExpression(path) {
+        const prepared = replacements.get(path.node);
+        if (!prepared) return;
+        path.node.arguments[0] = t.cloneNode(prepared.updater, true);
+        count += prepared.mutations;
+        path.skip();
+      },
+    });
+  }
+
   return {
     root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement,
     count,
@@ -5288,9 +5733,12 @@ function compileCandidate(
   candidate: Candidate,
   createComponentIdentifier: t.Identifier,
   keyedMapUpdateIdentifier: t.Identifier,
+  keyedCollectionUpdateIdentifier: t.Identifier,
+  keyedCollectionMutationIdentifier: t.Identifier,
   runtimeFeatureIdentifiers: ReadonlyMap<CompilerRuntimeFeatureName, t.Identifier>,
   usedRuntimeFeatures: Set<CompilerRuntimeFeatureName>,
   optimizationCounts: {
+    keyedCollectionUpdateHints: number;
     keyedIdentityTargets: number;
     keyedMapLookupTargets: number;
     keyedMembershipTargets: number;
@@ -5313,6 +5761,7 @@ function compileCandidate(
   const safeGlobals = new Set(
     [...SAFE_GLOBAL_CALLS, "Math"].filter((name) => !path.scope.getBinding(name)),
   );
+  const globalCollections = new Set(["Set", "Map"].filter((name) => !path.scope.getBinding(name)));
 
   const states: StateBinding[] = [];
   const locals: LocalBinding[] = [];
@@ -5576,6 +6025,58 @@ function compileCandidate(
       optimizationCounts.keyedMapUpdateHints += hintedRoot.count;
     }
   }
+  const keyedCollectionTargetKinds = new Map<number, KeyedCollectionTargetKind>();
+  const conflictingKeyedCollectionTargets = new Set<number>();
+  for (const plan of blockAnalysis.plans || []) {
+    if (plan.kind !== "keyed-rows") continue;
+    for (const binding of plan.bindings) {
+      const target = binding.membershipTarget || binding.mapLookupTarget;
+      if (!target) continue;
+      const kind: KeyedCollectionTargetKind = binding.membershipTarget ? "set" : "map";
+      const previousKind = keyedCollectionTargetKinds.get(target.dependency);
+      if (previousKind && previousKind !== kind) {
+        conflictingKeyedCollectionTargets.add(target.dependency);
+      } else {
+        keyedCollectionTargetKinds.set(target.dependency, kind);
+      }
+    }
+  }
+  for (const dependency of conflictingKeyedCollectionTargets) {
+    keyedCollectionTargetKinds.delete(dependency);
+  }
+  const keyedCollectionHintedRoot = rewriteKeyedCollectionUpdateHints(
+    expandedReactiveRoot,
+    keyedCollectionTargetKinds,
+    states,
+    statesBySetter,
+    keyedCollectionUpdateIdentifier,
+    keyedCollectionMutationIdentifier,
+    globalCollections,
+  );
+  if (keyedCollectionHintedRoot.count > 0) {
+    const hintedBlockAnalysis = analyzeComposableBlocks(
+      keyedCollectionHintedRoot.root,
+      reactiveByValue,
+      safeGlobals,
+      listNames,
+      allowedComponentNames,
+    );
+    const hintedAnalysis = analyzeHostTree(
+      keyedCollectionHintedRoot.root,
+      reactiveByValue,
+      safeGlobals,
+      hintedBlockAnalysis.conditionalExpressions || new Set<t.Expression>(),
+      hintedBlockAnalysis.keyedExpressions || new Set<t.Expression>(),
+      hintedBlockAnalysis.ownedElements || new Set<t.JSXElement>(),
+      hintedBlockAnalysis.componentElements || new Set<t.JSXElement>(),
+    );
+    if (!hintedBlockAnalysis.reason && !hintedAnalysis.reason) {
+      expandedReactiveRoot = keyedCollectionHintedRoot.root;
+      blockAnalysis = hintedBlockAnalysis;
+      analysis = hintedAnalysis;
+      optimizationCounts.keyedCollectionUpdateHints += keyedCollectionHintedRoot.count;
+    }
+  }
   const blockPlans = blockAnalysis.plans || [];
   optimizationCounts.keyedIdentityTargets += blockPlans.reduce(
     (count, plan) =>
@@ -5786,6 +6287,7 @@ export async function compileReactModule(
   const compiled: string[] = [];
   const diagnostics: CompilerDiagnostic[] = [];
   const optimizationCounts = {
+    keyedCollectionUpdateHints: 0,
     keyedIdentityTargets: 0,
     keyedMapLookupTargets: 0,
     keyedMembershipTargets: 0,
@@ -5831,6 +6333,12 @@ export async function compileReactModule(
         const keyedMapUpdateIdentifier = programPath.scope.generateUidIdentifier(
           "createCompilerKeyedMapUpdate",
         );
+        const keyedCollectionUpdateIdentifier = programPath.scope.generateUidIdentifier(
+          "createCompilerKeyedCollectionUpdate",
+        );
+        const keyedCollectionMutationIdentifier = programPath.scope.generateUidIdentifier(
+          "applyCompilerKeyedCollectionMutation",
+        );
         const runtimeFeatureIdentifiers = new Map<CompilerRuntimeFeatureName, t.Identifier>(
           Object.entries(COMPILER_RUNTIME_FEATURE_EXPORTS).map(([feature, exportName]) => [
             feature as CompilerRuntimeFeatureName,
@@ -5853,6 +6361,8 @@ export async function compileReactModule(
             candidate,
             createComponentIdentifier,
             keyedMapUpdateIdentifier,
+            keyedCollectionUpdateIdentifier,
+            keyedCollectionMutationIdentifier,
             runtimeFeatureIdentifiers,
             usedRuntimeFeatures,
             optimizationCounts,
@@ -5887,6 +6397,18 @@ export async function compileReactModule(
                       t.importSpecifier(
                         keyedMapUpdateIdentifier,
                         t.identifier("createCompilerKeyedMapUpdate"),
+                      ),
+                    ]
+                  : []),
+                ...(optimizationCounts.keyedCollectionUpdateHints > 0
+                  ? [
+                      t.importSpecifier(
+                        keyedCollectionUpdateIdentifier,
+                        t.identifier("createCompilerKeyedCollectionUpdate"),
+                      ),
+                      t.importSpecifier(
+                        keyedCollectionMutationIdentifier,
+                        t.identifier("applyCompilerKeyedCollectionMutation"),
                       ),
                     ]
                   : []),


### PR DESCRIPTION
## Summary

- prove compiler-owned immutable Set and Map functional updaters and record only native mutation keys that execute
- carry queued key deltas into bounded persistent runtime snapshots, with conservative snapshot or React fallback for unsupported values and ownership
- add compiler observability, public documentation, persisted runtime-size coverage, and a dense browser benchmark against an equivalent compiled snapshot control

## Correctness and compatibility

- 50 Vitest files / 418 tests pass
- 2,000 randomized hinted Set mutations and 2,000 randomized hinted Map mutations match normal React
- covers queued updates, Strict Mode unmounts, hydration, long-chain compaction, ordinary replacements, and unsafe key/value fallback
- React 18.3.1 and React 19.2.8 compatibility suites pass
- dashboard and docs production builds pass; docs navigation passes

## Performance evidence

The application still pays its immutable new Set/current or new Map/current copy. This change removes the compiler runtime second complete collection scan.

At 20,000 entries in the production browser benchmark:

- Set delta: 0.30 ms versus 2.00 ms compiled snapshot control (6.67x faster)
- Map delta: 0.90 ms versus 4.90 ms compiled snapshot control (5.44x faster)
- all existing correctness, React-relative, persistence, and normalized scalability gates pass
- compiled owner executions remain zero

## Size

- optional keyed fixture premium: +922 B gzip for the delta helpers
- direct compiler premium remains unchanged at 3,678 B gzip
- isolated core runtime remains unchanged at 3,766 B gzip and retains a 77.2% reduction versus the full compatibility runtime

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Carries Set/Map mutation keys from compiler-proven immutable functional updaters into the runtime, replacing the second full collection scan that previously computed keyed deltas.

- Records only the native `add`, `delete`, or `set` calls that execute, and validates them against the previous committed collection.
- Unsupported values, proxies, or non-compiler-owned state fall back to the prior snapshot or normal React update path.
- Adds a `keyedCollectionUpdateHints` count to the compiler report.
- Dense 20,000-entry benchmark: Set 0.30 ms versus 2.00 ms and Map 0.90 ms versus 4.90 ms against the compiled snapshot control.
- Keyed fixture grows 922 B gzip; direct compiler and isolated core runtime premiums are unchanged.

<sup>Written for commit d6f39fcdc163caab815422a0d2b278ce5f98b5c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

