### PR TITLE
fix(ssg): report corrupt manifests

### DIFF
--- a/packages/farm/src/__tests__/ssg-manifest.test.ts
+++ b/packages/farm/src/__tests__/ssg-manifest.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ServerRenderer } from "../server/renderer";
+
+const tempDirs = new Set<string>();
+
+function createRenderer(manifest?: string): ServerRenderer {
+  const root = mkdtempSync(path.join(tmpdir(), "farm-ssg-manifest-"));
+  tempDirs.add(root);
+
+  if (manifest !== undefined) {
+    const outDir = path.join(root, "dist");
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(path.join(outDir, "__ssg_manifest.json"), manifest);
+  }
+
+  return new ServerRenderer({ root, outDir: "dist" } as any, {} as any);
+}
+
+describe("SSG manifest loading", () => {
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+      tempDirs.delete(dir);
+    }
+  });
+
+  it("allows a missing manifest before the first production build", () => {
+    expect(() => createRenderer()).not.toThrow();
+  });
+
+  it("reports malformed JSON instead of silently disabling SSG", () => {
+    expect(() => createRenderer("[{")).toThrowError(
+      /Failed to parse SSG manifest at .*__ssg_manifest\.json:/,
+    );
+  });
+
+  it("reports an invalid manifest root", () => {
+    expect(() => createRenderer(JSON.stringify({ pages: [] }))).toThrowError(
+      /Invalid SSG manifest at .*__ssg_manifest\.json: expected an array of pages/,
+    );
+  });
+
+  it("reports the index of an invalid manifest entry", () => {
+    expect(() =>
+      createRenderer(
+        JSON.stringify([
+          { urlPath: "/valid", params: {} },
+          { urlPath: "/invalid", params: { slug: 42 } },
+        ]),
+      ),
+    ).toThrowError(
+      /Invalid SSG manifest at .*__ssg_manifest\.json: page 1 must have string params/,
+    );
+  });
+
+  it("loads the generated manifest shape", () => {
+    expect(() =>
+      createRenderer(
+        JSON.stringify([
+          { urlPath: "/about", params: {} },
+          { urlPath: "/blog/hello", params: { slug: "hello" }, revalidate: 60 },
+        ]),
+      ),
+    ).not.toThrow();
+  });
+});

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -96,6 +96,61 @@ interface CachedPPRShell {
   html: string;
 }
 
+function formatSSGManifestError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function parseSSGManifest(content: string, manifestPath: string): SSGPage[] {
+  let manifest: unknown;
+
+  try {
+    manifest = JSON.parse(content);
+  } catch (error) {
+    throw new Error(
+      `Failed to parse SSG manifest at ${manifestPath}: ${formatSSGManifestError(error)}`,
+    );
+  }
+
+  if (!Array.isArray(manifest)) {
+    throw new Error(`Invalid SSG manifest at ${manifestPath}: expected an array of pages.`);
+  }
+
+  for (const [index, page] of manifest.entries()) {
+    if (!page || typeof page !== "object" || Array.isArray(page)) {
+      throw new Error(`Invalid SSG manifest at ${manifestPath}: page ${index} must be an object.`);
+    }
+
+    const entry = page as Record<string, unknown>;
+    if (typeof entry.urlPath !== "string") {
+      throw new Error(
+        `Invalid SSG manifest at ${manifestPath}: page ${index} must have a string urlPath.`,
+      );
+    }
+    if (
+      !entry.params ||
+      typeof entry.params !== "object" ||
+      Array.isArray(entry.params) ||
+      Object.values(entry.params).some((value) => typeof value !== "string")
+    ) {
+      throw new Error(
+        `Invalid SSG manifest at ${manifestPath}: page ${index} must have string params.`,
+      );
+    }
+    if (
+      entry.revalidate !== undefined &&
+      (typeof entry.revalidate !== "number" ||
+        !Number.isFinite(entry.revalidate) ||
+        entry.revalidate <= 0)
+    ) {
+      throw new Error(
+        `Invalid SSG manifest at ${manifestPath}: page ${index} revalidate must be a positive number.`,
+      );
+    }
+  }
+
+  return manifest as SSGPage[];
+}
+
 interface PPRShellCacheOptions {
   pathname: string;
   search: string;
@@ -614,16 +669,23 @@ export class ServerRenderer {
    * Load SSG manifest from build output
    */
   private loadSSGManifest(): void {
+    const manifestPath = path.join(this.config.root, this.config.outDir, "__ssg_manifest.json");
+    let content: string;
+
     try {
-      const manifestPath = path.join(this.config.root, this.config.outDir, "__ssg_manifest.json");
-      if (fs.existsSync(manifestPath)) {
-        const content = fs.readFileSync(manifestPath, "utf-8");
-        this.ssgManifest = JSON.parse(content);
-        logger.info(`Loaded SSG manifest: ${this.ssgManifest.length} pages`);
+      content = fs.readFileSync(manifestPath, "utf-8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return;
       }
-    } catch {
-      // No manifest in dev mode or first build
+
+      throw new Error(
+        `Failed to read SSG manifest at ${manifestPath}: ${formatSSGManifestError(error)}`,
+      );
     }
+
+    this.ssgManifest = parseSSGManifest(content, manifestPath);
+    logger.info(`Loaded SSG manifest: ${this.ssgManifest.length} pages`);
   }
 
   /**


### PR DESCRIPTION
## Problem

An existing malformed `__ssg_manifest.json` was treated the same as a missing manifest. Production startup silently disabled SSG, and an invalid non-array root could fail later in request handling with an unrelated error.

## Root cause

The renderer wrapped existence checks, file reads, and `JSON.parse` in one empty catch block, so every manifest failure was discarded without distinguishing a normal first build from corrupt generated output.

## Change

Only a missing manifest (`ENOENT`) is now ignored. Existing manifests are parsed and checked against the generated page shape, with the manifest path and failing entry included in diagnostics.

## Safety and compatibility

The no-manifest development and first-build path is unchanged. The accepted shape matches Farm’s current manifest generator, including optional `revalidate`; unknown extra fields remain compatible.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/ssg-manifest.test.ts src/__tests__/ssg.test.ts` (21 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/server/renderer.ts packages/farm/src/__tests__/ssg-manifest.test.ts`
- `pnpm exec oxfmt packages/farm/src/server/renderer.ts packages/farm/src/__tests__/ssg-manifest.test.ts`

The three corruption regression cases fail on `main` and pass with this change.

## Documentation and release

None; this changes diagnostics for an internal generated build artifact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SSG manifest handling so a corrupt manifest no longer silently disables static generation; only a missing manifest is ignored.

- Only `ENOENT` (missing file) is ignored; other read errors and malformed JSON now throw with the manifest path.
- Invalid manifest shape (non-array root, invalid page entries) is reported with the failing entry index.
- The no-manifest dev/first-build path is unchanged.

<sup>Written for commit cdedcb2b161584e74d698be11f268961aab802e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

