### PR TITLE
fix(routing): honor configured not-found component

### DIFF
--- a/docs/farm.config.ts
+++ b/docs/farm.config.ts
@@ -3,9 +3,6 @@ import { withDocs } from "@farming-labs/farmjs/config";
 
 export default withDocs(
   defineConfig({
-    notFound: {
-      component: "./src/app/not-found.tsx",
-    },
     async headers() {
       return [
         {

--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -973,6 +973,18 @@ export default function DashboardError({ error, reset }: ErrorProps) {
 
 `error.tsx` receives `error`, `reset`, `params`, `path`, `search`, `searchParams`, middleware data, and plugin context. The closest route error boundary handles normal render/data failures. Redirects and `notFound()` still escape to Farm's redirect and not-found handling.
 
+Place `not-found.*` at the app root to customize unmatched URLs. When the component lives elsewhere,
+set its project-relative path explicitly; Farm uses the same file in development and production and
+fails startup or build when the path is missing or incompatible with the selected renderer:
+
+```ts title="farm.config.ts"
+export default defineConfig({
+  notFound: {
+    component: "./src/ui/not-found.tsx",
+  },
+});
+```
+
 ## Catch-all routes
 
 Catch-all routes are useful for docs, CMS content, and nested marketing pages where the page is resolved from content instead of a fixed file for every URL.

--- a/packages/farm/src/__tests__/not-found.test.ts
+++ b/packages/farm/src/__tests__/not-found.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveConfig } from "../config";
+import { resolveFarmNotFoundComponentPath } from "../not-found";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    fs.rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+function createRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-not-found-"));
+  tempDirs.push(root);
+  return root;
+}
+
+function write(root: string, relativePath: string): string {
+  const filePath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, "export default function NotFound() { return null; }\n");
+  return filePath;
+}
+
+describe("resolveFarmNotFoundComponentPath", () => {
+  it("prefers an explicitly configured component over the app convention", async () => {
+    const root = createRoot();
+    write(root, "src/app/not-found.tsx");
+    const configured = write(root, "src/ui/missing.tsx");
+    const config = await resolveConfig(
+      { root, notFound: { component: "./src/ui/missing.tsx" } },
+      "development",
+    );
+
+    expect(resolveFarmNotFoundComponentPath(config, [path.join(root, "src/app")])).toBe(configured);
+  });
+
+  it("fails clearly when the configured component is missing", async () => {
+    const root = createRoot();
+    const config = await resolveConfig(
+      { root, notFound: { component: "./src/ui/missing.tsx" } },
+      "production",
+    );
+
+    expect(() => resolveFarmNotFoundComponentPath(config, [path.join(root, "src/app")])).toThrow(
+      `notFound.component was not found: ${path.join(root, "src/ui/missing.tsx")}`,
+    );
+  });
+
+  it("rejects component formats unsupported by the configured renderer", async () => {
+    const root = createRoot();
+    write(root, "src/ui/missing.vue");
+    const config = await resolveConfig(
+      { root, notFound: { component: "./src/ui/missing.vue" } },
+      "production",
+    );
+
+    expect(() => resolveFarmNotFoundComponentPath(config, [path.join(root, "src/app")])).toThrow(
+      "notFound.component must use one of the configured renderer extensions",
+    );
+  });
+
+  it("keeps project conventions ahead of extended app directories", async () => {
+    const root = createRoot();
+    const baseApp = path.join(root, "base/app");
+    const projectApp = path.join(root, "src/app");
+    write(root, "base/app/not-found.tsx");
+    const projectNotFound = write(root, "src/app/not-found.tsx");
+    const config = await resolveConfig({ root }, "production");
+
+    expect(resolveFarmNotFoundComponentPath(config, [baseApp, projectApp])).toBe(projectNotFound);
+  });
+});

--- a/packages/farm/src/app.ts
+++ b/packages/farm/src/app.ts
@@ -176,6 +176,7 @@ export class FarmApp {
             mode: process.env.NODE_ENV === "production" ? "production" : "development",
           }),
       deploymentId: config.deploymentId || "development",
+      notFound: config.notFound || {},
       serverRuntimeConfig: config.serverRuntimeConfig || {},
       publicRuntimeConfig: config.publicRuntimeConfig || {},
       docs: isResolvedDocsConfig(config.docs) ? config.docs : defaultDocsConfig,

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -383,6 +383,7 @@ export interface ResolvedFarmConfig extends Required<
 > {
   /** @internal Tracks whether `context` came from user/layer config instead of the default noop. */
   [FARM_RESOLVED_CUSTOM_CONTEXT]?: boolean;
+  root: string;
   extends: readonly FarmLayerEntry[];
   layers: ResolvedFarmLayer[];
   plugins: FarmPlugin[];
@@ -407,6 +408,7 @@ export interface ResolvedFarmConfig extends Required<
   theme: ResolvedFarmThemeConfig;
   renderer: FarmRenderer;
   routeRules: FarmRouteRules;
+  notFound: NotFoundConfig;
 }
 
 export function hasCustomFarmRouteContext(config: ResolvedFarmConfig): boolean {

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -77,11 +77,7 @@ import { createFarmSourceAlias } from "../server/vite-config";
 import { DEFAULT_NOT_FOUND_STYLES } from "../components/not-found-styles";
 import { createFarmThemeCssPlugin } from "../theme/vite";
 import { resolveFarmInstrumentationFile } from "../instrumentation";
-import {
-  isReactRenderer,
-  loadFarmRendererVitePlugins,
-  REACT_RENDERER,
-} from "../renderer";
+import { isReactRenderer, loadFarmRendererVitePlugins, REACT_RENDERER } from "../renderer";
 import type { FarmRenderer } from "../renderer";
 
 // Type alias for OutputBundle

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -64,6 +64,7 @@ import type { FarmRouteRuntimeManifest, FarmRouteRuntimeManifestEntry } from "..
 import { createFarmVercelRouteRuntimeFunctions } from "./vercel-route-runtime";
 import { createFarmVercelImmutableAssetRoute } from "./vercel-assets";
 import { createFarmNodeServerEntry } from "./node-server-entry";
+import { resolveFarmNotFoundComponentPath } from "../not-found";
 import { readFarmI18nCatalogs } from "../i18n/catalog";
 import type { FarmI18nCatalogs } from "../i18n/types";
 import { getFarmIntegrationPluginServerRuntime } from "../integrations";
@@ -77,7 +78,6 @@ import { DEFAULT_NOT_FOUND_STYLES } from "../components/not-found-styles";
 import { createFarmThemeCssPlugin } from "../theme/vite";
 import { resolveFarmInstrumentationFile } from "../instrumentation";
 import {
-  getFarmRendererComponentExtensions,
   isReactRenderer,
   loadFarmRendererVitePlugins,
   REACT_RENDERER,
@@ -3372,20 +3372,7 @@ async function buildSSRInMemory(
   const instrumentationPath = resolveFarmInstrumentationFile(root, config.srcDir || "src");
 
   // Check for custom not-found page
-  let notFoundPath: string | null = null;
-  const notFoundExtensions = getFarmRendererComponentExtensions(config.renderer);
-  for (const sourceAppDir of appDirs) {
-    for (const ext of notFoundExtensions) {
-      const checkPath = path.join(sourceAppDir, `not-found${ext}`);
-      try {
-        await fs.access(checkPath);
-        notFoundPath = checkPath;
-        break;
-      } catch {
-        // File doesn't exist, continue checking
-      }
-    }
-  }
+  const notFoundPath = resolveFarmNotFoundComponentPath(config, appDirs);
   if (notFoundPath) logger.info(`📋 Found custom 404 page: ${notFoundPath}`);
 
   // Sort layouts by depth (root first)

--- a/packages/farm/src/not-found.ts
+++ b/packages/farm/src/not-found.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs";
+import path from "node:path";
+import { getFarmRendererComponentExtensions, type FarmRenderer } from "./renderer";
+
+interface FarmNotFoundPathConfig {
+  root: string;
+  renderer: FarmRenderer;
+  notFound?: {
+    component?: string;
+  };
+}
+
+export function resolveFarmNotFoundComponentPath(
+  config: FarmNotFoundPathConfig,
+  appDirs: readonly string[],
+): string | null {
+  const extensions = getFarmRendererComponentExtensions(config.renderer);
+  const configuredPath = config.notFound?.component?.trim();
+
+  if (configuredPath) {
+    const componentPath = path.isAbsolute(configuredPath)
+      ? path.normalize(configuredPath)
+      : path.resolve(config.root, configuredPath);
+    if (!extensions.some((extension) => componentPath.endsWith(extension))) {
+      throw new Error(
+        `notFound.component must use one of the configured renderer extensions: ${extensions.join(", ")}`,
+      );
+    }
+    if (!fs.existsSync(componentPath) || !fs.statSync(componentPath).isFile()) {
+      throw new Error(`notFound.component was not found: ${componentPath}`);
+    }
+    return componentPath;
+  }
+
+  let discoveredPath: string | null = null;
+  for (const appDir of appDirs) {
+    for (const extension of extensions) {
+      const candidate = path.join(appDir, `not-found${extension}`);
+      if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+        discoveredPath = candidate;
+        break;
+      }
+    }
+  }
+  return discoveredPath;
+}

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -29,6 +29,8 @@ import { matchSSGPage, resolveRouteRenderingConfigFromFile } from "../ssg";
 import { getIntegrationProviders, getRegisteredIntegrationAPIManifest } from "../integrations";
 import { _runWithCurrentRequest, createWebRequestFromFarmRequest } from "./request";
 import { createFarmCacheKey, getFarmDataCache, normalizeRevalidatePath } from "../cache";
+import { resolveFarmNotFoundComponentPath } from "../not-found";
+import { getFarmAppDirectories } from "../layers";
 import { emitFarmEvent } from "../observability";
 import {
   getFarmRedirectError,
@@ -402,6 +404,10 @@ export class ServerRenderer {
 
   async initialize(): Promise<void> {
     if (this.rendererRuntime) return;
+
+    if (this.config.notFound.component?.trim()) {
+      resolveFarmNotFoundComponentPath(this.config, getFarmAppDirectories(this.config));
+    }
 
     const loaded = isReactRenderer(this.config.renderer)
       ? await import("../renderer/react/server")
@@ -2477,15 +2483,10 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
       // Look for custom not-found page
       const appDir = path.join(this.config.root, this.config.srcDir, "app");
       const notFoundExtensions = getFarmRendererComponentExtensions(this.config.renderer);
-      let notFoundPath: string | null = null;
-
-      for (const ext of notFoundExtensions) {
-        const checkPath = path.join(appDir, `not-found${ext}`);
-        if (fs.existsSync(checkPath)) {
-          notFoundPath = checkPath;
-          break;
-        }
-      }
+      const notFoundPath = resolveFarmNotFoundComponentPath(
+        this.config,
+        getFarmAppDirectories(this.config),
+      );
 
       if (notFoundPath) {
         // Use routeManager to load the module (uses Vite's ssrLoadModule in dev)

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -405,7 +405,7 @@ export class ServerRenderer {
   async initialize(): Promise<void> {
     if (this.rendererRuntime) return;
 
-    if (this.config.notFound.component?.trim()) {
+    if (this.config.notFound?.component?.trim()) {
       resolveFarmNotFoundComponentPath(this.config, getFarmAppDirectories(this.config));
     }
 

--- a/packages/farm/src/types.ts
+++ b/packages/farm/src/types.ts
@@ -207,6 +207,10 @@ export interface FarmConfig {
   i18n?: FarmI18nUserConfig | ResolvedFarmI18nConfig | false;
   /** Build identifier used to detect stale clients during rolling deployments. */
   deploymentId?: string;
+  /** Optional project-relative module used for unmatched page routes. */
+  notFound?: {
+    component?: string;
+  };
   /** Server-only application runtime values. */
   serverRuntimeConfig?: Record<string, unknown>;
   /** Serializable application values exposed to `src/client.ts`. */


### PR DESCRIPTION
## Problem

`notFound.component` was accepted and resolved by configuration, but both the development renderer and production builder ignored it and only searched for an app-root `not-found.*` convention.

## Root cause

The two rendering paths implemented their own convention-only file lookup instead of consuming the resolved configuration. The base app config type also omitted the existing option, so the development config normalization could not carry it consistently.

## Change

- Resolve explicit project-relative or absolute `notFound.component` paths before convention lookup.
- Share the resolver between development rendering and the production universal build.
- Preserve renderer-specific extensions and layer/project convention precedence.
- Validate explicit paths at development startup and production build time.
- Document the explicit path behavior.

## Safety and compatibility

Existing app-root `not-found.*` files continue to work. Project conventions still override extended-layer conventions. An explicit path now takes precedence and produces an actionable error when it is missing or uses an extension unsupported by the configured renderer.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/not-found.test.ts src/__tests__/not-found.test.tsx`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/not-found.ts packages/farm/src/app.ts packages/farm/src/config.ts packages/farm/src/server/renderer.ts packages/farm/src/nitro/universal-build.ts packages/farm/src/types.ts packages/farm/src/__tests__/not-found.test.ts` (0 errors; one unrelated existing `deployOutputDir` warning)
- `pnpm --dir examples/ssr-ssg-demo exec farm build --preset node-server`
- Started the built node server and requested `/this-route-does-not-exist`; it returned HTTP 404 with the configured `Oops! Page Not Found` component.

## Documentation and release

Updated the routing guide. No release metadata or generated artifacts changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `notFound.component` being ignored: both the development renderer and production builder only searched for an app-root `not-found.*` file. Configured project-relative or absolute paths are now resolved before convention lookup, shared across both rendering paths, and validated at development startup and production build time.

Existing `not-found.*` conventions still work, project conventions still override extended layers, and an explicit path now takes precedence with a clear error when missing or using an unsupported renderer extension.

<sup>Written for commit 5e11e7af5fbba0094f23e16152afe63487f3a9e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

