### PR TITLE
perf(react): carry keyed filter hints

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -303,6 +303,7 @@ After a successful build, Farm writes `.farm/react-compiler.json`:
     "compiled": 2,
     "fallback": 2,
     "keyedArrayAppendHints": 1,
+    "keyedArrayFilterHints": 1,
     "keyedCollectionUpdateHints": 3,
     "keyedIdentityTargets": 2,
     "keyedMapLookupTargets": 1,
@@ -321,6 +322,7 @@ After a successful build, Farm writes `.farm/react-compiler.json`:
       "compiled": ["ProductRow"],
       "optimizations": {
         "keyedArrayAppendHints": 1,
+        "keyedArrayFilterHints": 1,
         "keyedCollectionUpdateHints": 3,
         "keyedIdentityTargets": 2,
         "keyedMapLookupTargets": 1,
@@ -353,7 +355,8 @@ executed keys to the runtime.
 can report its changed row indexes while an immutable `map()` runs. The same counts appear per
 module.
 `keyedArrayAppendHints` counts setter sites where the compiler proved a direct keyed array append
-and can hand the appended suffix to the runtime. `selected` is `true` when an annotation explicitly
+and can hand the appended suffix to the runtime. `keyedArrayFilterHints` counts concise keyed-array
+filter sites that can report removed positions. `selected` is `true` when an annotation explicitly
 requested compilation. Module paths are relative to the project root, and the output is sorted and
 contains no timestamp, so CI can compare reports without machine-specific noise.
 
@@ -900,6 +903,34 @@ dirty dependency, or any failed source/length check also discards the hint. Thes
 normal React behavior; the syntax does not opt the component into a different correctness model.
 The compiler report exposes emitted sites as `keyedArrayAppendHints`, and the hinted runtime is
 retained only when a module emits at least one append or same-order map hint.
+
+#### Keyed array filter hints
+
+A concise immutable filter on a direct keyed `useState` array can remove rows without rebuilding
+every surviving row:
+
+```tsx
+setItems((current) => current.filter((item) => item.id !== removedId));
+```
+
+At build time, Farm recognizes the direct functional setter and a synchronous, one-parameter,
+expression-bodied predicate from the compiler's safe expression subset. The native `filter()`
+still runs normally. Its generated wrapper records rejected positions and links queued filters to
+the last committed array.
+
+At update time, Farm validates the native-array chain, result lengths, surviving item identities,
+and surviving keys before changing the DOM. It then removes only rejected row elements, updates
+the stored positions used by delegated row events, and keeps all surviving elements in place. Row
+descriptors and bindings are not recreated or reread, and the owner component does not rerun.
+
+The proof applies only to compiler-owned host rows whose render callback and key do not observe the
+row index. An index-aware row or predicate, collection-derived key, block-bodied updater or
+predicate, custom filter method, sparse or subclassed array, binding that reads the collection,
+React-owned row structure, nested host block, row conditional, unrelated dirty dependency, or
+failed runtime validation keeps complete keyed reconciliation. A filter queued after an unhinted
+update also falls back. These checks make the hint an internal optimization rather than a new
+behavior contract. Reports expose emitted sites as `keyedArrayFilterHints`; the optional hinted
+runtime is retained only when a module emits a supported update hint.
 
 #### Interactive host rows
 
@@ -1675,6 +1706,9 @@ The package and example test suites verify more than generated code:
 - 2,000 deterministic keyed-array appends match normal React; targeted tests require key,
   descriptor, and binding reads to equal only the appended suffix and cover queued updates,
   multi-boundary sharing, StrictMode hydration/unmount, and conservative fallback;
+- 2,000 deterministic randomized keyed-array removals match normal React; targeted tests require
+  zero surviving descriptor and binding reads, preserve DOM identity, and cover queued filters,
+  unhinted-chain fallback, collection-reading rows, StrictMode hydration, and unmount cleanup;
 - the production browser experiment derives a keyed window from 2,048 source rows without
   rerunning the owner component or corrupting the existing compiler experiments;
 - the package reactivity benchmark updates one prop across 2,048 bindings, requires identical
@@ -1691,7 +1725,7 @@ The package and example test suites verify more than generated code:
   inserts a row, and observes zero owner update executions;
 - the production 10,000/20,000-row benchmark requires nonzero `keyedIdentityTargets`,
   `keyedMapLookupTargets`, `keyedMembershipTargets`, `keyedCollectionUpdateHints`, and
-  `keyedMapUpdateHints` and `keyedArrayAppendHints` report counts,
+  `keyedMapUpdateHints`, `keyedArrayAppendHints`, and `keyedArrayFilterHints` report counts,
   preserves the keyed-update speedup floor, checks that scalar selection, Set membership, and Map
   lookups remain key-directed at scale, compares dense hinted Set/Map updates with equivalent
   compiled snapshot controls, and passes DOM correctness, React-relative regression, direct-delta,

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -1,11 +1,11 @@
 # Complex dashboard and 20,000-row scale result
 
-Date: 2026-08-28
+Date: 2026-08-29
 
-Result: **PASS.** Correctness, React-relative performance, keyed update, keyed append, scalar
+Result: **PASS.** Correctness, React-relative performance, keyed update, keyed append, keyed filter, scalar
 selection, Set-membership, Map-lookup, collection-delta, and normalized scalability gates all pass.
 The production run compares two bracketing React baselines with static and hybrid compiler builds
-from the exact same component source. Append and dense Set/Map operations also compare each new
+from the exact same component source. Append, filter, and dense Set/Map operations also compare each new
 handoff with an unhinted compiled snapshot control.
 
 ## Environment and method
@@ -22,6 +22,8 @@ handoff with an unhinted compiled snapshot control.
 - Keyed-update persistence gate: at least 8x faster than React at both 10,000 and 20,000 rows
 - Keyed-append persistence gate: at least 4x faster than React at both 10,000 and up to 20,000 rows,
   and at least 1.25x faster than the equivalent compiled snapshot path
+- Keyed-filter persistence gate: at least 3x faster than React at both 1,000 and 20,000 rows, and
+  at least 1.25x faster than the equivalent compiled snapshot path
 - Key-directed selection gate: at least 10x faster than React at 20,000 rows and no more than 2x
   normalized growth
 - Key-directed Set-membership gate: at least 10x faster than React at 20,000 rows and no more than
@@ -35,9 +37,9 @@ handoff with an unhinted compiled snapshot control.
 Every trial passed DOM assertions and browser-error checks. The compiler report proved that both
 workloads compiled, delegated keyed rows were present only in compiler builds, exactly two scalar
 key-directed bindings, two Set-membership bindings, two Map-lookup bindings, 19 Set/Map mutation
-sites, one mutation-aware keyed-map update site, and one keyed-array append site were emitted.
-Hybrid/static added zero owner executions. The two React baselines added 1,430 dashboard and 462
-table owner executions each.
+sites, one mutation-aware keyed-map update site, one keyed-array append site, and one keyed-array
+filter site were emitted. Hybrid/static added zero owner executions. The two React baselines added
+1,430 dashboard and 492 table owner executions each.
 
 ## Complex dashboard
 
@@ -46,42 +48,51 @@ bindings.
 
 | Interaction                 | React median | Hybrid median | Hybrid vs React |
 | --------------------------- | -----------: | ------------: | --------------: |
-| Active live pulse           |      0.10 ms |       0.10 ms |          parity |
-| Inactive branch update      |      0.08 ms |       0.02 ms |    3.75x faster |
+| Active live pulse           |      0.10 ms |       0.08 ms |    1.25x faster |
+| Inactive branch update      |     0.065 ms |       0.02 ms |    3.25x faster |
 | Switch live/snapshot branch |     0.100 ms |      0.100 ms |          parity |
 
 ## Standard table operations
 
 | Operation               |             Rows | React median | Hybrid median | Hybrid vs React |
 | ----------------------- | ---------------: | -----------: | ------------: | --------------: |
-| Create                  |            1,000 |     12.50 ms |      11.40 ms |    1.10x faster |
-| Replace all             |            1,000 |     18.45 ms |      11.90 ms |    1.55x faster |
-| Create many             |           10,000 |    284.00 ms |     157.20 ms |    1.81x faster |
-| Append                  | 10,000 -> 11,000 |     71.55 ms |      13.30 ms |    5.38x faster |
-| Append snapshot control | 10,000 -> 11,000 |     82.55 ms |      25.60 ms |    3.22x faster |
-| Update every 10th       |           10,000 |     58.60 ms |       2.60 ms |   22.54x faster |
-| Select                  |            1,000 |      3.75 ms |       0.10 ms |   37.50x faster |
-| Mark two rows           |            1,000 |      3.85 ms |       0.10 ms |   38.50x faster |
-| Queue two rows          |            1,000 |      4.15 ms |       0.10 ms |   41.50x faster |
-| Dense Set delta         |            1,000 |      4.00 ms |       0.10 ms |   40.00x faster |
-| Dense Map delta         |            1,000 |      4.20 ms |       0.10 ms |   42.00x faster |
-| Swap rows 2 / 999       |            1,000 |      7.90 ms |       1.20 ms |    6.58x faster |
-| Remove one row          |            1,000 |      4.70 ms |       2.10 ms |    2.24x faster |
-| Clear                   |           10,000 |     48.00 ms |       9.10 ms |    5.27x faster |
+| Create                  |            1,000 |     12.25 ms |      11.20 ms |    1.09x faster |
+| Replace all             |            1,000 |     16.60 ms |      11.80 ms |    1.41x faster |
+| Create many             |           10,000 |    286.20 ms |     128.00 ms |    2.24x faster |
+| Append                  | 10,000 -> 11,000 |     71.25 ms |      13.90 ms |    5.13x faster |
+| Append snapshot control | 10,000 -> 11,000 |     68.60 ms |      28.20 ms |    2.43x faster |
+| Update every 10th       |           10,000 |     42.15 ms |       2.70 ms |   15.61x faster |
+| Select                  |            1,000 |      3.65 ms |       0.10 ms |   36.50x faster |
+| Mark two rows           |            1,000 |      3.70 ms |       0.10 ms |   37.00x faster |
+| Queue two rows          |            1,000 |      3.70 ms |       0.00 ms | near timer floor |
+| Dense Set delta         |            1,000 |      3.65 ms |       0.10 ms |   36.50x faster |
+| Dense Map delta         |            1,000 |      3.75 ms |       0.10 ms |   37.50x faster |
+| Swap rows 2 / 999       |            1,000 |      8.00 ms |       1.20 ms |    6.67x faster |
+| Remove one row          |            1,000 |      4.10 ms |       0.70 ms |    5.86x faster |
+| Remove snapshot control |            1,000 |      4.30 ms |       1.40 ms |    3.07x faster |
+| Clear                   |           10,000 |     46.60 ms |       9.30 ms |    5.01x faster |
 
 `Append` is the new keyed-array suffix path. The application still allocates the next array and
 creates 1,000 required DOM rows, but the generated hint lets Farm skip all 10,000 existing keys and
-bindings. Hybrid measured `13.30 ms`, **5.38x faster than React** and **1.92x faster than the
-equivalent `25.60 ms` compiled snapshot control**. Repeated batches through 20,000 rows remained
-7.09x faster than React. The gate requires at least 4x versus React and 1.25x versus the control in
+bindings. Hybrid measured `13.90 ms`, **5.13x faster than React** and **2.03x faster than the
+equivalent `28.20 ms` compiled snapshot control**. Repeated batches through 20,000 rows remained
+6.83x faster than React. The gate requires at least 4x versus React and 1.25x versus the control in
 both compiler modes.
 
 `Update every 10th` is the targeted mutation-aware path. The application still executes its native
 immutable `map()` over 10,000 items and creates 1,000 replacement objects. The generated hint lets
 the keyed runtime validate and patch those 1,000 rows without a second scan of all 10,000 keys and
-bindings. The 8x persistence floor leaves substantial headroom below this run's 13.38x-22.54x
+bindings. The 8x persistence floor leaves substantial headroom below this run's 11.12x-15.61x
 result across compiler modes and row counts while still rejecting a silent return to the older
 roughly 5x full-reconciliation path.
+
+`Remove one row` is the keyed-array filter path. The application still executes native `filter()`
+over the collection. The generated hint carries removed positions into the keyed runtime, which
+validates surviving identities and keys, removes only rejected DOM rows, and skips descriptor and
+binding reads for every survivor. Hybrid measured `0.70 ms`, **5.86x faster than React** and
+**2.00x faster than the equivalent `1.40 ms` compiled snapshot control**. At 20,000 rows it
+measured `13.70 ms`, **9.09x faster than React**. The gate requires at least 3x versus React and
+1.25x versus the compiled control in both compiler modes.
 
 `Select` is the key-directed path added by this result. When a primitive state value is compared
 strictly with the exact row key, the compiler records that identity proof. The runtime then reads
@@ -106,7 +117,7 @@ primitive entries and immutably clone the collection, so the application's requi
 actually execute. The runtime validates those keys and extends a bounded persistent snapshot,
 instead of iterating every previous and next entry again. At 20,000 entries, the Set delta measured
 `0.30 ms` versus `2.10 ms` for the equivalent compiled snapshot control (**7.00x faster**); the Map
-delta measured `1.00 ms` versus `4.80 ms` (**4.80x faster**) in hybrid mode. These direct
+delta measured `0.90 ms` versus `4.70 ms` (**5.22x faster**) in hybrid mode. These direct
 compiler-to-compiler comparisons are the evidence for this PR's incremental win.
 
 ## Repeated 20,000-row scale profile
@@ -117,19 +128,19 @@ values, swaps rows, removes a middle row, and clears. Lower time is better.
 
 | Operation at scale       | React median | React p95 | Hybrid median | Hybrid p95 | Speedup |
 | ------------------------ | -----------: | --------: | ------------: | ---------: | ------: |
-| Create initial 10,000    |    315.00 ms | 436.25 ms |     122.90 ms |  126.50 ms |    2.56x |
-| Append a 1,000-row batch |     93.55 ms | 134.15 ms |      13.20 ms |   18.80 ms |    7.09x |
-| Update every 10th at 20k |    108.35 ms | 140.25 ms |       8.10 ms |   19.80 ms |   13.38x |
-| Select at 20k            |    100.45 ms | 145.10 ms |       3.40 ms |    6.50 ms |   29.54x |
-| Mark two rows at 20k     |    117.05 ms | 123.80 ms |       0.20 ms |    0.20 ms |  585.25x |
-| Queue two rows at 20k    |    104.20 ms | 112.15 ms |       0.20 ms |    0.30 ms |  521.00x |
-| Dense Set delta at 20k   |    102.90 ms | 153.10 ms |       0.30 ms |    0.40 ms |  343.00x |
-| Dense Set snapshot       |    117.70 ms | 122.45 ms |       2.10 ms |    2.20 ms |   56.05x |
-| Dense Map delta at 20k   |    103.90 ms | 118.00 ms |       1.00 ms |    1.00 ms |  103.90x |
-| Dense Map snapshot       |    103.30 ms | 111.50 ms |       4.80 ms |    4.80 ms |   21.52x |
-| Swap at 20k              |    115.85 ms | 120.05 ms |      34.30 ms |   36.00 ms |    3.38x |
-| Remove middle row at 20k |    114.00 ms | 127.80 ms |      41.70 ms |   41.70 ms |    2.73x |
-| Clear 20k                |    200.00 ms | 234.05 ms |      20.00 ms |   20.80 ms |   10.00x |
+| Create initial 10,000    |    315.35 ms | 352.00 ms |     109.10 ms |  129.30 ms |    2.89x |
+| Append a 1,000-row batch |     90.90 ms | 115.80 ms |      13.30 ms |   20.20 ms |    6.83x |
+| Update every 10th at 20k |    112.30 ms | 114.20 ms |      10.10 ms |   19.00 ms |   11.12x |
+| Select at 20k            |     98.60 ms | 132.15 ms |       3.60 ms |    4.60 ms |   27.39x |
+| Mark two rows at 20k     |    108.10 ms | 125.60 ms |       0.20 ms |    0.20 ms |  540.50x |
+| Queue two rows at 20k    |     98.35 ms | 104.55 ms |       0.20 ms |    0.30 ms |  491.75x |
+| Dense Set delta at 20k   |    102.45 ms | 175.80 ms |       0.30 ms |    0.30 ms |  341.50x |
+| Dense Set snapshot       |    108.90 ms | 138.60 ms |       2.10 ms |    2.30 ms |   51.86x |
+| Dense Map delta at 20k   |    103.80 ms | 111.60 ms |       0.90 ms |    1.00 ms |  115.33x |
+| Dense Map snapshot       |    109.65 ms | 115.35 ms |       4.70 ms |    4.70 ms |   23.33x |
+| Swap at 20k              |    125.30 ms | 128.10 ms |      32.20 ms |   37.20 ms |    3.89x |
+| Remove middle row at 20k |    124.55 ms | 141.55 ms |      13.70 ms |   16.10 ms |    9.09x |
+| Clear 20k                |    160.20 ms | 193.60 ms |      20.70 ms |   20.70 ms |    7.74x |
 
 ## Scalability gate
 
@@ -138,22 +149,22 @@ The gate divides observed timing growth by row-count growth. A value near 1 mean
 
 | Path               | Row growth | Timing growth | Normalized growth |
 | ------------------ | ---------: | ------------: | ----------------: |
-| Create 10k repeat    |      1.00x |         0.78x |             0.78x |
-| Update 10k -> 20k    |      2.00x |         3.12x |             1.56x |
-| Select 1k -> 20k     |     20.00x |        13.60x |             0.68x |
+| Create 10k repeat    |      1.00x |         0.85x |             0.85x |
+| Update 10k -> 20k    |      2.00x |         3.74x |             1.87x |
+| Select 1k -> 20k     |     20.00x |        14.40x |             0.72x |
 | Mark Set 1k -> 20k   |     20.00x |         0.80x |             0.04x |
 | Read Map 1k -> 20k   |     20.00x |         0.80x |             0.04x |
 | Dense Set delta      |     20.00x |         1.20x |             0.06x |
-| Dense Map delta      |     20.00x |         4.00x |             0.20x |
+| Dense Map delta      |     20.00x |         3.60x |             0.18x |
 | Dense Set snapshot   |     20.00x |         8.40x |             0.42x |
-| Dense Map snapshot   |     20.00x |        16.00x |             0.80x |
-| Swap 1k -> 20k       |     20.00x |        28.58x |             1.43x |
-| Remove 1k -> 20k     |     20.00x |        19.86x |             0.99x |
-| Clear 10k -> 20k     |      2.00x |         2.20x |             1.10x |
+| Dense Map snapshot   |     20.00x |        15.67x |             0.78x |
+| Swap 1k -> 20k       |     20.00x |        26.83x |             1.34x |
+| Remove 1k -> 20k     |     20.00x |        19.57x |             0.98x |
+| Clear 10k -> 20k     |      2.00x |         2.23x |             1.11x |
 
 This demonstrates approximately linear rather than quadratic end-to-end growth. Key-directed
 scalar selection performs constant row-binding work—at most the previous and next keyed
-instances—while its complete event-to-DOM timing remains 29.54x faster than React at 20,000 rows.
+instances—while its complete event-to-DOM timing remains 27.39x faster than React at 20,000 rows.
 Set membership and Map lookup evaluate bindings only for changed keys. Their 0.10-0.20 ms medians
 are near browser timer resolution, so deterministic exact-read gates remain the primary complexity
 evidence. The dense delta-versus-snapshot controls remain above that floor and independently prove
@@ -164,13 +175,13 @@ keys and maintaining row indices.
 
 | Build           | Page chunk raw | Page chunk gzip |
 | --------------- | -------------: | --------------: |
-| React baseline  |       21,888 B |         4,999 B |
-| Static compiler |       89,156 B |        18,732 B |
-| Hybrid compiler |       89,156 B |        18,731 B |
+| React baseline  |       22,138 B |         5,043 B |
+| Static compiler |       91,774 B |        19,298 B |
+| Hybrid compiler |       91,774 B |        19,296 B |
 
-This deliberately broad page now pays a 13,732-byte hybrid gzip premium for the compiler runtime,
+This deliberately broad page now pays a 14,253-byte hybrid gzip premium for the compiler runtime,
 including keyed append, mutation-aware map, scalar key-directed, Set-membership, Map-lookup, and
-collection-delta paths. Smaller
+collection-delta and keyed-filter paths. Smaller
 direct-only applications retain less of the runtime; the package-level fixtures and persisted size
 gate are documented in `packages/farm-react/RUNTIME_SIZE_RESULTS.md`.
 
@@ -178,12 +189,13 @@ gate are documented in `packages/farm-react/RUNTIME_SIZE_RESULTS.md`.
 
 The compiled path scales successfully through the tested 20,000-row mixed workload: all DOM and
 event assertions pass, there are no browser errors or owner rerenders, every scale operation beats
-the bracketed React baseline, and normalized growth stays at or below 1.43x for the measured
+the bracketed React baseline, and normalized growth stays at or below 1.87x for the measured
 workload. Scalar selection performs at most two row-binding reads, while Set membership and Map
 lookup evaluate only changed keys that map to rows. For dense collections, producer deltas were
-7.00x faster for Set and 4.80x faster for Map than equivalent compiled snapshot scans. Keyed append
-was 1.92x faster than its compiled snapshot control and 7.09x faster than React while scaling to
-20,000 rows. The evidence claims only measured end-to-end behavior within this range—not unlimited
+7.00x faster for Set and 5.22x faster for Map than equivalent compiled snapshot scans. Keyed append
+was 2.03x faster than its compiled snapshot control and 6.83x faster than React while scaling to
+20,000 rows. Keyed filter was 2.00x faster than its compiled snapshot control at 1,000 rows and
+9.09x faster than React at 20,000 rows. The evidence claims only measured end-to-end behavior within this range—not unlimited
 constant-time browser work.
 
 The machine-readable output is `/tmp/farm-react-dashboard-benchmark.json`. Re-run

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -135,6 +135,10 @@ async function inspectBuild(compilerMode) {
       "The compiler build did not emit a keyed-array append hint.",
     );
     assert(
+      compilerReport.summary.keyedArrayFilterHints > 0,
+      "The compiler build did not emit a keyed-array filter hint.",
+    );
+    assert(
       compilerReport.summary.keyedCollectionUpdateHints > 0,
       "The compiler build did not emit a keyed Set/Map collection-delta hint.",
     );
@@ -626,6 +630,21 @@ async function measureTrial(browser, trial, compilerMode, port) {
           },
         );
 
