### PR TITLE
fix(api): preserve HEAD request semantics

### DIFF
--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -61,6 +61,9 @@ src/app/api/files/[...path]/route.ts -> /api/files/*
 
 Use `createEndpoint` when you want input validation and typed client generation. Use plain `GET`, `POST`, `PATCH`, and friends when you want to handle the raw `Request`.
 
+`HEAD` follows normal HTTP semantics. A route can export a dedicated `HEAD` handler, otherwise Farm
+uses its `GET` handler and returns the same status and headers without a response body.
+
 ## Body and query input
 
 ```ts

--- a/packages/farm/src/__tests__/api-route-manager.test.ts
+++ b/packages/farm/src/__tests__/api-route-manager.test.ts
@@ -19,6 +19,81 @@ afterEach(() => {
 });
 
 describe("APIRouteManager", () => {
+  it("uses GET for HEAD requests and strips the response body", async () => {
+    const manager = new APIRouteManager("/tmp/farm-api-head-test");
+    const getHandler = async () =>
+      new Response("payload", {
+        status: 201,
+        headers: { "x-handler": "get" },
+      });
+    manager.getRoutes().set("/api/status", {
+      path: "/api/status",
+      filePath: "/tmp/farm-api-head-test/status/route.ts",
+      methods: ["GET"],
+      endpoints: { GET: getHandler },
+    });
+
+    const response = await manager.getHandler()!(
+      new Request("http://example.com/api/status", { method: "HEAD" }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(response.headers.get("x-handler")).toBe("get");
+    expect(await response.text()).toBe("");
+  });
+
+  it("strips bodies returned by explicit HEAD handlers", async () => {
+    const manager = new APIRouteManager("/tmp/farm-api-head-test");
+    manager.getRoutes().set("/api/status", {
+      path: "/api/status",
+      filePath: "/tmp/farm-api-head-test/status/route.ts",
+      methods: ["GET", "HEAD"],
+      endpoints: {
+        GET: async () => new Response("get"),
+        HEAD: async () => new Response("head", { headers: { "x-handler": "head" } }),
+      },
+    });
+
+    const response = await manager.getHandler()!(
+      new Request("http://example.com/api/status", { method: "HEAD" }),
+    );
+
+    expect(response.headers.get("x-handler")).toBe("head");
+    expect(await response.text()).toBe("");
+  });
+
+  it("includes implicit HEAD support in Allow headers", async () => {
+    const manager = new APIRouteManager("/tmp/farm-api-head-test");
+    manager.getRoutes().set("/api/status", {
+      path: "/api/status",
+      filePath: "/tmp/farm-api-head-test/status/route.ts",
+      methods: ["GET", "POST"],
+      endpoints: {
+        GET: async () => new Response("get"),
+        POST: async () => new Response("post"),
+      },
+    });
+
+    const response = await manager.getHandler()!(
+      new Request("http://example.com/api/status", { method: "DELETE" }),
+    );
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get("allow")).toBe("GET, HEAD, POST");
+  });
+
+  it("uses the same HEAD method helpers in the generated production runtime", () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), "src", "nitro", "universal-build.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain("const endpoint = resolveAPIRouteEndpoint(route, method);");
+    expect(source).toContain('"Allow": getAllowedAPIRouteMethods(route).join(", ")');
+    expect(source).toContain("endpoints: ${varName}");
+    expect(source).not.toContain("const endpoint = route.handlers[method];");
+  });
+
   it("passes through Next-style Response objects with stream bodies", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-api-route-"));
     tempDirs.push(root);

--- a/packages/farm/src/api/route-manager.ts
+++ b/packages/farm/src/api/route-manager.ts
@@ -11,7 +11,13 @@ import {
   type FarmRouteRuntimeConfig,
 } from "../route-runtime";
 import { _runWithFarmI18nRequest, type FarmI18nRuntime } from "../i18n/server";
-import { invokeAPIRouteEndpoint, matchAPIRoute, type APIRouteMatch } from "./runtime";
+import {
+  getAllowedAPIRouteMethods,
+  invokeAPIRouteEndpoint,
+  matchAPIRoute,
+  resolveAPIRouteEndpoint,
+  type APIRouteMatch,
+} from "./runtime";
 
 export interface APIRoute extends FarmRouteRuntimeConfig {
   path: string;
@@ -313,12 +319,12 @@ export class APIRouteManager {
 
       // Check if method is supported
       const { route, params } = match;
-      const endpoint = route.endpoints[method];
+      const endpoint = resolveAPIRouteEndpoint(route, method);
       if (!endpoint) {
         return new Response(JSON.stringify({ error: "Method Not Allowed" }), {
           status: 405,
           headers: {
-            Allow: route.methods.join(", "),
+            Allow: getAllowedAPIRouteMethods(route).join(", "),
             "Content-Type": "application/json",
           },
         });
@@ -365,9 +371,11 @@ export class APIRouteManager {
 }
 
 export {
+  getAllowedAPIRouteMethods,
   invokeAPIRouteEndpoint,
   isWebResponse,
   matchAPIRoute,
   normalizeRouteResponse,
+  resolveAPIRouteEndpoint,
 } from "./runtime";
 export type { APIRouteMatch, APIRouteParams, APIRouteParamValue } from "./runtime";

--- a/packages/farm/src/api/runtime.ts
+++ b/packages/farm/src/api/runtime.ts
@@ -19,6 +19,31 @@ export interface APIRouteMatch<T extends { path: string }> {
   params: APIRouteParams;
 }
 
+interface APIRouteMethodTable {
+  methods: string[];
+  endpoints: Record<string, any>;
+}
+
+export function resolveAPIRouteEndpoint(
+  route: APIRouteMethodTable,
+  method: string,
+): any | undefined {
+  const normalizedMethod = method.toUpperCase();
+  return (
+    route.endpoints[normalizedMethod] ??
+    (normalizedMethod === "HEAD" ? route.endpoints.GET : undefined)
+  );
+}
+
+export function getAllowedAPIRouteMethods(route: APIRouteMethodTable): string[] {
+  const methods = [...route.methods];
+  const getIndex = methods.indexOf("GET");
+  if (getIndex >= 0 && !methods.includes("HEAD")) {
+    methods.splice(getIndex + 1, 0, "HEAD");
+  }
+  return methods;
+}
+
 export function matchAPIRoute<T extends { path: string }>(
   routes: Map<string, T>,
   pathname: string,
@@ -60,9 +85,19 @@ export async function invokeAPIRouteEndpoint(
     throw error;
   }
 
-  return _runWithCurrentRequest(request, () =>
+  const response = await _runWithCurrentRequest(request, () =>
     invokeAPIRouteEndpointInContext(endpoint, request, params),
   );
+
+  if (request.method.toUpperCase() !== "HEAD") {
+    return response;
+  }
+
+  return new Response(null, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
 }
 
 async function invokeAPIRouteEndpointInContext(

--- a/packages/farm/src/api/vite-plugin.ts
+++ b/packages/farm/src/api/vite-plugin.ts
@@ -16,7 +16,13 @@
  */
 
 import type { Plugin, ViteDevServer } from "vite";
