### PR TITLE
fix(ssg): keep request-bound routes dynamic

### DIFF
--- a/docs/src/app/docs/server-rendering/page.md
+++ b/docs/src/app/docs/server-rendering/page.md
@@ -81,6 +81,11 @@ Review each suggestion, including its imported code, then add the static export 
 keeps personalized pages dynamic while making stable pages easy to move onto the fastest rendering
 and caching path.
 
+If an explicitly static route directly reads request APIs or request props, Farm reports the unsafe
+read and keeps the route dynamic instead of freezing request-specific HTML into a shared artifact.
+This check covers the route module itself; continue reviewing imported components and data loaders,
+because request-bound work in transitive imports cannot be proven safe from the route source alone.
+
 **src/app/about/page.tsx**
 
 ```tsx

--- a/packages/farm/src/__tests__/production-ssg.test.ts
+++ b/packages/farm/src/__tests__/production-ssg.test.ts
@@ -192,7 +192,9 @@ export default function SafeRulePage() {
   return root;
 }
 
-async function createRuntimeSensitiveFixture(kind: "context" | "plugin" | "i18n"): Promise<string> {
+async function createRuntimeSensitiveFixture(
+  kind: "context" | "plugin" | "i18n" | "route",
+): Promise<string> {
   const root = await fs.mkdtemp(path.join(packageRoot, `.tmp-production-ssg-${kind}-`));
   await fs.mkdir(path.join(root, "node_modules", "@farm.js"), { recursive: true });
   await fs.symlink(packageRoot, path.join(root, "node_modules", "@farm.js", "core"), "junction");
@@ -227,7 +229,17 @@ export default function PluginPage() {
   return <main>plugin-page</main>;
 }
 `.trim()
-        : `
+        : kind === "route"
+          ? `
+import { getCurrentRequest } from "@farm.js/core/request";
+
+export const ssg = true;
+export default function RequestPage() {
+  const tenant = getCurrentRequest().headers.get("x-tenant") || "public";
+  return <main>request-{tenant}</main>;
+}
+`.trim()
+          : `
 export const ssg = true;
 export default function I18nPage() {
   return <main>i18n-page</main>;
@@ -260,7 +272,8 @@ export default {
   }],
 };
 `.trim()
-        : `
+        : kind === "i18n"
+          ? `
 export default {
   srcDir: "src",
   images: { provider: "none" },
@@ -270,6 +283,12 @@ export default {
     routing: "prefix-always",
     detection: ["url", "cookie", "accept-language"],
   },
+};
+`.trim()
+          : `
+export default {
+  srcDir: "src",
+  images: { provider: "none" },
 };
 `.trim(),
   );
@@ -640,4 +659,36 @@ describe("production SSG output", () => {
       }
     }
   }, 180_000);
+
+  it("keeps an explicitly static route that reads the request server-handled", async () => {
+    const root = await createRuntimeSensitiveFixture("route");
+    let production: Awaited<ReturnType<typeof startProductionServer>> | undefined;
+
+    try {
+      const config = await loadFixtureConfig(root);
+      await build(config, { root, preset: "node-server" });
+      await expect(
+        fs.access(path.join(root, ".farm", ".output", "public", "sensitive", "index.html")),
+      ).rejects.toThrow();
+
+      production = await startProductionServer(
+        path.join(root, ".farm", ".output", "server"),
+        "/sensitive",
+      );
+      const tenantAHtml = await fetch(`${production.origin}/sensitive`, {
+        headers: { "x-tenant": "tenant-a" },
+      }).then((response) => response.text());
+      const tenantBHtml = await fetch(`${production.origin}/sensitive`, {
+        headers: { "x-tenant": "tenant-b" },
+      }).then((response) => response.text());
+
+      expect(tenantAHtml).toMatch(/request-(?:<!-- -->)?tenant-a/);
+      expect(tenantAHtml).not.toContain("tenant-b");
+      expect(tenantBHtml).toMatch(/request-(?:<!-- -->)?tenant-b/);
+      expect(tenantBHtml).not.toContain("tenant-a");
+    } finally {
+      await production?.stop();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }, 120_000);
 });

