### PR TITLE
fix(navigation): restore scroll by query location

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -223,6 +223,8 @@ Page state is stored in `history.state`, so back/forward navigation restores the
 ## Scroll restoration
 
 Farm restores window scroll during SPA navigation. Register nested scroll areas when a layout owns its own scroll container.
+Locations with different query strings keep independent positions, so browser history restores the
+correct filtered, searched, or paginated view.
 
 ```tsx
 "use client";

--- a/packages/farm/src/__tests__/spa-router-scroll-query.test.ts
+++ b/packages/farm/src/__tests__/spa-router-scroll-query.test.ts
@@ -1,0 +1,47 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SPARouter } from "../client/spa-router";
+
+describe("SPA router query scroll restoration", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/items?page=1");
+    sessionStorage.clear();
+    Object.defineProperty(window, "scrollX", { configurable: true, value: 12 });
+    Object.defineProperty(window, "scrollY", { configurable: true, value: 34 });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          props: {},
+          modulePath: "/src/app/items/page.tsx",
+          metadata: {},
+        }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("stores and restores positions for the complete pathname and query", async () => {
+    vi.useFakeTimers();
+    sessionStorage.setItem("farm-scroll-/items?page=2", JSON.stringify({ x: 56, y: 78 }));
+    const scrollTo = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+    const router = new SPARouter();
+    router.setNavigationHandler(async () => undefined);
+
+    await router.navigate("/items?page=2", { scroll: false });
+    vi.runOnlyPendingTimers();
+
+    expect(sessionStorage.getItem("farm-scroll-/items?page=1")).toBe(
+      JSON.stringify({ x: 12, y: 34 }),
+    );
+    expect(sessionStorage.getItem("farm-scroll-/items")).toBeNull();
+    expect(scrollTo).toHaveBeenCalledWith(56, 78);
+    router.destroy();
+  });
+});

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -178,7 +178,7 @@ export class SPARouter {
       event.preventDefault();
       event.returnValue = "";
     }
-    this.saveScrollPosition(window.location.pathname);
+    this.saveScrollPosition(window.location.pathname + window.location.search);
   };
 
   constructor(options: RouterOptions = {}) {
@@ -290,7 +290,7 @@ export class SPARouter {
 
     // Save current scroll position
     if (this.options.scrollRestoration) {
-      this.saveScrollPosition(window.location.pathname);
+      this.saveScrollPosition(window.location.pathname + window.location.search);
     }
 
     this.startNavigation({
@@ -441,7 +441,7 @@ export class SPARouter {
 
   registerScrollElement(key: string, element: HTMLElement): () => void {
     this.scrollElements.set(key, element);
-    this.restoreScrollElement(window.location.pathname, key, element);
+    this.restoreScrollElement(window.location.pathname + window.location.search, key, element);
     return () => {
       if (this.scrollElements.get(key) === element) {
         this.scrollElements.delete(key);
@@ -522,7 +522,7 @@ export class SPARouter {
         window.scrollTo(0, 0);
       }
     } else if (this.options.scrollRestoration) {
-      this.restoreScrollPosition(options.pathname);
+      this.restoreScrollPosition(this.currentHistoryPath ?? options.fullPath);
     }
   }
 
@@ -704,7 +704,7 @@ export class SPARouter {
 
       // Restore scroll position
       if (this.options.scrollRestoration) {
-        this.restoreScrollPosition(window.location.pathname);
+        this.restoreScrollPosition(window.location.pathname + window.location.search);
       }
 
       if (clientNavigation) {

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1999,7 +1999,7 @@ ${generateUniversalRouterStateProperties()}
     const from = this.currentPath;
     if (await this.shouldBlockNavigation({ from, to, action })) return;
 
-    this.saveScrollPosition(window.location.pathname);
+    this.saveScrollPosition(window.location.pathname + window.location.search);
     this.startNavigation(from, url, action);
     let clientNavigation;
     try {
@@ -2028,7 +2028,7 @@ ${generateUniversalRouterStateProperties()}
           if (url.hash) document.querySelector(url.hash)?.scrollIntoView();
           else window.scrollTo(0, 0);
         } else {
-          this.restoreScrollPosition(url.pathname);
+          this.restoreScrollPosition(to);
         }
       });
       await farmClientRuntime.resolveNavigation(clientNavigation);
@@ -2197,7 +2197,7 @@ window.addEventListener("beforeunload", function(event) {
     event.preventDefault();
     event.returnValue = "";
   }
-  spaRouter.saveScrollPosition(window.location.pathname);
+  spaRouter.saveScrollPosition(window.location.pathname + window.location.search);
 });
 
 // Handle popstate (back/forward)
@@ -2843,7 +2843,7 @@ ${generateUniversalRouterStateProperties()}
 
     // A route transition invalidates any trigger waiting on the previous DOM boundary.
     cancelPendingPageHydration();
-    this.saveScrollPosition(window.location.pathname);
+    this.saveScrollPosition(window.location.pathname + window.location.search);
     this.startNavigation(from, url, action);
     let clientNavigation;
 
@@ -2974,7 +2974,7 @@ ${generateUniversalRouterStateProperties()}
         if (url.hash) document.querySelector(url.hash)?.scrollIntoView();
         else window.scrollTo(0, 0);
       } else {
-        this.restoreScrollPosition(url.pathname);
+        this.restoreScrollPosition(to);
       }
       await farmClientRuntime.resolveNavigation(clientNavigation);
       void farmClientRuntime.scheduleNavigationRendered(clientNavigation);
@@ -3193,7 +3193,7 @@ window.addEventListener("beforeunload", function(event) {
     event.preventDefault();
     event.returnValue = "";
   }
-  spaRouter.saveScrollPosition(window.location.pathname);
+  spaRouter.saveScrollPosition(window.location.pathname + window.location.search);
 });
 
 // Handle popstate (back/forward)

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -3722,7 +3722,7 @@ class LegacyManifestSPARouter {
     }
 
     // Save scroll position
-    this.saveScrollPosition(window.location.pathname);
+    this.saveScrollPosition(window.location.pathname + window.location.search);
 
     try {
       // CLIENT-SIDE route matching - no server request!
@@ -3863,7 +3863,7 @@ class LegacyManifestSPARouter {
       };
 
       if (this.onNavigate) await this.onNavigate(pageData);
-      this.restoreScrollPosition(pathname);
+      this.restoreScrollPosition(pathname + search);
     } catch (error) {
       console.error('[Farm.js] Popstate error:', error);
       window.location.reload();


### PR DESCRIPTION
## Problem

Routes that differ only by query string share one scroll-storage key. Navigating between `/items?page=1` and `/items?page=2` overwrites the first page's position, so back/forward restores the wrong viewport and nested container positions.

## Root cause

The SPA runtimes save and restore scroll with `window.location.pathname` while their history and page-data keys already use `pathname + search`.

## Change

Use the complete pathname and query as the scroll key in the shared router, Vite legacy runtime, and both universal production runtimes. Registered nested scroll containers use the same key.

## Safety and compatibility

Paths without a query keep their existing storage keys. Hashes remain excluded because they identify positions within the same route location.

## Verification

- `pnpm --filter @farm.js/core test -- src/__tests__/spa-router-scroll-query.test.ts src/__tests__/navigation-state.test.tsx`
- `pnpm --filter @farm.js/core type-check`
- focused `oxfmt` and `oxlint`

The regression test verifies independent saved and restored positions for two query variants.

## Documentation and release

Updated the routing guide's scroll restoration contract.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes scroll restoration for routes that differ only by query string. The scroll key now includes the query string in the shared router, Vite legacy runtime, and both universal production runtimes.

- Nested scroll containers use the same pathname + search key.
- Paths without query strings keep their existing storage keys.
- Hashes remain excluded because they identify positions within the same route.
- Added a regression test for two query variants and updated the routing guide.

<sup>Written for commit 32b306c45c62ca545c1ad76e3a5789402e443818. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

