### PR TITLE
fix(middleware): keep checking matchers after a function matcher returns false

### DIFF
--- a/packages/farm/src/__tests__/middleware-function-matcher.test.ts
+++ b/packages/farm/src/__tests__/middleware-function-matcher.test.ts
@@ -1,0 +1,88 @@
+import { IncomingMessage, ServerResponse } from "node:http";
+import { Socket } from "node:net";
+import { describe, expect, it } from "vitest";
+import { MiddlewareManager } from "../middleware/manager";
+import { createProductionMiddlewareRunner } from "../middleware/production-runtime";
+import type { MiddlewareContext, MiddlewareMatcher } from "../middleware/types";
+
+const isBeta = (ctx: MiddlewareContext) => ctx.pathname.startsWith("/beta");
+const never = () => false;
+
+function createRequest(url: string): IncomingMessage {
+  const req = new IncomingMessage(new Socket());
+  req.url = url;
+  req.method = "GET";
+  req.headers = { host: "localhost" };
+  return req;
+}
+
+async function runDev(matcher: MiddlewareMatcher[], paths: string[]) {
+  const seen: Array<{ path: string; params: Record<string, string> }> = [];
+  const manager = new MiddlewareManager("/tmp", undefined, [
+    {
+      matcher,
+      async handler(ctx, next) {
+        seen.push({ path: ctx.request.url ?? "", params: { ...ctx.params } });
+        await next();
+      },
+    },
+  ]);
+  for (const path of paths) {
+    const req = createRequest(path);
+    await manager.execute(req, new ServerResponse(req));
+  }
+  return seen;
+}
+
+async function runProduction(matcher: MiddlewareMatcher[], paths: string[]) {
+  const seen: Array<{ path: string; params: Record<string, string> }> = [];
+  const runner = createProductionMiddlewareRunner({
+    config: [
+      {
+        matcher,
+        handler(ctx) {
+          seen.push({ path: ctx.pathname, params: { ...ctx.params } });
+        },
+      },
+    ],
+  });
+  for (const path of paths) {
+    await runner(new Request(`https://example.com${path}`));
+  }
+  return seen;
+}
+
+const paths = ["/beta/x", "/dashboard/home", "/other"];
+
+describe.each([
+  ["dev middleware manager", runDev],
+  ["production middleware runtime", runProduction],
+])("%s: function matcher in a matcher list", (_name, run) => {
+  it("keeps checking later matchers when the function returns false", async () => {
+    const seen = await run([isBeta, "/dashboard/:path*"], paths);
+    expect(seen.map((entry) => entry.path)).toEqual(["/beta/x", "/dashboard/home"]);
+  });
+
+  it("matches the same paths regardless of matcher order", async () => {
+    const functionFirst = await run([isBeta, "/dashboard/:path*"], paths);
+    const stringFirst = await run(["/dashboard/:path*", isBeta], paths);
+    expect(functionFirst.map((entry) => entry.path)).toEqual(
+      stringFirst.map((entry) => entry.path),
+    );
+  });
+
+  it("does not run the handler when every matcher is false", async () => {
+    const seen = await run([never, never, "/admin/:path*"], paths);
+    expect(seen).toEqual([]);
+  });
+
+  it("still matches when the function returns true", async () => {
+    const seen = await run([never, isBeta], paths);
+    expect(seen.map((entry) => entry.path)).toEqual(["/beta/x"]);
+  });
+
+  it("exposes params from a string matcher that follows a false function", async () => {
+    const seen = await run([never, "/dashboard/[section]"], ["/dashboard/reports"]);
+    expect(seen).toEqual([{ path: "/dashboard/reports", params: { section: "reports" } }]);
+  });
+});

--- a/packages/farm/src/middleware/manager.ts
+++ b/packages/farm/src/middleware/manager.ts
@@ -392,8 +392,8 @@ export class MiddlewareManager {
           if (result.matched) {
             return result;
           }
-        } else if (typeof matcher === "function") {
-          return { matched: matcher(ctx) };
+        } else if (typeof matcher === "function" && matcher(ctx)) {
+          return { matched: true };
         }
       }
       return { matched: false };

--- a/packages/farm/src/middleware/production-runtime.ts
+++ b/packages/farm/src/middleware/production-runtime.ts
@@ -513,8 +513,8 @@ function matchesConfig(
         if (result.matched) {
           return result;
         }
-      } else if (typeof matcher === "function") {
-        return { matched: matcher(ctx) };
+      } else if (typeof matcher === "function" && matcher(ctx)) {
+        return { matched: true };
       }
     }
     return { matched: false };


### PR DESCRIPTION
Fixes #570

## Problem

In a `matcher` list, string and RegExp entries only return early on a match, but a function entry returned its result unconditionally. A function returning `false` ended the loop and skipped every matcher after it, so `[isBeta, "/dashboard/:path*"]` never ran the handler for `/dashboard/home` while `["/dashboard/:path*", isBeta]` did. The same bug was in both the dev `MiddlewareManager` and the production runtime.

## Fix

In both `matchesConfig` implementations the function branch now returns only on `true`, so a `false` result falls through to the remaining entries and the trailing `return { matched: false }` handles an all-false list. Params from a later string matcher are returned as before.

## Tests

New `middleware-function-matcher.test.ts` runs the same cases through `MiddlewareManager.execute` and `createProductionMiddlewareRunner`:

- a false function followed by a matching string runs the handler
- the same list matches the same paths in either order
- an all-false list does not run the handler
- a true function still matches
- params from a string matcher after a false function reach `ctx.params`

8 of 10 fail on `main` with only the two source files reverted (the all-false cases pass either way). Existing `middleware.test.ts` and `production-middleware-http.test.ts` still pass. `tsc --noEmit`, oxlint and oxfmt are clean for the changed files.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #570: a function matcher returning `false` in a middleware matcher list previously stopped the loop and skipped remaining matchers, so `[isBeta, "/dashboard/:path*"]` never matched `/dashboard/home` while the reverse order did. Now a `false` result falls through to later matchers in both the dev `MiddlewareManager` and the production runtime, and an all-false list still matches nothing.

Adds `middleware-function-matcher.test.ts` covering both runners, including params extracted from a string matcher after a false function and order-independence.

<sup>Written for commit f3d84e0af81f1310d5a854a7da58b205b7026ace. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

