### PR TITLE
fix(routing): apply global trailing slash

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -245,6 +245,7 @@ mount, and shortcut together.
 | mdx           | Rendering `page.md` and `page.mdx` app routes, plus MDX components.               |
 | deploy        | Selecting a target, preset, and output directory.                                 |
 | deploymentId  | Detecting stale browser requests during rolling deployments.                      |
+| trailingSlash | Choosing the canonical URL shape for application page routes and links.           |
 | routeRules    | Applying rendering, cache, redirect, CORS, and header behavior to route patterns. |
 | security      | Applying an app-wide CSP with an enforcing or report-only response header.        |
 | serverActions | Restricting trusted action origins and request body size.                         |
@@ -252,6 +253,22 @@ mount, and shortcut together.
 | performance   | Budgeting image and font preload hints without changing the rendered resources.   |
 | experimental  | Auditing or enabling opt-in rendering experiments such as isolated hydration.     |
 | openapi       | Publishing API reference docs.                                                    |
+
+## Trailing slashes
+
+Application page URLs omit a trailing slash by default. Set `trailingSlash: true` to generate
+framework links with a slash and redirect matching page requests to that canonical URL in both
+development and production:
+
+```ts title="farm.config.ts"
+export default defineConfig({
+  trailingSlash: true,
+});
+```
+
+The redirect uses status 308 and preserves the query string. The root URL remains `/`, and API,
+integration, image, and metadata routes keep their own URL contracts. A `<Link trailingSlash={false}>`
+or `<Link trailingSlash>` prop overrides the app default for that link.
 
 ## API client base URL
 

--- a/packages/farm/src/__tests__/link.test.tsx
+++ b/packages/farm/src/__tests__/link.test.tsx
@@ -6,6 +6,7 @@ import { act, createElement } from "react";
 import { expectTypeOf } from "vitest";
 import { createRoot } from "react-dom/client";
 import { Link, type LinkProps, type RouteHref } from "../client/link";
+import { setFarmTrailingSlashPreference } from "../trailing-slash";
 
 const prefetch = vi.fn().mockResolvedValue(undefined);
 const navigate = vi.fn();
