### PR TITLE
perf(react): optimize keyed range removals

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -372,8 +372,8 @@ filter sites that can report removed positions. `keyedArrayPrependHints` counts 
 the compiler proved a direct keyed array prepend and can hand the new prefix to the runtime.
 `keyedArraySliceHints` counts direct keyed-array slices whose build-time bounds identify one exact
 retained interval.
-`keyedArrayPositionHints` counts native keyed-array insertions, removals, and replacements whose
-exact position is known at build time.
+`keyedArrayPositionHints` counts compiler-proven native keyed-array insertions, single or
+contiguous-range removals, and replacements with an exact guarded position.
 `keyedArrayReorderHints` counts direct native keyed-array reversals whose complete permutation is
 known at build time.
 `keyedArraySortHints` counts direct native keyed-array sorts whose resulting permutation can be
@@ -1026,6 +1026,7 @@ Native immutable array methods can state an exact insertion, removal, or replace
 ```tsx
 setItems((current) => current.toSpliced(selectedIndex, 0, nextItem));
 setItems((current) => current.toSpliced(selectedIndex, 1));
+setItems((current) => current.toSpliced(selectedIndex, 25));
 setItems((current) => current.toSpliced(selectedIndex, 1, replacement));
 setItems((current) => current.with(selectedIndex, replacement));
 ```
@@ -1034,28 +1035,31 @@ At build time, Farm recognizes only concise functional setters whose position is
 safe-integer literal or a compiler-safe runtime expression. Identifiers, property reads,
 side-effect-free arithmetic and conditionals, and safe `Math` calls are supported. User-defined
 calls, assignments, update expressions, and other effectful forms are not transformed.
-`toSpliced()` must insert exactly one item with a zero delete count, remove exactly one item, or
-replace exactly one item with a delete count of one; `with()` must replace exactly one item. Farm
-preserves the original method lookup, evaluates every argument once in its original order, and
-preserves the native call, return value, coercion, and thrown errors. If the method is not native or
-the evaluated position is not already a safe integer, the update still runs normally but no
+`toSpliced()` must insert exactly one item with a zero delete count, remove one item or a contiguous
+range using a positive safe-integer literal delete count, or replace exactly one item with a delete
+count of one; `with()` must replace exactly one item. Farm preserves the original method lookup,
+evaluates every argument once in its original order, and preserves the native call, return value,
+coercion, and thrown errors. If the method is not native, the evaluated position is not already a
+safe integer, or the removal count is dynamic or unsafe, the update still runs normally but no
 metadata is recorded.
 
 At update time, Farm validates the committed native source, result length, source token, normalized
-position, and any incoming key before changing the DOM. An insertion creates one row at that
-position, preserves surrounding elements, and shifts only stored event indexes. A removal cleans up
-and removes only the known row while preserving every surviving element. A same-key replacement
-patches that row in place; a new-key replacement creates and swaps one host row. The owner component
-does not rerun, and surviving row keys, descriptors, and bindings are not reread.
+position, clamped removal count, and any incoming key before changing the DOM. An insertion creates
+one row at that position, preserves surrounding elements, and shifts only stored event indexes. A
+removal cleans up and removes only the known row or contiguous range while preserving every
+surviving element. A same-key replacement patches that row in place; a new-key replacement creates
+and swaps one host row. The owner component does not rerun, and surviving row keys, descriptors,
+and bindings are not reread.
 
 The proof requires compiler-owned host rows whose render and key do not observe the row index.
 Effectful position expressions, runtime values that are fractional or otherwise not safe integers,
-other `toSpliced()` shapes, block-bodied updaters, unsafe incoming expressions, custom methods,
-queued uncommitted position updates, duplicate or reused keys, collection-reading bindings,
-React-owned rows, nested host blocks, row conditionals, unrelated dirty dependencies, and failed
-runtime checks keep complete keyed reconciliation. Negative safe-integer positions use the native
-methods' normal indexing rules. No new option or component is required. Reports expose emitted
-sites as `keyedArrayPositionHints`; position-only modules retain a separate optional runtime
+dynamic, zero, negative, or fractional removal counts, other `toSpliced()` shapes, block-bodied
+updaters, unsafe incoming expressions, custom methods, queued uncommitted position updates,
+duplicate or reused keys, collection-reading bindings, React-owned rows, nested host blocks, row
+conditionals, unrelated dirty dependencies, and failed runtime checks keep complete keyed
+reconciliation. Negative safe-integer positions and counts larger than the remaining suffix use the
+native method's normal clamping rules. No new option or component is required. Reports expose
+emitted sites as `keyedArrayPositionHints`; position-only modules retain a separate optional runtime
 capability.
 
 #### Keyed array reorder hints
@@ -1931,11 +1935,12 @@ The package and example test suites verify more than generated code:
 - 2,000 deterministic randomized keyed-array removals match normal React; targeted tests require
   zero surviving descriptor and binding reads, preserve DOM identity, and cover queued filters,
   unhinted-chain fallback, collection-reading rows, StrictMode hydration, and unmount cleanup;
