### PR TITLE
perf(react): batch exact-position keyed insertions

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1025,6 +1025,8 @@ Native immutable array methods can state an exact insertion, removal, or replace
 
 ```tsx
 setItems((current) => current.toSpliced(selectedIndex, 0, nextItem));
+setItems((current) => current.toSpliced(selectedIndex, 0, nextA, nextB));
+setItems((current) => current.toSpliced(selectedIndex, 0, ...incomingItems));
 setItems((current) => current.toSpliced(selectedIndex, 1));
 setItems((current) => current.toSpliced(selectedIndex, 25));
 setItems((current) => current.toSpliced(selectedIndex, 1, replacement));
@@ -1035,18 +1037,24 @@ At build time, Farm recognizes only concise functional setters whose position is
 safe-integer literal or a compiler-safe runtime expression. Identifiers, property reads,
 side-effect-free arithmetic and conditionals, and safe `Math` calls are supported. User-defined
 calls, assignments, update expressions, and other effectful forms are not transformed.
-`toSpliced()` must insert exactly one item with a zero delete count, remove one item or a contiguous
-range using a positive safe-integer literal delete count, or replace exactly one item with a delete
-count of one; `with()` must replace exactly one item. Farm preserves the original method lookup,
+`toSpliced()` must insert compiler-safe items with a zero delete count, remove one item or a
+contiguous range using a positive safe-integer literal delete count, or replace exactly one item
+with a delete count of one; `with()` must replace exactly one item. An explicit pair or a safe
+spread such as `...incomingItems` selects the batch path when at least two items are produced at
+runtime. Farm preserves the original method lookup,
 evaluates every argument once in its original order, and preserves the native call, return value,
 coercion, and thrown errors. If the method is not native, the evaluated position is not already a
 safe integer, or the removal count is dynamic or unsafe, the update still runs normally but no
 metadata is recorded.
 
 At update time, Farm validates the committed native source, result length, source token, normalized
-position, clamped removal count, and any incoming key before changing the DOM. An insertion creates
-one row at that position, preserves surrounding elements, and shifts only stored event indexes. A
-removal cleans up and removes only the known row or contiguous range while preserving every
+position, clamped removal count, and any incoming key before changing the DOM. For a batch, Farm
+computes every key, descriptor, binding snapshot, and detached host row before mutating the live
+tree. Duplicate incoming keys or collisions with existing keys therefore take complete
+reconciliation without a partial insertion. Valid rows are mounted in one document fragment;
+surrounding elements remain connected and only stored suffix indexes shift. A single insertion
+creates one row at that position. A removal cleans up and removes only the known row or contiguous
+range while preserving every
 surviving element. A same-key replacement patches that row in place; a new-key replacement creates
 and swaps one host row. The owner component does not rerun, and surviving row keys, descriptors,
 and bindings are not reread.
@@ -1059,8 +1067,9 @@ duplicate or reused keys, collection-reading bindings, React-owned rows, nested 
 conditionals, unrelated dirty dependencies, and failed runtime checks keep complete keyed
 reconciliation. Negative safe-integer positions and counts larger than the remaining suffix use the
 native method's normal clamping rules. No new option or component is required. Reports expose
-emitted sites as `keyedArrayPositionHints`; position-only modules retain a separate optional runtime
-capability.
+emitted sites as `keyedArrayPositionHints`. Batch insertions select a separate optional runtime
+capability, so modules with only the existing single-row position operations retain their previous
+runtime size.
 
 #### Keyed array reorder hints
 

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,27 @@
 
 Date: 2026-08-29
 
+## Exact-position batch insertion follow-up — 2026-08-30
+
+The full bracketed production-browser run added an isolated 10,000-row workload for concise native
+`toSpliced(position, 0, ...incoming)` updates that insert 64 rows in the middle. Both compiler
+builds emitted the fifth expected `keyedArrayPositionHints` site, preserved the DOM nodes on both
+sides of the insertion, produced zero owner executions, and passed the independent 4x React and
+1.5x compiled-control floors.
+
+| Mode   | React median | Hinted batch | Compiled control | vs React | vs control |
+| ------ | -----------: | -----------: | ---------------: | -------: | ---------: |
+| Static |     71.70 ms |      8.50 ms |         20.80 ms |    8.44x |      2.45x |
+| Hybrid |     71.70 ms |      8.50 ms |         21.80 ms |    8.44x |      2.56x |
+
+Package tests separately verify one-fragment insertion, work proportional to the 64 incoming rows,
+retained-row identity checks, duplicate and colliding key fallback before live DOM mutation, custom
+method semantics and errors, queued-update fallback, 1,000 differential updates, controlled-input
+focus and selection, delegated event indexes, hydration, Strict Mode, and unmount cleanup. The
+batch-only runtime-size fixture has a 12,470 B gzip compiler premium. Direct and core-only bundles
+remain unchanged, and modules that emit only the previous single-position operations do not retain
+the batch helper or runtime capability.
+
 ## Native contiguous `toSpliced()` removal follow-up — 2026-08-30
 
 The full bracketed production-browser run added one isolated 10,000-row workload for concise native

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -96,15 +96,20 @@ React and 1.25x faster than the compiled control. The report must contain a nonz
 work proportional only to the incoming suffix.
 
 Exact-position insertions, removals, and replacements have separate 10,000-row comparisons. Concise
-native `toSpliced(position, 0, item)`, `toSpliced(position, 1)`,
+native `toSpliced(position, 0, item)`, `toSpliced(position, 0, ...items)`, `toSpliced(position, 1)`,
 `toSpliced(position, 64)`, `toSpliced(position, 1, replacement)`, and
 `with(position, replacement)` updates use event-local runtime position variables and are measured
 against bracketed React and equivalent block-bodied compiled controls. The compiler report must
-contain all four dashboard `keyedArrayPositionHints`; package tests separately require zero
+contain all five dashboard `keyedArrayPositionHints`; package tests separately require zero
 surviving key/descriptor/binding reads for removal, surrounding DOM identity, randomized
 differential correctness, runtime-position and count fallback, hydration, and cleanup. Both the
 single-row and 64-row removal gates must remain at least 4x faster than React and 1.5x faster than
 their compiled controls.
+
+The batch insertion case mounts 64 new rows at the middle of a 10,000-row table. It must preserve
+both surrounding DOM nodes, add no owner executions, remain at least 4x faster than React, and stay
+at least 1.5x faster than the equivalent block-bodied compiled control. This gate is independent of
+the older single-row position gates, so a batch regression cannot hide inside their aggregate.
 
 Native keyed-array reversal has a separate 10,000-row comparison. Concise `toReversed()` is
 measured against bracketed React and an equivalent block-bodied compiled control. Both compiler

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -143,8 +143,8 @@ async function inspectBuild(compilerMode) {
       "The compiler build did not emit a keyed-array prepend hint.",
     );
     assert(
-      compilerReport.summary.keyedArrayPositionHints >= 4,
-      "The compiler build did not emit all four keyed-array exact-position hints.",
+      compilerReport.summary.keyedArrayPositionHints >= 5,
+      "The compiler build did not emit the keyed-array exact-position hints.",
     );
     assert(
       compilerReport.summary.keyedArrayReorderHints > 0,
@@ -606,6 +606,38 @@ async function measureTrial(browser, trial, compilerMode, port) {
               () =>
                 rowCount() === 10_001 &&
                 table.querySelectorAll("tbody tr")[9_001] === previousAtPosition,
+            );
+          },
+        );
+
+        const tablePositionBatchInsert = await measureTable(
+          async () => ensure10000(),
+          async () => {
+            const rows = table.querySelectorAll("tbody tr");
+            const before = rows[4_999];
+            const previousAtPosition = rows[5_000];
+            await runTableAction(
+              () => tableButton("table-position-batch-insert").click(),
+              () =>
+                rowCount() === 10_064 &&
+                table.querySelectorAll("tbody tr")[4_999] === before &&
+                table.querySelectorAll("tbody tr")[5_064] === previousAtPosition,
+            );
+          },
+        );
+
+        const tablePositionBatchInsertSnapshot = await measureTable(
+          async () => ensure10000(),
+          async () => {
+            const rows = table.querySelectorAll("tbody tr");
+            const before = rows[4_999];
+            const previousAtPosition = rows[5_000];
+            await runTableAction(
+              () => tableButton("table-position-batch-insert-snapshot").click(),
+              () =>
+                rowCount() === 10_064 &&
+                table.querySelectorAll("tbody tr")[4_999] === before &&
+                table.querySelectorAll("tbody tr")[5_064] === previousAtPosition,
             );
           },
         );
@@ -1142,6 +1174,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             membership: tableMembership,
             prepend: tablePrepend,
             prependSnapshot: tablePrependSnapshot,
+            positionBatchInsert: tablePositionBatchInsert,
+            positionBatchInsertSnapshot: tablePositionBatchInsertSnapshot,
             positionInsert: tablePositionInsert,
             positionInsertSnapshot: tablePositionInsertSnapshot,
             positionRemove: tablePositionRemove,
@@ -1240,6 +1274,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
         membership: timingSummary(result.table.membership),
         prepend: timingSummary(result.table.prepend),
         prependSnapshot: timingSummary(result.table.prependSnapshot),
+        positionBatchInsert: timingSummary(result.table.positionBatchInsert),
+        positionBatchInsertSnapshot: timingSummary(result.table.positionBatchInsertSnapshot),
         positionInsert: timingSummary(result.table.positionInsert),
         positionInsertSnapshot: timingSummary(result.table.positionInsertSnapshot),
         positionRemove: timingSummary(result.table.positionRemove),
@@ -1334,6 +1370,8 @@ const tableMetrics = [
   "appendSnapshot",
   "prepend",
   "prependSnapshot",
+  "positionBatchInsert",
+  "positionBatchInsertSnapshot",
   "positionInsert",
   "positionInsertSnapshot",
   "positionRemove",
@@ -1582,6 +1620,29 @@ const keyedRollingWindowRegressions = keyedRollingWindowResults.filter(
     speedup < keyedRollingWindowMinimumSpeedup ||
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedRollingWindowMinimumSnapshotSpeedup,
+);
+// A compiler-proven toSpliced(position, 0, ...items) insertion creates the incoming rows in one
+// fragment and leaves both retained sides untouched. Protect that exact 10,000-row/64-row workload
+// against React and the equivalent block-bodied compiled control without changing older gates.
+const keyedBatchInsertMinimumSpeedup = 4;
+const keyedBatchInsertMinimumSnapshotSpeedup = 1.5;
+const keyedBatchInsertResults = ["static", "hybrid"].map((mode) => {
+  const batchMedianMs = comparisons.table.positionBatchInsert[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.positionBatchInsertSnapshot[mode].medianMs;
+  return {
+    batchMedianMs,
+    mode,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / batchMedianMs,
+    speedup: comparisons.table.positionBatchInsert[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedBatchInsertRegressions = keyedBatchInsertResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedBatchInsertMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedBatchInsertMinimumSnapshotSpeedup,
 );
 // Native toSpliced()/with() calls with event-local runtime positions expose one exact insertion,
 // removal, or replacement position. The hinted runtime should beat both React and an equivalent
@@ -1855,6 +1916,7 @@ const passed =
   keyedPrependRegressions.length === 0 &&
   keyedSliceRegressions.length === 0 &&
   keyedRollingWindowRegressions.length === 0 &&
+  keyedBatchInsertRegressions.length === 0 &&
   keyedPositionRegressions.length === 0 &&
   keyedRangeRemovalRegressions.length === 0 &&
   keyedReorderRegressions.length === 0 &&
@@ -1907,6 +1969,13 @@ const report = {
     regressions: keyedRollingWindowRegressions,
     results: keyedRollingWindowResults,
     status: keyedRollingWindowRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedBatchInsertHintGate: {
+    minimumSnapshotSpeedup: keyedBatchInsertMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedBatchInsertMinimumSpeedup,
+    regressions: keyedBatchInsertRegressions,
+    results: keyedBatchInsertResults,
+    status: keyedBatchInsertRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedPositionHintGate: {
     insertMinimumSnapshotSpeedup: keyedPositionInsertMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -8,6 +8,7 @@ declare global {
     toSorted(compare?: (left: T, right: T) => number): T[];
     toSpliced(start: number, deleteCount: number): T[];
     toSpliced(start: number, deleteCount: number, item: T): T[];
+    toSpliced(start: number, deleteCount: number, ...items: T[]): T[];
     with(index: number, item: T): T[];
   }
 }
@@ -282,6 +283,38 @@ export function StandardTableBenchmark() {
           }}
         >
           Insert at runtime position (snapshot control)
+        </button>
+        <button
+          data-action="table-position-batch-insert"
+          type="button"
+          onClick={() => {
+            const nextSeed = seed + 1;
+            const additions = buildRows(64, nextSeed);
+            const position = 5_000;
+            setSeed(nextSeed);
+            setRows((current) => current.toSpliced(position, 0, ...additions));
+            setOperation("insert batch at runtime position");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Insert 64 at runtime position
+        </button>
+        <button
+          data-action="table-position-batch-insert-snapshot"
+          type="button"
+          onClick={() => {
+            const nextSeed = seed + 1;
+            const additions = buildRows(64, nextSeed);
+            const position = 5_000;
+            setSeed(nextSeed);
+            setRows((current) => {
+              return current.toSpliced(position, 0, ...additions);
+            });
+            setOperation("insert batch at runtime position (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Insert 64 at runtime position (snapshot control)
         </button>
         <button
           data-action="table-position-remove"

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -301,6 +301,8 @@ Native known-position updates can avoid a complete keyed scan too:
 
 ```tsx
 setItems((current) => current.toSpliced(selectedIndex, 0, nextItem));
