### PR TITLE
perf(react): carry keyed append hints

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -302,6 +302,7 @@ After a successful build, Farm writes `.farm/react-compiler.json`:
     "componentsConsidered": 4,
     "compiled": 2,
     "fallback": 2,
+    "keyedArrayAppendHints": 1,
     "keyedCollectionUpdateHints": 3,
     "keyedIdentityTargets": 2,
     "keyedMapLookupTargets": 1,
@@ -319,6 +320,7 @@ After a successful build, Farm writes `.farm/react-compiler.json`:
       "id": "src/Products.tsx",
       "compiled": ["ProductRow"],
       "optimizations": {
+        "keyedArrayAppendHints": 1,
         "keyedCollectionUpdateHints": 3,
         "keyedIdentityTargets": 2,
         "keyedMapLookupTargets": 1,
@@ -349,9 +351,11 @@ native `Set`.
 executed keys to the runtime.
 `keyedMapUpdateHints` counts setter sites where the compiler proved that a direct keyed collection
 can report its changed row indexes while an immutable `map()` runs. The same counts appear per
-module. `selected` is `true` when an annotation explicitly requested compilation. Module paths are
-relative to the project root, and the output is sorted and contains no timestamp, so CI can compare
-reports without machine-specific noise.
+module.
+`keyedArrayAppendHints` counts setter sites where the compiler proved a direct keyed array append
+and can hand the appended suffix to the runtime. `selected` is `true` when an annotation explicitly
+requested compilation. Module paths are relative to the project root, and the output is sorted and
+contains no timestamp, so CI can compare reports without machine-specific noise.
 
 Use a different project-relative output path when CI collects artifacts elsewhere:
 
@@ -866,6 +870,36 @@ LIS path. Derived collections, non-functional setters, block-bodied mappers, mut
 and other unproven shapes also keep that existing path. This is an optimization hint, not a new
 correctness contract or a way to bypass React fallback behavior. The compiler report exposes the
 number of emitted sites as `keyedMapUpdateHints`.
+
+#### Keyed array append hints
+
+A direct keyed `useState` array can also avoid rescanning all existing rows for common immutable
+appends:
+
+```tsx
+setItems((current) => [...current, nextItem]);
+setItems((current) => [...current, ...nextItems]);
+```
+
+At build time, Farm recognizes a concise functional setter whose array literal starts with exactly
+`...current` and has at least one trailing item or spread. The application still creates its normal
+immutable array. Generated metadata connects that result to the last committed array and records
+where its appended suffix begins. Queued functional appends form one validated chain.
+
+At update time, existing keyed rows already have the same item, key, and index. Farm therefore
+reads keys, descriptors, and bindings only for the appended suffix, creates only those host rows,
+and inserts them together with a document fragment. It does not rerun the owner component or touch
+the existing row DOM.
+
+The proof is intentionally narrow. Both values must be native arrays. Prepend, middle insertion,
+removal, direct replacement, a copy with no appended entries, block-bodied updaters, duplicate
+keys, React-owned or nested host-block rows, row conditionals, and rows whose bindings read the
+collection itself keep complete keyed reconciliation. Keys that read the collection also prevent
+the compiler from emitting the hint. A preceding unhinted update, an unrelated
+dirty dependency, or any failed source/length check also discards the hint. These fallbacks preserve
+normal React behavior; the syntax does not opt the component into a different correctness model.
+The compiler report exposes emitted sites as `keyedArrayAppendHints`, and the hinted runtime is
+retained only when a module emits at least one append or same-order map hint.
 
 #### Interactive host rows
 
@@ -1638,6 +1672,9 @@ The package and example test suites verify more than generated code:
   textarea, checkbox, radio, and select properties while the compiled owner stays at one execution;
 - 2,000 deterministic row-conditional data and structural transitions match normal React while the
   compiled owner remains at one execution;
+- 2,000 deterministic keyed-array appends match normal React; targeted tests require key,
+  descriptor, and binding reads to equal only the appended suffix and cover queued updates,
+  multi-boundary sharing, StrictMode hydration/unmount, and conservative fallback;
 - the production browser experiment derives a keyed window from 2,048 source rows without
   rerunning the owner component or corrupting the existing compiler experiments;
 - the package reactivity benchmark updates one prop across 2,048 bindings, requires identical
@@ -1654,7 +1691,7 @@ The package and example test suites verify more than generated code:
   inserts a row, and observes zero owner update executions;
 - the production 10,000/20,000-row benchmark requires nonzero `keyedIdentityTargets`,
   `keyedMapLookupTargets`, `keyedMembershipTargets`, `keyedCollectionUpdateHints`, and
-  `keyedMapUpdateHints` report counts,
+  `keyedMapUpdateHints` and `keyedArrayAppendHints` report counts,
   preserves the keyed-update speedup floor, checks that scalar selection, Set membership, and Map
   lookups remain key-directed at scale, compares dense hinted Set/Map updates with equivalent
   compiled snapshot controls, and passes DOM correctness, React-relative regression, direct-delta,

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,11 +2,11 @@
 
 Date: 2026-08-28
 
-Result: **PASS.** Correctness, the React-relative performance gate, keyed-update, scalar selection,
-Set-membership, Map-lookup, collection-delta, and normalized scalability gates all pass. The
-production run compares two bracketing React baselines with static and hybrid compiler builds from
-the exact same component source. Dense Set/Map operations also compare the new delta handoff with
-an unhinted snapshot control inside each compiler build.
+Result: **PASS.** Correctness, React-relative performance, keyed update, keyed append, scalar
+selection, Set-membership, Map-lookup, collection-delta, and normalized scalability gates all pass.
+The production run compares two bracketing React baselines with static and hybrid compiler builds
+from the exact same component source. Append and dense Set/Map operations also compare each new
+handoff with an unhinted compiled snapshot control.
 
 ## Environment and method
 
@@ -20,6 +20,8 @@ an unhinted snapshot control inside each compiler build.
 - Baseline values average the medians from the two bracketing React trials
 - Performance gate: more than 10% and 0.25 ms slower than the bracketed baseline
 - Keyed-update persistence gate: at least 8x faster than React at both 10,000 and 20,000 rows
+- Keyed-append persistence gate: at least 4x faster than React at both 10,000 and up to 20,000 rows,
+  and at least 1.25x faster than the equivalent compiled snapshot path
 - Key-directed selection gate: at least 10x faster than React at 20,000 rows and no more than 2x
   normalized growth
 - Key-directed Set-membership gate: at least 10x faster than React at 20,000 rows and no more than
@@ -33,8 +35,9 @@ an unhinted snapshot control inside each compiler build.
 Every trial passed DOM assertions and browser-error checks. The compiler report proved that both
 workloads compiled, delegated keyed rows were present only in compiler builds, exactly two scalar
 key-directed bindings, two Set-membership bindings, two Map-lookup bindings, 19 Set/Map mutation
-sites, and one mutation-aware keyed-map update site were emitted. Hybrid/static added zero owner
-executions. The two React baselines added 1,430 dashboard and 432 table owner executions each.
+sites, one mutation-aware keyed-map update site, and one keyed-array append site were emitted.
+Hybrid/static added zero owner executions. The two React baselines added 1,430 dashboard and 462
+table owner executions each.
 
 ## Complex dashboard
 
@@ -43,32 +46,40 @@ bindings.
 
 | Interaction                 | React median | Hybrid median | Hybrid vs React |
 | --------------------------- | -----------: | ------------: | --------------: |
-| Active live pulse           |      0.10 ms |       0.08 ms |    1.25x faster |
-| Inactive branch update      |     0.065 ms |       0.02 ms |    3.25x faster |
+| Active live pulse           |      0.10 ms |       0.10 ms |          parity |
+| Inactive branch update      |      0.08 ms |       0.02 ms |    3.75x faster |
 | Switch live/snapshot branch |     0.100 ms |      0.100 ms |          parity |
 
 ## Standard table operations
 
-| Operation         |             Rows | React median | Hybrid median | Hybrid vs React |
-| ----------------- | ---------------: | -----------: | ------------: | --------------: |
-| Create            |            1,000 |     12.60 ms |      11.50 ms |    1.10x faster |
-| Replace all       |            1,000 |     16.60 ms |      12.30 ms |    1.35x faster |
-| Create many       |           10,000 |    270.60 ms |     123.60 ms |    2.19x faster |
-| Append            | 10,000 -> 11,000 |     71.15 ms |      27.40 ms |    2.60x faster |
-| Update every 10th |           10,000 |     43.65 ms |       2.60 ms |   16.79x faster |
-| Select            |            1,000 |      3.90 ms |       0.10 ms |   39.00x faster |
-| Mark two rows     |            1,000 |      3.75 ms |       0.10 ms |   37.50x faster |
-| Queue two rows    |            1,000 |      3.70 ms |       0.10 ms |   37.00x faster |
-| Dense Set delta   |            1,000 |      3.75 ms |       0.10 ms |   37.50x faster |
-| Dense Map delta   |            1,000 |      3.75 ms |       0.10 ms |   37.50x faster |
-| Swap rows 2 / 999 |            1,000 |      7.80 ms |       1.30 ms |    6.00x faster |
-| Remove one row    |            1,000 |      4.60 ms |       2.00 ms |    2.30x faster |
-| Clear             |           10,000 |     58.00 ms |       9.40 ms |    6.17x faster |
+| Operation               |             Rows | React median | Hybrid median | Hybrid vs React |
+| ----------------------- | ---------------: | -----------: | ------------: | --------------: |
+| Create                  |            1,000 |     12.50 ms |      11.40 ms |    1.10x faster |
+| Replace all             |            1,000 |     18.45 ms |      11.90 ms |    1.55x faster |
+| Create many             |           10,000 |    284.00 ms |     157.20 ms |    1.81x faster |
+| Append                  | 10,000 -> 11,000 |     71.55 ms |      13.30 ms |    5.38x faster |
+| Append snapshot control | 10,000 -> 11,000 |     82.55 ms |      25.60 ms |    3.22x faster |
+| Update every 10th       |           10,000 |     58.60 ms |       2.60 ms |   22.54x faster |
+| Select                  |            1,000 |      3.75 ms |       0.10 ms |   37.50x faster |
+| Mark two rows           |            1,000 |      3.85 ms |       0.10 ms |   38.50x faster |
+| Queue two rows          |            1,000 |      4.15 ms |       0.10 ms |   41.50x faster |
+| Dense Set delta         |            1,000 |      4.00 ms |       0.10 ms |   40.00x faster |
+| Dense Map delta         |            1,000 |      4.20 ms |       0.10 ms |   42.00x faster |
+| Swap rows 2 / 999       |            1,000 |      7.90 ms |       1.20 ms |    6.58x faster |
+| Remove one row          |            1,000 |      4.70 ms |       2.10 ms |    2.24x faster |
+| Clear                   |           10,000 |     48.00 ms |       9.10 ms |    5.27x faster |
+
+`Append` is the new keyed-array suffix path. The application still allocates the next array and
+creates 1,000 required DOM rows, but the generated hint lets Farm skip all 10,000 existing keys and
+bindings. Hybrid measured `13.30 ms`, **5.38x faster than React** and **1.92x faster than the
+equivalent `25.60 ms` compiled snapshot control**. Repeated batches through 20,000 rows remained
+7.09x faster than React. The gate requires at least 4x versus React and 1.25x versus the control in
+both compiler modes.
 
 `Update every 10th` is the targeted mutation-aware path. The application still executes its native
 immutable `map()` over 10,000 items and creates 1,000 replacement objects. The generated hint lets
 the keyed runtime validate and patch those 1,000 rows without a second scan of all 10,000 keys and
-bindings. The 8x persistence floor leaves substantial headroom below this run's 14.45x-16.18x
+bindings. The 8x persistence floor leaves substantial headroom below this run's 13.38x-22.54x
 result across compiler modes and row counts while still rejecting a silent return to the older
 roughly 5x full-reconciliation path.
 
@@ -94,8 +105,8 @@ primitive entries and immutably clone the collection, so the application's requi
 `new Map()` work remains in both paths. A proven updater records only the native mutation keys that
 actually execute. The runtime validates those keys and extends a bounded persistent snapshot,
 instead of iterating every previous and next entry again. At 20,000 entries, the Set delta measured
-`0.30 ms` versus `2.00 ms` for the equivalent compiled snapshot control (**6.67x faster**); the Map
-delta measured `0.90 ms` versus `4.90 ms` (**5.44x faster**) in hybrid mode. These direct
+`0.30 ms` versus `2.10 ms` for the equivalent compiled snapshot control (**7.00x faster**); the Map
+delta measured `1.00 ms` versus `4.80 ms` (**4.80x faster**) in hybrid mode. These direct
 compiler-to-compiler comparisons are the evidence for this PR's incremental win.
 
 ## Repeated 20,000-row scale profile
@@ -106,19 +117,19 @@ values, swaps rows, removes a middle row, and clears. Lower time is better.
 
 | Operation at scale       | React median | React p95 | Hybrid median | Hybrid p95 | Speedup |
 | ------------------------ | -----------: | --------: | ------------: | ---------: | ------: |
-| Create initial 10,000    |    331.25 ms | 352.75 ms |     124.50 ms |  124.90 ms |    2.66x |
-| Append a 1,000-row batch |     90.10 ms | 119.40 ms |      30.50 ms |   36.20 ms |    2.95x |
-| Update every 10th at 20k |    102.25 ms | 114.35 ms |       6.20 ms |    6.30 ms |   16.49x |
-| Select at 20k            |    100.20 ms | 116.00 ms |       3.00 ms |    4.30 ms |   33.40x |
-| Mark two rows at 20k     |    107.60 ms | 119.20 ms |       0.10 ms |    0.20 ms | 1076.00x |
-| Queue two rows at 20k    |    100.20 ms | 116.60 ms |       0.20 ms |    0.20 ms |  501.00x |
-| Dense Set delta at 20k   |    117.15 ms | 134.35 ms |       0.30 ms |    0.30 ms |  390.50x |
-| Dense Set snapshot       |    115.05 ms | 116.45 ms |       2.00 ms |    2.20 ms |   57.53x |
-| Dense Map delta at 20k   |    102.60 ms | 142.25 ms |       0.90 ms |    1.00 ms |  114.00x |
-| Dense Map snapshot       |    111.85 ms | 134.20 ms |       4.90 ms |    4.90 ms |   22.83x |
-| Swap at 20k              |    123.45 ms | 156.35 ms |      28.20 ms |   28.30 ms |    4.38x |
-| Remove middle row at 20k |    124.05 ms | 138.40 ms |      41.50 ms |   42.30 ms |    2.99x |
-| Clear 20k                |    171.85 ms | 281.50 ms |      20.40 ms |   20.80 ms |    8.42x |
+| Create initial 10,000    |    315.00 ms | 436.25 ms |     122.90 ms |  126.50 ms |    2.56x |
+| Append a 1,000-row batch |     93.55 ms | 134.15 ms |      13.20 ms |   18.80 ms |    7.09x |
+| Update every 10th at 20k |    108.35 ms | 140.25 ms |       8.10 ms |   19.80 ms |   13.38x |
+| Select at 20k            |    100.45 ms | 145.10 ms |       3.40 ms |    6.50 ms |   29.54x |
+| Mark two rows at 20k     |    117.05 ms | 123.80 ms |       0.20 ms |    0.20 ms |  585.25x |
+| Queue two rows at 20k    |    104.20 ms | 112.15 ms |       0.20 ms |    0.30 ms |  521.00x |
+| Dense Set delta at 20k   |    102.90 ms | 153.10 ms |       0.30 ms |    0.40 ms |  343.00x |
+| Dense Set snapshot       |    117.70 ms | 122.45 ms |       2.10 ms |    2.20 ms |   56.05x |
+| Dense Map delta at 20k   |    103.90 ms | 118.00 ms |       1.00 ms |    1.00 ms |  103.90x |
+| Dense Map snapshot       |    103.30 ms | 111.50 ms |       4.80 ms |    4.80 ms |   21.52x |
+| Swap at 20k              |    115.85 ms | 120.05 ms |      34.30 ms |   36.00 ms |    3.38x |
+| Remove middle row at 20k |    114.00 ms | 127.80 ms |      41.70 ms |   41.70 ms |    2.73x |
+| Clear 20k                |    200.00 ms | 234.05 ms |      20.00 ms |   20.80 ms |   10.00x |
 
 ## Scalability gate
 
@@ -127,22 +138,22 @@ The gate divides observed timing growth by row-count growth. A value near 1 mean
 
 | Path               | Row growth | Timing growth | Normalized growth |
 | ------------------ | ---------: | ------------: | ----------------: |
-| Create 10k repeat    |      1.00x |         1.01x |             1.01x |
-| Update 10k -> 20k    |      2.00x |         2.38x |             1.19x |
-| Select 1k -> 20k     |     20.00x |        12.00x |             0.60x |
-| Mark Set 1k -> 20k   |     20.00x |         0.40x |             0.02x |
+| Create 10k repeat    |      1.00x |         0.78x |             0.78x |
+| Update 10k -> 20k    |      2.00x |         3.12x |             1.56x |
+| Select 1k -> 20k     |     20.00x |        13.60x |             0.68x |
+| Mark Set 1k -> 20k   |     20.00x |         0.80x |             0.04x |
 | Read Map 1k -> 20k   |     20.00x |         0.80x |             0.04x |
 | Dense Set delta      |     20.00x |         1.20x |             0.06x |
-| Dense Map delta      |     20.00x |         3.60x |             0.18x |
-| Dense Set snapshot   |     20.00x |         8.00x |             0.40x |
-| Dense Map snapshot   |     20.00x |        16.33x |             0.82x |
-| Swap 1k -> 20k       |     20.00x |        21.69x |             1.08x |
-| Remove 1k -> 20k     |     20.00x |        20.75x |             1.04x |
-| Clear 10k -> 20k     |      2.00x |         2.17x |             1.09x |
+| Dense Map delta      |     20.00x |         4.00x |             0.20x |
+| Dense Set snapshot   |     20.00x |         8.40x |             0.42x |
+| Dense Map snapshot   |     20.00x |        16.00x |             0.80x |
+| Swap 1k -> 20k       |     20.00x |        28.58x |             1.43x |
+| Remove 1k -> 20k     |     20.00x |        19.86x |             0.99x |
+| Clear 10k -> 20k     |      2.00x |         2.20x |             1.10x |
 
 This demonstrates approximately linear rather than quadratic end-to-end growth. Key-directed
 scalar selection performs constant row-binding work—at most the previous and next keyed
-instances—while its complete event-to-DOM timing remains 33.40x faster than React at 20,000 rows.
+instances—while its complete event-to-DOM timing remains 29.54x faster than React at 20,000 rows.
 Set membership and Map lookup evaluate bindings only for changed keys. Their 0.10-0.20 ms medians
 are near browser timer resolution, so deterministic exact-read gates remain the primary complexity
 evidence. The dense delta-versus-snapshot controls remain above that floor and independently prove
@@ -153,13 +164,13 @@ keys and maintaining row indices.
 
 | Build           | Page chunk raw | Page chunk gzip |
 | --------------- | -------------: | --------------: |
-| React baseline  |       21,650 B |         4,959 B |
-| Static compiler |       87,011 B |        18,259 B |
-| Hybrid compiler |       87,011 B |        18,257 B |
+| React baseline  |       21,888 B |         4,999 B |
+| Static compiler |       89,156 B |        18,732 B |
+| Hybrid compiler |       89,156 B |        18,731 B |
 
-This deliberately broad page now pays a 13,298-byte hybrid gzip premium for the compiler runtime,
-including the mutation-aware, scalar key-directed, Set-membership, Map-lookup, and collection-delta
-paths. Smaller
+This deliberately broad page now pays a 13,732-byte hybrid gzip premium for the compiler runtime,
+including keyed append, mutation-aware map, scalar key-directed, Set-membership, Map-lookup, and
+collection-delta paths. Smaller
 direct-only applications retain less of the runtime; the package-level fixtures and persisted size
 gate are documented in `packages/farm-react/RUNTIME_SIZE_RESULTS.md`.
 
@@ -167,12 +178,13 @@ gate are documented in `packages/farm-react/RUNTIME_SIZE_RESULTS.md`.
 
 The compiled path scales successfully through the tested 20,000-row mixed workload: all DOM and
 event assertions pass, there are no browser errors or owner rerenders, every scale operation beats
-the bracketed React baseline, and normalized growth stays at or below 1.19x for the primary
+the bracketed React baseline, and normalized growth stays at or below 1.43x for the measured
 workload. Scalar selection performs at most two row-binding reads, while Set membership and Map
 lookup evaluate only changed keys that map to rows. For dense collections, producer deltas were
-6.67x faster for Set and 5.44x faster for Map than equivalent compiled snapshot scans. The evidence
-claims only measured end-to-end behavior within this range—not unlimited constant-time browser
-work.
+7.00x faster for Set and 4.80x faster for Map than equivalent compiled snapshot scans. Keyed append
+was 1.92x faster than its compiled snapshot control and 7.09x faster than React while scaling to
+20,000 rows. The evidence claims only measured end-to-end behavior within this range—not unlimited
+constant-time browser work.
 
 The machine-readable output is `/tmp/farm-react-dashboard-benchmark.json`. Re-run
 `pnpm --filter farm-react-compiler-dashboard-example benchmark` to reproduce it.

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -65,6 +65,12 @@ row-binding reads, which is the deterministic guard against returning to a full 
 performance, scalability, or persistence gate writes the JSON report and exits with a nonzero
 status.
 
+Keyed array appends have a separate persistence gate. A concise functional append is measured
+against bracketed React and an equivalent block-bodied compiled snapshot control. Both compiler
+modes must remain at least 4x faster than React at 10,000 and up to 20,000 rows, and at least 1.25x
+faster than the compiled control. The report must contain a nonzero `keyedArrayAppendHints` count;
+deterministic package tests separately require work to equal only the appended suffix.
+
 Set membership has a separate operation and persistence gate. The table alternates two marked row
 keys with `markedIds.has(row.id)` at 1,000 and 20,000 rows. Both compiler modes must remain at least
 10x faster than React at 20,000 rows, normalized growth may not exceed 2x, and the compiler report
@@ -114,6 +120,8 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
 - The dense collection controls show only the incremental delta benefit: both compiler paths keep
   the application's immutable collection copy, while the hinted path avoids the runtime's second
   complete entry scan.
+- The append snapshot control creates the same 1,000 array items and DOM rows but intentionally uses
+  an unsupported block-bodied updater, isolating the saved full key-and-binding scan.
 - This is an operation-compatible local benchmark, not an official `js-framework-benchmark`
   submission or a score comparable to its published result table. This app has richer rows and
   measures event dispatch through an asserted DOM result without CPU throttling.

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -131,6 +131,10 @@ async function inspectBuild(compilerMode) {
       "The compiler build did not emit a mutation-aware keyed-map update hint.",
     );
     assert(
+      compilerReport.summary.keyedArrayAppendHints > 0,
+      "The compiler build did not emit a keyed-array append hint.",
+    );
+    assert(
       compilerReport.summary.keyedCollectionUpdateHints > 0,
       "The compiler build did not emit a keyed Set/Map collection-delta hint.",
     );
@@ -451,6 +455,16 @@ async function measureTrial(browser, trial, compilerMode, port) {
           async () => {
             await runTableAction(
               () => tableButton("table-append").click(),
+              () => rowCount() === 11_000,
+            );
+          },
+        );
+
+        const tableAppendSnapshot = await measureTable(
+          async () => ensure10000(),
+          async () => {
+            await runTableAction(
+              () => tableButton("table-append-snapshot").click(),
               () => rowCount() === 11_000,
             );
           },
@@ -783,6 +797,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
           },
           table: {
             append: tableAppend,
+            appendSnapshot: tableAppendSnapshot,
             clear: tableClear,
             create: tableCreate,
             createMany: tableCreateMany,
@@ -859,6 +874,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
       },
       table: {
         append: timingSummary(result.table.append),
+        appendSnapshot: timingSummary(result.table.appendSnapshot),
         clear: timingSummary(result.table.clear),
         create: timingSummary(result.table.create),
         createMany: timingSummary(result.table.createMany),
@@ -941,6 +957,7 @@ const tableMetrics = [
   "replace",
   "createMany",
   "append",
+  "appendSnapshot",
   "updateEvery10th",
   "select",
   "membership",
@@ -1067,6 +1084,33 @@ const keyedUpdateSpeedups = keyedUpdateCases.flatMap(([group, metric]) =>
 const keyedUpdateRegressions = keyedUpdateSpeedups.filter(
   ({ speedup }) => !Number.isFinite(speedup) || speedup < keyedUpdateMinimumSpeedup,
 );
+// A compiler-proven functional append already creates the new array and DOM rows. The append hint
+// avoids rescanning every existing key and binding before mounting only the appended suffix. Compare
+// it with both React and an equivalent block-bodied compiled updater that intentionally stays on
+// complete keyed reconciliation.
+const keyedAppendMinimumSpeedup = 4;
+const keyedAppendMinimumSnapshotSpeedup = 1.25;
+const keyedAppendResults = ["static", "hybrid"].map((mode) => {
+  const appendMedianMs = comparisons.table.append[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.appendSnapshot[mode].medianMs;
+  return {
+    appendMedianMs,
+    mode,
+    scaleSpeedup: comparisons.scale.appendTo20k[`${mode}VsBaseline`].speedup,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / appendMedianMs,
+    speedup: comparisons.table.append[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedAppendRegressions = keyedAppendResults.filter(
+  ({ scaleSpeedup, snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedAppendMinimumSpeedup ||
+    !Number.isFinite(scaleSpeedup) ||
+    scaleSpeedup < keyedAppendMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedAppendMinimumSnapshotSpeedup,
+);
 // Selection is a separate-state update whose value is compared with the exact row key. The unit
 // suite deterministically requires at most two row-binding reads. This browser gate protects a
 // substantial end-to-end win and rejects growth beyond the same normalized 2x scalability ceiling
@@ -1185,6 +1229,7 @@ const passed =
   performanceRegressions.length === 0 &&
   scalabilityRegressions.length === 0 &&
   keyedUpdateRegressions.length === 0 &&
+  keyedAppendRegressions.length === 0 &&
   keyedIdentityRegressions.length === 0 &&
   keyedMembershipRegressions.length === 0 &&
   keyedMapLookupRegressions.length === 0 &&
@@ -1204,6 +1249,13 @@ const report = {
     regressions: keyedUpdateRegressions,
     speedups: keyedUpdateSpeedups,
     status: keyedUpdateRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedAppendHintGate: {
+    minimumSnapshotSpeedup: keyedAppendMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedAppendMinimumSpeedup,
+    regressions: keyedAppendRegressions,
+    results: keyedAppendResults,
+    status: keyedAppendRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedIdentityTargetGate: {
     maximumNormalizedGrowth: keyedIdentityMaximumNormalizedGrowth,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -132,13 +132,30 @@ export function StandardTableBenchmark() {
           type="button"
           onClick={() => {
             const nextSeed = seed + 1;
+            const additions = buildRows(1_000, nextSeed);
             setSeed(nextSeed);
-            setRows((current) => [...current, ...buildRows(1_000, nextSeed)]);
+            setRows((current) => [...current, ...additions]);
             setOperation("append 1,000");
             setRevision((value) => value + 1);
           }}
         >
           Append 1,000
+        </button>
+        <button
+          data-action="table-append-snapshot"
+          type="button"
+          onClick={() => {
+            const nextSeed = seed + 1;
+            setSeed(nextSeed);
+            setRows((current) => {
+              const additions = buildRows(1_000, nextSeed);
+              return [...current, ...additions];
+            });
+            setOperation("append 1,000 (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Append 1,000 (snapshot control)
         </button>
         <button
           data-action="table-replace"

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -234,6 +234,22 @@ new option is required. A compiler report exposes the emitted-site count as
 `keyedMapUpdateHints`. The separate hint runtime capability is imported only when that count is
 nonzero, so direct-only and ordinary keyed builds do not retain it.
 
+The same optional runtime recognizes conservative immutable appends on a direct keyed array:
+
+```tsx
+setItems((current) => [...current, nextItem]);
+setItems((current) => [...current, ...nextItems]);
+```
+
+Because every existing item keeps its key and index, Farm validates the committed source and the
+queued append chain, reads keys and descriptors only for the appended suffix, and mounts that
+suffix in one fragment. Existing row DOM is left untouched. The concise functional updater and
+native arrays are required; prepend, middle insertion, removal, direct replacement, duplicate
+keys, rows that read the collection itself, and failed runtime checks use complete keyed
+reconciliation. A key that reads the collection prevents hint emission entirely. The compiler
+report exposes the emitted-site count as
+`keyedArrayAppendHints`.
+
 An otherwise eligible host row may also contain an inline synchronous React event:
 
 ```tsx
@@ -515,7 +531,8 @@ reasons aggregated by count. Its summary and per-module `optimizations` also rep
 `keyedMapLookupTargets`, the number of native-Map keyed lookup bindings;
 `keyedMembershipTargets`, the number of native-Set membership bindings;
 `keyedCollectionUpdateHints`, the number of compiler-proven native Set/Map mutation sites; and
-`keyedMapUpdateHints`, the number of compiler-proven direct keyed `map()` update sites. A custom
+`keyedMapUpdateHints`, the number of compiler-proven direct keyed `map()` update sites; and
+`keyedArrayAppendHints`, the number of compiler-proven direct keyed-array append sites. A custom
 project-relative `reportFile` also enables reporting.
 
 The runtime test compares the same counter interaction on both paths: ordinary React performs a

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -26,14 +26,31 @@
         "brotli": 51897
       },
       "compilerOn": {
-        "raw": 230600,
-        "gzip": 71136,
-        "brotli": 60895
+        "raw": 230838,
+        "gzip": 71162,
+        "brotli": 60951
       },
       "compilerPremium": {
-        "raw": 37481,
-        "gzip": 10957,
-        "brotli": 8998
+        "raw": 37719,
+        "gzip": 10983,
+        "brotli": 9054
+      }
+    },
+    "keyedAppend": {
+      "compilerOff": {
+        "raw": 192901,
+        "gzip": 60085,
+        "brotli": 51772
+      },
+      "compilerOn": {
+        "raw": 232093,
+        "gzip": 71469,
+        "brotli": 61229
+      },
+      "compilerPremium": {
+        "raw": 39192,
+        "gzip": 11384,
+        "brotli": 9457
       }
     },
     "isolatedRuntime": {
@@ -43,18 +60,18 @@
         "brotli": 51666
       },
       "full": {
-        "raw": 268071,
-        "gzip": 76403,
-        "brotli": 65852
+        "raw": 269496,
+        "gzip": 76860,
+        "brotli": 66171
       },
       "coreOnly": {
         "raw": 204922,
         "gzip": 63685,
         "brotli": 54902
       },
-      "fullRuntimePremiumGzip": 16484,
+      "fullRuntimePremiumGzip": 16941,
       "coreRuntimePremiumGzip": 3766,
-      "gzipReductionPercent": 77.2
+      "gzipReductionPercent": 77.8
     }
   }
 }

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.md
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.md
@@ -24,18 +24,20 @@ is enforced on every pull request instead of serving only as a manually recorded
 | Fixture                                           | Compiler off gzip | Compiler on gzip | Compiler premium |
 | ------------------------------------------------- | ----------------: | ---------------: | ---------------: |
 | Direct text, attribute, style, and event bindings |          60,043 B |         63,721 B |          3,678 B |
-| Keyed rows, LIS, scalar, Set, and Map targeting   |          60,179 B |         71,136 B |         10,957 B |
+| Keyed rows, LIS, scalar, Set, and Map targeting   |          60,179 B |         71,162 B |         10,983 B |
+| Keyed rows with append hints                      |          60,085 B |         71,469 B |         11,384 B |
 
-The isolated compatibility runtime contributes 16,484 B gzip over the React control. The
-compiler-selected core contributes 3,766 B, a **77.2% reduction**. This comparison uses the same
+The isolated compatibility runtime contributes 16,941 B gzip over the React control. The
+compiler-selected core contributes 3,766 B, a **77.8% reduction**. This comparison uses the same
 hand-authored compiled definition and changes only the runtime entry used to create it.
 
 The keyed fixture retains `FarmCompiledKeyedRows` plus compiler-emitted `identityTarget`,
 `membershipTarget`, and `mapLookupTarget` metadata, plus Set/Map producer-delta helpers. It rejects
-the optional row-conditional and keyed-map-hint runtimes. The collection-delta fixture raises the
-keyed compiler premium by 922 B gzip while keeping the direct compiler premium and isolated core
-runtime byte-for-byte unchanged. The direct fixture rejects every structural runtime marker. The
-checked machine-readable result is [`RUNTIME_SIZE_RESULTS.json`](./RUNTIME_SIZE_RESULTS.json).
+the optional row-conditional and keyed-update runtimes. The append fixture separately proves that
+a recognized functional append retains the hinted runtime. The new capability keeps the direct
+compiler premium and isolated core runtime byte-for-byte unchanged; the ordinary keyed premium
+moves by only 26 B gzip. The direct fixture rejects every structural runtime marker. The checked
+machine-readable result is [`RUNTIME_SIZE_RESULTS.json`](./RUNTIME_SIZE_RESULTS.json).
 
 ## Existing production benchmark audit
 

--- a/packages/farm-react/fixtures/runtime-size/keyed-append.tsx
+++ b/packages/farm-react/fixtures/runtime-size/keyed-append.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from "react";
+import { createRoot } from "react-dom/client";
+
+interface Row {
+  id: number;
+  label: string;
+}
+
+export function AppendTable() {
+  const [rows, setRows] = useState<Row[]>(
+    Array.from({ length: 1_000 }, (_, id) => ({ id, label: `Row ${id}` })),
+  );
+  return (
+    <main>
+      <button
+        onClick={() =>
+          setRows((current) => [...current, { id: current.length, label: `Row ${current.length}` }])
+        }
+      >
+        Append
+      </button>
+      <ul>
+        {rows.map((row) => (
+          <li data-id={row.id} key={row.id}>
+            {row.label}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+
+createRoot(document.body).render(<AppendTable />);

--- a/packages/farm-react/scripts/benchmark-runtime-size.mjs
+++ b/packages/farm-react/scripts/benchmark-runtime-size.mjs
@@ -48,16 +48,27 @@ async function bundle(entry, compiler) {
   };
 }
 
-const [directOff, directOn, keyedOff, keyedOn, runtimeControl, runtimeCore, runtimeFull] =
-  await Promise.all([
-    bundle("direct.tsx", false),
-    bundle("direct.tsx", true),
-    bundle("keyed.tsx", false),
-    bundle("keyed.tsx", true),
-    bundle("runtime-control.tsx", false),
-    bundle("runtime-core.tsx", false),
-    bundle("runtime-full.tsx", false),
-  ]);
+const [
+  directOff,
+  directOn,
+  keyedOff,
+  keyedOn,
+  keyedAppendOff,
+  keyedAppendOn,
+  runtimeControl,
+  runtimeCore,
+  runtimeFull,
+] = await Promise.all([
+  bundle("direct.tsx", false),
+  bundle("direct.tsx", true),
+  bundle("keyed.tsx", false),
+  bundle("keyed.tsx", true),
+  bundle("keyed-append.tsx", false),
+  bundle("keyed-append.tsx", true),
+  bundle("runtime-control.tsx", false),
+  bundle("runtime-core.tsx", false),
+  bundle("runtime-full.tsx", false),
+]);
 
 const forbiddenDirectMarkers = [
   "FarmCompiledConditionalBlock",
@@ -96,6 +107,12 @@ if (!keyedOn.code.includes("mapLookupTarget")) {
 if (!keyedOn.code.includes('"set-add"') || !keyedOn.code.includes('"map-set"')) {
   throw new Error("Keyed selection fixture did not retain its Set/Map collection-delta helpers.");
 }
+if (
+  !keyedAppendOn.code.includes("FarmCompiledKeyedRows") ||
+  !keyedAppendOn.code.includes("keyed-rows:hinted")
+) {
+  throw new Error("Keyed append fixture did not retain its optional hinted runtime.");
+}
 
 const fullRuntimePremium = runtimeFull.gzip - runtimeControl.gzip;
 const coreRuntimePremium = runtimeCore.gzip - runtimeControl.gzip;
@@ -128,6 +145,23 @@ const results = {
         brotli: keyedOn.brotli - keyedOff.brotli,
       },
     },
+    keyedAppend: {
+      compilerOff: {
+        raw: keyedAppendOff.raw,
+        gzip: keyedAppendOff.gzip,
+        brotli: keyedAppendOff.brotli,
+      },
+      compilerOn: {
+        raw: keyedAppendOn.raw,
+        gzip: keyedAppendOn.gzip,
+        brotli: keyedAppendOn.brotli,
+      },
+      compilerPremium: {
+        raw: keyedAppendOn.raw - keyedAppendOff.raw,
+        gzip: keyedAppendOn.gzip - keyedAppendOff.gzip,
+        brotli: keyedAppendOn.brotli - keyedAppendOff.brotli,
+      },
+    },
     isolatedRuntime: {
       control: {
         raw: runtimeControl.raw,
@@ -155,6 +189,11 @@ if (checkOnly) {
       name: "keyed compiler premium",
       current: results.fixtures.keyed.compilerPremium.gzip,
       maximum: reference.fixtures.keyed.compilerPremium.gzip + 256,
+    },
+    {
+      name: "keyed append compiler premium",
+      current: results.fixtures.keyedAppend.compilerPremium.gzip,
+      maximum: reference.fixtures.keyedAppend.compilerPremium.gzip + 256,
     },
     {
       name: "core runtime premium",

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -42,6 +42,7 @@ const testSource = String.raw`
   const {
     createCompiledComponent,
     createCompiledComponentWithFeatures,
+    createCompilerKeyedArrayAppend,
     createCompilerKeyedMapUpdate,
   } = await import(
     "@farm.js/react/compiler-runtime"
@@ -1415,6 +1416,69 @@ const testSource = String.raw`
   assert.equal(interactiveAlpha.querySelector("[data-status]").textContent, "Alpha!!! done");
   assert.deepEqual(interactiveCalls, ["Alpha:0:0", "Alpha!:0:0", "Alpha!!:1:1"]);
   flushSync(() => interactiveRoot.unmount());
+
+  let appendRows = () => undefined;
+  let appendKeyReads = 0;
+  const AppendRows = createCompiledComponent({
+    displayName: "CompatibilityAppendRows",
+    initialize: () => [[{ id: "a", label: "Alpha" }]],
+    render(_props, state, blocks) {
+      const items = () => state[0].get();
+      appendRows = (addition) =>
+        state[0].set((previous) =>
+          createCompilerKeyedArrayAppend(
+            previous,
+            [...previous, addition],
+          ),
+        );
+      return React.createElement(
+        "section",
+        null,
+        React.createElement(blocks.KeyedRows, {
+          collectionDependency: 0,
+          dependencies: [0],
+          id: 0,
+          items,
+          structureDependencies: [0],
+          render: () =>
+            React.createElement(
+              "ul",
+              null,
+              items().map((item) =>
+                React.createElement("li", { "data-key": item.id, key: item.id }, item.label),
+              ),
+            ),
+          rowKey: (item) => {
+            appendKeyReads += 1;
+            return item.id;
+          },
+          create: (item) => ({
+            kind: "element",
+            tag: "li",
+            attributes: [{ name: "data-key", value: item.id }],
+            styles: [],
+            children: [item.label],
+          }),
+          bindings: [{ kind: "text", path: [], dependencies: [], read: (item) => [item.label] }],
+        }),
+      );
+    },
+    bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+  });
+  const appendContainer = document.createElement("div");
+  document.body.append(appendContainer);
+  const appendRoot = createRoot(appendContainer);
+  flushSync(() => appendRoot.render(React.createElement(AppendRows)));
+  const appendAlpha = appendContainer.querySelector("[data-key='a']");
+  appendKeyReads = 0;
+  appendRows({ id: "b", label: "Beta" });
+  appendRows({ id: "c", label: "Gamma" });
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(appendContainer.textContent, "AlphaBetaGamma");
+  assert.equal(appendContainer.querySelector("[data-key='a']"), appendAlpha);
+  assert.equal(appendKeyReads, 2);
+  flushSync(() => appendRoot.unmount());
 
   let editableRowExecutions = 0;
   let editableListRenders = 0;

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-append-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-append-hints.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true);
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/KeyedArrayAppendHints.tsx", infer);
+}
+
+describe("React AOT keyed-array append hints", () => {
+  it("records functional array-literal appends for compiled keyed rows", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inventory() {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <main>
+          <button onClick={() => setRows((current) => [...current, { id: "b", label: "Beta" }])}>
+            Append one
+          </button>
+          <button onClick={() => { const additions = makeRows(); setRows((current) => [...current, ...additions]); }}>
+            Append many
+          </button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedArrayAppendHints).toBe(2);
+    expect(result.code).toContain("createCompilerKeyedArrayAppend");
+    expect(result.code).toContain("keyedRowsHintedRuntimeFeature");
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedArrayAppendHints.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("createCompilerKeyedArrayAppend"),
+    });
+  });
+
+  it("supports the public List primitive without another option", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List } from "@farm.js/react/list";
+      export function Inventory() {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <main>
+          <button onClick={() => setRows((current) => [...current, { id: "b", label: "Beta" }])}>
+            Append
+          </button>
+          <ul>
+            <List each={rows} by={(row) => row.id}>
+              {(row) => <li>{row.label}</li>}
+            </List>
+          </ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.optimizations.keyedArrayAppendHints).toBe(1);
+    expect(result.code).toContain("createCompilerKeyedArrayAppend");
+    expect(result.code).toContain("collectionDependency={0}");
+  });
+
+  it("does not hint a collection when an existing row key reads its length", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inventory() {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <main>
+          <button onClick={() => setRows((current) => [...current, { id: "b", label: "Beta" }])}>
+            Append
+          </button>
+          <ul>{rows.map((row) => <li key={row.id + rows.length}>{row.label}</li>)}</ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.optimizations.keyedArrayAppendHints).toBe(0);
+    expect(result.code).not.toContain("createCompilerKeyedArrayAppend");
+  });
+
+  it.each([
+    {
+      name: "a captured direct replacement",
+      update: 'setRows([...rows, { id: "b", label: "Beta" }])',
+    },
+    {
+      name: "a prepend",
+      update: 'setRows((current) => [{ id: "b", label: "Beta" }, ...current])',
+    },
+    {
+      name: "a middle spread",
+      update:
+        'setRows((current) => [{ id: "b", label: "Beta" }, ...current, { id: "c", label: "Gamma" }])',
+    },
+    {
+      name: "a copy without appended entries",
+      update: "setRows((current) => [...current])",
+    },
+    {
+      name: "a block-bodied updater",
+      update:
+        'setRows((current) => { const next = [...current, { id: "b", label: "Beta" }]; return next; })',
+    },
+    {
+      name: "a side-effecting trailing call",
+      update: "setRows((current) => [...current, ...makeRows(current)])",
+    },
+  ])("does not hint $name", async ({ update }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inventory() {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <main>
+          <button onClick={() => { ${update}; }}>Update</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.optimizations.keyedArrayAppendHints).toBe(0);
+    expect(result.code).not.toContain("createCompilerKeyedArrayAppend");
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-keyed-lists.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-lists.test.ts
@@ -32,7 +32,9 @@ describe("React AOT keyed list compiler", () => {
 
     expect(result.compiled).toEqual(["Inventory"]);
     expect(result.diagnostics).toEqual([]);
-    expect(result.code).toContain("keyedRowsRuntimeFeature");
+    expect(result.optimizations.keyedArrayAppendHints).toBe(1);
+    expect(result.code).toContain("createCompilerKeyedArrayAppend");
+    expect(result.code).toContain("keyedRowsHintedRuntimeFeature");
     expect(result.code).not.toContain("keyedRowsConditionalRuntimeFeature");
     expect(result.code).not.toContain("keyedRowsHostRuntimeFeature");
     expect(result.code).toContain("farmBlocks.KeyedRows");

--- a/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
@@ -40,6 +40,7 @@ describe("React AOT keyed update hints", () => {
     expect(result.compiled).toEqual(["Inventory"]);
     expect(result.diagnostics).toEqual([]);
     expect(result.optimizations).toEqual({
+      keyedArrayAppendHints: 0,
       keyedCollectionUpdateHints: 0,
       keyedIdentityTargets: 0,
       keyedMapLookupTargets: 0,

--- a/packages/farm-react/src/__tests__/compiler-report.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-report.test.ts
@@ -28,6 +28,7 @@ function observations(projectRoot: string): ReactCompilerModuleObservation[] {
         compiled: ["Counter"],
         diagnostics: [],
         optimizations: {
+          keyedArrayAppendHints: 0,
           keyedCollectionUpdateHints: 0,
           keyedIdentityTargets: 0,
           keyedMapLookupTargets: 0,
@@ -53,6 +54,7 @@ function observations(projectRoot: string): ReactCompilerModuleObservation[] {
           },
         ],
         optimizations: {
+          keyedArrayAppendHints: 4,
           keyedCollectionUpdateHints: 6,
           keyedIdentityTargets: 4,
           keyedMapLookupTargets: 5,
@@ -74,6 +76,7 @@ describe("React compiler coverage report", () => {
       componentsConsidered: 4,
       compiled: 2,
       fallback: 2,
+      keyedArrayAppendHints: 4,
       keyedCollectionUpdateHints: 6,
       keyedIdentityTargets: 4,
       keyedMapLookupTargets: 5,
@@ -94,6 +97,7 @@ describe("React compiler coverage report", () => {
       selected: true,
     });
     expect(report.modules[1]?.optimizations).toEqual({
+      keyedArrayAppendHints: 4,
       keyedCollectionUpdateHints: 6,
       keyedIdentityTargets: 4,
       keyedMapLookupTargets: 5,

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-append-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-append-hints.test.tsx
@@ -397,7 +397,7 @@ describe("compiled keyed-array append hints", () => {
       );
     }
     expect(harness.counters.executions).toBe(1);
-  });
+  }, 15_000);
 
   it("hydrates in StrictMode and drops a queued append after unmount", async () => {
     const harness = createAppendHarness([{ id: "a", label: "Alpha" }]);

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-append-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-append-hints.test.tsx
@@ -1,0 +1,439 @@
+import React, { StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createCompiledComponent,
+  createCompilerKeyedArrayAppend,
+  type CompilerKeyedRowElement,
+} from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Item {
+  id: string;
+  label: string;
+}
+
+interface Counters {
+  executions: number;
+  listRenders: number;
+  keyReads: number;
+  descriptorReads: number;
+  bindingReads: number;
+}
+
+const roots: Root[] = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function hintedAppend(previous: Item[], additions: readonly Item[]): unknown {
+  return createCompilerKeyedArrayAppend(previous, [...previous, ...additions]);
+}
+
+function rowDescriptor(item: Item, text = item.label): CompilerKeyedRowElement {
+  return {
+    kind: "element",
+    tag: "li",
+    attributes: [{ name: "data-key", value: item.id }],
+    styles: [],
+    children: [text],
+  };
+}
+
+function createAppendHarness(initialItems: Item[], readsCollection = false) {
+  const counters: Counters = {
+    executions: 0,
+    listRenders: 0,
+    keyReads: 0,
+    descriptorReads: 0,
+    bindingReads: 0,
+  };
+  let append: (additions: readonly Item[]) => void = () => undefined;
+  let plainThenAppend: (addition: Item) => void = () => undefined;
+  const Inventory = createCompiledComponent({
+    displayName: "AppendInventory",
+    initialize: () => [initialItems],
+    render(_props: Record<string, never>, state, blocks) {
+      counters.executions += 1;
+      const items = () => state[0].get() as Item[];
+      append = (additions) =>
+        state[0].set((previous) => hintedAppend(previous as Item[], additions));
+      plainThenAppend = (addition) => {
+        state[0].set((previous) => [...(previous as Item[])]);
+        state[0].set((previous) => hintedAppend(previous as Item[], [addition]));
+      };
+      const text = (item: Item) =>
+        readsCollection ? `${items().length}: ${item.label}` : item.label;
+      return (
+        <section>
+          <blocks.KeyedRows
+            collectionDependency={0}
+            dependencies={[0]}
+            id={0}
+            items={items}
+            structureDependencies={[0]}
+            render={() => {
+              counters.listRenders += 1;
+              return (
+                <ul>
+                  {items().map((item) => (
+                    <li data-key={item.id} key={item.id}>
+                      {text(item)}
+                    </li>
+                  ))}
+                </ul>
+              );
+            }}
+            rowKey={(item) => {
+              counters.keyReads += 1;
+              return (item as Item).id;
+            }}
+            create={(item) => {
+              counters.descriptorReads += 1;
+              const row = item as Item;
+              return rowDescriptor(row, text(row));
+            }}
+            bindings={[
+              {
+                kind: "text",
+                path: [],
+                dependencies: readsCollection ? [0] : [],
+                read: (item) => {
+                  counters.bindingReads += 1;
+                  return [text(item as Item)];
+                },
+              },
+            ]}
+          />
+        </section>
+      );
+    },
+    bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+  });
+  return {
+    Inventory,
+    counters,
+    append: (additions: readonly Item[]) => append(additions),
+    plainThenAppend: (addition: Item) => plainThenAppend(addition),
+  };
+}
+
+describe("compiled keyed-array append hints", () => {
+  it("creates only appended rows while preserving every existing DOM identity", async () => {
+    const initialItems = Array.from(
+      { length: 2_048 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createAppendHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Inventory />));
+    const first = container.querySelector('[data-key="row-0"]');
+    const last = container.querySelector('[data-key="row-2047"]');
+    harness.counters.keyReads = 0;
+    harness.counters.descriptorReads = 0;
+    harness.counters.bindingReads = 0;
+
+    await act(async () => {
+      harness.append([
+        { id: "row-2048", label: "Row 2048" },
+        { id: "row-2049", label: "Row 2049" },
+      ]);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector('[data-key="row-0"]')).toBe(first);
+    expect(container.querySelector('[data-key="row-2047"]')).toBe(last);
+    expect(container.querySelectorAll("li")).toHaveLength(2_050);
+    expect(container.querySelector("li:last-child")?.textContent).toBe("Row 2049");
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.listRenders).toBe(1);
+    expect(harness.counters.keyReads).toBe(2);
+    expect(harness.counters.descriptorReads).toBe(2);
+    expect(harness.counters.bindingReads).toBe(2);
+  });
+
+  it("composes queued append hints before one compiler flush", async () => {
+    const harness = createAppendHarness([{ id: "a", label: "Alpha" }]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Inventory />));
+    harness.counters.keyReads = 0;
+
+    await act(async () => {
+      harness.append([{ id: "b", label: "Beta" }]);
+      harness.append([
+        { id: "c", label: "Gamma" },
+        { id: "d", label: "Delta" },
+      ]);
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Alpha",
+      "Beta",
+      "Gamma",
+      "Delta",
+    ]);
+    expect(harness.counters.keyReads).toBe(3);
+  });
+
+  it("rejects a hint chained after an unhinted update in the same flush", async () => {
+    const harness = createAppendHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Inventory />));
+    harness.counters.keyReads = 0;
+
+    await act(async () => {
+      harness.plainThenAppend({ id: "c", label: "Gamma" });
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelectorAll("li")).toHaveLength(3);
+    expect(harness.counters.keyReads).toBe(3);
+  });
+
+  it("keeps custom iterators and revoked proxies on behavior-preserving fallback", async () => {
+    const initialItems: Item[] = [{ id: "a", label: "Alpha" }];
+    const harness = createAppendHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Inventory />));
+    Object.defineProperty(initialItems, Symbol.iterator, {
+      configurable: true,
+      value: function* () {
+        yield { id: "x", label: "Iterator row" };
+      },
+    });
+
+    await act(async () => {
+      harness.append([{ id: "b", label: "Beta" }]);
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Iterator row",
+      "Beta",
+    ]);
+
+    const { proxy, revoke } = Proxy.revocable([], {});
+    revoke();
+    const next: Item[] = [{ id: "safe", label: "Safe" }];
+    expect(() => createCompilerKeyedArrayAppend(proxy, next)).not.toThrow();
+    expect(createCompilerKeyedArrayAppend(proxy, next)).toBe(next);
+  });
+
+  it("keeps complete reconciliation when existing rows read collection state", async () => {
+    const harness = createAppendHarness(
+      [
+        { id: "a", label: "Alpha" },
+        { id: "b", label: "Beta" },
+      ],
+      true,
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Inventory />));
+    harness.counters.keyReads = 0;
+
+    await act(async () => {
+      harness.append([{ id: "c", label: "Gamma" }]);
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "3: Alpha",
+      "3: Beta",
+      "3: Gamma",
+    ]);
+    expect(harness.counters.keyReads).toBe(3);
+  });
+
+  it("shares one append hint across multiple keyed boundaries", async () => {
+    const initialItems: Item[] = [{ id: "a", label: "Alpha" }];
+    let append: () => void = () => undefined;
+    let keyReads = 0;
+    const Inventory = createCompiledComponent({
+      displayName: "SharedAppendInventory",
+      initialize: () => [initialItems],
+      render(_props: Record<string, never>, state, blocks) {
+        const items = () => state[0].get() as Item[];
+        append = () =>
+          state[0].set((previous) =>
+            hintedAppend(previous as Item[], [{ id: "b", label: "Beta" }]),
+          );
+        const list = (id: number, owner: string) => (
+          <blocks.KeyedRows
+            collectionDependency={0}
+            dependencies={[0]}
+            id={id}
+            items={items}
+            structureDependencies={[0]}
+            render={() => (
+              <ul data-owner={owner}>
+                {items().map((item) => (
+                  <li data-key={item.id} key={item.id}>
+                    {item.label}
+                  </li>
+                ))}
+              </ul>
+            )}
+            rowKey={(item) => {
+              keyReads += 1;
+              return (item as Item).id;
+            }}
+            create={(item) => rowDescriptor(item as Item)}
+            bindings={[{ kind: "text", path: [], read: (item) => [(item as Item).label] }]}
+          />
+        );
+        return (
+          <section>
+            {list(0, "first")}
+            {list(1, "second")}
+          </section>
+        );
+      },
+      bindings: [
+        { kind: "block", id: 0, dependencies: [0] },
+        { kind: "block", id: 1, dependencies: [0] },
+      ],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Inventory />));
+    keyReads = 0;
+
+    await act(async () => {
+      append();
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector('[data-owner="first"]')?.textContent).toBe("AlphaBeta");
+    expect(container.querySelector('[data-owner="second"]')?.textContent).toBe("AlphaBeta");
+    expect(keyReads).toBe(2);
+  });
+
+  it("matches React through 2,000 deterministic appends", async () => {
+    const initialItems: Item[] = [{ id: "seed", label: "Seed" }];
+    const harness = createAppendHarness(initialItems);
+    let appendReact: (item: Item) => void = () => undefined;
+    function Normal() {
+      const [items, setItems] = useState(initialItems);
+      appendReact = (item) => setItems((previous) => [...previous, item]);
+      return (
+        <ol data-owner="react">
+          {items.map((item) => (
+            <li data-key={item.id} key={item.id}>
+              {item.label}
+            </li>
+          ))}
+        </ol>
+      );
+    }
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <>
+          <div data-owner="compiled">
+            <harness.Inventory />
+          </div>
+          <Normal />
+        </>,
+      ),
+    );
+
+    let random = 0x12345678;
+    for (let batch = 0; batch < 100; batch += 1) {
+      await act(async () => {
+        for (let update = 0; update < 20; update += 1) {
+          random = (Math.imul(random, 1_664_525) + 1_013_904_223) >>> 0;
+          const item = { id: `row-${batch}-${update}`, label: `Value ${random % 10_000}` };
+          harness.append([item]);
+          appendReact(item);
+        }
+        await flushCompilerUpdates();
+      });
+      expect(
+        [...container.querySelectorAll('[data-owner="compiled"] li')].map((row) => row.outerHTML),
+      ).toEqual(
+        [...container.querySelectorAll('[data-owner="react"] li')].map((row) => row.outerHTML),
+      );
+    }
+    expect(harness.counters.executions).toBe(1);
+  });
+
+  it("hydrates in StrictMode and drops a queued append after unmount", async () => {
+    const harness = createAppendHarness([{ id: "a", label: "Alpha" }]);
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(
+      <StrictMode>
+        <harness.Inventory />
+      </StrictMode>,
+    );
+    document.body.append(container);
+    const recoverable: unknown[] = [];
+    let root!: Root;
+    await act(async () => {
+      root = hydrateRoot(
+        container,
+        <StrictMode>
+          <harness.Inventory />
+        </StrictMode>,
+        { onRecoverableError: (error) => recoverable.push(error) },
+      );
+    });
+    roots.push(root);
+
+    await act(async () => {
+      harness.append([{ id: "b", label: "Beta" }]);
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("AlphaBeta");
+    expect(recoverable).toEqual([]);
+
+    roots.pop();
+    act(() => {
+      harness.append([{ id: "c", label: "Gamma" }]);
+      root.unmount();
+    });
+    await flushCompilerUpdates();
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/packages/farm-react/src/__tests__/vite.test.ts
+++ b/packages/farm-react/src/__tests__/vite.test.ts
@@ -85,6 +85,7 @@ describe("React renderer Vite integration", () => {
       componentsConsidered: 2,
       compiled: 2,
       fallback: 0,
+      keyedArrayAppendHints: 0,
       keyedCollectionUpdateHints: 0,
       keyedIdentityTargets: 0,
       keyedMapLookupTargets: 0,

--- a/packages/farm-react/src/compiler-report.ts
+++ b/packages/farm-react/src/compiler-report.ts
@@ -18,6 +18,7 @@ export interface ReactCompilerReport {
     componentsConsidered: number;
     compiled: number;
     fallback: number;
+    keyedArrayAppendHints: number;
     keyedCollectionUpdateHints: number;
     keyedIdentityTargets: number;
     keyedMapLookupTargets: number;
@@ -32,6 +33,7 @@ export interface ReactCompilerReport {
     id: string;
     compiled: readonly string[];
     optimizations: {
+      keyedArrayAppendHints: number;
       keyedCollectionUpdateHints: number;
       keyedIdentityTargets: number;
       keyedMapLookupTargets: number;
@@ -54,6 +56,7 @@ export function createReactCompilerReport(
   let componentsConsidered = 0;
   let compiled = 0;
   let fallback = 0;
+  let keyedArrayAppendHints = 0;
   let keyedCollectionUpdateHints = 0;
   let keyedIdentityTargets = 0;
   let keyedMapLookupTargets = 0;
@@ -65,6 +68,7 @@ export function createReactCompilerReport(
       componentsConsidered += result.compiled.length + result.diagnostics.length;
       compiled += result.compiled.length;
       fallback += result.diagnostics.length;
+      keyedArrayAppendHints += result.optimizations.keyedArrayAppendHints || 0;
       keyedCollectionUpdateHints += result.optimizations.keyedCollectionUpdateHints || 0;
       keyedIdentityTargets += result.optimizations.keyedIdentityTargets || 0;
       keyedMapLookupTargets += result.optimizations.keyedMapLookupTargets || 0;
@@ -95,6 +99,7 @@ export function createReactCompilerReport(
       componentsConsidered,
       compiled,
       fallback,
+      keyedArrayAppendHints,
       keyedCollectionUpdateHints,
       keyedIdentityTargets,
       keyedMapLookupTargets,

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -11,6 +11,13 @@ interface CompilerKeyedMapUpdateHint {
   readonly previous?: CompilerKeyedMapUpdateHint;
 }
 
+interface CompilerKeyedArrayAppendHint {
+  readonly sourceToken: object;
+  readonly startIndex: number;
+  readonly resultLength: number;
+  readonly previous?: CompilerKeyedArrayAppendHint;
+}
+
 type CompilerKeyedCollectionKind = "set" | "map";
 type CompilerKeyedCollectionMutation = "set-add" | "set-delete" | "map-set" | "map-delete";
 
@@ -31,6 +38,10 @@ const COMPILER_KEYED_MAP_UPDATES = /* @__PURE__ */ new WeakMap<
   object,
   CompilerKeyedMapUpdateHint
 >();
+const COMPILER_KEYED_ARRAY_APPENDS = /* @__PURE__ */ new WeakMap<
+  object,
+  CompilerKeyedArrayAppendHint
+>();
 const COMPILER_KEYED_COLLECTION_DRAFTS = /* @__PURE__ */ new WeakMap<
   object,
   CompilerKeyedCollectionDraft
@@ -40,6 +51,8 @@ const COMPILER_KEYED_COLLECTION_UPDATES = /* @__PURE__ */ new WeakMap<
   CompilerKeyedCollectionUpdateHint
 >();
 const COMPILER_KEYED_COMMITTED_COLLECTIONS = /* @__PURE__ */ new WeakSet<object>();
+const NATIVE_ARRAY_PROTOTYPE = Array.prototype;
+const NATIVE_ARRAY_ITERATOR = Array.prototype[Symbol.iterator];
 const NATIVE_REFLECT_APPLY = Reflect.apply;
 
 function compilerObject(value: unknown): object | undefined {
@@ -85,6 +98,33 @@ function compilerKeyedMapChangedIndices(
   return changedIndices;
 }
 
+function compilerKeyedArrayAppendStart(
+  value: unknown,
+  sourceToken: object | undefined,
+  expectedStart: number,
+): number | undefined {
+  const target = compilerObject(value);
+  if (!target || !sourceToken || !Array.isArray(value)) return undefined;
+  const update = COMPILER_KEYED_ARRAY_APPENDS.get(target);
+  if (!update || update.sourceToken !== sourceToken) return undefined;
+  const updates: CompilerKeyedArrayAppendHint[] = [];
+  for (
+    let current: CompilerKeyedArrayAppendHint | undefined = update;
+    current;
+    current = current.previous
+  ) {
+    if (current.sourceToken !== sourceToken) return undefined;
+    updates.push(current);
+  }
+  let length = expectedStart;
+  for (let index = updates.length - 1; index >= 0; index -= 1) {
+    const current = updates[index];
+    if (current.startIndex !== length || current.resultLength < length) return undefined;
+    length = current.resultLength;
+  }
+  return length === value.length ? expectedStart : undefined;
+}
+
 function compilerKeyedCollectionChangedKeys(
   value: unknown,
   sourceToken: object | undefined,
@@ -127,6 +167,42 @@ export function createCompilerKeyedMapUpdate(
     });
   }
   return value;
+}
+
+/** @internal Records a compiler-proven immutable keyed-array append and returns the Array. */
+export function createCompilerKeyedArrayAppend(previous: unknown, value: unknown): unknown {
+  try {
+    const previousTarget = compilerObject(previous);
+    const valueTarget = compilerObject(value);
+    if (
+      !previousTarget ||
+      !valueTarget ||
+      !Array.isArray(previous) ||
+      !Array.isArray(value) ||
+      Object.getPrototypeOf(previous) !== NATIVE_ARRAY_PROTOTYPE ||
+      Object.getPrototypeOf(value) !== NATIVE_ARRAY_PROTOTYPE ||
+      previous[Symbol.iterator] !== NATIVE_ARRAY_ITERATOR
+    ) {
+      return value;
+    }
+    const startIndex = previous.length;
+    if (value.length < startIndex) return value;
+    const sourceToken = compilerKeyedCollectionToken(previousTarget);
+    if (!sourceToken) return value;
+    const previousUpdate = !COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget)
+      ? COMPILER_KEYED_ARRAY_APPENDS.get(previousTarget)
+      : undefined;
+    COMPILER_KEYED_ARRAY_APPENDS.set(valueTarget, {
+      sourceToken: previousUpdate?.sourceToken || sourceToken,
+      startIndex,
+      resultLength: value.length,
+      ...(previousUpdate ? { previous: previousUpdate } : {}),
+    });
+    return value;
+  } catch {
+    // Metadata must never change the behavior of an otherwise valid update.
+    return value;
+  }
 }
 
 /** @internal Preserves a proven native collection mutation while recording its executed key. */
@@ -3242,8 +3318,16 @@ interface KeyedRowHostRuntime {
   ): CompilerHostTreeScope | null;
 }
 
-interface KeyedMapUpdateRuntime {
+interface KeyedUpdateRuntime {
   commit(value: unknown): object | undefined;
+  append(
+    props: CompilerKeyedRowsBlockProps,
+    dirtyState: ReadonlySet<number>,
+    collectionToken: object | undefined,
+    instances: ReadonlyMap<string, CompilerKeyedRowInstance>,
+    root: Element,
+    reactOwnedRows: boolean,
+  ): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined;
   reconcile(
     props: CompilerKeyedRowsBlockProps,
     dirtyState: ReadonlySet<number>,
@@ -3264,7 +3348,8 @@ interface KeyedMapUpdateRuntime {
     | undefined;
 }
 
-const keyedMapUpdateRuntime: KeyedMapUpdateRuntime = {
+const keyedUpdateRuntime: KeyedUpdateRuntime = {
+  append: reconcileCompilerKeyedArrayAppend,
   commit: commitCompilerKeyedCollection,
   reconcile: reconcileCompilerKeyedMapUpdate,
 };
@@ -3272,7 +3357,7 @@ const keyedMapUpdateRuntime: KeyedMapUpdateRuntime = {
 interface KeyedRowsRuntimeOptions {
   conditionals?: KeyedRowConditionalRuntime;
   hostBlocks?: KeyedRowHostRuntime;
-  keyedMapUpdates?: KeyedMapUpdateRuntime;
+  keyedUpdates?: KeyedUpdateRuntime;
 }
 
 function reconcileCompilerKeyedMapUpdate(
@@ -3281,7 +3366,7 @@ function reconcileCompilerKeyedMapUpdate(
   collectionToken: object | undefined,
   instances: ReadonlyMap<string, CompilerKeyedRowInstance>,
   conditionals: KeyedRowConditionalRuntime | undefined,
-): ReturnType<KeyedMapUpdateRuntime["reconcile"]> {
+): ReturnType<KeyedUpdateRuntime["reconcile"]> {
   const dependency = props.collectionDependency;
   if (dependency === undefined) return undefined;
   const dependencies = props.dependencies || props.structureDependencies || [];
@@ -3338,6 +3423,70 @@ function reconcileCompilerKeyedMapUpdate(
     conditionalChanges,
     fallback: false,
   };
+}
+
+function reconcileCompilerKeyedArrayAppend(
+  props: CompilerKeyedRowsBlockProps,
+  dirtyState: ReadonlySet<number>,
+  collectionToken: object | undefined,
+  instances: ReadonlyMap<string, CompilerKeyedRowInstance>,
+  root: Element,
+  reactOwnedRows: boolean,
+): ReturnType<KeyedUpdateRuntime["append"]> {
+  if (
+    reactOwnedRows ||
+    props.hostBlocks ||
+    (props.conditionals?.length || 0) > 0 ||
+    props.collectionDependency === undefined
+  ) {
+    return undefined;
+  }
+  const collectionDependency = props.collectionDependency;
+  if (props.bindings.some((binding) => binding.dependencies?.includes(collectionDependency))) {
+    // Existing rows may read the collection itself (for example,
+    // `rows.length`). Appending would need to refresh those rows too, so keep
+    // the complete keyed reconciliation path for that shape.
+    return undefined;
+  }
+  const dependencies = props.dependencies || props.structureDependencies;
+  const relevantDirty = (dependencies || []).filter((index) => dirtyState.has(index));
+  if (relevantDirty.length !== 1 || relevantDirty[0] !== collectionDependency) {
+    return undefined;
+  }
+
+  const finalValue = props.items();
+  const startIndex = compilerKeyedArrayAppendStart(finalValue, collectionToken, instances.size);
+  if (startIndex === undefined || !Array.isArray(finalValue)) return undefined;
+
+  const nextInstances = new Map(instances);
+  const appended: CompilerKeyedRowInstance[] = [];
+  try {
+    for (let index = startIndex; index < finalValue.length; index += 1) {
+      const item = finalValue[index];
+      const key = keyedRowIdentity(props.rowKey(item, index));
+      if (nextInstances.has(key)) return undefined;
+      const descriptor = props.create(item, index);
+      const instance: CompilerKeyedRowInstance = {
+        key,
+        element: createCompilerHostElement(root.ownerDocument, descriptor),
+        values: readKeyedRowBindingValues(props, item, index),
+        item,
+        index,
+        conditionalValues: EMPTY_KEYED_ROW_CONDITIONAL_VALUES,
+      };
+      appended.push(instance);
+      nextInstances.set(key, instance);
+    }
+  } catch {
+    return undefined;
+  }
+
+  if (appended.length > 0) {
+    const fragment = root.ownerDocument.createDocumentFragment();
+    for (const instance of appended) fragment.append(instance.element);
+    root.append(fragment);
+  }
+  return nextInstances;
 }
 
 function createKeyedRowConditionalRuntime(): KeyedRowConditionalRuntime {
@@ -3673,7 +3822,7 @@ function createKeyedRowsBlockComponent(
     }
 
     private commitCurrentCollection(dirtyState?: ReadonlySet<number>): void {
-      this.collectionToken = options.keyedMapUpdates?.commit(this.currentProps.items());
+      this.collectionToken = options.keyedUpdates?.commit(this.currentProps.items());
       this.commitKeyedTargets(dirtyState);
     }
 
@@ -4335,14 +4484,8 @@ function createKeyedRowsBlockComponent(
     }
 
     private refresh: CompilerBlockRefresh = (afterCommit, dirtyState) => {
-      if (
-        dirtyState &&
-        options.keyedMapUpdates &&
-        this.mounted &&
-        this.root &&
-        !this.state.fallback
-      ) {
-        const result = options.keyedMapUpdates.reconcile(
+      if (dirtyState && options.keyedUpdates && this.mounted && this.root && !this.state.fallback) {
+        const result = options.keyedUpdates.reconcile(
           this.currentProps,
           dirtyState,
           this.collectionToken,
@@ -4355,6 +4498,21 @@ function createKeyedRowsBlockComponent(
             this.collectionToken = result.collectionToken;
             this.notifyConditionalChanges(result.conditionalChanges, afterCommit);
           }
+          return;
+        }
+        const appendedInstances = options.keyedUpdates.append(
+          this.currentProps,
+          dirtyState,
+          this.collectionToken,
+          this.instances,
+          this.root,
+          this.hasReactOwnedRows(),
+        );
+        if (appendedInstances) {
+          this.instances = new Map(appendedInstances);
+          this.rebuildElementIndex(this.instances);
+          this.commitCurrentCollection(dirtyState);
+          afterCommit?.();
           return;
         }
       }
@@ -4922,7 +5080,7 @@ export const keyedRowsRuntimeFeature: CompilerRuntimeFeature = {
 export const keyedRowsHintedRuntimeFeature: CompilerRuntimeFeature = {
   name: "keyed-rows:hinted",
   create: (owner) => ({
-    KeyedRows: createKeyedRowsBlockComponent(owner, { keyedMapUpdates: keyedMapUpdateRuntime }),
+    KeyedRows: createKeyedRowsBlockComponent(owner, { keyedUpdates: keyedUpdateRuntime }),
   }),
 };
 
@@ -4940,7 +5098,7 @@ export const keyedRowsConditionalHintedRuntimeFeature: CompilerRuntimeFeature = 
   create: (owner) => ({
     KeyedRows: createKeyedRowsBlockComponent(owner, {
       conditionals: createKeyedRowConditionalRuntime(),
-      keyedMapUpdates: keyedMapUpdateRuntime,
+      keyedUpdates: keyedUpdateRuntime,
     }),
   }),
 };
@@ -4959,7 +5117,7 @@ export const keyedRowsHostHintedRuntimeFeature: CompilerRuntimeFeature = {
   create: (owner) => ({
     KeyedRows: createKeyedRowsBlockComponent(owner, {
       hostBlocks: createKeyedRowHostRuntime(),
-      keyedMapUpdates: keyedMapUpdateRuntime,
+      keyedUpdates: keyedUpdateRuntime,
     }),
   }),
 };
@@ -4980,7 +5138,7 @@ export const keyedRowsCompleteHintedRuntimeFeature: CompilerRuntimeFeature = {
     KeyedRows: createKeyedRowsBlockComponent(owner, {
       conditionals: createKeyedRowConditionalRuntime(),
       hostBlocks: createKeyedRowHostRuntime(),
-      keyedMapUpdates: keyedMapUpdateRuntime,
+      keyedUpdates: keyedUpdateRuntime,
     }),
   }),
 };

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -13,6 +13,7 @@ export interface CompileReactModuleResult {
   compiled: readonly string[];
   diagnostics: readonly CompilerDiagnostic[];
   optimizations: {
+    keyedArrayAppendHints: number;
     keyedCollectionUpdateHints: number;
     keyedIdentityTargets: number;
     keyedMapLookupTargets: number;
@@ -1121,6 +1122,99 @@ function rewriteKeyedMapUpdateHints(
               t.cloneNode(previous),
               t.cloneNode(nextValue),
               t.cloneNode(changedIndices),
+            ]),
+          ),
+        ]),
+      );
+      count += 1;
+      path.skip();
+    },
+  });
+  return {
+    root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement,
+    count,
+  };
+}
+
+function rewriteKeyedArrayAppendHints(
+  root: t.JSXElement,
+  hintedStateIndices: ReadonlySet<number>,
+  statesBySetter: ReadonlyMap<string, StateBinding>,
+  helperIdentifier: t.Identifier,
+  safeGlobals: ReadonlySet<string>,
+): { root: t.JSXElement; count: number } {
+  if (hintedStateIndices.size === 0) return { root: t.cloneNode(root, true), count: 0 };
+  const file = expressionFile(t.cloneNode(root, true));
+  let count = 0;
+  traverse(file, {
+    CallExpression(path) {
+      const callee = path.get("callee");
+      if (!callee.isIdentifier() || callee.scope.hasBinding(callee.node.name)) return;
+      const state = statesBySetter.get(callee.node.name);
+      if (!state || !hintedStateIndices.has(state.index) || path.node.arguments.length !== 1) {
+        return;
+      }
+      const updater = path.node.arguments[0];
+      if (
+        !t.isArrowFunctionExpression(updater) ||
+        updater.async ||
+        updater.generator ||
+        updater.params.length !== 1 ||
+        !t.isIdentifier(updater.params[0]) ||
+        !t.isArrayExpression(updater.body) ||
+        updater.body.elements.length < 2 ||
+        updater.body.elements.some((element) => element === null) ||
+        !t.isSpreadElement(updater.body.elements[0]) ||
+        !t.isIdentifier(updater.body.elements[0].argument, { name: updater.params[0].name })
+      ) {
+        return;
+      }
+      const safeAppendValue = (value: t.Expression): boolean => {
+        if (t.isArrayExpression(value)) {
+          return value.elements.every(
+            (element) =>
+              element !== null &&
+              !t.isJSXNamespacedName(element) &&
+              !t.isArgumentPlaceholder(element) &&
+              safeAppendValue(t.isSpreadElement(element) ? element.argument : element),
+          );
+        }
+        if (t.isObjectExpression(value)) {
+          return value.properties.every((property) => {
+            if (t.isSpreadElement(property)) return safeAppendValue(property.argument);
+            if (!t.isObjectProperty(property) || !t.isExpression(property.value)) return false;
+            return (
+              (!property.computed ||
+                (t.isExpression(property.key) && safeAppendValue(property.key))) &&
+              safeAppendValue(property.value)
+            );
+          });
+        }
+        return validateDerivedExpression(value, safeGlobals) === undefined;
+      };
+      if (
+        updater.body.elements.slice(1).some((element) => {
+          if (!element || t.isJSXNamespacedName(element) || t.isArgumentPlaceholder(element)) {
+            return true;
+          }
+          return !safeAppendValue(t.isSpreadElement(element) ? element.argument : element);
+        })
+      ) {
+        return;
+      }
+
+      const previous = t.cloneNode(updater.params[0]);
+      const nextValue = path.scope.generateUidIdentifier("farmNextItems");
+      path.node.arguments[0] = t.arrowFunctionExpression(
+        [t.cloneNode(previous)],
+        t.blockStatement([
+          t.variableDeclaration("const", [
+            t.variableDeclarator(t.cloneNode(nextValue), t.cloneNode(updater.body, true)),
+          ]),
+          t.returnStatement(
+            t.callExpression(t.cloneNode(helperIdentifier), [
+              t.cloneNode(previous),
+              t.cloneNode(nextValue),
             ]),
           ),
         ]),
@@ -5733,11 +5827,13 @@ function compileCandidate(
   candidate: Candidate,
   createComponentIdentifier: t.Identifier,
   keyedMapUpdateIdentifier: t.Identifier,
+  keyedArrayAppendIdentifier: t.Identifier,
   keyedCollectionUpdateIdentifier: t.Identifier,
   keyedCollectionMutationIdentifier: t.Identifier,
   runtimeFeatureIdentifiers: ReadonlyMap<CompilerRuntimeFeatureName, t.Identifier>,
   usedRuntimeFeatures: Set<CompilerRuntimeFeatureName>,
   optimizationCounts: {
+    keyedArrayAppendHints: number;
     keyedCollectionUpdateHints: number;
     keyedIdentityTargets: number;
     keyedMapLookupTargets: number;
@@ -6025,6 +6121,52 @@ function compileCandidate(
       optimizationCounts.keyedMapUpdateHints += hintedRoot.count;
     }
   }
+  const appendHintedStateIndices = new Set(hintedStateIndices);
+  for (const plan of blockAnalysis.plans || []) {
+    if (plan.kind !== "keyed-rows" || plan.collectionDependency === undefined) continue;
+    const keyExpression = returnedExpression(plan.keyCallback);
+    if (
+      !keyExpression ||
+      collectStateDependencies(keyExpression, reactiveByValue).includes(plan.collectionDependency)
+    ) {
+      // Appending changes collection-derived keys on every existing row. Do not
+      // emit a suffix-only hint for any boundary that consumes this state.
+      appendHintedStateIndices.delete(plan.collectionDependency);
+    }
+  }
+  const appendHintedRoot = rewriteKeyedArrayAppendHints(
+    expandedReactiveRoot,
+    appendHintedStateIndices,
+    statesBySetter,
+    keyedArrayAppendIdentifier,
+    safeGlobals,
+  );
+  let appliedKeyedArrayAppendHints = 0;
+  if (appendHintedRoot.count > 0) {
+    const hintedBlockAnalysis = analyzeComposableBlocks(
+      appendHintedRoot.root,
+      reactiveByValue,
+      safeGlobals,
+      listNames,
+      allowedComponentNames,
+    );
+    const hintedAnalysis = analyzeHostTree(
+      appendHintedRoot.root,
+      reactiveByValue,
+      safeGlobals,
+      hintedBlockAnalysis.conditionalExpressions || new Set<t.Expression>(),
+      hintedBlockAnalysis.keyedExpressions || new Set<t.Expression>(),
+      hintedBlockAnalysis.ownedElements || new Set<t.JSXElement>(),
+      hintedBlockAnalysis.componentElements || new Set<t.JSXElement>(),
+    );
+    if (!hintedBlockAnalysis.reason && !hintedAnalysis.reason) {
+      expandedReactiveRoot = appendHintedRoot.root;
+      blockAnalysis = hintedBlockAnalysis;
+      analysis = hintedAnalysis;
+      appliedKeyedArrayAppendHints = appendHintedRoot.count;
+      optimizationCounts.keyedArrayAppendHints += appendHintedRoot.count;
+    }
+  }
   const keyedCollectionTargetKinds = new Map<number, KeyedCollectionTargetKind>();
   const conflictingKeyedCollectionTargets = new Set<number>();
   for (const plan of blockAnalysis.plans || []) {
@@ -6102,7 +6244,8 @@ function compileCandidate(
         : 0),
     0,
   );
-  const runtimeFeatures = runtimeFeaturesForPlans(blockPlans, appliedKeyedMapUpdateHints > 0);
+  const hasKeyedUpdateHints = appliedKeyedMapUpdateHints > 0 || appliedKeyedArrayAppendHints > 0;
+  const runtimeFeatures = runtimeFeaturesForPlans(blockPlans, hasKeyedUpdateHints);
   markShortCircuitBindings(analysis.bindings || []);
   assignStableBindingTargets(analysis.bindings || []);
 
@@ -6121,7 +6264,7 @@ function compileCandidate(
     blockPlans,
     blockParameter,
     listNames,
-    appliedKeyedMapUpdateHints > 0,
+    hasKeyedUpdateHints,
   );
   const rewrittenRoot = rewriteStateAccess(
     rootWithBlocks,
@@ -6287,6 +6430,7 @@ export async function compileReactModule(
   const compiled: string[] = [];
   const diagnostics: CompilerDiagnostic[] = [];
   const optimizationCounts = {
+    keyedArrayAppendHints: 0,
     keyedCollectionUpdateHints: 0,
     keyedIdentityTargets: 0,
     keyedMapLookupTargets: 0,
@@ -6333,6 +6477,9 @@ export async function compileReactModule(
         const keyedMapUpdateIdentifier = programPath.scope.generateUidIdentifier(
           "createCompilerKeyedMapUpdate",
         );
+        const keyedArrayAppendIdentifier = programPath.scope.generateUidIdentifier(
+          "createCompilerKeyedArrayAppend",
+        );
         const keyedCollectionUpdateIdentifier = programPath.scope.generateUidIdentifier(
           "createCompilerKeyedCollectionUpdate",
         );
@@ -6361,6 +6508,7 @@ export async function compileReactModule(
             candidate,
             createComponentIdentifier,
             keyedMapUpdateIdentifier,
+            keyedArrayAppendIdentifier,
             keyedCollectionUpdateIdentifier,
             keyedCollectionMutationIdentifier,
             runtimeFeatureIdentifiers,
@@ -6397,6 +6545,14 @@ export async function compileReactModule(
                       t.importSpecifier(
                         keyedMapUpdateIdentifier,
                         t.identifier("createCompilerKeyedMapUpdate"),
+                      ),
+                    ]
+                  : []),
+                ...(optimizationCounts.keyedArrayAppendHints > 0
+                  ? [
+                      t.importSpecifier(
+                        keyedArrayAppendIdentifier,
+                        t.identifier("createCompilerKeyedArrayAppend"),
                       ),
                     ]
                   : []),


### PR DESCRIPTION
## Summary

- recognize conservative immutable keyed-array appends such as `setItems(current => [...current, nextItem])`
- carry a validated append chain to the keyed runtime and create only the appended host rows while preserving existing DOM identity
- fall back to complete keyed reconciliation for unsupported updater shapes, non-native arrays, duplicate keys, collection-dependent keys or bindings, nested structures, unrelated dirty state, and failed runtime validation
- expose `keyedArrayAppendHints` in compiler reports and document syntax, behavior, limitations, testing, and bundle cost
- add a compiled snapshot control and a dedicated production-browser persistence gate

## Performance

Production Chrome benchmark on the 10,000 to 11,000 row append:

- hybrid: 13.30 ms versus React 71.55 ms, 5.38x faster
- hybrid: 13.30 ms versus compiled snapshot 25.60 ms, 1.92x faster
- static: 5.15x faster than React and 1.91x faster than compiled snapshot
- repeated append batches through 20,000 rows: 6.63x to 7.09x faster than React

All existing performance and scalability gates pass. Direct and isolated core runtime sizes remain unchanged; the ordinary keyed premium changes by 26 B gzip. The append-enabled fixture records an 11,384 B gzip compiler premium.

## Verification

- `pnpm --filter @farm.js/react test` — 52 files, 435 tests
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8
- `pnpm --filter farm-react-compiler-dashboard-example benchmark`
- `pnpm --filter farmjs-docs build`
- targeted oxlint, oxfmt, and diff checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The React compiler now recognizes immutable keyed-array appends like `setItems(current => [...current, nextItem])` and creates only the appended rows, preserving existing DOM identity. Previously, all keyed updates required full reconciliation.

**New Features**

- Adds a validated append chain to the keyed runtime; existing rows keep their DOM and only the suffix is mounted in one fragment.
- Falls back to complete keyed reconciliation for prepends, middle insertions, removals, block-bodied updaters, duplicate keys, collection-dependent keys, nested structures, and any failed runtime validation.
- Exposes `keyedArrayAppendHints` in compiler reports; the hinted runtime is retained only when a module emits at least one append or same-order map hint.
- Adds a compiled snapshot control and a production-browser persistence gate for append performance.
- Benchmarks 10,000→11,000 row append at 13.30 ms versus React's 71.55 ms (5.38x faster) and 25.60 ms for the compiled snapshot control (1.92x faster); repeated batches to 20,000 rows stay up to 7.09x faster than React.
- The ordinary keyed compiler premium changes by 26 B gzip; the append-enabled fixture records an 11,384 B gzip premium.

<sup>Written for commit e8b136c04b4dbaad55d72240095286b2c250e80c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

