### PR TITLE
perf(react): optimize keyed toSpliced replacements

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1026,6 +1026,7 @@ Native immutable array methods can state an exact insertion, removal, or replace
 ```tsx
 setItems((current) => current.toSpliced(selectedIndex, 0, nextItem));
 setItems((current) => current.toSpliced(selectedIndex, 1));
+setItems((current) => current.toSpliced(selectedIndex, 1, replacement));
 setItems((current) => current.with(selectedIndex, replacement));
 ```
 
@@ -1033,11 +1034,12 @@ At build time, Farm recognizes only concise functional setters whose position is
 safe-integer literal or a compiler-safe runtime expression. Identifiers, property reads,
 side-effect-free arithmetic and conditionals, and safe `Math` calls are supported. User-defined
 calls, assignments, update expressions, and other effectful forms are not transformed.
-`toSpliced()` must insert exactly one item with a zero delete count or remove exactly one item;
-`with()` must replace exactly one item. Farm preserves the original method lookup, evaluates every
-argument once in its original order, and preserves the native call, return value, coercion, and
-thrown errors. If the method is not native or the evaluated position is not already a safe integer,
-the update still runs normally but no metadata is recorded.
+`toSpliced()` must insert exactly one item with a zero delete count, remove exactly one item, or
+replace exactly one item with a delete count of one; `with()` must replace exactly one item. Farm
+preserves the original method lookup, evaluates every argument once in its original order, and
+preserves the native call, return value, coercion, and thrown errors. If the method is not native or
+the evaluated position is not already a safe integer, the update still runs normally but no
+metadata is recorded.
 
 At update time, Farm validates the committed native source, result length, source token, normalized
 position, and any incoming key before changing the DOM. An insertion creates one row at that

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,25 @@
 
 Date: 2026-08-29
 
+## Native `toSpliced()` replacement follow-up — 2026-08-30
+
+The full bracketed production-browser run changed the exact-position replacement workload to the
+concise native `toSpliced(position, 1, replacement)` form. Both compiler builds emitted the three
+expected `keyedArrayPositionHints` sites and passed DOM correctness, every React-relative and
+compiled-control persistence gate, and normalized scalability through the 21,000-row peak.
+
+| Mode   | React median | Hinted replacement | Compiled control | vs React | vs control |
+| ------ | -----------: | -----------------: | ---------------: | -------: | ---------: |
+| Static |     47.35 ms |            3.80 ms |         13.40 ms |   12.46x |      3.53x |
+| Hybrid |     47.35 ms |            3.70 ms |         13.80 ms |   12.80x |      3.73x |
+
+Static and hybrid each added zero owner executions. Package tests separately prove same-key DOM
+identity, one-row new-key replacement, the existing native `with()` path, 1,000 differential
+updates, native clamping and errors, out-of-range and subclass fallback, focus and selection,
+delegated events, hydration, Strict Mode, and unmount cleanup. The optional known-position fixture
+grew by 13 B gzip, from a 12,188 B to a 12,201 B compiler premium; the isolated core runtime
+reduction remains 80.5%.
+
 ## Compiler-safe runtime positions follow-up — 2026-08-30
 
 The full bracketed production-browser run replaced the three literal position controls with

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -96,7 +96,8 @@ React and 1.25x faster than the compiled control. The report must contain a nonz
 work proportional only to the incoming suffix.
 
 Exact-position insertions, removals, and replacements have separate 10,000-row comparisons. Concise
-native `toSpliced(position, 0, item)`, `toSpliced(position, 1)`, and `with(position, item)` updates
+native `toSpliced(position, 0, item)`, `toSpliced(position, 1)`,
+`toSpliced(position, 1, replacement)`, and `with(position, replacement)` updates
 use event-local runtime position variables and are measured against bracketed React and equivalent
 block-bodied compiled controls. The compiler report must contain a nonzero
 `keyedArrayPositionHints` count; package tests separately require zero surviving
