### PR TITLE
fix(dev): honor build activity indicators

### DIFF
--- a/docs/src/app/docs/devtools/page.md
+++ b/docs/src/app/docs/devtools/page.md
@@ -54,6 +54,26 @@ export default defineConfig({
 
 `mod` maps to `Command` on macOS and `Ctrl` on Windows and Linux. Farm also accepts `ctrl`, `meta`, `alt`, and `shift` explicitly. DevTools remains development-only even when `enabled: true` is present in production configuration.
 
+## Configure the build activity indicator
+
+During HMR, Farm briefly shows build status in the bottom-right corner. Move it when that corner
+overlaps application controls, or disable it independently from DevTools:
+
+```ts title="farm.config.ts"
+import { defineConfig } from "@farm.js/core";
+
+export default defineConfig({
+  devIndicators: {
+    buildActivity: true,
+    buildActivityPosition: "top-left",
+  },
+});
+```
+
+`buildActivityPosition` accepts `top-left`, `top-right`, `bottom-left`, or `bottom-right`. Set
+`buildActivity: false` to emit no indicator runtime. Dev indicators are omitted from production
+output regardless of this setting.
+
 ## What the dashboard shows
 
 | View     | What Farm reports                                                                                                            |

--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -303,6 +303,26 @@ describe("resolveConfig", () => {
     expect(customized.devtools).toEqual({ enabled: true, shortcut: "mod+shift+d" });
   });
 
+  it("keeps build activity development-only and resolves its corner", async () => {
+    const development = await resolveConfig(
+      { devIndicators: { buildActivityPosition: "top-left" } },
+      "development",
+    );
+    const production = await resolveConfig(
+      { devIndicators: { buildActivity: true, buildActivityPosition: "top-left" } },
+      "production",
+    );
+
+    expect(development.devIndicators).toEqual({
+      buildActivity: true,
+      buildActivityPosition: "top-left",
+    });
+    expect(production.devIndicators).toEqual({
+      buildActivity: false,
+      buildActivityPosition: "top-left",
+    });
+  });
+
   it("resolves explicit and generated deployment IDs", async () => {
     delete process.env.FARM_DEPLOYMENT_ID;
     delete process.env.VERCEL_GIT_COMMIT_SHA;

--- a/packages/farm/src/__tests__/dev-indicators.test.ts
+++ b/packages/farm/src/__tests__/dev-indicators.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  generateFarmDevIndicatorsClientRuntime,
+  resolveFarmDevIndicatorsConfig,
+} from "../dev-indicators";
+
+describe("development build activity indicator", () => {
+  it("resolves development defaults and configured positions", () => {
+    expect(resolveFarmDevIndicatorsConfig(undefined, "development")).toEqual({
+      buildActivity: true,
+      buildActivityPosition: "bottom-right",
+    });
+    expect(
+      resolveFarmDevIndicatorsConfig(
+        { buildActivity: true, buildActivityPosition: "top-left" },
+        "development",
+      ),
+    ).toEqual({
+      buildActivity: true,
+      buildActivityPosition: "top-left",
+    });
+  });
+
+  it("emits a corner-aware, accessible HMR runtime", () => {
+    const runtime = generateFarmDevIndicatorsClientRuntime({
+      buildActivity: true,
+      buildActivityPosition: "top-left",
+    });
+
+    expect(runtime).toContain("left: 16px; top: 16px;");
+    expect(runtime).toContain('indicator.setAttribute("role", "status")');
+    expect(runtime).toContain('hot.on("vite:beforeUpdate", onBeforeUpdate)');
+    expect(runtime).toContain('hot.on("vite:afterUpdate", onAfterUpdate)');
+    expect(runtime).toContain('hot.on("vite:error", onError)');
+    expect(runtime).toContain('hot.on("vite:beforeFullReload", onBeforeFullReload)');
+    expect(runtime).toContain('window.sessionStorage.setItem(reloadMarker, "1")');
+  });
+
+  it("emits no client runtime when disabled or in production", () => {
+    expect(resolveFarmDevIndicatorsConfig(undefined, "production").buildActivity).toBe(false);
+    expect(
+      generateFarmDevIndicatorsClientRuntime({
+        buildActivity: false,
+        buildActivityPosition: "bottom-right",
+      }),
+    ).toBe("");
+  });
+});

--- a/packages/farm/src/app.ts
+++ b/packages/farm/src/app.ts
@@ -19,6 +19,10 @@ import { findProgrammaticRouteFiles } from "./routes.server";
 import path from "path";
 import type { ViteDevServer } from "vite";
 import { resolveFarmDevtoolsConfig, type ResolvedFarmDevtoolsConfig } from "./devtools-config";
+import {
+  resolveFarmDevIndicatorsConfig,
+  type ResolvedFarmDevIndicatorsConfig,
+} from "./dev-indicators";
 import { resolveFarmI18nConfig } from "./i18n/config";
 import {
   createFarmI18nRuntime,
@@ -39,7 +43,7 @@ import { normalizeFarmAPIConfig, type ResolvedFarmAPIConfig } from "./api/config
 
 type NormalizedFarmConfig = Omit<
   Required<FarmConfig>,
-  "api" | "devtools" | "images" | "i18n" | "performance" | "security" | "theme"
+  "api" | "devtools" | "devIndicators" | "images" | "i18n" | "performance" | "security" | "theme"
 > & {
   api: ResolvedFarmAPIConfig;
   docs: FarmDocsResolvedConfig;
@@ -48,6 +52,7 @@ type NormalizedFarmConfig = Omit<
   cron: FarmCronResolvedConfig;
   workflows: FarmWorkflowsResolvedConfig;
   devtools: ResolvedFarmDevtoolsConfig;
+  devIndicators: ResolvedFarmDevIndicatorsConfig;
   images: ResolvedFarmImageConfig;
   i18n: ResolvedFarmI18nConfig;
   auth: ResolvedFarmAuthConfig;
@@ -184,6 +189,10 @@ export class FarmApp {
       observability: config.observability ?? false,
       devtools: resolveFarmDevtoolsConfig(
         config.devtools,
+        process.env.NODE_ENV === "production" ? "production" : "development",
+      ),
+      devIndicators: resolveFarmDevIndicatorsConfig(
+        config.devIndicators,
         process.env.NODE_ENV === "production" ? "production" : "development",
       ),
       env: config.env || { server: {}, public: {} },

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -53,6 +53,11 @@ import { logger } from "./utils";
 import { normalizeFarmDeploymentId } from "./deployment";
 import { resolveFarmDevtoolsConfig, type ResolvedFarmDevtoolsConfig } from "./devtools-config";
 import {
+  resolveFarmDevIndicatorsConfig,
+  type FarmDevIndicatorsConfig,
+  type ResolvedFarmDevIndicatorsConfig,
+} from "./dev-indicators";
+import {
   resolveFarmImageConfig,
   type FarmImageConfig,
   type ResolvedFarmImageConfig,
@@ -136,6 +141,11 @@ export type {
   FarmDevtoolsUserConfig,
   ResolvedFarmDevtoolsConfig,
 } from "./devtools-config";
+export type {
+  FarmBuildActivityPosition,
+  FarmDevIndicatorsConfig,
+  ResolvedFarmDevIndicatorsConfig,
+} from "./dev-indicators";
 export type {
   FarmPerformanceConfig,
   FarmPreloadMode,
@@ -334,10 +344,7 @@ export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite" | "docs" | "
   generateBuildId?: () => string | Promise<string>;
   compress?: boolean;
 
-  devIndicators?: {
-    buildActivity?: boolean;
-    buildActivityPosition?: "bottom-right" | "bottom-left" | "top-right" | "top-left";
-  };
+  devIndicators?: FarmDevIndicatorsConfig;
 
   serverRuntimeConfig?: Record<string, any>;
   publicRuntimeConfig?: Record<string, any>;
@@ -372,6 +379,7 @@ export interface ResolvedFarmConfig extends Required<
     | "server"
     | "serverActions"
     | "devtools"
+    | "devIndicators"
     | "images"
     | "i18n"
     | "auth"
@@ -399,6 +407,7 @@ export interface ResolvedFarmConfig extends Required<
   server: ResolvedFarmServerConfig;
   serverActions: ResolvedFarmServerActionsConfig;
   devtools: ResolvedFarmDevtoolsConfig;
+  devIndicators: ResolvedFarmDevIndicatorsConfig;
   images: ResolvedFarmImageConfig;
   i18n: ResolvedFarmI18nConfig;
   auth: ResolvedFarmAuthConfig;
@@ -984,11 +993,7 @@ export async function resolveConfig(
     distDir: userConfig.distDir || ".farm",
     generateBuildId,
     compress: userConfig.compress ?? true,
-    devIndicators: {
-      buildActivity: true,
-      buildActivityPosition: "bottom-right",
-      ...userConfig.devIndicators,
-    },
+    devIndicators: resolveFarmDevIndicatorsConfig(userConfig.devIndicators, mode),
     serverRuntimeConfig: userConfig.serverRuntimeConfig || {},
     publicRuntimeConfig: userConfig.publicRuntimeConfig || {},
     env,

--- a/packages/farm/src/dev-indicators.ts
+++ b/packages/farm/src/dev-indicators.ts
@@ -1,0 +1,170 @@
+export type FarmBuildActivityPosition = "bottom-right" | "bottom-left" | "top-right" | "top-left";
+
+export interface FarmDevIndicatorsConfig {
+  /** Show build and HMR activity in the browser during development. */
+  buildActivity?: boolean;
+  /** Corner used by the build activity indicator. */
+  buildActivityPosition?: FarmBuildActivityPosition;
+}
+
+export interface ResolvedFarmDevIndicatorsConfig {
+  buildActivity: boolean;
+  buildActivityPosition: FarmBuildActivityPosition;
+}
+
+export function resolveFarmDevIndicatorsConfig(
+  config: FarmDevIndicatorsConfig | undefined,
+  mode: "development" | "production" = "development",
+): ResolvedFarmDevIndicatorsConfig {
+  return {
+    buildActivity: mode === "development" && (config?.buildActivity ?? true),
+    buildActivityPosition: config?.buildActivityPosition ?? "bottom-right",
+  };
+}
+
+export function generateFarmDevIndicatorsClientRuntime(
+  config: ResolvedFarmDevIndicatorsConfig,
+): string {
+  if (!config.buildActivity) return "";
+
+  const position = {
+    "bottom-right": "right: 16px; bottom: 16px;",
+    "bottom-left": "left: 16px; bottom: 16px;",
+    "top-right": "right: 16px; top: 16px;",
+    "top-left": "left: 16px; top: 16px;",
+  }[config.buildActivityPosition];
+  const styles = `
+    #__farm_build_activity__ {
+      position: fixed;
+      ${position}
+      z-index: 2147483645;
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      min-height: 30px;
+      padding: 0 10px;
+      border: 1px solid rgb(255 255 255 / 0.16);
+      border-radius: 999px;
+      background: rgb(17 17 17 / 0.9);
+      box-shadow: 0 8px 24px rgb(0 0 0 / 0.2);
+      color: rgb(250 250 250);
+      font: 500 12px/1 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      letter-spacing: -0.01em;
+      opacity: 0;
+      pointer-events: none;
+      transform: translateY(4px);
+      transition: opacity 120ms ease-out, transform 120ms ease-out;
+    }
+    #__farm_build_activity__[data-visible="true"] {
+      opacity: 1;
+      transform: translateY(0);
+    }
+    #__farm_build_activity__::before {
+      width: 8px;
+      height: 8px;
+      border: 1.5px solid rgb(255 255 255 / 0.32);
+      border-top-color: currentColor;
+      border-radius: 50%;
+      content: "";
+      animation: farm-build-activity-spin 650ms linear infinite;
+    }
+    #__farm_build_activity__[data-state="ready"]::before {
+      border-color: currentColor;
+      animation: none;
+    }
+    #__farm_build_activity__[data-state="error"] {
+      border-color: rgb(248 113 113 / 0.55);
+      color: rgb(254 202 202);
+    }
+    #__farm_build_activity__[data-state="error"]::before {
+      border-color: currentColor;
+      animation: none;
+    }
+    @keyframes farm-build-activity-spin { to { transform: rotate(360deg); } }
+    @media (prefers-reduced-motion: reduce) {
+      #__farm_build_activity__ { transition: none; }
+      #__farm_build_activity__::before { animation-duration: 1.4s; }
+    }
+  `;
+
+  return `
+if (import.meta.hot) {
+  (() => {
+    const hot = import.meta.hot;
+    const indicatorId = "__farm_build_activity__";
+    const styleId = "__farm_build_activity_styles__";
+    const runtimeKey = "__FARM_BUILD_ACTIVITY_RUNTIME__";
+    const reloadMarker = "__FARM_BUILD_ACTIVITY_RELOADING__";
+    let hideTimer;
+
+    const ensureIndicator = () => {
+      let style = document.getElementById(styleId);
+      if (!style) {
+        style = document.createElement("style");
+        style.id = styleId;
+        style.textContent = ${JSON.stringify(styles)};
+        document.head.appendChild(style);
+      }
+
+      let indicator = document.getElementById(indicatorId);
+      if (!indicator) {
+        indicator = document.createElement("div");
+        indicator.id = indicatorId;
+        indicator.setAttribute("role", "status");
+        indicator.setAttribute("aria-live", "polite");
+        document.body.appendChild(indicator);
+      }
+      return indicator;
+    };
+
+    const show = (state, label) => {
+      window.clearTimeout(hideTimer);
+      const indicator = ensureIndicator();
+      indicator.dataset.state = state;
+      indicator.dataset.visible = "true";
+      indicator.textContent = label;
+    };
+    const hide = () => {
+      const indicator = document.getElementById(indicatorId);
+      if (indicator) indicator.dataset.visible = "false";
+    };
+    const onBeforeUpdate = () => show("building", "Farm updating");
+    const onAfterUpdate = () => {
+      show("ready", "Farm ready");
+      hideTimer = window.setTimeout(hide, 500);
+    };
+    const onError = () => show("error", "Build failed");
+    const onBeforeFullReload = () => {
+      try {
+        window.sessionStorage.setItem(reloadMarker, "1");
+      } catch {}
+      show("building", "Farm updating");
+    };
+
+    window[runtimeKey]?.dispose?.();
+    ensureIndicator();
+    let completedReload = false;
+    try {
+      completedReload = window.sessionStorage.getItem(reloadMarker) === "1";
+      window.sessionStorage.removeItem(reloadMarker);
+    } catch {}
+    if (completedReload) onAfterUpdate();
+    else hide();
+    hot.on("vite:beforeUpdate", onBeforeUpdate);
+    hot.on("vite:afterUpdate", onAfterUpdate);
+    hot.on("vite:error", onError);
+    hot.on("vite:beforeFullReload", onBeforeFullReload);
+    window[runtimeKey] = {
+      dispose() {
+        window.clearTimeout(hideTimer);
+        hot.off("vite:beforeUpdate", onBeforeUpdate);
+        hot.off("vite:afterUpdate", onAfterUpdate);
+        hot.off("vite:error", onError);
+        hot.off("vite:beforeFullReload", onBeforeFullReload);
+        document.getElementById(indicatorId)?.remove();
+      },
+    };
+  })();
+}
+`;
+}

--- a/packages/farm/src/index.ts
+++ b/packages/farm/src/index.ts
@@ -127,6 +127,7 @@ export * from "./markdown";
 export * from "./app-markdown";
 export * from "./observability";
 export * from "./devtools-config";
+export * from "./dev-indicators";
 export * from "./workflows";
 export * from "./cron";
 export * from "./env";

--- a/packages/farm/src/types.ts
+++ b/packages/farm/src/types.ts
@@ -16,6 +16,7 @@ import type { FarmServerConfig } from "./server-http";
 import type { FarmLayerEntry, ResolvedFarmLayer } from "./layers";
 import type { FarmRouteMaxDuration, FarmRouteRegions, FarmRouteRuntime } from "./route-runtime";
 import type { FarmDevtoolsUserConfig } from "./devtools-config";
+import type { FarmDevIndicatorsConfig } from "./dev-indicators";
 import type { FarmImageConfig } from "./image-config";
 import type { FarmPlugin } from "./plugin";
 import type { FarmI18nUserConfig, ResolvedFarmI18nConfig } from "./i18n/types";
@@ -217,6 +218,8 @@ export interface FarmConfig {
   observability?: FarmObservabilityUserConfig;
   /** Development-only runtime inspector. Enabled by default during `farm dev`. */
   devtools?: FarmDevtoolsUserConfig;
+  /** Development-only browser feedback for build and HMR activity. */
+  devIndicators?: FarmDevIndicatorsConfig;
   /**
    * When true, Link href is not strictly typed (accepts any string).
    * Use when you want to skip route-type errors on Link or don't use generated route types.

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -40,6 +40,7 @@ import {
   FARM_DEVTOOLS_PATH,
   resolveFarmDevtoolsConfig,
 } from "./devtools-config";
+import { generateFarmDevIndicatorsClientRuntime } from "./dev-indicators";
 import * as fs from "fs";
 import * as path from "path";
 import { pathToFileURL } from "node:url";
@@ -2572,6 +2573,9 @@ window.__FARM_MANIFEST__ = ${inlineValue({
         const generatedDevtoolsClientRuntime = devtoolsClientRuntime
           ? devtoolsClientRuntime.generateFarmDevtoolsClientRuntime(devtools)
           : "";
+        const generatedDevIndicatorsClientRuntime = farmApp
+          ? generateFarmDevIndicatorsClientRuntime(farmApp.getConfig().devIndicators)
+          : "";
 
         return generateClientCode(
           isReactRenderer(renderer) ? getIntegrationProviders(integrations) : [],
@@ -2580,7 +2584,7 @@ window.__FARM_MANIFEST__ = ${inlineValue({
             ...(docsRuntime?.getFarmDocsDocumentNavigationMatchers(docs) ?? []),
           ],
           generatedDocsSearchRuntime,
-          generatedDevtoolsClientRuntime,
+          `${generatedDevtoolsClientRuntime}\n${generatedDevIndicatorsClientRuntime}`,
           resolvedConfig?.plugins || [],
           root,
           resolvedConfig?.srcDir || options.srcDir || "src",


### PR DESCRIPTION
## Problem

`devIndicators` was accepted and resolved, but Farm never emitted a browser indicator. Changing its position or disabling it had no observable effect.

## Root cause

The configuration was a copied shape with no client runtime connected to Vite HMR. Farm also reloads some route modules completely during development, so an update-only listener would lose its completion state across navigation.

## Change

Resolve the configuration by mode and inject a renderer-neutral activity runtime into the development client. It handles HMR updates, errors, and full reloads, preserves completion through session storage, supports all four corners, and can be omitted entirely with `buildActivity: false`.

## Safety and compatibility

The runtime is development-only and is not generated for production builds. It does not depend on React or another renderer, uses an accessible status element, respects reduced motion, and keeps the existing bottom-right default.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/dev-indicators.test.ts src/__tests__/config.test.ts src/__tests__/devtools-client.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/__tests__/config.test.ts packages/farm/src/__tests__/dev-indicators.test.ts packages/farm/src/app.ts packages/farm/src/config.ts packages/farm/src/dev-indicators.ts packages/farm/src/index.ts packages/farm/src/types.ts packages/farm/src/vite.ts`
- `pnpm docs:check-navigation`
- `pnpm docs:build`
- Browser verification on macOS with Node 23: a client route reloaded, reported `Farm ready`, remained in the configured bottom-right corner, and produced no console or overlay errors.

## Documentation and release

Documented `devIndicators.buildActivity`, all position values, the development-only behavior, and production omission on the DevTools page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `devIndicators.buildActivity` so the config now drives a visible build status indicator in the browser during development. Previously the option resolved but had no effect; now HMR updates, errors, and full reloads show in the configured position, and `buildActivity: false` disables the indicator.

**Bug Fixes**
- The runtime is development-only and never emitted for production builds.
- Completion state survives full page reloads through session storage, since route modules reload entirely.
- Keeps the existing bottom-right default and works without a renderer framework.
- Uses an accessible status element and respects `prefers-reduced-motion`.

<sup>Written for commit 36f583dc7e13e95ddd48074a8312686026d27a0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

