### PR TITLE
fix(config): reject misleading output modes

### DIFF
--- a/docs/src/app/docs/deployment/page.md
+++ b/docs/src/app/docs/deployment/page.md
@@ -265,6 +265,11 @@ export default defineConfig({
 });
 ```
 
+Both options belong inside `deploy`. A top-level `output: "standalone"`, `"static"`, or `"export"`
+does not select Farm rendering behavior. Choose a deployment target here, then configure static
+pages with `dynamic = "force-static"` or `routeRules` as described in
+[Server Rendering](/docs/server-rendering).
+
 ## Platform deploys
 
 | Command                                | What it expects                                         |

--- a/examples/basic/farm.config.ts
+++ b/examples/basic/farm.config.ts
@@ -262,7 +262,6 @@ export default defineConfig({
   },
 
   // Build configuration
-  output: 'standalone',
   compress: true,
 
   // Development indicators

--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -74,6 +74,18 @@ describe("config helpers", () => {
     });
   });
 
+  it("warns instead of silently accepting a top-level output mode", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const config = await resolveConfig({ output: "export" }, "production");
+
+    expect(config).not.toHaveProperty("output");
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('top-level "output" option is not supported'),
+    );
+    warn.mockRestore();
+  });
+
   it("resolves smart preload budgets", async () => {
     const defaults = await resolveConfig({}, "production");
     const configured = await resolveConfig(

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -329,7 +329,6 @@ export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite" | "docs" | "
 
   notFound?: NotFoundConfig;
 
-  output?: "standalone" | "static" | "export";
   distDir?: string;
   generateBuildId?: () => string | Promise<string>;
   compress?: boolean;
@@ -419,7 +418,6 @@ export type FarmLayerConfig = Omit<
   | "outDir"
   | "distDir"
   | "deploy"
-  | "output"
   | "preset"
   | "publicDir"
   | "generateBuildId"
@@ -859,6 +857,12 @@ export async function resolveConfig(
   });
   userConfig = layerResolution.config;
 
+  if ((userConfig as Record<string, unknown>).output !== undefined) {
+    logger.warn(
+      'The top-level "output" option is not supported and has no effect. Configure `deploy.target`, `deploy.preset`, or `deploy.outputDir` for deployment output, and use route rendering configuration for static pages.',
+    );
+  }
+
   // The docs adapter runtime is React-only today; other renderers keep the
   // embedded docs handler without any migration notice.
   if (isReactRenderer(resolveFarmRenderer(userConfig.renderer))) {
@@ -980,7 +984,6 @@ export async function resolveConfig(
     serverActions: resolveServerActionsConfig(userConfig.serverActions),
     security,
     deploymentId,
-    output: userConfig.output || "standalone",
     distDir: userConfig.distDir || ".farm",
     generateBuildId,
     compress: userConfig.compress ?? true,


### PR DESCRIPTION
## Problem

Farm exposed a top-level `output: "standalone" | "static" | "export"` option and resolved a default value, but no build or runtime path consumed it. This made copied output configuration look supported while having no effect.

## Root cause

The option was added as configuration shape only. Farm deployment output is actually controlled by `deploy.target`, `deploy.preset`, and `deploy.outputDir`, while static rendering is selected per route.

## Change

Remove the dead option from the public and resolved configuration, warn when an existing project still supplies it, remove it from the basic example, and document the supported deployment and static-rendering controls.

## Safety and compatibility

Existing configurations receive an actionable warning instead of being silently ignored. Deployment target, preset, and output directory behavior are unchanged, and no rendering mode is changed implicitly.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/config.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/config.ts packages/farm/src/__tests__/config.test.ts examples/basic/farm.config.ts`
- `pnpm docs:check-navigation`
- `pnpm docs:build`

## Documentation and release

Updated deployment documentation to distinguish `deploy.output` from static route rendering and removed the misleading setting from the basic example.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the top-level `output` config option, which was accepted and resolved to a default but never used by any build or runtime path. Existing configurations that still set it now get a warning pointing to `deploy.target`, `deploy.preset`, `deploy.outputDir`, and route rendering options.

- Warns instead of silently ignoring a supplied `output` value.
- Removes the option from the public and resolved config types and drops the default value.
- Updates deployment docs and the basic example to stop promoting the option.

<sup>Written for commit a624494a63ea324cc441044a970d263b737bdd8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

