### PR TITLE
perf(react): carry keyed prepend hints

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -304,6 +304,7 @@ After a successful build, Farm writes `.farm/react-compiler.json`:
     "fallback": 2,
     "keyedArrayAppendHints": 1,
     "keyedArrayFilterHints": 1,
+    "keyedArrayPrependHints": 1,
     "keyedCollectionUpdateHints": 3,
     "keyedIdentityTargets": 2,
     "keyedMapLookupTargets": 1,
@@ -323,6 +324,7 @@ After a successful build, Farm writes `.farm/react-compiler.json`:
       "optimizations": {
         "keyedArrayAppendHints": 1,
         "keyedArrayFilterHints": 1,
+        "keyedArrayPrependHints": 1,
         "keyedCollectionUpdateHints": 3,
         "keyedIdentityTargets": 2,
         "keyedMapLookupTargets": 1,
@@ -356,9 +358,11 @@ can report its changed row indexes while an immutable `map()` runs. The same cou
 module.
 `keyedArrayAppendHints` counts setter sites where the compiler proved a direct keyed array append
 and can hand the appended suffix to the runtime. `keyedArrayFilterHints` counts concise keyed-array
-filter sites that can report removed positions. `selected` is `true` when an annotation explicitly
-requested compilation. Module paths are relative to the project root, and the output is sorted and
-contains no timestamp, so CI can compare reports without machine-specific noise.
+filter sites that can report removed positions. `keyedArrayPrependHints` counts setter sites where
+the compiler proved a direct keyed array prepend and can hand the new prefix to the runtime.
+`selected` is `true` when an annotation explicitly requested compilation. Module paths are relative
+to the project root, and the output is sorted and contains no timestamp, so CI can compare reports
+without machine-specific noise.
 
 Use a different project-relative output path when CI collects artifacts elsewhere:
 
@@ -894,8 +898,8 @@ reads keys, descriptors, and bindings only for the appended suffix, creates only
 and inserts them together with a document fragment. It does not rerun the owner component or touch
 the existing row DOM.
 
-The proof is intentionally narrow. Both values must be native arrays. Prepend, middle insertion,
-removal, direct replacement, a copy with no appended entries, block-bodied updaters, duplicate
+The proof is intentionally narrow. Both values must be native arrays. Middle insertion, removal,
+direct replacement, a copy with no appended entries, block-bodied updaters, duplicate
 keys, React-owned or nested host-block rows, row conditionals, and rows whose bindings read the
 collection itself keep complete keyed reconciliation. Keys that read the collection also prevent
 the compiler from emitting the hint. A preceding unhinted update, an unrelated
@@ -903,6 +907,36 @@ dirty dependency, or any failed source/length check also discards the hint. Thes
 normal React behavior; the syntax does not opt the component into a different correctness model.
 The compiler report exposes emitted sites as `keyedArrayAppendHints`, and the hinted runtime is
 retained only when a module emits at least one append or same-order map hint.
+
+#### Keyed array prepend hints
+
+A direct keyed `useState` array can avoid rescanning every existing row when new items are inserted
+at the beginning:
+
+```tsx
+setItems((current) => [nextItem, ...current]);
+setItems((current) => [...nextItems, ...current]);
+```
+
+At build time, Farm recognizes a concise functional setter whose array literal ends with exactly
+`...current` and has at least one leading item or spread. The application still creates its normal
+immutable array. Generated metadata connects the result to the last committed array and records
+the prefix length. Multiple hinted prepends queued before one compiler flush form one validated
+chain.
+
+At update time, Farm verifies native arrays, source identity, lengths, and every existing suffix
+item before changing the DOM. It reads keys, descriptors, and bindings only for the new prefix,
+creates only those host rows, inserts them before the first existing row, and shifts the stored
+indexes used by delegated row events. Existing row DOM is neither recreated nor rebound.
+
+This proof requires compiler-owned host rows whose render callback and key do not read the row
+index. Index-aware rows, collection-derived keys, collection-reading bindings, React-owned or
+nested host-block rows, row conditionals, middle insertion, removal, direct replacement,
+block-bodied updaters, duplicate keys, custom, sparse, or subclassed arrays, an unrelated dirty
+dependency, or any failed runtime check keeps complete keyed reconciliation. A prepend queued
+after an unhinted update also falls back. Reports expose emitted sites as
+`keyedArrayPrependHints`; the optional runtime capability is retained only when a module emits the
+matching hint.
 
 #### Keyed array filter hints
 
@@ -1706,6 +1740,10 @@ The package and example test suites verify more than generated code:
 - 2,000 deterministic keyed-array appends match normal React; targeted tests require key,
   descriptor, and binding reads to equal only the appended suffix and cover queued updates,
   multi-boundary sharing, StrictMode hydration/unmount, and conservative fallback;
+- 2,000 deterministic keyed-array prepends match normal React; targeted tests require key,
+  descriptor, and binding reads to equal only the inserted prefix, preserve every existing DOM
+  row, update delegated event indexes, and cover queued updates, StrictMode hydration, unmount,
+  invalid metadata, custom arrays, and conservative fallback;
 - 2,000 deterministic randomized keyed-array removals match normal React; targeted tests require
   zero surviving descriptor and binding reads, preserve DOM identity, and cover queued filters,
   unhinted-chain fallback, collection-reading rows, StrictMode hydration, and unmount cleanup;
@@ -1725,7 +1763,8 @@ The package and example test suites verify more than generated code:
   inserts a row, and observes zero owner update executions;
 - the production 10,000/20,000-row benchmark requires nonzero `keyedIdentityTargets`,
   `keyedMapLookupTargets`, `keyedMembershipTargets`, `keyedCollectionUpdateHints`, and
-  `keyedMapUpdateHints`, `keyedArrayAppendHints`, and `keyedArrayFilterHints` report counts,
+  `keyedMapUpdateHints`, `keyedArrayAppendHints`, `keyedArrayPrependHints`, and
+  `keyedArrayFilterHints` report counts,
   preserves the keyed-update speedup floor, checks that scalar selection, Set membership, and Map
   lookups remain key-directed at scale, compares dense hinted Set/Map updates with equivalent
   compiled snapshot controls, and passes DOM correctness, React-relative regression, direct-delta,

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -1,12 +1,13 @@
-# Complex dashboard and 20,000-row scale result
+# Complex dashboard and 21,000-row peak result
 
 Date: 2026-08-29
 
-Result: **PASS.** Correctness, React-relative performance, keyed update, keyed append, keyed filter, scalar
-selection, Set-membership, Map-lookup, collection-delta, and normalized scalability gates all pass.
+Result: **PASS.** Correctness, React-relative performance, keyed update, keyed append, keyed prepend,
+keyed filter, scalar selection, Set-membership, Map-lookup, collection-delta, and normalized
+scalability gates all pass.
 The production run compares two bracketing React baselines with static and hybrid compiler builds
-from the exact same component source. Append, filter, and dense Set/Map operations also compare each new
-handoff with an unhinted compiled snapshot control.
+from the exact same component source. Append, prepend, filter, and dense Set/Map operations also
+compare each new handoff with an unhinted compiled snapshot control.
 
 ## Environment and method
 
@@ -15,13 +16,15 @@ handoff with an unhinted compiled snapshot control.
 - Four production builds: React baseline A, static compiler, hybrid compiler, React baseline B
 - Dashboard: 60 measured samples x 10 updates, after 5 warmup samples
 - Standard table: 10 measured samples per operation, after 5 warmup samples
-- Scale profile: 3 complete cycles peaking at 20,000 rich rows
+- Scale profile: 3 complete cycles peaking at 21,000 rich rows
 - Timing boundary: event dispatch through an asserted DOM mutation
 - Baseline values average the medians from the two bracketing React trials
 - Performance gate: more than 10% and 0.25 ms slower than the bracketed baseline
 - Keyed-update persistence gate: at least 8x faster than React at both 10,000 and 20,000 rows
 - Keyed-append persistence gate: at least 4x faster than React at both 10,000 and up to 20,000 rows,
   and at least 1.25x faster than the equivalent compiled snapshot path
+- Keyed-prepend persistence gate: at least 3x faster than React at both 10,000 and 20,000 existing
+  rows, and at least 1.25x faster than the equivalent compiled snapshot path at 10,000 rows
 - Keyed-filter persistence gate: at least 3x faster than React at both 1,000 and 20,000 rows, and
   at least 1.25x faster than the equivalent compiled snapshot path
 - Key-directed selection gate: at least 10x faster than React at 20,000 rows and no more than 2x
@@ -37,9 +40,9 @@ handoff with an unhinted compiled snapshot control.
 Every trial passed DOM assertions and browser-error checks. The compiler report proved that both
 workloads compiled, delegated keyed rows were present only in compiler builds, exactly two scalar
 key-directed bindings, two Set-membership bindings, two Map-lookup bindings, 19 Set/Map mutation
-sites, one mutation-aware keyed-map update site, one keyed-array append site, and one keyed-array
-filter site were emitted. Hybrid/static added zero owner executions. The two React baselines added
-1,430 dashboard and 492 table owner executions each.
+sites, one mutation-aware keyed-map update site, one keyed-array append site, one keyed-array
+prepend site, and one keyed-array filter site were emitted. Hybrid/static added zero owner
+executions. The two React baselines added 1,430 dashboard and 558 table owner executions each.
 
 ## Complex dashboard
 
@@ -48,50 +51,60 @@ bindings.
 
 | Interaction                 | React median | Hybrid median | Hybrid vs React |
 | --------------------------- | -----------: | ------------: | --------------: |
-| Active live pulse           |      0.10 ms |       0.08 ms |    1.25x faster |
-| Inactive branch update      |     0.065 ms |       0.02 ms |    3.25x faster |
+| Active live pulse           |      0.10 ms |       0.10 ms |          parity |
+| Inactive branch update      |     0.075 ms |       0.02 ms |    3.75x faster |
 | Switch live/snapshot branch |     0.100 ms |      0.100 ms |          parity |
 
 ## Standard table operations
 
 | Operation               |             Rows | React median | Hybrid median | Hybrid vs React |
 | ----------------------- | ---------------: | -----------: | ------------: | --------------: |
-| Create                  |            1,000 |     12.25 ms |      11.20 ms |    1.09x faster |
-| Replace all             |            1,000 |     16.60 ms |      11.80 ms |    1.41x faster |
-| Create many             |           10,000 |    286.20 ms |     128.00 ms |    2.24x faster |
-| Append                  | 10,000 -> 11,000 |     71.25 ms |      13.90 ms |    5.13x faster |
-| Append snapshot control | 10,000 -> 11,000 |     68.60 ms |      28.20 ms |    2.43x faster |
-| Update every 10th       |           10,000 |     42.15 ms |       2.70 ms |   15.61x faster |
-| Select                  |            1,000 |      3.65 ms |       0.10 ms |   36.50x faster |
-| Mark two rows           |            1,000 |      3.70 ms |       0.10 ms |   37.00x faster |
-| Queue two rows          |            1,000 |      3.70 ms |       0.00 ms | near timer floor |
-| Dense Set delta         |            1,000 |      3.65 ms |       0.10 ms |   36.50x faster |
-| Dense Map delta         |            1,000 |      3.75 ms |       0.10 ms |   37.50x faster |
-| Swap rows 2 / 999       |            1,000 |      8.00 ms |       1.20 ms |    6.67x faster |
-| Remove one row          |            1,000 |      4.10 ms |       0.70 ms |    5.86x faster |
-| Remove snapshot control |            1,000 |      4.30 ms |       1.40 ms |    3.07x faster |
-| Clear                   |           10,000 |     46.60 ms |       9.30 ms |    5.01x faster |
+| Create                   |            1,000 |     12.60 ms |      10.80 ms |    1.17x faster |
+| Replace all              |            1,000 |     16.20 ms |      11.50 ms |    1.41x faster |
+| Create many              |           10,000 |    297.70 ms |     124.20 ms |    2.40x faster |
+| Append                   | 10,000 -> 11,000 |     69.45 ms |      13.20 ms |    5.26x faster |
+| Append snapshot control  | 10,000 -> 11,000 |     69.10 ms |      27.10 ms |    2.55x faster |
+| Prepend                  | 10,000 -> 11,000 |     70.75 ms |      15.40 ms |    4.59x faster |
+| Prepend snapshot control | 10,000 -> 11,000 |     71.60 ms |      29.00 ms |    2.47x faster |
+| Update every 10th        |           10,000 |     41.80 ms |       3.10 ms |   13.48x faster |
+| Select                   |            1,000 |      3.50 ms |       0.10 ms |   35.00x faster |
+| Mark two rows            |            1,000 |      3.45 ms |       0.00 ms | near timer floor |
+| Queue two rows           |            1,000 |      3.85 ms |       0.10 ms |   38.50x faster |
+| Dense Set delta          |            1,000 |      3.70 ms |       0.10 ms |   37.00x faster |
+| Dense Map delta          |            1,000 |      3.70 ms |       0.20 ms |   18.50x faster |
+| Swap rows 2 / 999        |            1,000 |      7.10 ms |       1.30 ms |    5.46x faster |
+| Remove one row           |            1,000 |      4.05 ms |       0.90 ms |    4.50x faster |
+| Remove snapshot control  |            1,000 |      4.05 ms |       1.60 ms |    2.53x faster |
+| Clear                    |           10,000 |     48.65 ms |      11.20 ms |    4.34x faster |
 
 `Append` is the new keyed-array suffix path. The application still allocates the next array and
 creates 1,000 required DOM rows, but the generated hint lets Farm skip all 10,000 existing keys and
-bindings. Hybrid measured `13.90 ms`, **5.13x faster than React** and **2.03x faster than the
-equivalent `28.20 ms` compiled snapshot control**. Repeated batches through 20,000 rows remained
-6.83x faster than React. The gate requires at least 4x versus React and 1.25x versus the control in
+bindings. Hybrid measured `13.20 ms`, **5.26x faster than React** and **2.05x faster than the
+equivalent `27.10 ms` compiled snapshot control**. Repeated batches through 20,000 rows remained
+6.30x faster than React. The gate requires at least 4x versus React and 1.25x versus the control in
 both compiler modes.
+
+`Prepend` is the corresponding keyed-array prefix path. The application still allocates the next
+array and creates and inserts 1,000 required DOM rows. The generated hint proves that the existing
+10,000 items form an unchanged suffix, so Farm evaluates only the new prefix and updates stored
+event indexes without rebuilding old descriptors or bindings. Hybrid measured `15.40 ms`,
+**4.59x faster than React** and **1.88x faster than the equivalent `29.00 ms` compiled snapshot
+control**. With 20,000 existing rows it measured `20.20 ms`, **6.60x faster than React**. Static
+mode measured 5.02x and 7.80x versus React, so both modes clear the 3x persistence floor.
 
 `Update every 10th` is the targeted mutation-aware path. The application still executes its native
 immutable `map()` over 10,000 items and creates 1,000 replacement objects. The generated hint lets
 the keyed runtime validate and patch those 1,000 rows without a second scan of all 10,000 keys and
-bindings. The 8x persistence floor leaves substantial headroom below this run's 11.12x-15.61x
+bindings. The 8x persistence floor leaves substantial headroom below this run's 13.48x-17.03x
 result across compiler modes and row counts while still rejecting a silent return to the older
 roughly 5x full-reconciliation path.
 
 `Remove one row` is the keyed-array filter path. The application still executes native `filter()`
 over the collection. The generated hint carries removed positions into the keyed runtime, which
 validates surviving identities and keys, removes only rejected DOM rows, and skips descriptor and
-binding reads for every survivor. Hybrid measured `0.70 ms`, **5.86x faster than React** and
-**2.00x faster than the equivalent `1.40 ms` compiled snapshot control**. At 20,000 rows it
-measured `13.70 ms`, **9.09x faster than React**. The gate requires at least 3x versus React and
+binding reads for every survivor. Hybrid measured `0.90 ms`, **4.50x faster than React** and
+**1.78x faster than the equivalent `1.60 ms` compiled snapshot control**. At 20,000 rows it
+measured `16.10 ms`, **6.92x faster than React**. The gate requires at least 3x versus React and
 1.25x versus the compiled control in both compiler modes.
 
 `Select` is the key-directed path added by this result. When a primitive state value is compared
@@ -116,55 +129,58 @@ primitive entries and immutably clone the collection, so the application's requi
 `new Map()` work remains in both paths. A proven updater records only the native mutation keys that
 actually execute. The runtime validates those keys and extends a bounded persistent snapshot,
 instead of iterating every previous and next entry again. At 20,000 entries, the Set delta measured
-`0.30 ms` versus `2.10 ms` for the equivalent compiled snapshot control (**7.00x faster**); the Map
-delta measured `0.90 ms` versus `4.70 ms` (**5.22x faster**) in hybrid mode. These direct
+`0.30 ms` versus `2.30 ms` for the equivalent compiled snapshot control (**7.67x faster**); the Map
+delta measured `1.10 ms` versus `5.20 ms` (**4.73x faster**) in hybrid mode. These direct
 compiler-to-compiler comparisons are the evidence for this PR's incremental win.
 
-## Repeated 20,000-row scale profile
+## Repeated 21,000-row scale profile
 
-Each of the three cycles creates 10,000 rows, appends ten 1,000-row batches to 20,000, updates
-2,000 rows, performs two distant selections, replaces two marked Set members and two mapped queue
-values, swaps rows, removes a middle row, and clears. Lower time is better.
+Each of the three cycles creates 10,000 rows, appends ten 1,000-row batches to 20,000, prepends
+1,000 rows, restores the 20,000-row working set, updates 2,000 rows, performs two distant
+selections, replaces two marked Set members and two mapped queue values, swaps rows, removes a
+middle row, and clears. Lower time is better.
 
 | Operation at scale       | React median | React p95 | Hybrid median | Hybrid p95 | Speedup |
 | ------------------------ | -----------: | --------: | ------------: | ---------: | ------: |
-| Create initial 10,000    |    315.35 ms | 352.00 ms |     109.10 ms |  129.30 ms |    2.89x |
-| Append a 1,000-row batch |     90.90 ms | 115.80 ms |      13.30 ms |   20.20 ms |    6.83x |
-| Update every 10th at 20k |    112.30 ms | 114.20 ms |      10.10 ms |   19.00 ms |   11.12x |
-| Select at 20k            |     98.60 ms | 132.15 ms |       3.60 ms |    4.60 ms |   27.39x |
-| Mark two rows at 20k     |    108.10 ms | 125.60 ms |       0.20 ms |    0.20 ms |  540.50x |
-| Queue two rows at 20k    |     98.35 ms | 104.55 ms |       0.20 ms |    0.30 ms |  491.75x |
-| Dense Set delta at 20k   |    102.45 ms | 175.80 ms |       0.30 ms |    0.30 ms |  341.50x |
-| Dense Set snapshot       |    108.90 ms | 138.60 ms |       2.10 ms |    2.30 ms |   51.86x |
-| Dense Map delta at 20k   |    103.80 ms | 111.60 ms |       0.90 ms |    1.00 ms |  115.33x |
-| Dense Map snapshot       |    109.65 ms | 115.35 ms |       4.70 ms |    4.70 ms |   23.33x |
-| Swap at 20k              |    125.30 ms | 128.10 ms |      32.20 ms |   37.20 ms |    3.89x |
-| Remove middle row at 20k |    124.55 ms | 141.55 ms |      13.70 ms |   16.10 ms |    9.09x |
-| Clear 20k                |    160.20 ms | 193.60 ms |      20.70 ms |   20.70 ms |    7.74x |
+| Create initial 10,000    |    321.95 ms | 353.35 ms |     134.10 ms |  139.70 ms |    2.40x |
+| Append a 1,000-row batch |     90.70 ms | 117.10 ms |      14.40 ms |   20.60 ms |    6.30x |
+| Prepend 1,000 at 20k     |    133.40 ms | 142.45 ms |      20.20 ms |   22.30 ms |    6.60x |
+| Update every 10th at 20k |    112.40 ms | 142.20 ms |       7.70 ms |    8.30 ms |   14.60x |
+| Select at 20k            |    101.00 ms | 137.85 ms |       4.90 ms |    7.60 ms |   20.61x |
+| Mark two rows at 20k     |    103.65 ms | 106.25 ms |       0.20 ms |    0.20 ms |  518.25x |
+| Queue two rows at 20k    |    111.75 ms | 135.50 ms |       0.20 ms |    0.20 ms |  558.75x |
+| Dense Set delta at 20k   |    106.55 ms | 141.60 ms |       0.30 ms |    0.30 ms |  355.17x |
+| Dense Set snapshot       |    101.10 ms | 119.00 ms |       2.30 ms |    2.30 ms |   43.96x |
+| Dense Map delta at 20k   |    105.65 ms | 113.50 ms |       1.10 ms |    1.10 ms |   96.05x |
+| Dense Map snapshot       |    109.75 ms | 141.80 ms |       5.20 ms |    5.30 ms |   21.11x |
+| Swap at 20k              |    114.15 ms | 139.20 ms |      35.60 ms |   36.00 ms |    3.21x |
+| Remove middle row at 20k |    111.35 ms | 127.55 ms |      16.10 ms |   17.80 ms |    6.92x |
+| Clear 20k                |    176.05 ms | 224.55 ms |      23.40 ms |   24.20 ms |    7.52x |
 
 ## Scalability gate
 
 The gate divides observed timing growth by row-count growth. A value near 1 means linear scaling;
 2 is the failure threshold. All measured paths pass.
 
-| Path               | Row growth | Timing growth | Normalized growth |
-| ------------------ | ---------: | ------------: | ----------------: |
-| Create 10k repeat    |      1.00x |         0.85x |             0.85x |
-| Update 10k -> 20k    |      2.00x |         3.74x |             1.87x |
-| Select 1k -> 20k     |     20.00x |        14.40x |             0.72x |
+| Path                 | Row growth | Timing growth | Normalized growth |
+| -------------------- | ---------: | ------------: | ----------------: |
+| Create 10k repeat    |      1.00x |         1.08x |             1.08x |
+| Prepend 10k -> 20k   |      2.00x |         1.31x |             0.66x |
+| Update 10k -> 20k    |      2.00x |         2.48x |             1.24x |
+| Select 1k -> 20k     |     20.00x |        19.60x |             0.98x |
 | Mark Set 1k -> 20k   |     20.00x |         0.80x |             0.04x |
 | Read Map 1k -> 20k   |     20.00x |         0.80x |             0.04x |
 | Dense Set delta      |     20.00x |         1.20x |             0.06x |
-| Dense Map delta      |     20.00x |         3.60x |             0.18x |
-| Dense Set snapshot   |     20.00x |         8.40x |             0.42x |
-| Dense Map snapshot   |     20.00x |        15.67x |             0.78x |
-| Swap 1k -> 20k       |     20.00x |        26.83x |             1.34x |
-| Remove 1k -> 20k     |     20.00x |        19.57x |             0.98x |
-| Clear 10k -> 20k     |      2.00x |         2.23x |             1.11x |
+| Dense Map delta      |     20.00x |         4.40x |             0.22x |
+| Dense Set snapshot   |     20.00x |         9.20x |             0.46x |
+| Dense Map snapshot   |     20.00x |        17.33x |             0.87x |
+| Swap 1k -> 20k       |     20.00x |        27.38x |             1.37x |
+| Remove 1k -> 20k     |     20.00x |        17.89x |             0.89x |
+| Clear 10k -> 20k     |      2.00x |         2.09x |             1.04x |
 
 This demonstrates approximately linear rather than quadratic end-to-end growth. Key-directed
 scalar selection performs constant row-binding work—at most the previous and next keyed
-instances—while its complete event-to-DOM timing remains 27.39x faster than React at 20,000 rows.
+instances—while its complete event-to-DOM timing remains 20.61x faster than React at 20,000 rows.
 Set membership and Map lookup evaluate bindings only for changed keys. Their 0.10-0.20 ms medians
 are near browser timer resolution, so deterministic exact-read gates remain the primary complexity
 evidence. The dense delta-versus-snapshot controls remain above that floor and independently prove
@@ -175,28 +191,29 @@ keys and maintaining row indices.
 
 | Build           | Page chunk raw | Page chunk gzip |
 | --------------- | -------------: | --------------: |
-| React baseline  |       22,138 B |         5,043 B |
-| Static compiler |       91,774 B |        19,298 B |
-| Hybrid compiler |       91,774 B |        19,296 B |
+| React baseline  |       22,710 B |         5,117 B |
+| Static compiler |       94,700 B |        19,687 B |
+| Hybrid compiler |       94,700 B |        19,686 B |
 
-This deliberately broad page now pays a 14,253-byte hybrid gzip premium for the compiler runtime,
-including keyed append, mutation-aware map, scalar key-directed, Set-membership, Map-lookup, and
-collection-delta and keyed-filter paths. Smaller
+This deliberately broad page now pays a 14,569-byte hybrid gzip premium for the compiler runtime,
+including keyed append and prepend, mutation-aware map, scalar key-directed, Set-membership,
+Map-lookup, collection-delta, and keyed-filter paths. Smaller
 direct-only applications retain less of the runtime; the package-level fixtures and persisted size
 gate are documented in `packages/farm-react/RUNTIME_SIZE_RESULTS.md`.
 
 ## Conclusion
 
-The compiled path scales successfully through the tested 20,000-row mixed workload: all DOM and
-event assertions pass, there are no browser errors or owner rerenders, every scale operation beats
-the bracketed React baseline, and normalized growth stays at or below 1.87x for the measured
+The compiled path scales successfully through the tested 21,000-row peak mixed workload: all DOM
+and event assertions pass, there are no browser errors or owner rerenders, every scale operation
+beats the bracketed React baseline, and normalized growth stays at or below 1.37x for the measured
 workload. Scalar selection performs at most two row-binding reads, while Set membership and Map
 lookup evaluate only changed keys that map to rows. For dense collections, producer deltas were
-7.00x faster for Set and 5.22x faster for Map than equivalent compiled snapshot scans. Keyed append
-was 2.03x faster than its compiled snapshot control and 6.83x faster than React while scaling to
-20,000 rows. Keyed filter was 2.00x faster than its compiled snapshot control at 1,000 rows and
-9.09x faster than React at 20,000 rows. The evidence claims only measured end-to-end behavior within this range—not unlimited
-constant-time browser work.
+7.67x faster for Set and 4.73x faster for Map than equivalent compiled snapshot scans. Keyed append
+was 2.05x faster than its compiled snapshot control and 6.30x faster than React while scaling to
+20,000 rows. Keyed prepend was 1.88x faster than its compiled snapshot control and 6.60x faster
+than React with 20,000 existing rows. Keyed filter was 1.78x faster than its compiled snapshot
+control at 1,000 rows and 6.92x faster than React at 20,000 rows. The evidence claims only measured
+end-to-end behavior within this range—not unlimited constant-time browser work.
 
 The machine-readable output is `/tmp/farm-react-dashboard-benchmark.json`. Re-run
 `pnpm --filter farm-react-compiler-dashboard-example benchmark` to reproduce it.

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -5,7 +5,8 @@ update path in a realistic dashboard and a standard keyed-table workload.
 
 The table operation set is adapted from
 [`js-framework-benchmark`](https://github.com/krausest/js-framework-benchmark): create and replace
-1,000 rows, create 10,000, append 1,000, update every 10th row, select, swap, remove, and clear.
+1,000 rows, create 10,000, append or prepend 1,000, update every 10th row, select, swap, remove, and
+clear.
 
 The page contains two independently measured components:
 
@@ -13,12 +14,14 @@ The page contains two independently measured components:
   branch-sensitive chart bindings. Its inactive-branch action distinguishes static scheduling from
   default hybrid scheduling without changing the visible chart.
 - `StandardTableBenchmark`: the common 1,000/10,000-row create, replace, append, update-every-10th,
-  select, swap, remove, and clear operations used by browser framework benchmarks.
+  select, swap, remove, and clear operations used by browser framework benchmarks, plus an
+  equivalent 1,000-row prepend case.
 
 After the standard operation set, the production runner also performs three mixed scale cycles.
-Each cycle creates 10,000 rows, appends to 20,000, updates every 10th row, selects two distant rows,
-swaps, removes a middle row, and clears the table. A normalized-growth gate fails if the compiled
-paths grow more than 2x beyond the expected row-count growth, guarding against quadratic drift.
+Each cycle creates 10,000 rows, appends to 20,000, prepends 1,000 rows, restores the 20,000-row
+working set, updates every 10th row, selects two distant rows, swaps, removes a middle row, and
+clears the table. A normalized-growth gate fails if the compiled paths grow more than 2x beyond the
+expected row-count growth, guarding against quadratic drift.
 The calculation floors sub-millisecond reference timings at 0.25 ms to avoid browser timer
 quantization turning a one-tick difference into a false scalability failure.
 
@@ -71,6 +74,13 @@ modes must remain at least 4x faster than React at 10,000 and up to 20,000 rows,
 faster than the compiled control. The report must contain a nonzero `keyedArrayAppendHints` count;
 deterministic package tests separately require work to equal only the appended suffix.
 
+Keyed array prepends have the same independent comparison. A concise functional prepend is
+measured against bracketed React and an equivalent block-bodied compiled snapshot control. Both
+compiler modes must remain at least 3x faster than React at 10,000 and 20,000 existing rows, and at
+least 1.25x faster than the compiled control at 10,000 rows. The report must contain a nonzero
+`keyedArrayPrependHints` count; deterministic package tests separately require key, descriptor, and
+binding work to equal only the new prefix while preserving every existing DOM row.
+
 Set membership has a separate operation and persistence gate. The table alternates two marked row
 keys with `markedIds.has(row.id)` at 1,000 and 20,000 rows. Both compiler modes must remain at least
 10x faster than React at 20,000 rows, normalized growth may not exceed 2x, and the compiler report
@@ -122,6 +132,8 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
   complete entry scan.
 - The append snapshot control creates the same 1,000 array items and DOM rows but intentionally uses
   an unsupported block-bodied updater, isolating the saved full key-and-binding scan.
+- The prepend snapshot control does the same work at the beginning of the array. It isolates the
+  saved suffix scan while the hinted path still creates and inserts every required new DOM row.
 - This is an operation-compatible local benchmark, not an official `js-framework-benchmark`
   submission or a score comparable to its published result table. This app has richer rows and
   measures event dispatch through an asserted DOM result without CPU throttling.

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -139,6 +139,10 @@ async function inspectBuild(compilerMode) {
       "The compiler build did not emit a keyed-array filter hint.",
     );
     assert(
+      compilerReport.summary.keyedArrayPrependHints > 0,
+      "The compiler build did not emit a keyed-array prepend hint.",
+    );
+    assert(
       compilerReport.summary.keyedCollectionUpdateHints > 0,
       "The compiler build did not emit a keyed Set/Map collection-delta hint.",
     );
@@ -474,6 +478,36 @@ async function measureTrial(browser, trial, compilerMode, port) {
           },
         );
 
+        const tablePrepend = await measureTable(
+          async () => ensure10000(),
+          async () => {
+            const previousFirstRow = table.querySelector("tbody tr");
+            const previousFirst = previousFirstRow?.getAttribute("data-row-id");
+            await runTableAction(
+              () => tableButton("table-prepend").click(),
+              () =>
+                rowCount() === 11_000 &&
+                table.querySelector("tbody tr")?.getAttribute("data-row-id") !== previousFirst &&
+                table.querySelectorAll("tbody tr")[1_000] === previousFirstRow,
+            );
+          },
+        );
+
+        const tablePrependSnapshot = await measureTable(
+          async () => ensure10000(),
+          async () => {
+            const previousFirstRow = table.querySelector("tbody tr");
+            const previousFirst = previousFirstRow?.getAttribute("data-row-id");
+            await runTableAction(
+              () => tableButton("table-prepend-snapshot").click(),
+              () =>
+                rowCount() === 11_000 &&
+                table.querySelector("tbody tr")?.getAttribute("data-row-id") !== previousFirst &&
+                table.querySelectorAll("tbody tr")[1_000] === previousFirstRow,
+            );
+          },
+        );
+
         const tableUpdate = await measureTable(
           async () => ensure10000(),
           async () => {
@@ -658,6 +692,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
           denseMembership20k: [],
           mapLookup20k: [],
           membership20k: [],
+          prependAt20k: [],
           remove20k: [],
           select20k: [],
           snapshotMapLookup20k: [],
@@ -681,6 +716,23 @@ async function measureTrial(browser, trial, compilerMode, port) {
             scale.appendTo20k.push(performance.now() - appendStartedAt);
             peakRows = Math.max(peakRows, rowCount());
           }
+
+          const previousFirstRow = table.querySelector("tbody tr");
+          const previousFirst = previousFirstRow?.getAttribute("data-row-id");
+          const prependStartedAt = performance.now();
+          await runTableAction(
+            () => tableButton("table-prepend").click(),
+            () =>
+              rowCount() === 21_000 &&
+              table.querySelector("tbody tr")?.getAttribute("data-row-id") !== previousFirst &&
+              table.querySelectorAll("tbody tr")[1_000] === previousFirstRow,
+          );
+          scale.prependAt20k.push(performance.now() - prependStartedAt);
+          peakRows = Math.max(peakRows, rowCount());
+          await runTableAction(
+            () => tableButton("table-drop-prefix").click(),
+            () => rowCount() === 20_000,
+          );
 
           const firstLabel = table.querySelector("tbody tr td:nth-child(2)")?.textContent || "";
           const updateStartedAt = performance.now();
@@ -825,6 +877,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             executionsAdded: Number(tableExecutions.textContent) - initialTableExecutions,
             mapLookup: tableMapLookup,
             membership: tableMembership,
+            prepend: tablePrepend,
+            prependSnapshot: tablePrependSnapshot,
             remove: tableRemove,
             removeSnapshot: tableRemoveSnapshot,
             replace: tableReplace,
@@ -851,7 +905,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
     assert.equal(result.correctness.finalMarkedCount, 0);
     assert.equal(result.correctness.finalQueueCount, 0);
     assert.equal(result.correctness.finalTableRows, 0);
-    assert.equal(result.correctness.scalePeakRows, 20_000);
+    assert.equal(result.correctness.scalePeakRows, 21_000);
     assert.equal(browserErrors.length, 0, browserErrors.join("\n"));
     if (compilerEnabled) {
       assert.equal(result.dashboard.executionsAdded, 0);
@@ -885,6 +939,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
         denseMembership20k: timingSummary(result.scale.denseMembership20k),
         mapLookup20k: timingSummary(result.scale.mapLookup20k),
         membership20k: timingSummary(result.scale.membership20k),
+        prependAt20k: timingSummary(result.scale.prependAt20k),
         remove20k: timingSummary(result.scale.remove20k),
         select20k: timingSummary(result.scale.select20k),
         snapshotMapLookup20k: timingSummary(result.scale.snapshotMapLookup20k),
@@ -903,6 +958,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
         executionsAdded: result.table.executionsAdded,
         mapLookup: timingSummary(result.table.mapLookup),
         membership: timingSummary(result.table.membership),
+        prepend: timingSummary(result.table.prepend),
+        prependSnapshot: timingSummary(result.table.prependSnapshot),
         remove: timingSummary(result.table.remove),
         removeSnapshot: timingSummary(result.table.removeSnapshot),
         replace: timingSummary(result.table.replace),
@@ -979,6 +1036,8 @@ const tableMetrics = [
   "createMany",
   "append",
   "appendSnapshot",
+  "prepend",
+  "prependSnapshot",
   "updateEvery10th",
   "select",
   "membership",
@@ -995,6 +1054,7 @@ const tableMetrics = [
 const scaleMetrics = [
   "create10k",
   "appendTo20k",
+  "prependAt20k",
   "updateEvery10th20k",
   "select20k",
   "membership20k",
@@ -1032,6 +1092,7 @@ const scalabilityThresholdNormalizedGrowth = 2;
 const timingResolutionFloorMs = 0.25;
 const scalabilityCases = [
   ["create10k", "createMany", 1],
+  ["prependAt20k", "prepend", 2],
   ["updateEvery10th20k", "updateEvery10th", 2],
   ["select20k", "select", 20],
   ["membership20k", "membership", 20],
@@ -1132,6 +1193,32 @@ const keyedAppendRegressions = keyedAppendResults.filter(
     scaleSpeedup < keyedAppendMinimumSpeedup ||
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedAppendMinimumSnapshotSpeedup,
+);
+// A compiler-proven prepend creates only the new prefix while preserving the existing keyed DOM
+// suffix. Compare it with React and an equivalent block-bodied compiled snapshot path, and keep a
+// separate 20,000-row floor so the optimization cannot silently collapse into a full row refresh.
+const keyedPrependMinimumSpeedup = 3;
+const keyedPrependMinimumSnapshotSpeedup = 1.25;
+const keyedPrependResults = ["static", "hybrid"].map((mode) => {
+  const prependMedianMs = comparisons.table.prepend[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.prependSnapshot[mode].medianMs;
+  return {
+    mode,
+    prependMedianMs,
+    scaleSpeedup: comparisons.scale.prependAt20k[`${mode}VsBaseline`].speedup,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / prependMedianMs,
+    speedup: comparisons.table.prepend[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedPrependRegressions = keyedPrependResults.filter(
+  ({ scaleSpeedup, snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedPrependMinimumSpeedup ||
+    !Number.isFinite(scaleSpeedup) ||
+    scaleSpeedup < keyedPrependMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedPrependMinimumSnapshotSpeedup,
 );
 // A concise native filter carries removal positions into the keyed-row runtime. Compare it with
 // React and an equivalent block-bodied compiled update that intentionally takes complete keyed
@@ -1278,6 +1365,7 @@ const passed =
   scalabilityRegressions.length === 0 &&
   keyedUpdateRegressions.length === 0 &&
   keyedAppendRegressions.length === 0 &&
+  keyedPrependRegressions.length === 0 &&
   keyedFilterRegressions.length === 0 &&
   keyedIdentityRegressions.length === 0 &&
   keyedMembershipRegressions.length === 0 &&
@@ -1305,6 +1393,13 @@ const report = {
     regressions: keyedAppendRegressions,
     results: keyedAppendResults,
     status: keyedAppendRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedPrependHintGate: {
+    minimumSnapshotSpeedup: keyedPrependMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedPrependMinimumSpeedup,
+    regressions: keyedPrependRegressions,
+    results: keyedPrependResults,
+    status: keyedPrependRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedFilterHintGate: {
     minimumSnapshotSpeedup: keyedFilterMinimumSnapshotSpeedup,
@@ -1357,8 +1452,8 @@ const report = {
     metric: "DOM event dispatch through asserted DOM mutation",
     standardReference: "https://github.com/krausest/js-framework-benchmark",
     scaleCycles,
-    scalePeakRows: 20_000,
-    tableRows: [1_000, 10_000, 11_000],
+    scalePeakRows: 21_000,
+    tableRows: [1_000, 10_000, 11_000, 20_000, 21_000],
     tableSamplesPerTrial: tableSamples,
     warmupSamples,
   },

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -158,6 +158,47 @@ export function StandardTableBenchmark() {
           Append 1,000 (snapshot control)
         </button>
         <button
+          data-action="table-prepend"
+          type="button"
+          onClick={() => {
+            const nextSeed = seed + 1;
+            const additions = buildRows(1_000, nextSeed);
+            setSeed(nextSeed);
+            setRows((current) => [...additions, ...current]);
+            setOperation("prepend 1,000");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Prepend 1,000
+        </button>
+        <button
+          data-action="table-prepend-snapshot"
+          type="button"
+          onClick={() => {
+            const nextSeed = seed + 1;
+            setSeed(nextSeed);
+            setRows((current) => {
+              const additions = buildRows(1_000, nextSeed);
+              return [...additions, ...current];
+            });
+            setOperation("prepend 1,000 (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Prepend 1,000 (snapshot control)
+        </button>
+        <button
+          data-action="table-drop-prefix"
+          type="button"
+          onClick={() => {
+            setRows((current) => current.slice(1_000));
+            setOperation("drop benchmark prefix");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Drop benchmark prefix
+        </button>
+        <button
           data-action="table-replace"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -244,11 +244,25 @@ setItems((current) => [...current, ...nextItems]);
 Because every existing item keeps its key and index, Farm validates the committed source and the
 queued append chain, reads keys and descriptors only for the appended suffix, and mounts that
 suffix in one fragment. Existing row DOM is left untouched. The concise functional updater and
-native arrays are required; prepend, middle insertion, removal, direct replacement, duplicate
+native arrays are required; middle insertion, removal, direct replacement, duplicate
 keys, rows that read the collection itself, and failed runtime checks use complete keyed
 reconciliation. A key that reads the collection prevents hint emission entirely. The compiler
 report exposes the emitted-site count as
 `keyedArrayAppendHints`.
+
+The mirror-image prepend form is supported when the keyed row and key do not read the row index:
+
+```tsx
+setItems((current) => [nextItem, ...current]);
+setItems((current) => [...nextItems, ...current]);
+```
+
+Farm validates the committed source and queued prepend chain, creates only the new prefix, inserts
+it before the first existing row, and shifts the stored indexes used by delegated row events.
+Existing row DOM and bindings stay in place. Index-aware rows, collection-reading bindings or
+keys, React-owned row structures, middle insertion, direct replacement, duplicate keys, custom or
+sparse arrays, and failed validation use complete keyed reconciliation. The compiler report
+exposes the emitted-site count as `keyedArrayPrependHints`.
 
 Concise immutable filters on a direct keyed array can carry removal positions into the same
 optional runtime:
@@ -549,7 +563,8 @@ reasons aggregated by count. Its summary and per-module `optimizations` also rep
 `keyedCollectionUpdateHints`, the number of compiler-proven native Set/Map mutation sites; and
 `keyedMapUpdateHints`, the number of compiler-proven direct keyed `map()` update sites; and
 `keyedArrayAppendHints`, the number of compiler-proven direct keyed-array append sites; and
-`keyedArrayFilterHints`, the number of compiler-proven direct keyed-array filter sites. A custom
+`keyedArrayFilterHints`, the number of compiler-proven direct keyed-array filter sites; and
+`keyedArrayPrependHints`, the number of compiler-proven direct keyed-array prepend sites. A custom
 project-relative `reportFile` also enables reporting.
 
 The runtime test compares the same counter interaction on both paths: ordinary React performs a

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -26,14 +26,14 @@
         "brotli": 51897
       },
       "compilerOn": {
-        "raw": 231209,
-        "gzip": 71221,
-        "brotli": 60994
+        "raw": 231491,
+        "gzip": 71259,
+        "brotli": 61038
       },
       "compilerPremium": {
-        "raw": 38090,
-        "gzip": 11042,
-        "brotli": 9097
+        "raw": 38372,
+        "gzip": 11080,
+        "brotli": 9141
       }
     },
     "keyedAppend": {
@@ -43,14 +43,14 @@
         "brotli": 51772
       },
       "compilerOn": {
-        "raw": 232474,
-        "gzip": 71532,
-        "brotli": 61342
+        "raw": 232766,
+        "gzip": 71576,
+        "brotli": 61365
       },
       "compilerPremium": {
-        "raw": 39573,
-        "gzip": 11447,
-        "brotli": 9570
+        "raw": 39865,
+        "gzip": 11491,
+        "brotli": 9593
       }
     },
     "keyedFilter": {
@@ -60,14 +60,31 @@
         "brotli": 51833
       },
       "compilerOn": {
-        "raw": 234091,
-        "gzip": 71978,
-        "brotli": 61697
+        "raw": 234383,
+        "gzip": 72021,
+        "brotli": 61687
       },
       "compilerPremium": {
-        "raw": 41211,
-        "gzip": 11890,
-        "brotli": 9864
+        "raw": 41503,
+        "gzip": 11933,
+        "brotli": 9854
+      }
+    },
+    "keyedPrepend": {
+      "compilerOff": {
+        "raw": 192902,
+        "gzip": 60087,
+        "brotli": 51826
+      },
+      "compilerOn": {
+        "raw": 234316,
+        "gzip": 71984,
+        "brotli": 61665
+      },
+      "compilerPremium": {
+        "raw": 41414,
+        "gzip": 11897,
+        "brotli": 9839
       }
     },
     "isolatedRuntime": {
@@ -77,18 +94,18 @@
         "brotli": 51666
       },
       "full": {
-        "raw": 271299,
-        "gzip": 77240,
-        "brotli": 66527
+        "raw": 273099,
+        "gzip": 77561,
+        "brotli": 66731
       },
       "coreOnly": {
         "raw": 204922,
         "gzip": 63685,
         "brotli": 54902
       },
-      "fullRuntimePremiumGzip": 17321,
+      "fullRuntimePremiumGzip": 17642,
       "coreRuntimePremiumGzip": 3766,
-      "gzipReductionPercent": 78.3
+      "gzipReductionPercent": 78.7
     }
   }
 }

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.md
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.md
@@ -24,21 +24,23 @@ is enforced on every pull request instead of serving only as a manually recorded
 | Fixture                                           | Compiler off gzip | Compiler on gzip | Compiler premium |
 | ------------------------------------------------- | ----------------: | ---------------: | ---------------: |
 | Direct text, attribute, style, and event bindings |          60,043 B |         63,721 B |          3,678 B |
-| Keyed rows, LIS, scalar, Set, and Map targeting   |          60,179 B |         71,221 B |         11,042 B |
-| Keyed rows with append hints                      |          60,085 B |         71,532 B |         11,447 B |
-| Keyed rows with filter hints                      |          60,088 B |         71,978 B |         11,890 B |
+| Keyed rows, LIS, scalar, Set, and Map targeting   |          60,179 B |         71,259 B |         11,080 B |
+| Keyed rows with append hints                      |          60,085 B |         71,576 B |         11,491 B |
+| Keyed rows with prepend hints                     |          60,087 B |         71,984 B |         11,897 B |
+| Keyed rows with filter hints                      |          60,088 B |         72,021 B |         11,933 B |
 
-The isolated compatibility runtime contributes 17,321 B gzip over the React control. The
-compiler-selected core contributes 3,766 B, a **78.3% reduction**. This comparison uses the same
+The isolated compatibility runtime contributes 17,642 B gzip over the React control. The
+compiler-selected core contributes 3,766 B, a **78.7% reduction**. This comparison uses the same
 hand-authored compiled definition and changes only the runtime entry used to create it.
 
 The keyed fixture retains `FarmCompiledKeyedRows` plus compiler-emitted `identityTarget`,
 `membershipTarget`, and `mapLookupTarget` metadata, plus Set/Map producer-delta helpers. It rejects
-the optional row-conditional and keyed-update runtimes. Separate append and filter fixtures prove
-that recognized functional updates retain the matching hinted runtime. Filter support is selected
-only for modules with an emitted filter hint. The direct compiler premium and isolated core runtime
-remain byte-for-byte unchanged; the append fixture adds only 63 B gzip over its previous persisted
-result. The direct fixture rejects every structural runtime marker. The checked
+the optional row-conditional and keyed-update runtimes. Separate append, prepend, and filter
+fixtures prove that recognized functional updates retain only the matching hinted runtime. The
+direct compiler premium and isolated core runtime remain byte-for-byte unchanged. The new prepend
+fixture pays an 817 B gzip premium over the ordinary keyed fixture while keeping prepend code out
+of direct, ordinary keyed, append-only, and filter-only bundles. The direct fixture rejects every
+structural runtime marker. The checked
 machine-readable result is [`RUNTIME_SIZE_RESULTS.json`](./RUNTIME_SIZE_RESULTS.json).
 
 ## Existing production benchmark audit

--- a/packages/farm-react/fixtures/runtime-size/keyed-prepend.tsx
+++ b/packages/farm-react/fixtures/runtime-size/keyed-prepend.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from "react";
+import { createRoot } from "react-dom/client";
+
+interface Row {
+  id: number;
+  label: string;
+}
+
+export function PrependTable() {
+  const [rows, setRows] = useState<Row[]>(
+    Array.from({ length: 1_000 }, (_, id) => ({ id, label: `Row ${id}` })),
+  );
+  return (
+    <main>
+      <button
+        onClick={() =>
+          setRows((current) => [{ id: current.length, label: `Row ${current.length}` }, ...current])
+        }
+      >
+        Prepend
+      </button>
+      <ul>
+        {rows.map((row) => (
+          <li data-id={row.id} key={row.id}>
+            {row.label}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+
+createRoot(document.body).render(<PrependTable />);

--- a/packages/farm-react/scripts/benchmark-runtime-size.mjs
+++ b/packages/farm-react/scripts/benchmark-runtime-size.mjs
@@ -57,6 +57,8 @@ const [
   keyedAppendOn,
   keyedFilterOff,
   keyedFilterOn,
+  keyedPrependOff,
+  keyedPrependOn,
   runtimeControl,
   runtimeCore,
   runtimeFull,
@@ -69,6 +71,8 @@ const [
   bundle("keyed-append.tsx", true),
   bundle("keyed-filter.tsx", false),
   bundle("keyed-filter.tsx", true),
+  bundle("keyed-prepend.tsx", false),
+  bundle("keyed-prepend.tsx", true),
   bundle("runtime-control.tsx", false),
   bundle("runtime-core.tsx", false),
   bundle("runtime-full.tsx", false),
@@ -123,6 +127,30 @@ if (
   !keyedFilterOn.code.includes("filterIndexIndependent")
 ) {
   throw new Error("Keyed filter fixture did not retain its optional filter-hint runtime.");
+}
+if (
+  !keyedPrependOn.code.includes("FarmCompiledKeyedRows") ||
+  !keyedPrependOn.code.includes("keyed-rows:prepend-hinted") ||
+  !keyedPrependOn.code.includes("prependIndexIndependent")
+) {
+  throw new Error("Keyed prepend fixture did not retain its optional prepend-hint runtime.");
+}
+for (const [name, output] of [
+  ["direct", directOn],
+  ["plain keyed", keyedOn],
+  ["append-only", keyedAppendOn],
+  ["filter-only", keyedFilterOn],
+]) {
+  if (
+    output.code.includes("prependIndexIndependent") ||
+    output.code.includes("keyed-rows:prepend-hinted") ||
+    output.code.includes("keyed-rows:filter-prepend-hinted")
+  ) {
+    throw new Error(`${name} fixture retained the optional prepend-hint runtime.`);
+  }
+}
+if (keyedPrependOn.code.includes("filterIndexIndependent")) {
+  throw new Error("Prepend-only fixture retained the optional filter-hint runtime.");
 }
 
 const fullRuntimePremium = runtimeFull.gzip - runtimeControl.gzip;
@@ -190,6 +218,23 @@ const results = {
         brotli: keyedFilterOn.brotli - keyedFilterOff.brotli,
       },
     },
+    keyedPrepend: {
+      compilerOff: {
+        raw: keyedPrependOff.raw,
+        gzip: keyedPrependOff.gzip,
+        brotli: keyedPrependOff.brotli,
+      },
+      compilerOn: {
+        raw: keyedPrependOn.raw,
+        gzip: keyedPrependOn.gzip,
+        brotli: keyedPrependOn.brotli,
+      },
+      compilerPremium: {
+        raw: keyedPrependOn.raw - keyedPrependOff.raw,
+        gzip: keyedPrependOn.gzip - keyedPrependOff.gzip,
+        brotli: keyedPrependOn.brotli - keyedPrependOff.brotli,
+      },
+    },
     isolatedRuntime: {
       control: {
         raw: runtimeControl.raw,
@@ -227,6 +272,11 @@ if (checkOnly) {
       name: "keyed filter compiler premium",
       current: results.fixtures.keyedFilter.compilerPremium.gzip,
       maximum: (reference.fixtures.keyedFilter?.compilerPremium.gzip ?? 12_000) + 256,
+    },
+    {
+      name: "keyed prepend compiler premium",
+      current: results.fixtures.keyedPrepend.compilerPremium.gzip,
+      maximum: (reference.fixtures.keyedPrepend?.compilerPremium.gzip ?? 12_000) + 256,
     },
     {
       name: "core runtime premium",

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -44,6 +44,7 @@ const testSource = String.raw`
     createCompiledComponentWithFeatures,
     createCompilerKeyedArrayAppend,
     createCompilerKeyedArrayFilter,
+    createCompilerKeyedArrayPrepend,
     createCompilerKeyedMapUpdate,
   } = await import(
     "@farm.js/react/compiler-runtime"
@@ -1563,6 +1564,83 @@ const testSource = String.raw`
   assert.equal(filterKeyReads, 2);
   assert.equal(filterBindingReads, 0);
   flushSync(() => filterRoot.unmount());
+
+  let prependRows = () => undefined;
+  let prependKeyReads = 0;
+  let prependBindingReads = 0;
+  const PrependRows = createCompiledComponent({
+    displayName: "CompatibilityPrependRows",
+    initialize: () => [[
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+    ]],
+    render(_props, state, blocks) {
+      const items = () => state[0].get();
+      prependRows = (addition) =>
+        state[0].set((previous) =>
+          createCompilerKeyedArrayPrepend(previous, [addition, ...previous]),
+        );
+      return React.createElement(
+        "section",
+        null,
+        React.createElement(blocks.KeyedRows, {
+          collectionDependency: 0,
+          dependencies: [0],
+          prependIndexIndependent: true,
+          id: 0,
+          items,
+          structureDependencies: [0],
+          render: () =>
+            React.createElement(
+              "ul",
+              null,
+              items().map((item) =>
+                React.createElement("li", { "data-key": item.id, key: item.id }, item.label),
+              ),
+            ),
+          rowKey: (item) => {
+            prependKeyReads += 1;
+            return item.id;
+          },
+          create: (item) => ({
+            kind: "element",
+            tag: "li",
+            attributes: [{ name: "data-key", value: item.id }],
+            styles: [],
+            children: [item.label],
+          }),
+          bindings: [{
+            kind: "text",
+            path: [],
+            dependencies: [],
+            read: (item) => {
+              prependBindingReads += 1;
+              return [item.label];
+            },
+          }],
+        }),
+      );
+    },
+    bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+  });
+  const prependContainer = document.createElement("div");
+  document.body.append(prependContainer);
+  const prependRoot = createRoot(prependContainer);
+  flushSync(() => prependRoot.render(React.createElement(PrependRows)));
+  const prependAlpha = prependContainer.querySelector("[data-key='a']");
+  const prependBeta = prependContainer.querySelector("[data-key='b']");
+  prependKeyReads = 0;
+  prependBindingReads = 0;
+  prependRows({ id: "c", label: "Gamma" });
+  prependRows({ id: "d", label: "Delta" });
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(prependContainer.textContent, "DeltaGammaAlphaBeta");
+  assert.equal(prependContainer.querySelector("[data-key='a']"), prependAlpha);
+  assert.equal(prependContainer.querySelector("[data-key='b']"), prependBeta);
+  assert.equal(prependKeyReads, 2);
+  assert.equal(prependBindingReads, 2);
+  flushSync(() => prependRoot.unmount());
 
   let editableRowExecutions = 0;
   let editableListRenders = 0;

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-prepend-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-prepend-hints.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true);
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/KeyedArrayPrependHints.tsx", infer);
+}
+
+describe("React AOT keyed-array prepend hints", () => {
+  it("records safe immutable prepends for index-independent keyed rows", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Feed() {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <main>
+          <button onClick={() => setRows((current) => [{ id: "b", label: "Beta" }, ...current])}>
+            Prepend
+          </button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Feed"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedArrayPrependHints).toBe(1);
+    expect(result.code).toContain("createCompilerKeyedArrayPrepend");
+    expect(result.code).toContain("prependIndexIndependent={true}");
+    expect(result.code).toContain("keyedRowsPrependHintedRuntimeFeature");
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedArrayPrependHints.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("createCompilerKeyedArrayPrepend"),
+    });
+  });
+
+  it("supports safe prefix batches and the public List primitive", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      import { List } from "@farm.js/react/list";
+      export function Feed() {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <main>
+          <button onClick={() => { const batch = makeRows(); setRows((current) => [...batch, { id: "c", label: "Gamma" }, ...current]); }}>
+            Prepend
+          </button>
+          <ul><List each={rows} by={(row) => row.id}>{(row) => <li>{row.label}</li>}</List></ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Feed"]);
+    expect(result.optimizations.keyedArrayPrependHints).toBe(1);
+    expect(result.code).toContain("prependIndexIndependent={true}");
+  });
+
+  it("selects the combined optional runtime when filter and prepend sites coexist", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Feed() {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <main>
+          <button onClick={() => setRows((current) => [{ id: "b", label: "Beta" }, ...current])}>
+            Prepend
+          </button>
+          <button onClick={() => setRows((current) => current.filter((row) => row.id !== "a"))}>
+            Remove
+          </button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </main>;
+      }
+    `);
+
+    expect(result.optimizations.keyedArrayPrependHints).toBe(1);
+    expect(result.optimizations.keyedArrayFilterHints).toBe(1);
+    expect(result.code).toContain("keyedRowsFilterPrependHintedRuntimeFeature");
+  });
+
+  it.each([
+    {
+      name: "an index-sensitive row",
+      row: "(row, index) => <li key={row.id}>{index}: {row.label}</li>",
+      update: 'setRows((current) => [{ id: "b", label: "Beta" }, ...current])',
+    },
+    {
+      name: "a collection-derived key",
+      row: "(row) => <li key={row.id + rows.length}>{row.label}</li>",
+      update: 'setRows((current) => [{ id: "b", label: "Beta" }, ...current])',
+    },
+    {
+      name: "a block-bodied updater",
+      row: "(row) => <li key={row.id}>{row.label}</li>",
+      update: 'setRows((current) => { return [{ id: "b", label: "Beta" }, ...current]; })',
+    },
+    {
+      name: "an append",
+      row: "(row) => <li key={row.id}>{row.label}</li>",
+      update: 'setRows((current) => [...current, { id: "b", label: "Beta" }])',
+    },
+    {
+      name: "a middle insertion",
+      row: "(row) => <li key={row.id}>{row.label}</li>",
+      update: 'setRows((current) => [current[0], { id: "b", label: "Beta" }, ...current.slice(1)])',
+    },
+    {
+      name: "no new prefix",
+      row: "(row) => <li key={row.id}>{row.label}</li>",
+      update: "setRows((current) => [...current])",
+    },
+    {
+      name: "a potentially side-effecting prefix",
+      row: "(row) => <li key={row.id}>{row.label}</li>",
+      update: "setRows((current) => [createRow(), ...current])",
+    },
+  ])("keeps $name off the prepend fast path", async ({ row, update }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Feed() {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <main>
+          <button onClick={() => { ${update}; }}>Prepend</button>
+          <ul>{rows.map(${row})}</ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Feed"]);
+    expect(result.optimizations.keyedArrayPrependHints).toBe(0);
+    expect(result.code).not.toContain("createCompilerKeyedArrayPrepend");
+    expect(result.code).not.toContain("prependIndexIndependent");
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
@@ -42,6 +42,7 @@ describe("React AOT keyed update hints", () => {
     expect(result.optimizations).toEqual({
       keyedArrayAppendHints: 0,
       keyedArrayFilterHints: 0,
+      keyedArrayPrependHints: 0,
       keyedCollectionUpdateHints: 0,
       keyedIdentityTargets: 0,
       keyedMapLookupTargets: 0,

--- a/packages/farm-react/src/__tests__/compiler-report.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-report.test.ts
@@ -30,6 +30,7 @@ function observations(projectRoot: string): ReactCompilerModuleObservation[] {
         optimizations: {
           keyedArrayAppendHints: 0,
           keyedArrayFilterHints: 0,
+          keyedArrayPrependHints: 0,
           keyedCollectionUpdateHints: 0,
           keyedIdentityTargets: 0,
           keyedMapLookupTargets: 0,
@@ -57,6 +58,7 @@ function observations(projectRoot: string): ReactCompilerModuleObservation[] {
         optimizations: {
           keyedArrayAppendHints: 4,
           keyedArrayFilterHints: 3,
+          keyedArrayPrependHints: 2,
           keyedCollectionUpdateHints: 6,
           keyedIdentityTargets: 4,
           keyedMapLookupTargets: 5,
@@ -80,6 +82,7 @@ describe("React compiler coverage report", () => {
       fallback: 2,
       keyedArrayAppendHints: 4,
       keyedArrayFilterHints: 3,
+      keyedArrayPrependHints: 2,
       keyedCollectionUpdateHints: 6,
       keyedIdentityTargets: 4,
       keyedMapLookupTargets: 5,
@@ -102,6 +105,7 @@ describe("React compiler coverage report", () => {
     expect(report.modules[1]?.optimizations).toEqual({
       keyedArrayAppendHints: 4,
       keyedArrayFilterHints: 3,
+      keyedArrayPrependHints: 2,
       keyedCollectionUpdateHints: 6,
       keyedIdentityTargets: 4,
       keyedMapLookupTargets: 5,

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-prepend-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-prepend-hints.test.tsx
@@ -1,0 +1,447 @@
+import React, { StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createCompiledComponent,
+  createCompilerKeyedArrayPrepend,
+  type CompilerKeyedRowElement,
+} from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Item {
+  id: string;
+  label: string;
+}
+
+interface Counters {
+  executions: number;
+  listRenders: number;
+  keyReads: number;
+  descriptorReads: number;
+  bindingReads: number;
+}
+
+const roots: Root[] = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function hintedPrepend(previous: Item[], additions: readonly Item[]): Item[] {
+  return createCompilerKeyedArrayPrepend(previous, [...additions, ...previous]) as Item[];
+}
+
+function rowDescriptor(item: Item, text = item.label): CompilerKeyedRowElement {
+  return {
+    kind: "element",
+    tag: "li",
+    attributes: [{ name: "data-key", value: item.id }],
+    styles: [],
+    children: [text],
+  };
+}
+
+function createPrependHarness(initialItems: Item[], readsCollection = false) {
+  const counters: Counters = {
+    executions: 0,
+    listRenders: 0,
+    keyReads: 0,
+    descriptorReads: 0,
+    bindingReads: 0,
+  };
+  let prepend: (additions: readonly Item[]) => void = () => undefined;
+  let plainThenPrepend: (addition: Item) => void = () => undefined;
+  let mismatchedPrepend: (addition: Item) => void = () => undefined;
+  const Feed = createCompiledComponent({
+    displayName: "PrependFeed",
+    initialize: () => [initialItems],
+    render(_props: Record<string, never>, state, blocks) {
+      counters.executions += 1;
+      const items = () => state[0].get() as Item[];
+      prepend = (additions) =>
+        state[0].set((previous) => hintedPrepend(previous as Item[], additions));
+      plainThenPrepend = (addition) => {
+        state[0].set((previous) => [...(previous as Item[])]);
+        state[0].set((previous) => hintedPrepend(previous as Item[], [addition]));
+      };
+      mismatchedPrepend = (addition) => {
+        state[0].set((previous) => {
+          const source = previous as Item[];
+          return createCompilerKeyedArrayPrepend(source, [
+            addition,
+            ...source.slice().reverse(),
+          ]) as Item[];
+        });
+      };
+      const text = (item: Item) =>
+        readsCollection ? `${items().length}: ${item.label}` : item.label;
+      return (
+        <section>
+          <blocks.KeyedRows
+            collectionDependency={0}
+            dependencies={[0]}
+            id={0}
+            items={items}
+            prependIndexIndependent
+            structureDependencies={[0]}
+            render={() => {
+              counters.listRenders += 1;
+              return (
+                <ul>
+                  {items().map((item) => (
+                    <li data-key={item.id} key={item.id}>
+                      {text(item)}
+                    </li>
+                  ))}
+                </ul>
+              );
+            }}
+            rowKey={(item) => {
+              counters.keyReads += 1;
+              return (item as Item).id;
+            }}
+            create={(item) => {
+              counters.descriptorReads += 1;
+              const row = item as Item;
+              return rowDescriptor(row, text(row));
+            }}
+            bindings={[
+              {
+                kind: "text",
+                path: [],
+                dependencies: readsCollection ? [0] : [],
+                read: (item) => {
+                  counters.bindingReads += 1;
+                  return [text(item as Item)];
+                },
+              },
+            ]}
+          />
+        </section>
+      );
+    },
+    bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+  });
+  return {
+    Feed,
+    counters,
+    mismatchedPrepend: (addition: Item) => mismatchedPrepend(addition),
+    plainThenPrepend: (addition: Item) => plainThenPrepend(addition),
+    prepend: (additions: readonly Item[]) => prepend(additions),
+  };
+}
+
+describe("compiled keyed-array prepend hints", () => {
+  it("creates only prepended rows and preserves every existing DOM identity", async () => {
+    const initialItems = Array.from(
+      { length: 2_048 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createPrependHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Feed />));
+    const first = container.querySelector('[data-key="row-0"]');
+    const middle = container.querySelector('[data-key="row-1024"]');
+    const last = container.querySelector('[data-key="row-2047"]');
+    harness.counters.keyReads = 0;
+    harness.counters.descriptorReads = 0;
+    harness.counters.bindingReads = 0;
+
+    await act(async () => {
+      harness.prepend([
+        { id: "row-new-0", label: "New 0" },
+        { id: "row-new-1", label: "New 1" },
+      ]);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector("li:first-child")?.textContent).toBe("New 0");
+    expect(container.querySelector('[data-key="row-0"]')).toBe(first);
+    expect(container.querySelector('[data-key="row-1024"]')).toBe(middle);
+    expect(container.querySelector('[data-key="row-2047"]')).toBe(last);
+    expect(container.querySelectorAll("li")).toHaveLength(2_050);
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.listRenders).toBe(1);
+    expect(harness.counters.keyReads).toBe(2);
+    expect(harness.counters.descriptorReads).toBe(2);
+    expect(harness.counters.bindingReads).toBe(2);
+  });
+
+  it("composes queued prepends and rejects an unhinted or invalid source chain", async () => {
+    const harness = createPrependHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Feed />));
+
+    await act(async () => {
+      harness.prepend([{ id: "c", label: "Gamma" }]);
+      harness.prepend([
+        { id: "d", label: "Delta" },
+        { id: "e", label: "Epsilon" },
+      ]);
+      await flushCompilerUpdates();
+    });
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Delta",
+      "Epsilon",
+      "Gamma",
+      "Alpha",
+      "Beta",
+    ]);
+
+    harness.counters.bindingReads = 0;
+    await act(async () => {
+      harness.plainThenPrepend({ id: "f", label: "Phi" });
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector("li:first-child")?.textContent).toBe("Phi");
+    expect(harness.counters.bindingReads).toBeGreaterThan(1);
+
+    harness.counters.bindingReads = 0;
+    await act(async () => {
+      harness.mismatchedPrepend({ id: "g", label: "Gamma 2" });
+      await flushCompilerUpdates();
+    });
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Gamma 2",
+      "Beta",
+      "Alpha",
+      "Gamma",
+      "Epsilon",
+      "Delta",
+      "Phi",
+    ]);
+    expect(harness.counters.bindingReads).toBeGreaterThan(1);
+  });
+
+  it("keeps custom iterators, collection reads, and revoked proxies on fallback", async () => {
+    const initialItems: Item[] = [{ id: "a", label: "Alpha" }];
+    const harness = createPrependHarness(initialItems, true);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Feed />));
+    Object.defineProperty(initialItems, Symbol.iterator, {
+      configurable: true,
+      value: function* () {
+        yield { id: "x", label: "Iterator row" };
+      },
+    });
+
+    await act(async () => {
+      harness.prepend([{ id: "b", label: "Beta" }]);
+      await flushCompilerUpdates();
+    });
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "2: Beta",
+      "2: Iterator row",
+    ]);
+
+    const { proxy, revoke } = Proxy.revocable([], {});
+    revoke();
+    const next: Item[] = [{ id: "safe", label: "Safe" }];
+    expect(() => createCompilerKeyedArrayPrepend(proxy, next)).not.toThrow();
+    expect(createCompilerKeyedArrayPrepend(proxy, next)).toBe(next);
+  });
+
+  it("updates delegated event indexes after existing rows shift", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+    ];
+    let prepend = () => undefined;
+    const calls: string[] = [];
+    const Feed = createCompiledComponent({
+      displayName: "PrependEventFeed",
+      initialize: () => [initialItems],
+      render(_props: Record<string, never>, state, blocks) {
+        const items = () => state[0].get() as Item[];
+        prepend = () =>
+          state[0].set((previous) =>
+            hintedPrepend(previous as Item[], [{ id: "x", label: "Extra" }]),
+          );
+        return (
+          <section>
+            <blocks.KeyedRows
+              collectionDependency={0}
+              delegateEvents
+              dependencies={[0]}
+              events={[
+                {
+                  invoke: (item, index) => calls.push(`${(item as Item).id}:${index}`),
+                  name: "onClick",
+                  path: [0],
+                },
+              ]}
+              id={0}
+              items={items}
+              prependIndexIndependent
+              structureDependencies={[0]}
+              render={(event) => (
+                <ul>
+                  {items().map((item, index) => (
+                    <li data-key={item.id} key={item.id}>
+                      <button data-row-button={item.id} onClick={event(item, index, 0)}>
+                        {item.label}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+              create={(item) => {
+                const row = item as Item;
+                return {
+                  kind: "element",
+                  tag: "li",
+                  attributes: [{ name: "data-key", value: row.id }],
+                  styles: [],
+                  children: [
+                    {
+                      kind: "element",
+                      tag: "button",
+                      attributes: [{ name: "data-row-button", value: row.id }],
+                      styles: [],
+                      children: [row.label],
+                    },
+                  ],
+                };
+              }}
+              bindings={[]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Feed />));
+
+    await act(async () => {
+      prepend();
+      await flushCompilerUpdates();
+    });
+    await act(async () => {
+      (container.querySelector('[data-row-button="b"]') as HTMLButtonElement).click();
+    });
+    expect(calls).toEqual(["b:2"]);
+  });
+
+  it("matches React through 2,000 deterministic prepends", async () => {
+    const initialItems: Item[] = [{ id: "seed", label: "Seed" }];
+    const harness = createPrependHarness(initialItems);
+    let prependReact: (item: Item) => void = () => undefined;
+    function Normal() {
+      const [items, setItems] = useState(initialItems);
+      prependReact = (item) => setItems((previous) => [item, ...previous]);
+      return (
+        <ol data-owner="react">
+          {items.map((item) => (
+            <li data-key={item.id} key={item.id}>
+              {item.label}
+            </li>
+          ))}
+        </ol>
+      );
+    }
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <>
+          <div data-owner="compiled">
+            <harness.Feed />
+          </div>
+          <Normal />
+        </>,
+      ),
+    );
+
+    for (let batch = 0; batch < 100; batch += 1) {
+      await act(async () => {
+        for (let update = 0; update < 20; update += 1) {
+          const index = batch * 20 + update;
+          const item = { id: `row-${index}`, label: `Value ${index}` };
+          harness.prepend([item]);
+          prependReact(item);
+        }
+        await flushCompilerUpdates();
+      });
+      expect(
+        [...container.querySelectorAll('[data-owner="compiled"] li')].map((row) => row.outerHTML),
+      ).toEqual(
+        [...container.querySelectorAll('[data-owner="react"] li')].map((row) => row.outerHTML),
+      );
+    }
+    expect(harness.counters.executions).toBe(1);
+  }, 15_000);
+
+  it("hydrates in StrictMode and drops a queued prepend after unmount", async () => {
+    const harness = createPrependHarness([{ id: "a", label: "Alpha" }]);
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(
+      <StrictMode>
+        <harness.Feed />
+      </StrictMode>,
+    );
+    document.body.append(container);
+    const recoverable: unknown[] = [];
+    let root!: Root;
+    await act(async () => {
+      root = hydrateRoot(
+        container,
+        <StrictMode>
+          <harness.Feed />
+        </StrictMode>,
+        { onRecoverableError: (error) => recoverable.push(error) },
+      );
+    });
+    roots.push(root);
+
+    await act(async () => {
+      harness.prepend([{ id: "b", label: "Beta" }]);
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("BetaAlpha");
+    expect(recoverable).toEqual([]);
+
+    roots.pop();
+    act(() => {
+      harness.prepend([{ id: "c", label: "Gamma" }]);
+      root.unmount();
+    });
+    await flushCompilerUpdates();
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/packages/farm-react/src/__tests__/vite.test.ts
+++ b/packages/farm-react/src/__tests__/vite.test.ts
@@ -87,6 +87,7 @@ describe("React renderer Vite integration", () => {
       fallback: 0,
       keyedArrayAppendHints: 0,
       keyedArrayFilterHints: 0,
+      keyedArrayPrependHints: 0,
       keyedCollectionUpdateHints: 0,
       keyedIdentityTargets: 0,
       keyedMapLookupTargets: 0,

--- a/packages/farm-react/src/compiler-report.ts
+++ b/packages/farm-react/src/compiler-report.ts
@@ -20,6 +20,7 @@ export interface ReactCompilerReport {
     fallback: number;
     keyedArrayAppendHints: number;
     keyedArrayFilterHints: number;
+    keyedArrayPrependHints: number;
     keyedCollectionUpdateHints: number;
     keyedIdentityTargets: number;
     keyedMapLookupTargets: number;
@@ -36,6 +37,7 @@ export interface ReactCompilerReport {
     optimizations: {
       keyedArrayAppendHints: number;
       keyedArrayFilterHints: number;
+      keyedArrayPrependHints: number;
       keyedCollectionUpdateHints: number;
       keyedIdentityTargets: number;
       keyedMapLookupTargets: number;
@@ -60,6 +62,7 @@ export function createReactCompilerReport(
   let fallback = 0;
   let keyedArrayAppendHints = 0;
   let keyedArrayFilterHints = 0;
+  let keyedArrayPrependHints = 0;
   let keyedCollectionUpdateHints = 0;
   let keyedIdentityTargets = 0;
   let keyedMapLookupTargets = 0;
@@ -73,6 +76,7 @@ export function createReactCompilerReport(
       fallback += result.diagnostics.length;
       keyedArrayAppendHints += result.optimizations.keyedArrayAppendHints || 0;
       keyedArrayFilterHints += result.optimizations.keyedArrayFilterHints || 0;
+      keyedArrayPrependHints += result.optimizations.keyedArrayPrependHints || 0;
       keyedCollectionUpdateHints += result.optimizations.keyedCollectionUpdateHints || 0;
       keyedIdentityTargets += result.optimizations.keyedIdentityTargets || 0;
       keyedMapLookupTargets += result.optimizations.keyedMapLookupTargets || 0;
@@ -105,6 +109,7 @@ export function createReactCompilerReport(
       fallback,
       keyedArrayAppendHints,
       keyedArrayFilterHints,
+      keyedArrayPrependHints,
       keyedCollectionUpdateHints,
       keyedIdentityTargets,
       keyedMapLookupTargets,

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -26,6 +26,14 @@ interface CompilerKeyedArrayFilterHint {
   readonly previous?: CompilerKeyedArrayFilterHint;
 }
 
+interface CompilerKeyedArrayPrependHint {
+  readonly sourceToken: object;
+  readonly sourceLength: number;
+  readonly resultLength: number;
+  readonly prefixLength: number;
+  readonly previous?: CompilerKeyedArrayPrependHint;
+}
+
 type CompilerKeyedCollectionKind = "set" | "map";
 type CompilerKeyedCollectionMutation = "set-add" | "set-delete" | "map-set" | "map-delete";
 
@@ -53,6 +61,10 @@ const COMPILER_KEYED_ARRAY_APPENDS = /* @__PURE__ */ new WeakMap<
 const COMPILER_KEYED_ARRAY_FILTERS = /* @__PURE__ */ new WeakMap<
   object,
   CompilerKeyedArrayFilterHint
+>();
+const COMPILER_KEYED_ARRAY_PREPENDS = /* @__PURE__ */ new WeakMap<
+  object,
+  CompilerKeyedArrayPrependHint
 >();
 const COMPILER_KEYED_COLLECTION_DRAFTS = /* @__PURE__ */ new WeakMap<
   object,
@@ -174,6 +186,42 @@ function compilerKeyedArrayFilterSurvivors(
   return survivors.length === value.length ? survivors : undefined;
 }
 
+function compilerKeyedArrayPrependLength(
+  value: unknown,
+  sourceToken: object | undefined,
+  expectedLength: number,
+): number | undefined {
+  const target = compilerObject(value);
+  if (!target || !sourceToken || !Array.isArray(value)) return undefined;
+  const update = COMPILER_KEYED_ARRAY_PREPENDS.get(target);
+  if (!update || update.sourceToken !== sourceToken) return undefined;
+  const updates: CompilerKeyedArrayPrependHint[] = [];
+  for (
+    let current: CompilerKeyedArrayPrependHint | undefined = update;
+    current;
+    current = current.previous
+  ) {
+    if (current.sourceToken !== sourceToken) return undefined;
+    updates.push(current);
+  }
+
+  let length = expectedLength;
+  let prefixLength = 0;
+  for (let index = updates.length - 1; index >= 0; index -= 1) {
+    const current = updates[index];
+    if (
+      current.sourceLength !== length ||
+      current.prefixLength < 1 ||
+      current.resultLength !== current.sourceLength + current.prefixLength
+    ) {
+      return undefined;
+    }
+    length = current.resultLength;
+    prefixLength += current.prefixLength;
+  }
+  return length === value.length ? prefixLength : undefined;
+}
+
 function compilerKeyedCollectionChangedKeys(
   value: unknown,
   sourceToken: object | undefined,
@@ -245,6 +293,44 @@ export function createCompilerKeyedArrayAppend(previous: unknown, value: unknown
       sourceToken: previousUpdate?.sourceToken || sourceToken,
       startIndex,
       resultLength: value.length,
+      ...(previousUpdate ? { previous: previousUpdate } : {}),
+    });
+    return value;
+  } catch {
+    // Metadata must never change the behavior of an otherwise valid update.
+    return value;
+  }
+}
+
+/** @internal Records a compiler-proven immutable keyed-array prepend and returns the Array. */
+export function createCompilerKeyedArrayPrepend(previous: unknown, value: unknown): unknown {
+  try {
+    const previousTarget = compilerObject(previous);
+    const valueTarget = compilerObject(value);
+    if (
+      !previousTarget ||
+      !valueTarget ||
+      !Array.isArray(previous) ||
+      !Array.isArray(value) ||
+      Object.getPrototypeOf(previous) !== NATIVE_ARRAY_PROTOTYPE ||
+      Object.getPrototypeOf(value) !== NATIVE_ARRAY_PROTOTYPE ||
+      previous[Symbol.iterator] !== NATIVE_ARRAY_ITERATOR
+    ) {
+      return value;
+    }
+    const sourceLength = previous.length;
+    const prefixLength = value.length - sourceLength;
+    if (prefixLength < 1) return value;
+    const sourceToken = compilerKeyedCollectionToken(previousTarget);
+    if (!sourceToken) return value;
+    const previousUpdate = !COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget)
+      ? COMPILER_KEYED_ARRAY_PREPENDS.get(previousTarget)
+      : undefined;
+    COMPILER_KEYED_ARRAY_PREPENDS.set(valueTarget, {
+      sourceToken: previousUpdate?.sourceToken || sourceToken,
+      sourceLength,
+      resultLength: value.length,
+      prefixLength,
       ...(previousUpdate ? { previous: previousUpdate } : {}),
     });
     return value;
@@ -631,6 +717,8 @@ export interface CompilerKeyedRowsBlockProps {
   collectionDependency?: number;
   /** Compiler proof that shifted row indexes are not observed by this boundary. */
   filterIndexIndependent?: boolean;
+  /** Compiler proof that prepending cannot expose shifted indexes to existing rows. */
+  prependIndexIndependent?: boolean;
   rowKey(item: unknown, index: number): React.Key;
   create(item: unknown, index: number): CompilerKeyedRowElement;
   bindings: readonly CompilerKeyedRowBinding[];
@@ -3468,6 +3556,14 @@ interface KeyedUpdateRuntime {
     instances: ReadonlyMap<string, CompilerKeyedRowInstance>,
     reactOwnedRows: boolean,
   ): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined;
+  prepend?(
+    props: CompilerKeyedRowsBlockProps,
+    dirtyState: ReadonlySet<number>,
+    collectionToken: object | undefined,
+    instances: ReadonlyMap<string, CompilerKeyedRowInstance>,
+    root: Element,
+    reactOwnedRows: boolean,
+  ): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined;
   reconcile(
     props: CompilerKeyedRowsBlockProps,
     dirtyState: ReadonlySet<number>,
@@ -3497,6 +3593,16 @@ const keyedUpdateRuntime: KeyedUpdateRuntime = {
 const keyedFilterUpdateRuntime: KeyedUpdateRuntime = {
   ...keyedUpdateRuntime,
   filter: reconcileCompilerKeyedArrayFilter,
+};
+
+const keyedPrependUpdateRuntime: KeyedUpdateRuntime = {
+  ...keyedUpdateRuntime,
+  prepend: reconcileCompilerKeyedArrayPrepend,
+};
+
+const keyedFilterPrependUpdateRuntime: KeyedUpdateRuntime = {
+  ...keyedFilterUpdateRuntime,
+  prepend: reconcileCompilerKeyedArrayPrepend,
 };
 
 interface KeyedRowsRuntimeOptions {
@@ -3637,6 +3743,77 @@ function reconcileCompilerKeyedArrayAppend(
     root.append(fragment);
   }
   return nextInstances;
+}
+
+function reconcileCompilerKeyedArrayPrepend(
+  props: CompilerKeyedRowsBlockProps,
+  dirtyState: ReadonlySet<number>,
+  collectionToken: object | undefined,
+  instances: ReadonlyMap<string, CompilerKeyedRowInstance>,
+  root: Element,
+  reactOwnedRows: boolean,
+): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
+  if (
+    reactOwnedRows ||
+    props.hostBlocks ||
+    (props.conditionals?.length || 0) > 0 ||
+    !props.prependIndexIndependent ||
+    props.collectionDependency === undefined
+  ) {
+    return undefined;
+  }
+  const collectionDependency = props.collectionDependency;
+  if (props.bindings.some((binding) => binding.dependencies?.includes(collectionDependency))) {
+    return undefined;
+  }
+  const dependencies = props.dependencies || props.structureDependencies;
+  const relevantDirty = (dependencies || []).filter((index) => dirtyState.has(index));
+  if (relevantDirty.length !== 1 || relevantDirty[0] !== collectionDependency) {
+    return undefined;
+  }
+
+  const finalValue = props.items();
+  const prefixLength = compilerKeyedArrayPrependLength(finalValue, collectionToken, instances.size);
+  if (prefixLength === undefined || !Array.isArray(finalValue)) return undefined;
+  const previousInstances = [...instances.values()];
+  for (let index = 0; index < previousInstances.length; index += 1) {
+    const instance = previousInstances[index];
+    if (instance.index !== index || !Object.is(instance.item, finalValue[prefixLength + index])) {
+      return undefined;
+    }
+  }
+
+  const knownKeys = new Set(instances.keys());
+  const prepended: CompilerKeyedRowInstance[] = [];
+  try {
+    for (let index = 0; index < prefixLength; index += 1) {
+      const item = finalValue[index];
+      const key = keyedRowIdentity(props.rowKey(item, index));
+      if (knownKeys.has(key)) return undefined;
+      knownKeys.add(key);
+      const descriptor = props.create(item, index);
+      prepended.push({
+        key,
+        element: createCompilerHostElement(root.ownerDocument, descriptor),
+        values: readKeyedRowBindingValues(props, item, index),
+        item,
+        index,
+        conditionalValues: EMPTY_KEYED_ROW_CONDITIONAL_VALUES,
+      });
+    }
+  } catch {
+    return undefined;
+  }
+
+  if (prepended.length > 0) {
+    const fragment = root.ownerDocument.createDocumentFragment();
+    for (const instance of prepended) fragment.append(instance.element);
+    root.insertBefore(fragment, root.firstChild);
+  }
+  for (let index = 0; index < previousInstances.length; index += 1) {
+    previousInstances[index].index = prefixLength + index;
+  }
+  return new Map([...prepended, ...previousInstances].map((instance) => [instance.key, instance]));
 }
 
 function reconcileCompilerKeyedArrayFilter(
@@ -4763,6 +4940,21 @@ function createKeyedRowsBlockComponent(
           afterCommit?.();
           return;
         }
+        const prependedInstances = options.keyedUpdates.prepend?.(
+          this.currentProps,
+          dirtyState,
+          this.collectionToken,
+          this.instances,
+          this.root,
+          this.hasReactOwnedRows(),
+        );
+        if (prependedInstances) {
+          this.instances = new Map(prependedInstances);
+          this.rebuildElementIndex(this.instances);
+          this.commitCurrentCollection(dirtyState);
+          afterCommit?.();
+          return;
+        }
       }
       if (dirtyState && this.refreshDirtyBindings(dirtyState, afterCommit)) return;
       this.reconcile(afterCommit, dirtyState);
@@ -5343,6 +5535,24 @@ export const keyedRowsFilterHintedRuntimeFeature: CompilerRuntimeFeature = {
   }),
 };
 
+export const keyedRowsPrependHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:prepend-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      keyedUpdates: keyedPrependUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsFilterPrependHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:filter-prepend-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      keyedUpdates: keyedFilterPrependUpdateRuntime,
+    }),
+  }),
+};
+
 export const keyedRowsConditionalRuntimeFeature: CompilerRuntimeFeature = {
   name: "keyed-rows:conditional",
   create: (owner) => ({
@@ -5368,6 +5578,26 @@ export const keyedRowsConditionalFilterHintedRuntimeFeature: CompilerRuntimeFeat
     KeyedRows: createKeyedRowsBlockComponent(owner, {
       conditionals: createKeyedRowConditionalRuntime(),
       keyedUpdates: keyedFilterUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsConditionalPrependHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:conditional:prepend-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      keyedUpdates: keyedPrependUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsConditionalFilterPrependHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:conditional:filter-prepend-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      keyedUpdates: keyedFilterPrependUpdateRuntime,
     }),
   }),
 };
@@ -5401,6 +5631,26 @@ export const keyedRowsHostFilterHintedRuntimeFeature: CompilerRuntimeFeature = {
   }),
 };
 
+export const keyedRowsHostPrependHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:host:prepend-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedUpdates: keyedPrependUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsHostFilterPrependHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:host:filter-prepend-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedUpdates: keyedFilterPrependUpdateRuntime,
+    }),
+  }),
+};
+
 export const keyedRowsCompleteRuntimeFeature: CompilerRuntimeFeature = {
   name: "keyed-rows:complete",
   create: (owner) => ({
@@ -5429,6 +5679,28 @@ export const keyedRowsCompleteFilterHintedRuntimeFeature: CompilerRuntimeFeature
       conditionals: createKeyedRowConditionalRuntime(),
       hostBlocks: createKeyedRowHostRuntime(),
       keyedUpdates: keyedFilterUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsCompletePrependHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:complete:prepend-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedUpdates: keyedPrependUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsCompleteFilterPrependHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:complete:filter-prepend-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedUpdates: keyedFilterPrependUpdateRuntime,
     }),
   }),
 };
@@ -6015,7 +6287,7 @@ const COMPLETE_RUNTIME_FEATURES: readonly CompilerRuntimeFeature[] = [
   hostConditionalRuntimeFeature,
   conditionalRangesRuntimeFeature,
   keyedListRuntimeFeature,
-  keyedRowsCompleteFilterHintedRuntimeFeature,
+  keyedRowsCompleteFilterPrependHintedRuntimeFeature,
   keyedRangesRuntimeFeature,
   mixedRangesRuntimeFeature,
   componentRuntimeFeature,

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -15,6 +15,7 @@ export interface CompileReactModuleResult {
   optimizations: {
     keyedArrayAppendHints: number;
     keyedArrayFilterHints: number;
+    keyedArrayPrependHints: number;
     keyedCollectionUpdateHints: number;
     keyedIdentityTargets: number;
     keyedMapLookupTargets: number;
@@ -362,15 +363,23 @@ type CompilerRuntimeFeatureName =
   | "keyed-rows"
   | "keyed-rows-hinted"
   | "keyed-rows-filter-hinted"
+  | "keyed-rows-prepend-hinted"
+  | "keyed-rows-filter-prepend-hinted"
   | "keyed-rows-conditional"
   | "keyed-rows-conditional-hinted"
   | "keyed-rows-conditional-filter-hinted"
+  | "keyed-rows-conditional-prepend-hinted"
+  | "keyed-rows-conditional-filter-prepend-hinted"
   | "keyed-rows-host"
   | "keyed-rows-host-hinted"
   | "keyed-rows-host-filter-hinted"
+  | "keyed-rows-host-prepend-hinted"
+  | "keyed-rows-host-filter-prepend-hinted"
   | "keyed-rows-complete"
   | "keyed-rows-complete-hinted"
   | "keyed-rows-complete-filter-hinted"
+  | "keyed-rows-complete-prepend-hinted"
+  | "keyed-rows-complete-filter-prepend-hinted"
   | "keyed-ranges"
   | "mixed-ranges"
   | "component";
@@ -383,15 +392,24 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
   "keyed-rows": "keyedRowsRuntimeFeature",
   "keyed-rows-hinted": "keyedRowsHintedRuntimeFeature",
   "keyed-rows-filter-hinted": "keyedRowsFilterHintedRuntimeFeature",
+  "keyed-rows-prepend-hinted": "keyedRowsPrependHintedRuntimeFeature",
+  "keyed-rows-filter-prepend-hinted": "keyedRowsFilterPrependHintedRuntimeFeature",
   "keyed-rows-conditional": "keyedRowsConditionalRuntimeFeature",
   "keyed-rows-conditional-hinted": "keyedRowsConditionalHintedRuntimeFeature",
   "keyed-rows-conditional-filter-hinted": "keyedRowsConditionalFilterHintedRuntimeFeature",
+  "keyed-rows-conditional-prepend-hinted": "keyedRowsConditionalPrependHintedRuntimeFeature",
+  "keyed-rows-conditional-filter-prepend-hinted":
+    "keyedRowsConditionalFilterPrependHintedRuntimeFeature",
   "keyed-rows-host": "keyedRowsHostRuntimeFeature",
   "keyed-rows-host-hinted": "keyedRowsHostHintedRuntimeFeature",
   "keyed-rows-host-filter-hinted": "keyedRowsHostFilterHintedRuntimeFeature",
+  "keyed-rows-host-prepend-hinted": "keyedRowsHostPrependHintedRuntimeFeature",
+  "keyed-rows-host-filter-prepend-hinted": "keyedRowsHostFilterPrependHintedRuntimeFeature",
   "keyed-rows-complete": "keyedRowsCompleteRuntimeFeature",
   "keyed-rows-complete-hinted": "keyedRowsCompleteHintedRuntimeFeature",
   "keyed-rows-complete-filter-hinted": "keyedRowsCompleteFilterHintedRuntimeFeature",
+  "keyed-rows-complete-prepend-hinted": "keyedRowsCompletePrependHintedRuntimeFeature",
+  "keyed-rows-complete-filter-prepend-hinted": "keyedRowsCompleteFilterPrependHintedRuntimeFeature",
   "keyed-ranges": "keyedRangesRuntimeFeature",
   "mixed-ranges": "mixedRangesRuntimeFeature",
   component: "componentRuntimeFeature",
@@ -401,6 +419,7 @@ function runtimeFeaturesForPlans(
   plans: readonly ComposableBlockPlan[],
   keyedMapUpdateHints: boolean,
   keyedArrayFilterHints: boolean,
+  keyedArrayPrependHints: boolean,
 ): CompilerRuntimeFeatureName[] {
   const features = new Set<CompilerRuntimeFeatureName>();
   let keyedRowsHaveConditionals = false;
@@ -424,13 +443,17 @@ function runtimeFeaturesForPlans(
           : keyedRowsHaveHostBlocks
             ? "keyed-rows-host"
             : "keyed-rows";
-    features.add(
-      keyedArrayFilterHints
-        ? (`${keyedRowsFeature}-filter-hinted` as CompilerRuntimeFeatureName)
-        : keyedMapUpdateHints
-          ? (`${keyedRowsFeature}-hinted` as CompilerRuntimeFeatureName)
-          : keyedRowsFeature,
-    );
+    const hintSuffix =
+      keyedArrayFilterHints && keyedArrayPrependHints
+        ? "-filter-prepend-hinted"
+        : keyedArrayFilterHints
+          ? "-filter-hinted"
+          : keyedArrayPrependHints
+            ? "-prepend-hinted"
+            : keyedMapUpdateHints
+              ? "-hinted"
+              : "";
+    features.add(`${keyedRowsFeature}${hintSuffix}` as CompilerRuntimeFeatureName);
   }
   return [...features].sort();
 }
@@ -1244,6 +1267,109 @@ function rewriteKeyedArrayAppendHints(
   return {
     root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement,
     count,
+  };
+}
+
+function rewriteKeyedArrayPrependHints(
+  root: t.JSXElement,
+  hintedStateIndices: ReadonlySet<number>,
+  statesBySetter: ReadonlyMap<string, StateBinding>,
+  helperIdentifier: t.Identifier,
+  safeGlobals: ReadonlySet<string>,
+): { root: t.JSXElement; count: number; stateIndices: ReadonlySet<number> } {
+  if (hintedStateIndices.size === 0) {
+    return { root: t.cloneNode(root, true), count: 0, stateIndices: new Set() };
+  }
+  const file = expressionFile(t.cloneNode(root, true));
+  const stateIndices = new Set<number>();
+  let count = 0;
+  traverse(file, {
+    CallExpression(path) {
+      const callee = path.get("callee");
+      if (!callee.isIdentifier() || callee.scope.hasBinding(callee.node.name)) return;
+      const state = statesBySetter.get(callee.node.name);
+      if (!state || !hintedStateIndices.has(state.index) || path.node.arguments.length !== 1) {
+        return;
+      }
+      const updater = path.node.arguments[0];
+      if (
+        !t.isArrowFunctionExpression(updater) ||
+        updater.async ||
+        updater.generator ||
+        updater.params.length !== 1 ||
+        !t.isIdentifier(updater.params[0]) ||
+        !t.isArrayExpression(updater.body) ||
+        updater.body.elements.length < 2 ||
+        updater.body.elements.some((element) => element === null)
+      ) {
+        return;
+      }
+      const suffix = updater.body.elements[updater.body.elements.length - 1];
+      if (
+        !t.isSpreadElement(suffix) ||
+        !t.isIdentifier(suffix.argument, { name: updater.params[0].name })
+      ) {
+        return;
+      }
+      const safePrependValue = (value: t.Expression): boolean => {
+        if (t.isArrayExpression(value)) {
+          return value.elements.every(
+            (element) =>
+              element !== null &&
+              !t.isJSXNamespacedName(element) &&
+              !t.isArgumentPlaceholder(element) &&
+              safePrependValue(t.isSpreadElement(element) ? element.argument : element),
+          );
+        }
+        if (t.isObjectExpression(value)) {
+          return value.properties.every((property) => {
+            if (t.isSpreadElement(property)) return safePrependValue(property.argument);
+            if (!t.isObjectProperty(property) || !t.isExpression(property.value)) return false;
+            return (
+              (!property.computed ||
+                (t.isExpression(property.key) && safePrependValue(property.key))) &&
+              safePrependValue(property.value)
+            );
+          });
+        }
+        return validateDerivedExpression(value, safeGlobals) === undefined;
+      };
+      if (
+        updater.body.elements.slice(0, -1).some((element) => {
+          if (!element || t.isJSXNamespacedName(element) || t.isArgumentPlaceholder(element)) {
+            return true;
+          }
+          return !safePrependValue(t.isSpreadElement(element) ? element.argument : element);
+        })
+      ) {
+        return;
+      }
+
+      const previous = t.cloneNode(updater.params[0]);
+      const nextValue = path.scope.generateUidIdentifier("farmNextItems");
+      path.node.arguments[0] = t.arrowFunctionExpression(
+        [t.cloneNode(previous)],
+        t.blockStatement([
+          t.variableDeclaration("const", [
+            t.variableDeclarator(t.cloneNode(nextValue), t.cloneNode(updater.body, true)),
+          ]),
+          t.returnStatement(
+            t.callExpression(t.cloneNode(helperIdentifier), [
+              t.cloneNode(previous),
+              t.cloneNode(nextValue),
+            ]),
+          ),
+        ]),
+      );
+      count += 1;
+      stateIndices.add(state.index);
+      path.skip();
+    },
+  });
+  return {
+    root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement,
+    count,
+    stateIndices,
   };
 }
 
@@ -4455,6 +4581,7 @@ function keyedRowsBoundary(
   plan: KeyedRowsPlan,
   keyedMapUpdateHints: boolean,
   keyedArrayFilterHintedStateIndices: ReadonlySet<number>,
+  keyedArrayPrependHintedStateIndices: ReadonlySet<number>,
 ): t.JSXElement {
   const name = t.jsxMemberExpression(
     t.jsxIdentifier(blockRuntime.name),
@@ -4527,6 +4654,15 @@ function keyedRowsBoundary(
           ? [
               t.jsxAttribute(
                 t.jsxIdentifier("filterIndexIndependent"),
+                t.jsxExpressionContainer(t.booleanLiteral(true)),
+              ),
+            ]
+          : []),
+        ...(plan.collectionDependency !== undefined &&
+        keyedArrayPrependHintedStateIndices.has(plan.collectionDependency)
+          ? [
+              t.jsxAttribute(
+                t.jsxIdentifier("prependIndexIndependent"),
                 t.jsxExpressionContainer(t.booleanLiteral(true)),
               ),
             ]
@@ -5559,6 +5695,7 @@ function lowerComposableBlocks(
   listNames: ReadonlySet<string>,
   keyedMapUpdateHints: boolean,
   keyedArrayFilterHintedStateIndices: ReadonlySet<number>,
+  keyedArrayPrependHintedStateIndices: ReadonlySet<number>,
 ): t.JSXElement {
   const planBySource = new Map<t.Node, ComposableBlockPlan>(
     plans.map((plan) => [plan.source, plan]),
@@ -5590,6 +5727,7 @@ function lowerComposableBlocks(
             plan,
             keyedMapUpdateHints,
             keyedArrayFilterHintedStateIndices,
+            keyedArrayPrependHintedStateIndices,
           );
         }
         if (plan?.kind === "keyed-ranges") {
@@ -6022,6 +6160,7 @@ function compileCandidate(
   keyedMapUpdateIdentifier: t.Identifier,
   keyedArrayAppendIdentifier: t.Identifier,
   keyedArrayFilterIdentifier: t.Identifier,
+  keyedArrayPrependIdentifier: t.Identifier,
   keyedCollectionUpdateIdentifier: t.Identifier,
   keyedCollectionMutationIdentifier: t.Identifier,
   runtimeFeatureIdentifiers: ReadonlyMap<CompilerRuntimeFeatureName, t.Identifier>,
@@ -6029,6 +6168,7 @@ function compileCandidate(
   optimizationCounts: {
     keyedArrayAppendHints: number;
     keyedArrayFilterHints: number;
+    keyedArrayPrependHints: number;
     keyedCollectionUpdateHints: number;
     keyedIdentityTargets: number;
     keyedMapLookupTargets: number;
@@ -6370,7 +6510,7 @@ function compileCandidate(
       optimizationCounts.keyedArrayAppendHints += appendHintedRoot.count;
     }
   }
-  const filterHintedStateIndices = new Set(hintedStateIndices);
+  const shiftedIndexIndependentStateIndices = new Set(hintedStateIndices);
   for (const plan of blockAnalysis.plans || []) {
     if (plan.kind !== "keyed-rows" || plan.collectionDependency === undefined) continue;
     const keyExpression = returnedExpression(plan.keyCallback);
@@ -6379,15 +6519,50 @@ function compileCandidate(
       !keyExpression ||
       collectStateDependencies(keyExpression, reactiveByValue).includes(plan.collectionDependency)
     ) {
-      // Removing rows shifts later indexes. A row callback that accepts the
-      // index, or a key that reads the whole collection, must take the full
-      // reconciliation path so existing row state cannot become stale.
-      filterHintedStateIndices.delete(plan.collectionDependency);
+      // Removing or prepending rows shifts existing indexes. A row callback
+      // that accepts the index, or a key that reads the whole collection,
+      // must take the full reconciliation path so row state cannot go stale.
+      shiftedIndexIndependentStateIndices.delete(plan.collectionDependency);
+    }
+  }
+  const prependHintedRoot = rewriteKeyedArrayPrependHints(
+    expandedReactiveRoot,
+    shiftedIndexIndependentStateIndices,
+    statesBySetter,
+    keyedArrayPrependIdentifier,
+    safeGlobals,
+  );
+  let appliedKeyedArrayPrependHints = 0;
+  let appliedPrependHintedStateIndices: ReadonlySet<number> = new Set();
+  if (prependHintedRoot.count > 0) {
+    const hintedBlockAnalysis = analyzeComposableBlocks(
+      prependHintedRoot.root,
+      reactiveByValue,
+      safeGlobals,
+      listNames,
+      allowedComponentNames,
+    );
+    const hintedAnalysis = analyzeHostTree(
+      prependHintedRoot.root,
+      reactiveByValue,
+      safeGlobals,
+      hintedBlockAnalysis.conditionalExpressions || new Set<t.Expression>(),
+      hintedBlockAnalysis.keyedExpressions || new Set<t.Expression>(),
+      hintedBlockAnalysis.ownedElements || new Set<t.JSXElement>(),
+      hintedBlockAnalysis.componentElements || new Set<t.JSXElement>(),
+    );
+    if (!hintedBlockAnalysis.reason && !hintedAnalysis.reason) {
+      expandedReactiveRoot = prependHintedRoot.root;
+      blockAnalysis = hintedBlockAnalysis;
+      analysis = hintedAnalysis;
+      appliedKeyedArrayPrependHints = prependHintedRoot.count;
+      appliedPrependHintedStateIndices = prependHintedRoot.stateIndices;
+      optimizationCounts.keyedArrayPrependHints += prependHintedRoot.count;
     }
   }
   const filterHintedRoot = rewriteKeyedArrayFilterHints(
     expandedReactiveRoot,
-    filterHintedStateIndices,
+    shiftedIndexIndependentStateIndices,
     statesBySetter,
     keyedArrayFilterIdentifier,
     safeGlobals,
@@ -6500,11 +6675,13 @@ function compileCandidate(
   const hasKeyedUpdateHints =
     appliedKeyedMapUpdateHints > 0 ||
     appliedKeyedArrayAppendHints > 0 ||
-    appliedKeyedArrayFilterHints > 0;
+    appliedKeyedArrayFilterHints > 0 ||
+    appliedKeyedArrayPrependHints > 0;
   const runtimeFeatures = runtimeFeaturesForPlans(
     blockPlans,
     hasKeyedUpdateHints,
     appliedKeyedArrayFilterHints > 0,
+    appliedKeyedArrayPrependHints > 0,
   );
   markShortCircuitBindings(analysis.bindings || []);
   assignStableBindingTargets(analysis.bindings || []);
@@ -6526,6 +6703,7 @@ function compileCandidate(
     listNames,
     hasKeyedUpdateHints,
     appliedFilterHintedStateIndices,
+    appliedPrependHintedStateIndices,
   );
   const rewrittenRoot = rewriteStateAccess(
     rootWithBlocks,
@@ -6693,6 +6871,7 @@ export async function compileReactModule(
   const optimizationCounts = {
     keyedArrayAppendHints: 0,
     keyedArrayFilterHints: 0,
+    keyedArrayPrependHints: 0,
     keyedCollectionUpdateHints: 0,
     keyedIdentityTargets: 0,
     keyedMapLookupTargets: 0,
@@ -6745,6 +6924,9 @@ export async function compileReactModule(
         const keyedArrayFilterIdentifier = programPath.scope.generateUidIdentifier(
           "createCompilerKeyedArrayFilter",
         );
+        const keyedArrayPrependIdentifier = programPath.scope.generateUidIdentifier(
+          "createCompilerKeyedArrayPrepend",
+        );
         const keyedCollectionUpdateIdentifier = programPath.scope.generateUidIdentifier(
           "createCompilerKeyedCollectionUpdate",
         );
@@ -6775,6 +6957,7 @@ export async function compileReactModule(
             keyedMapUpdateIdentifier,
             keyedArrayAppendIdentifier,
             keyedArrayFilterIdentifier,
+            keyedArrayPrependIdentifier,
             keyedCollectionUpdateIdentifier,
             keyedCollectionMutationIdentifier,
             runtimeFeatureIdentifiers,
@@ -6827,6 +7010,14 @@ export async function compileReactModule(
                       t.importSpecifier(
                         keyedArrayFilterIdentifier,
                         t.identifier("createCompilerKeyedArrayFilter"),
+                      ),
+                    ]
+                  : []),
+                ...(optimizationCounts.keyedArrayPrependHints > 0
+                  ? [
+                      t.importSpecifier(
+                        keyedArrayPrependIdentifier,
+                        t.identifier("createCompilerKeyedArrayPrepend"),
                       ),
                     ]
                   : []),


### PR DESCRIPTION
## Summary

- recognize conservative direct immutable keyed-array prepends such as `setItems(current => [next, ...current])`
- carry a validated prepend chain into an optional keyed-row runtime that creates only the new prefix, preserves existing DOM rows, and updates delegated event indexes
- keep index-aware, collection-reading, React-owned, conditional, custom-array, duplicate-key, mixed-update, and invalid-metadata cases on complete keyed reconciliation
- expose `keyedArrayPrependHints` in compiler reports and document syntax, limits, fallback behavior, verification, and bundle cost

## Verification

- `pnpm --filter @farm.js/react test` — 56 files, 467 tests passed
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and React 19.2.8 passed
- `pnpm docs:build`
- production browser benchmark with two React baselines plus static and hybrid compiler builds — every correctness, performance, append, prepend, filter, keyed update, collection delta, and scalability gate passed

## Measured prepend result

- 10,000 existing rows: 5.02x static and 4.59x hybrid faster than React
- 20,000 existing rows: 7.80x static and 6.60x hybrid faster than React
- versus an equivalent compiled snapshot control: 1.99x static and 1.88x hybrid faster
- exact 2,048-row instrumentation reads 2 keys, descriptors, and bindings for a 2-row prefix while preserving all existing DOM identities
- 2,000 deterministic prepends match normal React
- optional prepend fixture premium: 817 B gzip over the ordinary keyed fixture; prepend code remains absent from direct, ordinary keyed, append-only, and filter-only bundles

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds keyed-array prepend hints so immutable prepends like `setItems(current => [next, ...current])` avoid full keyed reconciliation. Before, prepends always ran the complete reconciliation path; now the runtime mounts only the new prefix, leaves existing DOM rows untouched, refreshes delegated event indexes, and compiler reports expose a new `keyedArrayPrependHints` count.

**Performance**
- At 10,000 existing rows, prepends are 5.02x (static) and 4.59x (hybrid) faster than React.
- At 20,000 existing rows, prepends are 7.80x (static) and 6.60x (hybrid) faster than React.
- The prepend runtime adds 817 B gzip only where the hint is reached, and React 18 and 19 compatibility tests pass.

**Fallback**
- Index-aware rows, rows that read the collection, React-owned arrays, conditional rows, custom arrays, duplicate keys, mixed updates, and invalid metadata still use complete keyed reconciliation.

<sup>Written for commit 890cbe5c897274e25ba465d211e942e18ce5b613. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