+        const tableRemoveSnapshot = await measureTable(
+          async () => {
+            if (rowCount() !== 1_000) await create1000();
+          },
+          async () => {
+            const row = table.querySelectorAll("tbody tr")[500];
+            const id = row?.getAttribute("data-row-id");
+            if (!id) throw new Error("Snapshot remove target is missing.");
+            await runTableAction(
+              () => tableButton("table-remove-snapshot").click(),
+              () => rowCount() === 999 && !table.querySelector(`[data-row-id="${id}"]`),
+            );
+          },
+        );
+
         const tableClear = await measureTable(
           async () => ensure10000(),
           async () => clearRows(),
@@ -807,6 +826,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
             mapLookup: tableMapLookup,
             membership: tableMembership,
             remove: tableRemove,
+            removeSnapshot: tableRemoveSnapshot,
             replace: tableReplace,
             select: tableSelect,
             snapshotMapLookup: tableSnapshotMapLookup,
@@ -884,6 +904,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
         mapLookup: timingSummary(result.table.mapLookup),
         membership: timingSummary(result.table.membership),
         remove: timingSummary(result.table.remove),
+        removeSnapshot: timingSummary(result.table.removeSnapshot),
         replace: timingSummary(result.table.replace),
         select: timingSummary(result.table.select),
         snapshotMapLookup: timingSummary(result.table.snapshotMapLookup),
@@ -968,6 +989,7 @@ const tableMetrics = [
   "snapshotMapLookup",
   "swap",
   "remove",
+  "removeSnapshot",
   "clear",
 ];
 const scaleMetrics = [
@@ -1111,6 +1133,32 @@ const keyedAppendRegressions = keyedAppendResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedAppendMinimumSnapshotSpeedup,
 );
+// A concise native filter carries removal positions into the keyed-row runtime. Compare it with
+// React and an equivalent block-bodied compiled update that intentionally takes complete keyed
+// reconciliation, while also preserving the 20,000-row end-to-end speedup.
+const keyedFilterMinimumSpeedup = 3;
+const keyedFilterMinimumSnapshotSpeedup = 1.25;
+const keyedFilterResults = ["static", "hybrid"].map((mode) => {
+  const filterMedianMs = comparisons.table.remove[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.removeSnapshot[mode].medianMs;
+  return {
+    filterMedianMs,
+    mode,
+    scaleSpeedup: comparisons.scale.remove20k[`${mode}VsBaseline`].speedup,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / filterMedianMs,
+    speedup: comparisons.table.remove[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedFilterRegressions = keyedFilterResults.filter(
+  ({ scaleSpeedup, snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedFilterMinimumSpeedup ||
+    !Number.isFinite(scaleSpeedup) ||
+    scaleSpeedup < keyedFilterMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedFilterMinimumSnapshotSpeedup,
+);
 // Selection is a separate-state update whose value is compared with the exact row key. The unit
 // suite deterministically requires at most two row-binding reads. This browser gate protects a
 // substantial end-to-end win and rejects growth beyond the same normalized 2x scalability ceiling
@@ -1230,6 +1278,7 @@ const passed =
   scalabilityRegressions.length === 0 &&
   keyedUpdateRegressions.length === 0 &&
   keyedAppendRegressions.length === 0 &&
+  keyedFilterRegressions.length === 0 &&
   keyedIdentityRegressions.length === 0 &&
   keyedMembershipRegressions.length === 0 &&
   keyedMapLookupRegressions.length === 0 &&
@@ -1256,6 +1305,13 @@ const report = {
     regressions: keyedAppendRegressions,
     results: keyedAppendResults,
     status: keyedAppendRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedFilterHintGate: {
+    minimumSnapshotSpeedup: keyedFilterMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedFilterMinimumSpeedup,
+    regressions: keyedFilterRegressions,
+    results: keyedFilterResults,
+    status: keyedFilterRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedIdentityTargetGate: {
     maximumNormalizedGrowth: keyedIdentityMaximumNormalizedGrowth,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -176,6 +176,20 @@ export function StandardTableBenchmark() {
           Replace 1,000
         </button>
         <button
+          data-action="table-remove-snapshot"
+          type="button"
+          onClick={() => {
+            setRows((current) => {
+              const target = current[Math.floor(current.length / 2)];
+              return target ? current.filter((item) => item.id !== target.id) : current;
+            });
+            setOperation("remove row (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Remove middle (snapshot control)
+        </button>
+        <button
           data-action="table-update"
           id="update"
           type="button"
@@ -404,7 +418,7 @@ export function StandardTableBenchmark() {
             </tr>
           </thead>
           <tbody data-table-body>
-            {rows.map((row, index) => (
+            {rows.map((row) => (
               <tr
                 className={selected === row.id ? "table-row--selected" : ""}
                 data-marked={markedIds.has(row.id)}
@@ -416,7 +430,7 @@ export function StandardTableBenchmark() {
                 key={row.id}
               >
                 <td>
-                  <span className="row-index">{index + 1}</span>
+                  <span className="row-index">{row.id}</span>
                   <code>ord_{row.id}</code>
                 </td>
                 <td>{row.label}</td>

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -250,6 +250,22 @@ reconciliation. A key that reads the collection prevents hint emission entirely.
 report exposes the emitted-site count as
 `keyedArrayAppendHints`.
 
+Concise immutable filters on a direct keyed array can carry removal positions into the same
+optional runtime:
+
+```tsx
+setItems((current) => current.filter((item) => item.id !== removedId));
+```
+
+For compiler-owned host rows whose render and key do not observe the row index, Farm validates the
+native filter chain, every surviving item identity, and every surviving key before removing only
+the rejected DOM rows. It does not recreate descriptors or reread bindings for unchanged rows,
+and queued filters compose before one compiler flush. Index-aware rows or predicates,
+block-bodied updates, custom filter methods, sparse or subclassed arrays, collection-reading
+bindings or keys, React-owned row structures, mixed dirty dependencies, and failed validation use
+complete keyed reconciliation. No option or new component is required. The compiler report exposes
+the emitted-site count as `keyedArrayFilterHints`.
+
 An otherwise eligible host row may also contain an inline synchronous React event:
 
 ```tsx
@@ -532,7 +548,8 @@ reasons aggregated by count. Its summary and per-module `optimizations` also rep
 `keyedMembershipTargets`, the number of native-Set membership bindings;
 `keyedCollectionUpdateHints`, the number of compiler-proven native Set/Map mutation sites; and
 `keyedMapUpdateHints`, the number of compiler-proven direct keyed `map()` update sites; and
-`keyedArrayAppendHints`, the number of compiler-proven direct keyed-array append sites. A custom
+`keyedArrayAppendHints`, the number of compiler-proven direct keyed-array append sites; and
+`keyedArrayFilterHints`, the number of compiler-proven direct keyed-array filter sites. A custom
 project-relative `reportFile` also enables reporting.
 
 The runtime test compares the same counter interaction on both paths: ordinary React performs a

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -26,14 +26,14 @@
         "brotli": 51897
       },
       "compilerOn": {
-        "raw": 230838,
-        "gzip": 71162,
-        "brotli": 60951
+        "raw": 231209,
+        "gzip": 71221,
+        "brotli": 60994
       },
       "compilerPremium": {
-        "raw": 37719,
-        "gzip": 10983,
-        "brotli": 9054
+        "raw": 38090,
+        "gzip": 11042,
+        "brotli": 9097
       }
     },
     "keyedAppend": {
@@ -43,14 +43,31 @@
         "brotli": 51772
       },
       "compilerOn": {
-        "raw": 232093,
-        "gzip": 71469,
-        "brotli": 61229
+        "raw": 232474,
+        "gzip": 71532,
+        "brotli": 61342
       },
       "compilerPremium": {
-        "raw": 39192,
-        "gzip": 11384,
-        "brotli": 9457
+        "raw": 39573,
+        "gzip": 11447,
+        "brotli": 9570
+      }
+    },
+    "keyedFilter": {
+      "compilerOff": {
+        "raw": 192880,
+        "gzip": 60088,
+        "brotli": 51833
+      },
+      "compilerOn": {
+        "raw": 234091,
+        "gzip": 71978,
+        "brotli": 61697
+      },
+      "compilerPremium": {
+        "raw": 41211,
+        "gzip": 11890,
+        "brotli": 9864
       }
     },
     "isolatedRuntime": {
@@ -60,18 +77,18 @@
         "brotli": 51666
       },
       "full": {
-        "raw": 269496,
-        "gzip": 76860,
-        "brotli": 66171
+        "raw": 271299,
+        "gzip": 77240,
+        "brotli": 66527
       },
       "coreOnly": {
         "raw": 204922,
         "gzip": 63685,
         "brotli": 54902
       },
-      "fullRuntimePremiumGzip": 16941,
+      "fullRuntimePremiumGzip": 17321,
       "coreRuntimePremiumGzip": 3766,
-      "gzipReductionPercent": 77.8
+      "gzipReductionPercent": 78.3
     }
   }
 }

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.md
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.md
@@ -24,19 +24,21 @@ is enforced on every pull request instead of serving only as a manually recorded
 | Fixture                                           | Compiler off gzip | Compiler on gzip | Compiler premium |
 | ------------------------------------------------- | ----------------: | ---------------: | ---------------: |
 | Direct text, attribute, style, and event bindings |          60,043 B |         63,721 B |          3,678 B |
-| Keyed rows, LIS, scalar, Set, and Map targeting   |          60,179 B |         71,162 B |         10,983 B |
-| Keyed rows with append hints                      |          60,085 B |         71,469 B |         11,384 B |
+| Keyed rows, LIS, scalar, Set, and Map targeting   |          60,179 B |         71,221 B |         11,042 B |
+| Keyed rows with append hints                      |          60,085 B |         71,532 B |         11,447 B |
+| Keyed rows with filter hints                      |          60,088 B |         71,978 B |         11,890 B |
 
-The isolated compatibility runtime contributes 16,941 B gzip over the React control. The
-compiler-selected core contributes 3,766 B, a **77.8% reduction**. This comparison uses the same
+The isolated compatibility runtime contributes 17,321 B gzip over the React control. The
+compiler-selected core contributes 3,766 B, a **78.3% reduction**. This comparison uses the same
 hand-authored compiled definition and changes only the runtime entry used to create it.
 
 The keyed fixture retains `FarmCompiledKeyedRows` plus compiler-emitted `identityTarget`,
 `membershipTarget`, and `mapLookupTarget` metadata, plus Set/Map producer-delta helpers. It rejects
-the optional row-conditional and keyed-update runtimes. The append fixture separately proves that
-a recognized functional append retains the hinted runtime. The new capability keeps the direct
-compiler premium and isolated core runtime byte-for-byte unchanged; the ordinary keyed premium
-moves by only 26 B gzip. The direct fixture rejects every structural runtime marker. The checked
+the optional row-conditional and keyed-update runtimes. Separate append and filter fixtures prove
+that recognized functional updates retain the matching hinted runtime. Filter support is selected
+only for modules with an emitted filter hint. The direct compiler premium and isolated core runtime
+remain byte-for-byte unchanged; the append fixture adds only 63 B gzip over its previous persisted
+result. The direct fixture rejects every structural runtime marker. The checked
 machine-readable result is [`RUNTIME_SIZE_RESULTS.json`](./RUNTIME_SIZE_RESULTS.json).
 
 ## Existing production benchmark audit

--- a/packages/farm-react/fixtures/runtime-size/keyed-filter.tsx
+++ b/packages/farm-react/fixtures/runtime-size/keyed-filter.tsx
@@ -1,0 +1,29 @@
+import React, { useState } from "react";
+import { createRoot } from "react-dom/client";
+
+interface Row {
+  id: number;
+  label: string;
+}
+
+export function FilterTable() {
+  const [rows, setRows] = useState<Row[]>(
+    Array.from({ length: 1_000 }, (_, id) => ({ id, label: `Row ${id}` })),
+  );
+  return (
+    <main>
+      <button onClick={() => setRows((current) => current.filter((row) => row.id !== 500))}>
+        Remove
+      </button>
+      <ul>
+        {rows.map((row) => (
+          <li data-id={row.id} key={row.id}>
+            {row.label}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+
+createRoot(document.body).render(<FilterTable />);

--- a/packages/farm-react/scripts/benchmark-runtime-size.mjs
+++ b/packages/farm-react/scripts/benchmark-runtime-size.mjs
@@ -55,6 +55,8 @@ const [
   keyedOn,
   keyedAppendOff,
   keyedAppendOn,
+  keyedFilterOff,
+  keyedFilterOn,
   runtimeControl,
   runtimeCore,
   runtimeFull,
@@ -65,6 +67,8 @@ const [
   bundle("keyed.tsx", true),
   bundle("keyed-append.tsx", false),
   bundle("keyed-append.tsx", true),
+  bundle("keyed-filter.tsx", false),
+  bundle("keyed-filter.tsx", true),
   bundle("runtime-control.tsx", false),
   bundle("runtime-core.tsx", false),
   bundle("runtime-full.tsx", false),
@@ -112,6 +116,13 @@ if (
   !keyedAppendOn.code.includes("keyed-rows:hinted")
 ) {
   throw new Error("Keyed append fixture did not retain its optional hinted runtime.");
+}
+if (
+  !keyedFilterOn.code.includes("FarmCompiledKeyedRows") ||
+  !keyedFilterOn.code.includes("keyed-rows:filter-hinted") ||
+  !keyedFilterOn.code.includes("filterIndexIndependent")
+) {
+  throw new Error("Keyed filter fixture did not retain its optional filter-hint runtime.");
 }
 
 const fullRuntimePremium = runtimeFull.gzip - runtimeControl.gzip;
@@ -162,6 +173,23 @@ const results = {
         brotli: keyedAppendOn.brotli - keyedAppendOff.brotli,
       },
     },
+    keyedFilter: {
+      compilerOff: {
+        raw: keyedFilterOff.raw,
+        gzip: keyedFilterOff.gzip,
+        brotli: keyedFilterOff.brotli,
+      },
+      compilerOn: {
+        raw: keyedFilterOn.raw,
+        gzip: keyedFilterOn.gzip,
+        brotli: keyedFilterOn.brotli,
+      },
+      compilerPremium: {
+        raw: keyedFilterOn.raw - keyedFilterOff.raw,
+        gzip: keyedFilterOn.gzip - keyedFilterOff.gzip,
+        brotli: keyedFilterOn.brotli - keyedFilterOff.brotli,
+      },
+    },
     isolatedRuntime: {
       control: {
         raw: runtimeControl.raw,
@@ -194,6 +222,11 @@ if (checkOnly) {
       name: "keyed append compiler premium",
       current: results.fixtures.keyedAppend.compilerPremium.gzip,
       maximum: reference.fixtures.keyedAppend.compilerPremium.gzip + 256,
+    },
+    {
+      name: "keyed filter compiler premium",
+      current: results.fixtures.keyedFilter.compilerPremium.gzip,
+      maximum: (reference.fixtures.keyedFilter?.compilerPremium.gzip ?? 12_000) + 256,
     },
     {
       name: "core runtime premium",

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -43,6 +43,7 @@ const testSource = String.raw`
     createCompiledComponent,
     createCompiledComponentWithFeatures,
     createCompilerKeyedArrayAppend,
+    createCompilerKeyedArrayFilter,
     createCompilerKeyedMapUpdate,
   } = await import(
     "@farm.js/react/compiler-runtime"
@@ -1479,6 +1480,89 @@ const testSource = String.raw`
   assert.equal(appendContainer.querySelector("[data-key='a']"), appendAlpha);
   assert.equal(appendKeyReads, 2);
   flushSync(() => appendRoot.unmount());
+
+  let filterRows = () => undefined;
+  let filterKeyReads = 0;
+  let filterBindingReads = 0;
+  const FilterRows = createCompiledComponent({
+    displayName: "CompatibilityFilterRows",
+    initialize: () => [[
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+    ]],
+    render(_props, state, blocks) {
+      const items = () => state[0].get();
+      filterRows = (removedId) =>
+        state[0].set((previous) =>
+          createCompilerKeyedArrayFilter(
+            previous,
+            previous.filter,
+            (item) => item.id !== removedId,
+          ),
+        );
+      return React.createElement(
+        "section",
+        null,
+        React.createElement(blocks.KeyedRows, {
+          collectionDependency: 0,
+          dependencies: [0],
+          filterIndexIndependent: true,
+          id: 0,
+          items,
+          structureDependencies: [0],
+          render: () =>
+            React.createElement(
+              "ul",
+              null,
+              items().map((item) =>
+                React.createElement("li", { "data-key": item.id, key: item.id }, item.label),
+              ),
+            ),
+          rowKey: (item) => {
+            filterKeyReads += 1;
+            return item.id;
+          },
+          create: (item) => ({
+            kind: "element",
+            tag: "li",
+            attributes: [{ name: "data-key", value: item.id }],
+            styles: [],
+            children: [item.label],
+          }),
+          bindings: [{
+            kind: "text",
+            path: [],
+            dependencies: [],
+            read: (item) => {
+              filterBindingReads += 1;
+              return [item.label];
+            },
+          }],
+        }),
+      );
+    },
+    bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+  });
+  const filterContainer = document.createElement("div");
+  document.body.append(filterContainer);
+  const filterRoot = createRoot(filterContainer);
+  flushSync(() => filterRoot.render(React.createElement(FilterRows)));
+  const filterAlpha = filterContainer.querySelector("[data-key='a']");
+  const filterGamma = filterContainer.querySelector("[data-key='c']");
+  filterKeyReads = 0;
+  filterBindingReads = 0;
+  filterRows("b");
+  filterRows("d");
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(filterContainer.textContent, "AlphaGamma");
+  assert.equal(filterContainer.querySelector("[data-key='a']"), filterAlpha);
+  assert.equal(filterContainer.querySelector("[data-key='c']"), filterGamma);
+  assert.equal(filterKeyReads, 2);
+  assert.equal(filterBindingReads, 0);
+  flushSync(() => filterRoot.unmount());
 
   let editableRowExecutions = 0;
   let editableListRenders = 0;

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-filter-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-filter-hints.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true);
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/KeyedArrayFilterHints.tsx", infer);
+}
+
+describe("React AOT keyed-array filter hints", () => {
+  it("records concise immutable filters for index-independent keyed rows", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inventory() {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <main>
+          <button onClick={() => setRows((current) => current.filter((row) => row.id !== "a"))}>
+            Remove
+          </button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedArrayFilterHints).toBe(1);
+    expect(result.code).toContain("createCompilerKeyedArrayFilter");
+    expect(result.code).toContain("filterIndexIndependent={true}");
+    expect(result.code).toContain("keyedRowsFilterHintedRuntimeFeature");
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedArrayFilterHints.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("createCompilerKeyedArrayFilter"),
+    });
+  });
+
+  it("supports the public List primitive", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List } from "@farm.js/react/list";
+      export function Inventory() {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <main>
+          <button onClick={() => setRows((current) => current.filter((row) => row.id !== "a"))}>
+            Remove
+          </button>
+          <ul><List each={rows} by={(row) => row.id}>{(row) => <li>{row.label}</li>}</List></ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.optimizations.keyedArrayFilterHints).toBe(1);
+    expect(result.code).toContain("filterIndexIndependent={true}");
+  });
+
+  it.each([
+    {
+      name: "an index-sensitive row",
+      row: "(row, index) => <li key={row.id}>{index}: {row.label}</li>",
+      update: "setRows((current) => current.filter((row) => row.id !== 'a'))",
+    },
+    {
+      name: "a collection-derived key",
+      row: "(row) => <li key={row.id + rows.length}>{row.label}</li>",
+      update: "setRows((current) => current.filter((row) => row.id !== 'a'))",
+    },
+    {
+      name: "a block-bodied updater",
+      row: "(row) => <li key={row.id}>{row.label}</li>",
+      update:
+        "setRows((current) => { const next = current.filter((row) => row.id !== 'a'); return next; })",
+    },
+    {
+      name: "a block-bodied predicate",
+      row: "(row) => <li key={row.id}>{row.label}</li>",
+      update: "setRows((current) => current.filter((row) => { return row.id !== 'a'; }))",
+    },
+    {
+      name: "an index-aware predicate",
+      row: "(row) => <li key={row.id}>{row.label}</li>",
+      update: "setRows((current) => current.filter((row, index) => index !== 0))",
+    },
+    {
+      name: "a potentially side-effecting predicate",
+      row: "(row) => <li key={row.id}>{row.label}</li>",
+      update: "setRows((current) => current.filter((row) => shouldKeep(row)))",
+    },
+    {
+      name: "a filter thisArg",
+      row: "(row) => <li key={row.id}>{row.label}</li>",
+      update: "setRows((current) => current.filter((row) => row.id !== 'a', scope))",
+    },
+  ])("keeps $name on complete reconciliation", async ({ row, update }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inventory() {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <main>
+          <button onClick={() => { ${update}; }}>Remove</button>
+          <ul>{rows.map(${row})}</ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.optimizations.keyedArrayFilterHints).toBe(0);
+    expect(result.code).not.toContain("createCompilerKeyedArrayFilter");
+    expect(result.code).not.toContain("filterIndexIndependent");
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
@@ -41,6 +41,7 @@ describe("React AOT keyed update hints", () => {
     expect(result.diagnostics).toEqual([]);
     expect(result.optimizations).toEqual({
       keyedArrayAppendHints: 0,
+      keyedArrayFilterHints: 0,
       keyedCollectionUpdateHints: 0,
       keyedIdentityTargets: 0,
       keyedMapLookupTargets: 0,

--- a/packages/farm-react/src/__tests__/compiler-report.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-report.test.ts
@@ -29,6 +29,7 @@ function observations(projectRoot: string): ReactCompilerModuleObservation[] {
         diagnostics: [],
         optimizations: {
           keyedArrayAppendHints: 0,
+          keyedArrayFilterHints: 0,
           keyedCollectionUpdateHints: 0,
           keyedIdentityTargets: 0,
           keyedMapLookupTargets: 0,
@@ -55,6 +56,7 @@ function observations(projectRoot: string): ReactCompilerModuleObservation[] {
         ],
         optimizations: {
           keyedArrayAppendHints: 4,
+          keyedArrayFilterHints: 3,
           keyedCollectionUpdateHints: 6,
           keyedIdentityTargets: 4,
           keyedMapLookupTargets: 5,
@@ -77,6 +79,7 @@ describe("React compiler coverage report", () => {
       compiled: 2,
       fallback: 2,
       keyedArrayAppendHints: 4,
+      keyedArrayFilterHints: 3,
       keyedCollectionUpdateHints: 6,
       keyedIdentityTargets: 4,
       keyedMapLookupTargets: 5,
@@ -98,6 +101,7 @@ describe("React compiler coverage report", () => {
     });
     expect(report.modules[1]?.optimizations).toEqual({
       keyedArrayAppendHints: 4,
+      keyedArrayFilterHints: 3,
       keyedCollectionUpdateHints: 6,
       keyedIdentityTargets: 4,
       keyedMapLookupTargets: 5,

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-filter-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-filter-hints.test.tsx
@@ -1,0 +1,434 @@
+import React, { StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createCompiledComponent,
+  createCompilerKeyedArrayFilter,
+  type CompilerKeyedRowElement,
+} from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Item {
+  id: string;
+  label: string;
+}
+
+interface Counters {
+  executions: number;
+  listRenders: number;
+  keyReads: number;
+  descriptorReads: number;
+  bindingReads: number;
+}
+
+const roots: Root[] = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function hintedFilter(items: Item[], removed: ReadonlySet<string>): Item[] {
+  return createCompilerKeyedArrayFilter(
+    items,
+    items.filter,
+    (item: Item) => !removed.has(item.id),
+  ) as Item[];
+}
+
+function rowDescriptor(item: Item): CompilerKeyedRowElement {
+  return {
+    kind: "element",
+    tag: "li",
+    attributes: [{ name: "data-key", value: item.id }],
+    styles: [],
+    children: [item.label],
+  };
+}
+
+function createFilterHarness(initialItems: Item[], readsCollection = false) {
+  const counters: Counters = {
+    executions: 0,
+    listRenders: 0,
+    keyReads: 0,
+    descriptorReads: 0,
+    bindingReads: 0,
+  };
+  let remove: (ids: readonly string[]) => void = () => undefined;
+  let plainThenFilter: (id: string) => void = () => undefined;
+  const Inventory = createCompiledComponent({
+    displayName: "FilterInventory",
+    initialize: () => [initialItems],
+    render(_props: Record<string, never>, state, blocks) {
+      counters.executions += 1;
+      const items = () => state[0].get() as Item[];
+      remove = (ids) => state[0].set((previous) => hintedFilter(previous as Item[], new Set(ids)));
+      plainThenFilter = (id) => {
+        state[0].set((previous) => [...(previous as Item[])]);
+        state[0].set((previous) => hintedFilter(previous as Item[], new Set([id])));
+      };
+      const text = (item: Item) =>
+        readsCollection ? `${items().length}: ${item.label}` : item.label;
+      return (
+        <section>
+          <blocks.KeyedRows
+            collectionDependency={0}
+            dependencies={[0]}
+            filterIndexIndependent
+            id={0}
+            items={items}
+            structureDependencies={[0]}
+            render={() => {
+              counters.listRenders += 1;
+              return (
+                <ul>
+                  {items().map((item) => (
+                    <li data-key={item.id} key={item.id}>
+                      {text(item)}
+                    </li>
+                  ))}
+                </ul>
+              );
+            }}
+            rowKey={(item) => {
+              counters.keyReads += 1;
+              return (item as Item).id;
+            }}
+            create={(item) => {
+              counters.descriptorReads += 1;
+              return rowDescriptor(item as Item);
+            }}
+            bindings={[
+              {
+                kind: "text",
+                path: [],
+                dependencies: readsCollection ? [0] : [],
+                read: (item) => {
+                  counters.bindingReads += 1;
+                  return [text(item as Item)];
+                },
+              },
+            ]}
+          />
+        </section>
+      );
+    },
+    bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+  });
+  return {
+    Inventory,
+    counters,
+    plainThenFilter: (id: string) => plainThenFilter(id),
+    remove: (ids: readonly string[]) => remove(ids),
+  };
+}
+
+describe("compiled keyed-array filter hints", () => {
+  it("removes only rejected rows and preserves every surviving DOM identity", async () => {
+    const initialItems = Array.from(
+      { length: 2_048 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createFilterHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Inventory />));
+    const first = container.querySelector('[data-key="row-0"]');
+    const middle = container.querySelector('[data-key="row-1024"]');
+    const last = container.querySelector('[data-key="row-2047"]');
+    harness.counters.keyReads = 0;
+    harness.counters.descriptorReads = 0;
+    harness.counters.bindingReads = 0;
+
+    await act(async () => {
+      harness.remove(["row-100", "row-1500"]);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector('[data-key="row-0"]')).toBe(first);
+    expect(container.querySelector('[data-key="row-1024"]')).toBe(middle);
+    expect(container.querySelector('[data-key="row-2047"]')).toBe(last);
+    expect(container.querySelectorAll("li")).toHaveLength(2_046);
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.listRenders).toBe(1);
+    expect(harness.counters.keyReads).toBe(2_046);
+    expect(harness.counters.descriptorReads).toBe(0);
+    expect(harness.counters.bindingReads).toBe(0);
+  });
+
+  it("composes queued removals and rejects a chain after an unhinted update", async () => {
+    const harness = createFilterHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Inventory />));
+
+    await act(async () => {
+      harness.remove(["b"]);
+      harness.remove(["d"]);
+      await flushCompilerUpdates();
+    });
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Alpha",
+      "Gamma",
+    ]);
+
+    harness.counters.bindingReads = 0;
+    await act(async () => {
+      harness.plainThenFilter("a");
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("Gamma");
+    expect(harness.counters.bindingReads).toBeGreaterThan(0);
+  });
+
+  it("keeps collection-reading rows on complete reconciliation", async () => {
+    const harness = createFilterHarness(
+      [
+        { id: "a", label: "Alpha" },
+        { id: "b", label: "Beta" },
+        { id: "c", label: "Gamma" },
+      ],
+      true,
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Inventory />));
+
+    await act(async () => {
+      harness.remove(["b"]);
+      await flushCompilerUpdates();
+    });
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "2: Alpha",
+      "2: Gamma",
+    ]);
+    expect(harness.counters.bindingReads).toBeGreaterThan(3);
+  });
+
+  it("updates delegated event indexes after earlier rows are removed", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ];
+    let removeFirst = () => undefined;
+    const calls: string[] = [];
+    const Inventory = createCompiledComponent({
+      displayName: "FilterEventInventory",
+      initialize: () => [initialItems],
+      render(_props: Record<string, never>, state, blocks) {
+        const items = () => state[0].get() as Item[];
+        removeFirst = () =>
+          state[0].set((previous) => hintedFilter(previous as Item[], new Set(["a"])));
+        return (
+          <section>
+            <blocks.KeyedRows
+              collectionDependency={0}
+              delegateEvents
+              dependencies={[0]}
+              events={[
+                {
+                  invoke: (item, index) => calls.push(`${(item as Item).id}:${index}`),
+                  name: "onClick",
+                  path: [0],
+                },
+              ]}
+              filterIndexIndependent
+              id={0}
+              items={items}
+              structureDependencies={[0]}
+              render={(event) => (
+                <ul>
+                  {items().map((item, index) => (
+                    <li data-key={item.id} key={item.id}>
+                      <button data-row-button={item.id} onClick={event(item, index, 0)}>
+                        {item.label}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+              create={(item) => {
+                const row = item as Item;
+                return {
+                  kind: "element",
+                  tag: "li",
+                  attributes: [{ name: "data-key", value: row.id }],
+                  styles: [],
+                  children: [
+                    {
+                      kind: "element",
+                      tag: "button",
+                      attributes: [{ name: "data-row-button", value: row.id }],
+                      styles: [],
+                      children: [row.label],
+                    },
+                  ],
+                };
+              }}
+              bindings={[]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Inventory />));
+
+    await act(async () => {
+      removeFirst();
+      await flushCompilerUpdates();
+    });
+    await act(async () => {
+      (container.querySelector('[data-row-button="c"]') as HTMLButtonElement).click();
+    });
+    expect(calls).toEqual(["c:1"]);
+  });
+
+  it("preserves custom filter behavior and predicate errors", () => {
+    const items = [{ id: "a", label: "Alpha" }];
+    const custom = function (this: Item[], predicate: (item: Item) => boolean) {
+      expect(predicate(this[0])).toBe(true);
+      return [{ id: "custom", label: "Custom" }];
+    };
+    expect(createCompilerKeyedArrayFilter(items, custom, (item: Item) => item.id === "a")).toEqual([
+      { id: "custom", label: "Custom" },
+    ]);
+    const failure = new Error("predicate failed");
+    expect(() =>
+      createCompilerKeyedArrayFilter(items, items.filter, () => {
+        throw failure;
+      }),
+    ).toThrow(failure);
+  });
+
+  it("matches React through 2,000 deterministic randomized removals", async () => {
+    const initialItems = Array.from(
+      { length: 2_001 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Value ${index}` }),
+    );
+    const harness = createFilterHarness(initialItems);
+    let removeReact: (id: string) => void = () => undefined;
+    function Normal() {
+      const [items, setItems] = useState(initialItems);
+      removeReact = (id) => setItems((previous) => previous.filter((item) => item.id !== id));
+      return (
+        <ol data-owner="react">
+          {items.map((item) => (
+            <li data-key={item.id} key={item.id}>
+              {item.label}
+            </li>
+          ))}
+        </ol>
+      );
+    }
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <>
+          <div data-owner="compiled">
+            <harness.Inventory />
+          </div>
+          <Normal />
+        </>,
+      ),
+    );
+
+    let random = 0x9e3779b9;
+    const active = initialItems.map((item) => item.id);
+    for (let batch = 0; batch < 100; batch += 1) {
+      await act(async () => {
+        for (let update = 0; update < 20; update += 1) {
+          random = (Math.imul(random, 1_664_525) + 1_013_904_223) >>> 0;
+          const index = random % active.length;
+          const [id] = active.splice(index, 1);
+          harness.remove([id]);
+          removeReact(id);
+        }
+        await flushCompilerUpdates();
+      });
+      expect(
+        [...container.querySelectorAll('[data-owner="compiled"] li')].map((row) => row.outerHTML),
+      ).toEqual(
+        [...container.querySelectorAll('[data-owner="react"] li')].map((row) => row.outerHTML),
+      );
+    }
+    expect(harness.counters.executions).toBe(1);
+  }, 15_000);
+
+  it("hydrates in StrictMode and drops a queued removal after unmount", async () => {
+    const harness = createFilterHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+    ]);
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(
+      <StrictMode>
+        <harness.Inventory />
+      </StrictMode>,
+    );
+    document.body.append(container);
+    const recoverable: unknown[] = [];
+    let root!: Root;
+    await act(async () => {
+      root = hydrateRoot(
+        container,
+        <StrictMode>
+          <harness.Inventory />
+        </StrictMode>,
+        { onRecoverableError: (error) => recoverable.push(error) },
+      );
+    });
+    roots.push(root);
+
+    await act(async () => {
+      harness.remove(["a"]);
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("Beta");
+    expect(recoverable).toEqual([]);
+
+    roots.pop();
+    act(() => {
+      harness.remove(["b"]);
+      root.unmount();
+    });
+    await flushCompilerUpdates();
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/packages/farm-react/src/__tests__/vite.test.ts
+++ b/packages/farm-react/src/__tests__/vite.test.ts
@@ -86,6 +86,7 @@ describe("React renderer Vite integration", () => {
       compiled: 2,
       fallback: 0,
       keyedArrayAppendHints: 0,
+      keyedArrayFilterHints: 0,
       keyedCollectionUpdateHints: 0,
       keyedIdentityTargets: 0,
       keyedMapLookupTargets: 0,

--- a/packages/farm-react/src/compiler-report.ts
+++ b/packages/farm-react/src/compiler-report.ts
@@ -19,6 +19,7 @@ export interface ReactCompilerReport {
     compiled: number;
     fallback: number;
     keyedArrayAppendHints: number;
+    keyedArrayFilterHints: number;
     keyedCollectionUpdateHints: number;
     keyedIdentityTargets: number;
     keyedMapLookupTargets: number;
@@ -34,6 +35,7 @@ export interface ReactCompilerReport {
     compiled: readonly string[];
     optimizations: {
       keyedArrayAppendHints: number;
+      keyedArrayFilterHints: number;
       keyedCollectionUpdateHints: number;
       keyedIdentityTargets: number;
       keyedMapLookupTargets: number;
@@ -57,6 +59,7 @@ export function createReactCompilerReport(
   let compiled = 0;
   let fallback = 0;
   let keyedArrayAppendHints = 0;
+  let keyedArrayFilterHints = 0;
   let keyedCollectionUpdateHints = 0;
   let keyedIdentityTargets = 0;
   let keyedMapLookupTargets = 0;
@@ -69,6 +72,7 @@ export function createReactCompilerReport(
       compiled += result.compiled.length;
       fallback += result.diagnostics.length;
       keyedArrayAppendHints += result.optimizations.keyedArrayAppendHints || 0;
+      keyedArrayFilterHints += result.optimizations.keyedArrayFilterHints || 0;
       keyedCollectionUpdateHints += result.optimizations.keyedCollectionUpdateHints || 0;
       keyedIdentityTargets += result.optimizations.keyedIdentityTargets || 0;
       keyedMapLookupTargets += result.optimizations.keyedMapLookupTargets || 0;
@@ -100,6 +104,7 @@ export function createReactCompilerReport(
       compiled,
       fallback,
       keyedArrayAppendHints,
+      keyedArrayFilterHints,
       keyedCollectionUpdateHints,
       keyedIdentityTargets,
       keyedMapLookupTargets,

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -18,6 +18,14 @@ interface CompilerKeyedArrayAppendHint {
   readonly previous?: CompilerKeyedArrayAppendHint;
 }
 
+interface CompilerKeyedArrayFilterHint {
+  readonly sourceToken: object;
+  readonly sourceLength: number;
+  readonly resultLength: number;
+  readonly removedIndices: readonly number[];
+  readonly previous?: CompilerKeyedArrayFilterHint;
+}
+
 type CompilerKeyedCollectionKind = "set" | "map";
 type CompilerKeyedCollectionMutation = "set-add" | "set-delete" | "map-set" | "map-delete";
 
@@ -42,6 +50,10 @@ const COMPILER_KEYED_ARRAY_APPENDS = /* @__PURE__ */ new WeakMap<
   object,
   CompilerKeyedArrayAppendHint
 >();
+const COMPILER_KEYED_ARRAY_FILTERS = /* @__PURE__ */ new WeakMap<
+  object,
+  CompilerKeyedArrayFilterHint
+>();
 const COMPILER_KEYED_COLLECTION_DRAFTS = /* @__PURE__ */ new WeakMap<
   object,
   CompilerKeyedCollectionDraft
@@ -53,6 +65,7 @@ const COMPILER_KEYED_COLLECTION_UPDATES = /* @__PURE__ */ new WeakMap<
 const COMPILER_KEYED_COMMITTED_COLLECTIONS = /* @__PURE__ */ new WeakSet<object>();
 const NATIVE_ARRAY_PROTOTYPE = Array.prototype;
 const NATIVE_ARRAY_ITERATOR = Array.prototype[Symbol.iterator];
+const NATIVE_ARRAY_FILTER = Array.prototype.filter;
 const NATIVE_REFLECT_APPLY = Reflect.apply;
 
 function compilerObject(value: unknown): object | undefined {
@@ -123,6 +136,42 @@ function compilerKeyedArrayAppendStart(
     length = current.resultLength;
   }
   return length === value.length ? expectedStart : undefined;
+}
+
+function compilerKeyedArrayFilterSurvivors(
+  value: unknown,
+  sourceToken: object | undefined,
+  expectedLength: number,
+): readonly number[] | undefined {
+  const target = compilerObject(value);
+  if (!target || !sourceToken || !Array.isArray(value)) return undefined;
+  const update = COMPILER_KEYED_ARRAY_FILTERS.get(target);
+  if (!update || update.sourceToken !== sourceToken) return undefined;
+  const updates: CompilerKeyedArrayFilterHint[] = [];
+  for (
+    let current: CompilerKeyedArrayFilterHint | undefined = update;
+    current;
+    current = current.previous
+  ) {
+    if (current.sourceToken !== sourceToken) return undefined;
+    updates.push(current);
+  }
+
+  let survivors = Array.from({ length: expectedLength }, (_, index) => index);
+  for (let updateIndex = updates.length - 1; updateIndex >= 0; updateIndex -= 1) {
+    const current = updates[updateIndex];
+    if (current.sourceLength !== survivors.length) return undefined;
+    const removed = new Set<number>();
+    for (const index of current.removedIndices) {
+      if (!Number.isSafeInteger(index) || index < 0 || index >= current.sourceLength) {
+        return undefined;
+      }
+      removed.add(index);
+    }
+    if (current.resultLength !== current.sourceLength - removed.size) return undefined;
+    survivors = survivors.filter((_sourceIndex, index) => !removed.has(index));
+  }
+  return survivors.length === value.length ? survivors : undefined;
 }
 
 function compilerKeyedCollectionChangedKeys(
@@ -203,6 +252,81 @@ export function createCompilerKeyedArrayAppend(previous: unknown, value: unknown
     // Metadata must never change the behavior of an otherwise valid update.
     return value;
   }
+}
+
+/** @internal Executes Array.filter while recording compiler-proven removal positions. */
+export function createCompilerKeyedArrayFilter(
+  previous: unknown,
+  method: unknown,
+  predicate: unknown,
+): unknown {
+  let canHint = false;
+  let sourceLength = 0;
+  try {
+    canHint =
+      Array.isArray(previous) &&
+      Object.getPrototypeOf(previous) === NATIVE_ARRAY_PROTOTYPE &&
+      method === NATIVE_ARRAY_FILTER &&
+      typeof predicate === "function";
+    if (canHint) sourceLength = (previous as unknown[]).length;
+  } catch {
+    canHint = false;
+  }
+
+  if (!canHint) {
+    return NATIVE_REFLECT_APPLY(method as (...args: unknown[]) => unknown, previous, [predicate]);
+  }
+
+  const removedIndices: number[] = [];
+  let visited = 0;
+  const wrappedPredicate = function (
+    this: unknown,
+    item: unknown,
+    index: number,
+    collection: unknown[],
+  ): unknown {
+    visited += 1;
+    const keep = NATIVE_REFLECT_APPLY(predicate as (...args: unknown[]) => unknown, this, [
+      item,
+      index,
+      collection,
+    ]);
+    if (!keep) removedIndices.push(index);
+    return keep;
+  };
+  const value = NATIVE_REFLECT_APPLY(method as (...args: unknown[]) => unknown, previous, [
+    wrappedPredicate,
+  ]);
+
+  try {
+    const previousTarget = compilerObject(previous);
+    const valueTarget = compilerObject(value);
+    if (
+      !previousTarget ||
+      !valueTarget ||
+      !Array.isArray(value) ||
+      Object.getPrototypeOf(value) !== NATIVE_ARRAY_PROTOTYPE ||
+      visited !== sourceLength ||
+      value.length !== sourceLength - removedIndices.length
+    ) {
+      return value;
+    }
+    const sourceToken = compilerKeyedCollectionToken(previousTarget);
+    if (!sourceToken) return value;
+    const previousUpdate = !COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget)
+      ? COMPILER_KEYED_ARRAY_FILTERS.get(previousTarget)
+      : undefined;
+    COMPILER_KEYED_ARRAY_FILTERS.set(valueTarget, {
+      sourceToken: previousUpdate?.sourceToken || sourceToken,
+      sourceLength,
+      resultLength: value.length,
+      removedIndices,
+      ...(previousUpdate ? { previous: previousUpdate } : {}),
+    });
+  } catch {
+    // Metadata must never change the result of a successful native filter.
+  }
+  return value;
 }
 
 /** @internal Preserves a proven native collection mutation while recording its executed key. */
@@ -505,6 +629,8 @@ export interface CompilerKeyedRowsBlockProps {
   structureDependencies?: readonly number[];
   /** Direct state cell supplying items, eligible for compiler-emitted update hints. */
   collectionDependency?: number;
+  /** Compiler proof that shifted row indexes are not observed by this boundary. */
+  filterIndexIndependent?: boolean;
   rowKey(item: unknown, index: number): React.Key;
   create(item: unknown, index: number): CompilerKeyedRowElement;
   bindings: readonly CompilerKeyedRowBinding[];
@@ -1352,7 +1478,10 @@ function keyedMapLookupSnapshotValue(
     if (changed) return changed;
     if (current.values) {
       const present = NATIVE_MAP_HAS.call(current.values, key);
-      return { present, ...(present ? { value: NATIVE_MAP_GET.call(current.values, key) } : {}) };
+      return {
+        present,
+        ...(present ? { value: NATIVE_MAP_GET.call(current.values, key) } : {}),
+      };
     }
   }
   return undefined;
@@ -1566,7 +1695,11 @@ function keyedRowConditionalChanged(
 }
 
 type CompilerHostConditionalSelection =
-  | { kind: "branch"; key: "truthy" | "falsy"; branch: CompilerHostConditionalBranch }
+  | {
+      kind: "branch";
+      key: "truthy" | "falsy";
+      branch: CompilerHostConditionalBranch;
+    }
   | { kind: "empty" }
   | { kind: "fallback" };
 type CompilerHostConditionalPreparedSelection = Exclude<
@@ -3328,6 +3461,13 @@ interface KeyedUpdateRuntime {
     root: Element,
     reactOwnedRows: boolean,
   ): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined;
+  filter?(
+    props: CompilerKeyedRowsBlockProps,
+    dirtyState: ReadonlySet<number>,
+    collectionToken: object | undefined,
+    instances: ReadonlyMap<string, CompilerKeyedRowInstance>,
+    reactOwnedRows: boolean,
+  ): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined;
   reconcile(
     props: CompilerKeyedRowsBlockProps,
     dirtyState: ReadonlySet<number>,
@@ -3352,6 +3492,11 @@ const keyedUpdateRuntime: KeyedUpdateRuntime = {
   append: reconcileCompilerKeyedArrayAppend,
   commit: commitCompilerKeyedCollection,
   reconcile: reconcileCompilerKeyedMapUpdate,
+};
+
+const keyedFilterUpdateRuntime: KeyedUpdateRuntime = {
+  ...keyedUpdateRuntime,
+  filter: reconcileCompilerKeyedArrayFilter,
 };
 
 interface KeyedRowsRuntimeOptions {
@@ -3399,7 +3544,12 @@ function reconcileCompilerKeyedMapUpdate(
     return undefined;
   }
 
-  const conditionalChanges: Array<{ key: string; id: number; item: unknown; index: number }> = [];
+  const conditionalChanges: Array<{
+    key: string;
+    id: number;
+    item: unknown;
+    index: number;
+  }> = [];
   for (const { key, item, index, instance } of updates) {
     if (props.hostBlocks) {
       const descriptor = props.create(item, index);
@@ -3487,6 +3637,72 @@ function reconcileCompilerKeyedArrayAppend(
     root.append(fragment);
   }
   return nextInstances;
+}
+
+function reconcileCompilerKeyedArrayFilter(
+  props: CompilerKeyedRowsBlockProps,
+  dirtyState: ReadonlySet<number>,
+  collectionToken: object | undefined,
+  instances: ReadonlyMap<string, CompilerKeyedRowInstance>,
+  reactOwnedRows: boolean,
+): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
+  if (
+    reactOwnedRows ||
+    props.hostBlocks ||
+    (props.conditionals?.length || 0) > 0 ||
+    !props.filterIndexIndependent ||
+    props.collectionDependency === undefined
+  ) {
+    return undefined;
+  }
+  const collectionDependency = props.collectionDependency;
+  if (props.bindings.some((binding) => binding.dependencies?.includes(collectionDependency))) {
+    return undefined;
+  }
+  const dependencies = props.dependencies || props.structureDependencies;
+  const relevantDirty = (dependencies || []).filter((index) => dirtyState.has(index));
+  if (relevantDirty.length !== 1 || relevantDirty[0] !== collectionDependency) {
+    return undefined;
+  }
+
+  const finalValue = props.items();
+  const survivorIndices = compilerKeyedArrayFilterSurvivors(
+    finalValue,
+    collectionToken,
+    instances.size,
+  );
+  if (!survivorIndices || !Array.isArray(finalValue)) return undefined;
+  const previousInstances = [...instances.values()];
+  const survivors: CompilerKeyedRowInstance[] = [];
+  try {
+    for (let index = 0; index < survivorIndices.length; index += 1) {
+      const sourceIndex = survivorIndices[index];
+      const instance = previousInstances[sourceIndex];
+      const item = finalValue[index];
+      if (
+        !instance ||
+        instance.index !== sourceIndex ||
+        !Object.is(instance.item, item) ||
+        keyedRowIdentity(props.rowKey(item, index)) !== instance.key
+      ) {
+        return undefined;
+      }
+      survivors.push(instance);
+    }
+  } catch {
+    return undefined;
+  }
+
+  const survivorSet = new Set(survivorIndices);
+  for (let index = 0; index < previousInstances.length; index += 1) {
+    if (survivorSet.has(index)) continue;
+    previousInstances[index].scope?.cleanup();
+    previousInstances[index].element.remove();
+  }
+  for (let index = 0; index < survivors.length; index += 1) {
+    survivors[index].index = index;
+  }
+  return new Map(survivors.map((instance) => [instance.key, instance]));
 }
 
 function createKeyedRowConditionalRuntime(): KeyedRowConditionalRuntime {
@@ -4221,7 +4437,12 @@ function createKeyedRowsBlockComponent(
         );
         for (const [id, values] of conditionalValues) {
           if (options.conditionals?.changed(existing.conditionalValues.get(id), values)) {
-            conditionalChanges.push({ key, id, item: rows.items[index], index });
+            conditionalChanges.push({
+              key,
+              id,
+              item: rows.items[index],
+              index,
+            });
           }
         }
         existing.conditionalValues = conditionalValues;
@@ -4279,7 +4500,12 @@ function createKeyedRowsBlockComponent(
         );
         for (const [id, values] of conditionalValues) {
           if (options.conditionals?.changed(existing.conditionalValues.get(id), values)) {
-            conditionalChanges.push({ key, id, item: rows.items[index], index });
+            conditionalChanges.push({
+              key,
+              id,
+              item: rows.items[index],
+              index,
+            });
           }
         }
         existing.conditionalValues = conditionalValues;
@@ -4407,7 +4633,12 @@ function createKeyedRowsBlockComponent(
           );
           for (const [id, values] of conditionalValues) {
             if (options.conditionals?.changed(existing.conditionalValues.get(id), values)) {
-              conditionalChanges.push({ key, id, item: rows.items[index], index });
+              conditionalChanges.push({
+                key,
+                id,
+                item: rows.items[index],
+                index,
+              });
             }
           }
           existing.conditionalValues = conditionalValues;
@@ -4511,6 +4742,23 @@ function createKeyedRowsBlockComponent(
         if (appendedInstances) {
           this.instances = new Map(appendedInstances);
           this.rebuildElementIndex(this.instances);
+          this.commitCurrentCollection(dirtyState);
+          afterCommit?.();
+          return;
+        }
+        const filteredInstances = options.keyedUpdates.filter?.(
+          this.currentProps,
+          dirtyState,
+          this.collectionToken,
+          this.instances,
+          this.hasReactOwnedRows(),
+        );
+        if (filteredInstances) {
+          this.instances = new Map(filteredInstances);
+          this.rebuildElementIndex(this.instances);
+          const keys = [...this.instances.keys()];
+          this.pruneEventHandlers(keys);
+          this.pruneConditionalListeners(keys);
           this.commitCurrentCollection(dirtyState);
           afterCommit?.();
           return;
@@ -5080,7 +5328,18 @@ export const keyedRowsRuntimeFeature: CompilerRuntimeFeature = {
 export const keyedRowsHintedRuntimeFeature: CompilerRuntimeFeature = {
   name: "keyed-rows:hinted",
   create: (owner) => ({
-    KeyedRows: createKeyedRowsBlockComponent(owner, { keyedUpdates: keyedUpdateRuntime }),
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      keyedUpdates: keyedUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsFilterHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:filter-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      keyedUpdates: keyedFilterUpdateRuntime,
+    }),
   }),
 };
 
@@ -5099,6 +5358,16 @@ export const keyedRowsConditionalHintedRuntimeFeature: CompilerRuntimeFeature = 
     KeyedRows: createKeyedRowsBlockComponent(owner, {
       conditionals: createKeyedRowConditionalRuntime(),
       keyedUpdates: keyedUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsConditionalFilterHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:conditional:filter-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      keyedUpdates: keyedFilterUpdateRuntime,
     }),
   }),
 };
@@ -5122,6 +5391,16 @@ export const keyedRowsHostHintedRuntimeFeature: CompilerRuntimeFeature = {
   }),
 };
 
+export const keyedRowsHostFilterHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:host:filter-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedUpdates: keyedFilterUpdateRuntime,
+    }),
+  }),
+};
+
 export const keyedRowsCompleteRuntimeFeature: CompilerRuntimeFeature = {
   name: "keyed-rows:complete",
   create: (owner) => ({
@@ -5139,6 +5418,17 @@ export const keyedRowsCompleteHintedRuntimeFeature: CompilerRuntimeFeature = {
       conditionals: createKeyedRowConditionalRuntime(),
       hostBlocks: createKeyedRowHostRuntime(),
       keyedUpdates: keyedUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsCompleteFilterHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:complete:filter-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedUpdates: keyedFilterUpdateRuntime,
     }),
   }),
 };
@@ -5193,7 +5483,9 @@ export function createCompiledComponentWithFeatures<Props>(
     }
   }
 
-  const definitionReference: CompiledDefinitionReference<Props> = { current: definition };
+  const definitionReference: CompiledDefinitionReference<Props> = {
+    current: definition,
+  };
   const refreshListeners = new Set<() => void>();
 
   class FarmCompiledComponent extends React.Component<Props, Record<string, never>, boolean> {
@@ -5723,7 +6015,7 @@ const COMPLETE_RUNTIME_FEATURES: readonly CompilerRuntimeFeature[] = [
   hostConditionalRuntimeFeature,
   conditionalRangesRuntimeFeature,
   keyedListRuntimeFeature,
-  keyedRowsCompleteHintedRuntimeFeature,
+  keyedRowsCompleteFilterHintedRuntimeFeature,
   keyedRangesRuntimeFeature,
   mixedRangesRuntimeFeature,
   componentRuntimeFeature,

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -14,6 +14,7 @@ export interface CompileReactModuleResult {
   diagnostics: readonly CompilerDiagnostic[];
   optimizations: {
     keyedArrayAppendHints: number;
+    keyedArrayFilterHints: number;
     keyedCollectionUpdateHints: number;
     keyedIdentityTargets: number;
     keyedMapLookupTargets: number;
@@ -360,12 +361,16 @@ type CompilerRuntimeFeatureName =
   | "keyed-list"
   | "keyed-rows"
   | "keyed-rows-hinted"
+  | "keyed-rows-filter-hinted"
   | "keyed-rows-conditional"
   | "keyed-rows-conditional-hinted"
+  | "keyed-rows-conditional-filter-hinted"
   | "keyed-rows-host"
   | "keyed-rows-host-hinted"
+  | "keyed-rows-host-filter-hinted"
   | "keyed-rows-complete"
   | "keyed-rows-complete-hinted"
+  | "keyed-rows-complete-filter-hinted"
   | "keyed-ranges"
   | "mixed-ranges"
   | "component";
@@ -377,12 +382,16 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
   "keyed-list": "keyedListRuntimeFeature",
   "keyed-rows": "keyedRowsRuntimeFeature",
   "keyed-rows-hinted": "keyedRowsHintedRuntimeFeature",
+  "keyed-rows-filter-hinted": "keyedRowsFilterHintedRuntimeFeature",
   "keyed-rows-conditional": "keyedRowsConditionalRuntimeFeature",
   "keyed-rows-conditional-hinted": "keyedRowsConditionalHintedRuntimeFeature",
+  "keyed-rows-conditional-filter-hinted": "keyedRowsConditionalFilterHintedRuntimeFeature",
   "keyed-rows-host": "keyedRowsHostRuntimeFeature",
   "keyed-rows-host-hinted": "keyedRowsHostHintedRuntimeFeature",
+  "keyed-rows-host-filter-hinted": "keyedRowsHostFilterHintedRuntimeFeature",
   "keyed-rows-complete": "keyedRowsCompleteRuntimeFeature",
   "keyed-rows-complete-hinted": "keyedRowsCompleteHintedRuntimeFeature",
+  "keyed-rows-complete-filter-hinted": "keyedRowsCompleteFilterHintedRuntimeFeature",
   "keyed-ranges": "keyedRangesRuntimeFeature",
   "mixed-ranges": "mixedRangesRuntimeFeature",
   component: "componentRuntimeFeature",
@@ -391,6 +400,7 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
 function runtimeFeaturesForPlans(
   plans: readonly ComposableBlockPlan[],
   keyedMapUpdateHints: boolean,
+  keyedArrayFilterHints: boolean,
 ): CompilerRuntimeFeatureName[] {
   const features = new Set<CompilerRuntimeFeatureName>();
   let keyedRowsHaveConditionals = false;
@@ -415,9 +425,11 @@ function runtimeFeaturesForPlans(
             ? "keyed-rows-host"
             : "keyed-rows";
     features.add(
-      keyedMapUpdateHints
-        ? (`${keyedRowsFeature}-hinted` as CompilerRuntimeFeatureName)
-        : keyedRowsFeature,
+      keyedArrayFilterHints
+        ? (`${keyedRowsFeature}-filter-hinted` as CompilerRuntimeFeatureName)
+        : keyedMapUpdateHints
+          ? (`${keyedRowsFeature}-hinted` as CompilerRuntimeFeatureName)
+          : keyedRowsFeature,
     );
   }
   return [...features].sort();
@@ -906,7 +918,9 @@ function rewriteHandlerAccess(
   });
   return reason
     ? { reason }
-    : { root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement };
+    : {
+        root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement,
+      };
 }
 
 function isSafeCompilerCall(
@@ -1063,7 +1077,9 @@ function rewriteKeyedMapUpdateHints(
         !t.isCallExpression(updater.body) ||
         !t.isMemberExpression(updater.body.callee) ||
         updater.body.callee.computed ||
-        !t.isIdentifier(updater.body.callee.object, { name: updater.params[0].name }) ||
+        !t.isIdentifier(updater.body.callee.object, {
+          name: updater.params[0].name,
+        }) ||
         !t.isIdentifier(updater.body.callee.property, { name: "map" })
       ) {
         return;
@@ -1165,7 +1181,9 @@ function rewriteKeyedArrayAppendHints(
         updater.body.elements.length < 2 ||
         updater.body.elements.some((element) => element === null) ||
         !t.isSpreadElement(updater.body.elements[0]) ||
-        !t.isIdentifier(updater.body.elements[0].argument, { name: updater.params[0].name })
+        !t.isIdentifier(updater.body.elements[0].argument, {
+          name: updater.params[0].name,
+        })
       ) {
         return;
       }
@@ -1229,6 +1247,90 @@ function rewriteKeyedArrayAppendHints(
   };
 }
 
+function rewriteKeyedArrayFilterHints(
+  root: t.JSXElement,
+  hintedStateIndices: ReadonlySet<number>,
+  statesBySetter: ReadonlyMap<string, StateBinding>,
+  helperIdentifier: t.Identifier,
+  safeGlobals: ReadonlySet<string>,
+): { root: t.JSXElement; count: number; stateIndices: ReadonlySet<number> } {
+  if (hintedStateIndices.size === 0) {
+    return { root: t.cloneNode(root, true), count: 0, stateIndices: new Set() };
+  }
+  const file = expressionFile(t.cloneNode(root, true));
+  const stateIndices = new Set<number>();
+  let count = 0;
+  traverse(file, {
+    CallExpression(path) {
+      const callee = path.get("callee");
+      if (!callee.isIdentifier() || callee.scope.hasBinding(callee.node.name)) return;
+      const state = statesBySetter.get(callee.node.name);
+      if (!state || !hintedStateIndices.has(state.index) || path.node.arguments.length !== 1) {
+        return;
+      }
+      const updater = path.node.arguments[0];
+      if (
+        !t.isArrowFunctionExpression(updater) ||
+        updater.async ||
+        updater.generator ||
+        updater.params.length !== 1 ||
+        !t.isIdentifier(updater.params[0]) ||
+        !t.isCallExpression(updater.body) ||
+        updater.body.arguments.length !== 1 ||
+        !t.isMemberExpression(updater.body.callee) ||
+        updater.body.callee.computed ||
+        !t.isIdentifier(updater.body.callee.object, {
+          name: updater.params[0].name,
+        }) ||
+        !t.isIdentifier(updater.body.callee.property, { name: "filter" })
+      ) {
+        return;
+      }
+      const predicate = updater.body.arguments[0];
+      if (
+        !t.isArrowFunctionExpression(predicate) ||
+        predicate.async ||
+        predicate.generator ||
+        predicate.params.length !== 1 ||
+        !t.isIdentifier(predicate.params[0]) ||
+        !t.isExpression(predicate.body) ||
+        validateDerivedExpression(predicate.body, safeGlobals)
+      ) {
+        return;
+      }
+
+      const previous = t.cloneNode(updater.params[0]);
+      const filterMethod = path.scope.generateUidIdentifier("farmFilter");
+      path.node.arguments[0] = t.arrowFunctionExpression(
+        [t.cloneNode(previous)],
+        t.blockStatement([
+          t.variableDeclaration("const", [
+            t.variableDeclarator(
+              t.cloneNode(filterMethod),
+              t.memberExpression(t.cloneNode(previous), t.identifier("filter")),
+            ),
+          ]),
+          t.returnStatement(
+            t.callExpression(t.cloneNode(helperIdentifier), [
+              t.cloneNode(previous),
+              t.cloneNode(filterMethod),
+              t.cloneNode(predicate, true),
+            ]),
+          ),
+        ]),
+      );
+      count += 1;
+      stateIndices.add(state.index);
+      path.skip();
+    },
+  });
+  return {
+    root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement,
+    count,
+    stateIndices,
+  };
+}
+
 type KeyedCollectionTargetKind = "set" | "map";
 
 interface PreparedKeyedCollectionUpdater {
@@ -1247,7 +1349,9 @@ function isCollectionConstruction(
 ): expression is t.NewExpression {
   if (
     !t.isNewExpression(expression) ||
-    !t.isIdentifier(expression.callee, { name: collectionConstructorName(kind) })
+    !t.isIdentifier(expression.callee, {
+      name: collectionConstructorName(kind),
+    })
   ) {
     return false;
   }
@@ -1294,7 +1398,9 @@ function collectionStateHasOnlyOwnedReads(
       const parent = path.parentPath;
       if (
         parent.isNewExpression() &&
-        t.isIdentifier(parent.node.callee, { name: collectionConstructorName(kind) }) &&
+        t.isIdentifier(parent.node.callee, {
+          name: collectionConstructorName(kind),
+        }) &&
         parent.node.arguments.length === 1 &&
         parent.node.arguments[0] === path.node
       ) {
@@ -1505,7 +1611,9 @@ function prepareKeyedCollectionUpdater(
           parent.isNewExpression() &&
           parent.node.arguments.length === 1 &&
           parent.node.arguments[0] === path.node &&
-          t.isIdentifier(parent.node.callee, { name: collectionConstructorName(kind) })
+          t.isIdentifier(parent.node.callee, {
+            name: collectionConstructorName(kind),
+          })
         ) {
           return;
         }
@@ -2045,7 +2153,9 @@ function analyzeMapList(
   const collection = callee.object as t.Expression;
   const collectionUnsupported = validateCollectionPipeline(collection, safeGlobals);
   if (collectionUnsupported) {
-    return { reason: `keyed list collection cannot use ${collectionUnsupported}` };
+    return {
+      reason: `keyed list collection cannot use ${collectionUnsupported}`,
+    };
   }
   if (
     expression.arguments.length !== 1 ||
@@ -2056,14 +2166,19 @@ function analyzeMapList(
   }
   const callback = expression.arguments[0];
   if (containsDirectHookCall(callback)) {
-    return { reason: "Hooks cannot be called directly inside a keyed list callback" };
+    return {
+      reason: "Hooks cannot be called directly inside a keyed list callback",
+    };
   }
   const row = returnedExpression(callback);
   if (!row || !t.isJSXElement(row)) {
     return { reason: "keyed list map callbacks must return one React element" };
   }
   const key = jsxKeyExpression(row);
-  if (!key) return { reason: "automatically compiled lists require an explicit item key" };
+  if (!key)
+    return {
+      reason: "automatically compiled lists require an explicit item key",
+    };
   const keyReason = validateKeyFunction(callback, key, safeGlobals);
   if (keyReason) return { reason: keyReason };
   return { dependencies: collectStateDependencies(expression, statesByValue) };
@@ -2089,7 +2204,9 @@ function analyzePublicList(
   safeGlobals: ReadonlySet<string>,
 ): { dependencies?: number[]; reason?: string } {
   if (element.openingElement.attributes.some((attribute) => t.isJSXSpreadAttribute(attribute))) {
-    return { reason: "compiled List boundaries do not support JSX attribute spreads" };
+    return {
+      reason: "compiled List boundaries do not support JSX attribute spreads",
+    };
   }
   const each = listAttributeExpression(element, "each");
   const by = listAttributeExpression(element, "by");
@@ -2114,7 +2231,9 @@ function analyzePublicList(
     (!t.isArrowFunctionExpression(children[0].expression) &&
       !t.isFunctionExpression(children[0].expression))
   ) {
-    return { reason: "compiled List children must use one inline render function" };
+    return {
+      reason: "compiled List children must use one inline render function",
+    };
   }
   const render = children[0].expression;
   if (!returnedExpression(render)) {
@@ -2303,7 +2422,9 @@ function analyzeKeyedRowTree(
     !t.isIdentifier(renderCallback.params[0]) ||
     (renderCallback.params[1] !== undefined && !t.isIdentifier(renderCallback.params[1]))
   ) {
-    return { reason: "compiled keyed rows require item and optional index identifiers" };
+    return {
+      reason: "compiled keyed rows require item and optional index identifiers",
+    };
   }
 
   const bindings: PendingKeyedRowBinding[] = [];
@@ -2512,7 +2633,11 @@ function analyzeKeyedRowTree(
           parts.push(cloneExpression(child.expression));
         }
       }
-      bindings.push({ kind: "text", path: [...path], value: t.arrayExpression(parts) });
+      bindings.push({
+        kind: "text",
+        path: [...path],
+        value: t.arrayExpression(parts),
+      });
     }
 
     let elementIndex = 0;
@@ -2958,7 +3083,11 @@ function analyzeHostConditionalTree(
           parts.push(cloneExpression(child.expression));
         }
       }
-      bindings.push({ kind: "text", path: [...path], value: t.arrayExpression(parts) });
+      bindings.push({
+        kind: "text",
+        path: [...path],
+        value: t.arrayExpression(parts),
+      });
     }
 
     let elementIndex = 0;
@@ -3175,7 +3304,11 @@ function analyzeRecursiveHostTree(
               id,
               allocateId,
             )
-          : { bindings: [], plans: [], blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>() };
+          : {
+              bindings: [],
+              plans: [],
+              blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>(),
+            };
         const falsy = shape.falsy
           ? analyzeRecursiveHostTree(
               shape.falsy,
@@ -3185,7 +3318,11 @@ function analyzeRecursiveHostTree(
               id,
               allocateId,
             )
-          : { bindings: [], plans: [], blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>() };
+          : {
+              bindings: [],
+              plans: [],
+              blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>(),
+            };
         if (truthy.reason) return truthy.reason;
         if (falsy.reason) return falsy.reason;
         plans.push(...truthy.plans, ...falsy.plans);
@@ -3352,7 +3489,11 @@ function analyzeRecursiveHostTree(
           parts.push(cloneExpression(child.expression));
         }
       }
-      bindings.push({ kind: "text", path: [...path], value: t.arrayExpression(parts) });
+      bindings.push({
+        kind: "text",
+        path: [...path],
+        value: t.arrayExpression(parts),
+      });
     }
 
     let elementIndex = 0;
@@ -3468,7 +3609,11 @@ function analyzeHostConditionalContainer(
         parent,
         allocateId,
       )
-    : { bindings: [], plans: [], blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>() };
+    : {
+        bindings: [],
+        plans: [],
+        blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>(),
+      };
   const falsyAnalysis = shape.falsy
     ? analyzeRecursiveHostTree(
         shape.falsy,
@@ -3478,7 +3623,11 @@ function analyzeHostConditionalContainer(
         parent,
         allocateId,
       )
-    : { bindings: [], plans: [], blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>() };
+    : {
+        bindings: [],
+        plans: [],
+        blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>(),
+      };
   if (truthyAnalysis.reason || falsyAnalysis.reason) return undefined;
 
   const dependencies = new Set(collectStateDependencies(shape.test, statesByValue));
@@ -3556,7 +3705,11 @@ function analyzeConditionalRangesContainer(
               parent,
               allocateId,
             )
-          : { bindings: [], plans: [], blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>() };
+          : {
+              bindings: [],
+              plans: [],
+              blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>(),
+            };
         const falsyAnalysis = shape.falsy
           ? analyzeRecursiveHostTree(
               shape.falsy,
@@ -3566,7 +3719,11 @@ function analyzeConditionalRangesContainer(
               parent,
               allocateId,
             )
-          : { bindings: [], plans: [], blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>() };
+          : {
+              bindings: [],
+              plans: [],
+              blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>(),
+            };
         if (truthyAnalysis.reason || falsyAnalysis.reason) return undefined;
         nestedPlans.push(...truthyAnalysis.plans, ...falsyAnalysis.plans);
         for (const [element, plan] of truthyAnalysis.blocks) descriptorBlocks.set(element, plan);
@@ -3693,7 +3850,11 @@ function analyzeMixedRangesContainer(
               parent,
               allocateId,
             )
-          : { bindings: [], plans: [], blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>() };
+          : {
+              bindings: [],
+              plans: [],
+              blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>(),
+            };
         const falsyAnalysis = shape.falsy
           ? analyzeRecursiveHostTree(
               shape.falsy,
@@ -3703,7 +3864,11 @@ function analyzeMixedRangesContainer(
               parent,
               allocateId,
             )
-          : { bindings: [], plans: [], blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>() };
+          : {
+              bindings: [],
+              plans: [],
+              blocks: new Map<t.JSXElement, HostDescriptorBlockPlan>(),
+            };
         if (!mergeAnalysis(truthyAnalysis) || !mergeAnalysis(falsyAnalysis)) return undefined;
         for (const dependency of collectStateDependencies(shape.test, statesByValue)) {
           dependencies.add(dependency);
@@ -4289,6 +4454,7 @@ function keyedRowsBoundary(
   blockRuntime: t.Identifier,
   plan: KeyedRowsPlan,
   keyedMapUpdateHints: boolean,
+  keyedArrayFilterHintedStateIndices: ReadonlySet<number>,
 ): t.JSXElement {
   const name = t.jsxMemberExpression(
     t.jsxIdentifier(blockRuntime.name),
@@ -4356,6 +4522,15 @@ function keyedRowsBoundary(
                 t.jsxExpressionContainer(t.numericLiteral(plan.collectionDependency)),
               ),
             ]),
+        ...(plan.collectionDependency !== undefined &&
+        keyedArrayFilterHintedStateIndices.has(plan.collectionDependency)
+          ? [
+              t.jsxAttribute(
+                t.jsxIdentifier("filterIndexIndependent"),
+                t.jsxExpressionContainer(t.booleanLiteral(true)),
+              ),
+            ]
+          : []),
         t.jsxAttribute(
           t.jsxIdentifier("rowKey"),
           t.jsxExpressionContainer(t.cloneNode(plan.keyCallback, true)),
@@ -4757,7 +4932,9 @@ function analyzeComponentIslandElement(
 ): { dependencies?: number[]; reason?: string } {
   const name = element.openingElement.name;
   if (!t.isJSXIdentifier(name) || !isComponentName(name.name)) {
-    return { reason: "component islands require a direct component identifier" };
+    return {
+      reason: "component islands require a direct component identifier",
+    };
   }
   if (!allowedComponentNames.has(name.name)) {
     return {
@@ -4765,20 +4942,28 @@ function analyzeComponentIslandElement(
     };
   }
   if (meaningfulJsxChildren(element).length > 0) {
-    return { reason: `component island ${name.name} does not support children yet` };
+    return {
+      reason: `component island ${name.name} does not support children yet`,
+    };
   }
 
   const dependencies = new Set<number>();
   for (const attribute of element.openingElement.attributes) {
     if (t.isJSXSpreadAttribute(attribute)) {
-      return { reason: `component island ${name.name} does not support JSX attribute spreads` };
+      return {
+        reason: `component island ${name.name} does not support JSX attribute spreads`,
+      };
     }
     const attributeName = jsxAttributeName(attribute);
     if (!attributeName) {
-      return { reason: `component island ${name.name} does not support namespaced JSX attributes` };
+      return {
+        reason: `component island ${name.name} does not support namespaced JSX attributes`,
+      };
     }
     if (attributeName === "ref" || attributeName === "key" || attributeName === "children") {
-      return { reason: `component island ${name.name} does not support ${attributeName} yet` };
+      return {
+        reason: `component island ${name.name} does not support ${attributeName} yet`,
+      };
     }
     if (
       !t.isJSXExpressionContainer(attribute.value) ||
@@ -4804,7 +4989,9 @@ function analyzeComponentIslandElement(
     );
   }
 
-  return { dependencies: [...dependencies].sort((left, right) => left - right) };
+  return {
+    dependencies: [...dependencies].sort((left, right) => left - right),
+  };
 }
 
 function componentIslandBoundary(
@@ -5371,6 +5558,7 @@ function lowerComposableBlocks(
   blockRuntime: t.Identifier,
   listNames: ReadonlySet<string>,
   keyedMapUpdateHints: boolean,
+  keyedArrayFilterHintedStateIndices: ReadonlySet<number>,
 ): t.JSXElement {
   const planBySource = new Map<t.Node, ComposableBlockPlan>(
     plans.map((plan) => [plan.source, plan]),
@@ -5397,7 +5585,12 @@ function lowerComposableBlocks(
           return mixedRangesBoundary(blockRuntime, plan);
         }
         if (plan?.kind === "keyed-rows") {
-          return keyedRowsBoundary(blockRuntime, plan, keyedMapUpdateHints);
+          return keyedRowsBoundary(
+            blockRuntime,
+            plan,
+            keyedMapUpdateHints,
+            keyedArrayFilterHintedStateIndices,
+          );
         }
         if (plan?.kind === "keyed-ranges") {
           return keyedRangesBoundary(blockRuntime, plan);
@@ -5828,12 +6021,14 @@ function compileCandidate(
   createComponentIdentifier: t.Identifier,
   keyedMapUpdateIdentifier: t.Identifier,
   keyedArrayAppendIdentifier: t.Identifier,
+  keyedArrayFilterIdentifier: t.Identifier,
   keyedCollectionUpdateIdentifier: t.Identifier,
   keyedCollectionMutationIdentifier: t.Identifier,
   runtimeFeatureIdentifiers: ReadonlyMap<CompilerRuntimeFeatureName, t.Identifier>,
   usedRuntimeFeatures: Set<CompilerRuntimeFeatureName>,
   optimizationCounts: {
     keyedArrayAppendHints: number;
+    keyedArrayFilterHints: number;
     keyedCollectionUpdateHints: number;
     keyedIdentityTargets: number;
     keyedMapLookupTargets: number;
@@ -5917,9 +6112,17 @@ function compileCandidate(
       if (declaration.init.async || declaration.init.generator) {
         return `event handler ${declaration.id.name} must be synchronous`;
       }
-      locals.push({ kind: "handler", name: declaration.id.name, value: declaration.init });
+      locals.push({
+        kind: "handler",
+        name: declaration.id.name,
+        value: declaration.init,
+      });
     } else {
-      locals.push({ kind: "derived", name: declaration.id.name, value: declaration.init });
+      locals.push({
+        kind: "derived",
+        name: declaration.id.name,
+        value: declaration.init,
+      });
     }
   }
 
@@ -6167,6 +6370,56 @@ function compileCandidate(
       optimizationCounts.keyedArrayAppendHints += appendHintedRoot.count;
     }
   }
+  const filterHintedStateIndices = new Set(hintedStateIndices);
+  for (const plan of blockAnalysis.plans || []) {
+    if (plan.kind !== "keyed-rows" || plan.collectionDependency === undefined) continue;
+    const keyExpression = returnedExpression(plan.keyCallback);
+    if (
+      plan.renderCallback.params.length > 1 ||
+      !keyExpression ||
+      collectStateDependencies(keyExpression, reactiveByValue).includes(plan.collectionDependency)
+    ) {
+      // Removing rows shifts later indexes. A row callback that accepts the
+      // index, or a key that reads the whole collection, must take the full
+      // reconciliation path so existing row state cannot become stale.
+      filterHintedStateIndices.delete(plan.collectionDependency);
+    }
+  }
+  const filterHintedRoot = rewriteKeyedArrayFilterHints(
+    expandedReactiveRoot,
+    filterHintedStateIndices,
+    statesBySetter,
+    keyedArrayFilterIdentifier,
+    safeGlobals,
+  );
+  let appliedKeyedArrayFilterHints = 0;
+  let appliedFilterHintedStateIndices: ReadonlySet<number> = new Set();
+  if (filterHintedRoot.count > 0) {
+    const hintedBlockAnalysis = analyzeComposableBlocks(
+      filterHintedRoot.root,
+      reactiveByValue,
+      safeGlobals,
+      listNames,
+      allowedComponentNames,
+    );
+    const hintedAnalysis = analyzeHostTree(
+      filterHintedRoot.root,
+      reactiveByValue,
+      safeGlobals,
+      hintedBlockAnalysis.conditionalExpressions || new Set<t.Expression>(),
+      hintedBlockAnalysis.keyedExpressions || new Set<t.Expression>(),
+      hintedBlockAnalysis.ownedElements || new Set<t.JSXElement>(),
+      hintedBlockAnalysis.componentElements || new Set<t.JSXElement>(),
+    );
+    if (!hintedBlockAnalysis.reason && !hintedAnalysis.reason) {
+      expandedReactiveRoot = filterHintedRoot.root;
+      blockAnalysis = hintedBlockAnalysis;
+      analysis = hintedAnalysis;
+      appliedKeyedArrayFilterHints = filterHintedRoot.count;
+      appliedFilterHintedStateIndices = filterHintedRoot.stateIndices;
+      optimizationCounts.keyedArrayFilterHints += filterHintedRoot.count;
+    }
+  }
   const keyedCollectionTargetKinds = new Map<number, KeyedCollectionTargetKind>();
   const conflictingKeyedCollectionTargets = new Set<number>();
   for (const plan of blockAnalysis.plans || []) {
@@ -6244,8 +6497,15 @@ function compileCandidate(
         : 0),
     0,
   );
-  const hasKeyedUpdateHints = appliedKeyedMapUpdateHints > 0 || appliedKeyedArrayAppendHints > 0;
-  const runtimeFeatures = runtimeFeaturesForPlans(blockPlans, hasKeyedUpdateHints);
+  const hasKeyedUpdateHints =
+    appliedKeyedMapUpdateHints > 0 ||
+    appliedKeyedArrayAppendHints > 0 ||
+    appliedKeyedArrayFilterHints > 0;
+  const runtimeFeatures = runtimeFeaturesForPlans(
+    blockPlans,
+    hasKeyedUpdateHints,
+    appliedKeyedArrayFilterHints > 0,
+  );
   markShortCircuitBindings(analysis.bindings || []);
   assignStableBindingTargets(analysis.bindings || []);
 
@@ -6265,6 +6525,7 @@ function compileCandidate(
     blockParameter,
     listNames,
     hasKeyedUpdateHints,
+    appliedFilterHintedStateIndices,
   );
   const rewrittenRoot = rewriteStateAccess(
     rootWithBlocks,
@@ -6431,6 +6692,7 @@ export async function compileReactModule(
   const diagnostics: CompilerDiagnostic[] = [];
   const optimizationCounts = {
     keyedArrayAppendHints: 0,
+    keyedArrayFilterHints: 0,
     keyedCollectionUpdateHints: 0,
     keyedIdentityTargets: 0,
     keyedMapLookupTargets: 0,
@@ -6480,6 +6742,9 @@ export async function compileReactModule(
         const keyedArrayAppendIdentifier = programPath.scope.generateUidIdentifier(
           "createCompilerKeyedArrayAppend",
         );
+        const keyedArrayFilterIdentifier = programPath.scope.generateUidIdentifier(
+          "createCompilerKeyedArrayFilter",
+        );
         const keyedCollectionUpdateIdentifier = programPath.scope.generateUidIdentifier(
           "createCompilerKeyedCollectionUpdate",
         );
@@ -6509,6 +6774,7 @@ export async function compileReactModule(
             createComponentIdentifier,
             keyedMapUpdateIdentifier,
             keyedArrayAppendIdentifier,
+            keyedArrayFilterIdentifier,
             keyedCollectionUpdateIdentifier,
             keyedCollectionMutationIdentifier,
             runtimeFeatureIdentifiers,
@@ -6553,6 +6819,14 @@ export async function compileReactModule(
                       t.importSpecifier(
                         keyedArrayAppendIdentifier,
                         t.identifier("createCompilerKeyedArrayAppend"),
+                      ),
+                    ]
+                  : []),
+                ...(optimizationCounts.keyedArrayFilterHints > 0
+                  ? [
+                      t.importSpecifier(
+                        keyedArrayFilterIdentifier,
+                        t.identifier("createCompilerKeyedArrayFilter"),
                       ),
                     ]
                   : []),


### PR DESCRIPTION
## Summary

- recognize conservative direct keyed-array `filter()` setters and emit removal-position metadata
- validate native filter chains, lengths, item identity, and keys before removing rejected DOM rows
- preserve full React-compatible reconciliation for index-aware, custom, sparse, mixed, or otherwise unsupported cases
- expose `keyedArrayFilterHints`, tree-shake the optional runtime, and document the supported syntax and fallbacks

## Correctness coverage

- compiler acceptance and conservative fallback cases
- exact 2,048-row descriptor/binding/key-read assertions and survivor DOM identity
- 2,000 deterministic randomized removals compared with normal React
- queued filters, unhinted-chain fallback, collection-reading rows, delegated event indexes, custom filter behavior, and thrown predicates
- StrictMode hydration, recoverable hydration errors, queued unmount cleanup
- packaged React 18.3.1 and React 19.2.8 compatibility
- production Vercel/Nitro docs build

## Performance and size

- 1,000 rows: 0.70 ms hybrid, 5.86x faster than React and 2.00x faster than the equivalent compiled snapshot fallback
- 20,000 rows: 13.70 ms hybrid, 9.09x faster than React
- all existing keyed update, append, selection, Set, Map, scalability, correctness, and browser-error gates remain green
- direct compiler premium remains 3,678 B gzip; filter-hinted keyed fixture is 11,890 B gzip; filter support is retained only when emitted

## Verification

- `pnpm --filter @farm.js/react test` (54 files, 451 tests)
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --filter @farm.js/react test:compat`
- `pnpm --dir examples/react-compiler-dashboard benchmark`
- `pnpm docs:build`
- scoped oxlint and oxfmt checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds keyed-array filter hints so direct immutable `filter()` updates remove only the rejected DOM rows instead of falling back to full keyed reconciliation.

The compiler now identifies concise `setItems((current) => current.filter(...))` setters on index-independent keyed rows, emits removal-position metadata, and passes it to the optional runtime. The runtime validates the native filter chain, result lengths, surviving item identity, and keys before deleting rows and preserves queued filter composition. Index-aware rows or predicates, block-bodied updates, custom filter methods, sparse/subclassed arrays, collection-reading bindings or keys, and failed validation use the full keyed reconciliation path.

- Adds `keyedArrayFilterHints` to the compiler coverage report.
- Adds runtime-size and benchmark fixtures plus docs coverage for supported syntax and fallbacks.

<sup>Written for commit ec6a3f2d7d950c77c863fcedd8a079f8d3d87a58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

