### PR TITLE
perf(react): optimize dynamic keyed positions

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1024,16 +1024,20 @@ all-hint runtime.
 Native immutable array methods can state an exact insertion, removal, or replacement position:
 
 ```tsx
-setItems((current) => current.toSpliced(500, 0, nextItem));
-setItems((current) => current.toSpliced(500, 1));
-setItems((current) => current.with(500, replacement));
+setItems((current) => current.toSpliced(selectedIndex, 0, nextItem));
+setItems((current) => current.toSpliced(selectedIndex, 1));
+setItems((current) => current.with(selectedIndex, replacement));
 ```
 
-At build time, Farm recognizes only concise functional setters with a safe-integer position known
-by the compiler. `toSpliced()` must insert exactly one item with a zero delete count or remove
-exactly one item; `with()` must replace exactly one item. Farm preserves the original method lookup,
-argument evaluation, native call, return value, and thrown errors. If the method is not the native
-array method, the update still runs normally but no metadata is recorded.
+At build time, Farm recognizes only concise functional setters whose position is either a
+safe-integer literal or a compiler-safe runtime expression. Identifiers, property reads,
+side-effect-free arithmetic and conditionals, and safe `Math` calls are supported. User-defined
+calls, assignments, update expressions, and other effectful forms are not transformed.
+`toSpliced()` must insert exactly one item with a zero delete count or remove exactly one item;
+`with()` must replace exactly one item. Farm preserves the original method lookup, evaluates every
+argument once in its original order, and preserves the native call, return value, coercion, and
+thrown errors. If the method is not native or the evaluated position is not already a safe integer,
+the update still runs normally but no metadata is recorded.
 
 At update time, Farm validates the committed native source, result length, source token, normalized
 position, and any incoming key before changing the DOM. An insertion creates one row at that
@@ -1042,14 +1046,15 @@ and removes only the known row while preserving every surviving element. A same-
 patches that row in place; a new-key replacement creates and swaps one host row. The owner component
 does not rerun, and surviving row keys, descriptors, and bindings are not reread.
 
-The first proof requires compiler-owned host rows whose render and key do not observe the row index.
-Dynamic or fractional positions, other `toSpliced()` shapes, block-bodied updaters, unsafe incoming
-expressions, custom methods, queued uncommitted position updates, duplicate or reused keys,
-collection-reading bindings, React-owned rows, nested host blocks, row conditionals, unrelated dirty
-dependencies, and failed runtime checks keep complete keyed reconciliation. Negative safe-integer
-positions use the native methods' normal indexing rules. No new option or component is required.
-Reports expose emitted sites as `keyedArrayPositionHints`; position-only modules retain a separate
-optional runtime capability.
+The proof requires compiler-owned host rows whose render and key do not observe the row index.
+Effectful position expressions, runtime values that are fractional or otherwise not safe integers,
+other `toSpliced()` shapes, block-bodied updaters, unsafe incoming expressions, custom methods,
+queued uncommitted position updates, duplicate or reused keys, collection-reading bindings,
+React-owned rows, nested host blocks, row conditionals, unrelated dirty dependencies, and failed
+runtime checks keep complete keyed reconciliation. Negative safe-integer positions use the native
+methods' normal indexing rules. No new option or component is required. Reports expose emitted
+sites as `keyedArrayPositionHints`; position-only modules retain a separate optional runtime
+capability.
 
 #### Keyed array reorder hints
 
@@ -1924,10 +1929,11 @@ The package and example test suites verify more than generated code:
 - 2,000 deterministic randomized keyed-array removals match normal React; targeted tests require
   zero surviving descriptor and binding reads, preserve DOM identity, and cover queued filters,
   unhinted-chain fallback, collection-reading rows, StrictMode hydration, and unmount cleanup;
