### PR TITLE
fix(routing): surface custom 404 failures

### DIFF
--- a/packages/farm/src/__tests__/server-renderer-route-states.test.tsx
+++ b/packages/farm/src/__tests__/server-renderer-route-states.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
 import React from "react";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -537,6 +537,49 @@ describe("file route loading.tsx and error.tsx", () => {
     expect(html).toContain('id="__farm_page__"');
     expect(html).toContain('data-farm-client="false"');
     expect(html).toContain("Settings fragment");
+  });
+});
+
+describe("custom not-found rendering", () => {
+  it("surfaces a root layout import failure through the error response", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "farm-not-found-layout-"));
+    temporaryDirectories.push(directory);
+    const appDirectory = path.join(directory, "src", "app");
+    const notFoundPath = path.join(appDirectory, "not-found.tsx");
+    const rootLayoutPath = path.join(appDirectory, "layout.tsx");
+    await mkdir(appDirectory, { recursive: true });
+    await Promise.all([writeFile(notFoundPath, ""), writeFile(rootLayoutPath, "")]);
+
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    const response = createMockResponse();
+    const routeManager = {
+      matchMetadataRoute: () => null,
+      matchMetadataImage: () => null,
+      matchRoute: () => ({ route: null, params: {}, layouts: [], slots: [] }),
+      async loadRouteModule(modulePath: string) {
+        expect(modulePath).toBe(notFoundPath);
+        return {
+          default: function CustomNotFound() {
+            return React.createElement("main", null, "Custom not found");
+          },
+        };
+      },
+      async loadLayoutModule(modulePath: string) {
+        expect(modulePath).toBe(rootLayoutPath);
+        throw new Error("root layout import failed");
+      },
+    };
+    const renderer = new ServerRenderer(
+      { ...createConfig(), root: directory } as Required<FarmConfig>,
+      routeManager as any,
+    );
+
+    await renderer.renderPage(createMockRequest("/missing"), response);
+
+    expect(response.statusCode).toBe(500);
+    expect(response.body).toContain("Internal Server Error");
+    expect(response.body).not.toContain("Custom not found");
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("root layout import failed"));
   });
 });
 

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -1486,7 +1486,9 @@ export class ServerRenderer {
           });
         });
       });
-    } catch (error) {
+    } catch (caughtError) {
+      let error = caughtError;
+
       if (isWebResponse(error)) {
         if (!res.headersSent && !(res as any).writableEnded) {
           await sendWebResponse(res, error);
@@ -1524,12 +1526,20 @@ export class ServerRenderer {
       if (isFarmNotFoundError(error)) {
         emitFarmEvent({ type: "route.notFound", pathname });
         if (!res.headersSent && !(res as any).writableEnded) {
-          await this.render404(req, res);
-        } else if (!(res as any).writableEnded) {
-          res.end();
+          try {
+            await this.render404(req, res);
+            completeRender(404, pathname);
+            return;
+          } catch (notFoundRenderError) {
+            error = notFoundRenderError;
+          }
+        } else {
+          if (!(res as any).writableEnded) {
+            res.end();
+          }
+          completeRender(404, pathname);
+          return;
         }
-        completeRender(404, pathname);
-        return;
       }
 
       emitFarmEvent({ type: "render.error", route: pathname, error });
@@ -2498,12 +2508,8 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
           for (const ext of notFoundExtensions) {
             const layoutPath = path.join(appDir, `layout${ext}`);
             if (fs.existsSync(layoutPath)) {
-              try {
-                const layoutModule = await this.routeManager.loadLayoutModule(layoutPath);
-                LayoutComponent = layoutModule.default;
-              } catch {
-                // Layout import failed, continue without it
-              }
+              const layoutModule = await this.routeManager.loadLayoutModule(layoutPath);
+              LayoutComponent = layoutModule.default;
               break;
             }
           }
@@ -2529,7 +2535,7 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
         }
       }
     } catch (error) {
-      logger.warn(`Failed to render custom 404 page: ${error}`);
+      throw new Error(`Failed to render custom 404 page: ${error}`);
     }
 
     // Render the shared adaptive fallback when the app does not provide its own page.


### PR DESCRIPTION
## Problem

When an app had a custom `not-found.tsx` but its root layout failed to import, Farm silently discarded the error and served an unwrapped fallback 404. This hid the application failure and made the missing route appear to work without the app shell.

## Root cause

`render404()` swallowed both the layout import error and the resulting custom-404 failure. Because `notFound()` signals are handled inside the renderer catch path, simply allowing the error to escape also required forwarding that nested failure into the normal render-error flow.

## Change

Custom not-found module, layout, and render failures now flow through Farm’s normal 500 diagnostics response. A genuinely absent custom not-found page still renders the built-in adaptive 404.

## Safety and compatibility

Successful custom 404s and the built-in fallback are unchanged. The behavior changes only when application code for a custom 404 cannot load or render; those failures are no longer misreported as a valid 404.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/server-renderer-route-states.test.tsx src/__tests__/not-found.test.tsx src/__tests__/navigation.test.ts` (22 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/server/renderer.ts packages/farm/src/__tests__/server-renderer-route-states.test.tsx`
- `pnpm exec oxfmt packages/farm/src/server/renderer.ts packages/farm/src/__tests__/server-renderer-route-states.test.tsx`

The regression test returns 404 on `main` and 500 with the underlying layout import error after this change.

## Documentation and release

None; this corrects error handling without changing the routing API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes custom 404 rendering so failures to load or render the custom not-found page (including a failing root layout) now return a 500 with diagnostics instead of silently serving a fallback 404.

**Bug Fixes**
- Custom 404 load/render errors now propagate to the standard error response.
- Successful custom 404s and the built-in adaptive 404 for missing pages are unchanged.

<sup>Written for commit 82f5cb37843d4936d3af663e6fbbaab124d14b1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