--- a/packages/farm/src/__tests__/ssg.test.ts
+++ b/packages/farm/src/__tests__/ssg.test.ts
@@ -262,6 +262,36 @@ describe("route rendering config", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  it("keeps explicitly static routes dynamic when they read request data", async () => {
+    const dir = await createTempDir("farm-request-bound-static-");
+    const pagePath = path.join(dir, "page.tsx");
+    const source = `
+      import { getCurrentRequest } from "@farm.js/core/request";
+
+      export const dynamic = "force-static";
+      export default function TenantPage() {
+        return <main>{getCurrentRequest().headers.get("x-tenant")}</main>;
+      }
+    `;
+    await writeFile(pagePath, source);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    expect(resolveRouteRenderingConfig({ dynamic: "force-static" }, source)).toMatchObject({
+      ssg: false,
+      dynamic: "force-static",
+    });
+    await expect(
+      collectSSGPages(
+        [{ path: "/tenant", filePath: pagePath, isDynamic: false, pattern: "/tenant" }],
+        async () => ({ dynamic: "force-static" }) as RouteModule,
+      ),
+    ).resolves.toEqual({ ssg: [], ssr: ["/tenant"] });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Static rendering disabled for "/tenant"'),
+    );
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("the current Request"));
+  });
+
   it("collects static pages marked by source directives", async () => {
     const dir = await createTempDir("farm-ssg-directive-");
     const pagePath = path.join(dir, "page.tsx");

--- a/packages/farm/src/ssg.ts
+++ b/packages/farm/src/ssg.ts
@@ -114,7 +114,7 @@ const ROUTE_PROP_LABELS = new Map<string, string>([
  * Resolve route rendering from Farm exports, Next-compatible exports, and
  * top-of-file directives such as `"use ssg";` or `"use ssg; 60";`.
  */
-export function resolveRouteRenderingConfig(
+function resolveConfiguredRouteRenderingConfig(
   mod: RouteModule | null | undefined,
   source?: string,
 ): RouteRenderingConfig {
@@ -167,6 +167,31 @@ export function resolveRouteRenderingConfig(
     revalidate: ssg || ppr ? revalidate : undefined,
     dynamic,
     directive: directiveConfig?.directive,
+  };
+}
+
+/**
+ * Resolve the effective rendering mode. Direct request reads make an explicitly
+ * static route dynamic so request-specific HTML cannot enter a shared artifact.
+ */
+export function resolveRouteRenderingConfig(
+  mod: RouteModule | null | undefined,
+  source?: string,
+): RouteRenderingConfig {
+  const rendering = resolveConfiguredRouteRenderingConfig(mod, source);
+  if (!rendering.ssg || !source) {
+    return rendering;
+  }
+
+  const requestBlockers = findRequestBoundSourceBlockers(source);
+  if (requestBlockers.length === 0) {
+    return rendering;
+  }
+
+  return {
+    ...rendering,
+    ssg: false,
+    revalidate: undefined,
   };
 }
 
@@ -634,7 +659,17 @@ export async function collectSSGPages(
       }
 
       const source = await readFile(route.filePath, "utf8").catch(() => undefined);
+      const configuredRendering = resolveConfiguredRouteRenderingConfig(mod, source);
       const rendering = resolveRouteRenderingConfig(mod, source);
+
+      if (configuredRendering.ssg && !rendering.ssg && source) {
+        const blockers = findRequestBoundSourceBlockers(source);
+        console.warn(
+          `[Farm.js] Static rendering disabled for "${route.path}" because ${blockers.join(
+            " and ",
+          )}. Farm will render this route on each request instead.`,
+        );
+      }
 
       // Check if page is marked for SSG
       if (rendering.ssg) {


### PR DESCRIPTION
## Problem

A route could opt into static generation while directly reading cookies, headers, the current request, search parameters, middleware data, or request context. Farm trusted the static flag and could freeze request-specific HTML into a shared production artifact.

## Root cause

Request-source analysis was only used to suggest static candidates. Explicit SSG configuration bypassed that safety analysis, so both the runtime manifest and prerender collector continued to classify the route as static.

## Change

The effective rendering resolver now falls directly request-bound static routes back to dynamic rendering. The build names the detected dependency and explains the fallback. Documentation records both this safeguard and its transitive-import limitation.

## Safety and compatibility

Safe SSG, ISR, and PPR routes are unchanged. Detection is limited to direct calls and request props in the route module; imported components and loaders still require developer review. Falling back to per-request rendering favors data isolation over an unsafe static optimization.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/ssg.test.ts src/__tests__/route-runtime-deployment.test.ts` (22 tests)
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/production-ssg.test.ts -t "keeps an explicitly static route that reads the request server-handled"`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/ssg.ts packages/farm/src/__tests__/ssg.test.ts packages/farm/src/__tests__/production-ssg.test.ts`
- `pnpm docs:check-navigation`
- `pnpm docs:build`

The production fixture proves no public SSG artifact is emitted and two requests with different tenant headers receive different HTML.

## Documentation and release

Updated the Rendering Model guide with the direct-source fallback and the limitation for transitive imports. No release metadata changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents routes that explicitly opt into static generation while directly reading request data from freezing request-specific HTML into a shared artifact. These routes now fall back to per-request rendering instead.

- The build warns and names the request API or route prop that disabled SSG for the route.
- Detection covers direct calls and request props in the route module; imported components and loaders are not checked and still need review.
- Safe SSG, ISR, and PPR routes are unchanged, and the docs describe the safeguard and its transitive-import limitation.

<sup>Written for commit 23c2de1a763610e6a4c632b04ab7d87c83ae6b46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