-- 1,000 deterministic known-position insertions, removals, and replacements match normal React;
-  targeted removal tests require zero surviving key, descriptor, or binding reads, preserve focused
-  input and surrounding DOM identity, and cover native semantics, negative positions, custom
-  methods, queued updates, collection-reading rows, StrictMode hydration, and cleanup;
+- 1,000 deterministic exact-position insertions, removals, and replacements match normal React;
+  compiler tests cover literal and guarded runtime expressions, while targeted removal tests
+  require zero surviving key, descriptor, or binding reads, preserve focused input and surrounding
+  DOM identity, and cover native evaluation and coercion, negative and non-integer runtime values,
+  custom methods, queued updates, collection-reading rows, StrictMode hydration, and cleanup;
 - 2,000 deterministic randomized reversals match normal React; a 4,096-row targeted test requires
   exactly `n - 1` connected DOM moves and zero key, descriptor, or binding reads, while fallback
   tests cover custom methods, queued updates, collection-reading rows, StrictMode hydration, and

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,30 @@
 
 Date: 2026-08-29
 
+## Compiler-safe runtime positions follow-up — 2026-08-30
+
+The full bracketed production-browser run replaced the three literal position controls with
+event-local runtime variables. Both compiler builds emitted all three `keyedArrayPositionHints`
+sites and passed DOM correctness, the React-relative regression gate, every existing optimization
+persistence gate, and normalized scalability.
+
+| Operation   | Mode   | React median | Hinted update | Compiled control | vs React | vs control |
+| ----------- | ------ | -----------: | ------------: | ---------------: | -------: | ---------: |
+| Insert      | Static |     83.60 ms |       8.70 ms |         24.40 ms |    9.61x |      2.80x |
+| Insert      | Hybrid |     83.60 ms |       8.10 ms |         25.30 ms |   10.32x |      3.12x |
+| Remove      | Static |     83.70 ms |      10.30 ms |         23.90 ms |    8.13x |      2.32x |
+| Remove      | Hybrid |     83.70 ms |       9.80 ms |         24.30 ms |    8.54x |      2.48x |
+| Replace     | Static |     60.00 ms |       6.50 ms |         21.10 ms |    9.23x |      3.25x |
+| Replace     | Hybrid |     60.00 ms |       5.10 ms |         17.00 ms |   11.76x |      3.33x |
+
+Static and hybrid each added zero owner executions. The full suite retained its 4x React and 1.5x
+compiled-control removal floors and every older append, prepend, slice, rolling-window, reverse,
+sort, filter, keyed-update, key-directed, collection-delta, general regression, and scalability
+floor. Because this follow-up broadens compiler eligibility and reuses the existing guarded runtime
+unchanged, runtime-size fixtures stayed byte-for-byte identical: the known-position fixture remains
+72,264 B gzip, direct and core-only premiums are unchanged, and core runtime reduction remains
+80.5%.
+
 ## Known-position removal follow-up — 2026-08-30
 
 The full default production run for concise `toSpliced(position, 1)` support passed correctness,

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -95,13 +95,14 @@ React and 1.25x faster than the compiled control. The report must contain a nonz
 `keyedArrayRollingWindowHints` count; package tests separately require retained DOM identity and
 work proportional only to the incoming suffix.
 
-Known-position insertions, removals, and replacements have separate 10,000-row comparisons. Concise
+Exact-position insertions, removals, and replacements have separate 10,000-row comparisons. Concise
 native `toSpliced(position, 0, item)`, `toSpliced(position, 1)`, and `with(position, item)` updates
