### PR TITLE
fix(tests): stop the Windows production middleware test hanging in cleanup

### DIFF
--- a/packages/farm/src/__tests__/fixtures/middleware-production-fixture.ts
+++ b/packages/farm/src/__tests__/fixtures/middleware-production-fixture.ts
@@ -9,7 +9,7 @@ const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "
 const FIXTURE_PREFIX = ".tmp-production-middleware-";
 
 export async function createMiddlewareProductionFixture(): Promise<string> {
-  await removeStaleFixtures();
+  if (process.platform === "win32") await removeStaleFixtures();
   const root = await fs.mkdtemp(path.join(packageRoot, FIXTURE_PREFIX));
 
   await fs.mkdir(path.join(root, "node_modules", "@farm.js"), {
@@ -462,21 +462,23 @@ export async function cleanupMiddlewareProductionFixture(root: string): Promise<
   // module, so that one file is undeletable until the process exits. A
   // recursive remove retries it at every level on the way up and never
   // finishes, which used to exhaust the whole test timeout. Remove what is not
-  // locked instead and leave the rest for the operating system.
+  // locked instead. Exiting releases the lock, and the next run sweeps what is
+  // left behind.
   await removeUnlockedEntries(root);
 }
 
 /**
  * Sweep fixtures an earlier run could not finish removing.
  *
- * On Windows the locked native binary is released when that process exits, so
- * the leftovers are deletable by the time the next run starts.
+ * Windows only. The process that held the native binary has exited by now, so
+ * its leftovers are removable.
  */
 async function removeStaleFixtures(): Promise<void> {
   let entries: Dirent[];
   try {
     entries = await fs.readdir(packageRoot, { withFileTypes: true });
-  } catch {
+  } catch (error) {
+    if (!isLockError(error)) throw error;
     return;
   }
 
@@ -488,10 +490,18 @@ async function removeStaleFixtures(): Promise<void> {
         force: true,
         maxRetries: 0,
       });
-    } catch {
-      // Still held by a concurrent run, leave it.
+    } catch (error) {
+      // A concurrent run may still hold it. Anything else is unexpected.
+      if (!isLockError(error)) throw error;
     }
   }
+}
+
+/** Windows reports these while another handle is still open. */
+const LOCK_ERROR_CODES = new Set(["EPERM", "EBUSY", "ENOTEMPTY", "ENOENT"]);
+
+function isLockError(error: unknown): boolean {
+  return LOCK_ERROR_CODES.has((error as NodeJS.ErrnoException)?.code ?? "");
 }
 
 /** Best effort removal that steps over entries Windows still holds. */
@@ -499,7 +509,9 @@ async function removeUnlockedEntries(dir: string): Promise<void> {
   let entries: Dirent[];
   try {
     entries = await fs.readdir(dir, { withFileTypes: true });
-  } catch {
+  } catch (error) {
+    // Already gone, or held open. Anything else is a real failure.
+    if (!isLockError(error)) throw error;
     return;
   }
 
@@ -508,14 +520,15 @@ async function removeUnlockedEntries(dir: string): Promise<void> {
     if (entry.isDirectory() && !entry.isSymbolicLink()) await removeUnlockedEntries(full);
     try {
       await fs.rm(full, { recursive: true, force: true, maxRetries: 0 });
-    } catch {
-      // Locked, leave it for the operating system to reclaim.
+    } catch (error) {
+      // Leave locked entries for the next run, but do not hide real failures.
+      if (!isLockError(error)) throw error;
     }
   }
 
   try {
     await fs.rmdir(dir);
-  } catch {
-    // Still holds a locked child.
+  } catch (error) {
+    if (!isLockError(error)) throw error;
   }
 }

--- a/packages/farm/src/__tests__/fixtures/middleware-production-fixture.ts
+++ b/packages/farm/src/__tests__/fixtures/middleware-production-fixture.ts
@@ -1,3 +1,4 @@
+import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -5,8 +6,11 @@ import sharp from "sharp";
 
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
 
