### PR TITLE
fix(api): discover JSX route files

### DIFF
--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -52,6 +52,7 @@ export async function GET() {
 ## Route file shape
 
 Farm follows the familiar route-file convention: each route lives in `src/app/api/**/route.ts` and exports one or more HTTP methods.
+The equivalent `route.tsx`, `route.js`, and `route.jsx` filenames use the same discovery and generated-type behavior.
 
 ```txt
 src/app/api/hello/route.ts          -> /api/hello

--- a/packages/farm/src/__tests__/api-route-manager.test.ts
+++ b/packages/farm/src/__tests__/api-route-manager.test.ts
@@ -19,6 +19,27 @@ afterEach(() => {
 });
 
 describe("APIRouteManager", () => {
+  it("discovers JSX route files", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-api-route-"));
+    tempDirs.push(root);
+
+    const routeDir = path.join(root, "api", "jsx");
+    fs.mkdirSync(routeDir, { recursive: true });
+    const routeFile = path.join(routeDir, "route.jsx");
+    fs.writeFileSync(routeFile, "export const GET = () => new Response('jsx');\n");
+
+    const manager = new APIRouteManager(root, {
+      ssrLoadModule: async (filePath: string) => {
+        expect(filePath).toBe(routeFile);
+        return { GET: async () => new Response("jsx") };
+      },
+    } as any);
+
+    await manager.discoverRoutes();
+
+    expect(manager.getRoutes().get("/api/jsx")?.methods).toEqual(["GET"]);
+  });
+
   it("uses GET for HEAD requests and strips the response body", async () => {
     const manager = new APIRouteManager("/tmp/farm-api-head-test");
     const getHandler = async () =>

--- a/packages/farm/src/api/route-files.ts
+++ b/packages/farm/src/api/route-files.ts
@@ -1,0 +1,3 @@
+export function isFarmAPIRouteFileName(fileName: string): boolean {
+  return /^route\.(?:ts|tsx|js|jsx)$/.test(fileName);
+}

--- a/packages/farm/src/api/route-manager.ts
+++ b/packages/farm/src/api/route-manager.ts
@@ -18,6 +18,7 @@ import {
   resolveAPIRouteEndpoint,
   type APIRouteMatch,
 } from "./runtime";
+import { isFarmAPIRouteFileName } from "./route-files";
 
 export interface APIRoute extends FarmRouteRuntimeConfig {
   path: string;
@@ -115,11 +116,7 @@ export class APIRouteManager {
 
       if (entry.isDirectory()) {
         files.push(...this.findRouteFiles(fullPath));
-      } else if (
-        entry.name === "route.ts" ||
-        entry.name === "route.tsx" ||
-        entry.name === "route.js"
-      ) {
+      } else if (isFarmAPIRouteFileName(entry.name)) {
         files.push(fullPath);
       }
     }

--- a/packages/farm/src/api/vite-plugin.ts
+++ b/packages/farm/src/api/vite-plugin.ts
@@ -24,6 +24,7 @@ import {
   resolveAPIRouteEndpoint,
 } from "./route-manager";
 import { sendWebResponse } from "../server/response";
+import { isFarmAPIRouteFileName } from "./route-files";
 import { _withAfterNodeMiddleware } from "../after";
 import { isProgrammaticRoutesFileName } from "../routes-shared";
 import { findProgrammaticRouteFilesInDir } from "../routes.server";
@@ -185,11 +186,7 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
             const fullPath = path.join(dir, entry.name);
             if (entry.isDirectory()) {
               files.push(...findRouteFiles(fullPath));
-            } else if (
-              entry.name === "route.ts" ||
-              entry.name === "route.tsx" ||
-              entry.name === "route.js"
-            ) {
+            } else if (isFarmAPIRouteFileName(entry.name)) {
               files.push(fullPath);
             }
           }

--- a/packages/farm/src/type-generator.ts
+++ b/packages/farm/src/type-generator.ts
@@ -1,6 +1,7 @@
 import { readFileSync, existsSync, readdirSync, mkdirSync } from "fs";
 import { join, relative, dirname } from "path";
 import { writeFileIfChanged } from "./write-file-if-changed";
+import { isFarmAPIRouteFileName } from "./api/route-files";
 
 export interface APIRouteInfo {
   path: string;
@@ -45,7 +46,7 @@ export class APITypeGenerator {
       if (item.isDirectory()) {
         const newBasePath = basePath ? `${basePath}/${item.name}` : item.name;
         this.scanDirectory(fullPath, appDir, routes, newBasePath);
-      } else if (/^route\.(ts|tsx|js|jsx)$/.test(item.name)) {
+      } else if (isFarmAPIRouteFileName(item.name)) {
         const routeInfo = this.extractRouteInfo(fullPath, appDir, basePath);
         if (routeInfo) {
           routes.push(routeInfo);


### PR DESCRIPTION
## Problem

`route.jsx` files are included in generated API client types but ignored by development and production API route discovery. The generated client can therefore describe an endpoint that always returns 404.

## Root cause

The type generator and runtime route managers maintain separate extension lists, and only the generator includes JSX.

## Change

Use one internal API route filename predicate in the type generator, the API route manager, and the Vite development plugin.

## Safety and compatibility

Existing `.ts`, `.tsx`, and `.js` routes are unchanged. The additional `.jsx` extension is processed through the same module loading and endpoint validation path.

## Verification

- `pnpm --filter @farm.js/core test -- src/__tests__/api-route-manager.test.ts src/__tests__/type-generator.test.ts`
- `pnpm --filter @farm.js/core type-check`
- focused `oxfmt` and `oxlint`

The new regression test fails on `main` because the manager discovers no `/api/jsx` route.

## Documentation and release

Documented the equivalent supported route filenames on the API routes page.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `route.jsx` files discoverable by the API route manager and Vite dev plugin, so endpoints defined in JSX routes match the generated API client types instead of returning 404.

- Extracts the route filename check into a shared `isFarmAPIRouteFileName` predicate used by the type generator, route manager, and dev plugin.
- Adds a regression test verifying `route.jsx` discovery in the API route manager.
- Documents the supported `route.tsx`, `route.js`, and `route.jsx` filename equivalents.

<sup>Written for commit 208e845bd5da7678dbc650411da9c5fd0aba8e6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

