### PR TITLE
fix(navigation): wire router refresh and prefetch

### DIFF
--- a/docs/src/app/docs/migrations/nextjs/page.md
+++ b/docs/src/app/docs/migrations/nextjs/page.md
@@ -83,16 +83,16 @@ export default function Page() {
 
 Farm provides a deliberately small compatibility surface for common App Router behavior:
 
-| API                   | Farm behavior                                                |
-| --------------------- | ------------------------------------------------------------ |
-| `redirect()`          | Produces a redirect response through Farm's redirect signal. |
-| `permanentRedirect()` | Produces the same signal with status 308.                    |
-| `notFound()`          | Produces a not-found signal that Farm renders as a 404.      |
-| `useRouter()`         | Uses Farm's client router.                                   |
-| `usePathname()`       | Reads the current pathname on the client.                    |
-| `useSearchParams()`   | Reads the current URL search parameters on the client.       |
-| `headers()`           | Reads the current request headers on the server.             |
-| `cookies()`           | Reads the current request cookies on the server.             |
+| API                   | Farm behavior                                                    |
+| --------------------- | ---------------------------------------------------------------- |
+| `redirect()`          | Produces a redirect response through Farm's redirect signal.     |
+| `permanentRedirect()` | Produces the same signal with status 308.                        |
+| `notFound()`          | Produces a not-found signal that Farm renders as a 404.          |
+| `useRouter()`         | Uses Farm's client router for navigation, refresh, and prefetch. |
+| `usePathname()`       | Reads the current pathname on the client.                        |
+| `useSearchParams()`   | Reads the current URL search parameters on the client.           |
+| `headers()`           | Reads the current request headers on the server.                 |
+| `cookies()`           | Reads the current request cookies on the server.                 |
 
 ## Manual review
 

--- a/packages/farm/src/__tests__/navigation-router-methods.test.tsx
+++ b/packages/farm/src/__tests__/navigation-router-methods.test.tsx
@@ -1,0 +1,52 @@
+/** @vitest-environment jsdom */
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SPARouter } from "../client/spa-router";
+import { useRouter } from "../navigation";
+
+describe("navigation useRouter methods", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+  let router: SPARouter;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    router = new SPARouter({ scrollRestoration: false });
+    (window as Window & { __FARM_SPA_ROUTER__?: SPARouter }).__FARM_SPA_ROUTER__ = router;
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    router.destroy();
+    container.remove();
+    delete (window as Window & { __FARM_SPA_ROUTER__?: SPARouter }).__FARM_SPA_ROUTER__;
+    delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
+    vi.restoreAllMocks();
+  });
+
+  function renderHook() {
+    let value!: ReturnType<typeof useRouter>;
+    function Probe() {
+      value = useRouter();
+      return null;
+    }
+    root = createRoot(container);
+    act(() => root.render(createElement(Probe)));
+    return () => value;
+  }
+
+  it("delegates prefetch and refresh to the installed SPA router", async () => {
+    const prefetch = vi.spyOn(router, "prefetch").mockResolvedValue();
+    const refresh = vi.spyOn(router, "refresh").mockResolvedValue();
+    const getRouter = renderHook();
+
+    await getRouter().prefetch("/reports");
+    await getRouter().refresh();
+
+    expect(prefetch).toHaveBeenCalledWith("/reports");
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/farm/src/navigation.ts
+++ b/packages/farm/src/navigation.ts
@@ -1,4 +1,5 @@
 import { useRouter as useFarmRouter } from "./client/router";
+import { getRouter as getFarmSPARouter } from "./client/spa-router";
 
 export {
   getFarmRedirectError,
@@ -18,12 +19,12 @@ export function useRouter() {
     back: router.back,
     forward: router.forward,
     refresh() {
-      if (typeof window !== "undefined") {
-        window.location.reload();
-      }
+      if (typeof window === "undefined") return Promise.resolve();
+      return getFarmSPARouter().refresh();
     },
-    prefetch(_href: string) {
-      return Promise.resolve();
+    prefetch(href: string) {
+      if (typeof window === "undefined") return Promise.resolve();
+      return getFarmSPARouter().prefetch(href);
     },
   };
 }


### PR DESCRIPTION
## Problem

The `@farm.js/core/navigation` router exposes `prefetch()` and `refresh()`, but prefetch resolves without doing anything and refresh reloads the whole document.

## Root cause

The compatibility wrapper never delegates these methods to Farm's installed SPA router, even though that router already implements fresh page-data refresh and cache-aware prefetch.

## Change

Delegate both methods to the installed SPA router while keeping server-side calls safe no-ops.

## Safety and compatibility

The method names and call shapes are unchanged. Refresh now preserves the document, layouts, and current history entry. Prefetch uses the existing deployment-mismatch and cache behavior.

## Verification

- `pnpm --filter @farm.js/core test -- src/__tests__/navigation-router-methods.test.tsx src/__tests__/navigation.test.ts`
- `pnpm --filter @farm.js/core type-check`
- focused `oxfmt` and `oxlint`

The regression test spies on the installed SPA router and fails on `main` because neither method is called.

## Documentation and release

Updated the Next.js migration compatibility table to describe refresh and prefetch support.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `useRouter()` in `@farm.js/core` so `refresh()` and `prefetch()` actually delegate to Farm's SPA router instead of reloading the document or resolving as no-ops.

- Server-side calls remain safe no-ops.
- Method names and call shapes stay unchanged.
- Adds a regression test that spies on the SPA router.
- Updates the Next.js migration compatibility table.

<sup>Written for commit c0b6f9f55678be7ce4b4e1bf2294a73f18454a89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