-- 1,000 deterministic exact-position insertions, removals, and replacements match normal React;
-  compiler tests cover literal and guarded runtime expressions, while targeted removal tests
-  require zero surviving key, descriptor, or binding reads, preserve focused input and surrounding
-  DOM identity, and cover native evaluation and coercion, negative and non-integer runtime values,
-  custom methods, queued updates, collection-reading rows, StrictMode hydration, and cleanup;
+- 1,000 deterministic exact-position insertions, single and contiguous-range removals, and
+  replacements match normal React; compiler tests cover literal counts and guarded runtime
+  positions, while targeted removal tests require zero surviving key, descriptor, or binding reads,
+  preserve focused input and surrounding DOM identity, and cover native evaluation and coercion,
+  clamping, unsafe runtime positions and counts, custom methods, queued updates,
+  collection-reading rows, StrictMode hydration, and cleanup;
 - 2,000 deterministic randomized reversals match normal React; a 4,096-row targeted test requires
   exactly `n - 1` connected DOM moves and zero key, descriptor, or binding reads, while fallback
   tests cover custom methods, queued updates, collection-reading rows, StrictMode hydration, and
@@ -1965,8 +1970,9 @@ The package and example test suites verify more than generated code:
   `keyedArrayRollingWindowHints`, and `keyedArraySliceHints` report counts,
   preserves the keyed-update speedup floor, checks that scalar selection, Set membership, and Map
   lookups remain key-directed at scale, compares dense hinted Set/Map updates with equivalent
-  compiled snapshot controls, and passes DOM correctness, React-relative regression, direct-delta,
-  and normalized scalability gates;
+  compiled snapshot controls, requires separate single-row and contiguous-range removal speedup
+  floors, and passes DOM correctness, React-relative regression, direct-delta, and normalized
+  scalability gates;
 - the public `List` renders iterable and nullish collections correctly with the compiler off;
 - the packaged runtime, including a keyed-range component root, editable and interactive keyed-row
   events, row-local conditions, reorders, identity, selection, and hydration, is exercised

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,25 @@
 
 Date: 2026-08-29
 
+## Native contiguous `toSpliced()` removal follow-up — 2026-08-30
+
+The full bracketed production-browser run added one isolated 10,000-row workload for concise native
+`toSpliced(position, 64)` updates. Both compiler builds emitted all four expected
+`keyedArrayPositionHints` sites and passed DOM correctness, every existing performance and
+optimization-persistence gate, and normalized scalability through the 21,000-row peak.
+
+| Mode   | React median | Hinted range removal | Compiled control | vs React | vs control |
+| ------ | -----------: | -------------------: | ---------------: | -------: | ---------: |
+| Static |     66.75 ms |              8.40 ms |         21.50 ms |    7.95x |      2.56x |
+| Hybrid |     66.75 ms |              7.10 ms |         20.60 ms |    9.40x |      2.90x |
+
+Static and hybrid each added zero owner executions. Package tests separately prove exact range
+cleanup, surrounding DOM identity, clamped native counts, unsafe-count fallback, 1,000 mixed
+differential updates, focus and selection, delegated event indexes, hydration, Strict Mode, and
+unmount cleanup. The optional known-position fixture grew by 84 B gzip, from a 12,201 B to a
+12,285 B compiler premium; direct and core-only fixtures remain protected, and the isolated core
+runtime reduction is 80.6%.
+
 ## Native `toSpliced()` replacement follow-up — 2026-08-30
 
 The full bracketed production-browser run changed the exact-position replacement workload to the

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -97,13 +97,14 @@ work proportional only to the incoming suffix.
 
 Exact-position insertions, removals, and replacements have separate 10,000-row comparisons. Concise
 native `toSpliced(position, 0, item)`, `toSpliced(position, 1)`,
-`toSpliced(position, 1, replacement)`, and `with(position, replacement)` updates
-use event-local runtime position variables and are measured against bracketed React and equivalent
-block-bodied compiled controls. The compiler report must contain a nonzero
-`keyedArrayPositionHints` count; package tests separately require zero surviving
-key/descriptor/binding reads for removal, surrounding DOM identity, randomized differential
-correctness, runtime-position fallback, hydration, and cleanup. Exact-position removal must remain
-at least 4x faster than React and 1.5x faster than the compiled control.
+`toSpliced(position, 64)`, `toSpliced(position, 1, replacement)`, and
+`with(position, replacement)` updates use event-local runtime position variables and are measured
+against bracketed React and equivalent block-bodied compiled controls. The compiler report must
+contain all four dashboard `keyedArrayPositionHints`; package tests separately require zero
+surviving key/descriptor/binding reads for removal, surrounding DOM identity, randomized
+differential correctness, runtime-position and count fallback, hydration, and cleanup. Both the
+single-row and 64-row removal gates must remain at least 4x faster than React and 1.5x faster than
+their compiled controls.
 
 Native keyed-array reversal has a separate 10,000-row comparison. Concise `toReversed()` is
 measured against bracketed React and an equivalent block-bodied compiled control. Both compiler
@@ -178,7 +179,7 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
   `toSpliced()` updates and compare them with equivalent block-bodied compiled controls. Package
   tests cover the equivalent `with()` replacement path too.
   They verify surrounding DOM identity and isolate the saved full keyed scan for one insertion,
