### PR TITLE
fix(config): reject ineffective TypeScript settings

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -39,6 +39,24 @@ export default defineConfig({
 
 `defineConfig` is the canonical Farm helper. `defineFarmConfig` remains available as a deprecated exact alias for existing applications.
 
+## TypeScript
+
+Farm transpiles TypeScript through the selected renderer and Vite. It reads the project's normal
+`tsconfig.json`, but `farm build` does not run a separate project type check. Keep type checking as
+an explicit script so the same command runs locally and in CI:
+
+```json title="package.json"
+{
+  "scripts": {
+    "type-check": "tsc --noEmit"
+  }
+}
+```
+
+A top-level `typescript.tsconfigPath` or `typescript.ignoreBuildErrors` setting has no effect in
+Farm. Configure compiler behavior in `tsconfig.json`; point an explicit `tsc -p` command at a
+different file when needed.
+
 ## Renderer
 
 React remains the default renderer, so existing applications and configurations do not need to

--- a/examples/basic/farm.config.ts
+++ b/examples/basic/farm.config.ts
@@ -271,11 +271,6 @@ export default defineConfig({
     buildActivityPosition: 'bottom-right',
   },
 
-  // TypeScript
-  typescript: {
-    ignoreBuildErrors: false,
-  },
-
   // OpenAPI Documentation
   openapi: {
     enabled: true,

--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -74,6 +74,21 @@ describe("config helpers", () => {
     });
   });
 
+  it("warns instead of silently accepting TypeScript build settings", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const config = await resolveConfig(
+      { typescript: { tsconfigPath: "config/tsconfig.json", ignoreBuildErrors: true } },
+      "production",
+    );
+
+    expect(config).not.toHaveProperty("typescript");
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('top-level "typescript" option is not supported'),
+    );
+    warn.mockRestore();
+  });
+
   it("resolves smart preload budgets", async () => {
     const defaults = await resolveConfig({}, "production");
     const configured = await resolveConfig(

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -344,11 +344,6 @@ export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite" | "docs" | "
 
   env?: FarmEnvConfig<any, any>;
 
-  typescript?: {
-    tsconfigPath?: string;
-    ignoreBuildErrors?: boolean;
-  };
-
   vite?: ViteUserConfig | ((config: ViteUserConfig) => ViteUserConfig);
 
   [key: string]: any;
@@ -859,6 +854,12 @@ export async function resolveConfig(
   });
   userConfig = layerResolution.config;
 
+  if ((userConfig as Record<string, unknown>).typescript !== undefined) {
+    logger.warn(
+      'The top-level "typescript" option is not supported and has no effect. Configure TypeScript in `tsconfig.json` and run `tsc --noEmit` separately when builds must enforce project type errors.',
+    );
+  }
+
   // The docs adapter runtime is React-only today; other renderers keep the
   // embedded docs handler without any migration notice.
   if (isReactRenderer(resolveFarmRenderer(userConfig.renderer))) {
@@ -992,11 +993,6 @@ export async function resolveConfig(
     serverRuntimeConfig: userConfig.serverRuntimeConfig || {},
     publicRuntimeConfig: userConfig.publicRuntimeConfig || {},
     env,
-    typescript: {
-      tsconfigPath: "tsconfig.json",
-      ignoreBuildErrors: false,
-      ...userConfig.typescript,
-    },
     vite: typeof userConfig.vite === "function" ? userConfig.vite({}) : userConfig.vite || {},
   };
 


### PR DESCRIPTION
## Problem

Farm exposed `typescript.tsconfigPath` and `typescript.ignoreBuildErrors`, but neither setting affected Vite transpilation, the production build, or a project type check. The options implied guarantees that did not exist.

## Root cause

The values were copied into resolved configuration without any consumer. Farm transpiles TypeScript during bundling and intentionally leaves whole-project type checking to an explicit TypeScript command.

## Change

Remove the ineffective settings from public and resolved configuration, warn existing projects that still supply them, remove them from the basic example, and document the supported `tsconfig.json` plus `tsc --noEmit` workflow.

## Safety and compatibility

Runtime and bundle behavior are unchanged because the removed values were never read. Existing projects now receive an actionable warning instead of silent acceptance.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/config.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/config.ts packages/farm/src/__tests__/config.test.ts examples/basic/farm.config.ts`
- `pnpm docs:check-navigation`
- `pnpm docs:build`

## Documentation and release

Added a TypeScript configuration section and removed the ineffective settings from the basic example.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the top-level `typescript.tsconfigPath` and `typescript.ignoreBuildErrors` options, which were accepted but never read. Runtime and bundle behavior are unchanged; users who still supply them now get a warning pointing to `tsconfig.json` and an explicit `tsc --noEmit` script.

- Updates the docs to describe the supported TypeScript workflow for transpilation and type checking.
- Removes the ineffective example config block.

<sup>Written for commit 75e52d47eaba5b87c6610e559ebca7acb666690e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