+setItems((current) => current.toSpliced(selectedIndex, 0, nextA, nextB));
+setItems((current) => current.toSpliced(selectedIndex, 0, ...incomingItems));
 setItems((current) => current.toSpliced(selectedIndex, 1));
 setItems((current) => current.toSpliced(selectedIndex, 25));
 setItems((current) => current.toSpliced(selectedIndex, 1, replacement));
@@ -309,20 +311,24 @@ setItems((current) => current.with(selectedIndex, replacement));
 
 The compiler recognizes only a concise functional setter and either a safe-integer literal or a
 compiler-safe runtime position expression, such as an identifier, property read, arithmetic,
-conditional, or safe `Math` call. The update must insert one item with zero removals, remove one
-item or a fixed positive safe-integer literal range, or replace one item through either
-`toSpliced()` or `with()`. Farm preserves method lookup,
+conditional, or safe `Math` call. The update must insert one or more compiler-safe items with zero
+removals, remove one item or a fixed positive safe-integer literal range, or replace one item
+through either `toSpliced()` or `with()`. Farm preserves method lookup,
 evaluates the position and remaining arguments once in their original order, executes the ordinary
 native call, and records metadata only after validating the committed native source, result, and
-actual safe-integer position and clamped removal count. The runtime creates one inserted row,
+actual safe-integer position and clamped removal count. A batch requires at least two evaluated
+items at runtime. Farm creates every incoming key, descriptor, binding snapshot, and detached row
+before changing the live DOM, rejects key collisions, and inserts the complete batch through one
+document fragment. The runtime otherwise creates one inserted row,
 removes only the known row or range, or patches/replaces one row at that position without rereading
 every existing key, descriptor, and binding. Surviving rows keep their DOM identity. Index-aware or
 collection-reading rows, custom methods, position expressions with user calls or mutations,
 runtime positions that are not safe integers, dynamic, zero, negative, or fractional removal
 counts, other `toSpliced()` forms, block-bodied updaters, unsafe incoming expressions, queued
 uncommitted updates, reused keys, nested or React-owned rows, and failed checks use complete keyed
-reconciliation. Reports expose the site count as `keyedArrayPositionHints`; the capability is
-tree-shaken from modules that do not emit it.
+reconciliation. Reports expose the site count as `keyedArrayPositionHints`. Batch insertion uses a
+separate optional runtime capability, so existing single-position and non-position bundles do not
+retain its validation or fragment-mounting code.
 
 A direct native reverse can carry its complete permutation to a separate optional runtime:
 

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -104,6 +104,23 @@
         "brotli": 10174
       }
     },
+    "keyedBatchPosition": {
+      "compilerOff": {
+        "raw": 192917,
+        "gzip": 60091,
+        "brotli": 51753
+      },
+      "compilerOn": {
+        "raw": 237460,
+        "gzip": 72561,
+        "brotli": 62216
+      },
+      "compilerPremium": {
+        "raw": 44543,
+        "gzip": 12470,
+        "brotli": 10463
+      }
+    },
     "keyedReorder": {
       "compilerOff": {
         "raw": 192847,
@@ -179,18 +196,18 @@
         "brotli": 51666
       },
       "full": {
-        "raw": 279783,
-        "gzip": 79263,
-        "brotli": 67731
+        "raw": 281382,
+        "gzip": 79585,
+        "brotli": 68029
       },
       "coreOnly": {
         "raw": 204922,
         "gzip": 63685,
         "brotli": 54902
       },
-      "fullRuntimePremiumGzip": 19344,
+      "fullRuntimePremiumGzip": 19666,
       "coreRuntimePremiumGzip": 3766,
-      "gzipReductionPercent": 80.5
+      "gzipReductionPercent": 80.9
     }
   }
 }

