### PR TITLE
fix(middleware): ignore route groups in paths

### DIFF
--- a/docs/src/app/docs/middleware/page.md
+++ b/docs/src/app/docs/middleware/page.md
@@ -27,6 +27,7 @@ Data and headers written during middleware are request-scoped:
 ## Route middleware
 
 Middleware can live near the routes it protects. Use it for auth, request metadata, A/B flags, rate limit checks, or headers that belong to an area of the app.
+Route-group directories such as `(marketing)` organize middleware without adding a URL segment.
 
 **src/app/dashboard/middleware.ts**
 

--- a/packages/farm/src/__tests__/middleware-route-groups.test.ts
+++ b/packages/farm/src/__tests__/middleware-route-groups.test.ts
@@ -1,0 +1,39 @@
+/** @vitest-environment node */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { MiddlewareManager } from "../middleware/manager";
+import { discoverMiddlewareRoutes } from "../nitro/universal-build";
+
+describe("middleware route groups", () => {
+  it("keeps route-group directory names out of development and production paths", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-middleware-groups-"));
+    const appDir = path.join(root, "src", "app");
+    const groupDir = path.join(appDir, "(marketing)");
+    const pricingDir = path.join(groupDir, "pricing");
+    await fs.mkdir(pricingDir, { recursive: true });
+    await fs.writeFile(path.join(groupDir, "middleware.ts"), "export {};\n");
+    await fs.writeFile(path.join(pricingDir, "middleware.ts"), "export {};\n");
+
+    try {
+      const viteServer = {
+        ssrLoadModule: vi.fn().mockResolvedValue({
+          default: async (_ctx: unknown, next: () => Promise<void>) => next(),
+        }),
+      };
+      const manager = new MiddlewareManager(appDir, viteServer as never);
+      await manager.discover();
+
+      expect(manager.getMiddlewares().map((middleware) => middleware.path)).toEqual([
+        "/",
+        "/pricing",
+      ]);
+
+      const productionRoutes = await discoverMiddlewareRoutes(appDir);
+      expect(productionRoutes.map((middleware) => middleware.path)).toEqual(["/", "/pricing"]);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/farm/src/middleware/manager.ts
+++ b/packages/farm/src/middleware/manager.ts
@@ -25,6 +25,7 @@ import { emitFarmEvent } from "../observability";
 import { stripFarmLocaleFromPathname } from "../i18n/routing";
 import type { ResolvedFarmI18nConfig } from "../i18n/types";
 import { createCliColors } from "../cli-colors";
+import { appendMiddlewareRoutePath } from "./path";
 
 export interface DiscoveredMiddleware {
   path: string;
@@ -143,7 +144,7 @@ export class MiddlewareManager {
     for (const entry of entries) {
       if (entry.isDirectory() && !entry.name.startsWith(".") && !entry.name.startsWith("_")) {
         const subPath = path.join(dir, entry.name);
-        const subRoutePath = path.posix.join(routePath, entry.name);
+        const subRoutePath = appendMiddlewareRoutePath(routePath, entry.name);
         await this.discoverInDirectory(subPath, subRoutePath, discovered);
       }
     }

--- a/packages/farm/src/middleware/path.ts
+++ b/packages/farm/src/middleware/path.ts
@@ -1,0 +1,7 @@
+export function appendMiddlewareRoutePath(routePath: string, directoryName: string): string {
+  if (directoryName.startsWith("(") && directoryName.endsWith(")")) {
+    return routePath;
+  }
+
+  return routePath === "/" ? `/${directoryName}` : `${routePath}/${directoryName}`;
+}

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -78,6 +78,7 @@ import { DEFAULT_NOT_FOUND_STYLES } from "../components/not-found-styles";
 import { createFarmThemeCssPlugin } from "../theme/vite";
 import { resolveFarmInstrumentationFile } from "../instrumentation";
 import { isReactRenderer, loadFarmRendererVitePlugins, REACT_RENDERER } from "../renderer";
+import { appendMiddlewareRoutePath } from "../middleware/path";
 import type { FarmRenderer } from "../renderer";
 
 // Type alias for OutputBundle
@@ -678,7 +679,7 @@ export async function discoverMiddlewareRoutes(
         continue;
       }
 
-      const childRoutePath = routePath === "/" ? `/${entry.name}` : `${routePath}/${entry.name}`;
+      const childRoutePath = appendMiddlewareRoutePath(routePath, entry.name);
       await walk(path.join(dir, entry.name), childRoutePath, discovered);
     }
   }


### PR DESCRIPTION
## Problem

Middleware under `src/app/(marketing)/pricing/middleware.ts` is discovered at `/(marketing)/pricing`, so it does not run for the page URL `/pricing`.

## Root cause

Development and universal production middleware discovery append every directory name to the public route path. Page route discovery separately removes route-group segments.

## Change

Add one internal middleware-path helper that keeps `(group)` directories out of the public path, and use it in both development and universal production discovery.

## Safety and compatibility

Filesystem traversal and middleware cascade order are unchanged. Static and dynamic directory names retain their existing paths. The change only removes route-group segments that are already absent from page URLs.

## Verification

- `pnpm --filter @farm.js/core test -- src/__tests__/middleware-route-groups.test.ts`
- `pnpm --filter @farm.js/core type-check`
- focused `oxfmt` and `oxlint`

The regression test verifies both development discovery and production manifest discovery for group-root and nested middleware.

## Documentation and release

Updated the middleware route documentation to state that route groups do not add URL segments.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes middleware discovery so route-group directories like `(marketing)` no longer appear in the public middleware path. Middleware in `src/app/(marketing)/pricing/middleware.ts` previously ran for `/(marketing)/pricing` and never matched `/pricing`; it now matches the page URL directly.

- Adds `appendMiddlewareRoutePath`, a shared helper used by both development and production discovery.
- Filesystem traversal and middleware cascade order are unchanged; only route-group segments are stripped.
- Adds a regression test covering group-root and nested middleware in both discovery modes.
- Updates the middleware route docs to note route groups don't add URL segments.

<sup>Written for commit 06e0a1fdfdcb5ab7f8f306ad40d4942ab390fcb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

