### PR TITLE
fix(cache): serialize binary key contents

### DIFF
--- a/packages/farm/src/__tests__/cache-key-binary.test.ts
+++ b/packages/farm/src/__tests__/cache-key-binary.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { createFarmCacheKey } from "../cache";
+
+describe("createFarmCacheKey with binary values", () => {
+  it("uses ArrayBuffer contents", () => {
+    const first = Uint8Array.from([1, 2]).buffer;
+    const second = Uint8Array.from([1, 3]).buffer;
+
+    expect(createFarmCacheKey([first])).toBe("[arraybuffer:0102]");
+    expect(createFarmCacheKey([first])).not.toBe(createFarmCacheKey([second]));
+  });
+
+  it("uses SharedArrayBuffer contents", () => {
+    const first = new SharedArrayBuffer(2);
+    const second = new SharedArrayBuffer(2);
+    new Uint8Array(first).set([1, 2]);
+    new Uint8Array(second).set([1, 3]);
+
+    expect(createFarmCacheKey([first])).toBe("[sharedarraybuffer:0102]");
+    expect(createFarmCacheKey([first])).not.toBe(createFarmCacheKey([second]));
+  });
+
+  it("uses only the visible bytes of a DataView", () => {
+    const backing = Uint8Array.from([9, 1, 2, 9]).buffer;
+    const sliced = new DataView(backing, 1, 2);
+    const sameContents = new DataView(Uint8Array.from([1, 2]).buffer);
+    const differentContents = new DataView(Uint8Array.from([1, 3]).buffer);
+
+    expect(createFarmCacheKey([sliced])).toBe("[binary:DataView:0102]");
+    expect(createFarmCacheKey([sliced])).toBe(createFarmCacheKey([sameContents]));
+    expect(createFarmCacheKey([sliced])).not.toBe(createFarmCacheKey([differentContents]));
+  });
+
+  it("keeps binary view types distinct", () => {
+    expect(createFarmCacheKey([Uint8Array.from([1, 2])])).not.toBe(
+      createFarmCacheKey([Uint8ClampedArray.from([1, 2])]),
+    );
+  });
+
+  it("does not collide with plain objects containing numeric keys", () => {
+    expect(createFarmCacheKey([Uint8Array.from([1, 2])])).not.toBe(
+      createFarmCacheKey([{ 0: 1, 1: 2 }]),
+    );
+  });
+});

--- a/packages/farm/src/cache.ts
+++ b/packages/farm/src/cache.ts
@@ -1008,6 +1008,10 @@ function compareCodepoint(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
 }
 
+function serializeBinaryBytes(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
 function stableSerialize(value: unknown, seen = new WeakSet<object>()): string {
   if (value === null) return "null";
   if (value === undefined) return "undefined";
@@ -1032,6 +1036,17 @@ function stableSerialize(value: unknown, seen = new WeakSet<object>()): string {
   }
   if (value instanceof RegExp) {
     return `regexp:${value.toString()}`;
+  }
+  if (value instanceof ArrayBuffer) {
+    return `arraybuffer:${serializeBinaryBytes(new Uint8Array(value))}`;
+  }
+  if (typeof SharedArrayBuffer !== "undefined" && value instanceof SharedArrayBuffer) {
+    return `sharedarraybuffer:${serializeBinaryBytes(new Uint8Array(value))}`;
+  }
+  if (ArrayBuffer.isView(value)) {
+    const viewType = Object.prototype.toString.call(value).slice(8, -1);
+    const bytes = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+    return `binary:${viewType}:${serializeBinaryBytes(bytes)}`;
   }
 
   if (Array.isArray(value)) {


### PR DESCRIPTION
## Problem

Structured cache keys did not safely identify binary values. All `ArrayBuffer` and `DataView` instances serialized as `{}`, while typed arrays could collide with another typed-array class or a plain object containing the same numeric properties.

## Root cause

Binary values fell through to generic `Object.entries` serialization, which cannot see buffer contents and does not preserve binary view identity.

## Change

Serialize the visible bytes as portable hexadecimal data with distinct prefixes for `ArrayBuffer`, `SharedArrayBuffer`, and each binary view type. A `DataView` uses only its visible byte range rather than the entire backing buffer.

## Safety and compatibility

Non-binary keys are unchanged. Equal binary types with equal visible bytes still share a key; differing bytes or view types do not. This does not touch the separately assigned Invalid Date issue (#576).

## Verification

- Confirmed all four original regression cases fail on `main`: buffer contents, DataView contents, typed-array type identity, and typed-array/plain-object separation.
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/cache-key-binary.test.ts src/__tests__/cache-key-set-map.test.ts src/__tests__/cache.test.ts` (35 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/cache.ts packages/farm/src/__tests__/cache-key-binary.test.ts`

## Documentation and release

No public API or configuration changes. Added focused regression coverage; no release metadata changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cache key serialization for binary values so `ArrayBuffer`, `SharedArrayBuffer`, and typed arrays/DataViews now encode their visible bytes as distinct portable hex strings instead of falling back to generic object serialization.

**Bug Fixes**
- Binary values previously serialized as `{}` (buffers, DataViews) or collided with other types (typed arrays vs plain objects).
- Each binary type now gets its own prefix, and `DataView` uses only its visible byte range.
- Non-binary cache keys are unchanged; the separate Invalid Date issue (#576) is not addressed here.
- Added regression tests covering buffer contents, DataView slicing, type separation, and plain-object collisions.

<sup>Written for commit 9846e557253324eb774add9e8810aa2ffa89099c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