-are measured against bracketed React and equivalent block-bodied compiled controls. The compiler
-report must contain a nonzero `keyedArrayPositionHints` count; package tests separately require zero
-surviving key/descriptor/binding reads for removal, surrounding DOM identity, randomized
-differential correctness, hydration, and cleanup. Known-position removal must remain at least 4x
-faster than React and 1.5x faster than the compiled control.
+use event-local runtime position variables and are measured against bracketed React and equivalent
+block-bodied compiled controls. The compiler report must contain a nonzero
+`keyedArrayPositionHints` count; package tests separately require zero surviving
+key/descriptor/binding reads for removal, surrounding DOM identity, randomized differential
+correctness, runtime-position fallback, hydration, and cleanup. Exact-position removal must remain
+at least 4x faster than React and 1.5x faster than the compiled control.
 
 Native keyed-array reversal has a separate 10,000-row comparison. Concise `toReversed()` is
 measured against bracketed React and an equivalent block-bodied compiled control. Both compiler
@@ -172,9 +173,10 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
   saved suffix scan while the hinted path still creates and inserts every required new DOM row.
 - The slice snapshot control retains the same 9,000-row suffix through an unsupported block-bodied
   updater. It isolates the saved survivor scan while both paths remove the same 1,000 DOM rows.
-- The known-position controls compare concise native `toSpliced()`/`with()` updates with equivalent
-  block-bodied compiled controls. They verify surrounding DOM identity and isolate the saved full
-  keyed scan for one insertion, removal, or replacement.
+- The exact-position controls pass event-local runtime variables to concise native
+  `toSpliced()`/`with()` updates and compare them with equivalent block-bodied compiled controls.
+  They verify surrounding DOM identity and isolate the saved full keyed scan for one insertion,
+  removal, or replacement.
 - The reverse control compares concise native `toReversed()` with an equivalent block-bodied
   compiled update. Both paths move the same keyed DOM rows; the hint isolates the saved key,
   descriptor, binding, and generic LIS work.

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -144,7 +144,7 @@ async function inspectBuild(compilerMode) {
     );
     assert(
       compilerReport.summary.keyedArrayPositionHints > 0,
-      "The compiler build did not emit a keyed-array known-position hint.",
+      "The compiler build did not emit a keyed-array exact-position hint.",
     );
     assert(
       compilerReport.summary.keyedArrayReorderHints > 0,
@@ -1537,9 +1537,9 @@ const keyedRollingWindowRegressions = keyedRollingWindowResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedRollingWindowMinimumSnapshotSpeedup,
 );
