### PR TITLE
perf(react): optimize keyed position removals

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -372,8 +372,8 @@ filter sites that can report removed positions. `keyedArrayPrependHints` counts 
 the compiler proved a direct keyed array prepend and can hand the new prefix to the runtime.
 `keyedArraySliceHints` counts direct keyed-array slices whose build-time bounds identify one exact
 retained interval.
-`keyedArrayPositionHints` counts native keyed-array insertions and replacements whose exact
-position is known at build time.
+`keyedArrayPositionHints` counts native keyed-array insertions, removals, and replacements whose
+exact position is known at build time.
 `keyedArrayReorderHints` counts direct native keyed-array reversals whose complete permutation is
 known at build time.
 `keyedArraySortHints` counts direct native keyed-array sorts whose resulting permutation can be
@@ -1021,24 +1021,26 @@ all-hint runtime.
 
 #### Keyed array known-position hints
 
-Native immutable array methods can state an exact insertion or replacement position:
+Native immutable array methods can state an exact insertion, removal, or replacement position:
 
 ```tsx
 setItems((current) => current.toSpliced(500, 0, nextItem));
+setItems((current) => current.toSpliced(500, 1));
 setItems((current) => current.with(500, replacement));
 ```
 
 At build time, Farm recognizes only concise functional setters with a safe-integer position known
-by the compiler. `toSpliced()` must insert exactly one item with a zero delete count; `with()` must
-replace exactly one item. Farm preserves the original method lookup, argument evaluation, native
-call, return value, and thrown errors. If the method is not the native array method, the update
-still runs normally but no metadata is recorded.
+by the compiler. `toSpliced()` must insert exactly one item with a zero delete count or remove
+exactly one item; `with()` must replace exactly one item. Farm preserves the original method lookup,
+argument evaluation, native call, return value, and thrown errors. If the method is not the native
+array method, the update still runs normally but no metadata is recorded.
 
 At update time, Farm validates the committed native source, result length, source token, normalized
-position, and incoming key before changing the DOM. An insertion creates one row at that position,
-preserves surrounding elements, and shifts only stored event indexes. A same-key replacement
+position, and any incoming key before changing the DOM. An insertion creates one row at that
+position, preserves surrounding elements, and shifts only stored event indexes. A removal cleans up
+and removes only the known row while preserving every surviving element. A same-key replacement
 patches that row in place; a new-key replacement creates and swaps one host row. The owner component
-does not rerun, and existing row keys, descriptors, and bindings are not reread.
+does not rerun, and surviving row keys, descriptors, and bindings are not reread.
 
 The first proof requires compiler-owned host rows whose render and key do not observe the row index.
 Dynamic or fractional positions, other `toSpliced()` shapes, block-bodied updaters, unsafe incoming
@@ -1922,9 +1924,10 @@ The package and example test suites verify more than generated code:
 - 2,000 deterministic randomized keyed-array removals match normal React; targeted tests require
   zero surviving descriptor and binding reads, preserve DOM identity, and cover queued filters,
   unhinted-chain fallback, collection-reading rows, StrictMode hydration, and unmount cleanup;
-- 400 deterministic known-position insertions and replacements match normal React; targeted tests
-  require one-row key, descriptor, and binding work, preserve surrounding DOM identity, and cover
-  custom methods, queued updates, collection-reading rows, StrictMode hydration, and cleanup;
+- 1,000 deterministic known-position insertions, removals, and replacements match normal React;
+  targeted removal tests require zero surviving key, descriptor, or binding reads, preserve focused
+  input and surrounding DOM identity, and cover native semantics, negative positions, custom
+  methods, queued updates, collection-reading rows, StrictMode hydration, and cleanup;
 - 2,000 deterministic randomized reversals match normal React; a 4,096-row targeted test requires
   exactly `n - 1` connected DOM moves and zero key, descriptor, or binding reads, while fallback
   tests cover custom methods, queued updates, collection-reading rows, StrictMode hydration, and

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,28 @@
 
 Date: 2026-08-29
 
+## Known-position removal follow-up — 2026-08-30
+
+The full default production run for concise `toSpliced(position, 1)` support passed correctness,
+the React-relative regression gate, every existing optimization-persistence gate, and normalized
+scalability. The new 10,000-row known-position removal comparison measured:
+
+| Mode   | React median | Hinted removal | Compiled control | vs React | vs control |
+| ------ | -----------: | -------------: | ---------------: | -------: | ---------: |
+| Static |     64.95 ms |        7.00 ms |         17.00 ms |    9.28x |      2.43x |
+| Hybrid |     64.95 ms |        7.00 ms |         16.80 ms |    9.28x |      2.40x |
+
+The persisted gate requires at least 4x versus React and 1.5x versus the equivalent block-bodied
+compiled control. All three paths execute the same native immutable array removal and disconnect
+the same row. The hinted path preserves surrounding DOM identity, performs zero surviving key,
+descriptor, or binding reads, and avoids rerunning the owner component. The compiler report emitted
+three `keyedArrayPositionHints` sites—one insertion, one removal, and one replacement—in each
+compiled build. Both compiler modes added zero owner executions, while all existing append,
+prepend, slice, rolling-window, reverse, sort, filter, keyed-update, key-directed,
+collection-delta, general regression, and scalability gates remained green. The optional
+known-position package fixture grew by 58 B gzip; direct and core-only premiums were unchanged and
+the core runtime reduction remained 80.5%.
+
 ## Native keyed sort follow-up — 2026-08-30
 
 The full default production run for native `toSorted()` support also passed correctness, the

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -95,11 +95,13 @@ React and 1.25x faster than the compiled control. The report must contain a nonz
 `keyedArrayRollingWindowHints` count; package tests separately require retained DOM identity and
 work proportional only to the incoming suffix.
 
