### PR TITLE
fix(navigation): use document navigation for external URLs

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -174,6 +174,9 @@ export function CurrentUserTab() {
 }
 ```
 
+Imperative `push()` and `replace()` calls use SPA navigation for same-origin routes. Absolute
+cross-origin URLs use normal document navigation instead of Farm's local page-data endpoint.
+
 ## Navigation blocking
 
 Use `useBlocker` when a client component needs to protect unsaved work before SPA navigation continues.

--- a/packages/farm/src/__tests__/spa-router-external-navigation.test.ts
+++ b/packages/farm/src/__tests__/spa-router-external-navigation.test.ts
@@ -1,0 +1,38 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { isFarmExternalNavigationURL, SPARouter } from "../client/spa-router";
+
+describe("external SPA router URLs", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/");
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("distinguishes cross-origin and non-HTTP URLs from same-origin routes", () => {
+    expect(
+      isFarmExternalNavigationURL(new URL("https://example.com/reports"), window.location.origin),
+    ).toBe(true);
+    expect(
+      isFarmExternalNavigationURL(new URL("mailto:team@example.com"), window.location.origin),
+    ).toBe(true);
+    expect(
+      isFarmExternalNavigationURL(
+        new URL("/reports", window.location.origin),
+        window.location.origin,
+      ),
+    ).toBe(false);
+  });
+
+  it("does not prefetch cross-origin URLs through the local page-data endpoint", async () => {
+    const router = new SPARouter({ scrollRestoration: false });
+
+    await router.prefetch("https://example.com/reports");
+
+    expect(fetch).not.toHaveBeenCalled();
+    router.destroy();
+  });
+});

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -261,6 +261,7 @@ export class SPARouter {
     const fullPath = pathname + search;
 
     if (
+      isFarmExternalNavigationURL(url, window.location.origin) ||
       isFarmLocaleChangeHref(url.toString()) ||
       this.options.shouldUseDocumentNavigation(pathname)
     ) {
@@ -360,6 +361,7 @@ export class SPARouter {
   async prefetch(href: string): Promise<void> {
     if (isFarmLocaleChangeHref(href)) return;
     const url = new URL(href, window.location.origin);
+    if (isFarmExternalNavigationURL(url, window.location.origin)) return;
     const fullPath = url.pathname + url.search;
     const interceptFrom = window.location.pathname + window.location.search;
 
@@ -856,6 +858,10 @@ export class SPARouter {
   clearCache(): void {
     this.cache.clear();
   }
+}
+
+export function isFarmExternalNavigationURL(url: URL, currentOrigin: string): boolean {
+  return url.origin !== currentOrigin;
 }
 
 function readBrowserDeploymentId(): string | undefined {


### PR DESCRIPTION
## Problem

Imperative navigation to an absolute cross-origin URL is treated as a Farm route. Depending on the pathname, it either does nothing or requests the local `__farm/page-data` endpoint. Imperative prefetch has the same origin leak.

## Root cause

`SPARouter.navigate()` parses the URL but only checks locale and configured pathname fallbacks. Its existing external check is limited to link observation and is not based on the resolved URL origin.

## Change

Compare the resolved URL origin with the current origin before SPA navigation or prefetch. Cross-origin and non-HTTP URLs use document navigation; external prefetches are skipped.

## Safety and compatibility

Relative and same-origin absolute URLs retain SPA behavior. Configured document-navigation paths and locale changes keep their existing precedence and replace/push behavior.

## Verification

- `pnpm --filter @farm.js/core test -- src/__tests__/spa-router-external-navigation.test.ts src/__tests__/router-push-delegation.test.tsx`
- `pnpm --filter @farm.js/core type-check`
- focused `oxfmt` and `oxlint`

The regression coverage verifies origin classification and that external URLs never call the local page-data fetcher.

## Documentation and release

Documented same-origin SPA versus cross-origin document behavior in the routing guide.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes imperative `push()`/`replace()` navigation and prefetch for cross-origin and non-HTTP URLs so they use document navigation instead of Farm's local page-data endpoint.

**Notes**
- External prefetches are skipped entirely.
- Same-origin and relative URLs keep SPA navigation; locale changes and configured document-navigation paths keep their existing precedence.
- Adds regression tests for origin classification and the page-data fetch guard, and documents the behavior in the routing guide.

<sup>Written for commit 8fd0a5b3aa27cfc8c075c4913d8a2f3949449bc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