@@ -44,6 +45,7 @@ describe("Link", () => {
     delete (globalThis as any).IS_REACT_ACT_ENVIRONMENT;
     delete (window as any).__FARM_SPA_ROUTER__;
     delete (window as any).__FARM_MANIFEST__;
+    setFarmTrailingSlashPreference(false);
   });
 
   function render(ui: React.ReactElement) {
@@ -174,6 +176,24 @@ describe("Link", () => {
   });
 
   describe("navigation", () => {
+    it("inherits the app trailing-slash preference", () => {
+      setFarmTrailingSlashPreference(true);
+      const el = render(
+        createElement(Link, { href: "/about?tab=team", hash: "people" }),
+      ) as HTMLAnchorElement;
+
+      expect(el.getAttribute("href")).toBe("/about/?tab=team#people");
+    });
+
+    it("lets the link override the app trailing-slash preference", () => {
+      setFarmTrailingSlashPreference(true);
+      const el = render(
+        createElement(Link, { href: "/about", trailingSlash: false }),
+      ) as HTMLAnchorElement;
+
+      expect(el.getAttribute("href")).toBe("/about");
+    });
+
     it("internal click prevents default and calls router.navigate", () => {
       const el = render(createElement(Link, { href: "/dashboard" })) as HTMLAnchorElement;
       const e = new MouseEvent("click", { bubbles: true, button: 0, cancelable: true });

--- a/packages/farm/src/__tests__/searchparams.test.ts
+++ b/packages/farm/src/__tests__/searchparams.test.ts
@@ -226,7 +226,7 @@ describe("SearchParams in the production runtime", () => {
     const source = readSource("nitro", "universal-build.ts");
 
     expect(source).toContain(
-      'import { createClientPluginManager, installChunkErrorRecovery, scheduleFarmIslandHydration, searchParamsToObject } from "@farm.js/core/internal/client-runtime";',
+      'import { createClientPluginManager, installChunkErrorRecovery, scheduleFarmIslandHydration, searchParamsToObject, setFarmTrailingSlashPreference } from "@farm.js/core/internal/client-runtime";',
     );
     expect(source).toContain(
       "const searchParams = searchParamsToObject(new URLSearchParams(window.location.search));",

--- a/packages/farm/src/__tests__/trailing-slash.test.ts
+++ b/packages/farm/src/__tests__/trailing-slash.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getFarmTrailingSlashPreference,
+  normalizeFarmTrailingSlashPathname,
+  resolveFarmTrailingSlashRedirect,
+  setFarmTrailingSlashPreference,
+} from "../trailing-slash";
+import { ServerRenderer } from "../server/renderer";
+
+afterEach(() => {
+  setFarmTrailingSlashPreference(false);
+});
+
+describe("trailing slash routing", () => {
+  it("normalizes non-root page paths in both modes", () => {
+    expect(normalizeFarmTrailingSlashPathname("/about", true)).toBe("/about/");
+    expect(normalizeFarmTrailingSlashPathname("/about/", true)).toBe("/about/");
+    expect(normalizeFarmTrailingSlashPathname("/about/", false)).toBe("/about");
+    expect(normalizeFarmTrailingSlashPathname("/", true)).toBe("/");
+  });
+
+  it("preserves the request query in canonical redirects", () => {
+    expect(
+      resolveFarmTrailingSlashRedirect(new URL("https://farm.test/about?tab=team"), true),
+    ).toBe("/about/?tab=team");
+    expect(
+      resolveFarmTrailingSlashRedirect(new URL("https://farm.test/about/?tab=team"), false),
+    ).toBe("/about?tab=team");
+    expect(resolveFarmTrailingSlashRedirect(new URL("https://farm.test/about/"), true)).toBeNull();
+  });
+
+  it("shares the configured preference across framework entry points", () => {
+    setFarmTrailingSlashPreference(true);
+    expect(getFarmTrailingSlashPreference()).toBe(true);
+  });
+
+  it("redirects a matched development page before rendering it", async () => {
+    const routeManager = {
+      matchMetadataRoute: () => null,
+      matchMetadataImage: () => null,
+      matchRoute: () => ({
+        route: { pattern: "/about" },
+        params: {},
+        layouts: [],
+        slots: [],
+      }),
+    };
+    const renderer = new ServerRenderer(
+      {
+        root: process.cwd(),
+        outDir: ".farm-test-missing",
+        basePath: "/",
+        deploymentId: "test",
+        trailingSlash: true,
+      } as any,
+      routeManager as any,
+    );
+    (renderer as any).initialize = async () => undefined;
+
+    const headers = new Map<string, unknown>();
+    const response = {
+      statusCode: 200,
+      setHeader: (name: string, value: unknown) => headers.set(name, value),
+      getHeader: (name: string) => headers.get(name),
+      end: () => undefined,
+    };
+
+    await renderer.renderPage(
+      {
+        method: "GET",
+        url: "/about?tab=team",
+        headers: { host: "farm.test" },
+      } as any,
+      response as any,
+    );
+
+    expect(response.statusCode).toBe(308);
+    expect(headers.get("Location")).toBe("/about/?tab=team");
+  });
+});

--- a/packages/farm/src/app.ts
+++ b/packages/farm/src/app.ts
@@ -148,6 +148,7 @@ export class FarmApp {
       layers: [...(config.layers || [])],
       outDir: config.outDir || "dist",
       basePath: config.basePath || "/",
+      trailingSlash: config.trailingSlash ?? false,
       renderer: resolveFarmRenderer(config.renderer),
       preset: config.preset ?? "node-server",
       deploy: config.deploy || {},

--- a/packages/farm/src/client/link.tsx
+++ b/packages/farm/src/client/link.tsx
@@ -11,6 +11,7 @@ import {
 import type { FarmViewTransitionMode } from "./spa-router";
 import { isFarmLocaleChangeHref, localizeActiveFarmHref } from "../i18n/client-runtime";
 import type { FarmI18nLocale } from "../i18n/types";
+import { getFarmTrailingSlashPreference } from "../trailing-slash";
 
 /**
  * Prefetch strategy (TanStack Router–style):
@@ -245,7 +246,7 @@ function LinkInner<TRoute extends string = DefaultRouteHref>(
   const baseHref = resolveLinkHref(href, params, {
     query,
     hash,
-    trailingSlash,
+    trailingSlash: trailingSlash ?? getFarmTrailingSlashPreference(),
   });
   const resolvedHref = localizeActiveFarmHref(baseHref, locale);
   const isExternal = isExternalUrl(resolvedHref);

--- a/packages/farm/src/client/production-runtime.ts
+++ b/packages/farm/src/client/production-runtime.ts
@@ -2,3 +2,4 @@ export { installChunkErrorRecovery } from "./chunk-recovery";
 export { scheduleFarmIslandHydration } from "./island-runtime";
 export { createClientPluginManager } from "./plugin";
 export { searchParamsToObject } from "../search-params";
+export { setFarmTrailingSlashPreference } from "../trailing-slash";

--- a/packages/farm/src/nitro/production-runtime.ts
+++ b/packages/farm/src/nitro/production-runtime.ts
@@ -55,6 +55,10 @@ export {
   reportFarmPreloadWarnings,
 } from "../preload";
 export { searchParamsToObject } from "../search-params";
+export {
+  resolveFarmTrailingSlashRedirect,
+  setFarmTrailingSlashPreference,
+} from "../trailing-slash";
 
 export function appendFarmLinkHeader(headers: Headers, value: string): void {
   const current = headers.get("Link");

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1339,6 +1339,7 @@ async function buildClient(
     config.plugins,
     config.renderer,
     config.publicRuntimeConfig,
+    config.trailingSlash,
   );
 
   // Write the client entry to a temporary file
@@ -1853,6 +1854,7 @@ function generateClientHydrationEntry(
   plugins: readonly FarmPlugin[] = [],
   renderer: FarmRenderer = REACT_RENDERER,
   publicRuntimeConfig: Record<string, unknown> | undefined = undefined,
+  trailingSlash = false,
 ): string {
   const toImportPath = (targetPath: string) => targetPath.replace(/\\/g, "/");
   const clientPluginEntry: FarmClientPluginEntryCode = generateFarmClientPluginEntryCode(
@@ -1961,13 +1963,14 @@ async function hydrateFarmDocsAdapterRuntime() {
 // Farm.js Client Runtime (no client components)
 ${cssImport}
 ${layoutImports}
-import { createClientPluginManager, installChunkErrorRecovery } from "@farm.js/core/internal/client-runtime";
+import { createClientPluginManager, installChunkErrorRecovery, setFarmTrailingSlashPreference } from "@farm.js/core/internal/client-runtime";
 ${clientPluginEntry.imports}
 ${i18nClientRuntime}
 ${docsNavigationRuntime}
 ${docsAdapterRuntime}
 ${generateFarmDocsSearchClientRuntime(docsSearchEnabled, docsSearchModuleId)}
 
+setFarmTrailingSlashPreference(${JSON.stringify(trailingSlash)});
 installChunkErrorRecovery();
 mountFarmDocsSearch();
 
@@ -2336,7 +2339,7 @@ async function hydrateFarmIsolatedClientBoundaries(scope = document) {
 ${cssImport}
 ${layoutImports}
 ${rendererClientImports}
-import { createClientPluginManager, installChunkErrorRecovery, scheduleFarmIslandHydration, searchParamsToObject } from "@farm.js/core/internal/client-runtime";
+import { createClientPluginManager, installChunkErrorRecovery, scheduleFarmIslandHydration, searchParamsToObject, setFarmTrailingSlashPreference } from "@farm.js/core/internal/client-runtime";
 import { matchFarmRoute } from "@farm.js/core/router";
 ${clientPluginEntry.imports}
 ${i18nClientRuntime}
@@ -2346,6 +2349,7 @@ ${docsAdapterRuntime}
 ${imports.join("\n")}
 ${generateFarmDocsSearchClientRuntime(docsSearchEnabled, docsSearchModuleId)}
 
+setFarmTrailingSlashPreference(${JSON.stringify(trailingSlash)});
 installChunkErrorRecovery();
 
 // Client component routes
@@ -3968,10 +3972,12 @@ function generateVirtualEntryCode(
   reportFarmPreloadWarnings,
   renderMetadataHead,
   resolveFarmRouteContext,
+  resolveFarmTrailingSlashRedirect,
   resolveDefaultErrorStatus,
   resolveFarmInstrumentationRuntime,
   runWithFarmRequestSpan,
   searchParamsToObject,
+  setFarmTrailingSlashPreference,
   stripFarmLocaleFromPathname,
   withFarmRouteContext,
 } from "@farm.js/core/internal/production-runtime";`;
@@ -4192,6 +4198,7 @@ const farmUserConfig = ${
   };
 const farmRuntimeConfigs = [${[...layerConfigValues, "farmUserConfig"].join(", ")}].filter(Boolean);
 const farmResolvedRuntimeConfig = Object.assign({}, ...farmRuntimeConfigs);
+setFarmTrailingSlashPreference(${JSON.stringify(config.trailingSlash)});
 const hasConfiguredRouteContext = typeof farmResolvedRuntimeConfig.context === "function";
 const configuredIntegrations = Object.assign(
   {},
@@ -5919,6 +5926,19 @@ async function handleFarmRequestInContext(
   emitFarmEvent({ type: "render.start", route: pathname, pathname });
   const matchedRoute = matchPageRoute(routePathname);
   if (matchedRoute) {
+    const trailingSlashLocation = resolveFarmTrailingSlashRedirect(
+      url,
+      ${JSON.stringify(config.trailingSlash)}
+    );
+    if (trailingSlashLocation) {
+      return applyProductionMiddlewareHeaders(
+        new Response(null, {
+          status: 308,
+          headers: { Location: trailingSlashLocation },
+        }),
+        middlewareHeaders
+      );
+    }
     const { route, params } = matchedRoute;
     emitFarmEvent({ type: "route.matched", pathname, route: route.pattern, params });
     

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -59,6 +59,10 @@ import { sendWebResponse } from "./response";
 import { renderFarmFontDevHead } from "../font-vite";
 import { createFarmMetadataImageResponse } from "../metadata-image";
 import { createFarmMetadataRouteResponse } from "../metadata-route";
+import {
+  resolveFarmTrailingSlashRedirect,
+  setFarmTrailingSlashPreference,
+} from "../trailing-slash";
 import { DEFAULT_NOT_FOUND_STYLES } from "../components/not-found-styles";
 import {
   createDefaultErrorMarkup,
@@ -891,6 +895,7 @@ export class ServerRenderer {
 
   async renderPage(req: FarmRequest, res: FarmResponse): Promise<void> {
     await this.initialize();
+    setFarmTrailingSlashPreference(this.config.trailingSlash);
     const request = createWebRequestFromFarmRequest(req);
     const runtime = this.i18nRuntime;
 
@@ -966,6 +971,18 @@ export class ServerRenderer {
 
       this.applyDeploymentHeaders(req, res);
 
+      const match = this.routeManager.matchRoute(pathname);
+      if (match.route) {
+        const redirectLocation = resolveFarmTrailingSlashRedirect(url, this.config.trailingSlash);
+        if (redirectLocation) {
+          res.statusCode = 308;
+          res.setHeader("Location", redirectLocation);
+          res.end();
+          completeRender(308, match.route.pattern);
+          return;
+        }
+      }
+
       // Check for pre-rendered SSG page first (production only)
       if (process.env.NODE_ENV === "production") {
         const ssgPage = await this.shouldServeSSG(pathname);
@@ -979,7 +996,6 @@ export class ServerRenderer {
       }
 
       // Match route
-      const match = this.routeManager.matchRoute(pathname);
       const route = match.route;
       params = match.params;
       layouts = match.layouts;

--- a/packages/farm/src/trailing-slash.ts
+++ b/packages/farm/src/trailing-slash.ts
@@ -1,0 +1,26 @@
+const FARM_TRAILING_SLASH_PREFERENCE = Symbol.for("farm.trailingSlashPreference");
+
+function getFarmGlobalState(): Record<PropertyKey, unknown> {
+  return globalThis as unknown as Record<PropertyKey, unknown>;
+}
+
+/** @internal Configure the app-wide URL preference for framework link rendering. */
+export function setFarmTrailingSlashPreference(enabled: boolean | undefined): void {
+  getFarmGlobalState()[FARM_TRAILING_SLASH_PREFERENCE] = enabled === true;
+}
+
+/** @internal Read the app-wide URL preference used by framework links. */
+export function getFarmTrailingSlashPreference(): boolean {
+  return getFarmGlobalState()[FARM_TRAILING_SLASH_PREFERENCE] === true;
+}
+
+export function normalizeFarmTrailingSlashPathname(pathname: string, enabled: boolean): string {
+  if (pathname === "/") return pathname;
+  if (enabled) return pathname.endsWith("/") ? pathname : `${pathname}/`;
+  return pathname.replace(/\/+$/, "") || "/";
+}
+
+export function resolveFarmTrailingSlashRedirect(url: URL, enabled: boolean): string | null {
+  const pathname = normalizeFarmTrailingSlashPathname(url.pathname, enabled);
+  return pathname === url.pathname ? null : `${pathname}${url.search}`;
+}

--- a/packages/farm/src/types.ts
+++ b/packages/farm/src/types.ts
@@ -150,6 +150,8 @@ export interface FarmConfig {
   layers?: readonly ResolvedFarmLayer[];
   outDir?: string;
   basePath?: string;
+  /** Generate and canonicalize non-root application page URLs with a trailing slash. */
+  trailingSlash?: boolean;
   /**
    * Component renderer used for JSX compilation, SSR, and browser hydration.
    * React is used when omitted.

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -2588,6 +2588,7 @@ window.__FARM_MANIFEST__ = ${inlineValue({
           isReactRenderer(renderer) ? docs?.adapter?.react : undefined,
           renderer,
           resolvedConfig?.experimental?.isolatedClientHydration === "enabled",
+          resolvedConfig?.trailingSlash ?? false,
         );
       }
 
@@ -3447,6 +3448,7 @@ function generateClientCode(
   docsAdapterReact?: string,
   renderer: FarmRenderer = REACT_RENDERER,
   isolatedHydrationEnabled = false,
+  trailingSlash = false,
 ): string {
   const hasClerkProvider = integrationProviders.some((provider) => provider.type === "clerk");
   const providerImportBlock = hasClerkProvider
@@ -3531,7 +3533,7 @@ async function hydrateFarmIsolatedClientBoundaries(scope = document) {
 ${rendererClientImports}
 import { installChunkErrorRecovery, SPARouter } from '@farm.js/core/client'
 import { createClientPluginManager } from '@farm.js/core/plugin/client'
-import { scheduleFarmIslandHydration, searchParamsToObject } from '@farm.js/core/internal/client-runtime'
+import { scheduleFarmIslandHydration, searchParamsToObject, setFarmTrailingSlashPreference } from '@farm.js/core/internal/client-runtime'
 import { reviveDeferredData } from '@farm.js/core/deferred'
 import {
   createFarmDeploymentMismatchError,
@@ -3553,6 +3555,7 @@ window.__FARM_REACT__ = React;
 const integrationProviders = ${JSON.stringify(integrationProviders)};
 const integrationDocumentNavigationMatchers = ${JSON.stringify(documentNavigationMatchers)};
 
+setFarmTrailingSlashPreference(${JSON.stringify(trailingSlash)});
 installChunkErrorRecovery();
 
 let reactRoot = null;


### PR DESCRIPTION
## Problem

The top-level `trailingSlash` option was resolved but did not affect framework links or page requests. Applications had to set every `<Link>` independently, and development/production accepted both URL shapes without a canonical redirect.

## Root cause

The base app config dropped the option, client runtimes never received it, and neither the development renderer nor the generated production page handler applied a shared URL rule.

## Change

- Carry `trailingSlash` through the app config and both generated client runtimes.
- Let `<Link>` inherit the app preference while preserving its existing per-link override.
- Canonicalize matched application page requests with a 308 redirect in development and production.
- Preserve query strings and keep `/` unchanged.
- Leave API, integration, image, and metadata URL contracts untouched.
- Document the behavior and override.

## Safety and compatibility

The default remains `false`. Only matched application page routes are canonicalized; non-page handlers retain precedence. Redirects use 308 so the method is preserved. The implementation is renderer-neutral and shared by server and browser entry points.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/trailing-slash.test.ts src/__tests__/link.test.tsx src/__tests__/router.test.ts src/__tests__/searchparams.test.ts src/__tests__/universal-build-router-runtime.test.ts` (59 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint <changed TypeScript files>` (0 errors; one unrelated existing `deployOutputDir` warning in `universal-build.ts`)
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`
- Built `examples/basic` with the node-server preset and tested both settings against the real output:
  - `false`: `/about/?tab=team` returned 308 to `/about?tab=team`
  - `true`: `/about?tab=team` returned 308 to `/about/?tab=team`
  - canonical pages and `/` returned 200
  - `/api/test/` remained an API response and returned 200

## Documentation and release

Updated the configuration guide. No template, generated artifact, or release metadata changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies the top-level `trailingSlash` config option so framework links and page requests now follow one canonical URL shape instead of the option being dropped.

- `<Link>` inherits the app preference while keeping its existing per-link override.
- Matched app page requests redirect with 308 in development and production, preserving query strings and leaving `/` unchanged.
- API, integration, image, and metadata routes keep their own URL contracts; the default stays `false`.
- Documents the option and the per-link override in the configuration guide.

<sup>Written for commit 8756aee3a45fb8bfecf33c4ff80c4efb8499fb8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

