### PR TITLE
fix(router): read the request URL in client hooks during server rendering

### DIFF
--- a/packages/farm/src/__tests__/navigation-ssr-request-url.test.tsx
+++ b/packages/farm/src/__tests__/navigation-ssr-request-url.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { renderToString } from "react-dom/server";
+import { usePathname, useSearchParams } from "../navigation";
+import { useQueryState } from "../query/client";
+import { asString } from "../query/parsers";
+import { _runWithCurrentRequest } from "../server/request";
+
+/**
+ * A node environment on purpose. There is no `window`, so these take the same
+ * path a client hook takes while the page is rendered on the server.
+ */
+
+function PathProbe() {
+  return <span>{`path:${usePathname()}`}</span>;
+}
+
+function SearchProbe() {
+  return <span>{`search:${useSearchParams().toString()}`}</span>;
+}
+
+function QueryProbe() {
+  const [url] = useQueryState("url", asString);
+  return <span>{`url:${url ?? ""}`}</span>;
+}
+
+describe("client hooks rendered on the server", () => {
+  it("runs without a window", () => {
+    expect(typeof window).toBe("undefined");
+  });
+
+  it("usePathname reflects the request path rather than the site root", async () => {
+    await _runWithCurrentRequest(new Request("https://farmjs.dev/users/42?tab=posts"), () => {
+      expect(renderToString(<PathProbe />)).toContain("path:/users/42");
+    });
+  });
+
+  it("useSearchParams reflects the request query rather than an empty one", async () => {
+    await _runWithCurrentRequest(new Request("https://farmjs.dev/users/42?tab=posts"), () => {
+      expect(renderToString(<SearchProbe />)).toContain("search:tab=posts");
+    });
+  });
+
+  it("useQueryState reads the value from the request", async () => {
+    await _runWithCurrentRequest(
+      new Request("https://farmjs.dev/scan?url=https%3A%2F%2Ffarmjs.dev"),
+      () => {
+        expect(renderToString(<QueryProbe />)).toContain("url:https://farmjs.dev");
+      },
+    );
+  });
+
+  it("falls back to the site root outside a request", () => {
+    expect(renderToString(<PathProbe />)).toContain("path:/");
+    expect(renderToString(<SearchProbe />)).toContain("search:");
+  });
+});

--- a/packages/farm/src/client/router.ts
+++ b/packages/farm/src/client/router.ts
@@ -9,6 +9,7 @@ import {
 } from "./spa-router";
 import { notifyHistoryChange, subscribeHistoryChange } from "./history-sync";
 import { getFarmI18nClientState } from "../i18n/client-runtime";
