### PR TITLE
fix(build): run the plugin configure hook during builds

### DIFF
--- a/docs/src/app/docs/plugins/create-plugin/page.md
+++ b/docs/src/app/docs/plugins/create-plugin/page.md
@@ -179,7 +179,7 @@ Keep the public surface small: export the factory, its options, and any intentio
 
 ## Transform config
 
-`configure` runs before Farm resolves config. Return only when the plugin needs to replace the current value.
+`configure` runs after Farm loads the app config and before it creates the development or production pipeline. Return only when the plugin needs to replace the current value.
 
 ```ts
 export const observabilityDefaults = definePlugin({

--- a/docs/src/app/docs/plugins/page.md
+++ b/docs/src/app/docs/plugins/page.md
@@ -134,16 +134,16 @@ export const frameworkPlugin = definePlugin({
 
 Only define the groups your plugin needs.
 
-| Surface     | Purpose                                                                        |
-| ----------- | ------------------------------------------------------------------------------ |
-| `configure` | Transform Farm config before resolution.                                       |
-| `setup`     | Create private, typed plugin state for one plugin manager.                     |
-| `runtime`   | Wrap Web `Request` and `Response` handling.                                    |
-| `router`    | Observe route discovery, generation, and matching.                             |
-| `render`    | Observe rendering or transform final HTML.                                     |
-| `build`     | Run around bundling and configure the Nitro build.                             |
-| `dev`       | Access the Vite server and HMR updates.                                        |
-| `client`    | Define browser setup, hydration, navigation, errors, performance, and cleanup. |
+| Surface     | Purpose                                                                         |
+| ----------- | ------------------------------------------------------------------------------- |
+| `configure` | Transform Farm config before the development or production pipeline is created. |
+| `setup`     | Create private, typed plugin state for one plugin manager.                      |
+| `runtime`   | Wrap Web `Request` and `Response` handling.                                     |
+| `router`    | Observe route discovery, generation, and matching.                              |
+| `render`    | Observe rendering or transform final HTML.                                      |
+| `build`     | Run around bundling and configure the Nitro build.                              |
+| `dev`       | Access the Vite server and HMR updates.                                         |
+| `client`    | Define browser setup, hydration, navigation, errors, performance, and cleanup.  |
 
 ## Complete lifecycle reference
 
@@ -154,7 +154,7 @@ Only define the groups your plugin needs.
 | `name`      | Yes      | Stable plugin identity. Package authors should namespace it, such as `acme:security`.  |
 | `version`   | No       | Optional plugin version metadata for package authors and tooling.                      |
 | `enforce`   | No       | Places the plugin in the `pre` or `post` ordering group. Omit it for normal order.     |
-| `configure` | No       | Receives Farm config before resolution and may return replacement config.              |
+| `configure` | No       | Receives Farm config before pipeline creation and may return replacement config.       |
 | `setup`     | No       | Runs once per plugin manager and returns private state inferred by every grouped hook. |
 | `runtime`   | No       | Handles portable Web `Request` and `Response` lifecycle work.                          |
 | `router`    | No       | Observes route discovery, route graph generation, and page matching.                   |

--- a/packages/farm-cli/src/build.ts
+++ b/packages/farm-cli/src/build.ts
@@ -21,6 +21,7 @@ export interface BuildFarmOptions {
  */
 export async function buildFarm(options: BuildFarmOptions = {}) {
   const root = options.root || process.cwd();
+  const hasDeployOverride = options.preset !== undefined || options.target !== undefined;
 
   try {
     await withProductionNodeEnv(async () => {
@@ -49,7 +50,7 @@ export async function buildFarm(options: BuildFarmOptions = {}) {
       const config = await resolveConfig(userConfig, mode);
 
       // Override preset/target if provided via CLI
-      if (options.preset || options.target) {
+      if (hasDeployOverride) {
         const deploy = resolveDeployConfig(userConfig, {
           preset: options.preset as any,
           target: options.target,
@@ -62,7 +63,7 @@ export async function buildFarm(options: BuildFarmOptions = {}) {
       // also knows the preset and output directory; a second banner here
       // would only repeat it.
       await buildRuntimeResult.value.build(config, {
-        preset: config.preset,
+        preset: hasDeployOverride ? config.preset : undefined,
         root,
         productionVite: productionViteResult.value,
       });

--- a/packages/farm-cli/test/build.test.mjs
+++ b/packages/farm-cli/test/build.test.mjs
@@ -118,3 +118,62 @@ test("loads and resolves production config while NODE_ENV is production", async 
     await rm(root, { recursive: true, force: true });
   }
 });
+
+async function observeBuildPreset(cliPreset) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "farm-cli-build-preset-"));
+
+  try {
+    await writeFile(
+      path.join(root, "farm.config.mjs"),
+      [
+        "export default {",
+        '  preset: "vercel",',
+        "  plugins: [{",
+        '    name: "test:configure-preset",',
+        "    configure(config) {",
+        "      return {",
+        "        ...config,",
+        '        preset: "node-server",',
+        "        deploy: {",
+        "          ...config.deploy,",
+        '          target: "node",',
+        '          preset: "node-server",',
+        '          outputDir: ".farm/.output",',
+        "        },",
+        "      };",
+        "    },",
+        "    build: {",
+        "      before(bundle) {",
+        "        throw new Error(`observed-build-preset:${bundle.preset}`);",
+        "      },",
+        "    },",
+        "  }],",
+        "};",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const args = [cliBin, "build", "--root", root];
+    if (cliPreset) args.push("--preset", cliPreset);
+
+    try {
+      await execFileAsync(process.execPath, args);
+      assert.fail("expected the preset probe to stop the build");
+    } catch (error) {
+      return `${error.stdout || ""}\n${error.stderr || ""}`.match(
+        /observed-build-preset:([^\s]+)/,
+      )?.[1];
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+test("lets configure change the preset when the CLI has no deploy override", async () => {
+  assert.equal(await observeBuildPreset(), "node-server");
+});
+
+test("keeps an explicit CLI preset ahead of configure", async () => {
+  assert.equal(await observeBuildPreset("vercel"), "vercel");
+});

--- a/packages/farm/src/__tests__/build-configure-hook.test.ts
+++ b/packages/farm/src/__tests__/build-configure-hook.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { build } from "../build";
+import { loadConfig, resolveConfig } from "../config";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const FIXTURE_PREFIX = ".tmp-configure-hook-";
+const created: string[] = [];
+
+/** Writes a minimal app whose farm.config.ts is `configSource`. */
+async function createFixture(configSource: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(packageRoot, FIXTURE_PREFIX));
+  created.push(root);
+  await fs.mkdir(path.join(root, "node_modules", "@farm.js"), { recursive: true });
+  // Junctions need no Windows privilege; the type is ignored on POSIX.
+  await fs.symlink(packageRoot, path.join(root, "node_modules", "@farm.js", "core"), "junction");
+  await fs.mkdir(path.join(root, "src", "app"), { recursive: true });
+  await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ type: "module" }));
+  await fs.writeFile(path.join(root, "src", "app", "globals.css"), "body{margin:0}");
+  await fs.writeFile(
+    path.join(root, "src", "app", "page.tsx"),
+    `export default function Page() { return <div>hi</div>; }`,
+  );
+  await fs.writeFile(path.join(root, "farm.config.ts"), configSource);
+  return root;
+}
+
+async function buildFixture(root: string): Promise<void> {
+  const userConfig = await loadConfig(root, undefined, "production");
+  const config = await resolveConfig({ ...userConfig, root }, "production");
+  await build(config, { root, preset: "vercel" });
+}
+
+async function exists(target: string): Promise<boolean> {
+  return fs
+    .access(target)
+    .then(() => true)
+    .catch(() => false);
+}
+
+afterEach(async () => {
+  await Promise.all(
+    created
+      .splice(0)
+      .map((root) =>
+        fs
+          .rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+          .catch(() => {}),
+      ),
+  );
+});
+
+describe("plugin configure hook during build", () => {
+  it("runs the hook", async () => {
+    const marker = "configure-ran.txt";
+    const root = await createFixture(
+      `import fs from "node:fs";
+import path from "node:path";
+import { definePlugin } from "@farm.js/core";
+
+export default {
+  srcDir: "src",
+  plugins: [
+    definePlugin({
+      name: "test:ran",
+      configure(config) {
+        fs.writeFileSync(path.join(config.root, ${JSON.stringify(marker)}), "ran");
+        return config;
+      },
+    }),
+  ],
+};
+`,
+    );
+
+    await buildFixture(root);
+
+    expect(await exists(path.join(root, marker))).toBe(true);
+  }, 300000);
+
+  it("derives build output from the config the hook returns", async () => {
+    const root = await createFixture(
+      `import { definePlugin } from "@farm.js/core";
+
+export default {
+  srcDir: "src",
+  plugins: [
+    definePlugin({
+      name: "test:dist-dir",
+      configure(config) {
+        return { ...config, distDir: ".farm-from-plugin" };
+      },
+    }),
+  ],
+};
+`,
+    );
+
+    await buildFixture(root);
+
+    // distDir is read while the build computes its output paths. Running the
+    // hook after that point would leave the build writing to the original
+    // directory even though the returned config asked for another one.
+    const manifest = "route-runtime-manifest.json";
+    expect(await exists(path.join(root, ".farm-from-plugin", manifest))).toBe(true);
+    expect(await exists(path.join(root, ".farm", manifest))).toBe(false);
+  }, 300000);
+
+  it("keeps the current config when the hook returns nothing", async () => {
+    // `configure` is documented as returning a value only when the plugin needs
+    // to replace one, so a void return has to leave the build on the config it
+    // already had rather than on undefined.
+    const root = await createFixture(
+      `import { definePlugin } from "@farm.js/core";
+
+export default {
+  srcDir: "src",
+  distDir: ".farm-configured",
+  plugins: [
+    definePlugin({
+      name: "test:void-return",
+      configure() {},
+    }),
+  ],
+};
+`,
+    );
+
+    await buildFixture(root);
+
+    expect(await exists(path.join(root, ".farm-configured", "route-runtime-manifest.json"))).toBe(
+      true,
+    );
+  }, 300000);
+
+  it("passes the returned config to later hooks", async () => {
+    const seen = "seen-dist-dir.txt";
+    const root = await createFixture(
+      `import fs from "node:fs";
+import path from "node:path";
+import { definePlugin } from "@farm.js/core";
+
+export default {
+  srcDir: "src",
+  plugins: [
+    definePlugin({
+      name: "test:later-hooks",
+      configure(config) {
+        return { ...config, distDir: ".farm-from-plugin" };
+      },
+      build: {
+        before(bundle, context) {
+          fs.writeFileSync(
+            path.join(context.config.root, ${JSON.stringify(seen)}),
+            JSON.stringify({ bundle: bundle.distDir, context: context.config.distDir }),
+          );
+        },
+      },
+    }),
+  ],
+};
+`,
+    );
+
+    await buildFixture(root);
+
+    const seenValues = JSON.parse(await fs.readFile(path.join(root, seen), "utf8"));
+    expect(seenValues).toEqual({
+      bundle: ".farm-from-plugin",
+      context: ".farm-from-plugin",
+    });
+  }, 300000);
+});

--- a/packages/farm/src/__tests__/build-configure-hook.test.ts
+++ b/packages/farm/src/__tests__/build-configure-hook.test.ts
@@ -29,10 +29,13 @@ async function createFixture(configSource: string): Promise<string> {
   return root;
 }
 
-async function buildFixture(root: string): Promise<void> {
+async function buildFixture(
+  root: string,
+  options: { preset?: string } = { preset: "vercel" },
+): Promise<void> {
   const userConfig = await loadConfig(root, undefined, "production");
   const config = await resolveConfig({ ...userConfig, root }, "production");
-  await build(config, { root, preset: "vercel" });
+  await build(config, { root, ...options });
 }
 
 async function exists(target: string): Promise<boolean> {
@@ -100,7 +103,7 @@ export default {
 `,
     );
 