+const FIXTURE_PREFIX = ".tmp-production-middleware-";
+
 export async function createMiddlewareProductionFixture(): Promise<string> {
-  const root = await fs.mkdtemp(path.join(packageRoot, ".tmp-production-middleware-"));
+  await removeStaleFixtures();
+  const root = await fs.mkdtemp(path.join(packageRoot, FIXTURE_PREFIX));
 
   await fs.mkdir(path.join(root, "node_modules", "@farm.js"), {
     recursive: true,
@@ -448,6 +452,70 @@ export default function userSitemap({ params, path }: any) {
 }
 
 export async function cleanupMiddlewareProductionFixture(root: string): Promise<void> {
-  // Windows keeps handles on spawned servers and loaded .node files briefly after exit.
-  await fs.rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  if (process.platform !== "win32") {
+    await fs.rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+    return;
+  }
+
+  // The build copies sharp's native binary into the output, and this process
+  // loads it while optimizing images. Windows refuses to unlink a loaded
+  // module, so that one file is undeletable until the process exits. A
+  // recursive remove retries it at every level on the way up and never
+  // finishes, which used to exhaust the whole test timeout. Remove what is not
+  // locked instead and leave the rest for the operating system.
+  await removeUnlockedEntries(root);
+}
+
+/**
+ * Sweep fixtures an earlier run could not finish removing.
+ *
+ * On Windows the locked native binary is released when that process exits, so
+ * the leftovers are deletable by the time the next run starts.
+ */
+async function removeStaleFixtures(): Promise<void> {
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(packageRoot, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !entry.name.startsWith(FIXTURE_PREFIX)) continue;
+    try {
+      await fs.rm(path.join(packageRoot, entry.name), {
+        recursive: true,
+        force: true,
+        maxRetries: 0,
+      });
+    } catch {
+      // Still held by a concurrent run, leave it.
+    }
+  }
+}
+
+/** Best effort removal that steps over entries Windows still holds. */
+async function removeUnlockedEntries(dir: string): Promise<void> {
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory() && !entry.isSymbolicLink()) await removeUnlockedEntries(full);
+    try {
+      await fs.rm(full, { recursive: true, force: true, maxRetries: 0 });
+    } catch {
+      // Locked, leave it for the operating system to reclaim.
+    }
+  }
+
+  try {
+    await fs.rmdir(dir);
+  } catch {
+    // Still holds a locked child.
+  }
 }

--- a/packages/farm/src/__tests__/production-middleware.test.ts
+++ b/packages/farm/src/__tests__/production-middleware.test.ts
@@ -33,9 +33,7 @@ function readInlineFarmProps(html: string): Record<string, any> {
 }
 
 describe("production middleware runtime", () => {
-  // Windows: image optimization stalls loading the WASM codec (#434).
-  it("runs farm.config middleware and app middleware in a production build", async (ctx) => {
-    if (process.platform === "win32") ctx.skip();
+  it("runs farm.config middleware and app middleware in a production build", async () => {
     const root = await createMiddlewareProductionFixture();
     const originalFetch = globalThis.fetch;
 


### PR DESCRIPTION
Closes #434.

## What it was

Not the wasm image codec, despite how the issue was originally titled. Every request in the
test finishes quickly, including the one that loads the codec, at 3ms, and the whole test body
runs in under 9 seconds. The 120s went entirely to fixture teardown.

Bisecting the tree found one file:

```
EPERM: operation not permitted, unlink
  .vercel/output/functions/__nitro.func/node_modules/@img/sharp-win32-x64/lib/sharp-win32-x64.node
```

The build copies sharp's native binary into the output and the test process loads it while
optimizing images. Windows will not unlink a loaded module, so the recursive remove retries
that file at every parent directory on the way up and never finishes.

## The change

On Windows, remove what is removable and leave the locked file. Each run also sweeps fixtures
an earlier run could not finish, which works because the lock is released when that process
exits. One 428KB file survives a run and the next run clears it. Other platforms keep the
existing recursive remove.

The Windows skip on the test is no longer needed.

## Verification

The test passes on Windows in about 8s, previously a 120s timeout. Core suite is green at 1268
passed and 0 failed, with skipped going from 6 to 5 because this test now runs.

## Ruled out

Two explanations that looked right and were not:

- `fs.rm` following the `node_modules/@farm.js/core` junction into `packages/farm`. It does not
  follow junctions, the target is untouched and it returns in 0ms.
- The dynamically imported entry holding a lock. Importing an `.mjs` and deleting it from the
  same process takes 2ms.