+import { _resolveCurrentRequest } from "../server/request-bridge";
 import { stripFarmLocaleFromPathname } from "../i18n/routing";
 
 interface RouterState {
@@ -204,7 +205,8 @@ export function useScrollRestoration<TElement extends HTMLElement = HTMLElement>
 }
 
 function readRouterState(basePath: string, routeMatcher: FarmRouter | null): RouterState {
-  if (typeof window === "undefined") {
+  const url = readCurrentUrl();
+  if (!url) {
     return {
       pathname: "/",
       searchParams: new URLSearchParams(),
@@ -213,7 +215,6 @@ function readRouterState(basePath: string, routeMatcher: FarmRouter | null): Rou
     };
   }
 
-  const url = new URL(window.location.href);
   const pathname = normalizeClientPathname(url.pathname, basePath);
   const i18n = getFarmI18nClientState();
   const routePathname = i18n ? stripFarmLocaleFromPathname(pathname, i18n) : pathname;
@@ -221,8 +222,34 @@ function readRouterState(basePath: string, routeMatcher: FarmRouter | null): Rou
     pathname,
     searchParams: url.searchParams,
     params: routeMatcher?.match(routePathname)?.params || {},
-    pageState: readPageState(),
+    pageState: typeof window === "undefined" ? null : readPageState(),
   };
+}
+
+/**
+ * The URL being rendered, on either side of hydration.
+ *
+ * On the server this came back as `/` with no search params, so a component
+ * reading the path or the query string rendered one thing on the server and
+ * another in the browser, which React reports as a hydration mismatch and
+ * leaves the route without useful server rendered markup.
+ */
+function readCurrentUrl(): URL | undefined {
+  if (typeof window !== "undefined") {
+    try {
+      return new URL(window.location.href);
+    } catch {
+      return undefined;
+    }
+  }
+
+  const request = _resolveCurrentRequest();
+  if (!request) return undefined;
+  try {
+    return new URL(request.url);
+  } catch {
+    return undefined;
+  }
 }
 
 function normalizeClientPathname(pathname: string, basePath: string) {

--- a/packages/farm/src/query/client.ts
+++ b/packages/farm/src/query/client.ts
@@ -8,6 +8,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { notifyHistoryChange, subscribeHistoryChange } from "../client/history-sync";
+import { _resolveCurrentRequest } from "../server/request-bridge";
 import { emitter } from "./sync";
 export { parseRouteParams, loadRouteParams, type RouteParamsInput } from "./params";
 
@@ -38,8 +39,18 @@ export interface Options {
 }
 
 const getCurrentSearchParams = (): URLSearchParams => {
-  if (typeof window === "undefined") return new URLSearchParams();
-  return new URLSearchParams(window.location.search);
+  if (typeof window !== "undefined") return new URLSearchParams(window.location.search);
+
+  // Server rendering used to see an empty query string here, so a hook read one
+  // value on the server and another in the browser. React reports that as a
+  // hydration mismatch and discards the server rendered markup for the branch.
+  const request = _resolveCurrentRequest();
+  if (!request) return new URLSearchParams();
+  try {
+    return new URL(request.url).searchParams;
+  } catch {
+    return new URLSearchParams();
+  }
 };
 
 const throttleTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -150,7 +161,6 @@ export function useQueryState<TParser extends Parser<any>>(
 ] {
   type T = NonNullable<ReturnType<TParser["parse"]>>;
   const [state, setState] = useState<T | null>(() => {
-    if (typeof window === "undefined") return parser.parse("");
     const searchParams = getCurrentSearchParams();
     const value = searchParams.get(key);
     const parsed = parser.parse(value ?? "");
@@ -247,8 +257,7 @@ export function useQueryStates<T extends Record<string, Parser<any>>>(
   const watchKeys = keys.join("&");
 
   const [state, setState] = useState<{ [K in keyof T]: ReturnType<T[K]["parse"]> }>(() => {
-    const searchParams =
-      typeof window === "undefined" ? new URLSearchParams() : getCurrentSearchParams();
+    const searchParams = getCurrentSearchParams();
     const result = {} as { [K in keyof T]: ReturnType<T[K]["parse"]> };
 
     Object.entries(parsers).forEach(([key, parser]) => {


### PR DESCRIPTION
Closes #561.

## Problem

`usePathname`, `useSearchParams` and the query hooks read `window.location`, which does not
exist while a page is rendered on the server. Instead of having no answer, they returned a
made up one:

```ts
pathname: "/",
searchParams: new URLSearchParams(),
```

So for a request to `/scan?url=https://example.com`, the server rendered the page as if the
request had been for the site root with no query string, and the browser then rendered it with
the real values. React compares the two, finds they differ, and discards the server rendered
markup for that branch. That surfaces as React error #418.

The console error is the smaller half. The route is not usefully server rendered: a shared link
arrives as an empty form, and anything that does not run JavaScript sees only that.

## Change

The server already holds the request while rendering. These hooks now read it.

They also run in the browser, so they cannot import the request store directly without pulling
`node:async_hooks` into the client bundle. `server/request-bridge.ts` already exists for exactly
this, holds no imports, and is registered by the server runtime, so the hooks resolve the
request through it.

Browser behaviour is unchanged. Outside a request, for example in a unit test, they still fall
back to the site root with an empty query string.

## Tests

Five, rendering real components through `renderToString` in a node environment, so they take the
same path a client hook takes during server rendering. Without the change:

```
expected '<span>path:/</span>'   to contain 'path:/users/42'
expected '<span>search:</span>'  to contain 'search:tab=posts'
expected '<span>url:</span>'     to contain 'url:https://farmjs.dev'
```

Core suite green, 1276 passed and 0 failed. Type check and lint clean.

## Note

`query/client.ts` describes itself as client only and `loadSearchParams` exists as the server
side path, so `useQueryState` returning an empty value was arguably by design. It is included
here because it produces the same mismatch, and reading the request costs nothing once the
bridge is in place. Happy to split it out if you would rather keep that hook browser only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `usePathname`, `useSearchParams`, and the query hooks read the current request URL during server rendering instead of returning a hardcoded "/" and empty query string, eliminating React hydration mismatch errors and making server-rendered HTML reflect the actual request.

**Details**
- Reads the request through the existing `request-bridge`, which holds no browser-incompatible imports.
- Browser behavior is unchanged; outside a request the hooks still fall back to the site root with no query string.
- `useQueryState` and `useQueryStates` now honor the request query rather than returning empty values.
- Closes #561.

<sup>Written for commit 0a652f9edcdc1c6c8a8e479e2a095a48d305764e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