-// Native toSpliced()/with() calls expose one exact insertion, removal, or replacement position. The hinted
-// runtime should beat both React and an equivalent block-bodied compiled control while preserving
-// the same row identities around the changed position.
+// Native toSpliced()/with() calls with event-local runtime positions expose one exact insertion,
+// removal, or replacement position. The hinted runtime should beat both React and an equivalent
+// block-bodied compiled control while preserving the same row identities around the changed position.
 const keyedPositionInsertMinimumSpeedup = 1.1;
 const keyedPositionInsertMinimumSnapshotSpeedup = 1.1;
 const keyedPositionRemoveMinimumSpeedup = 4;

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -257,13 +257,14 @@ export function StandardTableBenchmark() {
           onClick={() => {
             const nextSeed = seed + 1;
             const addition = buildRows(1, nextSeed)[0];
+            const position = 9_000;
             setSeed(nextSeed);
-            setRows((current) => current.toSpliced(9_000, 0, addition));
-            setOperation("insert at known position");
+            setRows((current) => current.toSpliced(position, 0, addition));
+            setOperation("insert at runtime position");
             setRevision((value) => value + 1);
           }}
         >
-          Insert at known position
+          Insert at runtime position
         </button>
         <button
           data-action="table-position-insert-snapshot"
@@ -271,67 +272,72 @@ export function StandardTableBenchmark() {
           onClick={() => {
             const nextSeed = seed + 1;
             const addition = buildRows(1, nextSeed)[0];
+            const position = 9_000;
             setSeed(nextSeed);
             setRows((current) => {
-              return current.toSpliced(9_000, 0, addition);
+              return current.toSpliced(position, 0, addition);
             });
-            setOperation("insert at known position (snapshot control)");
+            setOperation("insert at runtime position (snapshot control)");
             setRevision((value) => value + 1);
           }}
         >
-          Insert at known position (snapshot control)
+          Insert at runtime position (snapshot control)
         </button>
         <button
           data-action="table-position-remove"
           type="button"
           onClick={() => {
-            setRows((current) => current.toSpliced(9_000, 1));
-            setOperation("remove at known position");
+            const position = 9_000;
+            setRows((current) => current.toSpliced(position, 1));
+            setOperation("remove at runtime position");
             setRevision((value) => value + 1);
           }}
         >
-          Remove at known position
+          Remove at runtime position
         </button>
         <button
           data-action="table-position-remove-snapshot"
           type="button"
           onClick={() => {
+            const position = 9_000;
             setRows((current) => {
-              return current.toSpliced(9_000, 1);
+              return current.toSpliced(position, 1);
             });
-            setOperation("remove at known position (snapshot control)");
+            setOperation("remove at runtime position (snapshot control)");
             setRevision((value) => value + 1);
           }}
         >
-          Remove at known position (snapshot control)
+          Remove at runtime position (snapshot control)
         </button>
         <button
           data-action="table-position-replace"
           type="button"
           onClick={() => {
-            const current = rows[100];
+            const position = 100;
+            const current = rows[position];
             const replacement = { ...current, label: `${current.label} @` };
-            setRows((items) => items.with(100, replacement));
-            setOperation("replace at known position");
+            setRows((items) => items.with(position, replacement));
+            setOperation("replace at runtime position");
             setRevision((value) => value + 1);
           }}
         >
-          Replace at known position
+          Replace at runtime position
         </button>
         <button
           data-action="table-position-replace-snapshot"
           type="button"
           onClick={() => {
-            const current = rows[100];
+            const position = 100;
+            const current = rows[position];
             const replacement = { ...current, label: `${current.label} @` };
             setRows((items) => {
-              return items.with(100, replacement);
+              return items.with(position, replacement);
             });
-            setOperation("replace at known position (snapshot control)");
+            setOperation("replace at runtime position (snapshot control)");
             setRevision((value) => value + 1);
           }}
         >
-          Replace at known position (snapshot control)
+          Replace at runtime position (snapshot control)
         </button>
         <button
           data-action="table-reverse"

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -300,21 +300,25 @@ expose the site count as `keyedArrayRollingWindowHints`.
 Native known-position updates can avoid a complete keyed scan too:
 
 ```tsx
-setItems((current) => current.toSpliced(500, 0, nextItem));
-setItems((current) => current.toSpliced(500, 1));
-setItems((current) => current.with(500, replacement));
+setItems((current) => current.toSpliced(selectedIndex, 0, nextItem));
+setItems((current) => current.toSpliced(selectedIndex, 1));
+setItems((current) => current.with(selectedIndex, replacement));
 ```
 
-The compiler recognizes only a concise functional setter, a build-time safe-integer position, one
-inserted item with zero removals, one removed item, or one direct replacement. Farm preserves the
-ordinary native method call and records metadata only after validating the committed native source
-and result. The runtime creates one inserted row, removes one known row, or patches/replaces one row
-at the known position without rereading every existing key, descriptor, and binding. Surviving rows
-keep their DOM identity. Index-aware or collection-reading rows, custom methods, other
-`toSpliced()` forms, block-bodied updaters, unsafe incoming expressions, queued uncommitted updates,
-reused keys, nested or React-owned rows, and failed checks use complete keyed reconciliation.
-Reports expose the site count as `keyedArrayPositionHints`; the capability is tree-shaken from
-modules that do not emit it.
+The compiler recognizes only a concise functional setter and either a safe-integer literal or a
+compiler-safe runtime position expression, such as an identifier, property read, arithmetic,
+conditional, or safe `Math` call. The update must insert one item with zero removals, remove one
+item, or directly replace one item. Farm preserves method lookup, evaluates the position and
+remaining arguments once in their original order, executes the ordinary native call, and records
+metadata only after validating the committed native source, result, and actual safe-integer
+position. The runtime creates one inserted row, removes one known row, or patches/replaces one row
+at that position without rereading every existing key, descriptor, and binding. Surviving rows keep
+their DOM identity. Index-aware or collection-reading rows, custom methods, position expressions
+with user calls or mutations, runtime positions that are not safe integers, other `toSpliced()`
+forms, block-bodied updaters, unsafe incoming expressions, queued uncommitted updates, reused keys,
+nested or React-owned rows, and failed checks use complete keyed reconciliation. Reports expose the
+site count as `keyedArrayPositionHints`; the capability is tree-shaken from modules that do not emit
+it.
 
 A direct native reverse can carry its complete permutation to a separate optional runtime:
 
@@ -653,8 +657,8 @@ reasons aggregated by count. Its summary and per-module `optimizations` also rep
 `keyedArrayAppendHints`, the number of compiler-proven direct keyed-array append sites; and
 `keyedArrayFilterHints`, the number of compiler-proven direct keyed-array filter sites; and
 `keyedArrayPrependHints`, the number of compiler-proven direct keyed-array prepend sites; and
-`keyedArrayPositionHints`, the number of compiler-proven native known-position insertion, removal,
-or replacement sites; and
+`keyedArrayPositionHints`, the number of compiler-proven native exact-position insertion, removal,
+or replacement sites, including guarded compiler-safe runtime positions; and
 `keyedArrayReorderHints`, the number of compiler-proven direct native keyed-array reverse sites; and
 `keyedArraySortHints`, the number of compiler-proven direct native keyed-array sort sites; and
 `keyedArrayRollingWindowHints`, the number of compiler-proven retained-tail plus incoming-suffix

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-position-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-position-hints.test.ts
@@ -45,16 +45,34 @@ describe("React AOT keyed-array position hints", () => {
     expect(result.optimizations.keyedArrayPositionHints).toBe(2);
   });
 
+  it("records compiler-safe runtime position expressions", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ next, offset, delta, positions }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <section>
+          <button onClick={() => setRows((current) => current.toSpliced(offset, 0, next))}>Insert</button>
+          <button onClick={() => setRows((current) => current.toSpliced(positions.remove, 1))}>Remove</button>
+          <button onClick={() => setRows((current) => current.with(offset + delta, next))}>Replace</button>
+          <button onClick={() => setRows((current) => current.with(current.length - 1, next))}>Replace last</button>
+          <button onClick={() => setRows((current) => current.with(Math.trunc(offset), next))}>Replace rounded</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.optimizations.keyedArrayPositionHints).toBe(5);
+    expect(result.code).toContain("createCompilerKeyedArrayPositionUpdate");
+    expect(result.code).toMatch(/\.get\(\)\.remove/);
+    expect(result.code).toContain("current.length - 1");
+  });
+
   it.each([
     {
       name: "an index-dependent row",
       row: "(row, index) => <li key={row.id}>{index}: {row.label}</li>",
       update: "current.with(0, next)",
-    },
-    {
-      name: "a dynamic position",
-      row: "row => <li key={row.id}>{row.label}</li>",
-      update: "current.with(offset, next)",
     },
     {
       name: "a block-bodied updater",
@@ -106,10 +124,30 @@ describe("React AOT keyed-array position hints", () => {
       row: "row => <li key={row.id}>{row.label}</li>",
       update: "current.toSpliced(0, 1, next)",
     },
+    {
+      name: "a fractional literal position",
+      row: "row => <li key={row.id}>{row.label}</li>",
+      update: "current.with(0.5, next)",
+    },
+    {
+      name: "a position call",
+      row: "row => <li key={row.id}>{row.label}</li>",
+      update: "current.with(getOffset(), next)",
+    },
+    {
+      name: "a position assignment",
+      row: "row => <li key={row.id}>{row.label}</li>",
+      update: "current.with(offset = 1, next)",
+    },
+    {
+      name: "a position update expression",
+      row: "row => <li key={row.id}>{row.label}</li>",
+      update: "current.with(offset++, next)",
+    },
   ])("keeps $name off the position fast path", async ({ row, update }) => {
     const result = await compile(`
       import { useState } from "react";
-      export function Table({ next, offset, deleteCount, makeNext }) {
+      export function Table({ next, offset, deleteCount, makeNext, getOffset }) {
         const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
         return <section>
           <button onClick={() => setRows((current) => ${update})}>Change</button>

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-position-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-position-hints.test.tsx
@@ -330,6 +330,76 @@ describe("compiled keyed-array position hints", () => {
     ).toThrow(error);
   });
 
+  it("evaluates coercible runtime positions once and preserves their native result", () => {
+    const source = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ] as PositionArray;
+    let coercions = 0;
+    const position = {
+      valueOf() {
+        coercions += 1;
+        return 1;
+      },
+    };
+
+    const result = createCompilerKeyedArrayPositionUpdate(
+      source,
+      source.toSpliced,
+      "remove",
+      position as unknown as number,
+      1,
+    ) as Item[];
+
+    expect(result.map((item) => item.id)).toEqual(["a", "c"]);
+    expect(coercions).toBe(1);
+  });
+
+  it("falls back while preserving fractional, NaN, and infinite runtime positions", async () => {
+    const harness = createPositionHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+
+    await act(async () => {
+      harness.remove(1.75);
+      await flushCompilerUpdates();
+    });
+    expect([...container.querySelectorAll("li")].map((node) => node.textContent)).toEqual([
+      "Alpha",
+      "Gamma",
+      "Delta",
+    ]);
+
+    await act(async () => {
+      harness.remove(Number.NaN);
+      await flushCompilerUpdates();
+    });
+    const gamma = container.querySelector('[data-key="c"]');
+    const delta = container.querySelector('[data-key="d"]');
+    expect([...container.querySelectorAll("li")].map((node) => node.textContent)).toEqual([
+      "Gamma",
+      "Delta",
+    ]);
+
+    await act(async () => {
+      harness.remove(Number.POSITIVE_INFINITY);
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+    expect(container.querySelector('[data-key="d"]')).toBe(delta);
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
+  });
+
   it("preserves native negative, clamped, empty, and subclass removal behavior", async () => {
     class ItemArray extends Array<Item> {}
     const initialItems = new ItemArray(

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -1572,6 +1572,21 @@ function staticSliceIndex(expression: t.Node): number | undefined {
   return undefined;
 }
 
+function validateKeyedArrayPositionExpression(
+  expression: t.Expression,
+  safeGlobals: ReadonlySet<string>,
+): string | undefined {
+  const isNumericLiteral =
+    t.isNumericLiteral(expression) ||
+    (t.isUnaryExpression(expression) &&
+      (expression.operator === "+" || expression.operator === "-") &&
+      t.isNumericLiteral(expression.argument));
+  if (isNumericLiteral && staticSliceIndex(expression) === undefined) {
+    return "non-safe-integer position literals";
+  }
+  return validateDerivedExpression(expression, safeGlobals);
+}
+
 function rewriteKeyedArrayPositionHints(
   root: t.JSXElement,
   hintedStateIndices: ReadonlySet<number>,
@@ -1624,10 +1639,10 @@ function rewriteKeyedArrayPositionHints(
               ? "remove"
               : undefined;
       if (!kind || !t.isExpression(args[0])) return;
-      const position = staticSliceIndex(args[0]);
+      const position = args[0];
       const item = kind === "remove" ? undefined : args.at(-1);
       if (
-        position === undefined ||
+        validateKeyedArrayPositionExpression(position, safeGlobals) !== undefined ||
         (item !== undefined &&
           (!t.isExpression(item) || validateDerivedExpression(item, safeGlobals) !== undefined))
       ) {


### PR DESCRIPTION
## Problem

The keyed-array exact-position fast path only accepted build-time numeric literals. Common updates such as setRows(current => current.toSpliced(selectedIndex, 1)) therefore fell back to complete keyed reconciliation even when the runtime position was safe and the existing position runtime could validate it.

## Root cause

The runtime helper already executes the original native method and validates the committed source, source token, result length, normalized position, key ownership, and safe-integer position before DOM mutation. Compiler eligibility stopped earlier because it required staticSliceIndex() to return a literal value.

## Change

- accept compiler-safe runtime position expressions for concise native toSpliced() and with() updates
- retain compile-time rejection for fractional numeric literals and effectful calls, assignments, or update expressions
- preserve method lookup, argument evaluation order, native coercion, return values, and thrown errors
- exercise event-local runtime positions in the production dashboard benchmark
- document supported syntax, runtime validation, fallback behavior, observability, and measured results

## Safety and compatibility

- native arrays and native methods remain required at runtime
- the evaluated position must be a safe integer before metadata is recorded
- custom methods, invalid positions, unsupported syntax, queued uncommitted updates, reused keys, index-aware rows, collection-reading bindings, React-owned rows, nested blocks, mixed dirty dependencies, and failed validation retain complete keyed reconciliation
- React 18.3.1 and React 19.2.8 compatibility pass
- no public option or API changes
- no runtime implementation change; runtime-size fixtures remain byte-for-byte identical

## Verification

- pnpm --filter @farm.js/react exec vitest run --maxWorkers=2 — 66 files and 561 tests passed
- focused compiler and runtime position suites — 30 tests passed
- pnpm --filter @farm.js/react type-check
- pnpm --filter farm-react-compiler-dashboard-example type-check
- pnpm --filter @farm.js/react test:compat
- pnpm --filter @farm.js/react test:runtime-size
- pnpm --filter farm-react-compiler-dashboard-example benchmark — PASS
- pnpm docs:check-navigation
- pnpm docs:build
- focused oxfmt and oxlint
- git diff --check

Production browser position results:

| Operation | Static vs React | Hybrid vs React | Static vs compiled control | Hybrid vs compiled control |
| --- | ---: | ---: | ---: | ---: |
| Insert | 9.61x | 10.32x | 2.80x | 3.12x |
| Remove | 8.13x | 8.54x | 2.32x | 2.48x |
| Replace | 9.23x | 11.76x | 3.25x | 3.33x |

Every existing correctness, performance, optimization-persistence, and scalability gate passed with zero compiler owner executions.

## Documentation and release

Updated the React renderer guide, package README, dashboard README, production benchmark fixture, and persisted benchmark results. Release changes are intentionally separate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the keyed-array exact-position fast path to accept compiler-safe runtime position expressions, so updates like `setRows(current => current.toSpliced(selectedIndex, 1))` no longer fall back to full keyed reconciliation. The evaluated position is still validated as a safe integer at runtime before DOM changes.

- The compiler now accepts identifiers, property reads, side-effect-free arithmetic/conditionals, and safe `Math` calls as positions for concise native `toSpliced()` and `with()` updates.
- Fractional literals, user-defined calls, assignments, and update expressions are still rejected at compile time.
- Native method lookup, argument evaluation order, coercions, return values, and thrown errors remain unchanged.
- Invalid runtime positions, custom methods, unsupported syntax, and the existing fallback conditions still use complete keyed reconciliation.
- Updated the dashboard benchmark and fixture to use event-local runtime positions; production browser results show 2.3x–3.3x speedups over the compiled control.
- No public API changes; the runtime implementation is untouched, so runtime-size fixtures stay byte-for-byte identical.

<sup>Written for commit 3c11e8fc90300a67afae369fa66f4f3b4e5207f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

