### PR TITLE
fix(cache): distinguish sparse array keys

### DIFF
--- a/packages/farm/src/__tests__/cache-key-sparse-array.test.ts
+++ b/packages/farm/src/__tests__/cache-key-sparse-array.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { createFarmCacheKey } from "../cache";
+
+describe("createFarmCacheKey with sparse arrays", () => {
+  it("distinguishes an empty slot from an empty array and explicit undefined", () => {
+    const sparse: unknown[] = [];
+    sparse.length = 1;
+
+    expect(createFarmCacheKey([sparse])).toBe("[[[Hole]]]");
+    expect(createFarmCacheKey([sparse])).not.toBe(createFarmCacheKey([[]]));
+    expect(createFarmCacheKey([sparse])).not.toBe(createFarmCacheKey([[undefined]]));
+  });
+
+  it("keeps the position of empty slots", () => {
+    const leading: unknown[] = [];
+    leading.length = 2;
+    leading[1] = 1;
+    const trailing = [1];
+    trailing.length = 2;
+
+    expect(createFarmCacheKey([leading])).not.toBe(createFarmCacheKey([trailing]));
+  });
+
+  it("does not change dense array keys", () => {
+    expect(createFarmCacheKey([[1, undefined]])).toBe("[[number:1,undefined]]");
+  });
+});

--- a/packages/farm/src/cache.ts
+++ b/packages/farm/src/cache.ts
@@ -1035,7 +1035,15 @@ function stableSerialize(value: unknown, seen = new WeakSet<object>()): string {
   }
 
   if (Array.isArray(value)) {
-    return `[${value.map((item) => stableSerialize(item, seen)).join(",")}]`;
+    const items: string[] = [];
+    for (let index = 0; index < value.length; index++) {
+      items.push(
+        Object.prototype.hasOwnProperty.call(value, index)
+          ? stableSerialize(value[index], seen)
+          : "[Hole]",
+      );
+    }
+    return `[${items.join(",")}]`;
   }
 
   if (value && typeof value === "object") {


### PR DESCRIPTION
## Problem

A structured cache key containing a one-slot sparse array serialized to the same key as an empty array. Different inputs could therefore share cached data or invalidate each other.

## Root cause

`Array.prototype.map` skips empty slots, and joining the result erased the sparse array's length and hole position.

## Change

Serialize array indices explicitly and emit a typed `[Hole]` marker for missing own entries.

## Safety and compatibility

Dense array serialization is unchanged, including explicit `undefined` values. Sparse arrays now retain their length and hole positions. This PR is independent of the circular-array fix and does not touch the assigned Invalid Date issue (#576).

## Verification

- Confirmed the regression test fails on `main` because a sparse array and empty array both produce `[[]]`.
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/cache-key-sparse-array.test.ts src/__tests__/cache-key-set-map.test.ts src/__tests__/cache.test.ts` (34 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/cache.ts packages/farm/src/__tests__/cache-key-sparse-array.test.ts`

## Documentation and release

No public API or configuration changes. Added focused regression coverage; no release metadata changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cache key serialization so sparse arrays no longer collide with empty arrays or explicit undefined values. Sparse array keys now include `[Hole]` markers that preserve length and hole positions; dense array keys are unchanged.

**Bug Fixes**
- Adds regression tests covering sparse, empty, explicit undefined, and hole-position cases.
- No public API or configuration changes.

<sup>Written for commit 8b1c234aff6dbb3661aa21e5c021e876221a361c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

