### PR TITLE
fix(dev): report a layout that fails to load instead of dropping it quietly

### DIFF
--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -2,7 +2,7 @@ import { pathToFileURL } from "node:url";
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getClientModuleMetadata,
   getIslandStrategyExport,
@@ -581,6 +581,56 @@ export function Chart() {}
     // The same applies to a loading boundary that cannot be loaded.
     expect(source).not.toContain("console.warn('[Farm.js] Could not load loading boundary");
     expect(source).toContain("[Farm.js] Loading boundary failed to load and was skipped: ");
+  });
+
+  it("reports the failing loading module without masking the original error", async () => {
+    const source = fs.readFileSync(path.join(process.cwd(), "src", "vite.ts"), "utf-8");
+    const start = source.indexOf("async function buildClientHydrationElement(");
+    const end = source.indexOf("\n\nasync function loadLayoutComponents", start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    const emittedFunction = source.slice(start, end);
+    const testableFunction = emittedFunction.replace(
+      "import(/* @vite-ignore */ loadingModulePath)",
+      "loadModule(loadingModulePath)",
+    );
+    expect(testableFunction).not.toBe(emittedFunction);
+
+    const loadFailure = new Error("loading module failed");
+    const React = {
+      createElement(type: unknown, props: unknown, ...children: unknown[]) {
+        return { type, props, children };
+      },
+      Suspense: Symbol("Suspense"),
+    };
+    const buildClientHydrationElement = new Function(
+      "React",
+      "loadModule",
+      `return (${testableFunction});`,
+    )(React, async () => {
+      throw loadFailure;
+    }) as (
+      component: () => null,
+      props: Record<string, unknown>,
+      loadingModulePath: string,
+    ) => Promise<{ type: unknown }>;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const Page = () => null;
+
+    try {
+      const element = await buildClientHydrationElement(Page, {}, "/src/app/loading.tsx");
+
+      expect(element.type).toBe(Page);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Loading boundary failed to load and was skipped: /src/app/loading.tsx",
+        ),
+        loadFailure,
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it("keeps the emitted diagnostics free of escapes the template literal would consume", () => {

--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -568,6 +568,32 @@ export function Chart() {}
     );
   });
 
+  it("reports a layout that fails to load, rather than dropping it quietly", () => {
+    const source = fs.readFileSync(path.join(process.cwd(), "src", "vite.ts"), "utf-8");
+
+    // Skipping a layout makes the client tree differ from the server's, so React
+    // discards the server rendered markup for that branch. A warning is too quiet
+    // for something that deletes visible UI.
+    expect(source).not.toContain("console.warn('[Farm.js] Could not load layout:");
+    expect(source).toContain("[Farm.js] Layout failed to load and was skipped: ");
+    expect(source).toContain("server rendered markup for this route");
+
+    // The same applies to a loading boundary that cannot be loaded.
+    expect(source).not.toContain("console.warn('[Farm.js] Could not load loading boundary");
+    expect(source).toContain("[Farm.js] Loading boundary failed to load and was skipped: ");
+  });
+
+  it("keeps the emitted diagnostics free of escapes the template literal would consume", () => {
+    const source = fs.readFileSync(path.join(process.cwd(), "src", "vite.ts"), "utf-8");
+    const start = source.indexOf("Layout failed to load and was skipped");
+    expect(start).toBeGreaterThan(-1);
+
+    // A backslash-n inside the surrounding template literal becomes a real
+    // newline in the emitted client runtime, which breaks the JS string literal.
+    const message = source.slice(start, start + 400);
+    expect(message.includes(String.fromCharCode(92) + "n")).toBe(false);
+  });
+
   it("composes every applicable layout in the development hydration runtime", () => {
     const source = fs.readFileSync(path.join(process.cwd(), "src", "vite.ts"), "utf-8");
 

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -3961,7 +3961,7 @@ async function buildClientHydrationElement(
       }
     } catch (error) {
       console.error(
-        '[Farm.js] Loading boundary failed to load and was skipped: ' + loading.modulePath,
+        '[Farm.js] Loading boundary failed to load and was skipped: ' + loadingModulePath,
         error,
       );
     }

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -3960,7 +3960,10 @@ async function buildClientHydrationElement(
         element = React.createElement(React.Suspense, { fallback: loadingFallback }, element);
       }
     } catch (error) {
-      console.warn('[Farm.js] Could not load loading boundary for hydration:', error);
+      console.error(
+        '[Farm.js] Loading boundary failed to load and was skipped: ' + loading.modulePath,
+        error,
+      );
     }
   }
 
@@ -3983,7 +3986,15 @@ async function loadLayoutComponents(layouts = []) {
       }
       if (LayoutComponent) loadedLayouts.push({ ...layout, Component: LayoutComponent });
     } catch (error) {
-      console.warn('[Farm.js] Could not load layout:', layout.modulePath, error);
+      // Skipping the layout leaves the client tree different from the server's,
+      // so React discards the server rendered markup for this branch, including
+      // whatever the layout drew. Losing visible UI deserves more than a warning.
+      console.error(
+        '[Farm.js] Layout failed to load and was skipped: ' + layout.modulePath +
+          '. The client tree no longer matches the server, so React will discard the ' +
+          'server rendered markup for this route, including anything this layout renders.',
+        error,
+      );
     }
   }
 


### PR DESCRIPTION
Closes #560.

## Problem

A layout module that throws while being imported on the client is caught, warned about, and
skipped.

Skipping it leaves the client tree different from the server's, so React discards the server
rendered markup for that branch. Anything the layout drew, a header for example, disappears the
moment hydration runs. The only signal is a `console.warn`.

Any error in a layout module causes this, not just one kind. A typo or a bad import has the same
effect.

## Change

The layout and loading boundary failures now report through `console.error` and state the
consequence:

```
[Farm.js] Layout failed to load and was skipped: /src/app/layout.tsx. The client tree no
longer matches the server, so React will discard the server rendered markup for this route,
including anything this layout renders.
```

This does not make a broken layout work. It replaces a silent loss of UI with a message that
names the cause.

## Note on the process.env part of the issue

The issue first suggested Farm should apply the `process.env` replacement in dev that the
production client build applies. That is not correct, so it is not part of this change.

Vite skips define replacement for client modules in dev by design:

```js
async transform(code, id, options) {
  const ssr = options?.ssr === true;
  if (!ssr && !isBuild) {
    return;
  }
```

Adding a define in Farm would not help, because the plugin returns before user defines are
considered. Reading `process.env` from a client reachable module is an application level
mistake, and `import.meta.env` is the supported alternative. The issue has been corrected.

## Tests

Two, both failing without this change:

1. The layout and loading boundary failures report through `console.error` and name the
   consequence.
2. The message contains no newline escape. The surrounding template literal would consume it and
   emit a real newline inside a JS string in the generated client runtime.

## Verification

Reproduced on `farm dev` with a layout whose module throws in the browser. Before, the only clue
was a warning and a header that vanished. After correcting the module, the layout survives
hydration: `header` and `[data-farm-layout-boundary="true"]` both go from 0 to 1.

Core suite green, 1270 passed and 0 failed. Type check and lint clean.