@@ -174,7 +175,8 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
 - The slice snapshot control retains the same 9,000-row suffix through an unsupported block-bodied
   updater. It isolates the saved survivor scan while both paths remove the same 1,000 DOM rows.
 - The exact-position controls pass event-local runtime variables to concise native
-  `toSpliced()`/`with()` updates and compare them with equivalent block-bodied compiled controls.
+  `toSpliced()` updates and compare them with equivalent block-bodied compiled controls. Package
+  tests cover the equivalent `with()` replacement path too.
   They verify surrounding DOM identity and isolate the saved full keyed scan for one insertion,
   removal, or replacement.
 - The reverse control compares concise native `toReversed()` with an equivalent block-bodied

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -316,7 +316,7 @@ export function StandardTableBenchmark() {
             const position = 100;
             const current = rows[position];
             const replacement = { ...current, label: `${current.label} @` };
-            setRows((items) => items.with(position, replacement));
+            setRows((items) => items.toSpliced(position, 1, replacement));
             setOperation("replace at runtime position");
             setRevision((value) => value + 1);
           }}
@@ -331,7 +331,7 @@ export function StandardTableBenchmark() {
             const current = rows[position];
             const replacement = { ...current, label: `${current.label} @` };
             setRows((items) => {
-              return items.with(position, replacement);
+              return items.toSpliced(position, 1, replacement);
             });
             setOperation("replace at runtime position (snapshot control)");
             setRevision((value) => value + 1);

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -302,19 +302,21 @@ Native known-position updates can avoid a complete keyed scan too:
 ```tsx
 setItems((current) => current.toSpliced(selectedIndex, 0, nextItem));
 setItems((current) => current.toSpliced(selectedIndex, 1));
+setItems((current) => current.toSpliced(selectedIndex, 1, replacement));
 setItems((current) => current.with(selectedIndex, replacement));
 ```
 
 The compiler recognizes only a concise functional setter and either a safe-integer literal or a
 compiler-safe runtime position expression, such as an identifier, property read, arithmetic,
 conditional, or safe `Math` call. The update must insert one item with zero removals, remove one
-item, or directly replace one item. Farm preserves method lookup, evaluates the position and
-remaining arguments once in their original order, executes the ordinary native call, and records
-metadata only after validating the committed native source, result, and actual safe-integer
-position. The runtime creates one inserted row, removes one known row, or patches/replaces one row
-at that position without rereading every existing key, descriptor, and binding. Surviving rows keep
-their DOM identity. Index-aware or collection-reading rows, custom methods, position expressions
-with user calls or mutations, runtime positions that are not safe integers, other `toSpliced()`
+item, or replace one item through either `toSpliced()` or `with()`. Farm preserves method lookup,
+evaluates the position and remaining arguments once in their original order, executes the ordinary
+native call, and records metadata only after validating the committed native source, result, and
+actual safe-integer position. The runtime creates one inserted row, removes one known row, or
+patches/replaces one row at that position without rereading every existing key, descriptor, and
+binding. Surviving rows keep their DOM identity. Index-aware or collection-reading rows, custom
+methods, position expressions with user calls or mutations, runtime positions that are not safe
+integers, other `toSpliced()`
 forms, block-bodied updaters, unsafe incoming expressions, queued uncommitted updates, reused keys,
 nested or React-owned rows, and failed checks use complete keyed reconciliation. Reports expose the
 site count as `keyedArrayPositionHints`; the capability is tree-shaken from modules that do not emit

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-position-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-position-hints.test.ts
@@ -17,6 +17,7 @@ describe("React AOT keyed-array position hints", () => {
         return <section>
           <button onClick={() => setRows((current) => current.toSpliced(1, 0, next))}>Insert</button>
           <button onClick={() => setRows((current) => current.toSpliced(0, 1))}>Remove</button>
+          <button onClick={() => setRows((current) => current.toSpliced(0, 1, next))}>Splice replace</button>
           <button onClick={() => setRows((current) => current.with(0, next))}>Replace</button>
           <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
         </section>;
@@ -24,7 +25,7 @@ describe("React AOT keyed-array position hints", () => {
     `);
 
     expect(result.compiled).toEqual(["Table"]);
-    expect(result.optimizations.keyedArrayPositionHints).toBe(3);
+    expect(result.optimizations.keyedArrayPositionHints).toBe(4);
     expect(result.code).toContain("createCompilerKeyedArrayPositionUpdate");
     expect(result.code).toContain("keyedRowsPositionHintedRuntimeFeature");
   });
@@ -36,13 +37,14 @@ describe("React AOT keyed-array position hints", () => {
         const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
         return <section>
           <button onClick={() => setRows((current) => current.with(-1, next))}>Replace</button>
+          <button onClick={() => setRows((current) => current.toSpliced(-1, 1, next))}>Splice replace</button>
           <button onClick={() => setRows((current) => current.toSpliced(-1, 1))}>Remove</button>
           <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
         </section>;
       }
     `);
 
-    expect(result.optimizations.keyedArrayPositionHints).toBe(2);
+    expect(result.optimizations.keyedArrayPositionHints).toBe(3);
   });
 
   it("records compiler-safe runtime position expressions", async () => {
@@ -53,6 +55,7 @@ describe("React AOT keyed-array position hints", () => {
         return <section>
           <button onClick={() => setRows((current) => current.toSpliced(offset, 0, next))}>Insert</button>
           <button onClick={() => setRows((current) => current.toSpliced(positions.remove, 1))}>Remove</button>
+          <button onClick={() => setRows((current) => current.toSpliced(offset + delta, 1, next))}>Splice replace</button>
           <button onClick={() => setRows((current) => current.with(offset + delta, next))}>Replace</button>
           <button onClick={() => setRows((current) => current.with(current.length - 1, next))}>Replace last</button>
           <button onClick={() => setRows((current) => current.with(Math.trunc(offset), next))}>Replace rounded</button>
@@ -62,7 +65,7 @@ describe("React AOT keyed-array position hints", () => {
     `);
 
     expect(result.compiled).toEqual(["Table"]);
-    expect(result.optimizations.keyedArrayPositionHints).toBe(5);
+    expect(result.optimizations.keyedArrayPositionHints).toBe(6);
     expect(result.code).toContain("createCompilerKeyedArrayPositionUpdate");
     expect(result.code).toMatch(/\.get\(\)\.remove/);
     expect(result.code).toContain("current.length - 1");
@@ -120,9 +123,9 @@ describe("React AOT keyed-array position hints", () => {
       update: "current.toSpliced(0, 0, next, next)",
     },
     {
-      name: "a direct toSpliced replacement",
+      name: "a multi-item replacement",
       row: "row => <li key={row.id}>{row.label}</li>",
-      update: "current.toSpliced(0, 1, next)",
+      update: "current.toSpliced(0, 1, next, next)",
     },
     {
       name: "a fractional literal position",

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-position-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-position-hints.test.tsx
@@ -65,6 +65,18 @@ function hintedReplace(previous: Item[], position: number, item: Item): Item[] {
   ) as Item[];
 }
 
+function hintedSpliceReplace(previous: Item[], position: number, item: Item): Item[] {
+  const source = previous as PositionArray;
+  return createCompilerKeyedArrayPositionUpdate(
+    source,
+    source.toSpliced,
+    "replace",
+    position,
+    1,
+    item,
+  ) as Item[];
+}
+
 function hintedRemove(previous: Item[], position: number): Item[] {
   const source = previous as PositionArray;
   return createCompilerKeyedArrayPositionUpdate(
@@ -91,6 +103,7 @@ function createPositionHarness(initialItems: Item[], readsCollection = false) {
   let insert: (position: number, item: Item) => void = () => undefined;
   let remove: (position: number) => void = () => undefined;
   let replace: (position: number, item: Item) => void = () => undefined;
+  let withReplace: (position: number, item: Item) => void = () => undefined;
   let queueTwo: (first: Item, second: Item) => void = () => undefined;
   let queueRemoveTwo: () => void = () => undefined;
   let customInsert: (item: Item) => void = () => undefined;
@@ -104,6 +117,8 @@ function createPositionHarness(initialItems: Item[], readsCollection = false) {
         state[0].set((previous) => hintedInsert(previous as Item[], position, item));
       remove = (position) => state[0].set((previous) => hintedRemove(previous as Item[], position));
       replace = (position, item) =>
+        state[0].set((previous) => hintedSpliceReplace(previous as Item[], position, item));
+      withReplace = (position, item) =>
         state[0].set((previous) => hintedReplace(previous as Item[], position, item));
       queueTwo = (first, second) => {
         state[0].set((previous) => hintedInsert(previous as Item[], 1, first));
@@ -179,6 +194,7 @@ function createPositionHarness(initialItems: Item[], readsCollection = false) {
     queueRemoveTwo: () => queueRemoveTwo(),
     remove: (position: number) => remove(position),
     replace: (position: number, item: Item) => replace(position, item),
+    withReplace: (position: number, item: Item) => withReplace(position, item),
   };
 }
 
@@ -252,7 +268,7 @@ describe("compiled keyed-array position hints", () => {
     expect(harness.counters.bindings).toBe(0);
   });
 
-  it("patches a same-key replacement and creates one host row for a new key", async () => {
+  it("patches a same-key toSpliced replacement and creates one host row for a new key", async () => {
     const harness = createPositionHarness([
       { id: "a", label: "Alpha" },
       { id: "b", label: "Beta" },
@@ -288,6 +304,17 @@ describe("compiled keyed-array position hints", () => {
     expect(harness.counters.keys).toBe(2);
     expect(harness.counters.descriptors).toBe(1);
     expect(harness.counters.bindings).toBe(2);
+
+    const alpha = container.querySelector('[data-key="a"]');
+    await act(async () => {
+      harness.withReplace(0, { id: "a", label: "Alpha updated" });
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(alpha?.textContent).toBe("Alpha updated");
+    expect(harness.counters.keys).toBe(3);
+    expect(harness.counters.descriptors).toBe(1);
+    expect(harness.counters.bindings).toBe(3);
   });
 
   it("preserves native removal arguments, return values, and errors", () => {
@@ -328,6 +355,117 @@ describe("compiled keyed-array position hints", () => {
         1,
       ),
     ).toThrow(error);
+  });
+
+  it("preserves native toSpliced replacement clamping, return values, and errors", () => {
+    const source = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ] as PositionArray;
+    const replacement = { id: "d", label: "Delta" };
+    const replaced = createCompilerKeyedArrayPositionUpdate(
+      source,
+      source.toSpliced,
+      "replace",
+      -99,
+      1,
+      replacement,
+    ) as Item[];
+    expect(replaced.map((item) => item.id)).toEqual(["d", "b", "c"]);
+    expect(source.map((item) => item.id)).toEqual(["a", "b", "c"]);
+
+    const appended = createCompilerKeyedArrayPositionUpdate(
+      source,
+      source.toSpliced,
+      "replace",
+      99,
+      1,
+      replacement,
+    ) as Item[];
+    expect(appended.map((item) => item.id)).toEqual(["a", "b", "c", "d"]);
+
+    const customResult = [replacement];
+    const custom = function (this: Item[], position: number, deleteCount: number, item: Item) {
+      expect(this).toBe(source);
+      expect([position, deleteCount, item]).toEqual([1, 1, replacement]);
+      return customResult;
+    };
+    expect(
+      createCompilerKeyedArrayPositionUpdate(source, custom, "replace", 1, 1, replacement),
+    ).toBe(customResult);
+
+    const error = new Error("replace failed");
+    expect(() =>
+      createCompilerKeyedArrayPositionUpdate(
+        source,
+        () => {
+          throw error;
+        },
+        "replace",
+        1,
+        1,
+        replacement,
+      ),
+    ).toThrow(error);
+  });
+
+  it("falls back for out-of-range and subclass toSpliced replacements", async () => {
+    const harness = createPositionHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const alpha = container.querySelector('[data-key="a"]');
+    const beta = container.querySelector('[data-key="b"]');
+    const gamma = container.querySelector('[data-key="c"]');
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.replace(99, { id: "d", label: "Delta" });
+      await flushCompilerUpdates();
+    });
+    expect([...container.querySelectorAll("li")].map((node) => node.textContent)).toEqual([
+      "Alpha",
+      "Beta",
+      "Gamma",
+      "Delta",
+    ]);
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-key="b"]')).toBe(beta);
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+    expect(harness.counters.keys).toBe(4);
+
+    class ItemArray extends Array<Item> {}
+    const subclass = createPositionHarness(
+      new ItemArray(
+        { id: "a", label: "Alpha" },
+        { id: "b", label: "Beta" },
+        { id: "c", label: "Gamma" },
+      ),
+    );
+    const subclassContainer = document.createElement("div");
+    document.body.append(subclassContainer);
+    const subclassRoot = createRoot(subclassContainer);
+    roots.push(subclassRoot);
+    await act(async () => subclassRoot.render(<subclass.Table />));
+    subclass.counters.keys = 0;
+
+    await act(async () => {
+      subclass.replace(1, { id: "d", label: "Delta" });
+      await flushCompilerUpdates();
+    });
+    expect([...subclassContainer.querySelectorAll("li")].map((node) => node.textContent)).toEqual([
+      "Alpha",
+      "Delta",
+      "Gamma",
+    ]);
+    expect(subclass.counters.keys).toBe(3);
   });
 
   it("evaluates coercible runtime positions once and preserves their native result", () => {

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -721,11 +721,15 @@ export function createCompilerKeyedArrayPositionUpdate(
       value.length === sourceLength - 1;
     const validReplace =
       kind === "replace" &&
-      method === NATIVE_ARRAY_WITH &&
-      args.length === 1 &&
-      position >= -sourceLength &&
-      position < sourceLength &&
-      value.length === sourceLength;
+      value.length === sourceLength &&
+      ((method === NATIVE_ARRAY_WITH &&
+        args.length === 1 &&
+        position >= -sourceLength &&
+        position < sourceLength) ||
+        (method === NATIVE_ARRAY_TO_SPLICED &&
+          args.length === 2 &&
+          Object.is(args[0], 1) &&
+          normalizedPosition < sourceLength));
     if (!validInsert && !validRemove && !validReplace) return value;
 
     const sourceToken = compilerKeyedCollectionToken(previousTarget);

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -1634,10 +1634,14 @@ function rewriteKeyedArrayPositionHints(
               t.isNumericLiteral(args[1], { value: 0 })
             ? "insert"
             : methodName === "toSpliced" &&
-                args.length === 2 &&
+                args.length === 3 &&
                 t.isNumericLiteral(args[1], { value: 1 })
-              ? "remove"
-              : undefined;
+              ? "replace"
+              : methodName === "toSpliced" &&
+                  args.length === 2 &&
+                  t.isNumericLiteral(args[1], { value: 1 })
+                ? "remove"
+                : undefined;
       if (!kind || !t.isExpression(args[0])) return;
       const position = args[0];
       const item = kind === "remove" ? undefined : args.at(-1);


### PR DESCRIPTION
## Problem

A concise keyed update such as `setRows((current) => current.toSpliced(index, 1, replacement))` states one exact replacement, but the experimental React compiler does not currently recognize it. The update therefore takes complete keyed reconciliation even though the native operation provides a safe known position.

## Root cause

The compiler classifies `toSpliced(index, 0, item)` as an insertion and `toSpliced(index, 1)` as a removal, but only classifies `with(index, item)` as a replacement. The runtime replacement validator likewise accepts only the native `Array.prototype.with` method. The existing tests intentionally listed direct `toSpliced` replacement as unsupported.

## Change

- Recognize concise `toSpliced(position, 1, replacement)` functional setters as known-position replacements when the position and incoming item expressions are compiler-safe.
- Extend the existing position helper to record replacement metadata only for the native `Array.prototype.toSpliced` method, an exact delete count of one, an in-range normalized position, and an unchanged result length.
- Exercise this syntax in the maintained 10,000-row production benchmark while retaining the equivalent block-bodied compiled control.
- Add compiler, runtime, differential, fallback, compatibility, size, benchmark, package, and public documentation coverage.

## Safety and compatibility

The transformed code preserves method lookup and evaluates arguments once in source order before executing the ordinary native call. Its return value and thrown errors remain authoritative.

Metadata is recorded only after the previous collection is a committed ordinary native array, the executed method is the captured native `toSpliced`, the position is already a safe integer, the delete count is exactly one, the result is an ordinary native array with the same length, and the normalized position replaced an existing item. Out-of-range `toSpliced` calls still append exactly as JavaScript specifies but deliberately receive no replacement hint. Custom methods, subclasses, unsafe expressions, block-bodied updaters, queued uncommitted updates, React-owned rows, duplicate keys, collection-dependent rows, and failed runtime checks keep complete keyed reconciliation.

The existing native `with()` fast path is preserved and covered. This remains React-renderer-specific, experimental, disabled with the compiler flag, and tree-shakeable through the existing optional position runtime. There is no public API or configuration change. React 18.3.1 and 19.2.8 both pass.

## Verification

- `pnpm --filter @farm.js/react test -- --maxWorkers=2` — 66 files / 563 tests pass.
- `pnpm --filter @farm.js/react type-check`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`
- `pnpm --filter @farm.js/react build`
- `(cd packages/farm-react && node scripts/test-react-version.mjs 18.3.1 && node scripts/test-react-version.mjs 19.2.8)`
- `(cd packages/farm-react && node scripts/benchmark-runtime-size.mjs --check)` — known-position premium is 12,201 B gzip, +13 B; isolated core reduction remains 80.5%.
- `pnpm --filter farm-react-compiler-dashboard-example type-check`
- `pnpm --filter farm-react-compiler-dashboard-example benchmark` — correctness and every regression/persistence/scalability gate pass on Chromium 145, Apple M1, macOS arm64.
  - Static replacement: 3.80 ms vs React 47.35 ms and compiled control 13.40 ms — 12.46x / 3.53x faster.
  - Hybrid replacement: 3.70 ms vs React 47.35 ms and compiled control 13.80 ms — 12.80x / 3.73x faster.
  - Static and hybrid compiler builds add zero owner executions.
- `pnpm docs:check-navigation`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm docs:build`
- Focused `oxfmt`, `oxlint`, and `git diff --check` pass.

## Documentation and release

Updated the React package guide, public React renderer guide, benchmark README, executable workload, and recorded benchmark results. No version or release-flow change is included; this follow-up can ship in a later beta.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimizes `toSpliced(index, 1, replacement)` updates so they use the known-position keyed reconciliation path instead of a full keyed scan. Previously only `toSpliced` insert/remove and `with` replacement were recognized; now concise `toSpliced` replacements are also classified as replacements when the method is native, the delete count is exactly one, and the position is in range.

- Extends the compiler's position hint detection to classify `toSpliced` with delete count 1 as a replacement.
- Adds runtime validation for `toSpliced` replacements, including clamping and out-of-range fallback.
- Updates the production benchmark, tests, and documentation to cover the new syntax.

<sup>Written for commit ec848b500e759d7bda5f291f4fded22d8a9468a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