-Known-position insertions and replacements have separate 10,000-row comparisons. Concise native
-`toSpliced(position, 0, item)` and `with(position, item)` updates are measured against bracketed
-React and equivalent block-bodied compiled controls. The compiler report must contain a nonzero
-`keyedArrayPositionHints` count; package tests separately require one-row key/descriptor/binding
-work, surrounding DOM identity, randomized differential correctness, hydration, and cleanup.
+Known-position insertions, removals, and replacements have separate 10,000-row comparisons. Concise
+native `toSpliced(position, 0, item)`, `toSpliced(position, 1)`, and `with(position, item)` updates
+are measured against bracketed React and equivalent block-bodied compiled controls. The compiler
+report must contain a nonzero `keyedArrayPositionHints` count; package tests separately require zero
+surviving key/descriptor/binding reads for removal, surrounding DOM identity, randomized
+differential correctness, hydration, and cleanup. Known-position removal must remain at least 4x
+faster than React and 1.5x faster than the compiled control.
 
 Native keyed-array reversal has a separate 10,000-row comparison. Concise `toReversed()` is
 measured against bracketed React and an equivalent block-bodied compiled control. Both compiler
@@ -172,7 +174,7 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
   updater. It isolates the saved survivor scan while both paths remove the same 1,000 DOM rows.
 - The known-position controls compare concise native `toSpliced()`/`with()` updates with equivalent
   block-bodied compiled controls. They verify surrounding DOM identity and isolate the saved full
-  keyed scan for one insertion or replacement.
+  keyed scan for one insertion, removal, or replacement.
 - The reverse control compares concise native `toReversed()` with an equivalent block-bodied
   compiled update. Both paths move the same keyed DOM rows; the hint isolates the saved key,
   descriptor, binding, and generic LIS work.

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -610,6 +610,42 @@ async function measureTrial(browser, trial, compilerMode, port) {
           },
         );
 
