### PR TITLE
fix(cache): serialize invalid dates to a stable marker instead of throwing

### DIFF
--- a/packages/farm/src/__tests__/cache-key-invalid-date.test.ts
+++ b/packages/farm/src/__tests__/cache-key-invalid-date.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { configureFarmCache, createFarmCacheKey, unstable_cache } from "../cache";
+import { createServerQueryCallKey } from "../server-query-runtime";
+
+afterEach(() => {
+  configureFarmCache(undefined);
+});
+
+describe("createFarmCacheKey with invalid Date", () => {
+  it("serializes an invalid date to a stable marker instead of throwing", () => {
+    expect(createFarmCacheKey([new Date("not-a-date")])).toBe("[date:invalid]");
+    expect(createFarmCacheKey([new Date(NaN)])).toBe("[date:invalid]");
+    expect(createFarmCacheKey([new Date("2024-13-45")])).toBe(
+      createFarmCacheKey([new Date("also-invalid")]),
+    );
+  });
+
+  it("keeps valid date serialization unchanged", () => {
+    expect(createFarmCacheKey([new Date("2024-02-01T00:00:00.000Z")])).toBe(
+      "[date:2024-02-01T00:00:00.000Z]",
+    );
+  });
+
+  it("serializes an invalid date nested in objects, arrays, sets and maps", () => {
+    const invalid = new Date(NaN);
+    expect(createFarmCacheKey([{ from: invalid, list: [invalid] }])).toBe(
+      '[{"from":date:invalid,"list":[date:invalid]}]',
+    );
+    expect(createFarmCacheKey([new Set([invalid])])).toBe("[set:[date:invalid]]");
+    expect(createFarmCacheKey([new Map([["from", invalid]])])).toBe(
+      '[map:[["from",date:invalid]]]',
+    );
+  });
+
+  it("lets unstable_cache run the wrapped function for an invalid date argument", async () => {
+    let calls = 0;
+    const report = unstable_cache(
+      async (from: Date) => {
+        calls++;
+        return Number.isNaN(from.getTime()) ? "invalid input" : `rows since ${from.toISOString()}`;
+      },
+      ["report"],
+    );
+
+    await expect(report(new Date("2024-13-45"))).resolves.toBe("invalid input");
+    await expect(report(new Date("also-invalid"))).resolves.toBe("invalid input");
+    expect(calls).toBe(1);
+
+    await expect(report(new Date("2024-02-01T00:00:00.000Z"))).resolves.toBe(
+      "rows since 2024-02-01T00:00:00.000Z",
+    );
+    expect(calls).toBe(2);
+  });
+
+  it("builds a server query call key for an invalid date input", () => {
+    const query = (async () => null) as any;
+    const key = createServerQueryCallKey(query, { from: new Date("2024-02-31x"), page: 1 });
+    expect(key).toContain('"from":date:invalid');
+    expect(key).toBe(createServerQueryCallKey(query, { from: new Date(NaN), page: 1 }));
+    expect(key).not.toBe(
+      createServerQueryCallKey(query, { from: new Date("2024-02-01T00:00:00.000Z"), page: 1 }),
+    );
+  });
+});

--- a/packages/farm/src/cache.ts
+++ b/packages/farm/src/cache.ts
@@ -1029,7 +1029,10 @@ function stableSerialize(value: unknown, seen = new WeakSet<object>()): string {
   }
 
   if (value instanceof Date) {
-    return `date:${value.toISOString()}`;
+    // toISOString throws on an Invalid Date. Key building must not throw on a
+    // supported type, so all invalid dates share one stable marker and the
+    // caller's own validation decides what to do with the input.
+    return Number.isNaN(value.getTime()) ? "date:invalid" : `date:${value.toISOString()}`;
   }
   if (value instanceof URL) {
     return `url:${value.toString()}`;


### PR DESCRIPTION
Fixes #576

## Problem

`stableSerialize` calls `value.toISOString()` on every `Date`, and that throws `RangeError: Invalid time value` on an Invalid Date. Key building runs before anything else, so `unstable_cache` threw before the wrapped function ran and `createServerQueryCallKey` threw while computing the call key. An Invalid Date is easy to get from URL input, since `new Date(searchParams.get("from"))` returns one for any malformed value instead of throwing.

## Fix

The `Date` branch now checks `Number.isNaN(value.getTime())` and serializes an invalid date as the stable marker `date:invalid`. All invalid dates share one key, valid date serialization is unchanged, and the caller's own validation decides what to do with the input.

## Tests

New `cache-key-invalid-date.test.ts` covers:

- `createFarmCacheKey` with invalid dates, top level and nested in objects, arrays, sets and maps
- valid date serialization unchanged
- `unstable_cache` runs the wrapped function for an invalid date argument and caches per marker
- `createServerQueryCallKey` builds a key for an invalid date input, equal across invalid dates and distinct from a valid one

4 of 5 fail on `main` with only `cache.ts` reverted (the valid-date test passes either way). Existing `cache.test.ts` and `cache-key-set-map.test.ts` still pass. `tsc --noEmit`, oxlint and oxfmt are clean.

Binary value handling (`ArrayBuffer`, `DataView`, typed arrays) is left out as requested, so this fix stays focused.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cache key building so an invalid `Date` (for example from URL input via `new Date(searchParams.get("from"))`) serializes to a stable `date:invalid` marker instead of throwing `RangeError: Invalid time value`. Valid date serialization is unchanged, and the caller's own validation decides what to do with the invalid input.

**Tests**
- New tests cover invalid dates at the top level and nested in objects, arrays, sets, and maps, plus `unstable_cache` and server query call key behavior.

<sup>Written for commit 2036585d27e22bec7b7ccb5124f94aa99e8062d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