-  removal, or replacement.
+  one replacement, or a single/contiguous-range removal.
 - The reverse control compares concise native `toReversed()` with an equivalent block-bodied
   compiled update. Both paths move the same keyed DOM rows; the hint isolates the saved key,
   descriptor, binding, and generic LIS work.

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -143,8 +143,8 @@ async function inspectBuild(compilerMode) {
       "The compiler build did not emit a keyed-array prepend hint.",
     );
     assert(
-      compilerReport.summary.keyedArrayPositionHints > 0,
-      "The compiler build did not emit a keyed-array exact-position hint.",
+      compilerReport.summary.keyedArrayPositionHints >= 4,
+      "The compiler build did not emit all four keyed-array exact-position hints.",
     );
     assert(
       compilerReport.summary.keyedArrayReorderHints > 0,
@@ -646,6 +646,46 @@ async function measureTrial(browser, trial, compilerMode, port) {
           },
         );
 
+        const tablePositionRangeRemove = await measureTable(
+          async () => ensure10000(),
+          async () => {
+            const rows = table.querySelectorAll("tbody tr");
+            const before = rows[7_999];
+            const firstRemoved = rows[8_000];
+            const lastRemoved = rows[8_063];
+            const after = rows[8_064];
+            await runTableAction(
+              () => tableButton("table-position-range-remove").click(),
+              () =>
+                rowCount() === 9_936 &&
+                table.querySelectorAll("tbody tr")[7_999] === before &&
+                table.querySelectorAll("tbody tr")[8_000] === after &&
+                !firstRemoved?.isConnected &&
+                !lastRemoved?.isConnected,
+            );
+          },
+        );
+
+        const tablePositionRangeRemoveSnapshot = await measureTable(
+          async () => ensure10000(),
+          async () => {
+            const rows = table.querySelectorAll("tbody tr");
+            const before = rows[7_999];
+            const firstRemoved = rows[8_000];
+            const lastRemoved = rows[8_063];
+            const after = rows[8_064];
+            await runTableAction(
+              () => tableButton("table-position-range-remove-snapshot").click(),
+              () =>
+                rowCount() === 9_936 &&
+                table.querySelectorAll("tbody tr")[7_999] === before &&
+                table.querySelectorAll("tbody tr")[8_000] === after &&
+                !firstRemoved?.isConnected &&
+                !lastRemoved?.isConnected,
+            );
+          },
+        );
+
         const tablePositionReplace = await measureTable(
           async () => ensure10000(),
           async () => {
@@ -1106,6 +1146,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             positionInsertSnapshot: tablePositionInsertSnapshot,
             positionRemove: tablePositionRemove,
             positionRemoveSnapshot: tablePositionRemoveSnapshot,
+            positionRangeRemove: tablePositionRangeRemove,
+            positionRangeRemoveSnapshot: tablePositionRangeRemoveSnapshot,
             positionReplace: tablePositionReplace,
             positionReplaceSnapshot: tablePositionReplaceSnapshot,
             reverse: tableReverse,
@@ -1202,6 +1244,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
         positionInsertSnapshot: timingSummary(result.table.positionInsertSnapshot),
         positionRemove: timingSummary(result.table.positionRemove),
         positionRemoveSnapshot: timingSummary(result.table.positionRemoveSnapshot),
+        positionRangeRemove: timingSummary(result.table.positionRangeRemove),
+        positionRangeRemoveSnapshot: timingSummary(result.table.positionRangeRemoveSnapshot),
         positionReplace: timingSummary(result.table.positionReplace),
         positionReplaceSnapshot: timingSummary(result.table.positionReplaceSnapshot),
         reverse: timingSummary(result.table.reverse),
@@ -1294,6 +1338,8 @@ const tableMetrics = [
   "positionInsertSnapshot",
   "positionRemove",
   "positionRemoveSnapshot",
+  "positionRangeRemove",
+  "positionRangeRemoveSnapshot",
   "positionReplace",
   "positionReplaceSnapshot",
   "reverse",
@@ -1591,6 +1637,29 @@ const keyedPositionRegressions = keyedPositionResults.filter(
     !Number.isFinite(replaceSnapshotSpeedup) ||
     replaceSnapshotSpeedup < keyedPositionReplaceMinimumSnapshotSpeedup,
 );
+// A fixed positive toSpliced() delete count exposes one exact contiguous removal range. The hinted
+// runtime should remove only that range while retaining the surrounding DOM nodes, and it should
+// stay ahead of React and the equivalent block-bodied compiled control at 10,000 rows.
+const keyedRangeRemovalMinimumSpeedup = 4;
+const keyedRangeRemovalMinimumSnapshotSpeedup = 1.5;
+const keyedRangeRemovalResults = ["static", "hybrid"].map((mode) => {
+  const rangeMedianMs = comparisons.table.positionRangeRemove[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.positionRangeRemoveSnapshot[mode].medianMs;
+  return {
+    mode,
+    rangeMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / rangeMedianMs,
+    speedup: comparisons.table.positionRangeRemove[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedRangeRemovalRegressions = keyedRangeRemovalResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedRangeRemovalMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedRangeRemovalMinimumSnapshotSpeedup,
+);
 // A direct native reverse exposes the complete permutation. The hinted path should preserve the
 // same keyed DOM nodes while avoiding key, descriptor, binding, and generic LIS work. Compare it
 // with both React and the equivalent block-bodied compiled control at 10,000 rows.
@@ -1787,6 +1856,7 @@ const passed =
   keyedSliceRegressions.length === 0 &&
   keyedRollingWindowRegressions.length === 0 &&
   keyedPositionRegressions.length === 0 &&
+  keyedRangeRemovalRegressions.length === 0 &&
   keyedReorderRegressions.length === 0 &&
   keyedSortRegressions.length === 0 &&
   keyedFilterRegressions.length === 0 &&
@@ -1848,6 +1918,13 @@ const report = {
     replaceMinimumSpeedup: keyedPositionReplaceMinimumSpeedup,
     results: keyedPositionResults,
     status: keyedPositionRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedRangeRemovalHintGate: {
+    minimumSnapshotSpeedup: keyedRangeRemovalMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedRangeRemovalMinimumSpeedup,
+    regressions: keyedRangeRemovalRegressions,
+    results: keyedRangeRemovalResults,
+    status: keyedRangeRemovalRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedReorderHintGate: {
     minimumSnapshotSpeedup: keyedReorderMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -310,6 +310,32 @@ export function StandardTableBenchmark() {
           Remove at runtime position (snapshot control)
         </button>
         <button
+          data-action="table-position-range-remove"
+          type="button"
+          onClick={() => {
+            const position = 8_000;
+            setRows((current) => current.toSpliced(position, 64));
+            setOperation("remove range at runtime position");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Remove range at runtime position
+        </button>
+        <button
+          data-action="table-position-range-remove-snapshot"
+          type="button"
+          onClick={() => {
+            const position = 8_000;
+            setRows((current) => {
+              return current.toSpliced(position, 64);
+            });
+            setOperation("remove range at runtime position (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Remove range at runtime position (snapshot control)
+        </button>
+        <button
           data-action="table-position-replace"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -302,6 +302,7 @@ Native known-position updates can avoid a complete keyed scan too:
 ```tsx
 setItems((current) => current.toSpliced(selectedIndex, 0, nextItem));
 setItems((current) => current.toSpliced(selectedIndex, 1));
+setItems((current) => current.toSpliced(selectedIndex, 25));
 setItems((current) => current.toSpliced(selectedIndex, 1, replacement));
 setItems((current) => current.with(selectedIndex, replacement));
 ```
@@ -309,18 +310,19 @@ setItems((current) => current.with(selectedIndex, replacement));
 The compiler recognizes only a concise functional setter and either a safe-integer literal or a
 compiler-safe runtime position expression, such as an identifier, property read, arithmetic,
 conditional, or safe `Math` call. The update must insert one item with zero removals, remove one
-item, or replace one item through either `toSpliced()` or `with()`. Farm preserves method lookup,
+item or a fixed positive safe-integer literal range, or replace one item through either
+`toSpliced()` or `with()`. Farm preserves method lookup,
 evaluates the position and remaining arguments once in their original order, executes the ordinary
 native call, and records metadata only after validating the committed native source, result, and
-actual safe-integer position. The runtime creates one inserted row, removes one known row, or
-patches/replaces one row at that position without rereading every existing key, descriptor, and
-binding. Surviving rows keep their DOM identity. Index-aware or collection-reading rows, custom
-methods, position expressions with user calls or mutations, runtime positions that are not safe
-integers, other `toSpliced()`
-forms, block-bodied updaters, unsafe incoming expressions, queued uncommitted updates, reused keys,
-nested or React-owned rows, and failed checks use complete keyed reconciliation. Reports expose the
-site count as `keyedArrayPositionHints`; the capability is tree-shaken from modules that do not emit
-it.
+actual safe-integer position and clamped removal count. The runtime creates one inserted row,
+removes only the known row or range, or patches/replaces one row at that position without rereading
+every existing key, descriptor, and binding. Surviving rows keep their DOM identity. Index-aware or
+collection-reading rows, custom methods, position expressions with user calls or mutations,
+runtime positions that are not safe integers, dynamic, zero, negative, or fractional removal
+counts, other `toSpliced()` forms, block-bodied updaters, unsafe incoming expressions, queued
+uncommitted updates, reused keys, nested or React-owned rows, and failed checks use complete keyed
+reconciliation. Reports expose the site count as `keyedArrayPositionHints`; the capability is
+tree-shaken from modules that do not emit it.
 
 A direct native reverse can carry its complete permutation to a separate optional runtime:
 
@@ -659,8 +661,9 @@ reasons aggregated by count. Its summary and per-module `optimizations` also rep
 `keyedArrayAppendHints`, the number of compiler-proven direct keyed-array append sites; and
 `keyedArrayFilterHints`, the number of compiler-proven direct keyed-array filter sites; and
 `keyedArrayPrependHints`, the number of compiler-proven direct keyed-array prepend sites; and
-`keyedArrayPositionHints`, the number of compiler-proven native exact-position insertion, removal,
-or replacement sites, including guarded compiler-safe runtime positions; and
+`keyedArrayPositionHints`, the number of compiler-proven native exact-position insertion, single or
+contiguous-range removal, or replacement sites, including guarded compiler-safe runtime positions;
+and
 `keyedArrayReorderHints`, the number of compiler-proven direct native keyed-array reverse sites; and
 `keyedArraySortHints`, the number of compiler-proven direct native keyed-array sort sites; and
 `keyedArrayRollingWindowHints`, the number of compiler-proven retained-tail plus incoming-suffix

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-position-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-position-hints.test.ts
@@ -17,6 +17,7 @@ describe("React AOT keyed-array position hints", () => {
         return <section>
           <button onClick={() => setRows((current) => current.toSpliced(1, 0, next))}>Insert</button>
           <button onClick={() => setRows((current) => current.toSpliced(0, 1))}>Remove</button>
+          <button onClick={() => setRows((current) => current.toSpliced(0, 2))}>Remove range</button>
           <button onClick={() => setRows((current) => current.toSpliced(0, 1, next))}>Splice replace</button>
           <button onClick={() => setRows((current) => current.with(0, next))}>Replace</button>
           <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
@@ -25,7 +26,7 @@ describe("React AOT keyed-array position hints", () => {
     `);
 
     expect(result.compiled).toEqual(["Table"]);
-    expect(result.optimizations.keyedArrayPositionHints).toBe(4);
+    expect(result.optimizations.keyedArrayPositionHints).toBe(5);
     expect(result.code).toContain("createCompilerKeyedArrayPositionUpdate");
     expect(result.code).toContain("keyedRowsPositionHintedRuntimeFeature");
   });
@@ -55,6 +56,7 @@ describe("React AOT keyed-array position hints", () => {
         return <section>
           <button onClick={() => setRows((current) => current.toSpliced(offset, 0, next))}>Insert</button>
           <button onClick={() => setRows((current) => current.toSpliced(positions.remove, 1))}>Remove</button>
+          <button onClick={() => setRows((current) => current.toSpliced(offset + delta, 2))}>Remove range</button>
           <button onClick={() => setRows((current) => current.toSpliced(offset + delta, 1, next))}>Splice replace</button>
           <button onClick={() => setRows((current) => current.with(offset + delta, next))}>Replace</button>
           <button onClick={() => setRows((current) => current.with(current.length - 1, next))}>Replace last</button>
@@ -65,7 +67,7 @@ describe("React AOT keyed-array position hints", () => {
     `);
 
     expect(result.compiled).toEqual(["Table"]);
-    expect(result.optimizations.keyedArrayPositionHints).toBe(6);
+    expect(result.optimizations.keyedArrayPositionHints).toBe(7);
     expect(result.code).toContain("createCompilerKeyedArrayPositionUpdate");
     expect(result.code).toMatch(/\.get\(\)\.remove/);
     expect(result.code).toContain("current.length - 1");
@@ -85,7 +87,7 @@ describe("React AOT keyed-array position hints", () => {
     {
       name: "a block-bodied removal updater",
       row: "row => <li key={row.id}>{row.label}</li>",
-      update: "{ return current.toSpliced(0, 1); }",
+      update: "{ return current.toSpliced(0, 2); }",
     },
     {
       name: "an unsafe incoming call",
@@ -98,9 +100,14 @@ describe("React AOT keyed-array position hints", () => {
       update: "current.toSpliced(0, 0)",
     },
     {
-      name: "a multi-item removal",
+      name: "a negative range removal",
       row: "row => <li key={row.id}>{row.label}</li>",
-      update: "current.toSpliced(0, 2)",
+      update: "current.toSpliced(0, -2)",
+    },
+    {
+      name: "a fractional range removal",
+      row: "row => <li key={row.id}>{row.label}</li>",
+      update: "current.toSpliced(0, 1.5)",
     },
     {
       name: "a dynamic removal count",

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-position-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-position-hints.test.tsx
@@ -88,6 +88,17 @@ function hintedRemove(previous: Item[], position: number): Item[] {
   ) as Item[];
 }
 
+function hintedRemoveRange(previous: Item[], position: number, count: number): Item[] {
+  const source = previous as PositionArray;
+  return createCompilerKeyedArrayPositionUpdate(
+    source,
+    source.toSpliced,
+    "remove",
+    position,
+    count,
+  ) as Item[];
+}
+
 function rowDescriptor(item: Item, text = item.label): CompilerKeyedRowElement {
   return {
     kind: "element",
@@ -102,6 +113,7 @@ function createPositionHarness(initialItems: Item[], readsCollection = false) {
   const counters = { executions: 0, renders: 0, keys: 0, descriptors: 0, bindings: 0 };
   let insert: (position: number, item: Item) => void = () => undefined;
   let remove: (position: number) => void = () => undefined;
+  let removeRange: (position: number, count: number) => void = () => undefined;
   let replace: (position: number, item: Item) => void = () => undefined;
   let withReplace: (position: number, item: Item) => void = () => undefined;
   let queueTwo: (first: Item, second: Item) => void = () => undefined;
@@ -116,6 +128,8 @@ function createPositionHarness(initialItems: Item[], readsCollection = false) {
       insert = (position, item) =>
         state[0].set((previous) => hintedInsert(previous as Item[], position, item));
       remove = (position) => state[0].set((previous) => hintedRemove(previous as Item[], position));
+      removeRange = (position, count) =>
+        state[0].set((previous) => hintedRemoveRange(previous as Item[], position, count));
       replace = (position, item) =>
         state[0].set((previous) => hintedSpliceReplace(previous as Item[], position, item));
       withReplace = (position, item) =>
@@ -193,6 +207,7 @@ function createPositionHarness(initialItems: Item[], readsCollection = false) {
     queueTwo: (first: Item, second: Item) => queueTwo(first, second),
     queueRemoveTwo: () => queueRemoveTwo(),
     remove: (position: number) => remove(position),
+    removeRange: (position: number, count: number) => removeRange(position, count),
     replace: (position: number, item: Item) => replace(position, item),
     withReplace: (position: number, item: Item) => withReplace(position, item),
   };
@@ -268,6 +283,81 @@ describe("compiled keyed-array position hints", () => {
     expect(harness.counters.bindings).toBe(0);
   });
 
+  it("removes a known contiguous range without reading surviving keys or bindings", async () => {
+    const initialItems = Array.from(
+      { length: 4_096 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createPositionHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const before = container.querySelector('[data-key="row-2047"]');
+    const firstRemoved = container.querySelector('[data-key="row-2048"]');
+    const lastRemoved = container.querySelector('[data-key="row-2175"]');
+    const after = container.querySelector('[data-key="row-2176"]');
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.removeRange(2_048, 128);
+      await flushCompilerUpdates();
+    });
+
+    const rows = [...container.querySelectorAll("li")];
+    expect(rows[2_047]).toBe(before);
+    expect(rows[2_048]).toBe(after);
+    expect(firstRemoved?.isConnected).toBe(false);
+    expect(lastRemoved?.isConnected).toBe(false);
+    expect(rows).toHaveLength(3_968);
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
+    expect(harness.counters.keys).toBe(0);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(0);
+  });
+
+  it("clamps a known range at the array boundary and falls back for unsafe counts", async () => {
+    const harness = createPositionHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const alpha = container.querySelector('[data-key="a"]');
+    const beta = container.querySelector('[data-key="b"]');
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.removeRange(-2, 99);
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].map((node) => node.textContent)).toEqual([
+      "Alpha",
+      "Beta",
+    ]);
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-key="b"]')).toBe(beta);
+    expect(harness.counters.keys).toBe(0);
+
+    harness.counters.keys = 0;
+    await act(async () => {
+      harness.removeRange(0, 1.5);
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("Beta");
+    expect(harness.counters.keys).toBe(1);
+  });
+
   it("patches a same-key toSpliced replacement and creates one host row for a new key", async () => {
     const harness = createPositionHarness([
       { id: "a", label: "Alpha" },
@@ -331,6 +421,16 @@ describe("compiled keyed-array position hints", () => {
       1,
     ) as Item[];
     expect(removed.map((item) => item.id)).toEqual(["a", "b"]);
+    expect(source.map((item) => item.id)).toEqual(["a", "b", "c"]);
+
+    const rangeRemoved = createCompilerKeyedArrayPositionUpdate(
+      source,
+      source.toSpliced,
+      "remove",
+      -2,
+      99,
+    ) as Item[];
+    expect(rangeRemoved.map((item) => item.id)).toEqual(["a"]);
     expect(source.map((item) => item.id)).toEqual(["a", "b", "c"]);
 
     const customResult = [source[1]];
@@ -663,14 +763,18 @@ describe("compiled keyed-array position hints", () => {
     );
     const harness = createPositionHarness(initialItems);
     let updateReact: (
-      kind: "insert" | "remove" | "replace",
+      kind: "insert" | "remove" | "remove-range" | "replace",
       position: number,
       item?: Item,
+      count?: number,
     ) => void = () => undefined;
     function NormalTable() {
       const [items, setItems] = useState(initialItems);
-      updateReact = (kind, position, item) =>
+      updateReact = (kind, position, item, count) =>
         setItems((previous) => {
+          if (kind === "remove-range") {
+            return [...previous.slice(0, position), ...previous.slice(position + (count || 0))];
+          }
           if (kind === "remove") {
             return [...previous.slice(0, position), ...previous.slice(position + 1)];
           }
@@ -700,10 +804,22 @@ describe("compiled keyed-array position hints", () => {
 
     let length = initialItems.length;
     for (let step = 0; step < 1_000; step += 1) {
-      const kind = step % 7 === 0 ? "remove" : step % 5 === 0 ? "insert" : "replace";
-      const position = (step * 17) % (kind === "insert" ? length + 1 : length);
+      const kind =
+        length === 0
+          ? "insert"
+          : step % 13 === 0 && length > 3
+            ? "remove-range"
+            : step % 7 === 0
+              ? "remove"
+              : step % 5 === 0
+                ? "insert"
+                : "replace";
+      const count = kind === "remove-range" ? Math.min((step % 4) + 2, length) : 1;
+      const position =
+        (step * 17) %
+        (kind === "insert" ? length + 1 : kind === "remove-range" ? length - count + 1 : length);
       const item =
-        kind === "remove"
+        kind === "remove" || kind === "remove-range"
           ? undefined
           : {
               id: `${kind}-${step}`,
@@ -712,12 +828,18 @@ describe("compiled keyed-array position hints", () => {
       await act(async () => {
         if (kind === "insert") harness.insert(position, item!);
         else if (kind === "remove") harness.remove(position);
+        else if (kind === "remove-range") harness.removeRange(position, count);
         else harness.replace(position, item!);
-        updateReact(kind, position, item);
+        updateReact(kind, position, item, count);
         await flushCompilerUpdates();
       });
       if (kind === "insert") length += 1;
       else if (kind === "remove") length -= 1;
+      else if (kind === "remove-range") length -= count;
+      expect(
+        compiledContainer.querySelector("ul")?.textContent,
+        `step ${step}: ${kind} at ${position} with count ${count}`,
+      ).toBe(reactContainer.querySelector("ol")?.textContent);
     }
 
     expect(compiledContainer.querySelector("ul")?.textContent).toBe(
@@ -728,11 +850,12 @@ describe("compiled keyed-array position hints", () => {
     expect(harness.counters.renders).toBe(1);
   });
 
-  it("preserves focused input identity and selection when removing a preceding row", async () => {
+  it("preserves focused input identity and selection when removing preceding rows", async () => {
     const initialItems: Item[] = [
       { id: "a", label: "Alpha" },
       { id: "b", label: "Beta" },
       { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
     ];
     let remove = () => undefined;
     const FormRows = createCompiledComponent({
@@ -740,7 +863,7 @@ describe("compiled keyed-array position hints", () => {
       initialize: () => [initialItems],
       render(_props: Record<string, never>, state, blocks) {
         const items = () => state[0].get() as Item[];
-        remove = () => state[0].set((previous) => hintedRemove(previous as Item[], 0));
+        remove = () => state[0].set((previous) => hintedRemoveRange(previous as Item[], 0, 2));
         return (
           <section>
             <blocks.KeyedRows
@@ -781,7 +904,7 @@ describe("compiled keyed-array position hints", () => {
     const root = createRoot(container);
     roots.push(root);
     await act(async () => root.render(<FormRows />));
-    const input = container.querySelector('[data-key="b"]') as HTMLInputElement;
+    const input = container.querySelector('[data-key="c"]') as HTMLInputElement;
     input.focus();
     input.setSelectionRange(1, 3);
 
@@ -790,16 +913,17 @@ describe("compiled keyed-array position hints", () => {
       await flushCompilerUpdates();
     });
 
-    expect(container.querySelector('[data-key="b"]')).toBe(input);
+    expect(container.querySelector('[data-key="c"]')).toBe(input);
     expect(document.activeElement).toBe(input);
     expect([input.selectionStart, input.selectionEnd]).toEqual([1, 3]);
   });
 
-  it("updates delegated event indexes after removing an earlier row", async () => {
+  it("updates delegated event indexes after removing earlier rows", async () => {
     const initialItems: Item[] = [
       { id: "a", label: "Alpha" },
       { id: "b", label: "Beta" },
       { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
     ];
     let remove = () => undefined;
     const calls: string[] = [];
@@ -808,7 +932,7 @@ describe("compiled keyed-array position hints", () => {
       initialize: () => [initialItems],
       render(_props: Record<string, never>, state, blocks) {
         const items = () => state[0].get() as Item[];
-        remove = () => state[0].set((previous) => hintedRemove(previous as Item[], 0));
+        remove = () => state[0].set((previous) => hintedRemoveRange(previous as Item[], 0, 2));
         return (
           <section>
             <blocks.KeyedRows
@@ -874,9 +998,9 @@ describe("compiled keyed-array position hints", () => {
       await flushCompilerUpdates();
     });
     await act(async () => {
-      (container.querySelector('[data-row-button="c"]') as HTMLButtonElement).click();
+      (container.querySelector('[data-row-button="d"]') as HTMLButtonElement).click();
     });
-    expect(calls).toEqual(["c:1"]);
+    expect(calls).toEqual(["d:1"]);
   });
 
   it("hydrates in StrictMode and drops a queued position update after unmount", async () => {
@@ -912,10 +1036,10 @@ describe("compiled keyed-array position hints", () => {
     expect(recoverable).toEqual([]);
 
     await act(async () => {
-      harness.remove(-1);
+      harness.removeRange(-2, 2);
       await flushCompilerUpdates();
     });
-    expect(container.textContent).toBe("AlphaGamma");
+    expect(container.textContent).toBe("Alpha");
     expect(recoverable).toEqual([]);
 
     roots.pop();

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -331,7 +331,7 @@ function compilerKeyedArrayPosition(
     update.position > expectedLength ||
     (update.kind === "insert" && update.resultLength !== expectedLength + 1) ||
     (update.kind === "remove" &&
-      (update.position >= expectedLength || update.resultLength !== expectedLength - 1)) ||
+      (update.resultLength >= expectedLength || update.position > update.resultLength)) ||
     (update.kind === "replace" &&
       (update.position >= expectedLength || update.resultLength !== expectedLength))
   ) {
@@ -706,6 +706,8 @@ export function createCompilerKeyedArrayPositionUpdate(
     const sourceLength = previous.length;
     const normalizedPosition =
       position < 0 ? Math.max(sourceLength + position, 0) : Math.min(position, sourceLength);
+    const deleteCount = args[0];
+    const removedCount = sourceLength - value.length;
     const validInsert =
       kind === "insert" &&
       method === NATIVE_ARRAY_TO_SPLICED &&
@@ -716,9 +718,10 @@ export function createCompilerKeyedArrayPositionUpdate(
       kind === "remove" &&
       method === NATIVE_ARRAY_TO_SPLICED &&
       args.length === 1 &&
-      Object.is(args[0], 1) &&
+      Number.isSafeInteger(deleteCount) &&
+      (deleteCount as number) > 0 &&
       normalizedPosition < sourceLength &&
-      value.length === sourceLength - 1;
+      removedCount === Math.min(deleteCount as number, sourceLength - normalizedPosition);
     const validReplace =
       kind === "replace" &&
       value.length === sourceLength &&
@@ -4337,10 +4340,16 @@ function reconcileCompilerKeyedArrayPosition(
   const previous = previousInstances[update.position];
 
   if (update.kind === "remove") {
-    if (!previous || previous.index !== update.position) return undefined;
-    previous.scope?.cleanup();
-    previous.element.remove();
-    previousInstances.splice(update.position, 1);
+    const count = update.sourceLength - update.resultLength;
+    const removed = previousInstances.slice(update.position, update.position + count);
+    if (removed.some((instance, index) => instance.index !== update.position + index)) {
+      return undefined;
+    }
+    for (const instance of removed) {
+      instance.scope?.cleanup();
+      instance.element.remove();
+    }
+    previousInstances.splice(update.position, count);
     for (let index = update.position; index < previousInstances.length; index += 1) {
       previousInstances[index].index = index;
     }

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -1626,6 +1626,10 @@ function rewriteKeyedArrayPositionHints(
 
       const methodName = updater.body.callee.property.name;
       const args = updater.body.arguments;
+      const toSplicedDeleteCount =
+        methodName === "toSpliced" && args.length === 2 && t.isNumericLiteral(args[1])
+          ? args[1].value
+          : undefined;
       const kind =
         methodName === "with" && args.length === 2
           ? "replace"
@@ -1637,9 +1641,9 @@ function rewriteKeyedArrayPositionHints(
                 args.length === 3 &&
                 t.isNumericLiteral(args[1], { value: 1 })
               ? "replace"
-              : methodName === "toSpliced" &&
-                  args.length === 2 &&
-                  t.isNumericLiteral(args[1], { value: 1 })
+              : toSplicedDeleteCount !== undefined &&
+                  Number.isSafeInteger(toSplicedDeleteCount) &&
+                  toSplicedDeleteCount > 0
                 ? "remove"
                 : undefined;
       if (!kind || !t.isExpression(args[0])) return;


### PR DESCRIPTION
## Problem

The experimental React compiler could optimize one known-position keyed-row removal, but a native contiguous removal such as `current.toSpliced(position, 64)` returned to complete keyed reconciliation. That reread every surviving key, descriptor, and binding even though the native update already identified the only affected range.

## Root cause

The compiler accepted only a literal delete count of one for removal hints, and the runtime could not derive a proven multi-row DOM mutation range from its known-position metadata.

## Change

- recognize concise native `toSpliced(position, count)` removals when `count` is a positive safe-integer literal and the position is compiler-safe;
- derive the actual native-clamped removal span from validated source/result lengths without adding another metadata field;
- validate source identity, lengths, normalized position, and every affected stored row before touching the DOM;
- clean and remove only the contiguous range, preserve all surviving DOM nodes, and reindex the retained suffix;
- add focused compiler/runtime coverage and an isolated 10,000-row production-browser benchmark against both React and a block-bodied compiled control.

## Safety and compatibility

The native method lookup, argument evaluation order, return value, coercion, and errors remain authoritative. Dynamic, zero, negative, fractional, or otherwise unsafe counts; custom methods; subclassed or sparse collections; queued state; index-aware or collection-reading rows; nested/React-owned rows; ambiguous ownership; and failed runtime validation use the existing complete React reconciliation path.

The change is confined to the opt-in React compiler runtime. It adds no API or configuration, does not affect other renderers, and does not change existing benchmark floors. React 18.3.1 and 19.2.8 both pass. The optional known-position runtime fixture grows by 84 B gzip (12,201 B to 12,285 B); direct and core-only fixtures remain protected.

## Verification

- `pnpm --filter @farm.js/react test` — 566 tests passed
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8 passed
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --filter farm-react-compiler-dashboard-example type-check`
- `pnpm --filter farm-react-compiler-dashboard-example benchmark`
- `pnpm docs:check-navigation`
- `pnpm docs:build`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm test:e2e:framework`
- focused `oxfmt`, `oxlint`, and `git diff --check`

The post-size-fix 10,000-row gate measured 8.40 ms static and 7.10 ms hybrid, versus 66.75 ms for bracketed React and 21.50/20.60 ms for the equivalent compiled control: 7.95x/9.40x faster than React and 2.56x/2.90x faster than the control, with zero owner executions. Every pre-existing correctness, performance, persistence, and normalized-scalability gate also passed.

## Documentation and release

Updated the React renderer documentation, package README, benchmark contract, and recorded benchmark results. No version, lockfile, template, generated-route, or release-flow changes.