+        const tablePositionRemove = await measureTable(
+          async () => ensure10000(),
+          async () => {
+            const rows = table.querySelectorAll("tbody tr");
+            const before = rows[8_999];
+            const removed = rows[9_000];
+            const after = rows[9_001];
+            await runTableAction(
+              () => tableButton("table-position-remove").click(),
+              () =>
+                rowCount() === 9_999 &&
+                table.querySelectorAll("tbody tr")[8_999] === before &&
+                table.querySelectorAll("tbody tr")[9_000] === after &&
+                !removed?.isConnected,
+            );
+          },
+        );
+
+        const tablePositionRemoveSnapshot = await measureTable(
+          async () => ensure10000(),
+          async () => {
+            const rows = table.querySelectorAll("tbody tr");
+            const before = rows[8_999];
+            const removed = rows[9_000];
+            const after = rows[9_001];
+            await runTableAction(
+              () => tableButton("table-position-remove-snapshot").click(),
+              () =>
+                rowCount() === 9_999 &&
+                table.querySelectorAll("tbody tr")[8_999] === before &&
+                table.querySelectorAll("tbody tr")[9_000] === after &&
+                !removed?.isConnected,
+            );
+          },
+        );
+
         const tablePositionReplace = await measureTable(
           async () => ensure10000(),
           async () => {
@@ -1068,6 +1104,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             prependSnapshot: tablePrependSnapshot,
             positionInsert: tablePositionInsert,
             positionInsertSnapshot: tablePositionInsertSnapshot,
+            positionRemove: tablePositionRemove,
+            positionRemoveSnapshot: tablePositionRemoveSnapshot,
             positionReplace: tablePositionReplace,
             positionReplaceSnapshot: tablePositionReplaceSnapshot,
             reverse: tableReverse,
@@ -1162,6 +1200,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
         prependSnapshot: timingSummary(result.table.prependSnapshot),
         positionInsert: timingSummary(result.table.positionInsert),
         positionInsertSnapshot: timingSummary(result.table.positionInsertSnapshot),
+        positionRemove: timingSummary(result.table.positionRemove),
+        positionRemoveSnapshot: timingSummary(result.table.positionRemoveSnapshot),
         positionReplace: timingSummary(result.table.positionReplace),
         positionReplaceSnapshot: timingSummary(result.table.positionReplaceSnapshot),
         reverse: timingSummary(result.table.reverse),
@@ -1252,6 +1292,8 @@ const tableMetrics = [
   "prependSnapshot",
   "positionInsert",
   "positionInsertSnapshot",
+  "positionRemove",
+  "positionRemoveSnapshot",
   "positionReplace",
   "positionReplaceSnapshot",
   "reverse",
@@ -1495,16 +1537,20 @@ const keyedRollingWindowRegressions = keyedRollingWindowResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedRollingWindowMinimumSnapshotSpeedup,
 );
-// Native toSpliced()/with() calls expose one exact insertion or replacement position. The hinted
+// Native toSpliced()/with() calls expose one exact insertion, removal, or replacement position. The hinted
 // runtime should beat both React and an equivalent block-bodied compiled control while preserving
 // the same row identities around the changed position.
 const keyedPositionInsertMinimumSpeedup = 1.1;
 const keyedPositionInsertMinimumSnapshotSpeedup = 1.1;
+const keyedPositionRemoveMinimumSpeedup = 4;
+const keyedPositionRemoveMinimumSnapshotSpeedup = 1.5;
 const keyedPositionReplaceMinimumSpeedup = 2;
 const keyedPositionReplaceMinimumSnapshotSpeedup = 1.5;
 const keyedPositionResults = ["static", "hybrid"].map((mode) => {
   const insertMedianMs = comparisons.table.positionInsert[mode].medianMs;
   const insertSnapshotMedianMs = comparisons.table.positionInsertSnapshot[mode].medianMs;
+  const removeMedianMs = comparisons.table.positionRemove[mode].medianMs;
+  const removeSnapshotMedianMs = comparisons.table.positionRemoveSnapshot[mode].medianMs;
   const replaceMedianMs = comparisons.table.positionReplace[mode].medianMs;
   const replaceSnapshotMedianMs = comparisons.table.positionReplaceSnapshot[mode].medianMs;
   return {
@@ -1513,6 +1559,10 @@ const keyedPositionResults = ["static", "hybrid"].map((mode) => {
     insertSnapshotSpeedup: insertSnapshotMedianMs / insertMedianMs,
     insertSpeedup: comparisons.table.positionInsert[`${mode}VsBaseline`].speedup,
     mode,
+    removeMedianMs,
+    removeSnapshotMedianMs,
+    removeSnapshotSpeedup: removeSnapshotMedianMs / removeMedianMs,
+    removeSpeedup: comparisons.table.positionRemove[`${mode}VsBaseline`].speedup,
     replaceMedianMs,
     replaceSnapshotMedianMs,
     replaceSnapshotSpeedup: replaceSnapshotMedianMs / replaceMedianMs,
@@ -1520,11 +1570,22 @@ const keyedPositionResults = ["static", "hybrid"].map((mode) => {
   };
 });
 const keyedPositionRegressions = keyedPositionResults.filter(
-  ({ insertSnapshotSpeedup, insertSpeedup, replaceSnapshotSpeedup, replaceSpeedup }) =>
+  ({
+    insertSnapshotSpeedup,
+    insertSpeedup,
+    removeSnapshotSpeedup,
+    removeSpeedup,
+    replaceSnapshotSpeedup,
+    replaceSpeedup,
+  }) =>
     !Number.isFinite(insertSpeedup) ||
     insertSpeedup < keyedPositionInsertMinimumSpeedup ||
     !Number.isFinite(insertSnapshotSpeedup) ||
     insertSnapshotSpeedup < keyedPositionInsertMinimumSnapshotSpeedup ||
+    !Number.isFinite(removeSpeedup) ||
+    removeSpeedup < keyedPositionRemoveMinimumSpeedup ||
+    !Number.isFinite(removeSnapshotSpeedup) ||
+    removeSnapshotSpeedup < keyedPositionRemoveMinimumSnapshotSpeedup ||
     !Number.isFinite(replaceSpeedup) ||
     replaceSpeedup < keyedPositionReplaceMinimumSpeedup ||
     !Number.isFinite(replaceSnapshotSpeedup) ||
@@ -1781,6 +1842,8 @@ const report = {
     insertMinimumSnapshotSpeedup: keyedPositionInsertMinimumSnapshotSpeedup,
     insertMinimumSpeedup: keyedPositionInsertMinimumSpeedup,
     regressions: keyedPositionRegressions,
+    removeMinimumSnapshotSpeedup: keyedPositionRemoveMinimumSnapshotSpeedup,
+    removeMinimumSpeedup: keyedPositionRemoveMinimumSpeedup,
     replaceMinimumSnapshotSpeedup: keyedPositionReplaceMinimumSnapshotSpeedup,
     replaceMinimumSpeedup: keyedPositionReplaceMinimumSpeedup,
     results: keyedPositionResults,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -6,6 +6,7 @@ declare global {
   interface Array<T> {
     toReversed(): T[];
     toSorted(compare?: (left: T, right: T) => number): T[];
+    toSpliced(start: number, deleteCount: number): T[];
     toSpliced(start: number, deleteCount: number, item: T): T[];
     with(index: number, item: T): T[];
   }
@@ -279,6 +280,30 @@ export function StandardTableBenchmark() {
           }}
         >
           Insert at known position (snapshot control)
+        </button>
+        <button
+          data-action="table-position-remove"
+          type="button"
+          onClick={() => {
+            setRows((current) => current.toSpliced(9_000, 1));
+            setOperation("remove at known position");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Remove at known position
+        </button>
+        <button
+          data-action="table-position-remove-snapshot"
+          type="button"
+          onClick={() => {
+            setRows((current) => {
+              return current.toSpliced(9_000, 1);
+            });
+            setOperation("remove at known position (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Remove at known position (snapshot control)
         </button>
         <button
           data-action="table-position-replace"

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -301,18 +301,20 @@ Native known-position updates can avoid a complete keyed scan too:
 
 ```tsx
 setItems((current) => current.toSpliced(500, 0, nextItem));
+setItems((current) => current.toSpliced(500, 1));
 setItems((current) => current.with(500, replacement));
 ```
 
 The compiler recognizes only a concise functional setter, a build-time safe-integer position, one
-inserted item with zero removals, or one direct replacement. Farm preserves the ordinary native
-method call and records metadata only after validating the committed native source and result. The
-runtime creates one inserted row or patches/replaces one row at the known position without
-rereading every existing key, descriptor, and binding. Index-aware or collection-reading rows,
-custom methods, other `toSpliced()` forms, block-bodied updaters, unsafe incoming expressions,
-queued uncommitted updates, reused keys, nested or React-owned rows, and failed checks use complete
-keyed reconciliation. Reports expose the site count as `keyedArrayPositionHints`; the capability is
-tree-shaken from modules that do not emit it.
+inserted item with zero removals, one removed item, or one direct replacement. Farm preserves the
+ordinary native method call and records metadata only after validating the committed native source
+and result. The runtime creates one inserted row, removes one known row, or patches/replaces one row
+at the known position without rereading every existing key, descriptor, and binding. Surviving rows
+keep their DOM identity. Index-aware or collection-reading rows, custom methods, other
+`toSpliced()` forms, block-bodied updaters, unsafe incoming expressions, queued uncommitted updates,
+reused keys, nested or React-owned rows, and failed checks use complete keyed reconciliation.
+Reports expose the site count as `keyedArrayPositionHints`; the capability is tree-shaken from
+modules that do not emit it.
 
 A direct native reverse can carry its complete permutation to a separate optional runtime:
 
@@ -651,8 +653,8 @@ reasons aggregated by count. Its summary and per-module `optimizations` also rep
 `keyedArrayAppendHints`, the number of compiler-proven direct keyed-array append sites; and
 `keyedArrayFilterHints`, the number of compiler-proven direct keyed-array filter sites; and
 `keyedArrayPrependHints`, the number of compiler-proven direct keyed-array prepend sites; and
-`keyedArrayPositionHints`, the number of compiler-proven native known-position insertion or
-replacement sites; and
+`keyedArrayPositionHints`, the number of compiler-proven native known-position insertion, removal,
+or replacement sites; and
 `keyedArrayReorderHints`, the number of compiler-proven direct native keyed-array reverse sites; and
 `keyedArraySortHints`, the number of compiler-proven direct native keyed-array sort sites; and
 `keyedArrayRollingWindowHints`, the number of compiler-proven retained-tail plus incoming-suffix

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -94,14 +94,14 @@
         "brotli": 51741
       },
       "compilerOn": {
-        "raw": 235659,
-        "gzip": 72206,
-        "brotli": 61849
+        "raw": 236016,
+        "gzip": 72264,
+        "brotli": 61915
       },
       "compilerPremium": {
-        "raw": 42761,
-        "gzip": 12130,
-        "brotli": 10108
+        "raw": 43118,
+        "gzip": 12188,
+        "brotli": 10174
       }
     },
     "keyedReorder": {
@@ -179,16 +179,16 @@
         "brotli": 51666
       },
       "full": {
-        "raw": 279507,
-        "gzip": 79192,
-        "brotli": 67772
+        "raw": 279783,
+        "gzip": 79263,
+        "brotli": 67731
       },
       "coreOnly": {
         "raw": 204922,
         "gzip": 63685,
         "brotli": 54902
       },
-      "fullRuntimePremiumGzip": 19273,
+      "fullRuntimePremiumGzip": 19344,
       "coreRuntimePremiumGzip": 3766,
       "gzipReductionPercent": 80.5
     }

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.md
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.md
@@ -29,12 +29,12 @@ is enforced on every pull request instead of serving only as a manually recorded
 | Keyed rows with prepend hints                     |          60,087 B |         72,080 B |         11,993 B |
 | Keyed rows with filter hints                      |          60,088 B |         72,298 B |         12,210 B |
 | Keyed rows with slice hints                       |          60,075 B |         72,335 B |         12,260 B |
-| Keyed rows with known-position hints              |          60,076 B |         72,206 B |         12,130 B |
+| Keyed rows with known-position hints              |          60,076 B |         72,264 B |         12,188 B |
 | Keyed rows with reverse hints                     |          60,058 B |         72,164 B |         12,106 B |
 | Keyed rows with sort hints                        |          60,077 B |         72,219 B |         12,142 B |
 | Keyed rows with rolling-window hints              |          60,098 B |         73,082 B |         12,984 B |
 
-The isolated compatibility runtime contributes 19,273 B gzip over the React control. The
+The isolated compatibility runtime contributes 19,344 B gzip over the React control. The
 compiler-selected core contributes 3,766 B, an **80.5% reduction**. This comparison uses the same
 hand-authored compiled definition and changes only the runtime entry used to create it.
 
@@ -45,7 +45,7 @@ fixtures prove that recognized functional updates retain only the matching hinte
 reuses the filter removal capability. Position-only and rolling-window modules select separate
 hint runtimes only when the compiler emits those update shapes. Reverse and sort share the
 optional reorder capability; the direct and isolated core results remain byte-for-byte unchanged.
-The position fixture pays a 937 B gzip premium, reverse pays 913 B, sort pays 949 B, slice pays
+The position fixture pays a 995 B gzip premium, reverse pays 913 B, sort pays 949 B, slice pays
 1,067 B, and rolling-window pays 1,791 B over the ordinary keyed fixture. Unrelated bundles reject
 the optional position and reorder runtime markers, and the direct fixture rejects every structural
 runtime marker. The checked

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -44,6 +44,7 @@ const testSource = String.raw`
     createCompiledComponentWithFeatures,
     createCompilerKeyedArrayAppend,
     createCompilerKeyedArrayFilter,
+    createCompilerKeyedArrayPositionUpdate,
     createCompilerKeyedArrayPrepend,
     createCompilerKeyedArrayReorder,
     createCompilerKeyedArraySort,
@@ -88,6 +89,7 @@ const testSource = String.raw`
   flushSync(() => root.unmount());
 
   let reverseCompatibilityRows = () => undefined;
+  let removeCompatibilityRow = () => undefined;
   let sortCompatibilityRows = () => undefined;
   let reorderExecutions = 0;
   const ReorderRows = createCompiledComponent({
@@ -103,6 +105,16 @@ const testSource = String.raw`
       reverseCompatibilityRows = () =>
         state[0].set((previous) =>
           createCompilerKeyedArrayReorder(previous, previous.toReversed),
+        );
+      removeCompatibilityRow = () =>
+        state[0].set((previous) =>
+          createCompilerKeyedArrayPositionUpdate(
+            previous,
+            previous.toSpliced,
+            "remove",
+            1,
+            1,
+          ),
         );
       sortCompatibilityRows = () =>
         state[0].set((previous) =>
@@ -120,6 +132,7 @@ const testSource = String.raw`
           dependencies: [0],
           id: 0,
           items,
+          positionIndexIndependent: true,
           reorderIndexIndependent: true,
           structureDependencies: [0],
           render: () =>
@@ -160,6 +173,13 @@ const testSource = String.raw`
   sortCompatibilityRows();
   await Promise.resolve();
   await Promise.resolve();
+  assert.equal(reorderContainer.querySelector("li:first-child"), reorderBeta);
+  assert.equal(reorderContainer.querySelector("li:last-child"), reorderAlpha);
+  assert.equal(reorderExecutions, 1);
+  removeCompatibilityRow();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(reorderContainer.querySelector("[data-key='c']"), null);
   assert.equal(reorderContainer.querySelector("li:first-child"), reorderBeta);
   assert.equal(reorderContainer.querySelector("li:last-child"), reorderAlpha);
   assert.equal(reorderExecutions, 1);

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-position-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-position-hints.test.ts
@@ -9,13 +9,14 @@ async function compile(source: string) {
 }
 
 describe("React AOT keyed-array position hints", () => {
-  it("records native known-position insertion and replacement", async () => {
+  it("records native known-position insertion, removal, and replacement", async () => {
     const result = await compile(`
       import { useState } from "react";
       export function Table({ next }) {
         const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
         return <section>
           <button onClick={() => setRows((current) => current.toSpliced(1, 0, next))}>Insert</button>
+          <button onClick={() => setRows((current) => current.toSpliced(0, 1))}>Remove</button>
           <button onClick={() => setRows((current) => current.with(0, next))}>Replace</button>
           <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
         </section>;
@@ -23,7 +24,7 @@ describe("React AOT keyed-array position hints", () => {
     `);
 
     expect(result.compiled).toEqual(["Table"]);
-    expect(result.optimizations.keyedArrayPositionHints).toBe(2);
+    expect(result.optimizations.keyedArrayPositionHints).toBe(3);
     expect(result.code).toContain("createCompilerKeyedArrayPositionUpdate");
     expect(result.code).toContain("keyedRowsPositionHintedRuntimeFeature");
   });
@@ -35,12 +36,13 @@ describe("React AOT keyed-array position hints", () => {
         const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
         return <section>
           <button onClick={() => setRows((current) => current.with(-1, next))}>Replace</button>
+          <button onClick={() => setRows((current) => current.toSpliced(-1, 1))}>Remove</button>
           <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
         </section>;
       }
     `);
 
-    expect(result.optimizations.keyedArrayPositionHints).toBe(1);
+    expect(result.optimizations.keyedArrayPositionHints).toBe(2);
   });
 
   it.each([
@@ -60,14 +62,39 @@ describe("React AOT keyed-array position hints", () => {
       update: "{ return current.with(0, next); }",
     },
     {
+      name: "a block-bodied removal updater",
+      row: "row => <li key={row.id}>{row.label}</li>",
+      update: "{ return current.toSpliced(0, 1); }",
+    },
+    {
       name: "an unsafe incoming call",
       row: "row => <li key={row.id}>{row.label}</li>",
       update: "current.with(0, makeNext())",
     },
     {
-      name: "a removal",
+      name: "a zero-count removal",
       row: "row => <li key={row.id}>{row.label}</li>",
-      update: "current.toSpliced(0, 1)",
+      update: "current.toSpliced(0, 0)",
+    },
+    {
+      name: "a multi-item removal",
+      row: "row => <li key={row.id}>{row.label}</li>",
+      update: "current.toSpliced(0, 2)",
+    },
+    {
+      name: "a dynamic removal count",
+      row: "row => <li key={row.id}>{row.label}</li>",
+      update: "current.toSpliced(0, deleteCount)",
+    },
+    {
+      name: "a computed removal method",
+      row: "row => <li key={row.id}>{row.label}</li>",
+      update: 'current["toSpliced"](0, 1)',
+    },
+    {
+      name: "a chained removal source",
+      row: "row => <li key={row.id}>{row.label}</li>",
+      update: "current.slice().toSpliced(0, 1)",
     },
     {
       name: "a multi-item insertion",
@@ -82,7 +109,7 @@ describe("React AOT keyed-array position hints", () => {
   ])("keeps $name off the position fast path", async ({ row, update }) => {
     const result = await compile(`
       import { useState } from "react";
-      export function Table({ next, offset, makeNext }) {
+      export function Table({ next, offset, deleteCount, makeNext }) {
         const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
         return <section>
           <button onClick={() => setRows((current) => ${update})}>Change</button>

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-position-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-position-hints.test.tsx
@@ -19,6 +19,7 @@ interface Item {
 }
 
 type PositionArray = Item[] & {
+  toSpliced(start: number, deleteCount: number): Item[];
   toSpliced(start: number, deleteCount: number, item: Item): Item[];
   with(index: number, item: Item): Item[];
 };
@@ -64,6 +65,17 @@ function hintedReplace(previous: Item[], position: number, item: Item): Item[] {
   ) as Item[];
 }
 
+function hintedRemove(previous: Item[], position: number): Item[] {
+  const source = previous as PositionArray;
+  return createCompilerKeyedArrayPositionUpdate(
+    source,
+    source.toSpliced,
+    "remove",
+    position,
+    1,
+  ) as Item[];
+}
+
 function rowDescriptor(item: Item, text = item.label): CompilerKeyedRowElement {
   return {
     kind: "element",
@@ -77,8 +89,10 @@ function rowDescriptor(item: Item, text = item.label): CompilerKeyedRowElement {
 function createPositionHarness(initialItems: Item[], readsCollection = false) {
   const counters = { executions: 0, renders: 0, keys: 0, descriptors: 0, bindings: 0 };
   let insert: (position: number, item: Item) => void = () => undefined;
+  let remove: (position: number) => void = () => undefined;
   let replace: (position: number, item: Item) => void = () => undefined;
   let queueTwo: (first: Item, second: Item) => void = () => undefined;
+  let queueRemoveTwo: () => void = () => undefined;
   let customInsert: (item: Item) => void = () => undefined;
   const Table = createCompiledComponent({
     displayName: "PositionTable",
@@ -88,11 +102,16 @@ function createPositionHarness(initialItems: Item[], readsCollection = false) {
       const items = () => state[0].get() as Item[];
       insert = (position, item) =>
         state[0].set((previous) => hintedInsert(previous as Item[], position, item));
+      remove = (position) => state[0].set((previous) => hintedRemove(previous as Item[], position));
       replace = (position, item) =>
         state[0].set((previous) => hintedReplace(previous as Item[], position, item));
       queueTwo = (first, second) => {
         state[0].set((previous) => hintedInsert(previous as Item[], 1, first));
         state[0].set((previous) => hintedInsert(previous as Item[], 2, second));
+      };
+      queueRemoveTwo = () => {
+        state[0].set((previous) => hintedRemove(previous as Item[], 1));
+        state[0].set((previous) => hintedRemove(previous as Item[], 1));
       };
       customInsert = (item) =>
         state[0].set((previous) => {
@@ -157,6 +176,8 @@ function createPositionHarness(initialItems: Item[], readsCollection = false) {
     customInsert: (item: Item) => customInsert(item),
     insert: (position: number, item: Item) => insert(position, item),
     queueTwo: (first: Item, second: Item) => queueTwo(first, second),
+    queueRemoveTwo: () => queueRemoveTwo(),
+    remove: (position: number) => remove(position),
     replace: (position: number, item: Item) => replace(position, item),
   };
 }
@@ -196,6 +217,41 @@ describe("compiled keyed-array position hints", () => {
     expect(harness.counters.bindings).toBe(1);
   });
 
+  it("removes one row at a known position without reading surviving keys or bindings", async () => {
+    const initialItems = Array.from(
+      { length: 4_096 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createPositionHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const before = container.querySelector('[data-key="row-2047"]');
+    const removed = container.querySelector('[data-key="row-2048"]');
+    const after = container.querySelector('[data-key="row-2049"]');
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.remove(2_048);
+      await flushCompilerUpdates();
+    });
+
+    const rows = [...container.querySelectorAll("li")];
+    expect(rows[2_047]).toBe(before);
+    expect(rows[2_048]).toBe(after);
+    expect(removed?.isConnected).toBe(false);
+    expect(rows).toHaveLength(4_095);
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
+    expect(harness.counters.keys).toBe(0);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(0);
+  });
+
   it("patches a same-key replacement and creates one host row for a new key", async () => {
     const harness = createPositionHarness([
       { id: "a", label: "Alpha" },
@@ -232,6 +288,91 @@ describe("compiled keyed-array position hints", () => {
     expect(harness.counters.keys).toBe(2);
     expect(harness.counters.descriptors).toBe(1);
     expect(harness.counters.bindings).toBe(2);
+  });
+
+  it("preserves native removal arguments, return values, and errors", () => {
+    const source = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ] as PositionArray;
+    const removed = createCompilerKeyedArrayPositionUpdate(
+      source,
+      source.toSpliced,
+      "remove",
+      -1,
+      1,
+    ) as Item[];
+    expect(removed.map((item) => item.id)).toEqual(["a", "b"]);
+    expect(source.map((item) => item.id)).toEqual(["a", "b", "c"]);
+
+    const customResult = [source[1]];
+    const custom = function (this: Item[], position: number, deleteCount: number) {
+      expect(this).toBe(source);
+      expect([position, deleteCount]).toEqual([1, 1]);
+      return customResult;
+    };
+    expect(createCompilerKeyedArrayPositionUpdate(source, custom, "remove", 1, 1)).toBe(
+      customResult,
+    );
+
+    const error = new Error("remove failed");
+    expect(() =>
+      createCompilerKeyedArrayPositionUpdate(
+        source,
+        () => {
+          throw error;
+        },
+        "remove",
+        1,
+        1,
+      ),
+    ).toThrow(error);
+  });
+
+  it("preserves native negative, clamped, empty, and subclass removal behavior", async () => {
+    class ItemArray extends Array<Item> {}
+    const initialItems = new ItemArray(
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    );
+    const harness = createPositionHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+
+    await act(async () => {
+      harness.remove(-1);
+      await flushCompilerUpdates();
+    });
+    expect([...container.querySelectorAll("li")].map((node) => node.textContent)).toEqual([
+      "Alpha",
+      "Beta",
+    ]);
+
+    const alpha = container.querySelector('[data-key="a"]');
+    const beta = container.querySelector('[data-key="b"]');
+    await act(async () => {
+      harness.remove(99);
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-key="b"]')).toBe(beta);
+
+    await act(async () => {
+      harness.remove(-99);
+      await flushCompilerUpdates();
+      harness.remove(0);
+      await flushCompilerUpdates();
+      harness.remove(0);
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelectorAll("li")).toHaveLength(0);
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
   });
 
   it("falls back for custom methods, collection-dependent bindings, and queued hints", async () => {
@@ -275,35 +416,61 @@ describe("compiled keyed-array position hints", () => {
     ]);
 
     await act(async () => {
+      dependent.remove(1);
+      await flushCompilerUpdates();
+    });
+    expect([...dependentContainer.querySelectorAll("li")].map((node) => node.textContent)).toEqual([
+      "3: Alpha",
+      "3: Beta",
+      "3: Gamma",
+    ]);
+
+    await act(async () => {
       dependent.queueTwo({ id: "e", label: "Epsilon" }, { id: "f", label: "Phi" });
       await flushCompilerUpdates();
     });
     expect([...dependentContainer.querySelectorAll("li")].map((node) => node.textContent)).toEqual([
-      "6: Alpha",
-      "6: Epsilon",
-      "6: Phi",
-      "6: Delta",
-      "6: Beta",
-      "6: Gamma",
+      "5: Alpha",
+      "5: Epsilon",
+      "5: Phi",
+      "5: Beta",
+      "5: Gamma",
+    ]);
+
+    await act(async () => {
+      dependent.queueRemoveTwo();
+      await flushCompilerUpdates();
+    });
+    expect([...dependentContainer.querySelectorAll("li")].map((node) => node.textContent)).toEqual([
+      "3: Alpha",
+      "3: Beta",
+      "3: Gamma",
     ]);
   });
 
-  it("matches normal React through 400 deterministic inserts and replacements", async () => {
+  it("matches normal React through 1,000 deterministic position updates", async () => {
     const initialItems = Array.from(
       { length: 24 },
       (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
     );
     const harness = createPositionHarness(initialItems);
-    let updateReact: (kind: "insert" | "replace", position: number, item: Item) => void = () =>
-      undefined;
+    let updateReact: (
+      kind: "insert" | "remove" | "replace",
+      position: number,
+      item?: Item,
+    ) => void = () => undefined;
     function NormalTable() {
       const [items, setItems] = useState(initialItems);
       updateReact = (kind, position, item) =>
-        setItems((previous) =>
-          kind === "insert"
+        setItems((previous) => {
+          if (kind === "remove") {
+            return [...previous.slice(0, position), ...previous.slice(position + 1)];
+          }
+          if (!item) return previous;
+          return kind === "insert"
             ? [...previous.slice(0, position), item, ...previous.slice(position)]
-            : previous.map((current, index) => (index === position ? item : current)),
-        );
+            : previous.map((current, index) => (index === position ? item : current));
+        });
       return (
         <ol>
           {items.map((item) => (
@@ -324,19 +491,25 @@ describe("compiled keyed-array position hints", () => {
     });
 
     let length = initialItems.length;
-    for (let step = 0; step < 400; step += 1) {
-      const insert = step % 5 === 0;
-      const position = (step * 17) % (insert ? length + 1 : length);
-      const item = insert
-        ? { id: `insert-${step}`, label: `Insert ${step}` }
-        : { id: `replace-${step}`, label: `Replace ${step}` };
+    for (let step = 0; step < 1_000; step += 1) {
+      const kind = step % 7 === 0 ? "remove" : step % 5 === 0 ? "insert" : "replace";
+      const position = (step * 17) % (kind === "insert" ? length + 1 : length);
+      const item =
+        kind === "remove"
+          ? undefined
+          : {
+              id: `${kind}-${step}`,
+              label: `${kind === "insert" ? "Insert" : "Replace"} ${step}`,
+            };
       await act(async () => {
-        if (insert) harness.insert(position, item);
-        else harness.replace(position, item);
-        updateReact(insert ? "insert" : "replace", position, item);
+        if (kind === "insert") harness.insert(position, item!);
+        else if (kind === "remove") harness.remove(position);
+        else harness.replace(position, item!);
+        updateReact(kind, position, item);
         await flushCompilerUpdates();
       });
-      if (insert) length += 1;
+      if (kind === "insert") length += 1;
+      else if (kind === "remove") length -= 1;
     }
 
     expect(compiledContainer.querySelector("ul")?.textContent).toBe(
@@ -345,6 +518,157 @@ describe("compiled keyed-array position hints", () => {
     expect(compiledContainer.querySelectorAll("li")).toHaveLength(length);
     expect(harness.counters.executions).toBe(1);
     expect(harness.counters.renders).toBe(1);
+  });
+
+  it("preserves focused input identity and selection when removing a preceding row", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ];
+    let remove = () => undefined;
+    const FormRows = createCompiledComponent({
+      displayName: "PositionRemovalFormRows",
+      initialize: () => [initialItems],
+      render(_props: Record<string, never>, state, blocks) {
+        const items = () => state[0].get() as Item[];
+        remove = () => state[0].set((previous) => hintedRemove(previous as Item[], 0));
+        return (
+          <section>
+            <blocks.KeyedRows
+              collectionDependency={0}
+              dependencies={[0]}
+              id={0}
+              items={items}
+              positionIndexIndependent
+              structureDependencies={[0]}
+              render={() => (
+                <div>
+                  {items().map((item) => (
+                    <input data-key={item.id} key={item.id} readOnly value={item.label} />
+                  ))}
+                </div>
+              )}
+              rowKey={(item) => (item as Item).id}
+              create={(item) => ({
+                kind: "element",
+                tag: "input",
+                attributes: [
+                  { name: "data-key", value: (item as Item).id },
+                  { name: "readOnly", value: true },
+                  { name: "value", value: (item as Item).label },
+                ],
+                styles: [],
+                children: [],
+              })}
+              bindings={[]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<FormRows />));
+    const input = container.querySelector('[data-key="b"]') as HTMLInputElement;
+    input.focus();
+    input.setSelectionRange(1, 3);
+
+    await act(async () => {
+      remove();
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector('[data-key="b"]')).toBe(input);
+    expect(document.activeElement).toBe(input);
+    expect([input.selectionStart, input.selectionEnd]).toEqual([1, 3]);
+  });
+
+  it("updates delegated event indexes after removing an earlier row", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ];
+    let remove = () => undefined;
+    const calls: string[] = [];
+    const EventRows = createCompiledComponent({
+      displayName: "PositionRemovalEventRows",
+      initialize: () => [initialItems],
+      render(_props: Record<string, never>, state, blocks) {
+        const items = () => state[0].get() as Item[];
+        remove = () => state[0].set((previous) => hintedRemove(previous as Item[], 0));
+        return (
+          <section>
+            <blocks.KeyedRows
+              collectionDependency={0}
+              delegateEvents
+              dependencies={[0]}
+              events={[
+                {
+                  invoke: (item, index) => calls.push(`${(item as Item).id}:${index}`),
+                  name: "onClick",
+                  path: [0],
+                },
+              ]}
+              id={0}
+              items={items}
+              positionIndexIndependent
+              structureDependencies={[0]}
+              render={(event) => (
+                <ul>
+                  {items().map((item, index) => (
+                    <li data-key={item.id} key={item.id}>
+                      <button data-row-button={item.id} onClick={event(item, index, 0)}>
+                        {item.label}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+              create={(item) => {
+                const row = item as Item;
+                return {
+                  kind: "element",
+                  tag: "li",
+                  attributes: [{ name: "data-key", value: row.id }],
+                  styles: [],
+                  children: [
+                    {
+                      kind: "element",
+                      tag: "button",
+                      attributes: [{ name: "data-row-button", value: row.id }],
+                      styles: [],
+                      children: [row.label],
+                    },
+                  ],
+                };
+              }}
+              bindings={[]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<EventRows />));
+
+    await act(async () => {
+      remove();
+      await flushCompilerUpdates();
+    });
+    await act(async () => {
+      (container.querySelector('[data-row-button="c"]') as HTMLButtonElement).click();
+    });
+    expect(calls).toEqual(["c:1"]);
   });
 
   it("hydrates in StrictMode and drops a queued position update after unmount", async () => {
@@ -377,6 +701,13 @@ describe("compiled keyed-array position hints", () => {
       await flushCompilerUpdates();
     });
     expect(container.textContent).toBe("AlphaGammaBeta");
+    expect(recoverable).toEqual([]);
+
+    await act(async () => {
+      harness.remove(-1);
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("AlphaGamma");
     expect(recoverable).toEqual([]);
 
     roots.pop();

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -46,7 +46,7 @@ interface CompilerKeyedArrayRollingWindowHint {
 }
 
 interface CompilerKeyedArrayPositionHint {
-  readonly kind: "insert" | "replace";
+  readonly kind: "insert" | "remove" | "replace";
   readonly sourceToken: object;
   readonly sourceLength: number;
   readonly resultLength: number;
@@ -330,6 +330,8 @@ function compilerKeyedArrayPosition(
     update.position < 0 ||
     update.position > expectedLength ||
     (update.kind === "insert" && update.resultLength !== expectedLength + 1) ||
+    (update.kind === "remove" &&
+      (update.position >= expectedLength || update.resultLength !== expectedLength - 1)) ||
     (update.kind === "replace" &&
       (update.position >= expectedLength || update.resultLength !== expectedLength))
   ) {
@@ -670,11 +672,11 @@ export function createCompilerKeyedArrayRollingWindow(
   return value;
 }
 
-/** @internal Executes a native known-position insert or replacement and records its position. */
+/** @internal Executes a native known-position insert, removal, or replacement and records it. */
 export function createCompilerKeyedArrayPositionUpdate(
   previous: unknown,
   method: unknown,
-  kind: "insert" | "replace",
+  kind: "insert" | "remove" | "replace",
   position: number,
   ...args: readonly unknown[]
 ): unknown {
@@ -710,6 +712,13 @@ export function createCompilerKeyedArrayPositionUpdate(
       args.length === 2 &&
       Object.is(args[0], 0) &&
       value.length === sourceLength + 1;
+    const validRemove =
+      kind === "remove" &&
+      method === NATIVE_ARRAY_TO_SPLICED &&
+      args.length === 1 &&
+      Object.is(args[0], 1) &&
+      normalizedPosition < sourceLength &&
+      value.length === sourceLength - 1;
     const validReplace =
       kind === "replace" &&
       method === NATIVE_ARRAY_WITH &&
@@ -717,7 +726,7 @@ export function createCompilerKeyedArrayPositionUpdate(
       position >= -sourceLength &&
       position < sourceLength &&
       value.length === sourceLength;
-    if (!validInsert && !validReplace) return value;
+    if (!validInsert && !validRemove && !validReplace) return value;
 
     const sourceToken = compilerKeyedCollectionToken(previousTarget);
     if (!sourceToken) return value;
@@ -4322,6 +4331,17 @@ function reconcileCompilerKeyedArrayPosition(
   if (!update || !Array.isArray(finalValue)) return undefined;
   const previousInstances = [...instances.values()];
   const previous = previousInstances[update.position];
+
+  if (update.kind === "remove") {
+    if (!previous || previous.index !== update.position) return undefined;
+    previous.scope?.cleanup();
+    previous.element.remove();
+    previousInstances.splice(update.position, 1);
+    for (let index = update.position; index < previousInstances.length; index += 1) {
+      previousInstances[index].index = index;
+    }
+    return new Map(previousInstances.map((instance) => [instance.key, instance]));
+  }
 
   let item: unknown;
   let key: string;

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -1618,14 +1618,18 @@ function rewriteKeyedArrayPositionHints(
               args.length === 3 &&
               t.isNumericLiteral(args[1], { value: 0 })
             ? "insert"
-            : undefined;
-      if (!kind || !t.isExpression(args[0]) || !t.isExpression(args.at(-1))) return;
+            : methodName === "toSpliced" &&
+                args.length === 2 &&
+                t.isNumericLiteral(args[1], { value: 1 })
+              ? "remove"
+              : undefined;
+      if (!kind || !t.isExpression(args[0])) return;
       const position = staticSliceIndex(args[0]);
-      const item = args.at(-1)!;
+      const item = kind === "remove" ? undefined : args.at(-1);
       if (
         position === undefined ||
-        !t.isExpression(item) ||
-        validateDerivedExpression(item, safeGlobals) !== undefined
+        (item !== undefined &&
+          (!t.isExpression(item) || validateDerivedExpression(item, safeGlobals) !== undefined))
       ) {
         return;
       }


### PR DESCRIPTION
## Summary

- recognize conservative concise `toSpliced(staticPosition, 1)` keyed-array updates
- execute the original native method first, then record metadata only for a committed ordinary array with a valid source token, normalized in-range position, and one-row length change
- remove and clean up only the known keyed row, preserve every surviving DOM instance, update delegated event indexes, and retain complete reconciliation for every unsupported or failed proof
- document the behavior and extend the dashboard, compatibility, runtime-size, and observability coverage

## Performance

The full default production browser benchmark passed correctness, the general regression gate, normalized scalability, and every existing specialized optimization gate.

| Mode | React median | Hinted removal | Compiled fallback | vs React | vs fallback |
| --- | ---: | ---: | ---: | ---: | ---: |
| Static | 64.95 ms | 7.00 ms | 17.00 ms | 9.28x | 2.43x |
| Hybrid | 64.95 ms | 7.00 ms | 16.80 ms | 9.28x | 2.40x |

The persisted gate requires at least 4x versus React and 1.5x versus the equivalent block-bodied compiled control. Direct and core-only runtime premiums remain unchanged; the optional position capability grows by 58 B gzip and core runtime reduction remains 80.5%.

## Verification

- `pnpm --filter @farm.js/react test` — 66 files / 555 tests passed
- focused compiler/runtime removal coverage — 24 tests passed
- 1,000 deterministic mixed position updates compared with normal React
- 4,096-row removal requires zero surviving key, descriptor, or binding reads
- native errors/arguments, negative and clamped positions, array subclasses, queued fallback, collection dependencies, delegated event indexes, focused input selection, StrictMode hydration, and unmount cleanup covered
- React 18.3.1 and React 19.2.8 compatibility passed
- React package build and type-check passed
- dashboard type-check passed
- runtime-size regression gate passed
- full dashboard benchmark passed every gate
- docs production Vercel/Nitro build passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimizes keyed array removals using concise `toSpliced(position, 1)`. Previously only insertions and replacements used the exact-position fast path; now removals also avoid re-scanning all keys, descriptors, and bindings, preserve surviving DOM instances, and update delegated event indexes.

**Performance**
- Full default production browser benchmark passes correctness and regression gates.
- Hinted removal is 9.28x faster than React (static mode) and 2.43x faster than the compiled fallback.
- Optional position capability grows by 58 B gzip; core runtime reduction remains 80.5%.

<sup>Written for commit 5690e9afc038527ad91b9d0be6dda9ab1ddf6ae5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