-import { API_ROUTE_METHODS, invokeAPIRouteEndpoint, matchAPIRoute } from "./route-manager";
+import {
+  API_ROUTE_METHODS,
+  getAllowedAPIRouteMethods,
+  invokeAPIRouteEndpoint,
+  matchAPIRoute,
+  resolveAPIRouteEndpoint,
+} from "./route-manager";
 import { sendWebResponse } from "../server/response";
 import { _withAfterNodeMiddleware } from "../after";
 import { isProgrammaticRoutesFileName } from "../routes-shared";
@@ -130,12 +136,12 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
         }
 
         const { route, params } = match;
-        const endpoint = route.endpoints[method];
+        const endpoint = resolveAPIRouteEndpoint(route, method);
         if (!endpoint) {
           return new Response(JSON.stringify({ error: "Method Not Allowed" }), {
             status: 405,
             headers: {
-              Allow: route.methods.join(", "),
+              Allow: getAllowedAPIRouteMethods(route).join(", "),
               "Content-Type": "application/json",
             },
           });

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -3755,7 +3755,7 @@ function generateVirtualEntryCode(
   {
     path: ${JSON.stringify(route.path)},
     methods: ${JSON.stringify(route.methods)},
-    handlers: ${varName},
+    endpoints: ${varName},
   }`);
   });
 
@@ -3929,7 +3929,7 @@ function generateVirtualEntryCode(
     : "";
   const apiRouteHelpersImport =
     apiRoutes.length > 0
-      ? `import { invokeAPIRouteEndpoint, matchAPIRoute } from "@farm.js/core/api/runtime";`
+      ? `import { getAllowedAPIRouteMethods, invokeAPIRouteEndpoint, matchAPIRoute, resolveAPIRouteEndpoint } from "@farm.js/core/api/runtime";`
       : "";
   const productionRuntimeImport = `import {
   _runWithAfterRequest,
@@ -4085,14 +4085,14 @@ async function handleAPIRequest(request) {
     route: route.path,
     method,
   });
-  const endpoint = route.handlers[method];
+  const endpoint = resolveAPIRouteEndpoint(route, method);
   if (!endpoint) {
     const response = new Response(
       JSON.stringify({ error: "Method Not Allowed" }),
       {
         status: 405,
         headers: {
-          "Allow": route.methods.join(", "),
+          "Allow": getAllowedAPIRouteMethods(route).join(", "),
           "Content-Type": "application/json",
         },
       }


### PR DESCRIPTION
## Problem

API routes returned 405 for HEAD when only GET was exported, and explicit HEAD handlers could send response bodies. The generated Allow header also omitted the implicit HEAD support.

## Root cause

Development, the API route manager, and the generated production runtime selected handlers only by the exact request method. The shared endpoint invocation path did not normalize HEAD responses.

## Change

- Resolve HEAD to an explicit HEAD handler first and then fall back to GET.
- Strip bodies from every HEAD response while preserving status and headers.
- Include implicit HEAD in Allow whenever GET exists.
- Reuse the same method helpers in dev and generated production output.
- Document the behavior.

## Safety and compatibility

Existing explicit HEAD handlers keep precedence. GET, QUERY, mutation methods, route matching, validation, and response headers are unchanged. The behavior is renderer-neutral and matches HTTP semantics.

## Verification

- pnpm --filter @farm.js/core test -- api-route-manager.test.ts
- pnpm --filter @farm.js/core type-check
- pnpm exec oxlint on changed TypeScript files: zero errors; existing unrelated warnings remain
- git diff --check

The regression tests fail on main: GET-only HEAD returns 405 and explicit HEAD bodies are retained.

## Documentation and release

Updated the API routes guide. No template, example, generated artifact, or release version changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
HEAD request handling now matches HTTP semantics in API routes. GET-only routes no longer return 405 for HEAD; a HEAD request uses the GET handler with the response body stripped while keeping the status and headers.

- Explicit HEAD handlers still take precedence over GET.
- 405 `Allow` headers now include HEAD whenever the route supports GET.
- Dev server and generated production runtime share the same HEAD method resolution and `Allow` logic.
- API routes guide updated to document the behavior; no breaking changes or migration steps are required.

<sup>Written for commit 40cb7bdcb559f7057d6ef953540cf24a9ffb17ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

