### PR TITLE
fix(cache): serialize circular arrays safely

### DIFF
--- a/packages/farm/src/__tests__/cache-key-circular-array.test.ts
+++ b/packages/farm/src/__tests__/cache-key-circular-array.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { createFarmCacheKey } from "../cache";
+
+describe("createFarmCacheKey with circular arrays", () => {
+  it("serializes an array that contains itself", () => {
+    const circular: unknown[] = [];
+    circular.push(circular);
+
+    expect(createFarmCacheKey([circular])).toBe("[[[Circular]]]");
+  });
+
+  it("keeps non-circular array contents in the key", () => {
+    const first: unknown[] = [];
+    first.push(first, 1);
+    const second: unknown[] = [];
+    second.push(second, 2);
+
+    expect(createFarmCacheKey([first])).not.toBe(createFarmCacheKey([second]));
+  });
+
+  it("does not mark a shared array as circular", () => {
+    const shared = [1];
+
+    expect(createFarmCacheKey([shared, shared])).toBe("[[number:1],[number:1]]");
+  });
+});

--- a/packages/farm/src/cache.ts
+++ b/packages/farm/src/cache.ts
@@ -1034,15 +1034,17 @@ function stableSerialize(value: unknown, seen = new WeakSet<object>()): string {
     return `regexp:${value.toString()}`;
   }
 
-  if (Array.isArray(value)) {
-    return `[${value.map((item) => stableSerialize(item, seen)).join(",")}]`;
-  }
-
   if (value && typeof value === "object") {
     if (seen.has(value)) {
       return "[Circular]";
     }
     seen.add(value);
+
+    if (Array.isArray(value)) {
+      const serialized = value.map((item) => stableSerialize(item, seen)).join(",");
+      seen.delete(value);
+      return `[${serialized}]`;
+    }
 
     // Set and Map keep their contents internally, so Object.entries is empty
     // for both. Serialize the contents and sort them by codepoint so equal


### PR DESCRIPTION
## Problem

A structured cache key containing an array that referenced itself overflowed the call stack before the cached function, server query, or invalidation could run.

## Root cause

`stableSerialize` handled arrays before registering objects in its circular-reference tracker. Sets, maps, and plain objects used that tracker, but arrays recursively serialized without it.

## Change

Serialize arrays inside the existing tracked-object path and remove them from the active traversal set after their contents are complete. This also preserves reuse of the same non-circular array in multiple key positions.

## Safety and compatibility

Ordinary array key output is unchanged. Shared non-circular arrays are still serialized by value rather than marked circular. This does not touch the separately assigned Invalid Date issue (#576).

## Verification

- Confirmed the regression test fails on `main` with `RangeError: Maximum call stack size exceeded`.
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/cache-key-circular-array.test.ts src/__tests__/cache-key-set-map.test.ts src/__tests__/cache.test.ts` (34 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/cache.ts packages/farm/src/__tests__/cache-key-circular-array.test.ts`

## Documentation and release

No public API or configuration changes. Added focused regression coverage; no release metadata changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `stableSerialize` so cache keys containing self-referencing arrays no longer overflow the call stack before the cached function, server query, or invalidation runs. Arrays now go through the existing circular-reference tracker, so circular arrays serialize as `[Circular]` and ordinary array key output is unchanged.

**Verification**
- Adds regression tests for circular arrays, distinct circular arrays, and shared non-circular arrays.
- No public API, configuration, or release metadata changes.

<sup>Written for commit 3ab9dfecda523539ef013b0d671bc08991f7611b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