--- a/packages/farm-react/fixtures/runtime-size/keyed-batch-position.tsx
+++ b/packages/farm-react/fixtures/runtime-size/keyed-batch-position.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import { createRoot } from "react-dom/client";
+
+declare global {
+  interface Array<T> {
+    toSpliced(start: number, deleteCount: number, ...items: T[]): T[];
+  }
+}
+
+interface Row {
+  id: number;
+  label: string;
+}
+
+interface BatchPositionTableProps {
+  incoming: Row[];
+}
+
+export function BatchPositionTable({ incoming }: BatchPositionTableProps) {
+  const [rows, setRows] = useState<Row[]>([
+    { id: 1, label: "Alpha" },
+    { id: 2, label: "Beta" },
+  ]);
+  return (
+    <main>
+      <button onClick={() => setRows((current) => current.toSpliced(1, 0, ...incoming))}>
+        Insert rows
+      </button>
+      <ul>
+        {rows.map((row) => (
+          <li key={row.id}>{row.label}</li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+
+createRoot(document.body).render(
+  <BatchPositionTable
+    incoming={[
+      { id: 3, label: "Gamma" },
+      { id: 4, label: "Delta" },
+    ]}
+  />,
+);

--- a/packages/farm-react/scripts/benchmark-runtime-size.mjs
+++ b/packages/farm-react/scripts/benchmark-runtime-size.mjs
@@ -61,6 +61,8 @@ const [
   keyedPrependOn,
   keyedPositionOff,
   keyedPositionOn,
+  keyedBatchPositionOff,
+  keyedBatchPositionOn,
   keyedReorderOff,
   keyedReorderOn,
   keyedSortOff,
@@ -85,6 +87,8 @@ const [
   bundle("keyed-prepend.tsx", true),
   bundle("keyed-position.tsx", false),
   bundle("keyed-position.tsx", true),
+  bundle("keyed-batch-position.tsx", false),
+  bundle("keyed-batch-position.tsx", true),
   bundle("keyed-reorder.tsx", false),
   bundle("keyed-reorder.tsx", true),
   bundle("keyed-sort.tsx", false),
@@ -177,6 +181,19 @@ if (
   throw new Error(
     `Keyed position fixture did not retain its isolated position-hint runtime: rows=${keyedPositionOn.code.includes("FarmCompiledKeyedRows")}, feature=${keyedPositionOn.code.includes("keyed-rows:position-hinted")}, proof=${keyedPositionOn.code.includes("positionIndexIndependent")}.`,
   );
+}
+if (
+  !keyedBatchPositionOn.code.includes("FarmCompiledKeyedRows") ||
+  !keyedBatchPositionOn.code.includes("keyed-rows:batch-position-hinted") ||
+  !keyedBatchPositionOn.code.includes("positionIndexIndependent")
+) {
+  throw new Error("Keyed batch-position fixture did not retain its isolated batch runtime.");
+}
+if (
+  keyedPositionOn.code.includes("keyed-rows:batch-position-hinted") ||
+  keyedPositionOn.code.includes("createCompilerKeyedArrayBatchInsert")
+) {
+  throw new Error("Single-row position fixture retained the optional batch-insertion runtime.");
 }
 if (
   !keyedReorderOn.code.includes("FarmCompiledKeyedRows") ||
@@ -328,6 +345,23 @@ const results = {
         brotli: keyedPositionOn.brotli - keyedPositionOff.brotli,
       },
     },
+    keyedBatchPosition: {
+      compilerOff: {
+        raw: keyedBatchPositionOff.raw,
+        gzip: keyedBatchPositionOff.gzip,
+        brotli: keyedBatchPositionOff.brotli,
+      },
+      compilerOn: {
+        raw: keyedBatchPositionOn.raw,
+        gzip: keyedBatchPositionOn.gzip,
+        brotli: keyedBatchPositionOn.brotli,
+      },
+      compilerPremium: {
+        raw: keyedBatchPositionOn.raw - keyedBatchPositionOff.raw,
+        gzip: keyedBatchPositionOn.gzip - keyedBatchPositionOff.gzip,
+        brotli: keyedBatchPositionOn.brotli - keyedBatchPositionOff.brotli,
+      },
+    },
     keyedReorder: {
       compilerOff: {
         raw: keyedReorderOff.raw,
@@ -445,6 +479,13 @@ if (checkOnly) {
       maximum:
         (reference.fixtures.keyedPosition?.compilerPremium.gzip ??
           results.fixtures.keyedPosition.compilerPremium.gzip) + 256,
+    },
+    {
+      name: "keyed batch-position compiler premium",
+      current: results.fixtures.keyedBatchPosition.compilerPremium.gzip,
+      maximum:
+        (reference.fixtures.keyedBatchPosition?.compilerPremium.gzip ??
+          results.fixtures.keyedBatchPosition.compilerPremium.gzip) + 256,
     },
     {
       name: "keyed reorder compiler premium",

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -43,6 +43,7 @@ const testSource = String.raw`
     createCompiledComponent,
     createCompiledComponentWithFeatures,
     createCompilerKeyedArrayAppend,
+    createCompilerKeyedArrayBatchInsert,
     createCompilerKeyedArrayFilter,
     createCompilerKeyedArrayPositionUpdate,
     createCompilerKeyedArrayPrepend,
@@ -89,6 +90,7 @@ const testSource = String.raw`
   flushSync(() => root.unmount());
 
   let reverseCompatibilityRows = () => undefined;
+  let insertCompatibilityRows = () => undefined;
   let removeCompatibilityRow = () => undefined;
   let sortCompatibilityRows = () => undefined;
   let reorderExecutions = 0;
@@ -114,6 +116,16 @@ const testSource = String.raw`
             "remove",
             1,
             1,
+          ),
+        );
+      insertCompatibilityRows = () =>
+        state[0].set((previous) =>
+          createCompilerKeyedArrayBatchInsert(
+            previous,
+            previous.toSpliced,
+            1,
+            { id: "d", label: "Delta", rank: 4 },
+            { id: "e", label: "Epsilon", rank: 5 },
           ),
         );
       sortCompatibilityRows = () =>
@@ -180,6 +192,15 @@ const testSource = String.raw`
   await Promise.resolve();
   await Promise.resolve();
   assert.equal(reorderContainer.querySelector("[data-key='c']"), null);
+  assert.equal(reorderContainer.querySelector("li:first-child"), reorderBeta);
+  assert.equal(reorderContainer.querySelector("li:last-child"), reorderAlpha);
+  assert.equal(reorderExecutions, 1);
+  insertCompatibilityRows();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(reorderContainer.querySelectorAll("li").length, 4);
+  assert.equal(reorderContainer.querySelectorAll("li")[1].textContent, "Delta");
+  assert.equal(reorderContainer.querySelectorAll("li")[2].textContent, "Epsilon");
   assert.equal(reorderContainer.querySelector("li:first-child"), reorderBeta);
   assert.equal(reorderContainer.querySelector("li:last-child"), reorderAlpha);
   assert.equal(reorderExecutions, 1);

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-position-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-position-hints.test.ts
@@ -48,6 +48,25 @@ describe("React AOT keyed-array position hints", () => {
     expect(result.optimizations.keyedArrayPositionHints).toBe(3);
   });
 
+  it("records exact-position batch insertions without retaining the single-row helper", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ first, second, incoming, offset }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <section>
+          <button onClick={() => setRows((current) => current.toSpliced(offset, 0, first, second))}>Insert pair</button>
+          <button onClick={() => setRows((current) => current.toSpliced(-1, 0, ...incoming))}>Insert batch</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.optimizations.keyedArrayPositionHints).toBe(2);
+    expect(result.code).toContain("createCompilerKeyedArrayBatchInsert");
+    expect(result.code).toContain("keyedRowsBatchPositionHintedRuntimeFeature");
+    expect(result.code).not.toContain("createCompilerKeyedArrayPositionUpdate");
+  });
+
   it("records compiler-safe runtime position expressions", async () => {
     const result = await compile(`
       import { useState } from "react";
@@ -125,14 +144,14 @@ describe("React AOT keyed-array position hints", () => {
       update: "current.slice().toSpliced(0, 1)",
     },
     {
-      name: "a multi-item insertion",
-      row: "row => <li key={row.id}>{row.label}</li>",
-      update: "current.toSpliced(0, 0, next, next)",
-    },
-    {
       name: "a multi-item replacement",
       row: "row => <li key={row.id}>{row.label}</li>",
       update: "current.toSpliced(0, 1, next, next)",
+    },
+    {
+      name: "an unsafe incoming spread call",
+      row: "row => <li key={row.id}>{row.label}</li>",
+      update: "current.toSpliced(0, 0, ...makeRows())",
     },
     {
       name: "a fractional literal position",

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-batch-insert-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-batch-insert-hints.test.tsx
@@ -1,0 +1,618 @@
+import React, { StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createCompiledComponentWithFeatures,
+  createCompilerKeyedArrayBatchInsert,
+  keyedRowsBatchPositionHintedRuntimeFeature,
+  type CompilerKeyedRowElement,
+} from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Item {
+  id: string;
+  label: string;
+}
+
+type BatchArray = Item[] & {
+  toSpliced(start: number, deleteCount: number, ...items: Item[]): Item[];
+};
+
+const roots: Root[] = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function hintedBatchInsert(previous: Item[], position: number, items: readonly Item[]): Item[] {
+  const source = previous as BatchArray;
+  return createCompilerKeyedArrayBatchInsert(
+    source,
+    source.toSpliced,
+    position,
+    ...items,
+  ) as Item[];
+}
+
+function rowDescriptor(item: Item): CompilerKeyedRowElement {
+  return {
+    kind: "element",
+    tag: "li",
+    attributes: [{ name: "data-key", value: item.id }],
+    styles: [],
+    children: [item.label],
+  };
+}
+
+function createBatchHarness(initialItems: Item[]) {
+  const counters = { executions: 0, renders: 0, keys: 0, descriptors: 0, bindings: 0 };
+  let insert: (position: number, items: readonly Item[]) => void = () => undefined;
+  let remove: (position: number, count: number) => void = () => undefined;
+  let queueTwo: (first: readonly Item[], second: readonly Item[]) => void = () => undefined;
+  let customInsert: (position: number, items: readonly Item[]) => void = () => undefined;
+  const Table = createCompiledComponentWithFeatures(
+    {
+      displayName: "BatchPositionTable",
+      initialize: () => [initialItems],
+      render(_props: Record<string, never>, state, blocks) {
+        counters.executions += 1;
+        const items = () => state[0].get() as Item[];
+        insert = (position, incoming) =>
+          state[0].set((previous) => hintedBatchInsert(previous as Item[], position, incoming));
+        remove = (position, count) =>
+          state[0].set((previous) => (previous as BatchArray).toSpliced(position, count));
+        queueTwo = (first, second) => {
+          state[0].set((previous) => hintedBatchInsert(previous as Item[], 1, first));
+          state[0].set((previous) => hintedBatchInsert(previous as Item[], 2, second));
+        };
+        customInsert = (position, incoming) =>
+          state[0].set((previous) => {
+            const source = previous as Item[];
+            const method = function (
+              this: Item[],
+              start: number,
+              _remove: number,
+              ...next: Item[]
+            ) {
+              return [...this.slice(0, start), ...next, ...this.slice(start)].reverse();
+            };
+            return createCompilerKeyedArrayBatchInsert(source, method, position, ...incoming);
+          });
+        return (
+          <section>
+            <blocks.KeyedRows
+              collectionDependency={0}
+              dependencies={[0]}
+              id={0}
+              items={items}
+              positionIndexIndependent
+              structureDependencies={[0]}
+              render={() => {
+                counters.renders += 1;
+                return (
+                  <ul>
+                    {items().map((item) => (
+                      <li data-key={item.id} key={item.id}>
+                        {item.label}
+                      </li>
+                    ))}
+                  </ul>
+                );
+              }}
+              rowKey={(item) => {
+                counters.keys += 1;
+                return (item as Item).id;
+              }}
+              create={(item) => {
+                counters.descriptors += 1;
+                return rowDescriptor(item as Item);
+              }}
+              bindings={[
+                {
+                  kind: "text",
+                  path: [],
+                  read: (item) => {
+                    counters.bindings += 1;
+                    return [(item as Item).label];
+                  },
+                },
+              ]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    },
+    [keyedRowsBatchPositionHintedRuntimeFeature],
+  );
+  return {
+    Table,
+    counters,
+    customInsert: (position: number, items: readonly Item[]) => customInsert(position, items),
+    insert: (position: number, items: readonly Item[]) => insert(position, items),
+    remove: (position: number, count: number) => remove(position, count),
+    queueTwo: (first: readonly Item[], second: readonly Item[]) => queueTwo(first, second),
+  };
+}
+
+describe("compiled keyed-array batch insertion hints", () => {
+  it("preserves custom method arguments, return values, and errors", () => {
+    const source = [{ id: "a", label: "Alpha" }];
+    const first = { id: "b", label: "Beta" };
+    const second = { id: "c", label: "Gamma" };
+    const calls: unknown[][] = [];
+    const custom = function (this: Item[], ...args: unknown[]) {
+      calls.push([this, ...args]);
+      return { custom: true };
+    };
+
+    expect(createCompilerKeyedArrayBatchInsert(source, custom, -1, first, second)).toEqual({
+      custom: true,
+    });
+    expect(calls).toEqual([[source, -1, 0, first, second]]);
+
+    const error = new Error("custom batch failure");
+    expect(() =>
+      createCompilerKeyedArrayBatchInsert(
+        source,
+        () => {
+          throw error;
+        },
+        0,
+        first,
+        second,
+      ),
+    ).toThrow(error);
+  });
+
+  it("inserts one fragment without reading or replacing existing rows", async () => {
+    const initialItems = Array.from(
+      { length: 4_096 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createBatchHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const before = container.querySelector('[data-key="row-2047"]');
+    const after = container.querySelector('[data-key="row-2048"]');
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+    const incoming = Array.from(
+      { length: 64 },
+      (_, index): Item => ({ id: `insert-${index}`, label: `Insert ${index}` }),
+    );
+
+    await act(async () => {
+      harness.insert(2_048, incoming);
+      await flushCompilerUpdates();
+    });
+
+    const rows = [...container.querySelectorAll("li")];
+    expect(rows[2_047]).toBe(before);
+    expect(rows[2_048]?.textContent).toBe("Insert 0");
+    expect(rows[2_111]?.textContent).toBe("Insert 63");
+    expect(rows[2_112]).toBe(after);
+    expect(rows).toHaveLength(4_160);
+    expect(harness.counters).toEqual({
+      executions: 1,
+      renders: 1,
+      keys: 64,
+      descriptors: 64,
+      bindings: 64,
+    });
+  });
+
+  it("fully falls back before mutation for a key that collides with an existing row", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const harness = createBatchHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.insert(1, [
+        { id: "b", label: "Beta duplicate" },
+        { id: "d", label: "Delta" },
+      ]);
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].map((node) => node.textContent)).toEqual([
+      "Alpha",
+      "Beta duplicate",
+      "Delta",
+      "Beta",
+      "Gamma",
+    ]);
+    expect(harness.counters.keys).toBeGreaterThan(2);
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it("fully falls back for duplicate keys inside the incoming batch", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const harness = createBatchHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.insert(1, [
+        { id: "c", label: "Gamma one" },
+        { id: "c", label: "Gamma two" },
+      ]);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("AlphaGamma oneGamma twoBeta");
+    expect(harness.counters.keys).toBeGreaterThan(2);
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it("falls back when a spread produces fewer than two rows", async () => {
+    const harness = createBatchHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.insert(1, [{ id: "c", label: "Gamma" }]);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("AlphaGammaBeta");
+    expect(harness.counters.keys).toBeGreaterThan(1);
+  });
+
+  it("normalizes negative and oversized native positions", async () => {
+    const harness = createBatchHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.insert(-1, [
+        { id: "d", label: "Delta" },
+        { id: "e", label: "Epsilon" },
+      ]);
+      await flushCompilerUpdates();
+    });
+    await act(async () => {
+      harness.insert(100, [
+        { id: "f", label: "Phi" },
+        { id: "g", label: "Gamma two" },
+      ]);
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].map((node) => node.textContent)).toEqual([
+      "Alpha",
+      "Beta",
+      "Delta",
+      "Epsilon",
+      "Gamma",
+      "Phi",
+      "Gamma two",
+    ]);
+    expect(harness.counters.keys).toBe(4);
+    expect(harness.counters.executions).toBe(1);
+  });
+
+  it("preserves native custom-method behavior and rejects queued metadata", async () => {
+    const harness = createBatchHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+
+    await act(async () => {
+      harness.customInsert(1, [
+        { id: "c", label: "Gamma" },
+        { id: "d", label: "Delta" },
+      ]);
+      await flushCompilerUpdates();
+    });
+    expect([...container.querySelectorAll("li")].map((node) => node.textContent)).toEqual([
+      "Beta",
+      "Delta",
+      "Gamma",
+      "Alpha",
+    ]);
+
+    await act(async () => {
+      harness.queueTwo(
+        [
+          { id: "e", label: "Epsilon" },
+          { id: "f", label: "Phi" },
+        ],
+        [
+          { id: "g", label: "Gamma two" },
+          { id: "h", label: "Eta" },
+        ],
+      );
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("BetaEpsilonGamma twoEtaPhiDeltaGammaAlpha");
+  });
+
+  it("preserves controlled-input focus and updates delegated suffix event indexes", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ];
+    const calls: string[] = [];
+    let insert = () => undefined;
+    const InteractiveRows = createCompiledComponentWithFeatures(
+      {
+        displayName: "BatchInteractiveRows",
+        initialize: () => [initialItems],
+        render(_props: Record<string, never>, state, blocks) {
+          const items = () => state[0].get() as Item[];
+          insert = () =>
+            state[0].set((previous) =>
+              hintedBatchInsert(previous as Item[], 1, [
+                { id: "d", label: "Delta" },
+                { id: "e", label: "Epsilon" },
+              ]),
+            );
+          return (
+            <main>
+              <blocks.KeyedRows
+                collectionDependency={0}
+                delegateEvents
+                dependencies={[0]}
+                events={[
+                  {
+                    invoke: (item, index) => calls.push(`${(item as Item).id}:${index}`),
+                    name: "onClick",
+                    path: [1],
+                  },
+                ]}
+                id={0}
+                items={items}
+                positionIndexIndependent
+                structureDependencies={[0]}
+                render={(event) => (
+                  <ul>
+                    {items().map((item, index) => (
+                      <li data-key={item.id} key={item.id}>
+                        <input aria-label={`Edit ${item.id}`} value={item.label} readOnly />
+                        <button data-row-button={item.id} onClick={event(item, index, 0)}>
+                          Select
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                rowKey={(item) => (item as Item).id}
+                create={(item) => {
+                  const row = item as Item;
+                  return {
+                    kind: "element",
+                    tag: "li",
+                    attributes: [{ name: "data-key", value: row.id }],
+                    styles: [],
+                    children: [
+                      {
+                        kind: "element",
+                        tag: "input",
+                        attributes: [
+                          { name: "aria-label", value: `Edit ${row.id}` },
+                          { name: "value", value: row.label },
+                          { name: "readOnly", value: true },
+                        ],
+                        styles: [],
+                        children: [],
+                      },
+                      {
+                        kind: "element",
+                        tag: "button",
+                        attributes: [{ name: "data-row-button", value: row.id }],
+                        styles: [],
+                        children: ["Select"],
+                      },
+                    ],
+                  };
+                }}
+                bindings={[]}
+              />
+            </main>
+          );
+        },
+        bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+      },
+      [keyedRowsBatchPositionHintedRuntimeFeature],
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<InteractiveRows />));
+    const input = container.querySelector('[aria-label="Edit c"]') as HTMLInputElement;
+    input.focus();
+    input.setSelectionRange(1, 3);
+
+    await act(async () => {
+      insert();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector('[aria-label="Edit c"]')).toBe(input);
+    expect(document.activeElement).toBe(input);
+    expect([input.selectionStart, input.selectionEnd]).toEqual([1, 3]);
+
+    await act(async () => {
+      (container.querySelector('[data-row-button="d"]') as HTMLButtonElement).click();
+      (container.querySelector('[data-row-button="c"]') as HTMLButtonElement).click();
+    });
+    expect(calls).toEqual(["d:1", "c:4"]);
+  });
+
+  it("matches normal React through 1,000 deterministic batch insertions", async () => {
+    const initialItems = Array.from(
+      { length: 16 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createBatchHarness(initialItems);
+    let updateReact: (position: number, incoming: readonly Item[]) => void = () => undefined;
+    let removeReact: (position: number, count: number) => void = () => undefined;
+    function NormalTable() {
+      const [items, setItems] = useState(initialItems);
+      updateReact = (position, incoming) =>
+        setItems((previous) => [
+          ...previous.slice(0, position),
+          ...incoming,
+          ...previous.slice(position),
+        ]);
+      removeReact = (position, count) =>
+        setItems((previous) => [
+          ...previous.slice(0, position),
+          ...previous.slice(position + count),
+        ]);
+      return (
+        <ol>
+          {items.map((item) => (
+            <li key={item.id}>{item.label}</li>
+          ))}
+        </ol>
+      );
+    }
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<harness.Table />);
+      reactRoot.render(<NormalTable />);
+    });
+
+    for (let step = 0; step < 1_000; step += 1) {
+      const position = (step * 37) % (initialItems.length + 1);
+      const incoming = Array.from(
+        { length: (step % 5) + 2 },
+        (_, offset): Item => ({
+          id: `insert-${step}-${offset}`,
+          label: `Insert ${step}.${offset}`,
+        }),
+      );
+      await act(async () => {
+        harness.insert(position, incoming);
+        updateReact(position, incoming);
+        await flushCompilerUpdates();
+      });
+      expect(compiledContainer.querySelector("ul")?.textContent).toBe(
+        reactContainer.querySelector("ol")?.textContent,
+      );
+      await act(async () => {
+        harness.remove(position, incoming.length);
+        removeReact(position, incoming.length);
+        await flushCompilerUpdates();
+      });
+      expect(compiledContainer.querySelector("ul")?.textContent).toBe(
+        reactContainer.querySelector("ol")?.textContent,
+      );
+    }
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
+  }, 15_000);
+
+  it("hydrates in StrictMode and drops a queued batch after unmount", async () => {
+    const harness = createBatchHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+    ]);
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(
+      <StrictMode>
+        <harness.Table />
+      </StrictMode>,
+    );
+    document.body.append(container);
+    const recoverable: unknown[] = [];
+    let root!: Root;
+    await act(async () => {
+      root = hydrateRoot(
+        container,
+        <StrictMode>
+          <harness.Table />
+        </StrictMode>,
+        { onRecoverableError: (error) => recoverable.push(error) },
+      );
+    });
+    roots.push(root);
+
+    await act(async () => {
+      harness.insert(1, [
+        { id: "c", label: "Gamma" },
+        { id: "d", label: "Delta" },
+      ]);
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("AlphaGammaDeltaBeta");
+    expect(recoverable).toEqual([]);
+
+    roots.pop();
+    act(() => {
+      harness.insert(0, [
+        { id: "e", label: "Epsilon" },
+        { id: "f", label: "Phi" },
+      ]);
+      root.unmount();
+    });
+    await flushCompilerUpdates();
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -53,6 +53,13 @@ interface CompilerKeyedArrayPositionHint {
   readonly position: number;
 }
 
+interface CompilerKeyedArrayBatchInsertHint {
+  readonly sourceToken: object;
+  readonly sourceLength: number;
+  readonly resultLength: number;
+  readonly position: number;
+}
+
 interface CompilerKeyedArrayReorderHint {
   readonly kind: "reverse" | "sort";
   readonly sourceToken: object;
@@ -99,6 +106,10 @@ const COMPILER_KEYED_ARRAY_ROLLING_WINDOWS = /* @__PURE__ */ new WeakMap<
 const COMPILER_KEYED_ARRAY_POSITIONS = /* @__PURE__ */ new WeakMap<
   object,
   CompilerKeyedArrayPositionHint
+>();
+const COMPILER_KEYED_ARRAY_BATCH_INSERTS = /* @__PURE__ */ new WeakMap<
+  object,
+  CompilerKeyedArrayBatchInsertHint
 >();
 const COMPILER_KEYED_ARRAY_REORDERS = /* @__PURE__ */ new WeakMap<
   object,
@@ -334,6 +345,28 @@ function compilerKeyedArrayPosition(
       (update.resultLength >= expectedLength || update.position > update.resultLength)) ||
     (update.kind === "replace" &&
       (update.position >= expectedLength || update.resultLength !== expectedLength))
+  ) {
+    return undefined;
+  }
+  return update;
+}
+
+function compilerKeyedArrayBatchInsert(
+  value: unknown,
+  sourceToken: object | undefined,
+  expectedLength: number,
+): CompilerKeyedArrayBatchInsertHint | undefined {
+  const target = compilerObject(value);
+  if (!target || !sourceToken || !Array.isArray(value)) return undefined;
+  const update = COMPILER_KEYED_ARRAY_BATCH_INSERTS.get(target);
+  if (
+    !update ||
+    update.sourceToken !== sourceToken ||
+    update.sourceLength !== expectedLength ||
+    update.resultLength !== value.length ||
+    update.resultLength < expectedLength + 2 ||
+    update.position < 0 ||
+    update.position > expectedLength
   ) {
     return undefined;
   }
@@ -743,6 +776,57 @@ export function createCompilerKeyedArrayPositionUpdate(
       sourceLength,
       resultLength: value.length,
       position: normalizedPosition,
+    });
+  } catch {
+    // Metadata must never change the result of a successful native update.
+  }
+  return value;
+}
+
+/** @internal Executes a native exact-position batch insertion and records it. */
+export function createCompilerKeyedArrayBatchInsert(
+  previous: unknown,
+  method: unknown,
+  position: number,
+  ...items: readonly unknown[]
+): unknown {
+  const value = NATIVE_REFLECT_APPLY(
+    method as (...values: readonly unknown[]) => unknown,
+    previous,
+    [position, 0, ...items],
+  );
+
+  try {
+    const previousTarget = compilerObject(previous);
+    const valueTarget = compilerObject(value);
+    if (
+      !previousTarget ||
+      !valueTarget ||
+      !COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget) ||
+      !Array.isArray(previous) ||
+      !Array.isArray(value) ||
+      Object.getPrototypeOf(previous) !== NATIVE_ARRAY_PROTOTYPE ||
+      Object.getPrototypeOf(value) !== NATIVE_ARRAY_PROTOTYPE ||
+      method !== NATIVE_ARRAY_TO_SPLICED ||
+      !Number.isSafeInteger(position) ||
+      items.length < 2 ||
+      value.length !== previous.length + items.length
+    ) {
+      return value;
+    }
+    for (let index = 0; index < previous.length; index += 1) {
+      if (!Object.prototype.hasOwnProperty.call(previous, index)) return value;
+    }
+    const sourceToken = compilerKeyedCollectionToken(previousTarget);
+    if (!sourceToken) return value;
+    COMPILER_KEYED_ARRAY_BATCH_INSERTS.set(valueTarget, {
+      sourceToken,
+      sourceLength: previous.length,
+      resultLength: value.length,
+      position:
+        position < 0
+          ? Math.max(previous.length + position, 0)
+          : Math.min(position, previous.length),
     });
   } catch {
     // Metadata must never change the result of a successful native update.
@@ -4060,6 +4144,11 @@ const keyedPositionUpdateRuntime: KeyedUpdateRuntime = {
   position: reconcileCompilerKeyedArrayPosition,
 };
 
+const keyedBatchPositionUpdateRuntime: KeyedUpdateRuntime = {
+  ...keyedUpdateRuntime,
+  position: reconcileCompilerKeyedArrayPositionWithBatch,
+};
+
 const keyedReorderUpdateRuntime: KeyedUpdateRuntime = {
   ...keyedUpdateRuntime,
   reorder: reconcileCompilerKeyedArrayReorder,
@@ -4074,6 +4163,11 @@ const keyedEveryUpdateRuntime: KeyedUpdateRuntime = {
   ...keyedCompleteUpdateRuntime,
   position: reconcileCompilerKeyedArrayPosition,
   reorder: reconcileCompilerKeyedArrayReorder,
+};
+
+const keyedBatchEveryUpdateRuntime: KeyedUpdateRuntime = {
+  ...keyedEveryUpdateRuntime,
+  position: reconcileCompilerKeyedArrayPositionWithBatch,
 };
 
 interface KeyedRowsRuntimeOptions {
@@ -4419,6 +4513,90 @@ function reconcileCompilerKeyedArrayPosition(
   previous.element.replaceWith(replacement.element);
   previousInstances[update.position] = replacement;
   return new Map(previousInstances.map((instance) => [instance.key, instance]));
+}
+
+function reconcileCompilerKeyedArrayBatchInsert(
+  props: CompilerKeyedRowsBlockProps,
+  dirtyState: ReadonlySet<number>,
+  collectionToken: object | undefined,
+  instances: ReadonlyMap<string, CompilerKeyedRowInstance>,
+  root: Element,
+  reactOwnedRows: boolean,
+): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
+  if (
+    reactOwnedRows ||
+    props.hostBlocks ||
+    (props.conditionals?.length || 0) > 0 ||
+    !props.positionIndexIndependent ||
+    props.collectionDependency === undefined
+  ) {
+    return undefined;
+  }
+  const collectionDependency = props.collectionDependency;
+  if (props.bindings.some((binding) => binding.dependencies?.includes(collectionDependency))) {
+    return undefined;
+  }
+  const dependencies = props.dependencies || props.structureDependencies;
+  const relevantDirty = (dependencies || []).filter((index) => dirtyState.has(index));
+  if (relevantDirty.length !== 1 || relevantDirty[0] !== collectionDependency) {
+    return undefined;
+  }
+
+  const finalValue = props.items();
+  const update = compilerKeyedArrayBatchInsert(finalValue, collectionToken, instances.size);
+  if (!update || !Array.isArray(finalValue)) return undefined;
+  const previousInstances = [...instances.values()];
+  const insertCount = update.resultLength - update.sourceLength;
+  for (let sourceIndex = 0; sourceIndex < update.sourceLength; sourceIndex += 1) {
+    const instance = previousInstances[sourceIndex];
+    const resultIndex = sourceIndex < update.position ? sourceIndex : sourceIndex + insertCount;
+    if (
+      !instance ||
+      instance.index !== sourceIndex ||
+      !Object.is(instance.item, finalValue[resultIndex])
+    ) {
+      return undefined;
+    }
+  }
+  const knownKeys = new Set(instances.keys());
+  const incoming: CompilerKeyedRowInstance[] = [];
+  try {
+    for (let offset = 0; offset < insertCount; offset += 1) {
+      const index = update.position + offset;
+      const item = finalValue[index];
+      const key = keyedRowIdentity(props.rowKey(item, index));
+      if (knownKeys.has(key)) return undefined;
+      knownKeys.add(key);
+      const descriptor = props.create(item, index);
+      incoming.push({
+        key,
+        element: createCompilerHostElement(root.ownerDocument, descriptor),
+        values: readKeyedRowBindingValues(props, item, index),
+        item,
+        index,
+        conditionalValues: EMPTY_KEYED_ROW_CONDITIONAL_VALUES,
+      });
+    }
+  } catch {
+    return undefined;
+  }
+
+  const fragment = root.ownerDocument.createDocumentFragment();
+  for (const instance of incoming) fragment.append(instance.element);
+  root.insertBefore(fragment, previousInstances[update.position]?.element || null);
+  previousInstances.splice(update.position, 0, ...incoming);
+  for (let index = update.position + insertCount; index < previousInstances.length; index += 1) {
+    previousInstances[index].index = index;
+  }
+  return new Map(previousInstances.map((instance) => [instance.key, instance]));
+}
+
+function reconcileCompilerKeyedArrayPositionWithBatch(
+  ...args: Parameters<typeof reconcileCompilerKeyedArrayPosition>
+): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
+  return (
+    reconcileCompilerKeyedArrayBatchInsert(...args) || reconcileCompilerKeyedArrayPosition(...args)
+  );
 }
 
 function reconcileCompilerKeyedArrayReorder(
@@ -6381,6 +6559,15 @@ export const keyedRowsPositionHintedRuntimeFeature: CompilerRuntimeFeature = {
   }),
 };
 
+export const keyedRowsBatchPositionHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:batch-position-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      keyedUpdates: keyedBatchPositionUpdateRuntime,
+    }),
+  }),
+};
+
 export const keyedRowsReorderHintedRuntimeFeature: CompilerRuntimeFeature = {
   name: "keyed-rows:reorder-hinted",
   create: (owner) => ({
@@ -6404,6 +6591,15 @@ export const keyedRowsEveryHintedRuntimeFeature: CompilerRuntimeFeature = {
   create: (owner) => ({
     KeyedRows: createKeyedRowsBlockComponent(owner, {
       keyedUpdates: keyedEveryUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsBatchEveryHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:batch-every-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      keyedUpdates: keyedBatchEveryUpdateRuntime,
     }),
   }),
 };
@@ -6464,6 +6660,16 @@ export const keyedRowsConditionalPositionHintedRuntimeFeature: CompilerRuntimeFe
   }),
 };
 
+export const keyedRowsConditionalBatchPositionHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:conditional:batch-position-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      keyedUpdates: keyedBatchPositionUpdateRuntime,
+    }),
+  }),
+};
+
 export const keyedRowsConditionalReorderHintedRuntimeFeature: CompilerRuntimeFeature = {
   name: "keyed-rows:conditional:reorder-hinted",
   create: (owner) => ({
@@ -6490,6 +6696,16 @@ export const keyedRowsConditionalEveryHintedRuntimeFeature: CompilerRuntimeFeatu
     KeyedRows: createKeyedRowsBlockComponent(owner, {
       conditionals: createKeyedRowConditionalRuntime(),
       keyedUpdates: keyedEveryUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsConditionalBatchEveryHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:conditional:batch-every-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      keyedUpdates: keyedBatchEveryUpdateRuntime,
     }),
   }),
 };
@@ -6553,6 +6769,16 @@ export const keyedRowsHostPositionHintedRuntimeFeature: CompilerRuntimeFeature =
   }),
 };
 
+export const keyedRowsHostBatchPositionHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:host:batch-position-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedUpdates: keyedBatchPositionUpdateRuntime,
+    }),
+  }),
+};
+
 export const keyedRowsHostReorderHintedRuntimeFeature: CompilerRuntimeFeature = {
   name: "keyed-rows:host:reorder-hinted",
   create: (owner) => ({
@@ -6579,6 +6805,16 @@ export const keyedRowsHostEveryHintedRuntimeFeature: CompilerRuntimeFeature = {
     KeyedRows: createKeyedRowsBlockComponent(owner, {
       hostBlocks: createKeyedRowHostRuntime(),
       keyedUpdates: keyedEveryUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsHostBatchEveryHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:host:batch-every-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedUpdates: keyedBatchEveryUpdateRuntime,
     }),
   }),
 };
@@ -6645,6 +6881,17 @@ export const keyedRowsCompletePositionHintedRuntimeFeature: CompilerRuntimeFeatu
   }),
 };
 
+export const keyedRowsCompleteBatchPositionHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:complete:batch-position-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedUpdates: keyedBatchPositionUpdateRuntime,
+    }),
+  }),
+};
+
 export const keyedRowsCompleteReorderHintedRuntimeFeature: CompilerRuntimeFeature = {
   name: "keyed-rows:complete:reorder-hinted",
   create: (owner) => ({
@@ -6674,6 +6921,17 @@ export const keyedRowsCompleteEveryHintedRuntimeFeature: CompilerRuntimeFeature 
       conditionals: createKeyedRowConditionalRuntime(),
       hostBlocks: createKeyedRowHostRuntime(),
       keyedUpdates: keyedEveryUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsCompleteBatchEveryHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:complete:batch-every-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedUpdates: keyedBatchEveryUpdateRuntime,
     }),
   }),
 };
@@ -7293,7 +7551,7 @@ const COMPLETE_RUNTIME_FEATURES: readonly CompilerRuntimeFeature[] = [
   hostConditionalRuntimeFeature,
   conditionalRangesRuntimeFeature,
   keyedListRuntimeFeature,
-  keyedRowsCompleteEveryHintedRuntimeFeature,
+  keyedRowsCompleteBatchEveryHintedRuntimeFeature,
   keyedRangesRuntimeFeature,
   mixedRangesRuntimeFeature,
   componentRuntimeFeature,

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -368,36 +368,44 @@ type CompilerRuntimeFeatureName =
   | "keyed-rows"
   | "keyed-rows-hinted"
   | "keyed-rows-position-hinted"
+  | "keyed-rows-batch-position-hinted"
   | "keyed-rows-reorder-hinted"
   | "keyed-rows-all-hinted"
   | "keyed-rows-every-hinted"
+  | "keyed-rows-batch-every-hinted"
   | "keyed-rows-filter-hinted"
   | "keyed-rows-prepend-hinted"
   | "keyed-rows-filter-prepend-hinted"
   | "keyed-rows-conditional"
   | "keyed-rows-conditional-hinted"
   | "keyed-rows-conditional-position-hinted"
+  | "keyed-rows-conditional-batch-position-hinted"
   | "keyed-rows-conditional-reorder-hinted"
   | "keyed-rows-conditional-all-hinted"
   | "keyed-rows-conditional-every-hinted"
+  | "keyed-rows-conditional-batch-every-hinted"
   | "keyed-rows-conditional-filter-hinted"
   | "keyed-rows-conditional-prepend-hinted"
   | "keyed-rows-conditional-filter-prepend-hinted"
   | "keyed-rows-host"
   | "keyed-rows-host-hinted"
   | "keyed-rows-host-position-hinted"
+  | "keyed-rows-host-batch-position-hinted"
   | "keyed-rows-host-reorder-hinted"
   | "keyed-rows-host-all-hinted"
   | "keyed-rows-host-every-hinted"
+  | "keyed-rows-host-batch-every-hinted"
   | "keyed-rows-host-filter-hinted"
   | "keyed-rows-host-prepend-hinted"
   | "keyed-rows-host-filter-prepend-hinted"
   | "keyed-rows-complete"
   | "keyed-rows-complete-hinted"
   | "keyed-rows-complete-position-hinted"
+  | "keyed-rows-complete-batch-position-hinted"
   | "keyed-rows-complete-reorder-hinted"
   | "keyed-rows-complete-all-hinted"
   | "keyed-rows-complete-every-hinted"
+  | "keyed-rows-complete-batch-every-hinted"
   | "keyed-rows-complete-filter-hinted"
   | "keyed-rows-complete-prepend-hinted"
   | "keyed-rows-complete-filter-prepend-hinted"
@@ -413,18 +421,23 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
   "keyed-rows": "keyedRowsRuntimeFeature",
   "keyed-rows-hinted": "keyedRowsHintedRuntimeFeature",
   "keyed-rows-position-hinted": "keyedRowsPositionHintedRuntimeFeature",
+  "keyed-rows-batch-position-hinted": "keyedRowsBatchPositionHintedRuntimeFeature",
   "keyed-rows-reorder-hinted": "keyedRowsReorderHintedRuntimeFeature",
   "keyed-rows-all-hinted": "keyedRowsAllHintedRuntimeFeature",
   "keyed-rows-every-hinted": "keyedRowsEveryHintedRuntimeFeature",
+  "keyed-rows-batch-every-hinted": "keyedRowsBatchEveryHintedRuntimeFeature",
   "keyed-rows-filter-hinted": "keyedRowsFilterHintedRuntimeFeature",
   "keyed-rows-prepend-hinted": "keyedRowsPrependHintedRuntimeFeature",
   "keyed-rows-filter-prepend-hinted": "keyedRowsFilterPrependHintedRuntimeFeature",
   "keyed-rows-conditional": "keyedRowsConditionalRuntimeFeature",
   "keyed-rows-conditional-hinted": "keyedRowsConditionalHintedRuntimeFeature",
   "keyed-rows-conditional-position-hinted": "keyedRowsConditionalPositionHintedRuntimeFeature",
+  "keyed-rows-conditional-batch-position-hinted":
+    "keyedRowsConditionalBatchPositionHintedRuntimeFeature",
   "keyed-rows-conditional-reorder-hinted": "keyedRowsConditionalReorderHintedRuntimeFeature",
   "keyed-rows-conditional-all-hinted": "keyedRowsConditionalAllHintedRuntimeFeature",
   "keyed-rows-conditional-every-hinted": "keyedRowsConditionalEveryHintedRuntimeFeature",
+  "keyed-rows-conditional-batch-every-hinted": "keyedRowsConditionalBatchEveryHintedRuntimeFeature",
   "keyed-rows-conditional-filter-hinted": "keyedRowsConditionalFilterHintedRuntimeFeature",
   "keyed-rows-conditional-prepend-hinted": "keyedRowsConditionalPrependHintedRuntimeFeature",
   "keyed-rows-conditional-filter-prepend-hinted":
@@ -432,18 +445,22 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
   "keyed-rows-host": "keyedRowsHostRuntimeFeature",
   "keyed-rows-host-hinted": "keyedRowsHostHintedRuntimeFeature",
   "keyed-rows-host-position-hinted": "keyedRowsHostPositionHintedRuntimeFeature",
+  "keyed-rows-host-batch-position-hinted": "keyedRowsHostBatchPositionHintedRuntimeFeature",
   "keyed-rows-host-reorder-hinted": "keyedRowsHostReorderHintedRuntimeFeature",
   "keyed-rows-host-all-hinted": "keyedRowsHostAllHintedRuntimeFeature",
   "keyed-rows-host-every-hinted": "keyedRowsHostEveryHintedRuntimeFeature",
+  "keyed-rows-host-batch-every-hinted": "keyedRowsHostBatchEveryHintedRuntimeFeature",
   "keyed-rows-host-filter-hinted": "keyedRowsHostFilterHintedRuntimeFeature",
   "keyed-rows-host-prepend-hinted": "keyedRowsHostPrependHintedRuntimeFeature",
   "keyed-rows-host-filter-prepend-hinted": "keyedRowsHostFilterPrependHintedRuntimeFeature",
   "keyed-rows-complete": "keyedRowsCompleteRuntimeFeature",
   "keyed-rows-complete-hinted": "keyedRowsCompleteHintedRuntimeFeature",
   "keyed-rows-complete-position-hinted": "keyedRowsCompletePositionHintedRuntimeFeature",
+  "keyed-rows-complete-batch-position-hinted": "keyedRowsCompleteBatchPositionHintedRuntimeFeature",
   "keyed-rows-complete-reorder-hinted": "keyedRowsCompleteReorderHintedRuntimeFeature",
   "keyed-rows-complete-all-hinted": "keyedRowsCompleteAllHintedRuntimeFeature",
   "keyed-rows-complete-every-hinted": "keyedRowsCompleteEveryHintedRuntimeFeature",
+  "keyed-rows-complete-batch-every-hinted": "keyedRowsCompleteBatchEveryHintedRuntimeFeature",
   "keyed-rows-complete-filter-hinted": "keyedRowsCompleteFilterHintedRuntimeFeature",
   "keyed-rows-complete-prepend-hinted": "keyedRowsCompletePrependHintedRuntimeFeature",
   "keyed-rows-complete-filter-prepend-hinted": "keyedRowsCompleteFilterPrependHintedRuntimeFeature",
@@ -458,6 +475,7 @@ function runtimeFeaturesForPlans(
   keyedArrayFilterHints: boolean,
   keyedArrayPrependHints: boolean,
   keyedArrayPositionHints: boolean,
+  keyedArrayBatchInsertHints: boolean,
   keyedArrayReorderHints: boolean,
   keyedArrayRollingWindowHints: boolean,
 ): CompilerRuntimeFeatureName[] {
@@ -485,9 +503,12 @@ function runtimeFeaturesForPlans(
             : "keyed-rows";
     const arrayRangeHints =
       keyedArrayRollingWindowHints || keyedArrayFilterHints || keyedArrayPrependHints;
-    const hintSuffix =
-      (keyedArrayPositionHints && (arrayRangeHints || keyedArrayReorderHints)) ||
-      (keyedArrayReorderHints && arrayRangeHints)
+    const hintSuffix = keyedArrayBatchInsertHints
+      ? arrayRangeHints || keyedArrayReorderHints
+        ? "-batch-every-hinted"
+        : "-batch-position-hinted"
+      : (keyedArrayPositionHints && (arrayRangeHints || keyedArrayReorderHints)) ||
+          (keyedArrayReorderHints && arrayRangeHints)
         ? "-every-hinted"
         : keyedArrayRollingWindowHints
           ? "-all-hinted"
@@ -1592,14 +1613,26 @@ function rewriteKeyedArrayPositionHints(
   hintedStateIndices: ReadonlySet<number>,
   statesBySetter: ReadonlyMap<string, StateBinding>,
   helperIdentifier: t.Identifier,
+  batchInsertHelperIdentifier: t.Identifier,
   safeGlobals: ReadonlySet<string>,
-): { root: t.JSXElement; count: number; stateIndices: ReadonlySet<number> } {
+): {
+  root: t.JSXElement;
+  count: number;
+  batchInsertCount: number;
+  stateIndices: ReadonlySet<number>;
+} {
   if (hintedStateIndices.size === 0) {
-    return { root: t.cloneNode(root, true), count: 0, stateIndices: new Set() };
+    return {
+      root: t.cloneNode(root, true),
+      count: 0,
+      batchInsertCount: 0,
+      stateIndices: new Set(),
+    };
   }
   const file = expressionFile(t.cloneNode(root, true));
   const stateIndices = new Set<number>();
   let count = 0;
+  let batchInsertCount = 0;
   traverse(file, {
     CallExpression(path) {
       const callee = path.get("callee");
@@ -1626,12 +1659,18 @@ function rewriteKeyedArrayPositionHints(
 
       const methodName = updater.body.callee.property.name;
       const args = updater.body.arguments;
+      const isBatchInsert =
+        methodName === "toSpliced" &&
+        args.length >= 3 &&
+        t.isNumericLiteral(args[1], { value: 0 }) &&
+        (args.length > 3 || t.isSpreadElement(args[2]));
       const toSplicedDeleteCount =
         methodName === "toSpliced" && args.length === 2 && t.isNumericLiteral(args[1])
           ? args[1].value
           : undefined;
-      const kind =
-        methodName === "with" && args.length === 2
+      const kind = isBatchInsert
+        ? "batch-insert"
+        : methodName === "with" && args.length === 2
           ? "replace"
           : methodName === "toSpliced" &&
               args.length === 3 &&
@@ -1648,11 +1687,18 @@ function rewriteKeyedArrayPositionHints(
                 : undefined;
       if (!kind || !t.isExpression(args[0])) return;
       const position = args[0];
-      const item = kind === "remove" ? undefined : args.at(-1);
+      const incoming = kind === "batch-insert" ? args.slice(2) : [args.at(-1)];
       if (
         validateKeyedArrayPositionExpression(position, safeGlobals) !== undefined ||
-        (item !== undefined &&
-          (!t.isExpression(item) || validateDerivedExpression(item, safeGlobals) !== undefined))
+        (kind !== "remove" &&
+          incoming.some((item) => {
+            const expression = t.isSpreadElement(item) ? item.argument : item;
+            return (
+              !expression ||
+              !t.isExpression(expression) ||
+              validateDerivedExpression(expression, safeGlobals) !== undefined
+            );
+          }))
       ) {
         return;
       }
@@ -1671,16 +1717,24 @@ function rewriteKeyedArrayPositionHints(
             ),
           ]),
           t.returnStatement(
-            t.callExpression(t.cloneNode(helperIdentifier), [
-              t.cloneNode(previous),
-              t.cloneNode(method),
-              t.stringLiteral(kind),
-              ...args.map((argument) => t.cloneNode(argument, true)),
-            ]),
+            kind === "batch-insert"
+              ? t.callExpression(t.cloneNode(batchInsertHelperIdentifier), [
+                  t.cloneNode(previous),
+                  t.cloneNode(method),
+                  t.cloneNode(position, true),
+                  ...args.slice(2).map((argument) => t.cloneNode(argument, true)),
+                ])
+              : t.callExpression(t.cloneNode(helperIdentifier), [
+                  t.cloneNode(previous),
+                  t.cloneNode(method),
+                  t.stringLiteral(kind),
+                  ...args.map((argument) => t.cloneNode(argument, true)),
+                ]),
           ),
         ]),
       );
       count += 1;
+      if (kind === "batch-insert") batchInsertCount += 1;
       stateIndices.add(state.index);
       path.skip();
     },
@@ -1688,6 +1742,7 @@ function rewriteKeyedArrayPositionHints(
   return {
     root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement,
     count,
+    batchInsertCount,
     stateIndices,
   };
 }
@@ -6730,6 +6785,7 @@ function compileCandidate(
   keyedArrayFilterIdentifier: t.Identifier,
   keyedArrayPrependIdentifier: t.Identifier,
   keyedArrayPositionIdentifier: t.Identifier,
+  keyedArrayBatchInsertIdentifier: t.Identifier,
   keyedArrayReorderIdentifier: t.Identifier,
   keyedArraySortIdentifier: t.Identifier,
   keyedArrayRollingWindowIdentifier: t.Identifier,
@@ -6753,6 +6809,7 @@ function compileCandidate(
     keyedMembershipTargets: number;
     keyedMapUpdateHints: number;
   },
+  compilerUsage: { keyedArrayBatchInsertHints: number },
   useStateNames: ReadonlySet<string>,
   reactNames: ReadonlySet<string>,
   listNames: ReadonlySet<string>,
@@ -7179,9 +7236,11 @@ function compileCandidate(
     shiftedIndexIndependentStateIndices,
     statesBySetter,
     keyedArrayPositionIdentifier,
+    keyedArrayBatchInsertIdentifier,
     safeGlobals,
   );
   let appliedKeyedArrayPositionHints = 0;
+  let appliedKeyedArrayBatchInsertHints = 0;
   let appliedPositionHintedStateIndices: ReadonlySet<number> = new Set();
   if (positionHintedRoot.count > 0) {
     const hintedBlockAnalysis = analyzeComposableBlocks(
@@ -7205,8 +7264,10 @@ function compileCandidate(
       blockAnalysis = hintedBlockAnalysis;
       analysis = hintedAnalysis;
       appliedKeyedArrayPositionHints = positionHintedRoot.count;
+      appliedKeyedArrayBatchInsertHints = positionHintedRoot.batchInsertCount;
       appliedPositionHintedStateIndices = positionHintedRoot.stateIndices;
       optimizationCounts.keyedArrayPositionHints += positionHintedRoot.count;
+      compilerUsage.keyedArrayBatchInsertHints += positionHintedRoot.batchInsertCount;
     }
   }
   const reorderHintedRoot = rewriteKeyedArrayReorderHints(
@@ -7444,6 +7505,7 @@ function compileCandidate(
     hasKeyedArrayRemovalHints,
     appliedKeyedArrayPrependHints > 0,
     appliedKeyedArrayPositionHints > 0,
+    appliedKeyedArrayBatchInsertHints > 0,
     appliedKeyedArrayReorderHints > 0 || appliedKeyedArraySortHints > 0,
     appliedKeyedArrayRollingWindowHints > 0,
   );
@@ -7654,6 +7716,7 @@ export async function compileReactModule(
     keyedMembershipTargets: 0,
     keyedMapUpdateHints: 0,
   };
+  const compilerUsage = { keyedArrayBatchInsertHints: 0 };
   const plugin = (): PluginObj => ({
     name: "farm-react-aot",
     visitor: {
@@ -7706,6 +7769,9 @@ export async function compileReactModule(
         const keyedArrayPositionIdentifier = programPath.scope.generateUidIdentifier(
           "createCompilerKeyedArrayPositionUpdate",
         );
+        const keyedArrayBatchInsertIdentifier = programPath.scope.generateUidIdentifier(
+          "createCompilerKeyedArrayBatchInsert",
+        );
         const keyedArrayReorderIdentifier = programPath.scope.generateUidIdentifier(
           "createCompilerKeyedArrayReorder",
         );
@@ -7750,6 +7816,7 @@ export async function compileReactModule(
             keyedArrayFilterIdentifier,
             keyedArrayPrependIdentifier,
             keyedArrayPositionIdentifier,
+            keyedArrayBatchInsertIdentifier,
             keyedArrayReorderIdentifier,
             keyedArraySortIdentifier,
             keyedArrayRollingWindowIdentifier,
@@ -7759,6 +7826,7 @@ export async function compileReactModule(
             runtimeFeatureIdentifiers,
             usedRuntimeFeatures,
             optimizationCounts,
+            compilerUsage,
             useStateNames,
             reactNames,
             listNames,
@@ -7817,11 +7885,20 @@ export async function compileReactModule(
                       ),
                     ]
                   : []),
-                ...(optimizationCounts.keyedArrayPositionHints > 0
+                ...(optimizationCounts.keyedArrayPositionHints >
+                compilerUsage.keyedArrayBatchInsertHints
                   ? [
                       t.importSpecifier(
                         keyedArrayPositionIdentifier,
                         t.identifier("createCompilerKeyedArrayPositionUpdate"),
+                      ),
+                    ]
+                  : []),
+                ...(compilerUsage.keyedArrayBatchInsertHints > 0
+                  ? [
+                      t.importSpecifier(
+                        keyedArrayBatchInsertIdentifier,
+                        t.identifier("createCompilerKeyedArrayBatchInsert"),
                       ),
                     ]
                   : []),


### PR DESCRIPTION
## Problem

The React AOT compiler already optimizes one keyed-row insertion at a known position, but native `toSpliced(position, 0, ...items)` updates with multiple incoming rows fall back to complete keyed reconciliation. That rereads the existing 10,000-row collection even though the source, position, and retained row identities are known.

## Root cause

The compiler position metadata can describe only one inserted item. The keyed runtime therefore has no proof that a multi-row result is exactly one contiguous insertion, and cannot safely skip the complete scan.

## Change

- Recognize concise native `toSpliced(position, 0, first, second)` and safe spread forms.
- Emit a separate batch-insertion helper and tree-shaken runtime feature.
- Preserve ordinary method lookup, argument order, return values, coercion, and thrown errors.
- Validate the committed source token, native ordinary arrays, safe position, result length, retained item identity, and all incoming keys before live DOM mutation.
- Prepare every incoming descriptor, binding snapshot, and host row first, then insert one document fragment and shift only suffix indexes.
- Keep the public compiler report under the existing `keyedArrayPositionHints` count.
- Add an isolated 64-row middle-insertion workload and an independent persistence gate to the existing dashboard benchmark.

## Safety and compatibility

Custom methods, sparse or subclassed sources, fewer than two runtime spread items, queued hints, reused or duplicate keys, collection-reading or index-aware rows, React-owned rows, nested host blocks or conditionals, unrelated dirty state, and failed validation use the complete existing reconciliation path. No DOM node is mutated until every incoming row has been prepared and every retained identity has been checked.

Normal React fallback behavior, controlled-input focus and selection, delegated events, hydration, Strict Mode, unmount cleanup, and React 18/19 behavior are covered. Compiler-disabled builds do not include the feature. Modules that emit only the older single-row position hints do not retain the batch helper or runtime capability.

## Verification

- `pnpm --filter @farm.js/react test` — 67 files, 577 tests passed.
- `pnpm --filter @farm.js/react type-check` — passed.
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8 passed.
- `pnpm --filter @farm.js/react test:runtime-size` — passed. Batch-only compiler premium: 12,470 B gzip; direct and core-only premiums remain 3,678 B and 3,766 B.
- `pnpm --filter farm-react-compiler-dashboard-example type-check` — passed.
- `pnpm --filter farm-react-compiler-dashboard-example build` — production build passed.
- `pnpm docs:check-navigation` and `pnpm --dir docs exec farm generate --check` — passed.
- `pnpm docs:build` — Vercel production build passed.
- Focused `oxfmt` and `oxlint` — passed with zero lint findings.
- Full production browser benchmark — PASS on Chromium 145, macOS arm64, Apple M1, Node 23.11.0. Inserting 64 rows into the middle of 10,000 measured 8.50 ms in static and hybrid modes versus a 71.70 ms bracketed React median: 8.44x faster. The compiled snapshot controls measured 20.80 ms and 21.80 ms: 2.45x and 2.56x slower than the hinted path. All existing correctness, performance, persistence, and scalability gates remained green.

## Documentation and release

Updated the React renderer docs, package README, dashboard benchmark documentation, reproducible browser result, compatibility suite, and runtime-size fixture. No template, generated route, version, or release-flow change is required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up keyed array insertions with multiple incoming rows by batching them into a single position-hinted update, instead of falling back to full keyed reconciliation. Previously only single-row insertions were optimized; multi-row `toSpliced(position, 0, ...items)` and explicit pair calls reread all existing rows.

**Implementation**
- Adds a batch-insertion runtime feature and compiler rewrite for concise `toSpliced(position, 0, ...items)` and explicit two-item calls.
- Validates native source, result length, retained identity, and keys before touching the live DOM.
- Prepares all descriptors, bindings, and host rows upfront, then inserts one fragment and shifts suffix indexes.

**Compatibility**
- Custom methods, sparse arrays, fewer than two items, duplicate keys, and other unsafe cases fall back to the existing reconciliation path.
- Tree-shaken; modules that only emit single-row hints don't include the batch helper.
- Public report count stays under `keyedArrayPositionHints`.
- Benchmark: 64-row middle insert into 10,000 rows runs 8.44x faster than React (8.50 ms vs 71.70 ms median).

<sup>Written for commit a87704cf3237b9c230f7ee43a75801095c181cbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