-    await buildFixture(root);
+    await buildFixture(root, {});
 
     // distDir is read while the build computes its output paths. Running the
     // hook after that point would leave the build writing to the original
@@ -108,6 +111,8 @@ export default {
     const manifest = "route-runtime-manifest.json";
     expect(await exists(path.join(root, ".farm-from-plugin", manifest))).toBe(true);
     expect(await exists(path.join(root, ".farm", manifest))).toBe(false);
+    expect(await exists(path.join(root, ".farm-from-plugin", ".output"))).toBe(true);
+    expect(await exists(path.join(root, ".farm", ".output"))).toBe(false);
   }, 300000);
 
   it("keeps the current config when the hook returns nothing", async () => {
@@ -146,6 +151,7 @@ import { definePlugin } from "@farm.js/core";
 
 export default {
   srcDir: "src",
+  deploy: { outputDir: ".custom-output" },
   plugins: [
     definePlugin({
       name: "test:later-hooks",
@@ -173,5 +179,6 @@ export default {
       bundle: ".farm-from-plugin",
       context: ".farm-from-plugin",
     });
+    expect(await exists(path.join(root, ".custom-output"))).toBe(true);
   }, 300000);
 });

--- a/packages/farm/src/build/index.ts
+++ b/packages/farm/src/build/index.ts
@@ -37,18 +37,25 @@ export async function build(config: ResolvedFarmConfig, options: BuildOptions = 
   return withProductionNodeEnv(() => buildWithProductionNodeEnv(config, options));
 }
 
-async function buildWithProductionNodeEnv(config: ResolvedFarmConfig, options: BuildOptions) {
+/** Every build path derived from config, recomputed once plugins have transformed it. */
+function resolveBuildTargets(config: ResolvedFarmConfig, options: BuildOptions) {
   const root = options.root || config.root || process.cwd();
-  const preset = options.preset || config.preset || "node-server";
-  const srcDir = config.srcDir || "src";
-  const distDir = config.distDir || ".farm";
-  const deployOutputDir = resolveDeployOutputPath(root, config.deploy.outputDir);
+  return {
+    root,
+    preset: options.preset || config.preset || "node-server",
+    srcDir: config.srcDir || "src",
+    distDir: config.distDir || ".farm",
+    deployOutputDir: resolveDeployOutputPath(root, config.deploy.outputDir),
+  };
+}
+
+async function buildWithProductionNodeEnv(inputConfig: ResolvedFarmConfig, options: BuildOptions) {
+  let config = inputConfig;
+  let { root, preset, srcDir, distDir, deployOutputDir } = resolveBuildTargets(config, options);
   const productionViteResultPromise =
     options.universal === false
       ? undefined
       : Promise.allSettled([Promise.resolve(options.productionVite ?? loadFarmProductionVite())]);
-
-  logger.info(`🚜 Building Farm.js application with preset: ${preset}...`);
 
   const pluginManager = new PluginManager({
     config,
@@ -60,6 +67,17 @@ async function buildWithProductionNodeEnv(config: ResolvedFarmConfig, options: B
 
   try {
     await pluginManager.runHookParallel("init");
+
+    // Plugins transform config before anything reads it. Every target above is
+    // derived from config, so the hook has to settle first and the targets have
+    // to be recomputed, or the build writes to paths the returned config never
+    // asked for.
+    config = await pluginManager.runHookSerial("config", config);
+    pluginManager.updateConfig(config);
+    ({ root, preset, srcDir, distDir, deployOutputDir } = resolveBuildTargets(config, options));
+
+    logger.info(`🚜 Building Farm.js application with preset: ${preset}...`);
+
     await pluginManager.setupPlugins();
     await pluginManager.runHookParallel("beforeBundle", {
       root,

--- a/packages/farm/src/build/index.ts
+++ b/packages/farm/src/build/index.ts
@@ -1,5 +1,9 @@
 import type { ResolvedFarmConfig } from "../config";
-import { resolveDeployOutputPath } from "../config";
+import {
+  getDefaultDeployOutputDir,
+  getDeployTargetForPreset,
+  resolveDeployOutputPath,
+} from "../config";
 import type { ViteDevServer } from "vite";
 import path from "path";
 import { existsSync } from "node:fs";
@@ -30,6 +34,13 @@ interface BuildOptions {
   productionVite?: FarmProductionViteRuntime | Promise<FarmProductionViteRuntime>;
 }
 
+interface BuildTargetBaseline {
+  preset: string;
+  distDir: string;
+  outputDir: string;
+  outputWasDerived: boolean;
+}
+
 /**
  * Build Farm.js application for production
  */
@@ -38,20 +49,53 @@ export async function build(config: ResolvedFarmConfig, options: BuildOptions = 
 }
 
 /** Every build path derived from config, recomputed once plugins have transformed it. */
-function resolveBuildTargets(config: ResolvedFarmConfig, options: BuildOptions) {
+function createBuildTargetBaseline(config: ResolvedFarmConfig): BuildTargetBaseline {
+  const preset = config.preset || "node-server";
+  const distDir = config.distDir || ".farm";
+  const outputDir = config.deploy.outputDir;
+  return {
+    preset,
+    distDir,
+    outputDir,
+    outputWasDerived:
+      outputDir === getDefaultDeployOutputDir(config.deploy.target, preset, distDir),
+  };
+}
+
+function resolveBuildTargets(
+  config: ResolvedFarmConfig,
+  options: BuildOptions,
+  baseline: BuildTargetBaseline,
+) {
   const root = options.root || config.root || process.cwd();
+  const preset = options.preset || config.preset || "node-server";
+  const distDir = config.distDir || ".farm";
+  const outputWasReplaced = config.deploy.outputDir !== baseline.outputDir;
+  const shouldRefreshDerivedOutput =
+    baseline.outputWasDerived &&
+    !outputWasReplaced &&
+    (preset !== baseline.preset || distDir !== baseline.distDir);
+  const deployTarget =
+    preset === config.deploy.preset ? config.deploy.target : getDeployTargetForPreset(preset);
+  const outputDir = shouldRefreshDerivedOutput
+    ? getDefaultDeployOutputDir(deployTarget, preset, distDir)
+    : config.deploy.outputDir;
+
   return {
     root,
-    preset: options.preset || config.preset || "node-server",
+    preset,
     srcDir: config.srcDir || "src",
-    distDir: config.distDir || ".farm",
-    deployOutputDir: resolveDeployOutputPath(root, config.deploy.outputDir),
+    distDir,
+    deployTarget,
+    outputDir,
+    deployOutputDir: resolveDeployOutputPath(root, outputDir),
   };
 }
 
 async function buildWithProductionNodeEnv(inputConfig: ResolvedFarmConfig, options: BuildOptions) {
   let config = inputConfig;
-  let { root, preset, srcDir, distDir, deployOutputDir } = resolveBuildTargets(config, options);
+  const targetBaseline = createBuildTargetBaseline(config);
+  let targets: ReturnType<typeof resolveBuildTargets> | undefined;
   const productionViteResultPromise =
     options.universal === false
       ? undefined
@@ -68,13 +112,23 @@ async function buildWithProductionNodeEnv(inputConfig: ResolvedFarmConfig, optio
   try {
     await pluginManager.runHookParallel("init");
 
-    // Plugins transform config before anything reads it. Every target above is
-    // derived from config, so the hook has to settle first and the targets have
-    // to be recomputed, or the build writes to paths the returned config never
-    // asked for.
+    // Settle plugin config before deriving the paths and deployment plan used
+    // by the production pipeline. Otherwise the build can report the returned
+    // config while still writing to the original locations.
     config = await pluginManager.runHookSerial("config", config);
-    pluginManager.updateConfig(config);
-    ({ root, preset, srcDir, distDir, deployOutputDir } = resolveBuildTargets(config, options));
+    targets = resolveBuildTargets(config, options, targetBaseline);
+    config = {
+      ...config,
+      preset: targets.preset,
+      deploy: {
+        ...config.deploy,
+        target: targets.deployTarget,
+        preset: targets.preset,
+        outputDir: targets.outputDir,
+      },
+    };
+    pluginManager.updateContext({ config });
+    const { root, preset, srcDir, distDir, deployOutputDir } = targets;
 
     logger.info(`🚜 Building Farm.js application with preset: ${preset}...`);
 
@@ -195,6 +249,8 @@ async function buildWithProductionNodeEnv(inputConfig: ResolvedFarmConfig, optio
     logger.success(`✅ Build completed successfully! (preset: ${preset})`);
     logger.info(`📁 Output directory: ${deployOutputDir}`);
   } catch (error) {
+    const { root, preset, distDir, deployOutputDir } =
+      targets ?? resolveBuildTargets(config, options, targetBaseline);
     await pluginManager.runHookParallel("onError", {
       phase: "build",
       error,

--- a/packages/farm/src/plugin.ts
+++ b/packages/farm/src/plugin.ts
@@ -470,7 +470,7 @@ export interface FarmPlugin<
   version?: string;
   enforce?: "pre" | "post";
 
-  /** Transform Farm config before it is resolved. */
+  /** Transform Farm config before the development or production pipeline is created. */
   configure?: (
     config: FarmConfig,
     context: FarmPluginContextFor<TIntegrationInstance, TIntegrationBound>,
@@ -703,16 +703,6 @@ export class PluginManager {
         },
       },
     };
-  }
-
-  /**
-   * Replace the config every later hook sees. The `config` hook may return a
-   * transformed config, and hooks that run after it read `context.config`, so
-   * the manager has to be told rather than keeping the config it was built
-   * with.
-   */
-  updateConfig(config: FarmConfig): void {
-    this.context.config = config;
   }
 
   private createPluginHookContext(

--- a/packages/farm/src/plugin.ts
+++ b/packages/farm/src/plugin.ts
@@ -705,6 +705,16 @@ export class PluginManager {
     };
   }
 
+  /**
+   * Replace the config every later hook sees. The `config` hook may return a
+   * transformed config, and hooks that run after it read `context.config`, so
+   * the manager has to be told rather than keeping the config it was built
+   * with.
+   */
+  updateConfig(config: FarmConfig): void {
+    this.context.config = config;
+  }
+
   private createPluginHookContext(
     plugin: FarmPlugin,
     context: FarmPluginContext = this.context,


### PR DESCRIPTION
Closes #578

## Problem

The plugin `configure` hook ran when the development server started but not during `farm build`. Production builds could therefore ignore plugin changes to Vite config, source paths, output paths, or deployment presets.

## Root cause

The production build never dispatched the config hook and derived its build paths before plugins could transform the resolved config. The CLI also passed the config preset into the core build as though it were an explicit command-line override, which prevented a plugin from changing that preset.

## Change

The production build now runs `configure` once after plugin initialization and before it derives the paths and deployment plan consumed by the build pipeline or creates the Vite server.

After the hook settles, Farm:

- derives `root`, `preset`, `srcDir`, `distDir`, deployment target, and output path from the returned config
- refreshes a framework-derived output directory when the plugin changes `preset` or `distDir`
- preserves an explicitly configured custom deployment output directory
- updates the existing plugin-manager context so later hooks see the same config
- treats only an explicit CLI `--preset` or `--target` as an override

The plugin documentation now describes the hook's actual lifecycle timing.

## Safety and compatibility

Explicit CLI deployment options still win over plugin changes. A hook that returns nothing keeps the current config. Custom output directories remain unchanged. The fix is renderer-neutral and affects only production build behavior; the existing development path is unchanged.

## Verification

- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`
- `pnpm --filter @farm.js/core test -- build-configure-hook.test.ts` (4 passed)
- `pnpm --filter @farm.js/cli test` (88 passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/cli type-check`
- focused `oxfmt`, `oxlint`, and `git diff --check`
- `pnpm docs:check-navigation`
- `pnpm docs:build`

The production regression verifies both the route manifest and Nitro output are written beneath the plugin-selected `distDir`. CLI coverage verifies plugin preset changes work without an override and remain subordinate to an explicit `--preset`.

## Documentation and release

Updated the plugin lifecycle and plugin-authoring documentation. No release metadata or generated artifacts changed.