### PR TITLE
fix(link): preserve mailto navigation

### DIFF
--- a/packages/farm/src/__tests__/link.test.tsx
+++ b/packages/farm/src/__tests__/link.test.tsx
@@ -327,6 +327,19 @@ describe("Link", () => {
       expect(onClick).toHaveBeenCalled();
       expect(navigate).not.toHaveBeenCalled();
     });
+
+    it("preserves mailto hrefs without prefetching them", () => {
+      const el = render(
+        createElement(Link, {
+          href: "mailto:team@example.com?subject=Farm",
+          prefetch: "render",
+        }),
+      ) as HTMLAnchorElement;
+
+      expect(el.getAttribute("href")).toBe("mailto:team@example.com?subject=Farm");
+      expect(prefetch).not.toHaveBeenCalled();
+      expect(navigate).not.toHaveBeenCalled();
+    });
   });
 
   describe("typed href", () => {

--- a/packages/farm/src/client/link.tsx
+++ b/packages/farm/src/client/link.tsx
@@ -170,7 +170,13 @@ function isModifierEvent(e: React.MouseEvent): boolean {
 }
 
 function isExternalUrl(href: string): boolean {
-  return href.startsWith("http://") || href.startsWith("https://") || href.startsWith("//");
+  const normalizedHref = href.toLowerCase();
+  return (
+    normalizedHref.startsWith("http://") ||
+    normalizedHref.startsWith("https://") ||
+    href.startsWith("//") ||
+    normalizedHref.startsWith("mailto:")
+  );
 }
 
 function getRouter(): {


### PR DESCRIPTION
## Problem

`<Link href="mailto:...">` rewrites the address as an internal pathname and makes it eligible for Farm prefetch/navigation.

## Root cause

The runtime external-URL check recognizes HTTP and protocol-relative URLs, while the public `ExternalHref` type also accepts `mailto:` URLs.

## Change

Treat `mailto:` URLs, including case-insensitive schemes, as external links so their href is preserved and Farm does not prefetch or intercept them.

## Safety and compatibility

Internal routes and existing HTTP external links keep their current behavior. No renderer or server behavior changes.

## Verification

- `pnpm --filter @farm.js/core test -- src/__tests__/link.test.tsx`
- `pnpm exec oxfmt --check packages/farm/src/client/link.tsx packages/farm/src/__tests__/link.test.tsx`
- `pnpm exec oxlint packages/farm/src/client/link.tsx packages/farm/src/__tests__/link.test.tsx`

The regression test fails on `main` because the rendered href is `/team%40example.com?subject=Farm`.

## Documentation and release

None. This aligns runtime behavior with the existing documented public type.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `<Link>` rewriting `mailto:` hrefs as internal paths so they preserve the original address and are no longer prefetched or intercepted by Farm.

**Changes**
- `isExternalUrl` now recognizes `mailto:` schemes case-insensitively, aligning runtime behavior with the existing public `ExternalHref` type.
- Internal routes and HTTP external links keep their current behavior; no migration or rollout steps needed.

<sup>Written for commit b9e445de9896686ad8ffe9bf6b8f56a80b8d6076. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

