### PR TITLE
fix(cache): serialize Set and Map contents in cache keys

### DIFF
--- a/packages/farm/src/__tests__/cache-key-set-map.test.ts
+++ b/packages/farm/src/__tests__/cache-key-set-map.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { configureFarmCache, createFarmCacheKey, unstable_cache } from "../cache";
+
+afterEach(() => {
+  configureFarmCache(undefined);
+});
+
+describe("createFarmCacheKey with Set and Map", () => {
+  it("gives different keys to sets with different contents", () => {
+    expect(createFarmCacheKey([new Set([1, 2])])).toBe("[set:[number:1,number:2]]");
+    expect(createFarmCacheKey([new Set([9])])).toBe("[set:[number:9]]");
+    expect(createFarmCacheKey([new Set()])).toBe("[set:[]]");
+  });
+
+  it("gives different keys to maps with different contents", () => {
+    expect(createFarmCacheKey([new Map([["x", 1]])])).toBe('[map:[["x",number:1]]]');
+    expect(createFarmCacheKey([new Map([["y", 2]])])).toBe('[map:[["y",number:2]]]');
+    expect(createFarmCacheKey([new Map()])).toBe("[map:[]]");
+  });
+
+  it("does not confuse a set, a map, an array and an object with the same shape", () => {
+    const keys = [
+      createFarmCacheKey([new Set(["a"])]),
+      createFarmCacheKey([new Map([["a", "a"]])]),
+      createFarmCacheKey([["a"]]),
+      createFarmCacheKey([{ a: "a" }]),
+      createFarmCacheKey([{}]),
+    ];
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("gives the same key to equivalent contents in a different insertion order", () => {
+    expect(createFarmCacheKey([new Set([2, 1, 3])])).toBe(createFarmCacheKey([new Set([3, 2, 1])]));
+    expect(
+      createFarmCacheKey([
+        new Map([
+          ["b", 2],
+          ["a", 1],
+        ]),
+      ]),
+    ).toBe(
+      createFarmCacheKey([
+        new Map([
+          ["a", 1],
+          ["b", 2],
+        ]),
+      ]),
+    );
+  });
+
+  it("serializes nested values inside sets and maps", () => {
+    const key = createFarmCacheKey([
+      new Map<unknown, unknown>([
+        [{ id: 1 }, new Set([new Date("2024-01-01T00:00:00.000Z"), [1, "two"]])],
+        ["plain", new Map([["inner", null]])],
+      ]),
+    ]);
+    expect(key).toBe(
+      '[map:[["plain",map:[["inner",null]]],[{"id":number:1},set:[[number:1,"two"],date:2024-01-01T00:00:00.000Z]]]]',
+    );
+  });
+
+  it("handles sets and maps that contain themselves", () => {
+    const set = new Set<unknown>([1]);
+    set.add(set);
+    expect(createFarmCacheKey([set])).toBe("[set:[[Circular],number:1]]");
+
+    const map = new Map<unknown, unknown>([["a", 1]]);
+    map.set("self", map);
+    expect(createFarmCacheKey([map])).toBe('[map:[["a",number:1],["self",[Circular]]]]');
+  });
+
+  it("lets a set be reused in two places without being marked circular", () => {
+    const shared = new Set([1]);
+    expect(createFarmCacheKey([shared, shared])).toBe("[set:[number:1],set:[number:1]]");
+  });
+
+  it("caches unstable_cache calls separately per set contents", async () => {
+    let calls = 0;
+    const sum = unstable_cache(
+      async (ids: Set<number>) => {
+        calls++;
+        return [...ids].reduce((total, id) => total + id, 0);
+      },
+      ["sum"],
+    );
+
+    await expect(sum(new Set([1, 2]))).resolves.toBe(3);
+    await expect(sum(new Set([9]))).resolves.toBe(9);
+    await expect(sum(new Set([2, 1]))).resolves.toBe(3);
+    expect(calls).toBe(2);
+  });
+});

--- a/packages/farm/src/cache.ts
+++ b/packages/farm/src/cache.ts
@@ -1004,6 +1004,10 @@ function hashFunctionSource(source: string): string {
   return (hash >>> 0).toString(36);
 }
 
+function compareCodepoint(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
 function stableSerialize(value: unknown, seen = new WeakSet<object>()): string {
   if (value === null) return "null";
   if (value === undefined) return "undefined";
@@ -1040,11 +1044,28 @@ function stableSerialize(value: unknown, seen = new WeakSet<object>()): string {
     }
     seen.add(value);
 
+    // Set and Map keep their contents internally, so Object.entries is empty
+    // for both. Serialize the contents and sort them by codepoint so equal
+    // contents give the same key regardless of insertion order.
+    if (value instanceof Set) {
+      const items = Array.from(value, (item) => stableSerialize(item, seen)).sort(compareCodepoint);
+      seen.delete(value);
+      return `set:[${items.join(",")}]`;
+    }
+    if (value instanceof Map) {
+      const items = Array.from(
+        value,
+        ([key, item]) => `[${stableSerialize(key, seen)},${stableSerialize(item, seen)}]`,
+      ).sort(compareCodepoint);
+      seen.delete(value);
+      return `map:[${items.join(",")}]`;
+    }
+
     // Codepoint comparison, not localeCompare: the host locale must not
     // change how a "stable" key serializes, or invalidations computed on one
     // server can miss entries written by another.
     const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
-      a < b ? -1 : a > b ? 1 : 0,
+      compareCodepoint(a, b),
     );
     const serialized = entries
       .map(([key, item]) => `${JSON.stringify(key)}:${stableSerialize(item, seen)}`)


### PR DESCRIPTION
Fixes #569

## Problem

`stableSerialize` had no branch for `Set` or `Map`, so both fell into the generic object branch. `Object.entries` is empty for them, so every `Set` and every `Map` serialized to `{}` and shared one cache key. `unstable_cache(fn)(new Set([9]))` returned the value cached for `new Set([1, 2])`.

## Fix

Add explicit `Set` and `Map` handling ahead of the generic object branch:

- `set:[...]` and `map:[[key,value],...]` prefixes, so a set, a map, an array and an object with similar shape never collide.
- Items are serialized then sorted by codepoint, so equal contents give equal keys regardless of insertion order.
- Both go through the existing `seen` tracking, so a set or map that contains itself serializes as `[Circular]` instead of recursing.

The codepoint comparator used for object keys is pulled into `compareCodepoint` and shared.

## Tests

New `cache-key-set-map.test.ts` covers different contents, equivalent contents in different order, nested sets and maps, circular references, and the `unstable_cache` behaviour. 7 of 8 fail on `main` with only `cache.ts` reverted. Existing `cache.test.ts` still passes. `tsc --noEmit`, oxlint and oxfmt are clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cache key generation so `Set` and `Map` instances serialize their contents instead of collapsing to `{}`, which caused distinct values to share the same cache entry. The new serialization prefixes `set:` and `map:`, sorts items lexicographically, and tracks circular references.

<sup>Written for commit 614df5bb1885c41d8a0bfdfee7550911e09b560c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

