### PR TITLE
fix(api-types): detect exported HTTP aliases

### DIFF
--- a/packages/farm/src/__tests__/type-generator.test.ts
+++ b/packages/farm/src/__tests__/type-generator.test.ts
@@ -104,4 +104,35 @@ describe("APITypeGenerator", () => {
     expect(content).toContain("profile: {");
     expect(content).toContain("query: typeof QUERY_profile;");
   });
+
+  it("detects the HTTP names exposed by export lists", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "farm-api-types-"));
+    const appDir = path.join(root, "src", "app");
+    const aliasedRouteDir = path.join(appDir, "api", "aliased");
+    const listedRouteDir = path.join(appDir, "api", "listed");
+    const renamedRouteDir = path.join(appDir, "api", "renamed");
+    mkdirSync(aliasedRouteDir, { recursive: true });
+    mkdirSync(listedRouteDir, { recursive: true });
+    mkdirSync(renamedRouteDir, { recursive: true });
+
+    writeFileSync(
+      path.join(aliasedRouteDir, "route.ts"),
+      "const handler = async () => new Response('ok');\nexport { handler as GET };\n",
+    );
+    writeFileSync(
+      path.join(listedRouteDir, "route.ts"),
+      "const GET = async () => new Response('ok');\nconst POST = GET;\nexport { GET, POST };\n",
+    );
+    writeFileSync(
+      path.join(renamedRouteDir, "route.ts"),
+      "const GET = async () => new Response('ok');\nexport { GET as handler };\n",
+    );
+
+    const generator = new APITypeGenerator(appDir);
+    const routes = generator.scanAPIRoutes();
+
+    expect(routes.find((route) => route.path === "/api/aliased")?.methods).toEqual(["GET"]);
+    expect(routes.find((route) => route.path === "/api/listed")?.methods).toEqual(["GET", "POST"]);
+    expect(routes.some((route) => route.path === "/api/renamed")).toBe(false);
+  });
 });

--- a/packages/farm/src/type-generator.ts
+++ b/packages/farm/src/type-generator.ts
@@ -85,21 +85,28 @@ export class APITypeGenerator {
   private extractExportedMethods(content: string): string[] {
     const methods: string[] = [];
     const httpMethods = ["GET", "HEAD", "QUERY", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"];
+    const namedExports = new Set<string>();
+
+    for (const match of content.matchAll(/export\s*\{([\s\S]*?)\}/g)) {
+      for (const specifier of match[1].split(",")) {
+        const normalized = specifier.trim().replace(/^type\s+/, "");
+        if (!normalized) continue;
+
+        const alias = normalized.match(/^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/);
+        const exportedName = alias?.[2] ?? normalized.match(/^([A-Za-z_$][\w$]*)$/)?.[1];
+        if (exportedName) namedExports.add(exportedName);
+      }
+    }
 
     for (const method of httpMethods) {
-      // Look for export const METHOD = or export { METHOD }
+      // Look for a direct declaration or the name exposed by an export list.
       const patterns = [
         new RegExp(`export\\s+const\\s+${method}\\s*=`, "g"),
         new RegExp(`export\\s+(?:async\\s+)?function\\s+${method}\\s*\\(`, "g"),
-        new RegExp(`export\\s*{\\s*${method}\\s*}`, "g"),
-        new RegExp(`export\\s*{\\s*${method}\\s*as\\s+\\w+\\s*}`, "g"),
       ];
 
-      for (const pattern of patterns) {
-        if (pattern.test(content)) {
-          methods.push(method);
-          break;
-        }
+      if (namedExports.has(method) || patterns.some((pattern) => pattern.test(content))) {
+        methods.push(method);
       }
     }
 


### PR DESCRIPTION
## Problem

Generated API types omit valid handlers exported through lists such as `export { handler as GET }` or `export { GET, POST }`. They can also include `GET` after `export { GET as handler }`, even though the route module no longer exports that HTTP name.

## Root cause

The generator matches complete single-item export statements with regular expressions and interprets the local side of an alias as the exported name.

## Change

Collect the names exposed by every export list, then combine those names with direct `export const` and `export function` declarations.

## Safety and compatibility

Direct declarations retain their existing behavior. Re-exports and multiline/comma-separated export lists now follow JavaScript module semantics. Runtime API routing is unchanged.

## Verification

- `pnpm --filter @farm.js/core test -- src/__tests__/type-generator.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxfmt --check packages/farm/src/type-generator.ts packages/farm/src/__tests__/type-generator.test.ts`
- `pnpm exec oxlint packages/farm/src/type-generator.ts packages/farm/src/__tests__/type-generator.test.ts`

The regression test covers aliased, comma-separated, and renamed-away HTTP exports.

## Documentation and release

None. This makes generated declarations match standard module exports.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the API type generator so route handlers exported through `export` lists follow JavaScript module semantics: `export { handler as GET }` now surfaces `GET`, and `export { GET as handler }` no longer leaves `GET` in the generated types.

**Bug Fixes**

- Replaces regex matching of complete single-item export statements with collection of the names exposed by every export list.
- Direct `export const` / `export function` declarations and runtime routing behavior are unchanged.
- Adds a regression test covering aliased, comma-separated, and renamed-away HTTP exports.

<sup>Written for commit 3ac52357892b71e830498b0f79018244d116e772. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

